### PR TITLE
Fix test_permissions_role_crud in RBAC

### DIFF
--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -479,7 +479,7 @@ def _go_to(dest):
     return lambda: nav.go_to(dest)
 
 
-cat_name = "Configure"
+cat_name = "Settings"
 
 
 @pytest.mark.tier(3)


### PR DESCRIPTION
Fixing test_permissions_role_crud in rbac because its failing in upstream/downstream

{{pytest: -v -k 'test_permissions_role_crud'}}