### PR TITLE
[WIP] Fix fixture & register finalizer earlier & bz link

### DIFF
--- a/cfme/tests/infrastructure/test_pxe_provisioning.py
+++ b/cfme/tests/infrastructure/test_pxe_provisioning.py
@@ -67,9 +67,8 @@ def setup_pxe_servers_vm_prov(pxe_server, pxe_cust_template, provisioning):
 
 @pytest.fixture(scope="module")
 def vm_name():
-    # also tries to delete the VM that gets made with this name
     vm_name = 'test_pxe_prov_%s' % generate_random_string()
-    yield vm_name
+    return vm_name
 
 
 def cleanup_vm(vm_name, provider_key, provider_mgmt):
@@ -115,8 +114,11 @@ def test_pxe_provision_from_template(provider_key, provider_crud, provider_type,
         'vlan': pxe_vlan,
     }
 
+    # fails on upstream if ran after test_add_provider - BZ1087476
     fill(provisioning_form, provisioning_data, action=provisioning_form.submit_button)
     flash.assert_no_errors()
+
+    request.addfinalizer(lambda: cleanup_vm(vm_name, provider_key, provider_mgmt))
 
     # Wait for the VM to appear on the provider backend before proceeding to ensure proper cleanup
     logger.info('Waiting for vm %s to appear on provider %s', vm_name, provider_crud.key)
@@ -126,7 +128,6 @@ def test_pxe_provision_from_template(provider_key, provider_crud, provider_type,
     logger.info('Waiting for cfme provision request for vm %s' % vm_name)
     row_description = 'Provision from [%s] to [%s]' % (pxe_template, vm_name)
     cells = {'Description': row_description}
-    request.addfinalizer(lambda: cleanup_vm(vm_name, provider_key, provider_mgmt))
     row, __ = wait_for(requests.wait_for_request, [cells],
         fail_func=requests.reload, num_sec=1500, delay=20)
     assert row.last_message.text == 'VM Provisioned Successfully'


### PR DESCRIPTION
This will still fail on upstream jenkins if ran after test_add_provider.

Hovewer, on a clean appliance -> `py.test -k pxe_provision` should now run.
