### PR TITLE
More verbose menu navigation failures

### DIFF
--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -296,3 +296,7 @@ class MiddlewareServerNotFound(CFMEException):
 
 class UsingSharedTables(CFMEException):
     """Raised if the :py:class:`cfme.web_ui.Table` suspects there is a use of shared tables."""
+
+
+class MenuItemNotFound(CFMEException):
+    """Raised during navigation of certain menu item was not found."""

--- a/cfme/web_ui/menu.py
+++ b/cfme/web_ui/menu.py
@@ -2,6 +2,7 @@
 import inspect
 from ui_navigate import UINavigate
 
+from cfme.exceptions import MenuItemNotFound
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import accordion, toolbar
 from lya import AttrDict
@@ -391,8 +392,23 @@ class Menu(UINavigate):
             return True
 
     @staticmethod
-    def _try_nav(el):
-        href = sel.get_attribute(el, 'href')
+    def _try_nav(el, toplevel, secondlevel, thirdlevel=None):
+        try:
+            href = sel.get_attribute(el, 'href')
+        except NoSuchElementException as e:
+            # Make our own exception
+            if thirdlevel is None:
+                item = '{} / {}'.format(toplevel, secondlevel)
+            else:
+                item = '{} / {} / {}'.format(toplevel, secondlevel, thirdlevel)
+
+            message = '\n'.join([
+                'An error happened during selecting of the menu item: {}'.format(item),
+                str(e).rstrip(),  # An extra newline at the end.
+            ])
+
+            raise MenuItemNotFound(message)
+
         sel.execute_script('document.location.href = arguments[0];', href)
         sel.wait_for_ajax()
 
@@ -448,13 +464,13 @@ class Menu(UINavigate):
                     inactive_loc = (cls.TOP_LEV_INACTIVE + cls.SECOND_LEV_INACTIVE).format(
                         top_level, second_level)
                 el = "{} | {}".format(active_loc, inactive_loc)
-                cls._try_nav(el)
+                cls._try_nav(el, toplevel, secondlevel)
 
             else:
                 active_loc = cls.TOP_LEV_ACTIVE.format(top_level)
                 inactive_loc = cls.TOP_LEV_INACTIVE.format(top_level)
                 el = "{} | {}".format(active_loc, inactive_loc)
-                cls._try_nav(el)
+                cls._try_nav(el, toplevel, secondlevel)
 
             nav_fn = lambda: cls._nav_to_fn(toplevel, secondlevel, reset_action, _final=True)
             cls._try_reset_action(reset_action, _final, nav_fn)
@@ -473,7 +489,7 @@ class Menu(UINavigate):
                     loc = "{}{}".format(loc, loc_to_use).format(arg)
                 else:
                     break
-            cls._try_nav(loc)
+            cls._try_nav(loc, toplevel, secondlevel, thirdlevel)
 
             nav_fn = lambda: cls._nav_to_fn(toplevel, secondlevel, thirdlevel, reset_action,
                 _final=True)


### PR DESCRIPTION
You will see straight away which menu item failed to be selected, you don't need to decode the error message. The original error message is included. Throws a different exception.