### PR TITLE
SSHClient uses the appliance in env.yaml by default

### DIFF
--- a/scripts/loosen_pgssl_connections.py
+++ b/scripts/loosen_pgssl_connections.py
@@ -12,15 +12,17 @@ from utils.ssh import SSHClient
 def main():
     parser = argparse.ArgumentParser(epilog=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument('address', help='hostname or ip address of target appliance')
+    parser.add_argument('address', help='hostname or ip address of target appliance',
+        nargs='?', default=None)
 
     args = parser.parse_args()
 
     ssh_kwargs = {
         'username': credentials['ssh']['username'],
         'password': credentials['ssh']['password'],
-        'hostname': args.address
     }
+    if args.address:
+        ssh_kwargs['hostname'] = args.address
 
     # Init SSH client
     client = SSHClient(**ssh_kwargs)


### PR DESCRIPTION
so address is optional
