### PR TITLE
[Jenkins] Old timeline tests now wait for VM to be steady before powering on.

### DIFF
--- a/tests/ui/infrastructure/test_timelines.py
+++ b/tests/ui/infrastructure/test_timelines.py
@@ -55,6 +55,7 @@ def pytest_generate_tests(metafunc):
 
 @pytest.fixture(scope="module")
 def power_on_vm(mgmt_sys_api_clients, provider, vm_name):
+    mgmt_sys_api_clients[provider].wait_vm_steady(vm_name)
     mgmt_sys_api_clients[provider].start_vm(vm_name)
 
 

--- a/utils/mgmt_system.py
+++ b/utils/mgmt_system.py
@@ -246,6 +246,33 @@ class MgmtSystemAPIBase(object):
         requested_stats = requested_stats or self._stats_available
         return {stat: self._stats_available[stat](self) for stat in requested_stats}
 
+    def in_steady_state(self, vm_name):
+        """Return whether the specified virtual machine is in steady state
+
+        Args:
+            vm_name: VM name
+        Returns: boolean
+        """
+        return (
+            self.is_vm_running(vm_name)
+            or self.is_vm_stopped(vm_name)
+            or self.is_vm_suspended(vm_name)
+        )
+
+    def wait_vm_steady(self, vm_name, num_sec=120):
+        """Waits 2 (or user-specified time) minutes for VM to settle in steady state
+
+        Args:
+            vm_name: VM name
+            num_sec: Timeout for wait_for
+        """
+        return wait_for(
+            lambda: self.in_steady_state(vm_name),
+            num_sec=num_sec,
+            delay=2,
+            message="VM %s in steady state" % vm_name
+        )
+
 
 class VMWareSystem(MgmtSystemAPIBase):
     """Client to Vsphere API


### PR DESCRIPTION
Because powering on a restoring or suspending machine is not a good idea, as it makes problems.

The mgmt_sys maybe call `wait_vm_steady` function before all calls to power on, power off, suspend to prevent these problems automatically. Right?

_/me has very similar code in control actions testing_
