### PR TITLE
Fix datastore listing on vsphere

### DIFF
--- a/utils/mgmt_system.py
+++ b/utils/mgmt_system.py
@@ -574,7 +574,7 @@ class VMWareSystem(MgmtSystemAPIBase):
         return [str(h.name) for h in mobs.HostSystem.all(self.api)]
 
     def list_datastore(self):
-        return [str(h.name) for h in mobs.Datastore.all(self.api) if h.summary.accessible]
+        return [str(h.name) for h in mobs.Datastore.all(self.api) if h.host]
 
     def list_cluster(self):
         return [str(h.name) for h in mobs.ClusterComputeResource.all(self.api)]


### PR DESCRIPTION
vmware datastore listing was recently changed to ignore inaccessible
datastores. In fact this was not the problem, CFME does not show up a
datastore on a provider if it is not mounted by any hosts.

This commit changes the datastore listing function to mimic that
behaviour by checking if the datastore is mounted on any hosts.
