### PR TITLE
Update web_ui.search

### DIFF
--- a/cfme/web_ui/search.py
+++ b/cfme/web_ui/search.py
@@ -26,11 +26,31 @@ search_box = Region(
         toggle_advanced="(//button | //a)[@id='adv_search']",
 
         # Container for the advanced search box
+        # class changes when visible or hidden, first locator does not indicate visibility
         advanced_search_box="//div[@id='advsearchModal']//div[@class='modal-content']",
+        advanced_search_box_visible="//div[@id='advsearchModal' and @class='modal fade in']"
+                                    "//div[@class='modal-content']",
+
+        # Alt text is missing for some buttons, locators where FormButton won't work
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1380430
+        # Can remove locators when alt-text is consistent, and use FormButtons
+        load_filter='//button[(normalize-space(@alt)="Load a filter")]',
+        load_filter_disabled='//button[(normalize-space(@alt)="No saved filters or report '
+                                    'filters are available to load")]',
+
+        reset_filter='//a[@title="Reset the filter"]',
+        reset_filter_disabled='//button[contains(@class, "btn-disabled") and '
+                              'normalize-space(text())="Reset"]',
+
+        apply_filter='//a[@title="Apply the filter"]',
+        apply_filter_disabled='//button[contains(@class, "btn-disabled") and '
+                              'normalize-space(text())="Apply"]',
+
 
         # Buttons on main view
         apply_filter_button=FormButton("Apply the current filter"),
-        load_filter_button=FormButton("Load a filter"),
+        load_filter_button=FormButton(alt="Load a filter",
+            dimmed_alt="No saved filters or report filters are available to load"),
         delete_filter_button=FormButton("Delete the filter named", partial_alt=True),
         save_filter_button=FormButton("Save the current filter"),
         reset_filter_button=FormButton("Reset the filter"),
@@ -93,7 +113,7 @@ def has_quick_search_box():
 
 def is_advanced_search_opened():
     """Checks whether the advanced search box is currently opened"""
-    return sel.is_displayed(search_box.advanced_search_box)
+    return sel.is_displayed(search_box.advanced_search_box_visible)
 
 
 def is_advanced_search_possible():
@@ -122,27 +142,31 @@ def ensure_advanced_search_open():
     """Make sure the advanced search box is opened.
 
     If the advanced search box is closed, open it if it exists (otherwise exception raised).
-    If it is opened but not in the default view (expression editor), close it and open again to
-    ensure the default view is present.
     """
     if not is_advanced_search_possible():
         raise Exception("Advanced search is not possible in this location!")
     if not is_advanced_search_opened():
         sel.click(search_box.toggle_advanced)   # Open
-    elif not sel.is_displayed(search_box.load_filter_button):   # If we aren't in default view
-        if current_version() >= "5.4":
-            sel.click(search_box.close_button)
-        else:
-            sel.click(search_box.toggle_advanced)   # Close
-        wait_for(is_advanced_search_opened, fail_condition=True, num_sec=5)
-        sel.click(search_box.toggle_advanced)   # And open to see the default view
+
     wait_for(is_advanced_search_opened, fail_condition=False, num_sec=5)
 
 
 def reset_filter():
     """Clears the filter expression"""
     ensure_advanced_search_open()
-    sel.click(search_box.reset_filter_button)
+    if sel.is_displayed(search_box.reset_filter):
+        return sel.click(search_box.reset_filter_button)
+    else:
+        return False
+
+
+def apply_filter():
+    """Applies an existing filter"""
+    ensure_advanced_search_open()
+    if sel.is_displayed(search_box.apply_filter):
+        return sel.click(search_box.apply_filter_button)
+    else:
+        return False
 
 
 def delete_filter(cancel=False):
@@ -199,15 +223,16 @@ def save_filter(expression_program, save_name, global_search=False, cancel=False
         expression_program: the expression to be filled.
         save_name: Name of the filter to be saved with.
         global_search: Whether to check the Global search checkbox.
+        cancel: Whether to cancel the save dialog without saving
     """
     fill_expression(expression_program)
     sel.click(search_box.save_filter_button)
     fill(search_box.save_name, save_name)
     fill(search_box.global_search, global_search)
-    if cancel:
-        sel.click(search_box.cancel_save_filter_dialog_button)
-    else:
-        sel.click(search_box.save_filter_dialog_button)
+    button = search_box.cancel_save_filter_dialog_button if cancel \
+        else search_box.save_filter_dialog_button
+
+    return sel.click(button)
 
 
 def load_filter(saved_filter=None, report_filter=None, cancel=False):
@@ -216,20 +241,25 @@ def load_filter(saved_filter=None, report_filter=None, cancel=False):
     Args:
         saved_filter: `Choose a saved XYZ filter`
         report_filter: `Choose a XYZ report filter`
+        cancel: Whether to cancel the load dialog without loading
     """
+    ensure_advanced_search_open()
+    if sel.is_displayed(search_box.load_filter_disabled):
+        raise DisabledButtonException('Load Filter button disabled, '
+            'cannot load filter: {}'.format(saved_filter))
     assert saved_filter is not None or report_filter is not None, "At least 1 param required!"
     assert (saved_filter is not None) ^ (report_filter is not None), "You must provide just one!"
-    ensure_advanced_search_open()
+
     sel.click(search_box.load_filter_button)
     # We apply it to the whole form but it will fill only one of the selects
     if saved_filter is not None:
         fill(search_box.saved_filter, saved_filter)
     else:   # No other check needed, covered by those two asserts
         fill(search_box.report_filter, report_filter)
-    if cancel:
-        sel.click(search_box.cancel_load_filter_dialog_button)
-    else:
-        sel.click(search_box.load_filter_dialog_button)
+    button = search_box.cancel_load_filter_dialog_button if cancel \
+        else search_box.load_filter_dialog_button
+
+    return sel.click(button)
     # todo update flash message handler
 
 
@@ -296,3 +326,15 @@ def fill_and_apply_filter(expression_program, fill_callback=None, cancel_on_user
     sel.click(search_box.apply_filter_button)
     _process_user_filling(fill_callback, cancel_on_user_filling)
     ensure_advanced_search_closed()
+
+
+def save_and_apply_filter(expression_program, save_name, global_search=False):
+    save_filter(expression_program=expression_program, save_name=save_name,
+            global_search=global_search)
+    apply_filter()
+    ensure_advanced_search_closed()
+
+
+class DisabledButtonException(Exception):
+    def __init__(self, *args, **kwargs):
+        Exception.__init__(self, *args, **kwargs)


### PR DESCRIPTION
{{pytest: cfme/tests/infrastructure/test_advanced_search_vms.py cfme/tests/infrastructure/test_advanced_search_providers.py cfme/tests/infrastructure/test_advanced_search_host.py }}

Purpose or Intent
=================

Updating web_ui.search to:
  - include locators for disabled buttons that don't have alt-text
  - add dimmed-alt text where appropriate
  - made the reset_filter() function more robust
  - added an apply_filter() function
  - added a save_and_apply() function
  - modified single action functions (save, apply, delete) return the boolean result of the click
  -- Allows for tests that take multiple actions (save_and_load) to assert on each action taken.



This supports PR 3427 by @mmojzis and further improvements/fixes to the advanced search tests.