### PR TITLE
Fix utils.appliance

### DIFF
--- a/conf/cfme_data.yaml.template
+++ b/conf/cfme_data.yaml.template
@@ -130,7 +130,7 @@ management_hosts:
         ipmi_credentials: ipmi
         user_assigned_os: VMware ESX
 appliance_provisioning:
-    provider: provider_name
+    default_provider: provider_name
     default_flavors:
         ec2:
             - m3.medium

--- a/utils/appliance.py
+++ b/utils/appliance.py
@@ -356,7 +356,7 @@ def provision_appliance(version=None, vm_name_prefix='cfme', template=None, prov
         template_name = template
 
     if provider_name is None:
-        provider_name = conf.cfme_data['appliance_provisioning']['provider']
+        provider_name = conf.cfme_data['appliance_provisioning']['default_provider']
     prov_data = conf.cfme_data['management_systems'][provider_name]
 
     provider = provider_factory(provider_name)
@@ -366,7 +366,7 @@ def provision_appliance(version=None, vm_name_prefix='cfme', template=None, prov
     deploy_args['vm_name'] = vm_name
 
     if prov_data['type'] == 'rhevm':
-        deploy_args['cluster_name'] = prov_data['default_cluster']
+        deploy_args['cluster'] = prov_data['default_cluster']
 
     provider.deploy_template(template_name, **deploy_args)
 


### PR DESCRIPTION
a) There is no `appliance_provisioning > provider` anymore in the current cfme_data yamls, but `default_provider` is
b) Rhevm deployment expects `cluster` kwarg now (recent change), not `cluster_name`
https://github.com/RedHatQE/cfme_tests/blob/master/utils/mgmt_system.py#L929
