### PR TITLE
specify glance api version in template uploader commands.

### DIFF
--- a/scripts/clone_template.py
+++ b/scripts/clone_template.py
@@ -70,11 +70,11 @@ def main(**kwargs):
         credentials =\
             {'username': provider_dict['username'],
              'password': provider_dict['password'],
-             'tenant': provider_dict['template_upload'].get('tenant_admin', None),
+             'tenant': provider_dict['template_upload'].get('tenant_admin', 'admin'),
              'auth_url': provider_dict.get('auth_url', None),
              }
         provider = get_mgmt(kwargs['provider'], providers=providers, credentials=credentials)
-        flavors = provider_dict['template_upload'].get('flavors', [])
+        flavors = provider_dict['template_upload'].get('flavors', ['m1.medium'])
         provider_type = provider_data['management_systems'][kwargs['provider']]['type']
         deploy_args = {
             'vm_name': kwargs['vm_name'],

--- a/scripts/template_upload_rhos.py
+++ b/scripts/template_upload_rhos.py
@@ -59,6 +59,7 @@ def make_export(username, password, tenant_id, auth_url):
 def upload_qc2_file(ssh_client, image_url, template_name, export, provider):
     try:
         command = ['glance']
+        command.append("--os-image-api-version 1")
         command.append("image-create")
         command.append("--copy-from {}".format(image_url))
         command.append("--name {}".format(template_name))


### PR DESCRIPTION
Purpose or Intent
=================
  * newer openstack versions (rhos9) uses the newer image api version (2.0)
    the command line options changed for image v2.0, however we can still
    use the commands in our scripts by specifying the api version we are using (1.0)
  * this was affecting interop team to upload cfme images. this PR addresses that.