### PR TITLE
Provisioning swap to mgmt_system.py

### DIFF
--- a/cfme/infrastructure/provider.py
+++ b/cfme/infrastructure/provider.py
@@ -234,6 +234,12 @@ class Provider(Updateable):
                           delay=10)
         client.disconnect()
 
+    def refresh_provider_relationships(self):
+        """Clicks on Refresh relationships button in provider"""
+        sel.force_navigate('infrastructure_provider', context={"provider": self})
+        tb.select("Configuration", "Refresh Relationships and Power States", invokes_alert=True)
+        sel.handle_alert(cancel=False)
+
     def get_mgmt_system(self):
         """ Returns the mgmt_system using the :py:func:`utils.providers.provider_factory` method.
         """

--- a/utils/mgmt_system.py
+++ b/utils/mgmt_system.py
@@ -670,7 +670,7 @@ class RHEVMSystem(MgmtSystemAPIBase):
             vm.start()
             wait_for(
                 lambda: self.is_vm_running(vm_name),
-                num_sec=180,
+                num_sec=240,
                 delay=5,
                 message="RHEV VM %s started" % vm_name
             )
@@ -685,7 +685,7 @@ class RHEVMSystem(MgmtSystemAPIBase):
             vm.stop()
             wait_for(
                 lambda: self.is_vm_stopped(vm_name),
-                num_sec=180,
+                num_sec=240,
                 delay=5,
                 message="RHEV VM %s stopped" % vm_name
             )
@@ -800,7 +800,8 @@ class RHEVMSystem(MgmtSystemAPIBase):
             vm.suspend()
             wait_for(
                 lambda: self.is_vm_suspended(vm_name),
-                message="wait for RHEV VM %s suspended" % vm_name
+                message="wait for RHEV VM %s suspended" % vm_name,
+                num_sec=240
             )
             return True
 


### PR DESCRIPTION
- swap miq_soap's provision from one from mgmt_system.py
- skips tests for the provider when provider fails to provision a VM (eg. full RHEV)
- some time tweaks
- changed one-line comments format.

When squashed, can be merged
