### PR TITLE
fixing provisioning dialog tests

### DIFF
--- a/cfme/provisioning.py
+++ b/cfme/provisioning.py
@@ -157,6 +157,7 @@ provisioning_form = tabstrip.TabStripForm(
             ('cores_per_socket', {
                 version.LOWEST: ui.Select('select#hardware__cores_per_socket'),
                 '5.5': AngularSelect('hardware__cores_per_socket')}),
+            ('num_cpus', AngularSelect('hardware__number_of_cpus')),
             ('memory', {
                 version.LOWEST: ui.Select('select#hardware__vm_memory'),
                 '5.5': AngularSelect('hardware__vm_memory')}),


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ scvmm/uncollecting not applicable and blocked tests.

marking and new name generator
{{pytest: cfme/tests/infrastructure/test_provisioning_dialog.py --use-provider="scvmm" --use-provider="vsphere55" --long-running  }}