### PR TITLE
Some settings speed up work

### DIFF
--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -1,24 +1,17 @@
 from functools import partial
-from urlparse import urlparse
+from fixtures.pytest_store import store
 import cfme
 import cfme.fixtures.pytest_selenium as sel
 import cfme.web_ui.toolbar as tb
 from cfme.web_ui import Form, Select, CheckboxTree, accordion, fill, flash, form_buttons
 from cfme.web_ui.menu import nav
-from utils.db_queries import get_server_region
 from utils.update import Updateable
 from utils import version
 from utils.pretty import Pretty
 
 
-def get_ip_address():
-    """Returns an IP address of the appliance
-    """
-    return urlparse(sel.current_url()).netloc
-
-
 def server_region():
-    return get_server_region(get_ip_address())
+    return store.current_appliance.server_region()
 
 
 def server_region_pair():

--- a/cfme/configure/configuration/__init__.py
+++ b/cfme/configure/configuration/__init__.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 from functools import partial
-from urlparse import urlparse
 
 import cfme.fixtures.pytest_selenium as sel
+from fixtures.pytest_store import store
+
 import cfme.web_ui.tabstrip as tabs
 import cfme.web_ui.toolbar as tb
 from cfme.exceptions import ScheduleNotFound, AuthModeUnknown, ZoneNotFound
@@ -10,8 +11,6 @@ from cfme.web_ui import \
     (Calendar, Form, InfoBlock, MultiFill, Region, Select, Table, accordion, fill, flash,
     form_buttons)
 from cfme.web_ui.menu import nav
-from utils.db_queries import (get_server_id, get_server_name, get_server_region, get_server_zone_id,
-                              get_zone_description)
 from utils.log import logger
 from utils.timeutil import parsetime
 from utils.update import Updateable
