### PR TITLE
Avoid deleting providers tests to not mess the other tests

### DIFF
--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -12,6 +12,12 @@ from utils.update import update
 
 pytest_generate_tests = testgen.generate(testgen.infra_providers, scope="module")
 
+# To avoid issues with deleting and re-adding provider, this bugzilla is targeted at that problem
+# We create shortcut for it here, so we can then simply mark the tests that use
+# 'has_no_infra_providers' fixture.
+bz1087476 = pytest.mark.bugzilla(
+    1087476, unskip={1087476: lambda appliance_version: appliance_version < "5.3"})
+
 
 def test_empty_discovery_form_validation():
     """ Tests that the flash message is correct when discovery form is empty."""
@@ -115,6 +121,7 @@ def test_api_port_max_character_validation():
     prov.delete(cancel=False)
 
 
+@bz1087476
 @pytest.mark.usefixtures('has_no_infra_providers')
 def test_providers_discovery(provider_crud):
     provider.discover_from_provider(provider_crud)
@@ -122,6 +129,7 @@ def test_providers_discovery(provider_crud):
     provider.wait_for_a_provider()
 
 
+@bz1087476
 @pytest.mark.usefixtures('has_no_infra_providers')
 def test_provider_add_with_bad_credentials(provider_crud):
     provider_crud.credentials = provider.get_credentials_from_config('bad_credentials')
@@ -134,6 +142,7 @@ def test_provider_add_with_bad_credentials(provider_crud):
 
 
 @pytest.mark.smoke
+@bz1087476
 @pytest.mark.usefixtures('has_no_infra_providers')
 def test_provider_crud(provider_crud):
     """ Tests that a provider can be added """


### PR DESCRIPTION
This caused errors in upstream because of removing the providers. This PR should skip some of the provider tests in favour of not messing other tests until referenced BZ is resolved.
