### PR TITLE
Changes to Appliance class + others

### DIFF
--- a/scripts/clone_domain.py
+++ b/scripts/clone_domain.py
@@ -53,19 +53,25 @@ def main():
 
     # Make sure the working dir exists
     client.run_command('mkdir -p /tmp/miq')
+
     print 'Exporting domain...'
     export_opts = 'DOMAIN={} EXPORT_DIR=/tmp/miq PREVIEW=false OVERWRITE=true'.format(args.source)
     export_cmd = 'evm:automate:export {}'.format(export_opts)
     print export_cmd
-    client.run_rake_command(export_cmd)
+    status, output = client.run_rake_command(export_cmd)
+    if status != 0:
+        return 127
     ro_fix_cmd = "sed -i 's/system: true/system: false/g' /tmp/miq/ManageIQ/__domain__.yaml"
-    client.run_command(ro_fix_cmd)
+    status, output = client.run_command(ro_fix_cmd)
+    if status != 0:
+        return 127
     import_opts = 'DOMAIN={} IMPORT_DIR=/tmp/miq PREVIEW=false'.format(args.source)
     import_opts += ' OVERWRITE=true IMPORT_AS={}'.format(args.dest)
     import_cmd = 'evm:automate:import {}'.format(import_opts)
     print import_cmd
-    client.run_rake_command(import_cmd)
-
+    status, output = client.run_rake_command(import_cmd)
+    if status != 0:
+        return 127
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/utils/version.py
+++ b/utils/version.py
@@ -105,8 +105,14 @@ class Version(object):
             series: Another :py:class:`Version` to check against. If string provided, will be
                 converted to :py:class:`LooseVersion`
         """
+
         if isinstance(series, basestring):
-            series = LooseVersion(series)
+            series = get_version(series)
+        if self == LATEST or series == LATEST:
+            if series == self:
+                return True
+            else:
+                return False
         return series.version == self.version[:len(series.version)]
 
 # Taken from stdlib, just change classes to new-style and clean up


### PR DESCRIPTION
- clone_domain script now reports back if it fails at each step to let
  the new Appliance class builder know if it failed.
- version did not know how to asked if "master" was in "5.2" which
  caused big problems in the appliance version checking code. This has
  now been rectified.
- Appliance has many new changes:
  - Appliance.configure() used to perform custom configuration, this has
    been replaced with an Automatic configurator. However, if any args
    are passed to the .configure() method, it hands off to a
    custom_configure() method, which replicates the old behaviour.
  - does_vm_exist() method is added to aid in deletion.
  - precompile_assets, loosen_pgsql, clone_domain, deploy_merkyl,
    update_rhel methods have been added which interact with the scripts.
  - fix_ntp_clock has been replaced with a version that runs the
    external script. This was due to a significant slowness encountered
    with the internal operations of the fix_ntp_clock method. If the
    "newer" ntp fix is required, this should be tested and ported to the
    external script.
