### PR TITLE
Better YAML overriding

### DIFF
--- a/utils/conf_loader.py
+++ b/utils/conf_loader.py
@@ -39,7 +39,11 @@ class Config(dict):
         try:
             return super(Config, self).__getattribute__(attr)
         except AttributeError:
-            return self[attr]
+            value = self[attr]
+            if isinstance(value, dict) and not isinstance(value, self.__class__):
+                return self.__class__(value)
+            else:
+                return value
 
     def __getitem__(self, key):
         # Attempt a normal dict lookup to pull a cached conf


### PR DESCRIPTION
Now it does not take just the root element into the account, but it crawls throught the dictionary and only updates the values that are present in the new dictionary. It converts all dicts to Configs, other values than specified in override dict are not touched.

It also improves the `__getattribute__` behaviour - now it propagates the interface to the child nodes by converting all `dict` to `Config` before returning the value, so the dot operator can be used everywhere.
