### PR TITLE
Fixed issues with simple ldap tests

### DIFF
--- a/cfme_data.yaml.template
+++ b/cfme_data.yaml.template
@@ -182,7 +182,7 @@ group_roles:
                 - Utilization
                 - Planning
                 - Bottlenecks
-            Configuration:
+            Configure:
                 - My Settings
                 - Tasks
                 - SmartProxies
@@ -212,7 +212,7 @@ group_roles:
                 - Explorer
                 - Simulation
                 - Log
-            Configuration:
+            Configure:
                 - My Settings
                 - Tasks
                 - About
@@ -243,7 +243,7 @@ group_roles:
                 - Utilization
                 - Planning
                 - Bottlenecks
-            Configuration:
+            Configure:
                 - My Settings
                 - Tasks
                 - About
@@ -254,7 +254,7 @@ group_roles:
             Services:
                 - Requests
                 - Workloads
-            Configuration:
+            Configure:
                 - My Settings
                 - About
     evmgroup-operator:
@@ -276,7 +276,7 @@ group_roles:
                 - Resource Pools
                 - Datastores
                 - Repositories
-            Configuration:
+            Configure:
                 - My Settings
                 - Tasks
                 - About
@@ -303,7 +303,7 @@ group_roles:
                 - Explorer
                 - Simulation
                 - Log
-            Configuration:
+            Configure:
                 - My Settings
                 - Tasks
                 - About
@@ -347,7 +347,7 @@ group_roles:
                 - Utilization
                 - Planning
                 - Bottlenecks
-            Configuration:
+            Configure:
                 - My Settings
                 - Tasks
                 - Configuration
@@ -376,7 +376,7 @@ group_roles:
                 - Explorer
                 - Simulation
                 - Log
-            Configuration:
+            Configure:
                 - My Settings
                 - Tasks
                 - About
@@ -399,7 +399,7 @@ group_roles:
                 - Resource Pools
                 - Datastores
                 - Repositories
-            Configuration:
+            Configure:
                 - My Settings
                 - Tasks
                 - About
@@ -408,7 +408,7 @@ group_roles:
             Services:
                 - Requests
                 - Workloads
-            Configuration:
+            Configure:
                 - My Settings
                 - About
     evmgroup-user_self_service:
@@ -416,7 +416,7 @@ group_roles:
             Services:
                 - Requests
                 - Workloads
-            Configuration:
+            Configure:
                 - My Settings
                 - About
     evmgroup-vm_user:
@@ -424,7 +424,7 @@ group_roles:
             Services:
                 - Requests
                 - Workloads
-            Configuration:
+            Configure:
                 - My Settings
                 - About
 provisioning:

--- a/fixtures/mgmt_system.py
+++ b/fixtures/mgmt_system.py
@@ -101,7 +101,8 @@ def setup_infrastructure_providers(infra_providers_pg, cfme_data):
             prov_edit_pg = infra_providers_pg.click_on_edit_providers()
             prov_edit_pg.edit_provider(prov_data)
         prov_data['request'] = provider
-        infra_providers_pg.wait_for_provider_or_timeout(prov_data)
+        if prov_added:
+            infra_providers_pg.wait_for_provider_or_timeout(prov_data)
         infra_providers_pg.header.site_navigation_menu('Infrastructure').\
             sub_navigation_menu('Providers').click()
 
@@ -186,7 +187,8 @@ def setup_cloud_providers(cloud_providers_pg, cfme_data):
             prov_edit_pg = cloud_providers_pg.click_on_edit_providers()
             prov_edit_pg.edit_provider(prov_data)
         prov_data['request'] = provider
-        cloud_providers_pg.wait_for_provider_or_timeout(prov_data)
+        if prov_added:
+            cloud_providers_pg.wait_for_provider_or_timeout(prov_data)
         cloud_providers_pg.header.site_navigation_menu('Clouds').\
             sub_navigation_menu('Providers').click()
 

--- a/tests/ui/integration/test_ldap_auth_and_roles.py
+++ b/tests/ui/integration/test_ldap_auth_and_roles.py
@@ -5,47 +5,56 @@
 import pytest
 from unittestzero import Assert
 from pages.login import LoginPage
