### PR TITLE
adding order to the Provision Form filling

### DIFF
--- a/cfme/provisioning.py
+++ b/cfme/provisioning.py
@@ -249,7 +249,9 @@ provisioning_form = tabstrip.TabStripForm(
             # Infra
             ('stateless', ui.Input('schedule__stateless')),
         ])
-    ])
+    ]),
+    order=['Request', 'Purpose', 'Catalog', 'Environment', 'Hardware', 'Network', 'Properties',
+           'Customize', 'Schedule']
 )
 
 


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ order in Provisioning Form filling because it goes random based on dict hashes. which works for usual provisioning but fails on PXE provision. On PXE order is Network/Customize(which depends on  Custom's provision type)

{{pytest: cfme/tests/infrastructure/test_pxe_provisioning.py --use-provider vsphere55 }}
