### PR TITLE
Fix retirement test

### DIFF
--- a/cfme/tests/infrastructure/test_retirement.py
+++ b/cfme/tests/infrastructure/test_retirement.py
@@ -47,7 +47,7 @@ def vm(request, provider_init, provider_crud, provisioning):
     vm_name = 'test_retire_prov_%s' % generate_random_string()
     myvm = vms.Vm(name=vm_name, provider_crud=provider_crud, template_name=provisioning['template'])
     request.addfinalizer(myvm.delete_from_provider)
-    myvm.create_on_provider()
+    myvm.create_on_provider(find_in_cfme=True)
     return myvm
 
 


### PR DESCRIPTION
Retirement tests are failing because the vm is not in the UI, suspected
that a refresh just needs to occur.
