### PR TITLE
[RFR] Update CatalogItem callers to pass a provider object

### DIFF
--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -145,8 +145,8 @@ def services(request, rest_api, a_provider, dialog, service_catalogs):
                                prov_data=provisioning_data)
 
     catalog_item.create()
-    service_catalogs = ServiceCatalogs("service_name")
-    service_catalogs.order(catalog_item.catalog, catalog_item)
+    service_catalogs = ServiceCatalogs(catalog_item.name)
+    service_catalogs.order()
     row_description = catalog_item.name
     cells = {'Description': row_description}
     row, __ = wait_for(requests.wait_for_request, [cells, True],

--- a/cfme/services/catalogs/service_catalogs.py
+++ b/cfme/services/catalogs/service_catalogs.py
@@ -53,7 +53,7 @@ class ServiceCatalogs(Updateable, Pretty, Navigatable):
         if self.stack_data:
             stack_form.fill(self.stack_data)
         sel.click(form_buttons.submit)
-        wait_for(flash.get_messages, num_sec=10, delay=2)
+        wait_for(flash.get_messages, num_sec=10, delay=2, fail_condition=[], fail_func=tb.refresh())
         flash.assert_success_message("Order Request was Submitted")
 
 

--- a/cfme/services/catalogs/service_catalogs.py
+++ b/cfme/services/catalogs/service_catalogs.py
@@ -4,20 +4,17 @@ from functools import partial
 from navmazing import NavigateToSibling, NavigateToAttribute
 
 import cfme.fixtures.pytest_selenium as sel
-from cfme.web_ui import(accordion, flash, form_buttons, Form, Input, Select,
- match_location, toolbar as tb, PagedTable)
+from cfme.web_ui import (
+    accordion, flash, form_buttons, Form, Input, Select, match_location, toolbar as tb, PagedTable)
 from selenium.common.exceptions import NoSuchElementException
 from utils.appliance.implementations.ui import CFMENavigateStep, navigate_to, navigator
 from utils.appliance import Navigatable
 from utils.update import Updateable
 from utils.pretty import Pretty
 from utils.wait import wait_for
-from utils import version
 
-order_button = {
-    version.LOWEST: "//img[@title='Order this Service']",
-    '5.4': "//button[@title='Order this Service']"
-}
+order_button = "//button[@title='Order this Service']"
+
 accordion_tree = partial(accordion.tree, "Service Catalogs")
 list_tbl = PagedTable(table_locator="//div[@id='list_grid']//table")
 

--- a/cfme/services/myservice.py
+++ b/cfme/services/myservice.py
@@ -152,8 +152,9 @@ class MyService(Updateable, Navigatable):
         fill(edit_service_form, {'name': updated_name,
                                  'description': updated_description},
              action=form_buttons.angular_save)
+        wait_for(flash.get_messages, timeout=10, delay=2, fail_condition=[], fail_func=tb.refresh())
         if flash.assert_success_message('Service "{}" was saved'.format(updated_name)):
-            self.service_name = updated_name
+            setattr(self, 'service_name', updated_name)
 
     def delete(self):
         navigate_to(self, 'Details')

--- a/cfme/tests/infrastructure/test_vm_clone.py
+++ b/cfme/tests/infrastructure/test_vm_clone.py
@@ -79,7 +79,7 @@ def catalog_item(provider, vm_name, dialog, catalog, provisioning):
     catalog_item = CatalogItem(item_type=catalog_item_type, name=item_name,
                   description="my catalog", display_in=True, catalog=catalog,
                   dialog=dialog, catalog_name=template,
-                  provider=provider.name, prov_data=provisioning_data)
+                  provider=provider, prov_data=provisioning_data)
     yield catalog_item
 
 

--- a/cfme/tests/infrastructure/test_vm_clone.py
+++ b/cfme/tests/infrastructure/test_vm_clone.py
@@ -93,8 +93,8 @@ def clone_vm_name():
 def create_vm(provider, setup_provider, catalog_item, request):
     vm_name = catalog_item.provisioning_data["vm_name"]
     catalog_item.create()
