### PR TITLE
[RFR] Test Basic Metrics - Fixed assertions

### DIFF
--- a/cfme/tests/containers/test_basic_metrics.py
+++ b/cfme/tests/containers/test_basic_metrics.py
@@ -7,6 +7,7 @@ from utils.version import current_version
 
 pytestmark = [
     pytest.mark.uncollectif(lambda provider: current_version() < "5.6"),
+    pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate(
     testgen.container_providers, scope='function')

--- a/cfme/tests/containers/test_basic_metrics.py
+++ b/cfme/tests/containers/test_basic_metrics.py
@@ -1,4 +1,5 @@
 import pytest
+import re
 from utils import testgen
 from utils import conf
 from utils.version import current_version
@@ -6,13 +7,10 @@ from utils.version import current_version
 
 pytestmark = [
     pytest.mark.uncollectif(lambda provider: current_version() < "5.6"),
-    pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate(
     testgen.container_providers, scope='function')
 
-
-# CMP-10205
 
 def test_basic_metrics(provider, ssh_client):
     """ Basic Metrics availability test
@@ -26,5 +24,4 @@ def test_basic_metrics(provider, ssh_client):
     host_url = 'https://' + hostname + '/hawkular/metrics/'
     command = 'curl -X GET ' + host_url + ' --insecure'
     ssh_client = ssh_client(hostname=hostname, username=username, password=password)
-    metrics_string = str(ssh_client.run_command(command))
-    assert 'Hawkular Metrics' or 'Hawkular-Metrics' in metrics_string
+    assert re.search("Hawkular[ -]Metrics", str(ssh_client.run_command(command)))


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_basic_metrics.py -v --use-provider cm-env2 }}

This fixes the Basic Metrics test that allows him to actually fail when the OSE is down