### PR TITLE
Update test_csrf with new navigation, auto-test-fix

### DIFF
--- a/cfme/tests/test_csrf.py
+++ b/cfme/tests/test_csrf.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from cfme import dashboard, login
+from cfme import dashboard
+from cfme.login import LoginPage
+from cfme.base.ui import Server
+from utils.appliance.endpoints.ui import navigate_to
 from utils.wait import wait_for, TimedOutError
 
 
 @pytest.mark.tier(2)
-@pytest.mark.meta(blockers=[1285778, 'GH#ManageIQ/manageiq:5657'])
 def test_csrf_post():
     """CSRF should prevent forged POST requests
 
@@ -14,11 +16,11 @@ def test_csrf_post():
     to something invalid should set off the CSRF detector and reject the request
 
     """
-    pytest.sel.force_navigate("dashboard")
+    navigate_to(Server, 'Dashboard')
     dashboard.set_csrf_token("Bogus!")
     dashboard.reset_widgets()
 
     try:
-        wait_for(lambda: login.page.is_displayed(), num_sec=15, delay=0.2)
+        wait_for(lambda: LoginPage.is_displayed, num_sec=15, delay=0.2)
     except TimedOutError:
         pytest.fail("CSRF attack succeeded!")


### PR DESCRIPTION
{{ pytest: cfme/tests/test_csrf.py }}

Purpose or Intent
=================

Fix downstream 5.6 test failure:
https://cfmeqe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/downstream-56z-tests/1340/testReport/junit/cfme.tests/test_csrf/test_csrf_post/

Bug was fixed in 5.6, removing marker for blockers.

RHCFQE-1020