### PR TITLE
fixed timelines tests for infrastructure providers

### DIFF
--- a/cfme/infrastructure/cluster.py
+++ b/cfme/infrastructure/cluster.py
@@ -4,14 +4,14 @@
 :var page: A :py:class:`cfme.web_ui.Region` object describing common elements on the
            Cluster pages.
 """
-
 from cfme.web_ui.menu import nav
 from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import Quadicon, Region, listaccordion as list_acc, paginator, toolbar as tb, flash
+from cfme.web_ui import Quadicon, Region, listaccordion as list_acc, toolbar as tb, flash
 from functools import partial
 from utils.pretty import Pretty
-from utils.providers import get_crud
+from utils.providers import get_crud, get_provider_key
 from utils.wait import wait_for
+from utils.api import rest_api
 
 details_page = Region(infoblock_type='detail')
 
@@ -28,8 +28,8 @@ def nav_to_cluster_through_provider(context):
 nav.add_branch(
     'infrastructure_clusters', {
         'infrastructure_cluster':
-        lambda ctx: sel.click(Quadicon(ctx['cluster'].name, 'cluster'))
-        if 'provider' not in ctx else nav_to_cluster_through_provider(ctx)
+            lambda ctx: sel.click(Quadicon(ctx['cluster'].name, 'cluster'))
+            if 'provider' not in ctx else nav_to_cluster_through_provider(ctx)
     }
 )
 
@@ -49,10 +49,19 @@ class Cluster(Pretty):
 
     def __init__(self, name=None, provider_key=None):
         self.name = name
-        if provider_key:
-            self.provider = get_crud(provider_key)
-        else:
-            self.provider = None
+        self._short_name = self.name.split('in')[0].strip()
+
+        col = rest_api().collections
+        cluster = [cl for cl in col.clusters.all if cl.name == self._short_name][-1]
+        self._cluster_id = cluster.id
+        provider_id = cluster.ems_id
+
+        #  fixme: to remove this part when provider_key becomes mandatory field
+        if not provider_key:
+            provider_name = [pr.name for pr in col.providers.all if pr.id == provider_id][-1]
+            provider_key = get_provider_key(provider_name)
+
+        self.provider = get_crud(provider_key)
 
     def _get_context(self):
         context = {'cluster': self}
@@ -74,12 +83,12 @@ class Cluster(Pretty):
     def wait_for_delete(self):
         sel.force_navigate('infrastructure_clusters')
         wait_for(lambda: not self.exists, fail_condition=False,
-             message="Wait cluster to disappear", num_sec=500, fail_func=sel.refresh)
+                 message="Wait cluster to disappear", num_sec=500, fail_func=sel.refresh)
 
     def wait_for_appear(self):
         sel.force_navigate('infrastructure_clusters')
         wait_for(lambda: self.exists, fail_condition=False,
-             message="Wait cluster to appear", num_sec=1000, fail_func=sel.refresh)
+                 message="Wait cluster to appear", num_sec=1000, fail_func=sel.refresh)
 
     def get_detail(self, *ident):
         """ Gets details from the details infoblock
@@ -111,6 +120,16 @@ class Cluster(Pretty):
         except sel.NoSuchElementException:
             return False
 
+    @property
+    def cluster_id(self):
+        """extracts cluster id for this cluster"""
+        return self._cluster_id
+
+    @property
+    def short_name(self):
+        """returns only cluster's name exactly how it is stored in DB (without datacenter part)"""
+        return self._short_name
+
     def run_smartstate_analysis(self):
         sel.force_navigate('infrastructure_cluster', context={'cluster': self})
         tb.select('Configuration', 'Perform SmartState Analysis', invokes_alert=True)
@@ -118,13 +137,11 @@ class Cluster(Pretty):
         flash.assert_message_contain('Cluster / Deployment Role: scan successfully initiated')
 
 
-def get_all_clusters(do_not_navigate=False):
+def get_all_clusters():
     """Returns list of all clusters"""
-    if not do_not_navigate:
-        sel.force_navigate('infrastructure_clusters')
-    clusters = set([])
-    for page in paginator.pages():
-        for title in sel.elements(
-                "//div[@id='quadicon']/../../../tr/td/a[contains(@href,'cluster/show')]"):
-            clusters.add(sel.get_attribute(title, "title"))
+
+    sel.force_navigate('infrastructure_clusters')
+    clusters = []
+    for cluster in Quadicon.all(this_page=True):
+        clusters.append(Cluster(cluster.name))
     return clusters

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -456,8 +456,13 @@ class Vm(BaseVM, Common):
             return False
         return True
 
-    class CfmeRelationship(object):
+    @property
+    def cluster_id(self):
+        """returns id of cluster current vm belongs to"""
+        vm = self.get_vm_via_rest()
+        return int(vm.ems_cluster_id)
 
