### PR TITLE
skip template when ems record is missing

### DIFF
--- a/cfme/tests/infrastructure/test_provisioning_rest.py
+++ b/cfme/tests/infrastructure/test_provisioning_rest.py
@@ -16,7 +16,11 @@ pytest_generate_tests = testgen.generate(testgen.provider_by_type, ['virtualcent
 def provision_data(rest_api_modscope, provider, small_template_modscope):
     templates = rest_api_modscope.collections.templates.find_by(name=small_template_modscope)
     for template in templates:
-        if template.ems.name == provider.data["name"]:
+        try:
+            ems_id = template.ems_id
+        except AttributeError:
+            continue
+        if ems_id == provider.id:
             guid = template.guid
             break
     else:


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ behavior when we are looking for template located on specific provider and ems data is missing for currently evaluated template.

__Note to reviewers__ provisioning of vm is timeouting on PRT, but the template was already selected, so the changed code works.