### PR TITLE
test overcloud number of nodes

### DIFF
--- a/cfme/tests/openstack/test_host_devices.py
+++ b/cfme/tests/openstack/test_host_devices.py
@@ -1,0 +1,32 @@
+
+import pytest
+from utils import testgen
+from cfme.web_ui import Quadicon, toolbar
+from cfme.infrastructure.host import Host
+from cfme.web_ui import InfoBlock
+from cfme.fixtures import pytest_selenium as sel
+from cfme.configure.tasks import is_host_analysis_finished
+from utils.wait import wait_for
+
+
+pytest_generate_tests = testgen.generate(testgen.provider_by_type,
+                              ['openstack-infra'], scope='module')
+
+
+def get_integer_value(x):
+    return int(x.split(' ')[0])
+
+
+@pytest.mark.usefixtures("setup_provider_modscope")
+def test_host_devices(provider):
+    provider.load_details()
+    sel.click(InfoBlock.element("Relationships", "Nodes"))
+    my_quads = list(Quadicon.all())
+    assert len(my_quads) > 0
+    for quad in my_quads:
+        host = Host(name=quad.name)
+        host.run_smartstate_analysis()
+        wait_for(lambda: is_host_analysis_finished(host.name), delay=15,
+                 timeout="10m", fail_func=lambda: toolbar.select('Reload'))
+        result = get_integer_value(host.get_detail("Properties", "Devices"))
+        assert result > 0


### PR DESCRIPTION
Testing overcloud nodes, currently number greater than 0. 
We need to consider comparing the exact number of nodes. 
Looking for return the correct unit 
{{pytest:  cfme/tests/infrastructure/test_host_devices.py --use-provider tripleo}}