### PR TITLE
added timestamp to console logs

### DIFF
--- a/utils/log.py
+++ b/utils/log.py
@@ -153,12 +153,15 @@ _default_conf = {
     'max_file_backups': 0,
     'errors_to_console': False,
     'file_format': '%(asctime)-15s [%(levelname).1s] %(message)s (%(source)s)',
-    'stream_format': '[%(levelname)s] %(message)s (%(source)s)'
+    'stream_format': '[%(levelname)s] %(message)s (%(source)s)',
+    'default_format': '%(asctime)s,%(msecs)d [%(levelname)s] %(message)s'
 }
 
 # let logging know we made a TRACE level
 logging.TRACE = 5
 logging.addLevelName(logging.TRACE, 'TRACE')
+logging.basicConfig(format=_default_conf['default_format'],
+                    datefmt='%d-%m %H:%M:%S')
 
 
 class logger_wrap(object):


### PR DESCRIPTION
1. We don't setup rootLogger. So, it is setup and inherited from different packages. F.e. I see such issue when use get_crud. Stdout/stderror is formatted by formatter definded in cinder client package.
2. From time to time I need to know how much time was some command run or measure the time between two commands.
So, I added default logging format in order to fix such issues.