### PR TITLE
Added dispatcher for selects

### DIFF
--- a/cfme/cloud/instance.py
+++ b/cfme/cloud/instance.py
@@ -6,7 +6,7 @@
 :var edit_form: A :py:class:`cfme.web_ui.Form` object describing the instance edit form.
 """
 
-from cfme.web_ui import Region, Form, Tree
+from cfme.web_ui import Region, Form, Tree, Select
 
 
 # Common locators
@@ -46,8 +46,8 @@ edit_form = Form(
         ('custom_ident', "//*[@id='custom_1']"),
         ('description_tarea', "//textarea[@id='description']"),
         ('parent_sel', "//*[@id='chosen_parent']"),
-        ('child_sel', "//select[@id='kids_chosen']"),
-        ('vm_sel', "//select[@id='choices_chosen']"),
+        ('child_sel', Select("//select[@id='kids_chosen']", multi=True)),
+        ('vm_sel', Select("//select[@id='choices_chosen']", multi=True)),
         ('add_btn', "//img[@alt='Move selected VMs to left']"),
         ('remove_btn', "//img[@alt='Move selected VMs to right']"),
         ('remove_all_btn', "//img[@alt='Move all VMs to right']"),

--- a/cfme/cloud/provider.py
+++ b/cfme/cloud/provider.py
@@ -20,7 +20,7 @@ import cfme.web_ui.menu  # so that menu is already loaded before grafting onto i
 import cfme.web_ui.toolbar as tb
 import utils.conf as conf
 from cfme.exceptions import HostStatsNotContains, ProviderHasNoProperty, ProviderHasNoKey
-from cfme.web_ui import Region, Quadicon, Form, fill, paginator
+from cfme.web_ui import Region, Quadicon, Form, Select, fill, paginator
 from utils.log import logger
 from utils.providers import provider_factory
 from utils.update import Updateable
@@ -64,11 +64,11 @@ discover_form = Form(
 
 properties_form = Form(
     fields=[
-        ('type_select', "//*[@id='server_emstype']"),
+        ('type_select', Select("//*[@id='server_emstype']")),
         ('name_text', "//*[@id='name']"),
         ('hostname_text', "//*[@id='hostname']"),
         ('ipaddress_text', "//*[@id='ipaddress']"),
-        ('amazon_region_select', "//*[@id='hostname']"),
+        ('amazon_region_select', Select("//*[@id='hostname']")),
         ('api_port', "//*[@id='port']"),
     ])
 

--- a/cfme/configure/configuration.py
+++ b/cfme/configure/configuration.py
@@ -5,7 +5,7 @@ import cfme.fixtures.pytest_selenium as browser
 import cfme.web_ui.tabstrip as tabs
 import cfme.web_ui.toolbar as tb
 from cfme.exceptions import ScheduleNotFound
-from cfme.web_ui import Form, Region, Table, Tree, accordion, fill, flash
+from cfme.web_ui import Form, Region, Select, Table, Tree, accordion, fill, flash
 from cfme.web_ui.menu import nav
 from utils.timeutil import parsetime
 from utils.update import Updateable
@@ -58,7 +58,7 @@ ntp_servers = Form(
 
 db_configuration = Form(
     fields=[
-        ('type', "//select[@id='production_dbtype']"),
+        ('type', Select("//select[@id='production_dbtype']")),
         ('hostname', "//input[@id='production_host']"),
         ('database', "//input[@id='production_database']"),
         ('username', "//input[@id='production_username']"),
@@ -287,7 +287,7 @@ class ServerLogDepot(object):
 
         server_collect_logs = Form(
             fields=[
-                ("type", "//select[@id='log_protocol']"),
+                ("type", Select("//select[@id='log_protocol']")),
                 ("uri", "//input[@id='uri']"),
                 ("user", "//input[@id='log_userid']"),
                 ("password", "//input[@id='log_password']"),
@@ -500,8 +500,8 @@ class SMTPSettings(Updateable):
             ('port', "//input[@id='smtp_port']"),
             ('domain', "//input[@id='smtp_domain']"),
             ('start_tls', "//input[@id='smtp_enable_starttls_auto']"),
-            ('ssl_verify', "//select[@id='smtp_openssl_verify_mode']"),
-            ('auth', "//select[@id='smtp_authentication']"),
+            ('ssl_verify', Select("//select[@id='smtp_openssl_verify_mode']")),
+            ('auth', Select("//select[@id='smtp_authentication']")),
             ('username', "//input[@id='smtp_user_name']"),
             ('password', "//input[@id='smtp_password']"),
             ('from_email', "//input[@id='smtp_from']"),
@@ -553,9 +553,9 @@ class DatabaseAuthSetting(object):
     """
 
     form = Form(fields=[
-        ("timeout_h", "//select[@id='session_timeout_hours']"),
-        ("timeout_m", "//select[@id='session_timeout_mins']"),
-        ("auth_mode", "//select[@id='authentication_mode']")
+        ("timeout_h", Select("//select[@id='session_timeout_hours']")),
+        ("timeout_m", Select("//select[@id='session_timeout_mins']")),
+        ("auth_mode", Select("//select[@id='authentication_mode']"))
     ])
 
     def __init__(self, timeout_h=None, timeout_m=None):
