### PR TITLE
[1LP][WIPTEST] new azure events and event listener

### DIFF
--- a/cfme/tests/cloud/test_cloud_events.py
+++ b/cfme/tests/cloud/test_cloud_events.py
@@ -6,8 +6,10 @@ import re
 from cfme.common.vm import VM
 from cfme.cloud.provider.azure import AzureProvider
 from utils import testgen
+from utils.appliance import get_or_create_current_appliance
 from utils.events import EventBuilder
 from utils.generators import random_vm_name
+
 
 pytestmark = [
     pytest.mark.tier(3)
@@ -26,7 +28,7 @@ def test_manage_nsg_group(provider, setup_provider, register_event):
 
     # registering add/remove network security group events
     # we need to check raw data by regexps, since many azure events aren't parsed by CFME yet
-    builder = EventBuilder()
+    builder = EventBuilder(get_or_create_current_appliance())
     fd_regexp = '^\s*resourceId:.*?{nsg}.*?^\s*status:.*?^\s*value:\s*{stat}.*?^' \
                 '\s*subStatus:.*?^\s*value:\s*{sstat}'
 
@@ -72,7 +74,7 @@ def test_vm_capture(request, provider, setup_provider, register_event):
     request.addfinalizer(vm.delete_from_provider)
 
     # register event
-    builder = EventBuilder()
+    builder = EventBuilder(get_or_create_current_appliance())
     capt_regexp = '^\s*resourceId:.*?{}.*?^\s*status:.*?^\s*value:\s*Succeeded'.format(vm.name)
     full_data_attr = {'full_data': 'will be ignored',
                       'cmp_func': lambda _, y: bool(re.search(capt_regexp, y,

--- a/cfme/tests/cloud/test_cloud_events.py
+++ b/cfme/tests/cloud/test_cloud_events.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+"""This module tests only cloud specific events"""
+import pytest
+import re
+
+from cfme.common.vm import VM
+from cfme.cloud.provider.azure import AzureProvider
+from utils import testgen
+from utils.events import EventBuilder
+from utils.generators import random_vm_name
+
+pytestmark = [
+    pytest.mark.tier(3)
+]
+pytest_generate_tests = testgen.generate([AzureProvider], scope='module')
+
+
+@pytest.mark.uncollectif(lambda provider: not provider.one_of(AzureProvider))
+def test_manage_nsg_group(provider, setup_provider, register_event):
+    """
+    tests that create/remove azure network security groups events are received and parsed by CFME
+    """
+
+    nsg_name = random_vm_name(context='nsg')
+    resource_group = provider.data['provisioning']['resource_group']
+
+    # registering add/remove network security group events
+    # we need to check raw data by regexps, since many azure events aren't parsed by CFME yet
+    builder = EventBuilder()
+    fd_regexp = '^\s*resourceId:.*?{nsg}.*?^\s*status:.*?^\s*value:\s*{stat}.*?^' \
+                '\s*subStatus:.*?^\s*value:\s*{sstat}'
+
+    def add_cmp(_, y):
+        bool(re.search(fd_regexp.format(nsg=nsg_name, stat='Accepted',
+                                        sstat='Created'), y, re.M | re.U | re.S))
+    fd_add_attr = {'full_data': 'will be ignored',
+                   'cmp_func': add_cmp}
+
+    def rm_cmp(_, y):
+        bool(re.search(fd_regexp.format(nsg=nsg_name, stat='Succeeded',
+                                        sstat=' '), y, re.M | re.U | re.S))
+    fd_rm_attr = {'full_data': 'will be ignored',
+                  'cmp_func': rm_cmp}
+
+    add_event = builder.new_event(fd_add_attr, source=provider.type.upper(),
+                                  event_type='networkSecurityGroups_write_EndRequest')
+    register_event(add_event)
+
+    remove_event = builder.new_event(fd_rm_attr, source=provider.type.upper(),
+                                     event_type='networkSecurityGroups_delete_EndRequest')
+    register_event(remove_event)
+
+    # creating and removing network security group
+    provider.mgmt.create_netsec_group(nsg_name, resource_group)
+    provider.mgmt.remove_netsec_group(nsg_name, resource_group)
+
+
+@pytest.mark.uncollectif(lambda provider: not provider.one_of(AzureProvider))
+def test_vm_capture(request, provider, setup_provider, register_event):
+    """
+    tests that generalize and capture vm azure events are received and parsed by CFME
+    """
+
+    mgmt = provider.mgmt
+    vm = VM.factory(random_vm_name(context='capture'), provider)
+
+    if not mgmt.does_vm_exist(vm.name):
+        vm.create_on_provider(find_in_cfme=True, allow_skip="default")
+        vm.refresh_relationships()
+
+    # # deferred delete vm
+    request.addfinalizer(vm.delete_from_provider)
+
+    # register event
+    builder = EventBuilder()
+    capt_regexp = '^\s*resourceId:.*?{}.*?^\s*status:.*?^\s*value:\s*Succeeded'.format(vm.name)
+    full_data_attr = {'full_data': 'will be ignored',
+                      'cmp_func': lambda _, y: bool(re.search(capt_regexp, y,
+                                                              re.M | re.U | re.S))}
+
+    generalize_event = builder.new_event(full_data_attr, source='AZURE',
+                                         event_type='virtualMachines_generalize_EndRequest')
+    register_event(generalize_event)
+
+    capture_event = builder.new_event(full_data_attr, source='AZURE',
+                                      event_type='virtualMachines_capture_EndRequest')
+    register_event(capture_event)
+
+    # capture vm
+    image_name = vm.name
+    resource_group = provider.data['provisioning']['resource_group']
+
+    mgmt.capture_vm(vm.name, resource_group, 'templates', image_name)
+
+    # delete remaining image
+    container = 'system'
+    blob_images = mgmt.list_blob_images(container)
+    # removing both json and vhd files
+    test_image = [img for img in blob_images if image_name in img][-1]
+
+    mgmt.remove_blob_image(test_image, container)

--- a/cfme/tests/cloud_infra_common/test_events.py
+++ b/cfme/tests/cloud_infra_common/test_events.py
@@ -8,6 +8,7 @@ from cfme.control.explorer.policy_profiles import PolicyProfile
 from cfme.control.explorer.policies import VMControlPolicy
 from cfme.control.explorer.actions import Action
 from utils import testgen
+from utils.appliance import get_or_create_current_appliance
 from utils.events import EventBuilder
 from utils.wait import wait_for
 
@@ -73,7 +74,7 @@ def test_vm_create(request, vm_crud, provider, register_event):
     provider.assign_policy_profiles(profile.description)
     request.addfinalizer(lambda: provider.unassign_policy_profiles(profile.description))
 
-    event = EventBuilder().new_event(target_type='VmOrTemplate',
+    event = EventBuilder(get_or_create_current_appliance()).new_event(target_type='VmOrTemplate',
                                      target_name=vm_crud.name,
                                      event_type='vm_create')
     register_event(event)

--- a/cfme/tests/cloud_infra_common/test_events.py
+++ b/cfme/tests/cloud_infra_common/test_events.py
@@ -8,6 +8,7 @@ from cfme.control.explorer.policy_profiles import PolicyProfile
 from cfme.control.explorer.policies import VMControlPolicy
 from cfme.control.explorer.actions import Action
 from utils import testgen
+from utils.events import EventBuilder
 from utils.wait import wait_for
 
 
@@ -72,7 +73,11 @@ def test_vm_create(request, vm_crud, provider, register_event):
     provider.assign_policy_profiles(profile.description)
     request.addfinalizer(lambda: provider.unassign_policy_profiles(profile.description))
 
-    register_event('VmOrTemplate', vm_crud.name, 'vm_create')
+    event = EventBuilder().new_event(target_type='VmOrTemplate',
+                                     target_name=vm_crud.name,
+                                     event_type='vm_create')
+    register_event(event)
+
     vm_crud.create_on_provider()
     provider.refresh_provider_relationships()
     vm_crud.wait_to_appear()

--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -11,6 +11,7 @@ from cfme.exceptions import CFMEExceptionOccured
 from cfme.infrastructure.provider import InfraProvider
 from cfme.web_ui import flash, jstimelines
 from utils import ports, testgen
+from utils.appliance import get_or_create_current_appliance
 from utils.conf import credentials
 from utils.events import EventBuilder
 from utils.log import logger
@@ -212,7 +213,7 @@ def test_alert_vm_turned_on_more_than_twice_in_past_15_minutes(
     provider.refresh_provider_relationships()
 
     # preparing events to listen to
-    builder = EventBuilder()
+    builder = EventBuilder(get_or_create_current_appliance())
     base_evt = partial(builder.new_event, target_type='VmOrTemplate', target_name=vm_name)
     register_event(base_evt(event_type='request_vm_poweroff'), base_evt(event_type='vm_poweoff'))
 

--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import fauxfactory
 import pytest
+from functools import partial
 
 from cfme.common.provider import BaseProvider
 from cfme.common.vm import VM
@@ -11,6 +12,7 @@ from cfme.infrastructure.provider import InfraProvider
 from cfme.web_ui import flash, jstimelines
 from utils import ports, testgen
 from utils.conf import credentials
+from utils.events import EventBuilder
 from utils.log import logger
 from utils.net import net_check
 from utils.ssh import SSHClient
@@ -208,15 +210,23 @@ def test_alert_vm_turned_on_more_than_twice_in_past_15_minutes(
     if not provider.mgmt.is_vm_stopped(vm_name):
         provider.mgmt.stop_vm(vm_name)
     provider.refresh_provider_relationships()
-    register_event('VmOrTemplate', vm_name, ['request_vm_poweroff', 'vm_poweoff'])
+
+    # preparing events to listen to
+    builder = EventBuilder()
+    base_evt = partial(builder.new_event, target_type='VmOrTemplate', target_name=vm_name)
+    register_event(base_evt(event_type='request_vm_poweroff'), base_evt(event_type='vm_poweoff'))
+
     vm_crud.wait_for_vm_state_change(vm_crud.STATE_OFF)
     for i in range(5):
         vm_crud.power_control_from_cfme(option=vm_crud.POWER_ON, cancel=False)
-        register_event('VmOrTemplate', vm_name, ['request_vm_start', 'vm_start'])
+        register_event(base_evt(event_type='request_vm_start'), base_evt(event_type='vm_start'))
+
         wait_for(lambda: provider.mgmt.is_vm_running(vm_name), num_sec=300)
         vm_crud.wait_for_vm_state_change(vm_crud.STATE_ON)
         vm_crud.power_control_from_cfme(option=vm_crud.POWER_OFF, cancel=False)
-        register_event('VmOrTemplate', vm_name, ['request_vm_poweroff', 'vm_poweroff'])
+        register_event(base_evt(event_type='request_vm_poweroff'),
+                       base_evt(event_type='vm_poweroff'))
+
         wait_for(lambda: provider.mgmt.is_vm_stopped(vm_name), num_sec=300)
         vm_crud.wait_for_vm_state_change(vm_crud.STATE_OFF)
 

--- a/cfme/tests/distributed/test_appliance_replication.py
+++ b/cfme/tests/distributed/test_appliance_replication.py
@@ -13,7 +13,7 @@ from cfme.infrastructure.provider import wait_for_a_provider
 import cfme.fixtures.pytest_selenium as sel
 
 from utils import db, version
-from utils.appliance import provision_appliance, current_appliance
+from utils.appliance import provision_appliance, current_appliance, get_or_create_current_appliance
 from utils.appliance.implementations.ui import navigate_to
 from utils.conf import credentials
 from utils.events import EventBuilder
@@ -354,7 +354,7 @@ def test_distributed_vm_power_control(request, test_vm, vmware_provider, verify_
 
     appl2.ipapp.browser_steal = True
 
-    builder = EventBuilder()
+    builder = EventBuilder(get_or_create_current_appliance())
     base_evt = partial(builder.new_event, target_type='VmOrTemplate', target_name=test_vm.name)
 
     with appl2.ipapp:

--- a/cfme/tests/infrastructure/test_host_analysis.py
+++ b/cfme/tests/infrastructure/test_host_analysis.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+from functools import partial
 
 from cfme import test_requirements
 from cfme.configure.tasks import is_host_analysis_finished
@@ -7,9 +8,8 @@ from cfme.exceptions import ListAccordionLinkNotFound
 from cfme.infrastructure import host
 from cfme.infrastructure.provider import InfraProvider
 from cfme.web_ui import listaccordion as list_acc, toolbar, InfoBlock
-from utils import conf
-from utils import testgen
-from utils import version
+from utils import conf, testgen, version
+from utils.events import EventBuilder
 from utils.update import update
 from utils.wait import wait_for
 
@@ -82,7 +82,11 @@ def test_run_host_analysis(request, setup_provider, provider, host_type, host_na
                 test_host.credentials = host.Host.Credential(
                     principal="", secret="", verify_secret="")
 
-    register_event('Host', host_name, ["request_host_scan", "host_scan_complete"])
+    builder = EventBuilder()
+    base_evt = partial(builder.new_event, target_type='Host', target_name=host_name)
+
+    register_event(base_evt(event_type='request_host_scan'),
+                   base_evt(event_type='host_scan_complete'))
 
     # Initiate analysis
     test_host.run_smartstate_analysis()

--- a/cfme/tests/infrastructure/test_host_analysis.py
+++ b/cfme/tests/infrastructure/test_host_analysis.py
@@ -9,6 +9,7 @@ from cfme.infrastructure import host
 from cfme.infrastructure.provider import InfraProvider
 from cfme.web_ui import listaccordion as list_acc, toolbar, InfoBlock
 from utils import conf, testgen, version
+from utils.appliance import get_or_create_current_appliance
 from utils.events import EventBuilder
 from utils.update import update
 from utils.wait import wait_for
@@ -82,7 +83,7 @@ def test_run_host_analysis(request, setup_provider, provider, host_type, host_na
                 test_host.credentials = host.Host.Credential(
                     principal="", secret="", verify_secret="")
 
-    builder = EventBuilder()
+    builder = EventBuilder(get_or_create_current_appliance())
     base_evt = partial(builder.new_event, target_type='Host', target_name=host_name)
 
     register_event(base_evt(event_type='request_host_scan'),

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -9,7 +9,6 @@ from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.virtual_machines import get_all_vms
 from cfme.web_ui import toolbar
 from utils import testgen
-from utils.events import EventBuilder
 from utils.generators import random_vm_name
 from utils.log import logger
 from utils.wait import wait_for, TimedOutError
@@ -20,9 +19,6 @@ pytestmark = [
     pytest.mark.tier(2),
     pytest.mark.usefixtures('setup_provider'),
     test_requirements.power]
-
-builder = EventBuilder()
-base_evt = partial(builder.new_event, target_type='VmOrTemplate')
 
 
 pytest_generate_tests = testgen.generate([InfraProvider], scope="class")

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -9,6 +9,7 @@ from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.virtual_machines import get_all_vms
 from cfme.web_ui import toolbar
 from utils import testgen
+from utils.events import EventBuilder
 from utils.generators import random_vm_name
 from utils.log import logger
 from utils.wait import wait_for, TimedOutError
@@ -19,6 +20,9 @@ pytestmark = [
     pytest.mark.tier(2),
     pytest.mark.usefixtures('setup_provider'),
     test_requirements.power]
+
+builder = EventBuilder()
+base_evt = partial(builder.new_event, target_type='VmOrTemplate')
 
 
 pytest_generate_tests = testgen.generate([InfraProvider], scope="class")

--- a/cfme/tests/services/test_myservice.py
+++ b/cfme/tests/services/test_myservice.py
@@ -10,6 +10,7 @@ from cfme.services.catalogs.service_catalogs import ServiceCatalogs
 from cfme.services.myservice import MyService
 from cfme.web_ui import toolbar as tb
 from utils import browser, testgen, version
+from utils.appliance import get_or_create_current_appliance
 from utils.browser import ensure_browser_open
 from utils.events import EventBuilder
 from utils.log import logger
@@ -69,8 +70,9 @@ def test_retire_service(provider, myservice, register_event):
     Metadata:
         test_flag: provision
     """
-    event = EventBuilder().new_event(target_type='Service', target_name=myservice.service_name,
-                                     event_type='service_retired')
+    builder = EventBuilder(get_or_create_current_appliance())
+    event = builder.new_event(target_type='Service', target_name=myservice.service_name,
+                              event_type='service_retired')
     register_event(event)
     myservice.retire()
 

--- a/cfme/tests/services/test_myservice.py
+++ b/cfme/tests/services/test_myservice.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
+import pytest
 from datetime import datetime
 
-import pytest
 from cfme import test_requirements
 from cfme.common.provider import cleanup_vm
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
@@ -11,6 +11,7 @@ from cfme.services.myservice import MyService
 from cfme.web_ui import toolbar as tb
 from utils import browser, testgen, version
 from utils.browser import ensure_browser_open
+from utils.events import EventBuilder
 from utils.log import logger
 from utils.wait import wait_for
 
@@ -68,8 +69,10 @@ def test_retire_service(provider, myservice, register_event):
     Metadata:
         test_flag: provision
     """
+    event = EventBuilder().new_event(target_type='Service', target_name=myservice.service_name,
+                                     event_type='service_retired')
+    register_event(event)
     myservice.retire()
-    register_event('Service', myservice.service_name, 'service_retired')
 
 
 def test_retire_service_on_date(myservice):

--- a/cfme/tests/services/test_service_catalogs.py
+++ b/cfme/tests/services/test_service_catalogs.py
@@ -10,6 +10,7 @@ from cfme.services.catalogs.service_catalogs import ServiceCatalogs
 from cfme.services import requests
 from cfme.web_ui import flash
 from cfme import test_requirements
+from utils.appliance import get_or_create_current_appliance
 from utils.events import EventBuilder
 from utils.log import logger
 from utils.wait import wait_for
@@ -41,9 +42,9 @@ def test_order_catalog_item(provider, setup_provider, catalog_item, request, reg
     request.addfinalizer(lambda: cleanup_vm(vm_name + "_0001", provider))
     catalog_item.create()
 
-    event = EventBuilder().new_event(target_type='Service',
-                                     target_name=catalog_item.name,
-                                     event_type='service_provisioned')
+    builder = EventBuilder(get_or_create_current_appliance())
+    event = builder.new_event(target_type='Service', target_name=catalog_item.name,
+                              event_type='service_provisioned')
     register_event(event)
 
     service_catalogs = ServiceCatalogs(catalog_item.name)

--- a/fixtures/events.py
+++ b/fixtures/events.py
@@ -1,448 +1,152 @@
 # -*- coding: utf-8 -*-
-"""Event testing framework.
+"""Event testing fixture.
 
-Some very important tips:
+The idea of this fixture is to pass some "expected" events to
+:py:class:`utils.events.EventListener` and check whether all expected events are received
+at the test end.
 
-* You should run with artifactor in order to get per-test HTML event reports.
+register_event fixture accepts one or several expected events.
 
-Usage of ``register_event`` is explained in :py:func:`register_event`.
+simple example:
+    from utils.events import EventBuilder
+    event = EventBuilder().new_event(target_type = 'VmOrTemplate',
+                                     target_name = vm_crud.name,
+                                     event_type = 'vm_create')
+    register_event(event)
+more complex example:
 
-Uses :py:class:`utils.events.EventTool` through :py:class:`utils.appliance.IPAppliance`.
+    from utils.events import EventBuilder
+    builder = EventBuilder()
+    fd_regexp = '^\s*resourceId:.*?{nsg}.*?^\s*status:.*?^\s*value:\s*{stat}.*?^' \
+                '\s*subStatus:.*?^\s*value:\s*{sstat}'
+    add_cmp = lambda _, y: bool(re.search(fd_regexp.format(nsg=nsg_name, stat='Accepted',
+                                                           sstat='Created'), y, re.M | re.U | re.S))
+    fd_add_attr = {'full_data': 'will be ignored',
+                       'cmp_func': add_cmp}
+    add_event = builder.new_event(fd_add_attr, source='AZURE',
+                                      event_type='networkSecurityGroups_write_EndRequest')
+    register_event(add_event)
 
-Available event types:
+Expected events are defined by set of event attributes which should match to the same event
+attributes in event_streams db table except one fake attribute - target_name which is resolved into
+certain object's id.
 
-* ``assigned_company_tag``
-* ``assigned_company_tag_parent_ems_cluster``
-* ``assigned_company_tag_parent_host``
-* ``assigned_company_tag_parent_resource_pool``
-* ``assigned_company_tag_parent_storage``
-* ``containerimage_compliance_check``
-* ``containerimage_compliance_failed``
-* ``containerimage_compliance_passed``
-* ``containerimage_created``
-* ``containerimage_scan_complete``
-* ``cpu_usage_100``
-* ``cpu_usage_50``
-* ``cpu_usage_75``
-* ``cpu_usage_90``
-* ``disk_usage_100``
-* ``disk_usage_50``
-* ``disk_usage_75``
-* ``disk_usage_90``
-* ``ems_auth_changed``
-* ``ems_auth_error``
-* ``ems_auth_incomplete``
-* ``ems_auth_invalid``
-* ``ems_auth_unreachable``
-* ``ems_auth_valid``
-* ``ems_performance_gap_detected``
-* ``evm_server_boot_disk_high_usage``
-* ``evm_server_db_backup_low_space``
-* ``evm_server_db_disk_high_usage``
-* ``evm_server_home_disk_high_usage``
-* ``evm_server_is_master``
-* ``evm_server_memory_exceeded``
-* ``evm_server_miq_tmp_disk_high_usage``
-* ``evm_server_not_responding``
-* ``evm_server_start``
-* ``evm_server_stop``
-* ``evm_server_system_disk_high_usage``
-* ``evm_server_tmp_disk_high_usage``
-* ``evm_server_var_disk_high_usage``
-* ``evm_server_var_log_audit_disk_high_usage``
-* ``evm_server_var_log_disk_high_usage``
-* ``evm_worker_exit_file``
-* ``evm_worker_killed``
-* ``evm_worker_memory_exceeded``
-* ``evm_worker_not_responding``
-* ``evm_worker_start``
-* ``evm_worker_stop``
-* ``evm_worker_uptime_exceeded``
-* ``host_add_to_cluster``
-* ``host_auth_changed``
-* ``host_auth_error``
-* ``host_auth_incomplete``
-* ``host_auth_invalid``
-* ``host_auth_unreachable``
-* ``host_auth_valid``
-* ``host_compliance_check``
-* ``host_compliance_failed``
-* ``host_compliance_passed``
-* ``host_connect``
-* ``host_disconnect``
-* ``host_perf_complete``
-* ``host_provisioned``
-* ``host_remove_from_cluster``
-* ``host_scan_complete``
-* ``mem_usage_100``
-* ``mem_usage_50``
-* ``mem_usage_75``
-* ``mem_usage_90``
-* ``request_assign_company_tag``
-* ``request_host_disable_vmotion``
-* ``request_host_enable_vmotion``
-* ``request_host_enter_maintenance_mode``
-* ``request_host_exit_maintenance_mode``
-* ``request_host_reboot``
-* ``request_host_reset``
-* ``request_host_scan``
-* ``request_host_shutdown``
-* ``request_host_standby``
-* ``request_host_start``
-* ``request_host_stop``
-* ``request_service_retire``
-* ``request_service_start``
-* ``request_service_stop``
-* ``request_storage_scan``
-* ``request_unassign_company_tag``
-* ``request_vm_create_snapshot``
-* ``request_vm_destroy``
-* ``request_vm_pause``
-* ``request_vm_poweroff``
-* ``request_vm_reboot_guest``
-* ``request_vm_reset``
-* ``request_vm_retire``
-* ``request_vm_scan``
-* ``request_vm_shelve``
-* ``request_vm_shelve_offload``
-* ``request_vm_shutdown_guest``
-* ``request_vm_standby_guest``
-* ``request_vm_start``
-* ``request_vm_suspend``
-* ``request_vm_unregister``
-* ``service_provisioned``
-* ``service_retire_warn``
-* ``service_retired``
-* ``service_started``
-* ``service_stopped``
-* ``storage_scan_complete``
-* ``unassigned_company_tag``
-* ``unassigned_company_tag_parent_ems_cluster``
-* ``unassigned_company_tag_parent_host``
-* ``unassigned_company_tag_parent_resource_pool``
-* ``unassigned_company_tag_parent_storage``
-* ``vm_clone``
-* ``vm_clone_start``
-* ``vm_compliance_check``
-* ``vm_compliance_failed``
-* ``vm_compliance_passed``
-* ``vm_create``
-* ``vm_migrate``
-* ``vm_pause``
-* ``vm_perf_complete``
-* ``vm_poweroff``
-* ``vm_provisioned``
-* ``vm_reboot_guest``
-* ``vm_reconfigure``
-* ``vm_remote_console_connected``
-* ``vm_renamed_event``
-* ``vm_reset``
-* ``vm_resume``
-* ``vm_retire_warn``
-* ``vm_retired``
-* ``vm_scan_abort``
-* ``vm_scan_complete``
-* ``vm_scan_start``
-* ``vm_shelve``
-* ``vm_shelve_offload``
-* ``vm_shutdown_guest``
-* ``vm_snapshot``
-* ``vm_snapshot_complete``
-* ``vm_standby_guest``
-* ``vm_start``
-* ``vm_suspend``
-* ``vm_template``
-* ``vm_unregister``
-
-The types can be retrieved using the :py:class:`utils.events.EventTool` by calling
-:py:meth:`utils.events.EventTool.all_event_types` on it.
+Default match algorithm is ==. Event also accepts match function in order to change default
+match type.
 """
-from datetime import datetime
 import logging
-
 import pytest
 
-from fixtures.artifactor_plugin import art_client, get_test_idents
-from fixtures.pytest_store import store
-from utils.datafile import template_env
+from utils.appliance import get_or_create_current_appliance
+from utils.events import EventListener
 from utils.log import setup_logger
 from utils.wait import wait_for, TimedOutError
+
 
 # xxx better logger name
 logger = setup_logger(logging.getLogger('events'))
 
 
-class HTMLReport(object):
-    def __init__(self, test_name, registered_events, all_events):
-        self.registered_events = registered_events
-        self.test_name = test_name
-        self.all_events = all_events
+class EventListenerWrapper(object):
 
-    def generate(self):
-        template = template_env.get_template('event_testing.html')
-        return template.render(
-            test_name=self.test_name,
-            registered_events=self.registered_events,
-            all_events=self.all_events)
+    def __init__(self):
+        self._cur_appliance = get_or_create_current_appliance()
+        self._instances = []
 
+    def _register_instance(self, inst):
+        self._instances.append(inst)
 
-class EventExpectation(object):
-    """ Expectation for an event.
+    def _unregister_instance(self):
+        self._instances.pop()
 
-    This object embeds an expectation in order to be able to easily compare
-    whether the two expectations are the same but just with different time.
+    def new_instance(self):
+        inst = EventListener(self._cur_appliance)
+        self._register_instance(inst)
+        return inst
 
-    This is the actual object returned by the :py:func:`register_event` fixture.
-    """
-
-    TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
-
-    def __init__(self, target_type, target_id, event_type, time=None):
-        self.target_type = target_type
-        self.target_id = target_id
-        self.event_type = event_type
-        self.arrived = None
-        # These two following attributes are set from the events that come
-        self.message = None
-        self.id = id
-        self.real_target_id = None
-        if time:
-            self.time = time
-        else:
-            self.time = datetime.utcnow()
-
-    def __eq__(self, other):
+    @property
+    def current_instance(self):
         try:
-            return (
-                self.target_type == other.target_type and self.target_id == other.target_id and
-                self.event_type == other.event_type)
-        except AttributeError:
-            return False
-
-    @property
-    def colour(self):
-        return "green" if self.arrived else "red"
-
-    @property
-    def time_friendly(self):
-        return datetime.strftime(self.time, self.TIME_FORMAT)
-
-    @property
-    def success_friendly(self):
-        return "success" if self.arrived else "failed"
-
-    @property
-    def time_difference(self):
-        if self.arrived:
-            td = self.arrived - self.time
-            return int(round(td.total_seconds()))
-        else:
-            return "Did not come"
-
-    @property
-    def query_params(self):
-        return {
-            'target_type': self.target_type, 'target_id': self.target_id,
-            'event_type': self.event_type, 'since': self.time}
-
-
-class EventListener(object):
-
-    def __init__(self, appliance=None):
-        self.started = False
-        self.expectations = []
-        # last_id is used to "clear" the database
-        # When database is "cleared" the id of the last event is placed here. That is then used
-        # in queries to prevent events of this id and earlier to get in.
-        self.last_id = None
-        self.appliance = appliance or store.current_appliance
-
-    def delete_database(self):
-        try:
-            last_record = self.appliance.events.query_miq_events()[-1]
-            self.last_id = last_record['id']
+            return self._instances[-1]
         except IndexError:
-            # No events yet, so do nothing
-            pass
+            return None
 
-    def get_all_received_events(self):
-        return self.appliance.events.query_miq_events(from_id=self.last_id)
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_setup(self, item):
+        if "register_event" in item.funcargnames:
+            # store.current_appliance.wait_for_ssh()
+            event_listener = self.new_instance()
+            event_listener.reset_events()
+            event_listener.start()
+            event_listener.set_last_record()
 
-    def check_all_expectations(self):
-        """ Check whether all triggered events have been captured.
+        yield
 
-        Sets a flag for each event.
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_call(self, item):
+        try:
+            yield
+        finally:
+            if "register_event" in item.funcargnames:
+                event_listener = self.current_instance
+                soft_assert = item.funcargs["soft_assert"]
 
-        Returns:
-            Boolean whether all events have already been captured.
+                try:
+                    logger.info('Checking the events to come.')
+                    wait_for(event_listener.check_expected_events,
+                             delay=5,
+                             num_sec=180,
+                             handle_exception=True)
+                except TimedOutError:
+                    logger.info('checking collected events')
+                    for event in event_listener.got_events:
+                        soft_assert(len(event['matched_events']),
+                                    "Event {} did not come!".format(event['event']))
+                else:
+                    logger.info('Seems like all events have arrived!')
 
-        """
-        until = datetime.utcnow()
-        seen_ids = set()
-        for expectation in self.expectations:
-            try:
-                arrived_events = self.appliance.events.query_miq_events(
-                    until=until, from_id=self.last_id, **expectation.query_params)
-            except ValueError:
-                # An object name - not present in the database yet - assuming the event has not come
-                # .... yet
-                continue
-            for event in arrived_events:
-                if event['id'] in seen_ids:
-                    # Already processed
-                    continue
-                seen_ids.add(event['id'])
-                expectation.arrived = event['timestamp']
-                expectation.message = event['message']
-                expectation.id = event['id']
-                expectation.real_target_id = event['target_id']
-                logger.info(
-                    'Detected event {}/{} from {}/{} ({}): {}'.format(
-                        expectation.id,
-                        expectation.event_type,
-                        expectation.target_id,
-                        expectation.real_target_id,
-                        expectation.target_type,
-                        expectation.message))
-        return all(exp.arrived is not None for exp in self.expectations)
-
-    @property
-    def expectations_count(self):
-        return len(self.expectations)
-
-    def add_expectation(self, *args):
-        # Time added automatically if not given
-        self.expectations.append(EventExpectation(*args))
-
-    def __call__(self, target_type, target_id, event_types):
-        if not self.started:
-            # Ignore
-            return
-        if not isinstance(event_types, (list, tuple, set)):
-            event_types = [event_types]
-        for event_type in event_types:
-            logger.info("Event %s registration for %s/%d", event_type, target_type, target_id)
-            self.add_expectation(target_type, target_id, event_type)
-
-    def start(self):
-        self.started = True
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_teardown(self, item):
+        if "register_event" in item.funcargnames:
+            event_listener = self.current_instance
+            event_listener.stop()
+            event_listener.reset_events()
+            self._unregister_instance()
+        yield
 
 
-def pytest_addoption(parser):
-    parser.addoption('--event-testing',
-                     action='store_true',
-                     dest='event_testing_enabled',
-                     default=False,
-                     help='Enable testing of the events. (default: %default)')
-
-
-@pytest.mark.trylast
 def pytest_configure(config):
-    """ Event testing setup.
-
-    Sets up and registers the EventListener plugin for py.test.
-    If the testing is enabled, listener is started.
-    """
-    plugin = EventListener()
+    plugin = EventListenerWrapper()
     registration = config.pluginmanager.register(plugin, "event_testing")
     assert registration
-    if config.getoption("event_testing_enabled"):
-        plugin.start()
 
 
 @pytest.fixture(scope="function")
-def register_event(
-        uses_event_listener, request, soft_assert):
-    """register_event(target_type, target_id, event_types)
+def register_event(request, uses_event_listener, soft_assert):
+    """register_event(list of events)
     Event registration fixture.
 
     This fixture is used to notify the testing system that some event
-    should have occured during execution of the test case using it.
+    should have occurred during execution of the test case using it.
     It does not register anything by itself.
 
     Args:
-        target_type: Target type, in form of classname (VmOrTemplate, Host, Service, ...)
-        target_id: Database id (integer) of the object, but you can use a string in form of the
-            object's name since the :py:class:`utils.events.EventTool` can retrieve the id by itself
-        event_types: Names of the event(s). Can be either a string or a list of strings
+        event 1
+        ...
+        event N
 
-    Returns: :py:class:`EventExpectation`
+    Returns: None
 
     Usage:
 
         def test_something(foo, bar, register_event):
-            register_event("VmOrTemplate", 123, 'vm_start')
-            # or
-            register_event("VmOrTemplate", 123, ['request_vm_start', 'vm_start'])
-            # do_some_stuff_that_triggers()
+            event = EventBuilder().new_event(target_type = 'VmOrTemplate',
+                                             target_name = vm_crud.name,
+                                             event_type = 'vm_create')
+            register_event(event)
+
     """
     # We pull out the plugin directly.
-    self = request.config.pluginmanager.getplugin("event_testing")  # Workaround for bind
+    self = request.config.pluginmanager.getplugin("event_testing")
 
-    if self.started:
-        logger.info("Clearing the database before testing ...")
-        self.delete_database()
-        self.expectations = []
-
-    return self  # Run the test and provide the plugin as a fixture
-
-
-@pytest.mark.hookwrapper
-def pytest_runtest_call(item):
-    """If we use register_event, then collect the events and fail the test if not all came.
-
-    After the test function finishes, it checks the listener whether it has caught the events.
-    It uses `soft_assert` fixture.
-    Before and after each test run using `register_event` fixture, database is cleared.
-    """
-    if "register_event" in item.funcargs:
-        register_event = item.funcargs["register_event"]
-        store.current_appliance.wait_for_ssh()
-        register_event.delete_database()
-    else:
-        register_event = None
-    try:
-        yield
-    finally:
-        from fixtures.artifactor_plugin import SLAVEID
-        if register_event is None:
-            return
-
-        node_id = item._nodeid
-
-        # Event testing is enabled.
-        try:
-            logger.info('Checking the events to come.')
-            wait_for(register_event.check_all_expectations,
-                     delay=5,
-                     num_sec=75,
-                     handle_exception=True)
-        except TimedOutError:
-            logger.warning('Some of the events seem to not have come!')
-        else:
-            logger.info('Seems like all events have arrived!')
-
-        name, location = get_test_idents(item)
-
-        art_client.fire_hook(
-            'filedump',
-            test_name=name,
-            test_location=location,
-            description="Event testing report",
-            contents=HTMLReport(
-                node_id, register_event.expectations, register_event.get_all_received_events()
-            ).generate(),
-            file_type="html",
-            display_glyph="align-justify",
-            group_id="misc-artifacts",
-            slaveid=SLAVEID
-        )
-        logger.info("Clearing the database after testing ...")
-        register_event.delete_database()
-        soft_assert = item.funcargs["soft_assert"]
-        for expectation in register_event.expectations:
-            soft_assert(
-                expectation.arrived,
-                "Event {} for {} {} did not come!".format(
-                    expectation.event_type, expectation.target_type, expectation.target_id))
-        register_event.expectations = []
+    return self.current_instance  # Run the test and provide the plugin as a fixture

--- a/fixtures/soft_assert.py
+++ b/fixtures/soft_assert.py
@@ -100,8 +100,6 @@ def _soft_assert_cm():
     """
     _thread_locals.caught_asserts = []
     yield _thread_locals.caught_asserts
-    # if _thread_locals.caught_asserts:
-    #     raise SoftAssertionError(_thread_locals.caught_asserts)
 
 
 def handle_assert_artifacts(request, fail_message=None):

--- a/fixtures/soft_assert.py
+++ b/fixtures/soft_assert.py
@@ -39,16 +39,27 @@ import utils
 _thread_locals = local()
 
 
-@pytest.mark.hookwrapper
-def pytest_runtest_call(item):
-    """pytest hook to handle :py:func:`soft_assert` fixture usage"""
-    # If a test is using soft_assert, wrap it in the context manager
-    # This ensures SoftAssertionError will be raised in the call phase.
+@pytest.mark.hookwrapper(tryfirst=True)
+def pytest_runtest_protocol(item, nextitem):
     if 'soft_assert' in item.fixturenames:
         with _soft_assert_cm():
             yield
     else:
         yield
+
+
+@pytest.mark.hookwrapper(tryfirst=True)
+def pytest_runtest_teardown(item, nextitem):
+    """
+    pytest hook to handle :py:func:`soft_assert` fixture for case
+    when soft_assert is used in another fixture like register_event
+    """
+    try:
+        yield
+    finally:
+        if 'soft_assert' in item.fixturenames:
+            if _thread_locals.caught_asserts:
+                raise SoftAssertionError(_thread_locals.caught_asserts)
 
 
 class SoftAssertionError(AssertionError):
@@ -89,8 +100,8 @@ def _soft_assert_cm():
     """
     _thread_locals.caught_asserts = []
     yield _thread_locals.caught_asserts
-    if _thread_locals.caught_asserts:
-        raise SoftAssertionError(_thread_locals.caught_asserts)
+    # if _thread_locals.caught_asserts:
+    #     raise SoftAssertionError(_thread_locals.caught_asserts)
 
 
 def handle_assert_artifacts(request, fail_message=None):

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -26,7 +26,6 @@ from fixtures import ui_coverage
 from fixtures.pytest_store import store
 from utils import conf, datafile, db, db_queries, ssh, ports
 from utils.datafile import load_data_file
-from utils.events import EventTool
 from utils.log import logger, create_sublogger, logger_wrap
 from utils.net import net_check, resolve_hostname
 from utils.path import data_path, patches_path, scripts_path, conf_path
@@ -724,11 +723,6 @@ class IPAppliance(object):
         except (TypeError, ValueError):
             value = None
         return value
-
-    @cached_property
-    def events(self):
-        """Returns an instance of the event capturing class pointed to this appliance."""
-        return EventTool(self)
 
     def diagnose_evm_failure(self):
         """Go through various EVM processes, trying to figure out what fails

--- a/utils/events.py
+++ b/utils/events.py
@@ -13,8 +13,6 @@ from sqlalchemy.sql.expression import func
 from time import sleep
 from threading import Thread, Event as ThreadEvent
 
-
-from utils.appliance import get_or_create_current_appliance
 from utils.log import create_sublogger
 
 logger = create_sublogger('events')
@@ -160,13 +158,13 @@ class EventBuilder(object):
     this class just simplifies "expected" event creation.
 
     Usage:
-        builder = EventBuilder()
+        builder = EventBuilder(appliance)
         evt = builder.new_event(target_type='VmOrTemplate',
                                 target_name='my_lovely_vm',
                                 event_type='vm_create')
     """
-    def __init__(self):
-        self._tool = EventTool(get_or_create_current_appliance())
+    def __init__(self, appliance):
+        self._tool = EventTool(appliance)
 
     def new_event(self, *attrs, **kwattrs):
         event = Event(event_tool=self._tool)

--- a/utils/events.py
+++ b/utils/events.py
@@ -6,7 +6,18 @@
 
 from cached_property import cached_property
 from contextlib import contextmanager
+from collections import Iterable
 from datetime import datetime
+from numbers import Number
+from sqlalchemy.sql.expression import func
+from time import sleep
+from threading import Thread, Event as ThreadEvent
+
+
+from utils.appliance import get_or_create_current_appliance
+from utils.log import create_sublogger
+
+logger = create_sublogger('events')
 
 
 class EventTool(object):
@@ -34,6 +45,14 @@ class EventTool(object):
         """``event_streams`` table."""
         return self.appliance.db['event_streams']
 
+    @cached_property
+    def event_streams_attributes(self):
+        """``event_streams`` columns and python's column types"""
+        self.appliance.db._table('event_streams')
+        event_table = [tbl for tbl in self.appliance.db.metadata.sorted_tables
+                       if tbl.name == 'event_streams'][-1]
+        return [(cl.name, cl.type.python_type) for cl in event_table.c.values()]
+
     def query(self, *args, **kwargs):
         """Wrapper for the SQLAlchemy query method."""
         return self.appliance.db.session.query(*args, **kwargs)
@@ -47,7 +66,7 @@ class EventTool(object):
         """
         return {q[0] for q in self.query(self.miq_event_definitions.name)}
 
-    def process_id(self, target_type, target_id):
+    def process_id(self, target_type, target_name):
         """Resolves id, let it be a string or an id.
 
         In case the ``target_type`` is defined in the :py:const:`OBJECT_TABLE`, you can pass a
@@ -55,13 +74,13 @@ class EventTool(object):
 
         Args:
             target_type: What kind of object is the target of the event (MiqServer, VmOrTemplate...)
-            target_id: An id or a name of the object.
+            target_name: An id or a name of the object.
 
         Returns:
             :py:class:`int` with id of the object in the database.
         """
-        if isinstance(target_id, (int, long)):
-            return target_id
+        if isinstance(target_name, Number):
+            return target_name
         if target_type not in self.OBJECT_TABLE:
             raise TypeError(
                 ('Type {} is not specified in the auto-coercion OBJECT_TABLE. '
@@ -70,14 +89,13 @@ class EventTool(object):
         table = self.appliance.db[table_name]
         name_column = getattr(table, name_column)
         id_column = getattr(table, id_column)
-        o = self.appliance.db.session.query(id_column).filter(name_column == target_id).first()
+        o = self.appliance.db.session.query(id_column).filter(name_column == target_name).first()
         if o is None:
-            raise ValueError('{} with name {} not found.'.format(target_type, target_id))
+            raise ValueError('{} with name {} not found.'.format(target_type, target_name))
         return o[0]
 
-    def query_miq_events(
-            self, target_type=None, target_id=None, event_type=None, since=None, until=None,
-            from_id=None):
+    def query_miq_events(self, target_type=None, target_id=None, event_type=None, since=None,
+                         until=None, from_id=None):
         """Checks whether an event occured.
 
         Args:
@@ -135,3 +153,305 @@ class EventTool(object):
         if len(events) == 0:
             raise AssertionError(
                 'Event {}/{}/{} did not happen.'.format(event_type, target_type, target_id))
+
+
+class EventBuilder(object):
+    """
+    this class just simplifies "expected" event creation.
+
+    Usage:
+        builder = EventBuilder()
+        evt = builder.new_event(target_type='VmOrTemplate',
+                                target_name='my_lovely_vm',
+                                event_type='vm_create')
+    """
+    def __init__(self):
+        self._tool = EventTool(get_or_create_current_appliance())
+
+    def new_event(self, *attrs, **kwattrs):
+        event = Event(event_tool=self._tool)
+        for name, value in kwattrs.items():
+            event.add_attrs(EventAttr(**{name: value}))
+
+        for attr in attrs:
+            event.add_attrs(EventAttr(**attr))
+        return event
+
+
+class EventAttr(object):
+    """
+    contains one event attribute and the method for comparing it.
+    """
+    def __init__(self, attr_type=None, cmp_func=None, **attrs):
+        if len(attrs) > 1:
+            raise ValueError('event attribute can have only one key=value pair')
+
+        self.name, self.value = attrs.items()[-1]
+        self.type = attr_type or type(self.value)
+        self.cmp_func = cmp_func
+
+    def match(self, attr):
+        """
+        compares current attribute with passed attribute
+        """
+        if not isinstance(attr, EventAttr) or self.name != attr.name:
+            raise ValueError('Incorrect attribute is passed')
+
+        if attr.value is None or self.value is None:
+            return attr.value is None and self.value is None
+        elif self.cmp_func is not None:
+            return self.cmp_func(self.value, attr.value)
+        else:
+            return self.value == attr.value
+
+    def __repr__(self):
+        return "{name}({type})={val}, cmp_func {cmp}".format(name=self.name, type=self.type,
+                                                             val=self.value, cmp=self.cmp_func)
+
+
+# fixme: would it be better to create event prototype and just clone it ?
+class Event(object):
+    """
+    represents either db event received by CFME and stored in event_streams or an expected event
+    """
+    def __init__(self, *args, **kwargs):
+
+        # preparing connection to appliance db and filling metadata
+        if 'event_tool' in kwargs:
+            self._tool = kwargs.pop('event_tool')
+        else:
+            raise ValueError("event tool is required to create event")
+
+        # filling obtaining default attributes and their types
+        self._default_attrs = {}  # EventAttr obj
+        self._populate_defaults()
+
+        # container for event attributes
+        self.event_attrs = {}  # EventAttr obj
+
+        if len(args) > 0:
+            for arg in args:
+                if isinstance(arg, EventAttr):
+                    self.add_attrs(arg)
+                else:
+                    logger.warning("arg {} doesn't belong to EventAttr. ignoring it".format(arg))
+
+    def __repr__(self):
+        params = ", ".join(["{}={}".format(attr.name, attr.value) for attr in
+                            self.event_attrs.values()])
+        return "BaseEvent({})".format(params)
+
+    def _populate_defaults(self):
+        for attr_name, attr_type in self._tool.event_streams_attributes:
+            self._default_attrs[attr_name] = EventAttr(**{attr_name: None, 'attr_type': attr_type})
+
+    def _parse_raw_event(self, evt):
+        for attr in self._default_attrs:
+            default_type = self._default_attrs[attr].type
+            evt_value = getattr(evt, attr)
+            evt_type = type(evt_value)
+            # weird thing happens here. getattr sometimes takes value not equal to python_type
+            # so, force type conversion has to be done
+            if evt_value is not None and evt_type is not default_type:
+                if evt_type is unicode:
+                    evt_value = evt_value.encode('utf8')
+                else:
+                    evt_value = default_type(evt_value)
+
+            self.add_attrs(EventAttr(**{attr: evt_value}))
+
+    def _is_raw_event(self, evt):
+        return evt.__tablename__ == 'event_streams'
+
+    def matches(self, evt):
+        """
+        compares current event with passed event.
+        """
+        if not isinstance(evt, type(self)):
+            raise ValueError("passed event doesn't belong to {}".format(type(self)))
+
+        # checking only common attributes
+        if 'target_name' in self.event_attrs and 'target_id' not in self.event_attrs:
+            try:
+                target_id = self._tool.process_id(self.event_attrs['target_type'].value,
+                                                  self.event_attrs['target_name'].value)
+                self.event_attrs['target_id'] = EventAttr(**{'target_id': target_id})
+            except ValueError:
+                # vm or host name isn't added to db yet. need to wait
+                return False
+
+        common_attrs = set(self.event_attrs).intersection(set(evt.event_attrs))
+        for attr in common_attrs:
+            if not self.event_attrs[attr].match(evt.event_attrs[attr]):
+                return False
+        else:
+            return True
+
+    def add_attrs(self, *attrs):
+        """
+        event consists of attributes like event_type, etc.
+        this method allows to add an attribute to event
+        """
+        if isinstance(attrs, Iterable):
+            for attr in attrs:
+                if attr.name == 'target_name':
+                    # this is artificial attr which will be converted to target_id during matching
+                    self.event_attrs[attr.name] = attr
+                elif attr.name in self._default_attrs:
+                    # type check was removed because sqlalchemy's python_type
+                    # and type of returned values are different
+                    self.event_attrs[attr.name] = attr
+                else:
+                    logger.warning('The attribute {} type {} is absent in DB '
+                                   'or type mismatch.'.format(attr.name, attr.type))
+        else:
+            raise ValueError("incorrect parameters are passed {}".format(attrs))
+        return self
+
+    def build_from_raw_event(self, evt):
+        """
+        helper method which takes raw event from event_streams and prepares event object
+        """
+        # checking is this param - raw event, populating fields by this data then
+        if self._is_raw_event(evt):
+            self._parse_raw_event(evt)
+        return self
+
+
+class EventListener(Thread):
+    """
+     accepts "expected" events, listens to db events and compares showed up events with expected
+     events. Runs callback function if expected events have it.
+    """
+    def __init__(self, appliance):
+        super(EventListener, self).__init__()
+
+        self._tool = EventTool(appliance)
+
+        self._events_to_listen = []
+        # last_id is used to ignore already arrived messages the database
+        # When database is "cleared" the id of the last event is placed here. That is then used
+        # in queries to prevent events of this id and earlier to get in.
+        self._last_processed_id = None
+        self._stop_event = ThreadEvent()
+
+    def set_last_record(self, evt=None):
+        if evt is not None:
+            self._last_processed_id = evt.event_attrs['id'].value
+        else:
+            try:
+                self._last_processed_id = self._tool.query(
+                    func.max(self._tool.event_streams.id)).one()
+            except IndexError:
+                # No events yet, so do nothing
+                pass
+
+    def listen_to(self, *evts, **kwargs):
+        """
+        accepts one or many events
+        callback function will be called when event arrived in event_streams.
+        callback will receive expected event and got event as params.
+        """
+        if 'callback' in kwargs:
+            callback = kwargs['callback']
+        else:
+            callback = None
+
+        # if first_event = True, these expected events won't be checked after first match
+        if 'first_event' in kwargs and kwargs['first_event']:
+            first_event = True
+        else:
+            first_event = False
+
+        if isinstance(evts, Iterable):
+            for evt in evts:
+                if isinstance(evt, Event):
+                    logger.info("event {} is added to listening queue".format(evt))
+                    self._events_to_listen.append({'event': evt,
+                                                   'callback': callback,
+                                                   'matched_events': [],
+                                                   'first_event': first_event})
+                else:
+                    raise ValueError("one of events doesn't belong to Event class")
+        else:
+            raise ValueError('incorrect is passed')
+
+    def start(self):
+        logger.info('Event Listener has been started')
+        self.set_last_record()
+        self._stop_event.clear()
+        super(EventListener, self).start()
+
+    def stop(self):
+        logger.info('Event Listener has been stopped')
+        self._stop_event.set()
+
+    def run(self):
+        self.process_events()
+
+    @property
+    def started(self):
+        return super(EventListener, self).is_alive()
+
+    def process_events(self):
+        """
+        processes all new db events and compares them with expected events.
+        processed events are ignored next time
+        """
+        while not self._stop_event.is_set():
+            events = self.get_next_portion()
+            if len(events) == 0:
+                sleep(0.2)
+                continue
+            for got_event in events:
+                logger.debug("processing event id {}".format(got_event.id))
+                got_event = Event(event_tool=self._tool).build_from_raw_event(got_event)
+                for exp_event in self._events_to_listen:
+                    if exp_event['first_event'] and len(exp_event['matched_events']) > 0:
+                        continue
+
+                    if exp_event['event'].matches(got_event):
+                        if exp_event['callback'] is not None:
+                            exp_event['callback'](exp_event=exp_event['event'], got_event=got_event)
+                        exp_event['matched_events'].append(got_event)
+                self.set_last_record(got_event)
+
+                if self._stop_event.is_set():
+                    break
+
+    @property
+    def got_events(self):
+        """
+        returns dict with expected events and all the events matched to expected ones
+        """
+        evts = [(evt['event'], len(evt['matched_events'])) for evt in self._events_to_listen]
+        logger.info(evts)
+        return self._events_to_listen
+
+    def reset_matches(self):
+        for event in self._events_to_listen:
+            event['matched_events'] = []
+
+    def reset_events(self):
+        self._events_to_listen = []
+
+    def get_next_portion(self):
+        logger.debug("obtaining next portion of events")
+        return self._tool.query(self._tool.event_streams)\
+            .filter(self._tool.event_streams.id > self._last_processed_id)\
+            .order_by(self._tool.event_streams.id).yield_per(100).all()
+
+    def check_expected_events(self):
+        return all([len(event['matched_events']) for event in self.got_events])
+
+    def __call__(self, *evts, **kwargs):
+        """
+        it is called by register_event fixture.
+        bad idea, to replace register_event by object later
+        """
+        if 'first_event' in kwargs:
+            first_event = kwargs['first_event']
+        else:
+            first_event = True
+        logger.info("registering events: {}".format(evts))
+        self.listen_to(*evts, callback=None, first_event=first_event)


### PR DESCRIPTION
Purpose or Intent
=================
1.  added new azure events tests
2. moved event listener from fixture/events to utils/events and updated it
3. changed register_event fixture to support all event fields
4. updated all tests where register_event fixture was used.

P.S. this is the intermediate solution until everything is moved to collections. Afterwards, all objects like vms or providers will subscribe to event stream and provide all the events relevant to those objects.

related PRs: https://github.com/ManageIQ/wrapanapi/pull/87 , https://github.com/ManageIQ/wrapanapi/pull/75

{{pytest: --long-running cfme/tests/cloud_infra_common/test_events.py  cfme/tests/distributed/test_appliance_replication.py cfme/tests/infrastructure/test_host_analysis.py cfme/tests/infrastructure/test_vm_power_control.py cfme/tests/services/test_myservice.py cfme/tests/services/test_service_catalogs.py}}