### PR TITLE
Add debug-level logging to ajax check

### DIFF
--- a/cfme/js.py
+++ b/cfme/js.py
@@ -2,7 +2,7 @@ xpath = """
 return document.evaluate(path, document, null, 9, null).singleNodeValue;
 """
 
-nothing_in_flight = """
+in_flight = """
 function isHidden(el) {
     if(el === null) return true;
     return el.offsetParent === null;
@@ -14,6 +14,11 @@ function miqActive() { return window.miqAjaxTimers > 0; }
 function spinnerDisplayed() { return (!isHidden(document.getElementById("spinner_div")))
  && isHidden(document.getElementById("lightbox_div")); }
 function documentComplete() { return document.readyState == "complete"; }
-return !(jqueryActive() || prototypeActive() || miqActive() || spinnerDisplayed()
- || !(documentComplete()));
+return {
+    jquery: jqueryActive(),
+    prototype: prototypeActive(),
+    miq: miqActive(),
+    spinner: spinnerDisplayed(),
+    document: !documentComplete()
+};
 """


### PR DESCRIPTION
The js now returns dict with relevant keys and `True/False` values (which are then logged, if True) instead of just a single bool.

Update: Should be thread-safe and less spammy; logs the message only if it's different from the last one.

Example log:

```
2014-07-17 13:11:05,885 [D] Finished filling in form (utils/log.py:411)
2014-07-17 13:11:06,426 [D] Ajax running: jquery, spinner (utils/log.py:411)
2014-07-17 13:11:13,705 [D] Ajax done (utils/log.py:411)
2014-07-17 13:11:13,753 [I] Navigating to infrastructure_providers (utils/log.py:411)
2014-07-17 13:11:21,598 [D] force_navigate to infrastructure_providers, try 1 (utils/log.py:411)
2014-07-17 13:11:21,658 [I] Navigating to infrastructure_providers (utils/log.py:411)
2014-07-17 13:11:23,807 [D] Ajax running: document (utils/log.py:411)
2014-07-17 13:11:23,936 [D] Ajax done (utils/log.py:411)
2014-07-17 13:11:25,010 [D] Provider "XYZ" exists, skipping (utils/log.py:411)
2014-07-17 13:11:25,011 [D] force_navigate to infrastructure_hosts, try 1 (utils/log.py:411)
2014-07-17 13:11:25,053 [I] Navigating to infrastructure_hosts (utils/log.py:411)
2014-07-17 13:11:30,310 [D] force_navigate to infrastructure_hosts, try 1 (utils/log.py:411)
2014-07-17 13:11:30,355 [I] Navigating to infrastructure_hosts (utils/log.py:411)
2014-07-17 13:11:33,073 [D] Ajax running: document (utils/log.py:411)
2014-07-17 13:11:33,183 [D] Ajax done (utils/log.py:411)

```
