### PR TITLE
Fixed typo in test_relationships_tables.py

### DIFF
--- a/cfme/tests/containers/test_relationships_tables.py
+++ b/cfme/tests/containers/test_relationships_tables.py
@@ -159,7 +159,7 @@ def test_replicators_rel(provider, rel):
 @pytest.mark.meta(blockers=[1365878])
 @pytest.mark.parametrize('rel',
                          ['Containers Provider',
-                          'Image registry',
+                          'Image Registry',
                           'Projects',
                           'Pods',
                           'Containers',


### PR DESCRIPTION
Purpose or Intent
=================

{{pytest: cfme/tests/containers/test_relationships_tables.py -v --use-provider container }}

