### PR TITLE
Fixed block_info to return all elements from a timeline event popup

### DIFF
--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -2507,7 +2507,7 @@ class Timelines(Pretty):
                         data[kv[0]] = None
                 else:
                     data[kv[0]] = kv[1].strip()
-                    return data
+            return data
 
     class Marker(Object):
         """ A proxied object in case it needs more methods further down the line."""


### PR DESCRIPTION
This fixes block_info() in the Event class to return all elements from a timeline event popup.
