### PR TITLE
[RFR][1LP] BootstrapTreeview: Fix text matcher

### DIFF
--- a/widgetastic_patternfly.py
+++ b/widgetastic_patternfly.py
@@ -634,7 +634,7 @@ class BootstrapTreeview(Widget):
         ' and count(./span[contains(@class, "indent")])={indent}]')
     CHILD_ITEMS_TEXT = (
         './ul/li[starts-with(@data-nodeid, {id}) and not(@data-nodeid={id})'
-        ' and contains(@title, {text})'
+        ' and (contains(@title, {text}) or contains(normalize-space(.), {text}))'
         ' and count(./span[contains(@class, "indent")])={indent}]')
     ITEM_BY_NODEID = './ul/li[@data-nodeid={}]'
     IS_EXPANDABLE = './span[contains(@class, "expand-icon")]'


### PR DESCRIPTION
This might fail but it should not fail on tree operations

{{pytest: cfme/tests/control/test_basic.py::test_policy_crud -k VMControlPolicy -v --long-running}}