### PR TITLE
Data Integrity Properties test + get_names function on Container Objs

### DIFF
--- a/cfme/containers/container.py
+++ b/cfme/containers/container.py
@@ -58,3 +58,13 @@ class Container(Taggable, SummaryMixin):
         """
         self.load_details(refresh=True)
         return details_page.infoblock.text(*ident)
+
+    @staticmethod
+    def get_container_names():
+        sel.force_navigate('containers_containers')
+        return map(lambda r: r.name.text, list_tbl.rows())
+
+    @staticmethod
+    def get_pod_names():
+        sel.force_navigate('containers_containers')
+        return map(lambda r: r.pod_name.text, list_tbl.rows())

--- a/cfme/containers/image.py
+++ b/cfme/containers/image.py
@@ -1,69 +1,72 @@
 # -*- coding: utf-8 -*-
 # added new list_tbl definition
+from navmazing import NavigateToSibling, NavigateToAttribute
+
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import toolbar as tb, CheckboxTable
-from cfme.web_ui.menu import nav
-from . import details_page
+from cfme.web_ui import toolbar as tb, CheckboxTable, paginator, summary_title, InfoBlock
+from utils.appliance.endpoints.ui import CFMENavigateStep, navigator, navigate_to
+from utils.appliance import Navigatable
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
 
-nav.add_branch(
-    'containers_images',
-    {
-        'containers_image':
-        lambda ctx: list_tbl.select_row_by_cells(
-            {'Name': ctx['image'].name, 'Provider': ctx['image'].provider.name}),
 
-        'containers_image_detail':
-        lambda ctx: list_tbl.click_row_by_cells(
-            {'Name': ctx['image'].name, 'Provider': ctx['image'].provider.name}),
-    }
-)
+def match_title_and_controller():
+    title_match = sel.execute_script('return document.title;') == 'CFME: Images'
+    controller_match = sel.execute_script('return ManageIQ.controller;') == 'container_image'
+    return title_match and controller_match
 
 
-class Image(Taggable, SummaryMixin):
+class Image(Taggable, SummaryMixin, Navigatable):
 
-    def __init__(self, name, provider):
+    def __init__(self, name, provider, appliance=None):
         self.name = name
         self.provider = provider
+        Navigatable.__init__(self, appliance=appliance)
 
-    def _on_detail_page(self):
-        return sel.is_displayed(
-            '//div//h1[contains(., "{} (Summary)")]'.format(self.name))
-
+    # TODO: remove load_details and dynamic usage from cfme.common.Summary when nav is more complete
     def load_details(self, refresh=False):
-        if not self._on_detail_page():
-            self.navigate(detail=True)
-        elif refresh:
+        navigate_to(self, 'Details')
+        if refresh:
             tb.refresh()
-
-    def click_element(self, *ident):
-        self.load_details(refresh=True)
-        return sel.click(details_page.infoblock.element(*ident))
 
     def get_detail(self, *ident):
         """ Gets details from the details infoblock
-
         Args:
