### PR TITLE
Container node nav

### DIFF
--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -251,11 +251,10 @@ class Add(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        if version.current_version() > '5.6':
-            btn = 'Add Existing Containers Provider'
-        else:
-            btn = 'Add a New Containers Provider'
-        cfg_btn(btn)
+        cfg_btn(version.pick({
+            version.LOWEST: 'Add a New Containers Provider',
+            '5.7': 'Add Existing Containers Provider'
+        }))
 
 
 @navigator.register(ContainersProvider, 'Details')

--- a/cfme/tests/containers/test_containers_default_views.py
+++ b/cfme/tests/containers/test_containers_default_views.py
@@ -18,11 +18,12 @@ pytest_generate_tests = testgen.generate(
 VIEWS = ['Grid View', 'Tile View', 'List View']
 BUTTON_GROUP = ['Containers Providers', 'Projects', 'Routes', 'Nodes', 'Containers', 'Replicators']
 
+# TODO: Replace with navigator registered destinations when all container objects support them
 mapping = {
     'Containers Providers': 'containers_providers',
     'Projects': 'containers_projects',
     'Routes': 'containers_routes',
-    'Nodes': 'containers_nodes',
+    # 'Nodes': 'containers_nodes',
     'Containers': 'containers_containers',
     'Replicators': 'containers_replicators',
 }

--- a/cfme/tests/containers/test_data_integrity_for_topology.py
+++ b/cfme/tests/containers/test_data_integrity_for_topology.py
@@ -1,15 +1,15 @@
 import pytest
+import time
+
+from cfme.containers.container import Container, list_tbl as list_tbl_containers
+from cfme.containers.image_registry import ImageRegistry, list_tbl as list_tbl_image_registrys
+from cfme.containers.pod import Pod, list_tbl as list_tbl_pods
+from cfme.containers.project import Project, list_tbl as list_tbl_projects
+from cfme.containers.route import Route, list_tbl as list_tbl_routes
+from cfme.containers.service import Service, list_tbl as list_tbl_services
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import StatusBox, Quadicon
 from utils import testgen
-import time
-from cfme.containers.node import Node, list_tbl as list_tbl_nodes
-from cfme.containers.pod import Pod, list_tbl as list_tbl_pods
-from cfme.containers.container import Container, list_tbl as list_tbl_containers
-from cfme.containers.project import Project, list_tbl as list_tbl_projects
-from cfme.containers.image_registry import ImageRegistry, list_tbl as list_tbl_image_registrys
-from cfme.containers.service import Service, list_tbl as list_tbl_services
-from cfme.containers.route import Route, list_tbl as list_tbl_routes
 from utils.version import current_version
 from cfme.containers.provider import ContainersProvider
 
@@ -24,7 +24,7 @@ pytest_generate_tests = testgen.generate(
 # TEST_DATAS: Referenced from: Menu.sections()
 # TODO: Refactor to container objects with valid navmazing destinations
 TEST_DATAS = [
-    (Node, 'containers_nodes', 'Nodes', list_tbl_nodes),
+    # (Node, 'containers_nodes', 'Nodes', list_tbl_nodes),
     (Container, 'containers_containers', 'Containers', list_tbl_containers),
     (ImageRegistry, 'containers_image_registries', 'Registries', list_tbl_image_registrys),
     (Project, 'containers_projects', 'Projects', list_tbl_projects),

--- a/cfme/tests/containers/test_views_objects.py
+++ b/cfme/tests/containers/test_views_objects.py
@@ -4,6 +4,7 @@
 import pytest
 
 from cfme.containers.image import Image
+from cfme.containers.node import Node
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import toolbar as tb
 from utils import testgen
@@ -60,7 +61,7 @@ def test_services_views():
 
 
 def test_nodes_views():
-    sel.force_navigate('containers_nodes')
+    navigate_to(Node, 'All')
     tb.select('Grid View')
     assert tb.is_active('Grid View'), "Nodes grid view setting failed"
     tb.select('Tile View')


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_relationships_tables.py cfme/tests/containers/test_views_objects.py  --use-provider=cm-env1}}

Purpose or Intent
=================

Refactor cfme.container.node with navigation destinations, and modify anything that used previous navigation branches.
