### PR TITLE
Xvfb non-maximizing issue fix

### DIFF
--- a/utils/browser.py
+++ b/utils/browser.py
@@ -41,6 +41,12 @@ def start(_webdriver=None, base_url=None, **kwargs):
 
         browser = WebDriverWrapper(_webdriver(**browser_kwargs), base_url)
         browser.maximize_window()
+        # Xvfb has some issues with enlarging the horizontal dimension
+        dimensions = browser.get_window_size()
+        if dimensions["width"] < 1280:
+            browser.set_window_position(0, 0)
+            browser.set_window_size(1280, dimensions["height"])
+
         browser.get(base_url)
         thread_locals.browser = browser
 


### PR DESCRIPTION
Under Xvfb, chrome enlarges just to 1050 px and FF to 1200 px when maximized no matter the screen dimensions are.

This assumes that the screen has at least 1280px, so when the image is too small, it enlarges the width to 1280px. Height maximization works correctly so far.
