### PR TITLE
default ip write to outfile when local provider data is used.

### DIFF
--- a/scripts/clone_template.py
+++ b/scripts/clone_template.py
@@ -196,7 +196,7 @@ def main(**kwargs):
             ssh_client.close()
         return 10
 
-    if kwargs.get('outfile', None):
+    if kwargs.get('outfile', None) or kwargs.get('deploy', None):
         with open(kwargs['outfile'], 'w') as outfile:
             outfile.write("appliance_ip_address={}\n".format(ip))
 


### PR DESCRIPTION
Purpose or Intent
=================
   * deploy option is specified when local provider data is used.
     interop team requested to write the ip to outfile by default.
     this does not change cfmeqe deployments using clone_template.