### PR TITLE
Configuration.settings class for DefaultView

### DIFF
--- a/cfme/configure/settings.py
+++ b/cfme/configure/settings.py
@@ -6,9 +6,9 @@ from functools import partial
 import cfme.fixtures.pytest_selenium as sel
 import cfme.web_ui.tabstrip as tabs
 import cfme.web_ui.toolbar as tb
-from cfme.web_ui import (AngularSelect, Form, Region, fill, form_buttons, flash, Table,
-    ButtonGroup, Quadicon, CheckboxTree, Input, CFMECheckbox, BootstrapTreeview)
-from cfme.web_ui.menu import nav
+from cfme.web_ui import (
+    AngularSelect, Form, Region, fill, form_buttons, flash, Table, ButtonGroup, Quadicon,
+    CheckboxTree, Input, CFMECheckbox, BootstrapTreeview)
 from navmazing import NavigateToSibling, NavigateToAttribute
 from utils import version, deferred_verpick
 from utils.pretty import Pretty
@@ -21,15 +21,6 @@ details_page = Region(infoblock_type='detail')
 
 cfg_btn = partial(tb.select, 'Configuration')
 timeprofile_table = Table("//div[@id='main_div']//table")
-
-
-nav.add_branch(
-    'my_settings',
-    {
-
-        'my_settings_default_views': [lambda _: tabs.select_tab("Default Views"), {}],
-    }
-)
 
 
 class Timeprofile(Updateable, Navigatable):
@@ -348,10 +339,31 @@ class DefaultFilterAll(CFMENavigateStep):
         tabs.select_tab("Default Filters")
 
 
-def set_default_view(button_group_name, view):
-    bg = ButtonGroup(button_group_name)
-    sel.force_navigate("my_settings_default_views")
-    default_view = bg.active
-    if(default_view != view):
-        bg.choose(view)
-        sel.click(form_buttons.save)
+class DefaultView(Updateable, Navigatable):
+    # Basic class for navigation to default views screen
+    # TODO implement default views form with widgetastic to simplify setting views in tests
+
+    def __init__(self, appliance=None):
+        Navigatable.__init__(self, appliance=appliance)
+
+    @classmethod
+    def set_default_view(cls, button_group_name, default):
+        bg = ButtonGroup(button_group_name)
+        navigate_to(cls, 'All')
+        if bg.active != default:
+            bg.choose(default)
+            sel.click(form_buttons.save)
+
+    @classmethod
+    def get_default_view(cls, button_group_name):
+        bg = ButtonGroup(button_group_name)
+        navigate_to(cls, 'All')
+        return bg.active
+
+
+@navigator.register(DefaultView, 'All')
+class DefaultViewAll(CFMENavigateStep):
+    prerequisite = NavigateToAttribute('appliance.server', 'MySettings')
+
+    def step(self, *args, **kwargs):
+        tabs.select_tab('Default Views')

--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -231,6 +231,13 @@ class HostNotFound(CFMEException):
     pass
 
 
