### PR TITLE
Remove @removed from class

### DIFF
--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -74,7 +74,6 @@ if WebElement.__repr__ is not __repr__:
     WebElement.__repr__ = __repr__
 
 
-@removed
 class ByValue(Pretty):
     pretty_attrs = ['value']
 
@@ -88,7 +87,6 @@ class ByValue(Pretty):
         return str(self.value)
 
 
-@removed
 class ByText(Pretty):
     pretty_attrs = ['text']
 
@@ -1463,7 +1461,6 @@ class Select(SeleniumSelect, Pretty):
             type(self).__name__, repr(self._loc), repr(self.is_multiple))
 
 
-@removed
 @multidispatch
 def select(loc, o):
     raise NotImplementedError('Unable to select {} in this type: {}'.format(o, loc))


### PR DESCRIPTION
Purpose or Intent
=================

* @removed changes the class which is required for proper multimethod
  selection
* @removed has been removed from ByText and ByValue as it was causing
  them to fail