### PR TITLE
[RFR] Refactor utils.providers and testgen

### DIFF
--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -133,7 +133,7 @@ class CloudProvider(Pretty, CloudInfraProvider):
     """
     provider_types = {}
     in_version = (version.LOWEST, version.LATEST)
-    type_tclass = "cloud"
+    category = "cloud"
     pretty_attrs = ['name', 'credentials', 'zone', 'key']
     STATS_TO_MATCH = ['num_template', 'num_vm']
     string_name = "Cloud"

--- a/cfme/cloud/provider/azure.py
+++ b/cfme/cloud/provider/azure.py
@@ -12,15 +12,18 @@ class AzureProvider(CloudProvider):
                  tenant_id=None, subscription_id=None):
         super(AzureProvider, self).__init__(name=name, credentials=credentials,
                                             zone=zone, key=key)
-        self.region = region
+        self.region = region  # Region can be a string or a dict for version pick
         self.tenant_id = tenant_id
         self.subscription_id = subscription_id
 
     def _form_mapping(self, create=None, **kwargs):
+        region = kwargs.get('region')
+        if isinstance(region, dict):
+            region = pick(region)
         # Will still need to figure out where to put the tenant id.
         return {'name_text': kwargs.get('name'),
                 'type_select': create and 'Azure',
-                'region_select': kwargs.get('region'),
+                'region_select': region,
                 'azure_tenant_id': kwargs.get('tenant_id'),
                 'azure_subscription_id': kwargs.get('subscription_id')}
 
@@ -30,12 +33,9 @@ class AzureProvider(CloudProvider):
         credentials = cls.process_credential_yaml_key(credentials_key)
         # HACK: stray domain entry in credentials, so ensure it is not there
         credentials.domain = None
-        region = prov_config.get('region', None)
-        if region is not None and isinstance(region, dict):
-            region = pick(region)
         return cls(
             name=prov_config['name'],
-            region=region,
+            region=prov_config.get('region'),
             tenant_id=prov_config['tenant_id'],
             subscription_id=prov_config['subscription_id'],
             credentials={'default': credentials},

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -425,7 +425,7 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
         """ Checks if exists among managed providers
 
         """
-        if self in store.current_appliance.managed_providers:
+        if self in self.appliance.managed_providers:
             return True
         return False
 

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -36,7 +36,7 @@ details_page = Region(infoblock_type='detail')
 
 class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
     # List of constants that every non-abstract subclass must have defined
-    type_mapping = {}
+    base_types = {}
     STATS_TO_MATCH = []
     string_name = ""
     page_name = ""
@@ -51,7 +51,7 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
 
     @classmethod
     def add_base_type(cls, nclass):
-        cls.type_mapping[nclass.type_tclass] = nclass
+        cls.base_types[nclass.category] = nclass
         return nclass
 
     @classmethod
@@ -126,6 +126,12 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
             if self.type == 'service_account':
                 self.service_account = kwargs['service_account']
 
+    def __hash__(self):
+        return hash(self.key) ^ hash(type(self))
+
+    def __eq__(self, other):
+        return type(self) is type(other) and self.key == other.key
+
     @property
     def properties_form(self):
         if self._properties_region:
@@ -143,15 +149,11 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
 
     @property
     def type(self):
-        return self.data['type']
+        return self.type_name
 
     @property
     def version(self):
         return self.data['version']
-
-    @property
-    def category(self):
-        return self.type_tclass
 
     def get_yaml_data(self):
         """ Returns yaml data for this provider.
@@ -186,25 +188,42 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
             submit_button()
             flash.assert_no_errors()
 
-    def create(self, cancel=False, validate_credentials=True):
+    def create(self, cancel=False, validate_credentials=True, check_existing=False,
+               validate_inventory=False):
         """
         Creates a provider in the UI
 
         Args:
-           cancel (boolean): Whether to cancel out of the creation.  The cancel is done
-               after all the information present in the Provider has been filled in the UI.
-           validate_credentials (boolean): Whether to validate credentials - if True and the
-               credentials are invalid, an error will be raised.
+            cancel (boolean): Whether to cancel out of the creation.  The cancel is done
+                after all the information present in the Provider has been filled in the UI.
+            validate_credentials (boolean): Whether to validate credentials - if True and the
+                credentials are invalid, an error will be raised.
+            check_existing (boolean): Check if this provider already exists, skip if it does
+            validate_inventory (boolean): Whether or not to block until the provider stats in CFME
+                match the stats gleaned from the backend management system
+                (default: ``True``)
+
+        Returns:
+            True if it was created, False if it already existed
         """
-        navigate_to(self, 'Add')
-        fill(self.properties_form, self._form_mapping(True, **self.__dict__))
-        for cred in self.credentials:
-            fill(self.credentials[cred].form, self.credentials[cred],
-                 validate=validate_credentials)
-        self._submit(cancel, self.add_provider_button)
-        if not cancel:
-            flash.assert_message_match('{} Providers "{}" was saved'.format(self.string_name,
-                                                                            self.name))
+        if check_existing and self.exists:
+            created = False
+        else:
+            created = True
+            logger.info('Setting up provider: %s', self.key)
+            navigate_to(self, 'Add')
+            fill(self.properties_form, self._form_mapping(True, **self.__dict__))
+            for cred in self.credentials:
+                fill(self.credentials[cred].form, self.credentials[cred],
+                     validate=validate_credentials)
+            self._submit(cancel, self.add_provider_button)
+            if not cancel:
+                flash.assert_message_match('{} Providers "{}" was saved'.format(self.string_name,
+                                                                                self.name))
+        if validate_inventory:
+            self.validate()
+
+        return created
 
     def update(self, updates, cancel=False, validate_credentials=True):
         """
@@ -223,7 +242,8 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
         self._submit(cancel, self.save_button)
         name = updates.get('name', self.name)
         if not cancel:
-            flash.assert_message_match('{} Provider "{}" was saved'.format(self.string_name, name))
+            flash.assert_message_match(
+                '{} Provider "{}" was saved'.format(self.string_name, name))
 
     def delete(self, cancel=True):
         """
@@ -402,12 +422,12 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
 
     @property
     def exists(self):
-        ems = cfmedb()['ext_management_systems']
-        provs = (prov[0] for prov in cfmedb().session.query(ems.name))
-        if self.name in provs:
+        """ Checks if exists among managed providers
+
+        """
+        if self in store.current_appliance.managed_providers:
             return True
-        else:
-            return False
+        return False
 
     def wait_for_delete(self):
         navigate_to(self, 'All')
@@ -511,52 +531,31 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
         else:
             return cls.get_credentials_from_config(cred_yaml_key, cred_type=cred_type)
 
+    # Move to collection
     @staticmethod
-    def clear_provider_by_type(prov_class, validate=True):
-        string_name = prov_class.string_name
-        navigate_to(prov_class, 'All')
-        logger.debug('Checking for existing {} providers...'.format(prov_class.type_tclass))
-        total = paginator.rec_total()
-        if total > 0:
-            logger.info(' Providers exist, so removing all {} providers'.format(
-                prov_class.type_tclass))
-            paginator.results_per_page('100')
-            sel.click(paginator.check_all())
-            tb.select(
-                'Configuration', {
-                    version.LOWEST: 'Remove {} Providers from the VMDB'.format(string_name),
-                    '5.7': 'Remove {} Providers'.format(string_name),
-                },
-                invokes_alert=True)
-            sel.handle_alert()
-            if validate:
-                prov_class.wait_for_no_providers_by_type(prov_class)
+    def clear_providers_by_class(prov_class, validate=True):
+        """ Removes all providers that are an instance of given class or one of it's subclasses
+        """
+        from utils.providers import ProviderFilter, new_list_providers
+        pf = ProviderFilter(classes=[prov_class])
+        provs = new_list_providers(filters=[pf], use_global_filters=False)
+        # First, delete all
+        for prov in provs:
+            prov.delete_if_exists(cancel=False)
+        # Then, check that all were deleted
+        if validate:
+            for prov in provs:
+                prov.wait_for_delete()
 
-    @staticmethod
-    def wait_for_no_providers_by_type(prov_class):
-        navigate_to(prov_class, 'All')
-        logger.debug('Waiting for all {} providers to disappear...'.format(prov_class.type_tclass))
-        wait_for(
-            lambda: get_paginator_value() == 0, message="Delete all {} providers".format(
-                prov_class.type_tclass),
-            num_sec=1000, fail_func=sel.refresh
-        )
-
+    # Move to collection
     @staticmethod
     def clear_providers():
