### PR TITLE
New navigation for reports

### DIFF
--- a/cfme/tests/intelligence/test_download_report.py
+++ b/cfme/tests/intelligence/test_download_report.py
@@ -2,7 +2,7 @@
 import pytest
 import os
 import shutil
-from cfme.intelligence.reports import reports
+from cfme.intelligence.reports.reports import CannedSavedReport
 from utils.providers import setup_a_provider as _setup_a_provider
 from utils.wait import wait_for
 from utils import browser
@@ -38,7 +38,7 @@ def needs_firefox():
 @pytest.fixture(scope="module")
 def report():
     path = ["Configuration Management", "Virtual Machines", "Hardware Information for VMs"]
-    return reports.CannedSavedReport(path, reports.queue_canned_report(*path))
+    return CannedSavedReport(path, CannedSavedReport.queue_canned_report(path))
 
 
 # TODO Prevent Firefox from popping up "Save file" in order to add 'pdf' parametrization

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -1562,6 +1562,10 @@ class IPAppliance(object):
             return "ManageIQ Region: Region {} [{}]".format(r, r)
 
     @cached_property
+    def company_name(self):
+        return self.get_yaml_config("vmdb")["server"]["company"]
+
+    @cached_property
     def zone_description(self):
         return db_queries.get_zone_description(self.server_zone_id(), db=self.db)
 


### PR DESCRIPTION
{{ pytest: cfme/tests/intelligence/reports/test_crud.py  cfme/tests/intelligence/reports/test_canned_corresponds.py cfme/tests/intelligence/test_download_report.py -k "test_custom_report_crud or test_providers_summary or test_download_report_firefox" }} 