### PR TITLE
Update package dependencies in getting_started

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -63,7 +63,7 @@ Detailed steps (manual environment setup):
   * ``libxslt-devel``
   * ``zeromq3-devel``
   * ``libcurl-devel``
-  * ``redhat-rpm-config`` if you use some kind of really stripped system.
+  * ``redhat-rpm-config``
   * ``gcc-c++``
   * ``openssl-devel``
   * ``libffi-devel``


### PR DESCRIPTION
Purpose or Intent
=================

Clean/clear up the 'ReadTheDocs' Getting Started page.

There was a comment for the redhat-rpm-config package being for 'stripped down systems' - it looks like this package isn't included by default in Fed24 anymore so its a 'regular' prerequisite.