### PR TITLE
parallelizer: dont hide stderr output in order to show bad failures a…

### DIFF
--- a/fixtures/parallelizer/__init__.py
+++ b/fixtures/parallelizer/__init__.py
@@ -378,7 +378,7 @@ class ParallelSession(object):
         # worker output redirected to null; useful info comes via messages and logs
         slave = subprocess.Popen(
             ['python', remote.__file__, slaveid, base_url],
-            stdout=devnull, stderr=devnull,
+            stdout=devnull,
         )
         self.slaves[slaveid] = slave
         self.slave_spawn_count += 1


### PR DESCRIPTION
…t slave init