### PR TITLE
Simplify WT accordion openness detection

### DIFF
--- a/widgetastic_patternfly.py
+++ b/widgetastic_patternfly.py
@@ -501,8 +501,7 @@ class Accordion(View, ClickableMixin):
 
     @property
     def is_closed(self):
-        attr = self.browser.get_attribute('aria-expanded', self)
-        return attr is None or attr.lower().strip() == 'false'
+        return not self.is_opened
 
     def open(self):
         if self.is_closed:


### PR DESCRIPTION
Nandini noticed some errors which seem to come from accordion handling. Turns out I wrote it so it checks open and close separately. I removed the is_closed logic and replaced it with just a plain `not`.