### PR TITLE
Fix BZ mark

### DIFF
--- a/cfme/tests/configure/test_register_appliance.py
+++ b/cfme/tests/configure/test_register_appliance.py
@@ -88,9 +88,13 @@ def is_registration_complete(used_repo_or_channel):
         return False
 
 
-# Currently fails on 5.3 (0528) when using proxy BZ#1102724
 @pytest.mark.ignore_stream("upstream")
-@pytest.mark.bugzilla(1102724, 1048997)
+@pytest.mark.bugzilla(
+    1102724, 1132942,
+    unskip={
+        1102724: lambda proxy_url: proxy_url is None
+    }
+)
 def test_appliance_registration(request, unset_org_id,
                                 reg_method, reg_data, proxy_url, proxy_creds):
 


### PR DESCRIPTION
- removed bz [1048997](https://bugzilla.redhat.com/show_bug.cgi?id=1048997), because the tests arent affected by it (there is a workaround present)
- added unskip for [1102724](https://bugzilla.redhat.com/show_bug.cgi?id=1102724) when the test is not using proxy
- added [1132942](https://bugzilla.redhat.com/show_bug.cgi?id=1132942) - issue on 5.3
