### PR TITLE
Infra/host update, new host drift analysis test, host analysis test update and web_ui.toolbar fix

### DIFF
--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -66,6 +66,8 @@ manage_policies_tree = CheckboxTree(
     })
 )
 
+drift_table = CheckboxTable("//table[@class='style3']")
+
 host_add_btn = FormButton('Add this Host')
 
 cfg_btn = partial(tb.select, 'Configuration')
@@ -315,8 +317,9 @@ class Host(Updateable, Pretty):
         sel.force_navigate('infrastructure_host', context={'host': self})
         tb.select('Configuration', 'Perform SmartState Analysis', invokes_alert=True)
         sel.handle_alert()
+        flash.assert_message_contain('"{}": Analysis successfully initiated'.format(self.name))
 
-    def are_drift_results_equal(self, row_text, *indexes):
+    def equal_drift_results(self, row_text, *indexes):
         """ Compares drift analysis results of a row specified by it's title text
 
         Args:
@@ -333,8 +336,6 @@ class Host(Updateable, Pretty):
         # mark by indexes or mark all
         sel.force_navigate('infrastructure_host', context={'host': self})
         list_acc.select('Relationships', 'Show host drift history')
-        drift_table_loc = "//table[@class='style3']"
-        drift_table = CheckboxTable(drift_table_loc)
         if indexes:
             drift_table.select_rows_by_indexes(*indexes)
         else:

--- a/cfme/tests/infrastructure/test_host_analysis.py
+++ b/cfme/tests/infrastructure/test_host_analysis.py
@@ -4,7 +4,7 @@ from cfme.configure import tasks
 from cfme.exceptions import ListAccordionLinkNotFound
 from cfme.fixtures import pytest_selenium as sel
 from cfme.infrastructure import host
-from cfme.web_ui import flash, listaccordion as list_acc, tabstrip as tabs, toolbar as tb
+from cfme.web_ui import listaccordion as list_acc, tabstrip as tabs, toolbar as tb
 from utils import conf
 from utils import testgen
 from utils.wait import wait_for
@@ -84,7 +84,6 @@ def test_run_host_analysis(request, provider_key, host_type, host_name, register
 
     # Initiate analysis
     test_host.run_smartstate_analysis()
-    flash.assert_message_contain('"{}": Analysis successfully initiated'.format(host_name))
 
     # Wait for the task to finish
     def is_host_analysis_finished():

--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -2672,8 +2672,12 @@ class DriftGrid(Pretty):
             Selenium element of the cell.
         """
         self.expand_all_sections()
-        cell_loc = ".//div/div[1][contains(., '{}')]/../div[{}]"
-        cell = sel.element(cell_loc.format(row_text, col_index + 2), root=self.loc)
+        cell_loc = {
+            '5.3': ".//div/div[1][contains(., '{}')]/../div[{}]".format(row_text, col_index + 2),
+            version.LOWEST: ".//tr/td[1][contains(., '{}')]/../td[{}]"
+                            .format(row_text, col_index + 2)
+        }
+        cell = sel.element(cell_loc, root=self.loc)
         return cell
 
     def cell_indicates_change(self, row_text, col_index):
@@ -2699,16 +2703,23 @@ class DriftGrid(Pretty):
                 return True
         # or text
         except NoSuchElementException:
-            cell_textdiv = sel.element("./div", root=cell)
-            if 'mark' in sel.get_attribute(cell_textdiv, 'class'):
-                return True
+            if version.current_version() <= '5.3':
+                cell_textdiv = sel.element("./div", root=cell)
+                if 'mark' in sel.get_attribute(cell_textdiv, 'class'):
+                    return True
+            else:  # LOWEST
+                if 'color: rgb(33, 160, 236)' in sel.get_attribute(cell, 'style'):
+                    return True
         return False
 
     def expand_all_sections(self):
         """ Expands all sections to make the row elements found therein available
         """
         els_to_expand = sel.elements(
-            './/div/span[contains(@class, "toggle") and contains(@class, "expand")]',
+            {
+                '5.3': './/div/span[contains(@class, "toggle") and contains(@class, "expand")]',
+                version.LOWEST: './/div/img[contains(@src, "plus")]'
+            },
             root=self.loc
         )
         for el in els_to_expand:

--- a/cfme/web_ui/toolbar.py
+++ b/cfme/web_ui/toolbar.py
@@ -58,7 +58,7 @@ def select_n_move(el):
     """
     # .. if we don't move the "mouse" the button stays active
     sel.click(el)
-    sel.move_to_element((By.XPATH, '//div[@class="brand"]'))
+    sel.move_to_element((By.XPATH, '//div[@id="page_footer_div"]'))
 
 
 def select(root, sub=None, invokes_alert=False):


### PR DESCRIPTION
Update to infra/host:
Add run_smartstate_analysis_method
Add are_drift_results_equal method

Update host analysis test

Add new host drift analysis test

Make mouse move to footer instead of moving up over to the brand div (the mouse movement to brand div caused the browser to end up in Cloud / Availability Zones in 5.3 and Upstream when testing the host drift analysis).
