### PR TITLE
Accordion tree use in Services

### DIFF
--- a/cfme/services/catalogs/catalog.py
+++ b/cfme/services/catalogs/catalog.py
@@ -1,16 +1,14 @@
-import cfme.fixtures.pytest_selenium as sel
-import cfme.web_ui.accordion as accordion
-import cfme.web_ui.flash as flash
-import cfme.web_ui as web_ui
-import cfme.web_ui.menu  # load the menu nav endpoints
-import cfme.web_ui.toolbar as tb
-import ui_navigate as nav
-import functools
+# -*- coding: utf-8 -*-
+from functools import partial
+
+from cfme import web_ui
+from cfme.fixtures import pytest_selenium as sel
+from cfme.web_ui import accordion, flash, menu
+from cfme.web_ui import toolbar as tb
 from utils.update import Updateable
 
-assert cfme.web_ui.menu  # to placate flake8 (otherwise menu import is unused)
-
-tb_select = functools.partial(tb.select, "Configuration")
+cfg_btn = partial(tb.select, "Configuration")
+catalog_tree = partial(accordion.tree, "Catalogs")
 
 item_multiselect = web_ui.MultiSelect(
     "//select[@id='available_fields']",
@@ -37,17 +35,29 @@ item_form = web_ui.Form(
 
 
 def _all_catalogs_add_new(_):
-    accordion.tree('Catalogs', 'All Catalogs')
-    tb_select('Add a New Catalog')
+    catalog_tree('All Catalogs')
+    cfg_btn('Add a New Catalog')
 
 
-nav.add_branch(
+menu.nav.add_branch(
     'services_catalogs',
-    {'catalogs': [nav.partial(accordion.click, 'Catalogs'),
-                  {'catalog_new': _all_catalogs_add_new,
-                   'catalog': [lambda ctx: accordion.tree('Catalogs', 'All Catalogs',
-                                                          ctx['catalog'].name),
-                               {'catalog_edit': nav.partial(tb_select, "Edit this Item")}]}]})
+    {
+        'catalogs':
+        [
+            lambda _: accordion.click('Catalogs'),
+            {
+                'catalog_new': _all_catalogs_add_new,
+                'catalog':
+                [
+                    lambda ctx: catalog_tree('All Catalogs', ctx['catalog'].name),
+                    {
+                        'catalog_edit': lambda _: cfg_btn("Edit this Item")
+                    }
+                ]
+            }
+        ]
+    }
+)
 
 
 class Catalog(Updateable):
@@ -76,6 +86,6 @@ class Catalog(Updateable):
 
     def delete(self):
         sel.force_navigate('catalog', context={'catalog': self})
-        tb_select("Remove Item from the VMDB", invokes_alert=True)
+        cfg_btn("Remove Item from the VMDB", invokes_alert=True)
         sel.handle_alert()
         flash.assert_success_message('Catalog "{}": Delete successful'.format(self.description))

--- a/cfme/services/catalogs/catalog_item.py
+++ b/cfme/services/catalogs/catalog_item.py
@@ -1,15 +1,15 @@
-import functools
-
-import ui_navigate as nav
-
-import cfme.fixtures.pytest_selenium as sel
-import cfme.web_ui.toolbar as tb
+# -*- coding: utf-8 -*-
+from functools import partial
 from collections import OrderedDict
-from cfme.web_ui import Form, Select, fill, Table, tabstrip, Radio, accordion, flash
+
+from cfme.fixtures import pytest_selenium as sel
+from cfme.web_ui import Form, Radio, Select, Table, accordion, fill, flash, menu, tabstrip
+from cfme.web_ui import toolbar as tb
 from utils.update import Updateable
 
 
-tb_select = functools.partial(tb.select, "Configuration")
+cfg_btn = partial(tb.select, "Configuration")
+accordion_tree = partial(accordion.tree, "Catalog Items")
 
 template_select_form = Form(
     fields=[
@@ -96,31 +96,52 @@ resources_form = Form(
 
 
 def _all_catalogitems_add_new(context):
-    accordion.tree('Catalog Items', 'All Catalog Items')
-    tb_select('Add a New Catalog Item')
+    accordion_tree('All Catalog Items')
+    cfg_btn('Add a New Catalog Item')
     provider_type = context['provider_type']
     sel.select("//select[@id='st_prov_type']", provider_type)
 
 
 def _all_catalogbundle_add_new(context):
-    accordion.tree('Catalog Items', 'All Catalog Items')
-    tb_select('Add a New Catalog Bundle')
+    accordion_tree('All Catalog Items')
+    cfg_btn('Add a New Catalog Bundle')
 
 
-nav.add_branch(
+menu.nav.add_branch(
     'services_catalogs',
-    {'catalog_items': [nav.partial(accordion.click, 'Catalog Items'),
-        {'catalog_item_new': _all_catalogitems_add_new,
-         'catalog_item': [lambda ctx: accordion.tree('Catalog Items', 'All Catalog Items',
-                                     ctx['catalog'], ctx['catalog_item'].name),
-                          {'catalog_item_edit': nav.partial(tb_select,
-                                                            "Edit this Item")}]}],
-     'catalog_bundle': [nav.partial(accordion.click, 'Catalog Items'),
-        {'catalog_bundle_new': _all_catalogbundle_add_new,
-         'catalog_bundle': [lambda ctx: accordion.tree('Catalog Items', 'All Catalog Items',
-                                       ctx['catalog'], ctx['catalog_bundle'].name),
-                            {'catalog_bundle_edit': nav.partial(tb_select,
-                                                                "Edit this Item")}]}]})
+    {
+        'catalog_items':
+        [
+            lambda _: accordion.click('Catalog Items'),
+            {
+                'catalog_item_new': _all_catalogitems_add_new,
+                'catalog_item':
+                [
+                    lambda ctx: accordion_tree(
+                        'All Catalog Items', ctx['catalog'], ctx['catalog_item'].name),
+                    {
+                        'catalog_item_edit': lambda _: cfg_btn("Edit this Item")
+                    }
+                ]
+            }
+        ],
+        'catalog_bundle':
+        [
+            lambda _: accordion.click('Catalog Items'),
+            {
+                'catalog_bundle_new': _all_catalogbundle_add_new,
+                'catalog_bundle':
+                [
+                    lambda ctx: accordion_tree(
+                        'All Catalog Items', ctx['catalog'], ctx['catalog_bundle'].name),
+                    {
+                        'catalog_bundle_edit': lambda _: cfg_btn("Edit this Item")
+                    }
+                ]
+            }
+        ]
+    }
+)
 
 
 class CatalogItem(Updateable):
@@ -166,7 +187,7 @@ class CatalogItem(Updateable):
 
     def delete(self):
         sel.force_navigate('catalog_item', context={'catalog': self.catalog, 'catalog_item': self})
-        tb_select("Remove Item from the VMDB", invokes_alert=True)
+        cfg_btn("Remove Item from the VMDB", invokes_alert=True)
         sel.handle_alert()
         flash.assert_success_message('The selected Catalog Item was deleted')
 

--- a/cfme/services/catalogs/service_catalogs.py
+++ b/cfme/services/catalogs/service_catalogs.py
@@ -1,7 +1,8 @@
-import ui_navigate as nav
+# -*- coding: utf-8 -*-
+from functools import partial
 
 import cfme.fixtures.pytest_selenium as sel
-from cfme.web_ui import Form, accordion, fill, flash
+from cfme.web_ui import Form, accordion, fill, flash, menu
 from utils.update import Updateable
 
 order_button = "//img[@title='Order this Service']"
@@ -10,13 +11,27 @@ service_order_form = Form(
     fields=[('dialog_service_name_field', "//tr/td[@title='ele_desc']/input[@id='service_name']"),
             ('submit_button', "//img[@title='Submit']")])
 
+accordion_tree = partial(accordion.tree, "Service Catalogs")
 
-nav.add_branch(
+menu.nav.add_branch(
     'services_catalogs',
-    {'service_catalogs': [nav.partial(accordion.click, 'Service Catalogs'),
-        {'service_catalog': [lambda ctx: accordion.tree('Service Catalogs', 'All Services',
-        ctx['catalog'], ctx['catalog_item'].name),
-            {'order_service_catalog': nav.partial(sel.click, order_button)}]}]})
+    {
+        'service_catalogs':
+        [
+            lambda _: accordion.click('Service Catalogs'),
+            {
+                'service_catalog':
+                [
+                    lambda ctx: accordion_tree(
+                        'All Services', ctx['catalog'], ctx['catalog_item'].name),
+                    {
+                        'order_service_catalog': lambda _: sel.click(order_button)
+                    }
+                ]
+            }
+        ]
+    }
+)
 
 
 class ServiceCatalogs(Updateable):


### PR DESCRIPTION
- use `accordion.tree` instead of relying on custom locators.
- some refactoring.
  - import ordering.
  - tried to normalize some variable names to the common ones.
  - I tried to make the trees a bit more readable.

`test_generic_service_catalogs` gave me 100% pass, others still fail but not on nav issues or so.

Will probably also need #850 to get the best pass rate. 
