### PR TITLE
Include upstream_stable in trackerbot stream parse.

### DIFF
--- a/utils/trackerbot.py
+++ b/utils/trackerbot.py
@@ -26,6 +26,7 @@ stream_matchers = (
     (get_stream('5.6'), r'^cfme-56.*-(?P<month>\d{2})(?P<day>\d{2})'),
     # Nightly builds have potentially multiple version streams bound to them so we
     # cannot use get_stream()
+    ('upstream_stable', r'^miq-stable-darga-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})'),
     ('downstream-nightly', r'^cfme-nightly-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})'),
     # new format
     ('downstream-nightly', r'^cfme-nightly-\d*-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})'),


### PR DESCRIPTION
Updated trackerbot script to include "upstream_stable" in stream parser.
  * added "upstream_stable" to trackerbot stream_parser.