### PR TITLE
Performance imprvement for menu navigation

### DIFF
--- a/cfme/web_ui/menu.py
+++ b/cfme/web_ui/menu.py
@@ -128,8 +128,8 @@ sections = {
 
 def is_page_active(toplevel, secondlevel=None):
     try:
-        sel.element("//div[@class='navbar']/ul/li[@class='active']"
-                    "/a[normalize-space(.)='{}']/..".format(toplevel))
+        if get_current_toplevel_name() != toplevel:
+            return False
     except NoSuchElementException:
         return False
     if secondlevel:


### PR DESCRIPTION
When doing a navigation a workaround was employed to remove the need to
use the move_mouse functionality in selenium as is was becoming
problematic. However this method was slow as it introduced two clicks
for every nav. The following performance improvement is suggested
- When doing toplevel/secondlevel navigation we first check to see if
  the toplevel is active. If so, we avoid the click on the toplevel