-        """Rudely clear all providers on an appliance
+        """ Clear all providers on an appliance using UI """
+        BaseProvider.clear_providers_by_class(BaseProvider)
 
-        Uses the UI in an attempt to cleanly delete the providers
-        """
-        # Executes the deletes first, then validates in a second pass
-        logger.info('Destroying all appliance providers')
-
-        def do_for_provider_types(op):
-            for prov_class in BaseProvider.type_mapping.values():
-                if prov_class.in_version[0] < version.current_version() < prov_class.in_version[1]:
-                    op(prov_class)
-        do_for_provider_types(partial(BaseProvider.clear_provider_by_type, validate=False))
-        do_for_provider_types(BaseProvider.wait_for_no_providers_by_type)
+    def one_of(self, *classes):
+        """ Returns true if provider is an instance of any of the classes or sublasses there of"""
+        return isinstance(self, classes)
 
 
 def get_paginator_value():

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -63,7 +63,7 @@ match_page = partial(match_location, controller='ems_container',
 class ContainersProvider(BaseProvider, Pretty):
     provider_types = {}
     in_version = ('5.5', version.LATEST)
-    type_tclass = "container"
+    category = "container"
     pretty_attrs = ['name', 'key', 'zone']
     STATS_TO_MATCH = [
         'num_project',

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -128,7 +128,7 @@ class InfraProvider(Pretty, CloudInfraProvider):
     """
     provider_types = {}
     in_version = (version.LOWEST, version.LATEST)
-    type_tclass = "infra"
+    category = "infra"
     pretty_attrs = ['name', 'key', 'zone']
     STATS_TO_MATCH = ['num_template', 'num_vm', 'num_datastore', 'num_host', 'num_cluster']
     string_name = "Infrastructure"
@@ -156,7 +156,7 @@ class InfraProvider(Pretty, CloudInfraProvider):
         self.key = key
         self.provider_data = provider_data
         self.zone = zone
-        self.vm_name = version.pick({
+        self.vm_name = deferred_verpick({
             version.LOWEST: "VMs",
             '5.5': "VMs and Instances",
             '5.8': "Virtual Machines"})  # TODO: If it lands in some 5.7.x, change this version!

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -12,6 +12,7 @@ from functools import partial
 
 from navmazing import NavigateToSibling, NavigateToAttribute
 
+from cached_property import cached_property
 from cfme.common.provider import CloudInfraProvider, import_all_modules_of
 from cfme.fixtures import pytest_selenium as sel
 from cfme.infrastructure.host import Host
@@ -156,14 +157,17 @@ class InfraProvider(Pretty, CloudInfraProvider):
         self.key = key
         self.provider_data = provider_data
         self.zone = zone
-        self.vm_name = deferred_verpick({
-            version.LOWEST: "VMs",
-            '5.5': "VMs and Instances",
-            '5.8': "Virtual Machines"})  # TODO: If it lands in some 5.7.x, change this version!
         self.template_name = "Templates"
 
     def _form_mapping(self, create=None, **kwargs):
         return {'name_text': kwargs.get('name')}
+
+    @cached_property
+    def vm_name(self):
+        return version.pick({
+            version.LOWEST: "VMs",
+            '5.5': "VMs and Instances",
+            '5.8': "Virtual Machines"})  # TODO: If it lands in some 5.7.x, change this version!
 
     @variable(alias='db')
     def num_datastore(self):

--- a/cfme/middleware/datasource.py
+++ b/cfme/middleware/datasource.py
@@ -9,7 +9,7 @@ from utils import attributize_string
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
 from utils.db import cfmedb
-from utils.providers import get_crud, get_provider_key
+from utils.providers import get_crud, get_crud_by_name
 from utils.providers import list_providers
 from utils.varmeth import variable
 from . import LIST_TABLE_LOCATOR, MiddlewareBase, download, get_server_name
@@ -123,7 +123,7 @@ class MiddlewareDatasource(MiddlewareBase, Taggable, Navigatable, UtilizationMix
         _provider = provider
         for datasource in rows:
             if strict:
-                _provider = get_crud(get_provider_key(datasource.provider_name))
+                _provider = get_crud_by_name(datasource.provider_name)
             _server = MiddlewareServer(
                 name=datasource.server_name,
                 feed=datasource.feed,

--- a/cfme/middleware/deployment.py
+++ b/cfme/middleware/deployment.py
@@ -9,7 +9,7 @@ from cfme.web_ui import CheckboxTable, paginator, toolbar as tb
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
 from utils.db import cfmedb
-from utils.providers import get_crud, get_provider_key, list_providers
+from utils.providers import get_crud, get_crud_by_name, list_providers
 from utils.varmeth import variable
 from . import LIST_TABLE_LOCATOR, MiddlewareBase, download, get_server_name
 
@@ -119,7 +119,7 @@ class MiddlewareDeployment(MiddlewareBase, Taggable, Navigatable, Deployable):
         _provider = provider
         for deployment in rows:
             if strict:
-                _provider = get_crud(get_provider_key(deployment.provider_name))
+                _provider = get_crud_by_name(deployment.provider_name)
             _server = MiddlewareServer(
                 name=deployment.server_name,
                 feed=deployment.feed,
@@ -191,7 +191,7 @@ class MiddlewareDeployment(MiddlewareBase, Taggable, Navigatable, Deployable):
         deployment = _db_select_query(name=self.name, server=self.server,
                                       provider=self.provider).first()
         if deployment:
-            _provider = get_crud(get_provider_key(deployment.provider_name))
+            _provider = get_crud_by_name(deployment.provider_name)
             _server = MiddlewareServer(
                 name=deployment.server_name,
                 feed=deployment.feed,

--- a/cfme/middleware/domain.py
+++ b/cfme/middleware/domain.py
@@ -9,7 +9,7 @@ from utils import attributize_string
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
 from utils.db import cfmedb
-from utils.providers import get_crud, get_provider_key, list_providers
+from utils.providers import get_crud, get_crud_by_name, list_providers
 from utils.varmeth import variable
 from . import LIST_TABLE_LOCATOR, MiddlewareBase, download
 
@@ -87,7 +87,7 @@ class MiddlewareDomain(MiddlewareBase, Navigatable, Taggable):
             for _ in paginator.pages():
                 for row in list_tbl.rows():
                     if strict:
-                        _provider = get_crud(get_provider_key(row.provider.text))
+                        _provider = get_crud_by_name(row.provider.text)
                     domains.append(MiddlewareDomain(
                         name=row.domain_name.text,
                         feed=row.feed.text,
@@ -108,7 +108,7 @@ class MiddlewareDomain(MiddlewareBase, Navigatable, Taggable):
         _provider = provider
         for domain in rows:
             if strict:
-                _provider = get_crud(get_provider_key(domain.provider_name))
+                _provider = get_crud_by_name(domain.provider_name)
             domains.append(MiddlewareDomain(
                 name=domain.name,
                 feed=domain.feed,

--- a/cfme/middleware/messaging.py
+++ b/cfme/middleware/messaging.py
@@ -9,7 +9,7 @@ from utils import attributize_string
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
 from utils.db import cfmedb
-from utils.providers import get_crud, get_provider_key
+from utils.providers import get_crud, get_crud_by_name
 from utils.providers import list_providers
 from utils.varmeth import variable
 from . import LIST_TABLE_LOCATOR, MiddlewareBase, download, get_server_name
@@ -130,7 +130,7 @@ class MiddlewareMessaging(MiddlewareBase, Navigatable, Taggable, UtilizationMixi
         _provider = provider
         for messaging in rows:
             if strict:
-                _provider = get_crud(get_provider_key(messaging.provider_name))
+                _provider = get_crud_by_name(messaging.provider_name)
             _server = MiddlewareServer(
                 name=messaging.server_name,
                 feed=messaging.feed,

--- a/cfme/middleware/provider/__init__.py
+++ b/cfme/middleware/provider/__init__.py
@@ -44,7 +44,7 @@ properties_form = Form(
 @BaseProvider.add_base_type
 class MiddlewareProvider(BaseProvider):
     in_version = ('5.7', version.LATEST)
-    type_tclass = "middleware"
+    category = "middleware"
     page_name = 'middleware'
     string_name = 'Middleware'
     provider_types = {}

--- a/cfme/middleware/server.py
+++ b/cfme/middleware/server.py
@@ -14,7 +14,7 @@ from utils import attributize_string
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
 from utils.db import cfmedb
-from utils.providers import get_crud, get_provider_key, list_providers
+from utils.providers import get_crud, get_crud_by_name, list_providers
 from utils.varmeth import variable
 from . import LIST_TABLE_LOCATOR, pwr_btn, MiddlewareBase, download
 
@@ -117,7 +117,7 @@ class MiddlewareServer(MiddlewareBase, Taggable, Container, Navigatable, Utiliza
             for _ in paginator.pages():
                 for row in list_tbl.rows():
                     if strict:
-                        _provider = get_crud(get_provider_key(row.provider.text))
+                        _provider = get_crud_by_name(row.provider.text)
                     servers.append(MiddlewareServer(
                         name=row.server_name.text,
                         feed=row.feed.text,
@@ -143,7 +143,7 @@ class MiddlewareServer(MiddlewareBase, Taggable, Container, Navigatable, Utiliza
         _provider = provider
         for server in rows:
             if strict:
-                _provider = get_crud(get_provider_key(server.provider_name))
+                _provider = get_crud_by_name(server.provider_name)
             servers.append(MiddlewareServer(
                 name=server.name,
                 hostname=server.hostname,

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -28,7 +28,8 @@ pytest_generate_tests = testgen.generate(testgen.cloud_providers, scope="functio
 
 @pytest.fixture(scope="module")
 def setup_a_provider():
-    return providers.setup_a_provider(prov_class="cloud", validate=True, check_existing=True)
+    return providers.setup_a_provider_by_class(prov_class=CloudProvider, validate=True,
+                                               check_existing=True)
 
 
 @pytest.mark.tier(3)

--- a/cfme/tests/cloud_infra_common/test_genealogy.py
+++ b/cfme/tests/cloud_infra_common/test_genealogy.py
@@ -4,6 +4,9 @@ import pytest
 from cfme.common.vm import VM
 from utils import testgen
 from cfme import test_requirements
+from cfme.cloud.provider import CloudProvider
+from cfme.infrastructure.provider.rhevm import RHEVMProvider
+from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from utils.generators import random_vm_name
 
 pytestmark = [
@@ -22,7 +25,7 @@ def pytest_generate_tests(metafunc):
         args = dict(zip(argnames, argvalue_tuple))
 
         if metafunc.function in {test_vm_genealogy_detected} \
-                and args["provider"].type in {"scvmm", "rhevm"}:
+                and args["provider"].one_of(SCVMMProvider, RHEVMProvider):
             continue
 
         new_idlist.append(idlist[i])
@@ -42,7 +45,7 @@ def vm_crud(provider, small_template):
 @pytest.mark.parametrize("from_edit", [True, False], ids=["via_edit", "via_summary"])
 @test_requirements.genealogy
 @pytest.mark.uncollectif(
-    lambda provider, from_edit: provider.type_tclass == "cloud" and not from_edit)
+    lambda provider, from_edit: provider.one_of(CloudProvider) and not from_edit)
 def test_vm_genealogy_detected(
         request, setup_provider, provider, small_template, soft_assert, from_edit, vm_crud):
     """Tests vm genealogy from what CFME can detect.

--- a/cfme/tests/cloud_infra_common/test_retirement.py
+++ b/cfme/tests/cloud_infra_common/test_retirement.py
@@ -3,9 +3,11 @@ import datetime
 import pytest
 
 from cfme import test_requirements
+from cfme.common.provider import CloudInfraProvider
 from cfme.common.vm import VM
-from utils import testgen, providers
+from utils import testgen
 from utils.generators import random_vm_name
+from utils.providers import setup_a_provider_by_class
 from utils.timeutil import parsetime
 from utils.wait import wait_for
 from utils.version import current_version
@@ -34,15 +36,15 @@ def vm(request, provider, setup_provider, small_template):
 
 
 @pytest.fixture(scope="function")
-def existing_vm(request):
+def test_provider(request):
+    return setup_a_provider_by_class(CloudInfraProvider)
+
+
+@pytest.fixture(scope="function")
+def existing_vm(request, test_provider):
     """ Fixture will be using for set\unset retirement date for existing vm instead of
     creation a new one
     """
-    list_of_existing_providers = providers.existing_providers()
-    if list_of_existing_providers:
-        test_provider = providers.get_crud(list_of_existing_providers[0])
-    else:
-        test_provider = providers.setup_a_provider()
     all_vms = test_provider.mgmt.list_vm()
     need_to_create_vm = True
     for virtual_machine in all_vms:

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -511,16 +511,16 @@ cat_name = "Settings"
       {
           'my services': _go_to(MyService),
           'chargeback': _go_to(Server, 'Chargeback'),
-          'clouds providers': _go_to(BaseProvider.type_mapping['cloud']),
-          'infrastructure providers': _go_to(BaseProvider.type_mapping['infra']),
+          'clouds providers': _go_to(BaseProvider.base_types['cloud']),
+          'infrastructure providers': _go_to(BaseProvider.base_types['infra']),
           'control explorer': _go_to(Server, 'ControlExplorer'),
           'automate explorer': _go_to(Server, 'AutomateExplorer')}],
      [_mk_role(product_features=[[['Everything'], True]]),  # full permissions
       {
           'my services': _go_to(MyService),
           'chargeback': _go_to(Server, 'Chargeback'),
-          'clouds providers': _go_to(BaseProvider.type_mapping['cloud']),
-          'infrastructure providers': _go_to(BaseProvider.type_mapping['infra']),
+          'clouds providers': _go_to(BaseProvider.base_types['cloud']),
+          'infrastructure providers': _go_to(BaseProvider.base_types['infra']),
           'control explorer': _go_to(Server, 'ControlExplorer'),
           'automate explorer': _go_to(Server, 'AutomateExplorer')},
       {}]])

--- a/cfme/tests/containers/test_basic_metrics.py
+++ b/cfme/tests/containers/test_basic_metrics.py
@@ -10,7 +10,7 @@ pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate(
-    testgen.container_providers, scope='function')
+    testgen.containers_providers, scope='function')
 
 
 def test_basic_metrics(provider, ssh_client):

--- a/cfme/tests/containers/test_containers_default_project_replicators.py
+++ b/cfme/tests/containers/test_containers_default_project_replicators.py
@@ -13,7 +13,7 @@ pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate(
-    testgen.container_providers, scope='module')
+    testgen.containers_providers, scope='module')
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
 

--- a/cfme/tests/containers/test_containers_default_services.py
+++ b/cfme/tests/containers/test_containers_default_services.py
@@ -11,7 +11,7 @@ pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate(
-    testgen.container_providers, scope='function')
+    testgen.containers_providers, scope='function')
 
 
 DefaultServices = ['frontend',

--- a/cfme/tests/containers/test_containers_default_views.py
+++ b/cfme/tests/containers/test_containers_default_views.py
@@ -19,7 +19,7 @@ pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate(
-    testgen.container_providers, scope='function')
+    testgen.containers_providers, scope='function')
 
 VIEWS = ['Grid View', 'Tile View', 'List View']
 

--- a/cfme/tests/containers/test_containers_main_pages_sort.py
+++ b/cfme/tests/containers/test_containers_main_pages_sort.py
@@ -16,7 +16,7 @@ pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate(
-    testgen.container_providers, scope="function")
+    testgen.containers_providers, scope="function")
 
 # CMP-9924 CMP-9925 CMP-9926 CMP-9927 CMP-9928
 

--- a/cfme/tests/containers/test_containers_overview_data_integrity.py
+++ b/cfme/tests/containers/test_containers_overview_data_integrity.py
@@ -23,7 +23,7 @@ pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate(
-    testgen.container_providers, scope="function")
+    testgen.containers_providers, scope="function")
 
 
 DataSet = namedtuple('DataSet', ['object', 'name'])

--- a/cfme/tests/containers/test_containers_projects_summary.py
+++ b/cfme/tests/containers/test_containers_projects_summary.py
@@ -11,7 +11,7 @@ pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate(
-    testgen.container_providers, scope='function')
+    testgen.containers_providers, scope='function')
 
 
 projects_properties_fields = ['Name', 'Creation timestamp', 'Resource version']

