### PR TITLE
[Jenkins] Circumvent issue #716 in Control imp_exp

### DIFF
--- a/cfme/control/import_export.py
+++ b/cfme/control/import_export.py
@@ -34,7 +34,7 @@ def import_file(filename, cancel=False):
     fill(
         import_form,
         {"file_select": filename},
-        action=import_form.upload_button
     )
+    sel.click(import_form.upload_button)
     flash.assert_no_errors()
     return sel.click(upload_buttons.cancel_button if cancel else upload_buttons.commit_button)

--- a/cfme/tests/control/test_import_policies.py
+++ b/cfme/tests/control/test_import_policies.py
@@ -12,7 +12,7 @@ def import_policy_file(request):
     return data_path.join("ui/control/policies.yaml").realpath().strpath
 
 
-@pytest.sel.go_to('dashboard')
+@pytest.sel.go_to('control_import_export')
 def test_import_policies(import_policy_file):
     import_export.import_file(import_policy_file)
     flash.assert_no_errors()


### PR DESCRIPTION
When we learn automation to be able to use `<input type="submit">` in `fill(action=)`, then we can put it back.
