### PR TITLE
Added 'validate_tags' to test tags across middleware pages

### DIFF
--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -3,9 +3,13 @@ from functools import partial
 from urlparse import urlparse
 
 from cached_property import cached_property
+from cfme.configure.configuration import Category, Tag
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import CheckboxTree, flash, form_buttons, mixins, toolbar
+from sqlalchemy.orm import aliased
 from utils import attributize_string, version
+from utils.db import cfmedb
+from utils.varmeth import variable
 
 pol_btn = partial(toolbar.select, "Policy")
 
@@ -79,13 +83,71 @@ class Taggable(object):
         self.load_details(refresh=True)
         mixins.add_tag(tag, single_value=single_value, navigate=True)
 
+    def add_tags(self, tags):
+        """Add list of tags
+        tags: List of `Tag`
+        """
+        for tag in tags:
+            self.add_tag(tag=tag)
+
     def remove_tag(self, tag):
         self.load_details(refresh=True)
         mixins.remove_tag(tag)
 
+    def remove_tags(self, tags):
+        """Remove list of tags
+        tags: List of `Tag`
+        """
+        for tag in tags:
+            self.remove_tag(tag=tag)
+
+    @variable(alias='ui')
     def get_tags(self, tag="My Company Tags"):
         self.load_details(refresh=True)
-        return mixins.get_tags(tag=tag)
+        tags = []
+        # Sample out put from UI, [u'Department: Accounting | Engineering', u'Location: London']
+        for _tag in mixins.get_tags(tag=tag):
+            if _tag == 'No {} have been assigned'.format(tag):
+                return tags
+            _tag = _tag.split(':', 1)
+            if len(_tag) != 2:
+                raise RuntimeError('Unknown format of tagging in UI [{}]'.format(_tag))
+            if ' | ' in _tag[1]:
+                for _sub_tag in _tag[1].split(' | '):
+                    tags.append(Tag(category=Category(display_name=tag[0], single_value=None),
+                                    display_name=_sub_tag.strip()))
+            else:
+                tags.append(Tag(category=Category(display_name=_tag[0], single_value=None),
+                                display_name=_tag[1].strip()))
+        return tags
+
+    @get_tags.variant('db')
+    def get_tags_db(self):
+        """
+        Gets tags detail from database
+        Column order: `tag_id`, `db_id`, `category`, `tag_name`, `single_value`
+        """
+        # Some times object of db_id might changed in database, when we do CRUD operations,
+        # do update now
+        self.load_details(refresh=True)
+        if not self.db_id or not self.taggable_type:
+            raise KeyError("'db_id' and/or 'taggable_type' not set")
+        t_cls1 = aliased(cfmedb()['classifications'])
+        t_cls2 = aliased(cfmedb()['classifications'])
+        t_tgg = aliased(cfmedb()['taggings'])
+        query = cfmedb().session.query(t_cls1.tag_id, t_tgg.taggable_id.label('db_id'),
+                                       t_cls2.description.label('category'),
+                                       t_cls1.description.label('tag_name'), t_cls1.single_value)\
+            .join(t_cls2, t_cls1.parent_id == t_cls2.id)\
+            .join(t_tgg, t_tgg.tag_id == t_cls1.tag_id)\
+            .filter(t_tgg.taggable_id == self.db_id)\
+            .filter(t_tgg.taggable_type == self.taggable_type)
+        tags = []
+        for tag in query.all():
+            tags.append(Tag(category=Category(display_name=tag.category,
+                                              single_value=tag.single_value),
+                            display_name=tag.tag_name))
+        return tags
 
 
 class SummaryMixin(object):
@@ -326,3 +388,57 @@ class Validatable(SummaryMixin):
             assert expected_value == shown_value,\
                 ("Property '{}' has wrong value, expected '{}' but was '{}'"
                  .format(property_tuple, expected_value, shown_value))
