### PR TITLE
[1LP][WIP] ipappliance nonzero exit fix.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ docker-py
 fauxfactory>=2.0.7
 flake8
 functools32
+futures==3.0.5
 ipython
 iso8601
 Jinja2


### PR DESCRIPTION
Ensure that we getting nonzero exit from the process for any problem in
`call_appliance()` -- for example if the` IPAppliance` instantiantion fails,
it used to return 0 because an `Exception` there meant just thread exit,
without writing to the results.

Threads can be very cumbersome whereas futures are quite elegant way to
spin-up tasks on multiple threads. Let's use it to to make code hopefully more
readable and less error-prone.