### PR TITLE
Fix RHEV C&U validation (workaround), add flash.assert_success

### DIFF
--- a/cfme/web_ui/flash.py
+++ b/cfme/web_ui/flash.py
@@ -167,6 +167,21 @@ def assert_no_errors(messages=None):
 
 
 @verify_rails_error
+def assert_success(messages=None):
+    """Asserts that there is 1 or more successful messages, no errors. If no messages
+    are passed in, they will be retrieved from the UI."""
+
+    all_messages = messages or get_messages()
+    errors = [error.message for error in filter(is_error, all_messages)]
+    if not all_messages:
+        raise FlashMessageException('No flash messages found')
+    elif errors:
+        raise FlashMessageException(', '.join(errors))
+    else:
+        return all_messages
+
+
+@verify_rails_error
 @verpick_message
 @onexception_printall
 def assert_message_match(m):


### PR DESCRIPTION
Purpose or Intent
=================
SSIA + see comments and https://bugzilla.redhat.com/show_bug.cgi?id=1375253

`flash.assert_success` makes sure there was at least one successful message, unlike `flash.assert_no_errors`. We should potentially gradually replace one with the other.

@dajohnso ^

{{pytest: cfme/tests/infrastructure/test_providers.py --use-provider nested-rhevm34 --use-provider rhvqe40 }}