### PR TITLE
[RFR] Add Cloud Availiability Zone navigation, refactor tests for cloud/infra objects

### DIFF
--- a/cfme/cloud/availability_zone.py
+++ b/cfme/cloud/availability_zone.py
@@ -1,20 +1,67 @@
 """ A page functions for Availability Zone
-
-
-:var list_page: A :py:class:`cfme.web_ui.Region` object describing elements on the list page.
-:var details_page: A :py:class:`cfme.web_ui.Region` object describing elements on the detail page.
 """
+from functools import partial
 
-from cfme.web_ui import Region, SplitTable
+from navmazing import NavigateToSibling, NavigateToAttribute
 
+from cfme.web_ui import PagedTable, CheckboxTable, toolbar as tb, match_location
+from utils.appliance import Navigatable
+from utils.appliance.implementations.ui import CFMENavigateStep, navigator
 
 # Page specific locators
-list_page = Region(
-    locators={
-        'zone_table': SplitTable(header_data=('//div[@class="xhdr"]/table/tbody', 1),
-            body_data=('//div[@class="objbox"]/table/tbody', 1))
-    },
-    title='Availability Zones')
+listview_pagetable = PagedTable(table_locator="//div[@id='list_grid']//table")
+listview_checktable = CheckboxTable(table_locator="//div[@id='list_grid']//table")
+
+pol_btn = partial(tb.select, 'Policy')
+mon_btn = partial(tb.select, 'Monitoring')
+
+match_page = partial(match_location, controller='availability_zone', title='Availability Zones')
 
 
-details_page = Region(infoblock_type='detail')
+class AvailabilityZone(Navigatable):
+    def __init__(self, name, provider, appliance):
+        self.name = name
+        self.provider = provider
+        Navigatable.__init__(self, appliance=appliance)
+
+
+@navigator.register(AvailabilityZone, 'All')
+class AvailabilityZoneAll(CFMENavigateStep):
+    prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
+
+    def am_i_here(self):
+        match_page(summary='Availability Zones')
+
+    def step(self, *args, **kwargs):
+        from cfme.web_ui.menu import nav
+        nav._nav_to_fn('Compute', 'Clouds', 'Availability Zones')(None)
+
+
+@navigator.register(AvailabilityZone, 'Details')
+class AvailabilityZoneDetails(CFMENavigateStep):
+    prerequisite = NavigateToSibling('All')
+
+    def am_i_here(self):
+        match_page(summary='{} (Summary)'.format(self.obj.name))
+
+    def step(self, *args, **kwargs):
+        tb.select('List View')
+        listview_pagetable.find_row_by_cell_on_all_pages(
+            {'Name': self.obj.name,
+             'Cloud Provider': self.obj.provider.name})
+
+
+@navigator.register(AvailabilityZone, 'EditTags')
+class AvailabilityZoneEditTags(CFMENavigateStep):
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self, *args, **kwargs):
+        pol_btn('Edit Tags')
+
+
+@navigator.register(AvailabilityZone, 'Timelines')
+class AvailabilityZoneTimelines(CFMENavigateStep):
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self, *args, **kwargs):
+        mon_btn('Timelines')

--- a/cfme/tests/configure/test_default_views_cloud.py
+++ b/cfme/tests/configure/test_default_views_cloud.py
@@ -3,8 +3,11 @@ import pytest
 
 from cfme import test_requirements
 from cfme.cloud.provider import CloudProvider
+from cfme.cloud.availability_zone import AvailabilityZone
+from cfme.cloud.flavor import Flavor
+from cfme.cloud.instance import Instance
+from cfme.cloud.instance.image import Image
 from cfme.configure.settings import DefaultView
-from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import Quadicon, fill, toolbar as tb
 from utils.appliance.implementations.ui import navigate_to
 from utils.providers import setup_a_provider as _setup_a_provider
@@ -15,11 +18,10 @@ pytestmark = [pytest.mark.tier(3),
 
 gtl_params = {
     'Cloud Providers': CloudProvider,
-    'Availability Zones': 'clouds_availability_zones',
-    'Flavors': 'clouds_flavors',
-    'Instances': 'clouds_instances',
-    # clouds_images DNE, replace with proper object with navmazing destinations
-    # 'Images': 'clouds_images'
+    'Availability Zones': AvailabilityZone,
+    'Flavors': Flavor,
+    'Instances': Instance,
+    'Images': Image
 }
 
 
@@ -41,10 +43,7 @@ def select_two_quads():
 def set_and_test_default_view(group_name, view, page):
     old_default = DefaultView.get_default_view(group_name)
     DefaultView.set_default_view(group_name, view)
-    if isinstance(page, basestring):
-        sel.force_navigate(page)
-    else:
-        navigate_to(page, 'All', use_resetter=False)
+    navigate_to(page, 'All', use_resetter=False)
     assert tb.is_active(view), "{} view setting failed".format(view)
     DefaultView.set_default_view(group_name, old_default)
 
@@ -70,7 +69,7 @@ def test_grid_defaultview(request, key):
 def set_and_test_view(group_name, view):
     old_default = DefaultView.get_default_view(group_name)
     DefaultView.set_default_view(group_name, view)
-    sel.force_navigate('clouds_instances')
+    navigate_to(Instance, 'All')
     select_two_quads()
     tb.select('Configuration', 'Compare Selected items')
     assert tb.is_active(view), "{} setting failed".format(view)


### PR DESCRIPTION
Added cloud.availability_zone class  and nav destinations.  There are no existing tests for availiabity_zones, I didn't write any.

Refactored tests that had lists of infra/cloud force_navigate lists for objects+navmazing.

*PRT Results*
* 5.6: 88% pass, default view settings for clouds.images are failing in automation working manually
* 5.7: 89% pass, same tests/skips.

I would like to handle these test fixes in a separate PR, they're unrelated to navigation changes.