### PR TITLE
Add cmdline filtering of providers

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -22,5 +22,10 @@ def _pytest_plugins_generator(*extension_pkgs):
             if not is_package:
                 yield modname
 
+
+def pytest_addoption(parser):
+    parser.addoption("--use-provider", action="append", default=[],
+        help="list of providers or tags to include in test")
+
 pytest_plugins = tuple(_pytest_plugins_generator(fixtures, markers, cfme.fixtures))
 collect_ignore = ["tests/scenarios"]

--- a/utils/testgen.py
+++ b/utils/testgen.py
@@ -230,6 +230,14 @@ def provider_by_type(metafunc, provider_types, *fields):
             # Skip unwanted types
             continue
 
+        cmd_filter = metafunc.config.getvalueorskip('use_provider')
+        if not cmd_filter:
+            cmd_filter = ["default"]
+        tags = data.get('tags', [])
+        if cmd_filter:
+            if provider not in cmd_filter and not set(tags) & set(cmd_filter):
+                continue
+
         # Use the provider name for idlist, helps with readable parametrized test output
         idlist.append(provider)
 


### PR DESCRIPTION
Allows the usage of --use-provider to specify a provider to filter tests
by using the yaml key and allows a `tags: enabled, vsphere, drs` style key for each management system to allow filtering by groups/tags. `--use-provider vsphere --use-provider drs`
