### PR TITLE
cfme_data.data fixture usage becomes just cfme_data

### DIFF
--- a/fixtures/auto_placement.py
+++ b/fixtures/auto_placement.py
@@ -9,7 +9,7 @@ from unittestzero import Assert
 def auto_placement_setup_data(request, cfme_data):
     '''Returns data for Provisioning Scope'''
     param = request.param
-    return cfme_data.data["provisioning"][param]
+    return cfme_data["provisioning"][param]
 
 
 @pytest.fixture

--- a/fixtures/cfme_data.py
+++ b/fixtures/cfme_data.py
@@ -1,8 +1,3 @@
-'''
-Created on May 14, 2013
-
-@author: bcrochet
-'''
 import pytest
 
 from utils.cfme_data import load_cfme_data
@@ -14,20 +9,6 @@ def pytest_addoption(parser):
         dest='cfme_data_filename', metavar='CFME_DATA',
         help='location of yaml file containing fixture data')
 
-
-def pytest_runtest_setup(item):
-    # If cfme_data_filename is None, it will be autoloaded
-    CfmeSetup.data = load_cfme_data(item.config.option.cfme_data_filename)
-
-
-@pytest.fixture(scope="module")  # IGNORE:E1101
+@pytest.fixture(scope="session")
 def cfme_data(request):
-    return CfmeSetup(request)
-
-
-class CfmeSetup:
-    '''
-        This class is just used for monkey patching
-    '''
-    def __init__(self, request):
-        self.request = request
+    return load_cfme_data(request.config.option.cfme_data_filename)

--- a/fixtures/configure_auth_mode.py
+++ b/fixtures/configure_auth_mode.py
@@ -5,7 +5,7 @@ from unittestzero import Assert
 @pytest.fixture  # IGNORE:E1101
 def configure_auth_mode(cnf_configuration_pg, cfme_data):
     '''Configure authentication mode'''
-    server_data = cfme_data.data['ldap_server']
+    server_data = cfme_data['ldap_server']
     auth_pg = cnf_configuration_pg.click_on_settings()\
         .click_on_current_server_tree_node()\
         .click_on_authentication_tab()

--- a/fixtures/mgmt_system.py
+++ b/fixtures/mgmt_system.py
@@ -46,7 +46,7 @@ def setup_infrastructure_providers(infra_providers_pg, cfme_data):
 
     '''
     # Does provider exist
-    for provider, prov_data in cfme_data.data['management_systems'].iteritems():
+    for provider, prov_data in cfme_data['management_systems'].iteritems():
         if prov_data['type'] not in infra_provider_type_map:
             # short out if we don't care about this provider type
             continue
@@ -132,7 +132,7 @@ def setup_cloud_providers(cloud_providers_pg, cfme_data):
 
     '''
     # Does provider exist
-    for provider, prov_data in cfme_data.data['management_systems'].iteritems():
+    for provider, prov_data in cfme_data['management_systems'].iteritems():
         if prov_data['type'] not in cloud_provider_type_map:
             # short out if we don't care about this provider type
             continue
@@ -198,7 +198,7 @@ def setup_cloud_providers(cloud_providers_pg, cfme_data):
 def mgmt_sys_api_clients(mozwebqa, cfme_data):
     '''Returns a list of management system api clients'''
     clients = {}
-    for sys_name in cfme_data.data['management_systems']:
+    for sys_name in cfme_data['management_systems']:
         if sys_name in clients:
             # Overlapping sys_name entry in cfme_data.yaml
             logger.warning('Overriding existing entry for %s.' % sys_name)

--- a/fixtures/pxe_provision.py
+++ b/fixtures/pxe_provision.py
@@ -10,7 +10,7 @@ from datetime import datetime
                params=["rhevm_pxe_setup"])
 def provisioning_setup_data(request, cfme_data):
     param = request.param
-    return cfme_data.data["provisioning_setup"][param]
+    return cfme_data["provisioning_setup"][param]
 
 
 def setup_pxe_server(db_session, provisioning_setup_data):

--- a/fixtures/server_roles.py
+++ b/fixtures/server_roles.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 def server_roles_categories(cfme_data):
     """ Provides the ``server_roles`` section from cfme_data
     """
-    return cfme_data.data.get("server_roles", {})
+    return cfme_data.get("server_roles", {})
 
 
 @pytest.fixture
