### PR TITLE
[Review] CFME doesnt care about terminated instances on provider add

### DIFF
--- a/utils/mgmt_system.py
+++ b/utils/mgmt_system.py
@@ -991,8 +991,8 @@ class EC2System(MgmtSystemAPIBase):
         return '%s %s' % (boto.UserAgent, self.api.APIVersion)
 
     def list_vm(self):
-        """Returns a list from instance IDs currently known to EC2"""
-        return [instance.id for instance in self._get_all_instances()]
+        """Returns a list from instance IDs currently active on EC2 (not terminated)"""
+        return [inst.id for inst in self._get_all_instances() if inst.state != 'terminated']
 
     def list_template(self):
         private_images = self.api.get_all_images(owners=['self'],


### PR DESCRIPTION
`setup_cloud_providers` fixture randomly fails because when you add an EC2 provider, CFME only counts the non-terminated instances, whereas mgmt_system counts all available instances (even terminated ones), which leads to `num_vm` not matching, which leads to fixture fail.

Tested with terminated & stopped instances on ec2west on 5.2.4.2, 5.3.0.2 and miq-0811.
