### PR TITLE
fix for rhos6-ga-ssl setup

### DIFF
--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -81,8 +81,8 @@ properties_form_56 = TabStripForm(
     tab_fields={
         "Default": [
             ('hostname_text', Input("default_hostname")),
-            ('api_port', Input("default_api_port")),
             ('sec_protocol', AngularSelect("default_security_protocol", exact=True)),
+            ('api_port', Input("default_api_port")),
         ],
         "Events": [
             ('event_selection', Radio('event_stream_selection')),


### PR DESCRIPTION
Purpose or Intent
=================

Fixing rhos6-ga-ssl provider setup because it is currently failing: api_port gets replaced with some default value after we select "sec_protocol"

{{pytest: cfme/tests/cloud/test_providers.py::test_provider_crud --use-provider rhos6-ga-ssl}}