### PR TITLE
provider.py fixes for CFME 5.6.1

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -74,6 +74,7 @@ class BaseProvider(Taggable, Updateable, SummaryMixin):
                 "Default": [
                     ('default_principal', Input("default_userid")),
                     ('default_secret', Input("default_password")),
+                    ('default_verify_secret', Input("default_verify")),
                     ('token_secret', {
                         version.LOWEST: Input('bearer_password'),
                         '5.6': Input('default_password')

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -75,8 +75,8 @@ class BaseProvider(Taggable, Updateable, SummaryMixin):
                     ('default_principal', Input("default_userid")),
                     ('default_secret', Input("default_password")),
                     ('default_verify_secret', Input("default_verify")),
-                    ('token_secret', Input('bearer_password')),
-                    ('token_verify_secret', Input('bearer_verify')),
+                    ('token_secret', Input('default_password')),
+                    ('token_verify_secret', Input('default_verify')),
                 ],
 
                 "RSA key pair": [

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -74,9 +74,14 @@ class BaseProvider(Taggable, Updateable, SummaryMixin):
                 "Default": [
                     ('default_principal', Input("default_userid")),
                     ('default_secret', Input("default_password")),
-                    ('default_verify_secret', Input("default_verify")),
-                    ('token_secret', Input('default_password')),
-                    ('token_verify_secret', Input('default_verify')),
+                    ('token_secret', {
+                        version.LOWEST: Input('bearer_password'),
+                        '5.6': Input('default_password')
+                    }),
+                    ('token_verify_secret', {
+                        version.LOWEST: Input('bearer_verify'),
+                        '5.6': Input('default_verify')
+                    }),
                 ],
 
                 "RSA key pair": [


### PR DESCRIPTION
{{pytest: cfme/tests/containers/ --use-provider cm-env1}}