### PR TITLE
test_actions now use testgen

### DIFF
--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -2043,7 +2043,7 @@ def fill_cb_select_set(select, names):
 
 
 @fill.method((CheckboxSelect, Mapping))
-def fill_cb_select_dictlist(select, dictlist, action):
+def fill_cb_select_dictlist(select, dictlist):
     return select.check(dictlist)
 
 


### PR DESCRIPTION
- tested only first test function, but the principle what it works on is the same.
- I added `VMWrapper` class because I desperately needed to unify interaction with VM to one place.
