### PR TITLE
[1LP][RFR] Update services.test_rest_services, require provisioning fields

### DIFF
--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -141,7 +141,7 @@ def services(request, rest_api, a_provider, dialog, service_catalogs):
                                catalog=catalog,
                                dialog=dialog.label,
                                catalog_name=template,
-                               provider=a_provider.name,
+                               provider=a_provider,
                                prov_data=provisioning_data)
 
     catalog_item.create()

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -8,13 +8,26 @@ from cfme.rest.gen_data import services as _services
 from cfme.rest.gen_data import service_catalogs as _service_catalogs
 from cfme.rest.gen_data import service_templates as _service_templates
 from cfme import test_requirements
+from utils import error, version, testgen
 from utils.providers import setup_a_provider as _setup_a_provider
 from utils.wait import wait_for
-from utils import error, version
 
 
 pytestmark = [test_requirements.service,
               pytest.mark.tier(2)]
+
+
+def pytest_generate_tests(metafunc):
+    # cfme.rest.services requires several provisioning tags
+    argnames, argvalues, idlist = testgen.infra_providers(
+        metafunc,
+        required_fields=[['provisioning', 'template'],
+                         ['provisioning', 'host'],
+                         ['provisioning', 'datastore'],
+                         ['provisioning', 'iso_file'],
+                         ['provisioning', 'vlan'],
+                         ['provisioning', 'catalog_item_type']])
+    testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope='module')
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
{{ pytest: cfme/tests/services/test_rest_services.py --long-running }}

**PRT Results:** In run 9305 I saw failures that were unrelated to my changes, and were due to the request not succeeding or failing to submit. I would like to not address these failures in this PR, as the intent was to limit the scope of testing to only providers with relevant provisioning data in the YAML.

Jenkins failures against 5.7 were cropping up with the failure below.

The rhos_uc provider, along with other infra type providers, do not have the provisioning keys necessary to use the cfme.rest.services method.

Add a testgen/parametrize line to the start of the test to restrict testing to infra providers with the necessary provisioning keys.

If the RHOS team would like to have these REST tests executed against rhos_uc the corresponding CFME YAML file must be updated with the required provisioning fields.


NOTE: Also updated cfme.rest.services since CatalogItem class has been modified to take a provider object instead of the provider name.


https://cfmeqe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/downstream-57z-tests/332/Artifactor_Report/cfme/tests/services/test_rest_services.py/TestServiceRESTAPI.test_delete_service/filedump-traceback.log
```
    def services(request, rest_api, a_provider, dialog, service_catalogs):
        """
        The attempt to add the service entities via web
        """
        template, host, datastore, iso_file, vlan, catalog_item_type = map(a_provider.data.get(
>           "provisioning").get,
            ('template', 'host', 'datastore', 'iso_file', 'vlan', 'catalog_item_type'))
E       AttributeError: 'NoneType' object has no attribute 'get'

cfme/rest/__init__.py:119: AttributeError
```