### PR TITLE
Move report view tests out of configure.test_default_views_infra

### DIFF
--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -11,7 +11,7 @@ from cfme.fixtures import pytest_selenium as sel
 from cfme.intelligence.reports.ui_elements import (ColumnHeaderFormatTable, ColumnStyleTable,
     RecordGrouper)
 from cfme.web_ui import (CAndUGroupTable, Form, Table, Select, ShowingInputs, accordion, fill,
-    flash, form_buttons, paginator, table_in_object, tabstrip, toolbar)
+    flash, form_buttons, paginator, table_in_object, tabstrip, toolbar, CheckboxTable)
 from cfme.web_ui.expression_editor import Expression
 from cfme.web_ui.tabstrip import TabStripForm
 from cfme.web_ui.multibox import MultiBoxSelect
@@ -359,6 +359,8 @@ class CannedSavedReport(CustomSavedReport, Navigatable):
         datetime: Datetime of "Run At" of the report. That's what :py:func:`queue_canned_report`
             returns.
     """
+    saved_table = CheckboxTable('//div[@id="records_div"]//table')
+
     def __init__(self, path_to_report, datetime, candu=False, appliance=None):
         Navigatable.__init__(self, appliance=appliance)
         self.path = path_to_report
@@ -416,6 +418,13 @@ class CannedSavedReport(CustomSavedReport, Navigatable):
         except sel.NoSuchElementException:
             pass
         return results
+
+    def delete(self):
+        navigate_to(self, 'Saved')
+        self.saved_table.select_row(header='Run At', value=self.datetime_in_tree)
+        cfg_btn("Delete this Saved Report from the Database", invokes_alert=True)
+        sel.handle_alert()
+        flash.assert_no_errors()
 
 
 @navigator.register(CannedSavedReport, 'Details')

--- a/cfme/tests/configure/test_default_views_infra.py
+++ b/cfme/tests/configure/test_default_views_infra.py
@@ -11,7 +11,6 @@ from utils.providers import setup_a_provider as _setup_a_provider
 from cfme.configure import settings  # NOQA
 from cfme.services.catalogs import catalog_item  # NOQA
 from cfme.services import workloads  # NOQA
-from cfme.intelligence.reports.reports import CannedSavedReport
 
 pytestmark = [pytest.mark.tier(3),
               test_requirements.settings]
@@ -120,27 +119,3 @@ def test_details_view(request, setup_a_provider):
 @pytest.mark.meta(blockers=[1394331])
 def test_exists_view(request, setup_a_provider):
     set_and_test_view('Compare Mode', 'Exists Mode')
-
-
-def test_hybrid_view(request, setup_a_provider):
-    path = ["Configuration Management", "Hosts", "Virtual Infrastructure Platforms"]
-    report = CannedSavedReport.new(path)
-    report.navigate()
-    tb.select('Hybrid View')
-    assert tb.is_active('Hybrid View'), "Hybrid view setting failed"
-
-
-def test_graph_view(request, setup_a_provider):
-    path = ["Configuration Management", "Hosts", "Virtual Infrastructure Platforms"]
-    report = CannedSavedReport.new(path)
-    report.navigate()
-    tb.select('Graph View')
-    assert tb.is_active('Graph View'), "Graph view setting failed"
-
-
-def test_tabular_view(request, setup_a_provider):
-    path = ["Configuration Management", "Hosts", "Virtual Infrastructure Platforms"]
-    report = CannedSavedReport.new(path)
-    report.navigate()
-    tb.select('Tabular View')
-    assert tb.is_active('Tabular View'), "Tabular view setting failed"

--- a/cfme/tests/intelligence/reports/test_views.py
+++ b/cfme/tests/intelligence/reports/test_views.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+import cfme.web_ui.toolbar as tb
+from cfme import test_requirements
+from cfme.intelligence.reports.reports import CannedSavedReport
+from utils.blockers import BZ
+from utils.log import logger
+from utils.providers import setup_a_provider as _setup_a_provider
+
+pytestmark = [pytest.mark.tier(3),
+              test_requirements.report]
+
+
+@pytest.fixture(scope="module")
+def setup_a_provider():
+    _setup_a_provider(prov_class="infra", validate=True, check_existing=True)
+
+
+@pytest.yield_fixture(scope='module')
+def create_report():
+    # TODO parameterize on path, for now test infrastructure reports
+    path = ["Configuration Management", "Hosts", "Virtual Infrastructure Platforms"]
+    report = CannedSavedReport.new(path)
+    report_time = report.datetime
+    logger.debug('Created report for path {} and time {}'.format(path, report_time))
+    yield report
+
+    try:
+        report.delete()
+    except Exception:
+        logger.warning('Failed to delete report for path {} and time {}'.format(path, report_time))
+
+
+@pytest.mark.parametrize('view', ['Hybrid View', 'Graph View', 'Tabular View'])
+@pytest.mark.meta(blockers=[BZ(1396220)])
+def test_report_view(setup_a_provider, create_report, view):
+    create_report.navigate()
+    tb.select(view)
+    assert tb.is_active(view), "View setting failed for {}".format(view)


### PR DESCRIPTION
Purpose or Intent
=================

The 3 tests for the 3 types of report views were stuck into the configure.test_default_views_infra. Since the tests don't have anything to do with default views,  I moved them to the intelligence.report module and condensed the 3 into a paramaterized test and wrote a fixture for creating the report.

Added a delete function to CannedSavedReport

BZ 1396220 was written for 5.7 and upstream test failures, and added as a blocker. Test is not skipping:
```pytest
INFO:cfme:Calling metaplugin blockers(resolve_blockers) with meta signature ['blockers'] {}
INFO:cfme:Ignoring bug #1396220, appliance version not in bug release flag
INFO:cfme:Metaplugin blockers(resolve_blockers) with meta signature ['blockers'] {} has finished
```
https://bugzilla.redhat.com/show_bug.cgi?id=1396220


{{ pytest:  cfme/tests/intelligence/reports/test_views.py }}