### PR TITLE
Fix provider discovery to wait for one provider

### DIFF
--- a/cfme/cloud/provider.py
+++ b/cfme/cloud/provider.py
@@ -382,3 +382,10 @@ def discover(credential, cancel=False):
                           'password': credential.secret,
                           'password_verify': credential.verify_secret})
     fill(discover_form, form_data)
+
+
+def wait_for_a_provider():
+    sel.force_navigate('clouds_providers')
+    logger.info('Waiting for a provider to appear...')
+    wait_for(paginator.rec_total, fail_condition=None, message="Wait for any provider to appear",
+             num_sec=180, fail_func=sel.refresh)

--- a/cfme/infrastructure/provider.py
+++ b/cfme/infrastructure/provider.py
@@ -440,3 +440,10 @@ def discover(rhevm=False, vmware=False, cancel=False, start_ip=None, end_ip=None
         form_data.update({'to_3': end_octet})
 
     fill(discover_form, form_data)
+
+
+def wait_for_a_provider():
+    sel.force_navigate('infrastructure_providers')
+    logger.info('Waiting for a provider to appear...')
+    wait_for(paginator.rec_total, fail_condition=None, message="Wait for any provider to appear",
+             num_sec=180, fail_func=sel.refresh)

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -32,7 +32,7 @@ def test_providers_discovery():
     amazon_creds = provider.get_credentials_from_config('cloudqe_amazon')
     provider.discover(amazon_creds)
     flash.assert_message_match('Amazon Cloud Providers: Discovery successfully initiated')
-    # TODO - wait for it to finish (no reliable way to do that currently)
+    provider.wait_for_a_provider()
 
 
 @pytest.mark.usefixtures('has_no_providers')

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -31,7 +31,7 @@ def test_that_checks_flash_when_discovery_cancelled():
 def test_providers_discovery(provider_crud):
     provider.discover_from_provider(provider_crud)
     flash.assert_message_match('Infrastructure Providers: Discovery successfully initiated')
-    # TODO - wait for it to finish (no reliable way to do that currently)
+    provider.wait_for_a_provider()
 
 
 @pytest.mark.usefixtures('has_no_providers')


### PR DESCRIPTION
Fix provider discovery to wait for one provider
This is to fix a few more bugs in the jenkins run where providers are not "discovered" before the attempt to delete, hence no deletion occurs and clashes happen on subsequent tests.
