### PR TITLE
Reset normal search fields after tests

### DIFF
--- a/cfme/tests/infrastructure/test_advanced_search_host.py
+++ b/cfme/tests/infrastructure/test_advanced_search_host.py
@@ -175,11 +175,13 @@ def test_filter_save_and_load_cancel(request, hosts, hosts_with_vm_count, host_w
     assert_no_cfme_exception()
 
 
-def test_quick_search_without_filter(hosts, hosts_with_vm_count, host_with_median_vm):
+def test_quick_search_without_filter(request, hosts, hosts_with_vm_count, host_with_median_vm):
     sel.force_navigate("infrastructure_hosts")
     search.ensure_no_filter_applied()
     assert_no_cfme_exception()
     median_host, median_vm_count = host_with_median_vm
+    # Make sure that we empty the regular search field after the test
+    request.addfinalizer(search.ensure_normal_search_empty)
     # Filter this host only
     search.normal_search(median_host)
     assert_no_cfme_exception()
@@ -188,13 +190,15 @@ def test_quick_search_without_filter(hosts, hosts_with_vm_count, host_with_media
     assert len(all_hosts_visible) == 1 and median_host in all_hosts_visible
 
 
-def test_quick_search_with_filter(hosts, hosts_with_vm_count, host_with_median_vm):
+def test_quick_search_with_filter(request, hosts, hosts_with_vm_count, host_with_median_vm):
     sel.force_navigate("infrastructure_hosts")
     median_host, median_vm_count = host_with_median_vm
     search.fill_and_apply_filter(
         "fill_count(Host.VMs, >=, %d)" % median_vm_count
     )
     assert_no_cfme_exception()
+    # Make sure that we empty the regular search field after the test
+    request.addfinalizer(search.ensure_normal_search_empty)
     # Filter this host only
     search.normal_search(median_host)
     assert_no_cfme_exception()

--- a/cfme/tests/infrastructure/test_advanced_search_vms.py
+++ b/cfme/tests/infrastructure/test_advanced_search_vms.py
@@ -170,11 +170,13 @@ def test_filter_save_and_load_cancel(request, vms, subset_of_vms):
     assert_no_cfme_exception()
 
 
-def test_quick_search_without_filter(vms, subset_of_vms):
+def test_quick_search_without_filter(request, vms, subset_of_vms):
     sel.force_navigate("infra_vms")
     search.ensure_no_filter_applied()
     assert_no_cfme_exception()
     vm = pick(subset_of_vms, 1)[0]
+    # Make sure that we empty the regular search field after the test
+    request.addfinalizer(search.ensure_normal_search_empty)
     # Filter this host only
     search.normal_search(vm)
     assert_no_cfme_exception()
@@ -184,10 +186,12 @@ def test_quick_search_without_filter(vms, subset_of_vms):
 
 
 @pytest.mark.requires("test_can_open_advanced_search")
-def test_quick_search_with_filter(vms, subset_of_vms, expression_for_vms_subset):
+def test_quick_search_with_filter(request, vms, subset_of_vms, expression_for_vms_subset):
     sel.force_navigate("infra_vms")
     search.fill_and_apply_filter(expression_for_vms_subset)
     assert_no_cfme_exception()
+    # Make sure that we empty the regular search field after the test
+    request.addfinalizer(search.ensure_normal_search_empty)
     # Filter this host only
     chosen_vm = pick(subset_of_vms, 1)[0]
     search.normal_search(chosen_vm)

--- a/cfme/web_ui/search.py
+++ b/cfme/web_ui/search.py
@@ -161,6 +161,11 @@ def normal_search(search_term):
     sel.click(search_box.search_icon)
 
 
+def ensure_normal_search_empty():
+    """Makes sure that the normal search field is empty."""
+    normal_search('')
+
+
 def fill_expression(expression_program):
     """Wrapper to open the box and fill the expression
 


### PR DESCRIPTION
Made `test_host_analysis` fail because the active search blocked out some of the hosts for good.
Possible issues in VMs are fixed as well (haven't looked into the tests in that section so not sure if it's actually causing any problems or not).

To see fail X success, run **py.test -k "advanced_search and host or host_analysis" --use-provider=vsphere55** on master X this branch.
