### PR TITLE
Change multidispatch `str` -> `basestring`

### DIFF
--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -667,7 +667,7 @@ def _select_tuple(loc, val):
     select_by_value(Select(element(loc)), val.value)
 
 
-@select.method((object, str))
+@select.method((object, basestring))
 @select.method((object, ByText))
 def _select_str(loc, s):
     move_to_element(loc)  # Not having this caused problems in upstream, the select wasn't visible
@@ -742,7 +742,7 @@ def _deselect_val(loc, val):
     deselect_by_value(loc, val.value)
 
 
-@deselect.method((object, str))
+@deselect.method((object, basestring))
 @deselect.method((object, ByText))
 def _deselect_text(loc, s):
     deselect_by_text(loc, str(s))

--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -1740,7 +1740,7 @@ class DHTMLSelect(Select):
             self.select_by_index(index, _cascade=True)
 
 
-@sel.select.method((DHTMLSelect, str))
+@sel.select.method((DHTMLSelect, basestring))
 def select_dhtml(dhtml, s):
     dhtml.select_by_visible_text(s)
 


### PR DESCRIPTION
- caused recursion problems when filling Select with unicode as it treated unicode as iterable.
- so I changed all occurences I could find in pytest_selenium and web_ui.
