### PR TITLE
Since we're using jinja, I figured we ought to use jinja...

### DIFF
--- a/data/templates/base.html
+++ b/data/templates/base.html
@@ -1,0 +1,14 @@
+{%- set bootstrap_version = '3.0.3' -%}
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/{{bootstrap_version}}/css/bootstrap.min.css">
+        <title>{% block title %}{% endblock %}</title>
+    </head>
+    <body>
+        {% block content %}{% endblock %}
+        <script src="http://code.jquery.com/jquery.js"></script>
+        <script src="http://netdna.bootstrapcdn.com/bootstrap/{{bootstrap_version}}/js/bootstrap.min.js"></script>
+    </body>
+</html>

--- a/data/templates/event_testing.html
+++ b/data/templates/event_testing.html
@@ -1,49 +1,40 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css">
-        <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-theme.min.css">
-        <title>Event testing results</title>
-    </head>
+{% extends 'base.html' %}
+{% set title = 'Event testing results' %}
 
-    <body>
-        <div class="container">
-            <h1>Event testing results</h1>
-            <table class="zebra-striped">
-            {% for test_name, registered_events in events.iteritems() %}
-                <tr>
-                    <th colspan="7"><em>{{ test_name }}</em></th>
-                </tr>
-                <tr>
-                    <th>Time registered</th>
-                    <th>Succeeded?</th>
-                    <th>Delay [s]</th>
-                    <th>System type</th>
-                    <th>Object type</th>
-                    <th>Object</th>
-                    <th>Event</th>
-                </tr>
-                {% for event in registered_events %}
-                <tr>
-                    <td>{{ event.time_friendly }}</td>
-                    <td style="color: {{ event.colour }};">{{ event.success_friendly }}</td>
-                    <td style="color: {{ event.colour }};">{{ event.time_difference }}</td>
-                    <td>{{ event.sys_type }}</td>
-                    <td>{{ event.obj_type }}</td>
-                    <td>{{ event.obj }}</td>
-                    <td><i>{{ event.event }}</i></td>
-                </tr>
-                {% endfor %}
-            {% endfor %}
-            </table>
-            <p>
-                <i>If something breaks down, go kill <a href="mailto:mfalesni@redhat.com">mfalesni@redhat.com</a></i>
-            </p>
-        </div>
+{% block title %}{{title}}{% endblock %}
 
-    <!-- Le javascript -->
-    <script src="http://code.jquery.com/jquery.js"></script>
-    <script src="http://netdna.bootstrapcdn.com/bootstrap/3.0.0/js/bootstrap.min.js"></script>
-    </body>
-</html>
+{% block content %}
+<div class="container">
+    <h1>{{title}}</h1>
+    <table class="zebra-striped">
+    {% for test_name, registered_events in events.iteritems() %}
+        <tr>
+            <th colspan="7"><em>{{ test_name }}</em></th>
+        </tr>
+        <tr>
+            <th>Time registered</th>
+            <th>Succeeded?</th>
+            <th>Delay [s]</th>
+            <th>System type</th>
+            <th>Object type</th>
+            <th>Object</th>
+            <th>Event</th>
+        </tr>
+        {% for event in registered_events %}
+        <tr>
+            <td>{{ event.time_friendly }}</td>
+            <td style="color: {{ event.colour }};">{{ event.success_friendly }}</td>
+            <td style="color: {{ event.colour }};">{{ event.time_difference }}</td>
+            <td>{{ event.sys_type }}</td>
+            <td>{{ event.obj_type }}</td>
+            <td>{{ event.obj }}</td>
+            <td><i>{{ event.event }}</i></td>
+        </tr>
+        {% endfor %}
+    {% endfor %}
+    </table>
+    <p>
+        <i>If something breaks down, go kill <a href="mailto:mfalesni@redhat.com">mfalesni@redhat.com</a></i>
+    </p>
+</div>
+{% endblock %}

--- a/data/templates/failed_browser_tests.html
+++ b/data/templates/failed_browser_tests.html
@@ -1,54 +1,49 @@
-<!DOCTYPE html>
-<html lang="en">
-    <head>
-        <title>Failed Browser Test Screenshots</title>
-        <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css">
-        <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap-theme.min.css">
-    </head>
-    <body>
-        <header class="navbar navbar-static-top" role="banner">
-            <div class="container">
-                <div class="navbar-header">
-                    <span class="navbar-brand">Failed Browser Test Screenshots</span>
-                </div>
-                <div class="navbar-right">
-                    <span class="label label-warning navbar-text">{{total_failed}} Failed</span>
-                    <span class="label label-danger navbar-text">{{total_errored}} Error</span>
-                </div>
-            </div>
-        </header>
-        <div class="container" id="content">
-        {% for test in tests %}
-            <div class="panel panel-info">
-                <div class="panel-heading">
-                    <div class="row">
-                        <div class="col-md-10">
-                            <strong>{{test.name}}</strong>
-                        </div>
-                        <div class="col-md-2">
-                            {% if test.is_error %}
-                            <span class="label label-danger pull-right">Error</span>
-                            {% else %}
-                            <span class="label label-warning pull-right">Failed</span>
-                            {% endif %}
-                        </div>
-                    </div>
-                </div>
-                <div class="panel-body">
-                    <p>{{test.file}}</p>
-                    <pre class="well">{{test.short_tb}}</pre>
-                    {% if test.is_error %}
-                    <p class="text-muted">Error occured during test {{test.fail_stage}}</p>
-                    {% endif %}
-                    <div>
-                      <a href="data:image/png;base64,{{test.screenshot}}" class="btn btn-primary" role="button">Screenshot</a>
-                      <a href="data:text/plain;base64,{{test.full_tb}}" class="btn btn-success" role="button">Full Traceback</a>
-                    </div>
-                </div>
-            </div>
-        {% endfor %}
+{% extends 'base.html' %}
+{% set title = 'Failed Browser Test Screenshots' %}
+
+{% block title %}{{title}}{% endblock %}
+
+{% block content %}
+<header class="navbar navbar-static-top" role="banner">
+    <div class="container">
+        <div class="navbar-header">
+            <span class="navbar-brand">{{title}}</span>
         </div>
