### PR TITLE
Remove ovirt patching; not necessary anymore

### DIFF
--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -587,35 +587,6 @@ class IPAppliance(object):
             log_callback(msg)
             raise Exception(msg)
 
-    # this is temporary and can all be removed by 2016-11-15 most likely - dajo
-    # ==========================================================================
-    @property
-    def is_ovirt_gem_patch_candidate(self):
-        status, out = self.ssh_client.run_command(
-            "md5sum /opt/rh/cfme-gemset/gems/ovirt_metrics-1.3.0/lib/ovirt_metrics.rb")
-        return 'f465d3b5345a38bba376b4b2a8c49710' in out
-
-    @logger_wrap("Patch appliance with ovirt gem patch")
-    def patch_appliance_ovirt_gem(self, log_callback=None):
-        patch_args = (
-            (str(patches_path.join('ovirt_gem.patch')),
-             '/opt/rh/cfme-gemset/gems/ovirt_metrics-1.3.0/lib/ovirt_metrics.rb',
-             None),
-        )
-
-        for local_path, remote_path, md5 in patch_args:
-            self.ssh_client.patch_file(local_path, remote_path, md5)
-
-        self.restart_evm_service()
-        logger.info("Waiting for Web UI to start")
-        wait_for(
-            func=self.is_web_ui_running,
-            message='appliance.is_web_ui_running',
-            delay=20,
-            timeout=300)
-        logger.info("Web UI is up and running")
-
-    # ===========================================================================
 
     @property
     def is_miqqe_patch_candidate(self):

--- a/utils/appliance/implementations/ui.py
+++ b/utils/appliance/implementations/ui.py
@@ -157,13 +157,6 @@ class CFMENavigateStep(NavigateStep):
             _tries -= 1
             self.go(_tries)
 
-        # check for ovirt_gem patch on first try and patch the appliance if necessary
-        if self.appliance.is_ovirt_gem_patch_candidate:
-            self.appliance.patch_appliance_ovirt_gem()
-            self.appliance.browser.quit_browser()
-            _tries -= 1
-            self.go(_tries)
-
         br = self.appliance.browser
 
         try:


### PR DESCRIPTION
Purpose or Intent
=================
Both 5.6.z (5.6.3) and 5.7.0 (5.7.0.14) now contain ovirt_metrics-1.3.1.