### PR TITLE
browser_session - Make sure that base_url is reset when things go wrong

### DIFF
--- a/utils/browser.py
+++ b/utils/browser.py
@@ -144,9 +144,11 @@ def browser_session(*args, **kwargs):
     """
     conf.env['base_url'] = kwargs['base_url']
     browser = start(*args, **kwargs)
-    yield browser
-    quit()
-    conf.clear()
+    try:
+        yield browser
+    finally:
+        quit()
+        conf.clear()
 
 
 def _load_firefox_profile():


### PR DESCRIPTION
There is a wrong base_url present in `conf.env['base_url']` when vm_analysis test fails inside a `with browser_session(base_url=<ip_address>):`

see: https://url.corp.redhat.com/7386c31

I'm pretty sure it's because the code after the yield statement is not executed and this should fix it.
