### PR TITLE
Gce ui api representation

### DIFF
--- a/cfme/cloud/instance.py
+++ b/cfme/cloud/instance.py
@@ -361,6 +361,77 @@ class EC2Instance(Instance):
             raise OptionNotAvailable(option + " is not a supported action")
 
 
+@VM.register_for_provider_type("gce")
+class GCEInstance(Instance):
+    # CFME & provider power control options
+    START = "Start"
+    POWER_ON = START  # For compatibility with the infra objects.
+    STOP = "Stop"
+    DELETE = "Delete"
+    TERMINATE = deferred_verpick({
+        version.LOWEST: 'Terminate',
+        '5.6.1': 'Delete',
+    })
+    # CFME-only power control options
+    SOFT_REBOOT = "Soft Reboot"
+    # Provider-only power control options
+    RESTART = "Restart"
+
+    # CFME power states
+    STATE_ON = "on"
+    STATE_OFF = "off"
+    STATE_SUSPENDED = "suspended"
+    STATE_TERMINATED = "terminated"
+    STATE_ARCHIVED = "archived"
+    STATE_UNKNOWN = "unknown"
+
+    def create(self, email=None, first_name=None, last_name=None, availability_zone=None,
+               instance_type=None, cloud_network=None, boot_disk_size=None, cancel=False,
+               **prov_fill_kwargs):
+        """Provisions an GCE instance with the given properties through CFME
+
+        Args:
+            email: Email of the requester
+            first_name: Name of the requester
+            last_name: Surname of the requester
+            availability_zone: zone to deploy instance
+            cloud_network: Name of the cloud network the instance should belong to
+            instance_type: Type of the instance
+            boot_disk_size: size of root disk
+            cancel: Clicks the cancel button if `True`, otherwise clicks the submit button
+                    (Defaults to `False`)
+        Note:
+            For more optional keyword arguments, see
+            :py:data:`cfme.cloud.provisioning.provisioning_form`
+        """
+        from cfme.provisioning import provisioning_form
+        sel.force_navigate('clouds_provision_instances', context={
+            'provider': self.provider,
+            'template_name': self.template_name,
+        })
+
+        fill(provisioning_form, dict(
+            email=email,
+            first_name=first_name,
+            last_name=last_name,
+            instance_name=self.name,
+            availability_zone=availability_zone,
+            instance_type=instance_type,
+            cloud_network=cloud_network,
+            boot_disk_size=boot_disk_size,
+            **prov_fill_kwargs
+        ))
+
+        if cancel:
+            sel.click(provisioning_form.cancel_button)
+            flash.assert_success_message(
+                "Add of new VM Provision Request was cancelled by the user")
+        else:
+            sel.click(provisioning_form.submit_button)
+            flash.assert_success_message(
+                "VM Provision Request was Submitted, you will be notified when your VMs are ready")
+
+
 @VM.register_for_provider_type("azure")
 class AzureInstance(Instance):
     # CFME & provider power control options Added by Jeff Teehan on 5-16-2016

--- a/cfme/provisioning.py
+++ b/cfme/provisioning.py
@@ -123,6 +123,7 @@ provisioning_form = tabstrip.TabStripForm(
                 '5.5': AngularSelect('environment__floating_ip_address')}),
 
 
+
             # Infra
             ('provider_name', {
                 version.LOWEST: ui.Select('select#environment__placement_ems_name'),
@@ -188,6 +189,7 @@ provisioning_form = tabstrip.TabStripForm(
             ('hardware_monitoring', {
                 version.LOWEST: ui.Select('select#hardware__monitoring'),
                 '5.5': AngularSelect('hardware__monitoring')}),
+            ('boot_disk_size', AngularSelect('hardware__boot_disk_size')),
         ]),
 
         ('Customize', [


### PR DESCRIPTION
{{pytest : cfme/tests/cloud/test_provisioning.py -k "test_provision_from_template" --use-provider="gce_central"}}