### PR TITLE
test_relationships_tables.py metrics pod fix

### DIFF
--- a/cfme/containers/image.py
+++ b/cfme/containers/image.py
@@ -8,6 +8,8 @@ from . import details_page
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
 
+checkbox = ".//input[@class='list-grid-checkbox']"
+
 nav.add_branch(
     'containers_images',
     {

--- a/cfme/containers/project.py
+++ b/cfme/containers/project.py
@@ -8,6 +8,8 @@ from . import details_page
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
 
+link_to_prv_page = "//a[@href='/container_project/show_list']"
+
 nav.add_branch(
     'containers_projects',
     {

--- a/cfme/containers/route.py
+++ b/cfme/containers/route.py
@@ -7,6 +7,8 @@ from . import details_page
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
 
+link_to_prv_page = "//a[@href='/container_route/show_list']"
+
 nav.add_branch(
     'containers_routes',
     {

--- a/cfme/containers/service.py
+++ b/cfme/containers/service.py
@@ -54,6 +54,8 @@ class Service(Taggable, SummaryMixin):
     def navigate(self, detail=True):
         if detail is True:
             if not self._on_detail_page():
-                sel.force_navigate('containers_service_detail', context={'service': self})
+                sel.force_navigate(
+                    'containers_service_detail', context={
+                        'service': self})
         else:
             sel.force_navigate('containers_service', context={'service': self})

--- a/cfme/containers/service.py
+++ b/cfme/containers/service.py
@@ -8,6 +8,8 @@ from . import details_page
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
 
+link_to_prv_page = "//a[@href='/container_service/show_list']"
+
 nav.add_branch(
     'containers_services',
     {

--- a/cfme/tests/containers/test_containers_properties.py
+++ b/cfme/tests/containers/test_containers_properties.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+
+""" This module verifies data integrity in the Properties table for:
+    pods, routes and projects
+"""
+import pytest
+from cfme.fixtures import pytest_selenium as sel
+from cfme.containers.pod import Pod, list_tbl as list_tbl_pod
+from cfme.containers.route import Route, list_tbl as list_tbl_route
+from cfme.containers.project import Project, list_tbl as list_tbl_proj
+from utils import testgen
+from utils.version import current_version
+
+
+pytestmark = [
+    pytest.mark.uncollectif(
+        lambda: current_version() < "5.6"),
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.tier(1)]
+pytest_generate_tests = testgen.generate(
+    testgen.container_providers, scope="function")
+
+""" CMP-9911
+"""
+
+
+@pytest.mark.parametrize('rel',
+                         ['name',
+                          'phase',
+                          'creation_timestamp',
+                          'resource_version',
+                          'restart_policy',
+                          'dns_policy',
+                          'ip_address'
+                          ])
+def test_pods_properties_rel(provider, rel):
+    sel.force_navigate('containers_pods')
+    ui_pods = [r.name.text for r in list_tbl_pod.rows()]
+
+    for name in ui_pods:
+        obj = Pod(name, provider)
+        assert getattr(obj.summary.properties, rel).text_value
+
+
+""" CMP-9877
+"""
+
+
+@pytest.mark.parametrize('rel',
+                         ['name',
+                          'creation_timestamp',
+                          'resource_version',
+                          'host_name'
+                          ])
+def test_routes_properties_rel(provider, rel):
+    sel.force_navigate('containers_routes')
+    ui_routes = [r.name.text for r in list_tbl_route.rows()]
+
+    for name in ui_routes:
+        obj = Route(name, provider)
+        assert getattr(obj.summary.properties, rel).text_value
+
+
+""" CMP-9867
+"""
+
+
+@pytest.mark.parametrize('rel',
+                         ['name',
+                          'creation_timestamp',
+                          'resource_version'
+                          ])
+def test_projects_properties_rel(provider, rel):
+    sel.force_navigate('containers_projects')
+    ui_projects = [r.name.text for r in list_tbl_proj.rows()]
+
+    for name in ui_projects:
+        obj = Project(name, provider)
+        assert getattr(obj.summary.properties, rel).text_value

--- a/cfme/tests/containers/test_containers_properties.py
+++ b/cfme/tests/containers/test_containers_properties.py
@@ -1,8 +1,4 @@
 # -*- coding: utf-8 -*-
-
-""" This module verifies data integrity in the Properties table for:
-    pods, routes and projects
-"""
 import pytest
 from cfme.fixtures import pytest_selenium as sel
 from cfme.containers.pod import Pod, list_tbl as list_tbl_pod
@@ -20,8 +16,7 @@ pytestmark = [
 pytest_generate_tests = testgen.generate(
     testgen.container_providers, scope="function")
 
-""" CMP-9911
-"""
+# CMP-9911 # CMP-9877 # CMP-9867
 
 
 @pytest.mark.parametrize('rel',
@@ -34,16 +29,15 @@ pytest_generate_tests = testgen.generate(
                           'ip_address'
                           ])
 def test_pods_properties_rel(provider, rel):
+    """ This module verifies data integrity in the Properties table for:
+        pods, routes and projects
+    """
     sel.force_navigate('containers_pods')
     ui_pods = [r.name.text for r in list_tbl_pod.rows()]
 
     for name in ui_pods:
         obj = Pod(name, provider)
         assert getattr(obj.summary.properties, rel).text_value
-
-
-""" CMP-9877
-"""
 
 
 @pytest.mark.parametrize('rel',
@@ -59,10 +53,6 @@ def test_routes_properties_rel(provider, rel):
     for name in ui_routes:
         obj = Route(name, provider)
         assert getattr(obj.summary.properties, rel).text_value
-
-
-""" CMP-9867
-"""
 
 
 @pytest.mark.parametrize('rel',

--- a/cfme/tests/containers/test_containers_services.py
+++ b/cfme/tests/containers/test_containers_services.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+""" This module verifies data integrity in the Properties table
+    for services
+"""
+import pytest
+from cfme.fixtures import pytest_selenium as sel
+from cfme.containers.service import Service, list_tbl as list_tbl_srvc
+from utils import testgen
+from utils.version import current_version
+
+
+pytestmark = [
+    pytest.mark.uncollectif(
+        lambda: current_version() < "5.6"),
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.tier(1)]
+pytest_generate_tests = testgen.generate(
+    testgen.container_providers, scope="function")
+
+# CMP-9884
+
+
+@pytest.mark.parametrize('rel',
+                         ['name',
+                          'creation_timestamp',
+                          'resource_version',
+                          'session_affinity',
+                          'type',
+                          'portal_ip'
+                          ])
+def test_services_properties_rel(provider, rel):
+    sel.force_navigate('containers_services')
+    ui_services = [r.name.text for r in list_tbl_srvc.rows()]
+    mgmt_objs = provider.mgmt.list_service()
+
+    assert set(ui_services).issubset(
+        [obj.name for obj in mgmt_objs]), 'Missing objects'
+
+    for name in ui_services:
+        obj = Service(name, provider)
+        assert getattr(obj.summary.properties, rel).text_value

--- a/cfme/tests/containers/test_imgreg_proj_views.py
+++ b/cfme/tests/containers/test_imgreg_proj_views.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+""" The test_image_registries_views function verifies that
+    image registries can be viewed in grid, tile and list views
+    The test_project_list_views_function verifies that list view
+    is the default view for container projects
+"""
+import pytest
+from cfme.fixtures import pytest_selenium as sel
+from cfme.web_ui import toolbar as tb
+from utils import testgen
+from utils.version import current_version
+
+
+pytestmark = [
+    pytest.mark.uncollectif(
+        lambda: current_version() < "5.6"),
+    pytest.mark.usefixtures('setup_provider')]
+pytest_generate_tests = testgen.generate(
+    testgen.container_providers, scope="function")
+
+# CMP-9986 # CMP-9985 # CMP-9984
+
+
+def test_image_registries_views():
+    sel.force_navigate('containers_image_registries')
+    tb.select('Grid View')
+    assert tb.is_active(
+        'Grid View'), "Image Registries grid view setting failed"
+    tb.select('Tile View')
+    assert tb.is_active(
+        'Tile View'), "Image Registries tile view setting failed"
+    tb.select('List View')
+    assert tb.is_active(
+        'List View'), "Image Registries list view setting failed"
+
+# CMP-9886
+
+
+def test_projects_list_views():
+    sel.force_navigate('containers_projects')
+    assert tb.is_active(
+        'List View'), "Projects list view setting failed"

--- a/cfme/tests/containers/test_one_image_analysis.py
+++ b/cfme/tests/containers/test_one_image_analysis.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+from cfme.fixtures import pytest_selenium as sel
+from utils import testgen
+from utils.version import current_version
+from cfme.web_ui import flash, toolbar as tb, tabstrip as tabs
+from cfme.containers import image
+from utils.wait import wait_for, TimedOutError
+from cfme.configure import tasks
+
+
+pytestmark = [
+    pytest.mark.uncollectif(
+        lambda: current_version() < "5.6"),
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.tier(1)]
+pytest_generate_tests = testgen.generate(
+    testgen.container_providers, scope="function")
+
+
+def test_image_analysis_finished():
+    # CMP-10064
+    sel.force_navigate('containers_images')
+    m = 'Analysis successfully initiated'
+    sel.check(image.checkbox)
+    tb.select(
+        'Configuration',
+        'Perform SmartState Analysis',
+        invokes_alert=True)
+    sel.handle_alert()
+    flash.assert_message_contain(m)
+
+    is_task_finished()
+
+
+def is_task_finished():
+    tab_name = "All VM and Container Analysis Tasks"
+    page = sel.force_navigate('tasks_all_vm')
+    task_name = "Container image analysis"
+    expected_status = "finished"
+    if not sel.is_displayed(
+            tasks.tasks_table) or not tabs.is_tab_selected(tab_name):
+        sel.force_navigate(page)
+
+    el = tasks.tasks_table.find_row_by_cells({
+        'task_name': task_name,
+        'state': expected_status
+    })
+
+    if not el:
+        try:
+            wait_for(is_task_finished, delay=20, timeout="5m",
+                     fail_func=lambda: tb.select('Reload'))
+        except TimedOutError:
+            pytest.fail("Analysis has not completed")
+
+    if el:
+        tb.select('Delete Tasks', 'Delete All', invokes_alert=True)
+        sel.handle_alert(cancel=False)
+
+        return el

--- a/cfme/tests/containers/test_pods_prop_data_integrity.py
+++ b/cfme/tests/containers/test_pods_prop_data_integrity.py
@@ -37,4 +37,3 @@ def test_summary_properties_validation(provider):
         num_relationships_containers = getattr(
             obj.summary.relationships, 'containers').text_value
         assert num_container_status_summary == num_relationships_containers
-

--- a/cfme/tests/containers/test_pods_prop_data_integrity.py
+++ b/cfme/tests/containers/test_pods_prop_data_integrity.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+from cfme.fixtures import pytest_selenium as sel
+from cfme.containers.pod import Pod
+from utils import testgen
+from utils.version import current_version
+from cfme.web_ui import CheckboxTable
+
+
+pytestmark = [
+    pytest.mark.uncollectif(
+        lambda: current_version() < "5.6"),
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.tier(1)]
+pytest_generate_tests = testgen.generate(
+    testgen.container_providers, scope="function")
+
+# CMP-9934
+
+
+def test_summary_properties_validation(provider):
+    """
+          This test verifies that the number of running containers in the status summary table
+          is the same number that appears in the Relationships table
+    """
+    sel.force_navigate('containers_pods')
+    list_tbl_pod = CheckboxTable(table_locator="//div[@id='list_grid']//table")
+    ui_pods = [r.name.text for r in list_tbl_pod.rows()]
+    ui_pods_revised = filter(
+        lambda ch: not ch.startswith('metrics'),
+        ui_pods)
+
+    for name in ui_pods_revised:
+        obj = Pod(name, provider)
+        val_cont_stat_summary = obj.get_detail(
+            'Container Statuses Summary', 'Running')
+        val_cont_rel_tbl = obj.get_detail('Relationships', 'Containers')
+        assert val_cont_rel_tbl == val_cont_stat_summary

--- a/cfme/tests/containers/test_pods_prop_data_integrity.py
+++ b/cfme/tests/containers/test_pods_prop_data_integrity.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 import pytest
 from cfme.fixtures import pytest_selenium as sel
 from cfme.containers.pod import Pod
@@ -33,7 +32,9 @@ def test_summary_properties_validation(provider):
 
     for name in ui_pods_revised:
         obj = Pod(name, provider)
-        val_cont_stat_summary = obj.get_detail(
-            'Container Statuses Summary', 'Running')
-        val_cont_rel_tbl = obj.get_detail('Relationships', 'Containers')
-        assert val_cont_rel_tbl == val_cont_stat_summary
+        num_container_status_summary = getattr(
+            obj.summary.container_statuses_summary, 'running').text_value
+        num_relationships_containers = getattr(
+            obj.summary.relationships, 'containers').text_value
+        assert num_container_status_summary == num_relationships_containers
+

--- a/cfme/tests/containers/test_relationships_tables.py
+++ b/cfme/tests/containers/test_relationships_tables.py
@@ -1,11 +1,4 @@
 # -*- coding: utf-8 -*-
-
-""" This module verifies the integrity of the Relationships table
-    We also verify that clicking on the Relationships table field
-    takes the user to the correct page, and the number of rows
-    that appears on that page is equal to the number in the
-    Relationships table
-"""
 import pytest
 from cfme.fixtures import pytest_selenium as sel
 from cfme.containers.pod import Pod
@@ -18,10 +11,6 @@ from utils import testgen
 from utils.version import current_version
 from cfme.web_ui import InfoBlock, CheckboxTable
 
-
-# CMP-9929 # CMP-9930
-
-
 pytestmark = [
     pytest.mark.uncollectif(
         lambda: current_version() < "5.5"),
@@ -29,6 +18,9 @@ pytestmark = [
     pytest.mark.tier(2)]
 pytest_generate_tests = testgen.generate(
     testgen.container_providers, scope="function")
+
+# CMP-9929 # CMP-9930 # CMP-9892 # CMP-9965 # CMP=9962 # CMP-9983
+# CMP-9980 # CMP-9868 # CMP-9869
 
 
 @pytest.mark.parametrize('rel',
@@ -39,6 +31,13 @@ pytest_generate_tests = testgen.generate(
                           'Containers',
                           'Node'])
 def test_pods_rel(provider, rel):
+    """ This module verifies the integrity of the Relationships table
+          We also verify that clicking on the Relationships table field
+          takes the user to the correct page, and the number of rows
+          that appears on that page is equal to the number in the
+          Relationships table
+    """
+
     sel.force_navigate('containers_pods')
     list_tbl_pod = CheckboxTable(table_locator="//div[@id='list_grid']//table")
     ui_pods = [r.name.text for r in list_tbl_pod.rows()]
@@ -59,8 +58,6 @@ def test_pods_rel(provider, rel):
             assert len([r for r in list_tbl_pod.rows()]) == val
         except ValueError:
             assert val == InfoBlock.text('Properties', 'Name')
-
-# CMP-9892
 
 
 @pytest.mark.parametrize(
@@ -89,8 +86,6 @@ def test_services_rel(provider, rel):
             assert len([r for r in list_tbl_service.rows()]) == val
         except ValueError:
             assert val == InfoBlock.text('Properties', 'Name')
-
-# CMP-9965 # CMP=9962
 
 
 @pytest.mark.parametrize('rel',
@@ -125,8 +120,6 @@ def test_nodes_rel(provider, rel):
         except ValueError:
             assert val == InfoBlock.text('Properties', 'Name')
 
-# need to add the test case to Polarion
-
 
 @pytest.mark.parametrize(
     'rel', ['Containers Provider', 'Project', 'Pods', 'Nodes'])
@@ -155,8 +148,6 @@ def test_replicators_rel(provider, rel):
         except ValueError:
             assert val == InfoBlock.text('Properties', 'Name')
 
-# CMP-9983 # CMP-9980
-
 
 @pytest.mark.parametrize('rel',
                          ['Containers Provider',
@@ -183,8 +174,6 @@ def test_images_rel(provider, rel):
             assert len([r for r in list_tbl_image.rows()]) == val
         except ValueError:
             assert val == InfoBlock.text('Properties', 'Name')
-
-# CMP-9868 # CMP-9869
 
 
 @pytest.mark.parametrize('rel',

--- a/cfme/tests/containers/test_relationships_tables.py
+++ b/cfme/tests/containers/test_relationships_tables.py
@@ -1,6 +1,11 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
-# the test verifies data integrity in tables
+
+""" This module verifies the integrity of the Relationships table
+    We also verify that clicking on the Relationships table field
+    takes the user to the correct page, and the number of rows
+    that appears on that page is equal to the number in the
+    Relationships table
+"""
 import pytest
 from cfme.fixtures import pytest_selenium as sel
 from cfme.containers.pod import Pod
@@ -13,6 +18,10 @@ from utils import testgen
 from utils.version import current_version
 from cfme.web_ui import InfoBlock, CheckboxTable
 
+
+# CMP-9929 # CMP-9930
+
+
 pytestmark = [
     pytest.mark.uncollectif(
         lambda: current_version() < "5.5"),
@@ -22,9 +31,6 @@ pytest_generate_tests = testgen.generate(
     testgen.container_providers, scope="function")
 
 
-# container pods
-# verification of the data in relationships table and properties summary
-# table as related to pods
 @pytest.mark.parametrize('rel',
                          ['Containers Provider',
                           'Project',
@@ -36,14 +42,11 @@ def test_pods_rel(provider, rel):
     sel.force_navigate('containers_pods')
     list_tbl_pod = CheckboxTable(table_locator="//div[@id='list_grid']//table")
     ui_pods = [r.name.text for r in list_tbl_pod.rows()]
-    mgmt_objs = provider.mgmt.list_container_group()  # run only if table is not empty
+    ui_pods_revised = filter(
+        lambda ch: 'nginx' not in ch and not ch.startswith('metrics'),
+        ui_pods)
 
-    if ui_pods:
-        # verify that mgmt pods exist in ui listed pods
-        assert set(ui_pods).issubset(
-            [obj.name for obj in mgmt_objs]), 'Missing objects'
-
-    for name in ui_pods:
+    for name in ui_pods_revised:
         obj = Pod(name, provider)
 
         val = obj.get_detail('Relationships', rel)
@@ -57,10 +60,9 @@ def test_pods_rel(provider, rel):
         except ValueError:
             assert val == InfoBlock.text('Properties', 'Name')
 
+# CMP-9892
 
-# container services
-# verification of the data in relationships table and properties summary
-# table as related to services
+
 @pytest.mark.parametrize(
     'rel', ['Containers Provider', 'Project', 'Routes', 'Pods', 'Nodes'])
 def test_services_rel(provider, rel):
@@ -68,10 +70,9 @@ def test_services_rel(provider, rel):
     list_tbl_service = CheckboxTable(
         table_locator="//div[@id='list_grid']//table")
     ui_services = [r.name.text for r in list_tbl_service.rows()]
-    mgmt_objs = provider.mgmt.list_service()  # run only if table is not empty
+    mgmt_objs = provider.mgmt.list_service()
 
     if ui_services:
-        # verify that mgmt pods exist in ui listed pods
         assert set(ui_services).issubset(
             [obj.name for obj in mgmt_objs]), 'Missing objects'
 
@@ -89,10 +90,9 @@ def test_services_rel(provider, rel):
         except ValueError:
             assert val == InfoBlock.text('Properties', 'Name')
 
+# CMP-9965 # CMP=9962
 
-# container nodes
-# verification of the data in relationships table and properties summary
-# table as related to nodes
+
 @pytest.mark.parametrize('rel',
                          ['Containers Provider',
                           'Routes',
@@ -105,10 +105,9 @@ def test_nodes_rel(provider, rel):
     list_tbl_node = CheckboxTable(
         table_locator="//div[@id='list_grid']//table")
     ui_nodes = [r.name.text for r in list_tbl_node.rows()]
-    mgmt_objs = provider.mgmt.list_node()  # run only if table is not empty
+    mgmt_objs = provider.mgmt.list_node()
 
     if ui_nodes:
-        # verify that mgmt pods exist in ui listed pods
         assert set(ui_nodes).issubset(
             [obj.name for obj in mgmt_objs]), 'Missing objects'
 
@@ -126,10 +125,9 @@ def test_nodes_rel(provider, rel):
         except ValueError:
             assert val == InfoBlock.text('Properties', 'Name')
 
+# need to add the test case to Polarion
 
-# container replicators
-# verification of the data in relationships table and properties summary
-# table as related to replicators
+
 @pytest.mark.parametrize(
     'rel', ['Containers Provider', 'Project', 'Pods', 'Nodes'])
 def test_replicators_rel(provider, rel):
@@ -137,11 +135,9 @@ def test_replicators_rel(provider, rel):
     list_tbl_replicator = CheckboxTable(
         table_locator="//div[@id='list_grid']//table")
     ui_replicators = [r.name.text for r in list_tbl_replicator.rows()]
-    # run only if table is not empty
     mgmt_objs = provider.mgmt.list_replication_controller()
 
     if ui_replicators:
-        # verify that mgmt pods exist in ui listed pods
         assert set(ui_replicators).issubset(
             [obj.name for obj in mgmt_objs]), 'Missing objects'
 
@@ -159,13 +155,12 @@ def test_replicators_rel(provider, rel):
         except ValueError:
             assert val == InfoBlock.text('Properties', 'Name')
 
+# CMP-9983 # CMP-9980
 
-# container images
-# verification of the data in relationships table and properties summary
-# table as related to images
+
 @pytest.mark.parametrize('rel',
                          ['Containers Provider',
-                          'Image Registry',
+                          'Image registry',
                           'Projects',
                           'Pods',
                           'Containers',
@@ -180,8 +175,7 @@ def test_images_rel(provider, rel):
         obj = Image(name, provider)
 
         val = obj.get_detail('Relationships', rel)
-        if val == '0' or val == 'Unknown image source':
-            continue
+        assert val != 'Unknown image source'
         obj.click_element('Relationships', rel)
 
         try:
@@ -190,10 +184,9 @@ def test_images_rel(provider, rel):
         except ValueError:
             assert val == InfoBlock.text('Properties', 'Name')
 
+# CMP-9868 # CMP-9869
 
-# container projects
-# verification of the data in relationships table and properties summary
-# table as related to projects
+
 @pytest.mark.parametrize('rel',
                          ['Containers Provider',
                           'Routes',
@@ -206,10 +199,9 @@ def test_projects_rel(provider, rel):
     list_tbl_project = CheckboxTable(
         table_locator="//div[@id='list_grid']//table")
     ui_projects = [r.name.text for r in list_tbl_project.rows()]
-    mgmt_objs = provider.mgmt.list_project()  # run only if table is not empty
+    mgmt_objs = provider.mgmt.list_project()
 
     if ui_projects:
-        # verify that mgmt pods exist in ui listed pods
         assert set(ui_projects).issubset(
             [obj.name for obj in mgmt_objs]), 'Missing objects'
 

--- a/cfme/tests/containers/test_return_links.py
+++ b/cfme/tests/containers/test_return_links.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+import pytest
+from cfme.fixtures import pytest_selenium as sel
+from utils import testgen
+from utils.version import current_version
+from cfme.containers import service
+from cfme.containers import route
+from cfme.containers import project
+from cfme.containers.service import Service, list_tbl as list_tbl_service
+from cfme.containers.route import Route, list_tbl as list_tbl_route
+from cfme.containers.project import Project, list_tbl as list_tbl_project
+
+
+pytestmark = [
+    pytest.mark.uncollectif(
+        lambda: current_version() < "5.6"),
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.tier(2)]
+pytest_generate_tests = testgen.generate(
+    testgen.container_providers, scope="function")
+
+# CMP-9906 # CMP-9905 # CMP-9904
+
+
+def test_services_link(provider):
+    """ Module that deals with links that allow user to go back to previous page
+    """
+    sel.force_navigate('containers_services')
+    ui_services = [r.name.text for r in list_tbl_service.rows()]
+
+    for name in ui_services:
+        obj = Service(name, provider)
+        obj.navigate()
+        sel.click(service.link_to_prv_page)
+        assert "Services" in sel.title()
+
+
+def test_routes_link(provider):
+    sel.force_navigate('containers_routes')
+    ui_routes = [r.name.text for r in list_tbl_route.rows()]
+
+    for name in ui_routes:
+        obj = Route(name, provider)
+        obj.navigate()
+        sel.click(route.link_to_prv_page)
+        assert "Routes" in sel.title()
+
+
+def test_projects_link(provider):
+    sel.force_navigate('containers_projects')
+    ui_projects = [r.name.text for r in list_tbl_project.rows()]
+
+    for name in ui_projects:
+        obj = Project(name, provider)
+        obj.navigate()
+        sel.click(project.link_to_prv_page)
+        assert "Projects" in sel.title()

--- a/cfme/tests/containers/test_views_objects.py
+++ b/cfme/tests/containers/test_views_objects.py
@@ -1,6 +1,11 @@
-# the test verifies functionality
-# of different views such as grid view, tile view
-# and list view
+# -*- coding: utf-8 -*-
+
+
+""" the test verifies functionality
+    of different views such as grid view, tile view
+    and list view
+"""
+
 import pytest
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import toolbar as tb
@@ -15,6 +20,8 @@ pytestmark = [
 pytest_generate_tests = testgen.generate(
     testgen.container_providers, scope="function")
 
+# CMP-9907 # CMP-9908 # CMP-9909
+
 
 def test_pods_views():
     sel.force_navigate('containers_pods')
@@ -24,6 +31,9 @@ def test_pods_views():
     assert tb.is_active('Tile View'), "Pods tile view setting failed"
     tb.select('List View')
     assert tb.is_active('List View'), "Pods list view setting failed"
+
+
+# CMP-9918 # CMP-9919 # CMP-9920
 
 
 def test_replicators_views():
@@ -36,6 +46,9 @@ def test_replicators_views():
     assert tb.is_active('List View'), "Replicators list view setting failed"
 
 
+# CMP-9941 # CMP-9942 # CMP-9943
+
+
 def test_containers_views():
     sel.force_navigate('containers_containers')
     tb.select('Grid View')
@@ -44,6 +57,9 @@ def test_containers_views():
     assert tb.is_active('Tile View'), "Containers tile view setting failed"
     tb.select('List View')
     assert tb.is_active('List View'), "Containers list view setting failed"
+
+
+# CMP-9887 # CMP-9888 # CMP-9889
 
 
 def test_services_views():
@@ -56,6 +72,9 @@ def test_services_views():
     assert tb.is_active('List View'), "Services list view setting failed"
 
 
+# CMP-9956 # CMP-9957 # CMP-9958
+
+
 def test_nodes_views():
     sel.force_navigate('containers_nodes')
     tb.select('Grid View')
@@ -64,6 +83,9 @@ def test_nodes_views():
     assert tb.is_active('Tile View'), "Nodes tile view setting failed"
     tb.select('List View')
     assert tb.is_active('List View'), "Nodes list view setting failed"
+
+
+# CMP-9974 # CMP-9975 # CMP-9976
 
 
 def test_images_views():


### PR DESCRIPTION
**Purpose or Intent
=================**

Fixed test_relationships_tables.py to account for two pods lacking replicators associated with them. Also made sure that comments adhere to the proper format.

Added test_return_links.py

{{pytest: cfme/tests/containers/test_relationships_tables.py -v --use-provider container }}

