### PR TITLE
[WIPTEST] Cluster should require provider obj

### DIFF
--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -15,9 +15,10 @@ from navmazing import NavigateToSibling, NavigateToAttribute
 from cfme.common.provider import CloudInfraProvider, import_all_modules_of
 from cfme.fixtures import pytest_selenium as sel
 from cfme.infrastructure.host import Host
+from cfme.infrastructure.cluster import Cluster
 from cfme.web_ui import (
     Region, Quadicon, Form, Select, CheckboxTree, fill, form_buttons, paginator, Input,
-    AngularSelect, toolbar as tb, Radio
+    AngularSelect, toolbar as tb, Radio, InfoBlock
 )
 from cfme.web_ui.form_buttons import FormButton
 from cfme.web_ui.menu import nav
@@ -31,7 +32,6 @@ from utils.log import logger
 from utils.pretty import Pretty
 from utils.varmeth import variable
 from utils.wait import wait_for
-
 
 details_page = Region(infoblock_type='detail')
 
@@ -276,6 +276,13 @@ class Provider(Pretty, CloudInfraProvider):
                  end_ip=self.end_ip)
 
     @property
+    def id(self):
+        """
+        returns current provider id using rest api
+        """
+        return rest_api().collections.providers.find_by(name=self.name)[0].id
+
+    @property
     def hosts(self):
         """Returns list of :py:class:`cfme.infrastructure.host.Host` that should belong to this
         provider according to the YAML
@@ -290,6 +297,16 @@ class Provider(Pretty, CloudInfraProvider):
             )
             result.append(Host(name=host["name"], credentials=cred))
         return result
+
+    def get_clusters(self):
+        """returns the list of clusters belonging to the provider"""
+        web_clusters = []
+        sel.force_navigate('infrastructure_provider', context={'provider': self})
+        sel.click(InfoBlock.element('Relationships', 'Clusters'))
+        icons = Quadicon.all(qtype='cluster')
+        for icon in icons:
+            web_clusters.append(Cluster(icon.name, self))
+        return web_clusters
 
 
 @navigator.register(Provider, 'All')
@@ -410,5 +427,6 @@ def wait_for_a_provider():
     logger.info('Waiting for a provider to appear...')
     wait_for(paginator.rec_total, fail_condition=None, message="Wait for any provider to appear",
              num_sec=1000, fail_func=sel.refresh)
+
 
 import_all_modules_of('cfme.infrastructure.provider')

--- a/cfme/tests/infrastructure/test_cluster_analysis.py
+++ b/cfme/tests/infrastructure/test_cluster_analysis.py
@@ -35,7 +35,7 @@ def test_run_cluster_analysis(request, setup_provider, provider, remove_test, so
         test_flag: cluster_analysis
     """
     cluster_name = remove_test['cluster']
-    test_cluster = cluster.Cluster(name=cluster_name)
+    test_cluster = cluster.Cluster(name=cluster_name, provider=provider)
     wait_for(lambda: test_cluster.exists, delay=10, num_sec=120, fail_func=sel.refresh)
 
     # Initiate analysis

--- a/cfme/tests/infrastructure/test_delete_infra_object.py
+++ b/cfme/tests/infrastructure/test_delete_infra_object.py
@@ -39,7 +39,7 @@ def test_delete_cluster(setup_provider, provider, remove_test):
         test_flag: delete_object
     """
     cluster_name = remove_test['cluster']
-    test_cluster = cluster.Cluster(name=cluster_name)
+    test_cluster = cluster.Cluster(name=cluster_name, provider=provider)
     test_cluster.delete(cancel=False)
     test_cluster.wait_for_delete()
     provider.refresh_provider_relationships()

--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -3,7 +3,6 @@ import fauxfactory
 import pytest
 
 from cfme.common.vm import VM
-from cfme.infrastructure.cluster import get_all_clusters
 from cfme.rest import a_provider as _a_provider
 from cfme.rest import vm as _vm
 from cfme.web_ui import InfoBlock, toolbar, jstimelines
@@ -143,10 +142,18 @@ def test_cluster_event(provider, gen_events, test_vm):
         test_flag: timelines, provision
     """
     def nav_step():
-        cluster = [cl for cl in get_all_clusters() if cl.cluster_id == test_vm.cluster_id][-1]
-        pytest.sel.force_navigate('infrastructure_cluster',
-                                  context={'cluster': cluster})
-        toolbar.select('Monitoring', 'Timelines')
+        # fixme: sometimes get_clusters doesn't return all found clusters
+        # fixme: this try/except statement tries to avoid this
+        all_clusters = []
+        try:
+            all_clusters = provider.get_clusters()
+            cluster = [cl for cl in all_clusters if cl.id == test_vm.cluster_id][-1]
+            pytest.sel.force_navigate('infrastructure_cluster',
+                                      context={'cluster': cluster})
+            toolbar.select('Monitoring', 'Timelines')
+        except IndexError:
+            logger.error("the following clusters were "
+                         "found for provider {p}: {cl} ".format(p=provider.name, cl=all_clusters))
     wait_for(count_events, [test_vm, nav_step], timeout='5m',
              fail_condition=0, message="events to appear")
 


### PR DESCRIPTION
1. Cluster requires provider now;
2. get_all_clusters moved to Provider object;
3. all usage places are fixed;

{{pytest: cfme/tests/infrastructure/test_delete_infra_object.py cfme/tests/infrastructure/test_timelines.py cfme/tests/infrastructure/test_cluster_analysis.py}}

This PR is based on PR - https://github.com/ManageIQ/integration_tests/pull/3440