--- a/cfme/tests/containers/test_containers_properties.py
+++ b/cfme/tests/containers/test_containers_properties.py
@@ -15,7 +15,7 @@ pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate(
-    testgen.container_providers, scope="function")
+    testgen.containers_providers, scope="function")
 
 # CMP-9911
 

--- a/cfme/tests/containers/test_containers_route_views.py
+++ b/cfme/tests/containers/test_containers_route_views.py
@@ -13,7 +13,7 @@ pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate(
-    testgen.container_providers, scope='function')
+    testgen.containers_providers, scope='function')
 
 
 views = ['Grid View', 'Tile View', 'List View']

--- a/cfme/tests/containers/test_containers_simple_search.py
+++ b/cfme/tests/containers/test_containers_simple_search.py
@@ -16,7 +16,7 @@ pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(3)]
 pytest_generate_tests = testgen.generate(
-    testgen.container_providers, scope='function')
+    testgen.containers_providers, scope='function')
 
 
 PROJECTS_SEARCH_STRINGS = ['*', 'infra', '$', 'management-infra']

--- a/cfme/tests/containers/test_containers_summary.py
+++ b/cfme/tests/containers/test_containers_summary.py
@@ -8,11 +8,11 @@ from utils.version import current_version
 pytestmark = [
     pytest.mark.uncollectif(
         lambda: current_version() < "5.6"),
-    pytest.mark.usefixtures('has_no_container_providers'),
+    pytest.mark.usefixtures('has_no_containers_providers'),
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate(
-    testgen.container_providers, scope='function')
+    testgen.containers_providers, scope='function')
 
 
 # CMP-9827 # CMP-9826 # CMP-9825 # CMP-9824 # CMP-9823 # CMP-9822 # CMP-9821 # CMP-9820

--- a/cfme/tests/containers/test_data_integrity_for_topology.py
+++ b/cfme/tests/containers/test_data_integrity_for_topology.py
@@ -28,7 +28,7 @@ pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate(
-    testgen.container_providers, scope="function")
+    testgen.containers_providers, scope="function")
 
 DataSet = namedtuple('DataSet', ['object', 'name'])
 

--- a/cfme/tests/containers/test_pods_prop_data_integrity.py
+++ b/cfme/tests/containers/test_pods_prop_data_integrity.py
@@ -11,7 +11,7 @@ pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate(
-    testgen.container_providers, scope="function")
+    testgen.containers_providers, scope="function")
 
 # CMP-9934
 

--- a/cfme/tests/containers/test_provider_configuration_menu.py
+++ b/cfme/tests/containers/test_provider_configuration_menu.py
@@ -14,7 +14,7 @@ pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate(
-    testgen.container_providers, scope="function")
+    testgen.containers_providers, scope="function")
 
 
 def select_first_provider_and_get_its_name():

--- a/cfme/tests/containers/test_relationships_tables.py
+++ b/cfme/tests/containers/test_relationships_tables.py
@@ -20,7 +20,7 @@ pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate(
-    testgen.container_providers, scope="function")
+    testgen.containers_providers, scope="function")
 
 
 DataSet = namedtuple('DataSet', ['object', 'match_page'])

--- a/cfme/tests/containers/test_reload_button_provider.py
+++ b/cfme/tests/containers/test_reload_button_provider.py
@@ -11,7 +11,7 @@ pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(2)]
 pytest_generate_tests = testgen.generate(
-    testgen.container_providers, scope='function')
+    testgen.containers_providers, scope='function')
 
 # CMP-9878
 

--- a/cfme/tests/containers/test_static_custom_attributes.py
+++ b/cfme/tests/containers/test_static_custom_attributes.py
@@ -12,7 +12,7 @@ pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(2)]
 pytest_generate_tests = testgen.generate(
-    testgen.container_providers, scope="function")
+    testgen.containers_providers, scope="function")
 
 ATTRIBUTES_DATASET = [
     CustomAttribute('exp_date', '2017-01-02', 'Date'),

--- a/cfme/tests/containers/test_summary_pages_links.py
+++ b/cfme/tests/containers/test_summary_pages_links.py
@@ -20,7 +20,7 @@ pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate(
-    testgen.container_providers, scope="function")
+    testgen.containers_providers, scope="function")
 
 # CMP_9903  CMP_9904  CMP_9905  CMP_9906
 

--- a/cfme/tests/containers/test_topology.py
+++ b/cfme/tests/containers/test_topology.py
@@ -15,7 +15,7 @@ pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate(
-    testgen.container_providers, scope="function")
+    testgen.containers_providers, scope="function")
 
 
 # CMP-9996

--- a/cfme/tests/containers/test_views_objects.py
+++ b/cfme/tests/containers/test_views_objects.py
@@ -14,7 +14,7 @@ from cfme.containers.pod import Pod
 
 pytestmark = [pytest.mark.tier(2)]
 pytest_generate_tests = testgen.generate(
-    testgen.container_providers, scope="function")
+    testgen.containers_providers, scope="function")
 
 
 # CMP-9907 # CMP-9908 # CMP-9909

--- a/cfme/tests/infrastructure/test_advanced_search_vms.py
+++ b/cfme/tests/infrastructure/test_advanced_search_vms.py
@@ -6,19 +6,21 @@ import pytest
 from random import sample
 
 from cfme.infrastructure import virtual_machines
+from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.virtual_machines import Vm
 from cfme.web_ui import search
 from utils.appliance.implementations.ui import navigate_to
-from utils.providers import setup_a_provider
 from cfme.web_ui.cfme_exception import (assert_no_cfme_exception,
     is_cfme_exception, cfme_exception_text)
+from utils.providers import new_setup_a_provider, ProviderFilter
 
 
 @pytest.fixture(scope="module")
 def vms():
     """Ensure the infra providers are set up and get list of vms"""
     try:
-        setup_a_provider(prov_class="infra", required_keys=["large"])
+        pf = ProviderFilter(classes=[InfraProvider], required_fields=['large'])
+        new_setup_a_provider(filters=[pf])
     except Exception:
         pytest.skip("It's not possible to set up any providers, therefore skipping")
     navigate_to(Vm, 'VMsOnly')

--- a/cfme/tests/infrastructure/test_esx_direct_host.py
+++ b/cfme/tests/infrastructure/test_esx_direct_host.py
@@ -21,6 +21,8 @@ def pytest_generate_tests(metafunc):
 
     for i, argvalue_tuple in enumerate(argvalues):
         args = dict(zip(argnames, argvalue_tuple))
+        # TODO
+        # All this should be replaced with a proper ProviderFilter passed to testgen.providers()
         if args['provider'].type != "virtualcenter":
             continue
         hosts = args['provider'].data.get("hosts", [])

--- a/cfme/tests/infrastructure/test_provider_discovery.py
+++ b/cfme/tests/infrastructure/test_provider_discovery.py
@@ -2,6 +2,7 @@ import pytest
 from itertools import combinations
 
 from utils import testgen
+from utils.appliance import current_appliance
 from utils.providers import get_crud
 from cfme.common.provider import BaseProvider
 from cfme.infrastructure.provider import discover, InfraProvider
@@ -83,7 +84,7 @@ def pytest_generate_tests(metafunc):
 @pytest.yield_fixture(scope='function')
 def delete_providers_after_test():
     yield
-    BaseProvider.clear_provider_by_type(InfraProvider)
+    BaseProvider.clear_providers_by_class(InfraProvider)
 
 
 @pytest.mark.tier(2)
@@ -106,9 +107,9 @@ def test_discover_infra(providers_for_discover, start_ip, max_range):
     @pytest.wait_for(num_sec=count_timeout(start_ip, max_range), delay=5)
     def _wait_for_all_providers():
         for provider in providers_for_discover:
-            if provider.key not in pytest.store.current_appliance.managed_providers:
+            if not provider.exists:
                 return False
