### PR TITLE
Patch only below 5.6.3

### DIFF
--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -620,7 +620,7 @@ class IPAppliance(object):
 
     @property
     def is_miqqe_patch_candidate(self):
-        return not (self.version < "5.6" or self.version > "5.7.0.3")
+        return self.version < "5.6.3"
 
     @property
     def miqqe_patch_applied(self):


### PR DESCRIPTION
Purpose or Intent
=================

5.6.3.0 contains the Miq.qe stuff already and we can ignore 5.5 and 5.7.0.1-5.7.0.3 -> we only need to patch 5.6.0, 5.6.1 and 5.6.2.