### PR TITLE
Fix KeyPair test and objects

### DIFF
--- a/cfme/cloud/keypairs.py
+++ b/cfme/cloud/keypairs.py
@@ -30,9 +30,10 @@ class KeyPair(Taggable, SummaryMixin, Navigatable):
         name: Name of Keypairs.
     """
 
-    def __init__(self, name=None, appliance=None):
+    def __init__(self, name, provider, appliance=None):
         Navigatable.__init__(self, appliance=appliance)
         self.name = name
+        self.provider = provider
 
     def delete(self):
         navigate_to(self, 'All')
@@ -51,7 +52,8 @@ class KeyPair(Taggable, SummaryMixin, Navigatable):
         """Create new keypair"""
         navigate_to(self, 'All')
         cfg_btn('Add a new Key Pair')
-        fill(keypair_form, {'name': self.name}, action=keypair_form.save_button)
+        fill(keypair_form, {'name': self.name, 'provider': self.provider.name},
+             action=keypair_form.save_button)
         if not cancel:
             flash.assert_message_match('Creating Key Pair {}'.format(self.name))
         else:

--- a/cfme/tests/cloud/test_keypairs.py
+++ b/cfme/tests/cloud/test_keypairs.py
@@ -9,12 +9,11 @@ pytestmark = [
     pytest.mark.uncollectif(lambda: current_version() > '5.7')
 ]
 
-pytestmark = [pytest.mark.usefixtures("setup_a_provider")]
-
 
 @pytest.fixture(scope="module")
-def setup_a_provider():
-    _setup_a_provider(prov_class="cloud", prov_type="openstack", validate=True, check_existing=True)
+def a_provider():
+    return _setup_a_provider(
+        prov_class="cloud", prov_type="openstack", validate=True, check_existing=True)
 
 
 def pytest_generate_tests(metafunc):
@@ -24,7 +23,7 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.mark.tier(3)
-def test_keypair_crud():
+def test_keypair_crud(a_provider):
     """ This will test whether it will create new Keypair and then deletes it.
 
     Prerequisites:
@@ -35,6 +34,6 @@ def test_keypair_crud():
         * Select Cloud Provider.
         * Also delete it.
     """
-    keypair = KeyPair(name=fauxfactory.gen_alphanumeric())
+    keypair = KeyPair(name=fauxfactory.gen_alphanumeric(), provider=a_provider)
     keypair.create()
     keypair.delete()


### PR DESCRIPTION
Purpose or Intent
=================

* KeyPair object now requires a provider
* Test has been updated to assign the provider to the KeyPair on
  instantiation
* Form now chooses the provider instead of relying on a default