### PR TITLE
[RFR] Fix the relationship string for versions >euwe

### DIFF
--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -175,7 +175,7 @@ class InfraProvider(Pretty, CloudInfraProvider):
         self.vm_name = version.pick({
             version.LOWEST: "VMs",
             '5.5': "VMs and Instances",
-            '5.8': 'VMs & Templates'})  # TODO: If it lands in some 5.7.x, change this version!
+            '5.8': "Virtual Machines"})  # TODO: If it lands in some 5.7.x, change this version!
         self.template_name = "Templates"
 
     def _form_mapping(self, create=None, **kwargs):


### PR DESCRIPTION
The "above-5.7" verpick pointed to a bad relationship link.

{{pytest: cfme/tests/intelligence/reports/test_validate_chargeback_report.py::test_validate_custom_rate_memory_usage_cost -v --long-running --use-provider vsphere55}}