@@ -125,14 +124,8 @@ classification_table = Table("//div[@id='classification_entries_div']//table[@cl
 zones_table = Table("//div[@id='settings_list']/table[@class='style3']")
 
 
-def get_ip_address():
-    """Returns an IP address of the appliance
-    """
-    return urlparse(sel.current_url()).netloc
-
-
 def server_region():
-    return get_server_region(get_ip_address())
+    return store.current_appliance.server_region()
 
 
 def server_region_pair():
@@ -141,11 +134,11 @@ def server_region_pair():
 
 
 def server_name():
-    return get_server_name(get_ip_address())
+    return store.current_appliance.server_name()
 
 
 def server_id():
-    return get_server_id(get_ip_address())
+    return store.current_appliance.server_id()
 
 
 def add_tag(cat_name):
@@ -159,7 +152,7 @@ def edit_tag(cat_name, tag_name):
 
 
 def server_zone_description():
-    return get_zone_description(get_server_zone_id())
+    return store.current_appliance.zone_description
 
 nav.add_branch("configuration",
     {

--- a/utils/db_queries.py
+++ b/utils/db_queries.py
@@ -3,7 +3,7 @@
 from utils.db import cfmedb, database_on_server
 
 
-def get_configuration_details(ip_address=None):
+def get_configuration_details(db=None, ip_address=None):
     """Return details that are necessary to navigate through Configuration accordions.
 
     Args:
@@ -17,92 +17,70 @@ def get_configuration_details(ip_address=None):
     if ip_address is None:
         ip_address = cfmedb().hostname
 
-    with database_on_server(ip_address) as db:
-        SEQ_FACT = 1e12
-        miq_servers = db['miq_servers']
-        for region in db.session.query(db['miq_regions']):
-            reg_min = region.region * SEQ_FACT
-            reg_max = reg_min + SEQ_FACT
-            all_servers = db.session.query(miq_servers).all()
-            server = None
-            if len(all_servers) == 1:
-                # If there's only one server, it's the one we want
-                server = all_servers[0]
-            else:
-                # Otherwise, filter based on id and ip address
-                def server_filter(server):
-                    return all([
-                        server.id >= reg_min,
-                        server.id < reg_max,
-                        # XXX: This currently fails due to public/private addresses on openstack
-                        server.ipaddress == ip_address
-                    ])
-                servers = filter(server_filter, all_servers)
-                if servers:
-                    server = servers[0]
-            if server:
-                return region.region, server.name, server.id, server.zone_id
-            else:
-                return None, None, None, None
+    if db is None:
+        db = database_on_server(ip_address).gen.next()
+
+    SEQ_FACT = 1e12
+    miq_servers = db['miq_servers']
+    for region in db.session.query(db['miq_regions']):
+        reg_min = region.region * SEQ_FACT
+        reg_max = reg_min + SEQ_FACT
+        all_servers = db.session.query(miq_servers).all()
+        server = None
+        if len(all_servers) == 1:
+            # If there's only one server, it's the one we want
+            server = all_servers[0]
         else:
-            return None
-
-
-def get_server_id(ip_address=None):
-    try:
-        return get_configuration_details(ip_address)[2]
-    except TypeError:
+            # Otherwise, filter based on id and ip address
+            def server_filter(server):
+                return all([
+                    server.id >= reg_min,
+                    server.id < reg_max,
+                    # XXX: This currently fails due to public/private addresses on openstack
+                    server.ipaddress == ip_address
+                ])
+            servers = filter(server_filter, all_servers)
+            if servers:
+                server = servers[0]
+        if server:
+            return region.region, server.name, server.id, server.zone_id
+        else:
+            return None, None, None, None
+    else:
         return None
 
 
-def get_server_region(ip_address=None):
-    try:
-        return get_configuration_details(ip_address)[0]
-    except TypeError:
-        return None
-
-
-def get_server_name(ip_address=None):
-    try:
-        return get_configuration_details(ip_address)[1]
-    except TypeError:
-        return None
-
-
-def get_server_zone_id(ip_address=None):
-    try:
-        return get_configuration_details(ip_address)[3]
-    except TypeError:
-        return None
-
-
-def get_zone_description(zone_id, ip_address=None):
+def get_zone_description(zone_id, ip_address=None, db=None):
     if ip_address is None:
         ip_address = cfmedb().hostname
 
-    with database_on_server(ip_address) as db:
-        zones = list(
-            db.session.query(db["zones"]).filter(
-                db["zones"].id == zone_id
-            )
+    if db is None:
+        db = database_on_server(ip_address)
+
+    zones = list(
+        db.session.query(db["zones"]).filter(
+            db["zones"].id == zone_id
         )
-        if zones:
-            return zones[0].description
-        else:
-            return None
+    )
+    if zones:
+        return zones[0].description
+    else:
+        return None
 
 
-def get_host_id(hostname, ip_address=None):
+def get_host_id(hostname, ip_address=None, db=None):
     if ip_address is None:
         ip_address = cfmedb().hostname
 
-    with database_on_server(ip_address) as db:
-        hosts = list(
-            db.session.query(db["hosts"]).filter(
-                db["hosts"].name == hostname
-            )
+    if db is None:
+        db = database_on_server(ip_address)
+
+    hosts = list(
+        db.session.query(db["hosts"]).filter(
+            db["hosts"].name == hostname
         )
-        if hosts:
-            return str(hosts[0].id)
-        else:
-            return None
+    )
+    if hosts:
+        return str(hosts[0].id)
+    else:
+        return None

--- a/utils/tests/test_db_queries.py
+++ b/utils/tests/test_db_queries.py
@@ -3,29 +3,28 @@
 """Run against fresh instance to ensure that the data checked is correct.
 """
 import pytest
+from fixtures.pytest_store import store
 from utils import db_queries
-from utils.conf import env
-from urlparse import urlparse
 
 
 @pytest.fixture
 def appliance_ip():
-    return urlparse(env["base_url"]).netloc
+    return store.current_appliance.address
 
 
 def test_configuration_details(appliance_ip):
-    result = db_queries.get_configuration_details(appliance_ip)
+    result = db_queries.get_configuration_details(ip_address=appliance_ip)
     assert result is not None, "get_configuration_details returned None"
 
 
 def test_server_name(appliance_ip):
-    assert db_queries.get_server_name(appliance_ip) == "EVM"
+    assert store.current_appliance.server_name() == "EVM"
 
 
 def test_server_region_and_id(appliance_ip):
     """Server ID begins with region number, so check that.
     """
-    region = db_queries.get_server_region(appliance_ip)
+    region = store.current_appliance.server_region()
     if region == 0:
         pytest.skip("Can't check this if the region is 0")
-    assert str(db_queries.get_server_id(appliance_ip)).startswith(str(region))
+    assert str(store.current_appliance.server_id()).startswith(str(region))


### PR DESCRIPTION
Navigation to the settings page, in particular current_server_settings, took 62 seconds on my machine, deeper investigation showed that it was utilising at least 6 db look ups and that these db lookups were not cached. In fact one function hit 2 db queries at once and that was hit multiple times itself.

This idea moves some of the details into the current_appliance model and caches them.