@@ -588,9 +588,9 @@ class AmazonAuthSetting(object):
     """
 
     form = Form(fields=[
-        ("timeout_h", "//select[@id='session_timeout_hours']"),
-        ("timeout_m", "//select[@id='session_timeout_mins']"),
-        ("auth_mode", "//select[@id='authentication_mode']"),
+        ("timeout_h", Select("//select[@id='session_timeout_hours']")),
+        ("timeout_m", Select("//select[@id='session_timeout_mins']")),
+        ("auth_mode", Select("//select[@id='authentication_mode']")),
         ("access_key", "//input[@id='authentication_amazon_key']"),
         ("secret_key", "//input[@id='authentication_amazon_secret']"),
         ("get_groups", "//input[@id='amazon_role']"),
@@ -639,14 +639,14 @@ class LDAPAuthSetting(object):
 
     """
     form = Form(fields=[
-        ("timeout_h", "//select[@id='session_timeout_hours']"),
-        ("timeout_m", "//select[@id='session_timeout_mins']"),
-        ("auth_mode", "//select[@id='authentication_mode']"),
+        ("timeout_h", Select("//select[@id='session_timeout_hours']")),
+        ("timeout_m", Select("//select[@id='session_timeout_mins']")),
+        ("auth_mode", Select("//select[@id='authentication_mode']")),
         ("ldaphost_1", "//input[@id='authentication_ldaphost_1']"),
         ("ldaphost_2", "//input[@id='authentication_ldaphost_2']"),
         ("ldaphost_3", "//input[@id='authentication_ldaphost_3']"),
         ("ldapport", "//input[@id='authentication_ldapport']"),
-        ("user_type", "//select[@id='authentication_user_type']"),
+        ("user_type", Select("//select[@id='authentication_user_type']")),
         ("user_suffix", "//input[@id='authentication_user_suffix']"),
         ("get_groups", "//input[@id='ldap_role']"),
         ("get_direct_groups", "//input[@id='get_direct_groups']"),
@@ -775,18 +775,18 @@ class Schedule(object):
         ("description", "//input[@id='description']"),
         ("active", "//input[@id='enabled']"),
         ("name", "//input[@id='name']"),
-        ("action", "//select[@id='action_typ']"),
-        ("filter_type", "//select[@id='filter_typ']"),
-        ("filter_value", "//select[@id='filter_value']"),
-        ("timer_type", "//select[@id='timer_typ']"),
-        ("timer_hours", "//select[@id='timer_hours']"),
-        ("timer_days", "//select[@id='timer_days']"),
-        ("timer_weeks", "//select[@id='timer_weekss']"),    # Not a typo!
-        ("timer_months", "//select[@id='timer_months']"),
-        ("time_zone", "//select[@id='time_zone']"),
+        ("action", Select("//select[@id='action_typ']")),
+        ("filter_type", Select("//select[@id='filter_typ']")),
+        ("filter_value", Select("//select[@id='filter_value']")),
+        ("timer_type", Select("//select[@id='timer_typ']")),
+        ("timer_hours", Select("//select[@id='timer_hours']")),
+        ("timer_days", Select("//select[@id='timer_days']")),
+        ("timer_weeks", Select("//select[@id='timer_weekss']")),    # Not a typo!
+        ("timer_months", Select("//select[@id='timer_months']")),
+        ("time_zone", Select("//select[@id='time_zone']")),
         ("start_date", "//input[@id='miq_date_1']"),
-        ("start_hour", "//select[@id='start_hour']"),
-        ("start_min", "//select[@id='start_min']"),
+        ("start_hour", Select("//select[@id='start_hour']")),
+        ("start_min", Select("//select[@id='start_min']")),
     ])
 
     def __init__(self,

--- a/cfme/configure/tasks.py
+++ b/cfme/configure/tasks.py
@@ -8,7 +8,7 @@ Todo: Finish the rest of the things.
 
 import cfme.fixtures.pytest_selenium as browser
 import cfme.web_ui.tabstrip as tabs
-from cfme.web_ui import Form, Region, Table, fill, paginator
+from cfme.web_ui import Form, Region, Select, Table, fill, paginator
 from cfme.web_ui.menu import nav
 from utils.timeutil import parsetime
 from utils.wait import wait_for, TimedOutError
@@ -33,15 +33,15 @@ buttons = Region(
 
 filter_form = Form(
     fields=[
-        ("zone", "//select[@id='chosen_zone']"),
-        ("user", "//select[@id='user_choice']"),
-        ("time_period", "//select[@id='time_period']"),
+        ("zone", Select("//select[@id='chosen_zone']")),
+        ("user", Select("//select[@id='user_choice']")),
+        ("time_period", Select("//select[@id='time_period']")),
         ("task_status_queued", "//input[@id='queued']"),
         ("task_status_running", "//input[@id='running']"),
         ("task_status_ok", "//input[@id='ok']"),
         ("task_status_error", "//input[@id='error']"),
         ("task_status_warn", "//input[@id='warn']"),
-        ("task_state", "//select[@id='state_choice']"),
+        ("task_state", Select("//select[@id='state_choice']")),
     ]
 )
 

--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -22,7 +22,6 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.remote.webelement import WebElement
-from selenium.webdriver.support.select import Select
 
 from multimethods import singledispatch, multidispatch
 
@@ -568,7 +567,7 @@ def select(loc, o):
 
 
 @select.method((object, tuple))
-def _select_tuple(loc, o):
+def _select_tuple(select_element, o):
     """
     Takes a locator and an object and selects using the correct method.
 
@@ -582,17 +581,17 @@ def _select_tuple(loc, o):
     """
     vtype, value = o
     if vtype == TEXT:
-        select_by_text(loc, value)
+        select_by_text(select_element, value)
     if vtype == VALUE:
-        select_by_value(loc, value)
+        select_by_value(select_element, value)
 
 
 @select.method((object, str))
-def _select_str(loc, s):
-    select_by_text(loc, s)
+def _select_str(select_element, s):
+    select_by_text(select_element, s)
 
 
-def select_by_text(loc, text):
+def select_by_text(select_element, text):
     """
     Works on a select element and selects an option by the visible text.
 
@@ -601,13 +600,11 @@ def select_by_text(loc, text):
         text: The select element option's visible text.
     """
     if text is not None:
-        el = element(loc)
-        ActionChains(browser()).move_to_element(el).perform()
-        Select(el).select_by_visible_text(text)
+        select_element.select_by_visible_text(text)
         wait_for_ajax()
 
 
-def select_by_value(loc, value):
+def select_by_value(select_element, value):
     """
     Works on a select element and selects an option by the value attribute.
 
@@ -616,9 +613,7 @@ def select_by_value(loc, value):
         value: The select element's option value.
     """
     if value is not None:
-        el = element(loc)
-        ActionChains(browser()).move_to_element(el).perform()
-        Select(el).select_by_value(value)
+        select_element.select_by_value(value)
         wait_for_ajax()
 
 
@@ -644,7 +639,7 @@ def deselect(loc, o):
             deselect_by_value(loc, value)
 
 
-def deselect_by_text(loc, text):
+def deselect_by_text(select_element, text):
     """
     Works on a select element and deselects an option by the visible text.
 
@@ -653,13 +648,11 @@ def deselect_by_text(loc, text):
         text: The select element option's visible text.
     """
     if text is not None:
-        el = element(loc)
-        ActionChains(browser()).move_to_element(el).perform()
-        Select(el).deselect_by_visible_text(text)
+        select_element.deselect_by_visible_text(text)
         wait_for_ajax()
 
 
-def deselect_by_value(loc, value):
+def deselect_by_value(select_element, value):
     """
     Works on a select element and deselects an option by the value attribute.
 
@@ -668,7 +661,5 @@ def deselect_by_value(loc, value):
         value: The select element's option value.
     """
     if value is not None:
-        el = element(loc)
-        ActionChains(browser()).move_to_element(el).perform()
-        Select(el).deselect_by_value(value)
+        select_element.deselect_by_value(value)
         wait_for_ajax()

--- a/cfme/infrastructure/provider.py
+++ b/cfme/infrastructure/provider.py
@@ -20,7 +20,7 @@ import cfme.web_ui.menu  # so that menu is already loaded before grafting onto i
 import cfme.web_ui.toolbar as tb
 import utils.conf as conf
 from cfme.exceptions import HostStatsNotContains, ProviderHasNoProperty, ProviderHasNoKey
-from cfme.web_ui import Region, Quadicon, Form, fill, paginator
+from cfme.web_ui import Region, Quadicon, Form, Select, fill, paginator
 from utils.log import logger
 from utils.providers import provider_factory
 from utils.update import Updateable
@@ -68,11 +68,10 @@ discover_form = Form(
 
 properties_form = Form(
     fields=[
-        ('type_select', "//*[@id='server_emstype']"),
+        ('type_select', Select("//*[@id='server_emstype']")),
         ('name_text', "//*[@id='name']"),
         ('hostname_text', "//*[@id='hostname']"),
         ('ipaddress_text', "//*[@id='ipaddress']"),
-        ('amazon_region_select', "//*[@id='hostname']"),
         ('api_port', "//*[@id='port']"),
     ])
 

--- a/cfme/intelligence/chargeback.py
+++ b/cfme/intelligence/chargeback.py
@@ -5,7 +5,7 @@ from selenium.webdriver.common.by import By
 import cfme.web_ui.accordion as accordion
 import cfme.web_ui.toolbar as tb
 import cfme.fixtures.pytest_selenium as sel
-from cfme.web_ui import Form, Tree, fill, flash
+from cfme.web_ui import Form, Select, Tree, fill, flash
 from cfme.web_ui.menu import nav
 from utils.update import Updateable
 
@@ -23,7 +23,7 @@ class RateFormItem(object):
 
 def _mkitem(index):
     return RateFormItem((By.CSS_SELECTOR, "input#rate_" + str(index)),
-                        (By.CSS_SELECTOR, "select#per_time_" + str(index)))
+                        Select((By.CSS_SELECTOR, "select#per_time_" + str(index))))
 
 rate_form = Form(
     fields=[
@@ -102,7 +102,7 @@ class ComputeRate(Updateable):
         self.network_io = network_io
 
     def create(self):
-        nav.go_to('chargeback_rates_compute_new')
+        sel.force_navigate('chargeback_rates_compute_new')
         fill(rate_form,
             {'description_text': self.description,
              'alloc_cpu': self.cpu_alloc,

--- a/cfme/web_ui/paginator.py
+++ b/cfme/web_ui/paginator.py
@@ -1,4 +1,5 @@
 """A set of functions for dealing with the paginator controls."""
+from cfme.web_ui import Select
 import cfme.fixtures.pytest_selenium as sel
 import re
 
@@ -53,7 +54,7 @@ def results_per_page(num):
         num: Number of results per page
     """
     select = sel.element(_locator + _num_results)
-    sel.select(select, (sel.TEXT, str(num)))
+    sel.select(Select(select), (sel.TEXT, str(num)))
 
 
 def sort_by(sort):
@@ -63,7 +64,7 @@ def sort_by(sort):
         sort: Value to sort by (visible text in select box)
     """
     select = sel.element(_locator + _sort_by)
-    sel.select(select, (sel.TEXT, sort))
+    sel.select(Select(select), (sel.TEXT, sort))
 
 
 def rec_offset():


### PR DESCRIPTION
Added dispatcher for select objects
- In pytest_selenium fixture, select_by_visible_text() and select_by_value
  have been updated to receive a select element, rather than a locator. Just
  as have their deselect counterparts.
  This is required because of the introduction of the DHTMLSelect() object.
- A new Select() object has been created which subclasses the Selenium Select()
  object. This, along with changes to DHTMLSelect() mean that their methods
  are identical and hence the select() function in pytest_selenium can act on
  either element.
- paginator module has been updated to use the new Select() object.
- Multiple files have been updated to use the new Select() object in the Form
  definitions.
