### PR TITLE
Screenshots are recorded on browser failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ lib64
 
 # logs
 pip-log.txt
-log/*.log
+log/*
 
 # Unit test / coverage reports
 .coverage

--- a/cfme/fixtures/login.py
+++ b/cfme/fixtures/login.py
@@ -5,12 +5,12 @@ cfme.fixtures.login
 The :py:mod:`cfme.fixtures.login` module provides a generator for logging in as admin
 """
 import pytest
-from utils.browser import browser, ensure_browser_open
+from utils.browser import ensure_browser_open
 from cfme.login import login_admin
 
 
 @pytest.yield_fixture(scope='function')
-def logged_in():
+def logged_in(browser):
     """
     Logs into the system as admin and then returns the browser object.
 

--- a/data/templates/failed_browser_tests.html
+++ b/data/templates/failed_browser_tests.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>Failed Browser Test Screenshots</title>
+        <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css">
+        <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap-theme.min.css">
+    </head>
+    <body>
+        <header class="navbar navbar-static-top" role="banner">
+            <div class="container">
+                <div class="navbar-header">
+                    <span class="navbar-brand">Failed Browser Test Screenshots</span>
+                </div>
+                <div class="navbar-right">
+                    <span class="label label-warning navbar-text">{{total_failed}} Failed</span>
+                    <span class="label label-danger navbar-text">{{total_errored}} Error</span>
+                </div>
+            </div>
+        </header>
+        <div class="container" id="content">
+        {% for test in tests %}
+            <div class="panel panel-info">
+                <div class="panel-heading">
+                    <div class="row">
+                        <div class="col-md-10">
+                            <strong>{{test.name}}</strong>
+                        </div>
+                        <div class="col-md-2">
+                            {% if test.is_error %}
+                            <span class="label label-danger pull-right">Error</span>
+                            {% else %}
+                            <span class="label label-warning pull-right">Failed</span>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+                <div class="panel-body">
+                    <p>{{test.file}}</p>
+                    <pre class="well">{{test.short_tb}}</pre>
+                    {% if test.is_error %}
+                    <p class="text-muted">Error occured during test {{test.fail_stage}}</p>
+                    {% endif %}
+                    <div>
+                      <a href="data:image/png;base64,{{test.screenshot}}" class="btn btn-primary" role="button">Screenshot</a>
+                      <a href="data:text/plain;base64,{{test.full_tb}}" class="btn btn-success" role="button">Full Traceback</a>
+                    </div>
+                </div>
+            </div>
+        {% endfor %}
+        </div>
+        <script src="http://code.jquery.com/jquery.js"></script>
+        <script src="http://netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
+    </body>
+</html>

--- a/fixtures/browser.py
+++ b/fixtures/browser.py
@@ -1,21 +1,77 @@
+import atexit
+
 import pytest
+from py.error import ENOENT
+from jinja2 import Template
 
 import utils.browser
+from utils.path import data_path, log_path
+from fixtures import navigation
+#from utils.path import log_path
+
+nav_fixture_names = filter(lambda x: x.endswith('_pg'), dir(navigation))
+browser_fixtures = set(['browser'] + nav_fixture_names)
+
+failed_test_tracking = {
+    'tests': list(),
+    'total_failed': 0,
+    'total_errored': 0,
+}
 
 
 def pytest_runtest_setup(item):
-    if 'browser' not in item.fixturenames:
-        return
-    utils.browser.ensure_browser_open()
+    if set(item.fixturenames) & browser_fixtures:
+        utils.browser.ensure_browser_open()
 
 
-def pytest_unconfigure(config):
+def pytest_exception_interact(node, call, report):
+    if set(node.fixturenames) & browser_fixtures:
+        short_tb = '%s\n%s' % (call.excinfo.type.__name__, call.excinfo.value)
+        # base64 encoded to go into a data uri, same for screenshots
+        full_tb = str(report.longrepr).encode('base64').strip()
+        # errors are when exceptions are thrown outside of the test call phase
+        is_error = report.when != 'call'
+
+        template_data = {
+            'name': node.name,
+            'file': node.fspath,
+            'is_error': is_error,
+            'fail_stage': report.when,
+            'short_tb': short_tb,
+            'full_tb': full_tb,
+            'screenshot': utils.browser.browser().get_screenshot_as_base64()
+        }
+        failed_test_tracking['tests'].append(template_data)
+        if is_error:
+            failed_test_tracking['total_errored'] += 1
+        else:
+            failed_test_tracking['total_failed'] += 1
+
+
+def pytest_sessionfinish(session, exitstatus):
+    failed_tests_template = data_path.join('templates', 'failed_browser_tests.html').read()
+    outfile = log_path.join('failed_browser_tests.html')
+
+    # Clean out any old reports
     try:
-        utils.browser.browser().quit()
-    except:
+        outfile.remove(ignore_errors=True)
+    except ENOENT:
         pass
+
+    # Generate a new one if needed
+    if failed_test_tracking['tests']:
+        failed_tests_report = Template(failed_tests_template).render(**failed_test_tracking)
+        outfile.write(failed_tests_report)
 
 
 @pytest.fixture(scope='session')
 def browser():
     return utils.browser.browser
+
+
+def close_browser_no_matter_what():
+    try:
+        utils.browser.browser().quit()
+    except:
+        pass
+atexit.register(close_browser_no_matter_what)


### PR DESCRIPTION
- Results will end up in `log/failed_browser_tests.html`
- Tracebacks and screenshots are stored inline
- All styling is loaded from internet CDNs, so the page won't work
  well without an internet connection
- Modified the logged_in fixture to use browser to ensure it's
  recognized as a browser test
- Now using 'atexit' to REALLY make sure the browser is closed
  when python exits.
- Now ignoring everything in log/, just just *.log
