### PR TITLE
New REST API tests

### DIFF
--- a/cfme/tests/automate/test_rest.py
+++ b/cfme/tests/automate/test_rest.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+"""REST API specific automate tests."""
+import pytest
+
+from cfme import test_requirements
+from utils import version
+
+
+pytestmark = [test_requirements.rest]
+
+
+@pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
+def test_rest_search_automate(rest_api):
+    auto = rest_api.collections.automate
+    more_depth = auto.query_string(depth="2")
+    full_depth = auto.query_string(depth="-1")
+    search = auto.query_string(depth="-1", search_options="state_machines")
+    assert len(full_depth) > len(more_depth) > len(auto) and len(full_depth) > len(search) > 0

--- a/utils/api.py
+++ b/utils/api.py
@@ -136,11 +136,6 @@ class API(object):
         return sorted(self._versions.keys(), reverse=True, key=Version)
 
     @property
-    def new_id_behaviour(self):
-        """2.0.0 introduced a new id/href difference."""
-        return self.version >= "2.0.0"
-
-    @property
     def latest_version(self):
         return self.versions[0]
 
@@ -181,8 +176,8 @@ class CollectionsIndex(object):
 class SearchResult(object):
     def __init__(self, collection, data):
         self.collection = collection
-        self.count = data.pop("count")
-        self.subcount = data.pop("subcount")
+        self.count = data.pop("count", 0)
+        self.subcount = data.pop("subcount", 0)
         self.name = data.pop("name")
         self.resources = []
         for resource in data["resources"]:
@@ -227,8 +222,8 @@ class Collection(object):
             kwargs = {}
         self._data = self._api.get(self._href, **kwargs)
         self._resources = self._data["resources"]
-        self._count = self._data["count"]
-        self._subcount = self._data["subcount"]
+        self._count = self._data.get("count", 0)
+        self._subcount = self._data.get("subcount", 0)
         self._actions = self._data.pop("actions", [])
         if self._data["name"] != self.name:
             raise ValueError("Name mishap!")
@@ -237,29 +232,12 @@ class Collection(object):
         if self._data is None:
             self.reload()
 
+    def query_string(self, **params):
+        """Specify query string to use with collection."""
+        return SearchResult(self, self._api.get(self._href, **params))
+
     def find_by(self, **params):
         """Search items in collection. Filters based on keywords passed."""
-        if self._api.version == "2.0.0-pre":
-            # Special case, there can be both, so try sqlfilter first and if that does not work ...
-            try:
-                return self._find_by_sqlfilter(**params)
-            except APIException:
-                return self._find_by_filter(**params)
-        elif self._api.version.is_in_series("1.1") or self._api.version >= "2.0.0":
-            # New function
-            return self._find_by_filter(**params)
-        else:
-            # Old function
-            return self._find_by_sqlfilter(**params)
-
-    def _find_by_sqlfilter(self, **params):
-        search_query = []
-        for key, value in params.iteritems():
-            search_query.append("{} = {}".format(key, repr(str(value))))
-        return SearchResult(
-            self, self._api.get(self._href, **{"sqlfilter": " AND ".join(search_query)}))
-
-    def _find_by_filter(self, **params):
         search_query = []
         for key, value in params.iteritems():
             if isinstance(value, int):
@@ -332,7 +310,7 @@ class Entity(object):
     SUBCOLLECTIONS = dict(
         service_catalogs={"service_templates"},
         roles={"features"},
-        providers={"tags"},
+        providers={"tags", "custom_attributes"},
         hosts={"tags"},
         data_stores={"tags"},
         resource_pools={"tags"},
@@ -352,6 +330,7 @@ class Entity(object):
         self.action = ActionContainer(self)
         self._data = data
         self._incomplete = incomplete
+        self._href = None
         self._load_data()
 
     def _load_data(self):
@@ -373,18 +352,14 @@ class Entity(object):
             if isinstance(attributes, basestring):
                 attributes = [attributes]
             kwargs.update(attributes=",".join(attributes))
-        if get:
+        if "href" in self._data:
+            self._href = self._data["href"]
+        if get and self._href:
             new = self.collection._api.get(self._href, **kwargs)
             if self._data is None:
                 self._data = new
             else:
                 self._data.update(new)
-        if (
-                "id" in self._data and "href" in self._data
-                and isinstance(self._data["href"], basestring)):
-            self._href = self._data["href"]
-        else:
-            self._href = self._data["id" if not self.collection._api.new_id_behaviour else "href"]
         self._actions = self._data.pop("actions", [])
         for key, value in self._data.iteritems():
             if key in self.TIME_FIELDS:
@@ -396,14 +371,15 @@ class Entity(object):
                     self.collection._api.get_entity(self.COLLECTION_MAPPING[key], value)
                 )
                 setattr(self, key, value)
-            elif isinstance(value, dict) and "count" in value and "resources" in value:
+            elif (isinstance(value, dict) and self._href and
+                  "count" in value and "resources" in value):
                 href = self._href
                 if not href.endswith("/"):
                     href += "/"
                 subcol = Collection(self.collection._api, href + key, key)
                 setattr(self, key, subcol)
-            elif isinstance(value, list) and key in self.EXTENDED_COLLECTIONS.get(
-                    self.collection.name, set([])):
+            elif (isinstance(value, list) and self._href and
+                  key in self.EXTENDED_COLLECTIONS.get(self.collection.name, set([]))):
                 href = self._href
                 if not href.endswith("/"):
                     href += "/"
@@ -443,6 +419,8 @@ class Entity(object):
             return self.__dict__[attr]
         if attr not in self.SUBCOLLECTIONS.get(self.collection.name, set([])):
             raise AttributeError("No such attribute/subcollection {}".format(attr))
+        if not self._href:
+            raise AttributeError("Can't get URL of attribute/subcollection {}".format(attr))
         # Try to get subcollection
         href = self._href
         if not href.endswith("/"):
@@ -460,10 +438,10 @@ class Entity(object):
         return getattr(self, item)
 
     def __repr__(self):
-        return "<Entity {}>".format(repr(self._href))
+        return "<Entity {}>".format(repr(self._href if self._href else self._data["id"]))
 
     def _ref_repr(self):
-        return {"href": self._href}
+        return {"href": self._href} if self._href else {"id": self._data["id"]}
 
 
 class ActionContainer(object):


### PR DESCRIPTION
* Adding tests for automate and providers collections and for basic REST API functionality
* Removing redundant test `test_edit_user_password`
* Removing support for old REST API versions and old CFME versions
* Fixing behavior when entity doesn't contain "href" and contains "id"


__PRT outcome explained:__
* 5.7:
__1 failed__: timeout ->`Provider vsphere55 is behaving badly, marking it as bad.`
__6 errors__: `Exception: No providers could be set up matching the params`

* upstream:
`SproutException: Exception DoesNotExist raised! AppliancePool matching query does not exist.`

i.e. no problems caused by PR, can be approved and merged ;)
