### PR TITLE
Fixed automate tests

### DIFF
--- a/cfme/tests/automate/test_instance.py
+++ b/cfme/tests/automate/test_instance.py
@@ -36,7 +36,7 @@ def an_instance(a_class):
                     cls=a_class)
 
 
-def test_crud(an_instance):
+def test_instance_crud(an_instance):
     an_instance.create()
     origname = an_instance.name
     with update(an_instance):

--- a/scripts/clone_domain.py
+++ b/scripts/clone_domain.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python2
+
+"""Clone an Automate Domain
+
+eg, clone_domain.py xx.xx.xx.xx ManageIQ Default
+
+This can take several minutes to run.
+
+"""
+import argparse
+import sys
+
+from utils.conf import credentials
+from utils.ssh import SSHClient
+
+
+def main():
+    parser = argparse.ArgumentParser(epilog=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('hostname', nargs='?', default=None,
+        help='hostname or ip address of target appliance')
+    parser.add_argument('source', nargs='?', default='ManageIQ',
+        help='Source Domain name')
+    parser.add_argument('dest', nargs='?', default='Default',
+        help='Destination Domain name')
+    parser.add_argument('username', nargs='?', default=credentials['ssh']['username'],
+        help='SSH username for target appliance')
+    parser.add_argument('password', nargs='?', default=credentials['ssh']['password'],
+        help='SSH password for target appliance')
+
+    args = parser.parse_args()
+
+    ssh_kwargs = {
+        'username': args.username,
+        'password': args.password
+    }
+    if args.hostname is not None:
+        ssh_kwargs['hostname'] = args.hostname
+
+    client = SSHClient(stream_output=True, **ssh_kwargs)
+
+    print 'Exporting domain...'
+    export_opts = 'DOMAIN={} EXPORT_DIR=/tmp/miq PREVIEW=false OVERWRITE=true'.format(args.source)
+    export_cmd = 'evm:automate:export {}'.format(export_opts)
+    print export_cmd
+    client.run_rake_command(export_cmd)
+    ro_fix_cmd = "sed -i 's/system: true/system: false/g' /tmp/miq/ManageIQ/__domain__.yaml"
+    client.run_command(ro_fix_cmd)
+    import_opts = 'DOMAIN={} IMPORT_DIR=/tmp/miq PREVIEW=false'.format(args.source)
+    import_opts += ' OVERWRITE=true IMPORT_AS={}'.format(args.dest)
+    import_cmd = 'evm:automate:import {}'.format(import_opts)
+    print import_cmd
+    client.run_rake_command(import_cmd)
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
- A new class is added call Domain which represents the new Domain level in the Tree.
- At the moment domain is an arg to make_path which allows you to have the same ability to create namespaces from paths that you did before.
- Extra trickery is needed to sort the button labels, as the path length is no longer 1, but 2 because of the introduction of the domain.
- Changed test_crud to test_instance_crud in the instance tests.
