### PR TITLE
[RFR]SSHClient supports nonroot users

### DIFF
--- a/utils/ssh.py
+++ b/utils/ssh.py
@@ -204,6 +204,20 @@ class SSHClient(paramiko.SSHClient):
     def run_command(
             self, command, timeout=RUNCMD_TIMEOUT, reraise=False, ensure_host=False,
             ensure_user=False):
+        """Run a command over SSH.
+
+        Args:
+            command: The command. Supports taking dicts as version picking.
+            timeout: Timeout after which the command execution fails.
+            reraise: Does not muffle the paramiko exceptions in the log.
+            ensure_host: Ensure that the command is run on the machine with the IP given, not any
+                container or such that we might be using by default.
+            ensure_user: Ensure that the command is run as the user we logged in, so in case we are
+                not root, setting this to True will prevent from running sudo.
+
+        Returns:
+            A :py:class:`SSHResult` instance.
+        """
         if isinstance(command, dict):
             command = version.pick(command)
         logger.info("Running command `%s`", command)


### PR DESCRIPTION
The only condition is paswordless sudo.

I also managed to smuggle in an optimization:

``` python
Filename: string_concat.py

Line #    Mem usage    Increment   Line Contents
================================================
     7     44.0 MiB      0.0 MiB   @profile
     8                             def use_strings():
     9     44.0 MiB      0.0 MiB       result = ''
    10     58.6 MiB     14.6 MiB       for thing in STRINGS:
    11     58.6 MiB      0.0 MiB           result += thing
    12     53.9 MiB     -4.8 MiB       return result

Filename: string_concat.py

Line #    Mem usage    Increment   Line Contents
================================================
    15     44.0 MiB      0.0 MiB   @profile
    16                             def use_list():
    17     44.0 MiB      0.0 MiB       result = []
    18     44.1 MiB      0.1 MiB       for thing in STRINGS:
    19     44.1 MiB      0.0 MiB           result.append(thing)
    20     49.2 MiB      5.1 MiB       return ''.join(result)
```

putting things in a list and then concatenating saves memory and string creation/deletion every time.

I also tried to benchmark it by time. I was quite surprised:

``` bash
$ python -m timeit -n 5 -r 1 -s 'import string_concat' 'string_concat.use_strings()'
5 loops, best of 1: 3.25 sec per loop
$ python -m timeit -n 5 -r 1 -s 'import string_concat' 'string_concat.use_list()'
5 loops, best of 1: 3.04 msec per loop
```

1000x faster in "controlled" conditions :D
