### PR TITLE
[WIP] - Translator testing

### DIFF
--- a/cfme/cloud/provider.py
+++ b/cfme/cloud/provider.py
@@ -10,8 +10,10 @@
 """
 
 from functools import partial
+import re
 
 import cfme.fixtures.pytest_selenium as sel
+from fixtures.pytest_store import store as st
 from cfme.infrastructure.provider import OpenstackInfraProvider
 from cfme.web_ui import form_buttons
 from cfme.web_ui import toolbar as tb
@@ -132,6 +134,7 @@ class Provider(Pretty, CloudInfraProvider):
     pretty_attrs = ['name', 'credentials', 'zone', 'key']
     STATS_TO_MATCH = ['num_template', 'num_vm']
     string_name = "Cloud"
+    object_name = "Cloud Provider"
     page_name = "clouds"
     instances_page_name = "clouds_instances_by_provider"
     templates_page_name = "clouds_images_by_provider"
@@ -146,6 +149,9 @@ class Provider(Pretty, CloudInfraProvider):
     save_button = deferred_verpick(
         {version.LOWEST: form_buttons.FormButton("Save Changes"),
          '5.5': form_buttons.FormButton("Save changes")})
+
+    toolbar_add_button = lambda _: re.sub('#\{.*\}', _.object_name,
+        st.ca.translate['new_cloud_provider_toolbar'])
 
     def __init__(self, name=None, credentials=None, zone=None, key=None):
         if not credentials:

--- a/fixtures/pytest_store.py
+++ b/fixtures/pytest_store.py
@@ -94,6 +94,10 @@ class Store(object):
         return self._current_appliance[-1]
 
     @property
+    def ca(self):
+        return self.current_appliance
+
+    @property
     def any_appliance(self):
         return bool(self._current_appliance)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ ovirt-engine-sdk-python
 paramiko
 parsedatetime
 pdfminer
+polib
 progress
 psphere
 py

--- a/utils/appliance.py
+++ b/utils/appliance.py
@@ -33,6 +33,7 @@ from utils.path import data_path, patches_path, scripts_path
 from utils.providers import get_mgmt, get_crud
 from utils.version import Version, get_stream, pick, LATEST
 from utils.signals import fire
+from utils.translator import Translate
 from utils.wait import wait_for
 
 RUNNING_UNDER_SPROUT = os.environ.get("RUNNING_UNDER_SPROUT", "false") != "false"
@@ -366,6 +367,10 @@ class IPAppliance(object):
         if res.rc != 0:
             raise RuntimeError('Unable to retrieve appliance OS version')
         return Version(res.output)
+
+    @cached_property
+    def translate(self):
+        return Translate(self)
 
     @cached_property
     def log(self):

--- a/utils/translator.py
+++ b/utils/translator.py
@@ -1,0 +1,36 @@
+import re
+import polib
+from tempfile import NamedTemporaryFile
+
+
+class Translate(object):
+    def __init__(self, appliance):
+        self.appliance = appliance
+        self._po = None
+        self.lib = None
+
+    @property
+    def po(self):
+        if not self._po:
+            temp_file = NamedTemporaryFile()
+            self.appliance.ssh_client.get_file(
+                '/var/www/miq/vmdb/config/locales/manageiq.pot', temp_file.name)
+            self._po = polib.pofile(temp_file.name)
+        return self._po
+
+    def process_entries(self):
+        todo = [self.po.untranslated_entries(), self.po.translated_entries()]
+        for item in todo:
+            for t in item:
+                ident = re.findall('QE:\s(.*)', t.comment)
+                if ident:
+                    self.lib[ident[0]] = t.msgid
+
+    def __getitem__(self, name):
+        if not self.lib:
+            self.lib = {}
+            self.process_entries()
+        try:
+            return self.lib[name]
+        except KeyError:
+            return None


### PR DESCRIPTION
Adding this to the https://github.com/ManageIQ/manageiq/blob/master/app/helpers/application_helper/toolbar/ems_clouds_center.rb file

```ruby     
          'pficon pficon-add-circle-o fa-lg',
          #. QE: new_cloud_provider_toolbar
          t = N_('Add a New #{ui_lookup(:table=>"ems_cloud")}'),
          t,
```     
     
Means we can then access it like this

```    
In [1]: from utils.providers import get_crud
No handlers could be found for logger "psphere.config"

In [2]: aa = get_crud('rhos7-ga')

In [3]: aa.toolbar_add_button()
Out[3]: u'Add a New Cloud Provider'

In [4]: 
```