### PR TITLE
Structural update of some Control Explorer objects

### DIFF
--- a/cfme/tests/control/test_basic.py
+++ b/cfme/tests/control/test_basic.py
@@ -292,8 +292,7 @@ def test_modify_vm_condition_expression(
     if verify is not None:
         sel.force_navigate("vm_condition_edit",
             context={"condition_name": vm_condition_for_expressions.description})
-        if not vm_condition_for_expressions.is_editing_expression:
-            sel.click(vm_condition_for_expressions.buttons.edit_expression)
+        vm_condition_for_expressions.form.expression.show_func()
         soft_assert(expression_editor.get_expression_as_text() == verify)
 
 


### PR DESCRIPTION
Simplification in style of my newer code (special fill behaviour handling removal and so).

_I am thinking if we can make metaclass where we just throw fields, some navigational things and then we get automatically generated CRUD class, because if it is done in this style, the CRUD methods are the same, just strings differ_

The other objects still are in the 'old school way' but that is for another PR ...
