### PR TITLE
Added provider custom attributes functions and tests

### DIFF
--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -78,7 +78,11 @@ class OpenshiftProvider(ContainersProvider):
         return out
 
     def add_custom_attributes(self, *custom_attributes):
-        """Adding static custom attributes to provider."""
+        """Adding static custom attributes to provider.
+        Args:
+            custom_attributes: The custom attributes to add.
+        returns: response.
+        """
         if not custom_attributes:
             raise TypeError('{} takes at least 1 argument.'
                             .format(self.add_custom_attributes.__name__))
@@ -95,11 +99,15 @@ class OpenshiftProvider(ContainersProvider):
         for i, fld_tp in enumerate([attr.field_type for attr in custom_attributes]):
             if fld_tp:
                 payload['resources'][i]['field_type'] = fld_tp
-        self.appliance.rest_api.post(
+        return self.appliance.rest_api.post(
             path.join(self._href(), 'custom_attributes'), **payload)
 
     def edit_custom_attributes(self, *custom_attributes):
-        """Editing static custom attributes in provider."""
+        """Editing static custom attributes in provider.
+        Args:
+            custom_attributes: The custom attributes to edit.
+        returns: response.
+        """
         if not custom_attributes:
             raise TypeError('{} takes at least 1 argument.'
                             .format(self.edit_custom_attributes.__name__))
@@ -114,10 +122,15 @@ class OpenshiftProvider(ContainersProvider):
                 "href": filter(lambda attr: attr.name == ca.name, attribs)[-1].href,
                 "value": ca.value
             } for ca in custom_attributes]}
-        self.appliance.rest_api.post(path.join(self._href(), 'custom_attributes'), **payload)
+        return self.appliance.rest_api.post(
+            path.join(self._href(), 'custom_attributes'), **payload)
 
     def delete_custom_attributes(self, *names):
-        """Deleting static custom attributes from provider."""
+        """Deleting static custom attributes from provider.
+        Args:
+            names: The names of the custom attributes to delete.
+        returns: response.
+        """
         for name in names:
             if type(name) is not str:
                 raise TypeError('Type of names should be {}. ({} != {})'
@@ -130,5 +143,5 @@ class OpenshiftProvider(ContainersProvider):
             "resources": [{
                 "href": attr.href,
             } for attr in attribs if attr.name in names]}