+
+    def validate_tags(self, tags):
+        """Remove all tags and add `tags` from user input, validates added tags"""
+        self._validate_tags_internal()
+        tags_db = self.get_tags(method='db')
+        if len(tags_db) > 0:
+            self.remove_tags(tags=tags_db)
+            tags_db = self.get_tags(method='db')
+        assert len(tags_db) == 0, "Some of tags still available in database!"
+        self.add_tags(tags)
+        self._validate_tags_internal(reference_tags=tags)
+
+    def _validate_tags_internal(self, tag="My Company Tags", reference_tags=None):
+        self.tags_ = """
+        Validation method which check tagging between UI and database
+        To use this method, `self`/`caller` should be extended with `Taggable` class
+
+        tag: tag name, default is `My Company Tags`
+        reference_tags: If you want to compare user input with database
+         pass user input as `reference_tags`
+        """
+        if reference_tags and not isinstance(reference_tags, list):
+            raise KeyError("'reference_tags' should be an instance of list")
+        # Get tags from UI and DB
+        tags_ui = self.get_tags(method='ui')
+        tags_db = self.get_tags(method='db')
+        # Verify tags
+        assert len(tags_db) == len(tags_ui), \
+            ("Tags count between DB and UI mismatch, expected '{}' but was '{}'"
+             .format(tags_db, tags_ui))
+        if len(tags_ui) > 0:
+            tags_ui = sorted(tags_ui, key=lambda x: (x.category.display_name, x.display_name))
+            tags_db = sorted(tags_db, key=lambda x: (x.category.display_name, x.display_name))
+            for _index in range(len(tags_db)):
+                assert \
+                    tags_db[_index].category.display_name == tags_ui[_index].category.display_name,\
+                    ("Expected category '{}', but was '{}'".format(
+                        tags_db[_index].category.display_name,
+                        tags_ui[_index].category.display_name))
+                assert tags_db[_index].display_name == tags_ui[_index].display_name, \
+                    ("Expected tag_name '{}', but was '{}'".format(tags_db[_index].display_name,
+                                                                   tags_ui[_index].display_name))
+        # if user passed reference tags, validate with database
+        if reference_tags:
+            for _r_tag in reference_tags:
+                _found = False
+                for _d_tag in tags_db:
+                    if _r_tag.category.display_name == _d_tag.category.display_name \
+                            and _r_tag.display_name == _d_tag.display_name:
+                        _found = True
+                        assert _r_tag.category.single_value == _d_tag.category.single_value, \
+                            ("'single_value' of '{}' did not match'"
+                             .format(_r_tag))
+                assert _found, ("Tag '{}' not found in database".format(_r_tag))

--- a/cfme/tests/cloud_infra_common/test_events.py
+++ b/cfme/tests/cloud_infra_common/test_events.py
@@ -81,6 +81,7 @@ def test_vm_create(request, vm_crud, provider, register_event):
     vm_crud.wait_to_appear()
 
     def _check():
