### PR TITLE
Always take a browser screenshot

### DIFF
--- a/fixtures/browser.py
+++ b/fixtures/browser.py
@@ -51,6 +51,11 @@ def pytest_exception_interact(node, call, report):
         'full_tb': full_tb,
     }
 
+    # Before trying to take a screenshot, we used to check if one of the browser_fixtures was
+    # in this node's fixturenames, but that was too limited and preventing the capture of
+    # screenshots. If removing that conditional now makes this too broad, we should consider
+    # an isinstance(val, WebDriverException) check in addition to the browser fixture check that
+    # exists here in commit 825ef50fd84a060b58d7e4dc316303a8b61b35d2
     try:
         template_data['screenshot'] = utils.browser.browser().get_screenshot_as_base64()
         art_client.fire_hook('filedump', test_name=node.name, test_location=node.parent.name,


### PR DESCRIPTION
Many tests are failing because they aren't marked to use the browser,
despite doing so in the course of their tests.

So, rather than inspecting the fixtures to decide whether or not to take
a screenshot, we'll just go ahead and take one. There's enough info in
the artifactor report now that we can easily decide if the screenshot is
useful.
