### PR TITLE
[1LP][RFR] Don't uncollect uncollected stuff

### DIFF
--- a/markers/uncollect.py
+++ b/markers/uncollect.py
@@ -80,6 +80,9 @@ def uncollectif(item):
 
         try:
             values = extract_fixtures_values(item)
+            # The test has already been uncollected
+            if arg_names and not values:
+                return
             args = [values[arg] for arg in arg_names]
         except KeyError:
             missing_argnames = list(set(arg_names) - set(item._request.funcargnames))


### PR DESCRIPTION
SSIA

This change is necessary if we want to be able to collect / run tests with a limited subset of providers.
`py.test cfme/tests --use-provider ec2east --collect-only` will (without this fix) cause:
```
INTERNALERROR> Exception: Failed to uncollect test_power_options_from_on, best guess a fixture wasn't ready
```