### PR TITLE
Migrate server_roles fixture from old to new code

### DIFF
--- a/cfme/configure/configuration.py
+++ b/cfme/configure/configuration.py
@@ -1342,18 +1342,6 @@ def get_server_roles(navigate=True):
     return {name: sel.element(locator).is_selected() for (name, locator) in server_roles.fields}
 
 
-def set_server_role(role_name, state=True):
-    """ Change state of given role only
-
-    Args:
-        role_name: Name of the role to set/unset
-        state: Enable if `True`, disable otherwise (default `True`)
-    """
-    roles_to_set = get_server_roles()
-    roles_to_set[role_name] = state
-    set_server_roles(**roles_to_set)
-
-
 def set_ntp_servers(*servers):
     """ Set NTP servers on Configure / Configuration pages.
 

--- a/cfme/tests/configure/test_update_appliances.py
+++ b/cfme/tests/configure/test_update_appliances.py
@@ -5,7 +5,7 @@
 @author: jkrocil@redhat.com
 """
 
-from cfme.configure.configuration import set_server_role
+from cfme.configure.configuration import set_server_roles
 from cfme.configure import red_hat_updates
 from utils import conf
 from utils.appliance import provision_appliance_set
@@ -252,7 +252,7 @@ def rhn_mirror_setup(appliance_set):
     """
 
     with appliance_set.primary.browser_session():
-        set_server_role('rhn_mirror', True)
+        set_server_roles(rhn_mirror=True)
 
     appliance_set.primary.restart_evm_service()
 


### PR DESCRIPTION
This should get us a -1 on jenkins, because `test_pxe_provisioning.test_pxe_provision_from_template` is failing on server roles setup.

What is really happening is that the old code is not able to work around a different accordion being open in the  `Configure / Configuration` section - it tries to click the 'Server' tabbutton and fails -> we need `force_navigate` for that -> we have to use the new code.

Tested using downstream & upstream, test `test_mine_d` should fail (on purpose):

```
import pytest

@pytest.mark.fixtureconf(clear_roles=True)
def test_mine_a(server_roles):
    pass

@pytest.mark.fixtureconf(clear_roles=True)
def test_mine_a_again(server_roles):
    pass

@pytest.mark.fixtureconf(set_default_roles=True)
def test_mine_b(server_roles):
    pass

@pytest.mark.fixtureconf(server_roles='+rhn_mirror automate')
def test_mine_c(server_roles):
    pass

@pytest.mark.fixtureconf(server_roles='-nonexistent_role')
def test_mine_d(server_roles):
    pass

@pytest.mark.fixtureconf(server_roles_cfmedata=['server_roles', 'all'])
def test_mine_e(server_roles):
    pass
```

Also, `set_server_role` is removed and, where used, replaced with `set_server_roles` instead (in 1 file).