-        <script src="http://code.jquery.com/jquery.js"></script>
-        <script src="http://netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
-    </body>
-</html>
+        <div class="navbar-right">
+            <span class="label label-warning navbar-text">{{total_failed}} Failed</span>
+            <span class="label label-danger navbar-text">{{total_errored}} Error</span>
+        </div>
+    </div>
+</header>
+<div class="container" id="content">
+{% for test in tests %}
+    <div class="panel panel-info">
+        <div class="panel-heading">
+            <div class="row">
+                <div class="col-md-10">
+                    <strong>{{test.name}}</strong>
+                </div>
+                <div class="col-md-2">
+                    {% if test.is_error %}
+                    <span class="label label-danger pull-right">Error</span>
+                    {% else %}
+                    <span class="label label-warning pull-right">Failed</span>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+        <div class="panel-body">
+            <p>{{test.file}}</p>
+            <pre class="well">{{test.short_tb}}</pre>
+            {% if test.is_error %}
+            <p class="text-muted">Error occured during test {{test.fail_stage}}</p>
+            {% endif %}
+            <div>
+              <a href="data:image/png;base64,{{test.screenshot}}" class="btn btn-primary" role="button">Screenshot</a>
+              <a href="data:text/plain;base64,{{test.full_tb}}" class="btn btn-success" role="button">Full Traceback</a>
+            </div>
+        </div>
+    </div>
+{% endfor %}
+</div>
+{% endblock content %}

--- a/fixtures/browser.py
+++ b/fixtures/browser.py
@@ -2,12 +2,11 @@ import atexit
 
 import pytest
 from py.error import ENOENT
-from jinja2 import Template
 
 import utils.browser
-from utils.path import data_path, log_path
+from utils.datafile import template_env
+from utils.path import log_path
 from fixtures import navigation
-#from utils.path import log_path
 
 nav_fixture_names = filter(lambda x: x.endswith('_pg'), dir(navigation))
 browser_fixtures = set(['browser'] + nav_fixture_names)
@@ -49,7 +48,7 @@ def pytest_exception_interact(node, call, report):
 
 
 def pytest_sessionfinish(session, exitstatus):
-    failed_tests_template = data_path.join('templates', 'failed_browser_tests.html').read()
+    failed_tests_template = template_env.get_template('failed_browser_tests.html')
     outfile = log_path.join('failed_browser_tests.html')
 
     # Clean out any old reports
@@ -60,7 +59,7 @@ def pytest_sessionfinish(session, exitstatus):
 
     # Generate a new one if needed
     if failed_test_tracking['tests']:
-        failed_tests_report = Template(failed_tests_template).render(**failed_test_tracking)
+        failed_tests_report = failed_tests_template.render(**failed_test_tracking)
         outfile.write(failed_tests_report)
 
 

--- a/fixtures/events.py
+++ b/fixtures/events.py
@@ -5,11 +5,11 @@ import time
 from datetime import datetime
 
 import pytest
-from jinja2 import Template
 
 from utils.conf import cfme_data
+from utils.datafile import template_env
 from utils.log import create_logger
-from utils.path import data_path, scripts_path
+from utils.path import scripts_path
 from utils.wait import wait_for, TimedOutError
 
 
@@ -27,12 +27,9 @@ class HTMLReport(object):
         self.events = events
 
     def generate(self, filename):
-        tpl_filename = data_path.join('templates', 'event_testing.html').strpath
-
-        with open(tpl_filename, "r") as tpl, \
-                open(filename, "w") as f:
-            template = Template(tpl.read())
-            f.write(template.render(events=self.events))
+        template = template_env.get_template('event_testing.html')
+        with open(filename, "w") as outfile:
+            outfile.write(template.render(events=self.events))
 
 
 class EventExpectation(object):

--- a/utils/datafile.py
+++ b/utils/datafile.py
@@ -2,6 +2,11 @@ import os
 from string import Template
 from tempfile import NamedTemporaryFile
 
+from jinja2 import Environment, FileSystemLoader
+
+from utils.path import template_path
+
+
 def load_data_file(filename, replacements=None):
     """Opens the given filename, returning a file object
 
@@ -27,6 +32,7 @@ def load_data_file(filename, replacements=None):
         outfile.seek(0)
         return outfile
 
+
 def data_path_for_filename(filename, base_path, testmod_path=None):
     if testmod_path:
         # remove the base path from testmod path
@@ -50,3 +56,8 @@ def data_path_for_filename(filename, base_path, testmod_path=None):
         new_path = os.path.join(base_path, 'data', filename)
 
     return new_path
+
+
+template_env = Environment(
+    loader=FileSystemLoader(template_path.strpath)
+)

--- a/utils/path.py
+++ b/utils/path.py
@@ -31,3 +31,6 @@ log_path = project_path.join('log')
 
 #: interactive scripts, ``cfme_tests/scripts/``
 scripts_path = project_path.join('scripts')
+
+#: jinja2 templates, use with ``jinja2.FileSystemLoader``
+template_path = data_path.join('templates')


### PR DESCRIPTION
- jinja environment has been set up for template loading
- since the two templates we made were both using bootstrap 3,
  I merged them into a base template so future htmlers can benefit
- areas that use jinja templates use the new `utils.datafile.template_env`

Depends on #332, which should (maybe? hopefully?) drop the related commit from this pr.
