### PR TITLE
marking provision tests

### DIFF
--- a/cfme/tests/cloud/test_provisioning.py
+++ b/cfme/tests/cloud/test_provisioning.py
@@ -11,12 +11,14 @@ from cfme.cloud.instance import Instance
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.fixtures import pytest_selenium as sel
+from cfme import test_requirements
 from utils import testgen
 from utils.log import logger
 from utils.update import update
 from utils.wait import wait_for, RefreshTimer
 
-pytestmark = [pytest.mark.meta(server_roles="+automate")]
+pytestmark = [pytest.mark.meta(server_roles="+automate"),
+              test_requirements.provision, pytest.mark.tier(2)]
 
 
 def pytest_generate_tests(metafunc):
@@ -71,7 +73,6 @@ def vm_name(request):
     return vm_name
 
 
-@pytest.mark.tier(2)
 def test_provision_from_template(request, setup_provider, provider, testing_instance, soft_assert):
     """ Tests instance provision from template
 
@@ -94,7 +95,6 @@ def test_provision_from_template(request, setup_provider, provider, testing_inst
     soft_assert(instance.does_vm_exist_on_provider(), "Instance wasn't provisioned")
 
 
-@pytest.mark.tier(2)
 def test_provision_from_template_using_rest(
         request, setup_provider, provider, vm_name, rest_api, provisioning):
     """ Tests provisioning from a template using the REST API.
@@ -209,7 +209,6 @@ def copy_domains(domain):
 
 
 # Not collected for EC2 in generate_tests above
-@pytest.mark.tier(2)
 @pytest.mark.meta(blockers=[1152737])
 @pytest.mark.parametrize("disks", [1, 2])
 @pytest.mark.uncollectif(lambda provider: provider.type != 'openstack')
@@ -280,7 +279,6 @@ def test_provision_from_template_with_attached_disks(
 
 
 # Not collected for EC2 in generate_tests above
-@pytest.mark.tier(2)
 @pytest.mark.meta(blockers=[1160342])
 @pytest.mark.uncollectif(lambda provider: provider.type != 'openstack')
 def test_provision_with_boot_volume(request, setup_provider, provider, vm_name,
@@ -350,7 +348,6 @@ def test_provision_with_boot_volume(request, setup_provider, provider, vm_name,
 
 
 # Not collected for EC2 in generate_tests above
-@pytest.mark.tier(2)
 @pytest.mark.meta(blockers=[1186413])
 @pytest.mark.uncollectif(lambda provider: provider.type != 'openstack')
 def test_provision_with_additional_volume(request, setup_provider, provider, vm_name,


### PR DESCRIPTION
Purpose or Intent
=================
Marking Provisioning tests

{{pytest:  --use-provider ec2east cfme/tests/cloud/test_provisioning.py::test_provision_from_template}}