### PR TITLE
Update to use latest function_trace

### DIFF
--- a/cfme/fixtures/tracer.py
+++ b/cfme/fixtures/tracer.py
@@ -1,6 +1,4 @@
 import function_trace
-import itertools
-
 # disable traceback of the tracer functions
 function_trace.__tracebackhide__ = True
 
@@ -55,58 +53,57 @@ import cfme.web_ui.tabstrip
 import cfme.web_ui.toolbar
 
 
-default_to_trace = list(itertools.chain.from_iterable(
-    map(function_trace.all,
-        [
-            cfme.automate.explorer,
-            cfme.automate.service_dialogs,
-            cfme.cloud.instance,
-            cfme.cloud.provider,
-            cfme.cloud.provisioning,
-            cfme.cloud.security_group,
-            cfme.configure.configuration,
-            cfme.configure.red_hat_updates,
-            cfme.configure.tasks,
-            cfme.configure.access_control,
-            cfme.control.explorer,
-            cfme.control.import_export,
-            cfme.control.snmp_form,
-            cfme.fixtures.pytest_selenium,
-            cfme.infrastructure.datastore,
-            cfme.infrastructure.host,
-            cfme.infrastructure.provider,
-            cfme.infrastructure.provisioning,
-            cfme.infrastructure.pxe,
-            cfme.infrastructure.virtual_machines,
-            cfme.intelligence.chargeback,
-            cfme.intelligence.reports.dashboards,
-            cfme.intelligence.reports.import_export,
-            cfme.intelligence.reports.reports,
-            cfme.intelligence.reports.saved,
-            cfme.intelligence.reports.schedules,
-            cfme.intelligence.reports.ui_elements,
-            cfme.intelligence.reports.widgets,
-            cfme.login,
-            cfme.services.requests,
-            cfme.services.catalogs.catalog_item,
-            cfme.services.catalogs.catalog,
-            cfme.services.catalogs.cloud_catalog_item,
-            cfme.services.catalogs.service_catalogs,
-            cfme.web_ui,
-            cfme.web_ui.accordion,
-            cfme.web_ui.cfme_exception,
-            cfme.web_ui.expression_editor,
-            cfme.web_ui.flash,
-            cfme.web_ui.form_buttons,
-            cfme.web_ui.listaccordion,
-            cfme.web_ui.menu,
-            cfme.web_ui.multibox,
-            cfme.web_ui.paginator,
-            cfme.web_ui.search,
-            cfme.web_ui.tabstrip,
-            cfme.web_ui.toolbar
-
-        ])))
+default_to_trace = function_trace.mapcat(
+    function_trace.all,
+    [
+        cfme.automate.explorer,
+        cfme.automate.service_dialogs,
+        cfme.cloud.instance,
+        cfme.cloud.provider,
+        cfme.cloud.provisioning,
+        cfme.cloud.security_group,
+        cfme.configure.configuration,
+        cfme.configure.red_hat_updates,
+        cfme.configure.tasks,
+        cfme.configure.access_control,
+        cfme.control.explorer,
+        cfme.control.import_export,
+        cfme.control.snmp_form,
+        cfme.fixtures.pytest_selenium,
+        cfme.infrastructure.datastore,
+        cfme.infrastructure.host,
+        cfme.infrastructure.provider,
+        cfme.infrastructure.provisioning,
+        cfme.infrastructure.pxe,
+        cfme.infrastructure.virtual_machines,
+        cfme.intelligence.chargeback,
+        cfme.intelligence.reports.dashboards,
+        cfme.intelligence.reports.import_export,
+        cfme.intelligence.reports.reports,
+        cfme.intelligence.reports.saved,
+        cfme.intelligence.reports.schedules,
+        cfme.intelligence.reports.ui_elements,
+        cfme.intelligence.reports.widgets,
+        cfme.login,
+        cfme.services.requests,
+        cfme.services.catalogs.catalog_item,
+        cfme.services.catalogs.catalog,
+        cfme.services.catalogs.catalog.Catalog,
+        cfme.services.catalogs.service_catalogs,
+        cfme.web_ui,
+        cfme.web_ui.accordion,
+        cfme.web_ui.cfme_exception,
+        cfme.web_ui.expression_editor,
+        cfme.web_ui.flash,
+        cfme.web_ui.form_buttons,
+        cfme.web_ui.listaccordion,
+        cfme.web_ui.menu,
+        cfme.web_ui.multibox,
+        cfme.web_ui.paginator,
+        cfme.web_ui.search,
+        cfme.web_ui.tabstrip,
+        cfme.web_ui.toolbar
+    ])
 # 0 = do not trace into
 default_depths = {cfme.fixtures.pytest_selenium.wait_until: 0,
                   cfme.fixtures.pytest_selenium.wait_for_ajax: 0,
@@ -122,7 +119,8 @@ default_depths = {cfme.fixtures.pytest_selenium.wait_until: 0,
                   cfme.fixtures.pytest_selenium.check: 1,
                   cfme.web_ui.toolbar.is_greyed: 1,
                   cfme.web_ui.flash.message: 1,
-                  cfme.web_ui.fill_tag: 0}
+                  cfme.web_ui.fill_tag: 0
+                  }
 
 to_trace = default_to_trace
 depths = default_depths
@@ -136,10 +134,11 @@ def pytest_addoption(parser):
 def pytest_runtest_call(__multicall__, item):
     """hook to run each test with traced function calls"""
     if item.config.getvalue('tracer'):
-        with function_trace.trace_on(to_trace,
-                                     depths=depths,
-                                     tracer=function_trace.PerThreadFileTracer(
-                                         './tracelogs/' + item.name.replace("/", "_"))):
+        with function_trace.trace_on(
+                tracer=function_trace.PerThreadFileTracer(
+                    to_trace,
+                    depths=depths,
+                    filename='./tracelogs/' + item.name.replace("/", "_"))):
             __multicall__.execute()
 
 

--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -96,7 +96,7 @@ class Region(Pretty):
     pretty_attrs = ['title']
 
     def __getattr__(self, name):
-        if hasattr(self, 'locators'):
+        if hasattr(self, 'locators') and name in self.locators:
             return self.locators[name]
         else:
             raise AttributeError("Region has no attribute named " + name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ docker-py
 execnet
 flake8
 functools32
-function_trace<1.1.0
+function_trace
 ipython
 Jinja2
 ovirt-engine-sdk-python


### PR DESCRIPTION
latest function_trace contains non-backward compatible changes. I tried not to introduce changes to the interface but at least they are straightforward.  See https://github.com/RedHatQE/function_trace/commit/32e8dc640b5038af7f9c2fd00bc2a4d513f5523e

This PR updates to call `function_trace.trace_on` in the new way, and removes the PIP version restriction to once again allow the latest version.

Also contains a fix for a bug in a `getattr` method that was exposed by the latest function_trace.