-    service_catalogs = ServiceCatalogs("service_name")
-    service_catalogs.order(catalog_item.catalog, catalog_item)
+    service_catalogs = ServiceCatalogs(catalog_item.name)
+    service_catalogs.order()
     flash.assert_no_errors()
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     row_description = catalog_item.name

--- a/cfme/tests/services/test_add_remove_vm_to_service.py
+++ b/cfme/tests/services/test_add_remove_vm_to_service.py
@@ -40,8 +40,8 @@ def myservice(setup_provider, provider, catalog_item, request):
     vm_name = catalog_item.provisioning_data["vm_name"]
     request.addfinalizer(lambda: cleanup_vm(vm_name + "_0001", provider))
     catalog_item.create()
-    service_catalogs = ServiceCatalogs("service_name")
-    service_catalogs.order(catalog_item.catalog.name, catalog_item)
+    service_catalogs = ServiceCatalogs(catalog_item.name)
+    service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     row_description = catalog_item.name
     cells = {'Description': row_description}

--- a/cfme/tests/services/test_cloud_service_catalogs.py
+++ b/cfme/tests/services/test_cloud_service_catalogs.py
@@ -94,7 +94,7 @@ def test_cloud_catalog_item(setup_provider, provider, dialog, catalog, request, 
     catalog_item = cct.CatalogItem(item_type=provisioning['item_type'], name=item_name,
                   description="my catalog", display_in=True, catalog=catalog.name,
                   dialog=dialog, catalog_name=image,
-                  provider=provider.name, prov_data=provisioning_data)
+                  provider=provider, prov_data=provisioning_data)
     catalog_item.create()
     service_catalogs = ServiceCatalogs("service_name")
     service_catalogs.order(catalog.name, catalog_item)

--- a/cfme/tests/services/test_cloud_service_catalogs.py
+++ b/cfme/tests/services/test_cloud_service_catalogs.py
@@ -101,7 +101,7 @@ def test_cloud_catalog_item(setup_provider, provider, dialog, catalog, request, 
                                provider=provider,
                                prov_data=provisioning_data)
     catalog_item.create()
-    service_catalogs = ServiceCatalogs("service_name")
+    service_catalogs = ServiceCatalogs(catalog_item.name)
     service_catalogs.order()
     flash.assert_no_errors()
     logger.info('Waiting for cfme provision request for service %s', item_name)

--- a/cfme/tests/services/test_cloud_service_catalogs.py
+++ b/cfme/tests/services/test_cloud_service_catalogs.py
@@ -108,5 +108,5 @@ def test_cloud_catalog_item(setup_provider, provider, dialog, catalog, request, 
     row_description = item_name
     cells = {'Description': row_description}
     row, __ = wait_for(requests.wait_for_request, [cells, True],
-                       fail_func=requests.reload, num_sec=1000, delay=20)
+                       fail_func=requests.reload, num_sec=1200, delay=20)
     assert row.request_state.text == 'Finished'

--- a/cfme/tests/services/test_cloud_service_catalogs.py
+++ b/cfme/tests/services/test_cloud_service_catalogs.py
@@ -3,7 +3,7 @@ import fauxfactory
 import pytest
 
 from cfme.common.provider import cleanup_vm
-from cfme.services.catalogs import catalog_item as cct
+from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.automate.service_dialogs import ServiceDialog
 from cfme.services.catalogs.catalog import Catalog
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
@@ -91,13 +91,18 @@ def test_cloud_catalog_item(setup_provider, provider, dialog, catalog, request, 
             boot_disk_size=provisioning['boot_disk_size']
         )
     provisioning_data.update(updates)
-    catalog_item = cct.CatalogItem(item_type=provisioning['item_type'], name=item_name,
-                  description="my catalog", display_in=True, catalog=catalog.name,
-                  dialog=dialog, catalog_name=image,
-                  provider=provider, prov_data=provisioning_data)
+    catalog_item = CatalogItem(item_type=provisioning['item_type'],
+                               name=item_name,
+                               description="my catalog",
+                               display_in=True,
+                               catalog=catalog.name,
+                               dialog=dialog,
+                               catalog_name=image,
+                               provider=provider,
+                               prov_data=provisioning_data)
     catalog_item.create()
     service_catalogs = ServiceCatalogs("service_name")
