### PR TITLE
add REST API tests for service dialogs

### DIFF
--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -35,10 +35,9 @@ class TestServiceRESTAPI(object):
         return _services(request, rest_api, a_provider, dialog, service_catalogs)
 
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
-    @pytest.mark.parametrize("method", ["post", "delete"])
-    def test_delete_service_dialog(self, rest_api, dialog, method):
+    def test_delete_service_dialog(self, rest_api, dialog):
         service_dialog = rest_api.collections.service_dialogs.find_by(label=dialog.label)[0]
-        service_dialog.action.delete(force_method=method)
+        service_dialog.action.delete()
         with error.expected("ActiveRecord::RecordNotFound"):
             service_dialog.action.delete()
 

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -34,6 +34,19 @@ class TestServiceRESTAPI(object):
     def services(self, request, rest_api, a_provider, dialog, service_catalogs):
         return _services(request, rest_api, a_provider, dialog, service_catalogs)
 
+    @pytest.mark.parametrize("method", ["post", "delete"])
+    def test_delete_service_dialog(self, rest_api, dialog, method):
+        service_dialog = rest_api.collections.service_dialogs.find_by(label=dialog.label)[0]
+        service_dialog.action.delete(force_method=method)
+        with error.expected("ActiveRecord::RecordNotFound"):
+            service_dialog.action.delete()
+
+    def test_delete_service_dialogs(self, rest_api, dialog):
+        service_dialog = rest_api.collections.service_dialogs.find_by(label=dialog.label)[0]
+        rest_api.collections.service_dialogs.action.delete(service_dialog)
+        with error.expected("ActiveRecord::RecordNotFound"):
+            rest_api.collections.service_dialogs.action.delete(service_dialog)
+
     def test_edit_service(self, rest_api, services):
         """Tests editing a service.
         Prerequisities:

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -34,6 +34,7 @@ class TestServiceRESTAPI(object):
     def services(self, request, rest_api, a_provider, dialog, service_catalogs):
         return _services(request, rest_api, a_provider, dialog, service_catalogs)
 
+    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     @pytest.mark.parametrize("method", ["post", "delete"])
     def test_delete_service_dialog(self, rest_api, dialog, method):
         service_dialog = rest_api.collections.service_dialogs.find_by(label=dialog.label)[0]
@@ -41,6 +42,7 @@ class TestServiceRESTAPI(object):
         with error.expected("ActiveRecord::RecordNotFound"):
             service_dialog.action.delete()
 
+    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     def test_delete_service_dialogs(self, rest_api, dialog):
         service_dialog = rest_api.collections.service_dialogs.find_by(label=dialog.label)[0]
         rest_api.collections.service_dialogs.action.delete(service_dialog)

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -17,37 +17,32 @@ pytestmark = [test_requirements.service,
               pytest.mark.tier(2)]
 
 
+@pytest.fixture(scope="module")
+def a_provider():
+    return _setup_a_provider("infra")
+
+
+@pytest.fixture(scope="function")
+def dialog():
+    return _dialog()
+
+
+@pytest.fixture(scope="function")
+def service_catalogs(request, rest_api):
+    return _service_catalogs(request, rest_api)
+
+
+@pytest.fixture(scope="function")
+def services(request, rest_api, a_provider, dialog, service_catalogs):
+    return _services(request, rest_api, a_provider, dialog, service_catalogs)
+
+
+@pytest.fixture(scope='function')
+def service_templates(request, rest_api, dialog):
+    return _service_templates(request, rest_api, dialog)
+
+
 class TestServiceRESTAPI(object):
-    @pytest.fixture(scope="module")
-    def a_provider(self):
-        return _setup_a_provider("infra")
-
-    @pytest.fixture(scope="function")
-    def dialog(self):
-        return _dialog()
-
-    @pytest.fixture(scope="function")
-    def service_catalogs(self, request, rest_api):
-        return _service_catalogs(request, rest_api)
-
-    @pytest.fixture(scope="function")
-    def services(self, request, rest_api, a_provider, dialog, service_catalogs):
-        return _services(request, rest_api, a_provider, dialog, service_catalogs)
-
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
-    def test_delete_service_dialog(self, rest_api, dialog):
-        service_dialog = rest_api.collections.service_dialogs.find_by(label=dialog.label)[0]
-        service_dialog.action.delete()
-        with error.expected("ActiveRecord::RecordNotFound"):
-            service_dialog.action.delete()
-
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
-    def test_delete_service_dialogs(self, rest_api, dialog):
-        service_dialog = rest_api.collections.service_dialogs.find_by(label=dialog.label)[0]
-        rest_api.collections.service_dialogs.action.delete(service_dialog)
-        with error.expected("ActiveRecord::RecordNotFound"):
-            rest_api.collections.service_dialogs.action.delete(service_dialog)
-
     def test_edit_service(self, rest_api, services):
         """Tests editing a service.
         Prerequisities:
@@ -186,21 +181,26 @@ class TestServiceRESTAPI(object):
                 assert service.evm_owner.userid == user.userid
 
 
+class TestServiceDialogsRESTAPI(object):
+    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
+    @pytest.mark.parametrize("method", ["post", "delete"])
+    def test_delete_service_dialog(self, rest_api, dialog, method):
+        service_dialog = rest_api.collections.service_dialogs.find_by(label=dialog.label)[0]
+        service_dialog.action.delete(force_method=method)
+        with error.expected("ActiveRecord::RecordNotFound"):
+            service_dialog.action.delete()
+
+    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
+    def test_delete_service_dialogs(self, rest_api, dialog):
+        service_dialog = rest_api.collections.service_dialogs.find_by(label=dialog.label)[0]
+        rest_api.collections.service_dialogs.action.delete(service_dialog)
+        with error.expected("ActiveRecord::RecordNotFound"):
+            rest_api.collections.service_dialogs.action.delete(service_dialog)
+
+
 class TestServiceTemplateRESTAPI(object):
-    @pytest.fixture(scope='function')
-    def service_templates(self, request, rest_api, dialog):
-        return _service_templates(request, rest_api, dialog)
-
-    @pytest.fixture(scope="function")
-    def dialog(self):
-        return _dialog()
-
-    @pytest.fixture(scope="function")
-    def service_catalogs(self, request, rest_api):
-        return _service_catalogs(request, rest_api)
-
     def test_edit_service_template(self, rest_api, service_templates):
-        """Tests cediting a service template.
+        """Tests editing a service template.
         Prerequisities:
             * An appliance with ``/api`` available.
         Steps:

--- a/utils/api.py
+++ b/utils/api.py
@@ -461,7 +461,10 @@ class ActionContainer(object):
         self._obj.reload_if_needed()
         reloaded_actions = []
         for action in self._obj._actions:
-            # don't redefine actions with same name and different methods
+            # There can be multiple actions with the same name and different methods
+            # (e.g. actions "delete" with method POST and DELETE).
+            # This makes sure that the attribute refers to the first action and is not redefined
+            # by other action with the same name and different method.
             if action["name"] not in reloaded_actions:
                 reloaded_actions.append(action["name"])
                 setattr(
@@ -514,6 +517,8 @@ class Action(object):
         return self.collection.api
 
     def __call__(self, *args, **kwargs):
+        # possibility to override HTTP method that will be used with the action
+        # (e.g. force_method='delete')
         method = kwargs.pop('force_method', self._method)
         resources = []
         # We got resources to post


### PR DESCRIPTION
* adding tests for deleting service dialogs over REST API
* adding possibility to specify HTTP method for action (e.g. DELETE, POST)

__Note to reviewers__: infinispinny and/or jquery ajax issue makes it impossible to test this reliably on PRT