### PR TITLE
Script for controlling providers from the command line

### DIFF
--- a/scripts/providers.py
+++ b/scripts/providers.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+"""
+Given the name of a provider from cfme_data and using credentials from
+the credentials stash, call the corresponding action on that provider, along
+with any additional action arguments.
+
+See cfme_pages/common/mgmt_system.py for documentation on the callable methods
+themselves.
+
+Example usage:
+
+    scripts/providers.py providername stop_vm vm-name
+
+Note that attempts to be clever will likely be successful, but fruitless.
+For example, this will work but not do anyhting helpful:
+
+    scripts/providers.py providername __init__ username password
+
+"""
+import argparse
+import os
+import sys
+
+# Make sure the parent dir is on the path before importing provider_factory
+cfme_tests_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, cfme_tests_path)
+
+from utils.providers import provider_factory
+
+def main():
+    parser = argparse.ArgumentParser(epilog=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('provider_name',
+        help='provider name in cfme_data')
+    parser.add_argument('action',
+        help='action to take (list_vm, stop_vm, delete_vm, etc.)')
+    parser.add_argument('action_args', nargs='*',
+        help='foo')
+
+    args = parser.parse_args()
+    try:
+        result = call_provider(args.provider_name, args.action, *args.action_args)
+        if isinstance(result, list):
+            exit = 0
+            for entry in result:
+                print entry
+        elif isinstance(result, str):
+            exit = 0
+            print result
+        elif isinstance(result, bool):
+            # 'True' result becomes flipped exit 0, and vice versa for False
+            exit = int(not result)
+        else:
+            # Unknown type, explode
+            raise Exception('Unknown return type for "%s"' % args.action)
+    except Exception as e:
+        exit = 1
+        sys.stderr.write('%s\n' % e.message)
+
+    return exit
+
+
+def call_provider(provider_name, action, *args):
+    # Given a provider class, find the named method and call it with
+    # *args. This could possibly be generalized for other CLI tools.
+    provider = provider_factory(provider_name)
+
+    try:
+        call = getattr(provider, action)
+    except AttributeError:
+        raise Exception('Action "%s" not found' % action)
+    return call(*args)
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/utils/credentials.py
+++ b/utils/credentials.py
@@ -1,0 +1,19 @@
+import os
+
+import yaml
+from py.path import local
+
+def load_credentials(filename=None):
+    if filename is None:
+        this_file = os.path.abspath(__file__)
+        path = local(this_file).new(basename='../credentials.yaml')
+    else:
+        path = local(filename)
+    if path.check():
+        credentials_fh = path.open()
+        credentials_dict = yaml.load(credentials_fh)
+        return credentials_dict
+    else:
+        msg = 'Usable to load credentials file at %s' % path
+        raise Exception(msg)
+

--- a/utils/providers.py
+++ b/utils/providers.py
@@ -1,0 +1,27 @@
+from common import mgmt_system
+from cfme_data import load_cfme_data
+from credentials import load_credentials
+
+provider_type_map = {
+    'virtualcenter': mgmt_system.VMWareSystem,
+    'rhevm': mgmt_system.RHEVMSystem,
+}
+
+def provider_factory(provider_name, providers=None, credentials=None):
+    if providers is None:
+        cfme_data = load_cfme_data()
+        providers = cfme_data['management_systems']
+
+    provider = providers[provider_name]
+
+    if credentials is None:
+        credentials_dict = load_credentials()
+        credentials = credentials_dict[provider['credentials']]
+
+    provider_instance = provider_type_map[provider['type']](
+        provider['ipaddress'],
+        credentials['username'],
+        credentials['password']
+    )
+
+    return provider_instance


### PR DESCRIPTION
Also added support scripts:
- utils/credentials.py, analogous to utils/cfme_data.py
  (in fact, a copypasta)
- providers utils to help mix in cfme_data and credentials knowledge to
  get a provider instance based on cfme_data name alone
