### PR TITLE
[1LP][RFR] New test test_delete_all_actions_from_compliance_policy

### DIFF
--- a/cfme/tests/control/test_bugs.py
+++ b/cfme/tests/control/test_bugs.py
@@ -7,7 +7,6 @@ from cfme.common.vm import VM
 from cfme.control.explorer.policy_profiles import PolicyProfile
 from cfme.control.explorer.policies import VMCompliancePolicy, VMControlPolicy
 from cfme.control.explorer.actions import Action
-from cfme.exceptions import FlashMessageException
 from cfme.infrastructure.virtual_machines import Vm
 from utils.appliance.implementations.ui import navigate_to
 from utils.version import current_version
@@ -240,5 +239,5 @@ def test_delete_all_actions_from_compliance_policy(request):
             policy.delete()
 
     policy.create()
-    with pytest.raises(FlashMessageException):
+    with pytest.raises(AssertionError):
         policy.assign_actions_to_event("VM Compliance Check", [])

--- a/cfme/tests/control/test_bugs.py
+++ b/cfme/tests/control/test_bugs.py
@@ -17,6 +17,7 @@ from cfme import test_requirements
 from utils.generators import random_vm_name
 from widgetastic.widget import Text
 from utils.appliance import get_or_create_current_appliance
+from utils.blockers import BZ
 
 
 pytestmark = [
@@ -219,7 +220,7 @@ def test_check_compliance_history(request, vmware_provider, vmware_vm):
         vmware_vm.name)
 
 
-@pytest.mark.meta(blockers=[1395965], automates=[1395965])
+@pytest.mark.meta(blockers=[BZ(1395965, forced_streams=["5.6", "5.7"])])
 def test_delete_all_actions_from_compliance_policy(request):
     """We should not allow a compliance policy to be saved
     if there are no actions on the compliance event.

--- a/widgetastic_manageiq.py
+++ b/widgetastic_manageiq.py
@@ -374,7 +374,10 @@ class SummaryFormItem(Widget):
 
 class MultiBoxSelect(Widget):
 
-    TABLE = "//table[@id={}]{}"
+    TABLE = VersionPick({
+        Version.lowest(): "//table[@class='admintable']{1}//table[@id={0}]",
+        '5.7': "//table[@id={0}]{1}"
+    })
 
     def __init__(self, parent, id, number="", move_into=None, move_from=None,
             available_items="choices_chosen", chosen_items="members_chosen", logger=None):
@@ -406,9 +409,6 @@ class MultiBoxSelect(Widget):
 
     @property
     def move_into_button(self):
-        """This method is required to avoid 'Element is no longer attached to the DOM'
-        Selenium exception.
-        """
         if isinstance(self._move_into, Button):
             button = self._move_into
         elif isinstance(self._move_into, basestring):


### PR DESCRIPTION
{{pytest: -v -k 'test_delete_all_actions_from_compliance_policy'}}

Purpose or Intent
=================

New test for Control which tests deleting all actions from a compliance policy. We should not allow a compliance policy to be saved if there are no actions on the compliance event (since you can't add/remove events from compliance policies). https://bugzilla.redhat.com/show_bug.cgi?id=1395965
