### PR TITLE
[1LP][RFR] replacing old infra provisioning by navmazing destination

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -14,7 +14,6 @@ from cfme.exceptions import (CandidateNotFound, VmNotFound, OptionNotAvailable,
                              DestinationNotFound, TemplateNotFound)
 from cfme.fixtures import pytest_selenium as sel
 from cfme.services import requests
-from cfme.provisioning import provisioning_form
 import cfme.web_ui.toolbar as tb
 from cfme.web_ui import (
     CheckboxTree, Form, InfoBlock, Region, Quadicon, Tree, accordion, fill, flash, form_buttons,
@@ -923,6 +922,3 @@ class ProvisionVM(CFMENavigateStep):
         else:
             raise TemplateNotFound('Unable to find template "{}" for provider "{}"'.format(
                 self.obj.template_name, self.obj.provider.key))
-
-    def am_i_here(self, *args, **kwargs):
-            return match_page(summary='Provision Virtual Machines - Select a Template')

--- a/cfme/tests/infrastructure/test_infra_quota.py
+++ b/cfme/tests/infrastructure/test_infra_quota.py
@@ -7,10 +7,12 @@ from cfme import test_requirements
 from cfme.configure.access_control import Tenant
 from cfme.fixtures import pytest_selenium as sel
 from cfme.automate import explorer as automate
+from cfme.infrastructure.virtual_machines import Vm
 from cfme.provisioning import provisioning_form
 from cfme.services import requests
 from cfme.web_ui import fill, flash
 from utils import testgen, version
+from utils.appliance.implementations.ui import navigate_to
 from utils.wait import wait_for
 
 pytestmark = [
@@ -110,10 +112,8 @@ def template_name(provisioning):
 @pytest.fixture(scope="function")
 def provisioner(request, setup_provider, provider):
     def _provisioner(template, provisioning_data, delayed=None):
-        sel.force_navigate('infrastructure_provision_vms', context={
-            'provider': provider,
-            'template_name': template,
-        })
+        vm = Vm(name=vm_name, provider=provider, template_name=template)
+        navigate_to(vm, 'ProvisionVM')
 
         fill(provisioning_form, provisioning_data, action=provisioning_form.submit_button)
         flash.assert_no_errors()

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -7,11 +7,12 @@ import fauxfactory
 import pytest
 from cfme import test_requirements
 from cfme.common.provider import cleanup_vm
-from cfme.common.vm import VM
+from cfme.infrastructure.virtual_machines import Vm
 from cfme.provisioning import provisioning_form
 from cfme.services import requests
 from cfme.web_ui import InfoBlock, fill, flash
 from utils import mgmt_system, testgen
+from utils.appliance.implementations.ui import navigate_to
 from utils.blockers import BZ
 from utils.generators import random_vm_name
 from utils.log import logger
@@ -78,10 +79,8 @@ def prov_data(provisioning, provider):
 def provisioner(request, setup_provider, provider, vm_name):
 
     def _provisioner(template, provisioning_data, delayed=None):
-        pytest.sel.force_navigate('infrastructure_provision_vms', context={
-            'provider': provider,
-            'template_name': template,
-        })
+        vm = Vm(name=vm_name, provider=provider, template_name=template)
+        navigate_to(vm, 'ProvisionVM')
 
         fill(provisioning_form, provisioning_data, action=provisioning_form.submit_button)
         flash.assert_no_errors()
@@ -107,7 +106,7 @@ def provisioner(request, setup_provider, provider, vm_name):
         row, __ = wait_for(requests.wait_for_request, [cells],
                            fail_func=requests.reload, num_sec=900, delay=20)
         assert 'Successfully' in row.last_message.text and row.status.text != 'Error'
-        return VM.factory(vm_name, provider)
+        return vm
 
     return _provisioner
 

--- a/cfme/tests/services/test_operations.py
+++ b/cfme/tests/services/test_operations.py
@@ -4,12 +4,14 @@ import fauxfactory
 import pytest
 
 import cfme.provisioning
+from cfme.infrastructure.virtual_machines import Vm
 from cfme.fixtures import pytest_selenium as sel
 from cfme.login import login_admin
 from cfme.provisioning import provisioning_form
 from cfme.services import requests
 from cfme.web_ui import flash
 from cfme import test_requirements
+from utils.appliance.implementations.ui import navigate_to
 from utils.browser import browser
 from utils.providers import setup_a_provider
 from utils.wait import wait_for
@@ -60,10 +62,8 @@ def generated_request(provider, provider_data, provisioning, template_name, vm_n
     notes = fauxfactory.gen_alphanumeric()
     e_mail = "{}@{}.test".format(first_name, last_name)
     host, datastore = map(provisioning.get, ('host', 'datastore'))
-    pytest.sel.force_navigate('infrastructure_provision_vms', context={
-        'provider': provider,
-        'template_name': template_name,
-    })
+    vm = Vm(name=vm_name, provider=provider, template_name=template_name)
+    navigate_to(vm, 'ProvisionVM')
 
     provisioning_data = {
         'email': e_mail,


### PR DESCRIPTION
Since my changes made to virtual machines broke old infra provisioning navigation, I've had to quickly convert this remaing navigation to navmazing.

P.S. actually current provisioning destination and all provisioning related fixtures and functions have to be moved to appropriate vm's method. I've created a card about that and assigned it to myself.