-    service_catalogs.order(catalog.name, catalog_item)
+    service_catalogs.order()
     flash.assert_no_errors()
     logger.info('Waiting for cfme provision request for service %s', item_name)
     row_description = item_name

--- a/cfme/tests/services/test_config_provider_servicecatalogs.py
+++ b/cfme/tests/services/test_config_provider_servicecatalogs.py
@@ -90,7 +90,7 @@ def catalog_item(config_manager, dialog, catalog):
                                display_in=True,
                                catalog=catalog,
                                dialog=dialog,
-                               provider=provider,
+                               provider=config_manager_obj,
                                provider_type=provider_type,
                                config_template=template)
     return catalog_item

--- a/cfme/tests/services/test_config_provider_servicecatalogs.py
+++ b/cfme/tests/services/test_config_provider_servicecatalogs.py
@@ -104,8 +104,8 @@ def test_order_catalog_item(catalog_item, request):
         test_flag: provision
     """
     catalog_item.create()
-    service_catalogs = ServiceCatalogs("service_name")
-    service_catalogs.order(catalog_item.catalog, catalog_item)
+    service_catalogs = ServiceCatalogs(catalog_item.name)
+    service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     row_description = catalog_item.name
     cells = {'Description': row_description}

--- a/cfme/tests/services/test_different_dialogs_in_catalogs.py
+++ b/cfme/tests/services/test_different_dialogs_in_catalogs.py
@@ -84,7 +84,7 @@ def catalog_item(provider, provisioning, vm_name, tagcontrol_dialog, catalog):
     catalog_item = CatalogItem(item_type=catalog_item_type, name=item_name,
                   description="my catalog", display_in=True, catalog=catalog,
                   dialog=tagcontrol_dialog, catalog_name=template,
-                  provider=provider.name, prov_data=provisioning_data)
+                  provider=provider, prov_data=provisioning_data)
     return catalog_item
 
 

--- a/cfme/tests/services/test_different_dialogs_in_catalogs.py
+++ b/cfme/tests/services/test_different_dialogs_in_catalogs.py
@@ -98,8 +98,8 @@ def test_tagdialog_catalog_item(provider, setup_provider, catalog_item, request)
     vm_name = catalog_item.provisioning_data["vm_name"]
     request.addfinalizer(lambda: cleanup_vm(vm_name + "_0001", provider))
     catalog_item.create()
-    service_catalogs = ServiceCatalogs("service_name")
-    service_catalogs.order(catalog_item.catalog, catalog_item)
+    service_catalogs = ServiceCatalogs(catalog_item.name)
+    service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     row_description = catalog_item.name
     cells = {'Description': row_description}

--- a/cfme/tests/services/test_dynamicdd_dialogelement.py
+++ b/cfme/tests/services/test_dynamicdd_dialogelement.py
@@ -116,5 +116,5 @@ def test_dynamicdropdown_dialog(dialog, catalog):
                   description="my catalog", display_in=True, catalog=catalog.name,
                   dialog=dialog.label)
     catalog_item.create()
-    service_catalogs = ServiceCatalogs("service_name")
-    service_catalogs.order(catalog_item.catalog, catalog_item)
+    service_catalogs = ServiceCatalogs(catalog_item.name)
+    service_catalogs.order()

--- a/cfme/tests/services/test_generic_service_catalogs.py
+++ b/cfme/tests/services/test_generic_service_catalogs.py
@@ -41,14 +41,14 @@ def test_delete_catalog_deletes_service(dialog, catalog):
                   dialog=dialog)
     catalog_item.create()
     catalog.delete()
-    service_catalogs = ServiceCatalogs("service_name")
+    service_catalogs = ServiceCatalogs(catalog_item.name)
     with error.expected(NoSuchElementException):
         service_catalogs.order()
 
 
 def test_delete_catalog_item_deletes_service(catalog_item):
     catalog_item.delete()
-    service_catalogs = ServiceCatalogs("service_name")
+    service_catalogs = ServiceCatalogs(catalog_item.name)
     with error.expected(NoSuchElementException):
         service_catalogs.order()
 

--- a/cfme/tests/services/test_iso_service_catalogs.py
+++ b/cfme/tests/services/test_iso_service_catalogs.py
@@ -114,7 +114,7 @@ def catalog_item(setup_provider, provider, vm_name, dialog, catalog, provisionin
     catalog_item = CatalogItem(item_type="RHEV", name=item_name,
                   description="my catalog", display_in=True, catalog=catalog,
                   dialog=dialog, catalog_name=iso_template,
-                  provider=provider.name, prov_data=provisioning_data)
+                  provider=provider, prov_data=provisioning_data)
     yield catalog_item
 
 

--- a/cfme/tests/services/test_iso_service_catalogs.py
+++ b/cfme/tests/services/test_iso_service_catalogs.py
@@ -129,8 +129,8 @@ def test_rhev_iso_servicecatalog(setup_provider, provider, catalog_item, request
     vm_name = catalog_item.provisioning_data["vm_name"]
     request.addfinalizer(lambda: cleanup_vm(vm_name + "_0001", provider))
     catalog_item.create()
-    service_catalogs = ServiceCatalogs("service_name")
-    service_catalogs.order(catalog_item.catalog, catalog_item)
+    service_catalogs = ServiceCatalogs(catalog_item.name)
+    service_catalogs.order()
     # nav to requests page happens on successful provision
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     row_description = catalog_item.name

--- a/cfme/tests/services/test_myservice.py
+++ b/cfme/tests/services/test_myservice.py
@@ -49,8 +49,8 @@ def myservice(setup_provider, provider, catalog_item, request):
         version.LOWEST: catalog_item.provisioning_data["vm_name"] + '_0001',
         '5.7': catalog_item.provisioning_data["vm_name"] + '0001'})
     catalog_item.create()
-    service_catalogs = ServiceCatalogs("service_name")
-    service_catalogs.order(catalog_item.catalog.name, catalog_item)
+    service_catalogs = ServiceCatalogs(catalog_item.name)
+    service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     row_description = catalog_item.name
     cells = {'Description': row_description}

--- a/cfme/tests/services/test_myservice.py
+++ b/cfme/tests/services/test_myservice.py
@@ -11,7 +11,6 @@ from cfme.web_ui import toolbar as tb
 from utils import browser, testgen, version
 from utils.browser import ensure_browser_open
 from utils.log import logger
-from utils.version import current_version
 from utils.wait import wait_for
 
 pytestmark = [
@@ -96,7 +95,6 @@ def test_crud_set_ownership_and_edit_tags(myservice):
     myservice.delete()
 
 
-@pytest.mark.uncollectif(lambda: current_version() < "5.5")
 @pytest.mark.parametrize("filetype", ["Text", "CSV", "PDF"])
 def test_download_file(needs_firefox, myservice, filetype):
     """Tests my service download files

