### PR TITLE
Cloud Provider navmazing 

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -197,6 +197,7 @@ class BaseProvider(Taggable, Updateable, SummaryMixin):
            validate_credentials (boolean): Whether to validate credentials - if True and the
                credentials are invalid, an error will be raised.
         """
+        # TODO: replace with navigate_to() once implemented for all provider types
         sel.force_navigate('{}_provider_new'.format(self.page_name))
         fill(self.properties_form, self._form_mapping(True, **self.__dict__))
         for cred in self.credentials:
@@ -215,6 +216,7 @@ class BaseProvider(Taggable, Updateable, SummaryMixin):
            updates (dict): fields that are changing.
            cancel (boolean): whether to cancel out of the update.
         """
+        # TODO: replace with navigate_to() once implemented for all provider types
         sel.force_navigate('{}_{}'.format(self.page_name, self.edit_page_suffix),
             context={'provider': self})
         fill(self.properties_form, self._form_mapping(**updates))
@@ -325,6 +327,7 @@ class BaseProvider(Taggable, Updateable, SummaryMixin):
     def refresh_provider_relationships_ui(self, from_list_view=False):
         """Clicks on Refresh relationships button in provider"""
         if from_list_view:
+            # TODO: replace with navigate_to() once implemented for all provider types
             sel.force_navigate("{}_providers".format(self.page_name))
             sel.check(Quadicon(self.name, self.quad_name).checkbox())
         else:
@@ -410,6 +413,7 @@ class BaseProvider(Taggable, Updateable, SummaryMixin):
             return False
 
     def wait_for_delete(self):
+        # TODO: replace with navigate_to() once implemented for all provider types
         sel.force_navigate('{}_providers'.format(self.page_name))
         quad = Quadicon(self.name, self.quad_name)
         logger.info('Waiting for a provider to delete...')
@@ -434,6 +438,7 @@ class BaseProvider(Taggable, Updateable, SummaryMixin):
         """To be compatible with the Taggable and PolicyProfileAssignable mixins."""
         if not self._on_detail_page():
             logger.debug("load_details: not on details already, navigating")
+            # TODO: replace with navigate_to() once implemented for all provider types
             sel.force_navigate('{}_{}'.format(self.page_name, self.detail_page_suffix),
                 context={'provider': self})
         else:
@@ -520,6 +525,7 @@ class BaseProvider(Taggable, Updateable, SummaryMixin):
     def clear_provider_by_type(prov_class, validate=True):
         string_name = prov_class.string_name
         navigate = "{}_providers".format(prov_class.page_name)
+        # TODO: replace with navigate_to() once implemented for all provider types
         sel.force_navigate(navigate)
         logger.debug('Checking for existing {} providers...'.format(prov_class.type_tclass))
         total = paginator.rec_total()
@@ -541,6 +547,7 @@ class BaseProvider(Taggable, Updateable, SummaryMixin):
     @staticmethod
     def wait_for_no_providers_by_type(prov_class):
         navigate = "{}_providers".format(prov_class.page_name)
+        # TODO: replace with navigate_to() once implemented for all provider types
         sel.force_navigate(navigate)
         logger.debug('Waiting for all {} providers to disappear...'.format(prov_class.type_tclass))
         wait_for(
@@ -582,6 +589,7 @@ class CloudInfraProvider(BaseProvider, PolicyProfileAssignable):
         self.refresh_provider_relationships(from_list_view=True)
 
         def _wait_f():
+            # TODO: replace with navigate_to() once implemented for all provider types
             sel.force_navigate("{}_providers".format(self.page_name))
             q = Quadicon(self.name, self.quad_name)
             creds = q.creds
@@ -602,6 +610,7 @@ class CloudInfraProvider(BaseProvider, PolicyProfileAssignable):
 
         Returns: :py:class:`set` of :py:class:`str` of Policy Profile names
         """
+        # TODO: replace with navigate_to() once implemented for all provider types
         sel.force_navigate('{}_provider_policy_assignment'.format(self.page_name),
             context={'provider': self})
         return self._assigned_policy_profiles
@@ -619,6 +628,7 @@ class CloudInfraProvider(BaseProvider, PolicyProfileAssignable):
 
         Returns: :py:class:`set` of :py:class:`str` of Policy Profile names
         """
+        # TODO: replace with navigate_to() once implemented for all provider types
         sel.force_navigate('{}_provider_policy_assignment'.format(self.page_name),
             context={'provider': self})
         return self._unassigned_policy_profiles

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -15,6 +15,7 @@ from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.web_ui import fill, flash
 from utils import testgen, version
+from utils.appliance.endpoints.ui import navigate_to
 from utils.update import update
 
 pytest_generate_tests = testgen.generate(testgen.cloud_providers, scope="function")
@@ -121,7 +122,7 @@ def test_type_required_validation(request, soft_assert):
         with error.expected('Type is required'):
             prov.create()
     else:
-        pytest.sel.force_navigate("clouds_provider_new")
+        navigate_to(prov, 'Add')
         fill(prov.properties_form.name_text, "foo")
         soft_assert("ng-invalid-required" in prov.properties_form.type_select.classes)
         soft_assert(not prov.add_provider_button.can_be_clicked)
@@ -297,7 +298,7 @@ def test_api_port_max_character_validation(request):
 def test_openstack_provider_has_api_version():
     """Check whether the Keystone API version field is present for Openstack."""
     prov = Provider()
-    pytest.sel.force_navigate("clouds_provider_new")
+    navigate_to(prov, 'Add')
     fill(prop_region.properties_form, {"type_select": "OpenStack"})
     pytest.sel.wait_for_ajax()
     assert pytest.sel.is_displayed(


### PR DESCRIPTION
{{pytest: cfme/tests/cloud/test_providers.py}}

Purpose or Intent
=================

Modify cloud provider module to use navmazing

Update test_providers to remove sel.force_navigate() calls

Add TODO's to the common provider module where navigation changes will need to be made.


Currently, master branch has 16/21 tests passing for cfme/test/cloud/test_providers().  JIRA card RHCFQE-625 written to capture failures.  Tested locally with the same pass rate on new navigation.