### PR TITLE
Test summary pages links

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -8,7 +8,7 @@ import cfme.fixtures.pytest_selenium as sel
 from cfme.exceptions import (
     ProviderHasNoKey, HostStatsNotContains, ProviderHasNoProperty, FlashMessageException
 )
-from cfme.web_ui import breadcrumbs, summary_title
+from cfme.web_ui import breadcrumbs_names, summary_title
 from cfme.web_ui import flash, Quadicon, CheckboxTree, Region, fill, FileInput, Form, Input, Radio
 from cfme.web_ui import toolbar as tb
 from cfme.web_ui import form_buttons, paginator
@@ -430,7 +430,7 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
         ensure_browser_open()
         collection = '{} Providers'.format(self.string_name)
         title = '{} (Summary)'.format(self.name)
-        return breadcrumbs() == [collection, title] and summary_title() == title
+        return breadcrumbs_names() == [collection, title] and summary_title() == title
 
     def load_details(self, refresh=False):
         """To be compatible with the Taggable and PolicyProfileAssignable mixins."""

--- a/cfme/tests/containers/test_provider_configuration_menu.py
+++ b/cfme/tests/containers/test_provider_configuration_menu.py
@@ -2,7 +2,7 @@ import pytest
 from cfme.fixtures import pytest_selenium as sel
 from utils import testgen
 from utils.version import current_version
-from cfme.web_ui import toolbar as tb, Quadicon, breadcrumbs
+from cfme.web_ui import toolbar as tb, Quadicon, breadcrumbs_names
 from utils.appliance.implementations.ui import navigate_to
 from cfme.containers.provider import ContainersProvider
 
@@ -36,7 +36,7 @@ def test_edit_selected_containers_provider():
     provider = ContainersProvider(name)
     provider.load_details()
     navigate_to(provider, 'EditFromDetails')
-    assert 'Edit Containers Providers \'{}\''.format(name) == breadcrumbs()[-1]
+    assert 'Edit Containers Providers \'{}\''.format(name) == breadcrumbs_names()[-1]
 
 # CMP-9881
 

--- a/cfme/tests/containers/test_summary_pages_links.py
+++ b/cfme/tests/containers/test_summary_pages_links.py
@@ -1,0 +1,58 @@
+import pytest
+from cfme.fixtures import pytest_selenium as sel
+from cfme.containers.pod import list_tbl
+from utils import testgen
+from utils.version import current_version
+from utils.appliance.implementations.ui import navigate_to
+from cfme.containers.service import Service
+from cfme.containers.route import Route
+from cfme.containers.project import Project
+from cfme.containers.provider import ContainersProvider
+from random import choice
+from cfme.web_ui import breadcrumbs
+from collections import namedtuple
+from cfme.web_ui import toolbar as tb
+
+
+pytestmark = [
+    pytest.mark.uncollectif(
+        lambda: current_version() < "5.6"),
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.tier(1)]
+pytest_generate_tests = testgen.generate(
+    testgen.container_providers, scope="function")
+
+# CMP_9903  CMP_9904  CMP_9905  CMP_9906
+
+DataSet = namedtuple('DataSet', ['object', 'breadcrumb_member'])
+
+DATA_SETS = [DataSet(Service, 'Container Services'),
+             DataSet(Route, 'Routes'),
+             DataSet(Project, 'Projects'),
+             DataSet(ContainersProvider, 'Containers Providers')]
+
+
+@pytest.mark.parametrize(('cls'), DATA_SETS, ids=[cls.object.__name__ for cls in DATA_SETS])
+def test_summary_pages_links(provider, cls):
+
+    navigate_to(cls.object, 'All')
+    all_url = sel.current_url()
+    tb.select('List View')
+    name = choice([r[2].text for r in list_tbl.rows()])
+    obj = cls.object(name, provider)
+    obj.summary  # <- reload summary
+
+    breads = breadcrumbs()
+    bread_names = map(sel.text_sane, breads)
+
+    assert (cls.breadcrumb_member in bread_names) or \
+        (cls.breadcrumb_member.split(' ')[-1] in bread_names if
+        cls.breadcrumb_member.startswith('Container') else False)
+
+    chosen_link = filter(lambda b: sel.text_sane(b) ==
+                         cls.breadcrumb_member, breads)[0]
+
+    sel.click(chosen_link)
+
+    # TODO: replace with widgetastic view.is_displayed function when available
+    assert sel.current_url().split('?')[0] == all_url.split('?')[0]

--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -4012,14 +4012,19 @@ def fill_cfmecheckbox_switch(ob, val):
 
 
 def breadcrumbs():
-    """Returns a list of breadcrumbs.
+    """Returns a list of breadcrumbs names if names==True else return as elements.
 
     Returns:
         :py:class:`list` of breadcrumbs if they are present, :py:class:`NoneType` otherwise.
     """
-    result = map(sel.text_sane, sel.elements('//ol[contains(@class, "breadcrumb")]/li'))
-    return result if result else None
+    elems = sel.elements('//ol[contains(@class, "breadcrumb")]/li')
+    return elems if elems else None
 
+
+def breadcrumbs_names():
+    elems = breadcrumbs()
+    if elems:
+        return map(sel.text_sane, elems)
 
 SUMMARY_TITLE_LOCATORS = [
     '//h1'


### PR DESCRIPTION
Test summary pages links
{{pytest: cfme/tests/containers/test_summary_pages_links.py -v --use-provider container }}