### PR TITLE
Update DB-enabling scripts and utils.appliance

### DIFF
--- a/scripts/enable_external_db.py
+++ b/scripts/enable_external_db.py
@@ -56,36 +56,59 @@ def main():
         'password': credentials['ssh']['password'],
         'hostname': args.address
     }
-    rbt_repl = {
-        'miq_lib': '/var/www/miq/lib',
-        'host': args.db_address,
-        'database': args.database,
-        'region': args.region,
-        'username': args.username,
-        'password': args.password
-    }
 
-    # Find and load our rb template with replacements
-    base_path = os.path.dirname(__file__)
-    rbt = datafile.data_path_for_filename(
-        'enable-external-db.rbt', base_path)
-    rb = datafile.load_data_file(rbt, rbt_repl)
-
-    # Init SSH client and sent rb file over to /tmp
-    remote_file = '/tmp/%s' % generate_random_string()
     client = SSHClient(**ssh_kwargs)
-    client.put_file(rb.name, remote_file)
-
-    # Run the rb script, clean it up when done
     print 'Initializing Appliance External DB'
-    status, out = client.run_command('ruby %s' % remote_file)
-    client.run_command('rm %s' % remote_file)
-    if status != 0:
-        print 'Enabling DB failed with error:'
-        print out
-        sys.exit(1)
+
+    if client.run_command('ls -l /bin/appliance_console_cli')[0] == 0:
+        # copy v2 key
+        master_ssh_kwargs = ssh_kwargs.copy()
+        master_ssh_kwargs['hostname'] = args.db_address
+        master_client = SSHClient(**master_ssh_kwargs)
+        rand_filename = "/tmp/v2_key_{}".format(generate_random_string())
+        master_client.get_file("/var/www/miq/vmdb/certs/v2_key", rand_filename)
+        client.put_file(rand_filename, "/var/www/miq/vmdb/certs/v2_key")
+        # enable external DB
+        status, out = client.run_command(
+            'appliance_console_cli '
+            '--hostname {} --region {} --dbname {} --username {} --password {}'
+            .format(args.db_address, args.region, args.database, args.username, args.password)
+        )
+        if status != 0:
+            print 'Enabling DB failed with error:'
+            print out
+            sys.exit(1)
+        else:
+            print 'DB Enabled, evm watchdog should start the UI shortly.'
     else:
-        print 'DB Enabled, evm watchdog should start the UI shortly.'
+        rbt_repl = {
+            'miq_lib': '/var/www/miq/lib',
+            'host': args.db_address,
+            'database': args.database,
+            'region': args.region,
+            'username': args.username,
+            'password': args.password
+        }
+
+        # Find and load our rb template with replacements
+        base_path = os.path.dirname(__file__)
+        rbt = datafile.data_path_for_filename(
+            'enable-external-db.rbt', base_path)
+        rb = datafile.load_data_file(rbt, rbt_repl)
+
+        # Init SSH client and sent rb file over to /tmp
+        remote_file = '/tmp/%s' % generate_random_string()
+        client.put_file(rb.name, remote_file)
+
+        # Run the rb script, clean it up when done
+        status, out = client.run_command('ruby %s' % remote_file)
+        client.run_command('rm %s' % remote_file)
+        if status != 0:
+            print 'Enabling DB failed with error:'
+            print out
+            sys.exit(1)
+        else:
+            print 'DB Enabled, evm watchdog should start the UI shortly.'
 
 
 if __name__ == '__main__':

--- a/scripts/enable_internal_db.py
+++ b/scripts/enable_internal_db.py
@@ -50,8 +50,10 @@ def main():
 
     if client.run_command('ls -l /bin/appliance_console_cli')[0] == 0:
         # broken in 5.3.0.2
-        # status, out = client.run_command('appliance_console_cli --ca --region 1 --internal')
-        status, out = client.run_command('appliance_console_cli --region 1 --internal -k')
+        # status, out = client.run_command('appliance_console_cli --ca --region {} --internal -k')
+        #                                  .format(args.region))
+        status, out = client.run_command('appliance_console_cli --region {} --internal -k'
+                                         .format(args.region))
         if status != 0:
             print 'Enabling DB failed with error:'
             print out


### PR DESCRIPTION
Added v2_key copying from primary to secondary appliance when enabling external DB in 5.3
Fixed region setup when enabling internal DB in 5.3 (was forced to 1)
Added `loosen_pgssl` method and added it as part of `configure` (it is ran after DB setup; does nothing in versions below 5.3)
Added `is_db_ready` and `wait_for_db` methods (thanks psav)

**How to test:**

```
from utils import appliance, conf
appdata = conf.cfme_data['appliance_provisioning']['appliance_set']
apps = appliance.provision_appliance_set(appdata, 'test_pr1160')
```

This should provision 2 appliances (1 master, 1 slave) - you need to have the appliance versions set in the yaml + you need to have template names assigned to those versions there as well.
