### PR TITLE
Fix catalog item creation and success assertion for test_rest_services

### DIFF
--- a/cfme/rest/__init__.py
+++ b/cfme/rest/__init__.py
@@ -131,6 +131,7 @@ def services(request, rest_api, a_provider, dialog, service_catalogs):
         catalog_item_type = "RHEV"
     elif a_provider.type == 'virtualcenter':
         provisioning_data['provision_type'] = 'VMware'
+        provisioning_data['vlan'] = vlan
     catalog = service_catalogs[0].name
     item_name = fauxfactory.gen_alphanumeric()
     catalog_item = CatalogItem(item_type=catalog_item_type, name=item_name,
@@ -148,7 +149,8 @@ def services(request, rest_api, a_provider, dialog, service_catalogs):
     cells = {'Description': row_description}
     row, __ = wait_for(requests.wait_for_request, [cells, True],
         fail_func=requests.reload, num_sec=2000, delay=20)
-    assert row.last_message.text == 'Request complete'
+    assert (row.last_message.text == 'Request complete'
+            or 'Provisioned Successfully' in row.last_message.text)
     try:
         services = [_ for _ in rest_api.collections.services]
         services[0]

--- a/cfme/services/catalogs/catalog_item.py
+++ b/cfme/services/catalogs/catalog_item.py
@@ -15,6 +15,7 @@ from utils.appliance.implementations.ui import CFMENavigateStep, navigate_to, na
 from utils.update import Updateable
 from utils.pretty import Pretty
 from utils.version import current_version
+from utils.blockers import BZ
 
 cfg_btn = partial(tb.select, "Configuration")
 policy_btn = partial(tb.select, "Policy")
@@ -170,6 +171,9 @@ class CatalogItem(Updateable, Pretty, Navigatable):
             tabstrip.select_tab("Catalog")
             template = template_select_form.template_table.find_row_by_cells({
                 'Name': self.catalog_name,
+                # HACK to workaround BZ1390209
+                # revert back to Provider once it's fixed
+                'Deprecated' if BZ(1390209, forced_streams=["5.7", "upstream"]).blocks else
                 'Provider': self.provider
             })
             sel.click(template)

--- a/cfme/tests/services/test_cloud_service_catalogs.py
+++ b/cfme/tests/services/test_cloud_service_catalogs.py
@@ -13,7 +13,6 @@ from cfme import test_requirements
 from utils import testgen
 from utils.log import logger
 from utils.wait import wait_for
-from utils.blockers import BZ
 
 
 pytestmark = [
@@ -60,7 +59,6 @@ def catalog():
     yield catalog
 
 
-@pytest.mark.meta(blockers=[BZ(1390209, forced_streams=["5.7", "upstream"])])
 def test_cloud_catalog_item(setup_provider, provider, dialog, catalog, request, provisioning):
     """Tests cloud catalog item
 


### PR DESCRIPTION
# Purpose or Intent

Fixing assert when service was successfully added on 5.7.x:

```
>       assert row.last_message.text == 'Request complete'
E       assert '[EVM] Servic... Successfully' == 'Request complete'
E         - [EVM] Service [blvFGPk3jh] Provisioned Successfully
E         + Request complete
```

Also fixing catalog item creation. Some tests are still failing so WIP.

{{pytest: '''cfme/tests/services/test_rest_services.py::TestServiceRESTAPI::test_edit_service'' -v'}}
