### PR TITLE
Added new mixin for Timelines.

### DIFF
--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -7,6 +7,7 @@ from cfme.configure.configuration import Category, Tag
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import CheckboxTree, flash, form_buttons, mixins, toolbar
 from cfme.web_ui.topology import Topology
+from cfme.web_ui.timelines import Timelines
 from sqlalchemy.orm import aliased
 from utils import attributize_string, version
 from utils.db import cfmedb
@@ -472,3 +473,28 @@ class TopologyMixin(object):
     @cached_property
     def topology(self):
         return Topology(self)
+
+
+class TimelinesMixin(object):
+    """Use this mixin to have simple access to the Timelines page.
+    To use this `TimelinesMixin` you have to implement `load_timelines_page`
+    function, which should take to timelines page
+
+    Sample usage:
+
+    .. code-block:: python
+
+        # Change Timelines showing interval Select
+        timelines.change_interval('Hourly')
+        # Change Timelines showing event group Select
+        timelines.change_event_groups('Application')
+        # Change Level of showed Timelines
+        timelines.change_level('Detail')
+        # Check whether timelines contain particular event
+        # which is generated after provided datetime
+        timelines.contains_event('hawkular_deployment.ok', before_test_date)
+
+    """
+    @cached_property
+    def timelines(self):
+        return Timelines(self)

--- a/cfme/middleware/provider/hawkular.py
+++ b/cfme/middleware/provider/hawkular.py
@@ -1,16 +1,16 @@
 import re
-from cfme.common import TopologyMixin
+from cfme.common import TopologyMixin, TimelinesMixin
 from cfme.common.provider import BaseProvider
 from cfme.web_ui import form_buttons
 from mgmtsystem.hawkular import Hawkular
 from utils.db import cfmedb
 from utils.varmeth import variable
 from . import properties_form, _get_providers_page, _db_select_query
-from .. import download, MiddlewareBase, auth_btn
+from .. import download, MiddlewareBase, auth_btn, mon_btn
 
 
 @BaseProvider.add_type_map
-class HawkularProvider(MiddlewareBase, TopologyMixin, BaseProvider):
+class HawkularProvider(MiddlewareBase, TopologyMixin, TimelinesMixin, BaseProvider):
     """
     HawkularProvider class holds provider data. Used to perform actions on hawkular provider page
 
@@ -131,6 +131,10 @@ class HawkularProvider(MiddlewareBase, TopologyMixin, BaseProvider):
     def recheck_auth_status(self):
         self.load_details(refresh=True)
         auth_btn("Re-check Authentication Status")
+
+    def load_timelines_page(self):
+        self.load_details()
+        mon_btn("Timelines")
 
     @staticmethod
     def from_config(prov_config, prov_key):

--- a/cfme/tests/middleware/deployment_methods.py
+++ b/cfme/tests/middleware/deployment_methods.py
@@ -1,0 +1,39 @@
+import fauxfactory
+import os
+from cfme.middleware.server import MiddlewareServer
+from utils.path import middleware_resources_path
+
+RESOURCE_WAR_NAME = 'cfme_test_war_middleware.war'
+RESOURCE_JAR_NAME = 'cfme_test_jar_middleware.jar'
+RESOURCE_EAR_NAME = 'cfme_test_ear_middleware.ear'
+
+EAP_PRODUCT_NAME = 'JBoss EAP'
+HAWKULAR_PRODUCT_NAME = 'Hawkular'
+
+
+def deploy(provider, server, archive_name):
+    file_path = get_resource_path(archive_name)
+    runtime_name = generate_runtime_name(file_path)
+    deploy_archive(provider, server, file_path, runtime_name)
+    return runtime_name
+
+
+def deploy_archive(provider, server, file_path, runtime_name):
+    server.add_deployment(file_path, runtime_name)
+    provider.refresh_provider_relationships(method='ui')
+
+
+def generate_runtime_name(file_path):
+    return "{}_{}".format(fauxfactory.gen_alpha(8).lower(), os.path.basename(file_path))
+
+
+def get_server(provider, product):
+    for server in MiddlewareServer.servers(provider=provider):
+        if server.product == product:
+            return server
+    else:
+        raise ValueError('{} server was not found in servers list'.format(provider))
+
+
+def get_resource_path(archive_name):
+    return middleware_resources_path.join(archive_name).strpath

--- a/cfme/tests/middleware/test_middleware_deployment.py
+++ b/cfme/tests/middleware/test_middleware_deployment.py
@@ -1,15 +1,14 @@
 import pytest
 
-import os
-import fauxfactory
 from cfme.middleware import get_random_list
 from cfme.middleware.deployment import MiddlewareDeployment
-from cfme.middleware.server import MiddlewareServer
 from utils import testgen
 from utils.version import current_version
 from utils.wait import wait_for
-from utils.path import middleware_resources_path
-
+from deployment_methods import deploy, get_resource_path, get_server
+from deployment_methods import EAP_PRODUCT_NAME, HAWKULAR_PRODUCT_NAME
+from deployment_methods import RESOURCE_EAR_NAME, RESOURCE_JAR_NAME
+from deployment_methods import RESOURCE_WAR_NAME
 
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
@@ -17,13 +16,6 @@ pytestmark = [
 ]
 pytest_generate_tests = testgen.generate(testgen.provider_by_type, ["hawkular"], scope="function")
 ITEMS_LIMIT = 5  # when we have big list, limit number of items to test
-
-RESOURCE_WAR_NAME = 'cfme_test_war_middleware.war'
-RESOURCE_JAR_NAME = 'cfme_test_jar_middleware.jar'
-RESOURCE_EAR_NAME = 'cfme_test_ear_middleware.ear'
-
-EAP_PRODUCT_NAME = 'JBoss EAP'
-HAWKULAR_PRODUCT_NAME = 'Hawkular'
 
 
 def test_list_deployments(provider):
@@ -286,25 +278,6 @@ def get_deployments_statuses(deployments):
     'name' as key, 'status' as value
     """
     return {deployment.name: deployment.status for deployment in deployments}
