### PR TITLE
[WIPTEST] Fix adv search prov

### DIFF
--- a/cfme/web_ui/form_buttons.py
+++ b/cfme/web_ui/form_buttons.py
@@ -32,13 +32,17 @@ class FormButton(Pretty):
         TYPE_CONDITION = (
             "(contains(@class, 'button') or contains(@class, 'btn') or contains(@src, 'button'))"
         )
-        DIMMED = "(contains(@class, 'dimmed') or contains(@class, 'disabled'))"
+        DIMMED = "(contains(@class, 'dimmed') " \
+                "or contains(@class, 'disabled') " \
+                "or contains(@class, 'btn-disabled'))"
         NOT_DIMMED = "not{}".format(DIMMED)
         IS_DISPLAYED = (
             "not(ancestor::*[contains(@style, 'display:none') "
             "or contains(@style, 'display: none')])")
         ON_CURRENT_TAB = (
             "not(ancestor::div[contains(@class, 'tab-pane') and not(contains(@class, 'active'))])")
+
+        
 
     def __init__(self, alt, dimmed_alt=None, force_click=False, partial_alt=False, ng_click=None):
         self._alt = alt

--- a/cfme/web_ui/search.py
+++ b/cfme/web_ui/search.py
@@ -3,6 +3,7 @@
 import re
 from functools import partial
 import base64
