### PR TITLE
recreate db sessions to prevent errors

### DIFF
--- a/fixtures/events.py
+++ b/fixtures/events.py
@@ -378,7 +378,8 @@ def configure_appliance_for_event_testing(listener_info):
     """ This fixture ensures that the appliance is configured for event testing.
     """
     return setup_for_event_testing(
-        SSHClient(), db_session_maker(), listener_info, providers.list_infra_providers()
+        SSHClient(), db_session_maker(recreate=True), listener_info,
+        providers.list_infra_providers()
     )
 
 

--- a/utils/db_queries.py
+++ b/utils/db_queries.py
@@ -6,14 +6,6 @@ from functools import wraps
 from utils.cfmedb import db_session_maker
 
 
-def get_db_session():
-    """Caches and provides the db connection
-    """
-    if "db_session" not in globals():
-        globals()["db_session"] = db_session_maker()
-    return globals()["db_session"]
-
-
 def db_query(function):
     """Decorator providing the DB session for functions that want it.
 
@@ -25,7 +17,7 @@ def db_query(function):
     """
     @wraps(function)
     def f(*args, **kwargs):
-        return function(get_db_session(), *args, **kwargs)
+        return function(db_session_maker(recreate=True), *args, **kwargs)
     return f
 
 

--- a/utils/miq_soap.py
+++ b/utils/miq_soap.py
@@ -303,7 +303,7 @@ class MiqVM(HasManyDatastores, BelongsToCluster):
             email: Email of the requestee
         Returns: :py:class:`MiqVM` object with freshly provisioned VM.
         """
-        db_session = db_session_maker()
+        db_session = db_session_maker(recreate=True)
         for vm in db_session.query(db.Vm.name, db.Vm.guid).filter(db.Vm.template == True):
             # Previous line is ok, if you change it to `is`, it won't work!
             if vm.name.strip() == template_name.strip():


### PR DESCRIPTION
Quite a stupid fix to prevent errors dependent on preceeding errors, but should not slow down much.
