### PR TITLE
Fix RH updates

### DIFF
--- a/cfme/configure/red_hat_updates.py
+++ b/cfme/configure/red_hat_updates.py
@@ -178,6 +178,8 @@ def register_appliances(*appliance_names):
     """
     select_appliances(*appliance_names)
     sel.click(update_buttons.register)
+    flash.assert_message_match("Registration has been initiated for the selected Servers")
+    flash.dismiss()
 
 
 def update_appliances(*appliance_names):
@@ -188,6 +190,8 @@ def update_appliances(*appliance_names):
     """
     select_appliances(*appliance_names)
     sel.click(update_buttons.apply_updates)
+    flash.assert_message_match("Update has been initiated for the selected Servers")
+    flash.dismiss()
 
 
 def check_updates(*appliance_names):
@@ -198,6 +202,8 @@ def check_updates(*appliance_names):
     """
     select_appliances(*appliance_names)
     sel.click(update_buttons.check_updates)
+    flash.assert_message_match("Check for updates has been initiated for the selected Servers")
+    flash.dismiss()
 
 
 def are_registered(*appliance_names):

--- a/cfme/tests/configure/test_update_appliances.py
+++ b/cfme/tests/configure/test_update_appliances.py
@@ -7,7 +7,6 @@
 
 from cfme.configure.configuration import set_server_role
 from cfme.configure import red_hat_updates
-from cfme.web_ui import flash
 from utils import conf
 from utils.appliance import provision_appliance_set
 from utils.log import logger
@@ -142,13 +141,11 @@ def update_registration(appliance_set, rh_updates_data, reg_method):
             proxy_username=proxy_creds['username'],
             proxy_password=proxy_creds['password']
         )
-        flash.assert_message_match("Customer Information successfully saved")
 
 
 def register_appliances(appliance_set, appliances_to_register):
     with appliance_set.primary.browser_session():
         red_hat_updates.register_appliances(*appliances_to_register)
-        flash.assert_message_match("Registration has been initiated for the selected Servers")
 
         logger.info('Waiting for appliance statuses to change to Registered')
         wait_for(red_hat_updates.are_registered,
@@ -311,7 +308,6 @@ def run_cfme_updates(appliance_set, rh_updates_data, appliances_to_update):
     """
     with appliance_set.primary.browser_session():
         red_hat_updates.update_appliances(*appliances_to_update)
-        flash.assert_message_match("Update has been initiated for the selected Servers")
 
         version_match_args = [rh_updates_data['current_version']] + appliances_to_update
 


### PR DESCRIPTION
**Moved flash asserts from tests to page.**

Currently, the test fails because there is a flash assert for "_Customer Information successfully saved_" both in page and test - this PR takes care of that and introduces a few more flash msg checks.

**Downstream only.**
### To test:

---

**py.test -k register** (runtime: 5min - RHSM with http proxy fails in 5.2.4.x due to BZ1102724, but 5.2.3.x is full PASS)
**py.test -k update_appliances --long-running** (runtime: hours - but @mfalesni could stop by and check the results - whatchasay?)

Also **jkrocil-updates-test** job on jenkins (5.2.4.2 + firefox)...
