### PR TITLE
[WIP] Skip if order noncheckable. Compare to the ``sort()`` order

### DIFF
--- a/cfme/tests/containers/test_containers_main_pages_sort.py
+++ b/cfme/tests/containers/test_containers_main_pages_sort.py
@@ -18,12 +18,11 @@ pytestmark = [
 pytest_generate_tests = testgen.generate(
     testgen.container_providers, scope="function")
 
-# CMP-9924 CMP-9925 CMP-9926 CMP-9927 CMP-9928
-
 
 TEST_OBJECTS = [Project, Service, Replicator, Route, ContainersProvider]
 
 
+# CMP-9924 CMP-9925 CMP-9926 CMP-9927 CMP-9928
 @pytest.mark.meta(blockers=[1392413])
 @pytest.mark.parametrize('cls', TEST_OBJECTS)
 def test_containers_main_pages_sort(cls):

--- a/cfme/tests/containers/test_containers_main_pages_sort.py
+++ b/cfme/tests/containers/test_containers_main_pages_sort.py
@@ -44,4 +44,13 @@ def test_containers_main_pages_sort(cls):
         sort_tbl.sort_by(header_text, 'descending')
         rows_descending = [r[col].text for r in sort_tbl.rows()]
 
-        assert rows_ascending[::-1] == rows_descending
+        expected_ascending_order = sorted(rows_ascending)
+        expected_descending_order = expected_ascending_order[::-1]
+
+        if expected_ascending_order == expected_descending_order:
+            pytest.skip("There is no difference between the column %s"
+                        " sorted in ascending and descending order,"
+                        " therefore this test is not able to check is"
+                        " the ordering actualy working or not.")
+        assert rows_ascending == expected_ascending_order
+        assert rows_descending == expected_descending_order


### PR DESCRIPTION
__Fixing__ ordering check. Compare with the order of python ``sort()``. If ordering cannot be checked due to environment state (all items are the same), the test will be skipped.
