### PR TITLE
Made video recorder more robust

### DIFF
--- a/fixtures/video.py
+++ b/fixtures/video.py
@@ -15,15 +15,13 @@ import os
 import os.path
 import pytest
 import re
-import signal
-import subprocess
 
 from utils.conf import env
-from utils.log import logger
 from utils.path import log_path
-from utils.wait import wait_for, TimedOutError
+from utils.video import Recorder
 
 vid_options = env.get('logging', {}).get('video')
+recorder = None
 
 
 def get_path_and_file_name(node):
@@ -34,73 +32,34 @@ def get_path_and_file_name(node):
    Returns: 2-tuple `(path, filename)`
    """
     vid_name = re.sub(r"[^a-zA-Z0-9_.\-\[\]]", "_", node.name)  # Limit only sane characters
-    vid_name = re.sub(r"[/]", "_", vid_name)                    # To be sure this guy don't get in
+    vid_name = re.sub(r"[/]", "_", vid_name)                    # To be sure this guy doesn't get in
     vid_name = re.sub(r"__+", "_", vid_name)                    # Squash _'s to limit the length
     return node.parent.name, vid_name
 
 
-def process_running(pid):
-    """Check whether specified process is running"""
-    try:
-        os.kill(pid, 0)
-    except OSError as e:
-        if e.errno == 3:
-            return False
-        else:
-            raise
-    else:
-        return True
-
-
 @pytest.mark.tryfirst
 def pytest_runtest_setup(item):
+    global recorder
     if vid_options and vid_options['enabled']:
         vid_log_path = log_path.join(vid_options['dir'])
         vid_dir, vid_name = get_path_and_file_name(item)
         full_vid_path = vid_log_path.join(vid_dir)
         try:
-            os.makedirs(str(full_vid_path))
+            os.makedirs(full_vid_path.strpath)
         except OSError:
             pass
         vid_name = vid_name + ".ogv"
-        filename = str(full_vid_path.join(vid_name))
-        cmd_line = ['recordmydesktop',
-                    '--display', vid_options['display'],
-                    '-o', filename,
-                    '--no-sound',
-                    '--v_quality', vid_options['display'],
-                    '--on-the-fly-encoding',
-                    '--overwrite']
-        try:
-            proc = subprocess.Popen(cmd_line, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            with open(str(vid_log_path.join('pid')), "w") as f:
-                f.write(str(proc.pid))
-            try:
-                wait_for(
-                    lambda: full_vid_path.join(vid_name).exists(),
-                    num_sec=10, message="recording of %s started" % item.name
-                )
-            except TimedOutError:
-                logger.exception("Could not check whether recording of %s started!" % item.name)
-        except OSError:
-            logger.exception("Couldn't initialize videoer! Make sure recordmydesktop is installed!")
+        recorder = Recorder(full_vid_path.join(vid_name).strpath)
+        recorder.start()
 
 
 def stop_recording():
-    if vid_options and vid_options['enabled']:
-        vid_log_path = log_path.join(vid_options['dir'])
+    global recorder
+    if recorder is not None:
         try:
-            with open(str(vid_log_path.join('pid')), "r") as f:
-                pid = int(f.read())
-        except IOError:
-            return  # No PID file, therefore no recorder running.
-        if process_running(pid):
-            os.kill(pid, signal.SIGINT)
-            os.waitpid(pid, 0)
-            vid_log_path.join('pid').remove()
-            logger.info("Recording finished")
-        else:
-            logger.exception("Could not find recordmydesktop process %d!" % pid)
+            recorder.stop()
+        finally:
+            recorder = None
 
 
 @pytest.mark.trylast

--- a/scripts/record.py
+++ b/scripts/record.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+"""Video recording script.
+
+Use when you want to record something separately
+"""
+import time
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
+from utils.video import Recorder
+
+
+parser = ArgumentParser(
+    epilog=__doc__,
+    formatter_class=RawDescriptionHelpFormatter
+)
+
+parser.add_argument("filename", help="File name to save the recording in")
+parser.add_argument("--display", default=None, type=str, help="Display to record")
+parser.add_argument("--quality", default=None, type=int, help="Recording quality")
+args = parser.parse_args()
+
+with Recorder(args.filename, args.display, args.quality):
+    alive = True
+    while alive:
+        try:
+            time.sleep(1)
+        except KeyboardInterrupt:
+            alive = False
+        except:
+            pass

--- a/utils/video.py
+++ b/utils/video.py
@@ -1,0 +1,94 @@
+"""Video recording library
+
+Configuration for this module + fixture:
+```yaml
+    logging:
+       video:
+           enabled: True
+           dir: video
+           display: ":99"
+           quality: 10
+```
+"""
+
+import os
+import subprocess
+
+from py.path import local
+from signal import SIGINT
+
+from utils.conf import env
+from utils.log import logger
+from utils.wait import wait_for, TimedOutError
+
+vid_options = env.get('logging', {}).get('video')
+
+
+def process_running(pid):
+    """Check whether specified process is running"""
+    try:
+        os.kill(pid, 0)
+    except OSError as e:
+        if e.errno == 3:
+            return False
+        else:
+            raise
+    else:
+        return True
+
+
+class Recorder(object):
+    """Recorder class
+
+    Usage:
+
+        with Recorder(filename):
+            # do something
+
+        # or
+        r = Recorder(filename)
+        r.start()
+        # do something
+        r.stop()
+
+    The first way is preferred, obviously
+    """
+    def __init__(self, filename, display=None, quality=None):
+        self.filename = filename
+        self.display = display or vid_options["display"]
+        self.quality = quality or vid_options["quality"]
+        self.pid = None
+
+    def start(self):
+        cmd_line = ['recordmydesktop',
+                    '--display', str(self.display),
+                    '-o', str(self.filename),
+                    '--no-sound',
+                    '--v_quality', str(self.quality),
+                    '--on-the-fly-encoding',
+                    '--overwrite']
+        try:
+            proc = subprocess.Popen(cmd_line, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            self.pid = proc.pid
+        except OSError:
+            logger.exception("Couldn't initialize videoer! Make sure recordmydesktop is installed!")
+
+    def stop(self):
+        if self.pid is not None:
+            if process_running(self.pid):
+                os.kill(self.pid, SIGINT)
+                os.waitpid(self.pid, 0)
+                logger.info("Recording finished")
+                self.pid = None
+            else:
+                logger.exception("Could not find recordmydesktop process #%d" % self.pid)
+
+    def __enter__(self):
+        self.start()
+
+    def __exit__(self, t, v, tb):
+        self.stop()
+
+    def __del__(self):
+        """If the reference is lost and the object is destroyed ..."""
+        self.stop()


### PR DESCRIPTION
- sends sigint instead of sighup
- waits for the recorder process to finish
- runs the recorder shutdown code also on test interruption
# UPDATE
- separated the recorder into 3 files:
  - `utils/video.py` - does all the magic
  - `fixtures/video.py` - hooks into py.test
  - `scripts/recorder.py` - standalone script for recording
