### PR TITLE
Fix rbac flash messages

### DIFF
--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -262,9 +262,12 @@ def test_description_required_error_validation():
 
 
 @pytest.mark.tier(3)
+@pytest.mark.meta(blockers=[1351897])
 def test_delete_default_group():
-    flash_msg = \
-        'EVM Group "{}": Error during \'destroy\': A read only group cannot be deleted.'
+    flash_msg = version.pick({
+        '5.6': ("EVM Group \"{}\": Error during delete: A read only group cannot be deleted."),
+        '5.5': ("EVM Group \"{}\": Error during \'destroy\': A read only group cannot be deleted.")
+    })
     group = ac.Group(description='EvmGroup-administrator')
     sel.force_navigate("cfg_accesscontrol_groups")
     row = group_table.find_row_by_cells({'Name': group.description})
@@ -276,8 +279,9 @@ def test_delete_default_group():
 
 @pytest.mark.tier(3)
 def test_delete_group_with_assigned_user():
-    flash_msg = \
-        'EVM Group "{}": Error during \'destroy\': Still has users assigned'
+    flash_msg = version.pick({
+        '5.6': ("EVM Group \"{}\": Error during delete: Still has users assigned"),
+        '5.5': ("EVM Group \"{}\": Error during \'destroy\': Still has users assigned")})
     group = new_group()
     group.create()
     user = new_user(group=group)
@@ -349,9 +353,13 @@ def test_rolename_duplicate_validation():
 
 
 @pytest.mark.tier(3)
+@pytest.mark.meta(blockers=[1351897])
 def test_delete_default_roles():
-    flash_msg = \
-        'Role "{}": Error during \'destroy\': Cannot delete record because of dependent miq_groups'
+    flash_msg = version.pick({
+        '5.6': ("Role \"{}\": Error during delete: Cannot delete record "
+            "because of dependent entitlements"),
+        '5.5': ("Role \"{}\": Error during \'destroy\': Cannot delete record "
+            "because of dependent miq_groups")})
     role = ac.Role(name='EvmRole-approver')
     with error.expected(flash_msg.format(role.name)):
         role.delete()
@@ -366,8 +374,11 @@ def test_edit_default_roles():
 
 @pytest.mark.tier(3)
 def test_delete_roles_with_assigned_group():
-    flash_msg = \
-        'Role "{}": Error during \'destroy\': Cannot delete record because of dependent miq_groups'
+    flash_msg = version.pick({
+        '5.6': ("Role \"{}\": Error during delete: Cannot delete record "
+            "because of dependent entitlements"),
+        '5.5': ("Role \"{}\": Error during \'destroy\': Cannot delete record "
+            "because of dependent miq_groups")})
     role = new_role()
     role.create()
     group = new_group(role=role.name)


### PR DESCRIPTION
{{pytest: -v -k 'test_delete_default_group or test_delete_group_with_assigned_user or test_delete_default_roles or test_delete_roles_with_assigned_group'}}