### PR TITLE
added darga-41 version string to configure method picker.

### DIFF
--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -178,6 +178,7 @@ class IPAppliance(object):
             configure_function = pick({
                 '5.2': self._configure_5_2,
                 '5.3': self._configure_5_3,
+                'darga-4.1': self._configure_upstream,
                 LATEST: self._configure_upstream,
             })
             configure_function(log_callback=log_callback)


### PR DESCRIPTION
  * added darga-41 version string to configure method picker as darga41 needs to be configured as upstream appliance else it defaults to configure_cfme().