### PR TITLE
async utils for parallel operations in tests

### DIFF
--- a/utils/async.py
+++ b/utils/async.py
@@ -1,0 +1,36 @@
+from multiprocessing.pool import CLOSE, Pool
+
+class ResultsPool(Pool):
+    """multiprocessing.Pool boilerplate wrapper
+
+    - Stores results on a results property
+    - Task result successes are aggregated by the sucessful property
+
+    """
+    def __init__(self, *args, **kwargs):
+        super(ResultsPool, self).__init__(*args, **kwargs)
+
+    def apply_async(self, *args, **kwargs):
+        result = super(ResultsPool, self).apply_async(*args, **kwargs)
+        self.results.append(result)
+        return result
+
+    def map_async(self, *args, **kwargs):
+        result = super(ResultsPool, self).map_async(*args, **kwargs)
+        self.results.append(result)
+        return result
+
+    @property
+    def successful(self):
+        if self.results:
+            return all([result.successful() for result in self.results])
+        else:
+            return None
+
+    def __enter__(self):
+        self.results = list()
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.close()
+        self.join()

--- a/utils/tests/test_async.py
+++ b/utils/tests/test_async.py
@@ -1,0 +1,25 @@
+import string
+
+import pytest
+from unittestzero import Assert
+
+from utils.async import ResultsPool
+
+def async_task(arg1, arg2):
+    # Task to reverse argument. Asynchronously...
+    return arg2, arg1
+
+@pytest.mark.nondestructive
+@pytest.mark.skip_selenium
+def test_async():
+    with ResultsPool(processes=3) as pool:
+        for letter, digit in zip(string.letters[:3], string.digits[:3]):
+            pool.apply_async(async_task, [letter, digit])
+    Assert.true(pool.successful)
+
+    for result in pool.results:
+        # Result should have reversed args, i.e.
+        # digit, letter = async_task(letter, digit)
+        digit, letter = result.get()
+        Assert.contains(digit, string.digits)
+        Assert.contains(letter, string.letters)


### PR DESCRIPTION
More shenanigans!

This one lets you parallelize long-running operations, like (for example) resetting the region on three appliances simultaneously, which takes around 10 minutes per appliance.

This adds context manager behavior to the builtin multiprocessing Pool class, stashing all the pool setup and teardown boilerplate into the enter/exit methods.
