### PR TITLE
Initial Azure Power Control implementation - Revised

### DIFF
--- a/cfme/cloud/instance.py
+++ b/cfme/cloud/instance.py
@@ -7,6 +7,7 @@ from cfme.web_ui import (
     accordion, fill, flash, paginator, toolbar, CheckboxTree, Region, Tree, Quadicon)
 from cfme.web_ui.menu import extend_nav
 from functools import partial
+from utils import deferred_verpick, version
 from utils.api import rest_api
 from utils.wait import wait_for
 
@@ -162,6 +163,7 @@ class Instance(VM):
 
     def get_collection_via_rest(self):
         return rest_api().collections.instances
+
 
 @VM.register_for_provider_type("openstack")
 class OpenStackInstance(Instance):
@@ -367,7 +369,12 @@ class AzureInstance(Instance):
     START = "Start"
     POWER_ON = START  # For compatibility with the infra objects.
     STOP = "Stop"
-    TERMINATE = "Terminate"
+    SUSPEND = "Suspend"
+    DELETE = "Delete"
+    TERMINATE = deferred_verpick({
+        version.LOWEST: 'Terminate',
+        '5.6.1': 'Delete',
+    })
     # CFME-only power control options
     SOFT_REBOOT = "Soft Reboot"
     # Provider-only power control options
@@ -449,6 +456,8 @@ class AzureInstance(Instance):
             self.provider.mgmt.stop_vm(self.name)
         elif option == AzureInstance.RESTART:
             self.provider.mgmt.restart_vm(self.name)
+        elif option == AzureInstance.SUSPEND:
+            self.provider.mgmt.suspend_vm(self.name)
         elif option == AzureInstance.TERMINATE:
             self.provider.mgmt.delete_vm(self.name)
         else:

--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -51,7 +51,7 @@ properties_form_55 = Form(
                 "5.5": "api_port",
             }
         )),
