### PR TITLE
[WIP][NOTEST]too complex documentation string

### DIFF
--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -144,8 +144,8 @@ class Region(Pretty):
     Note:
 
         When specifying a region title, omit the "Cloudforms Management Engine: " or "ManageIQ: "
-        prefix. They're included on every page, and different for the two versions of the appliance,
-        and :py:meth:`is_displayed` strips them off before checking for equality.
+        prefix. They are included on every page, and different for the two versions of the
+        appliance, and :py:meth:`is_displayed` strips them off before checking for equality.
 
     """
     pretty_attrs = ['title']

--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -144,8 +144,8 @@ class Region(Pretty):
     Note:
 
         When specifying a region title, omit the "Cloudforms Management Engine: " or "ManageIQ: "
-        prefix. They are included on every page, and different for the two versions of the
-        appliance, and :py:meth:`is_displayed` strips them off before checking for equality.
+        prefix. They're included on every page, and different for the two versions of the appliance,
+        and :py:meth:`is_displayed` strips them off before checking for equality.
 
     """
     pretty_attrs = ['title']

--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -144,7 +144,7 @@ class Region(Pretty):
     Note:
 
         When specifying a region title, omit the "Cloudforms Management Engine: " or "ManageIQ: "
-        prefix. They're included on every page, and different for the two versions of the appliance,
+        prefix. They are included on every page, and different for the two versions of the appliance,
         and :py:meth:`is_displayed` strips them off before checking for equality.
 
     """


### PR DESCRIPTION
Simple change from 'they're' to 'they are' to prevent glitching of syntax highlight.