### PR TITLE
Adding QA Contact into reports

### DIFF
--- a/artifactor/plugins/reporter.py
+++ b/artifactor/plugins/reporter.py
@@ -148,6 +148,9 @@ class Reporter(ArtifactorBasePlugin):
                         test_data['emails'] = filename.replace(log_dir, "")
                     elif "events.html" in filename:
                         test_data['event_testing'] = filename.replace(log_dir, "")
+                    elif "qa_contact.txt" in filename:
+                        with open(filename) as qafile:
+                            test_data['qa_contact'] = qafile.read()
                 if "merkyl" in ident:
                     test_data['merkyl'] = [f.replace(log_dir, "")
                                            for f in test['files']['merkyl']]

--- a/data/templates/test_report.html
+++ b/data/templates/test_report.html
@@ -105,6 +105,10 @@ $(function() {
                     <br>
                     <strong>SLAVE:</strong> <em>{{test.slaveid}}</em>
                     {% endif %}
+                    {% if test.qa_contact %}
+                    <br>
+                    <strong>OWNER:</strong> <em>{{test.qa_contact}}</em>
+                    {% endif %}
                 </div>
                 <div class="col-md-2">
                     Setup

--- a/fixtures/qa_contact.py
+++ b/fixtures/qa_contact.py
@@ -1,0 +1,45 @@
+from collections import defaultdict
+import inspect
+import subprocess
+import re
+import operator
+from fixtures.artifactor_plugin import art_client
+
+
+def dig_code(node):
+    code_data = inspect.getsourcelines(node.function)
+    lineno = code_data[1]
+    offset = len(code_data[0])
+    filename = inspect.getfile(node.function)
+    line_param = '-L {},+{}'.format(lineno, offset)
+    cmd_params = ['git', 'blame', line_param, filename, '--show-email']
+
+    proc = subprocess.Popen(cmd_params, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    proc.wait()
+    lc_info = proc.stdout.readlines()
+    contact_stats = defaultdict(int)
+    for line in lc_info:
+        contact = re.findall('.{8} \(\<(.*)\> ', line)
+        contact_stats[contact[0]] += 1
+    sorted_x = sorted(contact_stats.items(), key=operator.itemgetter(1), reverse=True)
+    results = []
+    for item in sorted_x:
+        percen = float(item[1]) / float(offset) * 100
+        record = (item[0], percen)
+        results.append(record)
+    return results
+
+
+def pytest_exception_interact(node, call, report):
+    try:
+        qa_arr = []
+        results = dig_code(node)
+        for idx in range(min(2, len(results))):
+            qa_arr.append("{} ({:.2f}%)".format(results[idx][0], results[idx][1]))
+        qa_string = ", ".join(qa_arr)
+
+    except:
+        qa_string = "Unknown"
+    art_client.fire_hook('filedump', test_location=node.location[0],
+                         test_name=node.location[2],
+                         filename="qa_contact.txt", contents=str(qa_string), fd_ident="qa")


### PR DESCRIPTION
Uses simple heuristics to guess at the QA contact responsible for the
test and reports it. If there are more than one contributors to the
source, the first two are shown along with their relative ownership of
the test.
