### PR TITLE
long_running tests move to the start of the test run

### DIFF
--- a/markers/long_running.py
+++ b/markers/long_running.py
@@ -8,7 +8,13 @@ print that tests that are deselected in its own output, e.g.::
 
     1 tests deselected by "-m 'not long_running'"
 
+Long-running tests are run as early as possible in the test run to prevent parallelized
+test runs from running a long-running test toward the end of the suite, when the other
+test nodes have shut down
+
 """
+
+# XXX: Test reordering takes place in markers.smoke
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
I went down a rabbit-hole a little bit with the smoke vs. long_running test ordering, and the solution here isn't great but it's definitely good enough for now. I've got some ideas about how to handle the smoke test mark that we can discuss at the next team meeting, and we can clean this up properly based on what we decide then.
