### PR TITLE
Fixed versioning and comments in test_views_objects.py

### DIFF
--- a/cfme/tests/containers/test_views_objects.py
+++ b/cfme/tests/containers/test_views_objects.py
@@ -1,6 +1,3 @@
-# the test verifies functionality
-# of different views such as grid view, tile view
-# and list view
 import pytest
 
 from cfme.containers.container import Container
@@ -11,20 +8,24 @@ from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import toolbar as tb
 from utils import testgen
 from utils.appliance.implementations.ui import navigate_to
-from utils.version import current_version
 from cfme.containers.replicator import Replicator
 from cfme.containers.pod import Pod
 
 
-pytestmark = [
-    pytest.mark.uncollectif(
-        lambda: current_version() < "5.5"),
-    pytest.mark.usefixtures('setup_provider')]
+pytestmark = [pytest.mark.tier(2)]
 pytest_generate_tests = testgen.generate(
     testgen.container_providers, scope="function")
 
 
+# CMP-9907 # CMP-9908 # CMP-9909
+
+
 def test_pods_views():
+    """ This test verifies functionality of different views.
+        Views that are being tested are: grid view, tile view,
+        and list view
+
+    """
     navigate_to(Pod, 'All')
     tb.select('Grid View')
     assert tb.is_active('Grid View'), "Pods grid view setting failed"
@@ -32,6 +33,9 @@ def test_pods_views():
     assert tb.is_active('Tile View'), "Pods tile view setting failed"
     tb.select('List View')
     assert tb.is_active('List View'), "Pods list view setting failed"
+
+
+# CMP-9918 # CMP-9919 # CMP-9920
 
 
 def test_replicators_views():
@@ -44,6 +48,9 @@ def test_replicators_views():
     assert tb.is_active('List View'), "Replicators list view setting failed"
 
 
+# CMP-9941 # CMP-9942 # CMP-9943
+
+
 def test_containers_views():
     navigate_to(Container, 'All')
     tb.select('Grid View')
@@ -52,6 +59,9 @@ def test_containers_views():
     assert tb.is_active('Tile View'), "Containers tile view setting failed"
     tb.select('List View')
     assert tb.is_active('List View'), "Containers list view setting failed"
+
+
+# CMP-9887 # CMP-9888 # CMP-9889
 
 
 def test_services_views():
@@ -64,6 +74,9 @@ def test_services_views():
     assert tb.is_active('List View'), "Services list view setting failed"
 
 
+# CMP-9956 # CMP-9957 # CMP-9958
+
+
 def test_nodes_views():
     navigate_to(Node, 'All')
     tb.select('Grid View')
@@ -74,6 +87,9 @@ def test_nodes_views():
     assert tb.is_active('List View'), "Nodes list view setting failed"
 
 
+# CMP-9974 # CMP-9975 # CMP-9976
+
+
 def test_images_views():
     navigate_to(Image, 'All')
     tb.select('Grid View')
@@ -82,6 +98,9 @@ def test_images_views():
     assert tb.is_active('Tile View'), "Images tile view setting failed"
     tb.select('List View')
     assert tb.is_active('List View'), "Images list view setting failed"
+
+
+# CMP-9984 # CMP-9985 # CMP-9986
 
 
 def test_imageregistry_views():


### PR DESCRIPTION
py.test --use-provider container cfme/tests/containers/test_views_objects.py -v

Added comments with the relevant Polarion test cases' numbers.

