### PR TITLE
CFME Container Image Registry Navmazing conversion.

### DIFF
--- a/cfme/containers/image_registry.py
+++ b/cfme/containers/image_registry.py
@@ -1,42 +1,68 @@
 # -*- coding: utf-8 -*-
+from functools import partial
+
+from navmazing import NavigateToSibling, NavigateToAttribute
+
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import CheckboxTable, toolbar as tb
-from cfme.web_ui.menu import nav
+from cfme.web_ui import CheckboxTable, toolbar as tb, paginator, match_location
+from utils.appliance import Navigatable
+from utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
+from . import pol_btn
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
 
-nav.add_branch(
-    'containers_image_registries',
-    {
-        'containers_image_registry':
-        lambda ctx: list_tbl.select_row_by_cells(
-            {'Host': ctx['image_registry'].host, 'Provider': ctx['image_registry'].provider.name}),
 
-        'containers_image_registry_detail':
-        lambda ctx: list_tbl.click_row_by_cells(
-            {'Host': ctx['image_registry'].host, 'Provider': ctx['image_registry'].provider.name}),
-    }
-)
+match_page = partial(match_location, controller='container_image_registry',
+                     title='Image Registries')
 
 
-class ImageRegistry(Taggable, SummaryMixin):
+class ImageRegistry(Taggable, SummaryMixin, Navigatable):
 
-    def __init__(self, host, provider):
+    def __init__(self, host, provider, appliance=None):
         self.host = host
         self.provider = provider
+        Navigatable.__init__(self, appliance=appliance)
 
     def load_details(self, refresh=False):
-        if not self._on_detail_page():
-            self.navigate(detail=True)
-        elif refresh:
+        navigate_to(self, 'Details')
+        if refresh:
             tb.refresh()
 
-    def navigate(self, detail=True):
-        if detail is True:
-            if not self._on_detail_page():
-                sel.force_navigate('containers_image_registry_detail',
-                    context={'image_registry': self})
-        else:
-            sel.force_navigate('containers_image_registry',
-                context={'image_registry': self})
+
+@navigator.register(ImageRegistry, 'All')
+class ImageRegistryAll(CFMENavigateStep):
+    prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
+
+    def am_i_here(self):
+        return match_page(summary='Image Registries')
+
+    def step(self):
+        from cfme.web_ui.menu import nav
+        nav._nav_to_fn('Compute', 'Containers', 'Image Registries')(None)
+
+    def resetter(self):
+        tb.select('List View')
+        if paginator.page_controls_exist():
+            sel.check(paginator.check_all())
+            sel.uncheck(paginator.check_all())
+
+
+@navigator.register(ImageRegistry, 'Details')
+class ImageRegistryDetails(CFMENavigateStep):
+    prerequisite = NavigateToSibling('All')
+
+    def am_i_here(self):
+        return match_page(summary='{} (Summary)'.format(self.obj.host))
+
+    def step(self):
+        tb.select('List View')
+        list_tbl.click_row_by_cells({'Host': self.obj.host})
+
+
+@navigator.register(ImageRegistry, 'EditTags')
+class ImageRegistryEditTags(CFMENavigateStep):
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        pol_btn('Edit Tags')

--- a/cfme/tests/containers/test_data_integrity_for_topology.py
+++ b/cfme/tests/containers/test_data_integrity_for_topology.py
@@ -2,7 +2,6 @@ import pytest
 import time
 
 from cfme.containers.container import Container, list_tbl as list_tbl_containers
-from cfme.containers.image_registry import ImageRegistry, list_tbl as list_tbl_image_registrys
 from cfme.containers.pod import Pod, list_tbl as list_tbl_pods
 from cfme.containers.project import Project, list_tbl as list_tbl_projects
 from cfme.containers.route import Route, list_tbl as list_tbl_routes
@@ -26,7 +25,7 @@ pytest_generate_tests = testgen.generate(
 TEST_DATAS = [
     # (Node, 'containers_nodes', 'Nodes', list_tbl_nodes),
     (Container, 'containers_containers', 'Containers', list_tbl_containers),
-    (ImageRegistry, 'containers_image_registries', 'Registries', list_tbl_image_registrys),
+    # (ImageRegistry, 'containers_image_registries', 'Registries', list_tbl_image_registrys),
     (Project, 'containers_projects', 'Projects', list_tbl_projects),
     (Pod, 'containers_pods', 'Pods', list_tbl_pods),
     (Service, 'containers_services', 'Services', list_tbl_services),

--- a/cfme/tests/containers/test_views_objects.py
+++ b/cfme/tests/containers/test_views_objects.py
@@ -4,6 +4,7 @@
 import pytest
 
 from cfme.containers.image import Image
+from cfme.containers.image_registry import ImageRegistry
 from cfme.containers.node import Node
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import toolbar as tb
@@ -72,6 +73,16 @@ def test_nodes_views():
 
 def test_images_views():
     navigate_to(Image, 'All')
+    tb.select('Grid View')
+    assert tb.is_active('Grid View'), "Images grid view setting failed"
+    tb.select('Tile View')
+    assert tb.is_active('Tile View'), "Images tile view setting failed"
+    tb.select('List View')
+    assert tb.is_active('List View'), "Images list view setting failed"
+
+
+def test_imageregistry_views():
+    navigate_to(ImageRegistry, 'All')
     tb.select('Grid View')
     assert tb.is_active('Grid View'), "Images grid view setting failed"
     tb.select('Tile View')


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_views_objects.py::test_imageregistry_views[cm-env1] --use-provider cm-env1}}
# Purpose or Intent

Refactor cfme.containers.image_registry with navigation destinations, and modify anything that used previous navigation branches.
