### PR TITLE
fix provider setup in advanced search tests

### DIFF
--- a/cfme/tests/infrastructure/test_advanced_search_host.py
+++ b/cfme/tests/infrastructure/test_advanced_search_host.py
@@ -16,7 +16,7 @@ from utils.version import current_version
 def hosts():
     """Ensure the infra providers are set up and get list of hosts"""
     try:
-        setup_a_provider(prov_type="infra")
+        setup_a_provider(prov_class="infra")
     except Exception:
         pytest.skip("It's not possible to set up any providers, therefore skipping")
     pytest.sel.force_navigate("infrastructure_hosts")

--- a/cfme/tests/infrastructure/test_advanced_search_providers.py
+++ b/cfme/tests/infrastructure/test_advanced_search_providers.py
@@ -17,7 +17,7 @@ from cfme.web_ui.cfme_exception import (assert_no_cfme_exception,
 def providers():
     """Ensure the infra providers are set up and get list of hosts"""
     try:
-        setup_a_provider(prov_type="infra")
+        setup_a_provider(prov_class="infra")
     except Exception:
         pytest.skip("It's not possible to set up any providers, therefore skipping")
     pytest.sel.force_navigate("infrastructure_providers")

--- a/cfme/tests/infrastructure/test_advanced_search_vms.py
+++ b/cfme/tests/infrastructure/test_advanced_search_vms.py
@@ -16,7 +16,7 @@ from cfme.web_ui.cfme_exception import (assert_no_cfme_exception,
 def vms():
     """Ensure the infra providers are set up and get list of vms"""
     try:
-        setup_a_provider(prov_type="infra", required_keys="large")
+        setup_a_provider(prov_class="infra", required_keys=["large"])
     except Exception:
         pytest.skip("It's not possible to set up any providers, therefore skipping")
     pytest.sel.force_navigate("infra_vms")


### PR DESCRIPTION
Fixing `setup_a_provider`call in advanced search tests.
Fixing `setup_a_provider` function so that it doesn't iterate over chars of "required_keys" when "required_keys" is a string, not list (in `all(key in providers_data[provider] for key in required_keys)`).