### PR TITLE
Add patching to 5.5.5.0

### DIFF
--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -934,7 +934,7 @@ def force_navigate(page_name, _tries=0, *args, **kwargs):
 
     # check for MiqQE javascript patch in 5.6 on first try and patch the appliance if necessary
     # raise an exception on subsequent unsuccessful attempts to access the MiqQE javascript funcs
-    if store.current_appliance.version >= "5.6":
+    if store.current_appliance.version >= "5.5.5.0":
         def _patch_recycle_retry():
             store.current_appliance.patch_with_miqqe()
             browser().quit()
@@ -942,7 +942,7 @@ def force_navigate(page_name, _tries=0, *args, **kwargs):
         try:
             # latest js diff version always has to be placed here to keep this check current
             ver = execute_script("return MiqQE_version")
-            if ver < 1:
+            if ver < 2:
                 logger.info("Old patch present on appliance; patching appliance")
                 _patch_recycle_retry()
         except WebDriverException as ex:

--- a/data/patches/miq_application.js.diff
+++ b/data/patches/miq_application.js.diff
@@ -1,6 +1,6 @@
 --- miq_application.js	2016-05-23 15:46:51.571062620 +0200
 +++ miq_application.js.new	2016-05-23 15:48:51.438832567 +0200
-@@ -1,5 +1,52 @@
+@@ -1,5 +1,54 @@
  // MIQ specific JS functions
 
 +// MiqQE section
@@ -9,7 +9,7 @@
 +// Initialize MiqQE
 +// Make sure to update version here and in pytest_selenium when changed
 +var MiqQE = {'autofocus': 0, 'debounce': 0};
-+var MiqQE_version = 1;
++var MiqQE_version = 2;
 +
 +function checkMiqQE(key) {
 +  var v = MiqQE[key];
@@ -25,27 +25,29 @@
 +  return v_incomplete;
 +}
 +
-+// Override the default debounce fn
-+var orig_debounce = _.debounce;
-+_.debounce = function(func, wait, options) {
-+  // Override the original fn; new_func will be the original fn with wait prepended to it
-+  // We make sure that once this fn is actually run, it decreases the counter
-+  var new_func = function() {
-+    try {
-+      return func.apply(this, arguments);
-+    } finally {
-+      // this is run before the return above, always
-+      MiqQE['debounce'] -= 1;
++// Override the default debounce fn if used
++if (typeof _ !== 'undefined' && typeof _.debounce !== 'undefined') {
++  var orig_debounce = _.debounce;
++  _.debounce = function(func, wait, options) {
++    // Override the original fn; new_func will be the original fn with wait prepended to it
++    // We make sure that once this fn is actually run, it decreases the counter
++    var new_func = function() {
++      try {
++        return func.apply(this, arguments);
++      } finally {
++        // this is run before the return above, always
++        MiqQE['debounce'] -= 1;
++      }
 +    }
++    // Override the newly-created fn (prepended wait + original fn)
++    // We have to increase the counter before the waiting is initiated
++    var debounced_func = orig_debounce.call(this, new_func, wait, options);
++    var new_debounced_func = function() {
++      MiqQE['debounce'] += 1;
++      return debounced_func.apply(this, arguments);
++    }
++    return new_debounced_func;
 +  }
-+  // Override the newly-created fn (prepended wait + original fn)
-+  // We have to increase the counter before the waiting is initiated
-+  var debounced_func = orig_debounce.call(this, new_func, wait, options);
-+  var new_debounced_func = function() {
-+    MiqQE['debounce'] += 1;
-+    return debounced_func.apply(this, arguments);
-+  }
-+  return new_debounced_func;
 +}
 +// --------------
 +

--- a/utils/appliance.py
+++ b/utils/appliance.py
@@ -504,12 +504,12 @@ class IPAppliance(object):
 
     @logger_wrap("Patch appliance with MiqQE js: {}")
     def patch_with_miqqe(self, log_callback=None):
-        if self.version < "5.6":
+        if self.version < "5.5.5.0":
             return
 
         # (local_path, remote_path, md5/None) trio
         autofocus_patch = pick({
-            '5.6': 'autofocus.js.diff',
+            '5.5': 'autofocus.js.diff',
             LATEST: 'autofocus_upstream.js.diff'
         })
         patch_args = (
@@ -518,7 +518,7 @@ class IPAppliance(object):
              None),
             (str(patches_path.join(autofocus_patch)),
              '/var/www/miq/vmdb/app/assets/javascripts/directives/autofocus.js',
-             'f5ce9fa129d1662e6fe6f7c213458227'),
+             None),
         )
 
         patched_anything = False


### PR DESCRIPTION
Debounce has been introduced to 55z branch in 5.5.5.0. This will bump up our automation results on jenkins considerably.

Also:
 - raises patch ver to 2
 - removes md5 check from autofocus

{{pytest: -k "test_tag_crud or test_category_crud" --long-running -v }}