### PR TITLE
Fix linear nav mouse move issue

### DIFF
--- a/cfme/web_ui/menu.py
+++ b/cfme/web_ui/menu.py
@@ -85,6 +85,11 @@ def nav_to_fn(toplevel, secondlevel=None):
             sel.click(toplevel_elem)
         else:
             sel.move_to_element(toplevel_elem)
+            for (toplevel_dest, toplv), secondlevels in sections.items():
+                if toplv == toplevel:
+                    sel.move_to_element(sel.element(
+                        secondlevel_loc % (toplevel, secondlevels[0][1])))
+                    break
             sel.click(sel.element(secondlevel_loc % (toplevel, secondlevel)))
     return f
 


### PR DESCRIPTION
In the navigation selenuim seems to move from point A to point B in a
linear vector. Consequently in the navigation if this vector passes over
another top level navigation menu, the top level will be selected and
the intended second level navigation item will become invisibile leading
to a failure. This fix opens the top level navigation and then drops to
the first second level element, before moving to the intended second
level element, effectively creating an L shape two step navigation,
instead of a straight diagonal vector.
