### PR TITLE
[RFR] Moved fixtures and adding new test coverage for appliance_console_cli

### DIFF
--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -1,0 +1,69 @@
+from utils.version import get_stream
+from cfme.test_framework.sprout.client import SproutClient
+from utils.appliance import current_appliance
+from utils.conf import cfme_data, credentials
+from utils.log import logger
+import pytest
+
+
+@pytest.yield_fixture(scope="module")
+def appliance():
+    sp = SproutClient.from_config()
+    version = current_appliance.version.vstring
+    stream = get_stream(current_appliance.version)
+    apps, pool_id = sp.provision_appliances(
+        count=1, preconfigured=False, version=version, stream=stream)
+
+    yield apps[0]
+
+    sp.destroy_pool(pool_id)
+
+
+@pytest.yield_fixture(scope="module")
+def fqdn_appliance():
+    sp = SproutClient.from_config()
+    available_providers = set(sp.call_method('available_providers'))
+    required_providers = set(cfme_data['fqdn_providers'])
+    usable_providers = available_providers & required_providers
+    version = current_appliance.version.vstring
+    stream = get_stream(current_appliance.version)
+
+    for provider in usable_providers:
+        try:
+            apps, pool_id = sp.provision_appliances(
+                count=1, preconfigured=True, version=version, stream=stream, provider=provider)
+            break
+        except Exception as e:
+            logger.warning("Couldn't provision appliance with following error:")
+            logger.warning({}.format(e))
+            continue
+    else:
+        logger.error("Couldn't provision an appliance at all")
+
+    yield apps[0]
+
+    sp.destroy_pool(pool_id)
+
+
+@pytest.fixture()
+def app_creds():
+    return {
+        'username': credentials['database']['username'],
+        'password': credentials['database']['password'],
+        'sshlogin': credentials['ssh']['username'],
+        'sshpass': credentials['ssh']['password']
+    }
+
+
+@pytest.fixture()
+def ipa_creds():
+    fqdn = cfme_data['auth_modes']['ext_ipa']['ipaserver'].split('.', 1)
+    creds_key = cfme_data['auth_modes']['ext_ipa']['credentials']
+    return{
+        'hostname': fqdn[0],
+        'domain': fqdn[1],
+        'realm': cfme_data['auth_modes']['ext_ipa']['iparealm'],
+        'ipaserver': cfme_data['auth_modes']['ext_ipa']['ipaserver'],
+        'username': credentials[creds_key]['principal'],
+        'password': credentials[creds_key]['password']
+    }

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -27,6 +27,10 @@ def dedicated_db_appliance(app_creds):
     sp.destroy_pool(pool_id)
 
 
+""" The Following fixture 'fqdn_appliance' provisions one appliance for testing from an FQDN
+    provider unless there are no provisions available"""
+
+
 @pytest.yield_fixture(scope="function")
 def fqdn_appliance():
     sp = SproutClient.from_config()
@@ -35,7 +39,6 @@ def fqdn_appliance():
     usable_providers = available_providers & required_providers
     version = current_appliance.version.vstring
     stream = get_stream(current_appliance.version)
-
     for provider in usable_providers:
         try:
             apps, pool_id = sp.provision_appliances(
@@ -59,8 +62,6 @@ def ipa_crud(fqdn_appliance, app_creds, ipa_creds):
         ipa_creds['password'], ipa_creds['domain'], ipa_creds['realm'])
 
     yield(fqdn_appliance)
-
-    fqdn_appliance.ap_cli.uninstall_ipa_client()
 
 
 @pytest.fixture()

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -51,7 +51,7 @@ def fqdn_appliance():
     sp.destroy_pool(pool_id)
 
 
-@pytest.yield_fixture(scope="module")
+@pytest.yield_fixture()
 def ipa_crud(fqdn_appliance, app_creds, ipa_creds):
     fqdn_appliance.ap_cli.configure_ipa(ipa_creds['ipaserver'], ipa_creds['username'],
         ipa_creds['password'], ipa_creds['domain'], ipa_creds['realm'])

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -1,6 +1,6 @@
 from utils.version import get_stream
 from cfme.test_framework.sprout.client import SproutClient
-from utils.appliance import current_appliance, is_dedicated_db_active
+from utils.appliance import current_appliance
 from utils.conf import cfme_data, credentials
 from utils.log import logger
 import pytest
@@ -9,18 +9,18 @@ from cfme.test_framework.sprout.client import SproutException
 
 
 @pytest.yield_fixture(scope="function")
-def dedicated_db_appliance():
+def dedicated_db_appliance(app_creds):
     sp = SproutClient.from_config()
     version = current_appliance.version.vstring
     stream = get_stream(current_appliance.version)
     apps, pool_id = sp.provision_appliances(
         count=1, preconfigured=False, version=version, stream=stream)
     pwd = app_creds['password']
-    client = dedicated_db_appliance.ssh_client
+    client = apps[0].ssh_client
     channel = client.invoke_shell()
     stdin = channel.makefile('wb')
     stdin.write("ap \n 8 \n 1 \n 1 \n 1 \n y \n {} \n {} \n \n".format(pwd, pwd))
-    wait_for(is_dedicated_db_active, func_args=[dedicated_db_appliance])
+    wait_for(apps[0].is_dedicated_db_active)
 
     yield apps[0]
 

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -5,6 +5,7 @@ from utils.conf import cfme_data, credentials
 from utils.log import logger
 import pytest
 from wait_for import wait_for