-            *ident: An InfoBlock title, followed by the Key name, e.g. "Relationships", "Images"
-        Returns: A string representing the contents of the InfoBlock's value.
+            *ident: Table name and Key name, e.g. "Relationships", "Images"
+        Returns: A string representing the contents of the summary's value.
         """
-        self.load_details(refresh=True)
-        return details_page.infoblock.text(*ident)
-
-    def navigate(self, detail=True):
-        if detail is True:
-            if not self._on_detail_page():
-                sel.force_navigate(
-                    'containers_image_detail', context={
-                        'image': self})
-        else:
-            sel.force_navigate(
-                'containers_image', context={
-                    'image': self})
+        navigate_to(self, 'Details')
+        return InfoBlock.text(*ident)
 
     @staticmethod
     def get_names():
         sel.force_navigate('containers_images')
         return map(lambda r: r.name.text, list_tbl.rows())
+
+
+@navigator.register(Image, 'All')
+class All(CFMENavigateStep):
+    prerequisite = NavigateToAttribute('appliance', 'LoggedIn')
+
+    def step(self):
+        from cfme.web_ui.menu import nav
+        nav._nav_to_fn('Compute', 'Containers', 'Container Images')(None)
+
+    def resetter(self):
+        tb.select('Grid View')
+        sel.check(paginator.check_all())
+        sel.uncheck(paginator.check_all())
+
+
+@navigator.register(Image, 'Details')
+class Details(CFMENavigateStep):
+    prerequisite = NavigateToSibling('All')
+
+    def am_i_here(self):
+        summary_match = summary_title() == '{} (Summary)'.format(self.obj.name)
+        return summary_match and match_title_and_controller()
+
+    def step(self):
+        tb.select('List View')
+        list_tbl.click_row_by_cells({'Name': self.obj.name})

--- a/cfme/containers/image_registry.py
+++ b/cfme/containers/image_registry.py
@@ -3,6 +3,8 @@ from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import CheckboxTable, toolbar as tb
 from cfme.web_ui.menu import nav
+from . import details_page
+
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
 
@@ -26,6 +28,10 @@ class ImageRegistry(Taggable, SummaryMixin):
         self.host = host
         self.provider = provider
 
+    def _on_detail_page(self):
+        return sel.is_displayed(
+            '//div//h1[contains(., "{} (Summary)")]'.format(self.host))
+
     def load_details(self, refresh=False):
         if not self._on_detail_page():
             self.navigate(detail=True)
@@ -40,3 +46,17 @@ class ImageRegistry(Taggable, SummaryMixin):
         else:
             sel.force_navigate('containers_image_registry',
                 context={'image_registry': self})
+
+    def get_detail(self, *ident):
+        """ Gets details from the details infoblock
+        Args:
+            *ident: An InfoBlock title, followed by the Key name, e.g. "Relationships", "Images"
+        Returns: A string representing the contents of the InfoBlock's value.
+        """
+        self.load_details(refresh=True)
+        return details_page.infoblock.text(*ident)
+
+    @staticmethod
+    def get_names():
+        sel.force_navigate('containers_image_registries')
+        return map(lambda r: r.host.text, list_tbl.rows())

--- a/cfme/containers/node.py
+++ b/cfme/containers/node.py
@@ -57,3 +57,8 @@ class Node(Taggable, SummaryMixin):
                 sel.force_navigate('containers_node_detail', context={'node': self})
         else:
             sel.force_navigate('containers_node', context={'node': self})
+
+    @staticmethod
+    def get_names():
+        sel.force_navigate('containers_nodes')
+        return map(lambda r: r.name.text, list_tbl.rows())

--- a/cfme/containers/pod.py
+++ b/cfme/containers/pod.py
@@ -58,3 +58,8 @@ class Pod(Taggable, SummaryMixin):
                 sel.force_navigate('containers_pod_detail', context={'pod': self})
         else:
             sel.force_navigate('containers_pod', context={'pod': self})
+
+    @staticmethod
+    def get_names():
+        sel.force_navigate('containers_containers')
+        return map(lambda r: r.pod_name.text, list_tbl.rows())

--- a/cfme/tests/containers/test_containers_data_integrity_properties.py
+++ b/cfme/tests/containers/test_containers_data_integrity_properties.py
@@ -1,0 +1,95 @@
+import pytest
+from cfme.containers.image import Image
+from cfme.containers.image_registry import ImageRegistry
+from cfme.containers.pod import Pod
+from cfme.containers.provider import Provider
+from cfme.containers.node import Node
+from cfme.containers.container import Container
+from utils import testgen
+from utils.version import current_version
+from cfme.web_ui import history
+
+
+pytestmark = [
+    pytest.mark.uncollectif(
+        lambda: current_version() < "5.6"),
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.tier(1)]
+pytest_generate_tests = testgen.generate(
+    testgen.container_providers, scope='function')
+
+container_image_fields = ['Name', 'Image_Id', 'Full_Name']
+container_nodes_fields = ['Name', 'Creation_timestamp', 'Resource_version', 'Number_of_CPU_Cores',
+                          'Memory', 'Max_Pods_Capacity', 'System_BIOS_UUID', 'Machine_ID',
+                          'Infrastructure_Machine_ID', 'Runtime_version', 'Kubelet_version',
+                          'Proxy_version', 'Operating_System_Distribution', 'Kernel_version']
+container_fields = ['Name', 'State', 'Restart_count', 'Backing_Ref_Container_ID', 'Privileged']
+image_registry_field = ['Host']
+
+
+# CMP-9945
+def test_containers_integrity_properties():
+    """ Properties fields test in Containers
+        This test checks correct population of the Properties Fields in Containers' details menu
+        Steps:
+            * Goes to Containers -- > Containers menu
+            * Go through each Containers in the menu and check validity of Properties fields
+        """
+    container_names = Container.get_container_names()
+    container_pod_names = Container.get_pod_names()
+    dictionary = dict(zip(container_names, container_pod_names))
+    for container_name, container_pod_name in dictionary.iteritems():
+        for container_field in container_fields:
+            pod = Pod(container_pod_name, Provider)
+            cont = Container(container_name, pod)
+            assert cont.summary.properties.__getattribute__(container_field.lower())
+            history.select_nth_history_item(0)
+
+
+# CMP-9988
+def test_containers_image_registries_integrity_properties(provider):
+    """ Properties fields test in Image Registries
+        This test checks correct population of the Properties Fields in Image Registry's
+        details menu.
+        Prerequisites: Image Registries in CFME
+        Steps:
+            * Goes to Containers -- > Image Registries menu
+            * Go through each Image Registry in the menu and check validity of Properties fields
+        """
+    image_registry_hosts = ImageRegistry.get_names()
+    for host in image_registry_hosts:
+        for image in image_registry_field:
+            obj = ImageRegistry(host, provider)
+            assert obj.summary.properties.__getattribute__(image.lower())
+
+
+# CMP-9978
+def test_containers_images_integrity_properties(provider):
+    """ Properties fields test in Container Images
+        This test checks correct population of the Properties Fields in Containers Image's
+        details menu
+        Steps:
+            * Goes to Containers -- > Containers Images menu
+            * Go through each Container Image in the menu and check validity of Properties fields
+        """
+    container_images_names = Image.get_names()
+    for name in container_images_names:
+        for image in container_image_fields:
+            obj = Image(name, provider)
+            assert obj.summary.properties.__getattribute__(image.lower())
+
+
+# CMP-9960
+def test_containers_nodes_integrity_properties(provider):
+    """ Properties fields test in Container Nodes
+        This test checks correct population of the Properties Fields in Container Nodes'
+        details menu
+        Steps:
+            * Goes to Containers -- > Container Nodes menu
+            * Go through each Container in the menu and check validity of Properties fields
+        """
+    container_nodes_names = Node.get_names()
+    for name in container_nodes_names:
+        for node_field in container_nodes_fields:
+            obj = Node(name, provider)
+            assert obj.summary.properties.__getattribute__(node_field.lower())


### PR DESCRIPTION
This test checks correct population of the Properties Fields in Containers/Image Registries/Container Images and Container Nodes details menu.
Also added fixes for container/image/image_registry/node and pod objects to allow getting names for the existing objects

image_registry.py file was edited to allow get_detail on this object

{{pytest: cfme/tests/containers/test_containers_data_integrity_properties.py -v --use-provider container }}