### PR TITLE
[RFR]fix for test_tag

### DIFF
--- a/cfme/provisioning.py
+++ b/cfme/provisioning.py
@@ -53,7 +53,9 @@ provisioning_form = tabstrip.TabStripForm(
         ]),
 
         ('Purpose', [
-            ('apply_tags', ui.CheckboxTree('//div[@id="all_tags_treebox"]//ul'))
+            ('apply_tags', {
+                version.LOWEST: ui.CheckboxTree('//div[@id="all_tags_treebox"]//ul'),
+                '5.7': ui.BootstrapTreeview('all_tags_treebox')})
         ]),
 
         ('Catalog', [


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ test_tag in provisioning dialog tests. Tags tree was updated to Bootstraptreeview in 5.7
--
{{pytest: cfme/tests/infrastructure/test_provisioning_dialog.py "-k test_tag"  --long-running}}
