### PR TITLE
Better table scan

### DIFF
--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -351,7 +351,7 @@ class Table(object):
         matching_rows_list = list()
         for value in cells.values():
             # Get a root locator ready, self._body_loc is the SplitTable body locator
-            root = sel.element(self._root_loc)
+            root = sel.move_to_element(self._root_loc)
             # Get all td elements that contain the value text
             matching_rows_list.append(sel.elements(cell_text_loc % value, root=root))
 


### PR DESCRIPTION
This **should** fix  _test_services_request_direct_url_. It tries to circumvent the problem that sometimes when the element looked for is hidden, it is not correctly manipulated with selenium - not found. Usually when the element is hidden behind the bottom bar with crud buttons. Due to the nature of scanning, it should not hit the performance significantly. I could not reproduce that on my laptop though.
