### PR TITLE
conf load errors downgraded to warnings

### DIFF
--- a/utils/conf.py
+++ b/utils/conf.py
@@ -2,4 +2,4 @@ import sys
 
 from utils._conf import Config
 
-sys.modules[__name__] = Config()
+sys.modules[__name__] = Config(__file__)


### PR DESCRIPTION
The lack of a config file can eventually trigger ImportError, which
(among other things) breaks our docs build. It's also really rude.
This is now a warning, which prints a nice error message without
breaking everything.
