### PR TITLE
Style consistency update

### DIFF
--- a/cfme/tests/test_appliance.py
+++ b/cfme/tests/test_appliance.py
@@ -1,11 +1,8 @@
-''' Tests around the appliance '''
-
 # -*- coding: utf-8 -*-
-import re
+"""Tests around the appliance"""
 
 import pytest
-
-from unittestzero import Assert
+import re
 
 pytestmark = pytest.mark.smoke
 
@@ -25,35 +22,35 @@ pytestmark = pytest.mark.smoke
     'rhnlib',
 ])
 def test_rpms_present(ssh_client, package):
-    ''' Verifies nfs-util rpms are in place needed for pxe & nfs operations'''
+    """Verifies nfs-util rpms are in place needed for pxe & nfs operations"""
     exit, stdout = ssh_client.run_command('rpm -q %s' % package)
-    Assert.true('is not installed' not in stdout)
-    Assert.equal(exit, 0)
+    assert 'is not installed' not in stdout
+    assert exit == 0
 
 
 # this is going to fail on 5.1
 def test_selinux_enabled(ssh_client):
-    ''' Verfies selinux is enabled '''
+    """Verifies selinux is enabled"""
     stdout = ssh_client.run_command('getenforce')[1]
-    Assert.contains('Enforcing', stdout)
+    assert 'Enforcing' in stdout
 
 
 def test_iptables_running(ssh_client):
-    ''' Verifies iptables service is running on the appliance'''
+    """Verifies iptables service is running on the appliance"""
     stdout = ssh_client.run_command('service iptables status')[1]
-    Assert.true('is not running' not in stdout)
+    assert 'is not running' not in stdout
 
 
 def test_httpd_running(ssh_client):
-    ''' Verifies httpd service is running on the appliance '''
+    """Verifies httpd service is running on the appliance"""
     stdout = ssh_client.run_command('service httpd status')[1]
-    Assert.contains('is running', stdout)
+    assert 'is running' in stdout
 
 
 def test_evm_running(ssh_client):
-    ''' Verifies overall evm service is running on the appliance '''
+    """Verifies overall evm service is running on the appliance"""
     stdout = ssh_client.run_command('service evmserverd status | grep EVM')[1]
-    Assert.contains('started', stdout)
+    assert 'started' in stdout
 
 
 @pytest.mark.parametrize(('service'), [
@@ -64,9 +61,9 @@ def test_evm_running(ssh_client):
     'postgresql92-postgresql',
 ])
 def test_chkconfig_on(ssh_client, service):
-    ''' Verifies if key services are configured to start on boot up '''
+    """Verifies if key services are configured to start on boot up"""
     stdout = ssh_client.run_command('chkconfig | grep ' + service)[1]
-    Assert.contains('5:on', stdout)
+    assert '5:on' in stdout
 
 
 @pytest.mark.parametrize(('rule'), [
@@ -75,25 +72,25 @@ def test_chkconfig_on(ssh_client, service):
     'ACCEPT     tcp  --  anywhere             anywhere            state NEW tcp dpt:https'
 ])
 def test_iptables_rules(ssh_client, rule):
-    ''' Verifies key iptable rules are in place '''
+    """Verifies key iptable rules are in place"""
     stdout = ssh_client.run_command('iptables -L')[1]
-    Assert.contains(rule, stdout)
+    assert rule in stdout
 
 
 # this is based on expected changes tracked in github/ManageIQ/cfme_build repo
 def test_memory_total(ssh_client):
-    ''' Verifies that the total memory on the box is >= 6GB '''
+    """Verifies that the total memory on the box is >= 6GB"""
     stdout = ssh_client.run_command(
         'free -g | grep Mem: | awk \'{ print $2 }\'')[1]
-    Assert.true(stdout >= 6)
+    assert stdout >= 6
 
 
 # this is based on expected changes tracked in github/ManageIQ/cfme_build repo
 def test_cpu_total(ssh_client):
-    ''' Verifies that the total number of cpus is >= 4 '''
+    """Verifies that the total number of cpus is >= 4"""
     stdout = ssh_client.run_command(
         'lscpu | grep ^CPU\(s\): | awk \'{ print $2 }\'')[1]
-    Assert.true(stdout >= 4)
+    assert stdout >= 4
 
 
 @pytest.mark.parametrize(("filename", "given_md5"), [
@@ -101,7 +98,7 @@ def test_cpu_total(ssh_client):
     ("/etc/pki/product/167.pem", None)
 ])
 def test_certificates_present(ssh_client, filename, given_md5):