+class StackNotFound(CFMEException):
+    """
+    Raised if a specific stack cannot be found.
+    """
+    pass
+
+
 class OptionNotAvailable(CFMEException):
     """
     Raised if a specified option is not available.

--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -24,13 +24,6 @@ from utils import version
 from utils.timeutil import parsetime
 
 
-def reload_view():
-    """Reloads and keeps on the current tabstrip page"""
-    current = tabstrip.get_selected_tab()
-    toolbar.select("Reload current display")
-    tabstrip.select_tab(current)
-
-
 cfg_btn = partial(toolbar.select, "Configuration")
 download_btn = partial(toolbar.select, "Download")
 
@@ -44,6 +37,7 @@ def tag(tag_name, **kwargs):
         )
     else:
         return prefix
+
 
 input = partial(tag, "input")
 select = lambda **kwargs: Select(tag("select", **kwargs))
@@ -220,7 +214,7 @@ class CustomReport(Updateable, Navigatable):
                 _get_state,
                 delay=1,
                 message="wait for report generation finished",
-                fail_func=reload_view,
+                fail_func=toolbar.refresh(),
                 num_sec=300,
             )
 
@@ -392,6 +386,7 @@ class CannedSavedReport(CustomSavedReport, Navigatable):
         queued_at = sel.text(list(records_table.rows())[0].queued_at)
 
         def _get_state():
+            navigate_to(cls, 'Saved')
             row = records_table.find_row("queued_at", queued_at)
             status = sel.text(row.status).strip().lower()
             assert status != "error", sel.text(row)
@@ -400,9 +395,9 @@ class CannedSavedReport(CustomSavedReport, Navigatable):
 
         wait_for(
             _get_state,
-            delay=1,
+            delay=3,
             message="wait for report generation finished",
-            fail_func=reload_view
+            fail_func=toolbar.refresh()
         )
         return sel.text(list(records_table.rows())[0].run_at).encode("utf-8")
 

--- a/cfme/services/catalogs/catalog_item.py
+++ b/cfme/services/catalogs/catalog_item.py
@@ -152,7 +152,7 @@ class CatalogItem(Updateable, Pretty, Navigatable):
                                'select_catalog': catalog.name,
                                'select_dialog': dialog.name,
                                'select_orch_template': self.orch_template,
-                               'select_provider': self.provider_type,
+                               'select_provider': self.provider,
                                'select_config_template': self.config_template})
         if sel.text(basic_info_form.field_entry_point) == "":
             sel.click(basic_info_form.field_entry_point)

--- a/cfme/services/catalogs/service_catalogs.py
+++ b/cfme/services/catalogs/service_catalogs.py
@@ -66,6 +66,7 @@ class ServiceCatalogs(Updateable, Pretty):
                            context={'catalog': catalog,
                                     'catalog_item': catalog_item})
         sel.click(form_buttons.submit)
+        wait_for(flash.get_messages, num_sec=10, delay=2)
         flash.assert_success_message("Order Request was Submitted")
 
     def order_stack_item(self, catalog, catalog_item):

--- a/cfme/tests/configure/test_default_views_cloud.py
+++ b/cfme/tests/configure/test_default_views_cloud.py
@@ -1,27 +1,32 @@
 # -*- coding: utf-8 -*-
-
 import pytest
+
 from cfme import test_requirements
 from cfme.cloud.provider import CloudProvider
+from cfme.configure.settings import DefaultView
 from cfme.fixtures import pytest_selenium as sel
-import cfme.web_ui.toolbar as tb
-from cfme.web_ui import ButtonGroup, form_buttons, Quadicon, fill
+from cfme.web_ui import Quadicon, fill, toolbar as tb
 from utils.appliance.implementations.ui import navigate_to
 from utils.providers import setup_a_provider as _setup_a_provider
-from cfme.configure import settings  # NOQA
-from cfme.cloud import instance  # NOQA
 
 pytestmark = [pytest.mark.tier(3),
-              test_requirements.settings]
-
+              test_requirements.settings,
+              pytest.mark.usefixtures('setup_a_provider')]
 
 gtl_params = {
     'Cloud Providers': CloudProvider,
     'Availability Zones': 'clouds_availability_zones',
     'Flavors': 'clouds_flavors',
     'Instances': 'clouds_instances',
-    'Images': 'clouds_images'
+    # clouds_images DNE, replace with proper object with navmazing destinations
+    # 'Images': 'clouds_images'
 }
+
+
+# TODO refactor for setup_provider parametrization with new 'latest' tag
+@pytest.fixture(scope="module")
+def setup_a_provider():
+    _setup_a_provider(prov_class="cloud", prov_type="openstack", validate=True, check_existing=True)
 
 
 def select_two_quads():
@@ -33,84 +38,60 @@ def select_two_quads():
         fill(quad.checkbox(), True)
 
 
-@pytest.fixture(scope="module")
-def setup_a_provider():
-    _setup_a_provider(prov_class="cloud", prov_type="openstack", validate=True, check_existing=True)
-
-
-def set_view(group, button):
-    bg = ButtonGroup(group)
-    if bg.active != button:
-        bg.choose(button)
-        sel.click(form_buttons.save)
-
-
-def reset_default_view(name, default_view):
-    bg = ButtonGroup(name)
-    sel.force_navigate("my_settings_default_views")
-    if bg.active != default_view:
-        bg.choose(default_view)
-        sel.click(form_buttons.save)
-
-
-def get_default_view(name):
-    bg = ButtonGroup(name)
-    pytest.sel.force_navigate("my_settings_default_views")
-    default_view = bg.active
-    return default_view
-
-
 def set_and_test_default_view(group_name, view, page):
-    default_view = get_default_view(group_name)
-    set_view(group_name, view)
+    old_default = DefaultView.get_default_view(group_name)
+    DefaultView.set_default_view(group_name, view)
     if isinstance(page, basestring):
         sel.force_navigate(page)
     else:
         navigate_to(page, 'All', use_resetter=False)
     assert tb.is_active(view), "{} view setting failed".format(view)
-    reset_default_view(group_name, default_view)
+    DefaultView.set_default_view(group_name, old_default)
+
+# BZ 1283118 written against 5.5 has a mix of what default views do and don't work on different
+# pages in different releases
 
 
 @pytest.mark.parametrize('key', gtl_params, scope="module")
-def test_tile_defaultview(request, setup_a_provider, key):
+def test_tile_defaultview(request, key):
     set_and_test_default_view(key, 'Tile View', gtl_params[key])
 
 
 @pytest.mark.parametrize('key', gtl_params, scope="module")
-def test_list_defaultview(request, setup_a_provider, key):
+def test_list_defaultview(request, key):
     set_and_test_default_view(key, 'List View', gtl_params[key])
 
 
 @pytest.mark.parametrize('key', gtl_params, scope="module")
-def test_grid_defaultview(request, setup_a_provider, key):
+def test_grid_defaultview(request, key):
     set_and_test_default_view(key, 'Grid View', gtl_params[key])
 
 
 def set_and_test_view(group_name, view):
-    default_view = get_default_view(group_name)
-    set_view(group_name, view)
+    old_default = DefaultView.get_default_view(group_name)
+    DefaultView.set_default_view(group_name, view)
     sel.force_navigate('clouds_instances')
     select_two_quads()
     tb.select('Configuration', 'Compare Selected items')
     assert tb.is_active(view), "{} setting failed".format(view)
-    reset_default_view(group_name, default_view)
+    DefaultView.set_default_view(group_name, old_default)
 
 
 @pytest.mark.meta(blockers=[1394331])
-def test_expanded_view(request, setup_a_provider):
+def test_expanded_view(request):
     set_and_test_view('Compare', 'Expanded View')
 
 
 @pytest.mark.meta(blockers=[1394331])
-def test_compressed_view(request, setup_a_provider):
+def test_compressed_view(request):
     set_and_test_view('Compare', 'Compressed View')
 
 
 @pytest.mark.meta(blockers=[1394331])
-def test_details_view(request, setup_a_provider):
+def test_details_view(request):
     set_and_test_view('Compare Mode', 'Details Mode')
 
 
 @pytest.mark.meta(blockers=[1394331])
-def test_exists_view(request, setup_a_provider):
+def test_exists_view(request):
     set_and_test_view('Compare Mode', 'Exists Mode')

--- a/cfme/tests/configure/test_default_views_infra.py
+++ b/cfme/tests/configure/test_default_views_infra.py
@@ -2,28 +2,37 @@
 import pytest
 
 from cfme import test_requirements
+from cfme.configure.settings import DefaultView
 from cfme.fixtures import pytest_selenium as sel
 from cfme.infrastructure.provider import InfraProvider
+from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.myservice import MyService
-from cfme.web_ui import ButtonGroup, form_buttons, Quadicon, fill, toolbar as tb
+from cfme.services.workloads import services_workloads  # NOQA
+from cfme.web_ui import Quadicon, fill, toolbar as tb
 from utils.appliance.implementations.ui import navigate_to
 from utils.providers import setup_a_provider as _setup_a_provider
-from cfme.configure import settings  # NOQA
-from cfme.services.catalogs import catalog_item  # NOQA
-from cfme.services import workloads  # NOQA
+
 
 pytestmark = [pytest.mark.tier(3),
-              test_requirements.settings]
+              test_requirements.settings,
+              pytest.mark.usefixtures('setup_a_provider')]
 
 
-# TODO: infrastructure hosts, pools, stores, clusters, catalog_items are removed
-#  due to navmazing. all items have to be put back once navigation change is fully done
+# TODO refactor for setup_provider parametrization with new 'latest' tag
+@pytest.fixture(scope="module")
+def setup_a_provider():
+    _setup_a_provider(prov_class='infra', prov_type='virtualcenter', validate=True,
+                      check_existing=True)
+
+
+# TODO: infrastructure hosts, pools, stores, clusters are removed
+# due to navmazing. all items have to be put back once navigation change is fully done
 
 gtl_params = {
     'Infrastructure Providers': InfraProvider,
     'VMs': 'infra_vms',
     'My Services': MyService,
-    # 'Catalog Items/catalog_items',
+    'Catalog Items': CatalogItem,
     'VMs & Instances': 'service_vms_instances',
     'Templates & Images': 'service_templates_images'
 }
@@ -38,84 +47,60 @@ def select_two_quads():
         fill(quad.checkbox(), True)
 
 
-@pytest.fixture(scope="module")
-def setup_a_provider():
-    _setup_a_provider(prov_class="infra", validate=True, check_existing=True)
-
-
-def set_view(group, button):
-    bg = ButtonGroup(group)
-    if bg.active != button:
-        bg.choose(button)
-        sel.click(form_buttons.save)
-
-
-def reset_default_view(name, default_view):
-    bg = ButtonGroup(name)
-    sel.force_navigate("my_settings_default_views")
-    if bg.active != default_view:
-        bg.choose(default_view)
-        sel.click(form_buttons.save)
-
-
-def get_default_view(name):
-    bg = ButtonGroup(name)
-    pytest.sel.force_navigate("my_settings_default_views")
-    default_view = bg.active
-    return default_view
-
-
 def set_and_test_default_view(group_name, view, page):
-    default_view = get_default_view(group_name)
-    set_view(group_name, view)
+    old_default = DefaultView.get_default_view(group_name)
+    DefaultView.set_default_view(group_name, view)
     if isinstance(page, basestring):
         sel.force_navigate(page)
     else:
         navigate_to(page, 'All', use_resetter=False)
     assert tb.is_active(view), "{} view setting failed".format(view)
-    reset_default_view(group_name, default_view)
+    DefaultView.set_default_view(group_name, old_default)
+
+# BZ 1283118 written against 5.5 has a mix of what default views do and don't work on different
+# pages in different releases
 
 
 @pytest.mark.parametrize('key', gtl_params, scope="module")
-def test_tile_defaultview(request, setup_a_provider, key):
+def test_tile_defaultview(request, key):
     set_and_test_default_view(key, 'Tile View', gtl_params[key])
 
 
 @pytest.mark.parametrize('key', gtl_params, scope="module")
-def test_list_defaultview(request, setup_a_provider, key):
+def test_list_defaultview(request, key):
     set_and_test_default_view(key, 'List View', gtl_params[key])
 
 
 @pytest.mark.parametrize('key', gtl_params, scope="module")
-def test_grid_defaultview(request, setup_a_provider, key):
+def test_grid_defaultview(request, key):
     set_and_test_default_view(key, 'Grid View', gtl_params[key])
 
 
 def set_and_test_view(group_name, view):
-    default_view = get_default_view(group_name)
-    set_view(group_name, view)
+    old_default = DefaultView.get_default_view(group_name)
+    DefaultView.set_default_view(group_name, view)
     sel.force_navigate('infrastructure_virtual_machines')
     select_two_quads()
     tb.select('Configuration', 'Compare Selected items')
     assert tb.is_active(view), "{} setting failed".format(view)
-    reset_default_view(group_name, default_view)
+    DefaultView.set_default_view(group_name, old_default)
 
 
 @pytest.mark.meta(blockers=[1394331])
-def test_expanded_view(request, setup_a_provider):
+def test_expanded_view(request):
     set_and_test_view('Compare', 'Expanded View')
 
 
 @pytest.mark.meta(blockers=[1394331])
-def test_compressed_view(request, setup_a_provider):
+def test_compressed_view(request):
     set_and_test_view('Compare', 'Compressed View')
 
 
 @pytest.mark.meta(blockers=[1394331])
-def test_details_view(request, setup_a_provider):
+def test_details_view(request):
     set_and_test_view('Compare Mode', 'Details Mode')
 
 
 @pytest.mark.meta(blockers=[1394331])
-def test_exists_view(request, setup_a_provider):
+def test_exists_view(request):
     set_and_test_view('Compare Mode', 'Exists Mode')

--- a/cfme/tests/containers/test_containers_default_views.py
+++ b/cfme/tests/containers/test_containers_default_views.py
@@ -1,16 +1,14 @@
 import pytest
 from itertools import product
-from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import toolbar as tb, ButtonGroup, form_buttons
-from cfme.base import Server
+
+from cfme.configure.settings import DefaultView
 from cfme.containers.container import Container
 from cfme.containers.provider import ContainersProvider
 from cfme.containers.project import Project
 from cfme.containers.route import Route
 from cfme.containers.node import Node
 from cfme.containers.replicator import Replicator
-import cfme.web_ui.tabstrip as tabs
-from cfme.configure import settings  # noqa
+from cfme.web_ui import toolbar as tb
 from utils import testgen
 from utils.version import current_version
 from utils.appliance.implementations.ui import navigate_to
@@ -49,11 +47,6 @@ def test_containers_providers_default_view(button_group, view):
               to Grid/Tile/List view
             * Goes to Compute --> Containers --> Providers and verifies the selected view
         """
