### PR TITLE
Fix the provider nav for provisioning

### DIFF
--- a/cfme/cloud/instance.py
+++ b/cfme/cloud/instance.py
@@ -5,7 +5,7 @@
 """
 
 from cfme.cloud.provider import OpenStackProvider, EC2Provider
-from cfme.cloud.provisioning import provisioning_form
+from cfme.web_ui.prov_form import provisioning_form
 from cfme.exceptions import InstanceNotFound, OptionNotAvailable, UnknownProviderType
 from cfme.fixtures import pytest_selenium as sel
 from cfme.services import requests

--- a/cfme/cloud/provisioning.py
+++ b/cfme/cloud/provisioning.py
@@ -3,115 +3,34 @@
 """
 from cfme.fixtures import pytest_selenium as sel
 from cfme import web_ui as ui
-from cfme.web_ui import form_buttons, tabstrip, toolbar
+from cfme.web_ui import toolbar
 from cfme.web_ui.menu import nav
-from collections import OrderedDict
-
-submit_button = form_buttons.FormButton("Submit")
-
-template_select_form = ui.Form(
-    fields=[
-        ('template_table', ui.Table('//div[@id="pre_prov_div"]/fieldset/table')),
-        ('continue_button', submit_button),
-        ('cancel_button', form_buttons.cancel)
-    ]
-)
-
-
-def select_security_group(sg):
-    """Workaround for select box that is immediately replaced by the same
-       select box no matter what selenium clicks on (but works fine
-       manually).  For now only selects one item even though it's a
-       multiselect.
-
-    """
-    val = sel.get_attribute("//select[@id='environment__security_groups']/option[.='%s']" %
-                            sg, 'value')
-    sel.browser().execute_script(
-        "$j('#environment__security_groups').val('%s');"
-        "$j.ajax({type: 'POST', url: '/miq_request/prov_field_changed/new',"
-        " data: {'environment__security_groups':'%s'}})" % (val, val))
-    sel.wait_for_ajax()
-    sel.sleep(1)
+from cfme.web_ui import prov_form
+from cfme.cloud import instance
+assert instance
 
 instances_by_provider_tree = ui.Tree("//ul[@class='dynatree-container']")
-
-provisioning_form = tabstrip.TabStripForm(
-    fields=[
-        ('submit_button', submit_button),
-        ('cancel_button', form_buttons.cancel)
-    ],
-    tab_fields=OrderedDict([
-        ('Request', [
-            ('email', '//input[@name="requester__owner_email"]'),
-            ('first_name', '//input[@id="requester__owner_first_name"]'),
-            ('last_name', '//input[@id="requester__owner_last_name"]'),
-            ('notes', '//textarea[@id="requester__request_notes"]'),
-            ('manager_name', '//input[@id="requester__owner_manager"]')
-        ]),
-        ('Purpose', [
-            ('apply_tags', ui.Tree('//div[@id="all_tags_treebox"]//table'))
-        ]),
-        ('Catalog', [
-            ('num_instances', ui.Select('//select[@id="service__number_of_vms"]')),
-            ('instance_name', '//input[@name="service__vm_name"]'),
-            ('instance_description', '//textarea[@id="service__vm_description"]'),
-            ('catalog_name', ui.Table('//div[@id="prov_vm_div"]/table')),
-        ]),
-        ('Environment', [
-            ('automatic_placement', '//input[@id="environment__placement_auto"]'),
-            ('availability_zone',
-                ui.Select('//select[@id="environment__placement_availability_zone"]')),
-            ('virtual_private_cloud', ui.Select('//select[@id="environment__cloud_network"]')),
-            ('cloud_subnet', ui.Select('//select[@id="environment__cloud_subnet"]')),
-            ('cloud_network', ui.Select('//select[@id="environment__cloud_network"]')),
-            ('security_groups', select_security_group),
-            ('public_ip_address', ui.Select('//select[@id="environment__floating_ip_address"]'))
-        ]),
-        ('Properties', [
-            ('instance_type', ui.Select('//select[@id="hardware__instance_type"]')),
-            ('guest_keypair', ui.Select('//select[@id="hardware__guest_access_key_pair"]')),
-            ('hardware_monitoring', ui.Select('//select[@id="hardware__monitoring"]')),
-        ]),
-        ('Customize', [
-            ('specification', ui.Select('//select[@id="customize__sysprep_enabled"]')),
-            ('specification_name', ui.Table('//div[@id="prov_vc_div"]/table')),
-            ('computer_name', '//input[@id="customize__linux_host_name"]'),
-            ('domain_name', '//input[@id="customize__linux_domain_name"]'),
-            ('dns_servers', '//input[@id="customize__dns_servers"]'),
-            ('dns_suffixes', '//input[@id="customize__dns_suffixes"]'),
-        ]),
-        ('Schedule', [
-            ('schedule_type', ui.Radio('schedule__schedule_type')),
-            ('provision_date', ui.Calendar('miq_date_1')),
-            ('provision_start_hour', ui.Select('//select[@id="start_hour"]')),
-            ('provision_start_min', ui.Select('//select[@id="start_min"]')),
-            ('power_on', '//input[@id="schedule__vm_auto_start"]'),
-            ('retirement', ui.Select('//select[@id="schedule__retirement"]')),
-            ('retirement_warning', ui.Select('//select[@id="schedule__retirement_warn"]')),
-        ])
-    ])
-)
 
 
 # Nav targets and helpers
 def _nav_to_provision_form(context):
