### PR TITLE
Fixes to make Artifactor able to return data

### DIFF
--- a/scripts/dockerbot/pytestbase/setup.sh
+++ b/scripts/dockerbot/pytestbase/setup.sh
@@ -28,7 +28,7 @@ artifactor:
         reporter:
             enabled: True
             plugin: reporter
-            only_failed: False
+            only_failed: True
 
 mail_collector:
     ports:

--- a/utils/artifactor_start.py
+++ b/utils/artifactor_start.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python2
+
+import artifactor
+import argparse
+from artifactor.plugins import merkyl, logger, video, filedump, reporter
+from artifactor import parse_setup_dir
+from urlparse import urlparse
+from utils.conf import env
+from utils.path import log_path
+
+
+def run(run_id=None):
+    art_config = env.get('artifactor', {})
+    art = artifactor.artifactor
+
+    if 'log_dir' not in art_config:
+        art_config['log_dir'] = log_path.join('artifacts').strpath
+    art.set_config(art_config)
+
+    art.register_plugin(merkyl.Merkyl, "merkyl")
+    art.register_plugin(logger.Logger, "logger")
+    art.register_plugin(video.Video, "video")
+    art.register_plugin(filedump.Filedump, "filedump")
+    art.register_plugin(reporter.Reporter, "reporter")
+    art.register_hook_callback('filedump', 'pre', parse_setup_dir,
+                               name="filedump_dir_setup")
+
+    artifactor.initialize()
+    ip = urlparse(env['base_url']).hostname
+
+    art.configure_plugin('merkyl', ip=ip)
+    art.configure_plugin('logger')
+    art.configure_plugin('video')
+    art.configure_plugin('filedump')
+    art.configure_plugin('reporter')
+    art.fire_hook('start_session', run_id=run_id)
+
+    # Stash this where slaves can find it
+    # log.logger.info('artifactor listening on port %d', art_config['server_port'])
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(argument_default=None)
+    parser.add_argument('--run-id', default=None)
+    args = parser.parse_args()
+    run(args.run_id)

--- a/utils/log.py
+++ b/utils/log.py
@@ -402,7 +402,7 @@ class MultiLogger(object):
     def _art(self):
         if not self._art_instance:
             from fixtures.artifactor_plugin import art_client, SLAVEID
-            self._slaveid = SLAVEID
+            self._slaveid = SLAVEID or ""
             self._art_instance = art_client
         return self._art_instance
 
@@ -415,7 +415,7 @@ class MultiLogger(object):
                 extra_info['source_file'] = extra_info['source_file'].strpath
         log_record = {'level': name,
                       'message': str(args[0]),
-                      'extra': extra_info}
+                      'extra': extra_info or ""}
         self._art.fire_hook('log_message', log_record=log_record, slaveid=self._slaveid)
 
 

--- a/utils/video.py
+++ b/utils/video.py
@@ -18,7 +18,7 @@ import subprocess
 from signal import SIGINT
 
 from utils.conf import env
-from utils.log import logger
+# from utils.log import logger
 
 vid_options = env.get('logging', {}).get('video')
 
@@ -70,17 +70,22 @@ class Recorder(object):
             proc = subprocess.Popen(cmd_line, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             self.pid = proc.pid
         except OSError:
-            logger.exception("Couldn't initialize videoer! Make sure recordmydesktop is installed!")
+            # Had to disable for artifactor
+            # logger.exception("Couldn't initialize videoer! Is recordmydesktop installed?")
+            pass
 
     def stop(self):
         if self.pid is not None:
             if process_running(self.pid):
                 os.kill(self.pid, SIGINT)
                 os.waitpid(self.pid, 0)
-                logger.info("Recording finished")
+                # Had to disable for artifactor
+                # logger.info("Recording finished")
                 self.pid = None
             else:
-                logger.exception("Could not find recordmydesktop process #%d" % self.pid)
+                # Had to disable for artifactor
+                # logger.exception("Could not find recordmydesktop process #%d" % self.pid)
+                pass
 
     def __enter__(self):
         self.start()


### PR DESCRIPTION
- Made DockerBot only report failures in the log report
- Videoer is now unable to log due to nested fire_hooks not being
  supported in Artifactor yet
- log.py small changes to keep JSON happy
- Artifactor is now a separate process so that TCP communications are
  not deadlocked in the same process
