### PR TITLE
[wip][notest] opinionated Quickstart scripted try 2

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -25,7 +25,8 @@ and leaves you with a usable enabled virtualenv.
 * you run RHEL/Fedora or installed the build requirements on your own
 * you use bash as shell
 
-::
+.. code:: bash
+
   $ . ./scripts/quickstart.sh
   ...
   (.cfme_tests)$

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -10,6 +10,27 @@ carefully read this page from beginning to the end. That will make you familiari
 and will minimize the chance of doing it wrong. Then you can proceed the shortest way using the
 setup and execution scripts.
 
+
+opinionated quick.start script
+--------------------------------
+
+The opinionated quick-start script builds expects a certain base setup
+and leaves you with a usable enabled virtualenv.
+
+* you are in a checkout of ``cfme_tests``
+* you have a checkout of the RedHat internal repository
+  with the encrypted credentials
+* you already put ``.yaml_key`` in place
+* you are fine with symlinks instead of copies of the yaml data
+* you run RHEL/Fedora or installed the build requirements on your own
+* you use bash as shell
+
+::
+  $ . ./scripts/quickstart.sh
+  ...
+  (.cfme_tests)$
+
+
 Setup
 -----
 You can use this shortcut to install the system and python dependencies which will leave you only

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -1,22 +1,59 @@
 #!/usr/bin/env bash
 
-echo "setting up the needed system level tools"
-pkcon install -y \
-    python-pip gcc postgresql-devel \
-    libxml2-devel libxslt-devel \
-    zeromq3-devel libcurl-devel \
-    redhat-rpm-config
+# pass the cfme qe yamls repo as first argument
+QE_YAML_REPO=${1:-../cfme-qe-yamls}
 
-echo "user install of the latest pip/virtualenv to avoid old distro packages"
-pip install -U --user pip virtualenv
+setup_redhat_based_system() {
 
-echo "Creating Virtualenv"
-virtualenv .cfme_tests
+  echo "setting up the needed system level tools"
+  pkcon install -y \
+      python-pip gcc postgresql-devel \
+      libxml2-devel libxslt-devel \
+      zeromq3-devel libcurl-devel \
+      redhat-rpm-config
 
-# make our virtualenv setup a bit nicer, bash only
-echo "export PYTHONPATH='`pwd`'" | tee -a ./.cfme_tests/bin/activate
-echo "export PYTHONDONTWRITEBYTECODE=yes" | tee -a ./.cfme_tests/bin/activate
+  echo "user install of the latest pip/virtualenv to avoid old distro packages"
+  pip install -U -q --user pip virtualenv
+}
 
-. ./.cfme_tests/bin/activate
-PYCURL_SSL_LIBRARY=nss pip install -Ur ./requirements.txt
-echo "Run '. ./.cfme_tests/bin/activate' to load the virtualenv"
+
+append() {
+  grep -q "$2" "$1" || (echo "$2" >> $1)
+}
+
+setup_virtualenv() {
+
+  echo "Creating Virtualenv"
+  virtualenv .cfme_tests
+
+  # make our virtualenv setup a bit nicer, bash only
+  echo "Patching ./.cfme_tests/bin/activate"
+  append ./.cfme_tests/bin/activate "export PYTHONPATH='`pwd`'"
+  append ./.cfme_tests/bin/activate "export PYTHONDONTWRITEBYTECODE=yes"
+
+  . ./.cfme_tests/bin/activate
+  PYCURL_SSL_LIBRARY=nss pip install -Uqr ./requirements.txt
+  echo "Run '. ./.cfme_tests/bin/activate' to load the virtualenv"
+}
+
+link_yamls() {
+  ln -s -t "$2" "$1"/*.yaml
+  ln -s -t "$2" "$1"/*.eyaml
+}
+
+setup_yaml_symlinks() {
+  if   [ -d "$QE_YAML_REPO" ]
+  then
+    echo "Linkin qe repo yaml files"
+    link_yamls "$QE_YAML_REPO/complete" conf
+  else
+    echo "No qe yamls found"
+  fi
+}
+
+
+
+
+[ -f /etc/redhat-release ] && setup_redhat_based_system
+setup_virtualenv
+setup_yaml_symlinks

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -8,7 +8,8 @@ setup_redhat_based_system() {
       python-pip gcc postgresql-devel \
       libxml2-devel libxslt-devel \
       zeromq3-devel libcurl-devel \
-      redhat-rpm-config gcc-c++
+      redhat-rpm-config gcc-c++ \
+      openssl-devel libffi-devel
 
   echo "user install of the latest pip/virtualenv to avoid old distro packages"
   pip install -U -q --user pip virtualenv

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -10,7 +10,7 @@ setup_redhat_based_system() {
       python-pip gcc postgresql-devel \
       libxml2-devel libxslt-devel \
       zeromq3-devel libcurl-devel \
-      redhat-rpm-config
+      redhat-rpm-config  gcc-c++
 
   echo "user install of the latest pip/virtualenv to avoid old distro packages"
   pip install -U -q --user pip virtualenv

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+echo "setting up the needed system level tools"
+pkcon install -y \
+    python-pip gcc postgresql-devel \
+    libxml2-devel libxslt-devel \
+    zeromq3-devel libcurl-devel \
+    redhat-rpm-config
+
+echo "user install of the latest pip/virtualenv to avoid old distro packages"
+pip install -U --user pip virtualenv
+
+echo "Creating Virtualenv"
+virtualenv .cfme_tests
+
+# make our virtualenv setup a bit nicer, bash only
+echo "export PYTHONPATH='`pwd`'" | tee -a ./.cfme_tests/bin/activate
+echo "export PYTHONDONTWRITEBYTECODE=yes" | tee -a ./.cfme_tests/bin/activate
+
+. ./.cfme_tests/bin/activate
+PYCURL_SSL_LIBRARY=nss pip install -Ur ./requirements.txt
+echo "Run '. ./.cfme_tests/bin/activate' to load the virtualenv"


### PR DESCRIPTION
this pr adds a opinionated quickstart script

* it installs all build dependencies on fedora/rhel
* if applicable it symlinks the credentials from the internal repo
* its designed so it can be used instead of virtualenv actication

my hope is that we can slowly migrate to just invoking the script over doing configuration manually
the script is supposed to always set up the environment

i left the old documentation untouched for now