### PR TITLE
clone_template has sane defaults for all providers

### DIFF
--- a/conf/cfme_data.yaml.template
+++ b/conf/cfme_data.yaml.template
@@ -116,6 +116,7 @@ management_systems:
         credentials: rhos
         server_zone: default
         type: openstack
+        network: defaultnetwork
         test_vm_power_control:
             - pwr-ctl-vm-1-dnd
 management_hosts:
@@ -130,6 +131,11 @@ management_hosts:
         user_assigned_os: VMware ESX
 appliance_provisioning:
     provider: provider_name
+    default_flavors:
+        ec2:
+            - m3.medium
+        openstack:
+            - m1.medium
     versions:
         1.2.3: template_name_123
         1.3.3: template_name_133

--- a/scripts/clone_template.py
+++ b/scripts/clone_template.py
@@ -1,101 +1,140 @@
 #!/usr/bin/env python2
+"""Clone a template on a given provider to a VM instance
+
+Where possible, defaults will come from cfme_data"""
 import argparse
 import sys
 
+from utils.conf import cfme_data
 from utils.log import logger
-from utils.providers import provider_factory
+from utils.providers import destroy_vm, provider_factory
 from utils.wait import wait_for
 
 
-def destroy(provider, args):
-    try:
-        if provider.does_vm_exist(args.vm_name):
-            # Stop the vm first
-            logger.warning('Destroying VM %s', args.vm_name)
-            if provider.is_vm_running(args.vm_name):
-                provider.stop_vm(args.vm_name)
-            if provider.delete_vm(args.vm_name):
-                logger.info('VM %s destroyed', args.vm_name)
-            else:
-                logger.error('Error destroying VM %s', args.vm_name)
-    except Exception as e:
-        logger.error('Could not destroy VM %s (%s)', args.vm_name, e.message)
-        sys.exit(11)
-
-
 def main():
