### PR TITLE
Ability to check whether a version belongs to certain series

### DIFF
--- a/utils/version.py
+++ b/utils/version.py
@@ -82,6 +82,33 @@ class Version(object):
     def __repr__(self):
         return "%s ('%s')" % (self.__class__.__name__, str(self))
 
+    def __contains__(self, ver):
+        """Enables to use ``in`` expression for :py:meth:`Version.is_in_series`.
+
+        Example:
+            ``"5.2.5.2" in LooseVersion("5.2") returns ``True``
+
+        Args:
+            ver: Version that should be checked if it is in series of this version. If
+                :py:class:`str` provided, it will be converted to :py:class:`LooseVersion`.
+        """
+        if isinstance(ver, basestring):
+            ver = LooseVersion(ver)
+        return ver.is_in_series(self)
+
+    def is_in_series(self, series):
+        """This method checks wheter the version belongs to another version's series.
+
+        Eg.: ``LooseVersion("5.2.5.2").is_in_series("5.2")`` returns ``True``
+
+        Args:
+            series: Another :py:class:`Version` to check against. If string provided, will be
+                converted to :py:class:`LooseVersion`
+        """
+        if isinstance(series, basestring):
+            series = LooseVersion(series)
+        return series.version == self.version[:len(series.version)]
+
 # Taken from stdlib, just change classes to new-style and clean up
 # Interface for version-number classes -- must be implemented
 # by the following classes (the concrete ones -- Version should


### PR DESCRIPTION
This can be useful, I can then implement it into th BZ plugin for better checking of versions. Basically you can check whether certain version belongs to another version's series (like 5.2.5.2 belongs to 5.2 series and not to 5.1 or 5.3). This is done by cutting the specific version's fields to align with the series and then it is simply compared. The interface is very simple and actually quite straightforward:

``` python
specific_version.is_in_series(series_version)
# But we got a nice DSL shortcut here
specific_version in series_version
```

It works both with Version classes and strings are automatically converted to them.
