### PR TITLE
[1LP][RFR] Moved finalizer to correct place

### DIFF
--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -45,7 +45,7 @@ def test_vm(setup_provider_modscope, provider, vm_name, request):
 
     if not provider.mgmt.does_vm_exist(vm_name):
         vm.create_on_provider(find_in_cfme=True, allow_skip="default")
-        request.addfinalizer(test_vm.delete_from_provider)
+        request.addfinalizer(vm.delete_from_provider)
     return vm
 
 


### PR DESCRIPTION
Previously there were problems with snapshot tests not removing VM they
created on RHV golden environment, this should fix it.

Also, not removing the VM if it was already present, to make sure it doesn't break stable environments, where you always want to have that VM...
