### PR TITLE
Removed tenants and AZ tests, templates fix

### DIFF
--- a/cfme/tests/openstack/test_relationships.py
+++ b/cfme/tests/openstack/test_relationships.py
@@ -23,28 +23,6 @@ def test_assinged_roles(provider):
     assert result > 0
 
 
-def test_assinged_tenants(provider):
-    provider.load_details()
-    result = provider.summary.relationships.cloud_tenants.value
-    """
-    todo get the list of tenants from external resource and compare
-    it with result - currently not 0
-    """
-
-    assert result > 0
-
-
-def test_assinged_zones(provider):
-    provider.load_details()
-    result = provider.summary.relationships.availability_zones.value
-    """
-    todo get the list of tenants from external resource and compare
-    it with result - currently not 0
-    """
-
-    assert result > 0
-
-
 def test_nodes(provider):
     provider.load_details()
     result = provider.summary.relationships.nodes.value
@@ -61,10 +39,10 @@ def test_templates(provider):
     result = provider.summary.relationships.templates.value
     """
     todo get the list of images/templates from external resource and compare
-    it with result - currently  5
+    it with result - currently  bigger than 0
     """
 
-    assert result == 5
+    assert result > 0
 
 
 def test_stacks(provider):


### PR DESCRIPTION
# Purpose or Intent

Since version 5.6.2 in infra provider there is no need to verify AZ and tenants

{{pytest: cfme/tests/infrastructure/test_host_role_type.py cfme/tests/infrastructure/test_roles_names.py -v --use-provider tripleo }}
