### PR TITLE
Sprinkling around some pyflakes

### DIFF
--- a/cfme/configure/configuration.py
+++ b/cfme/configure/configuration.py
@@ -1,22 +1,15 @@
-#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
-
-import ui_navigate as nav
-import cfme
-import cfme.web_ui.menu  # so that menu is already loaded before grafting onto it
-from cfme.web_ui import Region, Form, Tree, Table
-import cfme.web_ui.flash as flash
-import cfme.fixtures.pytest_selenium as browser
-import utils.conf as conf
-from utils.update import Updateable
-import cfme.web_ui.toolbar as tb
-from cfme.web_ui import fill
-import cfme.web_ui.tabstrip as tabs
-import cfme.web_ui.accordion as accordion
-from utils.wait import wait_for, TimedOutError
-from utils.timeutil import parsetime
-from cfme.exceptions import ScheduleNotFound, NotAllItemsClicked
 from functools import partial
+
+import cfme.fixtures.pytest_selenium as browser
+import cfme.web_ui.tabstrip as tabs
+import cfme.web_ui.toolbar as tb
+from cfme.exceptions import ScheduleNotFound, NotAllItemsClicked
+from cfme.web_ui import Form, Region, Table, Tree, accordion, fill, flash
+from cfme.web_ui.menu import nav
+from utils.timeutil import parsetime
+from utils.update import Updateable
+from utils.wait import wait_for, TimedOutError
 
 
 def make_tree_locator(acc_name, root_name):

