### PR TITLE
quadicon locate always returns anchor

### DIFF
--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -1574,11 +1574,9 @@ class Quadicon(object):
         return "//input[@type='checkbox' and ../../..//a[@title='%s']]" % self._name
 
     def locate(self):
-        """ Returns:  a locator for the quadicon itself"""
-        return sel.move_to_element(sel.ver_pick({
-            '9.9.9.9': "//div[@id='quadicon']/../../..//a[@title='%s']" % self._name,
-            'default': "//div[@id='quadicon' and ../../..//a[@title='%s']]" % self._name
-        }))
+        """ Returns:  a locator for the quadicon anchor"""
+        return sel.move_to_element(sel.element('div/a',
+            root="//div[@id='quadicon' and ../../..//a[@title='%s']]" % self._name))
 
     def _locate_quadrant(self, corner):
         """ Returns: a locator for the specific quadrant"""


### PR DESCRIPTION
We had two locators for quadicons:
- `'9.9.9.9': "//div[@id='quadicon']/../../..//a[@title='%s']" % self._name`
- `'default': "//div[@id='quadicon' and ../../..//a[@title='%s']]" % self._name`

9.9.9.9 returns the anchor element, default returns div#quadicon.

My 5.2.3 appliance was breaking because it was getting the div back, and
doing sel.click on the quadicon div wasn't triggering navigation to the
quadicon's anchor href
