### PR TITLE
Split clear providers

### DIFF
--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -27,7 +27,7 @@ def test_that_checks_flash_when_discovery_cancelled():
     flash.assert_message_match('Amazon Cloud Providers Discovery was cancelled by the user')
 
 
-@pytest.mark.usefixtures('has_no_providers')
+@pytest.mark.usefixtures('has_no_cloud_providers')
 def test_providers_discovery():
     amazon_creds = provider.get_credentials_from_config('cloudqe_amazon')
     provider.discover(amazon_creds)
@@ -35,7 +35,7 @@ def test_providers_discovery():
     provider.wait_for_a_provider()
 
 
-@pytest.mark.usefixtures('has_no_providers')
+@pytest.mark.usefixtures('has_no_cloud_providers')
 def test_provider_add(provider_crud):
     """ Tests that a provider can be added """
     provider_crud.create()
@@ -43,14 +43,14 @@ def test_provider_add(provider_crud):
     provider_crud.validate()
 
 
-@pytest.mark.usefixtures('has_no_providers')
+@pytest.mark.usefixtures('has_no_cloud_providers')
 def test_provider_add_with_bad_credentials(provider_crud):
     provider_crud.credentials = provider.get_credentials_from_config('bad_credentials')
     with error.expected('Login failed due to a bad username or password.'):
         provider_crud.create(validate_credentials=True)
 
 
-@pytest.mark.usefixtures('has_no_providers')
+@pytest.mark.usefixtures('has_no_cloud_providers')
 def test_provider_edit(provider_crud):
     """ Tests that editing a management system shows the proper detail after an edit."""
     provider_crud.create()

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -27,14 +27,14 @@ def test_that_checks_flash_when_discovery_cancelled():
     flash.assert_message_match('Infrastructure Providers Discovery was cancelled by the user')
 
 
-@pytest.mark.usefixtures('has_no_providers')
+@pytest.mark.usefixtures('has_no_infra_providers')
 def test_providers_discovery(provider_crud):
     provider.discover_from_provider(provider_crud)
     flash.assert_message_match('Infrastructure Providers: Discovery successfully initiated')
     provider.wait_for_a_provider()
 
 
-@pytest.mark.usefixtures('has_no_providers')
+@pytest.mark.usefixtures('has_no_infra_providers')
 def test_provider_add(provider_crud):
     """ Tests that a provider can be added """
     provider_crud.create()
@@ -42,7 +42,7 @@ def test_provider_add(provider_crud):
     provider_crud.validate()
 
 
-@pytest.mark.usefixtures('has_no_providers')
+@pytest.mark.usefixtures('has_no_infra_providers')
 def test_provider_add_with_bad_credentials(provider_crud):
     provider_crud.credentials = provider.get_credentials_from_config('bad_credentials')
     if isinstance(provider_crud, provider.VMwareProvider):
@@ -53,7 +53,7 @@ def test_provider_add_with_bad_credentials(provider_crud):
             provider_crud.create(validate_credentials=True)
 
 
-@pytest.mark.usefixtures('has_no_providers')
+@pytest.mark.usefixtures('has_no_infra_providers')
 def test_provider_edit(provider_crud):
     """ Tests that editing a management system shows the proper detail after an edit."""
     provider_crud.create()