-    """ Test whether the required product certificates are present.
+    """Test whether the required product certificates are present.
 
     This test is parametrized with the given file and its MD5 hash.
     If the given MD5 hash is ``None``, it won't be checked.
@@ -110,12 +107,12 @@ def test_certificates_present(ssh_client, filename, given_md5):
     `Ships with /etc/pki/product/<id>.pem where RHEL is "69" and CF is "167"`
     """
     file_exists = bool(ssh_client.run_command("ls '%s'" % filename)[0]) == 0
-    Assert.true(file_exists, "File %s does not exist!" % filename)
+    assert file_exists, "File %s does not exist!" % filename
     if given_md5:
         md5_of_file = ssh_client.run_command("md5sum '%s'" % filename)[1].strip()
         # Format `abcdef0123456789<whitespace>filename
         md5_of_file = re.split(r"\s+", md5_of_file, 1)[0]
-        Assert.equal(given_md5, md5_of_file)
+        assert given_md5 == md5_of_file
 
 
 def test_db_connection(db):
@@ -123,7 +120,6 @@ def test_db_connection(db):
 
     This looks for a row in the miq_databases table, which should always exist
     on an appliance with a working database and UI
-
     """
     databases = db.session.query(db['miq_databases']).all()
-    Assert.greater(len(databases), 0)
+    assert len(databases) > 0

--- a/utils/tests/test_async.py
+++ b/utils/tests/test_async.py
@@ -1,13 +1,13 @@
-import string
-
+# -*- coding: utf-8 -*-
 import pytest
-from unittestzero import Assert
-
+import string
 from utils.async import ResultsPool
 
+
 def async_task(arg1, arg2):
-    # Task to reverse argument. Asynchronously...
+    """Task to reverse argument. Asynchronously..."""
     return arg2, arg1
+
 
 @pytest.mark.nondestructive
 @pytest.mark.skip_selenium
@@ -15,11 +15,12 @@ def test_async():
     with ResultsPool(processes=3) as pool:
         for letter, digit in zip(string.letters[:3], string.digits[:3]):
             pool.apply_async(async_task, [letter, digit])
-    Assert.true(pool.successful)
+
+    assert pool.successful
 
     for result in pool.results:
         # Result should have reversed args, i.e.
         # digit, letter = async_task(letter, digit)
         digit, letter = result.get()
-        Assert.contains(digit, string.digits)
-        Assert.contains(letter, string.letters)
+        assert digit in string.digits
+        assert letter in string.letters

--- a/utils/tests/test_datafile_fixture.py
+++ b/utils/tests/test_datafile_fixture.py
@@ -1,18 +1,21 @@
+# -*- coding: utf-8 -*-
 import pytest
-from unittestzero import Assert
 
 pytestmark = [
     pytest.mark.nondestructive,
     pytest.mark.skip_selenium
 ]
 
+
 def test_datafile_fixture_read(datafile, request):
     myfile = datafile('test_template')
-    Assert.equal(myfile.read(), '$replaceme')
+    assert myfile.read() == '$replaceme'
+
 
 def test_datafile_fixture_read_slash_path(datafile, request):
     myfile = datafile('/utils/test_datafile_fixture/test_template')
-    Assert.equal(myfile.read(), '$replaceme')
+    assert myfile.read() == '$replaceme'
+
 
 def test_datafile_fixture_read_template(datafile, request):
     replacements = {
@@ -20,4 +23,4 @@ def test_datafile_fixture_read_template(datafile, request):
     }
 
     myfile = datafile('test_template', replacements=replacements)
-    Assert.equal(myfile.read(), replacements['replaceme'])
+    assert myfile.read() == replacements['replaceme']

--- a/utils/tests/test_fixtureconf_fixture.py
+++ b/utils/tests/test_fixtureconf_fixture.py
@@ -5,12 +5,14 @@ pytestmark = [
     pytest.mark.skip_selenium
 ]
 
+
 @pytest.mark.fixtureconf('positional argument', kwarg='keyword argument')
 def test_fixtureconf_fixture_with_mark(fixtureconf):
     # args and kwargs should be in fixtureconf
     assert fixtureconf['args'] == ('positional argument',)
     assert fixtureconf['kwarg'] == 'keyword argument'
 
+
 def test_fixtureconf_fixture_without_mark(fixtureconf):
     # no mark = no args stored in fixtureconf, but the fixture should still work