-    navigate_to(Server, 'MySettings')
-    tabs.select_tab("Default Views")
-    bg = ButtonGroup(button_group)
-    if not bg.active == str(view):
-        bg.choose(view)
-        sel.click(form_buttons.save)
+    DefaultView.set_default_view(button_group_name=button_group, default=view)
     navigate_to(mapping[button_group], 'All', use_resetter=False)
     assert tb.is_active(view), "{}'s {} setting failed".format(view, button_group)

--- a/cfme/tests/intelligence/reports/test_views.py
+++ b/cfme/tests/intelligence/reports/test_views.py
@@ -33,7 +33,7 @@ def create_report():
 
 
 @pytest.mark.parametrize('view', ['Hybrid View', 'Graph View', 'Tabular View'])
-@pytest.mark.meta(blockers=[BZ(1396220)])
+@pytest.mark.meta(blockers=[BZ(1397335)])
 def test_report_view(create_report, view):
     create_report.navigate()
     tb.select(view)

--- a/cfme/tests/intelligence/reports/test_views.py
+++ b/cfme/tests/intelligence/reports/test_views.py
@@ -4,17 +4,17 @@ import pytest
 import cfme.web_ui.toolbar as tb
 from cfme import test_requirements
 from cfme.intelligence.reports.reports import CannedSavedReport
