### PR TITLE
selenium fixture now supports navigation fixtures

### DIFF
--- a/fixtures/selenium.py
+++ b/fixtures/selenium.py
@@ -1,6 +1,11 @@
+import types
+
 import pytest
 from pytest_mozwebqa import split_class_and_test_names
 from pytest_mozwebqa.selenium_client import Client
+
+from fixtures import navigation
+from pages.page import Page
 
 def pytest_runtest_setup(item):
     # If we're using the selenium fixture, mark the test as
@@ -17,16 +22,16 @@ def selenium(mozwebqa, request):
     test_id = '.'.join(split_class_and_test_names(request.node.nodeid))
     mozwebqa.selenium_client = Client(test_id, request.session.config.option)
 
-    def cm_wrapper(url, page_obj):
-        return SeleniumContextManager(mozwebqa, url, page_obj)
+    def cm_wrapper(url, page_or_fixture):
+        return SeleniumContextManager(mozwebqa, url, page_or_fixture)
 
     return cm_wrapper
 
 class SeleniumContextManager(object):
-    def __init__(self, testsetup, url, page_obj):
+    def __init__(self, testsetup, url, page_or_fixture):
         self.testsetup = testsetup
         self.url = url
-        self.page_obj = page_obj
+        self.page_or_fixture = page_or_fixture
 
     def __enter__(self):
         # More mozwebqa bootstrapping, start the browser, expose some
@@ -43,8 +48,19 @@ class SeleniumContextManager(object):
             setattr(self.testsetup, attr, getattr(self.testsetup.selenium_client, attr))
 
         self.testsetup.base_url = self.url
+        self.testsetup.selenium.maximize_window()
         self.testsetup.selenium.get(self.url)
-        return self.page_obj(self.testsetup)
+
+        # Is it a page or a fixture?
+        if type(self.page_or_fixture) == types.FunctionType:
+            # Function! It's a fixture and we should use it...
+            home_page_logged_in = navigation.home_page_logged_in(self.testsetup)
+            # If you passed in the home_page_logged_in fixture, this will be funny.
+            return self.page_or_fixture(home_page_logged_in)
+        else:
+            # Not a function! It's probably a Page class that we should set up
+            return self.page_or_fixture(self.testsetup)
+
 
     def __exit__(self, *args, **kwargs):
         self.testsetup.selenium_client.stop()

--- a/utils/tests/test_selenium_fixture.py
+++ b/utils/tests/test_selenium_fixture.py
@@ -4,11 +4,19 @@ import pytest
 
 from pages.page import Page
 
-@pytest.mark.nondestructive
-def test_selenium(selenium):
-    with selenium('http://www.redhat.com', Page) as page:
-        assert 'redhat.com' in page.selenium.current_url.lower()
+pytestmark = pytest.mark.nondestructive
 
+def test_selenium_page(selenium):
+    # Test an arbitrary URL and a Page object
     with selenium('http://www.google.com', Page) as page:
         assert 'google.com' in page.selenium.current_url.lower()
+
+def test_selenium_fixture(mozwebqa, selenium):
+    # Mock fixture to keep things as fast as possible
+    def mock_fixture(home_page_logged_in):
+        return home_page_logged_in
+
+    # Test the mozwebqa base_url and a fixture
+    with selenium(mozwebqa.base_url, mock_fixture) as page:
+        assert page.is_the_current_page
 


### PR DESCRIPTION
Now that the navigation fixtures are a thing, it's handy to be able to use them in my distributed testing.

In addition to letting you pass a URL and a Page class to represent it, you can now pass an appliance URL and a navigation fixture to use. The context object will be the fixture's return value.

selenium fixture API change is backward compatible, new test included
