### PR TITLE
Enable timeout change in _wait_for_visible_element.

### DIFF
--- a/pages/page.py
+++ b/pages/page.py
@@ -31,13 +31,20 @@ class Page(object):
         WebDriverWait(self.selenium, self.timeout).until(
                 lambda s: not self.is_element_visible(*self._updating_locator))
 
-    def _wait_for_visible_element(self, *locator):
-        # Used in forms where an element (submit button) is displayed after ajax
-        # validation is done, this validation request doesn't use the common
-        # notification loadmask so _wait_for_results_refresh can't be used.
-        # On pages that do not have ajax refresh this wait will have no effect.
-        WebDriverWait(self.selenium, self.timeout).until(
-                lambda s: self.is_element_visible(*locator))
+    def _wait_for_visible_element(self, by, location, visible_timeout=None):
+        """ Wait for an element to appear visible.
+
+        Used in forms where an element (submit button) is displayed after ajax
+        validation is done, this validation request doesn't use the common
+        notification loadmask so _wait_for_results_refresh can't be used.
+        On pages that do not have ajax refresh this wait will have no effect.
+
+        @param by: What method (By.XPATH, By.CSS_SELECTOR, ...)
+        @param location: Locator
+        @keyword visible_timeout: Override standard timeout.
+        """
+        WebDriverWait(self.selenium, visible_timeout or self.timeout)\
+            .until(lambda s: self.is_element_visible(by, location))
 
     @property
     def is_the_current_page(self):

--- a/pages/regions/policy_menu.py
+++ b/pages/regions/policy_menu.py
@@ -55,13 +55,25 @@ class PolicyMenu(Page):
             return self.reset_tag_edits
 
     class ManagePolicies(Base, PolicyMixin):
-        def save(self):
-            self.save_policy_assignment()
+        def save(self, visible_timeout=None):
+            """ Clicks on the Save button.
 
-        def cancel(self):
-            self.cancel_policy_assignment()
+            @keyword visible_timeout: Modify standard timeout for button's appearance.
+            """
+            self.save_policy_assignment(visible_timeout=visible_timeout)
 
-        def reset(self):
-            self.reset_policy_assignment()
+        def cancel(self, visible_timeout=None):
+            """ Clicks on the Cancel button.
+
+            @keyword visible_timeout: Modify standard timeout for button's appearance.
+            """
+            self.cancel_policy_assignment(visible_timeout=visible_timeout)
+
+        def reset(self, visible_timeout=None):
+            """ Clicks on the Reset button.
+
+            @keyword visible_timeout: Modify standard timeout for button's appearance.
+            """
+            self.reset_policy_assignment(visible_timeout=visible_timeout)
 
 

--- a/pages/regions/policy_mixin.py
+++ b/pages/regions/policy_mixin.py
@@ -15,18 +15,39 @@ class PolicyMixin(Page):
     _cancel_changes_button = (By.CSS_SELECTOR, "a[title='Cancel']")
     _reset_changes_button = (By.CSS_SELECTOR, "a[title='Reset Changes']")
 
-    def save_policy_assignment(self):
-        self._wait_for_visible_element(*self._save_changes_button)
+    def save_policy_assignment(self, visible_timeout=None):
+        """ Clicks on the Save button.
+
+        It waits with the timeout until the buton has been enabled
+        and then it clicks it.
+
+        @keyword visible_timeout: Modify standard timeout for button's appearance.
+        """
+        self._wait_for_visible_element(*self._save_changes_button, visible_timeout=visible_timeout)
         self.selenium.find_element(*self._save_changes_button).click()
         self._wait_for_results_refresh()
 
-    def cancel_policy_assignment(self):
-        self._wait_for_visible_element(*self._cancel_changes_button)
+    def cancel_policy_assignment(self, visible_timeout=None):
+        """ Clicks on the Cancel button.
+
+        It waits with the timeout until the buton has been enabled
+        and then it clicks it.
+
+        @keyword visible_timeout: Modify standard timeout for button's appearance.
+        """
+        self._wait_for_visible_element(*self._cancel_changes_button, visible_timeout=visible_timeout)
         self.selenium.find_element(*self._cancel_changes_button).click()
         self._wait_for_results_refresh()
 
-    def reset_policy_assignment(self):
-        self._wait_for_visible_element(*self._reset_changes_button)
+    def reset_policy_assignment(self, visible_timeout=None):
+        """ Clicks on the Reset button.
+
+        It waits with the timeout until the buton has been enabled
+        and then it clicks it.
+
+        @keyword visible_timeout: Modify standard timeout for button's appearance.
+        """
+        self._wait_for_visible_element(*self._reset_changes_button, visible_timeout=visible_timeout)
         self.selenium.find_element(*self._reset_changes_button).click()
         self._wait_for_results_refresh()
 


### PR DESCRIPTION
Sometimes it can be handy to override the standard timeout. I will use it in event testing setup as the original timeout  for save is too long if the automate policy is already assigned. And when I was into it, I've had also changed the reset and cancel to utilize this mod.