+from utils.cfme_data import load_cfme_data
 
 
-@pytest.mark.parametrize('ldap_groups',
-    [
-        'evmgroup-administrator',
-        'evmgroup-approver',
-        'evmgroup-auditor',
-        'evmgroup-desktop',
-        'evmgroup-operator',
-        'evmgroup-security',
-        'evmgroup-super_administrator',
-        'evmgroup-support',
-        'evmgroup-user',
-        'evmgroup-user_limited_self_service',
-        'evmgroup-user_self_service',
-        'evmgroup-vm_user'
-    ]
-)
-@pytest.mark.usefixtures(
-    'maximized', 'setup_infrastructure_providers', 'configure_auth_mode'
-)
-class TestLdap:
-    def test_default_ldap_group_roles(self, mozwebqa, ldap_groups, cfme_data):
-        """Basic default LDAP group role RBAC test
+def pytest_generate_tests(metafunc):
+    if 'ldap_groups_data' in metafunc.fixturenames:
+        param_group_data = []
+        data = load_cfme_data(metafunc.config.option.cfme_data_filename)
+        for group in data['group_roles']:
+            param_group_data.append(['', group, data['group_roles'][group]])
+        metafunc.parametrize(['ldap_groups_data', 'group_name', 'group_data'],
+                             param_group_data, scope="module")
 
-        Validates expected menu and submenu names are present for default
-        LDAP group roles
-        """
-        if ldap_groups not in cfme_data.data['group_roles']:
-            pytest.fail("No match in cfme_data for group '%s'" % ldap_groups)
-        group_roles = cfme_data.data['group_roles'][ldap_groups]
-        login_pg = LoginPage(mozwebqa)
-        login_pg.go_to_login_page()
-        if ldap_groups not in login_pg.testsetup.credentials:
-            pytest.fail("No match in credentials file for group '%s'" % ldap_groups)
 
-        # login as LDAP user
-        home_pg = login_pg.login(user=ldap_groups, force_dashboard=False)
-        Assert.true(home_pg.is_logged_in, 'Could not determine if logged in')
+def validate_menus(home_pg, group_roles, ldap_group):
+    for menu in group_roles["menus"]:
+        Assert.equal(home_pg.header.site_navigation_menu(menu).name, menu)
+        for item in home_pg.header.site_navigation_menu(menu).items:
+            Assert.contains(item.name, group_roles["menus"][menu],
+                            "LDAP group %s doesn't contain %s in roles" % (ldap_group, item.name))
 
-        for menu in group_roles['menus']:
-            Assert.equal(home_pg.header.site_navigation_menu(menu).name, menu)
-            for item in home_pg.header.site_navigation_menu(menu).items:
-                Assert.contains(item.name, group_roles['menus'][menu])
+
+@pytest.mark.usefixtures("maximized",
+                         "configure_auth_mode",
+                         "ldap_groups_data")
+def test_default_ldap_group_roles(mozwebqa, group_name, group_data):
+    """Basic default LDAP group role RBAC test
+
+    Validates expected menu and submenu names are present for default
+    LDAP group roles
+    """
+
+    #for ldap_group, menu_contents in cfme_data.data['group_roles'].iteritems():
+    login_pg = LoginPage(mozwebqa)
+    login_pg.go_to_login_page()
+    if group_name not in login_pg.testsetup.credentials:
+        pytest.fail("No match in credentials file for group '%s'" % group_name)
+    # login as LDAP user
+    home_pg = login_pg.login(user=group_name, force_dashboard=False)
+    Assert.true(home_pg.is_logged_in, "Could not determine if logged in")
+    validate_menus(home_pg, group_data, group_name)
+
+
+def test_auth_set_to_database(cnf_configuration_pg):
+    """Sets auth mode to internal
+
+    This test tests setting the auth_mode back to database, it also serves as cleanup
+    to the above test, test_default_ldap_group_roles()
+    """
+
+    auth_pg = cnf_configuration_pg.click_on_settings()\
+                                  .click_on_current_server_tree_node().click_on_authentication_tab()
+    auth_pg.select_dropdown_by_value('database', *auth_pg._auth_mode_selector)
+    auth_pg = auth_pg.save()


### PR DESCRIPTION
Remove parametrization of roles
Added ldap mode cleanup test_auth_set_to_database()
Created validate_menu() method
Fixed renaming of Configuration -> Configure in root menu in yaml template
Made provider setup only validate when setup has actually recently occured
