### PR TITLE
Fixed login tests

### DIFF
--- a/cfme/dashboard.py
+++ b/cfme/dashboard.py
@@ -2,21 +2,21 @@
 
 :var page: A :py:class:`cfme.web_ui.Region` holding locators on the dashboard page
 """
-from selenium.webdriver.common.by import By
 import cfme.fixtures.pytest_selenium as sel
-from cfme.web_ui import Region, Table
+from cfme.web_ui import Region, Table, toolbar
 from utils.timeutil import parsetime
 from utils.wait import wait_for
-from cfme.web_ui import Region
 
 _css_reset_button = 'div.dhx_toolbar_btn[title="Reset Dashboard Widgets to the defaults"] img'
 
 page = Region(
     title="CloudForms Management Engine: Dashboard",
     locators={
-        'reset_widgets_button': (By.CSS_SELECTOR, _css_reset_button),
+        'reset_widgets_button': toolbar.root_loc('Reset Dashboard Widgets'),
         'csrf_token': "//meta[@name='csrf-token']",
-    })
+        'user_dropdown': '//div[@id="page_header_div"]//li[contains(@class, "dropdown")]',
+    },
+    identifying_loc='reset_widgets_button')
 
 
 def reset_widgets(cancel=False):

--- a/cfme/login.py
+++ b/cfme/login.py
@@ -10,6 +10,7 @@ from selenium.webdriver.common.keys import Keys
 
 import cfme.fixtures.pytest_selenium as sel
 import cfme.web_ui.flash as flash
+from cfme import dashboard
 from cfme.web_ui import Region, Form, fill
 from utils import conf
 from utils.log import logger
@@ -26,17 +27,17 @@ class User(object):
         self.username = username
 
 
-page = Region(title="CloudForms Management Engine: Dashboard",
+page = Region(
+    title="Dashboard",
     locators={
         'username': '//input[@id="user_name"]',
         'password': '//input[@id="user_password"]',
         'submit_button': '//a[@id="login"]',
         # Login page has an abnormal flash div
         'flash': '//div[@id="flash_div"]',
-        'user_dropdown': '//div[@id="page_header_div"]//li[contains(@class, "dropdown")]',
         'logout': '//a[contains(@href, "/logout")]',
     },
-    identifying_loc='username')
+    identifying_loc='submit_button')
 
 _form_fields = ('username', 'password', 'submit_button')
 form = Form(fields=[loc for loc in page.locators.items() if loc[0] in _form_fields],
@@ -51,7 +52,7 @@ def _click_on_login():
 
 
 def logged_in():
-    if sel.is_displayed(page.user_dropdown):
+    if sel.is_displayed(dashboard.page.user_dropdown):
         return True
 
 
@@ -111,13 +112,13 @@ def logout():
     """
     if logged_in():
         if not sel.is_displayed(page.logout):
-            sel.click(page.user_dropdown)
+            sel.click(dashboard.page.user_dropdown)
         sel.click(page.logout)
         thread_locals.current_user = None
 
 
 def _full_name():
-    return sel.text(page.user_dropdown).split('|')[0].strip()
+    return sel.text(dashboard.page.user_dropdown).split('|')[0].strip()
 
 
 def current_full_name():

--- a/cfme/tests/test_login.py
+++ b/cfme/tests/test_login.py
@@ -2,7 +2,7 @@ import pytest
 from cfme import dashboard
 from cfme.login import login_admin, login, logout
 from cfme.login import page as login_page
-from utils import conf
+from utils import conf, error
 
 pytestmark = pytest.mark.usefixtures('browser')
 
@@ -13,19 +13,13 @@ def test_login():
     pytest.sel.get(pytest.sel.base_url())
     login_admin()
     assert dashboard.page.is_displayed(), "Could not determine if logged in"
+    logout()
+    assert login_page.is_displayed()
 
 
 def test_bad_password():
     """ Tests logging in with a bad password. """
     pytest.sel.get(pytest.sel.base_url())
-    login(conf.credentials['default']['username'], "badpassword@#$")
-    expected_error = 'the username or password you entered is incorrect'
-    assert login_page.is_displayed()
-    assert expected_error in pytest.sel.text(login_page.flash)
-
-
-@pytest.sel.go_to('dashboard')
-def test_logout(logged_in):
-    """ Testst that the provder can be logged out of. """
-    logout()
+    with error.expected('Sorry, the username or password you entered is incorrect.'):
+        login(conf.credentials['default']['username'], "badpassword@#$")
     assert login_page.is_displayed()

--- a/cfme/web_ui/flash.py
+++ b/cfme/web_ui/flash.py
@@ -8,17 +8,20 @@ from utils.log import logger
 from utils import version
 from cfme.versions import upstream
 
-area = Region(locators=
-              {'message': version.pick(
-                  {'default': '//div[starts-with(@id, "flash_") and '
-                   'not(ancestor::*[contains(@style,"display: none")])]//li'
-                   '| //div[@id="flash_div"]',  # login screen
-                   '5.3': '//div[starts-with(@id, "flash_") and '
-                   'not(ancestor::*[contains(@style,"display: none")])]'
-                   '//div[contains(@class,"alert")]'
-                   })
-               })
-
+area = Region(locators={
+    'message': version.pick({
+        'default': ' | '.join([
+            ('//div[starts-with(@id, "flash_") and '
+                'not(ancestor::*[contains(@style,"display: none")])]//li'),
+            '//div[@id="flash_div"]',  # login screen
+        ]),
+        '5.3': ' | '.join([
+            ('//div[starts-with(@id, "flash_") and '
+                'not(ancestor::*[contains(@style,"display: none")])]'),
+            '//div[contains(@class,"alert")]'
+        ])
+    })
+})
 _mapping_new = {
     "alert-warning": "warning",
     "alert-success": "success",


### PR DESCRIPTION
Major change is the logical OR-ing of locators in the flash region;
the login page flash_div was never being looked for based on my
selenium logging.

Minor changes:
- Login and logout are combined into one test
- Bad password test now expects the error being raised by a failed login
- user dropdown moved to dashboard, since it isn't visible on the login page
- dashboard gets an identifying_loc
