### PR TITLE
added navigatable property to Host

### DIFF
--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -88,7 +88,7 @@ pow_btn = partial(tb.select, 'Power')
 lif_btn = partial(tb.select, 'Lifecycle')
 
 
-class Host(Updateable, Pretty, Navigatable):
+class Host(Updateable, Navigatable, Pretty):
     """
     Model of an infrastructure host in cfme.
 


### PR DESCRIPTION
Since psav implemented Navigatable base class which helped to get rid of get_appliance call in every class, all get_appliance calls should be replaced by it.
So,  here I made such a replacement for Host class.