### PR TITLE
updated encrypt file in script to accept params.

### DIFF
--- a/scripts/encrypt_conf.py
+++ b/scripts/encrypt_conf.py
@@ -7,13 +7,32 @@ Usage:
    scripts/encrypt_conf.py confname1 confname2 ... confnameN
    scripts/encrypt_conf.py credentials
 """
-import sys
-
+import argparse
 import yaycl_crypt
 
 from utils import conf
 
-for conf_name in sys.argv[1:]:
-    conf_name = conf_name.strip()
-    yaycl_crypt.encrypt_yaml(conf, conf_name)
+
+def parse_cmd_line():
+    parser = argparse.ArgumentParser(argument_default=None)
+    parser.add_argument('-e', '--encrypt', default=False, dest='encrypt', action='store_true',
+                        help='encrypts the file specified')
+    parser.add_argument('-d', '--decrypt', default=False, dest='decrypt', action='store_true',
+                        help='decrypts the file specified')
+    parser.add_argument('--file', dest='file', default='credentials',
+                        help='file name in "conf" to be encrypted/decrypted')
+    parser.add_argument('--delete', dest='delete', default=False,
+                        help='If set to False, encrypt_yaml will not delete the unencrypted '
+                             'config of the same name, and decrypt_yaml will similarly not '
+                             'delete its encrypted counterpart.')
+    args = parser.parse_args()
+    return args
+
+args = parse_cmd_line()
+conf_name = args.file.strip()
+if args.encrypt:
+    yaycl_crypt.encrypt_yaml(conf, conf_name, delete=args.delete)
     print('{} conf encrypted'.format(conf_name))
+if args.decrypt:
+    yaycl_crypt.decrypt_yaml(conf, conf_name, delete=args.delete)
+    print('{} conf decrypted'.format(conf_name))


### PR DESCRIPTION
Purpose or Intent
=================
* script/encrypt.py always encrypts, which was of not much help when try to decrypt_yaml  credentials to    run tests locally.
*  scripts/encrypt now accepts params to -e encrypt, -d decrypt, --file conf file names. easy to decrypt/encrypt.
   