### PR TITLE
[FIX]  Found and added missing Azure Subscription ID reference

### DIFF
--- a/cfme/cloud/provider.py
+++ b/cfme/cloud/provider.py
@@ -53,7 +53,6 @@ properties_form_55 = Form(
                 "5.5": "api_port",
             }
         )),
-        ('azure_subscription_id', Input("subscription")),
         ('api_version', AngularSelect("api_version"), {"appeared_in": "5.5"}),
         ('sec_protocol', AngularSelect("security_protocol"), {"appeared_in": "5.5"}),
         ('infra_provider', {
@@ -174,7 +173,7 @@ class AzureProvider(Provider):
         self.subscription_id = subscription_id
 
     def _form_mapping(self, create=None, **kwargs):
-        # Will still need to figure out where to put the tenant id.
+        # Tenant ID and Subscription ID will have to live in cfme_data for now.
         return {'name_text': kwargs.get('name'),
                 'type_select': create and 'Azure',
                 'region_select': kwargs.get('region'),

--- a/utils/providers.py
+++ b/utils/providers.py
@@ -775,6 +775,7 @@ def get_crud(provider_config_name):
         return AzureProvider(name=prov_config['name'],
             region=prov_config['region'],
             tenant_id=prov_config['tenant_id'],
+            subscription_id=prov_config['subscription_id'],
             credentials={'default': credentials},
             key=provider_config_name)
     elif prov_type == 'openstack':


### PR DESCRIPTION
This is leftover from 2977.  It's a single line fix and works locally.  Nothing I can do about the location of these values until credentials allows for additional entries.

{{pytest: cfme/tests/cloud -k "test_provider_crud" --use-provider azure }}
