### PR TITLE
[WIP] Widgetastic conversion of cfme.cloud.instance

### DIFF
--- a/cfme/cloud/instance/azure.py
+++ b/cfme/cloud/instance/azure.py
@@ -1,8 +1,7 @@
+# -*- coding: utf-8 -*-
 from cfme.exceptions import OptionNotAvailable
-from cfme.web_ui import fill, flash
-from cfme.fixtures import pytest_selenium as sel
 from utils import version, deferred_verpick
-from . import Instance, select_provision_image
+from . import Instance
 
 
 class AzureInstance(Instance):
@@ -38,50 +37,18 @@ class AzureInstance(Instance):
         'off': [STOP, SUSPEND, SOFT_REBOOT]
     }
 
-    def create(self, email=None, first_name=None, last_name=None, availability_zone=None,
-               security_groups=None, instance_type=None, guest_keypair=None, cancel=False,
-               **prov_fill_kwargs):
+    def create(self, cancel=False, **prov_fill_kwargs):
         """Provisions an Azure instance with the given properties through CFME
 
         Args:
-            email: Email of the requester
-            first_name: Name of the requester
-            last_name: Surname of the requester
-            availability_zone: Name of the zone the instance should belong to
-            security_groups: List of security groups the instance should belong to
-                             (currently, only the first one will be used)
-            instance_type: Type of the instance
-            guest_keypair: Name of the key pair used to access the instance
             cancel: Clicks the cancel button if `True`, otherwise clicks the submit button
                     (Defaults to `False`)
+            prov_fill_kwargs: dictionary of provisioning field/value pairs
         Note:
             For more optional keyword arguments, see
-            :py:data:`cfme.cloud.provisioning.provisioning_form`
+            :py:data:`cfme.cloud.provisioning.ProvisioningForm`
         """
-        from cfme.provisioning import provisioning_form
-        select_provision_image(template_name=self.template_name, provider=self.provider)
-
-        fill(provisioning_form, dict(
-            email=email,
-            first_name=first_name,
-            last_name=last_name,
-            instance_name=self.name,
-            availability_zone=availability_zone,
-            # not supporting multiselect now, just take first value
-            security_groups=security_groups[0],
-            instance_type=instance_type,
-            guest_keypair=guest_keypair,
-            **prov_fill_kwargs
-        ))
-
-        if cancel:
-            sel.click(provisioning_form.cancel_button)
-            flash.assert_success_message(
-                "Add of new VM Provision Request was cancelled by the user")
-        else:
-            sel.click(provisioning_form.submit_button)
-            flash.assert_success_message(
-                "VM Provision Request was Submitted, you will be notified when your VMs are ready")
+        super(AzureInstance, self).create(form_values=prov_fill_kwargs, cancel=cancel)
 
     def power_control_from_provider(self, option):
         """Power control the instance from the provider

--- a/cfme/cloud/instance/ec2.py
+++ b/cfme/cloud/instance/ec2.py
@@ -1,8 +1,6 @@
-from utils import version, deferred_verpick
+# -*- coding: utf-8 -*-
 from cfme.exceptions import OptionNotAvailable
-from cfme.web_ui import fill, flash
-from cfme.fixtures import pytest_selenium as sel
-from . import Instance, select_provision_image
+from . import Instance
 
 
 class EC2Instance(Instance):
@@ -11,10 +9,7 @@ class EC2Instance(Instance):
     POWER_ON = START  # For compatibility with the infra objects.
     STOP = "Stop"
     DELETE = "Delete"
-    TERMINATE = deferred_verpick({
-        version.LOWEST: 'Terminate',
-        '5.6.1': 'Delete',
-    })
+    TERMINATE = 'Delete'
     # CFME-only power control options
     SOFT_REBOOT = "Soft Reboot"
     # Provider-only power control options
@@ -36,51 +31,19 @@ class EC2Instance(Instance):
         'off': [STOP, SOFT_REBOOT]
     }
 
-    def create(self, email=None, first_name=None, last_name=None, availability_zone=None,
-               security_groups=None, instance_type=None, guest_keypair=None, cancel=False,
-               **prov_fill_kwargs):
+    def create(self, cancel=False, **prov_fill_kwargs):
         """Provisions an EC2 instance with the given properties through CFME
 
         Args:
-            email: Email of the requester
-            first_name: Name of the requester
-            last_name: Surname of the requester
-            availability_zone: Name of the zone the instance should belong to
-            security_groups: List of security groups the instance should belong to
-                             (currently, only the first one will be used)
-            instance_type: Type of the instance
-            guest_keypair: Name of the key pair used to access the instance
             cancel: Clicks the cancel button if `True`, otherwise clicks the submit button
                     (Defaults to `False`)
+            prov_fill_kwargs: dictionary of provisioning field/value pairs
         Note:
             For more optional keyword arguments, see
-            :py:data:`cfme.cloud.provisioning.provisioning_form`
+            :py:data:`cfme.cloud.provisioning.ProvisioningForm`
         """
-        from cfme.provisioning import provisioning_form
-        # Nav to provision form and select image
-        select_provision_image(template_name=self.template_name, provider=self.provider)
 
-        fill(provisioning_form, dict(
-            email=email,
-            first_name=first_name,
-            last_name=last_name,
-            instance_name=self.name,
-            availability_zone=availability_zone,
-            # not supporting multiselect now, just take first value
-            security_groups=security_groups[0],
-            instance_type=instance_type,
-            guest_keypair=guest_keypair,
-            **prov_fill_kwargs
-        ))
-
-        if cancel:
-            sel.click(provisioning_form.cancel_button)
-            flash.assert_success_message(
-                "Add of new VM Provision Request was cancelled by the user")
-        else:
-            sel.click(provisioning_form.submit_button)
-            flash.assert_success_message(
-                "VM Provision Request was Submitted, you will be notified when your VMs are ready")
+        super(EC2Instance, self).create(form_values=prov_fill_kwargs, cancel=cancel)
 
     def power_control_from_provider(self, option):
         """Power control the instance from the provider

--- a/cfme/cloud/instance/gce.py
+++ b/cfme/cloud/instance/gce.py
@@ -1,8 +1,7 @@
-from utils import version, deferred_verpick
+# -*- coding: utf-8 -*-
 from cfme.exceptions import OptionNotAvailable
-from cfme.web_ui import fill, flash
-from cfme.fixtures import pytest_selenium as sel
-from . import Instance, select_provision_image
+from utils import version, deferred_verpick
+from . import Instance
 
 
 class GCEInstance(Instance):
@@ -37,49 +36,18 @@ class GCEInstance(Instance):
         'off': [STOP, SOFT_REBOOT]
     }
 
-    def create(self, email=None, first_name=None, last_name=None, availability_zone=None,
-               instance_type=None, cloud_network=None, boot_disk_size=None, cancel=False,
-               **prov_fill_kwargs):
+    def create(self, cancel=False, **prov_fill_kwargs):
         """Provisions an GCE instance with the given properties through CFME
 
         Args:
-            email: Email of the requester
-            first_name: Name of the requester
-            last_name: Surname of the requester
-            availability_zone: zone to deploy instance
-            cloud_network: Name of the cloud network the instance should belong to
-            instance_type: Type of the instance
-            boot_disk_size: size of root disk
             cancel: Clicks the cancel button if `True`, otherwise clicks the submit button
                     (Defaults to `False`)
+            prov_fill_kwargs: dictionary of provisioning field/value pairs
         Note:
             For more optional keyword arguments, see
-            :py:data:`cfme.cloud.provisioning.provisioning_form`
+            :py:data:`cfme.cloud.provisioning.ProvisioningForm`
         """
