### PR TITLE
[RFR] replaced force_navigate calls with navigate_to

### DIFF
--- a/cfme/intelligence/reports/menus.py
+++ b/cfme/intelligence/reports/menus.py
@@ -4,9 +4,11 @@ from contextlib import contextmanager
 
 from cfme.fixtures import pytest_selenium as sel
 from cfme.intelligence.reports.ui_elements import FolderManager
-from cfme.web_ui import Region, BootstrapTreeview, accordion, form_buttons, menu
+from cfme.web_ui import Region, BootstrapTreeview, Tree, accordion, form_buttons, menu
 from cfme.web_ui.multibox import MultiBoxSelect
+from utils import version
 from utils.log import logger
+
 
 menu.nav.add_branch(
     "reports",
@@ -16,8 +18,10 @@ menu.nav.add_branch(
     }
 )
 
-reports_tree = BootstrapTreeview("menu_roles_treebox")
-
+if version.current_version() >= '5.7':
+    reports_tree = BootstrapTreeview("menu_roles_treebox")
+else:
+    reports_tree = Tree("//div[@id='menu_roles_treebox']/ul")
 
 manager = FolderManager("//div[@id='folder_lists']/table")
 report_select = MultiBoxSelect(

--- a/cfme/intelligence/reports/menus.py
+++ b/cfme/intelligence/reports/menus.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 
 from cfme.fixtures import pytest_selenium as sel
 from cfme.intelligence.reports.ui_elements import FolderManager
-from cfme.web_ui import Region, Tree, accordion, form_buttons, menu
+from cfme.web_ui import Region, BootstrapTreeview, accordion, form_buttons, menu
 from cfme.web_ui.multibox import MultiBoxSelect
 from utils.log import logger
 
@@ -16,7 +16,8 @@ menu.nav.add_branch(
     }
 )
 
