### PR TITLE
Test Utilizatoin Graphs

### DIFF
--- a/fixtures/navigation.py
+++ b/fixtures/navigation.py
@@ -73,3 +73,8 @@ def automate_explorer_pg(home_page_logged_in):
     '''Navigate to Automate -> Explorer'''
     return home_page_logged_in.header.site_navigation_menu(
             "Automate").sub_navigation_menu("Explorer").click()
+
+@pytest.fixture
+def automate_infrastructure_vms_pg(home_page_logged_in):
+    '''Navigate to Service -> Workloads'''
+    return home_page_logged_in.header.site_navigation_menu("Infrastructure").sub_navigation_menu("Virtual Machines").click()

--- a/tests/cap_and_util/add_metrics.py
+++ b/tests/cap_and_util/add_metrics.py
@@ -1,0 +1,71 @@
+
+import time
+from unittestzero import Assert
+import datetime
+import db
+
+def insert_previous_hour_raw_metric_data(db_session, resource_id, columns):
+    resource_id = resource_id
+    columns = columns
+    date = datetime.datetime.utcnow()
+    date = date.replace(microsecond=0)
+    date = date.replace(second = 0)
+    #date = date.replace(minute = 0)
+    current_time = date
+    date = date - datetime.timedelta(hours = 1)
+    #previous_hour = date.hour
+    capture_interval_name = 'realtime'
+    session = db_session
+    while date <= current_time:
+        new_user = db.Metric(resource_id = resource_id)
+        session.add(new_user)
+        new_user.timestamp = date
+        new_user.capture_interval_name = capture_interval_name
+        date = date + datetime.timedelta(seconds = 20)
+        for key, value in columns.items():
+            setattr(new_user, key, value)
+    session.commit()
+
+def insert_previous_weeks_hourly_rollups(db_session, resource_id, columns):
+    resource_id = resource_id                                                                      
+    date=datetime.datetime.utcnow()
+    capture_interval_name = 'hourly'
+    date = date.replace(microsecond = 0)
+    date = date.replace(second = 0)
+    date = date.replace(minute = 0)
+    date = date.replace(hour = 0)
+    date = date - datetime.timedelta(days = 7)
+    columns = columns                                                                         
+    session = db_session                                                                                 
+    for x in range(0, 168):                                                                         
+        new_user = db.MetricRollup(resource_id = resource_id)
+        session.add(new_user)
+        new_user.timestamp = date
+        new_user.capture_interval_name = capture_interval_name
+        date = date + datetime.timedelta(hours = 1)
+        for key, value in columns.items():
+            setattr(new_user, key, value) 
+    session.commit()    
+
+
+def insert_previous_weeks_daily_rollups(db_session, resource_id, columns):
+    resource_id = resource_id
+    date=datetime.datetime.utcnow()
+    capture_interval_name = 'daily'
+    date = date.replace(microsecond = 0)
+    date = date.replace(second = 0)
+    date = date.replace(minute = 0)
+    date = date.replace(hour = 0)
+    date = date - datetime.timedelta(days = 7)
+    columns = columns
+    session = db_session
+    for x in range(0, 7):
+        new_user = db.MetricRollup(resource_id = resource_id)
+        session.add(new_user)
+        new_user.timestamp = date
+        new_user.capture_interval_name = capture_interval_name
+        date = date + datetime.timedelta(days = 1)
+        for key, value in columns.items():
+            setattr(new_user, key, value)
+    session.commit()
+

--- a/tests/cap_and_util/delete_metrics.py
+++ b/tests/cap_and_util/delete_metrics.py
@@ -1,0 +1,20 @@
+import time                                                           
+from unittestzero import Assert
+import datetime                                                                                         
+import db
+
+def delete_raw_metric_data(db_session, resource_id):
+    resource_id = resource_id
+    session = db_session  
+    session.query(db.Metric).filter(db.Metric.resource_id == resource_id).delete() 
+
+    session.commit()
+
+def delete_metric_rollup_data(db_session, resource_id):
+    resource_id = resource_id
+    session = db_session
+    session.query(db.MetricRollup).filter(db.MetricRollup.resource_id == resource_id).delete()
+
+    session.commit()
+
+

