### PR TITLE
Cloud Stack Navmazing

### DIFF
--- a/cfme/cloud/instance.py
+++ b/cfme/cloud/instance.py
@@ -113,6 +113,9 @@ class Instance(VM):
     QUADICON_TYPE = "instance"
     VM_TYPE = "Instance"
 
+    REMOVE_SINGLE = {version.LOWEST: "Remove from the VMDB",
+            '5.6': 'Remove Instance'}
+
     def create(self):
         """Provisions an instance with the given properties through CFME
         """

--- a/cfme/cloud/stack.py
+++ b/cfme/cloud/stack.py
@@ -1,26 +1,23 @@
-import cfme.fixtures.pytest_selenium as sel
-from cfme.web_ui import Quadicon, Region, SplitTable, flash, Form, fill, form_buttons, Table
-from utils.pretty import Pretty
 from functools import partial
-from cfme.web_ui import toolbar as tb
-from cfme.web_ui.menu import nav
-from cfme import web_ui as ui
 from xml.sax.saxutils import quoteattr
-from cfme.exceptions import CFMEException
+
+from navmazing import NavigateToSibling, NavigateToAttribute
+
+import cfme.fixtures.pytest_selenium as sel
+from cfme import web_ui as ui
+from cfme.exceptions import DestinationNotFound
+from cfme.web_ui import Quadicon, flash, Form, fill, form_buttons, paginator, toolbar as tb, \
+    summary_title, accordion
+from cfme.exceptions import CFMEException, FlashMessageException
+from utils.appliance import Navigatable
+from utils.appliance.endpoints.ui import navigator, navigate_to, CFMENavigateStep
+from utils.pretty import Pretty
 from utils.wait import wait_for
-from utils import version
 
 
-details_page = Region(infoblock_type='detail')
 cfg_btn = partial(tb.select, "Configuration")
 pol_btn = partial(tb.select, 'Policy')
 lifecycle_btn = partial(tb.select, 'Lifecycle')
