### PR TITLE
Automated timeline testing for cloud

### DIFF
--- a/cfme/cloud/provider.py
+++ b/cfme/cloud/provider.py
@@ -23,6 +23,7 @@ from cfme.exceptions import (
     HostStatsNotContains, ProviderHasNoProperty, ProviderHasNoKey, UnknownProviderType
 )
 from cfme.web_ui import Region, Quadicon, Form, Select, Tree, fill, paginator
+from cfme.web_ui import Timelines
 from utils import conf
 from utils.log import logger
 from utils.providers import provider_factory
@@ -78,8 +79,11 @@ manage_policies_form = Form(
 
 details_page = Region(infoblock_type='detail')
 
+prov_timeline = Timelines('//div[@id="miq_timeline"]')
+
 cfg_btn = partial(tb.select, 'Configuration')
 pol_btn = partial(tb.select, 'Policy')
+mon_btn = partial(tb.select, 'Monitoring')
 
 nav.add_branch('clouds_providers',
                {'clouds_provider_new': lambda _: cfg_btn('Add a New Cloud Provider'),
@@ -89,7 +93,9 @@ nav.add_branch('clouds_providers',
                                    {'clouds_provider_edit':
                                     lambda _: cfg_btn('Edit this Cloud Provider'),
                                     'clouds_provider_policy_assignment':
-                                    lambda _: pol_btn('Manage Policies')}]})
+                                    lambda _: pol_btn('Manage Policies'),
+                                    'cloud_provider_timelines':
+                                    lambda _: mon_btn('Timelines')}]})
 
 
 class Provider(Updateable, Pretty):

--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -1,0 +1,120 @@
+import pytest
+from cfme.cloud.instance import instance_factory, details_page
+from cfme.cloud.provider import prov_timeline
+from cfme.web_ui import toolbar
+from utils import testgen
+from utils.log import logger
+from utils.providers import setup_provider
+from utils.randomness import generate_random_string
+
+bz1127960 = pytest.mark.bugzilla(
+    1127960, unskip={1127960: lambda appliance_version: appliance_version >= "5.3"})
+
+pytestmark = [pytest.mark.usefixtures('setup_providers')]
+
+
+def pytest_generate_tests(metafunc):
+    # Filter out EC2 since EC2 doesn't support timelines
+    argnames, argvalues, idlist = testgen.provider_by_type(metafunc,
+        provider_types=['openstack'])
+    testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope="module")
+
+
+@pytest.fixture(scope="module")
+def delete_fx_provider_event(db, provider_crud):
+    logger.debug("Deleting timeline events for provider name {}".format(provider_crud.name))
+    ems = db['ext_management_systems']
+    ems_events = db['ems_events']
+    with db.transaction:
+        providers = (
+            db.session.query(ems_events.id)
+            .join(ems, ems_events.ems_id == ems.id)
+            .filter(ems.name == provider_crud.name)
+        )
+        db.session.query(ems_events).filter(ems_events.id.in_(providers.subquery())).delete(False)
+
+
+@pytest.fixture(scope="module")
+def setup_providers(provider_key):
+    # Normally function-scoped
+    setup_provider(provider_key)
+
+
+@pytest.fixture(scope="module")
+def vm_name():
+    return "test_instance_timeline_{}".format(generate_random_string())
+
+
+@pytest.fixture(scope="module")
+def delete_instances_fin(request):
+    """ Fixture to add a finalizer to delete provisioned instances at the end of tests
+
+    This is a "trashbin" fixture - it returns a mutable that you put stuff into.
+    """
+    provisioned_instances = {}
+
+    def delete_instances(instances_dict):
+        for instance in instances_dict.itervalues():
+            instance.delete_from_provider()
+    request.addfinalizer(lambda: delete_instances(provisioned_instances))
+    return provisioned_instances
+
+
+@pytest.fixture(scope="module")
+def test_instance(request, delete_instances_fin, provider_crud, provider_mgmt, vm_name):
+    """ Fixture to provision instance on the provider
+    """
+    instance = instance_factory(vm_name, provider_crud)
+    if not provider_mgmt.does_vm_exist(vm_name):
+        delete_instances_fin[provider_crud.key] = instance
+        instance.create_on_provider()
+    return instance
+
+
+@pytest.fixture(scope="module")
+def gen_events(delete_fx_provider_event, provider_crud, test_instance):
+    logger.debug('Starting, stopping VM')
+    mgmt = provider_crud.get_mgmt_system()
+    mgmt.stop_vm(test_instance.name)
+    mgmt.start_vm(test_instance.name)
+    provider_crud.refresh_provider_relationships()
+
+
+@pytest.mark.bugzilla(1127960)
+def test_provider_event(provider_crud, gen_events, test_instance):
+    pytest.sel.force_navigate('cloud_provider_timelines',
+                              context={'provider': provider_crud})
+    events = []
+    for event in prov_timeline.events():
+        data = event.block_info()
+        if test_instance.name in data.values():
+            events.append(event)
+            assert(len(events) > 0)
+            break
+
+
+@pytest.mark.bugzilla(1127960)
+def test_azone_event(provider_crud, gen_events, test_instance):
+    test_instance.load_details()
+    pytest.sel.click(details_page.infoblock.element('Relationships', 'Availability Zone'))
+    toolbar.select('Monitoring', 'Timelines')
+    events = []
+    for event in prov_timeline.events():
+        data = event.block_info()
+        if test_instance.name in data.values():
+            events.append(event)
+            assert(len(events) > 0)
+            break
+
+
+@pytest.mark.bugzilla(1127960)
+def test_vm_event(provider_crud, gen_events, test_instance):
+    test_instance.load_details()
+    toolbar.select('Monitoring', 'Timelines')
+    events = []
+    for event in prov_timeline.events():
+        data = event.block_info()
+        if test_instance.name in data.values():
+            events.append(event)
+            assert(len(events) > 0)
+            break


### PR DESCRIPTION
This is a test to generate events for RHOS provider and then verify that the events show up on the timelines of instance,availability zone and cloud provider.
