### PR TITLE
Adds the fixtureconf fixture

### DIFF
--- a/fixtures/baseurl.py
+++ b/fixtures/baseurl.py
@@ -1,10 +1,10 @@
 import pytest
 
 @pytest.fixture
-def baseurl(request, mozwebqa):
+def baseurl(fixtureconf, mozwebqa):
     """Override mozwebqa's baseurl for an individual test
 
     Put this fixture before other fixtures to ensure it takes effect
 
     """
-    mozwebqa.base_url = request.node._fixtureconf['base_url']
+    mozwebqa.base_url = fixtureconf['base_url']

--- a/fixtures/fixtureconf.py
+++ b/fixtures/fixtureconf.py
@@ -1,0 +1,6 @@
+import pytest
+
+@pytest.fixture
+def fixtureconf(request):
+    """Provides easy access to the fixtureconf dict in fixtures"""
+    return request.node._fixtureconf

--- a/fixtures/server_roles.py
+++ b/fixtures/server_roles.py
@@ -18,7 +18,7 @@ default_roles = (
 )
 
 @pytest.fixture
-def server_roles(request, cfme_data, cnf_configuration_pg):
+def server_roles(fixtureconf, cfme_data, cnf_configuration_pg):
     """Set the server roles based on a list of roles attached to the test using this fixture
 
     Usage examples:
@@ -34,8 +34,6 @@ def server_roles(request, cfme_data, cnf_configuration_pg):
         Roles can be pulled from the cfme_data fixture using yaml selectors,
         which will do a 'set' with the list of roles found at the target path:
 
-        from fixtures.roles import server_roles_cfme_data
-        @server_roles_cfme_data('level1', 'sublevel2'))
         @pytest.mark.fixtureconf(server_roles_cfmedata=('level1', 'sublevel2'))
         def test_appliance_roles(server_roles):
             assert len(server_roles) == 3
@@ -50,7 +48,7 @@ def server_roles(request, cfme_data, cnf_configuration_pg):
 
         To ensure the appliance has the default roles:
 
-        from fixtures.roles import server_roles_set, default_roles
+        from fixtures.server_roles import default_roles
 
         @pytest.mark.fixtureconf(server_roles=default_roles)
         def test_appliance_roles(server_roles):
@@ -77,14 +75,14 @@ def server_roles(request, cfme_data, cnf_configuration_pg):
 
     """
 
-    if 'server_roles' in request.node._fixtureconf:
-        roles_list = list(request.node._fixtureconf['server_roles'])
-    elif 'server_roles_cfmedata' in request.node._fixtureconf:
+    if 'server_roles' in fixtureconf:
+        roles_list = list(fixtureconf['server_roles'])
+    elif 'server_roles_cfmedata' in fixtureconf:
         roles_list = cfme_data.data
         # Drills down into cfme_data YAML by selector, expecting a list
         # of roles at the end. A KeyError here probably means the YAMe
         # selector is wrong
-        for selector in request.node._fixtureconf['server_roles_cfmedata']:
+        for selector in fixtureconf['server_roles_cfmedata']:
             roles_list = roles_list[selector]
     else:
         raise Exception('server_roles config not found on test callable')

--- a/markers/fixtureconf.py
+++ b/markers/fixtureconf.py
@@ -1,8 +1,10 @@
 '''fixtureconf: Marker for passing args and kwargs to test fixtures
 
-Arguments and keyword arguments to this marker will be stored on test items
+Positional and keyword arguments to this marker will be stored on test items
 in the _fixtureconf attribute (dict). kwargs will be stored as-is, the args
 tuple will be packed into the dict under the 'args' key.
+
+Use the "fixtureconf" fixture in tests to easily access the fixtureconf dict
 '''
 
 def pytest_configure(config):

--- a/utils/tests/test_fixtureconf_fixture.py
+++ b/utils/tests/test_fixtureconf_fixture.py
@@ -1,0 +1,16 @@
+import pytest
+
+pytestmark = [
+    pytest.mark.nondestructive,
+    pytest.mark.skip_selenium
+]
+
+@pytest.mark.fixtureconf('positional argument', kwarg='keyword argument')
+def test_fixtureconf_fixture_with_mark(fixtureconf):
+    # args and kwargs should be in fixtureconf
+    assert fixtureconf['args'] == ('positional argument',)
+    assert fixtureconf['kwarg'] == 'keyword argument'
+
+def test_fixtureconf_fixture_without_mark(fixtureconf):
+    # no mark = no args stored in fixtureconf, but the fixture should still work
+    assert fixtureconf == {'args': (),}


### PR DESCRIPTION
- Kept running into request.node._fixtureconf boilerplate, so now that's a fixture, which means you can use fixtureconf as a fixture in your fixture to conf your fixture.
- While I was in there, I also cleaned up the server_roles docstring, fixes #112
