### PR TITLE
Introduce summary unit parsing

### DIFF
--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -10,6 +10,7 @@ from cfme.web_ui.topology import Topology
 from sqlalchemy.orm import aliased
 from utils import attributize_string, version
 from utils.db import cfmedb
+from utils.units import Unit
 from utils.varmeth import variable
 
 pol_btn = partial(toolbar.select, "Policy")
@@ -325,7 +326,10 @@ class SummaryValue(object):
             try:
                 return float(self.text_value)
             except (ValueError, TypeError):
-                return self.text_value
+                try:
+                    return Unit.parse(self.text_value)
+                except ValueError:
+                    return self.text_value
 
     @cached_property
     def link(self):

--- a/utils/tests/test_units.py
+++ b/utils/tests/test_units.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from utils.units import Unit
+
+
+@pytest.mark.parametrize(
+    ('a', 'b'), [
+        ('1 KB', '1024 Bytes'),
+        ('1 KB', '1024 B'),
+        ('231 KB', 231 * 1024),
+        ('1 TB', '1024 GB'),
+    ])
+def test_compare_equal(a, b):
+    assert Unit.parse(a) == b
+
+
+@pytest.mark.parametrize(
+    ('a', 'b'), [
+        ('1 KB', '1025 Bytes'),
+        ('1 KB', '10000 B'),
+        ('231 KB', 231 * 1024 * 1024),
+        ('1 TB', '1500 GB'),
+    ])
+def test_compare_lt(a, b):
+    assert Unit.parse(a) < b

--- a/utils/units.py
+++ b/utils/units.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+import math
+import re
+
+# TODO: Split the 1000 and 1024 factor out. Now it is not an issue as it is used FOR COMPARISON ONLY
+FACTOR = 1024
+PREFIXES = ['', 'K', 'M', 'G', 'T', 'P']
+FACTORS = {prefix: int(math.pow(FACTOR, i)) for i, prefix in enumerate(PREFIXES)}
+
+UNITS = ['Byte', 'Bytes', 'B', 'b', 'Hz']
+
+EQUAL_UNITS = {
+    'B': ('Byte', 'Bytes')
+}
+
+# Sanity check
+for target_unit, units in EQUAL_UNITS.iteritems():
+    assert target_unit in UNITS
+    for unit in units:
+        assert unit in UNITS
+
+REGEXP = re.compile(
+    r'^\s*(\d+(?:\.\d+)?)\s*({})?({})\s*$'.format('|'.join(PREFIXES), '|'.join(UNITS)))
+
+
+class Unit(object):
+    """This class serves for simple comparison of numbers that have units.
+
+    Imagine you pull a text value from the UI. 2 GB. By doing ``Unit.parse('2 GB')`` you get an
+    instance of :py:class:`Unit`, which is comparable.
+
+    You can compare two :py:class:`Unit` instances or you can compare :py:class:`Unit` with
+    :py:class:`int`, :py:class:`float` or any :py:class:`str` as long as it can go through the
+    :py:method:`Unit.parse`.
+
+    If you compare :py:class:`Unit` only (or a string that gets subsequently parsed), it also takes
+    the kind of the unit it is, you cannot compare bytes with hertzes. It then calculates the
+    absolute value in the base units and that gets compared.
+
+    If you compare with a number, it does it like it was the number of the same unit. So eg.
+    doing ``Unit.parse('2 GB') == 2 *1024 * 1024 * 1024 `` is True.
+    """
+    __slots__ = ['number', 'prefix', 'unit_type']
+
+    @classmethod
+    def parse(cls, s):
+        s = str(s)
+        match = REGEXP.match(s)
+        if match is None:
+            raise ValueError('{} is not a proper value to be parsed!'.format(repr(s)))
+        number, prefix, unit_type = match.groups()
+        # Check if it isnt just an another name for another unit.
+        for target_unit, units in EQUAL_UNITS.iteritems():
+            if unit_type in units:
+                unit_type = target_unit
+        return cls(float(number), prefix, unit_type)
+
+    def __init__(self, number, prefix, unit_type):
+        self.number = float(number)
+        self.prefix = prefix
+        self.unit_type = unit_type
+
+    @property
+    def absolute(self):
+        return self.number * FACTORS[self.prefix]
+
+    def _as_same_unit(self, int_or_float):
+        return type(self)(int_or_float, PREFIXES[0], self.unit_type)
+
+    def __cmp__(self, other):
+        if isinstance(other, basestring):
+            other = self.parse(other)
+        elif isinstance(other, (int, float)):
+            other = self._as_same_unit(other)
+        elif not isinstance(other, Unit):
+            raise TypeError('Incomparable types {} and {}'.format(type(self), type(other)))
+        # other is instance of this class too now
+        if self.unit_type != other.unit_type:
+            raise TypeError('Incomparable units {} and {}'.format(self.unit_type, other.unit_type))
+
+        return cmp(self.absolute, other.absolute)
+
+    def __float__(self):
+        return self.absolute
+
+    def __int__(self):
+        return int(self.absolute)
+
+    def __repr__(self):
+        return '{}({}, {}, {})'.format(
+            type(self).__name__, repr(self.number), repr(self.prefix), repr(self.unit_type))
+
+    def __str__(self):
+        return '{} {}{}'.format(self.number, self.prefix, self.unit_type)


### PR DESCRIPTION
Sample usage:

```python
In [4]: from utils.providers import get_crud

In [5]: p = get_crud('provider')

In [6]: p.summary.properties.aggregate_host_cpus.value
Out[6]: 8

In [7]: p.summary.properties.aggregate_host_memory.value
Out[7]: Unit(464.0, 'G', 'B')

In [8]: p.summary.properties.aggregate_host_memory.value == '464 GB'
Out[8]: True

In [9]: p.summary.properties.aggregate_host_cpu_resources
Out[9]: '91.2 GHz'

In [10]: p.summary.properties.aggregate_host_cpu_resources.value
Out[10]: Unit(91.2, 'G', 'Hz')

In [11]: p.summary.properties.aggregate_host_memory.value > '400 GB'
Out[11]: True
```

So it is very easy to compare the numeric values. Even across the different prefixes.

The parsing also happens for the compared values.