### PR TITLE
Added miq_soap module.

### DIFF
--- a/utils/miq_soap.py
+++ b/utils/miq_soap.py
@@ -208,7 +208,7 @@ class MiqEms(HasManyDatastores, HasManyHosts, HasManyVMs, HasManyResourcePools):
         name = str(self.host_name)
         from utils.conf import cfme_data, credentials
         for prov_id, provider in cfme_data.get("management_systems", {}).iteritems():
-            if provider.get("hostname", None) == name:
+            if provider.get("hostname", None) == name or provider.get("region", None) == name:
                 credentials = credentials.get(provider["credentials"], {})
                 provider_id = prov_id
                 break


### PR DESCRIPTION
Enables to operate Infrastructure objects. It has better VM provisioning code. OOP encapsulated.

Some things to do on it:
- create a mgmt_system.py hook that will enable direct access to the machine.
- some sort of caching to speed it up? But probably not needed.

This is because there is no VM coverage yet in the new code yet and I need to access some CFME functionality

To test:

``` python
>>> from utils.miq_soap import * # or just MiqVM
>>> vm = MiqVM.provision_from_template("template_name", "vm_name")
>>> vm = MiqVM.provision_from_template("template_name", "vm_name", vlan="rhevm")  # fro rhevm
>>> vm.exists
>>> vm.power_off()
...
```

It might spit an error on one of the datastores, if it is picked. Next run will probably go well.
