### PR TITLE
Added else to save server role method

### DIFF
--- a/cfme/configure/configuration.py
+++ b/cfme/configure/configuration.py
@@ -1539,7 +1539,8 @@ def set_server_roles(**roles):
     if get_server_roles(navigate=False) == roles:
         logger.debug(' Roles already match, returning...')
         return
-    fill(server_roles, roles, action=form_buttons.save)
+    else:
+        fill(server_roles, roles, action=form_buttons.save)
 
 
 def get_server_roles(navigate=True):


### PR DESCRIPTION
Need someone to review this PR .
Raised this PR because of service automation failures on jenkins. 
Tests seems to wait too long in Configuration page for Server role fixtures (for Save button to activate , i think ) and then fail showing : 
"NoSuchElementException
Message: 'Element //div[contains(@class, "dhx_acc_item") or @class="topbar"]/*[contains(@class, "dhx_acc_item_label") or contains(@data-remote, "true")]//span[normalize-space(.)="Service Catalogs"] not found on page.' " 

These tests pass randomly . 
I guess we need not wait for Save button on Configuration page if role is already enabled . 
So i have added 
if : 
  roles already match , return 
else : 
    fill(server_roles, roles, action=form_buttons.save)

After adding this tests moved quickly and passed more often.
Not sure what impact it can have on other tests.
