### PR TITLE
Appliance util - asynchronous provisioning of appliance set

### DIFF
--- a/conf/cfme_data.yaml.template
+++ b/conf/cfme_data.yaml.template
@@ -100,20 +100,20 @@ management_hosts:
 appliance_provisioning:
     provider: provider_name
     versions:
-      1.2.3: template_name_123
-      1.3.3: template_name_133
+        1.2.3: template_name_123
+        1.3.3: template_name_133
     single_appliance:
-      name: name_single
-      version: 1.2.3
+        name: name_single
+        version: 1.2.3
     appliance_set:
-      primary_appliance:
-        name: name_primary
-        version: 1.3.3
-      secondary_appliances:
-        - name: name_secondary_1
-          version: 1.2.3
-        - name: name_secondary_2
-          version: 1.3.3
+        primary_appliance:
+            name: name_primary
+            version: 1.3.3
+        secondary_appliances:
+            - name: name_secondary_1
+              version: 1.2.3
+            - name: name_secondary_2
+              version: 1.3.3
 pxe:
     pxe_servers:
         rhel:


### PR DESCRIPTION
Edit:

Fix region parameter passing to subprocess.call() in Appliance.enable_external_db()

Update - Appliance.patch_ajax_wait() can now pass without triggering exception

Fix - return correct db address for session on non-db appliances

Update docs

Update wait_for_web_ui() - add 'running' parameter, timeout raised to 20sec

Fix - Appliance.name now correctly updated during Appliance.rename()