+from cfme.test_framework.sprout.client import SproutException
 
 
 def is_dedicated_db_active(appliance2):
@@ -75,7 +76,7 @@ def fqdn_appliance():
             continue
     else:
         logger.error("Couldn't provision an appliance at all")
-
+        raise SproutException('No provision available')
     yield apps[0]
 
     sp.destroy_pool(pool_id)

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -29,7 +29,7 @@ def dedicated_db(appliance2, app_creds):
     return appliance2
 
 
-@pytest.yield_fixture(scope="module")
+@pytest.yield_fixture(scope="function")
 def appliance():
     sp = SproutClient.from_config()
     version = current_appliance.version.vstring
@@ -42,7 +42,7 @@ def appliance():
     sp.destroy_pool(pool_id)
 
 
-@pytest.yield_fixture(scope="module")
+@pytest.yield_fixture(scope="function")
 def appliance2():
     sp = SproutClient.from_config()
     version = current_appliance.version.vstring
@@ -55,7 +55,7 @@ def appliance2():
     sp.destroy_pool(pool_id)
 
 
-@pytest.yield_fixture(scope="module")
+@pytest.yield_fixture(scope="function")
 def fqdn_appliance():
     sp = SproutClient.from_config()
     available_providers = set(sp.call_method('available_providers'))

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -19,7 +19,7 @@ def dedicated_db(fqdn_appliance, app_creds):
     client = fqdn_appliance.ssh_client
     channel = client.invoke_shell()
     stdin = channel.makefile('wb')
-    stdin.write("ap \n 8 \n 1 \n 1 \n 1 \n y \n {} \n {} \n \n".format(pwd, pwd))
+    stdin.write("ap \n \n 8 \n 1 \n 1 \n 1 \n y \n {} \n {} \n \n".format(pwd, pwd))
     wait_for(is_dedicated_db_active, func_args=[fqdn_appliance])
 
     return (fqdn_appliance)

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -8,8 +8,12 @@ from wait_for import wait_for
 
 
 def is_dedicated_db_active(appliance2):
+    if appliance2.version < '5.7':
+        postgres = 94
+    else:
+        postgres = 95
     return_code, output = appliance2.ssh_client.run_command(
-        "systemctl status rh-postgresql95-postgresql.service | grep running")
+        "systemctl status rh-postgresql{}-postgresql.service | grep running".format(postgres))
     return return_code == 0
 
 
@@ -21,9 +25,6 @@ def dedicated_db(appliance2, app_creds):
     stdin = channel.makefile('wb')
     stdin.write("ap \n 8 \n 1 \n 1 \n 1 \n y \n {} \n {} \n \n".format(pwd, pwd))
     wait_for(is_dedicated_db_active, func_args=[appliance2])
-    return_code, output = client.run_command(
-        "systemctl status rh-postgresql95-postgresql.service | grep running")
-    assert return_code == 0
 
     return appliance2
 

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -2,58 +2,27 @@ from utils.version import get_stream
 from cfme.test_framework.sprout.client import SproutClient
 from utils.appliance import current_appliance
 from utils.conf import cfme_data, credentials
+from utils.db import scl_name
 from utils.log import logger
 import pytest
 from wait_for import wait_for
 from cfme.test_framework.sprout.client import SproutException
 
 
-def is_dedicated_db_active(appliance2):
-    if appliance2.version < '5.7':
-        postgres = 94
-    else:
-        postgres = 95
-    return_code, output = appliance2.ssh_client.run_command(
-        "systemctl status rh-postgresql{}-postgresql.service | grep running".format(postgres))
-    return return_code == 0
-
-
 @pytest.fixture()
-def dedicated_db(appliance2, app_creds):
+def dedicated_db(fqdn_appliance, app_creds):
+    def is_dedicated_db_active(dedicated_db):
+        return_code, output = dedicated_db.ssh_client.run_command(
+            "systemctl status rh-postgresql{}-postgresql.service | grep running".format(scl_name()))
+        return return_code == 0
     pwd = app_creds['password']
-    client = appliance2.ssh_client
+    client = fqdn_appliance.ssh_client
     channel = client.invoke_shell()
     stdin = channel.makefile('wb')
-    stdin.write("ap \n 8 \n 1 \n 1 \n 1 \n y \n {} \n {} \n \n".format(pwd, pwd))
-    wait_for(is_dedicated_db_active, func_args=[appliance2])
+    stdin.write("ap \n \n 8 \n 1 \n 1 \n 1 \n y \n {} \n {} \n \n".format(pwd, pwd))
+    wait_for(is_dedicated_db_active, func_args=[fqdn_appliance])
 
-    return appliance2
-
-
-@pytest.yield_fixture(scope="function")
-def appliance():
-    sp = SproutClient.from_config()
-    version = current_appliance.version.vstring
-    stream = get_stream(current_appliance.version)
-    apps, pool_id = sp.provision_appliances(
-        count=1, preconfigured=False, version=version, stream=stream)
-
-    yield apps[0]
-
-    sp.destroy_pool(pool_id)
-
-
-@pytest.yield_fixture(scope="function")
-def appliance2():
-    sp = SproutClient.from_config()
-    version = current_appliance.version.vstring
-    stream = get_stream(current_appliance.version)
-    apps, pool_id = sp.provision_appliances(
-        count=1, preconfigured=False, version=version, stream=stream)
-
-    yield apps[0]
-
-    sp.destroy_pool(pool_id)
+    return (fqdn_appliance)
 
 
 @pytest.yield_fixture(scope="function")
