### PR TITLE
Join provider crud tasks into single test

### DIFF
--- a/cfme/cloud/provider.py
+++ b/cfme/cloud/provider.py
@@ -166,6 +166,8 @@ class Provider(Updateable):
         fill(properties_form, self._form_mapping(True, **self.__dict__))
         fill(credential_form, self.credentials, validate=validate_credentials)
         self._submit(cancel, add_page.add_submit)
+        if not cancel:
+            flash.assert_message_match('Cloud Providers "%s" was saved' % self.name)
 
     def update(self, updates, cancel=False, validate_credentials=False):
         """
@@ -181,6 +183,9 @@ class Provider(Updateable):
         fill(properties_form, self._form_mapping(**updates))
         fill(credential_form, updates.get('credentials', None), validate=validate_credentials)
         self._submit(cancel, edit_page.save_button)
+        name = updates['name'] or self.name
+        if not cancel:
+            flash.assert_message_match('Cloud Provider "%s" was saved' % name)
 
     def delete(self, cancel=True):
         """
@@ -193,6 +198,9 @@ class Provider(Updateable):
         sel.force_navigate('cloud_provider', context={'provider': self})
         cfg_btn('Remove this Cloud Provider from the VMDB', invokes_alert=True)
         sel.handle_alert(cancel=cancel)
+        if not cancel:
+            flash.assert_message_match(
+                'Delete initiated for 1 Cloud Provider from the CFME Database')
 
     def validate(self):
         """ Validates that the detail page matches the Providers information.

--- a/cfme/infrastructure/provider.py
+++ b/cfme/infrastructure/provider.py
@@ -160,6 +160,8 @@ class Provider(Updateable):
         fill(credential_form, self.credentials, validate=validate_credentials)
         fill(credential_form, self.candu, validate=validate_credentials)
         self._submit(cancel, add_infra_provider)
+        if not cancel:
+            flash.assert_message_match('Infrastructure Providers "%s" was saved' % self.name)
 
     def update(self, updates, cancel=False, validate_credentials=False):
         """
@@ -176,6 +178,9 @@ class Provider(Updateable):
         fill(credential_form, updates.get('credentials', None), validate=validate_credentials)
         fill(credential_form, updates.get('candu', None), validate=validate_credentials)
         self._submit(cancel, form_buttons.save)
+        name = updates['name'] or self.name
+        if not cancel:
+            flash.assert_message_match('Infrastructure Provider "%s" was saved' % name)
 
     def delete(self, cancel=True):
         """
@@ -188,6 +193,9 @@ class Provider(Updateable):
         sel.force_navigate('infrastructure_provider', context={'provider': self})
         cfg_btn('Remove this Infrastructure Provider from the VMDB', invokes_alert=True)
         sel.handle_alert(cancel=cancel)
+        if not cancel:
+            flash.assert_message_match(
+                'Delete initiated for 1 Infrastructure Provider from the CFME Database')
 
     def validate(self):
         """ Validates that the detail page matches the Providers information.

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -42,15 +42,6 @@ def test_providers_discovery_amazon():
     provider.wait_for_a_provider()
 
 
-@pytest.mark.smoke
-@pytest.mark.usefixtures('has_no_cloud_providers')
-def test_provider_add(provider_crud):
-    """ Tests that a provider can be added """
-    provider_crud.create()
-    flash.assert_message_match('Cloud Providers "%s" was saved' % provider_crud.name)
-    provider_crud.validate()
-
-
 @pytest.mark.usefixtures('has_no_cloud_providers')
 def test_provider_add_with_bad_credentials(provider_crud):
     provider_crud.credentials = provider.get_credentials_from_config('bad_credentials')
@@ -58,21 +49,19 @@ def test_provider_add_with_bad_credentials(provider_crud):
         provider_crud.create(validate_credentials=True)
 
 
+@pytest.mark.smoke
 @pytest.mark.usefixtures('has_no_cloud_providers')
-def test_provider_edit(provider_crud):
-    """ Tests that editing a management system shows the proper detail after an edit."""
+def test_provider_crud(provider_crud):
+    """ Tests that a provider can be added """
     provider_crud.create()
+    provider_crud.validate()
+
     old_name = provider_crud.name
     with update(provider_crud):
         provider_crud.name = str(uuid.uuid4())  # random uuid
-    flash.assert_message_match('Cloud Provider "%s" was saved' % provider_crud.name)
 
     with update(provider_crud):
         provider_crud.name = old_name  # old name
-    flash.assert_message_match('Cloud Provider "%s" was saved' % provider_crud.name)
 
-
-def test_provider_delete(provider_crud):
     provider_crud.delete(cancel=False)
-    flash.assert_message_match('Delete initiated for 1 Cloud Provider from the CFME Database')
     provider.wait_for_provider_delete(provider_crud)

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -122,16 +122,6 @@ def test_providers_discovery(provider_crud):
     provider.wait_for_a_provider()
 
 
-@pytest.mark.smoke
-@pytest.mark.usefixtures('has_no_infra_providers')
-def test_provider_add(provider_crud):
-    """ Tests that a provider can be added """
-    provider_crud.create()
-    flash.assert_message_match('Infrastructure Providers "%s" was saved' % provider_crud.name)
-    # Fails on upstream, all provider types - BZ1087476
-    provider_crud.validate()
-
-
 @pytest.mark.usefixtures('has_no_infra_providers')
 def test_provider_add_with_bad_credentials(provider_crud):
     provider_crud.credentials = provider.get_credentials_from_config('bad_credentials')
@@ -143,22 +133,20 @@ def test_provider_add_with_bad_credentials(provider_crud):
             provider_crud.create(validate_credentials=True)
 
 
+@pytest.mark.smoke
 @pytest.mark.usefixtures('has_no_infra_providers')
-def test_provider_edit(provider_crud):
-    """ Tests that editing a management system shows the proper detail after an edit."""
+def test_provider_crud(provider_crud):
+    """ Tests that a provider can be added """
     provider_crud.create()
+    # Fails on upstream, all provider types - BZ1087476
+    provider_crud.validate()
+
     old_name = provider_crud.name
     with update(provider_crud):
         provider_crud.name = str(uuid.uuid4())  # random uuid
-    flash.assert_message_match('Infrastructure Provider "%s" was saved' % provider_crud.name)
 
     with update(provider_crud):
         provider_crud.name = old_name  # old name
-    flash.assert_message_match('Infrastructure Provider "%s" was saved' % provider_crud.name)
 
-
-def test_provider_delete(provider_crud):
     provider_crud.delete(cancel=False)
-    flash.assert_message_match(
-        'Delete initiated for 1 Infrastructure Provider from the CFME Database')
     provider.wait_for_provider_delete(provider_crud)


### PR DESCRIPTION
- Provider tests were not able to run in isloation.
- Provider tests asserted flash messages instead of in crud operations.
- Add/Edit/Delete tests combined into single Crud tests and assertions
  moved into proper location.
