### PR TITLE
Updated ldap auth tests to cope with new nav fixture behavior

### DIFF
--- a/fixtures/configure_auth_mode.py
+++ b/fixtures/configure_auth_mode.py
@@ -1,15 +1,17 @@
 import pytest
 from unittestzero import Assert
 
+from fixtures.navigation import cnf_configuration_pg
+from utils.conf import cfme_data
 
-@pytest.fixture  # IGNORE:E1101
-def configure_auth_mode(cnf_configuration_pg, cfme_data):
+
+@pytest.yield_fixture(scope='module')  # IGNORE:E1101
+def configure_ldap_auth_mode():
     '''Configure authentication mode'''
     server_data = cfme_data['ldap_server']
-    auth_pg = cnf_configuration_pg.click_on_settings()\
+    auth_pg = cnf_configuration_pg().click_on_settings()\
         .click_on_current_server_tree_node()\
         .click_on_authentication_tab()
-    Assert.true(auth_pg.is_the_current_page)
     if auth_pg.current_auth_mode != server_data['mode']:
         auth_pg.ldap_server_fill_data(**server_data)
         if server_data['get_groups'] and server_data['mode'] != "database":
@@ -21,3 +23,11 @@ def configure_auth_mode(cnf_configuration_pg, cfme_data):
         Assert.contains("Authentication settings saved",
                         auth_pg.flash.message,
                         "Auth page save flash message did not match")
+
+    yield
+
+    auth_pg = cnf_configuration_pg().click_on_settings()\
+        .click_on_current_server_tree_node()\
+        .click_on_authentication_tab()
+    auth_pg.current_auth_mode = 'database'
+    auth_pg.save()

--- a/pages/configuration_subpages/settings_subpages/server_settings_subpages/authentication_settings_tab.py
+++ b/pages/configuration_subpages/settings_subpages/server_settings_subpages/authentication_settings_tab.py
@@ -53,7 +53,11 @@ class AuthenticationSettingsTab(Base):
 
     @property
     def current_auth_mode(self):
-        return self.selenium.find_element(*self._auth_mode_selector).get_attribute("value")
+        return self.get_element(*self._auth_mode_selector).get_attribute("value")
+
+    @current_auth_mode.setter
+    def current_auth_mode(self, auth_mode_id):
+        self.select_dropdown_by_value(auth_mode_id, *self._auth_mode_selector)
 
     def validate(self):
         if (self.current_auth_mode in ("ldap", "ldaps")):


### PR DESCRIPTION
Also turned configure_auth_mode into a yield fixture that cleans up after itself, and renamed it to match what it actually does.
