### PR TITLE
Service Catalog Item Navmazing

### DIFF
--- a/cfme/automate/service_dialogs.py
+++ b/cfme/automate/service_dialogs.py
@@ -154,7 +154,9 @@ class ServiceDialog(Updateable, Pretty, Navigatable, Fillable):
 
     def delete(self, cancel=False):
         navigate_to(self, 'Details')
-        cfg_btn("Remove from the VMDB", invokes_alert=True)
+        cfg_btn(version.pick({version.LOWEST: "Remove from the VMDB",
+                              '5.7': 'Remove Dialog'}),
+                invokes_alert=True)
         sel.handle_alert(cancel)
 
     def element_type(self, each_element):

--- a/cfme/tests/configure/test_default_views_infra.py
+++ b/cfme/tests/configure/test_default_views_infra.py
@@ -23,14 +23,14 @@ def minimise_dict(item):
     else:
         return item
 
-# todo: infrastructure hosts, pools, stores, clusters are removed due to changing navigation
-#  to navmazing. all items have to be put back once navigation change is fully done
+# TODO: infrastructure hosts, pools, stores, clusters, catalog_items are removed
+#  due to navmazing. all items have to be put back once navigation change is fully done
 
 gtl_params = [
     'Infrastructure Providers/infrastructure_providers',
     'VMs/infra_vms',
     'My Services/my_services',
-    'Catalog Items/catalog_items',
+    # 'Catalog Items/catalog_items',
     'VMs & Instances/service_vms_instances',
     'Templates & Images/service_templates_images'
 ]

--- a/cfme/tests/services/test_catalog_item.py
+++ b/cfme/tests/services/test_catalog_item.py
@@ -1,23 +1,27 @@
 # -*- coding: utf-8 -*-
 import fauxfactory
 import pytest
-from cfme.web_ui import flash
-from cfme.services.catalogs.catalog_item import CatalogItem
-from cfme.automate.service_dialogs import ServiceDialog
-from cfme.services.catalogs.catalog import Catalog
-from utils import error
-from utils.update import update
-from utils.blockers import BZ
+
+from selenium.common.exceptions import NoSuchElementException, TimeoutException
+
 import cfme.tests.configure.test_access_control as tac
 from cfme import test_requirements
+from cfme.automate.service_dialogs import ServiceDialog
+from cfme.services.catalogs.catalog_item import CatalogItem
+from cfme.services.catalogs.catalog import Catalog
+from cfme.web_ui import flash
+from utils import error
+from utils.blockers import BZ
+from utils.log import logger
+from utils.update import update
 
 
 pytestmark = [test_requirements.service, pytest.mark.tier(3)]
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.yield_fixture(scope="module")
 def dialog():
-    dialog = "dialog_" + fauxfactory.gen_alphanumeric()
+    dialog_name = "dialog_" + fauxfactory.gen_alphanumeric()
 
     element_data = dict(
         ele_label="ele_" + fauxfactory.gen_alphanumeric(),
@@ -27,33 +31,54 @@ def dialog():
         default_text_box="default value"
     )
 
-    service_dialog = ServiceDialog(label=dialog, description="my dialog",
+    service_dialog = ServiceDialog(label=dialog_name, description="my dialog",
                                    submit=True, cancel=True,
                                    tab_label="tab_" + fauxfactory.gen_alphanumeric(),
                                    tab_desc="my tab desc",
                                    box_label="box_" + fauxfactory.gen_alphanumeric(),
                                    box_desc="my box desc")
     service_dialog.create(element_data)
-    flash.assert_success_message('Dialog "{}" was added'.format(dialog))
-    yield dialog
+    flash.assert_success_message('Dialog "{}" was added'.format(dialog_name))
+    yield service_dialog
+
+    # fixture cleanup
+    try:
+        service_dialog.delete()
+    except NoSuchElementException or TimeoutException:
+        logger.warning('test_catalog_item: dialog yield fixture cleanup, dialog "{}" not '
+                       'found'.format(dialog_name))
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.yield_fixture(scope="module")
 def catalog():
-    catalog = "cat_" + fauxfactory.gen_alphanumeric()
-    cat = Catalog(name=catalog,
+    catalog_name = "test_cat_" + fauxfactory.gen_alphanumeric()
+    cat = Catalog(name=catalog_name,
                   description="my catalog")
     cat.create()
-    yield catalog
+    yield cat
+
+    # fixture cleanup
+    try:
+        cat.delete()
+    except NoSuchElementException:
+        logger.warning('test_catalog_item: catalog yield fixture cleanup, catalog "{}" not '
+                       'found'.format(catalog_name))
 
 
 @pytest.yield_fixture(scope="function")
 def catalog_item(dialog, catalog):
-    catalog_item = CatalogItem(item_type="Generic",
-                               name=fauxfactory.gen_alphanumeric(),
-                               description="my catalog", display_in=True,
-                               catalog=catalog, dialog=dialog)
-    yield catalog_item
+    cat_item = CatalogItem(item_type="Generic",
+                           name='test_item_' + fauxfactory.gen_alphanumeric(),
+                           description="my catalog item", display_in=True,
+                           catalog=catalog.name, dialog=dialog.label)
+    yield cat_item
+
+    # fixture cleanup
+    try:
+        cat_item.delete()
+    except NoSuchElementException:
+        logger.warning('test_catalog_item: catalog_item yield fixture cleanup, catalog item "{}" '
+                       'not found'.format(cat_item.name))
 
 
 def test_create_catalog_item(catalog_item):
@@ -64,7 +89,7 @@ def test_create_catalog_item(catalog_item):
 def test_update_catalog_item(catalog_item):
     catalog_item.create()
     with update(catalog_item):
-        catalog_item.description = "my edited description"
+        catalog_item.description = "my edited item description"
 
 
 def test_delete_catalog_item(catalog_item):
@@ -94,7 +119,7 @@ def test_catalog_item_duplicate_name(catalog_item):
         catalog_item.create()
 
 
-def test_permissions_catalog_item_add(setup_cloud_providers, catalog_item):
+def test_permissions_catalog_item_add(catalog_item):
     """Test that a catalog can be added only with the right permissions."""
     tac.single_task_permission_test([['Everything', 'Services', 'Catalogs Explorer',
                                       'Catalog Items']],

--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -1095,7 +1095,10 @@ class CheckboxTable(Table):
 
     def _set_row_by_cells(self, cells, set_to=False, partial_check=False):
         row = self.find_row_by_cells(cells, partial_check=partial_check)
-        self._set_row_checkbox(row, set_to)
+        if row:
+            self._set_row_checkbox(row, set_to)
+        else:
+            raise sel_exceptions.NoSuchElementException()
 
     def select_row_by_cells(self, cells, partial_check=False):
         """Select the first row matched by ``cells``


### PR DESCRIPTION
{{ pytest: cfme/tests/services/test_catalog_item.py --use-provider=ec2-east }}

Purpose or Intent
=================

Refactor catalog item and catalog bundle navigation to use navigator/navmazing destinations.

Reworked the test a bit to cleanup, and to more efficiently use fixtures - moved catalog and dialog to module scope so they are re-used instead of recreated for every function.
