### PR TITLE
Added wait_for_visible in taggable.py to prevent errors

### DIFF
--- a/pages/regions/taggable.py
+++ b/pages/regions/taggable.py
@@ -94,6 +94,7 @@ class Taggable(Page):
 
     @property
     def root(self):
+        self._wait_for_visible_element(*self._tag_table, visible_timeout=10)
         return self.selenium.find_element(*self._tag_table).find_elements(*self._tag_row_locator)
 
     @property


### PR DESCRIPTION
This is also issue with the refresh animation quitting quite soon and long ping to US, which caused selenium to query the table before it actually appeared ...
