### PR TITLE
Use sets for comparison of accessible pages

### DIFF
--- a/cfme/tests/integration/test_aws_iam_auth_and_roles.py
+++ b/cfme/tests/integration/test_aws_iam_auth_and_roles.py
@@ -23,4 +23,4 @@ def test_group_roles(configure_aws_iam_auth_mode, group_name, group_data):
         pytest.fail('No match in credentials file for group "%s"' % iam_group_name)
 
     force_login_user(username, password)
-    assert menu.visible_pages() == group_data
+    assert set(menu.visible_pages()) == set(group_data)

--- a/cfme/tests/integration/test_ldap_auth_and_roles.py
+++ b/cfme/tests/integration/test_ldap_auth_and_roles.py
@@ -22,4 +22,4 @@ def test_group_roles(configure_ldap_auth_mode, group_name, group_data):
         pytest.fail('No match in credentials file for group "%s"' % group_name)
 
     force_login_user(username, password)
-    assert menu.visible_pages() == group_data
+    assert set(menu.visible_pages()) == set(group_data)


### PR DESCRIPTION
# Before

```
>       assert menu.visible_pages() == group_data
E       assert ['about', 'ch...astores', ...] == ['about', 'cha...astores', ...]
E         At index 8 diff: 'infrastructure_pxe' != 'infrastructure_repositories'
E         Left contains more items, first extra item: 'timelines'
```
# After

```
>       assert set(menu.visible_pages()) == set(group_data)
E       assert set(['about',...ol_log', ...]) == set(['about', ...ol_log', ...])
E         Extra items in the left set:
E         'infrastructure_pxe'
```

Better and correct.
