### PR TITLE
[WIP] Data Integrity Properties test + get_names function on Container Objs

### DIFF
--- a/cfme/containers/container.py
+++ b/cfme/containers/container.py
@@ -41,6 +41,17 @@ class Container(Taggable, SummaryMixin, Navigatable):
         self.load_details(refresh=True)
         return details_page.infoblock.text(*ident)
 
+    @staticmethod
+    def get_container_names():
+        navigate_to(Container, 'All')
+        # sel.force_navigate('containers_containers')
+        return map(lambda r: r.name.text, list_tbl.rows())
+
+    @staticmethod
+    def get_pod_names():
+        navigate_to(Container, 'All')
+        # sel.force_navigate('containers_containers')
+        return map(lambda r: r.pod_name.text, list_tbl.rows())
 
 @navigator.register(Container, 'All')
 class ContainerAll(CFMENavigateStep):

--- a/cfme/containers/container.py
+++ b/cfme/containers/container.py
@@ -43,15 +43,14 @@ class Container(Taggable, SummaryMixin, Navigatable):
 
     @staticmethod
     def get_container_names():
-        navigate_to(Container, 'All')
-        # sel.force_navigate('containers_containers')
-        return map(lambda r: r.name.text, list_tbl.rows())
+        navigate_to(Container, 'All', use_resetter=False)
+        return [r.name.text for r in list_tbl.rows()]
 
     @staticmethod
     def get_pod_names():
-        navigate_to(Container, 'All')
-        # sel.force_navigate('containers_containers')
-        return map(lambda r: r.pod_name.text, list_tbl.rows())
+        navigate_to(Container, 'All', use_resetter=False)
+        return [r.pod_name.text for r in list_tbl.rows()]
+
 
 @navigator.register(Container, 'All')
 class ContainerAll(CFMENavigateStep):

--- a/cfme/containers/image.py
+++ b/cfme/containers/image.py
@@ -39,6 +39,11 @@ class Image(Taggable, SummaryMixin, Navigatable):
         navigate_to(self, 'Details')
         return InfoBlock.text(*ident)
 
+    @staticmethod
+    def get_names():
+        navigate_to(Image, 'All', use_resetter=False)
+        return [r.name.text for r in list_tbl.rows()]
+
 
 @navigator.register(Image, 'All')
 class All(CFMENavigateStep):

--- a/cfme/containers/image_registry.py
+++ b/cfme/containers/image_registry.py
@@ -29,6 +29,11 @@ class ImageRegistry(Taggable, SummaryMixin, Navigatable):
         if refresh:
             tb.refresh()
 
+    @staticmethod
+    def get_names():
+        navigate_to(ImageRegistry, 'All', use_resetter=False)
+        return [r.host.text for r in list_tbl.rows()]
+
 
 @navigator.register(ImageRegistry, 'All')
 class ImageRegistryAll(CFMENavigateStep):

--- a/cfme/containers/node.py
+++ b/cfme/containers/node.py
@@ -36,6 +36,11 @@ class Node(Taggable, SummaryMixin, Navigatable):
         self.load_details(refresh=False)
         return InfoBlock.text(*ident)
 
+    @staticmethod
+    def get_names():
+        navigate_to(Node, 'All', use_resetter=False)
+        return [r.name.text for r in list_tbl.rows()]
+
 
 @navigator.register(Node, 'All')
 class All(CFMENavigateStep):

