### PR TITLE
Add pytest.mark.polarion()

### DIFF
--- a/artifactor/plugins/ostriz.py
+++ b/artifactor/plugins/ostriz.py
@@ -29,8 +29,8 @@ class Ostriz(ArtifactorBasePlugin):
         self.configured = True
 
     @ArtifactorBasePlugin.check_configured
-    def ostriz_send(self, artifacts, test_location, test_name, slaveid, run_id, version, build,
-            stream):
+    def ostriz_send(self, artifacts, test_location, test_name, slaveid, polarion_ids, run_id,
+            version, build, stream):
         test_ident = "{}/{}".format(test_location, test_name)
         json_data = artifacts[test_ident]
         json_data['name'] = test_ident
@@ -41,5 +41,7 @@ class Ostriz(ArtifactorBasePlugin):
         json_data['build'] = build
         json_data['stream'] = stream
         json_data['method'] = "automated"
+        # Either None or a list of Polarion Test Case IDs
+        json_data['polarion'] = polarion_ids
         requests.post(self.url, data=json.dumps(json_data))
         return None, None

--- a/fixtures/artifactor_plugin.py
+++ b/fixtures/artifactor_plugin.py
@@ -26,6 +26,7 @@ import pytest
 
 from artifactor import ArtifactorClient
 from fixtures.pytest_store import write_line, store
+from markers.polarion import extract_polarion_ids
 from utils.conf import env, credentials
 from utils.net import random_port, net_check
 from utils.path import project_path
@@ -145,7 +146,7 @@ def pytest_runtest_teardown(item, nextitem):
                          slaveid=SLAVEID, ip=appliance_ip_address, grab_result=True)
     art_client.fire_hook('sanitize', test_location=location, test_name=name, words=words)
     art_client.fire_hook('ostriz_send', test_location=location, test_name=name,
-                         slaveid=SLAVEID,)
+                         slaveid=SLAVEID, polarion_ids=extract_polarion_ids(item))
 
 
 def pytest_runtest_logreport(report):

--- a/markers/__init__.py
+++ b/markers/__init__.py
@@ -21,4 +21,5 @@ pytest_plugins = """
     markers.uses
     markers.uncollect
     markers.smoke
+    markers.polarion
 """.strip().split()

--- a/markers/polarion.py
+++ b/markers/polarion.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+"""polarion(\*tcid): Marker for marking tests as automation for polarion test cases."""
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", __doc__.splitlines()[0])
+
+
+def extract_polarion_ids(item):
+    """Extracts Polarion TC IDs from the test item. Returns None if no marker present."""
+    polarion = item.get_marker('polarion')
+    if not polarion:
+        return None
+
+    return map(str, polarion.args)


### PR DESCRIPTION
This is for marking unparametrized test cases so far. This will inject the "polarion" key in the JSON that gets sent into Ostříž. If no marker is provided, it is None, otherwise it is a list of Polarion test cases associated with the test.

@psav - your opinion?
