### PR TITLE
Fix ldap auth roles

### DIFF
--- a/pages/infrastructure_subpages/provider_subpages/add.py
+++ b/pages/infrastructure_subpages/provider_subpages/add.py
@@ -1,19 +1,26 @@
-from selenium.webdriver.common.by import By
+'''
+Created on May 31, 2013
 
+@author: bcrochet
+'''
 from pages.base import Base
-
+from selenium.webdriver.common.by import By
 
 class ProvidersAdd(Base):
     '''Infrastructure Providers - Add an Infrastructure Provider page'''
     _page_title = 'CloudForms Management Engine: Infrastructure Providers'
 
-    _provider_add_button_locator = (By.CSS_SELECTOR,
-        "img[alt='Add this Infrastructure Provider']")
-    _provider_credentials_verify_button_locator = (By.CSS_SELECTOR,
-        "div#default_validate_buttons_on > ul#form_buttons > li > a > img")
-    _provider_credentials_verify_disabled_button_locator = (By.CSS_SELECTOR,
-        "div#default_validate_buttons_off > ul#form_buttons > li > a > img")
-    _provider_cancel_button_locator = (By.CSS_SELECTOR, "img[title='Cancel']")
+    _provider_add_button_locator = (
+            By.CSS_SELECTOR,
+            "img[alt='Add this Infrastructure Provider']")
+    _provider_credentials_verify_button_locator = (
+            By.CSS_SELECTOR,
+            "div#default_validate_buttons_on > ul#form_buttons > li > a > img")
+    _provider_credentials_verify_disabled_button_locator = (
+            By.CSS_SELECTOR,
+            "div#default_validate_buttons_off > ul#form_buttons > li > a > img")
+    _provider_cancel_button_locator = (
+            By.CSS_SELECTOR, "img[title='Cancel']")
     _provider_name_locator = (By.ID, "name")
     _provider_hostname_locator = (By.ID, "hostname")
     _provider_ipaddress_locator = (By.ID, "ipaddress")
@@ -25,11 +32,12 @@ class ProvidersAdd(Base):
     _provider_cu_password_locator = (By.ID, "metrics_password")
     _provider_cu_verify_locator = (By.ID, "metrics_verify")
     _server_zone_edit_field_locator = (By.ID, "server_zone")
-    _default_credentials_button_locator = (By.CSS_SELECTOR,
-        "div#auth_tabs > ul > li > a[href='#default']")
-    _metrics_credentials_button_locator = (By.CSS_SELECTOR,
-        "div#auth_tabs > ul > li > a[href='#metrics']")
-    _provider_api_port_locator = (By.ID, "port")
+    _default_credentials_button_locator = (
+            By.CSS_SELECTOR, "div#auth_tabs > ul > li > a[href='#default']")
+    _metrics_credentials_button_locator = (
+            By.CSS_SELECTOR, "div#auth_tabs > ul > li > a[href='#metrics']")
+    _provider_api_port_locator = (
+            By.ID, "port")
 
     @property
     def add_button(self):
@@ -43,14 +51,16 @@ class ProvidersAdd(Base):
         '''Verify button
 
         Returns a WebElement'''
-        return self.get_element(*self._provider_credentials_verify_button_locator)
+        return self.get_element(
+                *self._provider_credentials_verify_button_locator)
 
     @property
     def cancel_button(self):
         '''Cancel button
 
         Returns a WebElement'''
-        return self.get_element(*self._provider_cancel_button_locator)
+        return self.get_element(
+                *self._provider_cancel_button_locator)
 
     @property
     def name(self):
@@ -80,7 +90,8 @@ class ProvidersAdd(Base):
     @property
     def default_verify(self):
         '''Verify password on default credentials tab'''
-        return self.get_element(*self._provider_verify_password_locator)
+        return self.get_element(
+                *self._provider_verify_password_locator)
 
     @property
     def metrics_userid(self):
@@ -90,7 +101,8 @@ class ProvidersAdd(Base):
     @property
     def metrics_password(self):
         '''Password on C&U credentials tab'''
-        return self.get_element(*self._provider_cu_password_locator)
+        return self.get_element(
+                *self._provider_cu_password_locator)
 
     @property
     def metrics_verify(self):
