### PR TITLE
Added support for middleware topology page

### DIFF
--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -6,6 +6,7 @@ from cached_property import cached_property
 from cfme.configure.configuration import Category, Tag
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import CheckboxTree, flash, form_buttons, mixins, toolbar
+from cfme.web_ui.topology import Topology
 from sqlalchemy.orm import aliased
 from utils import attributize_string, version
 from utils.db import cfmedb
@@ -435,3 +436,41 @@ class Validatable(SummaryMixin):
                             ("'single_value' of '{}' did not match'"
                              .format(ref_tag))
                 assert found, ("Tag '{}' not found in database".format(ref_tag))
+
+
+class TopologyMixin(object):
+    """Use this mixin to have simple access to the Topology page.
+    To use this `TopologyMixin` you have to implement `load_topology_page`
+    function, which should take to topology page
+
+    Sample usage:
+
+    .. code-block:: python
+
+        # You can retrieve the elements details as it is in the UI
+        topology.elements  # => 'hostname'
+        # You can do actions on topology page
+        topology.display_names.enable()
+        topology.display_names.disable()
+        topology.display_names.is_enabled
+        # You can do actions on topology search box
+        topology.search_box.text(text='hello')
+        topology.search_box.text(text='hello', submit=False)
+        topology.search_box.submit()
+        topology.search_box.clear()
+        # You can get legends and can perform actions
+        topology.legends
+        topology.pod.name
+        topology.pod.is_active
+        topology.pod.set_active()
+        # You can get elements, element parents and children
+        topology.elements
+        topology.elements[0].parents
+        topology.elements[0].children
+        topology.elements[0].double_click()
+        topology.elements[0].is_displayed()
+
+    """
+    @cached_property
+    def topology(self):
+        return Topology(self)

--- a/cfme/middleware/provider/hawkular.py
+++ b/cfme/middleware/provider/hawkular.py
@@ -1,17 +1,16 @@
 import re
-
-from utils.varmeth import variable
-
+from cfme.common import TopologyMixin
 from cfme.common.provider import BaseProvider
+from cfme.web_ui import form_buttons
+from mgmtsystem.hawkular import Hawkular
+from utils.db import cfmedb
+from utils.varmeth import variable
 from . import properties_form, _get_providers_page, _db_select_query
 from .. import download, MiddlewareBase
-from mgmtsystem.hawkular import Hawkular
-from cfme.web_ui import form_buttons
-from utils.db import cfmedb
 
 
 @BaseProvider.add_type_map