-        if len(pytest.store.current_appliance.managed_providers) != len(providers_for_discover):
+        if len(current_appliance.managed_providers) != len(providers_for_discover):
             return False
         return True
 

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -23,7 +23,8 @@ pytest_generate_tests = testgen.generate(testgen.infra_providers, scope="functio
 
 @pytest.fixture(scope="module")
 def setup_a_provider():
-    return providers.setup_a_provider(prov_class="infra", validate=True, check_existing=True)
+    return providers.setup_a_provider_by_class(prov_class=InfraProvider, validate=True,
+                                               check_existing=True)
 
 
 @pytest.mark.tier(3)
@@ -187,7 +188,7 @@ def test_providers_discovery(request, provider):
     """
     provider.discover()
     flash.assert_message_match('Infrastructure Providers: Discovery successfully initiated')
-    request.addfinalizer(lambda: BaseProvider.clear_provider_by_type(InfraProvider))
+    request.addfinalizer(lambda: BaseProvider.clear_providers_by_class(InfraProvider))
     wait_for_a_provider()
 
 

--- a/cfme/tests/intelligence/reports/test_canned_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_canned_corresponds.py
@@ -6,7 +6,7 @@ from cfme.infrastructure.provider import InfraProvider, details_page
 from cfme.intelligence.reports.reports import CannedSavedReport
 from utils.appliance.implementations.ui import navigate_to
 from utils.net import ip_address, resolve_hostname
-from utils.providers import get_mgmt_by_name, setup_a_provider as _setup_a_provider
+from utils.providers import get_crud_by_name, setup_a_provider as _setup_a_provider
 from utils import version
 from cfme import test_requirements
 
@@ -62,7 +62,7 @@ def test_cluster_relationships(soft_assert, setup_a_provider):
         if not provider_name.strip():
             # If no provider name specified, ignore it
             continue
-        provider = get_mgmt_by_name(provider_name)
+        provider = get_crud_by_name(provider_name).mgmt
         host_name = relation["Host Name"].strip()
         soft_assert(name in provider.list_cluster(), "Cluster {} not found in {}".format(
             name, provider_name

--- a/cfme/tests/intelligence/reports/test_report_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_report_corresponds.py
@@ -5,7 +5,7 @@ from random import sample
 
 import utils
 from cfme.intelligence.reports.reports import CustomReport
-from utils.providers import get_mgmt_by_name, setup_a_provider
+from utils.providers import get_crud_by_name, setup_a_provider
 from utils.version import since_date_or_version
 from cfme import test_requirements
 
@@ -54,7 +54,7 @@ def test_custom_vm_report(soft_assert, report_vms):
         if row["Name"].startswith("test_"):
             continue  # Might disappear meanwhile
         provider_name = row["Cloud/Infrastructure Provider Name"]
-        provider = get_mgmt_by_name(provider_name)
+        provider = get_crud_by_name(provider_name).mgmt
         provider_hosts_and_ips = utils.net.resolve_ips(provider.list_host())
         provider_datastores = provider.list_datastore()
         provider_clusters = provider.list_cluster()

--- a/cfme/tests/intelligence/reports/test_views.py
+++ b/cfme/tests/intelligence/reports/test_views.py
@@ -13,7 +13,7 @@ pytestmark = [pytest.mark.tier(3),
               pytest.mark.usefixtures('setup_provider')]
 
 pytest_generate_tests = testgen.generate(
-    testgen.provider_by_type, ['openstack', 'ec2', 'rhevm', 'vsphere'],
+    testgen.provider_by_type, ['openstack', 'ec2', 'rhevm', 'virtualcenter'],
     scope='module')
 
 

--- a/cfme/tests/services/test_catalog.py
+++ b/cfme/tests/services/test_catalog.py
@@ -32,7 +32,7 @@ def test_catalog_duplicate_name():
 
 
 @pytest.mark.sauce
-def test_permissions_catalog_add(setup_cloud_providers):
+def test_permissions_catalog_add():
     """ Tests that a catalog can be added only with the right permissions"""
     cat = Catalog(name=fauxfactory.gen_alphanumeric(),
                   description="my catalog")

--- a/conftest.py
+++ b/conftest.py
@@ -13,6 +13,7 @@ from fixtures.artifactor_plugin import art_client, appliance_ip_address
 from cfme.fixtures.rdb import Rdb
 from fixtures.pytest_store import store
 from utils import ports
+from utils.appliance import ApplianceException
 from utils.conf import rdb
 from utils.log import logger
 from utils.path import data_path
@@ -46,6 +47,13 @@ def pytest_cmdline_main(config):
         if config.getoption(opt):
             print("The {} option has been REMOVED, it doesn't do anything; please, stop using it!"
                   .format(opt))
+
+
+def pytest_sessionstart(session):
+    try:
+        store.current_appliance.check_no_conflicting_providers()
+    except ApplianceException as e:
+        raise pytest.UsageError("Conflicting providers were found: {}".format(e))
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -157,6 +165,8 @@ pytest_plugins = (
     'fixtures.artifactor_plugin',
     'fixtures.parallelizer',
 
+    'fixtures.prov_filter',
+
     'fixtures.single_appliance_sprout',
     'fixtures.dev_branch',
     'fixtures.events',
@@ -175,7 +185,6 @@ pytest_plugins = (
     'fixtures.node_annotate',
     'fixtures.page_screenshots',
     'fixtures.perf',
-    'fixtures.prov_filter',
     'fixtures.provider',
     'fixtures.qa_contact',
     'fixtures.randomness',

--- a/fixtures/log.py
+++ b/fixtures/log.py
@@ -44,7 +44,9 @@ def pytest_runtest_logreport(report):
             try:
                 logger().info(
                     "Managed providers: {}".format(
-                        ", ".join(pytest.store.current_appliance.managed_providers)))
+                        ", ".join([
+                            prov.key for prov in pytest.store.current_appliance.managed_providers]))
+                )
             except KeyError as ex:
                 if 'ext_management_systems' in ex.msg:
                     logger().warning("Unable to query ext_management_systems table; DB issue")

--- a/fixtures/mgmt_system.py
+++ b/fixtures/mgmt_system.py
@@ -4,42 +4,6 @@ from cfme.common.provider import BaseProvider
 from utils import providers
 
 
-@pytest.fixture
-def setup_providers(uses_providers):
-    """Adds all providers listed in cfme_data.yaml
-
-    This includes both cloud and infra provider types.
-    """
-    providers.setup_providers(validate=True, check_existing=True)
-
-
-@pytest.fixture
-def setup_infrastructure_providers(uses_infra_providers):
-    """Adds all infrastructure providers listed in cfme_data.yaml
-
-    This includes ``rhev`` and ``virtualcenter`` provider types
-    """
-    providers._setup_providers('infra', validate=True, check_existing=True)
-
-
-@pytest.fixture
-def setup_cloud_providers(uses_cloud_providers):
-    """Adds all cloud providers listed in cfme_data.yaml
-
-    This includes ``ec2`` and ``openstack`` provider types
-    """
-    providers._setup_providers('cloud', validate=True, check_existing=True)
-
-
-@pytest.fixture
-def setup_container_providers(uses_container_providers):
-    """Adds all container providers listed in cfme_data.yaml
-
-    This includes ``kubernetes`` and ``openshift`` provider types
-    """
-    providers._setup_providers('container', validate=True, check_existing=True)
-
-
 @pytest.fixture(scope='module')  # IGNORE:E1101
 def mgmt_sys_api_clients(cfme_data, uses_providers):
     """Returns a list of management system api clients"""
@@ -66,7 +30,7 @@ def has_no_cloud_providers():
     This is a destructive fixture. It will clear all cloud managements systems from
     the current appliance.
     """
-    BaseProvider.clear_provider_by_type(BaseProvider.type_mapping['cloud'], validate=True)
+    BaseProvider.clear_providers_by_class(BaseProvider.base_types['cloud'], validate=True)
 
 
 @pytest.fixture
@@ -76,20 +40,20 @@ def has_no_infra_providers():
     This is a destructive fixture. It will clear all infrastructure managements systems from
     the current appliance.
     """
-    BaseProvider.clear_provider_by_type(BaseProvider.type_mapping['infra'], validate=True)
+    BaseProvider.clear_providers_by_class(BaseProvider.base_types['infra'], validate=True)
 
 
 @pytest.fixture
-def has_no_container_providers():
-    """ Clears all container providers from an appliance
+def has_no_containers_providers():
+    """ Clears all containers providers from an appliance
 
     This is a destructive fixture. It will clear all container managements systems from
     the current appliance.
     """
-    BaseProvider.clear_provider_by_type(BaseProvider.type_mapping['container'], validate=True)
+    BaseProvider.clear_providers_by_class(BaseProvider.base_types['container'], validate=True)
 
 
 @pytest.fixture
 def has_no_middleware_providers():
     """Clear all middleware providers."""
-    BaseProvider.clear_provider_by_type(BaseProvider.type_mapping['middleware'], validate=True)
+    BaseProvider.clear_providers_by_class(BaseProvider.base_types['middleware'], validate=True)

--- a/fixtures/prov_filter.py
+++ b/fixtures/prov_filter.py
@@ -1,62 +1,27 @@
-from utils.conf import cfme_data
 from utils.log import logger
-
-
-def provider_keys():
-    return cfme_data.get('management_systems', {}).keys()
-
-
-class ProviderFilter(object):
-    def __init__(self, defaults):
-        self._filtered_providers = defaults
-
-    @property
-    def providers(self):
-        return self._filtered_providers
-
-    @providers.setter
-    def providers(self, filtered):
-        self._filtered_providers = parse_filter(filtered)
-
-    def __contains__(self, provider):
-        return provider in self.providers
-
-
-filtered = ProviderFilter(provider_keys())
+from utils.providers import global_filters, new_list_providers, ProviderFilter
 
 
 def pytest_addoption(parser):
     # Create the cfme option group for use in other plugins
     parser.getgroup('cfme')
     parser.addoption("--use-provider", action="append", default=[],
-        help="list of providers or tags to include in test")
+        help="list of provider keys or provider tags to include in test")
 
 
 def pytest_configure(config):
-    """ Filters the list of providers as part of pytest configuration. """
+    """ Filters the list of providers as part of pytest configuration
+
+    Note:
+        Additional filter is added to the global_filters dict of active filters here.
+    """
 
     cmd_filter = config.getvalueorskip('use_provider')
     if not cmd_filter:
         cmd_filter = ["default"]
 
-    filtered.providers = cmd_filter
+    new_filter = ProviderFilter(keys=cmd_filter, required_tags=cmd_filter, conjunctive=False)
+    global_filters['use_provider'] = new_filter
 
     logger.debug('Filtering providers with {}, leaves {}'.format(
-        cmd_filter, filtered.providers))
-
-
-def parse_filter(cmd_filter):
-    """ Parse a list of command line filters and return a filtered set of providers.
-
-    Args:
-        cmd_filter: A list of ``--use-provider`` options.
-    """
-
-    filtered_providers = provider_keys()
-    for provider in provider_keys():
-        data = cfme_data['management_systems'][provider]
-        tags = data.get('tags', [])
-        if ('disabled' in tags) or \
-           ((provider not in cmd_filter) and not (set(tags) & set(cmd_filter))):
-            filtered_providers.remove(provider)
-    return filtered_providers
+        cmd_filter, [prov.key for prov in new_list_providers()]))

--- a/fixtures/templateloader.py
+++ b/fixtures/templateloader.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 """Preloads all templates on all providers that were selected for testing. Useful for test collect.
 """
-from fixtures.prov_filter import filtered
 from fixtures.pytest_store import store, write_line
 from utils import trackerbot
+from utils.providers import list_providers
 
 TEMPLATES = {}
 
@@ -14,5 +14,5 @@ def pytest_configure():
 
     write_line("Loading templates from trackerbot")
     provider_templates = trackerbot.provider_templates(trackerbot.api())
-    for provider in filtered.providers:
+    for provider in list_providers():
         TEMPLATES[provider] = provider_templates.get(provider, [])

--- a/scripts/clone_template.py
+++ b/scripts/clone_template.py
@@ -11,7 +11,7 @@ from utils.conf import cfme_data
 from utils.conf import credentials as cred
 from utils.log import logger
 from utils.path import log_path
-from utils.providers import destroy_vm, get_mgmt
+from utils.providers import get_mgmt
 from utils.wait import wait_for
 
 
@@ -59,6 +59,26 @@ def parse_cmd_line():
 
     args = parser.parse_args()
     return args
+
+
+def destroy_vm(provider_mgmt, vm_name):
+    """Given a provider backend and VM name, destroy an instance with logging and error guards
+
+    Returns ``True`` if the VM is deleted, ``False`` if the backend reports that it did not delete
+        the VM, and ``None`` if an error occurred (the error will be logged)
+
+    """
+    try:
+        if provider_mgmt.does_vm_exist(vm_name):
+            logger.info('Destroying VM %s', vm_name)
+            vm_deleted = provider_mgmt.delete_vm(vm_name)
+            if vm_deleted:
+                logger.info('VM %s destroyed', vm_name)
+            else:
+                logger.error('Destroying VM %s failed for unknown reasons', vm_name)
+            return vm_deleted
+    except Exception as e:
+        logger.error('%s destroying VM %s (%s)', type(e).__name__, vm_name, str(e))
 
 
 def main(**kwargs):

--- a/sprout/appliances/tasks.py
+++ b/sprout/appliances/tasks.py
@@ -1406,7 +1406,7 @@ def scavenge_managed_providers_from_appliance(self, appliance_id):
         return None
     try:
         managed_providers = appliance.ipapp.managed_providers
-        appliance.managed_providers = managed_providers
+        appliance.managed_providers = [prov.key for prov in managed_providers]
     except Exception as e:
         # To prevent single appliance messing up whole result
         provider_error_logger().error("{}: {}".format(type(e).__name__, str(e)))
@@ -1423,10 +1423,10 @@ def calculate_provider_management_usage(self, appliance_ids):
         except ObjectDoesNotExist:
             # Deleted in meanwhile
             continue
-        for provider in appliance.managed_providers:
-            if provider not in results:
-                results[provider] = []
-            results[provider].append(appliance.id)
+        for provider_key in appliance.managed_providers:
+            if provider_key not in results:
+                results[provider_key] = []
+            results[provider_key].append(appliance.id)
     for provider in Provider.objects.all():
         provider.appliances_manage_this_provider = results.get(provider.id, [])
 

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import fauxfactory
+import logging
 import os
 import random
 import re
@@ -39,6 +40,11 @@ from .implementations.ui import ViaUI
 
 
 RUNNING_UNDER_SPROUT = os.environ.get("RUNNING_UNDER_SPROUT", "false") != "false"
+
+# EMS types recognized by IP or credentials
+RECOGNIZED_BY_IP = [
+    "InfraManager", "ContainerManager", "MiddlewareManager", "Openstack::CloudManager"]
+RECOGNIZED_BY_CREDS = ["CloudManager"]
 
 
 def _current_miqqe_version():
@@ -370,40 +376,50 @@ class IPAppliance(object):
             ssh_client.run_command('echo "vm.swappiness = 1" >> /etc/sysctl.conf',
                 ensure_host=True)
 
-    @property
-    def managed_providers(self):
-        """Returns a set of providers that are managed by this appliance
+    def _encrypt_string(self, string):
+        try:
+            # Let's not log passwords
+            logging.disable(logging.CRITICAL)
+            rc, out = self.ssh_client.run_rails_command(
+                "puts MiqPassword.encrypt('{}')".format(string))
+            return out
+        finally:
+            logging.disable(logging.NOTSET)
 
-        Returns:
-            :py:class:`set` of :py:class:`str` - provider_key-s
-        """
-        ip_addresses = set([])
+    def _get_ems_ips(self, ems):
+        ep_table = self.db["endpoints"]
+        ip_addresses = set()
+        for ep in self.db.session.query(ep_table).filter(ep_table.resource_id == ems.id):
+            if ep.ipaddress is not None:
+                ip_addresses.add(ep.ipaddress)
+            elif ep.hostname is not None:
+                if re.match(r"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$", ep.hostname) is not None:
+                    ip_addresses.add(ep.hostname)
+                else:
+                    ip_address = resolve_hostname(ep.hostname)
+                    if ip_address is not None:
+                        ip_addresses.add(ip_address)
+        return list(ip_addresses)
 
+    def _list_ems(self):
+        ems_table = self.db["ext_management_systems"]
         # Fetch all providers at once, return empty list otherwise
         try:
-            query_res = list(self._query_endpoints())
+            ems_list = list(self.db.session.query(ems_table))
         except Exception as ex:
             self.log.warning("Unable to query DB for managed providers: %s", str(ex))
             return []
-
-        for ipaddress, hostname in query_res:
-            if ipaddress is not None:
-                ip_addresses.add(ipaddress)
-            elif hostname is not None:
-                if re.match(r"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$", hostname) is not None:
-                    ip_addresses.add(hostname)
-                else:
-                    ip_address = resolve_hostname(hostname)
-                    if ip_address is not None:
-                        ip_addresses.add(ip_address)
-        provider_keys = set([])
-        for provider_key, provider_data in conf.cfme_data.get("management_systems", {}).iteritems():
-            if provider_data.get("ipaddress", None) in ip_addresses:
-                provider_keys.add(provider_key)
-        return provider_keys
+        known_ems_list = []
+        for ems in ems_list:
+            # Skip any EMS types that we don't care about / can't recognize safely
+            if not any(p_type in ems.type for p_type in RECOGNIZED_BY_IP + RECOGNIZED_BY_CREDS):
+                continue
+            # Make sure we load current data from the DB
+            self.db.session.expire(ems)
+            known_ems_list.append(ems)
+        return known_ems_list
 
     def _query_endpoints(self):
