### PR TITLE
FIX: 'Getting Started' instructions

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -30,7 +30,8 @@ file, place it in the ``cfme_tests`` repository (along ``conftest.py``):
 
   . ./.cfme_tests/bin/activate
   python scripts/disable-bytecode.py
-  PYCURL_SSL_LIBRARY=nss pip install -Ur ./requirements.txt
+  pip install --upgrade pip
+  PYCURL_SSL_LIBRARY=nss pip install -Ur ./requirements.txt --no-cache-dir
   echo "Run '. ./.cfme_tests/bin/activate' to load the virtualenv"
 
 Detailed steps (manual environment setup):


### PR DESCRIPTION
Using a clean RHEL 7.2 install, the directions in the current 'Getting Started' produce 2 errors.

The cryptography package fails to build w/ AssertionError, and the docker package has an issue w/ pip.

This PR updates pip the address the docker package issue, and sets the 'no-cache-dir' when installing deps for force rebuild.