### PR TITLE
Fixed c_and_u tests a bit

### DIFF
--- a/pages/infrastructure_subpages/vms_subpages/virtual_machines.py
+++ b/pages/infrastructure_subpages/vms_subpages/virtual_machines.py
@@ -20,6 +20,8 @@ class VirtualMachines(VmCommonComponents):
         "table.buttons_cont tr[title='Clone this item']")
     _publish_items_button_locator = (By.CSS_SELECTOR,
         "table.buttons_cont tr[title='Publish selected VM to a Template']")
+    _all_vms_button_locator = (By.CSS_SELECTOR,
+        "a[title='All VMs & Templates that I can see']")
 
     @property
     def quadicon_region(self):
@@ -29,6 +31,10 @@ class VirtualMachines(VmCommonComponents):
     def search(self):
         from pages.regions.search import Search
         return Search(self.testsetup)
+
+    def return_to_all_vms(self):
+        button = self.selenium.find_element(*self._all_vms_button_locator)
+        button.click()
 
     def _mark_icon_and_call_method(self, vm_names, op_func):
         self.quadicon_region.mark_icon_checkbox(vm_names)
@@ -137,6 +143,8 @@ class VirtualMachines(VmCommonComponents):
     def find_vm_page(self, vm_name=None, vm_type=None, mark_checkbox=False,
             load_details=False, retries=0):
         logger.info("Trying to find VM quadicon (" + str(vm_name) + ") and/or vm_type: " + str(vm_type))
+        self.return_to_all_vms()
+        self._wait_for_results_refresh()
         found = None
         retry_attempts = 0
         while not found:

--- a/tests/cap_and_util/test_utilization_graphs.py
+++ b/tests/cap_and_util/test_utilization_graphs.py
@@ -14,7 +14,12 @@ from selenium.webdriver.common.keys import Keys
 def vm_info(db_session):
     import db
     session = db_session
-    vm_info = session.query(db.Vm).filter_by(power_state = 'on').first()
+    vm_info = session.query(db.Vm)\
+                     .join(db.ExtManagementSystem, db.Vm.ems_id == db.ExtManagementSystem.id)\
+                     .filter(db.Vm.power_state == 'on')\
+                     .filter((db.ExtManagementSystem.type == "EmsVmware")
+                             | (db.ExtManagementSystem.type == "EmsRedhat"))\
+                     .order_by(db.Vm.name).first()
     resource_id = vm_info.id
     name = vm_info.name
     vm_info = collections.namedtuple('vm_info', ['id', 'name'])


### PR DESCRIPTION
Was getting all hung up on the fact that the page wasn't the right one....a result of some of our browser session foo.
Previously, the test assumed it would only receive an infrastructure vm, but as it only received the first VM from the database, it could (and has been for me) a cloud vm. The query has now been altered to
 a) only return vms which are from an Infrastructure provider
 b) ordered by name alphabetically so we don't have to go through pages and pages of vms to find it (I frequently got one starting with w or v)
