### PR TITLE
Fix InfoBlock locator for 5.3 and upstream & update scheduled DB backup test

### DIFF
--- a/cfme/tests/configure/test_db_backup_schedule.py
+++ b/cfme/tests/configure/test_db_backup_schedule.py
@@ -108,11 +108,8 @@ def get_schedulable_datetime():
     """
     dt = datetime.utcnow()
     delta_min = 5 - (dt.minute % 5)
-    # If the schedule would be set for current minute
-    # or next minute while we have less than 40sec to set it
-    if (delta_min == 0) or (delta_min == 1 and dt.second > 20):
-        # Pad with 5 minutes
-        delta_min += 5
+    if (delta_min < 3):  # If the schedule would be set to run in less than 2mins
+        delta_min += 5   # Pad with 5 minutes
     dt += relativedelta(minutes=delta_min)
     return dt
 
@@ -182,7 +179,6 @@ def test_db_backup_schedule(request, db_backup_data):
     full_path = get_full_path_to_file(path_on_host, db_backup_data.schedule_name)
 
     sched = DatabaseBackupSchedule(**sched_args)
-    # Fails on upstream - BZ1099341
     sched.create()
     flash.assert_message_contain('Schedule "{}" was saved'.format(db_backup_data.schedule_name))
     # ----

--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -1693,8 +1693,7 @@ class InfoBlock(Pretty):
             self._pair_locator = 'table/tbody/tr/td[1][@class="label"][.="%s"]/..'
             self._value_locator = 'td[2]'
         elif itype == "form":
-            self._box_locator = version.pick({
-                version.LOWEST: '//fieldset/p[@class="legend"][contains(., "%s")]/..'})
+            self._box_locator = '//p[@class="legend"][contains(., "%s")]/..'
             self._pair_locator = 'table/tbody/tr/td[1][@class="key"][.="%s"]/..'
             self._value_locator = 'td[2]'
         else:


### PR DESCRIPTION
I had to remove the "fieldset" part of xpath, because it is not used (in some places) in 5.3 and Upstream.

Also, the automation now gets at least 2mins to set the schedule up instead of currently used 40secs.

Tested on 5.2, 5.3 and Upstream.
The samba db backup is disabled in our shared yamls, so we only test nfs on jenkins - but I tested samba as well (if you want to test it too, you need to set line 790 in current cfme_data.yaml - `log_db_depot > machine > smb > use_for_db_backups` to `True`)

I also tested if the modified InfoBlock locator works in Configuration > Current Server which is filled with InfoBlocks (that are inside a fieldset), and it worked.
