### PR TITLE
Added support of DBAllocator service in middleware provider tests.

### DIFF
--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -302,7 +302,11 @@ class MiddlewareDomainNotFound(CFMEException):
 
 
 class JDBCDriverConfigNotFound(CFMEException):
-    """Raised then cdme_data.yaml file does not contain configuration of 'jdbc_drivers'."""
+    """Raised when cdme_data.yaml file does not contain configuration of 'jdbc_drivers'."""
+
+
+class DbAllocatorConfigNotFound(CFMEException):
+    """Raised when cdme_data.yaml file does not contain configuration of 'db_allocator'."""
 
 
 class UsingSharedTables(CFMEException):

--- a/cfme/tests/middleware/datasource_methods.py
+++ b/cfme/tests/middleware/datasource_methods.py
@@ -1,36 +1,65 @@
-from cfme.middleware.datasource import MiddlewareDatasource
 from utils.wait import wait_for
-from jdbc_driver_methods import DB2_105, MSSQL_2014, MYSQL_57
-from jdbc_driver_methods import POSTGRESPLUS_94, POSTGRESQL_94
-from jdbc_driver_methods import SYBASE_157, ORACLE_12C, MARIADB10
+from jdbc_driver_methods import DB2_105_JDBC, MSSQL_2014_JDBC, MYSQL_57_JDBC
+from jdbc_driver_methods import POSTGRESPLUS_94_JDBC, POSTGRESQL_94_JDBC
+from jdbc_driver_methods import SYBASE_157_JDBC, ORACLE_12C_JDBC, MARIADB10_JDBC
+from cfme.middleware.datasource import MiddlewareDatasource
+from dballocator_methods import MSSQL_2014_DBALLO, DB2_105_DBALLO, POSTGRESPLUS_94_DBALLO
+from dballocator_methods import MYSQL_57_DBALLO, POSTGRESQL_94_DBALLO, SYBASE_157_DBALLO
+from dballocator_methods import ORACLE_12C_DBALLO, ORACLE_12C_RAC_DBALLO, MARIADB_10_DBALLO
 
 
-H2 = ['H2', 'H2DS', 'java:/H2DS', 'h2', 'com.h2database.h2', 'org.h2.Driver',
+"""Properties to be used during Datasource creation,
+each property is an array with necessary fields used during creation.
+PROPERTIES[0] Database Type used in creation form.
+PROPERTIES[1] name of datasource.
+PROPERTIES[2] JNDI name of datasource.
+PROPERTIES[3] name of driver.
+PROPERTIES[4] module name.
+PROPERTIES[5] jdbc driver class.
+PROPERTIES[6] Database connection URL.
+PROPERTIES[7] Database username.
+PROPERTIES[8] Database password.
+PROPERTIES[9] Database name in DBAllocator.
+"""
+H2_DS = ['H2', 'H2DS', 'java:/H2DS', 'h2', 'com.h2database.h2', 'org.h2.Driver',
       'jdbc:h2:mem:test;DB_CLOSE_DELAY=-1', 'admin', '']
-DB2_105 = ['IBM DB2', 'DB2DS', 'java:/DB2DS',
-           DB2_105[1], DB2_105[2], DB2_105[3],
-           'jdbc:ibmdb2://db2', 'admin', '']
-MSSQL_2014 = ['Microsoft SQL Server', 'MSSQLDS', 'java:/MSSQLDS',
-              MSSQL_2014[1], MSSQL_2014[2], MSSQL_2014[3],
-           'jdbc:sqlserver://localhost:1433;DatabaseName=MyDatabase', 'admin', '']
-MYSQL_57 = ['MySql', 'MySqlDS', 'java:/MySqlDS',
-            MYSQL_57[1], MYSQL_57[2], MYSQL_57[3],
-           'jdbc:mysql://localhost:3306/mysqldb', 'admin', '']
-POSTGRESPLUS_94 = ['Postgres', 'PostgresPlusDS', 'java:/PostgresPlusDS',
-                   POSTGRESPLUS_94[1], POSTGRESPLUS_94[2], POSTGRESPLUS_94[3],
-           'jdbc:postresql://localhost:5432/postgresdb', 'admin', '']
-POSTGRESQL_94 = ['Postgres', 'PostgresDS', 'java:/PostgresDS',
-                 POSTGRESQL_94[1], POSTGRESQL_94[2], POSTGRESQL_94[3],
-           'jdbc:postresql://localhost:5432/postgresdb', 'admin', '']
-SYBASE_157 = ['Sybase', 'SybaseDS', 'java:/SybaseDB',
-              SYBASE_157[1], SYBASE_157[2], SYBASE_157[3],
-           'jdbc:sybase:Tds:localhost:5000/mydatabase?JCONNECT_VERSION=6', 'admin', '']
-ORACLE_12C = ['Oracle', 'OracleDS', 'java:/OracleDS',
-              ORACLE_12C[1], ORACLE_12C[2], ORACLE_12C[3],
-           'jdbc:oracle:thin:@localhost:1521:orcalesid', 'admin', '']
-MARIADB10 = ['MariaDB', 'MariaDBDS', 'java:/MariaDBDS',
-             MARIADB10[1], MARIADB10[2], MARIADB10[3],
-           'jdbc:mariadb://localhost:3306/mariadb', 'admin', '']
+DB2_105_DS = ['IBM DB2', 'DB2DS', 'java:/DB2DS',
+           DB2_105_JDBC[1], DB2_105_JDBC[2], DB2_105_JDBC[3],
+           'jdbc:ibmdb2://db2', 'admin', '',
+           DB2_105_DBALLO]
+MSSQL_2014_DS = ['Microsoft SQL Server', 'MSSQLDS', 'java:/MSSQLDS',
+              MSSQL_2014_JDBC[1], MSSQL_2014_JDBC[2], MSSQL_2014_JDBC[3],
+              'jdbc:sqlserver://localhost:1433;DatabaseName=MyDatabase', 'admin', '',
+              MSSQL_2014_DBALLO]
+MYSQL_57_DS = ['MySql', 'MySqlDS', 'java:/MySqlDS',
+            MYSQL_57_JDBC[1], MYSQL_57_JDBC[2], MYSQL_57_JDBC[3],
+            'jdbc:mysql://localhost:3306/mysqldb', 'admin', '',
+            MYSQL_57_DBALLO]
+POSTGRESPLUS_94_DS = ['Postgres', 'PostgresPlusDS', 'java:/PostgresPlusDS',
+                   POSTGRESPLUS_94_JDBC[1], POSTGRESPLUS_94_JDBC[2], POSTGRESPLUS_94_JDBC[3],
+                   'jdbc:postresql://localhost:5432/postgresdb', 'admin', '',
+                   POSTGRESPLUS_94_DBALLO]
+POSTGRESQL_94_DS = ['Postgres', 'PostgresDS', 'java:/PostgresDS',
+                 POSTGRESQL_94_JDBC[1], POSTGRESQL_94_JDBC[2], POSTGRESQL_94_JDBC[3],
+                 'jdbc:postresql://localhost:5432/postgresdb', 'admin', '',
+                 POSTGRESQL_94_DBALLO]
+SYBASE_157_DS = ['Sybase', 'SybaseDS', 'java:/SybaseDB',
+              SYBASE_157_JDBC[1], SYBASE_157_JDBC[2], SYBASE_157_JDBC[3],
+              'jdbc:sybase:Tds:localhost:5000/mydatabase?JCONNECT_VERSION=6', 'admin', '',
+              SYBASE_157_DBALLO]
+ORACLE_12C_DS = ['Oracle', 'OracleDS', 'java:/OracleDS',
+              ORACLE_12C_JDBC[1], ORACLE_12C_JDBC[2], ORACLE_12C_JDBC[3],
+              'jdbc:oracle:thin:@localhost:1521:orcalesid', 'admin', '',
+              ORACLE_12C_DBALLO]
+ORACLE_12C_RAC_DS = ['Oracle', 'OracleRACDS', 'java:/OracleRACDS',
+                  ORACLE_12C_JDBC[1], ORACLE_12C_JDBC[2], ORACLE_12C_JDBC[3],
+                  'jdbc:oracle:thin:@(DESCRIPTION=(LOAD_BALANCE=on)(ADDRESS=(PROTOCOL=TCP)' +
+                  '(HOST=localhost)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=qaora)))', 'admin', '',
+                  ORACLE_12C_RAC_DBALLO]
+MARIADB10_DS = ['MariaDB', 'MariaDBDS', 'java:/MariaDBDS',
+             MARIADB10_JDBC[1], MARIADB10_JDBC[2], MARIADB10_JDBC[3],
+             'jdbc:mariadb://localhost:3306/mariadb', 'admin', '',
+             MARIADB_10_DBALLO]
 
 
 def get_datasources_set(datasources):

--- a/cfme/tests/middleware/dballocator_methods.py
+++ b/cfme/tests/middleware/dballocator_methods.py
@@ -1,0 +1,122 @@
+import pytest
+from contextlib import contextmanager
+from contextlib import closing
+from urllib2 import urlopen, HTTPError
+from cfme.exceptions import DbAllocatorConfigNotFound
+from utils import conf
+
+
+REQUESTEE = "cfme_tests"
+DS_UUID_PROP = 'uuid'
+DS_URL_PROP = 'db.jdbc_url'
+DS_USERNAME_PROP = 'db.username'
+DS_PASSWORD_PROP = 'db.password'
+DB2_105_DBALLO = 'db2_105'
+MSSQL_2014_DBALLO = 'mssql2014'
+MYSQL_57_DBALLO = 'mysql57'
+POSTGRESPLUS_94_DBALLO = 'postgresplus94'
+POSTGRESQL_94_DBALLO = 'postgresql94'
+SYBASE_157_DBALLO = 'sybase157'
+ORACLE_12C_DBALLO = 'oracle12c'
+ORACLE_12C_RAC_DBALLO = 'oracle12cRAC'
+MARIADB_10_DBALLO = 'mariadb10'
+SEP = '='
+
+
+@contextmanager
+def db_allocate(db_type, expiry=1):
+    """
+    Method for allocating database via DBAllocator tool by providing database type,
+    expiry time in minutes and the name of requestee.
+
+    It returns the result of DBAllocator allocate action in dictionary format,
+    which contains the connection properties to allocated database.
+    From returned properties, very important one is 'uuid',
+        which will be used for manually deallocating database.
+
+    Args:
+        db_type: type of the database which is registered in DBAllocator,
+            all possible types are in this class.
+        expiry: reservation duration in minutes after
+            which database will be automatically deallocated (optional).
+
+    Returns:
+        database connection properties as dictionary containing information:
+            db.password=password
+            hibernate.connection.password=password
+            hibernate41.dialect=org.hibernate.dialect.PostgresPlusDialect
+            broken=false
+            db.username=username
+            server_geo=location
+            dballoc.db_type=standard
+            db.jdbc_url=formatted jdbc url to connect
+            db.name=database name
+            db.hostname=database hostname
+            datasource.class.xa=XADataSource class
+            server_uid=server uid
+            hibernate33.dialect=org.hibernate.dialect{}Dialect
+            server_labels=server_label
+            hibernate.connection.username=username
+            db.jdbc_class=JDBC Driver Class
+            db.schema=schema name
+            hibernate.connection.driver_class=Driver Class
+            uuid=uuid of database instance in DBAllocator tool, will be used in deallocation
+            db.primary_label=label
+            db.port=port
+            server_label_primary=server label
+            hibernate.dialect=org.hibernate.dialect.{}Dialect
+            hibernate.connection.url=formatted jdbc url to connect
+            hibernate.connection.schema=schema name
+
+    Usage:
+        properties = db_allocate('oracle12c')
+    """
+    try:
+        db_allocate_url = conf.cfme_data.get(
+            'resources', {})['databases']['db_allocator']['db_allocate_url']
+        with closing(urlopen(db_allocate_url.format(db_type, expiry, REQUESTEE))) as http:
+            properties = http.read().strip()
+            db_metadata = parse_properties(properties)
+        yield db_metadata
+        db_deallocate(db_metadata[DS_UUID_PROP])
+    except KeyError:
+        raise DbAllocatorConfigNotFound(
+            "db_allocator configuration is missing in cfme_data.yaml")
+    except HTTPError as e:
+        pytest.fail('Error {} while allocating database {}'.format(e, db_type))
+
+
+def db_deallocate(uuid):
+    """
+    Method for deallocating reserved database from DBAllocator tool by provided uuid.
+    uuid parameter was returned as a property during allocation.
+
+    Args:
+        uuid=uuid of database instance in DBAllocator tool.
+
+    Usage:
+        properties = db_allocate('oracle12c')
+        db_deallocate(properties['uuid'])
+    """
+    try:
+        db_deallocate_url = conf.cfme_data.get(
+            'resources', {})['databases']['db_allocator']['db_deallocate_url']
+        with closing(urlopen(db_deallocate_url.format(uuid))) as http:
+            http.read().strip()
+    except KeyError:
+        raise DbAllocatorConfigNotFound(
+            "db_allocator configuration is missing in cfme_data.yaml")
+    except HTTPError as e:
+        # ignore error in deallocation
+        print(str(e))
+
+
+def parse_properties(props):
+    """Parses provided properties in string format into dictionary format.
+    It splits string into lines and splits each line into key and value by the first occurance."""
+    properties = {}
+    for line in props.splitlines():
+        pair = line.split(SEP, 1)
+        if len(pair) == 2:
+            properties.update({pair[0]: pair[1].replace('\'', '')})
+    return properties

--- a/cfme/tests/middleware/jdbc_driver_methods.py
+++ b/cfme/tests/middleware/jdbc_driver_methods.py
@@ -16,15 +16,17 @@ PROPERTIES[3] jdbc driver class.
 PROPERTIES[4] major version of driver.
 PROPERTIES[5] minor version of driver.
 """
-DB2_105 = ['db2-105', 'db2', 'com.ibm', 'com.ibm.db2.jcc.DB2Driver', '', '']
-MSSQL_2014 = ['mssql2014', 'mssql', 'com.microsoft',
+DB2_105_JDBC = ['db2-105', 'db2', 'com.ibm', 'com.ibm.db2.jcc.DB2Driver', '', '']
+MSSQL_2014_JDBC = ['mssql2014', 'mssql', 'com.microsoft',
               'com.microsoft.sqlserver.jdbc.SQLServerDriver', '', '']
-MYSQL_57 = ['mysql57', 'mysql', 'com.mysql', 'com.mysql.jdbc.Driver', '5', '1']
-POSTGRESPLUS_94 = ['postgresplus94', 'edb', 'com.edb', 'com.edb.Driver', '', '']
-POSTGRESQL_94 = ['postgresql94', 'postgresql', 'org.postgresql', 'org.postgresql.Driver', '', '']
-SYBASE_157 = ['sybase157', 'sybase', 'com.sybase', 'com.sybase.jdbc4.jdbc.SybDriver', '', '']
-ORACLE_12C = ['oracle12c', 'oracle12c', 'com.oracle', 'oracle.jdbc.OracleDriver', '', '']
-MARIADB10 = ['mariadb10', 'mariadb10', 'org.mariadb', 'org.mariadb.jdbc.Driver', '', '']
+MYSQL_57_JDBC = ['mysql57', 'mysql', 'com.mysql', 'com.mysql.jdbc.Driver', '5', '1']
+POSTGRESPLUS_94_JDBC = ['postgresplus94', 'edb', 'com.edb', 'com.edb.Driver', '', '']
+POSTGRESQL_94_JDBC = ['postgresql94', 'postgresql', 'org.postgresql',
+                      'org.postgresql.Driver', '', '']
+SYBASE_157_JDBC = ['sybase157', 'sybase', 'com.sybase',
+                   'com.sybase.jdbc4.jdbc.SybDriver', '', '']
+ORACLE_12C_JDBC = ['oracle12c', 'oracle12c', 'com.oracle', 'oracle.jdbc.OracleDriver', '', '']
+MARIADB10_JDBC = ['mariadb10', 'mariadb10', 'org.mariadb', 'org.mariadb.jdbc.Driver', '', '']
 
 
 def download_jdbc_driver(database_name):

--- a/cfme/tests/middleware/test_middleware_drivers.py
+++ b/cfme/tests/middleware/test_middleware_drivers.py
@@ -5,8 +5,8 @@ from utils.version import current_version
 from deployment_methods import get_server
 from deployment_methods import EAP_PRODUCT_NAME
 from jdbc_driver_methods import download_jdbc_driver, deploy_jdbc_driver
-from jdbc_driver_methods import ORACLE_12C, DB2_105, MSSQL_2014, MYSQL_57
-from jdbc_driver_methods import POSTGRESPLUS_94, POSTGRESQL_94, SYBASE_157
+from jdbc_driver_methods import ORACLE_12C_JDBC, DB2_105_JDBC, MSSQL_2014_JDBC, MYSQL_57_JDBC
+from jdbc_driver_methods import POSTGRESPLUS_94_JDBC, POSTGRESQL_94_JDBC, SYBASE_157_JDBC
 
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
@@ -15,13 +15,13 @@ pytestmark = [
 pytest_generate_tests = testgen.generate(testgen.provider_by_type, ["hawkular"], scope="function")
 ITEMS_LIMIT = 5  # when we have big list, limit number of items to test
 
-DATABASES = [ORACLE_12C,
-             DB2_105,
-             MSSQL_2014,
-             MYSQL_57,
-             POSTGRESPLUS_94,
-             POSTGRESQL_94,
-             SYBASE_157]
+DATABASES = [ORACLE_12C_JDBC,
+             DB2_105_JDBC,
+             MSSQL_2014_JDBC,
+             MYSQL_57_JDBC,
+             POSTGRESPLUS_94_JDBC,
+             POSTGRESQL_94_JDBC,
+             SYBASE_157_JDBC]
 
 
 @pytest.mark.parametrize("database_params", DATABASES)

--- a/conf/cfme_data.yaml.template
+++ b/conf/cfme_data.yaml.template
@@ -622,5 +622,8 @@ resources:
      databases:
         jdbc_drivers:
             jdbc_drivers_url: jdbc driver file url
+        db_allocator:
+            db_allocate_url: url for allocation
+            db_deallocate_url: url for deallocation
 
 cfme_annotations_path: data/testcase_tiers_and_types.csv


### PR DESCRIPTION
Added new methods to allocate and deallocate database on request.

Usage:
properties = db_allocate('oracle12c')
db_deallocate(properties['uuid'])
