### PR TITLE
provider setup functions for infra and cloud

### DIFF
--- a/cfme/cloud/provider.py
+++ b/cfme/cloud/provider.py
@@ -10,18 +10,21 @@
 """
 
 from functools import partial
+from time import sleep
+
 import ui_navigate as nav
+
 import cfme
-import cfme.web_ui.menu  # so that menu is already loaded before grafting onto it
-from cfme.web_ui import Region, Quadicon, Form, fill
-import cfme.web_ui.flash as flash
 import cfme.fixtures.pytest_selenium as browser
-import utils.conf as conf
-from utils.update import Updateable
+import cfme.web_ui.flash as flash
+import cfme.web_ui.menu  # so that menu is already loaded before grafting onto it
 import cfme.web_ui.toolbar as tb
-from utils.wait import wait_for
-from utils.providers import provider_factory
+import utils.conf as conf
 from cfme.exceptions import HostStatsNotContains, ProviderHasNoProperty, ProviderHasNoKey
+from cfme.web_ui import Region, Quadicon, Form, fill
+from utils.providers import provider_factory, list_cloud_providers
+from utils.update import Updateable
+from utils.wait import wait_for
 
 
 # Common locators
@@ -139,6 +142,7 @@ class Provider(Updateable):
             # browser.wait_for_element(page.configuration_btn)
         else:
             browser.click(submit_button)
+            sleep(3)
             flash.assert_no_errors()
 
     def create(self, cancel=False, validate_credentials=False):
@@ -359,3 +363,13 @@ def discover(credential, cancel=False):
                           'password': credential.secret,
                           'password_verify': credential.verify_secret})
     fill(discover_form, form_data)
+
+
+def setup_provider(provider_name):
+    provider = get_from_config(provider_name)
+    provider.create(validate_credentials=True)
+
+
+def setup_providers():
+    for provider_name in list_cloud_providers():
+        setup_provider(provider_name)

--- a/cfme/infrastructure/provider.py
+++ b/cfme/infrastructure/provider.py
@@ -10,18 +10,21 @@
 """
 
 from functools import partial
+from time import sleep
+
 import ui_navigate as nav
+
 import cfme
-import cfme.web_ui.menu  # so that menu is already loaded before grafting onto it
-from cfme.web_ui import Region, Quadicon, Form, fill
-import cfme.web_ui.flash as flash
 import cfme.fixtures.pytest_selenium as browser
-import utils.conf as conf
-from utils.update import Updateable
+import cfme.web_ui.flash as flash
+import cfme.web_ui.menu  # so that menu is already loaded before grafting onto it
 import cfme.web_ui.toolbar as tb
-from utils.wait import wait_for
-from utils.providers import provider_factory
+import utils.conf as conf
 from cfme.exceptions import HostStatsNotContains, ProviderHasNoProperty, ProviderHasNoKey
+from cfme.web_ui import Region, Quadicon, Form, fill
+from utils.providers import provider_factory, list_infra_providers
+from utils.update import Updateable
+from utils.wait import wait_for
 
 
 # Common locators
@@ -144,6 +147,7 @@ class Provider(Updateable):
             # browser.wait_for_element(page.configuration_btn)
         else:
             browser.click(submit_button)
+            sleep(3)
             flash.assert_no_errors()
 
     def create(self, cancel=False, validate_credentials=False):
@@ -416,3 +420,13 @@ def discover(rhevm=False, vmware=False, cancel=False, start_ip=None, end_ip=None
         form_data.update({'to_3': end_octet})
 
     fill(discover_form, form_data)
+
+
+def setup_provider(provider_name):
+    provider = get_from_config(provider_name)
+    provider.create(validate_credentials=True)
+
+
+def setup_providers():
+    for provider_name in list_infra_providers():
+        setup_provider(provider_name)


### PR DESCRIPTION
I think the setup functions are handy, but unfortunately the spooky spinny has been getting in my way, so they don't actually work.

For a reason I haven't yet found, adding a sleep after clicking the 'add' button when creating a new provider results in that provider being more reliably added (though still inherently unreliable because of the sleep). The click on the add_button is a pytest_selenium.click, so it should be calling wait_for_ajax as needed, so I think we're still missing something with this form. Unfortunately, whatever it is, I'm not seeing it and could use a hand getting rid of the sleeps.

Also pep8'd imports. :)
