### PR TITLE
DB Peeking speed up

### DIFF
--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -66,7 +66,7 @@ def test_provider_add_with_bad_credentials(provider_crud):
 def test_provider_crud(provider_crud):
     """ Tests that a provider can be added """
     provider_crud.create()
-    provider_crud.validate()
+    provider_crud.validate(db=False)
 
     old_name = provider_crud.name
     with update(provider_crud):

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -144,7 +144,7 @@ def test_provider_crud(provider_crud):
     """ Tests that a provider can be added """
     provider_crud.create()
     # Fails on upstream, all provider types - BZ1087476
-    provider_crud.validate()
+    provider_crud.validate(db=False)
 
     old_name = provider_crud.name
     with update(provider_crud):

--- a/utils/appliance.py
+++ b/utils/appliance.py
@@ -1035,6 +1035,13 @@ class IPAppliance(object):
     def host_id(self, hostname):
         return db_queries.get_host_id(hostname, db=self.db)
 
+    @lazycache
+    def db_yamls(self):
+        return db.db_yamls(self.db)
+
+    def get_yaml_config(self, config_name):
+        return self.db_yamls[config_name]
+
 
 class ApplianceSet(object):
     """Convenience class to ease access to appliances in appliance_set


### PR DESCRIPTION
Multiple changes here:
- Made cloud follow the STATS_TO_MATCH model from infrastructure
- Added in addition to UI based calls, added DB based calls for the
  following methods for providers; validate(), num_*() and
  _do_stats_match.
- get_server_roles, which is used in the server_roles fixture now has a
  DB companion, this uses the same logic as CFME to determine which
  roles are present in the UI.
- set_server_roles was modified to only navigate if the roles do not
  match, subsequently the entire fixture can be run without touching the
  UI assuming that the roles match.
- IPAppliance object now also has access to the server_configuration
  which is also cached and needs to be invalidated if any changes are
  made to the server configuration.
- PXE module received DB methods for many of its class exists() methods.
- By default all getters which have DB getting enabled, use DB by
  default and so certain tests have been modified to _NOT_ use the DB if
  the intention of the test is to test the UI elements.