-        from cfme.provisioning import provisioning_form
-        # Nav to provision form and select image
-        select_provision_image(template_name=self.template_name, provider=self.provider)
-
-        fill(provisioning_form, dict(
-            email=email,
-            first_name=first_name,
-            last_name=last_name,
-            instance_name=self.name,
-            availability_zone=availability_zone,
-            instance_type=instance_type,
-            cloud_network=cloud_network,
-            boot_disk_size=boot_disk_size,
-            **prov_fill_kwargs
-        ))
-
-        if cancel:
-            sel.click(provisioning_form.cancel_button)
-            flash.assert_success_message(
-                "Add of new VM Provision Request was cancelled by the user")
-        else:
-            sel.click(provisioning_form.submit_button)
-            flash.assert_success_message(
-                "VM Provision Request was Submitted, you will be notified when your VMs are ready")
+        super(GCEInstance, self).create(form_values=prov_fill_kwargs, cancel=cancel)
 
     def power_control_from_provider(self, option):
         """Power control the instance from the provider

--- a/cfme/cloud/instance/openstack.py
+++ b/cfme/cloud/instance/openstack.py
@@ -1,8 +1,7 @@
-from utils import version, deferred_verpick
+# -*- coding: utf-8 -*-
 from cfme.exceptions import OptionNotAvailable
-from cfme.web_ui import fill, flash
-from cfme.fixtures import pytest_selenium as sel
-from . import Instance, select_provision_image
+from utils import version, deferred_verpick
+from . import Instance
 
 
 class OpenStackInstance(Instance):
@@ -47,49 +46,18 @@ class OpenStackInstance(Instance):
         'off': [SUSPEND, SOFT_REBOOT, HARD_REBOOT]
     }
 
-    def create(self, email=None, first_name=None, last_name=None, cloud_network=None,
-               instance_type=None, cancel=False, **prov_fill_kwargs):
+    def create(self, cancel=False, **prov_fill_kwargs):
         """Provisions an OpenStack instance with the given properties through CFME
 
         Args:
-            email: Email of the requester
-            first_name: Name of the requester
-            last_name: Surname of the requester
-            cloud_network: Name of the cloud network the instance should belong to
-            instance_type: Type of the instance
             cancel: Clicks the cancel button if `True`, otherwise clicks the submit button
                     (Defaults to `False`)
+            prov_fill_kwargs: dictionary of provisioning field/value pairs
         Note:
             For more optional keyword arguments, see
-            :py:data:`cfme.cloud.provisioning.provisioning_form`
+            :py:data:`cfme.cloud.provisioning.ProvisioningForm`
         """
-        from cfme.provisioning import provisioning_form
-        # Nav to provision form and select image
-        select_provision_image(template_name=self.template_name, provider=self.provider)
-
-        # not supporting multiselect now, just take first value
-        security_groups = prov_fill_kwargs.pop('security_groups', None)
-        if security_groups:
-            prov_fill_kwargs['security_groups'] = security_groups[0]
-
-        fill(provisioning_form, dict(
-            email=email,
-            first_name=first_name,
-            last_name=last_name,
-            instance_name=self.name,
-            instance_type=instance_type,
-            cloud_network=cloud_network,
-            **prov_fill_kwargs
-        ))
-
-        if cancel:
-            sel.click(provisioning_form.cancel_button)
-            flash.assert_success_message(
-                "Add of new VM Provision Request was cancelled by the user")
-        else:
-            sel.click(provisioning_form.submit_button)
-            flash.assert_success_message(
-                "VM Provision Request was Submitted, you will be notified when your VMs are ready")
+        super(OpenStackInstance, self).create(form_values=prov_fill_kwargs, cancel=cancel)
 
     def power_control_from_provider(self, option):
         """Power control the instance from the provider

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -442,11 +442,11 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable, SummaryMixin
 
         Args:
             timeout: time (in seconds) to wait for it to appear
-            from_details: when found, should it load the vm details
+            load_details: when found, should it load the vm details
         """
         wait_for(
             lambda: self.exists,
-            num_sec=timeout, delay=30, fail_func=sel.refresh,
+            num_sec=timeout, delay=30, fail_func=self.provider.refresh_provider_relationships,
             message="wait for vm to appear")
         if load_details:
             self.load_details()
@@ -658,6 +658,7 @@ class VM(BaseVM):
                 :py:class:`datetime.datetime` or :py:class:`utils.timeutil.parsetime`.
             warn: When to warn, fills the select in the form in case the ``when`` is specified.
         """