-
-
-def deploy(provider, server, file_path):
-    runtime_name = "{}_{}".format(fauxfactory.gen_alpha(8).lower(), os.path.basename(file_path))
-    server.add_deployment(file_path, runtime_name)
-    provider.refresh_provider_relationships(method='ui')
-    return runtime_name
-
-
-def get_server(provider, product):
-    for server in MiddlewareServer.servers(provider=provider):
-        if server.product == product:
-            return server
-    else:
-        raise ValueError('{} server was not found in servers list'.format(provider))
-
-
-def get_resource_path(archive_name):
-    return middleware_resources_path.join(archive_name).strpath
 
 
 def get_deployment_from_list(provider, server, runtime_name):

--- a/cfme/tests/middleware/test_provider_timelines.py
+++ b/cfme/tests/middleware/test_provider_timelines.py
@@ -1,0 +1,58 @@
+import pytest
+from datetime import datetime
+
+from utils import testgen
+from utils.version import current_version
+from deployment_methods import get_server, get_resource_path
+from deployment_methods import EAP_PRODUCT_NAME, RESOURCE_WAR_NAME
+from deployment_methods import deploy_archive, generate_runtime_name
+from utils.wait import wait_for
+
+pytestmark = [
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.uncollectif(lambda: current_version() < '5.7'),
+]
+pytest_generate_tests = testgen.generate(testgen.provider_by_type, ["hawkular"], scope="function")
+
+
+def test_load_deployment_timelines(provider):
+    # events are shown in UTC timezone
+    before_test_date = datetime.utcnow()
+    gen_deploy_events(provider)
+    timelines = provider.timelines
+    load_event_details(timelines)
+    check_contains_event(timelines, before_test_date, 'hawkular_deployment.ok')
+    load_event_summary(timelines)
+    check_not_contains_event(timelines, before_test_date, 'hawkular_deployment.ok')
+
+
+def load_event_details(timelines):
+    timelines.change_interval('Hourly')
+    timelines.change_event_groups('Application')
+    timelines.change_level('Detail')
+
+
+def load_event_summary(timelines):
+    timelines.change_interval('Hourly')
+    timelines.change_event_groups('Application')
+    timelines.change_level('Summary')
+
+
+def check_contains_event(timelines, before_test_date, event):
+    wait_for(lambda: timelines.contains_event(event, before_test_date),
+        fail_func=timelines.reload, delay=10, num_sec=60,
+        message='Event {} must be listed in Timelines.'.format(event))
+
+
+def check_not_contains_event(timelines, before_test_date, event):
+    wait_for(lambda: not timelines.contains_event(event, before_test_date),
+        fail_func=timelines.reload, delay=10, num_sec=60,
+        message='Event {} must NOT be listed in Timelines.'.format(event))
+
+
+def gen_deploy_events(provider):
+    server = get_server(provider, EAP_PRODUCT_NAME)
+    file_path = get_resource_path(RESOURCE_WAR_NAME)
+    runtime_name = generate_runtime_name(file_path)
+    deploy_archive(provider, server, file_path, runtime_name)
+    return

