### PR TITLE
Firefox browser uses @mfalesni's download profile by default

### DIFF
--- a/data/firefox_profile.js.template
+++ b/data/firefox_profile.js.template
@@ -1,0 +1,7 @@
+{
+    "browser.download.folderList": 2,
+    "browser.download.manager.showWhenStarting": false,
+    "browser.download.dir": "$profile_dir",
+    "browser.helperApps.neverAsk.saveToDisk": "application/txt,application/csv,application/pdf,application/octet-stream",
+    "security.dialog_enable_delay": 0
+}

--- a/docs/modules/utils.rst
+++ b/docs/modules/utils.rst
@@ -2,6 +2,7 @@ utils
 =====
 
 .. automodule:: utils
+.. automodule:: utils.browser
 .. automodule:: utils.log
 .. automodule:: utils.path
 .. automodule:: utils.ipmi

--- a/fixtures/browser.py
+++ b/fixtures/browser.py
@@ -1,5 +1,3 @@
-import atexit
-
 import pytest
 from py.error import ENOENT
 from selenium.common.exceptions import WebDriverException
@@ -83,11 +81,3 @@ def pytest_sessionfinish(session, exitstatus):
 @pytest.fixture(scope='session')
 def browser():
     return utils.browser.browser
-
-
-def close_browser_no_matter_what():
-    try:
-        utils.browser.browser().quit()
-    except:
-        pass
-atexit.register(close_browser_no_matter_what)


### PR DESCRIPTION
A few other browser tweaks:
- Moved atexit (and related quit function) from fixtures.browser to utils.browser
- Added docstrings!
- ensure_browser_open now returns the browser it ensures is open, so you don't also have to import browser to use it.
