### PR TITLE
[WIPTEST] Detect and inform the user about dimmed tree and possibly forgotten form

### DIFF
--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -340,3 +340,7 @@ class MenuItemNotFound(CFMEException):
 
 class DestinationNotFound(CFMEException):
     """Raised during navigation where the navigator destination is not found"""
+
+
+class TreeDimmedException(CFMEException):
+    """Raised when you try to access a dimmed tree from an accordion."""


### PR DESCRIPTION
This test should fail and tell the user that the tree is dimmed and the form is still displayed.

{{pytest: cfme/tests/intelligence/reports/test_validate_chargeback_report.py::test_validate_custom_rate_memory_usage_cost -v --long-running --use-provider vsphere55}}