### PR TITLE
Implemented wait for provider functions

### DIFF
--- a/pages/infrastructure_subpages/provider_subpages/detail.py
+++ b/pages/infrastructure_subpages/provider_subpages/detail.py
@@ -56,6 +56,26 @@ class ProvidersDetail(Base):
         start, end = element_text.encode('utf-8').split('-')
         return {'start': int(start), 'end': int(end)}
 
+    @property
+    def cluster_count(self):
+        '''Count of clusters'''
+        return self.details.get_section('Relationships').get_item('Clusters').value
+
+    @property
+    def datastore_count(self):
+        '''Count of datastores'''
+        return self.details.get_section('Relationships').get_item('Datastores').value
+
+    @property
+    def host_count(self):
+        '''Count of hosts'''
+        return self.details.get_section('Relationships').get_item('Hosts').value
+
+    @property
+    def vm_count(self):
+        '''Count of VMs'''
+        return self.details.get_section('Relationships').get_item('VMs').value
+
     def all_vms(self):
         '''VMs list
 

--- a/tests/ui/infrastructure/test_infrastructure_providers.py
+++ b/tests/ui/infrastructure/test_infrastructure_providers.py
@@ -161,6 +161,7 @@ class TestInfrastructureProviders:
                 'Infrastructure Providers "%s" was saved' \
                  % provider_data['name'],
                 FLASH_MESSAGE_NOT_MATCHED)
+        prov_pg.wait_for_provider_or_timeout(provider_data)
 
     @pytest.mark.xfail(reason='https://bugzilla.redhat.com/show_bug.cgi?id=1003060')
     @pytest.mark.usefixtures('has_no_providers')

--- a/utils/mgmt_system.py
+++ b/utils/mgmt_system.py
@@ -306,6 +306,15 @@ class VMWareSystem(MgmtSystemAPIBase):
         # Unroll the VM name generator, and sort it to be more user-friendly
         return sorted(list(vm_name_generator()))
 
+    def list_host(self):
+        return self.api.get_hosts()
+
+    def list_datastore(self):
+        return self.api.get_datastores()
+
+    def list_cluster(self):
+        return self.api.get_clusters()
+
     def info(self):
         return '%s %s' % (self.api.get_server_type(), self.api.get_api_version())
 
@@ -460,6 +469,18 @@ class RHEVMSystem(MgmtSystemAPIBase):
         # but you can return a vm w/ a matched name
         vm_list = self.api.vms.list(**kwargs)
         return [vm.name for vm in vm_list]
+
+    def list_host(self, **kwargs):
+        host_list = self.api.hosts.list(**kwargs)
+        return [host.name for host in host_list]
+
+    def list_datastore(self, **kwargs):
+        datastore_list = self.api.storagedomains.list(**kwargs)
+        return [ds.name for ds in datastore_list if ds.get_status() is None]
+
+    def list_cluster(self, **kwargs):
+        cluster_list = self.api.clusters.list(**kwargs)
+        return [cluster.name for cluster in cluster_list]
 
     def info(self):
         # and we got nothing!

--- a/utils/wait.py
+++ b/utils/wait.py
@@ -1,0 +1,47 @@
+'''
+Created on Nov 11, 2013
+
+@author: psavage
+
+wait_for function, designed to wait for a certain length of time,
+either linearly in 1 second steps, or exponentially, up to a maximum.
+Returns the output from the function once it completes successfully,
+along with the time taken to complete the command.
+
+** Warning **
+If using the expo keyword, the returned elapsed time will be inaccurate
+as wait_for does not know the exact time that the function returned
+correctly, only that it returned correctly at last check
+'''
+
+import time
+
+
+def wait_for(func, func_args=[], func_kwargs={}, **kwargs):
+    st_time = time.time()
+    wait_time = 1
+    total_time = 0
+    num_sec = kwargs.get('num_sec', 120)
+    expo = kwargs.get('expo', False)
+    message = kwargs.get('message', func.func_name)
+    fail_condition = kwargs.get('fail_condition', False)
+    handle_exception = kwargs.get('handle_exception', False)
+
+    t_delta = 0
+    while t_delta <= num_sec:
+        try:
+            out = func(*func_args, **func_kwargs)
+        except:
+            if handle_exception:
+                out = fail_condition
+            else:
+                raise
+        if out == fail_condition:
+            time.sleep(wait_time)
+            total_time += wait_time
+            if expo:
+                wait_time *= 2
+        else:
+            return out, time.time() - st_time
+        t_delta = time.time() - st_time
+    raise Exception("Could not do %s in time" % message)


### PR DESCRIPTION
- Added new properties to provider detail page,
  - @cluster_count
  - @datastore_count
  - @host_count
  - @vm_count
- Added _get_provider_stats() private method to providers page for ESX
  and RHEVM
- Added is_quad_icon_available() method to providers page
- Added do_stats_match() method to providers page to compare a
  host_stats dictionary with the current page. Supports the ability to NOT
  match VM count, as it is the most likely parameter to change
- Added wait_for_provider_or_timeout() method to providers page which
  will ensure the quad icon is present, and that the core_stats
  (datastores, hosts, clusters) match before returning
- Fixed hypervisor_count, vendor and valid_credentials elements in the
  ProvidersQuadIconItem() class
- Made the infrastructure provider provision now wait for the provider
  to match core_stats before continuing
- Added list_host(), list_datastore() and list_cluster() methods to the
  VMWareSystem class
- Added list_host(), list_datastore() and list_cluster() methods to the
  RHEVMSystem class
- Created new wait_for() function in the utils module, see comments in
  page for more information
