### PR TITLE
Fix ldap and aws fixture

### DIFF
--- a/cfme/fixtures/configure_auth_mode.py
+++ b/cfme/fixtures/configure_auth_mode.py
@@ -1,6 +1,7 @@
 import pytest
 from utils.conf import cfme_data, credentials
 from cfme.configure import configuration
+from cfme.login import login_admin
 
 
 @pytest.fixture(scope='session')
@@ -15,6 +16,7 @@ def configure_ldap_auth_mode(browser, available_auth_modes):
         server_data = cfme_data['auth_modes']['ldap']
         configuration.set_auth_mode(**server_data)
         yield
+        login_admin()
         configuration.set_auth_mode(mode='database')
     else:
         yield
@@ -30,6 +32,7 @@ def configure_aws_iam_auth_mode(browser, available_auth_modes):
         aws_iam_data['secret_key'] = aws_iam_creds['password']
         configuration.set_auth_mode(**aws_iam_data)
         yield
+        login_admin()
         configuration.set_auth_mode(mode='database')
     else:
         yield


### PR DESCRIPTION
A tiny little fix, that does a lot of good.

It turns this:

```
cfme/tests/integration/test_aws_iam_auth_and_roles.py:11: test_group_roles[evmgroup-administrator] PASSED
cfme/tests/integration/test_aws_iam_auth_and_roles.py:11: test_group_roles[evmgroup-support] PASSED
cfme/tests/integration/test_aws_iam_auth_and_roles.py:11: test_group_roles[evmgroup-user_self_service] PASSED
cfme/tests/integration/test_aws_iam_auth_and_roles.py:11: test_group_roles[evmgroup-operator] FAILED
cfme/tests/integration/test_aws_iam_auth_and_roles.py:11: test_group_roles[evmgroup-approver] FAILED
cfme/tests/integration/test_aws_iam_auth_and_roles.py:11: test_group_roles[evmgroup-security] PASSED
cfme/tests/integration/test_aws_iam_auth_and_roles.py:11: test_group_roles[evmgroup-super_administrator] PASSED
cfme/tests/integration/test_aws_iam_auth_and_roles.py:11: test_group_roles[evmgroup-desktop] PASSED
cfme/tests/integration/test_aws_iam_auth_and_roles.py:11: test_group_roles[evmgroup-user] PASSED
cfme/tests/integration/test_aws_iam_auth_and_roles.py:11: test_group_roles[evmgroup-auditor] FAILED
cfme/tests/integration/test_aws_iam_auth_and_roles.py:11: test_group_roles[evmgroup-vm_user] PASSED
cfme/tests/integration/test_aws_iam_auth_and_roles.py:11: test_group_roles[evmgroup-user_limited_self_service] PASSED
cfme/tests/integration/test_aws_iam_auth_and_roles.py:11: test_group_roles[evmgroup-user_limited_self_service] ERROR
cfme/tests/integration/test_ldap_auth_and_roles.py:11: test_group_roles[evmgroup-administrator] ERROR
cfme/tests/integration/test_ldap_auth_and_roles.py:11: test_group_roles[evmgroup-support] ERROR
cfme/tests/integration/test_ldap_auth_and_roles.py:11: test_group_roles[evmgroup-user_self_service] ERROR
cfme/tests/integration/test_ldap_auth_and_roles.py:11: test_group_roles[evmgroup-operator] ERROR
cfme/tests/integration/test_ldap_auth_and_roles.py:11: test_group_roles[evmgroup-approver] ERROR
cfme/tests/integration/test_ldap_auth_and_roles.py:11: test_group_roles[evmgroup-security] ERROR
cfme/tests/integration/test_ldap_auth_and_roles.py:11: test_group_roles[evmgroup-super_administrator] ERROR
cfme/tests/integration/test_ldap_auth_and_roles.py:11: test_group_roles[evmgroup-desktop] ERROR
cfme/tests/integration/test_ldap_auth_and_roles.py:11: test_group_roles[evmgroup-user] ERROR
cfme/tests/integration/test_ldap_auth_and_roles.py:11: test_group_roles[evmgroup-auditor] ERROR
cfme/tests/integration/test_ldap_auth_and_roles.py:11: test_group_roles[evmgroup-vm_user] ERROR
cfme/tests/integration/test_ldap_auth_and_roles.py:11: test_group_roles[evmgroup-user_limited_self_service] ERROR

3 failed, 9 passed, 13 error
```

into this

```
cfme/tests/integration/test_aws_iam_auth_and_roles.py:11: test_group_roles[evmgroup-administrator] PASSED
cfme/tests/integration/test_aws_iam_auth_and_roles.py:11: test_group_roles[evmgroup-support] PASSED
cfme/tests/integration/test_aws_iam_auth_and_roles.py:11: test_group_roles[evmgroup-user_self_service] PASSED
cfme/tests/integration/test_aws_iam_auth_and_roles.py:11: test_group_roles[evmgroup-operator] FAILED
cfme/tests/integration/test_aws_iam_auth_and_roles.py:11: test_group_roles[evmgroup-approver] FAILED
cfme/tests/integration/test_aws_iam_auth_and_roles.py:11: test_group_roles[evmgroup-security] PASSED
cfme/tests/integration/test_aws_iam_auth_and_roles.py:11: test_group_roles[evmgroup-super_administrator] PASSED
cfme/tests/integration/test_aws_iam_auth_and_roles.py:11: test_group_roles[evmgroup-desktop] PASSED
cfme/tests/integration/test_aws_iam_auth_and_roles.py:11: test_group_roles[evmgroup-user] PASSED
cfme/tests/integration/test_aws_iam_auth_and_roles.py:11: test_group_roles[evmgroup-auditor] FAILED
cfme/tests/integration/test_aws_iam_auth_and_roles.py:11: test_group_roles[evmgroup-vm_user] PASSED
cfme/tests/integration/test_aws_iam_auth_and_roles.py:11: test_group_roles[evmgroup-user_limited_self_service] PASSED
cfme/tests/integration/test_ldap_auth_and_roles.py:11: test_group_roles[evmgroup-administrator] ^[OFPASSED
cfme/tests/integration/test_ldap_auth_and_roles.py:11: test_group_roles[evmgroup-support] PASSED
cfme/tests/integration/test_ldap_auth_and_roles.py:11: test_group_roles[evmgroup-user_self_service] PASSED
cfme/tests/integration/test_ldap_auth_and_roles.py:11: test_group_roles[evmgroup-operator] FAILED
cfme/tests/integration/test_ldap_auth_and_roles.py:11: test_group_roles[evmgroup-approver] FAILED
cfme/tests/integration/test_ldap_auth_and_roles.py:11: test_group_roles[evmgroup-security] PASSED
cfme/tests/integration/test_ldap_auth_and_roles.py:11: test_group_roles[evmgroup-super_administrator] PASSED
cfme/tests/integration/test_ldap_auth_and_roles.py:11: test_group_roles[evmgroup-desktop] PASSED
cfme/tests/integration/test_ldap_auth_and_roles.py:11: test_group_roles[evmgroup-user] PASSED
cfme/tests/integration/test_ldap_auth_and_roles.py:11: test_group_roles[evmgroup-auditor] FAILED
cfme/tests/integration/test_ldap_auth_and_roles.py:11: test_group_roles[evmgroup-vm_user] PASSED
cfme/tests/integration/test_ldap_auth_and_roles.py:11: test_group_roles[evmgroup-user_limited_self_service] PASSED

6 failed, 18 passed
```
