### PR TITLE
Add action-chain-based click to pytest_selenium.click() instead of the current element.click()

### DIFF
--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -273,7 +273,11 @@ def click(loc, wait_ajax=True):
         wait_ajax: Whether to wait for ajax call to finish. Default True but sometimes it's
             handy to not do that. (some toolbar clicks)
     """
-    move_to_element(loc).click()
+    # Move mouse cursor to element
+    move_to_element(loc)
+    # and then click on current mouse position
+    ActionChains(browser()).click().perform()
+    # -> using this approach, we don't check if we clicked a specific element
     if wait_ajax:
         wait_for_ajax()
 
@@ -290,8 +294,9 @@ def move_to_element(loc, **kwargs):
     brand = "//div[@id='page_header_div']//div[contains(@class, 'brand')]"
     wait_for_ajax()
     el = element(loc, **kwargs)
+    move_to = ActionChains(browser()).move_to_element(el)
     try:
-        ActionChains(browser()).move_to_element(el).perform()
+        move_to.perform()
     except MoveTargetOutOfBoundsException:
         # ff workaround
         browser().execute_script("arguments[0].scrollIntoView();", el)
@@ -301,6 +306,7 @@ def move_to_element(loc, **kwargs):
                 browser().execute_script("arguments[0].scrollIntoView();", element(brand))
             except MoveTargetOutOfBoundsException:
                 pass
+        move_to.perform()
     return el
 
 


### PR DESCRIPTION
This fixes the issue mentioned in #819 but not the issue in #827.

We first make sure that the mouse is moved to the right place and then just click - there is no checking for specific element present under the mouse pointer.