--- a/cfme/tests/containers/test_containers_data_integrity.py
+++ b/cfme/tests/containers/test_containers_data_integrity.py
@@ -1,0 +1,101 @@
+import pytest
+from cfme.containers.image import Image
+from cfme.containers.image_registry import ImageRegistry
+from cfme.containers.pod import Pod
+from cfme.containers.provider import ContainersProvider
+from cfme.containers.node import Node
+from cfme.containers.container import Container
+from utils import testgen
+from utils.version import current_version
+from cfme.web_ui import history
+from utils.appliance.implementations.ui import  navigate_to
+
+
+
+pytestmark = [
+    pytest.mark.uncollectif(
+        lambda: current_version() < "5.6"),
+    # pytest.mark.usefixtures('has_no_container_providers'),
+    # pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.tier(1)]
+pytest_generate_tests = testgen.generate(
+    testgen.container_providers, scope='function')
+
+container_image_fields = ['Name', 'Image_Id', 'Full_Name']
+container_nodes_fields = ['Name', 'Creation_timestamp', 'Resource_version', 'Number_of_CPU_Cores',
+                          'Memory', 'Max_Pods_Capacity', 'System_BIOS_UUID', 'Machine_ID',
+                          'Infrastructure_Machine_ID', 'Runtime_version', 'Kubelet_version',
+                          'Proxy_version', 'Operating_System_Distribution', 'Kernel_version']
+container_fields = ['Name', 'State', 'Restart_count', 'Backing_Ref_Container_ID', 'Privileged']
+image_registry_field = ['Host']
+
+
+# CMP-9945
+def test_containers_integrity_properties():
+    """ Properties fields test in Containers
+        This test checks correct population of the Properties Fields in Containers' details menu
+        Steps:
+            * Goes to Containers -- > Containers menu
+            * Go through each Containers in the menu and check validity of Properties fields
+        """
+    navigate_to(Container, 'All', use_resetter=False)
+    container_names = Container.get_container_names()
+    container_pod_names = Container.get_pod_names()
+    dictionary = dict(zip(container_names, container_pod_names))
+    for container_name, container_pod_name in dictionary.iteritems():
+        for container_field in container_fields:
+            pod = Pod(container_pod_name, ContainersProvider)
+            cont = Container(container_name, pod)
+            assert cont.summary.properties.__getattribute__(container_field.lower())
+            history.select_nth_history_item(0)
+
+
+# CMP-9988
+def test_containers_image_registries_integrity_properties(provider):
+    """ Properties fields test in Image Registries
+        This test checks correct population of the Properties Fields in Image Registry's
+        details menu.
+        Prerequisites: Image Registries in CFME
+        Steps:
+            * Goes to Containers -- > Image Registries menu
+            * Go through each Image Registry in the menu and check validity of Properties fields
+        """
+    image_registry_hosts = ImageRegistry.get_names()
+    for host in image_registry_hosts:
+        for image in image_registry_field:
+            obj = ImageRegistry(host, provider)
+            assert obj.summary.properties.__getattribute__(image.lower())
+
+
+# CMP-9978
+def test_containers_images_integrity_properties(provider):
+    """ Properties fields test in Container Images
+        This test checks correct population of the Properties Fields in Containers Image's
+        details menu
+        Steps:
+            * Goes to Containers -- > Containers Images menu
+            * Go through each Container Image in the menu and check validity of Properties fields
+        """
+    container_images_names = Image.get_names()
+    for name in container_images_names:
+        for image in container_image_fields:
+            obj = Image(name, provider)
+            assert obj.summary.properties.__getattribute__(image.lower())
+
+
+# CMP-9960
+def test_containers_nodes_integrity_properties(provider):
+    """ Properties fields test in Container Nodes
+        This test checks correct population of the Properties Fields in Container Nodes'
+        details menu
+        Steps:
+            * Goes to Containers -- > Container Nodes menu
+            * Go through each Container in the menu and check validity of Properties fields
+        """
+    container_nodes_names = Node.get_names()
+    for name in container_nodes_names:
+        for node_field in container_nodes_fields:
+            obj = Node(name, provider)
+            assert obj.summary.properties.__getattribute__(node_field.lower())
+
+

--- a/cfme/tests/containers/test_containers_data_integrity.py
+++ b/cfme/tests/containers/test_containers_data_integrity.py
@@ -11,12 +11,11 @@ from cfme.web_ui import history
 from utils.appliance.implementations.ui import  navigate_to
 
 
-
 pytestmark = [
     pytest.mark.uncollectif(
         lambda: current_version() < "5.6"),
     # pytest.mark.usefixtures('has_no_container_providers'),
-    # pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate(
     testgen.container_providers, scope='function')
@@ -38,15 +37,25 @@ def test_containers_integrity_properties():
             * Goes to Containers -- > Containers menu
             * Go through each Containers in the menu and check validity of Properties fields
         """
-    navigate_to(Container, 'All', use_resetter=False)
+    # navigate_to(Container, 'All', use_resetter=False)
     container_names = Container.get_container_names()
     container_pod_names = Container.get_pod_names()
     dictionary = dict(zip(container_names, container_pod_names))
+    # for container_name, container_pod_name in dictionary.iteritems():
+    #     for container_field in container_fields:
+    #         pod = Pod(container_pod_name, ContainersProvider)
+    #         cont = Container(container_name, pod)
+    #         somevalue = (str(cont.summary.properties.__getattribute__(container_field.lower())))
+    #         print(somevalue)
+    #         assert cont.summary.properties.__getattribute__(container_field.lower())
+    #         history.select_nth_history_item(0)
+
     for container_name, container_pod_name in dictionary.iteritems():
         for container_field in container_fields:
             pod = Pod(container_pod_name, ContainersProvider)
             cont = Container(container_name, pod)
-            assert cont.summary.properties.__getattribute__(container_field.lower())
+            somevalue = (str(cont.summary.properties.__getattr__(container_field.lower())))
+            assert cont.summary.properties.__getattr__(container_field.lower())
             history.select_nth_history_item(0)
 
 

--- a/cfme/tests/containers/test_containers_data_integrity.py
+++ b/cfme/tests/containers/test_containers_data_integrity.py
@@ -1,4 +1,5 @@
 import pytest
+import random
 from cfme.containers.image import Image
 from cfme.containers.image_registry import ImageRegistry
 from cfme.containers.pod import Pod
@@ -8,13 +9,11 @@ from cfme.containers.container import Container
 from utils import testgen
 from utils.version import current_version
 from cfme.web_ui import history
-from utils.appliance.implementations.ui import  navigate_to
 
 
 pytestmark = [
     pytest.mark.uncollectif(
         lambda: current_version() < "5.6"),
-    # pytest.mark.usefixtures('has_no_container_providers'),
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate(
@@ -35,28 +34,18 @@ def test_containers_integrity_properties():
         This test checks correct population of the Properties Fields in Containers' details menu
         Steps:
             * Goes to Containers -- > Containers menu
-            * Go through each Containers in the menu and check validity of Properties fields
+            * Select a random Container in the menu and check validity of its' Properties fields
         """
-    # navigate_to(Container, 'All', use_resetter=False)
     container_names = Container.get_container_names()
     container_pod_names = Container.get_pod_names()
     dictionary = dict(zip(container_names, container_pod_names))
-    # for container_name, container_pod_name in dictionary.iteritems():
-    #     for container_field in container_fields:
-    #         pod = Pod(container_pod_name, ContainersProvider)
-    #         cont = Container(container_name, pod)
-    #         somevalue = (str(cont.summary.properties.__getattribute__(container_field.lower())))
-    #         print(somevalue)
-    #         assert cont.summary.properties.__getattribute__(container_field.lower())
-    #         history.select_nth_history_item(0)
-
-    for container_name, container_pod_name in dictionary.iteritems():
-        for container_field in container_fields:
-            pod = Pod(container_pod_name, ContainersProvider)
-            cont = Container(container_name, pod)
-            somevalue = (str(cont.summary.properties.__getattr__(container_field.lower())))
-            assert cont.summary.properties.__getattr__(container_field.lower())
-            history.select_nth_history_item(0)
+    random_container_name = random.choice(dictionary.keys())
+    random_container_pod_name = dictionary.get(random_container_name)
+    for container_field in container_fields:
+        pod = Pod(random_container_pod_name, ContainersProvider)
+        cont = Container(random_container_name, pod.name)
+        assert getattr(cont.summary.properties, container_field.lower())
+        history.select_nth_history_item(0)
 
 
 # CMP-9988
@@ -67,29 +56,29 @@ def test_containers_image_registries_integrity_properties(provider):
         Prerequisites: Image Registries in CFME
         Steps:
             * Goes to Containers -- > Image Registries menu
-            * Go through each Image Registry in the menu and check validity of Properties fields
+            * Select a random Image Registry in the menu and check
+            validity of its' Properties fields
         """
-    image_registry_hosts = ImageRegistry.get_names()
-    for host in image_registry_hosts:
-        for image in image_registry_field:
-            obj = ImageRegistry(host, provider)
-            assert obj.summary.properties.__getattribute__(image.lower())
+    random_image_registry_host = random.choice(ImageRegistry.get_names())
+    for image in image_registry_field:
+        obj = ImageRegistry(random_image_registry_host, provider)
+        assert getattr(obj.summary.properties, image.lower())
 
 
 # CMP-9978
 def test_containers_images_integrity_properties(provider):
     """ Properties fields test in Container Images
-        This test checks correct population of the Properties Fields in Containers Image's
+        This test checks correct population of the Properties Fields in Container Image's
         details menu
         Steps:
             * Goes to Containers -- > Containers Images menu
-            * Go through each Container Image in the menu and check validity of Properties fields
+            * Select a random Container Image in the menu and check
+            validity of its' Properties fields
         """
-    container_images_names = Image.get_names()
-    for name in container_images_names:
-        for image in container_image_fields:
-            obj = Image(name, provider)
-            assert obj.summary.properties.__getattribute__(image.lower())
+    random_container_image_name = random.choice(Image.get_names())
+    for image in container_image_fields:
+        obj = Image(random_container_image_name, provider)
+        assert getattr(obj.summary.properties, image.lower())
 
 
 # CMP-9960
@@ -99,12 +88,9 @@ def test_containers_nodes_integrity_properties(provider):
         details menu
         Steps:
             * Goes to Containers -- > Container Nodes menu
-            * Go through each Container in the menu and check validity of Properties fields
+            * Select a random Node in the menu and check validity of its' Properties fields
         """
-    container_nodes_names = Node.get_names()
-    for name in container_nodes_names:
-        for node_field in container_nodes_fields:
-            obj = Node(name, provider)
-            assert obj.summary.properties.__getattribute__(node_field.lower())
-
-
+    random_container_node_name = random.choice(Node.get_names())
+    for node_field in container_nodes_fields:
+        obj = Node(random_container_node_name, provider)
+        assert getattr(obj.summary.properties, node_field.lower())


### PR DESCRIPTION
# Purpose or Intent

This test checks correct population of the Properties Fields in Containers/Image Registries/Container Images and Container Nodes details menu.
Also added fixes for container/image/image_registry/node and pod objects to allow getting names for the existing objects

image_registry.py file was edited to allow get_detail on this object

{{pytest: cfme/tests/containers/test_containers_data_integrity_properties.py -v --use-provider container }}
