### PR TITLE
mark the selenum-fixture classes as deprecated

### DIFF
--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -43,7 +43,7 @@ from utils.path import log_path
 from utils.log import logger
 from utils.wait import wait_for
 from utils.pretty import Pretty
-from utils.deprecation import removed_in_fw30
+from utils.deprecation import removed_in_fw30, removed_class_in_fw30
 
 from threading import local
 _thread_local = local()
@@ -74,6 +74,7 @@ if WebElement.__repr__ is not __repr__:
     WebElement.__repr__ = __repr__
 
 
+@removed_class_in_fw30
 class ByValue(Pretty):
     pretty_attrs = ['value']
 
@@ -87,6 +88,7 @@ class ByValue(Pretty):
         return str(self.value)
 
 
+@removed_class_in_fw30
 class ByText(Pretty):
     pretty_attrs = ['text']
 

--- a/utils/deprecation.py
+++ b/utils/deprecation.py
@@ -1,10 +1,9 @@
 import warnings
-
-from debtcollector.removals import remove
+from functools import partial
+from debtcollector.removals import remove, removed_class
 
 
 warnings.simplefilter('once', category=DeprecationWarning)
 
-removed_in_fw30 = remove(
-    removal_version="framework 3.0",
-)
+removed_in_fw30 = remove(removal_version="framework 3.0")
+removed_class_in_fw30 = partial(removed_class, removal_version="framework 3.0")


### PR DESCRIPTION
this one tries to correctly mark the classes that will go in fw 3.0 using removed_class from debt-collector

i didn't run a local test an will take a look at prt the next workday

{{pytest: cfme/tests/intelligence/reports/test_crud.py }}