+from utils import testgen
 from utils.blockers import BZ
 from utils.log import logger
-from utils.providers import setup_a_provider as _setup_a_provider
 
 pytestmark = [pytest.mark.tier(3),
-              test_requirements.report]
+              test_requirements.report,
+              pytest.mark.usefixtures('setup_provider')]
 
-
-@pytest.fixture(scope="module")
-def setup_a_provider():
-    _setup_a_provider(prov_class="infra", validate=True, check_existing=True)
+pytest_generate_tests = testgen.generate(
+    testgen.provider_by_type, ['openstack', 'ec2', 'rhevm', 'vsphere'],
+    scope='module')
 
 
 @pytest.yield_fixture(scope='module')
@@ -34,7 +34,7 @@ def create_report():
 
 @pytest.mark.parametrize('view', ['Hybrid View', 'Graph View', 'Tabular View'])
 @pytest.mark.meta(blockers=[BZ(1396220)])
-def test_report_view(setup_a_provider, create_report, view):
+def test_report_view(create_report, view):
     create_report.navigate()
     tb.select(view)
     assert tb.is_active(view), "View setting failed for {}".format(view)

--- a/cfme/tests/services/test_config_provider_servicecatalogs.py
+++ b/cfme/tests/services/test_config_provider_servicecatalogs.py
@@ -1,15 +1,16 @@
 import fauxfactory
 import pytest
