### PR TITLE
update version regex for downstream-57z.

### DIFF
--- a/utils/trackerbot.py
+++ b/utils/trackerbot.py
@@ -24,6 +24,7 @@ stream_matchers = (
     (get_stream('5.4'), r'^cfme-54.*-(?P<month>\d{2})(?P<day>\d{2})'),
     (get_stream('5.5'), r'^cfme-55.*-(?P<month>\d{2})(?P<day>\d{2})'),
     (get_stream('5.6'), r'^cfme-56.*-(?P<month>\d{2})(?P<day>\d{2})'),
+    (get_stream('5.7'), r'^cfme-57.*-(?P<month>\d{2})(?P<day>\d{2})'),
     # Nightly builds have potentially multiple version streams bound to them so we
     # cannot use get_stream()
     ('upstream_stable', r'^miq-stable-darga-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})'),

--- a/utils/version.py
+++ b/utils/version.py
@@ -337,6 +337,7 @@ version_stream_product_mapping = {
     '5.4': SPTuple('downstream-54z', '3.2'),
     '5.5': SPTuple('downstream-55z', '4.0'),
     '5.6': SPTuple('downstream-56z', '4.1'),
+    '5.7': SPTuple('downstream-57z', '4.2'),
     LATEST: SPTuple('upstream', 'master')
 }
 


### PR DESCRIPTION
  * added 5.7 version to version.py
  * trackerbot.py streammatchers are updated with regex for 5.7