### PR TITLE
Fix validate button

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -105,7 +105,7 @@ class BaseProvider(Taggable, Updateable, SummaryMixin):
                 ('amqp_verify_secret', Input("amqp_verify")),
             ]
 
-            return TabStripForm(fields, tab_fields, fields_end)
+            return TabStripForm(fields=fields, tab_fields=tab_fields, fields_end=fields_end)
 
         def __init__(self, **kwargs):
             super(BaseProvider.Credential, self).__init__(**kwargs)


### PR DESCRIPTION
Args were not matching on the TabStripForm constructor

{{pytest: -k test_provider_crud --use-provider vsphere55 cfme/tests/infrastructure/test_providers.py}}