### PR TITLE
updated the external_auth_ipa test.

### DIFF
--- a/cfme/configure/configuration/__init__.py
+++ b/cfme/configure/configuration/__init__.py
@@ -979,8 +979,8 @@ class ExternalAuthSetting(AuthSetting):
     pretty_attrs = ['timeout_h', 'timeout_m', 'get_groups']
 
     def __init__(self, get_groups=False, timeout_h="1", timeout_m="0"):
-        self.timeout_h = timeout_h,
-        self.timeout_m = timeout_m,
+        self.timeout_h = timeout_h
+        self.timeout_m = timeout_m
         self.auth_mode = "External (httpd)"
         self.get_groups = get_groups
 


### PR DESCRIPTION
  * the hostname is not correctly updated through
    appliance_console, workaround is been added to the test.
  * FQDN is a must for extrenal, which is included in the test.