### PR TITLE
Splitters UI tests rework

### DIFF
--- a/cfme/tests/test_ui_problems.py
+++ b/cfme/tests/test_ui_problems.py
@@ -6,7 +6,6 @@ from cfme.services.catalogs import service_catalogs  # NOQA
 from cfme.services.catalogs.catalog import Catalog
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.web_ui import AngularSelect, fill
-from cfme.web_ui.mixins import pull_splitter, left_half_size
 from utils.version import current_version
 
 
@@ -17,22 +16,6 @@ LOCATIONS = [
     # "services_catalogs",
     "services_workloads", "reports", "chargeback", "clouds_instances",
     "infrastructure_virtual_machines", "infrastructure_pxe", "configuration"]
-
-
-@pytest.mark.tier(3)
-@pytest.mark.parametrize("location", LOCATIONS)
-@pytest.mark.meta(blockers=[1219019])
-@pytest.mark.uncollectif(lambda: current_version() >= "5.5")
-def test_pull_splitter(location):
-    """This test tests whether the setting of the position of the left/right splitter is persisted
-    correctly."""
-    pytest.sel.force_navigate(location)
-    pull_splitter(-100)
-    original_position = left_half_size()
-    pytest.sel.force_navigate("dashboard")
-    pytest.sel.force_navigate(location)
-    assert original_position - TOLERANCE <= left_half_size() <= original_position + TOLERANCE,\
-        "Splitter fail!"
 
 
 @pytest.mark.tier(3)

--- a/cfme/tests/webui/test_splitter.py
+++ b/cfme/tests/webui/test_splitter.py
@@ -1,0 +1,44 @@
+import pytest
+from cfme.web_ui.splitter import pull_splitter_left, pull_splitter_right
+from xml.sax.saxutils import quoteattr, unescape
+from utils import version
+from utils.blockers import BZ
+LOCATIONS = [
+    "control_explorer", "automate_explorer", "automate_customization", "my_services",
+    "services_catalogs", "services_workloads", "reports", "chargeback", "clouds_instances_no_tree",
+    "infrastructure_virtual_machines_no_tree", "infrastructure_pxe", "configuration",
+    "infrastructure_datastores_no_tree", "infrastructure_config_management", "utilization",
+    "bottlenecks",
+    "infrastructure_networking"]
+
+pytestmark = [pytest.mark.parametrize("location", LOCATIONS), pytest.mark.uncollectif(lambda
+    location: location == "infrastructure_networking" and version.current_version() < '5.7')]
+
+
+@pytest.mark.meta(
+    blockers=[
+        BZ('1380443', unblock=lambda location: location != "bottlenecks")
+    ]
+)
+@pytest.mark.requirement('general_ui')
+@pytest.mark.tier(3)
+def test_pull_splitter_persistence(location):
+    pytest.sel.force_navigate(location)
+    # First we move splitter to hidden position by pulling it left twice
+    pull_splitter_left()
+    pull_splitter_left()
+    pytest.sel.force_navigate("dashboard")
+    pytest.sel.force_navigate(location)
+    # Then we check hidden position splitter
+    if not pytest.sel.elements("//div[@id='left_div'][contains(@class, 'hidden-md')]"):
+        pytest.fail("Splitter did not persist when on hidden position!")
+    # Then we iterate over all the other positions
+    for position in ["col-md-2", "col-md-3", "col-md-4", "col-md-5"]:
+        # Pull splitter left
+        pull_splitter_right()
+        pytest.sel.force_navigate("dashboard")
+        pytest.sel.force_navigate(location)
+        # Then check its position
+        if not pytest.sel.elements("//div[@id='left_div'][contains(@class, {})]"
+                .format(unescape(quoteattr(position)))):
+            pytest.fail("Splitter did not persist when on " + str(position) + " position!")

--- a/cfme/web_ui/menu.py
+++ b/cfme/web_ui/menu.py
@@ -293,6 +293,7 @@ class Menu(UINavigate):
                         ('clouds_instances', 'Instances',
                             self._tree_func_with_grid(
                                 "Instances by Provider", "Instances by Provider")),
