### PR TITLE
Fix uncollect

### DIFF
--- a/fixtures/parallelizer/__init__.py
+++ b/fixtures/parallelizer/__init__.py
@@ -79,6 +79,10 @@ recv_lock = Lock()
 # lock for protecting zmq socket access
 zmq_lock = Lock()
 
+if not conf.runtime['env'].get('ts'):
+    ts = str(time())
+    conf.runtime['env']['ts'] = ts
+
 
 def pytest_addoption(parser):
     group = parser.getgroup("cfme")
@@ -396,7 +400,7 @@ class ParallelSession(object):
 
         # worker output redirected to null; useful info comes via messages and logs
         slave = subprocess.Popen(
-            ['python', remote.__file__, slaveid, base_url],
+            ['python', remote.__file__, slaveid, base_url, conf.runtime['env']['ts']],
             stdout=devnull,
         )
         self.slaves[slaveid] = slave

--- a/fixtures/parallelizer/remote.py
+++ b/fixtures/parallelizer/remote.py
@@ -199,6 +199,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('slaveid', help='The name of this slave')
     parser.add_argument('base_url', help='The base URL for this slave to use')
+    parser.add_argument('ts', help='The timestap to use for collections')
     args = parser.parse_args()
 
     # overwrite the default logger before anything else is imported,
@@ -213,6 +214,7 @@ if __name__ == '__main__':
 
     conf.runtime['env']['slaveid'] = args.slaveid
     conf.runtime['env']['base_url'] = args.base_url
+    conf.runtime['env']['ts'] = args.ts
     store.parallelizer_role = 'slave'
 
     slave_args = conf.slave_config.pop('args')

--- a/utils/trackerbot.py
+++ b/utils/trackerbot.py
@@ -7,6 +7,7 @@ import urllib
 
 import slumber
 import requests
+import time
 
 from utils.conf import env
 from utils.providers import providers_data
@@ -303,8 +304,8 @@ def depaginate(api, result):
 
 def composite_uncollect(build):
     """Composite build function"""
-
-    url = "{}?build={}&source=jenkins".format(conf['ostriz'], urllib.quote(build))
+    since = env.get('ts', time.time())
+    url = "{}?build={}&source=jenkins&since={}".format(conf['ostriz'], urllib.quote(build), since)
     try:
         resp = requests.get(url, timeout=10)
         return resp.json()


### PR DESCRIPTION
Purpose or Intent
=================

So, there was an issue where uncollection would mess up paralleizer if the slave was restarted after some tests passed earlier in the run. This fixes that.