--- a/fixtures/mgmt_system.py
+++ b/fixtures/mgmt_system.py
@@ -52,3 +52,23 @@ def has_no_providers():
     the current appliance.
     """
     clear_providers()
+
+
+@pytest.fixture
+def has_no_cloud_providers():
+    """ Clears all cloud providers from an appliance
+
+    This is a destructive fixture. It will clear all cloud managements systems from
+    the current appliance.
+    """
+    providers.clear_cloud_providers()
+
+
+@pytest.fixture
+def has_no_infra_providers():
+    """ Clears all infrastructure providers from an appliance
+
+    This is a destructive fixture. It will clear all infrastructure managements systems from
+    the current appliance.
+    """
+    providers.clear_infra_providers()

--- a/utils/providers.py
+++ b/utils/providers.py
@@ -239,6 +239,48 @@ def setup_infrastructure_providers(validate=True, check_existing=True):
     return _setup_providers('infra', validate, check_existing)
 
 
+def clear_cloud_providers(validate=True):
+    sel.force_navigate('clouds_providers')
+    logger.debug('Checking for existing cloud providers...')
+    if paginator.rec_total():
+        logger.info(' Providers exist, so removing all cloud providers')
+        paginator.results_per_page('100')
+        sel.click(paginator.check_all())
+        toolbar.select('Configuration', 'Remove Cloud Providers from the VMDB',
+                       invokes_alert=True)
+        sel.handle_alert()
+        if validate:
+            wait_for_no_cloud_providers()
+
+
+def clear_infra_providers(validate=True):
+    sel.force_navigate('infrastructure_providers')
+    logger.debug('Checking for existing infrastructure providers...')
+    if paginator.rec_total():
+        logger.info(' Providers exist, so removing all infra providers')
+        paginator.results_per_page('100')
+        sel.click(paginator.check_all())
+        toolbar.select('Configuration', 'Remove Infrastructure Providers from the VMDB',
+                       invokes_alert=True)
+        sel.handle_alert()
+        if validate:
+            wait_for_no_infra_providers()
+
+
+def wait_for_no_cloud_providers():
+    sel.force_navigate('clouds_providers')
+    logger.debug('Waiting for all cloud providers to disappear...')
+    wait_for(lambda: not paginator.rec_total(), message="Delete all cloud providers",
+             num_sec=180, fail_func=sel.refresh)
+
+
+def wait_for_no_infra_providers():
+    sel.force_navigate('infrastructure_providers')
+    logger.debug('Waiting for all infra providers to disappear...')
+    wait_for(lambda: not paginator.rec_total(), message="Delete all infrastructure providers",
+             num_sec=180, fail_func=sel.refresh)
+
+
 def clear_providers():
     """Rudely clear all providers on an appliance
 
@@ -247,29 +289,10 @@ def clear_providers():
     # Executes the deletes first, then validates in a second pass
     logger.info('Destroying all appliance providers')
     perflog.start('utils.providers.clear_providers')
-    sel.force_navigate('clouds_providers')
-    if paginator.rec_total():
-        paginator.results_per_page('100')
-        sel.click(paginator.check_all())
-        toolbar.select('Configuration', 'Remove Cloud Providers from the VMDB',
-                       invokes_alert=True)
-        sel.handle_alert()
-
-    sel.force_navigate('infrastructure_providers')
-    if paginator.rec_total():
-        paginator.results_per_page('100')
-        sel.click(paginator.check_all())
-        toolbar.select('Configuration', 'Remove Infrastructure Providers from the VMDB',
-                       invokes_alert=True)
-        sel.handle_alert()
-
-    sel.force_navigate('clouds_providers')
-    wait_for(lambda: not paginator.rec_total(), message="Delete all cloud providers",
-             num_sec=180, fail_func=sel.refresh)
-
-    sel.force_navigate('infrastructure_providers')
-    wait_for(lambda: not paginator.rec_total(), message="Delete all infrastructure providers",
-             num_sec=180, fail_func=sel.refresh)
+    clear_cloud_providers(validate=False)
+    clear_infra_providers(validate=False)
+    wait_for_no_cloud_providers()
+    wait_for_no_cloud_providers()
     perflog.stop('utils.providers.clear_providers')
 
 


### PR DESCRIPTION
- clear_providers() is now split into clear_infra_providers() and
  clear_cloud_providers.
- The has_no_providers fixture has been joined by has_no_cloud_providers
  and has_no_infra_providers.
- Tests in the cloud and infrastructure directories of the new cfme code
  base have been updated to clear their respective provider types.

The rationale behind this is to a) reduce the risk of provider clearing
the wrong provider whilst developing and b) to speed up the fixture, as
it has to visit pages multiple times. Also, the delete validation is now
only triggered if there are providers to delete.
