### PR TITLE
[Proposal] Element chaining

### DIFF
--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -353,7 +353,7 @@ class Table(object):
             # Get a root locator ready, self._body_loc is the SplitTable body locator
             root = sel.element(self._root_loc)
             # Get all td elements that contain the value text
-            matching_rows_list.append(sel.elements(cell_text_loc % value, root))
+            matching_rows_list.append(sel.elements(cell_text_loc % value, root=root))
 
         # Now, find the common row elements that matched all the input cells
         # (though not yet matching values to headers)


### PR DESCRIPTION
This patch enables to pass also functions to elements() call. When the object that should be resolved as an element is callable, then it is called like elements(o()). This makes possible to chain functions that depend on some parent element without worrying about some of them being stale because all the element chain will be resolved on each call.

A stupid example follows:

``` python
table = lambda: element("//*[@id='consolidate_div']/fieldset[2]/table") 
tbody = lambda: element("./tbody", root=table) 
keys = lambda: element(".//td[contains(@class, 'key')]", root=tbody) 
element(keys)
=> <selenium.webdriver.remote.webelement.WebElement at 0x3321bd0>
```

If the root locator resolves to multiple elements, then all of them are used and the resulting list of webelements is made with joining all lists taht came from all root elements.
