### PR TITLE
Reporting fell over whilst tests were in progress

### DIFF
--- a/artifactor/plugins/reporter.py
+++ b/artifactor/plugins/reporter.py
@@ -52,9 +52,9 @@ class Reporter(ArtifactorBasePlugin):
         self.configured = True
 
     @ArtifactorBasePlugin.check_configured
-    def start_test(self, test_location, test_name):
+    def start_test(self, test_location, test_name, slaveid):
         test_ident = "{}/{}".format(test_location, test_name)
-        return None, {'artifacts': {test_ident: {'start_time': time.time()}}}
+        return None, {'artifacts': {test_ident: {'start_time': time.time(), 'slaveid': slaveid}}}
 
     @ArtifactorBasePlugin.check_configured
     def finish_test(self, test_location, test_name, slaveid):
@@ -111,7 +111,7 @@ class Reporter(ArtifactorBasePlugin):
             # Set the overall status and then process duration
             test['statuses']['overall'] = overall_status
             test_data = {'name': test_name, 'outcomes': test['statuses'],
-                         'slaveid': test['slaveid']}
+                         'slaveid': test.get('slaveid', "Unknown")}
 
             if test.get('start_time', None):
                 if test.get('finish_time', None):


### PR DESCRIPTION
Reporting fell over whilst tests were in progress
