### PR TITLE
Selenium fixture has better support for navigation fixtures

### DIFF
--- a/utils/tests/test_selenium_fixture.py
+++ b/utils/tests/test_selenium_fixture.py
@@ -1,22 +1,24 @@
-import time
-
 import pytest
 
 from pages.page import Page
+from unittestzero import Assert
 
 pytestmark = pytest.mark.nondestructive
 
-def test_selenium_page(selenium):
-    # Test an arbitrary URL and a Page object
-    with selenium('http://www.google.com', Page) as page:
-        assert 'google.com' in page.selenium.current_url.lower()
 
-def test_selenium_fixture(mozwebqa, selenium):
-    # Mock fixture to keep things as fast as possible
-    def mock_fixture(home_page_logged_in):
-        return home_page_logged_in
+# Mock fixture to keep things relatively fast
+def mock_fixture(home_page_logged_in):
+    return home_page_logged_in
 
+
+def test_selenium_fixture(selenium):
     # Test the mozwebqa base_url and a fixture
-    with selenium(mozwebqa.base_url, mock_fixture) as page:
-        assert page.is_the_current_page
+    with selenium(mock_fixture) as page:
+        Assert.true(page.is_the_current_page)
+        Assert.true(isinstance(page, Page))
 
+
+def test_selenium_fixture_string(selenium):
+    with selenium('cnf_about_pg') as page:
+        Assert.true(page.is_the_current_page)
+        Assert.true(isinstance(page, Page))


### PR DESCRIPTION
Given that the selenium fixture is only being used in its tests,
I thought now would be a good time to improve its interface to be
more useful. It can still navigate you to arbitrary URLs, but once
there it is contrained to using a navigation fixture. This allows
for a few assumptions to be made that drastically improve this
fixture's usability.