+                        ('clouds_instances_no_tree', 'Instances'),
                         ('clouds_stacks', 'Stacks'),
                         ('clouds_key_pairs', 'Key Pairs'),
                         ('clouds_object_stores', 'Object Stores'),
@@ -304,11 +305,14 @@ class Menu(UINavigate):
                         ('infrastructure_hosts', "/host"),
                         ('infrastructure_virtual_machines', 'Virtual Machines',
                             self._tree_func_with_grid("VMs & Templates", "All VMs & Templates")),
+                        ('infrastructure_virtual_machines_no_tree', 'Virtual Machines'),
                         ('infrastructure_resource_pools', 'Resource Pools'),
                         ('infrastructure_datastores', 'Datastores',
                             self._tree_func_with_grid("Datastores", "All Datastores")),
+                        ('infrastructure_datastores_no_tree', 'Datastores'),
                         ('infrastructure_pxe', 'PXE'),
                         ('infrastructure_requests', 'Requests'),
+                        ('infrastructure_networking', 'Networking'),
                         # ('infrastructure_config_management', 'Configuration Management')
                     ),
                     ('containers', 'Containers'): (
@@ -387,6 +391,9 @@ class Menu(UINavigate):
             }
         if version.current_version() >= '5.7':
             del sections[('configure', 'Settings')]
+            sections[('n_configuration', 'Configuration')] = (
+                ('infrastructure_config_management', 'Management'),
+            )
         return sections
 
     def is_page_active(self, toplevel, secondlevel=None, thirdlevel=None):

--- a/cfme/web_ui/mixins.py
+++ b/cfme/web_ui/mixins.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import re
-
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import fill, Form, AngularSelect, Table, toolbar, form_buttons, flash
 from xml.sax.saxutils import quoteattr
@@ -55,31 +53,3 @@ def get_tags(tag="My Company Tags"):
                 quoteattr(tag))):
         tags.append(sel.text(row).strip())
     return tags
-
-
-screen_splitter = (
-    "//div[contains(@class, 'dhtmlxLayoutObject')]"
-    "//td[contains(@class, 'dhtmlxLayoutPolySplitterVer')]")
-left_half = (
-    "//table[contains(@class, 'dhtmlxLayoutPolyContainer_dhx_blue')]/tbody/tr"
-    "/td[contains(@class, 'dhtmlxLayoutSinglePoly') and "
-    "following-sibling::td[contains(@class, 'dhtmlxLayoutPolySplitterVer')]]")
-
-
-def pull_splitter(x):
-    """Pulls the vertical separator between accordion and detail view.
-
-    Args:
-        x: Negative values move left, positive right.
-    """
-    sel.drag_and_drop_by_offset(screen_splitter, x)
-
-
-def left_half_size():
-    if not sel.is_displayed(screen_splitter) or not sel.is_displayed(left_half):
-        return None
-    style = sel.get_attribute(left_half, "style")
-    match = re.search(r"width:\s*(\d+)px", style)
-    if match is None:
-        return None
-    return int(match.groups()[0])

--- a/cfme/web_ui/splitter.py
+++ b/cfme/web_ui/splitter.py
@@ -1,0 +1,9 @@
+from cfme.fixtures import pytest_selenium as sel
+
+
+def pull_splitter_left():
+    sel.click("//span[@class='fa fa-angle-left']")
+
+
+def pull_splitter_right():
+    sel.click("//span[@class='fa fa-angle-right']")


### PR DESCRIPTION
{{pytest: cfme/tests/webui/test_splitter.py -v}}
Reworked pull splitter tests, because splitters ui was changed.
Deleted old splitters tests and methods.(broken_angular_select test is in same test file and it's not working so I told prt to test test_splitter.py only)
Added new splitters tests and methods.
Added webui folder in tests.
All the module changes are related to test_splitter only.