### PR TITLE
validate is now honoured when check_exsiting used

### DIFF
--- a/utils/providers.py
+++ b/utils/providers.py
@@ -176,10 +176,12 @@ def setup_provider(provider_key, validate=True, check_existing=True):
 
     provider = get_from_config(provider_key)
     if check_existing and provider.exists:
-        return provider
-
-    logger.info('Setting up provider: %s' % provider.key)
-    provider.create(validate_credentials=True)
+        # no need to create provider if the provider exists
+        # pass so we don't skip the validate step
+        pass
+    else:
+        logger.info('Setting up provider: %s' % provider.key)
+        provider.create(validate_credentials=True)
 
     if validate:
         provider.validate()


### PR DESCRIPTION
The validate parameter was effectively ignored if check_existing was
True. Although it is expected that a provider existing means that
it is validated, this is not always true and in situations where there
are a low number of workers, we cannot guarantee that if a provider
exists then it is validated. Hence if both arguments are checked, both
should be honoured.