+from datetime import datetime
 
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import expression_editor as exp_ed
@@ -30,16 +31,27 @@ search_box = Region(
         # Container for the advanced search box
         # class changes when visible or hidden, first locator does not indicate visibility
         advanced_search_box="//div[@id='advsearchModal']//div[@class='modal-content']",
-        advanced_search_box_visible="//div[@id='advsearchModal' and @class='modal fade in']//div[@class='modal-content']",
+        advanced_search_box_visible="//div[@id='advsearchModal' and @class='modal fade in']"
+                "//div[@class='modal-content']",
 
-        load_filter_loc='//button[(normalize-space(@alt)="Load a filter")]',
-        load_filter_disabled_loc='//button[(normalize-space(@alt)="No saved filters or report '
+        # Alt text is missing for some buttons, locators where FormButton won't work
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1380430
+        # Can remove locators when alt-text is consistent, and use FormButtons
+        load_filter='//button[(normalize-space(@alt)="Load a filter")]',
+        load_filter_disabled='//button[(normalize-space(@alt)="No saved filters or report '
                                  'filters are available to load")]',
+
+        reset_filter='//a[@title="Reset the filter"]',
+        reset_filter_disabled='//button[contains(@class, "btn-disabled") and text()="Reset"]',
+
+        apply_filter='//a[@title="Apply the filter"]',
+        apply_filter_disabled='//button[contains(@class, "btn-disabled") and text()="Apply"]',
+
 
         # Buttons on main view
         apply_filter_button=FormButton("Apply the current filter"),
-        load_filter_button=FormButton("Load a filter"),
-        load_filter_disabled_button=FormButton("No saved filters or report filters are available to load"),
+        load_filter_button=FormButton(alt="Load a filter",
+                dimmed_alt="No saved filters or report filters are available to load"),
         delete_filter_button=FormButton("Delete the filter named", partial_alt=True),
         save_filter_button=FormButton("Save the current filter"),
         reset_filter_button=FormButton("Reset the filter"),
@@ -131,70 +143,31 @@ def ensure_advanced_search_open():
     """Make sure the advanced search box is opened.
 
     If the advanced search box is closed, open it if it exists (otherwise exception raised).
-    If it is opened but not in the default view (expression editor), close it and open again to
-    ensure the default view is present.
     """
-    logger.critical('DEBUG: STARTING ENSURE_ADV_SEARCH_OPEN')
     if not is_advanced_search_possible():
         raise Exception("Advanced search is not possible in this location!")
     if not is_advanced_search_opened():
-        logger.debug('search::ensure_: clicking toggle_advanced')
         sel.click(search_box.toggle_advanced)   # Open
 
-    logger.debug('search::ensure_: filter button displayed? {}'.format(
-        sel.is_displayed(search_box.load_filter_loc)))
-
-    logger.debug('search::ensure_: filter disabled button displayed? {}'.format(
-        sel.is_displayed(search_box.load_filter_disabled_loc)))
-
-    if not sel.is_displayed(search_box.load_filter_loc)\
-            or not sel.is_displayed(search_box.load_filter_disabled_loc):
-        # If we aren't in default view
-        logger.debug('search::ensure_: load_filter_button not displayed')
-        if current_version() >= "5.4":
-            logger.debug('search::ensure_: clicking close_button')
-            sel.click(search_box.close_button)
-        else:
-            sel.click(search_box.toggle_advanced)   # Close
-        logger.debug('search::ensure_: waiting for is_adv_search_open to be closed')
-
-        # wait for advanced search to be closed
-        wait_for(is_advanced_search_opened, fail_condition=True, num_sec=5)
-
-        shot = sel.take_screenshot()
-        # DEBUG TODO: remove this
-        with open('/home/mshriver/Pictures/screenshot-preClick2.png', 'wb') as png:
-            if not shot.error:
-                png.write(base64.b64decode(shot.png))
-
-
-        toggleDisplay = sel.is_displayed(search_box.toggle_advanced)
-        logger.debug('search::ensure_: toggle displayed? {}'.format(toggleDisplay))
-        logger.debug('search::ensure_: clicking toggle_advanced(2)')
-        sel.click(search_box.toggle_advanced)   # And open to see the default view
-
-        toggleDisplay = sel.is_displayed(search_box.toggle_advanced)
-        logger.debug('search::ensure_: toggle displayed(2)? {}'.format(toggleDisplay))
-
-        shot = sel.take_screenshot()
-        # DEBUG TODO: remove this
-        with open('/home/mshriver/Pictures/screenshot-preFinalWait.png', 'wb') as png:
-            if not shot.error:
-                png.write(base64.b64decode(shot.png))
-
-    logger.debug('search::ensure_: search open? {}'.format(is_advanced_search_opened()))
-    if not is_advanced_search_opened():
-        logger.debug('search::ensure_: clicking toggle_advanced(3)')
-        sel.click(search_box.toggle_advanced)  # And open to see the default view
-
-    logger.debug('search::ensure_: final wait for is_advanced_search_open')
-    wait_for(is_advanced_search_opened, fail_condition=False, num_sec=6)
+    wait_for(is_advanced_search_opened, fail_condition=False, num_sec=5)
 
 
 def reset_filter():
     """Clears the filter expression"""
     ensure_advanced_search_open()
-    sel.click(search_box.reset_filter_button)
+    if sel.is_displayed(search_box.reset_filter):
+        return sel.click(search_box.reset_filter_button)
+    else:
+        return False
+
+
+def apply_filter():
+    """Applies an existing filter"""
+    ensure_advanced_search_open()
+    if sel.is_displayed(search_box.apply_filter):
+        return sel.click(search_box.apply_filter_button)
+    else:
+        return False
 
 
 def delete_filter(cancel=False):
@@ -251,15 +224,16 @@ def save_filter(expression_program, save_name, global_search=False, cancel=False
         expression_program: the expression to be filled.
         save_name: Name of the filter to be saved with.
         global_search: Whether to check the Global search checkbox.
+        cancel: Whether to cancel the save dialog without saving
     """
     fill_expression(expression_program)
     sel.click(search_box.save_filter_button)
     fill(search_box.save_name, save_name)
     fill(search_box.global_search, global_search)
     if cancel:
-        sel.click(search_box.cancel_save_filter_dialog_button)
+        return sel.click(search_box.cancel_save_filter_dialog_button)
     else:
-        sel.click(search_box.save_filter_dialog_button)
+        return sel.click(search_box.save_filter_dialog_button)
 
 
 def load_filter(saved_filter=None, report_filter=None, cancel=False):
@@ -268,35 +242,25 @@ def load_filter(saved_filter=None, report_filter=None, cancel=False):
     Args:
         saved_filter: `Choose a saved XYZ filter`
         report_filter: `Choose a XYZ report filter`
+        cancel: Whether to cancel the load dialog without loading
     """
-    logger.critical('DEBUG: START LOAD FILTER')
-    logger.debug('search::load_filter: calling ensure search open')
     ensure_advanced_search_open()
-    if sel.is_displayed(search_box.load_filter_disabled_button):
+    if sel.is_displayed(search_box.load_filter_disabled):
         raise DisabledButtonException('Load Filter button disabled, '
             'cannot load filter: {}'.format(saved_filter))
     assert saved_filter is not None or report_filter is not None, "At least 1 param required!"
     assert (saved_filter is not None) ^ (report_filter is not None), "You must provide just one!"
 
-    logger.debug('search::load_filter: search should be open, clicking load_filter')
-    shot = sel.take_screenshot()
-    # DEBUG TODO: remove this
-    with open('/home/mshriver/Pictures/screenshot-preClickLoad.png', 'wb') as png:
-        if not shot.error:
-            png.write(base64.b64decode(shot.png))
-
-
     sel.click(search_box.load_filter_button)
     # We apply it to the whole form but it will fill only one of the selects
     if saved_filter is not None:
-        logger.debug('search::load_filter: filling with {}'.format(saved_filter))
         fill(search_box.saved_filter, saved_filter)
     else:   # No other check needed, covered by those two asserts
         fill(search_box.report_filter, report_filter)
     if cancel:
-        sel.click(search_box.cancel_load_filter_dialog_button)
+        return sel.click(search_box.cancel_load_filter_dialog_button)
     else:
-        sel.click(search_box.load_filter_dialog_button)
+        return sel.click(search_box.load_filter_dialog_button)
     # todo update flash message handler
 
 
@@ -362,6 +326,13 @@ def fill_and_apply_filter(expression_program, fill_callback=None, cancel_on_user
     fill_expression(expression_program)
     sel.click(search_box.apply_filter_button)
     _process_user_filling(fill_callback, cancel_on_user_filling)
+    ensure_advanced_search_closed()
+
+
+def save_and_apply_filter(expression_program, save_name, global_search=False):
+    save_filter(expression_program=expression_program, save_name=save_name,
+            global_search=global_search)
+    apply_filter()
     ensure_advanced_search_closed()
 
 


### PR DESCRIPTION
{{pytest: cfme/tests/infrastructure/test_advanced_search_providers.py}}

Purpose or Intent
=================

Fix consistent automation failures in infrastructure.test_advanced_search_providers.py.

The intent devolved into making some updates to the web_ui modules for search and form buttons.

Added an apply_filter() function to search, and modified the save_filter(), load_filter(), etc functions to return a boolean.  Asserted on that return within the tests that execute multiple actions (save_and_load, etc).

Will likely conflict with PR3427, and will need to be coordinated, possibly splitting this PR into separate navigation and test/framework updates.