### PR TITLE
Revert "Add a warning if running unsupported appliance"

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -30,15 +30,6 @@ class _AppliancePoliceException(Exception):
         return "{} (port {})".format(self.message, self.port)
 
 
-def pytest_configure(config):
-    if store.current_appliance.version < '5.6':
-        store.write_line(
-            'WARNING: This version of the framework does not support the appliance you '
-            'are using, things may not work or be completely broken. YOU HAVE BEEN WARNED!!!',
-            red=True
-        )
-
-
 @pytest.mark.tryfirst
 def pytest_addoption(parser):
     # Create the cfme option group for use in other plugins
@@ -156,7 +147,6 @@ def _pytest_plugins_generator(*extension_pkgs):
         prefix = '%s.' % extension_pkg.__name__
         for importer, modname, is_package in iter_modules(path, prefix):
             yield modname
-
 
 pytest_plugins = (
 


### PR DESCRIPTION
Reverts ManageIQ/integration_tests#3815

Reverting due to Jenkins issues:
```
INTERNALERROR>   File "/home/jenkins/workspace/downstream-57z-tests/conftest.py", line 34, in pytest_configure
INTERNALERROR>     if store.current_appliance.version < '5.6':
INTERNALERROR>   File "/home/jenkins/shiningpanda/jobs/185abe92/virtualenvs/3b0c0aff/lib/python2.7/site-packages/werkzeug/local.py", line 343, in __getattr__
INTERNALERROR>     return getattr(self._get_current_object(), name)
INTERNALERROR>   File "/home/jenkins/shiningpanda/jobs/185abe92/virtualenvs/3b0c0aff/lib/python2.7/site-packages/werkzeug/local.py", line 302, in _get_current_object
INTERNALERROR>     return self.__local()
INTERNALERROR>   File "/home/jenkins/workspace/downstream-57z-tests/utils/appliance/__init__.py", line 2243, in get_or_create_current_appliance
INTERNALERROR>     raise ValueError('No IP address specified! Specified: {}'.format(repr(base_url)))
INTERNALERROR> ValueError: No IP address specified! Specified: 'None'
```