### PR TITLE
Event power integration

### DIFF
--- a/data/templates/event_testing.html
+++ b/data/templates/event_testing.html
@@ -9,8 +9,12 @@
 
     <body>
         <div class="container">
-            <h1>Total <strong>{{ num_events }}</strong> events</h1>
+            <h1>Event testing results</h1>
             <table class="zebra-striped">
+            {% for test_name, registered_events in events.iteritems() %}
+                <tr>
+                    <th colspan="7"><em>{{ test_name }}</em></th>
+                </tr>
                 <tr>
                     <th>Time registered</th>
                     <th>Succeeded?</th>
@@ -20,7 +24,7 @@
                     <th>Object</th>
                     <th>Event</th>
                 </tr>
-                {% for event in events %}
+                {% for event in registered_events %}
                 <tr>
                     <td>{{ event.time_friendly }}</td>
                     <td style="color: {{ event.colour }};">{{ event.success_friendly }}</td>
@@ -31,6 +35,7 @@
                     <td><i>{{ event.event }}</i></td>
                 </tr>
                 {% endfor %}
+            {% endfor %}
             </table>
             <p>
                 <i>If something breaks down, go kill <a href="mailto:mfalesni@redhat.com">mfalesni@redhat.com</a></i>

--- a/pages/control.py
+++ b/pages/control.py
@@ -4,6 +4,7 @@ from pages.base import Base
 from selenium.webdriver.common.by import By
 from pages.control_subpages.explorer import Explorer
 from pages.regions.taskbar.reload import ReloadMixin
+from selenium.webdriver.support.ui import Select
 import re
 
 
@@ -70,6 +71,7 @@ class Control(Base):
         _upload_button = (By.ID, "upload_atags")
         _commit_button = (By.CSS_SELECTOR, "a[title='Commit Import']")
         _policy_import_field = (By.ID, "upload_file")
+        _select_choices = (By.CSS_SELECTOR, "select#choices_chosen_")
 
         @property
         def upload(self):
@@ -78,6 +80,18 @@ class Control(Base):
         @property
         def commit(self):
             return self.selenium.find_element(*self._commit_button)
+
+        @property
+        def select_choices(self):
+            self._wait_for_visible_element(*self._select_choices, visible_timeout=5)
+            return Select(self.selenium.find_element(*self._select_choices))
+
+        @property
+        def available_profiles(self):
+            return [option.text for option in self.select_choices.options]
+
+        def has_profile_available(self, profile_name):
+            return profile_name in self.available_profiles
 
         def click_on_upload(self):
             self.upload.click()

--- a/pages/infrastructure_subpages/provider_subpages/add.py
+++ b/pages/infrastructure_subpages/provider_subpages/add.py
@@ -171,8 +171,10 @@ class ProvidersAdd(Base):
                 credentials = self.testsetup.credentials[value]
                 self.default_userid.clear()
                 self.default_userid.send_keys(credentials['username'])
+                self._wait_for_visible_element(*self._provider_credentials_validate_button_locator)
                 self.default_password.clear()
                 self.default_password.send_keys(credentials['password'])
+                self._wait_for_invisible_element(*self._provider_credentials_validate_button_locator)
                 self.default_verify.clear()
                 self.default_verify.send_keys(credentials['password'])
                 continue

--- a/pages/infrastructure_subpages/vms_subpages/common.py
+++ b/pages/infrastructure_subpages/vms_subpages/common.py
@@ -48,6 +48,7 @@ class VmCommonComponents(Base, PolicyMenu, PaginatorMixin):
             self._wait_for_results_refresh()
         except NoSuchElementException:
             self.selenium.refresh()
+            self._wait_for_results_refresh()
 
     @property
     def power_button(self):

--- a/pages/regions/taskbar/power.py
+++ b/pages/regions/taskbar/power.py
@@ -30,6 +30,7 @@ class CommonPowerButton(Button):
         item = self.selenium.find_element(*self._shutdown_option_locator)
         ActionChains(self.selenium).click(self._root_element).click(item).perform()
         self.handle_popup(click_cancel)
+        self._wait_for_results_refresh()
 
     def shutdown(self):
         self._shutdown(click_cancel=False)