@@ -122,7 +122,7 @@ def server_roles(fixtureconf, cfme_data, default_roles_list, cnf_configuration_p
                     logger.info("FIXTURE[server_roles]: No change with role setting %s" %
                                 role_message)
     elif 'server_roles_cfmedata' in fixtureconf:
-        roles_list = cfme_data.data
+        roles_list = cfme_data
         # Drills down into cfme_data YAML by selector, expecting a list
         # of roles at the end. A KeyError here probably means the YAMe
         # selector is wrong

--- a/tests/scenarios/refarch_2013_rhev/conftest.py
+++ b/tests/scenarios/refarch_2013_rhev/conftest.py
@@ -5,28 +5,28 @@ import pytest
 def provider(request, cfme_data):
     '''Returns management system data from cfme_data'''
     param = request.param
-    return cfme_data.data['management_systems'][param]
+    return cfme_data['management_systems'][param]
 
 
 @pytest.fixture(params=['qeblade29'])
 def host(request, cfme_data):
     '''Returns host data from cfme_data'''
     param = request.param
-    return cfme_data.data['management_systems']['rhevm32']['hosts'][param]
+    return cfme_data['management_systems']['rhevm32']['hosts'][param]
 
 
 @pytest.fixture(params=['iscsi'])
 def datastore(request, cfme_data):
     '''Returns datastore data from cfme_data'''
     param = request.param
-    return cfme_data.data['management_systems']['rhevm32']['datastores'][param]
+    return cfme_data['management_systems']['rhevm32']['datastores'][param]
 
 
 @pytest.fixture(params=['iscsi'])
 def cluster(request, cfme_data):
     '''Returns cluster data from cfme_data'''
     param = request.param
-    return cfme_data.data['management_systems']['rhevm32']['clusters'][param]
+    return cfme_data['management_systems']['rhevm32']['clusters'][param]
 
 
 @pytest.fixture(scope="module",
@@ -34,19 +34,19 @@ def cluster(request, cfme_data):
 def pxe_server(request, cfme_data):
     '''Returns pxe server data from cfme_data'''
     param = request.param
-    return cfme_data.data['pxe']['pxe_servers'][param]
+    return cfme_data['pxe']['pxe_servers'][param]
 
 
 @pytest.fixture(scope="module")
 def pxe_image_names(cfme_data):
     '''Returns pxe image names from cfme_data'''
-    return cfme_data.data['pxe']['images']
+    return cfme_data['pxe']['images']
 
 
 @pytest.fixture(scope="module")
 def pxe_datastore_names(cfme_data):
     '''Returns pxe datastore names from cfme_data'''
-    return cfme_data.data['pxe']['datastores']
+    return cfme_data['pxe']['datastores']
 
 
 @pytest.fixture(scope="module",
@@ -54,7 +54,7 @@ def pxe_datastore_names(cfme_data):
 def pxe_templates(request, cfme_data):
     '''Returns pxe templates from cfme_data'''
     param = request.param
-    return cfme_data.data['pxe']['templates'][param]
+    return cfme_data['pxe']['templates'][param]
 
 
 @pytest.fixture(scope="module",
@@ -62,7 +62,7 @@ def pxe_templates(request, cfme_data):
 def pxe_template_type(request, cfme_data):
     '''Returns pxe template type from cfme_data'''
     param = request.param
-    return cfme_data.data["pxe"]["templates"][param]["template_type"]
+    return cfme_data["pxe"]["templates"][param]["template_type"]
 
 
 @pytest.fixture(scope="module",
@@ -70,21 +70,21 @@ def pxe_template_type(request, cfme_data):
 def zone(request, cfme_data):
     '''Returns appliance zone from cfme_data'''
     param = request.param
-    return cfme_data.data['zones'][param]
+    return cfme_data['zones'][param]
 
 
 @pytest.fixture(params=['rhevm32'])
 def appliance(request, cfme_data):
     '''Returns appliance data from cfme_data'''
     param = request.param
-    return cfme_data.data['management_systems'][param]['appliance']
+    return cfme_data['management_systems'][param]['appliance']
 
 
 @pytest.fixture(params=['linux_template_workflow'])
 def provision(request, cfme_data):
     '''Returns provisioning data from cfme_data'''
     param = request.param
-    return cfme_data.data['provisioning'][param]
+    return cfme_data['provisioning'][param]
 
 
 @pytest.fixture(scope="module",
@@ -92,7 +92,7 @@ def provision(request, cfme_data):
 def roles(request, cfme_data):
     '''Returns server roles from cfme_data'''
     param = request.param
-    return cfme_data.data['server_roles'][param]
+    return cfme_data['server_roles'][param]
 
 
 @pytest.fixture(scope="module",
@@ -100,4 +100,4 @@ def roles(request, cfme_data):
 def user_group(request, cfme_data):
     '''Returns user groups from cfme_data'''
     param = request.param
-    return cfme_data.data['user_groups'][param]
+    return cfme_data['user_groups'][param]

--- a/tests/scenarios/refarch_2013_rhev/test_configuration.py
+++ b/tests/scenarios/refarch_2013_rhev/test_configuration.py
@@ -18,7 +18,7 @@ FLASH_MESSAGE_NOT_MATCHED = 'Flash message did not match expected value'
 def test_configure_auth_mode(cnf_configuration_pg, cfme_data):
     '''Configure authentication mode
     '''
-    server_data = cfme_data.data['ldap_server']
+    server_data = cfme_data['ldap_server']
     auth_pg = cnf_configuration_pg.click_on_settings().\
         click_on_current_server_tree_node().click_on_authentication_tab()
     if auth_pg.current_auth_mode != server_data['mode']:
@@ -49,7 +49,7 @@ def test_add_new_group(cnf_configuration_pg, user_group):
 def test_add_new_zone(cnf_configuration_pg, zone, cfme_data):
     '''Add new zone
     '''
-    win_domain_data = cfme_data.data['ldap_server']
+    win_domain_data = cfme_data['ldap_server']
     smartproxy_ip = urlparse(cnf_configuration_pg.testsetup.base_url).netloc
 
     zone_pg = cnf_configuration_pg.click_on_settings().click_on_zones()\

--- a/tests/scenarios/refarch_2013_rhev/test_policy_automate.py
+++ b/tests/scenarios/refarch_2013_rhev/test_policy_automate.py
@@ -17,7 +17,7 @@ FLASH_MESSAGE_NOT_MATCHED = 'Flash message did not match expected value'
 def test_import_policies(request, control_importexport_pg, cfme_data):
     '''Import policies
     '''
-    policy_file = cfme_data.data['policies']['import']
+    policy_file = cfme_data['policies']['import']
     policy_file = "%s/%s" % (request.session.fspath, policy_file)
 
     control_importexport_pg = control_importexport_pg.import_policies(
@@ -47,8 +47,8 @@ def test_policy_assignment(infra_providers_pg, provider):
 def test_import_namespace(request, cfme_data, ssh_client):
     ''''Import automate method namespace (rake method)
     '''
-    filename = cfme_data.data['automate']['import']['file']
-    automate_path = cfme_data.data['automate']['import']['path']
+    filename = cfme_data['automate']['import']['file']
+    automate_path = cfme_data['automate']['import']['path']
     automate_file = "%s/%s/%s" % \
         (request.session.fspath, automate_path, filename)
 
@@ -63,7 +63,7 @@ def test_import_namespace(request, cfme_data, ssh_client):
 def test_automate_instance_hook(cfme_data, automate_explorer_pg):
     '''Add automate instance that follows relationship to custom namespace
     '''
-    instance = cfme_data.data['automate']['instance']
+    instance = cfme_data['automate']['instance']
 
     class_pg = automate_explorer_pg.click_on_class_access_node(
         instance['parent_class'])

--- a/tests/test_setup_event_testing.py
+++ b/tests/test_setup_event_testing.py
@@ -9,7 +9,7 @@ from selenium.common.exceptions import TimeoutException
                 params=["rhevm32"])
 def mgmt_sys(request, cfme_data):
     param = request.param
-    return cfme_data.data['management_systems'][param]
+    return cfme_data['management_systems'][param]
 
 
 @pytest.mark.smoke

--- a/tests/ui/cloud/test_instance_power_control.py
+++ b/tests/ui/cloud/test_instance_power_control.py
@@ -54,7 +54,7 @@ class TestInstanceDetailsPowerControlPerProvider:
         """Test terminate operation from a instance details page.
         Verify instance is archived."""
 
-        prov_data = cfme_data.data["management_systems"][provider]
+        prov_data = cfme_data["management_systems"][provider]
         if prov_data["type"] == 'openstack':
             mgmt_sys_api_clients[provider].deploy_template(image_name, flavour_name='m1.tiny',
                 vm_name=random_string)

--- a/tests/ui/cloud/test_providers.py
+++ b/tests/ui/cloud/test_providers.py
@@ -15,7 +15,7 @@ DETAIL_NOT_MATCHED_TEMPLATE = '%s did not match'
 def provider_data(request, cfme_data):
     '''Returns management system data from cfme_data'''
     param = request.param
-    prov_data = cfme_data.data['management_systems'][param]
+    prov_data = cfme_data['management_systems'][param]
     prov_data['request'] = param
     return prov_data
 

--- a/tests/ui/configuration/test_server_roles.py
+++ b/tests/ui/configuration/test_server_roles.py
@@ -6,7 +6,7 @@ from unittestzero import Assert
                 params=["default"])
 def roles(request, cfme_data):
     param = request.param
-    return cfme_data.data['server_roles'][param]
+    return cfme_data['server_roles'][param]
 
 
 @pytest.mark.destructive

--- a/tests/ui/infrastructure/conftest.py
+++ b/tests/ui/infrastructure/conftest.py
@@ -29,7 +29,7 @@ def load_providers_vm_list(
         :rtype: Services.VirtualMachines
     '''
     provider_details = infra_providers_pg.load_provider_details(
-            cfme_data.data["management_systems"][provider]["name"])
+            cfme_data["management_systems"][provider]["name"])
     vm_pg = provider_details.all_vms()
     if vm_name is not None:
         vm_pg.find_vm_page(vm_name, None, False, False)
@@ -199,6 +199,6 @@ def load_providers_template_list(
         :rtype: Services.VirtualMachines
     '''
     provider_details = infra_providers_pg.load_provider_details(
-            cfme_data.data["management_systems"][provider]["name"])
+            cfme_data["management_systems"][provider]["name"])
     return provider_details.all_templates()
     

--- a/tests/ui/infrastructure/test_assign_policies.py
+++ b/tests/ui/infrastructure/test_assign_policies.py
@@ -13,7 +13,7 @@ from unittestzero import Assert
 def infra_provider(request, cfme_data):
     '''Return the data for a particular provider'''
     param = request.param
-    return cfme_data.data["management_systems"][param]
+    return cfme_data["management_systems"][param]
 
 
 @pytest.mark.usefixtures("maximized", "setup_infrastructure_providers")

--- a/tests/ui/infrastructure/test_infrastructure_providers_pages.py
+++ b/tests/ui/infrastructure/test_infrastructure_providers_pages.py
@@ -13,7 +13,7 @@ from utils.ipmi import IPMI
 
 @pytest.fixture(params=['esx'])
 def single_host_data(request, cfme_data):
-    return cfme_data.data['management_hosts'][request.param]
+    return cfme_data['management_hosts'][request.param]
 
 
 @pytest.fixture(params=[('title', 'Add this Infrastructure Provider'),

--- a/tests/ui/integration/test_event_listener.py
+++ b/tests/ui/integration/test_event_listener.py
@@ -10,7 +10,7 @@ import time
                 params=["rhevm32"])
 def mgmt_sys(request, cfme_data):
     param = request.param
-    return cfme_data.data['management_systems'][param]
+    return cfme_data['management_systems'][param]
 
 
 @pytest.mark.usefixtures("maximized")  # IGNORE:E1101

--- a/tests/ui/integration/test_ldap_auth_and_roles.py
+++ b/tests/ui/integration/test_ldap_auth_and_roles.py
@@ -36,7 +36,6 @@ def test_default_ldap_group_roles(mozwebqa, group_name, group_data):
     LDAP group roles
     """
 
-    #for ldap_group, menu_contents in cfme_data.data['group_roles'].iteritems():
     login_pg = LoginPage(mozwebqa)
     login_pg.go_to_login_page()
     if group_name not in login_pg.testsetup.credentials:

--- a/tests/ui/integration/test_pxe_setup.py
+++ b/tests/ui/integration/test_pxe_setup.py
@@ -9,27 +9,27 @@ from selenium.common.exceptions import NoSuchElementException
                 params=["rhel"])
 def pxe_server(request, cfme_data):
     param = request.param
-    return cfme_data.data["pxe"]["pxe_servers"][param]
+    return cfme_data["pxe"]["pxe_servers"][param]
 
 @pytest.fixture(scope="module")
 def pxe_image_names(cfme_data):
-    return cfme_data.data["pxe"]["images"]
+    return cfme_data["pxe"]["images"]
 
 @pytest.fixture(scope="module")
 def pxe_datastore_names(cfme_data):
-    return cfme_data.data["pxe"]["datastores"]
+    return cfme_data["pxe"]["datastores"]
 
 @pytest.fixture(scope="module",
                 params=["rhel"])
 def pxe_templates(request, cfme_data):
     param = request.param
-    return cfme_data.data["pxe"]["templates"][param]
+    return cfme_data["pxe"]["templates"][param]
 
 @pytest.fixture(scope="module",
                 params=["rhel"])
 def pxe_template_type(request, cfme_data):
     param = request.param
-    return cfme_data.data["pxe"]["templates"][param]["template_type"]
+    return cfme_data["pxe"]["templates"][param]["template_type"]
 
 FLASH_MESSAGE_NOT_MATCHED = 'Flash message not matched'
 

--- a/tests/ui/provisioning/conftest.py
+++ b/tests/ui/provisioning/conftest.py
@@ -22,7 +22,7 @@ def inst_provisioning_start_page(cloud_instances_pg):
 def provisioning_data(request, cfme_data):
     '''Returns all provisioning data'''
     param = request.param
-    return cfme_data.data["provisioning"][param]
+    return cfme_data["provisioning"][param]
 
 
 @pytest.fixture(scope="module",  # IGNORE:E1101
@@ -30,7 +30,7 @@ def provisioning_data(request, cfme_data):
 def ec2_provisioning_data(request, cfme_data):
     '''Returns all ec2 provisioning data'''
     param = request.param
-    return cfme_data.data["provisioning"][param]
+    return cfme_data["provisioning"][param]
 
 
 @pytest.fixture
@@ -44,7 +44,7 @@ def random_name(random_string):
 def provisioning_data_basic_only(request, cfme_data):
     '''Returns only one set of provisioning data'''
     param = request.param
-    return cfme_data.data["provisioning"][param]
+    return cfme_data["provisioning"][param]
 
 
 @pytest.fixture(scope="module",  # IGNORE:E1101
@@ -52,7 +52,7 @@ def provisioning_data_basic_only(request, cfme_data):
 def vmware_linux_setup_data(request, cfme_data):
     ''' Returns data for first VM for clone/retire tests'''
     param = request.param
-    return cfme_data.data["clone_retire_setup"][param]
+    return cfme_data["clone_retire_setup"][param]
 
 
 @pytest.fixture(scope="module",  # IGNORE:E1101
@@ -60,7 +60,7 @@ def vmware_linux_setup_data(request, cfme_data):
 def vmware_publish_to_template(request, cfme_data):
     '''Returns publish to template data'''
     param = request.param
-    return cfme_data.data["provisioning"][param]
+    return cfme_data["provisioning"][param]
 
 
 @pytest.fixture

--- a/tests/ui/services/test_service_catalogs.py
+++ b/tests/ui/services/test_service_catalogs.py
@@ -13,7 +13,7 @@ from unittestzero import Assert
 def provisioning_data(request, cfme_data):
     '''get data from cfme_data.yml'''
     param = request.param
-    return cfme_data.data["provisioning"][param]
+    return cfme_data["provisioning"][param]
 
 
 @pytest.fixture()

--- a/tests/ui/test_version.py
+++ b/tests/ui/test_version.py
@@ -13,7 +13,7 @@ from unittestzero import Assert
 def basic_info(request, cfme_data):
     '''Returns basic data from cfme_data'''
     param = request.param
-    return cfme_data.data[param]
+    return cfme_data[param]
 
 
 @pytest.mark.nondestructive

--- a/utils/cfme_data.py
+++ b/utils/cfme_data.py
@@ -38,4 +38,3 @@ def load_cfme_data(filename=None):
     else:
         msg = 'Usable to load cfme_data file at %s' % path
         raise Exception(msg)
-


### PR DESCRIPTION
This was a grepsed[0] after removing the .data from the cfme_data fixture
return. I spot-checked that the new calling format works and made sure
none of the altered py files have SyntaxErrors, but didn't thoroughly test
it otherwise.

Sadly, sed didn't lint anything for me, either. :(

[0]: `grep -r -l cfme_data\.data | xargs -n 1 sed -i 's/cfme_data\.data/cfme_data/g'`