-        return "Environment: Development" in vm_crud.get_tags()
+        return any(tag.category.display_name == "Environment" and tag.display_name == "Development"
+                   for tag in vm_crud.get_tags())
 
     wait_for(_check, num_sec=180, delay=15, message="tags to appear")

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -711,7 +711,8 @@ def test_action_tag(request, assign_policy_for_testing, vm, vm_off, vm_crud_refr
     Metadata:
         test_flag: actions, provision
     """
-    if "Service Level: Gold" in vm.crud.get_tags():
+    if any(tag.category.display_name == "Service Level" and tag.display_name == "Gold"
+           for tag in vm.crud.get_tags()):
         vm.crud.remove_tag(("Service Level", "Gold"))
 
     tag_assign_action = explorer.Action(
@@ -730,7 +731,8 @@ def test_action_tag(request, assign_policy_for_testing, vm, vm_off, vm_crud_refr
     vm_crud_refresh()
     try:
         wait_for(
-            lambda: "Service Level: Gold" in vm.crud.get_tags(),
+            lambda: any(tag.category.display_name == "Service Level" and tag.display_name == "Gold"
+                        for tag in vm.crud.get_tags()),
             num_sec=600,
             message="tag presence check"
         )
@@ -745,12 +747,14 @@ def test_action_untag(request, assign_policy_for_testing, vm, vm_off, vm_crud_re
     Metadata:
         test_flag: actions, provision
     """
-    if "Service Level: Gold" not in vm.crud.get_tags():
+    if not any(tag.category.display_name == "Service Level" and tag.display_name == "Gold"
+           for tag in vm.crud.get_tags()):
         vm.crud.add_tag(("Service Level", "Gold"), single_value=True)
 
     @request.addfinalizer
     def _remove_tag():
-        if "Service Level: Gold" in vm.crud.get_tags():
+        if any(tag.category.display_name == "Service Level" and tag.display_name == "Gold"
+               for tag in vm.crud.get_tags()):
             vm.crud.remove_tag(("Service Level", "Gold"))
 
     tag_unassign_action = explorer.Action(
@@ -770,7 +774,8 @@ def test_action_untag(request, assign_policy_for_testing, vm, vm_off, vm_crud_re
     try:
 
         wait_for(
-            lambda: "Service Level: Gold" not in vm.crud.get_tags(),
+            lambda: not any(tag.category.display_name == "Service Level" and
+                            tag.display_name == "Gold" for tag in vm.crud.get_tags()),
             num_sec=600,
             message="tag presence check"
         )

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -237,7 +237,8 @@ def test_tag(provisioner, prov_data, provider):
     vm = provisioner(template_name, prov_data)
 
     tags = vm.get_tags()
-    assert "Service Level: Gold" in tags, "Service Level: Gold not in tags ({})".format(str(tags))
+    assert any(tag.category.display_name == "Service Level" and tag.display_name == "Gold"
+               for tag in tags), "Service Level: Gold not in tags ({})".format(str(tags))
 
 
 @pytest.mark.meta(blockers=[1204115])

--- a/cfme/tests/middleware/test_middleware_deployment.py
+++ b/cfme/tests/middleware/test_middleware_deployment.py
@@ -1,4 +1,5 @@
 import pytest
+from cfme.configure.configuration import Category, Tag
 from cfme.middleware import get_random_list
 from cfme.middleware.deployment import MiddlewareDeployment
 from cfme.middleware.server import MiddlewareServer
@@ -113,3 +114,21 @@ def test_deployment(provider):
         assert dep_ui.server.name == dep_db.server.name, \
             "deployment server name does not match between UI and DB"
         dep_ui.validate_properties()
+
+
+def test_tags(provider):
+    """Tests tags in deployment page
+
+    Steps:
+        * Select a deployment randomly from database
+        * Run `validate_tags` with `tags` input
+    """
+    tags = [
+        Tag(category=Category(display_name='Environment', single_value=True), display_name='Test'),
+        Tag(category=Category(display_name='Department', single_value=False),
+            display_name='Engineering'),
+    ]
+    deps_db = MiddlewareDeployment.deployments_in_db(provider=provider)
+    assert len(deps_db) > 0, "There is no deployment(s) available in UI"
+    deployment = get_random_list(deps_db, 1)[0]
+    deployment.validate_tags(tags=tags)

--- a/cfme/tests/middleware/test_middleware_provider.py
+++ b/cfme/tests/middleware/test_middleware_provider.py
@@ -1,5 +1,7 @@
 import uuid
+
 import pytest
+from cfme.configure.configuration import Category, Tag
 from utils import testgen
 from utils.update import update
 from utils.version import current_version
@@ -40,3 +42,21 @@ def test_hawkular_crud(provider):
 
     provider.delete(cancel=False)
     provider.wait_for_delete()
+
+
+@pytest.mark.usefixtures('setup_provider')
+def test_tags(provider):
+    """Tests tags in provider page
+
+    Steps:
+        * Run `validate_tags` with `tags` input
+    """
+    tags = [
+        Tag(category=Category(display_name='Department', single_value=False),
+            display_name='Engineering'),
+        Tag(category=Category(display_name='Environment', single_value=True), display_name='Test'),
+        Tag(category=Category(display_name='Location', single_value=True), display_name='Paris'),
+        Tag(category=Category(display_name='Service Level', single_value=True),
+            display_name='Gold'),
+    ]
+    provider.validate_tags(tags=tags)

--- a/cfme/tests/middleware/test_middleware_server.py
+++ b/cfme/tests/middleware/test_middleware_server.py
@@ -1,9 +1,10 @@
 import pytest
+from cfme.configure.configuration import Category, Tag
 from cfme.middleware import get_random_list
 from cfme.middleware.server import MiddlewareServer
+from cfme.web_ui import flash
 from utils import testgen
 from utils.version import current_version
-from cfme.web_ui import flash
 from utils.wait import wait_for
 
 pytestmark = [
@@ -171,3 +172,22 @@ def _check_server_stopped(server):
 def _check_server_running(server):
     wait_for(lambda: server.is_running(method='db') and server.is_running(method='mgmt'),
             delay=10, num_sec=600, message='Server {} must be running'.format(server.name))
+
+
+def test_tags(provider):
+    """Tests tags in server page
+
+    Steps:
+        * Select a server randomly from database
+        * Run `validate_tags` with `tags` input
+    """
+    tags = [
+        Tag(category=Category(display_name='Environment', single_value=True), display_name='Test'),
+        Tag(category=Category(display_name='Location', single_value=True), display_name='New York'),
+        Tag(category=Category(display_name='Workload', single_value=False),
+            display_name='Application Servers'),
+    ]
+    servers_db = MiddlewareServer.servers_in_db(provider=provider)
+    assert len(servers_db) > 0, "There is no server(s) available in DB"
+    server = get_random_list(servers_db, 1)[0]
+    server.validate_tags(tags=tags)


### PR DESCRIPTION
 Added new function `validate_tags` in `Validatable` class and implemented across Middleware pages.
* Added support function for `validate_tags`
* Added tests (`test_tags`) for Middleware `Provider`, `Server` and `Deployment` pages
* For `Datasource` page test not included, blocks: https://github.com/ManageIQ/manageiq/issues/9211

{{pytest: cfme/tests/cloud_infra_common/test_events.py -v --long-running --use-provider nested-rhevm34}}