### PR TITLE
Misleading log message BEGONE!

### DIFF
--- a/cfme/fixtures/pytest_selenium.py
+++ b/cfme/fixtures/pytest_selenium.py
@@ -478,7 +478,7 @@ def wait_for_element(*locs, **kwargs):
         new_kwargs["timeout"] = kwargs["timeout"]
     wait_until(
         lambda s: filt([is_displayed(loc, move_to=True) for loc in locs]),
-        msg="{} of the elements '{}' did not appear as expected.".format(msg, str(locs)),
+        msg="{} of the elements '{}' to appear".format(msg, str(locs)),
         **kwargs
     )
 


### PR DESCRIPTION
Purpose or Intent
=================

This log message has persisted in our codebase for too long and it's very misleading, as it will say did not appear as expected, when it completes successfully.