### PR TITLE
Drop the need to patch the virtualenv activation script

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,10 @@ Top-level conftest.py does a couple of things:
 2) Load a number of plugins and fixtures automatically
 """
 from pkgutil import iter_modules
+import sys
+import os
+sys.dont_write_bytecode = True  # NOQA
+os.environ['PYTHONDONTWRITEBYTECODE'] = '1'  # NOQA
 
 import pytest
 import requests

--- a/conftest.py
+++ b/conftest.py
@@ -5,10 +5,6 @@ Top-level conftest.py does a couple of things:
 2) Load a number of plugins and fixtures automatically
 """
 from pkgutil import iter_modules
-import sys
-import os
-sys.dont_write_bytecode = True  # NOQA
-os.environ['PYTHONDONTWRITEBYTECODE'] = '1'  # NOQA
 
 import pytest
 import requests

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -53,7 +53,7 @@ Detailed steps (manual environment setup):
   * To activate the virtualenv later: ``source <name>/bin/activate``, but do not do it yet, it still
     needs finishing touches.
 
-* Fork and Clone this repository.d
+* Fork and Clone this repository
 * Get the shared encryption key (``.yaml_key``) for credentials. Ask in CFME QE.
 * Make sure you set the shared secret for the credentials files encryption. There are two ways:
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -36,6 +36,7 @@ file, place it in the ``cfme_tests`` repository (along ``conftest.py``):
   virtualenv .cfme_tests
 
   . ./.cfme_tests/bin/activate
+  python scripts/disable-bytecode.py
   PYCURL_SSL_LIBRARY=nss pip install -Ur ./requirements.txt
   echo "Run '. ./.cfme_tests/bin/activate' to load the virtualenv"
 
@@ -106,6 +107,7 @@ will not work.
       happen)
     * Run ``PYCURL_SSL_LIBRARY=nss pip install -U -r requirements.txt --no-cache-dir``
 
+* run ``python scripts/disable-bytecode.py`` if you want to avoid having to clean up python bytecode
 * You copy/symlink the required YAML files into ``conf/`` if you have access to team's internal YAML
   repository. Required YAML files are ``env``, ``cfme_data``, ``credentials``. If the file's
   extension is ``.yaml`` it is loaded normally, if its extension is ``.eyaml`` then it is encrypted

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -34,8 +34,6 @@ file, place it in the ``cfme_tests`` repository (along ``conftest.py``):
 
   sudo $YUM install -y python-virtualenv gcc postgresql-devel libxml2-devel libxslt-devel zeromq3-devel libcurl-devel redhat-rpm-config gcc-c++ openssl-devel libffi-devel
   virtualenv .cfme_tests
-  echo "export PYTHONPATH='`pwd`'" | tee -a ./.cfme_tests/bin/activate
-  echo "export PYTHONDONTWRITEBYTECODE=yes" | tee -a ./.cfme_tests/bin/activate
 
   . ./.cfme_tests/bin/activate
   PYCURL_SSL_LIBRARY=nss pip install -Ur ./requirements.txt
@@ -55,26 +53,7 @@ Detailed steps (manual environment setup):
   * To activate the virtualenv later: ``source <name>/bin/activate``, but do not do it yet, it still
     needs finishing touches.
 
-* Fork and Clone this repository.
-* Set the ``PYTHONPATH`` to include ``cfme_tests``. Edit your virtualenv's ``bin/activate`` script,
-  created with the virtualenv. At the end of the file, export a PYTHONPATH variable with the path to
-  the repository clone by adding this line (altered to match your repository locations):
-
-  * ``export PYTHONPATH='/path/to/cfme_tests_repo'``
-
-* Also add this line at the end of your virtualenv to prevent .pyc files polluting your folders:
-
-  * ``export PYTHONDONTWRITEBYTECODE="yes"``
-
-* If you forgot to do that and you have ``pyc`` files polluting your folders, this is a cure, placed
-  in ``~/.bashrc`` and usable everywhere:
-
-  .. code-block:: bash
-
-    alias rmpyc='find . -name \*.pyc -delete; find . -name __pycache__ -delete'
-
-  Reload your ``.bashrc`` and issue ``rmpyc`` command.
-
+* Fork and Clone this repository.d
 * Get the shared encryption key (``.yaml_key``) for credentials. Ask in CFME QE.
 * Make sure you set the shared secret for the credentials files encryption. There are two ways:
 

--- a/fixtures/parallelizer/remote.py
+++ b/fixtures/parallelizer/remote.py
@@ -1,6 +1,4 @@
-import os
 import signal
-import sys
 from collections import deque
 from urlparse import urlparse
 
@@ -211,12 +209,6 @@ if __name__ == '__main__':
     from fixtures import terminalreporter
     from fixtures.pytest_store import store
     from utils import conf
-
-    # These must be set before remote_initconfig is called and py.test starts
-    # TODO: Not sure this is necessary, since cwd should already be on the path?
-    import_path = os.getcwd()
-    sys.path.insert(0, import_path)
-    os.environ['PYTHONPATH'] = os.path.join(import_path, os.environ.get('PYTHONPATH', ''))
 
     conf.runtime['env']['slaveid'] = args.slaveid
     conf.runtime['env']['base_url'] = args.base_url

--- a/requirements.txt
+++ b/requirements.txt
@@ -82,3 +82,6 @@ pyzmq
 
 # werkzeug.local until extraction
 werkzeug
+
+# do editable self-install to avoid need for pythonpath changes
+-e .

--- a/scripts/disable-bytecode.py
+++ b/scripts/disable-bytecode.py
@@ -10,7 +10,7 @@ content = "import sys\nsys.dont_write_bytecode = True\n"
 if path.exists(target):
     with open(target) as fp:
         if content not in fp.read():
-            print('%r has unexpected content' % target)
+            print('{target!r} has unexpected content'.format(target=target))
             print('please open the file and add the following:')
             print(content)
             print("# end")

--- a/scripts/disable-bytecode.py
+++ b/scripts/disable-bytecode.py
@@ -9,7 +9,11 @@ content = "import sys\nsys.dont_write_bytecode = True\n"
 
 if path.exists(target):
     with open(target) as fp:
-        assert fp.read() == content
+        if content not in fp.read():
+            print('%r has unexpected content' % target)
+            print('please open the file and add the following:')
+            print(content)
+            print("# end")
 else:
     with open(target, 'w') as fp:
         fp.write(content)

--- a/scripts/disable-bytecode.py
+++ b/scripts/disable-bytecode.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python2
+from os import path
+import distutils
+
+site_packages = distutils.sysconfig_get_python_lib()
+target = path.join(site_packages, 'usercustomize.py')
+
+content = "import sys\nsys.dont_write_bytecode = True\n"
+
+if path.exists(target):
+    with open(target) as fp:
+        assert fp.read() == content
+else:
+    with open(target, 'w') as fp:
+        fp.write(content)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+# dummy for editable installs
+import sys
+from setuptools import setup
+assert 'develop' in sys.argv or 'egg_info' in sys.argv, \
+    'this is a hack, use pip install -e'
+
+setup(
+    name='manageiq-integration-tests',
+    packages=[],
+)


### PR DESCRIPTION
* create a dummy setup.py that can be used for editable install of the project folder
  (removes the need to patch PYTHONPATH)
* disable bytecode in conftest for current process and subprocesses
  (removes the need to set PYTHONDONTWRITEBYTECODE)