-        self.appliance.rest_api.post(
+        return self.appliance.rest_api.post(
             path.join(self._href(), 'custom_attributes'), **payload)

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -1,6 +1,8 @@
 from . import ContainersProvider
 from utils.varmeth import variable
 from mgmtsystem.openshift import Openshift
+from os import path
+from types import NoneType
 
 
 @ContainersProvider.add_provider_type
@@ -19,6 +21,10 @@ class OpenshiftProvider(ContainersProvider):
         # Workaround - randomly fails on 5.5.0.8 with no validation
         # probably a js wait issue, not reproducible manually
         super(OpenshiftProvider, self).create(validate_credentials=validate_credentials, **kwargs)
+
+    def _href(self):
+        return self.appliance.rest_api.collections.providers\
+            .find_by(name=self.name).resources[0].href
 
     def _form_mapping(self, create=None, **kwargs):
         return {'name_text': kwargs.get('name'),
@@ -47,3 +53,85 @@ class OpenshiftProvider(ContainersProvider):
             hostname=prov_config.get('hostname', None) or prov_config['ip_address'],
             port=prov_config['port'],
             provider_data=prov_config)
+
+    def custom_attributes(self):
+        """returns custom attributes in {name: {data}}"""
+        response = self.appliance.rest_api.get(
+            path.join(self._href(), 'custom_attributes'))
+        out = {}
+        for attr_dict in response['resources']:
+            attr = self.appliance.rest_api.get(attr_dict['href'])
+            out[attr['name']] = attr
+        return out
+
+    def add_custom_attributes(self, names, values, field_types):
+        """Adding static custom attributes to provider.
+        Args:
+            names: List of names of the attributes
+            value: List of values of the attributes
+            field_type: List of field types of the attributes
+                (field type could be None)
+        """
+        for arg in (names, values, field_types):
+            if type(arg) not in (tuple, list):
+                raise TypeError('add_custom_attributes(): '
+                    'Argument types should be list or tuple. got: {} = {}'
+                    .format(repr(arg), type(arg)))
+            elif not len(names) == len(arg):
+                raise Exception('add_custom_attributes(): '
+                    'All arguments should have the same length.')
+        payload = {
+            "action": "add",
+            "resources": [{
+                "name": name,
+                "value": str(value)
+            } for name, value in zip(names, values)]}
+        for i, fld_tp in enumerate(field_types):
+            if fld_tp:
+                payload['resources'][i]['field_type'] = fld_tp
+        self.appliance.rest_api.post(
+            path.join(self._href(), 'custom_attributes'), **payload)
+
+    def edit_custom_attributes(self, names, values):
+        """Editing static custom attributes in provider.
+        Args:
+            names: List of names of the attributes to edit
+            values: List of the new values to set
+        """
+        for arg in (names, values):
+            if type(arg) not in (tuple, list):
+                raise TypeError('add_custom_attributes(): '
+                    'Argument types should be list or tuple. got: {} = {}'
+                    .format(repr(arg), type(arg)))
+            elif not len(names) == len(arg):
+                raise Exception('add_custom_attributes(): '
+                    'All arguments should have the same length.')
+        attribs = self.custom_attributes()
+        payload = {
+            "action": "edit",
+            "resources": [{
+                "href": attribs[name]['href'],
+                "value": value
+            } for name, value in zip(names, values)]}
+        self.appliance.rest_api.post(path.join(self._href(), 'custom_attributes'), **payload)
+
+    def delete_custom_attributes(self, names=None):
+        """Deleting static custom attributes from provider.
+        Args:
+            names: List of names of the attributes to delete
+                if names is None: delete all
+        """
+        if type(names) not in (list, tuple, NoneType):
+            raise TypeError('delete_custom_attributes(names={}):'
+                            ' names type should be list, tuple or NoneType. got {}'
+                            .format(names, type(names)))
+        attribs = self.custom_attributes()
+        if not names:
+            names = attribs.keys()
+        payload = {
+            "action": "delete",
+            "resources": [{
+                "href": attr['href'],
+            } for name, attr in attribs.items() if name in names]}
+        self.appliance.rest_api.post(
+            path.join(self._href(), 'custom_attributes'), **payload)

--- a/cfme/tests/containers/test_static_custom_attributes.py
+++ b/cfme/tests/containers/test_static_custom_attributes.py
@@ -53,10 +53,10 @@ def test_edit_static_custom_attributes(provider):
     attribs_names = [attr.name for attr in provider.custom_attributes()]
     assert all([attr.name in attribs_names
                 for attr in ATTRIBUTES_DATASET])
-    EditedAttributes = ATTRIBUTES_DATASET
+    edited_attribs = ATTRIBUTES_DATASET
     for ii, value in enumerate(VALUE_UPDATES):
-        EditedAttributes[ii].value = value
-    provider.edit_custom_attributes(*EditedAttributes)
+        edited_attribs[ii].value = value
+    provider.edit_custom_attributes(*edited_attribs)
     custom_attr_ui = provider.summary.custom_attributes.items()
     for attr in ATTRIBUTES_DATASET:
         assert attr.name in custom_attr_ui

--- a/cfme/tests/containers/test_static_custom_attributes.py
+++ b/cfme/tests/containers/test_static_custom_attributes.py
@@ -22,7 +22,7 @@ VALUE_UPDATES = ['2018-07-12', 'ADF231VRWQ1', '1']
 
 # CMP-10281
 
-def tes1t_add_static_custom_attributes(provider):
+def test_add_static_custom_attributes(provider):
     """Tests adding of static custom attributes to provider
     Steps:
         * Add static custom attributes (API)
@@ -40,7 +40,7 @@ def tes1t_add_static_custom_attributes(provider):
 
 # CMP-10286
 
-def tes1t_edit_static_custom_attributes(provider):
+def test_edit_static_custom_attributes(provider):
     """Tests editing of static custom attributes from provider
     Prerequisite:
         * test_add_static_custom_attributes passed.
@@ -66,7 +66,7 @@ def tes1t_edit_static_custom_attributes(provider):
 
 # CMP-10285
 
-def tes1t_delete_static_custom_attributes(provider):
+def test_delete_static_custom_attributes(provider):
     """Tests deleting of static custom attributes from provider
     Steps:
         * Delete the static custom attributes that recently added (API)
@@ -108,3 +108,17 @@ def test_add_attribute_with_empty_name(provider):
 
     if hasattr(provider.summary, 'custom_attributes'):
         assert "" not in provider.summary.custom_attributes
+
+
+def test_add_date_value_with_wrong_value(provider):
+    ca = CustomAttribute('nondate', "koko", 'Date')
+    try:
+        provider.add_custom_attributes(ca)
+        pytest.fail('You have added custom attribute of type'
+                    '{} with value of {} and didn\'t get an error!'
+                    .format(ca.field_type, ca.value))
+    except APIException:
+        pass
+
+    if hasattr(provider.summary, 'custom_attributes'):
+        assert 'nondate' not in provider.summary.custom_attributes

--- a/cfme/tests/containers/test_static_custom_attributes.py
+++ b/cfme/tests/containers/test_static_custom_attributes.py
@@ -1,0 +1,87 @@
+import pytest
+from utils.version import current_version
+from utils import testgen
+
+pytestmark = [
+    pytest.mark.uncollectif(
+        lambda: current_version() < "5.7"),
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.tier(2)]
+pytest_generate_tests = testgen.generate(
+    testgen.container_providers, scope="function")
+
+attributes_dataset = {
+    'names': ['exp_date', 'sales_force_acount', 'expected_num_of_nodes'],
+    'values': ['2017-01-02', 'ADF231VRWQ1', '2'],
+    'values_update': ['2018-07-12', 'ADF231VRWQ1', '1'],
+    'field_types': ['Date', None, None]
+}
+
+
+# CMP-10281
+
+def test_add_static_custom_attributes(provider):
+    """Tests adding of static custom attributes to provider
+    Steps:
+        * Add static custom attributes (API)
+        * Go to provider summary page
+    Expected results:
+        * The attributes was successfully added
+    """
+    assert not provider.custom_attributes()
+    provider.add_custom_attributes(attributes_dataset['names'],
+                                   attributes_dataset['values'],
+                                   attributes_dataset['field_types'])
+    custom_attr_ui = provider.summary.custom_attributes.items()
+    for name, value in zip(attributes_dataset['names'],
+                           attributes_dataset['values']):
+        assert name in custom_attr_ui
+        assert custom_attr_ui[name].text_value == value
+
+
+# CMP-10286
+
+def test_edit_static_custom_attributes(provider):
+    """Tests editing of static custom attributes from provider
+    Prerequisite:
+        * test_add_static_custom_attributes passed.
+    Steps:
+        * Edit (update) the static custom attributes (API)
+        * Go to provider summary page
+    Expected results:
+        * The attributes was successfully updated to the new values
+    """
+    # Checking that all attributes_dataset was added.
+    attribs_api = provider.custom_attributes()
+    assert all([name in attribs_api
+                for name in attributes_dataset['names']])
+
+    provider.edit_custom_attributes(attributes_dataset['names'],
+                                    attributes_dataset['values_update'])
+    custom_attr_ui = provider.summary.custom_attributes.items()
+    for name, value in zip(attributes_dataset['names'],
+                           attributes_dataset['values_update']):
+        assert name in custom_attr_ui
+        assert custom_attr_ui[name].text_value == value
+
+
+# CMP-10285
+
+def test_delete_static_custom_attributes(provider):
+    """Tests deleting of static custom attributes from provider
+    Steps:
+        * Delete the static custom attributes that recently added (API)
+        * Go to provider summary page
+    Expected results:
+        * The attributes was successfully deleted
+        (you should not see a custom attributes table)
+    """
+    # Checking that all attributes_dataset was added.
+    attribs_api = provider.custom_attributes()
+    assert all([name in attribs_api
+                for name in attributes_dataset['names']])
+
+    provider.delete_custom_attributes(attributes_dataset['names'])
+    if hasattr(provider.summary, 'custom_attributes'):
+        for name in attributes_dataset['names']:
+            assert name not in provider.summary.custom_attributes

--- a/cfme/tests/containers/test_static_custom_attributes.py
+++ b/cfme/tests/containers/test_static_custom_attributes.py
@@ -1,6 +1,7 @@
 import pytest
 from utils.version import current_version
 from utils import testgen
+from cfme.containers.provider.openshift import CustomAttribute
 
 pytestmark = [
     pytest.mark.uncollectif(
@@ -10,12 +11,12 @@ pytestmark = [
 pytest_generate_tests = testgen.generate(
     testgen.container_providers, scope="function")
 
-attributes_dataset = {
-    'names': ['exp_date', 'sales_force_acount', 'expected_num_of_nodes'],
-    'values': ['2017-01-02', 'ADF231VRWQ1', '2'],
-    'values_update': ['2018-07-12', 'ADF231VRWQ1', '1'],
-    'field_types': ['Date', None, None]
-}
+ATTRIBUTES_DATASET = [
+    CustomAttribute('exp_date', '2017-01-02', 'Date'),
+    CustomAttribute('sales_force_acount', 'ADF231VRWQ1', None),
+    CustomAttribute('expected_num_of_nodes', '2', None),
+]
+VALUE_UPDATES = ['2018-07-12', 'ADF231VRWQ1', '1']
 
 
 # CMP-10281
@@ -29,14 +30,11 @@ def test_add_static_custom_attributes(provider):
         * The attributes was successfully added
     """
     assert not provider.custom_attributes()
-    provider.add_custom_attributes(attributes_dataset['names'],
-                                   attributes_dataset['values'],
-                                   attributes_dataset['field_types'])
+    provider.add_custom_attributes(*ATTRIBUTES_DATASET)
     custom_attr_ui = provider.summary.custom_attributes.items()
-    for name, value in zip(attributes_dataset['names'],
-                           attributes_dataset['values']):
-        assert name in custom_attr_ui
-        assert custom_attr_ui[name].text_value == value
+    for attr in ATTRIBUTES_DATASET:
+        assert attr.name in custom_attr_ui
+        assert custom_attr_ui[attr.name].text_value == attr.value
 
 
 # CMP-10286
@@ -51,18 +49,18 @@ def test_edit_static_custom_attributes(provider):
     Expected results:
         * The attributes was successfully updated to the new values
     """
-    # Checking that all attributes_dataset was added.
-    attribs_api = provider.custom_attributes()
-    assert all([name in attribs_api
-                for name in attributes_dataset['names']])
-
-    provider.edit_custom_attributes(attributes_dataset['names'],
-                                    attributes_dataset['values_update'])
+    # Checking that all ATTRIBUTES_DATASET was added.
+    attribs_names = [attr.name for attr in provider.custom_attributes()]
+    assert all([attr.name in attribs_names
+                for attr in ATTRIBUTES_DATASET])
+    EditedAttributes = ATTRIBUTES_DATASET
+    for ii, value in enumerate(VALUE_UPDATES):
+        EditedAttributes[ii].value = value
+    provider.edit_custom_attributes(*EditedAttributes)
     custom_attr_ui = provider.summary.custom_attributes.items()
-    for name, value in zip(attributes_dataset['names'],
-                           attributes_dataset['values_update']):
-        assert name in custom_attr_ui
-        assert custom_attr_ui[name].text_value == value
+    for attr in ATTRIBUTES_DATASET:
+        assert attr.name in custom_attr_ui
+        assert custom_attr_ui[attr.name].text_value == attr.value
 
 
 # CMP-10285
@@ -76,12 +74,12 @@ def test_delete_static_custom_attributes(provider):
         * The attributes was successfully deleted
         (you should not see a custom attributes table)
     """
-    # Checking that all attributes_dataset was added.
-    attribs_api = provider.custom_attributes()
-    assert all([name in attribs_api
-                for name in attributes_dataset['names']])
+    # Checking that all ATTRIBUTES_DATASET was added.
+    attribs_names = [attr.name for attr in provider.custom_attributes()]
+    assert all([attr.name in attribs_names
+                for attr in ATTRIBUTES_DATASET])
 
-    provider.delete_custom_attributes(attributes_dataset['names'])
+    provider.delete_custom_attributes()
     if hasattr(provider.summary, 'custom_attributes'):
-        for name in attributes_dataset['names']:
-            assert name not in provider.summary.custom_attributes
+        for attr in ATTRIBUTES_DATASET:
+            assert attr.name not in provider.summary.custom_attributes

--- a/cfme/tests/containers/test_static_custom_attributes.py
+++ b/cfme/tests/containers/test_static_custom_attributes.py
@@ -2,6 +2,7 @@ import pytest
 from utils.version import current_version
 from utils import testgen
 from cfme.containers.provider.openshift import CustomAttribute
+from utils.api import APIException
 
 pytestmark = [
     pytest.mark.uncollectif(
@@ -21,7 +22,7 @@ VALUE_UPDATES = ['2018-07-12', 'ADF231VRWQ1', '1']
 
 # CMP-10281
 
-def test_add_static_custom_attributes(provider):
+def tes1t_add_static_custom_attributes(provider):
     """Tests adding of static custom attributes to provider
     Steps:
         * Add static custom attributes (API)
@@ -39,7 +40,7 @@ def test_add_static_custom_attributes(provider):
 
 # CMP-10286
 
-def test_edit_static_custom_attributes(provider):
+def tes1t_edit_static_custom_attributes(provider):
     """Tests editing of static custom attributes from provider
     Prerequisite:
         * test_add_static_custom_attributes passed.
@@ -65,7 +66,7 @@ def test_edit_static_custom_attributes(provider):
 
 # CMP-10285
 
-def test_delete_static_custom_attributes(provider):
+def tes1t_delete_static_custom_attributes(provider):
     """Tests deleting of static custom attributes from provider
     Steps:
         * Delete the static custom attributes that recently added (API)
@@ -83,3 +84,27 @@ def test_delete_static_custom_attributes(provider):
     if hasattr(provider.summary, 'custom_attributes'):
         for attr in ATTRIBUTES_DATASET:
             assert attr.name not in provider.summary.custom_attributes
+
+
+# CMP-10303
+
+def test_add_attribute_with_empty_name(provider):
+    """Tests adding of static custom attributes with empty field
+    Steps:
+        * add the static custom attribute with name "" (API)
+        * Go to provider summary page
+    Expected results:
+        * You should get an error
+        * You should not see this attribute in the custom  attributes table
+    """
+    try:
+        provider.add_custom_attributes(
+            CustomAttribute('', "17")
+        )
+        pytest.fail('You have added custom attribute with empty name'
+                    'and didn\'t get an error!')
+    except APIException:
+        pass
+
+    if hasattr(provider.summary, 'custom_attributes'):
+        assert "" not in provider.summary.custom_attributes

--- a/utils/api.py
+++ b/utils/api.py
@@ -32,10 +32,6 @@ class API(object):
         self._session.headers.update({'Content-Type': 'application/json; charset=utf-8'})
         self._load_data()
 
-    @property
-    def entry_point(self):
-        return self._entry_point
-
     def _load_data(self):
         data = self.get(self._entry_point)
         self.collections = CollectionsIndex(self, data.pop("collections", []))

--- a/utils/api.py
+++ b/utils/api.py
@@ -294,10 +294,8 @@ class Collection(object):
 class Entity(object):
     # TODO: Extend these fields
     TIME_FIELDS = {
-        "updated_on", "created_on", "last_scan_attempt_on",
-        "state_changed_on", "lastlogon", "updated_at",
-        "created_at", "last_scan_on", "last_sync_on",
-        "last_refresh_date", "retires_on"}
+        "updated_on", "created_on", "last_scan_attempt_on", "state_changed_on", "lastlogon",
+        "updated_at", "created_at", "last_scan_on", "last_sync_on", "last_refresh_date", "retires_on",}
     COLLECTION_MAPPING = dict(
         ems_id="providers",
         storage_id="data_stores",

--- a/utils/api.py
+++ b/utils/api.py
@@ -32,6 +32,10 @@ class API(object):
         self._session.headers.update({'Content-Type': 'application/json; charset=utf-8'})
         self._load_data()
 
+    @property
+    def entry_point(self):
+        return self._entry_point
+
     def _load_data(self):
         data = self.get(self._entry_point)
         self.collections = CollectionsIndex(self, data.pop("collections", []))
@@ -294,8 +298,10 @@ class Collection(object):
 class Entity(object):
     # TODO: Extend these fields
     TIME_FIELDS = {
-        "updated_on", "created_on", "last_scan_attempt_on", "state_changed_on", "lastlogon",
-        "updated_at", "created_at", "last_scan_on", "last_sync_on", "last_refresh_date", "retires_on",}
+        "updated_on", "created_on", "last_scan_attempt_on",
+        "state_changed_on", "lastlogon", "updated_at",
+        "created_at", "last_scan_on", "last_sync_on",
+        "last_refresh_date", "retires_on"}
     COLLECTION_MAPPING = dict(
         ems_id="providers",
         storage_id="data_stores",


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_static_custom_attributes.py -v --use-provider cm-env2 }}

Added custom attributes CRUD functionality to openshift provider.
Added custom attributes CRUD tests.