### PR TITLE
Tweaks for Jenkins:

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -439,7 +439,7 @@ class Vm(Common):
         deploy_template(self.provider_crud.key, self.name, self.template_name)
         if find_in_cfme:
             self.provider_crud.refresh_provider_relationships()
-            self.wait_for_vm_to_appear(timeout=timeout, load_details=False)
+            self.wait_to_appear(timeout=timeout, load_details=False, is_vm=True)
 
     def load_details(self, refresh=False):
         self._load_details(is_vm=True, refresh=refresh)

--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -55,7 +55,7 @@ def test_vm(request, provider_crud, provider_mgmt, vm_name, provider_init):
     request.addfinalizer(vm.delete_from_provider)
 
     if not provider_mgmt.does_vm_exist(vm_name):
-        vm.create_on_provider()
+        vm.create_on_provider(find_in_cfme=True)
     return vm
 
 

--- a/fixtures/virtual_machine.py
+++ b/fixtures/virtual_machine.py
@@ -3,13 +3,8 @@
 
 
 import pytest
-import re
 from utils.log import logger
 from utils.wait import wait_for
-
-ON_REGEX = re.compile(r'up|POWERED\ ON|running|ACTIVE|poweredOn')
-OFF_REGEX = re.compile(r'down|POWERED\ OFF|stopped|poweredOff')
-SUSPEND_REGEX = re.compile(r'SUSPENDED|suspended')
 
 
 @pytest.fixture
@@ -24,15 +19,16 @@ def verify_vm_running(provider_mgmt, vm_name):
     """
 
     def _wait_for_vm_running():
-        state = provider_mgmt.vm_status(vm_name)
-        if ON_REGEX.match(state):
+        if provider_mgmt.is_vm_running(vm_name):
             return True
-        elif OFF_REGEX.match(state) or SUSPEND_REGEX.match(state):
+        elif provider_mgmt.is_vm_stopped(vm_name) or provider_mgmt.is_vm_suspended(vm_name):
             provider_mgmt.start_vm(vm_name)
-        logger.debug("Sleeping 15secs...(current state: " + state + ", needed state: running)")
+        logger.debug("Sleeping 15secs...(current state: {}, needed state: running)".format(
+            provider_mgmt.vm_status(vm_name)
+        ))
         return False
 
-    return wait_for(_wait_for_vm_running, num_sec=300, delay=15)
+    return wait_for(_wait_for_vm_running, num_sec=360, delay=15)
 
 
 @pytest.fixture
@@ -47,17 +43,19 @@ def verify_vm_stopped(provider_mgmt, vm_name):
     """
 
     def _wait_for_vm_stopped():
-        state = provider_mgmt.vm_status(vm_name)
-        if OFF_REGEX.match(state):
+        if provider_mgmt.is_vm_stopped(vm_name):
             return True
-        elif ON_REGEX.match(state):
+        elif provider_mgmt.is_vm_running(vm_name):
             provider_mgmt.stop_vm(vm_name)
-        elif SUSPEND_REGEX.match(state):
+        elif provider_mgmt.is_vm_suspended(vm_name):
             provider_mgmt.start_vm(vm_name)
-        logger.debug("Sleeping 15secs...(current state: " + state + ", needed state: stopped)")
+
+        logger.debug("Sleeping 15secs...(current state: {}, needed state: stopped)".format(
+            provider_mgmt.vm_status(vm_name)
+        ))
         return False
 
-    return wait_for(_wait_for_vm_stopped, num_sec=300, delay=15)
+    return wait_for(_wait_for_vm_stopped, num_sec=360, delay=15)
 
 
 @pytest.fixture
@@ -72,14 +70,16 @@ def verify_vm_suspended(provider_mgmt, vm_name):
     """
 
     def _wait_for_vm_suspended():
-        state = provider_mgmt.vm_status(vm_name)
-        if SUSPEND_REGEX.match(state):
-            return
-        elif ON_REGEX.match(state):
+        if provider_mgmt.is_vm_suspended(vm_name):
+            return True
+        elif provider_mgmt.is_vm_running(vm_name):
             provider_mgmt.suspend_vm(vm_name)
-        elif OFF_REGEX.match(state):
+        elif provider_mgmt.is_vm_stopped(vm_name):
             provider_mgmt.start_vm(vm_name)
-        logger.debug("Sleeping 15secs...(current state: " + state + ", needed state: suspended)")
+
+        logger.debug("Sleeping 15secs...(current state: {}, needed state: suspended)".format(
+            provider_mgmt.vm_status(vm_name)
+        ))
         return False
 
-    return wait_for(_wait_for_vm_suspended, num_sec=300, delay=15)
+    return wait_for(_wait_for_vm_suspended, num_sec=360, delay=15)

--- a/utils/providers.py
+++ b/utils/providers.py
@@ -311,7 +311,8 @@ def setup_infrastructure_providers(validate=True, check_existing=True):
 def clear_cloud_providers(validate=True):
     sel.force_navigate('clouds_providers')
     logger.debug('Checking for existing cloud providers...')
-    if paginator.rec_total():
+    total = paginator.rec_total()
+    if total is not None and int(total) > 0:
         logger.info(' Providers exist, so removing all cloud providers')
         paginator.results_per_page('100')
         sel.click(paginator.check_all())
@@ -325,7 +326,8 @@ def clear_cloud_providers(validate=True):
 def clear_infra_providers(validate=True):
     sel.force_navigate('infrastructure_providers')
     logger.debug('Checking for existing infrastructure providers...')
-    if paginator.rec_total():
+    total = paginator.rec_total()
+    if total is not None and int(total) > 0:
         logger.info(' Providers exist, so removing all infra providers')
         paginator.results_per_page('100')
         sel.click(paginator.check_all())
@@ -336,17 +338,25 @@ def clear_infra_providers(validate=True):
             wait_for_no_infra_providers()
 
 
+def get_paginator_value():
+    total = paginator.rec_total()
+    if total is None:
+        return 0
+    else:
+        return int(total.strip())
+
+
 def wait_for_no_cloud_providers():
     sel.force_navigate('clouds_providers')
     logger.debug('Waiting for all cloud providers to disappear...')
-    wait_for(lambda: not paginator.rec_total(), message="Delete all cloud providers",
+    wait_for(lambda: get_paginator_value() == 0, message="Delete all cloud providers",
              num_sec=1000, fail_func=sel.refresh)
 
 
 def wait_for_no_infra_providers():
     sel.force_navigate('infrastructure_providers')
     logger.debug('Waiting for all infra providers to disappear...')
-    wait_for(lambda: not paginator.rec_total(), message="Delete all infrastructure providers",
+    wait_for(lambda: get_paginator_value() == 0, message="Delete all infrastructure providers",
              num_sec=1000, fail_func=sel.refresh)
 
 


### PR DESCRIPTION
- `fixtures.virtual_machine` now uses the `mgmt_system` methods to detect the VM state.
- Creating VM via `create_on_provider` now checks and waits for the VM to appear in CFME (required for scvmm as it is very slow)
- Modified waiting procedures on `has_no_providers` fixture, now it should be reading the numbers properly
