### PR TITLE
[RFR] cloud.tenant CRUD and test

### DIFF
--- a/cfme/cloud/tenant.py
+++ b/cfme/cloud/tenant.py
@@ -9,12 +9,27 @@ from functools import partial
 from navmazing import NavigateToSibling, NavigateToAttribute
 from selenium.common.exceptions import NoSuchElementException
 
+from cfme.exceptions import TenantNotFound, DestinationNotFound, OptionNotAvailable
 from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import PagedTable, toolbar as tb, match_location
+from cfme.web_ui import (
+    PagedTable, CheckboxTable, toolbar as tb, match_location, Form, AngularSelect, Input,
+    form_buttons, flash, paginator)
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
+from utils.log import logger
+from utils.version import current_version
+from utils.wait import wait_for, TimedOutError
 
-listview_table = PagedTable(table_locator="//div[@id='list_grid']//table")
+create_tenant_form = Form(
+    fields=[
+        ('prov_select', AngularSelect("ems_id")),
+        ('name', Input('name')),
+        ('save_button', form_buttons.angular_save),
+        ('reset_button', form_buttons.reset)
+    ])
+
+listview_pagetable = PagedTable(table_locator="//div[@id='list_grid']//table")
+listview_checktable = CheckboxTable(table_locator="//div[@id='list_grid']//table")
 
 cfg_btn = partial(tb.select, 'Configuration')
 pol_btn = partial(tb.select, 'Policy')
