### PR TITLE
Toolbar alert fix.

### DIFF
--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -182,15 +182,18 @@ def handle_alert(cancel=False, wait=30.0, squash=False):
             raise
 
 
-def click(loc):
+def click(loc, wait_ajax=True):
     """
     Clicks on an element.
 
     Args:
         loc: A locator, expects either a string, WebElement, tuple.
+        wait_ajax: Whether to wait for ajax call to finish. Default True but sometimes it's
+            handy to not do that. (some toolbar clicks)
     """
     ActionChains(browser()).move_to_element(element(loc)).click().perform()
-    wait_for_ajax()
+    if wait_ajax:
+        wait_for_ajax()
 
 
 def move_to_element(loc):

--- a/cfme/web_ui/toolbar.py
+++ b/cfme/web_ui/toolbar.py
@@ -48,21 +48,32 @@ def select_n_move(el):
     sel.move_to_element((By.XPATH, '//div[@class="brand"]'))
 
 
-def select(root, sub=None):
+def select(root, sub=None, invokes_alert=False):
     """ Clicks on a button by calling the :py:meth:`click_n_move` method.
 
     Args:
         root: The root button's name as a string.
         sub: The sub button's name as a string. (optional)
+        invokes_alert: If ``True``, then the behaviour is little bit different. After the last
+            click, no ajax wait and no move away is done to be able to operate the alert that
+            appears after click afterwards. Defaults to ``False``.
     Returns: ``True`` if the button was enabled at time of clicking, ``False`` if not.
     """
     if not is_greyed(root):
-        select_n_move(root_loc(root))
+        if sub is None and invokes_alert:
+            # We arrived into a place where alert will pop up so no moving and no ajax
+            sel.click(root_loc(root), wait_ajax=False)
+        else:
+            select_n_move(root_loc(root))
     else:
         return False
     if sub:
         if not is_greyed(root, sub):
-            select_n_move(sub_loc(sub))
+            if invokes_alert:
+                # We arrived into a place where alert will pop up so no moving and no ajax
+                sel.click(sub_loc(sub), wait_ajax=False)
+            else:
+                select_n_move(sub_loc(sub))
         else:
             return False
     return True


### PR DESCRIPTION
When there is an action in the toolbar, that opens the alert(), it blocks all actions. Now it's possible to pass an 'invokes_alert' parameter, which will force the toolbar handling script do nothing after the final click (no moving, no ajax-waiting). Then the alert can be handled outside.
