### PR TITLE
adding preemtible vms for gce

### DIFF
--- a/cfme/provisioning.py
+++ b/cfme/provisioning.py
@@ -191,6 +191,9 @@ provisioning_form = tabstrip.TabStripForm(
                 version.LOWEST: ui.Select('select#hardware__monitoring'),
                 '5.5': AngularSelect('hardware__monitoring')}),
             ('boot_disk_size', AngularSelect('hardware__boot_disk_size')),
+            # GCE
+            ('is_preemtible', {version.LOWEST: None,
+                              '5.7': ui.Input('hardware__is_preemptible')})
         ]),
 
         ('Customize', [


### PR DESCRIPTION
Purpose
=================
__Adding Preemtible VM's provision on GCE. It was implemented in product version 5.7.0.4
as feature is not critical and only for GCE - there's no need to parametrize it separately or write test for preemtible VM 

+adding new naming in cloud provisioning tests

{{pytest: cfme/tests/cloud/test_provisioning.py -k "test_provision_from_template" --use-provider="gce_central"  --long-running }}