@@ -41,6 +42,7 @@ class CommonPowerButton(Button):
         item = self.selenium.find_element(*self._restart_option_locator)
         ActionChains(self.selenium).click(self._root_element).click(item).perform()
         self.handle_popup(click_cancel)
+        self._wait_for_results_refresh()
 
     def restart(self):
         self._restart(click_cancel=False)
@@ -52,6 +54,7 @@ class CommonPowerButton(Button):
         item = self.selenium.find_element(*self._power_on_option_locator)
         ActionChains(self.selenium).click(self._root_element).click(item).perform()
         self.handle_popup(click_cancel)
+        self._wait_for_results_refresh()
 
     def power_on(self):
         self._power_on(click_cancel=False)
@@ -63,6 +66,7 @@ class CommonPowerButton(Button):
         item = self.selenium.find_element(*self._power_off_option_locator)
         ActionChains(self.selenium).click(self._root_element).click(item).perform()
         self.handle_popup(click_cancel)
+        self._wait_for_results_refresh()
 
     def power_off(self):
         self._power_off(click_cancel=False)
@@ -74,6 +78,7 @@ class CommonPowerButton(Button):
         item = self.selenium.find_element(*self._suspend_option_locator)
         ActionChains(self.selenium).click(self._root_element).click(item).perform()
         self.handle_popup(click_cancel)
+        self._wait_for_results_refresh()
 
     def suspend(self):
         self._suspend(click_cancel=False)
@@ -85,6 +90,7 @@ class CommonPowerButton(Button):
         item = self.selenium.find_element(*self._reset_option_locator)
         ActionChains(self.selenium).click(self._root_element).click(item).perform()
         self.handle_popup(click_cancel)
+        self._wait_for_results_refresh()
 
     def reset(self):
         self._reset(click_cancel=False)

--- a/pages/regions/twisty.py
+++ b/pages/regions/twisty.py
@@ -29,6 +29,8 @@ class Twisty(Page):
     def click(self):
         self._root_element.find_element(*self._twisty_locator).click()
         self._wait_for_results_refresh()
+        # Workaround
+        self._wait_for_invisible_element(By.CSS_SELECTOR, "div#notification", visible_timeout=5)
     
     def expand(self):
         did_expand = False

--- a/scripts/listener.py
+++ b/scripts/listener.py
@@ -108,6 +108,13 @@ if __name__ == '__main__':
         db.commit()
         return dict(result='success')
 
+    @route('/events', method='DELETE')
+    def clear_database(db):
+        response.content_type = 'application/json'
+        db.execute("DELETE FROM event_log")
+        db.commit()
+        return dict(result="success")
+
     port = 65432
     if len(sys.argv) == 2:
         port = int(sys.argv[-1])

--- a/tests/test_setup_event_testing.py
+++ b/tests/test_setup_event_testing.py
@@ -3,10 +3,11 @@ import re
 from lxml import etree
 from py.path import local
 from selenium.common.exceptions import TimeoutException
+import utils.providers as providers
 
 
 @pytest.fixture(scope="module",  # IGNORE:E1101
-                params=["rhevm32"])
+                params=providers.list_infra_providers())
 def mgmt_sys(request, cfme_data):
     param = request.param
     return cfme_data['management_systems'][param]
@@ -116,6 +117,8 @@ def test_import_policies(request, maximized, home_page_logged_in):
     import_pg = home_pg.header.site_navigation_menu("Control")\
         .sub_navigation_menu("Import / Export")\
         .click()
+    if import_pg.has_profile_available("Automate event policies"):
+        pytest.skip(msg="Already imported!")
     import_pg = import_pg.import_policies(policy_path.strpath)
     assert import_pg.flash.message == "Press commit to Import"
     import_pg = import_pg.click_on_commit()


### PR DESCRIPTION
It seems to be working quite nicely. CFME correctly pushes the requests into the listener and the pickup works. There is, however,this problem:
- `vm_power_off_req` event is not invoked for some reason on power off. I didn't study it thoroughly, maybe it has some deeper meaning.

I've changed the register_event fixture to be a yield_fixture to make it possible to make individual setups and teardowns for each function using it.

I also changed the explicit 1m wait for wait_for. Now it queries the listener more, but it's likely to finish sooner (if all events come on time). The VM power control tests however use sleeps, so I will try to get rid of them,
