### PR TITLE
Adding a marker for Sauce, and marking initial tests.

### DIFF
--- a/cfme/tests/configure/test_server_name.py
+++ b/cfme/tests/configure/test_server_name.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
+import pytest
 
 from cfme.configure.configuration import BasicInformation
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import flash, InfoBlock
 
 
+@pytest.mark.sauce
 def test_server_name():
     """Tests that changing the server name updates the about page"""
     form_infoblocks = InfoBlock('form')

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -20,18 +20,21 @@ bz1087476 = pytest.mark.bugzilla(
     1087476, unskip={1087476: lambda appliance_version: appliance_version < "5.3"})
 
 
+@pytest.mark.sauce
 def test_empty_discovery_form_validation():
     """ Tests that the flash message is correct when discovery form is empty."""
     provider.discover(None)
     flash.assert_message_match('At least 1 item must be selected for discovery')
 
 
+@pytest.mark.sauce
 def test_discovery_cancelled_validation():
     """ Tests that the flash message is correct when discovery is cancelled."""
     provider.discover(None, cancel=True)
     flash.assert_message_match('Infrastructure Providers Discovery was cancelled by the user')
 
 
+@pytest.mark.sauce
 def test_add_cancelled_validation():
     """Tests that the flash message is correct when add is cancelled."""
     prov = provider.VMwareProvider()
@@ -39,6 +42,7 @@ def test_add_cancelled_validation():
     flash.assert_message_match('Add of new Infrastructure Provider was cancelled by the user')
 
 
+@pytest.mark.sauce
 def test_type_required_validation():
     """Test to validate type while adding a provider"""
     prov = provider.Provider()

--- a/cfme/tests/test_login.py
+++ b/cfme/tests/test_login.py
@@ -5,6 +5,7 @@ from utils import conf, error
 pytestmark = pytest.mark.usefixtures('browser')
 
 
+@pytest.mark.sauce
 @pytest.mark.smoke
 def test_login():
     """ Tests that the appliance can be logged into and shows dashboard page. """

--- a/cfme/tests/test_nav.py
+++ b/cfme/tests/test_nav.py
@@ -13,5 +13,6 @@ def pytest_generate_tests(metafunc):
     metafunc.parametrize(argnames, sorted(argvalues))
 
 
+@pytest.mark.sauce
 def test_nav_destination(nav_dest):
     pytest.sel.force_navigate(nav_dest)

--- a/markers/sauce.py
+++ b/markers/sauce.py
@@ -1,0 +1,20 @@
+"""sauce: Mark a test to run on sauce
+
+Mark a single test to run on sauce.
+
+"""
+
+
+def pytest_addoption(parser):
+    group = parser.getgroup('cfme')
+    group.addoption('--sauce', dest='sauce', action='store_true', default=False,
+        help="Run tests with the sauce marker on sauce labs.")
+
+
+def pytest_configure(config):
+    config.addinivalue_line('markers', __doc__.splitlines()[0])
+    if config.option.sauce:
+        if config.option.markexpr:
+            config.option.markexpr = 'sauce and (%s)' % config.option.markexpr
+        else:
+            config.option.markexpr = 'sauce'


### PR DESCRIPTION
This adds a marker for sauce and a flag for py.test to make use of the sauce markers. When the flag is enabled, all tests with the sauce marker will be run on sauce labs, and all tests that are not marked will be uncollected.
