### PR TITLE
Don't leave discovered infra providers

### DIFF
--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -7,6 +7,7 @@ import cfme.web_ui.flash as flash
 import utils.error as error
 from cfme.infrastructure import provider
 from utils import testgen
+from utils import providers
 from utils.randomness import generate_random_string
 from utils.update import update
 
@@ -123,9 +124,10 @@ def test_api_port_max_character_validation():
 
 @bz1087476
 @pytest.mark.usefixtures('has_no_infra_providers')
-def test_providers_discovery(provider_crud):
+def test_providers_discovery(request, provider_crud):
     provider.discover_from_provider(provider_crud)
     flash.assert_message_match('Infrastructure Providers: Discovery successfully initiated')
+    request.addfinalizer(providers.clear_infra_providers)
     provider.wait_for_a_provider()
 
 


### PR DESCRIPTION
<strike>When infra providers are discovered, they have a different name than when the auto creates them.  We will now keep track of what a provider's name is when discovered, and when we ask if the provider already exists in CFME, we'll check the discovered name too.  (in the yaml this name is `default_name`).</strike>

<strike>Not sure if this applies at all to cloud providers, there's no other fields in the yaml so i'll assume that both names are equal unless someone tells me otherwise.</strike>

The above technique probably won't work well, there's still code that depends on the yaml name.  Just blow away discovered providers after the test is over.