-output_table = lambda: version.pick(
-    {'5.5': Table('//div[@id="list_grid"]/table'),
-    '5.4': SplitTable(
-        ('//*[@id="list_grid"]//table[contains(@class, "hdr")]/tbody', 1),
-        ('//*[@id="list_grid"]//table[contains(@class, "obj")]/tbody', 1))}
-)
 
 edit_tags_form = Form(
     fields=[
@@ -28,28 +25,53 @@ edit_tags_form = Form(
         ("select_value", ui.Select("select#tag_add"))
     ])
 
-nav.add_branch(
-    'clouds_stacks', {
-        'clouds_stack':
-        lambda ctx: sel.click(Quadicon(ctx['stack'].name, 'stack'))
-    }
-)
+
+def match_title_and_controller():
+    title_match = sel.execute_script('return document.title;') == 'CFME: Stacks'
+    controller_match = sel.execute_script('return ManageIQ.controller;') == 'orchestration_stack'
+    return title_match and controller_match
 
 
-class Stack(Pretty):
+class Stack(Pretty, Navigatable):
     pretty_attrs = ['name']
 
-    def __init__(self, name=None):
+    def __init__(self, name=None, quad_name=None, appliance=None):
         self.name = name
+        self.quad_name = quad_name or 'stack'
+        Navigatable.__init__(self, appliance=appliance)
 
-    def delete(self):
-        sel.force_navigate('clouds_stack', context={'stack': self})
-        cfg_btn("Remove this Stack from the VMDB", invokes_alert=True)
+    def delete(self, from_dest='All'):
+        """
+        Delete the stack, starting from the destination provided by from_dest
+        @param from_dest: where to delete from, a valid navigation destination for Stack
+        """
+
+        # Navigate to the starting destination
+        if from_dest in navigator.list_destinations(self):
+            navigate_to(self, from_dest)
+        else:
+            msg = 'cfme.cloud.stack does not have destination {}'.format(from_dest)
+            raise DestinationNotFound(msg)
+
+        # Delete using the method appropriate for the starting destination
+        if from_dest == 'All':
+            sel.check(Quadicon(self.name, self.quad_name).checkbox())
+            cfg_btn("Remove Orchestration Stacks", invokes_alert=True)
+        elif from_dest == 'Details':
+            cfg_btn("Remove this Orchestration Stack", invokes_alert=True)
+
         sel.handle_alert()
-        flash.assert_success_message('The selected Orchestration Stack was deleted')
+        # The delete initiated message may get missed if the delete is fast
+        try:
+            flash.assert_message_contain("Delete initiated for 1 Orchestration Stacks")
+        except FlashMessageException as ex:
+            if 'No flash message contains' in ex.message:
+                flash.assert_message_contain("The selected Orchestration Stacks was deleted")
+
+        self.wait_for_delete()
 
     def edit_tags(self, tag, value):
-        sel.force_navigate('clouds_stack', context={'stack': self})
+        navigate_to(self, 'EditTags')
         pol_btn('Edit Tags', invokes_alert=True)
         fill(edit_tags_form, {'select_tag': tag,
                               'select_value': value},
@@ -60,52 +82,125 @@ class Stack(Pretty):
             raise CFMEException("{} ({}) tag is not assigned!".format(tag.replace(" *", ""), value))
 
     def get_tags(self):
-        sel.force_navigate('clouds_stack', context={'stack': self})
+        navigate_to(self, 'Details')
         row = sel.elements("//*[(self::th or self::td) and normalize-space(.)={}]/../.."
                      "//td[img[contains(@src, 'smarttag')]]".format(quoteattr("My Company Tags")))
         company_tag = sel.text(row).strip()
         return company_tag
 
-    def nav_to_security_group_link(self):
-        sel.force_navigate('clouds_stack', context={'stack': self})
-        if version.current_version() <= '5.4':
-            sel.click(details_page.infoblock.element("Relationships", "Security Groups"))
-        if version.current_version() >= '5.5':
-            sel.click(details_page.infoblock.element("Relationships", "Security groups"))
-
-    def nav_to_parameters_link(self):
-        sel.force_navigate('clouds_stack', context={'stack': self})
-        sel.click(details_page.infoblock.element("Relationships", "Parameters"))
-
-    def nav_to_output_link(self):
-        sel.force_navigate('clouds_stack', context={'stack': self})
-        sel.click(details_page.infoblock.element("Relationships", "Outputs"))
-        cells = {'Key': "WebsiteURL"}
-        output_table().click_rows_by_cells(cells, "Key", True)
-
-    def nav_to_resources_link(self):
-        sel.force_navigate('clouds_stack', context={'stack': self})
-        sel.click(details_page.infoblock.element("Relationships", "Resources"))
-
     def wait_for_delete(self):
-        sel.force_navigate("clouds_stacks")
-        quad = Quadicon(self.name, 'stack')
-        wait_for(lambda: not sel.is_displayed(quad), fail_condition=False,
-            message="Wait stack to disappear", num_sec=500, fail_func=sel.refresh)
+        navigate_to(self, 'All')
+        wait_for(lambda: not sel.is_displayed(Quadicon(self.name, self.quad_name)),
+            fail_condition=False, message="Wait stack to disappear", num_sec=500,
+            fail_func=sel.refresh)
 
     def wait_for_appear(self):
-        sel.force_navigate("clouds_stacks")
-        quad = Quadicon(self.name, 'stack')
-        wait_for(sel.is_displayed, func_args=[quad], fail_condition=False,
-            message="Wait stack to appear", num_sec=1000, fail_func=sel.refresh)
+        navigate_to(self, 'All')
+        wait_for(lambda: sel.is_displayed(Quadicon(self.name, self.quad_name)),
+            fail_condition=False, message="Wait stack to appear", num_sec=1000,
+            fail_func=sel.refresh)
 
-    def retire_stack(self):
-        sel.force_navigate('clouds_stack', context={'stack': self})
+    def retire_stack(self, wait=True):
+        navigate_to(self, 'All')
+        sel.check(Quadicon(self.name, self.quad_name).checkbox())
         lifecycle_btn("Retire this Orchestration Stack", invokes_alert=True)
         sel.handle_alert()
         flash.assert_success_message('Retirement initiated for 1 Orchestration'
         ' Stack from the CFME Database')
-        sel.force_navigate("clouds_stacks")
-        quad = Quadicon(self.name, 'stack')
-        wait_for(lambda: not sel.is_displayed(quad), fail_condition=False,
-            message="Wait stack to disappear", num_sec=500, fail_func=sel.refresh)
+        if wait:
+            self.wait_for_delete()
+
+
+@navigator.register(Stack, 'All')
+class All(CFMENavigateStep):
+    prerequisite = NavigateToAttribute('appliance', 'LoggedIn')
+
+    def am_i_here(self):
+        summary_match = summary_title() == 'Orchestration Stacks'
+        return match_title_and_controller() and summary_match
+
+    def step(self):
+        from cfme.web_ui.menu import nav
+        nav._nav_to_fn('Compute', 'Clouds', 'Stacks')(None)
+
+    def resetter(self):
+        tb.select('Grid View')
+        sel.check(paginator.check_all())
+        sel.uncheck(paginator.check_all())
+
+
+@navigator.register(Stack, 'Details')
+class Details(CFMENavigateStep):
+    prerequisite = NavigateToSibling('All')
+
+    def am_i_here(self):
+        summary_match = summary_title() == '{} (Summary)'.format(self.obj.name)
+        return match_title_and_controller() and summary_match
+
+    def step(self):
+        sel.click(Quadicon(self.obj.name, self.obj.quad_name))
+
+
+@navigator.register(Stack, 'EditTags')
+class EditTags(CFMENavigateStep):
+    prerequisite = NavigateToSibling('All')
+
+    def step(self):
+        sel.check(Quadicon(self.obj.name, self.obj.quad_name).checkbox())
+        pol_btn('Edit Tags')
+
+
+@navigator.register(Stack, 'RelationshipSecurityGroups')
+class RelationshipsSecurityGroups(CFMENavigateStep):
+    prerequisite = NavigateToSibling('Details')
+
+    def am_i_here(self):
+        summary_match = summary_title() == '{} (All Security Groups)'.format(self.obj.name)
+        return match_title_and_controller() and summary_match
+
+    def step(self):
+        accordion.click('Relationships')
+        # Click by anchor title since text contains a dynamic component
+        sel.click('//*[@id="stack_rel"]//a[@title="Show all Security Groups"]')
+
+
+@navigator.register(Stack, 'RelationshipParameters')
+class RelationshipParameters(CFMENavigateStep):
+    prerequisite = NavigateToSibling('Details')
+
+    def am_i_here(self):
+        summary_match = summary_title() == '{} (Parameters)'.format(self.obj.name)
+        return match_title_and_controller() and summary_match
+
+    def step(self):
+        accordion.click('Relationships')
+        # Click by anchor title since text contains a dynamic component
+        sel.click('//*[@id="stack_rel"]//a[@title="Show all Parameters"]')
+
+
+@navigator.register(Stack, 'RelationshipOutputs')
+class RelationshipOutputs(CFMENavigateStep):
+    prerequisite = NavigateToSibling('Details')
+
+    def am_i_here(self):
+        summary_match = summary_title() == '{} (Outputs)'.format(self.obj.name)
+        return match_title_and_controller() and summary_match
+
+    def step(self):
+        accordion.click('Relationships')
+        # Click by anchor title since text contains a dynamic component
+        sel.click('//*[@id="stack_rel"]//a[@title="Show all Outputs"]')
+
+
+@navigator.register(Stack, 'RelationshipResources')
+class RelationshipResources(CFMENavigateStep):
+    prerequisite = NavigateToSibling('Details')
+
+    def am_i_here(self):
+        summary_match = summary_title() == '{} (Resources)'.format(self.obj.name)
+        return match_title_and_controller() and summary_match
+
+    def step(self):
+        accordion.click('Relationships')
+        # Click by anchor title since text contains a dynamic component
+        sel.click('//*[@id="stack_rel"]//a[@title="Show all Resources"]')

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -21,8 +21,6 @@ from utils.update import Updateable
 from utils.virtual_machines import deploy_template
 from utils.wait import wait_for, TimedOutError
 
-from utils.log import logger
-
 from . import PolicyProfileAssignable, Taggable, SummaryMixin
 
 cfg_btn = partial(toolbar.select, "Configuration")
@@ -147,11 +145,10 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable, SummaryMixin
     TO_OPEN_EDIT = None  # Name of the item in Configuration that puts you in the form
     QUADICON_TYPE = "vm"
     # Titles of the delete buttons in configuration
-    REMOVE_SELECTED = { version.LOWEST: 'Remove selected items from the VMDB',
-            '5.6': 'Remove selected items' }
-    REMOVE_SINGLE = { version.LOWEST: "Remove from the VMDB",
+    REMOVE_SELECTED = {version.LOWEST: 'Remove selected items from the VMDB',
+            '5.6': 'Remove selected items'}
+    REMOVE_SINGLE = {version.LOWEST: "Remove from the VMDB",
             '5.6': 'Remove Virtual Machine'}
-
 
     ###
     # Shared behaviour
@@ -254,16 +251,10 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable, SummaryMixin
             cancel: Whether to cancel the action in the alert.
             from_details: Whether to use the details view or list view.
         """
-        logger.debug('vm.delete: Determine type')
-        vmtype = self.is_vm
-        logger.debug('vm.delete: is_vm? {}'.format(vmtype))
-
 
         if from_details:
             self.load_details(refresh=True)
-            btn_text = self.REMOVE_SINGLE
-            logger.debug('vm.delete: clicking cfg_btn for: {}'.format(btn_text))
-            cfg_btn(btn_text, invokes_alert=True)
+            cfg_btn(self.REMOVE_SINGLE, invokes_alert=True)
         else:
             self.find_quadicon(mark=True)
             cfg_btn(self.REMOVE_SELECTED, invokes_alert=True)

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -21,6 +21,8 @@ from utils.update import Updateable
 from utils.virtual_machines import deploy_template
 from utils.wait import wait_for, TimedOutError
 
+from utils.log import logger
+
 from . import PolicyProfileAssignable, Taggable, SummaryMixin
 
 cfg_btn = partial(toolbar.select, "Configuration")
@@ -145,8 +147,11 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable, SummaryMixin
     TO_OPEN_EDIT = None  # Name of the item in Configuration that puts you in the form
     QUADICON_TYPE = "vm"
     # Titles of the delete buttons in configuration
-    REMOVE_MULTI = "Remove selected items from the VMDB"    # For multiple items
-    REMOVE_SINGLE = "Remove from the VMDB"                  # For single item
+    REMOVE_SELECTED = { version.LOWEST: 'Remove selected items from the VMDB',
+            '5.6': 'Remove selected items' }
+    REMOVE_SINGLE = { version.LOWEST: "Remove from the VMDB",
+            '5.6': 'Remove Virtual Machine'}
+
 
     ###
     # Shared behaviour
@@ -249,12 +254,19 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable, SummaryMixin
             cancel: Whether to cancel the action in the alert.
             from_details: Whether to use the details view or list view.
         """
+        logger.debug('vm.delete: Determine type')
+        vmtype = self.is_vm
+        logger.debug('vm.delete: is_vm? {}'.format(vmtype))
+
+
         if from_details:
             self.load_details(refresh=True)
-            cfg_btn(self.REMOVE_SINGLE, invokes_alert=True)
+            btn_text = self.REMOVE_SINGLE
+            logger.debug('vm.delete: clicking cfg_btn for: {}'.format(btn_text))
+            cfg_btn(btn_text, invokes_alert=True)
         else:
             self.find_quadicon(mark=True)
-            cfg_btn(self.REMOVE_MULTI, invokes_alert=True)
+            cfg_btn(self.REMOVE_SELECTED, invokes_alert=True)
         sel.handle_alert(cancel=cancel)
 
     @property

--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -307,3 +307,7 @@ class UsingSharedTables(CFMEException):
 
 class MenuItemNotFound(CFMEException):
     """Raised during navigation of certain menu item was not found."""
+
+
+class DestinationNotFound(CFMEException):
+    """Raised during navigation where the navigator destination is not found"""

--- a/cfme/tests/cloud/test_delete_cloud_object.py
+++ b/cfme/tests/cloud/test_delete_cloud_object.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
-
-from cfme.fixtures import pytest_selenium as sel
-from cfme.cloud import stack
-from cfme.common.vm import VM
-from cfme.web_ui import toolbar
-from utils import testgen
-from utils.version import current_version
 import pytest
+
+from cfme.cloud.stack import Stack
+from cfme.common.vm import VM
+from cfme.fixtures import pytest_selenium as sel
+from cfme.web_ui import toolbar, Quadicon
+from utils import testgen
+from utils.appliance.endpoints.ui import navigate_to
+from utils.version import current_version
 
 
 def pytest_generate_tests(metafunc):
@@ -24,20 +25,18 @@ def set_grid():
     toolbar.select('Grid View')
 
 
-@pytest.fixture(scope="module")
-def set_grid_stack():
-    sel.force_navigate("clouds_stacks")
-    toolbar.select('Grid View')
-
-
 def reset():
+    # TODO replace this navigation with navmazing when cloud images supports it
     sel.force_navigate("clouds_images")
     toolbar.select('List View')
 
 
-def reset_grid_stack():
-    sel.force_navigate("clouds_stacks")
-    toolbar.select('List View')
+# TODO take generic object instead of stack when instance and image support navmazing destinations
+def refresh_and_wait(provider, stack):
+    provider.refresh_provider_relationships()
+    navigate_to(stack, 'All')
+    if not sel.is_displayed(Quadicon(stack.name, stack.quad_name)):
+        stack.wait_for_appear()
 
 
 def test_delete_instance(setup_provider, provider):
@@ -48,7 +47,7 @@ def test_delete_instance(setup_provider, provider):
     """
     instance_name = provider.data['remove_test']['instance']
     test_instance = VM.factory(instance_name, provider)
-    test_instance.delete()
+    test_instance.delete(from_details=False)
     test_instance.wait_for_delete()
     provider.refresh_provider_relationships()
     test_instance.wait_to_appear()
@@ -60,9 +59,11 @@ def test_delete_image(setup_provider, provider, set_grid, request):
     Metadata:
         test_flag: delete_object
     """
+    # TODO as of 5.6+ clouds_images is no longer in the menu tree
+    # Refactor to navigate via clouds instances accordion
     image_name = provider.data['remove_test']['image']
     test_image = VM.factory(image_name, provider, template=True)
-    test_image.delete()
+    test_image.delete(from_details=False)
     test_image.wait_for_delete()
     provider.refresh_provider_relationships()
     test_image.wait_to_appear()
@@ -70,16 +71,14 @@ def test_delete_image(setup_provider, provider, set_grid, request):
 
 
 @pytest.mark.uncollectif(lambda: current_version() < "5.4")
-def test_delete_stack(setup_provider, provider, set_grid_stack, request):
+def test_delete_stack(setup_provider, provider, provisioning, request):
     """ Tests delete stack
 
     Metadata:
         test_flag: delete_object
     """
-    stack_name = provider.data['remove_test']['stack']
-    test_stack = stack.Stack(stack_name)
-    test_stack.delete()
-    test_stack.wait_for_delete()
-    provider.refresh_provider_relationships()
-    test_stack.wait_for_appear()
-    request.addfinalizer(reset_grid_stack)
+    stack = Stack(provisioning['stack'])
+    refresh_and_wait(provider, stack)
+    stack.delete()
+    navigate_to(stack, 'All')
+    assert lambda: not sel.is_displayed(Quadicon(stack.name, stack.quad_name))

--- a/cfme/tests/configure/test_visual_cloud.py
+++ b/cfme/tests/configure/test_visual_cloud.py
@@ -20,7 +20,8 @@ grid_pages = [
     'clouds_volumes',
     'clouds_flavors',
     'clouds_instances',
-    'clouds_stacks',
+    # TODO cloud_stacks removed from list due to navmazing integration.
+    # Refactor when all grid pages have navmazing destinations
     'clouds_key_pairs',
     'clouds_object_stores',
 ]
@@ -88,6 +89,7 @@ def test_grid_page_per_item(request, setup_a_provider, page, set_grid):
     """
     request.addfinalizer(lambda: go_to_grid(page))
     limit = visual.grid_view_limit
+    # TODO replace with utils.appliance.endpoints.ui.navigate_to when all grid_pages support it
     sel.force_navigate(page)
     tb.select('Grid View')
     if paginator.rec_total() is not None:


### PR DESCRIPTION
{{pytest: cfme/tests/cloud/test_stack.py cfme/tests/cloud/test_delete_cloud_object.py cfme/tests/configure/test_visual_cloud.py}}


Purpose or Intent
=================

Integrate navmazing destinations into the cfme.cloud.stack module, and use those destinations test/cloud/test_stack.py

This includes some refactoring of the cloud tests that hit stacks, and some updates to vm methods to support refactoring and paramaterization of the delete tests.

Currently the test_delete_image() tests are failing, because clouds_images is no longer in the menu tree.


Marking WIP to address review comments and refactor some things from test into the object model.