### PR TITLE
Fix Chargeback Rate API tests

### DIFF
--- a/cfme/rest/__init__.py
+++ b/cfme/rest/__init__.py
@@ -168,7 +168,7 @@ def rates(request, rest_api):
     chargeback = rest_api.collections.chargebacks.get(rate_type='Compute')
     data = [{
         'description': 'test_rate_{}_{}'.format(_index, fauxfactory.gen_alphanumeric()),
-        'rate': 1,
+        'source': 'allocated',
         'group': 'cpu',
         'per_time': 'daily',
         'per_unit': 'megahertz',


### PR DESCRIPTION
{{pytest: '''cfme/tests/intelligence/test_chargeback.py::TestRatesViaREST'' -v'}}

Fix reflecting changes in the API.
See https://bugzilla.redhat.com/show_bug.cgi?id=1366019