### PR TITLE
quick fix: use hostname in SSHClient

### DIFF
--- a/utils/ssh.py
+++ b/utils/ssh.py
@@ -16,7 +16,8 @@ class SSHClient(paramiko.SSHClient):
     """
     def __init__(self, stream_output=False, **connect_kwargs):
         port = connect_kwargs.get('port', 22)
-        if not net_check(port):
+        addr = connect_kwargs.get('hostname', None)
+        if not net_check(port, addr=addr):
             raise Exception("Connection is not available as port is unavailable")
         super(SSHClient, self).__init__()
         self.set_missing_host_key_policy(paramiko.AutoAddPolicy())


### PR DESCRIPTION
When hostname is in connect_kwargs, use that as an address for checking port availability. If not, use base_url from env.yaml
