### PR TITLE
Add support for raw selenium clicks; make menu use them

### DIFF
--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -358,6 +358,18 @@ def click(loc, wait_ajax=True, no_custom_handler=False):
         wait_for_ajax()
 
 
+def raw_click(loc, wait_ajax=True):
+    """Does raw selenium's .click() call on element. Circumvents mouse move.
+
+    Args:
+        loc: Locator to click on.
+        wait_ajax: Whether to wait for ajax.
+    """
+    element(loc).click()
+    if wait_ajax:
+        wait_for_ajax()
+
+
 def double_click(loc, wait_ajax=True):
     """Double-clicks on an element.
 

--- a/cfme/web_ui/menu.py
+++ b/cfme/web_ui/menu.py
@@ -89,19 +89,20 @@ def nav_to_fn(toplevel, secondlevel=None):
                 return  # no menu at all, assume single permission
 
         if secondlevel is None:
-            sel.click(toplevel_elem)
+            sel.raw_click(toplevel_elem)
         else:
             sel.move_to_element(toplevel_elem)
             for (toplevel_dest, toplv), secondlevels in sections.items():
                 if toplv == toplevel:
+
                     try:
                         sel.move_to_element(sel.element(secondlevel_first_item_loc % toplevel))
                     except NoSuchElementException:
                         # Target menu is missing
-                        sel.click(toplevel_elem)
+                        sel.raw_click(toplevel_elem)
                         return  # no 2nd lvl menu, assume single permission
                     break
-            sel.click(sel.element(secondlevel_loc % (toplevel, secondlevel)))
+            sel.raw_click(secondlevel_loc % (toplevel, secondlevel))
     return f
 
 


### PR DESCRIPTION
Now it does move_to_element only on the top-level so that should not mess it up since between top-level menu and the brand logo there is really nothing to be hovered on.
