### PR TITLE
_block_until now actually uses the 'timeout' arg

### DIFF
--- a/tests/common/mgmt_system.py
+++ b/tests/common/mgmt_system.py
@@ -706,7 +706,7 @@ class EC2System(MgmtSystemAPIBase):
         """
         start = time.time()
         while self.vm_status(instance_id) not in expected:
-            if timeout is not None and time.time() - start > 90:
+            if timeout is not None and time.time() - start > timeout:
                 raise ActionTimedOutError
             time.sleep(3)
 


### PR DESCRIPTION
Went to all that trouble to make it easy to customize the timeout, then I didn't use the arg...doh!