-class HawkularProvider(MiddlewareBase, BaseProvider):
+class HawkularProvider(MiddlewareBase, TopologyMixin, BaseProvider):
     """
     HawkularProvider class holds provider data. Used to perform actions on hawkular provider page
 
@@ -124,6 +123,10 @@ class HawkularProvider(MiddlewareBase, BaseProvider):
             tmp_provider = _db_select_query(
                 name=self.name, type='ManageIQ::Providers::Hawkular::MiddlewareManager').first()
             self.db_id = tmp_provider.id
+
+    def load_topology_page(self):
+        self.summary.reload()
+        self.summary.overview.topology.click()
 
     @staticmethod
     def configloader(prov_config, prov_key):

--- a/cfme/middleware/topology.py
+++ b/cfme/middleware/topology.py
@@ -1,0 +1,9 @@
+from cfme.common import TopologyMixin
+from cfme.fixtures import pytest_selenium as sel
+
+
+class MiddlewareTopology(TopologyMixin):
+
+    @classmethod
+    def load_topology_page(cls):
+        sel.force_navigate('middleware_topology')

--- a/cfme/tests/middleware/test_middleware_provider.py
+++ b/cfme/tests/middleware/test_middleware_provider.py
@@ -60,3 +60,22 @@ def test_tags(provider):
             display_name='Gold'),
     ]
     provider.validate_tags(tags=tags)
+
+
+@pytest.mark.usefixtures('setup_provider')
+def test_topology(provider):
+    """Tests topology page from provider page
+
+    Steps:
+        * Get topology elements detail
+        * Check number of providers on the page
+        * Check number of `Servers`, `Deployments` on topology page
+    """
+    assert len(provider.topology.elements(element_type='Hawkular')) == 1,\
+        "More than one Hawkular providers found"
+    el_hawkular = provider.topology.elements(element_type='Hawkular')[0]
+    assert provider.num_server(method='db') == len(el_hawkular.children), \
+        "Number of server(s) miss match between topology page and in database"
+    assert provider.num_deployment(method='db') == len(
+        provider.topology.elements(element_type='MiddlewareDeployment')),\
+        "Number of deployment(s) miss match between topology page and in database"

--- a/cfme/web_ui/topology.py
+++ b/cfme/web_ui/topology.py
@@ -1,0 +1,222 @@
+import re
+from cfme.fixtures import pytest_selenium as sel
+from selenium.common.exceptions import ElementNotVisibleException, StaleElementReferenceException
+from utils import attributize_string
+from utils.browser import ensure_browser_open
+from wait_for import wait_for
+
+
+class Topology(object):
+    LEGENDS = '//kubernetes-topology-icon'
+    ELEMENTS = '//kubernetes-topology-graph//*[name()="g"]'
+    LINES = '//kubernetes-topology-graph//*[name()="line"]'
+
+    def __init__(self, o):
+        self._object = o
+        self._legends = []
+        self._elements = []
+        self._lines = []
+        self._el_ref = None
+        self.search_box = None
+        self.display_names = None
+        self.reload()
+
+    def __repr__(self):
+        return "<Topology {}>".format(", ".join(self._legends))
+
+    def reload(self):
+        ensure_browser_open()
+        self._object.load_topology_page()
+        self._reload()
+
+    def refresh(self):
+        ensure_browser_open()
+        sel.click("//*[contains(@class, 'container_topology')]//button[contains(., 'Refresh')]")
+        self._reload()
+
+    def _is_el_movement_stopped(self):
+        _el = TopologyElement(o=self, element=sel.elements(self.ELEMENTS)[-1])
+        if _el.x == self._el_ref.x and _el.y == self._el_ref.y:
+            return True
+        self._el_ref = _el
+        return False
+
+    def _reload(self):
+        self._legends = []
+        self._elements = []
+        self._lines = []
+        self.search_box = TopologySearchBox()
+        self.display_names = TopologyDisplayNames()
+        # load elements
+        # we have to wait few seconds, initial few seconds elements are moving
+        if len(sel.elements(self.ELEMENTS)) > 0:
+            self._el_ref = TopologyElement(o=self, element=sel.elements(self.ELEMENTS)[-1])
+            wait_for(lambda: self._is_el_movement_stopped(), delay=2, num_sec=30)
+
+            for element in sel.elements(self.ELEMENTS):
+                self._elements.append(TopologyElement(o=self, element=element))
+            # load lines
+            for line in sel.elements(self.LINES):
+                self._lines.append(TopologyLine(element=line))
+        # load legends
+        # remove old legends
+        for legend_id in self._legends:
+            try:
+                delattr(self, legend_id)
+            except AttributeError:
+                pass
+        # load available legends
+        for legend in sel.elements(self.LEGENDS):
+            legend_text = sel.text_sane(legend.find_element_by_tag_name('label'))
+            legend_id = attributize_string(legend_text.strip())
+            legend_object = TopologyLegend(name=legend_text, element=legend)
+            setattr(self, legend_id, legend_object)
+            self._legends.append(legend_id)
+
+    def __iter__(self):
+        """This enables you to iterate through like it was a dictionary, just without .iteritems"""
+        for legend_id in self._legends:
+            yield (legend_id, getattr(self, legend_id))
+
+    @property
+    def legends(self):
+        return self._legends
+
+    def elements(self, element_type=None):
+        if element_type:
+            return [el for el in self._elements if el.type == element_type]
+        return self._elements
+
+    def lines(self, connection=None):
+        if connection:
+            return [ln for ln in self._lines if ln.connection == connection]
+        return self._lines
+
+
+class TopologyLegend(object):
+    def __init__(self, name, element):
+        self._name = name
+        self._element = element
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def is_active(self):
+        return 'active' in self._element.get_attribute('class')
+
+    def set_active(self, active=True):
+        if active != self.is_active:
+            self._element.click()
+
+
+class TopologyDisplayNames(object):
+    DISPLAY_NAME = \
+        "//*[contains(@class, 'container_topology')]//label[contains(., 'Display Names')]/input"
+
+    def __init__(self):
+        self._el = sel.element(self.DISPLAY_NAME)
+
+    @property
+    def is_enabled(self):
+        return self._el.is_selected()
+
+    def enable(self, enable=True):
+        if self.is_enabled != enable:
+            self._el.click()
+
+    def disable(self):
+        self.enable(enable=False)
+
+
+class TopologySearchBox(object):
+    SEARCH_BOX = "//*[contains(@class, 'container_topology')]//input[@id='search']"
+    SEARCH_CLEAR = "//*[contains(@class, 'container_topology')]//button[contains(@class, 'clear')]"
+    SEARCH_SUBMIT = "//button[contains(@class, 'search-topology-button')]"
+
+    def clear(self):
+        try:
+            sel.element(self.SEARCH_CLEAR).click()
+        except ElementNotVisibleException:
+            pass
+
+    def submit(self):
+        sel.element(self.SEARCH_SUBMIT).click()
+
+    def text(self, submit=True, text=None):
+        if text is not None:
+            self.clear()
+            sel.element(self.SEARCH_BOX).send_keys(text)
+            if submit:
+                self.submit()
+        else:
+            return sel.element(self.SEARCH_BOX).text
+
+
+class TopologyElement(object):
+    def __init__(self, o, element):
+        if element is None:
+            raise KeyError('Element should not be None')
+        self.sel_element = element
+        self._object = o
+        el_data = re.search('Name: (.*) Type: (.*) Status: (.*)', element.text)
+        if len(el_data.groups()) != 3:
+            raise RuntimeError('Unexpected element')
+        self.name = el_data.group(1)
+        self.type = el_data.group(2)
+        self.status = el_data.group(3)
+        self.x = round(float(element.get_attribute('cx')), 1)
+        self.y = round(float(element.get_attribute('cy')), 1)
+
+    def __repr__(self):
+        return "<TopologyElement name:{}, type:{}, status:{}, x:{}, y:{}, is_hidden:{}>".format(
+            self.name, self.type, self.status, self.x, self.y, self.is_hidden)
+
+    @property
+    def is_hidden(self):
+        return 'opacity: 0.2' in self.sel_element.get_attribute('style')
+
+    @property
+    def parents(self):
+        elements = []
+        for line in [_line for _line in self._object.lines()
+                     if _line.x2 == self.x and _line.y2 == self.y]:
+            for _el in self._object.elements():
+                if _el.x == line.x1 and _el.y == line.y1:
+                    elements.append(_el)
+        return elements
+
+    @property
+    def children(self):
+        elements = []
+        for line in [_line for _line in self._object.lines()
+                     if _line.x1 == self.x and _line.y1 == self.y]:
+            for _el in self._object.elements():
+                if _el.x == line.x2 and _el.y == line.y2:
+                    elements.append(_el)
+        return elements
+
+    def double_click(self):
+        sel.double_click(self.sel_element)
+
+    def is_displayed(self):
+        try:
+            return self.sel_element.is_displayed()
+        except StaleElementReferenceException:
+            return False
+
+
+class TopologyLine(object):
+    def __init__(self, element):
+        if element is None:
+            raise KeyError('Element should not be None')
+        self.connection = element.get_attribute('class')
+        self.x1 = round(float(element.get_attribute('x1')), 1)
+        self.x2 = round(float(element.get_attribute('x2')), 1)
+        self.y1 = round(float(element.get_attribute('y1')), 1)
+        self.y2 = round(float(element.get_attribute('y2')), 1)
+
+    def __repr__(self):
+        return "<TopologyLine Connection:{}, x1,y1:{},{}, x2,y2:{},{}>".format(
+            self.connection, self.x1, self.y1, self.x2, self.y2)


### PR DESCRIPTION
Added new `Mixin` --> `TopologyMixin`. With this `Mixin` we can perform following actions,

* Get legends
* Get elements with filter support(optional)
* Get parents and children of an element
* Do actions on `Search box`, `Display Names`, `Legends`
* Perform `double_click` on an element

{{pytest: cfme/tests/middleware/ -v --long-running --use-provider hawkular}}