### PR TITLE
Update config.about and config.test_version, adding get_detail

### DIFF
--- a/cfme/configure/about.py
+++ b/cfme/configure/about.py
@@ -1,6 +1,15 @@
 # -*- coding: utf-8 -*-
-from cfme.web_ui import Region
+import re
+
+import cfme.fixtures.pytest_selenium as sel
+from cfme.exceptions import ElementOrBlockNotFound
+from cfme.web_ui import Region, InfoBlock
 from utils import version
+from utils.appliance import current_appliance
+from utils.appliance.implementations.ui import navigate_to
+from utils.log import logger
+from utils.version import current_version
+
 
 product_assistance = Region(
     locators={
@@ -55,3 +64,21 @@ product_assistance = Region(
     identifying_loc='quick_start_guide',
     infoblock_type="form"
 )
+
+
+def get_detail(properties):
+    navigate_to(current_appliance().server, 'About')
+    if current_version() < '5.7':
+        return InfoBlock.text(*properties).encode(
+            "utf-8").strip()
+    else:
+        locator = '//div[@class="product-versions-pf"]//li'
+        sel.wait_for_element(locator)
+        for element in sel.elements(locator):
+            logger.debug('Checking for detail match for "{}" in  "{}"'.format(properties,
+                                                                              element.text))
+            match = re.match("{}\s(?P<value>.*)".format(properties), element.text)
+            if match:
+                return match.group('value')
+        else:
+            raise ElementOrBlockNotFound('Could not match about detail {}'.format(properties))

--- a/cfme/tests/configure/test_version.py
+++ b/cfme/tests/configure/test_version.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from cfme.configure.about import product_assistance as about
-from utils.version import current_version
+from cfme.configure.about import get_detail
+import utils.version as version
 
 
 @pytest.mark.tier(3)
@@ -15,7 +15,8 @@ def test_version():
 
     So we check whether the UI version starts with SSH version
     """
-    pytest.sel.force_navigate("about")
-    ssh_version = str(current_version())
-    ui_version = about.infoblock.text("Session Information", "Version").encode("utf-8").strip()
+    ssh_version = str(version.current_version())
+    ui_version = get_detail(version.pick({
+        version.LOWEST: ('Session Information', 'Version'),
+        '5.7': 'Version'}))
     assert ui_version.startswith(ssh_version), "UI: {}, SSH: {}".format(ui_version, ssh_version)


### PR DESCRIPTION
Purpose or Intent
=================

The about screen drastically changed between CFME 5.6 and CFME 5.7. Wrote a get_detail() method to parse and return the given property.

{{ pytest: cfme/tests/configure/test_version.py }}