### PR TITLE
Fix catalog_item  None handling

### DIFF
--- a/cfme/services/catalogs/catalog_item.py
+++ b/cfme/services/catalogs/catalog_item.py
@@ -8,7 +8,7 @@ from cfme.web_ui import toolbar as tb
 from utils.update import Updateable
 from utils.pretty import Pretty
 from utils.version import current_version
-from utils import version
+from utils import version, fakeobject_or_object
 
 cfg_btn = partial(tb.select, "Configuration")
 accordion_tree = partial(accordion.tree, "Catalog Items")
@@ -210,11 +210,14 @@ class CatalogItem(Updateable, Pretty):
         sel.force_navigate('catalog_item_new',
                            context={'provider_type': self.item_type})
         sel.wait_for_element(basic_info_form.name_text)
+        catalog = fakeobject_or_object(self.catalog, "name", "<Unassigned>")
+        dialog = fakeobject_or_object(self.dialog, "name", "<No Dialog>")
+
         fill(basic_info_form, {'name_text': self.name,
                                'description_text': self.description,
                                'display_checkbox': self.display_in,
-                               'select_catalog': str(self.catalog),
-                               'select_dialog': str(self.dialog),
+                               'select_catalog': catalog.name,
+                               'select_dialog': dialog.name,
                                'select_orch_template': self.orch_template,
                                'select_provider': self.provider_type,
                                'select_config_template': self.config_template})
@@ -237,8 +240,9 @@ class CatalogItem(Updateable, Pretty):
         sel.click(template_select_form.add_button)
 
     def update(self, updates):
+        catalog = fakeobject_or_object(self.catalog, "name", "<Unassigned>")
         sel.force_navigate('catalog_item_edit',
-                           context={'catalog': self.catalog,
+                           context={'catalog': catalog.name,
                                     'catalog_item': self})
         fill(basic_info_form, {'name_text': updates.get('name', None),
                                'description_text':

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -11,6 +11,20 @@ from werkzeug.local import LocalProxy
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 
+class FakeObject(object):
+    def __init__(self, **kwargs):
+        self.__dict__ = kwargs
+
+
+def fakeobject_or_object(obj, attr, default=None):
+    if isinstance(obj, basestring):
+        return FakeObject(**{attr: obj})
+    elif not obj:
+        return FakeObject(**{attr: default})
+    else:
+        return obj
+
+
 def property_or_none(wrapped, *args, **kwargs):
     """property_or_none([fget[, fset[, fdel[, doc]]]])
     Property decorator that turns AttributeErrors into None returns


### PR DESCRIPTION
A string cast was added on the 13-Mar which effectively turned None into
"None". Since the UI doesn't have a "None", but only an "<Unassigned>"
or a "<No Dialog>" this was causing errors.

{{pytest: -k test_edit_service_template cfme/tests/services/test_rest_services.py --long-running --use-provider complete}}