### PR TITLE
Fix #129 - wait for hosts to show up

### DIFF
--- a/tests/scenarios/refarch_2013_rhev/test_01provider_setup.py
+++ b/tests/scenarios/refarch_2013_rhev/test_01provider_setup.py
@@ -20,6 +20,16 @@ FLASH_MESSAGE_NOT_MATCHED = 'Flash message did not match expected value'
 def test_add_host_credentials(infra_hosts_pg, host):
     '''Add host credentials
     '''
+    # wait for host quadicon to show up
+    sleep_time = 1
+    while not infra_hosts_pg.quadicon_region.does_quadicon_exist(
+            host['name']):
+        infra_hosts_pg.selenium.refresh()
+        time.sleep(sleep_time)
+        sleep_time *= 2
+        if sleep_time > 90:
+            raise Exception(
+                    'timeout reached for host icon to show up')
     hosts_pg = infra_hosts_pg.edit_host_and_save(host)
     Assert.contains(hosts_pg.flash.message,
         'Host "%s" was saved' % host['name'],


### PR DESCRIPTION
It could also be made as a mini fixture dependent on 'setup_infrastructure_providers' but since we don't test host credentials apart from the refarch scenario (or did I miss something?), there doesn't seem to be a need for that atm.

https://github.com/RedHatQE/cfme_tests/blob/0502c3/fixtures/mgmt_system.py#L12
