### PR TITLE
RHEV Support for more than 100 VMs.

### DIFF
--- a/utils/mgmt_system.py
+++ b/utils/mgmt_system.py
@@ -607,7 +607,7 @@ class RHEVMSystem(MgmtSystemAPIBase):
     """
 
     _stats_available = {
-        'num_vm': lambda self: len(self.list_vm()),
+        'num_vm': lambda self: self.api.get_summary().get_vms().total,
         'num_host': lambda self: len(self.list_host()),
         'num_cluster': lambda self: len(self.list_cluster()),
         'num_template': lambda self: len(self.list_template()),


### PR DESCRIPTION
RHEVM pages its response from the API when you list individual VMs, requesting the summary obtains the total number of VMs.