+
     toolbar.select('Lifecycle', 'Provision Instances')
     provider = context['provider']
     template_name = context['template_name']
 
-    template = template_select_form.template_table.find_row_by_cells({
+    template = prov_form.template_select_form.template_table.find_row_by_cells({
         'Name': template_name,
         'Provider': provider.name
     })
     if template:
         sel.click(template)
-        sel.click(template_select_form.continue_button)
+        sel.click(prov_form.template_select_form.continue_button)
     else:
         # Better exception?
         raise ValueError('Navigation failed: Unable to find template "%s" for provider "%s"' %
             (template_name, provider.name))
 
-nav.add_branch('clouds_instances', {
+nav.add_branch('clouds_instances_by_provider', {
     'clouds_provision_instances': _nav_to_provision_form
 })

--- a/cfme/infrastructure/provisioning.py
+++ b/cfme/infrastructure/provisioning.py
@@ -1,114 +1,13 @@
 """Provisioning-related forms and helper classes.
 
 """
-from collections import OrderedDict
-
 from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import Calendar, CheckboxTree, Form, Radio, Select, Table, form_buttons,\
-    tabstrip, toolbar
+from cfme.web_ui import toolbar
 from cfme.web_ui.menu import nav
-from utils import version
+from cfme.web_ui import prov_form
 
 import cfme.infrastructure.virtual_machines  # To ensure the infra_vm_and_templates is available
 assert cfme  # To prevent flake8 compalining
-
-
-submit_button = form_buttons.FormButton("Submit")
-
-template_select_form = Form(
-    fields=[
-        ('template_table', Table('//div[@id="pre_prov_div"]/fieldset/table')),
-        ('continue_button', submit_button),
-        ('cancel_button', form_buttons.cancel)
-    ]
-)
-
-provisioning_form = tabstrip.TabStripForm(
-    fields=[
-        ('submit_button', submit_button),
-        ('cancel_button', form_buttons.cancel),
-        ('host_submit_button', form_buttons.host_provision_submit),
-        ('host_cancel_button', form_buttons.host_provision_cancel)
-    ],
-    tab_fields=OrderedDict([
-        ('Request', [
-            ('email', '//input[@name="requester__owner_email"]'),
-            ('first_name', '//input[@id="requester__owner_first_name"]'),
-            ('last_name', '//input[@id="requester__owner_last_name"]'),
-            ('notes', '//textarea[@id="requester__request_notes"]'),
-            ('manager_name', '//input[@id="requester__owner_manager"]'),
-        ]),
-        ('Purpose', [
-            ('apply_tags', {
-                version.LOWEST: CheckboxTree('//div[@id="all_tags_treebox"]//table'),
-                "5.3": CheckboxTree('//div[@id="all_tags_treebox"]//ul')
-            })
-        ]),
-        ('Catalog', [
-            ('vm_filter', Select('//select[@id="service__vm_filter"]')),
-            ('catalog_name', Table('//div[@id="prov_vm_div"]/table')),
-            ('num_vms', Select('//select[@id="service__number_of_vms"]')),
-            ('vm_name', '//input[@name="service__vm_name"]'),
-            ('vm_description', '//textarea[@id="service__vm_description"]'),
-            ('provision_type', Select('//select[@id="service__provision_type"]')),
-            ('linked_clone', '//input[@id="service__linked_clone"]'),
-            ('pxe_server', Select('//select[@id="service__pxe_server_id"]')),
-            ('pxe_image', Table('//div[@id="prov_pxe_img_div"]/table')),
-            ('iso_file', Table('//div[@id="prov_iso_img_div"]/table'))
-        ]),
-        ('Environment', [
-            ('automatic_placement', '//input[@id="environment__placement_auto"]'),
-            ('provider_name', Select('//select[@id="environment__placement_ems_name"]')),
-            ('datacenter', Select('//select[@id="environment__placement_dc_name"]')),
-            ('cluster', Select('//select[@id="environment__placement_cluster_name"]')),
-            ('resource_pool', Select('//select[@id="environment__placement_rp_name"]')),
-            ('folder', Select('//select[@id="environment__placement_folder_name"]')),
-            ('host_filter', Select('//select[@id="environment__host_filter"]')),
-            ('host_name', Table('//div[@id="prov_host_div"]/table')),
-            ('datastore_create', '//*[@id="environment__new_datastore_create"]'),
-            ('datastore_filter', Select('//select[@id="environment__ds_filter"]')),
-            ('datastore_name', Table('//div[@id="prov_ds_div"]/table')),
-        ]),
-        ('Hardware', [
-            ('num_sockets', Select('//select[@id="hardware__number_of_sockets"]')),
-            ('cores_per_socket', Select('//select[@id="hardware__cores_per_socket"]')),
-            ('memory', Select('//select[@id="hardware__vm_memory"]')),
-            ('disk_format', Radio('hardware__disk_format')),
-            ('vm_limit_cpu', '//input[@id="hardware__cpu_limit"]'),
-            ('vm_limit_memory', '//input[@id="hardware__memory_limit"]'),
-            ('vm_reserve_cpu', '//input[@id="hardware__cpu_reserve"]'),
-            ('vm_reserve_memory', '//input[@id="hardware__memory_reserve"]'),
-        ]),
-        ('Network', [
-            ('vlan', Select('//select[@id="network__vlan"]')),
-        ]),
-        ('Customize', [
-            ('customize_type', Select('//select[@id="customize__sysprep_enabled"]')),
-            ('specification_name', Table('//div[@id="prov_vc_div"]/table')),
-            ('linux_host_name', '//input[@id="customize__linux_host_name"]'),
-            ('linux_domain_name', '//input[@id="customize__linux_domain_name"]'),
-            ('prov_host_name', '//input[@id="customize__hostname"]'),
-            ('ip_address', '//input[@id="customize__ip_addr"]'),
-            ('subnet_mask', '//input[@id="customize__subnet_mask"]'),
-            ('gateway', '//input[@id="customize__gateway"]'),
-            ('dns_servers', '//input[@id="customize__dns_servers"]'),
-            ('dns_suffixes', '//input[@id="customize__dns_suffixes"]'),
-            ('custom_template', Table('//div[@id="prov_template_div"]/table')),
-            ('root_password', '//input[@id="customize__root_password"]'),
-            ('vm_host_name', '//input[@id="customize__hostname"]'),
-        ]),
-        ('Schedule', [
-            ('schedule_type', Radio('schedule__schedule_type')),
-            ('provision_date', Calendar('miq_date_1')),
-            ('provision_start_hour', Select('//select[@id="start_hour"]')),
-            ('provision_start_min', Select('//select[@id="start_min"]')),
-            ('stateless', '//input[@id="schedule__stateless"]'),
-            ('retirement', Select('//select[@id="schedule__retirement"]')),
-            ('retirement_warning', Select('//select[@id="schedule__retirement_warn"]')),
-            ('power_on', '//input[@id="schedule__vm_auto_start"]')
-        ])
-    ])
-)
 
 
 # Nav targets and helpers
@@ -117,13 +16,13 @@ def _nav_to_provision_form(context):
     provider = context['provider']
     template_name = context['template_name']
 
-    template = template_select_form.template_table.find_row_by_cells({
+    template = prov_form.template_select_form.template_table.find_row_by_cells({
         'Name': template_name,
         'Provider': provider.name
     })
     if template:
         sel.click(template)
-        sel.click(template_select_form.continue_button)
+        sel.click(prov_form.template_select_form.continue_button)
         return
     else:
         # Better exception?

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -5,6 +5,7 @@ import re
 from cfme.exceptions import CandidateNotFound, VmNotFound, OptionNotAvailable, TemplateNotFound
 from cfme.fixtures import pytest_selenium as sel
 from cfme.services import requests
+from cfme.web_ui.prov_form import provisioning_form
 from cfme.web_ui import (
     CheckboxTree, Form, Region, Quadicon, Tree, accordion, fill, flash, form_buttons, paginator,
     toolbar, Calendar, Select
@@ -584,7 +585,7 @@ class Vm(Common):
             prov_data = cfme_data["management_systems"][self.provider_crud.key]["provisioning"]
         except (KeyError, IndexError):
             raise ValueError("You have to specify the correct options in cfme_data.yaml")
-        from cfme.infrastructure.provisioning import provisioning_form, submit_button
+
         provisioning_data = {
             "first_name": first_name,
             "last_name": last_name,
@@ -593,7 +594,7 @@ class Vm(Common):
             "host_name": {"name": prov_data.get("host")},
             "datastore_name": {"name": prov_data.get("datastore")},
         }
-        fill(provisioning_form, provisioning_data, action=submit_button)
+        fill(provisioning_form, provisioning_data, action=provisioning_form.submit_button)
         cells = {'Description': 'Publish from [%s] to [%s]' % (self.name, template_name)}
         row, __ = wait_for(
             requests.wait_for_request, [cells], fail_func=requests.reload, num_sec=900, delay=20)

--- a/cfme/services/catalogs/cloud_catalog_item.py
+++ b/cfme/services/catalogs/cloud_catalog_item.py
@@ -8,8 +8,7 @@ import ui_navigate as nav
 import cfme.fixtures.pytest_selenium as sel
 import cfme.web_ui as web_ui
 import cfme.web_ui.toolbar as tb
-from cfme.cloud import provisioning as prov
-from collections import OrderedDict
+from cfme.web_ui.prov_form import provisioning_form as request_form
 from cfme.web_ui import accordion, tabstrip, Form, Table, Select, fill, flash, form_buttons
 from utils.update import Updateable
 from utils import version
@@ -46,50 +45,6 @@ detail_form = Form(
     fields=[
         ('long_desc', "//textarea[@id='long_description']")
     ])
-
-
-request_form = tabstrip.TabStripForm(
-    tab_fields=OrderedDict([
-        ('Catalog', [
-            ('num_instances', web_ui.Select('//select[@id="service__number_of_vms"]')),
-            ('instance_name', '//input[@name="service__vm_name"]'),
-            ('instance_description', '//textarea[@id="service__vm_description"]'),
-            ('catalog_name', web_ui.Table('//div[@id="prov_vm_div"]/table')),
-        ]),
-        ('Environment', [
-            ('automatic_placement', '//input[@id="environment__placement_auto"]'),
-            ('availability_zone',
-                web_ui.Select('//select[@id="environment__placement_availability_zone"]')),
-            ('virtual_private_cloud', web_ui.Select('//select[@id="environment__cloud_network"]')),
-            ('cloud_tenant', web_ui.Select('//select[@id="environment__cloud_tenant"]')),
-            ('cloud_network', web_ui.Select('//select[@id="environment__cloud_network"]')),
-            ('security_groups', prov.select_security_group),
-            ('public_ip_address', web_ui.Select('//select[@id="environment__floating_ip_address"]'))
-        ]),
-        ('Properties', [
-            ('instance_type', web_ui.Select('//select[@id="hardware__instance_type"]')),
-            ('guest_keypair', web_ui.Select('//select[@id="hardware__guest_access_key_pair"]')),
-            ('hardware_monitoring', web_ui.Select('//select[@id="hardware__monitoring"]')),
-        ]),
-        ('Customize', [
-            ('specification', web_ui.Select('//select[@id="customize__sysprep_enabled"]')),
-            ('specification_name', web_ui.Table('//div[@id="prov_vc_div"]/table')),
-            ('computer_name', '//input[@id="customize__linux_host_name"]'),
-            ('domain_name', '//input[@id="customize__linux_domain_name"]'),
-            ('dns_servers', '//input[@id="customize__dns_servers"]'),
-            ('dns_suffixes', '//input[@id="customize__dns_suffixes"]'),
-        ]),
-        ('Schedule', [
-            ('schedule_type', web_ui.Radio('schedule__schedule_type')),
-            ('provision_date', web_ui.Calendar('miq_date_1')),
-            ('provision_start_hour', web_ui.Select('//select[@id="start_hour"]')),
-            ('provision_start_min', web_ui.Select('//select[@id="start_min"]')),
-            ('power_on', '//input[@id="schedule__vm_auto_start"]'),
-            ('retirement', web_ui.Select('//select[@id="schedule__retirement"]')),
-            ('retirement_warning', web_ui.Select('//select[@id="schedule__retirement_warn"]')),
-        ])
-    ])
-)
 
 
 def _all_catalogitems_add_new(context):

--- a/cfme/tests/infrastructure/test_host_provisioning.py
+++ b/cfme/tests/infrastructure/test_host_provisioning.py
@@ -5,7 +5,7 @@ from cfme.fixtures import pytest_selenium as sel
 from cfme.infrastructure.pxe import get_pxe_server_from_config, get_template_from_config
 from cfme.services import requests
 from cfme.web_ui import flash, fill
-from cfme.infrastructure.provisioning import provisioning_form
+from cfme.web_ui.prov_form import provisioning_form
 from utils.conf import cfme_data
 from utils.providers import setup_provider
 from utils.log import logger

--- a/cfme/tests/infrastructure/test_iso_provisioning.py
+++ b/cfme/tests/infrastructure/test_iso_provisioning.py
@@ -1,7 +1,7 @@
 import pytest
 
 from utils.conf import cfme_data
-from cfme.infrastructure.provisioning import provisioning_form
+from cfme.web_ui.prov_form import provisioning_form
 from cfme.infrastructure.pxe import get_template_from_config, ISODatastore
 from cfme.services import requests
 from cfme.web_ui import flash, fill

--- a/cfme/tests/infrastructure/test_provisioning.py
+++ b/cfme/tests/infrastructure/test_provisioning.py
@@ -1,6 +1,6 @@
 import pytest
 
-from cfme.infrastructure.provisioning import provisioning_form
+from cfme.web_ui.prov_form import provisioning_form
 from cfme.services import requests
 from cfme.web_ui import flash, fill
 from utils import testgen, version

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -3,7 +3,7 @@ import pytest
 import re
 from datetime import datetime, timedelta
 
-from cfme.infrastructure.provisioning import provisioning_form
+from cfme.web_ui.prov_form import provisioning_form
 from cfme.infrastructure.virtual_machines import Vm, details_page
 from cfme.services import requests
 from cfme.web_ui import fill, flash

--- a/cfme/tests/infrastructure/test_pxe_provisioning.py
+++ b/cfme/tests/infrastructure/test_pxe_provisioning.py
@@ -1,7 +1,7 @@
 import pytest
 
 from utils.conf import cfme_data
-from cfme.infrastructure.provisioning import provisioning_form
+from cfme.web_ui.prov_form import provisioning_form
 from cfme.infrastructure.pxe import get_pxe_server_from_config, get_template_from_config
 from cfme.services import requests
 from cfme.web_ui import flash, fill

--- a/cfme/tests/services/test_direct_links.py
+++ b/cfme/tests/services/test_direct_links.py
@@ -4,7 +4,7 @@ import pytest
 import random
 
 from cfme.fixtures import pytest_selenium as sel
-from cfme.infrastructure.provisioning import provisioning_form
+from cfme.web_ui.prov_form import provisioning_form
 from cfme.services import requests
 from cfme.web_ui import flash
 from utils.browser import browser

--- a/cfme/web_ui/prov_form.py
+++ b/cfme/web_ui/prov_form.py
@@ -1,0 +1,162 @@
+from cfme.fixtures import pytest_selenium as sel
+from cfme import web_ui as ui
+from cfme.web_ui import form_buttons, tabstrip
+from collections import OrderedDict
+from utils import version
+
+submit_button = form_buttons.FormButton("Submit")
+
+template_select_form = ui.Form(
+    fields=[
+        ('template_table', ui.Table('//div[@id="pre_prov_div"]/fieldset/table')),
+        ('continue_button', submit_button),
+        ('cancel_button', form_buttons.cancel)
+    ]
+)
+
+
+def select_security_group(sg):
+    """Workaround for select box that is immediately replaced by the same
+       select box no matter what selenium clicks on (but works fine
+       manually).  For now only selects one item even though it's a
+       multiselect.
+
+    """
+    val = sel.get_attribute("//select[@id='environment__security_groups']/option[.='%s']" %
+                            sg, 'value')
+    sel.browser().execute_script(
+        "$j('#environment__security_groups').val('%s');"
+        "$j.ajax({type: 'POST', url: '/miq_request/prov_field_changed/new',"
+        " data: {'environment__security_groups':'%s'}})" % (val, val))
+    sel.wait_for_ajax()
+    sel.sleep(1)
+
+provisioning_form = tabstrip.TabStripForm(
+    fields=[
+        ('submit_button', form_buttons.FormButton("Submit")),
+        ('cancel_button', form_buttons.cancel),
+        ('host_submit_button', form_buttons.host_provision_submit),
+        ('host_cancel_button', form_buttons.host_provision_cancel)
+    ],
+    tab_fields=OrderedDict([
+
+        ('Request', [
+            ('email', '//input[@name="requester__owner_email"]'),
+            ('first_name', '//input[@id="requester__owner_first_name"]'),
+            ('last_name', '//input[@id="requester__owner_last_name"]'),
+            ('notes', '//textarea[@id="requester__request_notes"]'),
+            ('manager_name', '//input[@id="requester__owner_manager"]')
+        ]),
+
+        ('Purpose', [
+            ('apply_tags', {
+                version.LOWEST: ui.CheckboxTree('//div[@id="all_tags_treebox"]//table'),
+                "5.3": ui.CheckboxTree('//div[@id="all_tags_treebox"]//ul')
+            })
+        ]),
+
+        ('Catalog', [
+            # Cloud
+            ('num_instances', ui.Select('//select[@id="service__number_of_vms"]')),
+            ('instance_name', '//input[@name="service__vm_name"]'),
+            ('instance_description', '//textarea[@id="service__vm_description"]'),
+
+            # Infra
+            ('vm_filter', ui.Select('//select[@id="service__vm_filter"]')),
+            ('num_vms', ui.Select('//select[@id="service__number_of_vms"]')),
+            ('vm_name', '//input[@name="service__vm_name"]'),
+            ('vm_description', '//textarea[@id="service__vm_description"]'),
+            ('catalog_name', ui.Table('//div[@id="prov_vm_div"]/table')),
+            ('provision_type', ui.Select('//select[@id="service__provision_type"]')),
+            ('linked_clone', '//input[@id="service__linked_clone"]'),
+            ('pxe_server', ui.Select('//select[@id="service__pxe_server_id"]')),
+            ('pxe_image', ui.Table('//div[@id="prov_pxe_img_div"]/table')),
+            ('iso_file', ui.Table('//div[@id="prov_iso_img_div"]/table'))
+        ]),
+
+        ('Environment', [
+            ('automatic_placement', '//input[@id="environment__placement_auto"]'),
+
+            # Cloud
+            ('availability_zone',
+                ui.Select('//select[@id="environment__placement_availability_zone"]')),
+            ('virtual_private_cloud', ui.Select('//select[@id="environment__cloud_network"]')),
+            ('cloud_subnet', ui.Select('//select[@id="environment__cloud_subnet"]')),
+            ('cloud_network', ui.Select('//select[@id="environment__cloud_network"]')),
+            ('security_groups', select_security_group),
+            ('public_ip_address', ui.Select('//select[@id="environment__floating_ip_address"]')),
+
+            # Infra
+            ('provider_name', ui.Select('//select[@id="environment__placement_ems_name"]')),
+            ('datacenter', ui.Select('//select[@id="environment__placement_dc_name"]')),
+            ('cluster', ui.Select('//select[@id="environment__placement_cluster_name"]')),
+            ('resource_pool', ui.Select('//select[@id="environment__placement_rp_name"]')),
+            ('folder', ui.Select('//select[@id="environment__placement_folder_name"]')),
+            ('host_filter', ui.Select('//select[@id="environment__host_filter"]')),
+            ('host_name', ui.Table('//div[@id="prov_host_div"]/table')),
+            ('datastore_create', '//*[@id="environment__new_datastore_create"]'),
+            ('datastore_filter', ui.Select('//select[@id="environment__ds_filter"]')),
+            ('datastore_name', ui.Table('//div[@id="prov_ds_div"]/table')),
+        ]),
+        ('Hardware', [
+            ('num_sockets', ui.Select('//select[@id="hardware__number_of_sockets"]')),
+            ('cores_per_socket', ui.Select('//select[@id="hardware__cores_per_socket"]')),
+            ('memory', ui.Select('//select[@id="hardware__vm_memory"]')),
+            ('disk_format', ui.Radio('hardware__disk_format')),
+            ('vm_limit_cpu', '//input[@id="hardware__cpu_limit"]'),
+            ('vm_limit_memory', '//input[@id="hardware__memory_limit"]'),
+            ('vm_reserve_cpu', '//input[@id="hardware__cpu_reserve"]'),
+            ('vm_reserve_memory', '//input[@id="hardware__memory_reserve"]'),
+        ]),
+
+        # Infra
+        ('Network', [
+            ('vlan', ui.Select('//select[@id="network__vlan"]')),
+        ]),
+
+        # Cloud
+        ('Properties', [
+            ('instance_type', ui.Select('//select[@id="hardware__instance_type"]')),
+            ('guest_keypair', ui.Select('//select[@id="hardware__guest_access_key_pair"]')),
+            ('hardware_monitoring', ui.Select('//select[@id="hardware__monitoring"]')),
+        ]),
+
+        ('Customize', [
+            # Common
+            ('dns_servers', '//input[@id="customize__dns_servers"]'),
+            ('dns_suffixes', '//input[@id="customize__dns_suffixes"]'),
+
+            # Cloud
+            ('specification', ui.Select('//select[@id="customize__sysprep_enabled"]')),
+            ('specification_name', ui.Table('//div[@id="prov_vc_div"]/table')),
+            ('computer_name', '//input[@id="customize__linux_host_name"]'),
+            ('domain_name', '//input[@id="customize__linux_domain_name"]'),
+
+            # Infra
+            ('customize_type', ui.Select('//select[@id="customize__sysprep_enabled"]')),
+            ('specification_name', ui.Table('//div[@id="prov_vc_div"]/table')),
+            ('linux_host_name', '//input[@id="customize__linux_host_name"]'),
+            ('linux_domain_name', '//input[@id="customize__linux_domain_name"]'),
+            ('prov_host_name', '//input[@id="customize__hostname"]'),
+            ('ip_address', '//input[@id="customize__ip_addr"]'),
+            ('subnet_mask', '//input[@id="customize__subnet_mask"]'),
+            ('gateway', '//input[@id="customize__gateway"]'),
+            ('custom_template', ui.Table('//div[@id="prov_template_div"]/table')),
+            ('root_password', '//input[@id="customize__root_password"]'),
+            ('vm_host_name', '//input[@id="customize__hostname"]'),
+        ]),
+        ('Schedule', [
+            # Common
+            ('schedule_type', ui.Radio('schedule__schedule_type')),
+            ('provision_date', ui.Calendar('miq_date_1')),
+            ('provision_start_hour', ui.Select('//select[@id="start_hour"]')),
+            ('provision_start_min', ui.Select('//select[@id="start_min"]')),
+            ('power_on', '//input[@id="schedule__vm_auto_start"]'),
+            ('retirement', ui.Select('//select[@id="schedule__retirement"]')),
+            ('retirement_warning', ui.Select('//select[@id="schedule__retirement_warn"]')),
+
+            # Infra
+            ('stateless', '//input[@id="schedule__stateless"]'),
+        ])
+    ])
+)


### PR DESCRIPTION
There were occasions where the instances page had been viewing an instance. In this case when it was returned to, the Provision Instances link was not present. This fix adds in the extra step of visiting the accordion to clear all instance selections.