+        # TODO: refactor for retirement nav destinations and widget form fill when child classes
         self.load_details()
         lcl_btn("Set Retirement Date")
         if callable(self.retire_form.date_retire):

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -15,14 +15,13 @@ from utils.log import logger
 from utils.wait import wait_for, TimedOutError, RefreshTimer
 
 
-def pytest_generate_tests(metafunc):
-    argnames, argvalues, idlist = testgen.providers_by_class(
-        metafunc, [CloudProvider],
-        required_fields=[('test_power_control', True)])
-    testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope="function")
+pytest_generate_tests = testgen.generate([CloudProvider],
+                                         scope='function',
+                                         required_fields=['test_power_control'])
 
-
-pytestmark = [pytest.mark.tier(2), pytest.mark.long_running, test_requirements.power]
+pytestmark = [pytest.mark.tier(2),
+              pytest.mark.long_running,
+              test_requirements.power]
 
 
 @pytest.yield_fixture(scope="function")
@@ -37,9 +36,7 @@ def testing_instance(request, setup_provider, provider):
         provider.mgmt.set_name(
             instance.name, 'test_terminated_{}'.format(fauxfactory.gen_alphanumeric(8)))
         instance.create_on_provider(allow_skip="default", find_in_cfme=True)
-
     provider.refresh_provider_relationships()
-    instance.wait_to_appear()
 
     yield instance
 

--- a/cfme/tests/cloud/test_provisioning.py
+++ b/cfme/tests/cloud/test_provisioning.py
@@ -56,20 +56,18 @@ def testing_instance(request, setup_provider, provider, provisioning, vm_name):
 
     recursive_update(inst_args, {'catalog': {'vm_name': vm_name}})
 
-    # Provider specific
     if not isinstance(provider, AzureProvider):
         recursive_update(inst_args, {
             'properties': {
                 'instance_type': provisioning['instance_type'],
-                'guest_keypair': provisioning['guest_keypair']
-            },
+                'guest_keypair': provisioning['guest_keypair']},
             'environment': {
                 'availability_zone': provisioning['availability_zone'],
                 # security group can be a list
-                'security_groups': [provisioning['security_group']]
-            }
+                'security_groups': [provisioning['security_group']]}
         })
 
+    # Provider specific
     if isinstance(provider, OpenStackProvider):
         recursive_update(inst_args, {
             'environment': {
@@ -91,19 +89,15 @@ def testing_instance(request, setup_provider, provider, provisioning, vm_name):
         # Azure uses different provisioning keys for some reason
         recursive_update(inst_args, {
             'environment': {
-                'cloud_network': provisioning['virtual_net'],
-                'cloud_subnet': provisioning['subnet_range'],
-                'security_groups': [provisioning['network_nsg']],
-                'resource_groups': provisioning['resource_group']
-            },
+                'cloud_network': provisioning['cloud_network'],
+                'cloud_subnet': provisioning['cloud_subnet'],
+                'security_groups': [provisioning['cloud_security_group']],
+                'resource_groups': provisioning['resource_group']},
             'properties': {
-                'instance_type': provisioning['vm_size'].lower()
-            },
+                'instance_type': provisioning['vm_size'].lower()},
             'customize': {
                 'admin_username': provisioning['vm_user'],
-                'admin_password': provisioning['vm_password']
-            }
-        })
+                'admin_password': provisioning['vm_password']}})
 
     yield instance, inst_args
 

--- a/cfme/tests/cloud/test_provisioning.py
+++ b/cfme/tests/cloud/test_provisioning.py
@@ -99,17 +99,18 @@ def testing_instance(request, setup_provider, provider, provisioning, vm_name):
                 'admin_username': provisioning['vm_user'],
                 'admin_password': provisioning['vm_password']}})
 