-        ('azure_subscription_id', Input("subscription")),
+        ('azure_subscription_id', Input("subscription"), {'appeared_in', '5.6'}),
         ('api_version', AngularSelect("api_version"), {"appeared_in": "5.5"}),
         ('sec_protocol', AngularSelect("security_protocol"), {"appeared_in": "5.5"}),
         ('infra_provider', {
@@ -64,7 +64,9 @@ properties_form_56 = TabStripForm(
     fields=[
         ('type_select', AngularSelect("ems_type")),
         ('name_text', Input("name")),
-        ('region_select', AngularSelect("ems_region")),
+        ('region_select', {
+            version.LOWEST: AngularSelect("ems_region"),
+            '5.7': AngularSelect('provider_region')}),
         ('google_region_select', AngularSelect("ems_preferred_region")),
         ('api_version', AngularSelect("ems_api_version")),
         ('infra_provider', AngularSelect("ems_infra_provider_id")),

--- a/cfme/cloud/provider/azure.py
+++ b/cfme/cloud/provider/azure.py
@@ -1,3 +1,4 @@
+from utils.version import pick
 from mgmtsystem.azure import AzureSystem
 from . import Provider
 
@@ -27,7 +28,14 @@ class AzureProvider(Provider):
     def configloader(cls, prov_config, prov_key):
         credentials_key = prov_config['credentials']
         credentials = cls.process_credential_yaml_key(credentials_key)
-        return cls(name=prov_config['name'],
+        # HACK: stray domain entry in credentials, so ensure it is not there
+        credentials.domain = None
+        region = prov_config.get('region', None)
+        if region is not None and isinstance(region, dict):
+            region = pick(region)
+        return cls(
+            name=prov_config['name'],
+            region=region,
             tenant_id=prov_config['tenant_id'],
             subscription_id=prov_config['subscription_id'],
             credentials={'default': credentials},

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -71,7 +71,7 @@ class BaseProvider(Taggable, Updateable, SummaryMixin):
                 ('google_service_account', Input('service_account')),
             ]
             tab_fields = {
-                "Default": [
+                ("Default", ('default_when_no_tabs', )): [
                     ('default_principal', Input("default_userid")),
                     ('default_secret', Input("default_password")),
                     ('default_verify_secret', Input("default_verify")),

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -614,9 +614,10 @@ class VM(BaseVM):
             return False
 
     def delete_from_provider(self):
+        logger.info("Begin delete_from_provider")
         if self.provider.mgmt.does_vm_exist(self.name):
             try:
-                if self.provider.mgmt.is_vm_suspended(self.name):
+                if self.provider.mgmt.is_vm_suspended(self.name) and self.provider.type != 'azure':
                     logger.debug("Powering up VM %s to shut it down correctly on %s.",
                                 self.name, self.provider.key)
                     self.provider.mgmt.start_vm(self.name)
@@ -629,6 +630,7 @@ class VM(BaseVM):
             # One more check (for the suspended one)
             if self.provider.mgmt.does_vm_exist(self.name):
                 try:
+                    logger.info("Mgmt System delete_vm")
                     return self.provider.mgmt.delete_vm(self.name)
                 except exceptions.VMInstanceNotFound:
                     # Does not exist already

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -7,12 +7,13 @@ from cfme.cloud.instance import (EC2Instance, Instance, OpenStackInstance,
 from cfme.fixtures import pytest_selenium as sel
 from utils import error, testgen, version
 from utils.blockers import GH
+from utils.log import logger
 from utils.wait import wait_for, TimedOutError
 
 
 def pytest_generate_tests(metafunc):
     argnames, argvalues, idlist = testgen.provider_by_type(
-        metafunc, ['ec2', 'openstack'], required_fields=[('test_power_control', True)])
+        metafunc, ['azure', 'ec2', 'openstack'], required_fields=[('test_power_control', True)])
     testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope="function")
 
 pytestmark = [pytest.mark.tier(2)]
@@ -154,7 +155,7 @@ def test_quadicon_terminate(setup_provider_funcscope, provider, testing_instance
 
 
 @pytest.mark.long_running
-@pytest.mark.uncollectif(lambda provider: provider.type != 'ec2')
+@pytest.mark.uncollectif(lambda provider: provider.type != 'ec2' and provider.type != 'azure')
 def test_stop(setup_provider_funcscope, provider, testing_instance, soft_assert, verify_vm_running):
     """ Tests instance stop
 
@@ -190,6 +191,10 @@ def test_start(
     testing_instance.power_control_from_cfme(
         option=testing_instance.START, cancel=False, from_details=True)
     flash.assert_message_contain("Start initiated")
+    logger.info("Start initiated Flash message\n")
+    if provider.type == 'azure':
+        # Adding this as wait_for_vm_state_change doesn't deal with Azure's multiple state changes
+        provider.mgmt.wait_vm_running(testing_instance.name)
     testing_instance.wait_for_vm_state_change(
         desired_state=testing_instance.STATE_ON, timeout=720, from_details=True)
     soft_assert(
@@ -222,7 +227,7 @@ def test_soft_reboot(setup_provider_funcscope, provider, testing_instance, soft_
 
 
 @pytest.mark.long_running
-@pytest.mark.uncollectif(lambda provider: provider.type != 'openstack')
+@pytest.mark.uncollectif(lambda provider: provider.type != 'openstack' and provider.type != 'azure')
 def test_hard_reboot(setup_provider_funcscope, provider, testing_instance, soft_assert,
                      verify_vm_running):
     """ Tests instance hard reboot
@@ -245,7 +250,7 @@ def test_hard_reboot(setup_provider_funcscope, provider, testing_instance, soft_
 
 
 @pytest.mark.long_running
-@pytest.mark.uncollectif(lambda provider: provider.type != 'openstack')
+@pytest.mark.uncollectif(lambda provider: provider.type != 'openstack' and provider.type != 'azure')
 def test_suspend(
         setup_provider_funcscope, provider, testing_instance, soft_assert, verify_vm_running):
     """ Tests instance suspend
@@ -259,6 +264,8 @@ def test_suspend(
     testing_instance.power_control_from_cfme(
         option=testing_instance.SUSPEND, cancel=False, from_details=True)
     flash.assert_message_contain("Suspend initiated")
+    if provider.type == 'azure':
+        provider.mgmt.wait_vm_suspended(testing_instance.name)
     testing_instance.wait_for_vm_state_change(
         desired_state=testing_instance.STATE_SUSPENDED, timeout=720, from_details=True)
     soft_assert(
@@ -267,7 +274,7 @@ def test_suspend(
 
 
 @pytest.mark.long_running
-@pytest.mark.uncollectif(lambda provider: provider.type != 'openstack')
+@pytest.mark.uncollectif(lambda provider: provider.type != 'openstack' and provider.type != 'azure')
 def test_unpause(
         setup_provider_funcscope, provider, testing_instance, soft_assert, verify_vm_paused):
     """ Tests instance unpause
@@ -289,7 +296,7 @@ def test_unpause(
 
 
 @pytest.mark.long_running
-@pytest.mark.uncollectif(lambda provider: provider.type != 'openstack')
+@pytest.mark.uncollectif(lambda provider: provider.type != 'openstack' and provider.type != 'azure')
 def test_resume(setup_provider_funcscope, provider, testing_instance, soft_assert,
                 verify_vm_suspended):
     """ Tests instance resume

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -27,12 +27,15 @@ def testing_instance(request, setup_provider, provider):
     if not provider.mgmt.does_vm_exist(instance.name):
         instance.create_on_provider(allow_skip="default", find_in_cfme=True)
         request.addfinalizer(instance.delete_from_provider)
+        provider.refresh_provider_relationships()
     elif instance.provider.type == "ec2" and \
             provider.mgmt.is_vm_state(instance.name, provider.mgmt.states['deleted']):
         provider.mgmt.set_name(
             instance.name, 'test_terminated_{}'.format(fauxfactory.gen_alphanumeric(8)))
         instance.create_on_provider(allow_skip="default", find_in_cfme=True)
         request.addfinalizer(instance.delete_from_provider)
+        provider.refresh_provider_relationships()
+    instance.wait_to_appear()
     return instance
 
 

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -144,7 +144,11 @@ def test_quadicon_terminate(setup_provider_funcscope, provider, testing_instance
     testing_instance.wait_for_vm_state_change(
         desired_state=testing_instance.STATE_ON, timeout=720)
     testing_instance.power_control_from_cfme(option=testing_instance.TERMINATE, cancel=False)
-    testing_instance.wait_to_disappear(timeout=300)
+    if provider.type == 'azure':
+        # It takes at least 300 for azure to delete it.
+        testing_instance.wait_to_disappear(timeout=720)
+    else:
+        testing_instance.wait_to_disappear(timeout=300)
     if provider.type == 'openstack':
         soft_assert(not testing_instance.does_vm_exist_on_provider(), "instance still exists")
     else:
@@ -230,7 +234,7 @@ def test_soft_reboot(setup_provider_funcscope, provider, testing_instance, soft_
 
 
 @pytest.mark.long_running
-@pytest.mark.uncollectif(lambda provider: provider.type != 'openstack' and provider.type != 'azure')
+@pytest.mark.uncollectif(lambda provider: provider.type != 'openstack')
 def test_hard_reboot(setup_provider_funcscope, provider, testing_instance, soft_assert,
                      verify_vm_running):
     """ Tests instance hard reboot

--- a/utils/virtual_machines.py
+++ b/utils/virtual_machines.py
@@ -4,6 +4,7 @@ import pytest
 
 from mgmtsystem.virtualcenter import VMWareSystem
 from mgmtsystem.scvmm import SCVMMSystem
+from mgmtsystem.azure import AzureSystem
 from mgmtsystem.ec2 import EC2System
 from mgmtsystem.openstack import OpenstackSystem
 from mgmtsystem.rhevm import RHEVMSystem
@@ -83,6 +84,8 @@ def deploy_template(provider_key, vm_name, template_name=None, timeout=900,
             deploy_args.update(host_group=data.get("host_group", "All Hosts"))
     elif isinstance(mgmt, EC2System):
         pass
+    elif isinstance(mgmt, AzureSystem):
+        deploy_args.update(data['provisioning'])
     elif isinstance(mgmt, OpenstackSystem):
         if ('network_name' not in deploy_args) and data.get('network'):
             deploy_args.update(network_name=data['network'])


### PR DESCRIPTION
This is the short version now that most of the provisioning stuff is already in master.

{{pytest: cfme/tests/cloud/test_instance_power_control.py -k "test_stop" --long-running --use-provider azure }}