### PR TITLE
[1LP][RFR] Update infra.Vm.current_snapshot_name to parse snapshot name in 5.6

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -379,11 +379,12 @@ class Vm(BaseVM, Common):
         sel.click(InfoBlock("Properties", "Snapshots"))
         text = sel.text("//a[contains(normalize-space(.), '(Active)')]|"
             "//li[contains(normalize-space(.), '(Active)')]").strip()
-        return re.sub(r"\s*\(Active\)$", "", text)
+        # In 5.6 the locator returns the entire tree string, snapshot name is after a newline
+        return re.sub(r"\s*\(Active\)$", "", text.split('\n')[-1:][0])
 
     @property
     def current_snapshot_description(self):
-        """Returns the current snapshot name."""
+        """Returns the current snapshot description."""
         self.load_details(refresh=True)
         sel.click(InfoBlock("Properties", "Snapshots"))
         l = "|".join([


### PR DESCRIPTION
RHCFQE-1415

Purpose or Intent
=================

Fixing snapshot name parsing for 5.6.

In 5.7 this was working, but in 5.7 the selector ends up getting the text of the entire snapshot tree. The text is newline delineated, so split and select the last item. The split returns a list that should contain a single item.

Also fix small typo in docstring for current_snapshot_description

{{ pytest: cfme/tests/control/test_actions.py --use-provider vsphere55 --long-running -k test_action_create_snapshot}}

Marked WIPTEST until I get pytest to actually collect the relevant functions. 