### PR TITLE
Fixed issue in paginator

### DIFF
--- a/cfme/web_ui/paginator.py
+++ b/cfme/web_ui/paginator.py
@@ -78,7 +78,7 @@ def rec_end():
     if offset:
         return offset.groups()[0]
     else:
-        return '1'
+        return rec_total()
 
 
 def rec_total():


### PR DESCRIPTION
rec_end() returned wrong value if number of records was not 1 and last
page contained one item.

Closes #470
