### PR TITLE
[WIPTEST] code cleanups in utils.appliance/db/db_queries

### DIFF
--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -1603,10 +1603,6 @@ class IPAppliance(object):
     def configuration_details(self):
         """Return details that are necessary to navigate through Configuration accordions.
 
-        Args:
-            ip_address: IP address of the server to match. If None, uses hostname from
-                ``conf.env['base_url']``
-
         Returns:
             If the data weren't found in the DB, :py:class:`NoneType`
             If the data were found, it returns tuple ``(region, server name,
@@ -1617,29 +1613,23 @@ class IPAppliance(object):
         except KeyError:
             return None
 
-    def server_id(self):
+    def _config_detail(self, idx):
         try:
-            return self.configuration_details[2]
+            return self.configuration_details[idx]
         except TypeError:
             return None
+
+    def server_id(self):
+        return self._config_detail(2)
 
     def server_region(self):
-        try:
-            return self.configuration_details[0]
-        except TypeError:
-            return None
+        return self._config_detail(0)
 
     def server_name(self):
-        try:
-            return self.configuration_details[1]
-        except TypeError:
-            return None
+        return self._config_detail(1)
 
     def server_zone_id(self):
-        try:
-            return self.configuration_details[3]
-        except TypeError:
-            return None
+        return self._config_detail(3)
 
     def server_region_string(self):
         r = self.server_region()

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -1613,23 +1613,10 @@ class IPAppliance(object):
         except KeyError:
             return None
 
-    def _config_detail(self, idx):
-        try:
-            return self.configuration_details[idx]
-        except TypeError:
-            return None
-
-    def server_id(self):
-        return self._config_detail(2)
-
-    def server_region(self):
-        return self._config_detail(0)
-
-    def server_name(self):
-        return self._config_detail(1)
-
-    def server_zone_id(self):
-        return self._config_detail(3)
+    server_id = db_queries.config_detail_method(db_queries.ConfigDetailResult.server_id)
+    server_region = db_queries.config_detail_method(db_queries.ConfigDetailResult.server_region)
+    server_name = db_queries.config_detail_method(db_queries.ConfigDetailResult.server_name)
+    server_zone_id = db_queries.config_detail_method(db_queries.ConfigDetailResult.server_zone_id)
 
     def server_region_string(self):
         r = self.server_region()

--- a/utils/db.py
+++ b/utils/db.py
@@ -284,6 +284,9 @@ class Db(Mapping):
                 logger.info('Unable to create table class for table "%s"')
                 return None
 
+    def get_first_of(self, db_table_name, **filter):
+        return self.session.query(self[db_table_name]).filter_by(**filter).first()
+
 
 @contextmanager
 def database_on_server(hostname, **kwargs):

--- a/utils/db_queries.py
+++ b/utils/db_queries.py
@@ -56,7 +56,7 @@ def get_configuration_details(db=None, ip_address=None):
 
 def get_zone_description(zone_id, ip_address=None, db=None):
     db = _db(db, ip_address)
-    zone = db.session.query(db["zones"]).filter_by(id=zone_id).first()
+    zone = db.get_first_of("zones", id=zone_id)
     if zone is not None:
         return zone.description
 
@@ -64,7 +64,7 @@ def get_zone_description(zone_id, ip_address=None, db=None):
 def get_host_id(hostname, ip_address=None, db=None):
     db = _db(db, ip_address)
 
-    host = db.session.query(db["hosts"]).filter_by(name=hostname).first()
+    host = db.db.get_first_of("hosts", name=hostname)
 
     if host is not None:
         return str(host.id)
@@ -73,8 +73,7 @@ def get_host_id(hostname, ip_address=None, db=None):
 def check_domain_enabled(domain, ip_address=None, db=None):
     db = _db(db, ip_address)
 
-    namespaces = db["miq_ae_namespaces"]
-    ns = db.session.query(namespaces).filter_by(parent_id=None, name=domain).first()
+    ns = db.get_first_of("miq_ae_namespaces", parent_id=None, name=domain)
     if ns is not None:
         return ns.enabled
     else:

--- a/utils/db_queries.py
+++ b/utils/db_queries.py
@@ -29,12 +29,7 @@ def config_detail_method(descriptor, attribute='configuration_details'):
 
 
 def _db(db=None, ip_address=None):
-    if ip_address is None:
-        ip_address = cfmedb().hostname
-
-    if db is None:
-        db = Db(hostname=ip_address)
-    return db
+    return db or Db(hostname=ip_address or cfmedb().hostname)
 
 
 def get_configuration_details(db=None, ip_address=None):

--- a/utils/db_queries.py
+++ b/utils/db_queries.py
@@ -37,12 +37,12 @@ def get_configuration_details(db=None, ip_address=None):
         else:
             # Otherwise, filter based on id and ip address
             def server_filter(server):
-                return all([
-                    server.id >= reg_min,
-                    server.id < reg_max,
+                return (
+                    server.id >= reg_min and
+                    server.id < reg_max and
                     # XXX: This currently fails due to public/private addresses on openstack
                     server.ipaddress == ip_address
-                ])
+                )
             servers = filter(server_filter, all_servers)
             if servers:
                 server = servers[0]


### PR DESCRIPTION
this pr cleans up `applianc.configuration_data` and simplifies `utils.db_queries`

it also introduces a `db.get_first_of(table_name, **filters)` method to the cfme db object