### PR TITLE
Enhancements to record UI transaction time.

### DIFF
--- a/conf/ui_bench_tests.yaml.template
+++ b/conf/ui_bench_tests.yaml.template
@@ -6,6 +6,7 @@ page_check:
     num_ems_resource_pool_check: 5
     num_storage_check: 20
 threshold:
+    transaction: 7000
     page_render: 5000
     query_time: 1000
     query_count: 1000

--- a/utils/pagestats.py
+++ b/utils/pagestats.py
@@ -6,11 +6,12 @@
 class PageStat(object):
 
     def __init__(self):
-        self.headers = ['request', 'status', 'completedin', 'viewstime', 'activerecordtime',
-            'selectcount', 'cachecount']
+        self.headers = ['request', 'status', 'transactiontime', 'completedintime', 'viewstime',
+            'activerecordtime', 'selectcount', 'cachecount']
         self.request = ''
         self.status = ''
-        self.completedin = 0
+        self.transactiontime = 0
+        self.completedintime = 0
         self.viewstime = 0
         self.activerecordtime = 0
         self.selectcount = 0
@@ -22,8 +23,8 @@ class PageStat(object):
             yield header, getattr(self, header)
 
     def __str__(self):
-        return 'Completed/Views/ActiveRecord: ' + str(self.completedin).rjust(6) + ':' + \
-            str(self.viewstime).rjust(8) + ':' + str(self.activerecordtime).rjust(8) + \
-            ' Select/Cached: ' + str(self.selectcount).rjust(5) + ':' + \
-            str(self.cachecount).rjust(5) + ', Request: ' + self.request + ', Status: ' + \
-            self.status
+        return 'Transaction/Completed/Views/ActiveRecord: ' + str(self.transactiontime).rjust(6) + \
+            ':' + str(self.completedintime).rjust(6) + ':' + str(self.viewstime).rjust(8) + ':' + \
+            str(self.activerecordtime).rjust(8) + ' Select/Cached: ' + \
+            str(self.selectcount).rjust(5) + ':' + str(self.cachecount).rjust(5) + ', Request: ' + \
+            self.request + ', Status: ' + self.status


### PR DESCRIPTION
I modified the existing UI Bench code to record the UI transaction time as well.  Transaction time helps us determine the actual end user experience of the UI vs the amount of time ruby spends creating the page or in active record.  The threshold for the UI to pass/fail this is configurable and set at a default of 7000ms.

The transaction time can be affected by a number of variables such as network latency and the load on the server handling the selenium interactions.  Benchmarking off of it must be done carefully to account for these variables.
