### PR TITLE
Set alert-related capability (FF and IE only)

### DIFF
--- a/conf/env.yaml.template
+++ b/conf/env.yaml.template
@@ -5,3 +5,4 @@ browser:
         desired_capabilities:
             platform: LINUX
             browserName: 'chrome'
+            unexpectedAlertBehaviour: 'ignore'


### PR DESCRIPTION
### What is this PR about and why do we want it in?

It turns out that Firefox and Internet Explorer (not tested) respond differently to expected and unexpected alerts (unexpected alert being an alert we are not waiting for actively using selenium).
When there is an unexpected alert present, Chrome ignores it and lets the user handle it, whereas FF dismisses it by default (not sure what IE does in such case).

However, for both IE and FF, this behavior can be set to ignore the unexpected alert and respond in the same way as Chrome does (= let user handle it).

And that's pretty much it.

**This PR takes care of UnexpectedAlertPresent issues in FF29 (and I bet IE as well, since it supports this capability too - although it is possible that the default response to an unexpected alert in IE is different from FF, so it might not be an issue there).**

Tested using `rananda/cloud-provider` branch, running

```
py.test cfme/tests/cloud/ -k "test_provider and (not crud)"
```
