### PR TITLE
fix for tb.select('Grid View') in 5.6 - updated

### DIFF
--- a/cfme/web_ui/toolbar.py
+++ b/cfme/web_ui/toolbar.py
@@ -119,8 +119,7 @@ def pf_select(root, sub=None, invokes_alert=False):
                         "return $('button:contains({})').trigger('click')".format(q_root))
                 except sel.NoSuchElementException:
                     # The view selection buttons?
-                    sel.click("//li/a[@title={}]/*[self::i or self::img]/../..".format(q_root))
-
+                    sel.click("//li/a[@title={}]/*[self::i or self::img]/..".format(q_root))
     if not invokes_alert:
         sel.wait_for_ajax()
     return True


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ toolbar.py for tb.select("Tile View")  because it is currently not working on our dockerbot image (sel 2.47.1 + ff) but works on local setup - ff 45 + sel 2.53.6

{{pytest: cfme/tests/infrastructure/ "-k test_no_template_power_control" --use-provider vsphere6-nested --long-running}}