### PR TITLE
browser fixture is more resilient to browsers closing

### DIFF
--- a/cfme/fixtures/login.py
+++ b/cfme/fixtures/login.py
@@ -5,11 +5,12 @@ cfme.fixtures.login
 The :py:mod:`cfme.fixtures.login` module provides a generator for logging in as admin
 """
 import pytest
+from utils.browser import browser, ensure_browser_open
 from cfme.login import login_admin
 
 
-@pytest.yield_fixture
-def logged_in(browser):
+@pytest.yield_fixture(scope='function')
+def logged_in():
     """
     Logs into the system as admin and then returns the browser object.
 
@@ -18,6 +19,6 @@ def logged_in(browser):
 
     Yields: Browser object
     """
-    b = browser
+    ensure_browser_open()
     login_admin()
-    yield b
+    yield browser()

--- a/cfme/tests/test_login.py
+++ b/cfme/tests/test_login.py
@@ -1,14 +1,21 @@
 import pytest
 from unittestzero import Assert
-from cfme.login import login_admin, login
+from cfme.login import login_admin, login, logout
+from cfme.login import page as login_page
 import cfme.dashboard as dashboard
 from utils import conf
 
+pytestmark = pytest.mark.usefixtures('browser')
 
-@pytest.mark.usefixtures("browser")
+
 def test_login():
     login_admin()
     Assert.true(dashboard.page.is_displayed(), "Could not determine if logged in")
+
+
+def test_logout(logged_in):
+    logout()
+    #Assert.true(login_page.is_displayed())
 
 
 def test_bad_password():

--- a/fixtures/browser.py
+++ b/fixtures/browser.py
@@ -1,32 +1,12 @@
 import pytest
 
-import utils
 import utils.browser
-from fixtures.navigation import home_page_logged_in
 
 
-@pytest.yield_fixture(scope='module')
-def browser():
-    with utils.browser.browser_session() as session:
-        yield session
-
-
-@pytest.yield_fixture(scope='function')
-def browser_funcscope():
-    with utils.browser.browser_session() as session:
-        yield session
-
-
-@pytest.yield_fixture(scope='function')
-def duckwebqa(browser_funcscope):
-    # duckwebqa quacks like a mozwebqa duck
-    yield utils.browser.testsetup
-
-
-@pytest.yield_fixture(scope='module')
-def duckwebqa_loggedin(browser):
-    # On login to rule them all!
-    yield home_page_logged_in(utils.browser.testsetup)
+def pytest_runtest_setup(item):
+    if 'browser' not in item.fixturenames:
+        return
+    utils.browser.ensure_browser_open()
 
 
 def pytest_unconfigure(config):
@@ -34,3 +14,8 @@ def pytest_unconfigure(config):
         utils.browser.browser().quit()
     except:
         pass
+
+
+@pytest.fixture(scope='session')
+def browser():
+    return utils.browser.browser

--- a/fixtures/navigation.py
+++ b/fixtures/navigation.py
@@ -3,13 +3,10 @@
 from functools import partial
 
 import pytest
-from selenium.common.exceptions import (
-    NoAlertPresentException,
-    WebDriverException
-)
+from selenium.common.exceptions import NoAlertPresentException
 
 from pages.login import LoginPage
-from utils.browser import browser, start, testsetup
+from utils.browser import browser, ensure_browser_open, testsetup
 
 _width_errmsg = '''The minimum supported width of CFME is 1280 pixels
 
@@ -32,17 +29,10 @@ def _squash_alert():
 
 
 def navigate(first_level, second_level):
-    page = LoginPage(testsetup)
-    # Attempt to locate the 'spinny'. Serves two purposes:
-    # - checks to see that there is a usable browser running and starts one if not
-    # - if the browser is running but the 'spinny' is up, clear it
-    try:
-        if page.is_element_visible(*page._updating_locator):
-            browser().execute_script('miqSparkleOff();')
-    except (AttributeError, WebDriverException):
-        # AttributeError happens if browser() is None
-        # WebDriverException happens if browser() is not None, but not usable
-        start()
+    # Make sure a browser is running
+    ensure_browser_open()
+    # Clear any potential permaspinnies before moving on
+    browser().execute_script('miqSparkleOff();')
 
     # Ensure browser is logged in as admin, reinitialize page to pick up any browser changes
     page = LoginPage(testsetup)

--- a/utils/browser.py
+++ b/utils/browser.py
@@ -17,6 +17,15 @@ def browser():
     return thread_locals.browser
 
 
+def ensure_browser_open():
+    try:
+        browser().current_url
+    except (AttributeError, WebDriverException):
+        # AttributeError: browser() was None, didn't have current_url attr
+        # WebDriverError: current_url couldn't be retrieved, browser was closed
+        start()
+
+
 def start(_webdriver=None, base_url=None, **kwargs):
     # Try to clean up an existing browser session if starting a new one
     if thread_locals.browser is not None:


### PR DESCRIPTION
The browser fixture is now being used as a mark, and returns the browser callable itself instead of whatever the value of `thread_locals.browser` was when the fixture was used. This has a few benefits:
- The browser is no longer started and stopped by a context manager. Rather, pytest hooks are used to manage the browser context.
- browser is always a callable, so using the browser fixture is no different than `from utils.browser import browser` (except using the fixture will start a browser for you inside py.test)

There is a new function, `utils.browser.ensure_browser_open` that will poke selenium to see if a working browser is open, and start a new one if not.

There are minor issues that I'll comment on inline.
