### PR TITLE
Automatic select resolution for value filling.

### DIFF
--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -954,6 +954,11 @@ def fill_tag(loc, value):
     raise NotImplementedError("Don't know how to fill {} into this type: {}".format(value, loc))
 
 
+@fill_tag.method(("select", Anything))
+def fill_select_tag(select, value):
+    return (sel.select, value)
+
+
 @fill_tag.method((Anything, 'text'))
 @fill_tag.method((Anything, 'textarea'))
 def fill_text(textbox, val):


### PR DESCRIPTION
This was bugging me for a long time since some of the form values mutate between input and select. fill function now knows about select tag and delegates the functionality to the appropriate function. This makes it possible to not write the `Select("input#asdf")` but just `input#asdf` since it picks up the select method correctly.
