### PR TITLE
[WIPTEST]Added safer way of handling discovered machines with nicer output

### DIFF
--- a/utils/wait.py
+++ b/utils/wait.py
@@ -1,6 +1,7 @@
-from wait_for import wait_for as wait_for_mod
 from wait_for import RefreshTimer, TimedOutError  # NOQA
 from utils.log import logger
 from functools import partial
+from wait_for import wait_for as wait_for_mod, wait_for_decorator as wait_for_decorator_mod
 
 wait_for = partial(wait_for_mod, logger=logger)
+wait_for_decorator = partial(wait_for_decorator_mod, logger=logger)


### PR DESCRIPTION
… in case of failure

Purpose or Intent
=================

__Extending__ provider discovery because previous approach was not safe enough. New one has nice output in case of failure.

{{pytest: -k 'test_discover_infra' --use-provider complete -s -v}}
