### PR TITLE
[RFR]Added test_reload_button_provider.py to test functionality of refresh button

### DIFF
--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -110,6 +110,7 @@ class ContainersProvider(BaseProvider, Pretty):
         'num_replication_controller',
         'num_pod',
         'num_node',
+        'num_image_registry',
         'num_container']
     # TODO add 'num_image_registry' and 'num_volume'
     string_name = "Containers"

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -110,8 +110,7 @@ class ContainersProvider(BaseProvider, Pretty):
         'num_replication_controller',
         'num_pod',
         'num_node',
-        'num_container',
-        'num_image']
+        'num_container']
     # TODO add 'num_image_registry' and 'num_volume'
     string_name = "Containers"
     page_name = "containers"

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -112,7 +112,7 @@ class ContainersProvider(BaseProvider, Pretty):
         'num_node',
         'num_image_registry',
         'num_container']
-    # TODO add 'num_image_registry' and 'num_volume'
+    # TODO add 'num_volume'
     string_name = "Containers"
     page_name = "containers"
     detail_page_suffix = 'provider_detail'

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -14,7 +14,8 @@ class CustomAttribute(object):
 
 @ContainersProvider.add_provider_type
 class OpenshiftProvider(ContainersProvider):
-    STATS_TO_MATCH = ContainersProvider.STATS_TO_MATCH + ['num_route'] + ['num_template']
+    num_route_template = ['num_route'] + ['num_template']
+    STATS_TO_MATCH = ContainersProvider.STATS_TO_MATCH + num_route_template
     type_name = "openshift"
     mgmt_class = Openshift
 

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -14,7 +14,7 @@ class CustomAttribute(object):
 
 @ContainersProvider.add_provider_type
 class OpenshiftProvider(ContainersProvider):
-    STATS_TO_MATCH = ContainersProvider.STATS_TO_MATCH + ['num_route']
+    STATS_TO_MATCH = ContainersProvider.STATS_TO_MATCH + ['num_route'] + ['num_template']
     type_name = "openshift"
     mgmt_class = Openshift
 
@@ -47,6 +47,14 @@ class OpenshiftProvider(ContainersProvider):
     @num_route.variant('ui')
     def num_route_ui(self):
         return int(self.get_detail("Relationships", "Routes"))
+
+    @variable(alias='db')
+    def num_template(self):
+        return self._num_db_generic('container_templates')
+
+    @num_template.variant('ui')
+    def num_template_ui(self):
+        return int(self.get_detail("Relationships", "Container Templates"))
 
     @staticmethod
     def from_config(prov_config, prov_key):

--- a/cfme/tests/containers/test_reload_button_provider.py
+++ b/cfme/tests/containers/test_reload_button_provider.py
@@ -1,0 +1,30 @@
+import pytest
+
+from utils.appliance.implementations.ui import navigate_to
+from cfme.containers.provider import ContainersProvider
+from utils import testgen
+from utils.version import current_version
+from cfme.web_ui import toolbar as tb
+
+pytestmark = [
+    pytest.mark.uncollectif(
+        lambda: current_version() < "5.6"),
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.tier(2)]
+pytest_generate_tests = testgen.generate(
+    testgen.container_providers, scope='function')
+
+# CMP-9878
+
+
+def test_reload_button_provider(provider):
+    """ This test verifies the data integrity of the fields in
+        the Relationships table after clicking the "reload"
+        button.
+
+    """
+
+    navigate_to(ContainersProvider, 'All')
+    provider.load_details()
+    tb.select('Reload Current Display')
+    provider.validate_stats(ui=True)

--- a/cfme/tests/containers/test_reload_button_provider.py
+++ b/cfme/tests/containers/test_reload_button_provider.py
@@ -1,14 +1,13 @@
 import pytest
 
-from utils.appliance.implementations.ui import navigate_to
-from cfme.containers.provider import ContainersProvider
 from utils import testgen, version
-from utils.version import current_version
 from cfme.web_ui import toolbar as tb
+from utils.appliance.implementations.ui import navigate_to
+
 
 pytestmark = [
     pytest.mark.uncollectif(
-        lambda: current_version() < "5.6"),
+        lambda: version.current_version() < "5.6"),
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(2)]
 pytest_generate_tests = testgen.generate(
@@ -28,8 +27,7 @@ def test_reload_button_provider(provider):
 
     """
 
-    navigate_to(ContainersProvider, 'All')
-    provider.load_details()
+    navigate_to(provider, 'Details')
     tb.select('Reload Current Display')
     provider.validate_stats(ui=True)
 
@@ -37,9 +35,7 @@ def test_reload_button_provider(provider):
     num_img_from_openshift = len(provider.mgmt.list_image())
 
     num_img_api_list = num_img_from_registry + num_img_from_openshift
-    num_img_ui = provider.num_image()
+    num_img_displayed_ui = provider.summary.relationships.container_images.value
 
-    if version.current_version() < "5.7":
-        assert num_img_ui == num_img_from_openshift
-    else:
-        assert num_img_api_list == num_img_ui
+    assert num_img_displayed_ui == version.pick({version.LOWEST: num_img_from_openshift,
+                                                 '5.7': num_img_api_list})

--- a/cfme/tests/containers/test_reload_button_provider.py
+++ b/cfme/tests/containers/test_reload_button_provider.py
@@ -2,7 +2,7 @@ import pytest
 
 from utils.appliance.implementations.ui import navigate_to
 from cfme.containers.provider import ContainersProvider
-from utils import testgen
+from utils import testgen, version
 from utils.version import current_version
 from cfme.web_ui import toolbar as tb
 
@@ -20,7 +20,11 @@ pytest_generate_tests = testgen.generate(
 def test_reload_button_provider(provider):
     """ This test verifies the data integrity of the fields in
         the Relationships table after clicking the "reload"
-        button.
+        button. Fields that are being verified as part of provider.validate.stats():
+        Projects, Routes, Container Services, Replicators, Pods, Containers, Nodes,
+        and Image Registries. Images are being verified separately, since the total
+        number of images in CFME 5.7 includes all images from the registry as well
+        as the images that are being created from the running pods
 
     """
 
@@ -28,3 +32,14 @@ def test_reload_button_provider(provider):
     provider.load_details()
     tb.select('Reload Current Display')
     provider.validate_stats(ui=True)
+
+    num_img_from_registry = len(provider.mgmt.o_api.get('image')[1]['items'])
+    num_img_from_openshift = len(provider.mgmt.list_image())
+
+    num_img_api_list = num_img_from_registry + num_img_from_openshift
+    num_img_ui = provider.num_image()
+
+    if version.current_version() < "5.7":
+        assert num_img_ui == num_img_from_openshift
+    else:
+        assert num_img_api_list == num_img_ui


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_reload_button_provider.py -v --use-provider cm-env2 }}

The test verifies data integrity of the fields in the Relationships table (while on provider summary page) after the reload button is clicked. 
Update: added new functionality to verify data integrity for images