@@ -23,18 +38,81 @@ match_page = partial(match_location, controller='cloud_tenant', title='Cloud Ten
 
 
 class Tenant(Navigatable):
-    def __init__(self, name, description, provider, appliance=None):
+    def __init__(self, name, provider, appliance=None):
         """Base class for a Tenant"""
         self.name = name
-        self.description = description
         self.provider = provider
         Navigatable.__init__(self, appliance=appliance)
+
+    def create(self, cancel=False):
+        navigate_to(self, 'Add')
+        create_tenant_form.fill(
+            {'prov_select': self.provider.name,
+             'name': self.name})
+        sel.click(form_buttons.cancel if cancel else create_tenant_form.save_button)
+
+        if cancel:
+            return flash.assert_success_message('Add of new Cloud Tenant was cancelled by the user')
+        else:
+            return flash.assert_success_message('Cloud Tenant "{}" created'.format(self.name))
+
+    def wait_for_disappear(self, timeout=300):
+        try:
+            return wait_for(self.exists,
+                            fail_condition=True,
+                            timeout=timeout,
+                            message='Wait for cloud tenant to disappear',
+                            delay=10,
+                            fail_func=sel.refresh)
+        except TimedOutError:
+            logger.error('Timed out waiting for tenant to disappear, continuing')
+
+    def delete(self, cancel=False, from_details=True, wait=True):
+        if current_version() < '5.7':
+            raise OptionNotAvailable('Cannot delete cloud tenants in CFME < 5.7')
+        if from_details:
+            # Generates no alert or confirmation
+            try:
+                navigate_to(self, 'Details')
+            except Exception as ex:
+                # Catch general navigation exceptions and raise
+                raise TenantNotFound('Exception while navigating to Tenant details: {}'
+                                     .format(ex))
+            cfg_btn('Delete Cloud Tenant')
+        else:
+            # Have to select the row in the list
+            navigate_to(self, 'All')
+            # double check we're in List View
+            tb.select('List View')
+            found = False
+            for page in paginator.pages():
+                try:
+                    listview_checktable.select_row_by_cells(
+                        {'Name': self.name,
+                         'Cloud Provider': self.provider.name})
+                    found = True
+                except NoSuchElementException:
+                    continue
+                else:
+                    break
+            if not found:
+                raise TenantNotFound('Could not locate tenant for delete by selection')
+            cfg_btn('Delete Cloud Tenants', invokes_alert=True)
+            sel.handle_alert(cancel=cancel)
+
+        # In both cases the flash message is the same
+        if not cancel:
+            result = flash.assert_success_message('Delete initiated for 1 Cloud Tenant.')
+            if wait:
+                result = self.wait_for_disappear()
+
+        return result
 
     def exists(self):
         try:
             navigate_to(self, 'Details')
             return True
-        except NoSuchElementException:
+        except Exception:
             return False
 
 
@@ -58,12 +136,12 @@ class TenantDetails(CFMENavigateStep):
         return match_page(summary='{} (Summary)'.format(self.obj.name))
 
     def step(self, *args, **kwargs):
-        sel.click(listview_table.find_row_by_cell_on_all_pages(
+        sel.click(listview_pagetable.find_row_by_cell_on_all_pages(
             {'Name': self.obj.name,
              'Cloud Provider': self.obj.provider.name}))
 
     def resetter(self):
-        tb.refresh()
+        sel.refresh()
 
 
 @navigator.register(Tenant, 'Add')
@@ -71,7 +149,10 @@ class TenantAdd(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self, *args, **kwargs):
-        cfg_btn('Create Cloud Tenant')
+        if current_version() >= '5.7':
+            cfg_btn('Create Cloud Tenant')
+        else:
+            raise DestinationNotFound('Cannot add Cloud Tenants in CFME < 5.7')
 
 
 @navigator.register(Tenant, 'Edit')
@@ -79,7 +160,10 @@ class TenantEdit(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self, *args, **kwargs):
-        cfg_btn('Edit Tenant')
+        if current_version() >= '5.7':
+            cfg_btn('Edit Cloud Tenant')
+        else:
+            raise DestinationNotFound('Cannot edit Cloud Tenants in CFME < 5.7')
 
 
 @navigator.register(Tenant, 'EditTags')

--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -226,6 +226,13 @@ class ImageNotFound(VmOrInstanceNotFound):
     pass
 
 
+class TenantNotFound(CFMEException):
+    """
+        Raised if a specific tenant cannot be found
+        """
+    pass
+
+
 class TemplateNotFound(CFMEException):
     """
     Raised if a specific Template cannot be found.

--- a/cfme/tests/cloud/test_tenant.py
+++ b/cfme/tests/cloud/test_tenant.py
@@ -4,23 +4,44 @@ import pytest
 
 from cfme.cloud.tenant import Tenant
 from utils import testgen
+from utils.log import logger
+from utils.version import current_version
+
 
 pytest_generate_tests = testgen.generate(testgen.provider_by_type, ['openstack'],
                                          scope='module')
 
-
-@pytest.fixture
-def tenant(provider):
-    return Tenant(name=fauxfactory.gen_alphanumeric(8),
-                  description=fauxfactory.gen_alphanumeric(8),
-                  provider_key=provider.key)
+# Tag requirements here, does not currently match any requirements categories
 
 
-@pytest.mark.uncollect()
-def test_tenant(tenant, provider):
-    """ Tests tenant (currently disabled)
+@pytest.yield_fixture(scope='function')
+def tenant(provider, setup_provider):
+    tenant = Tenant(name=fauxfactory.gen_alphanumeric(8), provider=provider)
+
+    yield tenant
+
+    try:
+        tenant.delete()
+    except Exception:
+        logger.warning('Exception while attempting to delete tenant fixture, continuing')
+        pass
+
+
+@pytest.mark.uncollectif(lambda: current_version() < '5.7')
+def test_tenant_crud(tenant):
+    """ Tests tenant create and delete
 
     Metadata:
         test_flag: tenant
     """
-    pass
+    tenant.create(cancel=True)
+    assert not tenant.exists()
+
+    tenant.create()
+    assert tenant.exists()
+
+    tenant.delete(from_details=False, cancel=True)
+    assert tenant.exists()
+
+    tenant.delete(from_details=True, cancel=False)
+    assert not tenant.exists()


### PR DESCRIPTION
{{pytest: cfme/tests/cloud/test_tenant.py --use-provider rhos7-ga}}

Improving the create/delete methods for cloud.tenant and wrote a little CRUD test.

**PRT Results**
* 5.6: uncollected purposefully
* 5.7 and upstream: rhos7-ga is cleaning up the tenants, which is causing failures. create/delete are working as expected otherwise 