### PR TITLE
Inlcude darga-vstring in appliances.

### DIFF
--- a/utils/version.py
+++ b/utils/version.py
@@ -175,6 +175,8 @@ class Version(object):
             vstring = str(vstring).strip()
         if vstring in ('master', 'latest', 'upstream'):
             vstring = 'master'
+        if vstring == 'darga-3':
+            vstring = '5.6.1'
 
         components = filter(lambda x: x and x != '.',
                             self.component_re.findall(vstring))


### PR DESCRIPTION

  * Including darga-3 in version, as darga-3 is versioned on top of 5.6.1,
    version string is set to 5.6.1 for darga-3