### PR TITLE
update disable ext_auth_openldap method.

### DIFF
--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -1801,7 +1801,7 @@ class IPAppliance(object):
                manageiq_ext_auth=manageiq_ext_auth)
         assert self.ssh_client.run_command(apache_config)
         self.ssh_client.run_command(
-            'setenforce 0 && systemctl restart sssd && systemctl restart evmserverd')
+            'setenforce 0 && systemctl restart sssd && systemctl restart httpd')
         self.wait_for_web_ui()
 
 

--- a/utils/ext_auth.py
+++ b/utils/ext_auth.py
@@ -104,9 +104,7 @@ def disable_external_auth_ipa():
     login_admin()
     auth = DatabaseAuthSetting()
     auth.update()
-    ssh.run_command("service evmserverd stop")
     assert ssh.run_command("appliance_console_cli --uninstall-ipa")
-    ssh.run_command("service evmserverd start")
     appliance.IPAppliance().wait_for_web_ui()
     logout()
 


### PR DESCRIPTION
Purpose or Intent
=================
  * updated ext_auth_openldap method. evm serverd service needs
    to be restarted only for openldap and not for ipa uninstall.