### PR TITLE
Report was happening before provider setup

### DIFF
--- a/cfme/tests/intelligence/test_download_report.py
+++ b/cfme/tests/intelligence/test_download_report.py
@@ -39,7 +39,7 @@ def report():
 
 @pytest.mark.parametrize("filetype", ["txt", "csv"])
 @pytest.sel.go_to('dashboard')
-def test_download_report_firefox(needs_firefox, report, filetype, setup_infrastructure_providers):
+def test_download_report_firefox(needs_firefox, setup_infrastructure_providers, report, filetype):
     """ Download the report as a file and check whether it was downloaded.
 
     This test skips for PDF as there are some issues with it.


### PR DESCRIPTION
- The order of the fixtures meant that the report was being generated
  before the provider was being set up
- The ordering has now been fixed
