### PR TITLE
browser manager: ability to attach cleanup functions for browser shut…

### DIFF
--- a/utils/appliance/implementations/ui.py
+++ b/utils/appliance/implementations/ui.py
@@ -374,7 +374,10 @@ class ViaUI(object):
     def widgetastic(self):
         """This gives us a widgetastic browser."""
         # TODO: Make this a property that could watch for browser change?
-        return MiqBrowser(self.open_browser(), self)
+        try:
+            return MiqBrowser(self.open_browser(), self)
+        finally:
+            manager.add_cleanup(self._reset_cache)
 
     def open_browser(self):
         # TODO: self.appliance.server.address() instead of None
@@ -382,6 +385,8 @@ class ViaUI(object):
 
     def quit_browser(self):
         manager.quit()
+
+    def _reset_cache(self):
         try:
             del self.widgetastic
         except AttributeError:

--- a/utils/browser.py
+++ b/utils/browser.py
@@ -229,7 +229,25 @@ class BrowserManager(object):
             self.start(url_key=url_key)
         return self.browser
 
+    def add_cleanup(self, callback):
+        assert self.browser is not None
+        try:
+            cl = self.browser.__cleanup
+        except AttributeError:
+            cl = self.browser.__cleanup = []
+        cl.append(callback)
+
+    def _consume_cleanups(self):
+        try:
+            cl = self.browser.__cleanup
+        except AttributeError:
+            pass
+        else:
+            while cl:
+                cl.pop()()
+
     def quit(self):
+        self._consume_cleanups()
         try:
             self.browser.quit()
         except:


### PR DESCRIPTION
this attaches cleanup functions to the browser object we run on exit,
atm it doesnt cache/log exceptions and defers that to the cleanup functions

it makes sense to defer the exception catching so each component can log the errors using its own logger
