### PR TITLE
[1LP][RFR] added update test in tenant CRUD

### DIFF
--- a/cfme/cloud/tenant.py
+++ b/cfme/cloud/tenant.py
@@ -67,6 +67,24 @@ class Tenant(Navigatable):
         except TimedOutError:
             logger.error('Timed out waiting for tenant to disappear, continuing')
 
+    def wait_for(self, timeout=300):
+        try:
+            return wait_for(self.exists,
+                            fail_condition=False,
+                            timeout=timeout,
+                            message='Wait for cloud tenant to appear',
+                            delay=10,
+                            fail_func=sel.refresh)
+        except TimedOutError:
+            logger.error('Timed out waiting for tenant to appear, continuing')
+
+    def update(self, updates, wait=True):
+        navigate_to(self, 'Edit')
+        updated_name = updates.get('name', self.name + '_edited')
+        create_tenant_form.fill({'name': updated_name})
+        sel.click(create_tenant_form.save_button)
+        flash.assert_success_message('Cloud Tenant "{}" updated'.format(updated_name))
+
     def delete(self, cancel=False, from_details=True, wait=True):
         if current_version() < '5.7':
             raise OptionNotAvailable('Cannot delete cloud tenants in CFME < 5.7')

--- a/cfme/cloud/tenant.py
+++ b/cfme/cloud/tenant.py
@@ -83,7 +83,7 @@ class Tenant(Navigatable):
         updated_name = updates.get('name', self.name + '_edited')
         create_tenant_form.fill({'name': updated_name})
         sel.click(create_tenant_form.save_button)
-        flash.assert_success_message('Cloud Tenant "{}" updated'.format(updated_name))
+        self.wait_for(600)
 
     def delete(self, cancel=False, from_details=True, wait=True):
         if current_version() < '5.7':
@@ -126,7 +126,7 @@ class Tenant(Navigatable):
             # Flash message is the same whether deleted from details or by selection
             result = flash.assert_success_message('Delete initiated for 1 Cloud Tenant.')
             if wait:
-                result = self.wait_for_disappear()
+                result = self.wait_for_disappear(600)
             return result
 
     def exists(self):

--- a/cfme/tests/cloud/test_tenant.py
+++ b/cfme/tests/cloud/test_tenant.py
@@ -11,11 +11,9 @@ from utils.version import current_version
 
 pytest_generate_tests = testgen.generate([OpenStackProvider], scope='module')
 
+
 # Tag requirements here, does not currently match any requirements categories
-
-
-def _refresh_provider(provider):
-    provider.load_details()
+def refresh_provider(provider):
     provider.refresh_provider_relationships()
 
 
@@ -44,20 +42,16 @@ def test_tenant_crud(tenant):
     assert not tenant.exists()
 
     tenant.create()
-    # # requires provider after each tenant CRUD
     assert tenant.exists()
 
-    tenant.update({'name': 'new_name'})
-    # requires provider after each tenant CRUD
-    _refresh_provider(tenant.provider)
+    tenant.update({'name': 'my_new_name'})
+    refresh_provider(tenant.provider)
     assert tenant.exists()
 
     tenant.delete(from_details=False, cancel=True)
-    # requires provider after each tenant CRUD
-    _refresh_provider(tenant.provider)
     assert tenant.exists()
 
     tenant.delete(from_details=True, cancel=False)
-    # requires provider after each tenant CRUD
-    _refresh_provider(tenant.provider)
+    # BZ#1411112  Delete cloud tenant not reflected in UI in cloud tenant list
+    refresh_provider(tenant.provider)
     assert not tenant.exists()

--- a/cfme/tests/cloud/test_tenant.py
+++ b/cfme/tests/cloud/test_tenant.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
 import fauxfactory
 import pytest
-
 from cfme.cloud.provider.openstack import OpenStackProvider
+from utils.update import update
 from cfme.cloud.tenant import Tenant
 from utils import testgen
 from utils.log import logger
@@ -10,11 +9,6 @@ from utils.version import current_version
 
 
 pytest_generate_tests = testgen.generate([OpenStackProvider], scope='module')
-
-
-# Tag requirements here, does not currently match any requirements categories
-def refresh_provider(provider):
-    provider.refresh_provider_relationships()
 
 
 @pytest.yield_fixture(scope='function')
@@ -26,7 +20,8 @@ def tenant(provider, setup_provider):
     try:
         tenant.delete()
     except Exception:
-        logger.warning('Exception while attempting to delete tenant fixture, continuing')
+        logger.warning(
+            'Exception while attempting to delete tenant fixture, continuing')
         pass
 
 
@@ -44,14 +39,15 @@ def test_tenant_crud(tenant):
     tenant.create()
     assert tenant.exists()
 
-    tenant.update({'name': 'my_new_name'})
-    refresh_provider(tenant.provider)
+    with update(tenant):
+        tenant.name = fauxfactory.gen_alphanumeric(8)
     assert tenant.exists()
 
     tenant.delete(from_details=False, cancel=True)
     assert tenant.exists()
 
     tenant.delete(from_details=True, cancel=False)
-    # BZ#1411112  Delete cloud tenant not reflected in UI in cloud tenant list
-    refresh_provider(tenant.provider)
+    # BZ#1411112 Delete/update cloud tenant
+    #  not reflected in UI in cloud tenant list
+    tenant.provider.refresh_provider_relationships()
     assert not tenant.exists()

--- a/cfme/tests/cloud/test_tenant.py
+++ b/cfme/tests/cloud/test_tenant.py
@@ -14,6 +14,11 @@ pytest_generate_tests = testgen.generate([OpenStackProvider], scope='module')
 # Tag requirements here, does not currently match any requirements categories
 
 
+def _refresh_provider(provider):
+    provider.load_details()
+    provider.refresh_provider_relationships()
+
+
 @pytest.yield_fixture(scope='function')
 def tenant(provider, setup_provider):
     tenant = Tenant(name=fauxfactory.gen_alphanumeric(8), provider=provider)
@@ -34,14 +39,25 @@ def test_tenant_crud(tenant):
     Metadata:
         test_flag: tenant
     """
+
     tenant.create(cancel=True)
     assert not tenant.exists()
 
     tenant.create()
+    # # requires provider after each tenant CRUD
+    assert tenant.exists()
+
+    tenant.update({'name': 'new_name'})
+    # requires provider after each tenant CRUD
+    _refresh_provider(tenant.provider)
     assert tenant.exists()
 
     tenant.delete(from_details=False, cancel=True)
+    # requires provider after each tenant CRUD
+    _refresh_provider(tenant.provider)
     assert tenant.exists()
 
     tenant.delete(from_details=True, cancel=False)
+    # requires provider after each tenant CRUD
+    _refresh_provider(tenant.provider)
     assert not tenant.exists()


### PR DESCRIPTION
Continuing #3942 added update test.
In test code a helper refresh provider function, since the delete and update requires a refresh provider before we query the tenant 'All' page
