### PR TITLE
[1LP][RFR] Handle confirmation alert in host power controls

### DIFF
--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -226,12 +226,12 @@ class Host(Updateable, Pretty, Navigatable):
 
     def power_on(self):
         navigate_to(self, 'Details')
-        pow_btn('Power On')
+        pow_btn('Power On', invokes_alert=True)
         sel.handle_alert()
 
     def power_off(self):
         navigate_to(self, 'Details')
-        pow_btn('Power Off')
+        pow_btn('Power Off', invokes_alert=True)
         sel.handle_alert()
 
     def get_ipmi(self):


### PR DESCRIPTION
Purpose or Intent
=================
host.power_off(), host.power_on() could not be invoked since there is a confirmation message.

Now with this change the host power controls handle confirm message and immediately invoke the power action 