### PR TITLE
force_navigate detects blocker_div and cfme exceptions

### DIFF
--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -17,7 +17,8 @@ import json
 from pkg_resources import parse_version
 from selenium.common.exceptions import \
     (ErrorInResponseException, InvalidSwitchToTargetException, NoSuchAttributeException,
-     NoSuchElementException, NoAlertPresentException, UnexpectedAlertPresentException)
+     NoSuchElementException, NoAlertPresentException, UnexpectedAlertPresentException,
+     InvalidElementStateException)
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
@@ -548,10 +549,6 @@ def force_navigate(page_name, _tries=0, *args, **kwargs):
     # Set this to True in the handlers below to trigger a browser restart
     recycle = False
 
-    # If the page is blocked, then recycle...
-    if is_displayed("//div[@id='blocker_div']"):
-        recycle = True
-
     try:
         # What we'd like to happen...
         login.login_admin()
@@ -578,6 +575,20 @@ def force_navigate(page_name, _tries=0, *args, **kwargs):
         # The some of the navigation steps cannot succeed
         logger.info('Cannot continue with navigation due to: %s; Recycling browser' % str(e))
         recycle = True
+    except (NoSuchElementException, InvalidElementStateException):
+        from cfme.web_ui import cfme_exception as cfme_exc  # To prevent circular imports
+        # If the page is blocked, then recycle...
+        if is_displayed("//div[@id='blocker_div']"):
+            logger.warning("Page was blocked with blocker div, recycling.")
+            recycle = True
+        elif cfme_exc.is_cfme_exception():
+            logger.exception("CFME Exception before force_navigate started!: `{}`".format(
+                cfme_exc.cfme_exception_text()
+            ))
+            recycle = True
+        else:
+            logger.error("Could not determine the reason for failing the navigation. Reraising.")
+            raise
 
     if recycle:
         browser().quit()


### PR DESCRIPTION
We can circumvent some situtions with this. This recycles browser when go_to faces an exception that it cannot find an element or it is not visible. Then if it is a blocker div or a cfme exception, browser will be recycled. Otherwise the exception is re-raised.