@@ -173,7 +185,8 @@ class ProvidersAdd(Base):
 
     def add_rhevm_provider(self, provider):
         '''Fill and click on add for a RHEV system'''
-        self.select_provider_type("Red Hat Enterprise Virtualization Manager")
+        self.select_provider_type(
+                "Red Hat Enterprise Virtualization Manager")
         self._fill_provider(provider)
         return self.click_on_add()
 
@@ -193,9 +206,11 @@ class ProvidersAdd(Base):
         if "virtualcenter" in provider["type"]:
             self.select_provider_type("VMware vCenter")
         elif "rhevm" in provider["type"]:
-            self.select_provider_type("Red Hat Enterprise Virtualization Manager")
+            self.select_provider_type(
+                    "Red Hat Enterprise Virtualization Manager")
         self._fill_provider(provider)
-        self._wait_for_visible_element(*self._provider_credentials_verify_button_locator)
+        self._wait_for_visible_element(
+                *self._provider_credentials_verify_button_locator)
         self.click_on_credentials_verify()
         self._wait_for_results_refresh()
         return self
@@ -203,14 +218,17 @@ class ProvidersAdd(Base):
     def select_provider_type(self, provider_type):
         '''Select a infrastructure provider type from the dropdown,
         and wait for the page to refresh'''
-        self.select_dropdown(provider_type, *self._provider_type_locator)
+        self.select_dropdown(
+                provider_type,
+                *self._provider_type_locator)
         self._wait_for_results_refresh()
         return ProvidersAdd(self.testsetup)
 
     def click_on_add(self):
         '''Click on the add button'''
         self.add_button.click()
-        from pages.infrastructure_subpages.providers import Providers
+        from pages.infrastructure_subpages.providers \
+                import Providers
         return Providers(self.testsetup)
 
     def click_on_credentials_verify(self):
@@ -224,5 +242,7 @@ class ProvidersAdd(Base):
 
         Returns Providers page'''
         self.cancel_button.click()
-        from pages.infrastructure_subpages.providers import Providers
+        from pages.infrastructure_subpages.providers \
+                import Providers
         return Providers(self.testsetup)
+

--- a/pages/login.py
+++ b/pages/login.py
@@ -12,10 +12,6 @@ class LoginPage(Base):
     _login_password_field_locator = (By.CSS_SELECTOR, '#user_password')
     _login_submit_button_locator = (By.ID, 'login')
 
-    # Demo locators
-    #_page_title = u"Mozilla \u2014 Home of the Mozilla Project \u2014 mozilla.org"
-    #_header_locator = (By.CSS_SELECTOR, 'h1')
-
     @property
     def is_the_current_page(self):
         '''Override the base implementation to make sure that we are actually on the login screen
@@ -47,20 +43,20 @@ class LoginPage(Base):
         driver = self.login_button.parent
         driver.execute_script("""miqResetSizeTimer();""")
 
-    def login(self, user='default'):
-        return self.login_with_mouse_click(user)
+    def login(self, *args, **kwargs):
+        return self.login_with_mouse_click(*args, **kwargs)
 
-    def login_with_enter_key(self, user='default'):
-        return self.__do_login(self._press_enter_on_login_button, user)
+    def login_with_enter_key(self, *args, **kwargs):
+        return self._do_login(self._press_enter_on_login_button, *args, **kwargs)
 
-    def login_with_mouse_click(self, user='default'):
-        return self.__do_login(self._click_on_login_button, user)
+    def login_with_mouse_click(self, *args, **kwargs):
+        return self._do_login(self._click_on_login_button, *args, **kwargs)
 
-    def login_and_send_window_size(self, user='default'):
-        return self.__do_login(self._click_on_login_and_send_window_size, user)
+    def login_and_send_window_size(self, *args, **kwargs):
+        return self._do_login(self._click_on_login_and_send_window_size, *args, **kwargs)
 
-    def __do_login(self, continue_function, user='default'):
-        self.__set_login_fields(user)
+    def _do_login(self, continue_function, user='default', force_dashboard=True):
+        self._set_login_fields(user)
         # TODO: Remove once bug is fixed
         time.sleep(1.25)
         continue_function()
@@ -70,15 +66,20 @@ class LoginPage(Base):
             self._wait_for_results_refresh()
 
         from pages.dashboard import DashboardPage
