### PR TITLE
[WIP]Replacing is_displayed property by assert_is_displayed() method

### DIFF
--- a/utils/appliance/implementations/ui.py
+++ b/utils/appliance/implementations/ui.py
@@ -137,9 +137,11 @@ class CFMENavigateStep(NavigateStep):
 
     def am_i_here(self):
         try:
-            return self.view.is_displayed
-        except (AttributeError, NoSuchElementException):
+            self.view.assert_is_displayed()
+        except (AttributeError, NoSuchElementException, AssertionError):
             return False
+        else:
+            return True
 
     def pre_navigate(self, _tries=0, *args, **kwargs):
         if _tries > 2:


### PR DESCRIPTION
Purpose or Intent
=================

I propose to replace `is_displayed` boolean property by `assert_is_displayed()` method. `assert_is_displayed()` should be just a bunch of assertions. It's much easier to catch an error if you know in which place it occurred. Check an example of the implementation in this commit 06cb408

