### PR TITLE
update miqqe_version with current version for upstream/>5.7.0.3

### DIFF
--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -994,7 +994,8 @@ def force_navigate(page_name, _tries=0, *args, **kwargs):
 
     # check for MiqQE javascript patch on first try and patch the appliance if necessary
     from utils.appliance import current_miqqe_version
-    if store.current_appliance.miqqe_version != current_miqqe_version:
+    if not (version.current_version() < "5.5.5.0" or version.current_version() > "5.7.0.3") and\
+            (store.current_appliance.miqqe_version != current_miqqe_version):
         store.current_appliance.patch_with_miqqe()
         browser().quit()
         force_navigate(page_name, _tries, *args, **kwargs)

--- a/utils/appliance/endpoints/ui.py
+++ b/utils/appliance/endpoints/ui.py
@@ -6,6 +6,7 @@ from selenium.common.exceptions import (
     InvalidElementStateException, WebDriverException, UnexpectedAlertPresentException,
     NoSuchElementException, StaleElementReferenceException)
 
+from utils import version
 from utils.log import logger
 from cfme import exceptions
 from cfme.fixtures.pytest_selenium import (
@@ -27,7 +28,8 @@ class CFMENavigateStep(NavigateStep):
 
         # check for MiqQE javascript patch on first try and patch the appliance if necessary
         from utils.appliance import current_miqqe_version
-        if store.current_appliance.miqqe_version != current_miqqe_version:
+        if not (version.current_version() < "5.5.5.0" or version.current_version() > "5.7.0.3") \
+                and (store.current_appliance.miqqe_version != current_miqqe_version):
             store.current_appliance.patch_with_miqqe()
             browser().quit()
             self.go(_tries)


### PR DESCRIPTION
  * upstream and > 5.7.0.3 versions are not patched with MiqQE JS anymore,
    but force_navigate checks for .miqqe_version and quits webdriver if
    its not matching current version. This patch addresses that problem,
    by updating .miqqe_version file to vmdb location.