### PR TITLE
ignore case in cleanup scripts.

### DIFF
--- a/scripts/cleanup_old_vms.py
+++ b/scripts/cleanup_old_vms.py
@@ -144,7 +144,7 @@ def cleanup_vms(texts, max_hours=24, providers=None, prompt=True):
     vms_to_delete = defaultdict(set)
     thread_queue = []
     # precompile regexes
-    matchers = [re.compile(text) for text in texts]
+    matchers = [re.compile(text, re.IGNORECASE) for text in texts]
 
     for provider_key in providers:
         provider_type = providers_data[provider_key].get('type', None)


### PR DESCRIPTION
Purpose or Intent
=================
  * Test, TEST, Jenkins, JENKINS, all of these needs to be included in deletion. This fix, ignores the case
    while matching the vm names.