### PR TITLE
fix for tb.select('Grid View') in 5.6

### DIFF
--- a/cfme/web_ui/toolbar.py
+++ b/cfme/web_ui/toolbar.py
@@ -118,9 +118,13 @@ def pf_select(root, sub=None, invokes_alert=False):
                     sel.execute_script(
                         "return $('button:contains({})').trigger('click')".format(q_root))
                 except sel.NoSuchElementException:
-                    # The view selection buttons?
-                    sel.click("//li/a[@title={}]/*[self::i or self::img]/../..".format(q_root))
-
+                    try:
+                        sel.element("//a[@title = {}]".format(q_root))
+                        sel.execute_script(
+                            "return $('a[title={}]').trigger('click')".format(q_root))
+                    except sel.NoSuchElementException:
+                        # The view selection buttons?
+                        sel.click("//li/a[@title={}]/*[self::i or self::img]/../..".format(q_root))
     if not invokes_alert:
         sel.wait_for_ajax()
     return True


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ test_no_template_power_control because it fails as tb.select("Grid View") fails - view menu items are not buttons in 5.6

{{pytest: cfme/tests/infrastructure/  "-k test_no_template_power_control" --long-running}}