-reports_tree = Tree("//div[@id='menu_roles_treebox']/ul")
+reports_tree = BootstrapTreeview("menu_roles_treebox")
+
 
 manager = FolderManager("//div[@id='folder_lists']/table")
 report_select = MultiBoxSelect(

--- a/cfme/services/myservice.py
+++ b/cfme/services/myservice.py
@@ -206,7 +206,8 @@ class MyServiceAll(CFMENavigateStep):
         nav._nav_to_fn('Services', 'My Services')(None)
 
     def resetter(self, *args, **kwargs):
-        my_service_tree().click_path('All Services')
+        if version.current_version() < '5.7':
+            my_service_tree().click_path('All Services')
         tb.refresh()
 
 
@@ -218,8 +219,9 @@ class MyServiceDetails(CFMENavigateStep):
         return match_page(summary='Service "{}"'.format(self.obj.service_name))
 
     def step(self, *args, **kwargs):
-        logger.debug('Clicking tree for service: {}'.format(self.obj.service_name))
-        my_service_tree().click_path('All Services', self.obj.service_name)
+        if version.current_version() < '5.7':
+            logger.debug('Clicking tree for service: {}'.format(self.obj.service_name))
+            my_service_tree().click_path('All Services', self.obj.service_name)
 
     def resetter(self, *args, **kwargs):
         tb.refresh()

--- a/cfme/tests/intelligence/reports/test_menus.py
+++ b/cfme/tests/intelligence/reports/test_menus.py
@@ -2,9 +2,10 @@
 import pytest
 import random
 
-from cfme.intelligence.reports import menus
+from cfme.intelligence.reports import menus, reports
 from cfme.web_ui import Tree, accordion
 from utils.blockers import BZ
+from utils.appliance.implementations.ui import navigate_to
 
 # EvmGroup-super_administrator -> user `admin`
 # If we add more, will need relogin + user creation
@@ -37,7 +38,7 @@ def test_shuffle_top_level(group, on_finish_default):
         for item in reversed(order):
             folder.move_first(item)
     # Now go and read the tree
-    pytest.sel.force_navigate("reports")
+    navigate_to(reports.CustomReport, 'All')
     tree = accordion.tree("Reports").read_contents()
     checked = Tree.flatten_level(Tree.browse(tree, "All Reports"))
     assert checked == order, "The order differs!"
@@ -48,7 +49,7 @@ def test_shuffle_top_level(group, on_finish_default):
 @pytest.mark.parametrize("group", GROUPS)
 def test_shuffle_first_level(group, on_finish_default):
     # Find a folder
-    pytest.sel.force_navigate("reports")
+    navigate_to(reports.CustomReport, 'All')
     tree = accordion.tree("Reports").read_contents()
     folders = Tree.browse(tree, "All Reports")
     # Select some folder that has at least 3 children
@@ -61,7 +62,7 @@ def test_shuffle_first_level(group, on_finish_default):
         for item in reversed(order):
             folder.move_first(item)
     # Now go and read the tree
-    pytest.sel.force_navigate("reports")
+    navigate_to(reports.CustomReport, 'All')
     tree = accordion.tree("Reports").read_contents()
     checked = Tree.flatten_level(Tree.browse(tree, "All Reports", selected_folder))
     assert checked == order, "The order differs!"

--- a/cfme/tests/webui/test_splitter.py
+++ b/cfme/tests/webui/test_splitter.py
@@ -1,18 +1,42 @@
 import pytest
-from cfme.web_ui.splitter import pull_splitter_left, pull_splitter_right
 from xml.sax.saxutils import quoteattr, unescape
+
+from cfme.base.ui import Server
+from cfme.cloud.instance import Instance
+from cfme.infrastructure.config_management import ConfigManager
+from cfme.infrastructure.datastore import Datastore
+from cfme.infrastructure.pxe import ISODatastore
+from cfme.infrastructure.virtual_machines import Vm
+from cfme.intelligence.chargeback import ComputeRate
+from cfme.intelligence.reports.reports import CustomReport
+from cfme.services.myservice import MyService
+from cfme.web_ui.splitter import pull_splitter_left, pull_splitter_right
 from utils import version
+from utils.appliance.implementations.ui import navigate_to
 from utils.blockers import BZ
+
+
 LOCATIONS = [
-    "control_explorer", "automate_explorer", "automate_customization", "my_services",
-    "services_catalogs", "services_workloads", "reports", "chargeback", "clouds_instances_no_tree",
-    "infrastructure_virtual_machines_no_tree", "infrastructure_pxe", "configuration",
-    "infrastructure_datastores_no_tree", "infrastructure_config_management", "utilization",
-    "bottlenecks",
+    "control_explorer", "automate_explorer", "automate_customization", MyService,
+    "services_catalogs", "services_workloads", CustomReport, ComputeRate, Instance, Vm,
+    ISODatastore, Server, Datastore, ConfigManager, "utilization", "bottlenecks",
     "infrastructure_networking"]
 
 pytestmark = [pytest.mark.parametrize("location", LOCATIONS), pytest.mark.uncollectif(lambda
     location: location == "infrastructure_networking" and version.current_version() < '5.7')]
+
+
+def nav_to(location):
+    if isinstance(location, basestring):
+        pytest.sel.force_navigate(location)
+    else:
+        dest = 'All'
+        if location is Vm:
+            dest = 'VMsOnly'
+        elif location is Server:
+            dest = 'Dashboard'
+
+        navigate_to(location, dest)
 
 
 @pytest.mark.meta(
@@ -23,12 +47,12 @@ pytestmark = [pytest.mark.parametrize("location", LOCATIONS), pytest.mark.uncoll
 @pytest.mark.requirement('general_ui')
 @pytest.mark.tier(3)
 def test_pull_splitter_persistence(location):
-    pytest.sel.force_navigate(location)
+    nav_to(location)
     # First we move splitter to hidden position by pulling it left twice
     pull_splitter_left()
     pull_splitter_left()
-    pytest.sel.force_navigate("dashboard")
-    pytest.sel.force_navigate(location)
+    navigate_to(Server, 'Dashboard')
+    nav_to(location)
     # Then we check hidden position splitter
     if not pytest.sel.elements("//div[@id='left_div'][contains(@class, 'hidden-md')]"):
         pytest.fail("Splitter did not persist when on hidden position!")
@@ -36,8 +60,8 @@ def test_pull_splitter_persistence(location):
     for position in ["col-md-2", "col-md-3", "col-md-4", "col-md-5"]:
         # Pull splitter left
         pull_splitter_right()
-        pytest.sel.force_navigate("dashboard")
-        pytest.sel.force_navigate(location)
+        navigate_to(Server, 'Dashboard')
+        nav_to(location)
         # Then check its position
         if not pytest.sel.elements("//div[@id='left_div'][contains(@class, {})]"
                 .format(unescape(quoteattr(position)))):


### PR DESCRIPTION
Purpose or Intent
=================
1. replaced force_navigate in several tests

{{pytest: --use-provider=vsphere55 cfme/tests/webui/test_splitter.py cfme/tests/intelligence/reports/test_menus.py }}