### PR TITLE
Patch that fixes line 25 in test_pods_prop_data_integrity.py

### DIFF
--- a/cfme/tests/containers/test_pods_prop_data_integrity.py
+++ b/cfme/tests/containers/test_pods_prop_data_integrity.py
@@ -22,7 +22,7 @@ def test_summary_properties_validation(provider):
         is the same number that appears in the Relationships table containers field
     """
     sel.force_navigate('containers_pods')
-    ui_pods = ui_pods = [r.name.text for r in list_tbl.rows()]
+    ui_pods = [r.name.text for r in list_tbl.rows()]
 
     for name in ui_pods:
         obj = Pod(name, provider)


### PR DESCRIPTION
Purpose or Intent
=================

{{pytest: cfme/tests/containers/test_pods_prop_data_integrity.py -v --use-provider container }}
