### PR TITLE
Compare major version matching on version check

### DIFF
--- a/tests/ui/test_version.py
+++ b/tests/ui/test_version.py
@@ -20,8 +20,8 @@ def basic_info(request, cfme_data):
 class TestVersion:
     def test_version(self, cnf_about_pg, basic_info):
         '''Tests version number against one present in cfme_data yaml'''
-        yaml_ver_number = tuple(basic_info['app_version'].split(".")[0:3])
-        page_ver_number = cnf_about_pg.version_number[0:3]
+        yaml_ver_number = basic_info['app_version'].split(".")[0]
+        page_ver_number = cnf_about_pg.version_number[0]
         Assert.equal(
             yaml_ver_number, page_ver_number,
             "Major version number should match")


### PR DESCRIPTION
This test was a tad too specific, so I made its behavior match its error message.

I'm still on the fence as to whether we should be checking the version number at all.
