### PR TITLE
[RFR][1LP] Extend DB migrate test, refactor appliance

### DIFF
--- a/cfme/tests/test_db_restore.py
+++ b/cfme/tests/test_db_restore.py
@@ -86,7 +86,10 @@ def test_db_restore(request, soft_assert):
     appl2.ipapp.browser_steal = True
     with appl2.ipapp:
         # Restore DB on the second appliance
+        appl2.ipapp.stop_evm_service()
+        appl2.ipapp.drop_database()
         appl2.ipapp.restore_database()
+        appl2.ipapp.start_evm_service()
         appl2.ipapp.wait_for_web_ui()
         wait_for_a_provider()
         cloud_provider.wait_for_a_provider()


### PR DESCRIPTION
Enhance the DB migration test to be able to migrate bigger databases
Refactor/update utils.appliance
Update DB restore test

{{pytest: -k "test_db_migrate and scvmm_5620"}}