### PR TITLE
Perf UI Bench Testing Code for vm infrastructure page

### DIFF
--- a/cfme/infrastructure/datastore.py
+++ b/cfme/infrastructure/datastore.py
@@ -132,3 +132,15 @@ class Datastore(object):
             if Quadicon(self.name, 'datastore').locate() in e.msg:
                 return False
             raise
+
+
+def get_all_datastores(do_not_navigate=False):
+    """Returns list of all datastores"""
+    if not do_not_navigate:
+        sel.force_navigate('infrastructure_datastores')
+    datastores = set([])
+    for page in paginator.pages():
+        for title in sel.elements(
+                "//div[@id='quadicon']/../../../tr/td/a[contains(@href,'storage/show')]"):
+            datastores.add(sel.get_attribute(title, "title"))
+    return datastores

--- a/cfme/infrastructure/provider.py
+++ b/cfme/infrastructure/provider.py
@@ -443,6 +443,18 @@ def _fill_credential(form, cred, validate=None):
         flash.assert_no_errors()
 
 
+def get_all_providers(do_not_navigate=False):
+    """Returns list of all providers"""
+    if not do_not_navigate:
+        sel.force_navigate('infrastructure_providers')
+    providers = set([])
+    for page in paginator.pages():
+        for title in sel.elements("//div[@id='quadicon']/../../../tr/td/a[contains(@href,"
+                "'ext_management_system/show')]"):
+            providers.add(sel.get_attribute(title, "title"))
+    return providers
+
+
 def get_credentials_from_config(credential_config_name):
     creds = conf.credentials[credential_config_name]
     return Provider.Credential(principal=creds['username'],

--- a/cfme/tests/perf/test_page_render_times_n_queries.py
+++ b/cfme/tests/perf/test_page_render_times_n_queries.py
@@ -1,0 +1,235 @@
+# -*- coding: utf-8 -*
+from cfme.infrastructure import virtual_machines
+from cfme.infrastructure.datastore import get_all_datastores
+from cfme.infrastructure.host import get_all_hosts
+from cfme.infrastructure.provider import get_all_providers
+from cfme.exceptions import CandidateNotFound
+from cfme.fixtures import pytest_selenium as sel
+from cfme.web_ui import listaccordion as list_acc
+from cfme.web_ui import paginator
+from cfme.web_ui import Quadicon
+from utils.conf import ui_bench_tests
+from utils.log import logger
+from utils.pagestats import PageStat
+from utils.path import log_path
+from utils.ssh import SSHTail
+from selenium.common.exceptions import NoSuchElementException
+import csv
+import datetime
+import re
+
+
+def analyze_page_stat(pages, soft_assert):
+    for page in pages:
+        logger.info(page)
+        if page.completedin > ui_bench_tests['page_render_threshold']:
+            soft_assert(False, 'Page Render Threshold ({} ms) exceeded: {}'.format(
+                ui_bench_tests['page_render_threshold'], page))
+            logger.warning('Slow Page, Slow Query(>1s) Count: %d' % len(page.slowselects))
+            for slow in page.slowselects:
+                logger.warning('Slow Query Log Line: ' + slow)
+        if page.selectcount > ui_bench_tests['query_count_threshold']:
+            soft_assert(False, 'Query Cnt Threshold ({}) exceeded:    {}'.format(
+                ui_bench_tests['query_count_threshold'], page))
+    return pages
+
+
+def navigate_every_quadicon(qnames, qtype, num_repeat, page_name, soft_assert, acc_topbars=[]):
+    for i in range(num_repeat):
+        for q in qnames:
+            for page in paginator.pages():
+                quadicon = Quadicon(str(q), qtype)
+                if sel.is_displayed(quadicon):
+                    sel.click(quadicon)
+                    for topbar in acc_topbars:
+                        try:
+                            links = list_acc.get_active_links(topbar)
+                            if not list_acc.is_active(topbar):
+                                list_acc.click(topbar)
+                            for link in range(len(links)):
+                                # Every click makes the previous list of links invalid
+                                links = list_acc.get_active_links(topbar)
+                                if link <= len(links):
+                                    if not 'parent' in links[link].title:
+                                        links[link].click()
+                        except NoSuchElementException:
+                            logger.warning('NoSuchElementException - page_name:{}, Quadicon:{},'
+                                ' topbar:{}, link title:{}'.format(page_name, q, topbar,
+                                links[link].title))
+                            soft_assert(False, 'NoSuchElementException - page_name:{}, Quadicon:{},'
+                                ' topbar:{}, link title:{}'.format(page_name, q, topbar,
+                                links[link].title))
+                            break
+                    break
+            sel.force_navigate(page_name)
+
+
+def navigate_tree_vms(tree_contents, path, paths):
+    if type(tree_contents) is list:
+        for item in tree_contents:
+            navigate_tree_vms(item, path, paths)
+    elif type(tree_contents) is tuple:
+        path.append(tree_contents[0])
+        navigate_tree_vms(tree_contents[1], path, paths)
+        path.pop()
+    else:
+        path.append(tree_contents)
+        paths.append(list(path))
+        path.pop()
+
+
+def standup_page_renders_n_queries(ssh_client):
+    # Use evmserverd status to determine MiqUiWorker Pid (assuming 1 worker)
+    exit_status, out = ssh_client.run_command('service evmserverd status | grep \'MiqUiWorker\'' +
+        ' | awk \'{print $7}\'')
+    assert exit_status == 0
+
+    miq_uiworker_pid = str(out).strip()
+    if out:
+        logger.info('Obtained MiqUiWorker PID: {}'.format(miq_uiworker_pid))
+    else:
+        logger.error('Could not obtain MiqUiWorker PID, check evmserverd running...')
+        assert out
+
+    logger.info('Opening /var/www/miq/vmdb/log/production.log for tail')
+    prod_tail = SSHTail('/var/www/miq/vmdb/log/production.log')
+    prod_tail.set_initial_file_end()
+
+    return miq_uiworker_pid, prod_tail
+
+
+def pages_to_csv(pages, file_name):
+    csvdata_path = log_path.join('csv_output', file_name)
+    outputfile = csvdata_path.open('w', ensure=True)
+    csvwriter = csv.DictWriter(outputfile, fieldnames=PageStat().headers, delimiter=',',
+        quotechar='\'', quoting=csv.QUOTE_MINIMAL)
+    csvwriter.writeheader()
+    for page in pages:
+        csvwriter.writerow(dict(page))
+
+
+def parse_production_log(miq_uiworker_pid, tailer):
+    # Regular Expressions to find the ruby production completed time and select query time
+    status_re = re.compile(r'Completed\s([0-9]*\s[a-zA-Z]*)\sin\s([0-9]*)ms')
+    select_query_time_re = re.compile(r'\s\(([0-9\.]*)ms\)')
+    worker_pid = '#' + miq_uiworker_pid
+
+    pgstats = []
+    pgstat = PageStat()
+    line_count = 0
+    starttime = datetime.datetime.utcnow()
+
+    for line in tailer:
+        line_count += 1
+        if worker_pid in line:
+            if 'SELECT' in line:
+                pgstat.selectcount += 1
+                selecttime = select_query_time_re.search(line)
+                if selecttime:
+                    if float(selecttime.group(1)) > ui_bench_tests['query_time_threshold']:
+                        pgstat.slowselects.append(line)
+            if 'CACHE' in line:
+                pgstat.cachecount += 1
+            if 'INFO -- : Started' in line:
+                # Obtain method and requested page
+                started_idx = line.index('Started') + 8
+                pgstat.request = line[started_idx:line.index('for', 72)]
+            if 'INFO -- : Completed' in line:
+                # Obtain status code and total render time
+                status_result = status_re.search(line)
+                if status_result:
+                    pgstat.status = status_result.group(1)
+                    pgstat.completedin = int(status_result.group(2))
+
+                # Redirects don't always have a view timing
+                try:
+                    vanchor = line.index('Views') + 7
+                    pgstat.viewstime = line[vanchor:line.index('ms', vanchor)]
+                except:
+                    pass
+                try:
+                    aranchor = line.index('ActiveRecord') + 14
+                    pgstat.activerecordtime = line[aranchor:line.index('ms', aranchor)]
+                except:
+                    pass
+                pgstats.append(pgstat)
+                pgstat = PageStat()
+
+    endtime = datetime.datetime.utcnow()
+    timediff = endtime - starttime
+    logger.info('Parsed ({}) lines in {}'.format(line_count, timediff))
+    return pgstats
+
+
+def test_ems_infra_render_times_n_queries(ssh_client, soft_assert):
+    miq_uiworker_pid, prod_tail = standup_page_renders_n_queries(ssh_client)
+
+    navigate_every_quadicon(get_all_providers(), 'infra_prov',
+        ui_bench_tests['num_repeat_provider'], 'infrastructure_providers', soft_assert)
+
+    pages = analyze_page_stat(parse_production_log(miq_uiworker_pid, prod_tail), soft_assert)
+
+    pages_to_csv(pages, 'page_renders_n_queries_ems_infra.csv')
+
+
+def test_host_render_times_n_queries(ssh_client, soft_assert):
+    miq_uiworker_pid, prod_tail = standup_page_renders_n_queries(ssh_client)
+
+    acc_bars = ['Properties', 'Relationships', 'Security', 'Configuration']
+
+    navigate_every_quadicon(get_all_hosts(), 'host', ui_bench_tests['num_repeat_host'],
+        'infrastructure_hosts', soft_assert, acc_bars)
+
+    pages = analyze_page_stat(parse_production_log(miq_uiworker_pid, prod_tail), soft_assert)
+
+    pages_to_csv(pages, 'page_renders_n_queries_host_infra.csv')
+
+
+def test_vm_infra_render_times_n_queries(ssh_client, soft_assert):
+    miq_uiworker_pid, prod_tail = standup_page_renders_n_queries(ssh_client)
+
+    sel.force_navigate('infrastructure_virtual_machines')
+    pages = analyze_page_stat(parse_production_log(miq_uiworker_pid, prod_tail), soft_assert)
+
+    # Read the infrastructure tree in by expanding each folder
+    logger.info('Starting to read the tree...')
+    tree_contents = virtual_machines.visible_tree.read_contents()
+    pages.extend(analyze_page_stat(parse_production_log(miq_uiworker_pid, prod_tail), soft_assert))
+
+    logger.info('Creating Navigation path to every VM/Template...')
+    vmpaths = []
+    navigate_tree_vms(tree_contents, [], vmpaths)
+
+    logger.info('Found {} VMs/Templates'.format(len(vmpaths)))
+    count = 0
+    for vm in vmpaths:
+        logger.info('Navigating to VM/Template: {}'.format(vm[-1]))
+        try:
+            virtual_machines.visible_tree.click_path(*vm)
+            pages.extend(analyze_page_stat(parse_production_log(miq_uiworker_pid, prod_tail),
+                soft_assert))
+            count += 1
+            # Navigate out of the vm infrastructure page every 4th vm
+            if (count % 4) == 3:
+                sel.force_navigate('dashboard')
+                sel.force_navigate('infrastructure_virtual_machines')
+        except CandidateNotFound:
+            logger.info('Could not navigate to: '.format(vm[-1]))
+
+        if count >= ui_bench_tests['num_vm_check']:
+            break
+
+    pages_to_csv(pages, 'page_renders_n_queries_vm_infra.csv')
+
+
+def test_storage_render_times_n_queries(ssh_client, soft_assert):
+    miq_uiworker_pid, prod_tail = standup_page_renders_n_queries(ssh_client)
+
+    acc_bars = ['Properties', 'Relationships', 'Content']
+
+    navigate_every_quadicon(get_all_datastores(), 'datastore',
+        ui_bench_tests['num_repeat_datastore'], 'infrastructure_datastores', soft_assert, acc_bars)
+
+    pages = analyze_page_stat(parse_production_log(miq_uiworker_pid, prod_tail), soft_assert)
+
+    pages_to_csv(pages, 'page_renders_n_queries_storage.csv')

--- a/conf/ui_bench_tests.yaml.template
+++ b/conf/ui_bench_tests.yaml.template
@@ -1,0 +1,7 @@
+num_vm_check: 50
+num_repeat_provider: 10
+num_repeat_host: 10
+num_repeat_datastore: 10
+page_render_threshold: 5000
+query_time_threshold: 1000
+query_count_threshold: 1000

--- a/utils/pagestats.py
+++ b/utils/pagestats.py
@@ -1,0 +1,29 @@
+"""Object that represents page statistics and a list of any associated slow queries.
+
+"""
+
+
+class PageStat(object):
+
+    def __init__(self):
+        self.headers = ['request', 'status', 'completedin', 'viewstime', 'activerecordtime',
+            'selectcount', 'cachecount']
+        self.request = ''
+        self.status = ''
+        self.completedin = 0
+        self.viewstime = 0
+        self.activerecordtime = 0
+        self.selectcount = 0
+        self.cachecount = 0
+        self.slowselects = []
+
+    def __iter__(self):
+        for header in self.headers:
+            yield header, getattr(self, header)
+
+    def __str__(self):
+        return 'Completed/Views/ActiveRecord: ' + str(self.completedin).rjust(6) + ':' + \
+            str(self.viewstime).rjust(8) + ':' + str(self.activerecordtime).rjust(8) + \
+            ' Select/Cached: ' + str(self.selectcount).rjust(5) + ':' + \
+            str(self.cachecount).rjust(5) + ', Request: ' + self.request + ', Status: ' + \
+            self.status


### PR DESCRIPTION
This code navigates to VMs/Templates and records page load times out of production.log.  When the appliance has rails debug turned on, it will record the number of select queries (cached/uncached).  

There are a few issues/assumptions with the code currently that I'd like to get worked out:
- Rails debug will work best on an appliance with only the UI role, as queries will become chatty in production.log and parsing production.log will consume large amounts of time.
- Appliance under test is pre-provisioned and loaded with a db or connected to a db appliance with data already on it.
- One MiqUIWorker on the appliance under test.

The output is logged to cfme.log and in a csv file to build charts from.  Ideally, charts can be generated of the most relevant ui pages to check using pygal or some other graph generating python module.  Pass/Fail criteria is checked per page load inside analyze_page_stat and logged as a warning.
