### PR TITLE
Fixed zones tests; fixed QA contact error with metadata

### DIFF
--- a/cfme/configure/configuration/__init__.py
+++ b/cfme/configure/configuration/__init__.py
@@ -636,6 +636,9 @@ class BasicInformation(Updateable, Pretty):
                 "$j.ajax({type: 'POST', url: '/ops/settings_form_field_changed/server',"
                 " data: {'server_zone':'%s'}})" % (self.details["appliance_zone"]))
         sel.click(form_buttons.save)
+        # TODO: Maybe make a cascaded delete on lazycache?
+        del store.current_appliance.configuration_details
+        del store.current_appliance.zone_description
 
 
 class SMTPSettings(Updateable):

--- a/cfme/tests/configure/test_zones.py
+++ b/cfme/tests/configure/test_zones.py
@@ -46,6 +46,7 @@ def test_zone_change_appliance_zone(request):
         name=generate_random_string(size=5),
         description=generate_random_string(size=8))
     request.addfinalizer(zone.delete)
+    request.addfinalizer(conf.BasicInformation(appliance_zone="default").update)
     zone.create()
     basic_info = conf.BasicInformation(appliance_zone=zone.name)
     basic_info.update()

--- a/fixtures/qa_contact.py
+++ b/fixtures/qa_contact.py
@@ -32,7 +32,7 @@ def dig_code(node):
 
 def pytest_exception_interact(node, call, report):
     name, location = get_test_idents(node)
-    if node._metadata.owner is not None:
+    if hasattr(node, "_metadata") and node._metadata.owner is not None:
         # The owner is specified in metadata
         art_client.fire_hook(
             'filedump', test_location=location, test_name=name, filename="qa_contact.txt",


### PR DESCRIPTION
This was ruining some tests after the zone tests due to caching issue.
