### PR TITLE
Fixed bug in module accessing

### DIFF
--- a/cfme/tests/configure/test_visual_cloud.py
+++ b/cfme/tests/configure/test_visual_cloud.py
@@ -145,7 +145,7 @@ def test_start_page(request, setup_a_provider, start_page):
     login.logout()
     login.login_admin()
     level = re.split(r"\/", start_page)
-    assert menu.is_page_active(level[0].strip(), level[1].strip()), "Landing Page Failed"
+    assert menu.nav.is_page_active(level[0].strip(), level[1].strip()), "Landing Page Failed"
 
 
 def test_cloudprovider_noquads(request, setup_a_provider, set_cloud_provider_quad):


### PR DESCRIPTION
* This occured because the menu became objectized and was my fault to
  not fix this
{{pytest: cfme/tests/configure/test_visual_cloud.py -k test_start_page}}