-
         if "endpoints" in self.db:
             return self._query_post_endpoints()
         else:
@@ -423,6 +439,92 @@ class IPAppliance(object):
                 ipaddress = endpoint.ipaddress
                 hostname = endpoint.hostname
                 yield ipaddress, hostname
+
+    @property
+    def managed_providers(self):
+        """Returns a set of provider crud objects of known providers managed by this appliance
+
+        Note:
+            Recognized by name only.
+        """
+        from utils.providers import new_list_providers
+        prov_cruds = new_list_providers(use_global_filters=False)
+
+        found_cruds = set()
+        unrecognized_ems_names = set()
+        for ems in self._list_ems():
+            for prov in prov_cruds:
+                # Name check is authoritative and the only proper way to recognize a known provider
+                if ems.name == prov.name:
+                    found_cruds.add(prov)
+                    break
+            else:
+                unrecognized_ems_names.add(ems.name)
+        if unrecognized_ems_names:
+            self.log.warning(
+                "Unrecognized managed providers: {}".format(','.join(unrecognized_ems_names)))
+        return list(found_cruds)
+
+    def check_no_conflicting_providers(self):
+        """ Checks that there are no conflicting providers set up on the appliance
+
+        Raises:
+            ApplianceException: If there are any conflicting providers present on the appliance
+
+        Note:
+            A conflicting provider is a provider with IP or credentials (depends on it's type)
+            known to our automation but whose name doesn't match the one found in yamls.
+            This is used to avoid hard-to-debug
+         automation issues.
+        """
+        from utils.providers import new_list_providers
+
+        def _recognized_by_ip(provider, ems):
+            if any(p_type in ems.type for p_type in RECOGNIZED_BY_IP):
+                try:
+                    prov_ip = getattr(provider, 'ip_address', None) \
+                        or resolve_hostname(provider.hostname)
+                except AttributeError:
+                    # Provider has no IP nor hostname; it should be looked up by credentials,
+                    # not by IP address
+                    return False
+                if prov_ip in self._get_ems_ips(ems):
+                    return True
+            return False
+
+        def _recognized_by_creds(provider, ems):
+            if any(p_type in ems.type for p_type in RECOGNIZED_BY_CREDS):
+                creds_table = self.db["authentications"]
+                try:
+                    default_creds = provider.credentials['default']
+                except KeyError:
+                    # Provider has no default credentials; it should be looked up by IP address,
+                    # not by credentials
+                    return False
+                auth = self.db.session.query(creds_table)\
+                    .filter(creds_table.resource_id == ems.id)\
+                    .filter(creds_table.userid == default_creds.principal)\
+                    .filter(creds_table.password == self._encrypt_string(default_creds.secret))\
+                    .order_by(creds_table.id.desc())\
+                    .first()
+                if auth is not None:
+                    return True
+            return False
+
+        prov_cruds = new_list_providers(use_global_filters=False)
+        managed_providers_names = [prov.name for prov in self.managed_providers]
+        for ems in self._list_ems():
+            # EMS found among managed providers can be safely ignored; they are not conflicting
+            if ems.name in managed_providers_names:
+                continue
+            # Otherwise, if the EMS matches a provider in our yamls by IP or credentials
+            # but isn't among managed providers -> same provider with a different name
+            for prov in prov_cruds:
+                if _recognized_by_ip(prov, ems) or _recognized_by_creds(prov, ems):
+                    raise ApplianceException(
+                        "Provider '{}' present on the appliance under the name '{}' instead"
+                        " of expected '{}', please rename or remove it before continuing"
+                        .format(prov.key, ems.name, prov.name))
 
     @property
     def has_os_infra(self):
@@ -1821,6 +1923,7 @@ class IPAppliance(object):
                 raise
 
     def delete_all_providers(self):
+        logger.info('Destroying all appliance providers')
         for prov in self.rest_api.collections.providers:
             prov.action.delete()
 
@@ -1912,18 +2015,18 @@ class Appliance(IPAppliance):
         super(Appliance, self).__init__(browser_steal=browser_steal, container=None)
         self.name = Appliance._default_name
 
-        self._provider_name = provider_name
+        self._provider_key = provider_name
         self.vmname = vm_name
 
     def __eq__(self, other):
         return isinstance(other, type(self)) and (
-            self.vmname == other.vmname and self._provider_name == other._provider_name)
+            self.vmname == other.vmname and self._provider_key == other._provider_key)
 
     def __ne__(self, other):
         return not self.__eq__(other)
 
     def __hash__(self):
-        return hash((self.vmname, self._provider_name))
+        return hash((self.vmname, self._provider_key))
 
     @property
     def ipapp(self):
@@ -1937,7 +2040,7 @@ class Appliance(IPAppliance):
             Cannot be cached because provider object is unpickable.
         """
         from utils.providers import get_mgmt
-        return get_mgmt(self._provider_name)
+        return get_mgmt(self._provider_key)
 
     @property
     def vm_name(self):
@@ -2009,7 +2112,7 @@ class Appliance(IPAppliance):
                          ``None`` (default ``None``)
 
         """
-        log_callback("Configuring appliance {} on {}".format(self.vmname, self._provider_name))
+        log_callback("Configuring appliance {} on {}".format(self.vmname, self._provider_key))
         if kwargs:
             with self:
                 self._custom_configure(**kwargs)
@@ -2047,13 +2150,13 @@ class Appliance(IPAppliance):
 
             # add provider
             log_callback('Setting up provider...')
-            setup_provider(self._provider_name)
+            setup_provider(self._provider_key)
 
             # credential hosts
             log_callback('Credentialing hosts...')
             if not RUNNING_UNDER_SPROUT:
                 from utils.hosts import setup_providers_hosts_credentials
-            setup_providers_hosts_credentials(self._provider_name, ignore_errors=True)
+            setup_providers_hosts_credentials(self._provider_key, ignore_errors=True)
 
             # if rhev, set relationship
             if self.is_on_rhev:
@@ -2061,7 +2164,7 @@ class Appliance(IPAppliance):
                 log_callback('Setting up CFME VM relationship...')
                 from cfme.common.vm import VM
                 from utils.providers import get_crud
-                vm = VM.factory(self.vm_name, get_crud(self._provider_name))
+                vm = VM.factory(self.vm_name, get_crud(self._provider_key))
                 cfme_rel = Vm.CfmeRelationship(vm)
                 cfme_rel.set_relationship(str(self.server_name()), self.server_id())
 

--- a/utils/appliance/implementations/ui.py
+++ b/utils/appliance/implementations/ui.py
@@ -212,7 +212,7 @@ class CFMENavigateStep(NavigateStep):
             logger.debug(store.current_appliance.ssh_client.run_command(
                 'top -c -b -n1 -o "%MEM" | head -30').output)  # noqa
             logger.debug('Managed Providers:')
-            logger.debug(store.current_appliance.managed_providers)
+            logger.debug('%r', [prov.key for prov in store.current_appliance.managed_providers])
             self.appliance.browser.quit_browser()
             self.appliance.browser.open_browser()
             self.go(_tries, *args, **go_kwargs)

--- a/utils/providers.py
+++ b/utils/providers.py
@@ -1,58 +1,396 @@
-"""Helper functions related to the creation and destruction of providers
+""" Helper functions related to the creation, listing, filtering and destruction of providers
 
-To quickly add all providers::
+The functions in this module that require the 'filters' parameter, such as list_providers,
+setup_a_provider etc depend on a (by default global) dict of filters by default.
+If you are writing tests or fixtures, you want to depend on those functions as de facto gateways.
 
-    setup_providers(validate=False)
+The rest of the functions, such as get_mgmt, get_crud etc ignore this global dict and will provide
+you with whatever you ask for with no limitations.
 
+The main clue to know what is limited by the filters and what isn't is the 'filters' parameter.
 """
+import operator
 import random
-from collections import Mapping
+import six
+from collections import Mapping, OrderedDict
+from copy import copy
 
-import cfme.fixtures.pytest_selenium as sel
 from fixtures.pytest_store import store
-from cfme.web_ui import Quadicon, paginator
 from cfme.common.provider import BaseProvider
-from cfme.containers import provider as container_providers # NOQA
+
+from cfme.containers import provider as containers_providers # NOQA
 from cfme.cloud import provider as cloud_providers # NOQA
 from cfme.infrastructure import provider as infrastructure_providers # NOQA
 from cfme.middleware import provider as middleware_providers # NOQA
 
-from fixtures.prov_filter import filtered
-from utils import conf
-from utils.appliance.implementations.ui import navigate_to
-from utils.log import logger, perflog
-
+from cfme.exceptions import UnknownProviderType
+from cfme.infrastructure.provider import InfraProvider
+from utils import conf, version
+from utils.log import logger
 
 providers_data = conf.cfme_data.get("management_systems", {})
+# Dict of active provider filters {name: ProviderFilter}
+global_filters = {}
 
-# This is a global variable. Not the most ideal way to do things but how can we track bad providers?
-problematic_providers = set([])
 
+class ProviderFilter(object):
+    """ Filter used to obtain only providers matching given requirements
 
-def list_providers(allowed_types=None):
-    """ Returns list of providers of selected type from configuration.
-
-    @param allowed_types: Passed by partial(), see top of this file.
-    @type allowed_types: dict, list, set, tuple
+    Args:
+        keys: List of acceptable provider keys, all if `None`
+        categories: List of acceptable provider categories, all if `None`
+        types: List of acceptable provider types, all if `None`
+        required_fields: List of required fields, see :py:func:`provider_by_type`
+        restrict_version: Checks provider version in yamls if `True`
+        required_tags: List of tags that must be set in yamls
+        inverted: Inclusive if `False`, exclusive otherwise
+        conjunctive: If true, all subfilters are applied and all must match (default)
+                     If false (disjunctive), at least one of the subfilters must match
     """
