### PR TITLE
BootstrapTreeview: Cast to string if not a known type

### DIFF
--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -1839,6 +1839,8 @@ class BootstrapTreeview(object):
             step = step[1]
         else:
             image = None
+        if not isinstance(step, (basestring, re._pattern_type)):
+            step = str(step)
         return image, step
 
     @staticmethod

--- a/widgetastic_patternfly.py
+++ b/widgetastic_patternfly.py
@@ -830,6 +830,8 @@ class BootstrapTreeview(Widget):
             step = step[1]
         else:
             image = None
+        if not isinstance(step, six.string_types + (re._pattern_type,)):
+            step = str(step)
         return image, step
 
     @staticmethod


### PR DESCRIPTION
Required for compatibility passing objects with `__str__`