### PR TITLE
Patch that fixes test_relationships_tables.py

### DIFF
--- a/cfme/tests/containers/test_relationships_tables.py
+++ b/cfme/tests/containers/test_relationships_tables.py
@@ -1,6 +1,4 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
-# the test verifies data integrity in tables
 import pytest
 from cfme.fixtures import pytest_selenium as sel
 from cfme.containers.pod import Pod
@@ -11,7 +9,7 @@ from cfme.containers.image import Image
 from cfme.containers.project import Project
 from utils import testgen
 from utils.version import current_version
-from cfme.web_ui import InfoBlock, CheckboxTable
+from cfme.web_ui import InfoBlock, CheckboxTable, toolbar as tb
 
 pytestmark = [
     pytest.mark.uncollectif(
@@ -22,9 +20,9 @@ pytest_generate_tests = testgen.generate(
     testgen.container_providers, scope="function")
 
 
-# container pods
-# verification of the data in relationships table and properties summary
-# table as related to pods
+# 9929 #9930
+
+
 @pytest.mark.parametrize('rel',
                          ['Containers Provider',
                           'Project',
@@ -33,17 +31,21 @@ pytest_generate_tests = testgen.generate(
                           'Containers',
                           'Node'])
 def test_pods_rel(provider, rel):
+    """   This module verifies the integrity of the Relationships table
+          We also verify that clicking on the Relationships table field
+          takes the user to the correct page, and the number of rows
+          that appears on that page is equal to the number in the
+          Relationships table
+    """
     sel.force_navigate('containers_pods')
+    tb.select('List View')
     list_tbl_pod = CheckboxTable(table_locator="//div[@id='list_grid']//table")
     ui_pods = [r.name.text for r in list_tbl_pod.rows()]
-    mgmt_objs = provider.mgmt.list_container_group()  # run only if table is not empty
+    ui_pods_revised = filter(
+        lambda ch: 'nginx' not in ch and not ch.startswith('metrics'),
+        ui_pods)
 
-    if ui_pods:
-        # verify that mgmt pods exist in ui listed pods
-        assert set(ui_pods).issubset(
-            [obj.name for obj in mgmt_objs]), 'Missing objects'
-
-    for name in ui_pods:
+    for name in ui_pods_revised:
         obj = Pod(name, provider)
 
         val = obj.get_detail('Relationships', rel)
@@ -58,22 +60,21 @@ def test_pods_rel(provider, rel):
             assert val == InfoBlock.text('Properties', 'Name')
 
 
-# container services
-# verification of the data in relationships table and properties summary
-# table as related to services
+# 9892
+
+
 @pytest.mark.parametrize(
     'rel', ['Containers Provider', 'Project', 'Routes', 'Pods', 'Nodes'])
 def test_services_rel(provider, rel):
     sel.force_navigate('containers_services')
+    tb.select('List View')
     list_tbl_service = CheckboxTable(
         table_locator="//div[@id='list_grid']//table")
     ui_services = [r.name.text for r in list_tbl_service.rows()]
-    mgmt_objs = provider.mgmt.list_service()  # run only if table is not empty
+    mgmt_objs = provider.mgmt.list_service()
 
-    if ui_services:
-        # verify that mgmt pods exist in ui listed pods
-        assert set(ui_services).issubset(
-            [obj.name for obj in mgmt_objs]), 'Missing objects'
+    assert set(ui_services).issubset(
+        [obj.name for obj in mgmt_objs]), 'Missing objects'
 
     for name in ui_services:
         obj = Service(name, provider)
@@ -89,10 +90,9 @@ def test_services_rel(provider, rel):
         except ValueError:
             assert val == InfoBlock.text('Properties', 'Name')
 
+# 9965 #9962
 
-# container nodes
-# verification of the data in relationships table and properties summary
-# table as related to nodes
+
 @pytest.mark.parametrize('rel',
                          ['Containers Provider',
                           'Routes',
@@ -102,15 +102,14 @@ def test_services_rel(provider, rel):
                           'Containers'])
 def test_nodes_rel(provider, rel):
     sel.force_navigate('containers_nodes')
+    tb.select('List View')
     list_tbl_node = CheckboxTable(
         table_locator="//div[@id='list_grid']//table")
     ui_nodes = [r.name.text for r in list_tbl_node.rows()]
-    mgmt_objs = provider.mgmt.list_node()  # run only if table is not empty
+    mgmt_objs = provider.mgmt.list_node()
 
-    if ui_nodes:
-        # verify that mgmt pods exist in ui listed pods
-        assert set(ui_nodes).issubset(
-            [obj.name for obj in mgmt_objs]), 'Missing objects'
+    assert set(ui_nodes).issubset(
+        [obj.name for obj in mgmt_objs]), 'Missing objects'
 
     for name in ui_nodes:
         obj = Node(name, provider)
@@ -127,23 +126,18 @@ def test_nodes_rel(provider, rel):
             assert val == InfoBlock.text('Properties', 'Name')
 
 
-# container replicators
-# verification of the data in relationships table and properties summary
-# table as related to replicators
 @pytest.mark.parametrize(
     'rel', ['Containers Provider', 'Project', 'Pods', 'Nodes'])
 def test_replicators_rel(provider, rel):
     sel.force_navigate('containers_replicators')
+    tb.select('List View')
     list_tbl_replicator = CheckboxTable(
         table_locator="//div[@id='list_grid']//table")
     ui_replicators = [r.name.text for r in list_tbl_replicator.rows()]
-    # run only if table is not empty
     mgmt_objs = provider.mgmt.list_replication_controller()
 
-    if ui_replicators:
-        # verify that mgmt pods exist in ui listed pods
-        assert set(ui_replicators).issubset(
-            [obj.name for obj in mgmt_objs]), 'Missing objects'
+    assert set(ui_replicators).issubset(
+        [obj.name for obj in mgmt_objs]), 'Missing objects'
 
     for name in ui_replicators:
         obj = Replicator(name, provider)
@@ -159,19 +153,22 @@ def test_replicators_rel(provider, rel):
         except ValueError:
             assert val == InfoBlock.text('Properties', 'Name')
 
+# 9983 #9980
 
-# container images
-# verification of the data in relationships table and properties summary
-# table as related to images
+
+@pytest.mark.meta(blockers=[1365878])
 @pytest.mark.parametrize('rel',
                          ['Containers Provider',
-                          'Image Registry',
+                          'Image registry',
                           'Projects',
                           'Pods',
                           'Containers',
                           'Nodes'])
 def test_images_rel(provider, rel):
+    """ https://bugzilla.redhat.com/show_bug.cgi?id=1365878
+    """
     sel.force_navigate('containers_images')
+    tb.select('List View')
     list_tbl_image = CheckboxTable(
         table_locator="//div[@id='list_grid']//table")
     ui_images = [r.name.text for r in list_tbl_image.rows()]
@@ -180,8 +177,7 @@ def test_images_rel(provider, rel):
         obj = Image(name, provider)
 
         val = obj.get_detail('Relationships', rel)
-        if val == '0' or val == 'Unknown image source':
-            continue
+        assert val != 'Unknown image source'
         obj.click_element('Relationships', rel)
 
         try:
@@ -190,10 +186,9 @@ def test_images_rel(provider, rel):
         except ValueError:
             assert val == InfoBlock.text('Properties', 'Name')
 
+# 9868 #9869
 
-# container projects
-# verification of the data in relationships table and properties summary
-# table as related to projects
+
 @pytest.mark.parametrize('rel',
                          ['Containers Provider',
                           'Routes',
@@ -203,15 +198,14 @@ def test_images_rel(provider, rel):
                           'Nodes'])
 def test_projects_rel(provider, rel):
     sel.force_navigate('containers_projects')
+    tb.select('List View')
     list_tbl_project = CheckboxTable(
         table_locator="//div[@id='list_grid']//table")
     ui_projects = [r.name.text for r in list_tbl_project.rows()]
-    mgmt_objs = provider.mgmt.list_project()  # run only if table is not empty
+    mgmt_objs = provider.mgmt.list_project()
 
-    if ui_projects:
-        # verify that mgmt pods exist in ui listed pods
-        assert set(ui_projects).issubset(
-            [obj.name for obj in mgmt_objs]), 'Missing objects'
+    assert set(ui_projects).issubset(
+        [obj.name for obj in mgmt_objs]), 'Missing objects'
 
     for name in ui_projects:
         obj = Project(name, provider)


### PR DESCRIPTION
Purpose or Intent
=================

Fixed test_relationships_tables.py to account for 2 pods missing replicators and "Unknown image source" as referenced in the opened bug. 

{{pytest: cfme/tests/containers/test_relationships_tables.py -v --use-provider container }}