-    parser = argparse.ArgumentParser(epilog=__doc__,
+    parser = argparse.ArgumentParser(description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument('--provider', dest='provider_name',
-        help='provider name in cfme_data')
+
+    # required options (heh)
+    parser.add_argument('--provider', help='provider key in cfme_data')
     parser.add_argument('--template', help='the name of the template to clone')
-    parser.add_argument('--vm_name', help='the name of the VM on which to act')
-    parser.add_argument('--rhev_cluster', help='the name of the VM on which to act', default=None)
-    parser.add_argument('--rhev_place_policy_host', help='the host for the vm to start on',
-        default=None)
-    parser.add_argument('--rhev_place_policy_aff', help='the affinity of the vm on a host',
-        default=None)
-    parser.add_argument('--ec2_flavor', help='ec2 flavor', default=None)
-    parser.add_argument('--rhos_flavor', help='rhos flavor', default=None)
-    parser.add_argument('--rhos_floating_ip_pool', dest='ip_pool', default=None,
-        help='openstack floating ip pool to use')
-    parser.add_argument('--destroy', dest='destroy',
-        help='Destroy the destination VM', action='store_true')
-    parser.add_argument('--log', dest='loglevel',
-        help='Set the log level', default='WARNING')
+    parser.add_argument('--vm_name', help='the name of the VM to create')
+
+    # generic options
+    parser.add_argument('--destroy', dest='destroy', action='store_true',
+        help='Destroy the destination VM')
+    parser.add_argument('--log', dest='loglevel', default='WARNING',
+        help='Set the log level')
     parser.add_argument('--outfile', dest='outfile',
         help='Write provisioning details to the named file', default='')
 
-    args = parser.parse_args()
-    if not args.provider_name:
-        parser.error('--provider is required')
+    # sub options organized for provider types
+    rhev_parser = parser.add_argument_group('rhev')
+    rhev_parser.add_argument('--cluster', default=None,
+        help='the name of the VM on which to act')
+    rhev_parser.add_argument('--place_policy_host', default=None,
+        help='the host for the vm to start on')
+    rhev_parser.add_argument('--place_policy_aff', default=None,
+        help='the affinity of the vm on a host')
 
-    logger.info('Connecting to %s', args.provider_name)
-    provider = provider_factory(args.provider_name)
+    cloud_parser = parser.add_argument_group('cloud')
+    cloud_parser.add_argument('--flavor', default=None,
+        help='ec2/rhos flavor')
+
+    openstack_parser = parser.add_argument_group('openstack')
+    openstack_parser.add_argument('--floating-ip-pool', default=None,
+        help='openstack floating ip pool to use')
+
+    args = parser.parse_args()
+
+    # provider_factory validates, since it will explode without an existing key or type
+    provider = provider_factory(args.provider)
+    provider_dict = cfme_data['management_systems'][args.provider]
+    provider_type = provider_dict['type']
+
+    # Used by the cloud provs
+    flavors = cfme_data['appliance_provisioning']['default_flavors'].get(provider_type, [])
+
+    logger.info('Connecting to %s', args.provider)
 
     if args.destroy:
-        destroy(provider, args)
-    else:
-        logger.info('Cloning %s to %s', args.template, args.vm_name)
-        # passing unused args to ec2 provider would blow up so I
-        #   had to make it a little more specific
-        deploy_args = {}
-        if args.vm_name is not None:
-            deploy_args.update(vm_name=args.vm_name)
-        if args.rhos_flavor is not None:
-            deploy_args.update(flavour_name=args.rhos_flavor)
-        if args.ip_pool is not None:
-            deploy_args.update(assign_floating_ip=args.ip_pool)
-        if args.rhev_cluster is not None:
-            deploy_args.update(cluster_name=args.rhev_cluster)
-        if args.rhev_place_policy_host is not None:
-            deploy_args.update(placement_policy_host=args.rhev_place_policy_host)
-        if args.rhev_place_policy_aff is not None:
-            deploy_args.update(placement_policy_affinity=args.rhev_place_policy_aff)
-        if args.ec2_flavor is not None:
-            deploy_args.update(instance_type=args.ec2_flavor)
+        # TODO: destroy should be its own script
+        # but it's easy enough to just hijack the parser here
+        # This returns True if destroy fails to give POSIXy exit codes (0 is good, False is 0, etc)
+        return not destroy_vm(provider, args.vm_name)
 
+    deploy_args = {
+        'vm_name': args.vm_name,
+        'template': args.template,
+    }
+
+    # Try to snag defaults from cfme_data here for each provider type
+    if provider_type == 'rhevm':
+        cluster = provider_dict.get('default_cluster', args.cluster)
+        if cluster is None:
+            raise Exception('--cluster is required for rhev instances and default is not set')
+        deploy_args['cluster'] = cluster
+
+        if args.place_policy_host and args.place_policy_aff:
+            deploy_args['placement_policy_host'] = args.place_policy_host
+            deploy_args['placement_policy_affinity'] = args.rhev_place_policy_aff
+    elif provider_type == 'ec2':
+        # ec2 doesn't have an api to list available flavors, so the first flavor is the default
         try:
-            vm_name = provider.deploy_template(args.template, **deploy_args)
-        except:
-            logger.exception(sys.exc_info()[0])
-            destroy(provider, args)
-            return 12
+            flavor = args.flavor or flavors[0]
+        except IndexError:
+            raise Exception('--flavor is required for EC2 instances and default is not set')
+        deploy_args['instance_type'] = flavor
+    elif provider_type == 'openstack':
+        # filter openstack flavors based on what's available
+        available_flavors = provider.list_flavor()
+        flavors = filter(lambda f: f in available_flavors, flavors)
+        try:
+            flavor = args.flavor or flavors[0]
+        except IndexError:
+            raise Exception('--flavor is required for RHOS instances and '
+                'default is not set or unavailable on provider')
+        # flavour? Thanks, psav...
+        deploy_args['flavour_name'] = flavor
 
-        if not provider.is_vm_running(vm_name):
-            logger.error("VM is not running")
-            return 10
+        if 'network' in provider_dict:
+            # support rhos4 network names
+            deploy_args['network_name'] = provider_dict['network']
 
-        ip, time_taken = wait_for(provider.get_ip_address, [vm_name], num_sec=900,
-                                  fail_condition=None)
-        logger.info("VM " + vm_name + " is running")
-        logger.info('IP Address returned is %s', ip)
-        if args.outfile:
-            with open(args.outfile, 'w') as outfile:
-                outfile.write("appliance_ip_address=%s\n" % ip)
-        # In addition to the outfile, drop the ip address on stdout for easy parsing
-        print ip
-    return 0
+        provider_pools = [p.name for p in provider.api.floating_ip_pools.list()]
+        try:
+            # TODO: If there are multiple pools, have a provider default in cfme_data
+            floating_ip_pool = args.floating_ip_pool or provider_pools[0]
+        except IndexError:
+            raise Exception('No floating IP pools available on provider')
+
+        if floating_ip_pool is not None:
+            deploy_args['floating_ip_pool'] = floating_ip_pool
+
+    # Do it!
+    try:
+        logger.info('Cloning %s to %s on %s', args.template, args.vm_name, args.provider)
+        provider.deploy_template(**deploy_args)
+    except:
+        logger.exception(sys.exc_info()[0])
+        logger.info('Clone failed, attempting to destroy %s' % args.vm_name)
+        destroy_vm(provider, args.vm_name)
+        return 12
+
+    if not provider.is_vm_running(args.vm_name):
+        logger.error("VM is not running")
+        return 10
+
+    ip, time_taken = wait_for(provider.get_ip_address, [args.vm_name], num_sec=900,
+                              fail_condition=None)
+    logger.info("VM %s is running" % args.vm_name)
+    logger.info('IP Address returned is %s', ip)
+    if args.outfile:
+        with open(args.outfile, 'w') as outfile:
+            outfile.write("appliance_ip_address=%s\n" % ip)
+
+    # In addition to the outfile, drop the ip address on stdout for easy parsing
+    print ip
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/utils/providers.py
+++ b/utils/providers.py
@@ -301,6 +301,26 @@ def clear_providers():
     perflog.stop('utils.providers.clear_providers')
 
 
+def destroy_vm(provider_mgmt, vm_name):
+    """Given a provider backend and VM name, destroy an instance with logging and error guards
+
+    Returns ``True`` if the VM is deleted, ``False`` if the backend reports that it did not delete
+        the VM, and ``None`` if an error occurred (the error will be logged)
+
+    """
+    try:
+        if provider_mgmt.does_vm_exist(vm_name):
+            logger.info('Destroying VM %s', vm_name)
+            vm_deleted = provider_mgmt.delete_vm(vm_name)
+            if vm_deleted:
+                logger.info('VM %s destroyed', vm_name)
+            else:
+                logger.error('Destroying VM %s failed for unknown reasons', vm_name)
+            return vm_deleted
+    except Exception as e:
+        logger.error('%s destroying VM %s (%s)', type(e).__name__, vm_name, e.message)
+
+
 class UnknownProvider(Exception):
     def __init__(self, provider_key, *args, **kwargs):
         super(UnknownProvider, self).__init__(provider_key, *args, **kwargs)


### PR DESCRIPTION
This is for smoke-testing templates on every provider, so making clone_template
as provider-agnostic as possible was needed.

Additional resulting changes:
- EC2 mgmt backend is able to deal with image names as well as AMIs, much as it does
  with instance names and IDs
- destroy_vm seemed generally useful, so it lives in utils.providers now
- minor cfme_data template changes, reflected in private yamls
