### PR TITLE
Update infra.pxe ISODatastoreDetails navigation

### DIFF
--- a/cfme/infrastructure/pxe.py
+++ b/cfme/infrastructure/pxe.py
@@ -711,7 +711,6 @@ class ISODatastoreDetails(CFMENavigateStep):
 
     def step(self):
         acc.tree("ISO Datastores", "All ISO Datastores", self.obj.provider)
-        image_table.click_cell('name', self.obj.pxe_image_type.name)
 
 
 def get_template_from_config(template_config_name):


### PR DESCRIPTION
{{pytest: cfme/tests/infrastructure/test_iso_datastore.py}}

Purpose or Intent
=================

Downstream-56z test failures due to duplicate navigation actions in the step to reach details.

The acc.tree() call hits the given provider's ISODatastore object. There is no pxe_image_type for ISO Datastore, and the table resulting from the existing accordion navigation cannot be clicked.

RHCFQE-1012