### PR TITLE
Minor log format tweaks

### DIFF
--- a/fixtures/log.py
+++ b/fixtures/log.py
@@ -12,19 +12,17 @@ def logger():
 
 @pytest.mark.tryfirst
 def pytest_runtest_setup(item):
-    cfme_logger.info(format_marker(_format_nodeid(item.nodeid), mark="-"))
-    cfme_logger.info('py.test starting %s' % _format_nodeid(item.nodeid),
-        extra={'source_file': item.fspath, 'source_lineno': None})
+    path, lineno, domaininfo = item.location
+    cfme_logger.info(format_marker(_format_nodeid(item.nodeid), mark="-"),
+        extra={'source_file': path, 'source_lineno': lineno})
 
 
 @pytest.mark.trylast
 def pytest_runtest_logreport(report):
     if report.when == 'teardown':
-        # items don't have line numbers, so leave it out here to be consistent with
-        # the pytest_runtest_setup hook
         path, lineno, domaininfo = report.location
-        cfme_logger.info('py.test finished %s' % _format_nodeid(report.nodeid),
-            extra={'source_file': path, 'source_lineno': None})
+        cfme_logger.info('finished %s' % _format_nodeid(report.nodeid),
+            extra={'source_file': path, 'source_lineno': lineno})
 
 
 def _format_nodeid(nodeid):

--- a/utils/log.py
+++ b/utils/log.py
@@ -314,14 +314,14 @@ def format_marker(mstring, mark="-"):
     Note: If the message string is too long to fit one character of leader/trailer and
         a space, then the message is returned as is.
     """
-    leader_req = MARKER_LEN - len(mstring)
-    if leader_req < 4:
-        return mstring
-    leader = mark * ((leader_req / 2) - 1)
-    marker = '%s %s %s' % (leader, mstring, leader)
-    if (MARKER_LEN - len(mstring)) % 2:
-        marker += mark
-    return marker
+    if len(mstring) <= MARKER_LEN - 2:
+        # Pad with spaces
+        mstring = ' {} '.format(mstring)
+        # Format centered, surrounded the leader_mark
+        format_spec = '{{:{leader_mark}^{marker_len}}}'\
+            .format(leader_mark='-', marker_len=MARKER_LEN)
+        mstring = format_spec.format(mstring)
+    return mstring
 
 logger = create_logger('cfme')
 # Capture warnings to the cfme logger using the warnings.showwarning hook


### PR DESCRIPTION
These are some of the changes I recommended in #438, specifically spoofing the test file/lineno on the test start line and using .format's native centered text functionality.
