### PR TITLE
Change test generator to generate tests for all relevant providers for C&U tests

### DIFF
--- a/cfme/tests/test_utilization.py
+++ b/cfme/tests/test_utilization.py
@@ -16,12 +16,13 @@ from utils.log import logger
 from utils.version import current_version
 
 
-# Tests for vmware and rhev providers have been moved to cfme/tests/test_utilization_metrics.py.
+# Tests for vmware,rhev, openstack, ec2, azure, gce providers have been moved to
+# cfme/tests/test_utilization_metrics.py.
 # Also, this test just verifies that C&U/perf data is being collected, whereas the tests in
 # test_utilization_metrics.py go a step further and verify that specific performance metrics are
 # being collected.Eventually, support should be added to verify that specific metrics are being
 # collected for *all* providers.
-pytest_generate_tests = testgen.generate(testgen.provider_by_type, ['cloud',
+pytest_generate_tests = testgen.generate(testgen.provider_by_type, [
     'container', 'middleware'], scope="module")
 
 

--- a/cfme/tests/test_utilization_metrics.py
+++ b/cfme/tests/test_utilization_metrics.py
@@ -20,7 +20,7 @@ from utils.version import current_version
 
 def pytest_generate_tests(metafunc):
     argnames, argvalues, idlist = testgen.provider_by_type(
-        metafunc, ['ec2', 'openstack', 'azure', 'gce'],
+        metafunc, ['virtualcenter', 'rhevm', 'ec2', 'openstack', 'azure', 'gce'],
         required_fields=[(['cap_and_util', 'capandu_vm'], 'cu-24x7')])
     testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope="module")
 


### PR DESCRIPTION
Purpose or Intent
-------------------------------------------------
1)Added vsphere, rhevm providers to test_utilization_metrics.py.
2)Removed cloud providers from test_utilization.py

{{pytest: -v -k 'test_raw_metric or test_metrics_collection' --long-running}}
