### PR TITLE
Add verpick for cfme57 postgres

### DIFF
--- a/utils/db.py
+++ b/utils/db.py
@@ -50,7 +50,8 @@ def scl_name():
     # so this is a little resolver to help keep the version picking centralized
     return version.pick({
         version.LOWEST: 'postgresql92',
-        '5.5': 'rh-postgresql94'
+        '5.5': 'rh-postgresql94',
+        '5.7': 'rh-postgresql95'
     })
 
 


### PR DESCRIPTION
New upstream (and 5.7) will run new version of posgres. This is one of the 2 issues blocking upstream template testing right now.