### PR TITLE
Fixed broken timelines test 

### DIFF
--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -158,7 +158,7 @@ class TestVmEventRESTAPI(object):
         }
         rest_vm = rest_api.collections.vms.get(name=vm)
         if from_detail:
-            assert rest_vm.action.add_event(event)["success"], "Could not add event"
+            assert rest_vm.action.add_event(**event)["success"], "Could not add event"
         else:
             response = rest_api.collections.vms.action.add_event(rest_vm, **event)
             assert len(response) > 0, "Could not add event"


### PR DESCRIPTION
The rest's add_event method supports only 'resource'. It skips all attributes if 'resources' (list) is passed. Fixed this issue.

{{pytest: cfme/tests/infrastructure/test_timelines.py}}