-    if not allowed_types:
-        allowed_types = [
-            k2 for k in BaseProvider.type_mapping.values() for k2 in k.provider_types.keys()
-        ]
-    providers = []
-    for provider, data in providers_data.items():
-        provider_type = data.get("type", None)
-        if provider not in filtered:
-            continue
-        assert provider_type is not None, "Provider {} has no type specified!".format(provider)
-        if provider_type in allowed_types:
-            providers.append(provider)
+    _version_operator_map = OrderedDict([('>=', operator.ge),
+                                        ('<=', operator.le),
+                                        ('==', operator.eq),
+                                        ('!=', operator.ne),
+                                        ('>', operator.gt),
+                                        ('<', operator.lt)])
+
+    def __init__(self, keys=None, classes=None, required_fields=None, required_tags=None,
+                 required_flags=None, restrict_version=False, inverted=False, conjunctive=True):
+        self.keys = keys
+        self.classes = classes
+        self.required_fields = required_fields
+        self.required_tags = required_tags
+        self.required_flags = required_flags
+        self.restrict_version = restrict_version
+        self.inverted = inverted
+        self.conjunctive = conjunctive
+
+    def _filter_keys(self, provider):
+        """ Filters by provider keys """
+        if self.keys is None:
+            return None
+        return provider.key in self.keys
+
+    def _filter_classes(self, provider):
+        """ Filters by provider (base) classes """
+        if self.classes is None:
+            return None
+        return any([provider.one_of(prov_class) for prov_class in self.classes])
+
+    def _filter_required_fields(self, provider):
+        """ Filters by required yaml fields (specified usually during test parametrization) """
+        if self.required_fields is None:
+            return None
+        for field_or_fields in self.required_fields:
+            if isinstance(field_or_fields, tuple):
+                field_ident, field_value = field_or_fields
+            else:
+                field_ident, field_value = field_or_fields, None
+            if isinstance(field_ident, six.string_types):
+                if field_ident not in provider.data:
+                    return False
+                else:
+                    if field_value:
+                        if provider.data[field_ident] != field_value:
+                            return False
+            else:
+                o = provider.data
+                try:
+                    for field in field_ident:
+                        o = o[field]
+                    if field_value:
+                        if o != field_value:
+                            return False
+                except (IndexError, KeyError):
+                    return False
+        return True
+
+    def _filter_required_tags(self, provider):
+        """ Filters by required yaml tags """
+        if self.required_tags is None:
+            return None
+        if set(self.required_tags) & set(provider.data.tags):
+            return True
+        return False
+
+    def _filter_required_flags(self, provider):
+        """ Filters by required yaml flags """
+        if self.required_flags is None:
+            return None
+        if self.required_flags:
+            test_flags = [flag.strip() for flag in self.required_flags]
+
+            defined_flags = conf.cfme_data.get('test_flags', '').split(',')
+            defined_flags = [flag.strip() for flag in defined_flags]
+
+            excluded_flags = provider.data.get('excluded_test_flags', '').split(',')
+            excluded_flags = [flag.strip() for flag in excluded_flags]
+
+            allowed_flags = set(defined_flags) - set(excluded_flags)
+
+            if set(test_flags) - allowed_flags:
+                logger.info("Filtering Provider %s out because it does not have the right flags, "
+                            "%s does not contain %s",
+                            provider.name, list(allowed_flags),
+                            list(set(test_flags) - allowed_flags))
+                return False
+        return True
+
+    def _filter_restricted_version(self, provider):
+        """ Filters by yaml version restriction; not applied if SSH is not available """
+        if self.restrict_version:
+            # TODO
+            # get rid of this since_version hotfix by translating since_version
+            # to restricted_version; in addition, restricted_version should turn into
+            # "version_restrictions" and it should be a sequence of restrictions with operators
+            # so that we can create ranges like ">= 5.6" and "<= 5.8"
+            version_restrictions = []
+            since_version = provider.data.get('since_version', None)
+            if since_version:
+                version_restrictions.append('>= {}'.format(since_version))
+            restricted_version = provider.data.get('restricted_version', None)
+            if restricted_version:
+                version_restrictions.append(restricted_version)
+            for restriction in version_restrictions:
+                for op, comparator in ProviderFilter._version_operator_map.items():
+                    # split string by op; if the split works, version won't be empty
+                    head, op, ver = restriction.partition(op)
+                    if not ver:  # This means that the operator was not found
+                        continue
+                    try:
+                        curr_ver = version.current_version()
+                    except:
+                        return True
+                    if not comparator(curr_ver, ver):
+                        return False
+                    break
+                else:
+                    raise Exception('Operator not found in {}'.format(restriction))
+        return None
+
+    def __call__(self, provider):
+        """ Applies this filter on a given provider
+
+        Usage:
+            pf = ProviderFilter('cloud_infra', categories=['cloud', 'infra'])
+            providers = new_list_providers([pf])
+            pf2 = ProviderFilter(
+                classes=[GCEProvider, EC2Provider], required_fields=['small_template'])
+            provider_keys = [prov.key for prov in new_list_providers([pf, pf2])]
+            ^ this will list keys of all GCE and EC2 providers
+            ...or...
+            pf = ProviderFilter(required_tags=['openstack', 'complete'])
+            pf_inverted = ProviderFilter(required_tags=['disabled'], inverted=True)
+            provider = new_setup_a_provider([pf, pf_inverted])
+            ^ this will setup a provider that has both the "openstack" and "complete" tags set
+              and at the same time does not have the "disabled" tag
+            ...or...
+            pf = ProviderFilter(keys=['rhevm34'], class=CloudProvider, conjunctive=False)
+            providers = new_list_providers([pf])
+            ^ this will list all providers that either have the 'rhevm34' key or are an instance
+              of the CloudProvider class and therefore are a cloud provider
+
+        Returns:
+            `True` if provider passed all checks and was not filtered out, `False` otherwise.
+            The result is opposite if the 'inverted' attribute is set to `True`.
+        """
+        keys_l = self._filter_keys(provider)
+        classes_l = self._filter_classes(provider)
+        fields_l = self._filter_required_fields(provider)
+        tags_l = self._filter_required_tags(provider)
+        flags_l = self._filter_required_flags(provider)
+        version_l = self._filter_restricted_version(provider)
+        results = [keys_l, classes_l, fields_l, tags_l, flags_l, version_l]
+        relevant_results = [res for res in results if res in [True, False]]
+        compiling_fn = all if self.conjunctive else any
+        # If all / any filters return true, the provider was not blocked (unless inverted)
+        if compiling_fn(relevant_results):
+            return not self.inverted
+        return self.inverted
+
+    def copy(self):
+        return copy(self)
+
+
+# Only providers without the 'disabled' tag
+global_filters['enabled_only'] = ProviderFilter(required_tags=['disabled'], inverted=True)
+# Only providers relevant for current appliance version (requires SSH access when used)
+global_filters['restrict_version'] = ProviderFilter(restrict_version=True)
+
+
+def new_list_providers(filters=None, use_global_filters=True):
+    """ Returns list of provider crud objects, optional filtering (enabled by default)
+
+    Args:
+        filters: List if :py:class:`ProviderFilter` or None
+        use_global_filters: Will apply global filters as well if `True`, will not otherwise
+    """
+    filters = filters or []
+    if use_global_filters:
+        filters = filters + global_filters.values()
+    providers = [get_crud(prov_key) for prov_key in providers_data]
+    for prov_filter in filters:
+        providers = filter(prov_filter, providers)
     return providers
 
 
-def get_mgmt(provider_key, providers=None, credentials=None):
+def list_providers_by_class(prov_class, validate=True, check_existing=True):
+    pf = ProviderFilter(classes=[prov_class])
+    return new_list_providers(filters=[pf])
+
+
+# Replaced by list_providers_by_class which returns objects, not keys
+def list_providers(allowed_types=None, use_global_filters=False):
+    """ Lists providers keys by given provider types """
+    if allowed_types is not None:
+        classes = [get_class_from_type(prov_type) for prov_type in allowed_types]
+    else:
+        classes = None
+    pf = ProviderFilter(classes=classes)
+    provs = new_list_providers(filters=[pf], use_global_filters=use_global_filters)
+    return [prov.key for prov in provs]
+
+
+def setup_provider(provider_key, validate=True, check_existing=True):
+    provider = get_crud(provider_key)
+    provider.create(validate_credentials=True, validate_inventory=validate,
+                    check_existing=check_existing)
+    return provider
+
+
+def new_setup_a_provider(filters=None, use_global_filters=True, validate=True, check_existing=True):
+    """ Sets up a single provider robustly.
+
+    Does some counter-badness measures.
+
+    Args:
+        filters: List if :py:class:`ProviderFilter` or None; infra providers by default
+        use_global_filters: Will apply global filters as well if `True`, will not otherwise
+        validate: Whether to validate the provider.
+        check_existing: Whether to check if the provider already exists.
     """
-    Provides a ``mgmtsystem`` object, based on the request.
+    filters = filters or []
+
+    providers = new_list_providers(filters=filters, use_global_filters=use_global_filters)
+    if not providers:
+        raise Exception("All providers have been filtered out, cannot setup any providers")
+
+    # If there is a provider already set up matching the user's requirements, reuse it
+    for provider in providers:
+        if provider.exists:
+            return provider
+
+    # Activate the 'nonproblematic' filter to filter out problematic providers (if any)
+    if global_filters.get('problematic') is None:
+        global_filters['problematic'] = ProviderFilter(keys=[], inverted=True)
+
+    # If there are no non-problematic providers, reset the filter
+    nonproblematic_providers = new_list_providers(filters=filters)
+    if not nonproblematic_providers:
+        global_filters['problematic'].keys = []
+        store.terminalreporter.write_line(
+            "Reached the point where all possible providers forthis case are marked as bad. "
+            "Clearing the bad provider list for a fresh start and next chance.", yellow=True)
+    # Otherwise, make non-problematic the new cool
+    else:
+        providers = nonproblematic_providers
+
+    # If we have more than one provider, try to pick one that doesnt have the do_not_prefer flag set
+    if len(providers) > 1:
+        do_not_prefer_filter = ProviderFilter(required_fields=[("do_not_prefer", False)],
+                                              inverted=True)
+        # If we find any providers without the 'do_not_prefer' flag, add  the filter to the list
+        # of active filters and make preferred providers the new cool
+        preferred_providers = new_list_providers(filters=filters + [do_not_prefer_filter])
+        if preferred_providers:
+            filters.append(do_not_prefer_filter)
+            providers = preferred_providers
+
+    # Try to set up a nonexisting provider (return if successful, otherwise try another)
+    non_existing = [prov for prov in providers if not prov.exists]
+    random.shuffle(non_existing)  # Make the provider load even (long-term) by shuffling them around
+    for provider in non_existing:
+        try:
+            store.terminalreporter.write_line(
+                "Trying to set up provider {}\n".format(provider.key), green=True)
+            provider.create(validate_credentials=True, validate_inventory=validate,
+                            check_existing=check_existing)
+            return provider
+        except Exception as e:
+            # In case of a known provider error:
+            logger.exception(e)
+            message = "Provider {} is behaving badly, marking it as bad. {}: {}".format(
+                provider.key, type(e).__name__, str(e))
+            logger.warning(message)
+            store.terminalreporter.write_line(message + "\n", red=True)
+            global_filters['problematic'].keys.append(provider.key)
+            if provider.exists:
+                # Remove it in order to not explode on next calls
+                provider.delete(cancel=False)
+                provider.wait_for_delete()
+                message = "Provider {} was deleted because it failed to set up.".format(
+                    provider.key)
+                logger.warning(message)
+                store.terminalreporter.write_line(message + "\n", red=True)
+    else:
+        raise Exception("No providers could be set up matching the params")
+
+    return provider
+
+
+def setup_a_provider_by_class(prov_class=InfraProvider, validate=True, check_existing=True):
+    pf = ProviderFilter(classes=[prov_class])
+    return new_setup_a_provider(filters=[pf], validate=validate, check_existing=check_existing)
+
+
+# Replaced by setup_a_provider_by_class
+def setup_a_provider(prov_class="infra", prov_type=None, validate=True, check_existing=True):
+    prov_class = get_class_from_type(prov_type or prov_class)
+    return setup_a_provider_by_class(
+        prov_class=prov_class, validate=validate, check_existing=check_existing)
+
+
+def get_class_from_type(prov_type):
+    """ Serves to translate both provider types and categories to actual classes """
+    all_classes_map = BaseProvider.base_types.copy()
+    for base_type in BaseProvider.base_types.itervalues():
+        all_classes_map.update(base_type.provider_types)
+    try:
+        return all_classes_map[prov_type]
+    except KeyError:
+        raise UnknownProviderType("Unknown provider type: {}!".format(prov_type))
+
+
+def get_crud(provider_key):
+    """ Creates a Provider object given a management_system key in cfme_data.
+
+    Usage:
+        get_crud('ec2east')
+
+    Returns: A Provider object that has methods that operate on CFME
+    """
+    prov_config = providers_data[provider_key]
+    prov_type = prov_config.get('type')
+
+    return get_class_from_type(prov_type).from_config(prov_config, provider_key)
+
+
+def get_crud_by_name(provider_name):
+    """ Creates a Provider object given a management_system name in cfme_data.
+
+    Usage:
+        get_crud_by_name('My RHEV 3.6 Provider')
+
+    Returns: A Provider object that has methods that operate on CFME
+    """
+    for provider_key, provider_data in providers_data.items():
+        if provider_data.get("name") == provider_name:
+            return get_crud(provider_key)
+    raise NameError("Could not find provider {}".format(provider_name))
+
+
+def get_mgmt(provider_key, providers=None, credentials=None):
+    """ Provides a ``mgmtsystem`` object, based on the request.
 
     Args:
         provider_key: The name of a provider, as supplied in the yaml configuration files.
@@ -67,14 +405,16 @@ def get_mgmt(provider_key, providers=None, credentials=None):
     """
     if providers is None:
         providers = providers_data
+    # provider_key can also be provider_data for some reason
+    # TODO rename the parameter; might break things
     if isinstance(provider_key, Mapping):
-        provider = provider_key
+        provider_data = provider_key
     else:
-        provider = providers[provider_key]
+        provider_data = providers[provider_key]
 
     if credentials is None:
         # We need to handle the in-place credentials
-        credentials = provider['credentials']
+        credentials = provider_data['credentials']
         # If it is not a mapping, it most likely points to a credentials yaml (as by default)
         if not isinstance(credentials, Mapping):
             credentials = conf.credentials[credentials]
@@ -82,307 +422,13 @@ def get_mgmt(provider_key, providers=None, credentials=None):
 
     # Munge together provider dict and creds,
     # Let the provider do whatever they need with them
