### PR TITLE
Add verification to text_content in pytest_selenium

### DIFF
--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -704,9 +704,10 @@ def text_content(loc, **kwargs):
 
     Returns: A string containing the text of the element.
     """
-    return execute_script(
+    text = execute_script(
         "return arguments[0].textContent || arguments[0].innerText;",
-        element(loc, **kwargs)).strip()
+        element(loc, **kwargs))
+    return text.strip() if text is not None else ""
 
 
 @removed


### PR DESCRIPTION
For empty string "arguments[0].innerText" in 5.6.2.1 returns None and whole script  "return arguments[0].textContent || arguments[0].innerText;" also returns None (Because arguments[0].textContent == "" and javascript returns last one arg if all OR statements if False) 