--- a/cfme/web_ui/timelines.py
+++ b/cfme/web_ui/timelines.py
@@ -1,0 +1,83 @@
+from datetime import datetime
+from cfme.web_ui import flash, jstimelines, Form, AngularSelect, Calendar, fill
+
+NONE_GROUP = 'NONE'
+
+timelines_form = Form(
+    fields=[
+        ('event_type', AngularSelect('tl_show')),
+        ('interval', AngularSelect('tl_typ')),
+        ('date', Calendar('miq_date_1')),
+        ('days_back', AngularSelect('tl_days')),
+        ('level', AngularSelect('tl_fl_typ')),
+        ('group1', AngularSelect('tl_fl_grp1')),
+        ('group2', AngularSelect('tl_fl_grp2')),
+        ('group3', AngularSelect('tl_fl_grp3')),
+    ])
+
+
+class Timelines(object):
+
+    def __init__(self, o):
+        self._object = o
+        self._events = []
+        self.reload()
+
+    def change_event_type(self, value):
+        self._change_select_value('event_type', value)
+        self._reload_events()
+
+    def change_interval(self, value):
+        self._change_select_value('interval', value)
+        self._reload_events()
+
+    def change_date(self, value):
+        fill(timelines_form, {'date': value})
+        self._reload_events()
+
+    def change_days_back(self, value):
+        self._change_select_value('days_back', value)
+        self._reload_events()
+
+    def change_level(self, value):
+        self._change_select_value('level', value)
+        self._reload_events()
+
+    def change_event_groups(self, new_group1, new_group2=NONE_GROUP, new_group3=NONE_GROUP):
+        # keep filling separetely, as page is reloaded after each select change
+        self._change_select_value('group1', new_group1)
+        self._change_select_value('group2', new_group2)
+        self._change_select_value('group3', new_group3)
+        self._reload_events()
+
+    def contains_event(self, event_type, date_after=datetime.min):
+        """Checks whether list of events contains provided particular
+        'event_type' with data not earlier than provided 'date_after'.
+        If 'date_after' is not provided, will use datetime.min.
+        """
+        if date_after and not isinstance(date_after, datetime):
+            raise KeyError("'date_after' should be an instance of date")
+        for event in self._events:
+            if event['Event Type'] == event_type and datetime.strptime(
+                    event['Date Time'], '%Y-%m-%d %H:%M:%S %Z') >= date_after:
+                return True
+        return False
+
+    def _change_select_value(self, field, value):
+        fill(timelines_form, {field: value})
+
+    def reload(self):
+        self._object.load_timelines_page()
+        self._reload_events()
+
+    def _reload_events(self):
+        self._events = self._read_events()
+
+    def _read_events(self):
+        events = []
+        # need first to check if timelines are loaded
+        if not any(["No records found for this timeline"
+                    in fm.message for fm in flash.get_messages()]):
+            for event in jstimelines.events():
+                events.append(event.block_info())
+        return events


### PR DESCRIPTION
 Used that TimelinesMixin in Hawkular provider. Added new test for hawkular timelines page. Moved general deployment functions into separate utility.

{{pytest: cfme/tests/middleware/test_provider_timelines.py cfme/tests/middleware/test_middleware_deployment.py -v --long-running --use-provider hawkular }}