### PR TITLE
get correct collection - vms or instances

### DIFF
--- a/cfme/tests/cloud_infra_common/test_power_control_rest.py
+++ b/cfme/tests/cloud_infra_common/test_power_control_rest.py
@@ -69,7 +69,7 @@ def test_stop(rest_api, vm_obj, from_detail):
     if from_detail:
         vm.action.stop()
     else:
-        rest_api.collections.vms.action.stop(vm)
+        vm_obj.get_collection_via_rest().action.stop(vm)
     wait_for(lambda: vm.power_state == vm_obj.STATE_OFF,
         num_sec=1000, delay=20, fail_func=vm.reload,
         message='Wait for VM to stop (current state: {})'.format(vm.power_state))
@@ -98,11 +98,11 @@ def test_start(rest_api, vm_obj, from_detail):
     vm = vm_obj.get_vm_via_rest()
     assert "start" in vm.action
     verify_vm_power_state(vm, state=vm_obj.STATE_SUSPENDED,
-        action=rest_api.collections.vms.action.suspend)
+        action=vm_obj.get_collection_via_rest().action.suspend)
     if from_detail:
         vm.action.start()
     else:
-        rest_api.collections.vms.action.start(vm)
+        vm_obj.get_collection_via_rest().action.start(vm)
     wait_for(lambda: vm.power_state == vm_obj.STATE_ON,
         num_sec=1000, delay=20, fail_func=vm.reload,
         message='Wait for VM to stop (current state: {})'.format(vm.power_state))
@@ -134,7 +134,7 @@ def test_suspend(rest_api, vm_obj, from_detail):
     if from_detail:
         vm.action.suspend()
     else:
-        rest_api.collections.vms.action.suspend(vm)
+        vm_obj.get_collection_via_rest().action.suspend(vm)
     wait_for(lambda: vm.power_state == vm_obj.STATE_SUSPENDED,
         num_sec=1000, delay=20, fail_func=vm.reload,
         message='Wait for VM to stop (current state: {})'.format(vm.power_state))


### PR DESCRIPTION
Fixing cloud tests where the desired action was performed on 'vms' collection instead of 'instances' collection and failed.
With this fix correct collection is selected - instances for cloud, vms for infra.

Update: PRT seems to be really fragile, I can't get it to pass reliably there. Narrowing test scope to see if it helps:

{{pytest: '''cfme/tests/cloud_infra_common/test_power_control_rest.py::test_start'' -v -k ''from_collection and not ec2west'''}}