### PR TITLE
fix ownership tests

### DIFF
--- a/cfme/tests/cloud_infra_common/test_vm_ownership.py
+++ b/cfme/tests/cloud_infra_common/test_vm_ownership.py
@@ -4,6 +4,7 @@ import pytest
 from cfme import Credential, login, test_requirements
 from cfme.common.vm import VM
 from utils import testgen
+from utils.blockers import BZ
 
 
 def pytest_generate_tests(metafunc):
@@ -13,6 +14,7 @@ def pytest_generate_tests(metafunc):
 
 pytestmark = [
     test_requirements.ownership,
+    pytest.mark.meta(blockers=[BZ(1380781, forced_streams=["5.7"])]),
     pytest.mark.tier(3)
 ]
 
@@ -128,10 +130,10 @@ def test_group_ownership_on_user_only_role(request, user2, setup_provider, provi
     group_ownership_vm = VM.factory(ownership_vm, provider)
     group_ownership_vm.set_ownership(group=user2.group.description)
     with user2:
-        assert group_ownership_vm.exists, "vm not found"
-    group_ownership_vm.unset_ownership()
+        assert not group_ownership_vm.exists, "vm not found"
+    group_ownership_vm.set_ownership(user=user2.name)
     with user2:
-        assert not group_ownership_vm.exists, "vm exists"
+        assert group_ownership_vm.exists, "vm exists"
 
 
 def test_group_ownership_on_user_or_group_role(

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -1652,10 +1652,10 @@ class IPAppliance(object):
 @navigator.register(IPAppliance)
 class LoggedIn(CFMENavigateStep):
     def step(self):
-        from cfme.login import login_admin
+        from cfme.login import login
         from utils.browser import browser
         browser()
-        login_admin()
+        login(store.user)
 
 
 @navigator.register(IPAppliance)


### PR DESCRIPTION
I found some kind an issue for this
https://github.com/ManageIQ/integration_tests/commit/ced20cc002f365301f0fad55a14807eb3f534d14#diff-1e8b179acb9ab9a36422fe2651bc0aa6R1645

if we use different from admin user (e.g. user_temp) in construction like this in tests
with user_temp:
    ...:     provider.load_details()

it login with this user, then makes logout, and login as admin

we have some tests about ownership. This thing make them failed

{{pytest: cfme/tests/cloud_infra_common/test_vm_ownership.py --use-provider="vsphere55"}}