+    class CfmeRelationship(object):
         relationship_form = Form(
             fields=[
                 ('server_select', Select("//*[@id='server_id']")),

--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -3,6 +3,7 @@ import fauxfactory
 import pytest
 
 from cfme.common.vm import VM
+from cfme.infrastructure.cluster import get_all_clusters
 from cfme.rest import a_provider as _a_provider
 from cfme.rest import vm as _vm
 from cfme.web_ui import InfoBlock, toolbar, jstimelines
@@ -11,6 +12,7 @@ from utils import testgen
 from utils import version
 from utils.log import logger
 from utils.wait import wait_for
+from selenium.common.exceptions import NoSuchElementException
 
 
 pytestmark = [pytest.mark.tier(2)]
@@ -52,6 +54,7 @@ def test_vm(request, provider, vm_name, setup_provider_modscope):
 
     if not provider.mgmt.does_vm_exist(vm_name):
         vm.create_on_provider(find_in_cfme=True, allow_skip="default")
+        vm.refresh_relationships()
     return vm
 
 
@@ -63,15 +66,19 @@ def gen_events(delete_fx_provider_event, provider, test_vm):
     mgmt.start_vm(test_vm.name)
 
 
-def count_events(vm_name, nav_step):
+def count_events(vm, nav_step):
     try:
         nav_step()
     except ToolbarOptionGreyedOrUnavailable:
         return 0
+    except NoSuchElementException:
+        vm.rediscover()
+        return 0
+
     events = []
     for event in jstimelines.events():
         data = event.block_info()
-        if vm_name in data.values():
+        if vm.name in data.values():
             events.append(event)
             if len(events) > 0:
                 return len(events)
@@ -90,7 +97,7 @@ def test_provider_event(provider, gen_events, test_vm):
         pytest.sel.force_navigate('infrastructure_provider',
                                   context={'provider': provider})
         toolbar.select('Monitoring', 'Timelines')
-    wait_for(count_events, [test_vm.name, nav_step], timeout=60, fail_condition=0,
+    wait_for(count_events, [test_vm, nav_step], timeout='5m', fail_condition=0,
              message="events to appear")
 
 
@@ -106,7 +113,8 @@ def test_host_event(provider, gen_events, test_vm):
         test_vm.load_details()
         pytest.sel.click(InfoBlock.element('Relationships', 'Host'))
         toolbar.select('Monitoring', 'Timelines')
-    wait_for(count_events, [test_vm.name, nav_step], timeout=60, fail_condition=0,
+
+    wait_for(count_events, [test_vm, nav_step], timeout='10m', fail_condition=0,
              message="events to appear")
 
 
@@ -121,7 +129,8 @@ def test_vm_event(provider, gen_events, test_vm):
     def nav_step():
         test_vm.load_details()
         toolbar.select('Monitoring', 'Timelines')
-    wait_for(count_events, [test_vm.name, nav_step], timeout=60, fail_condition=0,
+
+    wait_for(count_events, [test_vm, nav_step], timeout='3m', fail_condition=0,
              message="events to appear")
 
 
@@ -134,11 +143,12 @@ def test_cluster_event(provider, gen_events, test_vm):
         test_flag: timelines, provision
     """
     def nav_step():
-        test_vm.load_details()
-        pytest.sel.click(InfoBlock.element('Relationships', 'Cluster'))
+        cluster = [cl for cl in get_all_clusters() if cl.cluster_id == test_vm.cluster_id][-1]
+        pytest.sel.force_navigate('infrastructure_cluster',
+                                  context={'cluster': cluster})
         toolbar.select('Monitoring', 'Timelines')
-    wait_for(count_events, [test_vm.name, nav_step], timeout=60, fail_condition=0,
-             message="events to appear")
+    wait_for(count_events, [test_vm, nav_step], timeout='5m',
+             fail_condition=0, message="events to appear")
 
 
 class TestVmEventRESTAPI(object):

--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -2468,6 +2468,9 @@ class Quadicon(Pretty):
                 return False
         return sel.is_displayed(self._locate_quadrant("e"))  # Image has only 'e'
 
+    @property
+    def href(self):
+        return self.locate().get_attribute('href')
 
 class DHTMLSelect(Select):
     """


### PR DESCRIPTION
Fixed timelines tests
=================
Cluster and Host timelines tests often failed because just provisioned VM's often didn't have relationships for them. This issue appears mainly for RHEV providers. Appropriate BZ is submitted - 1373826.
I had to prepare the following workarounds due to that issue:
1. Correct cluster is discovered by vm's rest api now. The tests opened it via All Clusters page.
2. Correct host cannot be discovered via rest api. So, the tests use re-discover feature to get proper vm relationships.

{{pytest: cfme/tests/infrastructure/test_timelines.py}}