### PR TITLE
CFME Container containers Navmazing conversion.

### DIFF
--- a/cfme/tests/containers/test_data_integrity_for_topology.py
+++ b/cfme/tests/containers/test_data_integrity_for_topology.py
@@ -1,7 +1,7 @@
 import pytest
 import time
 
-# from cfme.containers.container import Container
+from cfme.containers.container import Container
 from cfme.containers.image_registry import ImageRegistry
 from cfme.containers.pod import Pod
 from cfme.containers.project import Project
@@ -29,8 +29,8 @@ pytest_generate_tests = testgen.generate(
 DataSet = namedtuple('DataSet', ['object', 'name'])
 
 # TODO: add the following to the list once possible:
-#     DataSet(Container, 'Containers')
 DATA_SETS = [
+    DataSet(Container, 'Containers'),
     DataSet(Node, 'Nodes'),
     DataSet(Project, 'Projects'),
     DataSet(Pod, 'Pods'),

--- a/cfme/tests/containers/test_views_objects.py
+++ b/cfme/tests/containers/test_views_objects.py
@@ -3,6 +3,7 @@
 # and list view
 import pytest
 
+from cfme.containers.container import Container
 from cfme.containers.image import Image
 from cfme.containers.image_registry import ImageRegistry
 from cfme.containers.node import Node
@@ -44,8 +45,7 @@ def test_replicators_views():
 
 
 def test_containers_views():
-    # TODO: navigate_to(Container, 'All') once ready
-    sel.force_navigate('containers_containers')
+    navigate_to(Container, 'All')
     tb.select('Grid View')
     assert tb.is_active('Grid View'), "Containers grid view setting failed"
     tb.select('Tile View')


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_views_objects.py::test_containers_views[cm-env1] --use-provider cm-env1}}

# Purpose or Intent
- Refactor cfme.containers.container with navigation destinations,
  and modify anything that used previous navigation branches.
