### PR TITLE
Added support of Middleware Server Alert Profile

### DIFF
--- a/cfme/control/explorer.py
+++ b/cfme/control/explorer.py
@@ -160,6 +160,7 @@ def _conditions(ugly, nice1, nice2):
         }
     ]
 
+
 nav.add_branch(
     "control_explorer",
     {
@@ -292,6 +293,11 @@ nav.add_branch(
 
         "server_alert_profile": _ap_single_branch("server", "Server"),
         "server_alert_profiles": _ap_multi_branch("server", "Server"),
+
+        "middleware_server_alert_profile": _ap_single_branch(
+            "middleware_server", "Middleware Server"),
+        "middleware_server_alert_profiles": _ap_multi_branch(
+            "middleware_server", "Middleware Server"),
 
         "provider_alert_profile": _ap_single_branch("provider", "Provider"),
         "provider_alert_profiles": _ap_multi_branch("provider", "Provider"),
@@ -983,7 +989,7 @@ class Alert(Updateable, Pretty):
             ("active", Input("enabled_cb")),
             ("based_on", {
                 version.LOWEST: Select("select#miq_alert_db"),
-                "5.5": AngularSelect("miq_alert_db")}),
+                "5.5": AngularSelect("miq_alert_db", exact=True)}),
             ("evaluate", {
                 version.LOWEST: Select("select#exp_name"),
                 "5.5": AngularSelect("exp_name")}),
@@ -1745,6 +1751,11 @@ class DatastoreAlertProfile(BaseAlertProfile):
 class HostAlertProfile(BaseAlertProfile):
     PREFIX = "host"
     TYPE = "Host / Node"
+
+
+class MiddlewareServerAlertProfile(BaseAlertProfile):
+    PREFIX = "middleware_server"
+    TYPE = "Middleware Server"
 
 
 class ProviderAlertProfile(BaseAlertProfile):

--- a/cfme/tests/control/test_basic.py
+++ b/cfme/tests/control/test_basic.py
@@ -210,14 +210,11 @@ ALERT_PROFILES = [
     explorer.ClusterAlertProfile,
     explorer.DatastoreAlertProfile,
     explorer.HostAlertProfile,
+    explorer.MiddlewareServerAlertProfile,
     explorer.ProviderAlertProfile,
     explorer.ServerAlertProfile,
     explorer.VMInstanceAlertProfile
 ]
-
-if current_version() >= "5.7":
-    ALERT_PROFILES.append(explorer.MiddlewareServerAlertProfile)
-
 
 @pytest.yield_fixture
 def random_vm_control_policy():
@@ -278,7 +275,8 @@ def control_policy(request):
     policy.delete()
 
 
-@pytest.yield_fixture(params=ALERT_PROFILES, ids=lambda alert_profile: alert_profile.__name__)
+@pytest.yield_fixture(params=ALERT_PROFILES,
+    ids=lambda alert_profile_class: alert_profile_class.__name__)
 def alert_profile(request):
     alert = explorer.Alert(
         fauxfactory.gen_alphanumeric(),
@@ -500,6 +498,8 @@ def test_control_alert_copy(random_alert, soft_assert):
 
 
 @pytest.mark.tier(2)
+@pytest.mark.uncollectif(lambda alert_profile: alert_profile.TYPE == "Middleware Server" and
+    current_version() < "5.7")
 def test_alert_profile_crud(alert_profile, soft_assert):
     alert_profile.create()
     soft_assert(alert_profile.exists, "The alert profile {} does not exist!".format(

--- a/cfme/tests/control/test_basic.py
+++ b/cfme/tests/control/test_basic.py
@@ -215,6 +215,9 @@ ALERT_PROFILES = [
     explorer.VMInstanceAlertProfile
 ]
 
+if current_version() >= "5.7":
+    ALERT_PROFILES.append(explorer.MiddlewareServerAlertProfile)
+
 
 @pytest.yield_fixture
 def random_vm_control_policy():


### PR DESCRIPTION
{{pytest: cfme/tests/control/test_basic.py -k test_alert_profile_crud --long-running}}