### PR TITLE
fix random restart worker failure

### DIFF
--- a/cfme/tests/configure/test_workers.py
+++ b/cfme/tests/configure/test_workers.py
@@ -7,4 +7,5 @@ from cfme.configure import configuration
 @pytest.mark.nondestructive
 @pytest.sel.go_to('dashboard')
 def test_restart_workers():
-    assert configuration.restart_workers("Generic Worker"), "Could not correctly restart workers!"
+    assert (configuration.restart_workers("Generic Worker", wait_time_min=3),
+            "Could not correctly restart workers!")


### PR DESCRIPTION
This is random failing and I believe its all due to it taking sometimes longer than 1 minute timeout based on appliance activity at the time.
