### PR TITLE
[1LP][RFR] Update web_ui.FileInput._fill_file_input, pass file abspath

### DIFF
--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -1617,6 +1617,9 @@ class FileInput(Input):
 
 @fill.method((FileInput, Anything))
 def _fill_file_input(i, a):
+    # TODO Upgrade selenium to 3.0.1+, this breaks in chrome at send_keys()
+    # https://github.com/SeleniumHQ/selenium/issues/2906
+
     # Engage the selenium's file detector so we can reliably transfer the file to the browser
     with browser().file_detector_context(LocalFileDetector):
         # We need a raw element so we can send_keys to it
@@ -1626,7 +1629,7 @@ def _fill_file_input(i, a):
             f = NamedTemporaryFile()
             f.write(str(a))
             f.flush()
-            input_el.send_keys(f.name)
+            input_el.send_keys(os.path.abspath(f.name))
             atexit.register(f.close)
         else:
             # It already is a file ...


### PR DESCRIPTION
Add comment noting selenium bug that breaks FileInput in chrome
Change to passing os.path.abspath() of the filename instead of the raw string.

Poorly named branch, this doesn't 'fix' FileInput.