-    provider_kwargs = provider.copy()
+    provider_kwargs = provider_data.copy()
     provider_kwargs.update(credentials)
-    if isinstance(provider_key, basestring):
+    if isinstance(provider_key, six.string_types):
         provider_kwargs['provider_key'] = provider_key
     provider_kwargs['logger'] = logger
 
-    return _get_provider_class_by_type(provider['type']).mgmt_class(**provider_kwargs)
-
-
-def _get_provider_class_by_type(prov_type):
-    for cls in BaseProvider.type_mapping.itervalues():
-        maybe_the_class = cls.provider_types.get(prov_type)
-        if maybe_the_class is not None:
-            return maybe_the_class
-
-
-def get_provider_key(provider_name):
-    for provider_key, provider_data in providers_data.items():
-        if provider_data.get("name") == provider_name:
-            return provider_key
-    else:
-        raise NameError("Could not find provider {}".format(provider_name))
-
-
-def get_mgmt_by_name(provider_name, *args, **kwargs):
-    """Provides a ``mgmtsystem`` object, based on the request.
-
-    For detailed parameter description, refer to the :py:func:`get_mgmt` (except its
-    `provider_key` parameter)
-
-    Args:
-        provider_name: 'Nice' provider name (name field from provider's YAML entry)
-    Return: A provider instance of the appropriate ``mgmtsystem``
-        subclass
-    """
-    return get_mgmt(get_provider_key(provider_name), *args, **kwargs)
-
-
-def setup_a_provider(prov_class="infra", prov_type=None, validate=True, check_existing=True,
-                     required_keys=None):
-    """Sets up a single provider robustly.
-
-    Does some counter-badness measures.
-
-    Args:
-        prov_class: "infra", "cloud", "container" or "middleware"
-        prov_type: "ec2", "virtualcenter" or any other valid type
-        validate: Whether to validate the provider.
-        check_existing: Whether to check if the provider already exists.
-        required_keys: A set of required keys for the provider data to have
-    """
-    if not required_keys:
-        required_keys = []
-    potential_providers = list_providers(
-        BaseProvider.type_mapping[prov_class].provider_types.keys())
-    if prov_type:
-        providers = []
-        for provider in potential_providers:
-            if providers_data[provider]['type'] == prov_type:
-                providers.append(provider)
-    else:
-        providers = potential_providers
-
-    final_providers = []
-    for provider in providers:
-        if all(key in providers_data[provider] for key in required_keys):
-            final_providers.append(provider)
-    providers = final_providers
-
-    # Check if the provider was behaving badly in the history
-    if problematic_providers:
-        filtered_providers = [
-            provider for provider in providers if provider not in problematic_providers]
-        if not filtered_providers:
-            # problematic_providers took all of the providers, so start over with clean list
-            # (next chance for bad guys) and use the original list. This will then slow down a
-            # little bit but make it more reliable.
-            problematic_providers.clear()
-            store.terminalreporter.write_line(
-                "Reached the point where all possible providers forthis case are marked as bad. "
-                "Clearing the bad provider list for a fresh start and next chance.", yellow=True)
-        else:
-            providers = filtered_providers
-
-    # If there is a provider that we want to specifically avoid ...
-    # If there is only a single provider, then do not do any filtering
-    # Specify `do_not_prefer` in provider's yaml to make it an object of avoidance.
-    if len(providers) > 1:
-        filtered_providers = [
-            provider
-            for provider
-            in providers
-            if not providers_data[provider].get("do_not_prefer", False)]
-        if filtered_providers:
-            # If our filtering yielded any providers, use them, otherwise do not bother with that
-            providers = filtered_providers
-
-    # If there is already a suitable provider, don't try to setup a new one.
-    already_existing = filter(is_provider_setup, providers)
-    random.shuffle(already_existing)        # Make the provider load more even by random chaice.
-    not_already_existing = filter(lambda x: not is_provider_setup(x), providers)
-    random.shuffle(not_already_existing)    # Make the provider load more even by random chaice.
-
-    # So, make this one loop and it tries the existing providers first, then the nonexisting
-    for provider in already_existing + not_already_existing:
-        try:
-            if provider in already_existing:
-                store.terminalreporter.write_line(
-                    "Trying to reuse provider {}\n".format(provider), green=True)
-            else:
-                store.terminalreporter.write_line(
-                    "Trying to set up provider {}\n".format(provider), green=True)
-            return setup_provider(provider, validate=validate, check_existing=check_existing)
-        except Exception as e:
-            # In case of a known provider error:
-            logger.exception(e)
-            message = "Provider {} is behaving badly, marking it as bad. {}: {}".format(
-                provider, type(e).__name__, str(e))
-            logger.warning(message)
-            store.terminalreporter.write_line(message + "\n", red=True)
-            problematic_providers.add(provider)
-            prov_object = get_crud(provider)
-            if prov_object.exists:
-                # Remove it in order to not explode on next calls
-                prov_object.delete(cancel=False)
-                prov_object.wait_for_delete()
-                message = "Provider {} was deleted because it failed to set up.".format(provider)
-                logger.warning(message)
-                store.terminalreporter.write_line(message + "\n", red=True)
-    else:
-        raise Exception("No providers could be set up matching the params")
-
-
-def is_provider_setup(provider_key):
-    """Checks whether provider is already existing in CFME
-
-    Args:
-        provider_key: YAML key of the provider
-
-    Returns:
-        :py:class:`bool` of existence
-    """
-    return get_crud(provider_key).exists
-
-
-def existing_providers():
-    """Lists all providers that are already set up in the appliance."""
-    return filter(is_provider_setup, list_providers())
-
-
-def setup_provider(provider_key, validate=True, check_existing=True):
-    """Add the named provider to CFME
-
-    Args:
-        provider_key: Provider key name from cfme_data
-        validate: Whether or not to block until the provider stats in CFME
-            match the stats gleaned from the backend management system
-            (default: ``True``)
-        check_existing: Check if this provider already exists, skip if it does
-
-    Returns:
-        An instance of :py:class:`cfme.cloud.provider.Provider` or
-        :py:class:`cfme.infrastructure.provider.Provider` for the named provider, as appropriate.
-
-    """
-    provider = get_crud(provider_key)
-    if check_existing and provider.exists:
-        # no need to create provider if the provider exists
-        # pass so we don't skip the validate step
-        pass
-    else:
-        logger.info('Setting up provider: %s', provider.key)
-        provider.create(validate_credentials=True)
-
-    if validate:
-        provider.validate()
-
-    return provider
-
-
-def setup_provider_by_name(provider_name, *args, **kwargs):
-    return setup_provider(get_provider_key(provider_name), *args, **kwargs)
-
-
-def setup_providers(prov_classes=['cloud', 'infra'], validate=True, check_existing=True):
-    """Run :py:func:`setup_provider` for every provider (cloud and infra only, by default)
-
-    Args:
-        prov_classes: list of provider classes to setup ('cloud', 'infra' and 'container')
-        validate: see description in :py:func:`setup_provider`
-        check_existing: see description in :py:func:`setup_provider`
-
-    Returns:
-        A list of provider object for the created providers, cloud and infrastructure.
-
-    """
-    perflog.start('utils.providers.setup_providers')
-    # Do cloud and infra separately to keep the browser navs down
-    added_providers = []
-
-    # Defer validation
-    setup_kwargs = {'validate': False, 'check_existing': check_existing}
-    for pclass in prov_classes:
-        added_providers.extend(_setup_providers(pclass, **setup_kwargs))
-
-    if validate:
-        for provider in added_providers:
-            provider.validate()
-
-    perflog.stop('utils.providers.setup_providers')
-
-    return added_providers
-
-
-def _setup_providers(prov_class, validate, check_existing):
-    """Helper to set up all cloud, infra or container providers, and then validate them
-
-    Args:
-        prov_class: Provider class - 'cloud, 'infra', 'container' or 'middleware' (a string)
-        validate: see description in :py:func:`setup_provider`
-        check_existing: see description in :py:func:`setup_provider`
-
-    Returns:
-        A list of provider objects that have been created.
-
-    """
-
-    # Check for existing providers all at once, to prevent reloading
-    # the providers page for every provider in cfme_data
-    if not list_providers(BaseProvider.type_mapping[prov_class].provider_types.keys()):
-        return []
-    if check_existing:
-        navigate_to(BaseProvider.type_mapping[prov_class], 'All')
-        add_providers = []
-        for provider_key in list_providers(
-                BaseProvider.type_mapping[prov_class].provider_types.keys()):
-            provider_name = conf.cfme_data.get('management_systems', {})[provider_key]['name']
-            quad_name = BaseProvider.type_mapping[prov_class].quad_name
-            quad = Quadicon(provider_name, quad_name)
-            for page in paginator.pages():
-                if sel.is_displayed(quad):
-                    logger.debug('Provider %s exists, skipping', provider_key)
-                    break
-            else:
-                add_providers.append(provider_key)
-    else:
-        # Add all cloud, infra or container providers unconditionally
-        add_providers = list_providers(BaseProvider.type_mapping[prov_class].provider_types.keys())
-
-    if add_providers:
-        logger.info('Providers to be added: %s', ', '.join(add_providers))
-
-    # Save the provider objects for validation and return
-    added_providers = []
-
-    for provider_name in add_providers:
-        # Don't validate in this step; add all providers, then go back and validate in order
-        provider = setup_provider(provider_name, validate=False, check_existing=False)
-        added_providers.append(provider)
-
-    if validate:
-        for provider in added_providers:
-            provider.validate()
-
-    return added_providers
-
-
-def destroy_vm(provider_mgmt, vm_name):
-    """Given a provider backend and VM name, destroy an instance with logging and error guards
-
-    Returns ``True`` if the VM is deleted, ``False`` if the backend reports that it did not delete
-        the VM, and ``None`` if an error occurred (the error will be logged)
-
-    """
-    try:
-        if provider_mgmt.does_vm_exist(vm_name):
-            logger.info('Destroying VM %s', vm_name)
-            vm_deleted = provider_mgmt.delete_vm(vm_name)
-            if vm_deleted:
-                logger.info('VM %s destroyed', vm_name)
-            else:
-                logger.error('Destroying VM %s failed for unknown reasons', vm_name)
-            return vm_deleted
-    except Exception as e:
-        logger.error('%s destroying VM %s (%s)', type(e).__name__, vm_name, str(e))
-
-
-def get_crud(provider_config_name):
-    """
-    Creates a Provider object given a yaml entry in cfme_data.
-
-    Usage:
-        get_crud('ec2east')
-
-    Returns: A Provider object that has methods that operate on CFME
-    """
-
-    prov_config = conf.cfme_data.get('management_systems', {})[provider_config_name]
-    prov_type = prov_config.get('type')
-
-    return _get_provider_class_by_type(prov_type).from_config(prov_config, provider_config_name)
+    return get_class_from_type(provider_data['type']).mgmt_class(**provider_kwargs)
 
 
 class UnknownProvider(Exception):

--- a/utils/testgen.py
+++ b/utils/testgen.py
@@ -86,23 +86,17 @@ More information on ``parametrize`` can be found in pytest's documentation:
 """
 import pytest
 
-from collections import OrderedDict
-from cfme.exceptions import UnknownProviderType
+from cfme.cloud.provider import CloudProvider
+from cfme.common.provider import BaseProvider
+from cfme.containers.provider import ContainersProvider
+from cfme.infrastructure.config_management import get_config_manager_from_config
+from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.pxe import get_pxe_server_from_config
-from fixtures.prov_filter import filtered
+from cfme.middleware.provider import MiddlewareProvider
 from cfme.roles import group_data
-from utils import version
 from utils.conf import cfme_data
 from utils.log import logger
-from utils.providers import get_crud
-from cfme.infrastructure.config_management import get_config_manager_from_config
-
-_version_operator_map = OrderedDict([('>=', lambda o, v: o >= v),
-                                    ('<=', lambda o, v: o <= v),
-                                    ('==', lambda o, v: o == v),
-                                    ('!=', lambda o, v: o != v),
-                                    ('>', lambda o, v: o > v),
-                                    ('<', lambda o, v: o < v)])
+from utils.providers import ProviderFilter, new_list_providers, get_class_from_type
 
 
 def generate(gen_func, *args, **kwargs):
@@ -190,238 +184,140 @@ def fixture_filter(metafunc, argnames, argvalues):
     return argnames, argvalues
 
 
-def _uncollect_restricted_version(data, metafunc, required_fields):
-    restricted_version = data.get('restricted_version', None)
-    if restricted_version:
-        logger.info('we found a restricted version')
-        for op, comparator in _version_operator_map.items():
-            # split string by op; if the split works, version won't be empty
-            head, op, ver = restricted_version.partition(op)
-            if not ver:  # This means that the operator was not found
-                continue
-            if not comparator(version.current_version(), ver):
-                return True
-            break
-        else:
-            raise Exception('Operator not found in {}'.format(restricted_version))
-    return False
+def providers(metafunc, filters=None):
+    """ Gets providers based on given (+ global) filters
 
