### PR TITLE
Support for external data in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ nosetests.xml
 chromedriver.log
 mozwebqa.cfg
 credentials.yaml
+cfme_data.yaml
 results
 pytest.ini
 

--- a/cfme_data.yaml.template
+++ b/cfme_data.yaml.template
@@ -1,0 +1,28 @@
+management_systems:
+    vsphere5:
+        name: vsphere 5
+        credentials: credential_name
+        hostname: vsphere5.example.com
+        ipaddress: 10.0.0.1
+        host_vnc_port:
+            start: 5900
+            end: 5980
+        server_zone: default
+        type: virtualcenter
+        discovery_range:
+            start: 10.0.0.1
+            end: 10.0.0.2
+    rhevm31:
+        name: RHEV 3.1
+        credentials: rhev_credential_name
+        hostname: rhevm.example.com
+        ipaddress: 10.0.0.1
+        host_vnc_port:
+            start: 5901
+            end: 5999
+        server_zone: default
+        type: rhevm
+        discovery_range:
+            start: 10.0.0.3
+            end: 10.0.0.3
+

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,30 @@
+import pytest
+
+def _read(filename):
+    stream = file(filename, 'r')
+    import yaml
+    return yaml.load(stream)
+
+def pytest_addoption(parser):
+    group = parser.getgroup('cfme', 'cfme')
+    group._addoption('--cfmedata',
+                     action='store',
+                     dest='cfme_data_filename',
+                     metavar='path',
+                     help='location of yaml file containing fixture data') 
+
+def pytest_runtest_setup(item):
+    if item.config.option.cfme_data_file:
+        CfmeSetup.data = _read(item.config.option.cfme_data_filename)
+
+
+@pytest.fixture
+def cfme_data(request):
+    return CfmeSetup(request)
+
+class CfmeSetup:
+    '''
+        This class is just used for monkey patching
+    '''
+    def __init__(self, request):
+        self.request = request


### PR DESCRIPTION
- Add a cfme_data.yaml.template
- Ignore cfme_data.yaml
- Add commandline param to specify cfme_data.yaml
- Adds a cfme_data fixture that contains the contents read from
  cfme_data.yaml