@@ -82,7 +51,7 @@ def fqdn_appliance():
     sp.destroy_pool(pool_id)
 
 
-@pytest.yield_fixture()
+@pytest.yield_fixture(scope="module")
 def ipa_crud(fqdn_appliance, app_creds, ipa_creds):
     fqdn_appliance.ap_cli.configure_ipa(ipa_creds['ipaserver'], ipa_creds['username'],
         ipa_creds['password'], ipa_creds['domain'], ipa_creds['realm'])

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -13,13 +13,13 @@ from cfme.test_framework.sprout.client import SproutException
 def dedicated_db(fqdn_appliance, app_creds):
     def is_dedicated_db_active(dedicated_db):
         return_code, output = dedicated_db.ssh_client.run_command(
-            "systemctl status rh-postgresql{}-postgresql.service | grep running".format(scl_name()))
+            "systemctl status {}-postgresql.service | grep running".format(scl_name()))
         return return_code == 0
     pwd = app_creds['password']
     client = fqdn_appliance.ssh_client
     channel = client.invoke_shell()
     stdin = channel.makefile('wb')
-    stdin.write("ap \n \n 8 \n 1 \n 1 \n 1 \n y \n {} \n {} \n \n".format(pwd, pwd))
+    stdin.write("ap \n 8 \n 1 \n 1 \n 1 \n y \n {} \n {} \n \n".format(pwd, pwd))
     wait_for(is_dedicated_db_active, func_args=[fqdn_appliance])
 
     return (fqdn_appliance)

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -6,27 +6,23 @@ from utils.log import logger
 import pytest
 from wait_for import wait_for
 from cfme.test_framework.sprout.client import SproutException
+from fixtures.appliance import temp_appliances
 
 
 @pytest.yield_fixture(scope="function")
 def dedicated_db_appliance(app_creds):
     if current_appliance.version.vstring > '5.7':
-        sp = SproutClient.from_config()
-        version = current_appliance.version.vstring
-        stream = get_stream(current_appliance.version)
-        apps, pool_id = sp.provision_appliances(
-            count=1, preconfigured=False, version=version, stream=stream)
-        pwd = app_creds['password']
-        client = apps[0].ssh_client
-        channel = client.invoke_shell()
-        stdin = channel.makefile('wb')
-        stdin.write("ap \n 8 \n 1 \n 1 \n 1 \n y \n {} \n {} \n \n".format(pwd, pwd))
-        wait_for(apps[0].is_dedicated_db_active)
+
+        with temp_appliances(count=1, preconfigured=False) as apps:
+            pwd = app_creds['password']
+            client = apps[0].ssh_client
+            channel = client.invoke_shell()
+            stdin = channel.makefile('wb')
+            stdin.write("ap \n 8 \n 1 \n 1 \n 1 \n y \n {} \n {} \n \n".format(pwd, pwd))
+            wait_for(apps[0].is_dedicated_db_active)
+            yield apps[0]
     else:
         raise Exception("Can't setup dedicated db on appliance below 5.7 builds")
