### PR TITLE
Try to protect from StaleElementReferenceException in is_displayed

### DIFF
--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -748,10 +748,13 @@ def detect_observed_field(loc):
     If found, that interval will be used instead of the default.
 
     """
-    if is_displayed(loc):
-        el = element(loc)
-    else:
-        # Element not visible, sort out
+    try:
+        if is_displayed(loc):
+            el = element(loc)
+        else:
+            # Element not visible, sort out
+            return
+    except StaleElementReferenceException:
         return
 
     # Default wait period, based on the default UI wait (700ms)


### PR DESCRIPTION
I noticed that this happened in last Jenkins build in `test_ldap_auth_and_roles.py`.

If the passed locator is retrievable multiple times (string, ...), it is tried multiple times. Ignored with WebElement, as it is already broken if it raises StaleElementException.

**I could not reproduce this on my laptop**
