### PR TITLE
fixed timelines tests for infra provider for 5.6.2.2

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -145,10 +145,12 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable, SummaryMixin
     TO_OPEN_EDIT = None  # Name of the item in Configuration that puts you in the form
     QUADICON_TYPE = "vm"
     # Titles of the delete buttons in configuration
-    REMOVE_SELECTED = {version.LOWEST: 'Remove selected items from the VMDB',
-            '5.6': 'Remove selected items'}
-    REMOVE_SINGLE = {version.LOWEST: "Remove from the VMDB",
-            '5.6': 'Remove Virtual Machine'}
+    REMOVE_SELECTED = {'5.6': 'Remove selected items',
+                       '5.6.2.2': 'Remove selected items from the VMDB',
+                       '5.7': 'Remove selected items'}
+    REMOVE_SINGLE = {'5.6': 'Remove Virtual Machine',
+                     '5.6.2.2': 'Remove from the VMDB',
+                     '5.7': 'Remove Virtual Machine'}
 
     ###
     # Shared behaviour

--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -86,7 +86,6 @@ def count_events(vm, nav_step):
     return 0
 
 
-@pytest.mark.ignore_stream("upstream")
 @pytest.mark.meta(blockers=[1264183, 1281746])
 def test_provider_event(provider, gen_events, test_vm):
     """Tests provider event on timelines
@@ -102,7 +101,6 @@ def test_provider_event(provider, gen_events, test_vm):
              message="events to appear")
 
 
-@pytest.mark.ignore_stream("upstream")
 @pytest.mark.meta(blockers=[1281746])
 def test_host_event(provider, gen_events, test_vm):
     """Tests host event on timelines
@@ -119,7 +117,6 @@ def test_host_event(provider, gen_events, test_vm):
              message="events to appear")
 
 
-@pytest.mark.ignore_stream("upstream")
 @pytest.mark.meta(blockers=[1281746])
 def test_vm_event(provider, gen_events, test_vm):
     """Tests vm event on timelines
@@ -135,7 +132,6 @@ def test_vm_event(provider, gen_events, test_vm):
              message="events to appear")
 
 
-@pytest.mark.ignore_stream("upstream")
 @pytest.mark.meta(blockers=[1281746])
 def test_cluster_event(provider, gen_events, test_vm):
     """Tests cluster event on timelines


### PR DESCRIPTION
{{ pytest: cfme/tests/infrastructure/test_timelines.py }}
