### PR TITLE
Test infra port

### DIFF
--- a/cfme/tests/openstack/test_api_port.py
+++ b/cfme/tests/openstack/test_api_port.py
@@ -1,0 +1,16 @@
+from utils import testgen
+import pytest
+
+
+pytestmark = [pytest.mark.meta(server_roles='+smartproxy +smartstate')]
+
+
+pytest_generate_tests = testgen.generate(testgen.provider_by_type,
+                                         ['openstack-infra'],
+                                         scope='module')
+
+
+@pytest.mark.usefixtures("setup_provider_modscope")
+def test_api_port(provider, soft_assert):
+    soft_assert(provider.summary.properties.api_port.value.isdigit(),
+                "Invalid API Port")


### PR DESCRIPTION
Openstack infra provider test: API port different than nothing. default is 5000

{{pytest: cfme/tests/infrastructure/test_api_port.py -v --use-provider tripleo }}