### PR TITLE
simplify the parallelizer test generator

### DIFF
--- a/fixtures/parallelizer/__init__.py
+++ b/fixtures/parallelizer/__init__.py
@@ -279,7 +279,6 @@ class ParallelSession(object):
                 url = "https://{}/".format(appliance["ip_address"])
                 self.appliances.append(url)
                 self.terminal.write("- {} is {}\n".format(url, appliance['name']))
-            map(lambda a: "https://{}/".format(a["ip_address"]), request["appliances"])
             self._reset_timer()
             # Set the base_url for collection purposes on the first appliance
             conf.runtime["env"]["base_url"] = self.appliances[0]

--- a/fixtures/parallelizer/__init__.py
+++ b/fixtures/parallelizer/__init__.py
@@ -378,7 +378,7 @@ class ParallelSession(object):
         # worker output redirected to null; useful info comes via messages and logs
         slave = subprocess.Popen(
             ['python', remote.__file__, slaveid, base_url],
-            stdout=devnull, stderr=devnull,
+            stdout=devnull,
         )
         self.slaves[slaveid] = slave
         self.slave_spawn_count += 1

--- a/fixtures/parallelizer/__init__.py
+++ b/fixtures/parallelizer/__init__.py
@@ -245,40 +245,59 @@ class ParallelSession(object):
                 date=self.config.option.sprout_date,
                 lease_time=self.config.option.sprout_timeout
             )
-            self.terminal.write("Pool {}. Waiting for fulfillment ...\n".format(pool_id))
+            self.println("Pool {}. Waiting for fulfillment ...".format(pool_id))
             self.sprout_pool = pool_id
             at_exit(self.sprout_client.destroy_pool, self.sprout_pool)
             if self.config.option.sprout_desc is not None:
                 self.sprout_client.set_pool_description(
                     pool_id, str(self.config.option.sprout_desc))
+
+            def detailed_check():
+                try:
+                    result = self.sprout_client.request_check(self.sprout_pool)
+                except SproutException as e:
+                    # TODO: ensure we only exit this way on sprout usage
+                    try:
+                        self.sprout_client.destroy_pool(pool_id)
+                    except:
+                        pass
+                    self.println(
+                        "sprout pool could not be fulfilled\n{}".format(e))
+                    pytest.exit(1)
+
+                self.println("[{now:%H:%M}] fulfilled at {progress:2}%".format(
+                    now=datetime.now(),
+                    progress=result['progress']
+                ))
+                return result["fulfilled"]
             try:
                 result = wait_for(
-                    lambda: self.sprout_client.request_check(self.sprout_pool)["fulfilled"],
+                    detailed_check,
                     num_sec=self.config.option.sprout_provision_timeout * 60,
                     delay=5,
                     message="requesting appliances was fulfilled"
                 )
-            except:
+            except Exception:
                 pool = self.sprout_client.request_check(self.sprout_pool)
-                dump_pool_info(lambda x: self.terminal.write("{}\n".format(x)), pool)
-                self.terminal.write("Destroying the pool on error.\n")
+                dump_pool_info(self.println, pool)
+                self.println("Destroying the pool on error.")
                 self.sprout_client.destroy_pool(pool_id)
                 raise
             else:
                 pool = self.sprout_client.request_check(self.sprout_pool)
-                dump_pool_info(lambda x: self.terminal.write("{}\n".format(x)), pool)
-            self.terminal.write("Provisioning took {0:.1f} seconds\n".format(result.duration))
+                dump_pool_info(self.println, pool)
+            self.println("Provisioning took {0:.1f} seconds".format(result.duration))
             request = self.sprout_client.request_check(self.sprout_pool)
             self.appliances = []
             # Push an appliance to the stack to have proper reference for test collection
             # FIXME: this is a bad hack based on the need for controll of collection partitioning
             appliance_stack.push(
                 IPAppliance(address=request["appliances"][0]["ip_address"]))
-            self.terminal.write("Appliances were provided:\n")
+            self.println("Appliances were provided:")
             for appliance in request["appliances"]:
                 url = "https://{}/".format(appliance["ip_address"])
                 self.appliances.append(url)
-                self.terminal.write("- {} is {}\n".format(url, appliance['name']))
+                self.println("- {} is {}".format(url, appliance['name']))
             self._reset_timer()
             # Set the base_url for collection purposes on the first appliance
             conf.runtime["env"]["base_url"] = self.appliances[0]
@@ -288,7 +307,7 @@ class ParallelSession(object):
             self.terminal.write("appliance_template=\"{}\";\n".format(template_name))
             with project_path.join('.appliance_template').open('w') as template_file:
                 template_file.write('export appliance_template="{}"'.format(template_name))
-            self.terminal.write("Parallelized Sprout setup finished.\n")
+            self.println("Parallelized Sprout setup finished.")
             self.slave_appliances_data = {}
             for appliance in request["appliances"]:
                 self.slave_appliances_data[appliance["ip_address"]] = (
@@ -440,6 +459,9 @@ class ParallelSession(object):
                 return self._recv_queue.popleft()
         except IndexError:
             return None, None, None
+
+    def println(self, line):
+        self.terminal.write(line.lstrip('\n') + '\n')
 
     def print_message(self, message, prefix='master', **markup):
         """Print a message from a node to the py.test console

--- a/fixtures/parallelizer/__init__.py
+++ b/fixtures/parallelizer/__init__.py
@@ -641,9 +641,8 @@ class ParallelSession(object):
                 elif event_name == 'runtest_logreport':
                     self.ack(slaveid, event_name)
                     report = unserialize_report(event_data['report'])
-                    if (report.when in ('call', 'teardown')
-                            and report.nodeid in self.slave_tests[slaveid]):
-                        self.slave_tests[slaveid].remove(report.nodeid)
+                    if report.when in ('call', 'teardown'):
+                        self.slave_tests[slaveid].discard(report.nodeid)
                     self.trdist.runtest_logreport(slaveid, report)
                 elif event_name == 'internalerror':
                     self.ack(slaveid, event_name)

--- a/fixtures/parallelizer/parallelizer_tester.py
+++ b/fixtures/parallelizer/parallelizer_tester.py
@@ -12,18 +12,19 @@ from time import sleep
 import pytest
 from utils import testgen
 
-# add 'wait' to this to slow things down, if desired
-pytestmark = pytest.mark.usefixtures('param')
-# increase or decrease this to change the number of tests generated
+# uncommment this to slow things down, if desired
+# pytestmark= pytest.mark.usefixtures("wait")
+
 num_copies = 20
 
 
-def pytest_generate_tests(metafunc):
-    # Starts at 10 for vane reason: Artifactor report does a naive sort, so 10 comes before 1
-    ids = [i + 10 for i in xrange(num_copies)]
-    random.shuffle(ids)
-    argvalues = [[v] for v in ids]
-    testgen.parametrize(metafunc, ['param'], argvalues, ids=ids, scope='module')
+@pytest.fixture(
+    params=xrange(10, 10 * num_copies),
+    autouse=True,
+    scope='module',
+)
+def the_param():
+    pass
 
 
 @pytest.fixture


### PR DESCRIPTION
instead of dequeues uses nested generators,

one for the sequence of test nodes, one to tie up the pairs of `node` and `next_node|None`

this one needs extra careful review and perhaps an eye of @seandst 