### PR TITLE
Update test_server_roles, database_synchronization removed in 5.7

### DIFF
--- a/cfme/tests/configure/test_server_roles.py
+++ b/cfme/tests/configure/test_server_roles.py
@@ -21,6 +21,8 @@ def all_possible_roles():
     if version.current_version() < 5.6:
         roles.remove('git_owner')
         roles.remove('websocket')
+    if version.current_version() >= 5.7:
+        roles.remove('database_synchronization')
     return roles
 
 


### PR DESCRIPTION
Purpose or Intent
=================

Jenkins 5.7 failure due to database_synchronization not being present in the server roles form in CFME 5.7.

Remove it from the all_possible_roles fixture depending on version.

{{ pytest: cfme/tests/configure/test_server_roles.py }}