### PR TITLE
[1LP][RFR] REST API tests for services collection

### DIFF
--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -162,10 +162,15 @@ def service_data(request, rest_api, a_provider, dialog, service_catalogs):
 
     @request.addfinalizer
     def _finished():
-        a_provider.mgmt.delete_vm(vm_name)
+        try:
+            a_provider.mgmt.delete_vm(vm_name)
+        except Exception:
+            # vm can be deleted/retired by test
+            logger.warning("Failed to delete vm '{}'.".format(vm_name))
         try:
             rest_api.collections.services.get(name=catalog_item.name).action.delete()
         except ValueError:
+            # service can be deleted by test
             logger.warning("Failed to delete service '{}'.".format(catalog_item.name))
 
     return {'service_name': catalog_item.name, 'vm_name': vm_name}


### PR DESCRIPTION
Adding power operations tests for `/api/services` collection.
Reviving `test_set_service_owner` and `test_set_services_owner`

**PRT results**
all tests on upstream are failing on `ServiceDialog.create()` with `NoSuchElementException`. That's unrelated to changes in this PR.