### PR TITLE
Enable YAML file encryption

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -26,6 +26,11 @@ Setup
 
   * ``export PYTHONDONTWRITEBYTECODE="yes"``
 
+* Make sure you set the shared secret for the credentials files encryption. There are two ways:
+
+  * add ``export CFME_TESTS_KEY="our shared key"`` into the activate script
+  * create ``.yaml_key`` file in project root containing the key
+
 
 * Ensure the following devel packages are installed (for building python dependencies):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ py
 PyGithub
 PyPDF2
 pytest
+pycrypto
 python-bugzilla>=1.1.0
 python-dateutil
 python-keystoneclient

--- a/scripts/encrypt_conf.py
+++ b/scripts/encrypt_conf.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+"""Script to encrypt config files.
+
+Usage:
+
+   scripts/encrypt_conf.py confname1 confname2 ... confnameN
+   scripts/encrypt_conf.py credentials
+"""
+import sys
+from utils import _conf
+
+for conf_name in sys.argv[1:]:
+    _conf.encrypt_yaml(conf_name.strip())

--- a/utils/_conf.py
+++ b/utils/_conf.py
@@ -1,11 +1,15 @@
+# -*- coding: utf-8 -*-
 from collections import defaultdict
 from warnings import catch_warnings, warn
 
 import copy
+import hashlib
+import os
 import yaml
 from yaml.loader import Loader
+from Crypto.Cipher import AES
 
-from utils.path import conf_path
+from utils.path import conf_path, project_path
 
 
 class YamlConfigLoader(Loader):
@@ -358,19 +362,74 @@ class RecursiveUpdateDict(dict):
         return self
 
 
+def get_aes_key():
+    """Retrieve the AES key used for encryption/decryption.
+
+    Looks in the environment variable and if it does not find it, looks in .yaml_key file located
+    in the project root.
+    """
+    if "CFME_TESTS_KEY" in os.environ:
+        data = os.environ["CFME_TESTS_KEY"].strip()
+    else:
+        try:
+            with open(project_path.join(".yaml_key").strpath, "r") as f:
+                data = f.read().strip()
+        except IOError:
+            data = None
+    return hashlib.sha256(data).digest() if data is not None else None
+
+
 def load_yaml(filename=None, warn_on_fail=True):
     # Find the requested yaml in the config dir, relative to this file's location
     # (aiming for cfme_tests/config)
-    path = conf_path.join('%s.yaml' % filename)
+    filename_unencrypted = conf_path.join('{}.yaml'.format(filename))
+    filename_encrypted = conf_path.join('{}.eyaml'.format(filename))
 
-    if path.check():
-        with path.open() as config_fh:
+    if filename_encrypted.check() and (
+            not filename_unencrypted.check()
+            or filename_encrypted.mtime() > filename_unencrypted.mtime()):
+        # Decrypt the file if unencrypted does not exist or it exists but only if it was modified
+        # after the encrypted file's modification time (prevent everwriting)
+        key = get_aes_key()
+        if key is None and not filename_unencrypted.check():
+            raise Exception(
+                "Cannot decrypt config file {} (no key) and no unencrypted version present!".format(
+                    filename))
+
+        cipher = AES.new(key, AES.MODE_ECB)
+        with filename_encrypted.open("r") as encrypted:
+            with filename_unencrypted.open("w") as unencrypted:
+                unencrypted.write(cipher.decrypt(encrypted.read()).rstrip())
+
+    if filename_unencrypted.check():
+        with filename_unencrypted.open() as config_fh:
             conf = yaml.load(config_fh, Loader=YamlConfigLoader)
             if isinstance(conf, dict):
                 return conf
 
     if warn_on_fail:
-        msg = 'Unable to load configuration file at %s' % path
+        msg = 'Unable to load configuration file at %s' % filename_unencrypted
         warn(msg, ConfigNotFound)
 
     return {}
+
+
+def encrypt_yaml(filename):
+    filename_unencrypted = conf_path.join('{}.yaml'.format(filename))
+    filename_encrypted = conf_path.join('{}.eyaml'.format(filename))
+
+    if filename_unencrypted.check():
+        # Decrypt the file
+        key = get_aes_key()
+        if key is None:
+            raise Exception(
+                "Cannot encrypt config file {} - no key provided!".format(filename))
+        cipher = AES.new(key, AES.MODE_ECB)
+        with filename_unencrypted.open("r") as unencrypted:
+            with filename_encrypted.open("w") as encrypted:
+                data = unencrypted.read()
+                while len(data) % len(hash) > 0:
+                    data += " "  # Padding with spaces, will be rstripped after load
+                encrypted.write(cipher.encrypt(data))
+    else:
+        raise Exception("No such file!")


### PR DESCRIPTION
An experiment, which works quite nicely. Just using pycrypto and shared key.

It works by having an encrypted file with .eyaml extension. If the .yaml file does not exist or it exists but is older than the encrypted file, the .eyaml file is decrypted using a key stored in environment or a file in project folder. Then the yaml file is loaded as usual (it does not intercept loading itself). You can encrypt specific configuration file by useing provided tool in scripts/
