### PR TITLE
[WIPTEST] disabling timelines for 5.7

### DIFF
--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -52,6 +52,7 @@ def delete_instances_fin(request):
     return provisioned_instances
 
 
+@pytest.mark.uncollectif(lambda: version.current_version() >= '5.7')
 @pytest.fixture(scope="module")
 def test_instance(setup_provider_modscope, request, delete_instances_fin, provider, vm_name):
     """ Fixture to provision instance on the provider
@@ -103,6 +104,7 @@ def db_event(db, provider):
     return event_count
 
 
+@pytest.mark.uncollectif(lambda: version.current_version() >= '5.7')
 @pytest.mark.meta(blockers=[BZ(1201923, unblock=lambda provider: provider.type != 'ec2',
                                forced_streams=['5.6']),
                             BZ(1390572, unblock=lambda provider: provider.type != 'azure',
@@ -120,6 +122,7 @@ def test_provider_event(setup_provider, provider, gen_events, test_instance):
              message="events to appear")
 
 
+@pytest.mark.uncollectif(lambda: version.current_version() >= '5.7')
 @pytest.mark.meta(blockers=[BZ(1201923, unblock=lambda provider: provider.type != 'ec2',
                                forced_streams=['5.6']),
                             BZ(1390572, unblock=lambda provider: provider.type != 'azure',
@@ -138,6 +141,7 @@ def test_azone_event(setup_provider, provider, gen_events, test_instance):
              message="events to appear")
 
 
+@pytest.mark.uncollectif(lambda: version.current_version() >= '5.7')
 @pytest.mark.meta(blockers=[BZ(1201923, unblock=lambda provider: provider.type != 'ec2',
                                forced_streams=['5.6']),
                             BZ(1390572, unblock=lambda provider: provider.type != 'azure',

--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -45,6 +45,7 @@ def vm_name():
     return "test_tt_" + fauxfactory.gen_alphanumeric(length=4)
 
 
+@pytest.mark.uncollectif(lambda: version.current_version() >= '5.7')
 @pytest.fixture(scope="module")
 def test_vm(request, provider, vm_name, setup_provider_modscope):
     """Fixture to provision appliance to the provider being tested if necessary"""
@@ -86,6 +87,7 @@ def count_events(vm, nav_step):
     return 0
 
 
+@pytest.mark.uncollectif(lambda: version.current_version() >= '5.7')
 @pytest.mark.meta(blockers=[1264183, 1281746])
 def test_provider_event(provider, gen_events, test_vm):
     """Tests provider event on timelines
@@ -101,6 +103,7 @@ def test_provider_event(provider, gen_events, test_vm):
              message="events to appear")
 
 
+@pytest.mark.uncollectif(lambda: version.current_version() >= '5.7')
 @pytest.mark.meta(blockers=[1281746])
 def test_host_event(provider, gen_events, test_vm):
     """Tests host event on timelines
@@ -117,6 +120,7 @@ def test_host_event(provider, gen_events, test_vm):
              message="events to appear")
 
 
+@pytest.mark.uncollectif(lambda: version.current_version() >= '5.7')
 @pytest.mark.meta(blockers=[1281746])
 def test_vm_event(provider, gen_events, test_vm):
     """Tests vm event on timelines
@@ -132,6 +136,7 @@ def test_vm_event(provider, gen_events, test_vm):
              message="events to appear")
 
 
+@pytest.mark.uncollectif(lambda: version.current_version() >= '5.7')
 @pytest.mark.meta(blockers=[1281746])
 def test_cluster_event(provider, gen_events, test_vm):
     """Tests cluster event on timelines


### PR DESCRIPTION
Since timelines are completely redesigned, the timelines tests are also need to be updated.
So, I'm disabling timelines tests until those are fixed.