### PR TITLE
fixing infrastucture providers power operations

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -14,6 +14,7 @@ from cfme.web_ui import (
     AngularCalendarInput, AngularSelect, Form, InfoBlock, Input, Quadicon, Select, fill, flash,
     form_buttons, paginator, toolbar, PagedTable, SplitPagedTable, search)
 from utils import version
+from utils.blockers import BZ
 from utils.log import logger
 from utils.pretty import Pretty
 from utils.timeutil import parsetime
@@ -390,11 +391,12 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable, SummaryMixin
             sel.click(self.find_quadicon())
         else:
             if refresh:
-                # bz1392139 for 5.7, should be fixed in 5.7.1 - dajo
-                if version.current_version() < "5.7":
-                    toolbar.refresh()
-                else:
+                # bz1389299 for 5.7, should be fixed in 5.7.1 - dajo
+                reload_bug = BZ(1329299)
+                if reload_bug.bugzilla.get_bug(1329299).is_opened:
                     sel.click(self.find_quadicon())
+                else:
+                    toolbar.refresh()
 
     def open_edit(self):
         """Loads up the edit page of the object."""


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ vm.py with temporary workaround as at the moment VM's Reload button brings us to all VM's page

and

__Adding__ with separate "check_power_option" test because it needs to be verified but shouldn't affect other tests

__N.B.__ I'll update testrun with different providers one by one

{{pytest: cfme/tests/infrastructure/  "-k test_power_options_from" --long-running --use-provider vsphere6-nested --use-provider scvmm}}