### PR TITLE
Using pytest marks to pass options to fixtures

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -34,6 +34,12 @@ def add_cfme_pages_to_path():
 
 add_cfme_pages_to_path()
 
-pytest_plugins = 'plugin.highlight', 'fixtures.cfmedata', 'fixtures.cfmedb', \
-        'fixtures.server_roles', 'fixtures.soap'
-
+pytest_plugins = (
+    'plugin.highlight',
+    'fixtures.baseurl',
+    'fixtures.cfmedata',
+    'fixtures.cfmedb',
+    'fixtures.server_roles',
+    'fixtures.soap',
+    'markers',
+)

--- a/fixtures/baseurl.py
+++ b/fixtures/baseurl.py
@@ -1,0 +1,10 @@
+import pytest
+
+@pytest.fixture
+def baseurl(request, mozwebqa):
+    """Override mozwebqa's baseurl for an individual test
+
+    Put this fixture before other fixtures to ensure it takes effect
+
+    """
+    mozwebqa.base_url = request.node._fixtureconf['base_url']

--- a/markers.py
+++ b/markers.py
@@ -1,0 +1,20 @@
+'''fixtureconf: Marker for passing args and kwargs to test fixtures
+
+Arguments and keyword arguments to this marker will be stored on test items
+in the _fixtureconf attribute (dict). kwargs will be stored as-is, the args
+tuple will be packed into the dict under the 'args' key.
+'''
+
+def pytest_configure(config):
+    config.addinivalue_line('markers', __doc__)
+
+def pytest_runtest_setup(item):
+    fixtureconf_mark = item.keywords.get('fixtureconf')
+    args = getattr(fixtureconf_mark, 'args', tuple())
+    kwargs = getattr(fixtureconf_mark, 'kwargs', dict())
+    fixtureconf = dict()
+    fixtureconf['args'] = args
+    fixtureconf.update(kwargs)
+    # "item" becomes "request.node" in fixtures down the line
+    # remember to use the request fixture in fixture funcargs
+    item._fixtureconf = fixtureconf


### PR DESCRIPTION
- Modified server_roles fixture to use the fixtureconf mark
- Added a baseurl fixture using the fixtureconf mark

Since fixtureconf is a more general way to pass options in to fixtures, I got rid of the decorators. I don't see any references to them in the code right now, but this might be a slight bump for people that need the server roles fixture.