-    yield instance, inst_args
+    yield instance, inst_args, image
 
     try:
-        instance.delete_from_provider()
+        if instance.does_vm_exist_on_provider():
+            instance.delete_from_provider()
     except Exception as ex:
         logger.warning('Exception while deleting instance fixture, continuing: {}'
                        .format(ex.message))
 
 
 @pytest.fixture(scope="function")
-def vm_name(request, provider):
+def vm_name(request):
     return random_vm_name('prov')
 
 
@@ -418,25 +419,26 @@ def copy_domains(original_request_class, domain):
 # Not collected for EC2 in generate_tests above
 @pytest.mark.meta(blockers=[1152737])
 @pytest.mark.parametrize("disks", [1, 2])
-@pytest.mark.uncollectif(lambda provider: provider.type != 'openstack')
-def test_provision_from_template_with_attached_disks(
-        request, setup_provider, provider, vm_name, provisioning,
-        disks, soft_assert, domain, modified_request_class, copy_domains):
+@pytest.mark.uncollectif(lambda provider: not provider.one_of(OpenStackProvider))
+def test_provision_from_template_with_attached_disks(request, testing_instance, provider, disks,
+                                                     soft_assert, domain, modified_request_class,
+                                                     copy_domains, provisioning):
     """ Tests provisioning from a template and attaching disks
 
     Metadata:
         test_flag: provision
     """
-    image = provisioning['image']['name']
-    note = ('Testing provisioning from image {} to vm {} on provider {}'.format(
-        image, vm_name, provider.key))
+    instance, inst_args, image = testing_instance
+    # Modify availiability_zone for Azure provider
+    if provider.one_of(AzureProvider):
+        recursive_update(inst_args, {'environment': {'availability_zone': provisioning("av_set")}})
 
-    DEVICE_NAME = "/dev/sd{}"
+    device_name = "/dev/sd{}"
     device_mapping = []
 
     with provider.mgmt.with_volumes(1, n=disks) as volumes:
         for i, volume in enumerate(volumes):
-            device_mapping.append((volume, DEVICE_NAME.format(chr(ord("b") + i))))
+            device_mapping.append((volume, device_name.format(chr(ord("b") + i))))
         # Set up automate
 
         method = modified_request_class.methods.instantiate(name="openstack_PreProvision")