-    assert fixtureconf == {'args': (),}
+    assert fixtureconf == {'args': (), }

--- a/utils/tests/test_randomness.py
+++ b/utils/tests/test_randomness.py
@@ -1,8 +1,5 @@
-import random
-
+# -*-coding: utf-8
 import pytest
-from unittestzero import Assert
-
 from utils import randomness
 
 pytestmark = [
@@ -10,38 +7,44 @@ pytestmark = [
     pytest.mark.skip_selenium,
 ]
 
+
 def test_generate_random_string_noargs():
     random_string = randomness.generate_random_string()
     # 8 is the default length
-    Assert.equal(len(random_string), 8)
+    assert len(random_string) == 8
+
 
 def test_generate_random_string_args():
     length = 16
     random_string = randomness.generate_random_string(length)
-    Assert.equal(len(random_string), length)
+    assert len(random_string) == length
+
 
 def test_generate_random_int_noargs():
     # maxint is the default max, so no need to check against it
     random_int = randomness.generate_random_int()
-    Assert.greater(random_int, 0)
+    assert random_int > 0
+
 
 def test_generate_random_int_args():
     maxvalue = 1
     random_int = randomness.generate_random_int(maxvalue)
-    Assert.greater_equal(random_int, 0)
-    Assert.less_equal(random_int, maxvalue)
+    assert 0 <= random_int <= maxvalue
+
 
 def test_generate_random_uuid():
-    # Not sure if there's a better test than a string of normal uuid length (36)
+    """Not sure if there's a better test than a string of normal uuid length (36)"""
     uuid = randomness.generate_random_uuid_as_str()
-    Assert.equal(len(uuid), 36)
-    Assert.true(isinstance(uuid, basestring))
+    assert len(uuid) == 36
+    assert isinstance(uuid, basestring)
+
 
 def test_randomness_fixtures(random_uuid_as_string, random_string):
-    # Make sure the fixtures work as intended
-    Assert.equal(len(random_uuid_as_string), 36)
-    Assert.true(isinstance(random_uuid_as_string, basestring))
-    Assert.true(isinstance(random_string, basestring))
+    """Make sure the fixtures work as intended"""
+    assert len(random_uuid_as_string) == 36
+    assert isinstance(random_uuid_as_string, basestring)
+    assert isinstance(random_string, basestring)
+
 
 @pytest.fixture(scope="class")
 def random_stash(request):
@@ -55,23 +58,24 @@ def random_stash(request):
     request.cls.after = randomness.RandomizeValues.from_dict(request.cls.before)
     request.cls.again = randomness.RandomizeValues.from_dict(request.cls.before)
 
+
 @pytest.mark.usefixtures("random_stash")
 class TestRandomizeValues(object):
     def test_randomizevalues(self):
         # These should be different in the two dicts
-        Assert.not_equal(self.after['str'], self.before['str'])
-        Assert.not_equal(self.after['tuple'], self.before['tuple'])
-        Assert.not_equal(self.after['list'], self.before['list'])
-        Assert.not_equal(self.after['set'], self.before['set'])
+        assert self.after['str'] != self.before['str']
+        assert self.after['tuple'] != self.before['tuple']
+        assert self.after['list'] != self.before['list']
+        assert self.after['set'] != self.before['set']
 
     def test_randomizevalues_type(self):
-        # Object type should still be dict
-        Assert.true(isinstance(self.after, type(self.before)))
+        """Object type should still be dict"""
+        assert isinstance(self.after, type(self.before))
 
     def test_randomizevalues_bogus_randomizer(self):
-        # Unmatched randomizer shouldn't change
-        Assert.equal(self.after['notrandom'], self.before['notrandom'])
+        """Unmatched randomizer shouldn't change"""
+        assert self.after['notrandom'] == self.before['notrandom']
 
     def test_randomizevalues_again(self):
-        # If we generate the dict again, it should be newly randomized
-        Assert.not_equal(self.after, self.again)
+        """If we generate the dict again, it should be newly randomized"""
+        assert self.after != self.again

--- a/utils/tests/test_ssh_client.py
+++ b/utils/tests/test_ssh_client.py
@@ -1,6 +1,5 @@
+# -*- coding: utf-8 -*-
 import pytest
-from unittestzero import Assert
-
 from utils.randomness import generate_random_string
 
 pytestmark = [
@@ -8,11 +7,13 @@ pytestmark = [
     pytest.mark.skip_selenium,
 ]
 
+
 def test_ssh_client_run_command(ssh_client):
     # Make sure the ssh command runner works
     exit_status, output = ssh_client.run_command('echo Testing!')
-    Assert.equal(exit_status, 0)
-    Assert.contains('Testing!', output)
+    assert exit_status == 0
+    assert 'Testing!' in output
+
 
 def test_ssh_client_copies(ssh_client):
     ssh_client_kwargs = {
@@ -25,27 +26,27 @@ def test_ssh_client_copies(ssh_client):
     ssh_client_copy = ssh_client(**ssh_client_kwargs)
     orig_kwargs = ssh_client._connect_kwargs
     copy_kwargs = ssh_client_copy._connect_kwargs
-    Assert.not_equal(orig_kwargs['username'], copy_kwargs['username'])
-    Assert.not_equal(orig_kwargs['password'], copy_kwargs['password'])
-    Assert.not_equal(orig_kwargs['hostname'], copy_kwargs['hostname'])
+    assert orig_kwargs['username'] != copy_kwargs['username']
+    assert orig_kwargs['password'] != copy_kwargs['password']
+    assert orig_kwargs['hostname'] != copy_kwargs['hostname']
 
     # And also make sure the ssh copy only updates new kwargs
     ssh_client_copy = ssh_client(hostname=generate_random_string())
     copy_kwargs = ssh_client_copy._connect_kwargs
-    Assert.equal(orig_kwargs['username'], copy_kwargs['username'])
-    Assert.equal(orig_kwargs['password'], copy_kwargs['password'])
-    Assert.not_equal(orig_kwargs['hostname'], copy_kwargs['hostname'])
+    assert orig_kwargs['username'] == copy_kwargs['username']
+    assert orig_kwargs['password'] == copy_kwargs['password']
+    assert orig_kwargs['hostname'] != copy_kwargs['hostname']
+
 
 def test_scp_client_can_put_a_file(ssh_client, tmpdir):
     # Make sure we can put a file, get a file, and they all match
     tmpfile = tmpdir.mkdir("sub").join("temp.txt")
     tmpfile.write("content")
     ssh_client.put_file(str(tmpfile), '/tmp')
-    exit_status, output = ssh_client.run_command(
-            "ls /tmp/%s" % tmpfile.basename)
-    Assert.equal(exit_status, 0)
-    Assert.contains(tmpfile.basename, output)
+    exit_status, output = ssh_client.run_command("ls /tmp/%s" % tmpfile.basename)
+    assert exit_status == 0
+    assert tmpfile.basename in output
     ssh_client.get_file("/tmp/%s" % tmpfile.basename, str(tmpdir))
-    Assert.contains("content", tmpfile.read())
+    assert "content" in tmpfile.read()
     # Clean up the server
     ssh_client.run_command("rm -f /tmp/%s" % tmpfile.basename)

--- a/utils/tests/test_wait.py
+++ b/utils/tests/test_wait.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=W0621
 import pytest
-from unittestzero import Assert
-from utils.wait import wait_for, TimedOutError
 import time
+from utils.wait import wait_for, TimedOutError
 
 pytestmark = [
     pytest.mark.nondestructive,
@@ -26,7 +25,7 @@ def test_simple_wait():
                       fail_condition=0,
                       delay=.05)
     print "Function output %s in time %s " % (ec, tc)
-    Assert.less(tc, 1, "Should take less than 1 seconds")
+    assert tc < 1, "Should take less than 1 seconds"
 
 
 def test_lambda_wait():
@@ -35,14 +34,10 @@ def test_lambda_wait():
                       [incman],
                       delay=.05)
     print "Function output %s in time %s " % (ec, tc)
-    Assert.less(tc, 2, "Should take less than 2 seconds")
+    assert tc < 2, "Should take less than 2 seconds"
 
 
 def test_lambda_long_wait():
     incman = Incrementor()
-    Assert.raises(TimedOutError,
-                  wait_for,
-                  lambda self: self.i_sleep_a_lot() > 10,
-                  [incman],
-                  num_sec=1,
-                  message="waiting for sleepy head")
+    with pytest.raises(TimedOutError):
+        wait_for(lambda self: self.i_sleep_a_lot() > 10, [incman], num_sec=1, message="this fails")


### PR DESCRIPTION
If anyone interested ...
- `tests/appliance/test_appliance.py` moved to `cfme/tests/`, its style updated to the latest standard
- tests in `utils/tests/` which did not conform the pep8 were restyled and `unittestzero.Assert` removed.
