### PR TITLE
Added uncollect

### DIFF
--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -55,6 +55,7 @@ def test_type_required_validation():
         prov.create()
 
 
+@pytest.mark.uncollectif(lambda: version.current_version() > "5.6")
 @pytest.mark.tier(3)
 def test_name_required_validation():
     """Tests to validate the name while adding a provider"""


### PR DESCRIPTION
This test is no longer required on 5.6 though we should probably write a
new test or adapt this one for testing the angular required fields stuff.

{{pytest: -k test_name_required_validation cfme/tests/infrastructure --use-provider vsphere55}}