### PR TITLE
Test containers providers default view fix final1

### DIFF
--- a/cfme/tests/containers/test_containers_default_views.py
+++ b/cfme/tests/containers/test_containers_default_views.py
@@ -2,9 +2,18 @@ import pytest
 from itertools import product
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import toolbar as tb, ButtonGroup, form_buttons
+from cfme.base import Server
+from cfme.containers.container import Container
+from cfme.containers.provider import ContainersProvider
+from cfme.containers.project import Project
+from cfme.containers.route import Route
+from cfme.containers.node import Node
+from cfme.containers.replicator import Replicator
+import cfme.web_ui.tabstrip as tabs
 from cfme.configure import settings  # noqa
 from utils import testgen
 from utils.version import current_version
+from utils.appliance.implementations.ui import navigate_to
 
 pytestmark = [
     pytest.mark.uncollectif(
@@ -14,22 +23,20 @@ pytestmark = [
 pytest_generate_tests = testgen.generate(
     testgen.container_providers, scope='function')
 
-
 VIEWS = ['Grid View', 'Tile View', 'List View']
 BUTTON_GROUP = ['Containers Providers', 'Projects', 'Routes', 'Nodes', 'Containers', 'Replicators']
 
-# TODO: Replace with navigator registered destinations when all container objects support them
 mapping = {
-    'Containers Providers': 'containers_providers',
-    'Projects': 'containers_projects',
-    'Routes': 'containers_routes',
-    # 'Nodes': 'containers_nodes',
-    'Containers': 'containers_containers',
-    'Replicators': 'containers_replicators',
+    'Containers Providers': ContainersProvider,
+    'Projects': Project,
+    'Routes': Route,
+    'Nodes': Node,
+    'Containers': Container,
+    'Replicators': Replicator
 }
 
-# CMP-9936 # CMP-9937 # CMP-9938 # CMP-10000 # CMP-10001 # CMP-10003
 
+# CMP-9936 # CMP-9937 # CMP-9938 # CMP-10000 # CMP-10001 # CMP-10003
 
 @pytest.mark.parametrize(('button_group', 'view'), product(BUTTON_GROUP, VIEWS))
 def test_containers_providers_default_view(button_group, view):
@@ -43,9 +50,11 @@ def test_containers_providers_default_view(button_group, view):
               to Grid/Tile/List view
             * Goes to Compute --> Containers --> Providers and verifies the selected view
         """
-    sel.force_navigate('my_settings_default_views')
+    navigate_to(Server, 'MySettings')
+    tabs.select_tab("Default Views")
     bg = ButtonGroup(button_group)
-    bg.choose(view)
-    sel.click(form_buttons.save)
-    sel.force_navigate(mapping[button_group])
+    if not bg.active == str(view):
+        bg.choose(view)
+        sel.click(form_buttons.save)
+    navigate_to(mapping[button_group], 'All', use_resetter=False)
     assert tb.is_active(view), "{}'s {} setting failed".format(view, button_group)

--- a/cfme/tests/containers/test_containers_default_views.py
+++ b/cfme/tests/containers/test_containers_default_views.py
@@ -24,7 +24,6 @@ pytest_generate_tests = testgen.generate(
     testgen.container_providers, scope='function')
 
 VIEWS = ['Grid View', 'Tile View', 'List View']
-BUTTON_GROUP = ['Containers Providers', 'Projects', 'Routes', 'Nodes', 'Containers', 'Replicators']
 
 mapping = {
     'Containers Providers': ContainersProvider,
@@ -38,7 +37,7 @@ mapping = {
 
 # CMP-9936 # CMP-9937 # CMP-9938 # CMP-10000 # CMP-10001 # CMP-10003
 
-@pytest.mark.parametrize(('button_group', 'view'), product(BUTTON_GROUP, VIEWS))
+@pytest.mark.parametrize(('button_group', 'view'), product(mapping.keys(), VIEWS))
 def test_containers_providers_default_view(button_group, view):
     """ Containers Providers/Projects/Routes/Nodes/Containers/Replicators default view test
         This test checks successful change of default views settings for Containers -->


### PR DESCRIPTION
Purpose or Intent
=================
{{pytest: cfme/tests/containers/test_containers_default_views.py -v --use-provider container }}
Fixing test_containers_provider_default_view to work with Navmazing