### PR TITLE
Metadata marker, integrating with QA contact plugin

### DIFF
--- a/fixtures/qa_contact.py
+++ b/fixtures/qa_contact.py
@@ -32,6 +32,12 @@ def dig_code(node):
 
 def pytest_exception_interact(node, call, report):
     name, location = get_test_idents(node)
+    if node._metadata.owner is not None:
+        # The owner is specified in metadata
+        art_client.fire_hook(
+            'filedump', test_location=location, test_name=name, filename="qa_contact.txt",
+            contents="{} (from metadata)".format(node._metadata.owner), fd_ident="qa")
+        return
     try:
         qa_arr = []
         results = dig_code(node)

--- a/markers/meta.py
+++ b/markers/meta.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""meta(\*\*metadata): Marker for metadata addition"""
+import pytest
+
+
+class metadict(dict):
+    """A dictionary that can access items as object variables, returns None if not found"""
+    def __getattr__(self, attr):
+        try:
+            return self[attr]
+        except KeyError:
+            return None
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", __doc__.splitlines()[0])
+
+
+@pytest.mark.tryfirst
+def pytest_collection_modifyitems(session, config, items):
+    for item in items:
+        item._metadata = metadict()
+        meta = item.get_marker("meta")
+        if meta is None:
+            continue
+        metas = reversed([x.kwargs for x in meta])  # Extract the kwargs, reverse the order
+        for meta in metas:
+            item._metadata.update(meta)
+
+
+@pytest.fixture(scope="function")
+def meta(request):
+    return request.node._metadata


### PR DESCRIPTION
Easy way how to add metadata to the tests. Then plugins can read them or tests can read them. Every test node receives a `._metadata` dictionary modified that it allows picking values up using object variable access (`.key`). It returns none if the value is not there so the checks are simple. Also a special fixture called `meta` is provided that is a shortcut for `request.node._metadata`.