+    Note:
+        Using the default 'function' scope, each test will be run individually for each provider
+        before moving on to the next test. To group all tests related to single provider together,
+        parametrize tests in the 'module' scope.
 
-def _check_required_fields(data, metafunc, required_fields):
-    if required_fields:
-        for field_or_fields in required_fields:
-            if isinstance(field_or_fields, tuple):
-                field_ident, field_value = field_or_fields
-            else:
-                field_ident, field_value = field_or_fields, None
-            if isinstance(field_ident, basestring):
-                if field_ident not in data:
-                    return True
-                else:
-                    if field_value:
-                        if data[field_ident] != field_value:
-                            return True
-            else:
-                o = data
-                try:
-                    for field in field_ident:
-                        o = o[field]
-                    if field_value:
-                        if o != field_value:
-                            return True
-                except (IndexError, KeyError):
-                    return True
-    return False
+    Note:
+        testgen for providers now requires the usage of test_flags for collection to work.
+        Please visit http://cfme-tests.readthedocs.org/guides/documenting.html#documenting-tests
+        for more details.
+    """
+    filters = filters or []
+    argnames = []
+    argvalues = []
+    idlist = []
 
-
-def _uncollect_test_flags(data, metafunc, required_fields):
-    # Test to see the test has meta data, if it does and that metadata contains
-    # a test_flag kwarg, then check to make sure the provider contains that test_flag
-    # if not, do not collect the provider for this particular test.
-
-    # Obtain the tests flags
+    # Obtains the test's flags in form of a ProviderFilter
     meta = getattr(metafunc.function, 'meta', None)
-    test_flags = getattr(meta, 'kwargs', {}) \
-        .get('from_docs', {}).get('test_flag', '').split(',')
-    if test_flags != ['']:
-        test_flags = [flag.strip() for flag in test_flags]
+    test_flag_str = getattr(meta, 'kwargs', {}).get('from_docs', {}).get('test_flag')
+    if test_flag_str:
+        test_flags = test_flag_str.split(',')
+        flags_filter = ProviderFilter(required_flags=test_flags)
+        filters = filters + [flags_filter]
 
-        defined_flags = cfme_data.get('test_flags', '').split(',')
-        defined_flags = [flag.strip() for flag in defined_flags]
+    for provider in new_list_providers(filters):
+        argvalues.append([provider])
+        # Use the provider key for idlist, helps with readable parametrized test output
+        idlist.append(provider.key)
+        # Add provider to argnames if missing
+        if 'provider' in metafunc.fixturenames and 'provider' not in argnames:
+            metafunc.function = pytest.mark.uses_testgen()(metafunc.function)
+            argnames.append('provider')
 
-        excluded_flags = data.get('excluded_test_flags', '').split(',')
-        excluded_flags = [flag.strip() for flag in excluded_flags]
-
-        allowed_flags = set(defined_flags) - set(excluded_flags)
-
-        if set(test_flags) - allowed_flags:
-            logger.info("Uncollecting Provider %s for test %s in module %s because "
-                "it does not have the right flags, "
-                "%s does not contain %s",
-                data['name'], metafunc.function.func_name, metafunc.function.__module__,
-                list(allowed_flags), list(set(test_flags) - allowed_flags))
-            return True
-    return False
+    return argnames, argvalues, idlist
 
 
-def _uncollect_since_version(data, metafunc, required_fields):
-    try:
-        if "since_version" in data:
-            # Ignore providers that are not supported in this version yet
-            if version.current_version() < data["since_version"]:
-                return True
-    except Exception:  # No SSH connection
-        return True
-    return False
+def providers_by_class(metafunc, classes, required_fields=None):
+    """ Gets providers by their class
+
+    Args:
+        metafunc: Passed in by pytest
+        classes: List of classes to fetch
+        required_fields: See :py:class:`cfme.utils.provider.ProviderFilter`
+
+    Usage:
+        # In the function itself
+        def pytest_generate_tests(metafunc):
+            argnames, argvalues, idlist = testgen.providers_by_class(
+                [GCEProvider, AzureProvider], required_fields=['provisioning']
+            )
+        metafunc.parametrize(argnames, argvalues, ids=idlist, scope='module')
+
+        # Using the parametrize wrapper
+        pytest_generate_tests = testgen.parametrize(testgen.providers_by_class, [GCEProvider],
+            scope='module')
+    """
+    pf = ProviderFilter(classes=classes, required_fields=required_fields)
+    return providers(metafunc, filters=[pf])
 
 
+# Replaced by providers_by_class, above
 def provider_by_type(metafunc, provider_types, required_fields=None):
     """Get the values of the named field keys from ``cfme_data.get('management_systems', {})``
-
     ``required_fields`` is special and can take many forms, it is used to ensure that
     yaml data is present for a particular key, or path of keys, and can even validate
     the values as long as they are not None.
-
-
     Args:
         provider_types: A list of provider types to include. If None, all providers are considered
-
     Returns:
         An tuple of ``(argnames, argvalues, idlist)`` for use in a pytest_generate_tests hook, or
         with the :py:func:`parametrize` helper.
-
     Usage:
-
         # In the function itself
         def pytest_generate_tests(metafunc):
             argnames, argvalues, idlist = testgen.provider_by_type(
                 ['openstack', 'ec2'], required_fields=['provisioning']
             )
         metafunc.parametrize(argnames, argvalues, ids=idlist, scope='module')
-
         # Using the parametrize wrapper
         pytest_generate_tests = testgen.parametrize(testgen.provider_by_type, ['openstack', 'ec2'],
             scope='module')
-
         # Using required_fields
-
         # Ensures that ``provisioning`` exists as a yaml field
         testgen.provider_by_type(
             ['openstack', 'ec2'], required_fields=['provisioning']
         )
-
         # Ensures that ``provisioning`` exists as a yaml field and has another field in it called
         # ``host``
         testgen.provider_by_type(
             ['openstack', 'ec2'], required_fields=[['provisioning', 'host']]
         )
-
         # Ensures that ``powerctl`` exists as a yaml field and has a value 'True'
         testgen.provider_by_type(
             ['openstack', 'ec2'], required_fields=[('powerctl', True)]
         )
-
-
-
     Note:
-
         Using the default 'function' scope, each test will be run individually for each provider
         before moving on to the next test. To group all tests related to single provider together,
         parametrize tests in the 'module' scope.
-
     Note:
-
         testgen for providers now requires the usage of test_flags for collection to work.
         Please visit http://cfme-tests.readthedocs.org/guides/documenting.html#documenting-tests
         for more details.
-
     """
-
-    argnames = []
-    argvalues = []
-    idlist = []
-
-    for provider in cfme_data.get('management_systems', {}):
-
-        # Check provider hasn't been filtered out with --use-provider
-        if provider not in filtered:
-            continue
-
-        try:
-            prov_obj = get_crud(provider)
-        except UnknownProviderType:
-            continue
-
-        if not prov_obj:
-            logger.debug("Whilst trying to create an object for %s we failed", provider)
-            continue
-
-        if provider_types is not None:
-            if not(prov_obj.type_tclass in provider_types or prov_obj.type_name in provider_types):
-                continue
-
-        # Run through all the testgen uncollect fns
-        uncollect = False
-        uncollect_fns = [_uncollect_restricted_version, _check_required_fields,
-            _uncollect_test_flags, _uncollect_since_version]
-        for fn in uncollect_fns:
-            if fn(prov_obj.data, metafunc, required_fields):
-                uncollect = True
-                break
-        if uncollect:
-            continue
-
-        if 'provider' in metafunc.fixturenames and 'provider' not in argnames:
-            metafunc.function = pytest.mark.uses_testgen()(metafunc.function)
-            argnames.append('provider')
-
-        # uncollect when required field is not present and option['require_field'] == True
-        argvalues.append([prov_obj])
-
-        # Use the provider name for idlist, helps with readable parametrized test output
-        idlist.append(provider)
-
-    return argnames, argvalues, idlist
-
-
-def cloud_providers(metafunc, **options):
-    """Wrapper for :py:func:`provider_by_type` that pulls types from
-    :py:attr:`utils.providers.cloud_provider_type_map`
-
-    """
-    return provider_by_type(metafunc, 'cloud', **options)
-
-
-def infra_providers(metafunc, **options):
-    """Wrapper for :py:func:`provider_by_type` that pulls types from
-    :py:attr:`utils.providers.infra_provider_type_map`
-
-    """
-    return provider_by_type(metafunc, 'infra', **options)
-
-
-def container_providers(metafunc, **options):
-    """Wrapper for :py:func:`provider_by_type` that pulls types from
-    :py:attr:`utils.providers.container_provider_type_map`
-
-    """
-    return provider_by_type(metafunc, 'container', **options)
-
-
-def middleware_providers(metafunc, **options):
-    """Wrapper for :py:func:`provider_by_type` that pulls types from
-    :py:attr:`utils.providers.container_provider_type_map`
-
-    """
-    return provider_by_type(metafunc, 'middleware', **options)
+    classes = [get_class_from_type(prov_type) for prov_type in provider_types]
+    return providers_by_class(metafunc=metafunc, classes=classes,
+                              required_fields=required_fields)
 
 
 def all_providers(metafunc, **options):
-    """Wrapper for :py:func:`provider_by_type` that pulls types from
-    :py:attr:`utils.providers.provider_type_map`
+    """ Returns providers of all types """
+    return providers_by_class(metafunc, [BaseProvider], **options)
 
-    """
-    return provider_by_type(metafunc, None, **options)
+
+def cloud_providers(metafunc, **options):
+    """ Returns only cloud providers """
+    return providers_by_class(metafunc, [CloudProvider], **options)
+
+
+def containers_providers(metafunc, **options):
+    """ Returns only containers providers """
+    return providers_by_class(metafunc, [ContainersProvider], **options)
+
+
+def infra_providers(metafunc, **options):
+    """ Returns only infrastructure providers """
+    return providers_by_class(metafunc, [InfraProvider], **options)
+
+
+def middleware_providers(metafunc, **options):
+    """ Returns only middleware providers """
+    return providers_by_class(metafunc, [MiddlewareProvider], **options)
 
 
 def auth_groups(metafunc, auth_mode):

--- a/utils/tests/test_ipappliance.py
+++ b/utils/tests/test_ipappliance.py
@@ -33,7 +33,7 @@ def test_ipappliance_use_baseurl():
 def test_ipappliance_managed_providers():
     ip_a = IPAppliance()
     provider = setup_a_provider(prov_class='infra')
-    assert provider.key in ip_a.managed_providers
+    assert provider in ip_a.managed_providers
 
 
 def test_context_hack(monkeypatch):


### PR DESCRIPTION
## Refactor `utils.providers` and `utils.testgen`:

Add `utils.providers.ProviderFilter`
Add `utils.providers.global_filters`
Passing provider objects around instead of provider keys
Provider objects now can be compared to one another
Fix `Appliance.managed_providers` to return all provider types
Rename `Provider.type_tclass` to `Provider.category`
`utils.providers.setup_provider` now goes directly through `Provider.create`
`utils.providers.existing_providers` now simply lists providers' whose `exists` returned `True`
`destroy_vm` moved out of `utils.providers` to the only place where it was being used
Remove `utils.providers.setup_provider_by_name`
Remove `utils.providers.setup_providers`
Remove `utils.providers._setup_providers`
Remove `utils.providers.is_provider_setup`
Remove `utils.providers.get_mgmt_by_name`
Add `utils.providers.get_crud_by_name`
Add `utils.providers.new_list_providers`
Add `utils.providers.new_setup_a_provider`
Add `utils.providers.setup_a_provider_by_class`
Add `testgen.providers_by_class`
Add `testgen.providers` which is used by `testgen.providers_by_class`
Replace `BaseProvider.type_mapping` with `BaseProvider.base_types`

Collection is the same as on master.

{{pytest: cfme/tests -k "test_provider_crud" --use-provider complete -v}}
