### PR TITLE
Fix testgen mark application

### DIFF
--- a/utils/testgen.py
+++ b/utils/testgen.py
@@ -331,8 +331,6 @@ def provider_by_type(metafunc, provider_types, required_fields=None):
 
     """
 
-    metafunc.function = pytest.mark.uses_testgen()(metafunc.function)
-
     argnames = []
     argvalues = []
     idlist = []
@@ -367,6 +365,7 @@ def provider_by_type(metafunc, provider_types, required_fields=None):
             continue
 
         if 'provider' in metafunc.fixturenames and 'provider' not in argnames:
+            metafunc.function = pytest.mark.uses_testgen()(metafunc.function)
             argnames.append('provider')
 
         # uncollect when required field is not present and option['require_field'] == True


### PR DESCRIPTION
Previously the mark was applied correctly, however in the testgen
refactor this became broken. As the mark was applied outside of the
loop, merely running "through" testgen was enough to mark the
test. Unfortunately this was not accurate. This mark has now been moved
to be applied only if the "provider" parameter has actually been used
and hence the test has been properly parametrized.

Fixes #3171 

{{pytest: -m uses_testgen --collect-only --use-provider vsphere55}}