### PR TITLE
Inaccessible datastores now ignored for stats

### DIFF
--- a/utils/mgmt_system.py
+++ b/utils/mgmt_system.py
@@ -574,7 +574,7 @@ class VMWareSystem(MgmtSystemAPIBase):
         return [str(h.name) for h in mobs.HostSystem.all(self.api)]
 
     def list_datastore(self):
-        return [str(h.name) for h in mobs.Datastore.all(self.api)]
+        return [str(h.name) for h in mobs.Datastore.all(self.api) if h.summary.accessible]
 
     def list_cluster(self):
         return [str(h.name) for h in mobs.ClusterComputeResource.all(self.api)]


### PR DESCRIPTION
CFME doesn't care about inaccessible datastores in VMware so now neither
do we.