-    yield apps[0]
-
-    sp.destroy_pool(pool_id)
 
 
 """ The Following fixture 'fqdn_appliance' provisions one appliance for testing from an FQDN

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -9,12 +9,12 @@ import paramiko
 
 @pytest.fixture()
 def dedicated_db(appliance, app_creds):
-    HOST = appliance.address
-    USER = app_creds['username']
-    PASS = app_creds['password']
+    hostname = appliance.address
+    username = app_creds['username']
+    password = app_creds['password']
     client = paramiko.SSHClient()
     client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    client.connect(HOST, username=USER, password=PASS)
+    client.connect(hostname, username=username, password=password)
     channel = client.invoke_shell()
     stdin = channel.makefile('wb')
     stdin.write("ap \n 8 \n 1 \n 1 \n 1 \n y \n {PASS} \n {PASS} \n \n")

--- a/cfme/test_framework/sprout/client.py
+++ b/cfme/test_framework/sprout/client.py
@@ -102,7 +102,7 @@ class SproutClient(object):
             stream = get_stream(current_appliance.version)
         request_id = self.call_method(
             'request_appliances', preconfigured=preconfigured, version=version,
-            group=stream, provider=provider, lease_time=lease_time, ram=ram, cpu=cpu
+            group=stream, provider=provider, lease_time=lease_time, ram=ram, cpu=cpu, count=count
         )
         wait_for(
             lambda: self.call_method('request_check', str(request_id))['finished'], num_sec=300)

--- a/cfme/tests/cli/test_appliance_cli.py
+++ b/cfme/tests/cli/test_appliance_cli.py
@@ -1,4 +1,6 @@
 from fixtures.pytest_store import store
+from utils.log_validator import LogValidator
+import pytest
 
 
 def test_set_hostname(request):
@@ -10,24 +12,60 @@ def test_set_hostname(request):
 
 
 def test_configure_appliance_internal_fetch_key(request, app_creds, appliance):
-    app = appliance
     fetch_key_ip = store.current_appliance.address
-    app.ap_cli.configure_appliance_internal_fetch_key(0, 'localhost',
+    appliance.ap_cli.configure_appliance_internal_fetch_key(0, 'localhost',
         app_creds['username'], app_creds['password'], 'vmdb_production', fetch_key_ip,
         app_creds['sshlogin'], app_creds['sshpass'])
-    app.wait_for_evm_service()
-    app.wait_for_web_ui()
+    appliance.wait_for_evm_service()
+    appliance.wait_for_web_ui()
+
+
+def test_configure_appliance_external_join(request, app_creds, appliance):
+    appliance_ip = store.current_appliance.address
+    appliance.ap_cli.configure_appliance_external_join(appliance_ip,
+        app_creds['username'], app_creds['password'], 'vmdb_production', appliance_ip,
+        app_creds['sshlogin'], app_creds['sshpass'])
+    appliance.wait_for_evm_service()
+    appliance.wait_for_web_ui()
+
+
+def test_configure_appliance_external_create(request, app_creds, appliance, dedicated_db):
+    HOST = dedicated_db.address
+    appliance.ap_cli.configure_appliance_external_create(5, HOST,
+        app_creds['username'], app_creds['password'], 'vmdb_production', HOST,
+        app_creds['sshlogin'], app_creds['sshpass'])
+    appliance.wait_for_evm_service()
+    appliance.wait_for_web_ui()
+    return_code, output = appliance.ssh_client.run_command("cat /var/www/miq/vmdb/REGION | grep 5")
+    assert return_code == 0
+
+
+@pytest.mark.parametrize('auth_type', ['sso_enabled', 'saml_enabled', 'local_login_disabled'],
+    ids=['sso', 'saml', 'local_login'])
+def test_external_auth(request, auth_type, ipa_crud, app_creds):
+    evm_tail = LogValidator('/var/www/miq/vmdb/log/evm.log',
+                            matched_patterns=['.*{} to true.*'.format(auth_type)],
+                            hostname=ipa_crud.address,
+                            username=app_creds['sshlogin'],
+                            password=app_creds['password'])
+    evm_tail.fix_before_start()
+    command = 'appliance_console_cli --extauth-opts="/authentication/{}=true"'.format(auth_type)
+    ipa_crud.ssh_client.run_command(command)
+    evm_tail.validate_logs()
+
+    evm_tail = LogValidator('/var/www/miq/vmdb/log/evm.log',
+                            matched_patterns=['.*{} to false.*'.format(auth_type)],
+                            hostname=ipa_crud.address,
+                            username=app_creds['sshlogin'],
+                            password=app_creds['password'])
+
+    evm_tail.fix_before_start()
+    command2 = 'appliance_console_cli --extauth-opts="/authentication/{}=false"'.format(auth_type)
+    ipa_crud.ssh_client.run_command(command2)
+    evm_tail.validate_logs()
 
 
 def test_ipa_crud(request, ipa_creds, fqdn_appliance):
-    app = fqdn_appliance
-    app.ap_cli.configure_ipa(ipa_creds['ipaserver'], ipa_creds['username'],
+    fqdn_appliance.ap_cli.configure_ipa(ipa_creds['ipaserver'], ipa_creds['username'],
         ipa_creds['password'], ipa_creds['domain'], ipa_creds['realm'])
-    assert app.ssh_client.run_command("systemctl status sssd | grep running")
-    return_code, output = app.ssh_client.run_command(
-        "cat /etc/ipa/default.conf | grep 'enable_ra = True'")
-    assert return_code == 0
-    app.ap_cli.uninstall_ipa_client()
-    return_code, output = app.ssh_client.run_command(
-        "cat /etc/ipa/default.conf")
-    assert return_code != 0
+    fqdn_appliance.ap_cli.uninstall_ipa_client()

--- a/cfme/tests/cli/test_appliance_cli.py
+++ b/cfme/tests/cli/test_appliance_cli.py
@@ -33,8 +33,8 @@ def test_configure_appliance_external_join(request, app_creds, temp_appliance_un
 
 @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
 def test_configure_appliance_external_create(
-        request, app_creds, dedicated_db, temp_appliance_unconfig_funcscope):
-    hostname = dedicated_db.address
+        request, app_creds, dedicated_db_appliance, temp_appliance_unconfig_funcscope):
+    hostname = dedicated_db_appliance.address
     temp_appliance_unconfig_funcscope.ap_cli.configure_appliance_external_create(5, hostname,
         app_creds['username'], app_creds['password'], 'vmdb_production', hostname,
         app_creds['sshlogin'], app_creds['sshpass'])

--- a/cfme/tests/cli/test_appliance_cli.py
+++ b/cfme/tests/cli/test_appliance_cli.py
@@ -12,32 +12,34 @@ def test_set_hostname(request):
     assert return_code == 0
 
 
-def test_configure_appliance_internal_fetch_key(request, app_creds, appliance):
+def test_configure_appliance_internal_fetch_key(
+        request, app_creds, temp_appliance_unconfig_funcscope):
     fetch_key_ip = store.current_appliance.address
-    appliance.ap_cli.configure_appliance_internal_fetch_key(0, 'localhost',
+    temp_appliance_unconfig_funcscope.ap_cli.configure_appliance_internal_fetch_key(0, 'localhost',
         app_creds['username'], app_creds['password'], 'vmdb_production', fetch_key_ip,
         app_creds['sshlogin'], app_creds['sshpass'])
-    appliance.wait_for_evm_service()
-    appliance.wait_for_web_ui()
+    temp_appliance_unconfig_funcscope.wait_for_evm_service()
+    temp_appliance_unconfig_funcscope.wait_for_web_ui()
 
 
-def test_configure_appliance_external_join(request, app_creds, appliance):
+def test_configure_appliance_external_join(request, app_creds, temp_appliance_unconfig_funcscope):
     appliance_ip = store.current_appliance.address
-    appliance.ap_cli.configure_appliance_external_join(appliance_ip,
+    temp_appliance_unconfig_funcscope.ap_cli.configure_appliance_external_join(appliance_ip,
         app_creds['username'], app_creds['password'], 'vmdb_production', appliance_ip,
         app_creds['sshlogin'], app_creds['sshpass'])
-    appliance.wait_for_evm_service()
-    appliance.wait_for_web_ui()
+    temp_appliance_unconfig_funcscope.wait_for_evm_service()
+    temp_appliance_unconfig_funcscope.wait_for_web_ui()
 
 
 @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
-def test_configure_appliance_external_create(request, app_creds, dedicated_db, appliance):
+def test_configure_appliance_external_create(
+        request, app_creds, dedicated_db, temp_appliance_unconfig_funcscope):
     hostname = dedicated_db.address
-    appliance.ap_cli.configure_appliance_external_create(5, hostname,
+    temp_appliance_unconfig_funcscope.ap_cli.configure_appliance_external_create(5, hostname,
         app_creds['username'], app_creds['password'], 'vmdb_production', hostname,
         app_creds['sshlogin'], app_creds['sshpass'])
-    appliance.wait_for_evm_service()
-    appliance.wait_for_web_ui()
+    temp_appliance_unconfig_funcscope.wait_for_evm_service()
+    temp_appliance_unconfig_funcscope.wait_for_web_ui()
 
 
 @pytest.mark.parametrize('auth_type', ['sso_enabled', 'saml_enabled', 'local_login_disabled'],

--- a/cfme/tests/cli/test_appliance_cli.py
+++ b/cfme/tests/cli/test_appliance_cli.py
@@ -1,7 +1,7 @@
 from fixtures.pytest_store import store
 from utils.log_validator import LogValidator
-import pytest
 from utils import version
+import pytest
 
 
 def test_set_hostname(request):

--- a/cfme/tests/cli/test_appliance_cli.py
+++ b/cfme/tests/cli/test_appliance_cli.py
@@ -36,8 +36,6 @@ def test_configure_appliance_external_create(request, app_creds, dedicated_db, a
         app_creds['sshlogin'], app_creds['sshpass'])
     appliance.wait_for_evm_service()
     appliance.wait_for_web_ui()
-    return_code, output = appliance.ssh_client.run_command("cat /var/www/miq/vmdb/REGION | grep 5")
-    assert return_code == 0
 
 
 @pytest.mark.parametrize('auth_type', ['sso_enabled', 'saml_enabled', 'local_login_disabled'],

--- a/cfme/tests/cli/test_appliance_cli.py
+++ b/cfme/tests/cli/test_appliance_cli.py
@@ -1,73 +1,4 @@
 from fixtures.pytest_store import store
-from utils.version import get_stream
-from cfme.test_framework.sprout.client import SproutClient
-from utils.appliance import current_appliance
-from utils.conf import cfme_data, credentials
-from utils.log import logger
-import pytest
-
-
-@pytest.yield_fixture(scope="module")
-def appliance():
-    sp = SproutClient.from_config()
-    version = current_appliance.version.vstring
-    stream = get_stream(current_appliance.version)
-    apps, pool_id = sp.provision_appliances(
-        count=1, preconfigured=False, version=version, stream=stream)
-
-    yield apps[0]
-
-    sp.destroy_pool(pool_id)
-
-
-@pytest.yield_fixture(scope="module")
-def fqdn_appliance():
-    sp = SproutClient.from_config()
-    available_providers = set(sp.call_method('available_providers'))
-    required_providers = set(cfme_data['fqdn_providers'])
-    usable_providers = available_providers & required_providers
-    version = current_appliance.version.vstring
-    stream = get_stream(current_appliance.version)
-
-    for provider in usable_providers:
-        try:
-            apps, pool_id = sp.provision_appliances(
-                count=1, preconfigured=True, version=version, stream=stream, provider=provider)
-            break
-        except Exception as e:
-            logger.warning("Couldn't provision appliance with following error:")
-            logger.warning("{}".format(e))
-            continue
-    else:
-        logger.error("Couldn't provision an appliance at all")
-
-    yield apps[0]
-
-    sp.destroy_pool(pool_id)
-
-
-@pytest.fixture()
-def app_creds():
-    return {
-        'username': credentials['database']['username'],
-        'password': credentials['database']['password'],
-        'sshlogin': credentials['ssh']['username'],
-        'sshpass': credentials['ssh']['password']
-    }
-
-
-@pytest.fixture()
-def ipa_creds():
-    fqdn = cfme_data['auth_modes']['ext_ipa']['ipaserver'].split('.', 1)
-    creds_key = cfme_data['auth_modes']['ext_ipa']['credentials']
-    return{
-        'hostname': fqdn[0],
-        'domain': fqdn[1],
-        'realm': cfme_data['auth_modes']['ext_ipa']['iparealm'],
-        'ipaserver': cfme_data['auth_modes']['ext_ipa']['ipaserver'],
-        'username': credentials[creds_key]['principal'],
-        'password': credentials[creds_key]['password']
-    }
 
 
 def test_set_hostname(request):
@@ -95,7 +26,7 @@ def test_ipa_crud(request, ipa_creds, fqdn_appliance):
     assert app.ssh_client.run_command("systemctl status sssd | grep running")
     return_code, output = app.ssh_client.run_command(
         "cat /etc/ipa/default.conf | grep 'enable_ra = True'")
-    assert return_code == 0   # TODO extend test to login as ipa user
+    assert return_code == 0
     app.ap_cli.uninstall_ipa_client()
     return_code, output = app.ssh_client.run_command(
         "cat /etc/ipa/default.conf")

--- a/cfme/tests/cli/test_appliance_cli.py
+++ b/cfme/tests/cli/test_appliance_cli.py
@@ -29,7 +29,7 @@ def test_configure_appliance_external_join(request, app_creds, appliance):
     appliance.wait_for_web_ui()
 
 
-def test_configure_appliance_external_create(request, app_creds, appliance, dedicated_db):
+def test_configure_appliance_external_create(request, app_creds, dedicated_db, appliance):
     hostname = dedicated_db.address
     appliance.ap_cli.configure_appliance_external_create(5, hostname,
         app_creds['username'], app_creds['password'], 'vmdb_production', hostname,

--- a/cfme/tests/cli/test_appliance_cli.py
+++ b/cfme/tests/cli/test_appliance_cli.py
@@ -30,9 +30,9 @@ def test_configure_appliance_external_join(request, app_creds, appliance):
 
 
 def test_configure_appliance_external_create(request, app_creds, appliance, dedicated_db):
-    HOST = dedicated_db.address
-    appliance.ap_cli.configure_appliance_external_create(5, HOST,
-        app_creds['username'], app_creds['password'], 'vmdb_production', HOST,
+    hostname = dedicated_db.address
+    appliance.ap_cli.configure_appliance_external_create(5, hostname,
+        app_creds['username'], app_creds['password'], 'vmdb_production', hostname,
         app_creds['sshlogin'], app_creds['sshpass'])
     appliance.wait_for_evm_service()
     appliance.wait_for_web_ui()

--- a/cfme/tests/cli/test_appliance_cli.py
+++ b/cfme/tests/cli/test_appliance_cli.py
@@ -1,6 +1,7 @@
 from fixtures.pytest_store import store
 from utils.log_validator import LogValidator
 import pytest
+from utils import version
 
 
 def test_set_hostname(request):
@@ -29,6 +30,7 @@ def test_configure_appliance_external_join(request, app_creds, appliance):
     appliance.wait_for_web_ui()
 
 
+@pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
 def test_configure_appliance_external_create(request, app_creds, dedicated_db, appliance):
     hostname = dedicated_db.address
     appliance.ap_cli.configure_appliance_external_create(5, hostname,

--- a/conftest.py
+++ b/conftest.py
@@ -202,6 +202,7 @@ pytest_plugins = (
 
     'markers',
 
+    'cfme.fixtures.cli',
     'cfme.fixtures.pytest_selenium',
     'cfme.fixtures.configure_auth_mode',
     'cfme.fixtures.rdb',

--- a/fixtures/appliance.py
+++ b/fixtures/appliance.py
@@ -4,9 +4,6 @@ In cases where you cannot run a certain test againts the primary appliance becau
 destructive potential (which could render all subsequent testing useless), you want to use
 a temporary appliance parallel to the primary one.
 
-For tests such as setting up an appliance (or multiple) in a certain setup, you will want to use
-the :py:func:`temp_appliance_unconfig` fixture and then configure the appliance(s) yourself.
-
 For tests where all you need is a single preconfigured appliance to run a database restore on for
 example, you will want to use the :py:func:`temp_appliance_preconfig` fixture.
 

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -97,7 +97,7 @@ class ApplianceConsoleCli(object):
                 dbname=dbname, fetch_key=fetch_key, sshlogin=sshlogin, sshpass=sshpass))
 
     def configure_ipa(self, ipaserver, username, password, domain, realm):
-        self.run("-e {isaserver} -n {username} -w {password} -o {domain} -l {realm}".format(
+        self.run("-e {ipaserver} -n {username} -w {password} -o {domain} -l {realm}".format(
             ipaserver=ipaserver, username=username, passwrod=password, domain=domain, realm=realm))
         assert self.appliance.ssh_client.run_command("systemctl status sssd | grep running")
         return_code, output = self.appliance.ssh_client.run_command(

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -73,26 +73,32 @@ class ApplianceConsoleCli(object):
             "appliance_console_cli {}".format(ap_cli_command))
 
     def set_hostname(self, hostname):
-        self.run("-H {}".format(hostname))
+        self.run("-H {host}".format(host=hostname))
 
     def configure_appliance_external_join(self, dbhostname,
             username, password, dbname, fetch_key, sshlogin, sshpass):
-        self.run("-h {} -U {} -p {} -d {} -v -K {} -s {} -a {}".format(
-            dbhostname, username, password, dbname, fetch_key, sshlogin, sshpass))
+        self.run("-h {hostname} -U {username} -p {password} -d {dbname} -v -K {fetch_key} "
+            "-s {sshlogin} -a {sshpass}".format(
+                dbhostname=dbhostname, username=username, passowrd=password, dbname=dbname,
+                fetch_key=fetch_key, sshlogin=sshlogin, sshpass=sshpass))
 
     def configure_appliance_external_create(self, region, dbhostname,
             username, password, dbname, fetch_key, sshlogin, sshpass):
-        self.run("-r {} -h {} -U {} -p {} -d {} -v -K {} -s {} -a {}".format(
-            region, dbhostname, username, password, dbname, fetch_key, sshlogin, sshpass))
+        self.run("-r {region} -h {dbhostname} -U {username} -p {password} "
+            "-d {dbname} -v -K {fetch_key} -s {sshlogin} -a {sshpass}".format(
+                region=region, dbhostname=dbhostname, username=username, password=password,
+                dbname=dbname, fetch_key=fetch_key, sshlogin=sshlogin, sshpass=sshpass))
 
     def configure_appliance_internal_fetch_key(self, region, dbhostname,
             username, password, dbname, fetch_key, sshlogin, sshpass):
-        self.run("-r {} -i -h {} -U {} -p {} -d {} -v -K {} -s {} -a {}".format(
-            region, dbhostname, username, password, dbname, fetch_key, sshlogin, sshpass))
+        self.run("-r {region} -i -h {dbhostname} -U {username} -p {password} "
+            "-d {dbname} -v -K {fetch_key} -s {sshlogin} -a {sshpass}".format(
+                region=region, dbhostname=dbhostname, username=username, password=password,
+                dbname=dbname, fetch_key=fetch_key, sshlogin=sshlogin, sshpass=sshpass))
 
     def configure_ipa(self, ipaserver, username, password, domain, realm):
-        self.run("-e {} -n {} -w {} -o {} -l {}".format(
-            ipaserver, username, password, domain, realm))
+        self.run("-e {isaserver} -n {username} -w {password} -o {domain} -l {realm}".format(
+            ipaserver=ipaserver, username=username, passwrod=password, domain=domain, realm=realm))
         assert self.appliance.ssh_client.run_command("systemctl status sssd | grep running")
         return_code, output = self.appliance.ssh_client.run_command(
             "cat /etc/ipa/default.conf | grep 'enable_ra = True'")

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -1406,8 +1406,8 @@ class IPAppliance(object):
 
         return status, out
 
-    def is_dedicated_db_active(dedicated_db):
-        return_code, output = dedicated_db.ssh_client.run_command(
+    def is_dedicated_db_active(self):
+        return_code, output = self.ssh_client.run_command(
             "systemctl status {}-postgresql.service | grep running".format(scl_name()))
         return return_code == 0
 

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -77,9 +77,9 @@ class ApplianceConsoleCli(object):
 
     def configure_appliance_external_join(self, dbhostname,
             username, password, dbname, fetch_key, sshlogin, sshpass):
-        self.run("-h {hostname} -U {username} -p {password} -d {dbname} -v -K {fetch_key} "
+        self.run("-h {dbhostname} -U {username} -p {password} -d {dbname} -v -K {fetch_key} "
             "-s {sshlogin} -a {sshpass}".format(
-                dbhostname=dbhostname, username=username, passowrd=password, dbname=dbname,
+                dbhostname=dbhostname, username=username, password=password, dbname=dbname,
                 fetch_key=fetch_key, sshlogin=sshlogin, sshpass=sshpass))
 
     def configure_appliance_external_create(self, region, dbhostname,
@@ -98,7 +98,7 @@ class ApplianceConsoleCli(object):
 
     def configure_ipa(self, ipaserver, username, password, domain, realm):
         self.run("-e {ipaserver} -n {username} -w {password} -o {domain} -l {realm}".format(
-            ipaserver=ipaserver, username=username, passwrod=password, domain=domain, realm=realm))
+            ipaserver=ipaserver, username=username, password=password, domain=domain, realm=realm))
         assert self.appliance.ssh_client.run_command("systemctl status sssd | grep running")
         return_code, output = self.appliance.ssh_client.run_command(
             "cat /etc/ipa/default.conf | grep 'enable_ra = True'")

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -69,36 +69,36 @@ class ApplianceConsoleCli(object):
     def __init__(self, appliance):
         self.appliance = appliance
 
-    def run(self, ap_cli_command):
+    def _run(self, ap_cli_command):
         return self.appliance.ssh_client.run_command(
             "appliance_console_cli {}".format(ap_cli_command))
 
     def set_hostname(self, hostname):
-        self.run("-H {host}".format(host=hostname))
+        self._run("-H {host}".format(host=hostname))
 
     def configure_appliance_external_join(self, dbhostname,
             username, password, dbname, fetch_key, sshlogin, sshpass):
-        self.run("-h {dbhostname} -U {username} -p {password} -d {dbname} -v -K {fetch_key} "
+        self._run("-h {dbhostname} -U {username} -p {password} -d {dbname} -v -K {fetch_key} "
             "-s {sshlogin} -a {sshpass}".format(
                 dbhostname=dbhostname, username=username, password=password, dbname=dbname,
                 fetch_key=fetch_key, sshlogin=sshlogin, sshpass=sshpass))
 
     def configure_appliance_external_create(self, region, dbhostname,
             username, password, dbname, fetch_key, sshlogin, sshpass):
-        self.run("-r {region} -h {dbhostname} -U {username} -p {password} "
+        self._run("-r {region} -h {dbhostname} -U {username} -p {password} "
             "-d {dbname} -v -K {fetch_key} -s {sshlogin} -a {sshpass}".format(
                 region=region, dbhostname=dbhostname, username=username, password=password,
                 dbname=dbname, fetch_key=fetch_key, sshlogin=sshlogin, sshpass=sshpass))
 
     def configure_appliance_internal_fetch_key(self, region, dbhostname,
             username, password, dbname, fetch_key, sshlogin, sshpass):
-        self.run("-r {region} -i -h {dbhostname} -U {username} -p {password} "
+        self._run("-r {region} -i -h {dbhostname} -U {username} -p {password} "
             "-d {dbname} -v -K {fetch_key} -s {sshlogin} -a {sshpass}".format(
                 region=region, dbhostname=dbhostname, username=username, password=password,
                 dbname=dbname, fetch_key=fetch_key, sshlogin=sshlogin, sshpass=sshpass))
 
     def configure_ipa(self, ipaserver, username, password, domain, realm):
-        self.run("-e {ipaserver} -n {username} -w {password} -o {domain} -l {realm}".format(
+        self._run("-e {ipaserver} -n {username} -w {password} -o {domain} -l {realm}".format(
             ipaserver=ipaserver, username=username, password=password, domain=domain, realm=realm))
         assert self.appliance.ssh_client.run_command("systemctl status sssd | grep running")
         return_code, output = self.appliance.ssh_client.run_command(
@@ -106,7 +106,7 @@ class ApplianceConsoleCli(object):
         assert return_code == 0
 
     def uninstall_ipa_client(self):
-        self.run("--uninstall-ipa")
+        self._run("--uninstall-ipa")
         return_code, output = self.appliance.ssh_client.run_command(
             "cat /etc/ipa/default.conf")
         assert return_code != 0

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -11,6 +11,7 @@ from textwrap import dedent
 from time import sleep
 from urlparse import ParseResult, urlparse
 from tempfile import NamedTemporaryFile
+from utils.db import scl_name
 
 from cached_property import cached_property
 
@@ -1404,6 +1405,11 @@ class IPAppliance(object):
             raise ApplianceException(msg)
 
         return status, out
+
+    def is_dedicated_db_active(dedicated_db):
+        return_code, output = dedicated_db.ssh_client.run_command(
+            "systemctl status {}-postgresql.service | grep running".format(scl_name()))
+        return return_code == 0
 
     def _check_appliance_ui_wait_fn(self):
         # Get the URL, don't verify ssl cert

--- a/utils/log_validator.py
+++ b/utils/log_validator.py
@@ -39,11 +39,9 @@ class LogValidator(object):
     """
 
     def __init__(self, remote_filename, **kwargs):