@@ -451,22 +453,6 @@ def test_provision_from_template_with_attached_disks(
             with update(method):
                 method.script = """prov = $evm.root["miq_provision"]"""
         request.addfinalizer(_finish_method)
-        instance = Instance.factory(vm_name, provider, image)
-        request.addfinalizer(instance.delete_from_provider)
-        inst_args = {
-            'email': 'image_provisioner@example.com',
-            'first_name': 'Image',
-            'last_name': 'Provisioner',
-            'notes': note,
-            'instance_type': provisioning['instance_type'],
-            "availability_zone": provisioning["availability_zone"] if provider.type != "azure" else
-            provisioning["av_set"],
-            'security_groups': [provisioning['security_group']],
-            'guest_keypair': provisioning['guest_keypair']
-        }
-
-        if isinstance(provider, OpenStackProvider):
-            inst_args['cloud_network'] = provisioning['cloud_network']
 
         instance.create(**inst_args)
 
@@ -480,17 +466,15 @@ def test_provision_from_template_with_attached_disks(
 
 # Not collected for EC2 in generate_tests above
 @pytest.mark.meta(blockers=[1160342])
-@pytest.mark.uncollectif(lambda provider: provider.type != 'openstack')
-def test_provision_with_boot_volume(request, setup_provider, provider, vm_name,
-        soft_assert, domain, copy_domains, provisioning, modified_request_class):
+@pytest.mark.uncollectif(lambda provider: not provider.one_of(OpenStackProvider))
+def test_provision_with_boot_volume(request, testing_instance, provider, soft_assert, copy_domains,
+                                    modified_request_class):
     """ Tests provisioning from a template and attaching one booting volume.
 
     Metadata:
         test_flag: provision, volumes
     """
-    image = provisioning['image']['name']
-    note = ('Testing provisioning from image {} to vm {} on provider {}'.format(
-        image, vm_name, provider.key))
+    instance, inst_args, image = testing_instance
 
     with provider.mgmt.with_volume(1, imageRef=provider.mgmt.get_template_id(image)) as volume:
         # Set up automate
@@ -516,21 +500,6 @@ def test_provision_with_boot_volume(request, setup_provider, provider, vm_name,
         def _finish_method():
             with update(method):
                 method.script = """prov = $evm.root["miq_provision"]"""
-        instance = Instance.factory(vm_name, provider, image)
-        request.addfinalizer(instance.delete_from_provider)
-        inst_args = {
-            'email': 'image_provisioner@example.com',
-            'first_name': 'Image',
-            'last_name': 'Provisioner',
-            'notes': note,
-            'instance_type': provisioning['instance_type'],
-            "availability_zone": provisioning["availability_zone"],
-            'security_groups': [provisioning['security_group']],
-            'guest_keypair': provisioning['guest_keypair']
-        }
-
-        if isinstance(provider, OpenStackProvider):
-            inst_args['cloud_network'] = provisioning['cloud_network']
 
         instance.create(**inst_args)
 
@@ -542,18 +511,16 @@ def test_provision_with_boot_volume(request, setup_provider, provider, vm_name,
 
 # Not collected for EC2 in generate_tests above
 @pytest.mark.meta(blockers=[1186413])
-@pytest.mark.uncollectif(lambda provider: provider.type != 'openstack')
-def test_provision_with_additional_volume(request, setup_provider, provider, vm_name,
-        soft_assert, copy_domains, domain, provisioning, modified_request_class):
+@pytest.mark.uncollectif(lambda provider: not provider.one_of(OpenStackProvider))
+def test_provision_with_additional_volume(request, testing_instance, provider, soft_assert,
+                                          copy_domains, domain, modified_request_class):
     """ Tests provisioning with setting specific image from AE and then also making it create and
     attach an additional 3G volume.
 
     Metadata:
         test_flag: provision, volumes
     """
-    image = provisioning['image']['name']
-    note = ('Testing provisioning from image {} to vm {} on provider {}'.format(
-        image, vm_name, provider.key))
+    instance, inst_args, image = testing_instance
 
     # Set up automate
     method = modified_request_class.methods.instantiate(name="openstack_CustomizeRequest")
@@ -583,21 +550,6 @@ def test_provision_with_additional_volume(request, setup_provider, provider, vm_
         with update(method):
             method.script = """prov = $evm.root["miq_provision"]"""
     request.addfinalizer(_finish_method)
-    instance = Instance.factory(vm_name, provider, image)
-    request.addfinalizer(instance.delete_from_provider)
-    inst_args = {
-        'email': 'image_provisioner@example.com',
-        'first_name': 'Image',
-        'last_name': 'Provisioner',
-        'notes': note,
-        'instance_type': provisioning['instance_type'],
-        "availability_zone": provisioning["availability_zone"],
-        'security_groups': [provisioning['security_group']],
-        'guest_keypair': provisioning['guest_keypair']
-    }
-
-    if isinstance(provider, OpenStackProvider):
-        inst_args['cloud_network'] = provisioning['cloud_network']
 
     instance.create(**inst_args)
 


### PR DESCRIPTION
Conversion of cfme.cloud.instance class to widgetastic views/forms.

Nested the forms in the views for each navigation destination. Not all of the navigation destinations are used by tests.

I do not plan to fix all failing tests within this PR, only to convert the navigation/form/widget use and to fix any failures that are a result of that conversion.

{{ pytest: cfme/tests/cloud/test_instance_power_control.py cfme/tests/cloud/test_provisioning.py --long-running --use-provider rhos7-ga --use-provider ec2west --use-provider azure }}

## PRT

Fixing deferred_verpick errors in tests with PR #4544 
Other failures/skips that I'm seeing aren't related to this migration but are in effected tests so they show up here.
