### PR TITLE
Added module for handling Rails exceptions

### DIFF
--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -10,6 +10,12 @@ class CFMEException(Exception):
     pass
 
 
+class CFMEExceptionOccured(CFMEException):
+    """Raised by :py:func:`cfme.web_ui.cfme_exception.assert_no_cfme_exception` when there is
+    a Rails exception currently on page."""
+    pass
+
+
 class AddProviderError(CFMEException):
     pass
 

--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -22,6 +22,7 @@
   * :py:class:`Table`
   * :py:class:`Tree`
   * :py:mod:`cfme.web_ui.accordion`
+  * :py:mod:`cfme.web_ui.cfme_exception`
   * :py:mod:`cfme.web_ui.flash`
   * :py:mod:`cfme.web_ui.listnav`
   * :py:mod:`cfme.web_ui.menu`

--- a/cfme/web_ui/cfme_exception.py
+++ b/cfme/web_ui/cfme_exception.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+"""Module handling the Rails exceptions from CFME"""
+
+from cfme.exceptions import CFMEExceptionOccured
+from cfme.fixtures import pytest_selenium as sel
+from cfme.web_ui import Region
+
+
+cfme_exception_region = Region(
+    locators=dict(
+        root_div="//div[@id='exception_div']",
+        error_text="//div[@id='exception_div']//td[@id='maincol']/div[2]/h3[2]",
+    ),
+    identifying_loc="root_div",
+)
+
+
+def is_cfme_exception():
+    """Check whether an exception is displayed on the page"""
+    return cfme_exception_region.is_displayed()
+
+
+def cfme_exception_text():
+    """Get the error message from the exception"""
+    return sel.text(cfme_exception_region.error_text)
+
+
+def assert_no_cfme_exception():
+    """Raise an exception if CFME exception occured
+
+    Raises: :py:class:`cfme.exceptions.CFMEExceptionOccured`
+    """
+    if is_cfme_exception():
+        raise CFMEExceptionOccured(cfme_exception_text())


### PR DESCRIPTION
To check whether an "Unexpected error encountered" screen is displayed.

_Idea: Maybe we could hook these calls into the pytest_selenium internals to log all the exceptions in some file? wait_for_ajax might do assert_no_exception() and could log that somehow. Also force_navigate should react properly on this exception by restarting browser_