-        self.skip_patterns = kwargs.pop('skip_patterns') if 'skip_patterns' in kwargs else []
-        self.failure_patterns = kwargs.pop(
-            'failure_patterns') if 'failure_patterns' in kwargs else []
-        self.matched_patterns = kwargs.pop(
-            'matched_patterns') if 'matched_patterns' in kwargs else []
+        self.skip_patterns = kwargs.pop('skip_patterns', [])
+        self.failure_patterns = kwargs.pop('failure_patterns', [])
+        self.matched_patterns = kwargs.pop('matched_patterns', [])
 
         self._remote_file_tail = SSHTail(remote_filename, **kwargs)
         self.matches = {}

--- a/utils/log_validator.py
+++ b/utils/log_validator.py
@@ -39,10 +39,13 @@ class LogValidator(object):
     """
 
     def __init__(self, remote_filename, **kwargs):
-        self._remote_file_tail = SSHTail(remote_filename)
-        self.skip_patterns = kwargs['skip_patterns'] if 'skip_patterns' in kwargs else []
-        self.failure_patterns = kwargs['failure_patterns'] if 'failure_patterns' in kwargs else []
-        self.matched_patterns = kwargs['matched_patterns'] if 'matched_patterns' in kwargs else []
+        self.skip_patterns = kwargs.pop('skip_patterns') if 'skip_patterns' in kwargs else []
+        self.failure_patterns = kwargs.pop(
+            'failure_patterns') if 'failure_patterns' in kwargs else []
+        self.matched_patterns = kwargs.pop(
+            'matched_patterns') if 'matched_patterns' in kwargs else []
+
+        self._remote_file_tail = SSHTail(remote_filename, **kwargs)
         self.matches = {}
 
     def fix_before_start(self):
@@ -77,5 +80,5 @@ class LogValidator(object):
 
     def _verify_match_logs(self):
         for pattern in self.matched_patterns:
-            if not self.matches[pattern]:
+            if pattern not in self.matches:
                 pytest.fail('Expected pattern {} did not match'.format(pattern))


### PR DESCRIPTION
Moved fixtures such as sprout provisioning, so new tests can call them rather then adding additional fixtures to each file.