### PR TITLE
pinning selenium to former release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,8 @@ PyYAML
 requests
 riggerlib>=2.0
 scp
-selenium
+# since 3.0 uses marionette by default
+selenium<3.0.0
 slumber
 sqlalchemy
 suds


### PR DESCRIPTION
Purpose or Intent
=================
 pinning selenium to former release since selenium 3 started using marionette by default for local firefox.