### PR TITLE
Adding retirement test and required methods

### DIFF
--- a/fixtures/soap_vm.py
+++ b/fixtures/soap_vm.py
@@ -18,7 +18,7 @@ def setup_soap_create_vm(
     # Check if VM already exists
     for name, guid, power_state in db_session.query(
             db.Vm.name, db.Vm.guid, db.Vm.power_state).filter(
-            db.Vm.template is False):
+            db.Vm.template == False):
         if vmware_linux_setup_data['vm_name'] in name:
             # VM exists
             print "VM exits"
@@ -29,7 +29,7 @@ def setup_soap_create_vm(
     else:
         # Find template guid
         template_guid = None
-        for name, guid in db_session.query(db.Vm.name, db.Vm.guid).filter(db.Vm.template is True):
+        for name, guid in db_session.query(db.Vm.name, db.Vm.guid).filter(db.Vm.template == True):
             if provisioning_data_basic_only['template'] in name:
                 template_guid = guid.strip()
                 break

--- a/pages/infrastructure_subpages/vms_subpages/virtual_machines.py
+++ b/pages/infrastructure_subpages/vms_subpages/virtual_machines.py
@@ -12,16 +12,18 @@ from selenium.webdriver.common.action_chains import ActionChains
 
 class VirtualMachines(VmCommonComponents):
 
-    _provision_vms_button_locator = (By.CSS_SELECTOR, 
+    _provision_vms_button_locator = (By.CSS_SELECTOR,
         "table.buttons_cont tr[title='Request to Provision VMs']")
     _clone_items_button_locator = (By.CSS_SELECTOR,
         "table.buttons_cont tr[title='Clone this item']")
     _publish_items_button_locator = (By.CSS_SELECTOR,
         "table.buttons_cont tr[title='Publish selected VM to a Template']")
+    _retire_items_button_locator = (By.CSS_SELECTOR,
+        "table.buttons_cont tr[title='Retire the selected items']")
 
     @property
     def quadicon_region(self):
-        return Quadicons(self.testsetup, 
+        return Quadicons(self.testsetup,
             VirtualMachines.VirtualMachineQuadIconItem)
 
     @property
@@ -37,66 +39,66 @@ class VirtualMachines(VmCommonComponents):
         self._mark_icon_and_call_method(vm_names, self.power_button.shutdown )
 
     def shutdown_and_cancel(self, vm_names):
-        self._mark_icon_and_call_method(vm_names, 
+        self._mark_icon_and_call_method(vm_names,
             self.power_button.shutdown_and_cancel )
 
     def restart(self, vm_names):
         self._mark_icon_and_call_method(vm_names, self.power_button.restart )
 
     def restart_and_cancel(self, vm_names):
-        self._mark_icon_and_call_method(vm_names, 
+        self._mark_icon_and_call_method(vm_names,
             self.power_button.restart_and_cancel )
 
     def power_on(self, vm_names):
         self._mark_icon_and_call_method(vm_names, self.power_button.power_on )
 
     def power_on_and_cancel(self, vm_names):
-        self._mark_icon_and_call_method(vm_names, 
+        self._mark_icon_and_call_method(vm_names,
             self.power_button.power_on_and_cancel )
 
     def power_off(self, vm_names):
         self._mark_icon_and_call_method(vm_names, self.power_button.power_off )
 
     def power_off_and_cancel(self, vm_names):
-        self._mark_icon_and_call_method(vm_names, 
+        self._mark_icon_and_call_method(vm_names,
             self.power_button.power_off_and_cancel )
 
     def reset(self, vm_names):
         self._mark_icon_and_call_method(vm_names, self.power_button.reset )
 
     def reset_and_cancel(self, vm_names):
-        self._mark_icon_and_call_method(vm_names, 
+        self._mark_icon_and_call_method(vm_names,
             self.power_button.reset_and_cancel )
 
     def suspend(self, vm_names):
         self._mark_icon_and_call_method(vm_names, self.power_button.suspend )
 
     def suspend_and_cancel(self, vm_names):
-        self._mark_icon_and_call_method(vm_names, 
+        self._mark_icon_and_call_method(vm_names,
             self.power_button.suspend_and_cancel )
 
     def smart_state_scan(self, vm_names):
-        self._mark_icon_and_call_method(vm_names, 
+        self._mark_icon_and_call_method(vm_names,
             self.config_button.perform_smart_state_analysis )
 
     def smart_state_scan_and_cancel(self, vm_names):
-        self._mark_icon_and_call_method(vm_names, 
+        self._mark_icon_and_call_method(vm_names,
             self.config_button.perform_smart_state_analysis_and_cancel )
 
     def refresh_relationships(self, vm_names):
-        self._mark_icon_and_call_method(vm_names, 
+        self._mark_icon_and_call_method(vm_names,
             self.config_button.refresh_relationships )
 
     def refresh_relationships_and_cancel(self, vm_names):
-        self._mark_icon_and_call_method(vm_names, 
+        self._mark_icon_and_call_method(vm_names,
             self.config_button.refresh_relationships_and_cancel )
 
     def extract_running_processes(self, vm_names):
-        self._mark_icon_and_call_method(vm_names, 
+        self._mark_icon_and_call_method(vm_names,
             self.config_button.extract_running_processes )
 
     def extract_running_processes_and_cancel(self, vm_names):
-        self._mark_icon_and_call_method(vm_names, 
+        self._mark_icon_and_call_method(vm_names,
             self.config_button.extract_running_processes_and_cancel )
 
         #def edit_vm(self,vm_name,click_cancel):
@@ -108,11 +110,11 @@ class VirtualMachines(VmCommonComponents):
         #    return Services.SetOwnership(self.testsetup, vm_names)
 
     def remove_from_vmdb(self, vm_names):
-        self._mark_icon_and_call_method(vm_names, 
+        self._mark_icon_and_call_method(vm_names,
             self.config_button.remove_from_vmdb )
 
     def remove_from_vmdb_and_cancel(self, vm_names):
-        self._mark_icon_and_call_method(vm_names, 
+        self._mark_icon_and_call_method(vm_names,
             self.config_button.remove_from_vmdb_and_cancel )
 
     def click_on_provision_vms(self):
@@ -144,7 +146,25 @@ class VirtualMachines(VmCommonComponents):
         from pages.services_subpages.provision import Provision
         return Provision(self.testsetup)
 
-    def find_vm_page(self, vm_name = None, vm_type = None, 
+    def click_on_retire_items(self, vm_name):
+        self.find_vm_page(vm_name, None, True)
+        retire_items_button = self.get_element(
+            *self._retire_items_button_locator)
+        ActionChains(self.selenium).click(
+            self.center_buttons.lifecycle_button).click(
+            retire_items_button).perform()
+        self.handle_popup(cancel=False)
+        return VirtualMachines(self.testsetup)
+
+    def add_policy_profile(self, vm_name, policy_profile):
+        self.find_vm_page(vm_name, None, True)
+        manage_policies_pg = self.click_on_manage_policies()
+        manage_policies_pg.select_profile_item(policy_profile)
+        manage_policies_pg.save()
+        self._wait_for_results_refresh()
+        return VirtualMachines(self.testsetup)
+
+    def find_vm_page(self, vm_name = None, vm_type = None,
                     mark_checkbox = False, load_details = False):
         found = None
         while not found:

--- a/pages/regions/policy_mixin.py
+++ b/pages/regions/policy_mixin.py
@@ -11,7 +11,9 @@ class PolicyMixin(Page):
     '''This is included in the PolicyMenu mixin so you get this 
        functionality any time PolicyMenu is included in your class
     '''
-    _save_changes_button = (By.CSS_SELECTOR, "a[title='Save Changes']")
+    _save_changes_button = (
+        By.CSS_SELECTOR,
+        'div#buttons_on ul#form_buttons li img.button[title="Save Changes"]')
     _cancel_changes_button = (By.CSS_SELECTOR, "a[title='Cancel']")
     _reset_changes_button = (By.CSS_SELECTOR, "a[title='Reset Changes']")
 

--- a/tests/ui/provisioning/test_retirement.py
+++ b/tests/ui/provisioning/test_retirement.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=W0621
+import pytest
+import time
+from tests.ui.provisioning.test_base_provisioning import TestBaseProvisioning
+
+
+@pytest.mark.nondestructive
+@pytest.mark.fixtureconf(server_roles="+automate")
+@pytest.mark.usefixtures(
+    "maximized",
+    "setup_infrastructure_providers",
+    "setup_auto_placement_host",
+    "setup_auto_placement_datastore",
+    "mgmt_sys_api_clients",
+    "setup_soap_create_vm",
+    "setup_retirement_policies",
+    "db_session",
+    "soap_client")
+
+class TestVmRetirement(TestBaseProvisioning):
+    def test_vm_retire_delete(
+            self,
+            infra_vms_pg,
+            vmware_linux_setup_data,
+            mgmt_sys_api_clients,
+            db_session,
+            soap_client):
+        '''Test Retiring a VM'''
+        infra_vms_pg.add_policy_profile(
+            vmware_linux_setup_data['vm_name'],
+            vmware_linux_setup_data['policy_profile'])
+        infra_vms_pg.click_on_retire_items(vmware_linux_setup_data['vm_name'])
+        # Poll for the VM to be removed from the Provider
+        self.wait_for_vm_removed_from_provider(
+            db_session,
+            soap_client,
+            mgmt_sys_api_clients[vmware_linux_setup_data["provider_key"]],
+            vmware_linux_setup_data,
+            12)
+
+    def wait_for_vm_removed_from_provider(
+            self,
+            db_session,
+            soap_client,
+            provider,
+            vmware_linux_setup_data,
+            timeout_in_minutes):
+        ''' Poll for VM to be removed from provider'''
+        minute_count = 0
+        while (minute_count < timeout_in_minutes):
+            if not (vmware_linux_setup_data["vm_name"] + "/" +
+                    vmware_linux_setup_data["vm_name"] + ".vmx") \
+                    in provider.list_vm() and \
+                not vmware_linux_setup_data["vm_name"] \
+                    in provider.list_vm():
+                break
+            print "Sleeping 60 seconds, iteration " + str(minute_count + 1) + \
+                " of " + str(timeout_in_minutes)
+            time.sleep(60)
+            minute_count += 1
+            if (minute_count == timeout_in_minutes) and \
+                    not (
+                        vmware_linux_setup_data["vm_name"] + "/" +
+                        vmware_linux_setup_data["vm_name"] + ".vmx") \
+                    in provider.list_vm() and \
+                    not vmware_linux_setup_data["vm_name"] \
+                    in provider.list_vm():
+                raise Exception(
+                    "timeout reached(" + str(timeout_in_minutes) +
+                    " minutes) before vm removed from provider.")


### PR DESCRIPTION
This PR requires a retire policy to be present in CFME.
The PR does not contain the fixture to create the retirement policy - but it does contain the code to add the policy to the VM once the policy exists.

Creating a separate PR - dependent on https://github.com/RedHatQE/cfme_tests/pull/206 - with the "setup_retirement_policies" fixtures.