--- a/cfme/configure/tasks.py
+++ b/cfme/configure/tasks.py
@@ -6,19 +6,12 @@
 Todo: Finish the rest of the things.
 """
 
-import ui_navigate as nav
-import cfme
-import cfme.web_ui.menu  # so that menu is already loaded before grafting onto it
-from cfme.web_ui import Region, Form, Table
-import cfme.web_ui.flash as flash
-import cfme.web_ui.paginator as paginator
 import cfme.fixtures.pytest_selenium as browser
-import utils.conf as conf
-import cfme.web_ui.toolbar as tb
-from cfme.web_ui import fill
 import cfme.web_ui.tabstrip as tabs
-from utils.wait import wait_for, TimedOutError
+from cfme.web_ui import Form, Region, Table, fill, paginator
+from cfme.web_ui.menu import nav
 from utils.timeutil import parsetime
+from utils.wait import wait_for, TimedOutError
 
 
 nav.add_branch("tasks",

--- a/cfme/control/import_export.py
+++ b/cfme/control/import_export.py
@@ -1,14 +1,7 @@
-#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
-
-import ui_navigate as nav
-import cfme
-import cfme.web_ui.menu  # so that menu is already loaded before grafting onto it
-from cfme.web_ui import Region, Form
-import cfme.web_ui.flash as flash
 import cfme.fixtures.pytest_selenium as browser
-import utils.conf as conf
-from cfme.web_ui import fill
+from cfme.web_ui import Form, Region, fill, flash
+from cfme.web_ui.menu import nav
 
 
 import_form = Form(

--- a/cfme/intelligence/chargeback.py
+++ b/cfme/intelligence/chargeback.py
@@ -1,15 +1,15 @@
-from selenium.webdriver.common.by import By
-import cfme.web_ui.accordion as accordion
-import cfme.web_ui.menu # to load menu nav
-import cfme.web_ui as web_ui
-import cfme.web_ui.toolbar as tb
-import cfme.web_ui.flash as flash
-import cfme.fixtures.pytest_selenium as sel
-import ui_navigate as nav
-from utils.update import Updateable
 from functools import partial
 
-rate_tree = web_ui.Tree("//div[@id='cb_rates_treebox']/ul")
+from selenium.webdriver.common.by import By
+
+import cfme.web_ui.accordion as accordion
+import cfme.web_ui.toolbar as tb
+import cfme.fixtures.pytest_selenium as sel
+from cfme.web_ui import Form, Tree, fill, flash
+from cfme.web_ui.menu import nav
+from utils.update import Updateable
+
+rate_tree = Tree("//div[@id='cb_rates_treebox']/ul")
 tb_select = partial(tb.select, "Configuration")
 tb_select_new_chargeback = nav.fn(partial(tb_select, "Add a new Chargeback Rate"))
 tb_select_edit_chargeback = nav.fn(partial(tb_select, "Edit this Chargeback Rate"))
@@ -25,7 +25,7 @@ def _mkitem(index):
     return RateFormItem((By.CSS_SELECTOR, "input#rate_" + str(index)),
                         (By.CSS_SELECTOR, "select#per_time_" + str(index)))
 
-rate_form = web_ui.Form(
+rate_form = Form(
     fields=[
         ('description_text', (By.CSS_SELECTOR, "input#description")),
         # Compute form items
@@ -73,11 +73,11 @@ WEEKLY = 'weekly'
 MONTHLY = 'monthly'
 
 
-@web_ui.fill.register(RateFormItem)
+@fill.register(RateFormItem)
 def _sd_fill_rateform(rf, value):
     '''value should be a tuple like (5, HOURLY)'''
-    web_ui.fill(rf.rate_loc, value[0])
-    web_ui.fill(rf.unit_select_loc, (sel.VALUE, value[1]))
+    fill(rf.rate_loc, value[0])
+    fill(rf.unit_select_loc, (sel.VALUE, value[1]))
 
 
 class ComputeRate(Updateable):
@@ -103,32 +103,32 @@ class ComputeRate(Updateable):
 
     def create(self):
         nav.go_to('chargeback_rates_compute_new')
-        web_ui.fill(rate_form,
-                    {'description_text': self.description,
-                     'alloc_cpu': self.cpu_alloc,
-                     'used_cpu': self.cpu_used,
-                     'disk_io': self.disk_io,
-                     'fixed_1': self.fixed_cost_1,
-                     'fixed_2': self.fixed_cost_2,
-                     'alloc_mem': self.memory_allocated,
-                     'used_mem': self.memory_used,
-                     'net_io': self.network_io},
-                    action=rate_form.add_button)
+        fill(rate_form,
+            {'description_text': self.description,
+             'alloc_cpu': self.cpu_alloc,
+             'used_cpu': self.cpu_used,
+             'disk_io': self.disk_io,
+             'fixed_1': self.fixed_cost_1,
+             'fixed_2': self.fixed_cost_2,
+             'alloc_mem': self.memory_allocated,
+             'used_mem': self.memory_used,
+             'net_io': self.network_io},
+            action=rate_form.add_button)
         flash.assert_no_errors()
 
     def update(self, updates):
         nav.go_to('chargeback_rates_compute_edit', context={'chargeback': self})
-        web_ui.fill(rate_form,
-                    {'description_text': updates.get('description'),
-                     'alloc_cpu': updates.get('cpu_alloc'),
-                     'used_cpu': updates.get('cpu_used'),
-                     'disk_io': updates.get('disk_io'),
-                     'fixed_1': updates.get('fixed_cost_1'),
-                     'fixed_2': updates.get('fixed_cost_2'),
-                     'alloc_mem': updates.get('memory_allocated'),
-                     'used_mem': updates.get('memory_used'),
-                     'net_io': updates.get('network_io')},
-                    action=rate_form.save_button)
+        fill(rate_form,
+            {'description_text': updates.get('description'),
+             'alloc_cpu': updates.get('cpu_alloc'),
+             'used_cpu': updates.get('cpu_used'),
+             'disk_io': updates.get('disk_io'),
+             'fixed_1': updates.get('fixed_cost_1'),
+             'fixed_2': updates.get('fixed_cost_2'),
+             'alloc_mem': updates.get('memory_allocated'),
+             'used_mem': updates.get('memory_used'),
+             'net_io': updates.get('network_io')},
+            action=rate_form.save_button)
         flash.assert_no_errors()
 
     def delete(self):
@@ -136,7 +136,7 @@ class ComputeRate(Updateable):
         tb_select('Remove from the VMDB', invokes_alert=True)
         sel.handle_alert()
         flash.assert_no_errors()
-        
+
 
 class StorageRate(Updateable):
     def __init__(self, description=None,
@@ -152,23 +152,23 @@ class StorageRate(Updateable):
 
     def create(self):
         nav.go_to('chargeback_rates_storage_new')
-        web_ui.fill(rate_form,
-                    {'description_text': self.description,
-                     'fixed_storage_1': self.fixed_cost_1,
-                     'fixed_storage_2': self.fixed_cost_2,
-                     'alloc_storage': self.allocated_storage,
-                     'used_storage': self.used_storage},
-                    action=rate_form.add_button)
+        fill(rate_form,
+            {'description_text': self.description,
+             'fixed_storage_1': self.fixed_cost_1,
+             'fixed_storage_2': self.fixed_cost_2,
+             'alloc_storage': self.allocated_storage,
+             'used_storage': self.used_storage},
+            action=rate_form.add_button)
 
     def update(self, updates):
         nav.go_to('chargeback_rates_storage_edit', context={'chargeback': self})
-        web_ui.fill(rate_form,
-                    {'description_text': updates.get('description'),
-                     'fixed_storage_1': updates.get('fixed_cost_1'),
-                     'fixed_storage_2': updates.get('fixed_cost_2'),
-                     'alloc_storage': updates.get('allocated_storage'),
-                     'used_storage': updates.get('used_storage')},
-                    action=rate_form.save_button)
+        fill(rate_form,
+            {'description_text': updates.get('description'),
+             'fixed_storage_1': updates.get('fixed_cost_1'),
+             'fixed_storage_2': updates.get('fixed_cost_2'),
+             'alloc_storage': updates.get('allocated_storage'),
+             'used_storage': updates.get('used_storage')},
+            action=rate_form.save_button)
 
     def delete(self):
         nav.go_to('chargeback_rates_storage_named', context={'chargeback': self})


### PR DESCRIPTION
Common things that I noticed:
- The standalone `import cfme.web_ui.menu` should be replaced with `from cfme.web_ui.menu import nav`, `import ui_navigate as nav` should go away
- Imports need to be PEP8'd. flake8 doesn't catch this because it can't know what's builtin or not.
- `#!/usr/bin/env python2` should only be in scripts, and then it should be the canonical name of the python2 bin, `python`. 
  - `python` is always python 2. `python3` is always python 3.
  - `python2` is not guaranteed to exist if python 2 is installed.
-  Many unused imports removed
