### PR TITLE
[WIPTEST]Replaced DynamoDB and cleanup finalizer

### DIFF
--- a/cfme/services/catalogs/service_catalogs.py
+++ b/cfme/services/catalogs/service_catalogs.py
@@ -33,10 +33,14 @@ stack_form = Form(
         ('stack_name', Input("stack_name")),
         ('resource_group', Select("//select[@id='resource_group']")),
         ('mode', Select("//select[@id='deploy_mode']")),
+        ('user_image', Select("//select[@id='param_userImageName']")),
+        ('os_type', Select("//select[@id='param_operatingSystemType']")),
         ('vm_name', Input("param_virtualMachineName")),
         ('vm_user', Input("param_adminUserName")),
         ('vm_password', Input("param_adminPassword__protected")),
-        ('vm_size', Select("//select[@id='param_virtualMachineSize']"))
+        ('vm_size', Select("//select[@id='param_virtualMachineSize']")),
+        ('key_size', Select("//select[@id='param_InstanceType']")),
+        ('ssh_location', Input("param_SSHLocation"))
     ])
 
 

--- a/cfme/tests/services/test_provision_stack.py
+++ b/cfme/tests/services/test_provision_stack.py
@@ -26,68 +26,132 @@ pytestmark = [
 AWS_TEMPLATE = """
 {
   "AWSTemplateFormatVersion" : "2010-09-09",
-  "Description" : "AWS CloudFormation Sample Template DynamoDB_Table",
+
+  "Description" : "AWS CloudFormation Sample Template EC2InstanceWithSecurityGroupSample:",
+
   "Parameters" : {
-    "HaskKeyElementName" : {
-      "Description" : "HashType PrimaryKey Name",
+    "KeyName": {
+      "Description" : "Name of an existing EC2 KeyPair to enable SSH access to the instance",
+      "Type": "AWS::EC2::KeyPair::KeyName",
+      "ConstraintDescription" : "must be the name of an existing EC2 KeyPair."
+    },
+
+    "virtualMachineName" : {
+      "Description" : "Name of the Virtual Machine",
       "Type" : "String",
-      "AllowedPattern" : "[a-zA-Z0-9]*",
-      "Default" : "SSS",
-      "MinLength": "1",
-      "MaxLength": "2048",
-      "ConstraintDescription" : "must contain only alphanumberic characters"
+      "ConstraintDescription" : "must be a valid EC2 instance name."
     },
 
-    "HaskKeyElementType" : {
-      "Description" : "HashType PrimaryKey Type",
+    "InstanceType" : {
+      "Description" : "WebServer EC2 instance type",
       "Type" : "String",
-      "Default" : "S",
-      "AllowedPattern" : "[S|N]",
-      "MinLength": "1",
-      "MaxLength": "1",
-      "ConstraintDescription" : "must be either S or N"
+      "Default" : "t2.small",
+      "AllowedValues" : [ "t1.micro", "t2.nano", "t2.micro", "t2.small", "t2.medium", "t2.large"],
+      "ConstraintDescription" : "must be a valid EC2 instance type."
     },
 
-    "ReadCapacityUnits" : {
-      "Description" : "Provisioned read throughput",
-      "Type" : "Number",
-      "Default" : "5",
-      "MinValue": "5",
-      "MaxValue": "10000",
-      "ConstraintDescription" : "must be between 5 and 10000"
-    },
-
-    "WriteCapacityUnits" : {
-      "Description" : "Provisioned write throughput",
-      "Type" : "Number",
-      "Default" : "10",
-      "MinValue": "5",
-      "MaxValue": "10000",
-      "ConstraintDescription" : "must be between 5 and 10000"
-    }
+    "SSHLocation" : {
+      "Description" : "The IP address range that can be used to SSH to the EC2 instances",
+      "Type": "String",
+      "MinLength": "9",
+      "MaxLength": "18",
+      "Default": "0.0.0.0/0",
+      "ConstraintDescription": "must be a valid IP CIDR range of the form x.x.x.x/x."
+   }
   },
+
+  "Mappings" : {
+    "AWSInstanceType2Arch" : {
+      "t1.micro"    : { "Arch" : "PV64"   },
+      "t2.nano"     : { "Arch" : "HVM64"  },
+      "t2.micro"    : { "Arch" : "HVM64"  },
+      "t2.small"    : { "Arch" : "HVM64"  },
+      "t2.medium"   : { "Arch" : "HVM64"  },
+      "t2.large"    : { "Arch" : "HVM64"  }
+    },
+
+    "AWSInstanceType2NATArch" : {
+      "t1.micro"    : { "Arch" : "NATPV64"   },
+      "t2.nano"     : { "Arch" : "NATHVM64"  },
+      "t2.micro"    : { "Arch" : "NATHVM64"  },
+      "t2.small"    : { "Arch" : "NATHVM64"  },
+      "t2.medium"   : { "Arch" : "NATHVM64"  },
+      "t2.large"    : { "Arch" : "NATHVM64"  }
+    }
+,
+    "AWSRegionArch2AMI" : {
+      "us-east-1"        : {
+      "PV64" : "ami-2a69aa47", "HVM64" : "ami-6869aa05", "HVMG2" : "ami-2e5e9c43"},
+      "us-west-2"        : {
+      "PV64" : "ami-7f77b31f", "HVM64" : "ami-7172b611", "HVMG2" : "ami-83b770e3"},
+      "us-west-1"        : {
+      "PV64" : "ami-a2490dc2", "HVM64" : "ami-31490d51", "HVMG2" : "ami-fd76329d"},
+      "eu-west-1"        : {
+      "PV64" : "ami-4cdd453f", "HVM64" : "ami-f9dd458a", "HVMG2" : "ami-b9bd25ca"},
+      "eu-central-1"     : {
+      "PV64" : "ami-6527cf0a", "HVM64" : "ami-ea26ce85", "HVMG2" : "ami-7f04ec10"},
+      "ap-northeast-1"   : {
+      "PV64" : "ami-3e42b65f", "HVM64" : "ami-374db956", "HVMG2" : "ami-e0ee1981"},
+      "ap-northeast-2"   : {
+      "PV64" : "NOT_SUPPORTED", "HVM64" : "ami-2b408b45", "HVMG2" : "NOT_SUPPORTED"},
+      "ap-southeast-1"   : {
+      "PV64" : "ami-df9e4cbc", "HVM64" : "ami-a59b49c6", "HVMG2" : "ami-0cb5676f"},
+      "ap-southeast-2"   : {
+      "PV64" : "ami-63351d00", "HVM64" : "ami-dc361ebf", "HVMG2" : "ami-a71c34c4"},
+      "ap-south-1"       : {
+      "PV64" : "NOT_SUPPORTED", "HVM64" : "ami-ffbdd790", "HVMG2" : "ami-f5b2d89a"},
+      "sa-east-1"        : {
+      "PV64" : "ami-1ad34676", "HVM64" : "ami-6dd04501", "HVMG2" : "NOT_SUPPORTED"},
+      "cn-north-1"       : {
+      "PV64" : "ami-77559f1a", "HVM64" : "ami-8e6aa0e3", "HVMG2" : "NOT_SUPPORTED"}
+    }
+
+  },
+
   "Resources" : {
-    "myDynamoDBTable" : {
-      "Type" : "AWS::DynamoDB::Table",
+    "EC2Instance" : {
+      "Type" : "AWS::EC2::Instance",
       "Properties" : {
-        "AttributeDefinitions": [ {
-          "AttributeName" : {"Ref" : "HaskKeyElementName"},
-          "AttributeType" : {"Ref" : "HaskKeyElementType"}
-        } ],
-        "KeySchema": [
-          { "AttributeName": {"Ref" : "HaskKeyElementName"}, "KeyType": "HASH" }
-        ],
-        "ProvisionedThroughput" : {
-          "ReadCapacityUnits" : {"Ref" : "ReadCapacityUnits"},
-          "WriteCapacityUnits" : {"Ref" : "WriteCapacityUnits"}
-        }
+        "InstanceType" : { "Ref" : "InstanceType" },
+        "SecurityGroups" : [ { "Ref" : "InstanceSecurityGroup" } ],
+        "KeyName" : { "Ref" : "KeyName" },
+        "ImageId" : { "Fn::FindInMap" : [ "AWSRegionArch2AMI", { "Ref" : "AWS::Region" },
+                          { "Fn::FindInMap" : [ "AWSInstanceType2Arch",
+                          { "Ref" : "InstanceType" }, "Arch" ] } ] },
+        "Tags" : [{"Key" : "Name", "Value" : { "Ref" : "virtualMachineName" }}]
+      }
+    },
+
+    "InstanceSecurityGroup" : {
+      "Type" : "AWS::EC2::SecurityGroup",
+      "Properties" : {
+        "GroupDescription" : "Enable SSH access via port 22",
+        "SecurityGroupIngress" : [ {
+          "IpProtocol" : "tcp",
+          "FromPort" : "22",
+          "ToPort" : "22",
+          "CidrIp" : { "Ref" : "SSHLocation"}
+        } ]
       }
     }
   },
+
   "Outputs" : {
-    "TableName" : {
-      "Value" : {"Ref" : "myDynamoDBTable"},
-      "Description" : "Table name of the newly created DynamoDB table"
+    "InstanceId" : {
+      "Description" : "InstanceId of the newly created EC2 instance",
+      "Value" : { "Ref" : "EC2Instance" }
+    },
+    "AZ" : {
+      "Description" : "Availability Zone of the newly created EC2 instance",
+      "Value" : { "Fn::GetAtt" : [ "EC2Instance", "AvailabilityZone" ] }
+    },
+    "PublicDNS" : {
+      "Description" : "Public DNSName of the newly created EC2 instance",
+      "Value" : { "Fn::GetAtt" : [ "EC2Instance", "PublicDnsName" ] }
+    },
+    "PublicIP" : {
+      "Description" : "Public IP address of the newly created EC2 instance",
+      "Value" : { "Fn::GetAtt" : [ "EC2Instance", "PublicIp" ] }
     }
   }
 }
@@ -131,7 +195,6 @@ outputs:
     description: IP address of the instance
     value: { get_attr: [my_instance, first_address]}
 """
-
 
 def pytest_generate_tests(metafunc):
     # Filter out providers without templates defined
@@ -209,26 +272,37 @@ def random_desc():
 
 
 def prepare_stack_data(provider, provisioning):
-    stackname = "test" + fauxfactory.gen_alphanumeric()
+    stack_name = "test" + fauxfactory.gen_alphanumeric()
+    vm_name = stack_name
     if provider.type == "azure":
-        vm_name = "test" + fauxfactory.gen_alphanumeric()
         vm_user, vm_password, vm_size, resource_group,\
             user_image, os_type, mode = map(provisioning.get,
          ('vm_user', 'vm_password', 'vm_size', 'resource_group',
         'user_image', 'os_type', 'mode'))
 
         stack_data = {
-            'stack_name': stackname,
+            'stack_name': stack_name,
             'vm_name': vm_name,
             'resource_group': resource_group,
             'mode': mode,
             'vm_user': vm_user,
             'vm_password': vm_password,
-            'vm_size': vm_size
+            'vm_size': vm_size,
+            'user_image': user_image,
+            'os_type': os_type
+        }
+        return stack_data
+    elif provider.type == 'ec2':
+        guest_keypair, ssh_location = map(provisioning.get, ('guest_keypair', 'ssh_location'))
+        stack_data = {
+            'stack_name': stack_name,
+            'key_name': guest_keypair,
+            'vm_name': vm_name,
+            'ssh_location': ssh_location
         }
         return stack_data
     else:
-        stack_data = {'stack_name': stackname}
+        stack_data = {'stack_name': stack_name}
         return stack_data
 
 
@@ -310,7 +384,12 @@ def test_reconfigure_service(provider, provisioning, catalog, catalog_item, requ
     myservice.reconfigure_service()
 
 
-def test_remove_template_provisioning(provider, provisioning, catalog, catalog_item, template):
+def test_remove_template_provisioning(provider,
+                                      provisioning,
+                                      catalog,
+                                      catalog_item,
+                                      template,
+                                      request):
     """Tests stack provisioning
 
     Metadata:
@@ -318,10 +397,16 @@ def test_remove_template_provisioning(provider, provisioning, catalog, catalog_i
     """
     catalog_item, item_name = catalog_item
     stack_data = prepare_stack_data(provider, provisioning)
+
+    @request.addfinalizer
+    def _clean_provider():
+        clean_up(stack_data, provider)
+
     service_catalogs = ServiceCatalogs("service_name", stack_data)
     service_catalogs.order_stack_item(catalog.name, catalog_item)
     # This is part of test - remove template and see if provision fails , so not added as finalizer
-    template.delete()
+    if provider.type != "azure":
+        template.delete()
     row_description = 'Provisioning Service [{}] from [{}]'.format(item_name, item_name)
     cells = {'Description': row_description}
     wait_for(lambda: requests.find_request(cells), num_sec=500, delay=20)
@@ -341,6 +426,11 @@ def test_retire_stack(provider, provisioning, catalog, catalog_item, request):
     DefaultView.set_default_view("Stacks", "Grid View")
 
     stack_data = prepare_stack_data(provider, provisioning)
+
+    @request.addfinalizer
+    def _clean_provider():
+        clean_up(stack_data, provider)
+
     service_catalogs = ServiceCatalogs("service_name", stack_data)
     service_catalogs.order_stack_item(catalog.name, catalog_item)
     logger.info('Waiting for cfme provision request for service %s', item_name)
@@ -363,3 +453,11 @@ def test_retire_stack(provider, provisioning, catalog, catalog_item, request):
             logger.warning('Exception while checking/deleting stack, continuing: {}'
                            .format(ex.message))
             pass
+
+
+def clean_up(stack_data, provider):
+    if provider.mgmt.stack_exist(stack_data['stack_name']):
+        wait_for(lambda: provider.mgmt.delete_stack(stack_data['stack_name']),
+         delay=10, num_sec=900, message="wait for stack delete")
+    if provider.type == 'azure':
+        provider.mgmt.delete_vm(stack_data['vm_name'])


### PR DESCRIPTION
Purpose or Intent

Goal one was to replace DynamoDB with a standard instance.  This allows us to save money and leverage the existing cleanup script.

Also, VMs on EC2 and Azure were not being cleaned up properly.

Lastly, there were a few logic errors which were deleting files on the appliance the would cause subsequent tests to fail.

Still want to polish up the finalizer.
