### PR TITLE
Navigation fixtures no longer take args

### DIFF
--- a/pages/login.py
+++ b/pages/login.py
@@ -72,7 +72,7 @@ class LoginPage(Base):
         except AssertionError:
             if force_dashboard:
                 from fixtures.navigation import intel_dashboard_pg
-                page = intel_dashboard_pg(page)
+                page = intel_dashboard_pg()
             else:
                 # Not the dashboard page and not forcing dashboard page
                 # return a generic Base page

--- a/tests/test_navigation_fixtures.py
+++ b/tests/test_navigation_fixtures.py
@@ -8,8 +8,8 @@ fixture_names = filter(lambda x: x.endswith('_pg'), dir(navigation))
 
 @pytest.mark.nondestructive
 @pytest.mark.parametrize('fixture_name', fixture_names)
-def test_fixture(duckwebqa_loggedin, fixture_name):
-    fixture_pg = getattr(navigation, fixture_name)(duckwebqa_loggedin)
+def test_fixture(fixture_name):
+    fixture_pg = getattr(navigation, fixture_name)()
     Assert.true(fixture_pg.is_the_current_page)
     fixture_pg()
     Assert.true(fixture_pg.is_the_current_page)

--- a/utils/providers.py
+++ b/utils/providers.py
@@ -89,7 +89,7 @@ def setup_provider(provider_name):
 
 
 def setup_infrastructure_provider(provider_name, provider_data):
-    infra_providers_pg = navigation.infra_providers_pg(None)
+    infra_providers_pg = navigation.infra_providers_pg()
 
     # Bail out if the provider already exists
     if infra_providers_pg.quadicon_region.does_quadicon_exist(provider_data['name']):


### PR DESCRIPTION
- This allows for reusing an open browser in the legacy tests
- They also work the same in and out of py.test.
- Fortunately, there wasn't a lot of nav fixtures being called as functions,
  so it was a tiny refactor
- Also removed the NavigatoinFixture class, as it was only doing functional work