-from cfme.services.catalogs.service_catalogs import ServiceCatalogs
+
+from cfme import test_requirements
 from cfme.automate.service_dialogs import ServiceDialog
+from cfme.configure.settings import DefaultView
+from cfme.services import requests
+from cfme.services.catalogs.service_catalogs import ServiceCatalogs
 from cfme.services.catalogs.catalog import Catalog
 from cfme.services.catalogs.catalog_item import CatalogItem
-from cfme.configure.settings import set_default_view
 from utils import testgen, version
 from utils.log import logger
 from utils.wait import wait_for
-from cfme.services import requests
-from cfme import test_requirements
 
 pytestmark = [
     test_requirements.service,
@@ -37,7 +38,7 @@ def pytest_generate_tests(metafunc):
 @pytest.yield_fixture
 def config_manager(config_manager_obj):
     """ Fixture that provides a random config manager and sets it up"""
-    set_default_view("Configuration Management Providers", "Grid View")
+    DefaultView.set_default_view("Configuration Management Providers", "Grid View")
     if config_manager_obj.type == "Ansible Tower":
         config_manager_obj.create(validate=True)
     else:
@@ -102,4 +103,4 @@ def test_order_catalog_item(catalog_item, request):
     row, __ = wait_for(requests.wait_for_request, [cells, True],
         fail_func=requests.reload, num_sec=1400, delay=20)
     assert row.last_message.text == 'Service Provisioned Successfully'
-    set_default_view("Configuration Management Providers", "List View")
+    DefaultView.set_default_view("Configuration Management Providers", "List View")


### PR DESCRIPTION
Purpose or Intent
=================

Provide a DefaultView class in configuration.settings, with navmazing destination and classmethods for get/set view.

Refactor tests to use navigation and getter/setter functions.

May impact PR #3807 @pavelzag 

PRT Results
* Upstream: last run failed to get appliance from stack, previous runs had infini-spinny
* 5.7: infini-spinny and failures outside of scope
* 5.6: test_provision_stack failures unrelated to navigation, known bugs.

I would prefer to address the test_provision_stack failures in a different PR. There are some shortfalls of the stack functions that don't account for paged grid/table views and fail to find the stack.