### PR TITLE
increase vm scan timeout

### DIFF
--- a/tests/ui/infrastructure/test_vm_analysis.py
+++ b/tests/ui/infrastructure/test_vm_analysis.py
@@ -363,7 +363,7 @@ class TestVmAnalysis():
             return False
 
         tasks_pg.task_buttons.reload()
-        wait_for(is_task_finished, func_args=[tasks_pg, vm_name], delay=30, num_sec=600)
+        wait_for(is_task_finished, func_args=[tasks_pg, vm_name], delay=30, num_sec=900)
 
     def test_analyze_vm(self, provider, vm_name, fs_type, register_event):
         """Test scanning a VM"""


### PR DESCRIPTION
addresses failure in jenkins job #327,
tests.ui.infrastructure.test_vm_analysis.TestVmAnalysis.test_analyze_vm[-vsphere5-win7-ie10-ntfs]