--- a/tests/cap_and_util/test_utilization_graphs.py
+++ b/tests/cap_and_util/test_utilization_graphs.py
@@ -1,0 +1,143 @@
+import pytest
+import time
+import datetime
+import sys
+import collections
+from unittestzero import Assert
+from delete_metrics import delete_raw_metric_data
+from delete_metrics import delete_metric_rollup_data
+from add_metrics import insert_previous_hour_raw_metric_data
+from add_metrics import insert_previous_weeks_hourly_rollups
+from add_metrics import insert_previous_weeks_daily_rollups
+from selenium.webdriver.common.keys import Keys
+
+
+@pytest.fixture
+def get_vm_info(db_session):
+    import db
+    session = db_session
+    vm_info = session.query(db.Vm).filter_by(power_state = 'on').first()
+    resource_id = vm_info.id
+    name = vm_info.name
+    vm_info = collections.namedtuple('vm_info', ['id', 'name'])
+    vm_info = vm_info(resource_id, name)
+    return vm_info
+
+@pytest.mark.nondestructive
+@pytest.mark.usefixtures("maximized")
+#@pytest.mark.usefixtures("setup_infrastructure_providers")
+def test_delete_vm_metric_data(db_session, get_vm_info):
+    resource_id = get_vm_info.id
+    delete_raw_metric_data(db_session, resource_id)
+    
+    delete_metric_rollup_data(db_session, resource_id)
+
+@pytest.mark.nondestructive
+@pytest.mark.usefixtures("maximized")
+def test_add_previous_weeks_hourly_metrics(automate_infrastructure_vms_pg, mozwebqa, home_page_logged_in, db_session, get_vm_info):
+    resource_id = get_vm_info.id
+    vm_name = get_vm_info.name
+    columns = {
+        'resource_name': vm_name,
+        'resource_type': 'VmOrTemplate',
+        'cpu_usagemhz_rate_average': 200,
+        'net_usage_rate_average' : 500,
+        'disk_usage_rate_average': 70,
+        'derived_memory_used': 100,
+        'cpu_ready_delta_summation': 372579.208333333,
+        'cpu_used_delta_summation': 2143234.66666667
+    }
+    insert_previous_weeks_hourly_rollups(db_session, resource_id, columns)
+ 
+    vm_pg = automate_infrastructure_vms_pg
+    Assert.true(vm_pg.is_the_current_page)
+    vm_details_pg = vm_pg.find_vm_page(vm_name,None, False,True)
+    util_pg = vm_details_pg.click_on_utilization()
+    interval = 'Hourly'
+    date = datetime.date.today() - datetime.timedelta(days = 1)
+    time_zone = ""
+    compare_to = ""
+    show = ""
+    util_pg.fill_data(interval, show, time_zone, compare_to, date)
+    #util_pg.selenium.save_screenshot('./results/screenshots/test_add_previous_day_hourly_metrics_1.png')
+    util_pg.options_frame.click()
+    util_pg.selenium.switch_to_active_element().send_keys(Keys.PAGE_DOWN)
+    util_pg.selenium.save_screenshot('./results/screenshots/test_add_previous_day_hourly_metrics.png') #issue 81
+    
+@pytest.mark.nondestructive
+@pytest.mark.usefixtures("maximized")
+def test_add_previous_hour_raw_metrics(automate_infrastructure_vms_pg, mozwebqa, home_page_logged_in, db_session, get_vm_info):
+    resource_id = get_vm_info.id
+    vm_name = get_vm_info.name
+    columns = {
+        'resource_name': vm_name,
+        'resource_type': 'VmOrTemplate',
+        'cpu_usagemhz_rate_average': 700,
+        'net_usage_rate_average' : 800,
+        'disk_usage_rate_average': 300,
+        'derived_memory_used': 900,
+        'cpu_ready_delta_summation': 372579.208333333,
+        'cpu_used_delta_summation': 2143234.66666667
+    }
+    insert_previous_hour_raw_metric_data(db_session, resource_id, columns)
+    
+    vm_pg = automate_infrastructure_vms_pg
+    Assert.true(vm_pg.is_the_current_page)
+    vm_details_pg = vm_pg.find_vm_page(vm_name,None, False,True)
+    util_pg = vm_details_pg.click_on_utilization()
+    interval = 'Most Recent Hour'
+    date = ""
+    time_zone = ""
+    compare_to = ""
+    show = "1 Hour"
+    util_pg.fill_data(interval, show, time_zone, compare_to, date)
+    #util_pg.selenium.save_screenshot('./results/screenshots/test_add_previous_hour_raw_metrics_1.png')
+    util_pg.options_frame.click()
+    util_pg.selenium.switch_to_active_element().send_keys(Keys.PAGE_DOWN)    
+    util_pg.selenium.save_screenshot('./results/screenshots/test_add_previous_hour_raw_metrics.png') #issue 81
+    
+@pytest.mark.nondestructive
+@pytest.mark.usefixtures("maximized")
+def test_add_previous_weeks_daily_metrics(automate_infrastructure_vms_pg, mozwebqa, home_page_logged_in, db_session, get_vm_info):
+    resource_id = get_vm_info.id
+    vm_name = get_vm_info.name
+    columns = {
+        'resource_name': vm_name,
+        'resource_type': 'VmOrTemplate',
+        'time_profile_id': "1",
+        'cpu_usagemhz_rate_average': 400,
+        'net_usage_rate_average' : 700,
+        'disk_usage_rate_average': 20,
+        'derived_memory_used': 300,
+        'cpu_ready_delta_summation': 372579.208333333,
+        'cpu_used_delta_summation': 2143234.66666667,
+        'min_max' : '''---
+:min_cpu_usagemhz_rate_average: 100
+:max_cpu_usagemhz_rate_average: 800
+:min_derived_memory_used: 200
+:max_derived_memory_used: 700
+:min_disk_usage_rate_average: 10
+:max_disk_usage_rate_average: 40
+:min_net_usage_rate_average: 400
+:max_net_usage_rate_average: 900'''
+    }
+    insert_previous_weeks_daily_rollups(db_session, resource_id, columns)
+
+    vm_pg = automate_infrastructure_vms_pg
+    Assert.true(vm_pg.is_the_current_page)
+    vm_details_pg = vm_pg.find_vm_page(vm_name,None, False,True)
+    util_pg = vm_details_pg.click_on_utilization()
+    interval = 'Daily'
+    date = datetime.date.today() - datetime.timedelta(days = 1)
+    time_zone = ""
+    compare_to = ""
+    show = ""
+    util_pg.fill_data(interval, show, time_zone, compare_to, date)
+    #util_pg.selenium.save_screenshot('./results/screenshots/test_add_previous_weeks_daily_metrics_1.png')
+    util_pg.options_frame.click()
+    util_pg.selenium.switch_to_active_element().send_keys(Keys.PAGE_DOWN)
+    util_pg.selenium.save_screenshot('./results/screenshots/test_add_previous_weeks_daily_metrics.png') #issue 81
+    
+    delete_raw_metric_data(db_session, resource_id)
+    delete_metric_rollup_data(db_session, resource_id)
+


### PR DESCRIPTION
Injects data into the "metrics" and "metric_rollups" tables and navigates to the cap and utilization page and takes a screenshot of the graph.
