### PR TITLE
[WIPTEST]fixing finding Quadicon by short name in upstream

### DIFF
--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -2342,7 +2342,10 @@ class Quadicon(Pretty):
             return "contains(normalize-space(@title), {name})"\
                 .format(name=quoteattr('Name: {}'.format(self._name)))
         else:
-            return "@title={name} or @data-original-title={name}".format(name=quoteattr(self._name))
+            return "@title={name} or @data-original-title={name} or @title={short_name}".format(
+                name=quoteattr(self._name),
+                short_name=quoteattr("{}...{}".format(
+                    self._name[:5], self._name[-5:])) if len(self._name) > 12 else None)
 
     def locate(self):
         """ Returns:  a locator for the quadicon anchor"""


### PR DESCRIPTION
Purpose or Intent
=================

fixing search Quadicon by short name if name is greater than 12 symbols

A lot of test were failing as title in upstream was changed to title=test_...xlkjT(5 last symbols)

{{pytest: cfme/tests/cloud/test_instance_power_control.py::test_stop --long-running}}

