### PR TITLE
Update infra.test_config_mgmt, add blocking bug

### DIFF
--- a/cfme/tests/infrastructure/test_config_management.py
+++ b/cfme/tests/infrastructure/test_config_management.py
@@ -8,10 +8,10 @@ from utils.blockers import BZ
 
 
 pytest_generate_tests = generate(config_managers)
-# TODO
-# Investigate why this does not work
-# pytestmark = pytest.mark.uncollectif(lambda config_manager_obj: config_manager_obj.type ==
-#             "Ansible Tower" and version.current_version() > "5.6")
+pytestmark = [pytest.mark.uncollectif(lambda config_manager_obj:
+                                      config_manager_obj.type == "Ansible Tower"and
+                                      version.current_version() > "5.6"),
+              pytest.mark.meta(blockers=[BZ(1393987)])]
 
 
 @pytest.yield_fixture


### PR DESCRIPTION
Purpose or Intent
=================

The test_config_manager_detail_config_btn and test_config_manager_edit tests were failing in Jenkins with an Endpoint URL failure, related to propaged 5.7 bug 1393987.

Added the bug to the list of blockers for these two tests. Its possible this bug will effect the other tests as well, and should potentially be applied to all of them.

{{ pytest: cfme/tests/infrastructure/test_config_management.py }}