### PR TITLE
Handle errors when grabbing the browser screenshot

### DIFF
--- a/data/templates/failed_browser_tests.html
+++ b/data/templates/failed_browser_tests.html
@@ -39,8 +39,12 @@
             <p class="text-muted">Error occured during test {{test.fail_stage}}</p>
             {% endif %}
             <div>
-              <a href="data:image/png;base64,{{test.screenshot}}" class="btn btn-primary" role="button">Screenshot</a>
-              <a href="data:text/plain;base64,{{test.full_tb}}" class="btn btn-success" role="button">Full Traceback</a>
+                {% if test.screenshot %}
+                <a href="data:image/png;base64,{{test.screenshot}}" class="btn btn-primary" role="button">Screenshot</a>
+                {% else %} {# screenshot_error must be defined if screenshot is None #}
+                <p class="alert alert-danger">Unable to capture screenshot due to {{test.screenshot_error}}</p>
+                {% endif %}
+                <a href="data:text/plain;base64,{{test.full_tb}}" class="btn btn-success" role="button">Full Traceback</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
pytest internal errors were being caused in cases where either the
browser was closed when we tried to grab the screenshot, or otherwise
it was invalid (UnexpectedAlertException, for example). pytest internal
errors are bad, so this prevents them from occurring.
