### PR TITLE
[WIP] Generic UI Tests, Advanced Search (Bug 1380430)

### DIFF
--- a/cfme/tests/generic_ui/test_advanced_search.py
+++ b/cfme/tests/generic_ui/test_advanced_search.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""
+
+This testing module tests the generic behaviour of the advanced search box
+
+This can/should be parameterized for all of the screens where advanced search is possible
+There are existing advanced search tests that could be consolidated from infrastructure
+    and moved here to cover containers, cloud, and infra as params.
+
+"""
+import pytest
+
+import cfme.fixtures.pytest_selenium as sel
+from cfme.infrastructure.provider import InfraProvider
+from cfme.web_ui import search
+from utils.appliance.implementations.ui import navigate_to
+from utils.providers import setup_a_provider
+
+
+pytestmark = [pytest.mark.tier(3)]
+
+search_buttons = ['apply_filter_button', 'load_filter_button', 'save_filter_button',
+                  'reset_filter_button']
+
+
+@pytest.fixture(scope="module")
+def provider():
+    try:
+        # paramaterize provider type
+        setup_a_provider(prov_class="infra")
+        navigate_to(InfraProvider, 'All')
+    except Exception as ex:
+        pytest.skip("Exception setting up provider: {}".format(ex.message))
+
+
+def test_can_do_advanced_search(provider):
+    navigate_to(provider, 'All')
+    assert search.is_advanced_search_possible()
+
+
+# @pytest.mark.meta(blockers=[1380430])
+@pytest.mark.parametrize('button', search_buttons)
+def test_advanced_search_button_alt(provider, button):
+    # testing state of the buttons in the default advanced search box
+    # need to clear any existing filters, including the filter expressions, to get to default state
+    search.ensure_no_filter_applied(clear_expression=True)
+    search.ensure_advanced_search_open()
+    assert sel.is_displayed(getattr(search.search_box, button).locate)


### PR DESCRIPTION
# Purpose or Intent

Update web_ui.search.py to better handle clearing the filter expressions, to wait 10s for the search box to open with a fail_func, and to add some debug logging. (this can and likely should be pulled to another PR, but was useful for this new test)

**Now, the meat of the PR** - a new cfme.tests.generic_ui folder, with a new test_advanced_search module.  After discussion with @amavinag I prototyped this PR.

This test did not fit well into the other modules, and many of the advanced search tests are repeated in-large for infra.hosts, infra.vms, infra.providers.  We could consolidate and parameterize many of these tests so that advanced search is tested on all relevant pages with minimal code duplication.

I'm more than open to suggestion on a better place for tests like this to live, and if the above effort (to consolidate search tests) is worthy.

This is to automate bug 1280430, which causes all the tests to fail currently (buttons aren't found because alt-text isn't set while they're disabled).

@psav, @mmojzis, @jkrocil, @RonnyPfannschmidt, @otsuman, @dajohnso may want to weigh in.  If this is the direction we want to go, I can clean this up and expand things a bit.
