### PR TITLE
Changed names to make them less ambiguous

### DIFF
--- a/cfme/tests/automate/test_class.py
+++ b/cfme/tests/automate/test_class.py
@@ -28,7 +28,7 @@ def a_class(a_namespace):
                  namespace=a_namespace)
 
 
-def test_crud(a_class):
+def test_class_crud(a_class):
     a_class.create()
     orig = a_class.description
     with update(a_class):
@@ -39,7 +39,7 @@ def test_crud(a_class):
     assert not a_class.exists()
 
 
-def test_add_inherited(a_class):
+def test_add_class_inherited(a_class):
     subclass = Class(name=generate_random_string(8),
                      namespace=a_class.namespace,
                      description="subclass",
@@ -48,13 +48,13 @@ def test_add_inherited(a_class):
     subclass.create()
 
 
-def test_duplicate_disallowed(a_class):
+def test_duplicate_class_disallowed(a_class):
     a_class.create()
     with error.expected("Name has already been taken"):
         a_class.create()
 
 
-def test_same_name_different_namespace(a_namespace):
+def test_same_class_name_different_namespace(a_namespace):
     other_namespace = _make_namespace()
     name = generate_random_string(8)
     cls1 = Class(name=name, namespace=a_namespace)

--- a/cfme/tests/automate/test_method.py
+++ b/cfme/tests/automate/test_method.py
@@ -36,7 +36,7 @@ def a_method(a_class):
                   cls=a_class)
 
 
-def test_crud(a_method):
+def test_method_crud(a_method):
     a_method.create()
     origname = a_method.name
     with update(a_method):
@@ -48,7 +48,7 @@ def test_crud(a_method):
     assert not a_method.exists()
 
 
-def test_duplicate_disallowed(a_method):
+def test_duplicate_method_disallowed(a_method):
     a_method.create()
     with error.expected("Name has already been taken"):
         a_method.create()

--- a/cfme/tests/automate/test_namespace.py
+++ b/cfme/tests/automate/test_namespace.py
@@ -29,7 +29,7 @@ def namespace(request):
     return request.param()
 
 
-def test_crud(namespace):
+def test_namespace_crud(namespace):
     namespace.create()
     old_name = namespace.name
     with update(namespace):
@@ -40,7 +40,7 @@ def test_crud(namespace):
     assert not namespace.exists()
 
 
-def test_add_delete_nested(namespace):
+def test_add_delete_namespace_nested(namespace):
     namespace.create()
     nested_ns = Namespace(name="Nested", parent=namespace)
     nested_ns.create()
@@ -48,7 +48,7 @@ def test_add_delete_nested(namespace):
     assert not namespace.exists()
 
 
-def test_duplicate_disallowed(namespace):
+def test_duplicate_namespace_disallowed(namespace):
     namespace.create()
     with error.expected("Error during 'add': Validation failed: fqname must be unique"):
         namespace.create()


### PR DESCRIPTION
Changed names to make them less ambiguous, otherwise we can't run those specific tests from the cli without specifying the file they are from.