-        dashboard = DashboardPage(self.testsetup)
+        page = DashboardPage(self.testsetup)
         try:
-            dashboard.is_the_current_page
+            page.is_the_current_page
         except AssertionError:
-            from fixtures.navigation import intel_dashboard_pg
-            dashboard = intel_dashboard_pg(dashboard)
-        return dashboard
+            if force_dashboard:
+                from fixtures.navigation import intel_dashboard_pg
+                page = intel_dashboard_pg(page)
+            else:
+                # Not the dashboard page and not forcing dashboard page
+                # return a generic Base page
+                page = Base(self.testsetup)
+        return page
 
-    def __set_login_fields(self, user='default'):
+    def _set_login_fields(self, user='default'):
         credentials = self.testsetup.credentials[user]
         self.username.send_keys(credentials['username'])
         self.password.send_keys(credentials['password'])

--- a/tests/ui/integration/test_ldap_auth_and_roles.py
+++ b/tests/ui/integration/test_ldap_auth_and_roles.py
@@ -3,28 +3,29 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-import time
 from unittestzero import Assert
 from pages.login import LoginPage
 
 
-@pytest.mark.parametrize("ldap_groups", [
-    "evmgroup-administrator",
-    "evmgroup-approver",
-    "evmgroup-auditor",
-    "evmgroup-desktop",
-    "evmgroup-operator",
-    "evmgroup-security",
-    "evmgroup-super_administrator",
-    "evmgroup-support",
-    "evmgroup-user",
-    "evmgroup-user_limited_self_service",
-    "evmgroup-user_self_service",
-    "evmgroup-vm_user" ])
+@pytest.mark.parametrize('ldap_groups',
+    [
+        'evmgroup-administrator',
+        'evmgroup-approver',
+        'evmgroup-auditor',
+        'evmgroup-desktop',
+        'evmgroup-operator',
+        'evmgroup-security',
+        'evmgroup-super_administrator',
+        'evmgroup-support',
+        'evmgroup-user',
+        'evmgroup-user_limited_self_service',
+        'evmgroup-user_self_service',
+        'evmgroup-vm_user'
+    ]
+)
 @pytest.mark.usefixtures(
-        "maximized",
-        "setup_infrastructure_providers",
-        "configure_auth_mode")
+    'maximized', 'setup_infrastructure_providers', 'configure_auth_mode'
+)
 class TestLdap:
     def test_default_ldap_group_roles(self, mozwebqa, ldap_groups, cfme_data):
         """Basic default LDAP group role RBAC test
@@ -33,17 +34,18 @@ class TestLdap:
         LDAP group roles
         """
         if ldap_groups not in cfme_data.data['group_roles']:
-            pytest.xfail("No match in cfme_data for group '%s'" % ldap_groups)
-        _group_roles = cfme_data.data['group_roles'][ldap_groups]
+            pytest.fail("No match in cfme_data for group '%s'" % ldap_groups)
+        group_roles = cfme_data.data['group_roles'][ldap_groups]
         login_pg = LoginPage(mozwebqa)
         login_pg.go_to_login_page()
         if ldap_groups not in login_pg.testsetup.credentials:
-            pytest.xfail(
-                    "No match in credentials file for group '%s'" % ldap_groups)
+            pytest.fail("No match in credentials file for group '%s'" % ldap_groups)
+
         # login as LDAP user
-        home_pg = login_pg.login(user=ldap_groups)
-        Assert.true(home_pg.is_logged_in, "Could not determine if logged in")
-        for menu in _group_roles["menus"]:
+        home_pg = login_pg.login(user=ldap_groups, force_dashboard=False)
+        Assert.true(home_pg.is_logged_in, 'Could not determine if logged in')
+
+        for menu in group_roles['menus']:
             Assert.equal(home_pg.header.site_navigation_menu(menu).name, menu)
             for item in home_pg.header.site_navigation_menu(menu).items:
-                Assert.contains(item.name, _group_roles["menus"][menu])
+                Assert.contains(item.name, group_roles['menus'][menu])


### PR DESCRIPTION
The main fix is adding support for not forcing the dashboard page on login, and then using that feature in the ldap auto roles test so that roles without access to the dashboard don't explode.
