### PR TITLE
FIX: cryptography fails to build w/ AssertionError

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -30,6 +30,7 @@ file, place it in the ``cfme_tests`` repository (along ``conftest.py``):
 
   . ./.cfme_tests/bin/activate
   python scripts/disable-bytecode.py
+  pip install --upgrade pip
   PYCURL_SSL_LIBRARY=nss pip install -Ur ./requirements.txt
   echo "Run '. ./.cfme_tests/bin/activate' to load the virtualenv"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,8 @@ progress
 psphere
 py
 pycurl
+# cryptography fails to build w/ AssertError w/ >=2.14
+pycparser==2.13
 pycrypto
 pygal
 PyGithub


### PR DESCRIPTION
Defect in pycparser 2.14/2.15 causes cryptography build to fail with
"AssertionError: sorry, but this version only supports 100 named groups"