--- a/cfme/tests/services/test_operations.py
+++ b/cfme/tests/services/test_operations.py
@@ -4,13 +4,13 @@ import fauxfactory
 import pytest
 
 import cfme.provisioning
+from cfme import test_requirements
 from cfme.infrastructure.virtual_machines import Vm
 from cfme.fixtures import pytest_selenium as sel
 from cfme.login import login_admin
 from cfme.provisioning import provisioning_form
 from cfme.services import requests
-from cfme.web_ui import flash
-from cfme import test_requirements
+from cfme.web_ui import flash, fill
 from utils.appliance.implementations.ui import navigate_to
 from utils.browser import browser
 from utils.providers import setup_a_provider
@@ -89,8 +89,7 @@ def generated_request(provider, provider_data, provisioning, template_name, vm_n
         if provider_data["type"] == 'rhevm':
             raise pytest.fail('rhevm requires a vlan value in provisioning info')
 
-    provisioning_form.fill(provisioning_data)
-    pytest.sel.click(provisioning_form.submit_button)
+    fill(provisioning_form, provisioning_data, action=provisioning_form.submit_button)
     flash.assert_no_errors()
     request_cells = {
         "Description": "Provision from [{}] to [{}###]".format(template_name, vm_name),

--- a/cfme/tests/services/test_provision_stack.py
+++ b/cfme/tests/services/test_provision_stack.py
@@ -189,7 +189,7 @@ def catalog():
 
 
 @pytest.yield_fixture(scope="function")
-def catalog_item(dialog_name, catalog, template):
+def catalog_item(dialog_name, catalog, template, provider):
     item_name = fauxfactory.gen_alphanumeric()
 
     catalog_item = CatalogItem(item_type="Orchestration",
@@ -198,7 +198,8 @@ def catalog_item(dialog_name, catalog, template):
                                display_in=True,
                                catalog=catalog.name,
                                dialog=dialog_name,
-                               orch_template=template.template_name)
+                               orch_template=template.template_name,
+                               provider=provider)
     catalog_item.create()
 
     yield catalog_item, item_name
@@ -241,7 +242,7 @@ def provision_success_message(name):
     return success_message
 
 
-def test_provision_stack(provider, provisioning, catalog, catalog_item, request):
+def test_provision_stack(setup_provider, provider, provisioning, catalog, catalog_item, request):
     """Tests stack provisioning
 
     Metadata:
@@ -263,8 +264,8 @@ def test_provision_stack(provider, provisioning, catalog, catalog_item, request)
                            .format(ex.message))
             pass
 
-    service_catalogs = ServiceCatalogs("service_name", stack_data)
-    service_catalogs.order_stack_item(catalog.name, catalog_item)
+    service_catalogs = ServiceCatalogs(item_name, stack_data)
+    service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', item_name)
     row_description = item_name
     cells = {'Description': row_description}
@@ -296,8 +297,8 @@ def test_reconfigure_service(provider, provisioning, catalog, catalog_item, requ
                            .format(ex.message))
             pass
 
-    service_catalogs = ServiceCatalogs("service_name", stack_data)
-    service_catalogs.order_stack_item(catalog.name, catalog_item)
+    service_catalogs = ServiceCatalogs(item_name, stack_data)
+    service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', item_name)
     row_description = item_name
     cells = {'Description': row_description}
@@ -318,8 +319,8 @@ def test_remove_template_provisioning(provider, provisioning, catalog, catalog_i
     """
     catalog_item, item_name = catalog_item
     stack_data = prepare_stack_data(provider, provisioning)
-    service_catalogs = ServiceCatalogs("service_name", stack_data)
-    service_catalogs.order_stack_item(catalog.name, catalog_item)
+    service_catalogs = ServiceCatalogs(item_name, stack_data)
+    service_catalogs.order()
     # This is part of test - remove template and see if provision fails , so not added as finalizer
     template.delete()
     row_description = 'Provisioning Service [{}] from [{}]'.format(item_name, item_name)
@@ -341,8 +342,8 @@ def test_retire_stack(provider, provisioning, catalog, catalog_item, request):
     DefaultView.set_default_view("Stacks", "Grid View")
 
     stack_data = prepare_stack_data(provider, provisioning)
-    service_catalogs = ServiceCatalogs("service_name", stack_data)
-    service_catalogs.order_stack_item(catalog.name, catalog_item)
+    service_catalogs = ServiceCatalogs(item_name, stack_data)
+    service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', item_name)
     row_description = item_name
     cells = {'Description': row_description}

--- a/cfme/tests/services/test_pxe_service_catalogs.py
+++ b/cfme/tests/services/test_pxe_service_catalogs.py
@@ -127,7 +127,7 @@ def catalog_item(provider, vm_name, dialog, catalog, provisioning, setup_pxe_ser
     catalog_item = CatalogItem(item_type=catalog_item_type, name=item_name,
                   description="my catalog", display_in=True, catalog=catalog,
                   dialog=dialog, catalog_name=pxe_template,
-                  provider=provider.name, prov_data=provisioning_data)
+                  provider=provider, prov_data=provisioning_data)
     yield catalog_item
 
 

--- a/cfme/tests/services/test_pxe_service_catalogs.py
+++ b/cfme/tests/services/test_pxe_service_catalogs.py
@@ -141,8 +141,8 @@ def test_pxe_servicecatalog(setup_provider, provider, catalog_item, request):
     vm_name = catalog_item.provisioning_data["vm_name"]
     request.addfinalizer(lambda: cleanup_vm(vm_name + "_0001", provider))
     catalog_item.create()
-    service_catalogs = ServiceCatalogs("service_name")
-    service_catalogs.order(catalog_item.catalog, catalog_item)
+    service_catalogs = ServiceCatalogs(catalog_item.name)
+    service_catalogs.order()
     # nav to requests page happens on successful provision
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     row_description = catalog_item.name

--- a/cfme/tests/services/test_request.py
+++ b/cfme/tests/services/test_request.py
@@ -26,8 +26,8 @@ def test_copy_request(setup_provider, provider, catalog_item, request):
     vm_name = catalog_item.provisioning_data["vm_name"]
     request.addfinalizer(lambda: cleanup_vm(vm_name + "_0001", provider))
     catalog_item.create()
-    service_catalogs = ServiceCatalogs("service_name")
-    service_catalogs.order(catalog_item.catalog, catalog_item)
+    service_catalogs = ServiceCatalogs(catalog_item.name)
+    service_catalogs.order()
     row_description = catalog_item.name
     cells = {'Description': row_description}
     row, __ = wait_for(requests.wait_for_request, [cells, True],

--- a/cfme/tests/services/test_service_catalogs.py
+++ b/cfme/tests/services/test_service_catalogs.py
@@ -42,8 +42,8 @@ def test_order_catalog_item(provider, setup_provider, catalog_item, request, reg
     vm_name = catalog_item.provisioning_data["vm_name"]
     request.addfinalizer(lambda: cleanup_vm(vm_name + "_0001", provider))
     catalog_item.create()
-    service_catalogs = ServiceCatalogs("service_name")
-    service_catalogs.order(catalog_item.catalog.name, catalog_item)
+    service_catalogs = ServiceCatalogs(catalog_item.name)
+    service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     row_description = catalog_item.name
     cells = {'Description': row_description}
@@ -95,8 +95,8 @@ def test_order_catalog_bundle(provider, setup_provider, catalog_item, request):
     catalog_bundle = CatalogBundle(name=bundle_name, description="catalog_bundle",
                    display_in=True, catalog=catalog_item.catalog, dialog=catalog_item.dialog)
     catalog_bundle.create([catalog_item.name])
-    service_catalogs = ServiceCatalogs("service_name")
-    service_catalogs.order(catalog_item.catalog.name, catalog_bundle)
+    service_catalogs = ServiceCatalogs(catalog_bundle.name)
+    service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', bundle_name)
     row_description = bundle_name
     cells = {'Description': row_description}
@@ -145,8 +145,8 @@ def test_request_with_orphaned_template(provider, setup_provider, catalog_item):
         test_flag: provision
     """
     catalog_item.create()
-    service_catalogs = ServiceCatalogs("service_name")
-    service_catalogs.order(catalog_item.catalog.name, catalog_item)
+    service_catalogs = ServiceCatalogs(catalog_item.name)
+    service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     row_description = catalog_item.name
     cells = {'Description': row_description}

--- a/cfme/web_ui/flash.py
+++ b/cfme/web_ui/flash.py
@@ -213,6 +213,7 @@ def assert_success_message(m):
     """Asserts that there are no errors and a (green) info message
     matches the given string."""
     messages = get_messages()
+    logger.info('Asserting flash success message against messages: {}'.format(messages))
     assert_no_errors(messages)
     if not any([
             (fm.message == m and (fm.level in {"info", "success"}))


### PR DESCRIPTION
{{pytest: cfme/tests/services/ --long-running}}

PR 3894 updated CatalogItem class to take a provider object instead of the name.

Update callers to pass the object

PRT Results:

Lots of failures from form filling and flash message assertions, don't appear to be related to my changes but I'm debugging and trying to clean up the tests.