### PR TITLE
Fixes for timelines and is_displayed()

### DIFF
--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -28,7 +28,7 @@ def pytest_generate_tests(metafunc):
     testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope="module")
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def provider_init(provider_key):
     """cfme/infrastructure/provider.py provider object."""
     try:
@@ -43,7 +43,7 @@ def vm_name():
 
 
 @pytest.fixture(scope="module")
-def test_vm(request, provider_crud, provider_mgmt, vm_name):
+def test_vm(request, provider_crud, provider_mgmt, vm_name, provider_init):
     """Fixture to provision appliance to the provider being tested if necessary"""
     pytest.sel.force_navigate('infrastructure_providers')
     vm = Vm(vm_name, provider_crud)
@@ -64,7 +64,7 @@ def gen_events(delete_fx_provider_event, provider_crud, test_vm):
 
 
 @pytest.mark.downstream
-def test_provider_event(provider_crud, gen_events, test_vm, provider_init):
+def test_provider_event(provider_crud, gen_events, test_vm):
     pytest.sel.force_navigate('infrastructure_provider_timelines',
                               context={'provider': provider_crud})
     events = []
@@ -75,7 +75,7 @@ def test_provider_event(provider_crud, gen_events, test_vm, provider_init):
 
 
 @pytest.mark.downstream
-def test_host_event(provider_crud, gen_events, test_vm, provider_init):
+def test_host_event(provider_crud, gen_events, test_vm):
     test_vm.load_details()
     pytest.sel.click(details_page.infoblock.element('Relationships', 'Host'))
     toolbar.select('Monitoring', 'Timelines')
@@ -87,7 +87,7 @@ def test_host_event(provider_crud, gen_events, test_vm, provider_init):
 
 
 @pytest.mark.downstream
-def test_vm_event(provider_crud, gen_events, test_vm, provider_init):
+def test_vm_event(provider_crud, gen_events, test_vm):
     test_vm.load_details()
     toolbar.select('Monitoring', 'Timelines')
     events = []
@@ -98,7 +98,7 @@ def test_vm_event(provider_crud, gen_events, test_vm, provider_init):
 
 
 @pytest.mark.downstream
-def test_cluster_event(provider_crud, gen_events, test_vm, provider_init):
+def test_cluster_event(provider_crud, gen_events, test_vm):
     test_vm.load_details()
     pytest.sel.click(details_page.infoblock.element('Relationships', 'Cluster'))
     toolbar.select('Monitoring', 'Timelines')

--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -45,7 +45,6 @@ from datetime import date
 from collections import Sequence, Mapping, Callable
 
 from selenium.common import exceptions as sel_exceptions
-from selenium.webdriver.common.keys import Keys
 from selenium.common.exceptions import NoSuchElementException, MoveTargetOutOfBoundsException
 from multimethods import multimethod, multidispatch, Anything
 
@@ -129,7 +128,11 @@ class Region(object):
             logger.info('Identifying locator for region not found')
             ident_match = False
 
-        if self.title and browser_title == self.title:
+        if self.title is None:
+            # If we don't have a title we can't match it, and some Regions are multi-page
+            # so we can't have a title set.
+            title_match = True
+        elif self.title and browser_title == self.title:
             title_match = True
         else:
             logger.info("Title '%s' doesn't match expected title '%s'" %


### PR DESCRIPTION
- Timelines provider_init was not being set up before test_vm was
  attempting to refresh relationships. Made provider_init fixture a
  prerequisite for test_vm instead.
- is_displayed required a title to be set for a Region, but sometimes
  titles are not set as the Region is multipage, as title is not a
  required keyword, at the moment we jsut accept that if title is None,
  then the title matches.
