### PR TITLE
Flash message fix for provider delete

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -241,8 +241,8 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
         sel.handle_alert(cancel=cancel)
         if not cancel:
             flash.assert_message_match(
-                'Delete initiated for 1 {} Provider from the CFME Database'.format(
-                    self.string_name))
+                'Delete initiated for 1 {} Provider from the {} Database'.format(
+                    self.string_name, self.appliance.product_name))
 
     def delete_if_exists(self, *args, **kwargs):
         """Combines ``.exists`` and ``.delete()`` as a shortcut for ``request.addfinalizer``"""


### PR DESCRIPTION
Newer versions have ManageIQ instead CFME, this should cover the issue

{{pytest: cfme/tests/infrastructure/test_providers.py -v -k 'provider_crud'}}