### PR TITLE
Minor tweak to uncollect output

### DIFF
--- a/markers/uncollect.py
+++ b/markers/uncollect.py
@@ -30,4 +30,4 @@ def pytest_collection_modifyitems(session, config, items):
         # --collect-only output?
         terminalreporter = reporter(config)
         terminalreporter.write('collected %d items' % len_filtered, bold=True)
-        terminalreporter.write(' (uncollect mark removed %d items), ' % filtered_count)
+        terminalreporter.write(' (uncollected %d items)\n' % filtered_count)


### PR DESCRIPTION
The previous method doesn't look right in all situations,
particularly parallelized testing
