### PR TITLE
adding GCE power controls

### DIFF
--- a/cfme/cloud/instance.py
+++ b/cfme/cloud/instance.py
@@ -431,6 +431,25 @@ class GCEInstance(Instance):
             flash.assert_success_message(
                 "VM Provision Request was Submitted, you will be notified when your VMs are ready")
 
+    def power_control_from_provider(self, option):
+        """Power control the instance from the provider
+
+        Args:
+            option: power control action to take against instance
+        Raises:
+            OptionNotAvailable: option param must have proper value
+        """
+        if option == GCEInstance.START:
+            self.provider.mgmt.start_vm(self.name)
+        elif option == GCEInstance.STOP:
+            self.provider.mgmt.stop_vm(self.name)
+        elif option == GCEInstance.RESTART:
+            self.provider.mgmt.restart_vm(self.name)
+        elif option == GCEInstance.TERMINATE:
+            self.provider.mgmt.delete_vm(self.name)
+        else:
+            raise OptionNotAvailable(option + " is not a supported action")
+
 
 @VM.register_for_provider_type("azure")
 class AzureInstance(Instance):


### PR DESCRIPTION
Purpose - New provider added to the test run + new naming
=================
Adding GCE power control tests, as there were no power action tests before in our framework

{{pytest: cfme/tests/cloud/test_instance_power_control.py --use-provider gce_central --long-running }}