### PR TITLE
Trace loglevel

### DIFF
--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -235,9 +235,9 @@ def wait_for_ajax():
         # Log the message only if it's different from the last one
         if prev_log_msg != log_msg:
             _thread_local.ajax_log_msg = log_msg
-            logger.debug('Ajax running: {}'.format(log_msg))
+            logger.trace('Ajax running: {}'.format(log_msg))
         if (not anything_in_flight) and prev_log_msg:
-            logger.debug('Ajax done')
+            logger.trace('Ajax done')
 
         return not anything_in_flight
 

--- a/fixtures/parallelizer/remote.py
+++ b/fixtures/parallelizer/remote.py
@@ -36,14 +36,14 @@ class SlaveManager(object):
 
     def send_event(self, name, **kwargs):
         kwargs['_event_name'] = name
-        self.log.debug("sending %s %r", name, kwargs)
+        self.log.trace("sending %s %r", name, kwargs)
         self.sock.send_json(kwargs)
         recv = self.sock.recv_json()
         if recv == 'die':
             self.log.info('Slave instructed to die by master; shutting down')
             raise SystemExit()
         else:
-            self.log.debug('received "%r" from master', recv)
+            self.log.trace('received "%r" from master', recv)
             if recv != 'ack':
                 return recv
 

--- a/utils/wait.py
+++ b/utils/wait.py
@@ -62,7 +62,7 @@ def wait_for(func, func_args=[], func_kwargs={}, **kwargs):
     silent_fail = kwargs.get("silent_failure", False)
 
     t_delta = 0
-    logger.debug('Started {} at {}'.format(message, st_time))
+    logger.trace('Started {} at {}'.format(message, st_time))
     while t_delta <= num_sec:
         try:
             out = func(*func_args, **func_kwargs)
@@ -82,10 +82,10 @@ def wait_for(func, func_args=[], func_kwargs={}, **kwargs):
             duration = time.time() - st_time
             if not quiet:
                 logger.debug('Took %f to do %s' % (duration, message))
-            logger.debug('Finished {} at {}'.format(message, st_time + t_delta))
+            logger.trace('Finished {} at {}'.format(message, st_time + t_delta))
             return out, duration
         t_delta = time.time() - st_time
-    logger.debug('Finished at {}'.format(st_time + t_delta))
+    logger.trace('Finished at {}'.format(st_time + t_delta))
     if not silent_fail:
         logger.error('Could not complete %s in time, took %f' % (message, t_delta))
         raise TimedOutError("Could not do %s in time" % message)


### PR DESCRIPTION
This adds a new loglevel, TRACE. This gives us a level lower than DEBUG for putting really noisy stuff. I've put move of `wait_for`'s logging in there, as well as the AJAX wait detail reporting.

Working with the logging module is always a little painful. :(
