### PR TITLE
[TEST]Azure power control fixes

### DIFF
--- a/cfme/cloud/instance.py
+++ b/cfme/cloud/instance.py
@@ -384,6 +384,7 @@ class AzureInstance(Instance):
     STATE_SUSPENDED = "suspended"
     STATE_TERMINATED = "terminated"
     STATE_UNKNOWN = "unknown"
+    STATE_ARCHIVED = "archived"
 
     def create(self, email=None, first_name=None, last_name=None, availability_zone=None,
                security_groups=None, instance_type=None, guest_keypair=None, cancel=False,


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ azure power control tests because it is currently failing on test setup - fixture fails to prepare instance  with timeout 900

Soft_reboot is blocked by https://bugzilla.redhat.com/show_bug.cgi?id=1379071 

{{pytest: cfme/tests/cloud/test_instance_power_control.py --use-provider azure --use-provider ec2east  --long-running }}
