### PR TITLE
[RFR] Defer loading

### DIFF
--- a/cfme/cloud/provider/azure.py
+++ b/cfme/cloud/provider/azure.py
@@ -30,6 +30,10 @@ class AzureProvider(CloudProvider):
                 'azure_tenant_id': kwargs.get('tenant_id'),
                 'azure_subscription_id': kwargs.get('subscription_id')}
 
+    def deployment_helper(self, deploy_args):
+        """ Used in utils.virtual_machines """
+        return self.data['provisioning']
+
     @classmethod
     def from_config(cls, prov_config, prov_key):
         credentials_key = prov_config['credentials']

--- a/cfme/cloud/provider/azure.py
+++ b/cfme/cloud/provider/azure.py
@@ -1,12 +1,15 @@
 from utils.version import pick
-from mgmtsystem.azure import AzureSystem
 from . import CloudProvider
 
 
 @CloudProvider.add_provider_type
 class AzureProvider(CloudProvider):
     type_name = "azure"
-    mgmt_class = AzureSystem
+
+    @property
+    def mgmt_class(self):
+        from mgmtsystem.azure import AzureSystem
+        return AzureSystem
 
     def __init__(self, name=None, credentials=None, zone=None, key=None, region=None,
                  tenant_id=None, subscription_id=None):

--- a/cfme/cloud/provider/azure.py
+++ b/cfme/cloud/provider/azure.py
@@ -1,12 +1,13 @@
-from utils.version import pick
 from . import CloudProvider
+from utils.cached_property import cached_property
+from utils.version import pick
 
 
 @CloudProvider.add_provider_type
 class AzureProvider(CloudProvider):
     type_name = "azure"
 
-    @property
+    @cached_property
     def mgmt_class(self):
         from mgmtsystem.azure import AzureSystem
         return AzureSystem

--- a/cfme/cloud/provider/azure.py
+++ b/cfme/cloud/provider/azure.py
@@ -1,5 +1,6 @@
+from cached_property import cached_property
+
 from . import CloudProvider
-from utils.cached_property import cached_property
 from utils.version import pick
 
 

--- a/cfme/cloud/provider/ec2.py
+++ b/cfme/cloud/provider/ec2.py
@@ -1,6 +1,7 @@
+from cached_property import cached_property
+
 from . import CloudProvider
 import cfme.fixtures.pytest_selenium as sel
-from utils.cached_property import cached_property
 
 
 @CloudProvider.add_provider_type

--- a/cfme/cloud/provider/ec2.py
+++ b/cfme/cloud/provider/ec2.py
@@ -1,12 +1,13 @@
 from . import CloudProvider
 import cfme.fixtures.pytest_selenium as sel
+from utils.cached_property import cached_property
 
 
 @CloudProvider.add_provider_type
 class EC2Provider(CloudProvider):
     type_name = "ec2"
 
-    @property
+    @cached_property
     def mgmt_class(self):
         from mgmtsystem.ec2 import EC2System
         return EC2System

--- a/cfme/cloud/provider/ec2.py
+++ b/cfme/cloud/provider/ec2.py
@@ -1,4 +1,3 @@
-from mgmtsystem.ec2 import EC2System
 from . import CloudProvider
 import cfme.fixtures.pytest_selenium as sel
 
@@ -6,7 +5,11 @@ import cfme.fixtures.pytest_selenium as sel
 @CloudProvider.add_provider_type
 class EC2Provider(CloudProvider):
     type_name = "ec2"
-    mgmt_class = EC2System
+
+    @property
+    def mgmt_class(self):
+        from mgmtsystem.ec2 import EC2System
+        return EC2System
 
     def __init__(self, name=None, credentials=None, zone=None, key=None, region=None):
         super(EC2Provider, self).__init__(name=name, credentials=credentials,

--- a/cfme/cloud/provider/gce.py
+++ b/cfme/cloud/provider/gce.py
@@ -1,6 +1,7 @@
+from cached_property import cached_property
+
 from . import CloudProvider
 import cfme.fixtures.pytest_selenium as sel
-from utils.cached_property import cached_property
 
 
 @CloudProvider.add_provider_type

--- a/cfme/cloud/provider/gce.py
+++ b/cfme/cloud/provider/gce.py
@@ -1,4 +1,3 @@
-from mgmtsystem.google import GoogleCloudSystem
 from . import CloudProvider
 import cfme.fixtures.pytest_selenium as sel
 
@@ -6,7 +5,11 @@ import cfme.fixtures.pytest_selenium as sel
 @CloudProvider.add_provider_type
 class GCEProvider(CloudProvider):
     type_name = "gce"
-    mgmt_class = GoogleCloudSystem
+
+    @property
+    def mgmt_class(self):
+        from mgmtsystem.google import GoogleCloudSystem
+        return GoogleCloudSystem
 
     def __init__(self, name=None, project=None, zone=None, region=None, credentials=None, key=None):
         super(GCEProvider, self).__init__(name=name, zone=zone, key=key, credentials=credentials)

--- a/cfme/cloud/provider/gce.py
+++ b/cfme/cloud/provider/gce.py
@@ -1,12 +1,13 @@
 from . import CloudProvider
 import cfme.fixtures.pytest_selenium as sel
+from utils.cached_property import cached_property
 
 
 @CloudProvider.add_provider_type
 class GCEProvider(CloudProvider):
     type_name = "gce"
 
-    @property
+    @cached_property
     def mgmt_class(self):
         from mgmtsystem.google import GoogleCloudSystem
         return GoogleCloudSystem

--- a/cfme/cloud/provider/openstack.py
+++ b/cfme/cloud/provider/openstack.py
@@ -61,6 +61,12 @@ class OpenStackProvider(CloudProvider):
             })
         return data_dict
 
+    def deployment_helper(self, deploy_args):
+        """ Used in utils.virtual_machines """
+        if ('network_name' not in deploy_args) and self.data.get('network'):
+            return {'network_name': self.data['network']}
+        return {}
+
     @classmethod
     def from_config(cls, prov_config, prov_key):
         from utils.providers import get_crud

--- a/cfme/cloud/provider/openstack.py
+++ b/cfme/cloud/provider/openstack.py
@@ -1,4 +1,5 @@
-from utils.cached_property import cached_property
+from cached_property import cached_property
+
 from utils.version import current_version
 
 from . import CloudProvider

--- a/cfme/cloud/provider/openstack.py
+++ b/cfme/cloud/provider/openstack.py
@@ -1,3 +1,4 @@
+from utils.cached_property import cached_property
 from utils.version import current_version
 
 from . import CloudProvider
@@ -7,7 +8,7 @@ from . import CloudProvider
 class OpenStackProvider(CloudProvider):
     type_name = "openstack"
 
-    @property
+    @cached_property
     def mgmt_class(self):
         from mgmtsystem.openstack import OpenstackSystem
         return OpenstackSystem

--- a/cfme/cloud/provider/openstack.py
+++ b/cfme/cloud/provider/openstack.py
@@ -1,5 +1,3 @@
-from mgmtsystem.openstack import OpenstackSystem
-
 from utils.version import current_version
 
 from . import CloudProvider
@@ -8,7 +6,11 @@ from . import CloudProvider
 @CloudProvider.add_provider_type
 class OpenStackProvider(CloudProvider):
     type_name = "openstack"
-    mgmt_class = OpenstackSystem
+
+    @property
+    def mgmt_class(self):
+        from mgmtsystem.openstack import OpenstackSystem
+        return OpenstackSystem
 
     def __init__(self, name=None, credentials=None, zone=None, key=None, hostname=None,
                  ip_address=None, api_port=None, sec_protocol=None, amqp_sec_protocol=None,

--- a/cfme/containers/provider/kubernetes.py
+++ b/cfme/containers/provider/kubernetes.py
@@ -1,11 +1,12 @@
 from . import ContainersProvider
+from utils.cached_property import cached_property
 
 
 @ContainersProvider.add_provider_type
 class KubernetesProvider(ContainersProvider):
     type_name = "kubernetes"
 
-    @property
+    @cached_property
     def mgmt_class(self):
         from mgmtsystem.kubernetes import Kubernetes
         return Kubernetes

--- a/cfme/containers/provider/kubernetes.py
+++ b/cfme/containers/provider/kubernetes.py
@@ -1,5 +1,6 @@
+from cached_property import cached_property
+
 from . import ContainersProvider
-from utils.cached_property import cached_property
 
 
 @ContainersProvider.add_provider_type

--- a/cfme/containers/provider/kubernetes.py
+++ b/cfme/containers/provider/kubernetes.py
@@ -1,11 +1,14 @@
 from . import ContainersProvider
-from mgmtsystem.kubernetes import Kubernetes
 
 
 @ContainersProvider.add_provider_type
 class KubernetesProvider(ContainersProvider):
     type_name = "kubernetes"
-    mgmt_class = Kubernetes
+
+    @property
+    def mgmt_class(self):
+        from mgmtsystem.kubernetes import Kubernetes
+        return Kubernetes
 
     def __init__(self, name=None, credentials=None, key=None,
                  zone=None, hostname=None, port=None, provider_data=None):

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -1,6 +1,5 @@
 from . import ContainersProvider
 from utils.varmeth import variable
-from mgmtsystem.openshift import Openshift
 from os import path
 
 
@@ -17,7 +16,11 @@ class OpenshiftProvider(ContainersProvider):
     num_route_template = ['num_route'] + ['num_template']
     STATS_TO_MATCH = ContainersProvider.STATS_TO_MATCH + num_route_template
     type_name = "openshift"
-    mgmt_class = Openshift
+
+    @property
+    def mgmt_class(self):
+        from mgmtsystem.openshift import Openshift
+        return Openshift
 
     def __init__(self, name=None, credentials=None, key=None,
                  zone=None, hostname=None, port=None, provider_data=None):

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -1,4 +1,5 @@
 from . import ContainersProvider
+from utils.cached_property import cached_property
 from utils.varmeth import variable
 from os import path
 
@@ -17,7 +18,7 @@ class OpenshiftProvider(ContainersProvider):
     STATS_TO_MATCH = ContainersProvider.STATS_TO_MATCH + num_route_template
     type_name = "openshift"
 
-    @property
+    @cached_property
     def mgmt_class(self):
         from mgmtsystem.openshift import Openshift
         return Openshift

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -1,5 +1,6 @@
+from cached_property import cached_property
+
 from . import ContainersProvider
-from utils.cached_property import cached_property
 from utils.varmeth import variable
 from os import path
 

--- a/cfme/infrastructure/provider/openstack_infra.py
+++ b/cfme/infrastructure/provider/openstack_infra.py
@@ -1,4 +1,5 @@
 from . import InfraProvider, prop_region
+from utils.cached_property import cached_property
 
 
 @InfraProvider.add_provider_type
@@ -7,7 +8,7 @@ class OpenstackInfraProvider(InfraProvider):
     _properties_region = prop_region
     type_name = "openstack-infra"
 
-    @property
+    @cached_property
     def mgmt_class(self):
         from mgmtsystem.openstack_infra import OpenstackInfraSystem
         return OpenstackInfraSystem

--- a/cfme/infrastructure/provider/openstack_infra.py
+++ b/cfme/infrastructure/provider/openstack_infra.py
@@ -1,5 +1,6 @@
+from cached_property import cached_property
+
 from . import InfraProvider, prop_region
-from utils.cached_property import cached_property
 
 
 @InfraProvider.add_provider_type

--- a/cfme/infrastructure/provider/openstack_infra.py
+++ b/cfme/infrastructure/provider/openstack_infra.py
@@ -1,4 +1,3 @@
-from mgmtsystem.openstack_infra import OpenstackInfraSystem
 from . import InfraProvider, prop_region
 
 
@@ -7,7 +6,11 @@ class OpenstackInfraProvider(InfraProvider):
     STATS_TO_MATCH = ['num_template', 'num_host']
     _properties_region = prop_region
     type_name = "openstack-infra"
-    mgmt_class = OpenstackInfraSystem
+
+    @property
+    def mgmt_class(self):
+        from mgmtsystem.openstack_infra import OpenstackInfraSystem
+        return OpenstackInfraSystem
 
     def __init__(self, name=None, credentials=None, key=None, hostname=None,
                  ip_address=None, start_ip=None, end_ip=None, provider_data=None,

--- a/cfme/infrastructure/provider/rhevm.py
+++ b/cfme/infrastructure/provider/rhevm.py
@@ -32,6 +32,12 @@ class RHEVMProvider(InfraProvider):
                 'candu_hostname_text':
                 kwargs.get('hostname') if self.credentials.get('candu', None) else None}
 
+    def deployment_helper(self, deploy_args):
+        """ Used in utils.virtual_machines """
+        if 'default_cluster' not in deploy_args:
+            return {'cluster': self.data['default_cluster']}
+        return {}
+
     @classmethod
     def from_config(cls, prov_config, prov_key):
         credentials_key = prov_config['credentials']

--- a/cfme/infrastructure/provider/rhevm.py
+++ b/cfme/infrastructure/provider/rhevm.py
@@ -1,4 +1,3 @@
-from mgmtsystem.rhevm import RHEVMSystem
 from . import InfraProvider, prop_region
 
 
@@ -6,7 +5,11 @@ from . import InfraProvider, prop_region
 class RHEVMProvider(InfraProvider):
     _properties_region = prop_region
     type_name = "rhevm"
-    mgmt_class = RHEVMSystem
+
+    @property
+    def mgmt_class(self):
+        from mgmtsystem.rhevm import RHEVMSystem
+        return RHEVMSystem
 
     def __init__(self, name=None, credentials=None, zone=None, key=None, hostname=None,
                  ip_address=None, api_port=None, start_ip=None, end_ip=None,

--- a/cfme/infrastructure/provider/rhevm.py
+++ b/cfme/infrastructure/provider/rhevm.py
@@ -1,4 +1,5 @@
 from . import InfraProvider, prop_region
+from utils.cached_property import cached_property
 
 
 @InfraProvider.add_provider_type
@@ -6,7 +7,7 @@ class RHEVMProvider(InfraProvider):
     _properties_region = prop_region
     type_name = "rhevm"
 
-    @property
+    @cached_property
     def mgmt_class(self):
         from mgmtsystem.rhevm import RHEVMSystem
         return RHEVMSystem

--- a/cfme/infrastructure/provider/rhevm.py
+++ b/cfme/infrastructure/provider/rhevm.py
@@ -1,5 +1,6 @@
+from cached_property import cached_property
+
 from . import InfraProvider, prop_region
-from utils.cached_property import cached_property
 
 
 @InfraProvider.add_provider_type

--- a/cfme/infrastructure/provider/scvmm.py
+++ b/cfme/infrastructure/provider/scvmm.py
@@ -1,5 +1,6 @@
+from cached_property import cached_property
+
 from . import InfraProvider
-from utils.cached_property import cached_property
 
 
 @InfraProvider.add_provider_type

--- a/cfme/infrastructure/provider/scvmm.py
+++ b/cfme/infrastructure/provider/scvmm.py
@@ -1,4 +1,3 @@
-from mgmtsystem.scvmm import SCVMMSystem
 from . import InfraProvider
 
 
@@ -6,7 +5,11 @@ from . import InfraProvider
 class SCVMMProvider(InfraProvider):
     STATS_TO_MATCH = ['num_template', 'num_vm']
     type_name = "scvmm"
-    mgmt_class = SCVMMSystem
+
+    @property
+    def mgmt_class(self):
+        from mgmtsystem.scvmm import SCVMMSystem
+        return SCVMMSystem
 
     def __init__(self, name=None, credentials=None, key=None, zone=None, hostname=None,
                  ip_address=None, start_ip=None, end_ip=None, sec_protocol=None, sec_realm=None,

--- a/cfme/infrastructure/provider/scvmm.py
+++ b/cfme/infrastructure/provider/scvmm.py
@@ -39,6 +39,12 @@ class SCVMMProvider(InfraProvider):
 
         return values
 
+    def deployment_helper(self, deploy_args):
+        """ Used in utils.virtual_machines """
+        if 'host_group' not in deploy_args:
+            return {'host_group': self.data.get("host_group", "All Hosts")}
+        return {}
+
     @classmethod
     def from_config(cls, prov_config, prov_key):
         credentials_key = prov_config['credentials']

--- a/cfme/infrastructure/provider/scvmm.py
+++ b/cfme/infrastructure/provider/scvmm.py
@@ -1,4 +1,5 @@
 from . import InfraProvider
+from utils.cached_property import cached_property
 
 
 @InfraProvider.add_provider_type
@@ -6,7 +7,7 @@ class SCVMMProvider(InfraProvider):
     STATS_TO_MATCH = ['num_template', 'num_vm']
     type_name = "scvmm"
 
-    @property
+    @cached_property
     def mgmt_class(self):
         from mgmtsystem.scvmm import SCVMMSystem
         return SCVMMSystem

--- a/cfme/infrastructure/provider/virtualcenter.py
+++ b/cfme/infrastructure/provider/virtualcenter.py
@@ -1,5 +1,6 @@
+from cached_property import cached_property
+
 from . import InfraProvider
-from utils.cached_property import cached_property
 
 
 @InfraProvider.add_provider_type

--- a/cfme/infrastructure/provider/virtualcenter.py
+++ b/cfme/infrastructure/provider/virtualcenter.py
@@ -1,11 +1,12 @@
 from . import InfraProvider
+from utils.cached_property import cached_property
 
 
 @InfraProvider.add_provider_type
 class VMwareProvider(InfraProvider):
     type_name = "virtualcenter"
 
-    @property
+    @cached_property
     def mgmt_class(self):
         from mgmtsystem.virtualcenter import VMWareSystem
         return VMWareSystem

--- a/cfme/infrastructure/provider/virtualcenter.py
+++ b/cfme/infrastructure/provider/virtualcenter.py
@@ -1,11 +1,14 @@
-from mgmtsystem.virtualcenter import VMWareSystem
 from . import InfraProvider
 
 
 @InfraProvider.add_provider_type
 class VMwareProvider(InfraProvider):
     type_name = "virtualcenter"
-    mgmt_class = VMWareSystem
+
+    @property
+    def mgmt_class(self):
+        from mgmtsystem.virtualcenter import VMWareSystem
+        return VMWareSystem
 
     def __init__(self, name=None, credentials=None, key=None, zone=None, hostname=None,
                  ip_address=None, start_ip=None, end_ip=None, provider_data=None):

--- a/cfme/infrastructure/provider/virtualcenter.py
+++ b/cfme/infrastructure/provider/virtualcenter.py
@@ -1,12 +1,14 @@
 from . import InfraProvider
-from mgmtsystem.virtualcenter import VMWareSystem
 
 
 @InfraProvider.add_provider_type
 class VMwareProvider(InfraProvider):
     type_name = "virtualcenter"
 
-    mgmt_class = VMWareSystem
+    @property
+    def mgmt_class(self):
+        from mgmtsystem.virtualcenter import VMWareSystem
+        return VMWareSystem
 
     def __init__(self, name=None, credentials=None, key=None, zone=None, hostname=None,
                  ip_address=None, start_ip=None, end_ip=None, provider_data=None):

--- a/cfme/infrastructure/provider/virtualcenter.py
+++ b/cfme/infrastructure/provider/virtualcenter.py
@@ -1,14 +1,12 @@
 from . import InfraProvider
+from mgmtsystem.virtualcenter import VMWareSystem
 
 
 @InfraProvider.add_provider_type
 class VMwareProvider(InfraProvider):
     type_name = "virtualcenter"
 
-    @property
-    def mgmt_class(self):
-        from mgmtsystem.virtualcenter import VMWareSystem
-        return VMWareSystem
+    mgmt_class = VMWareSystem
 
     def __init__(self, name=None, credentials=None, key=None, zone=None, hostname=None,
                  ip_address=None, start_ip=None, end_ip=None, provider_data=None):
@@ -25,6 +23,12 @@ class VMwareProvider(InfraProvider):
                 'type_select': create and 'VMware vCenter',
                 'hostname_text': kwargs.get('hostname'),
                 'ipaddress_text': kwargs.get('ip_address')}
+
+    def deployment_helper(self, deploy_args):
+        """ Used in utils.virtual_machines """
+        if "allowed_datastores" not in deploy_args and "allowed_datastores" in self.data:
+            return {'allowed_datastores': self.data['allowed_datastores']}
+        return {}
 
     @classmethod
     def from_config(cls, prov_config, prov_key):

--- a/cfme/middleware/provider/hawkular.py
+++ b/cfme/middleware/provider/hawkular.py
@@ -3,6 +3,7 @@ import re
 from cfme.common import TopologyMixin, TimelinesMixin
 from . import MiddlewareProvider
 from utils.appliance import Navigatable
+from utils.cached_property import cached_property
 from utils.db import cfmedb
 from utils.varmeth import variable
 from . import _get_providers_page, _db_select_query
@@ -38,7 +39,7 @@ class HawkularProvider(MiddlewareBase, TopologyMixin, TimelinesMixin, Middleware
         [('name', 'Name'), ('hostname', 'Host Name'), ('port', 'Port'), ('provider_type', 'Type')]
     type_name = "hawkular"
 
-    @property
+    @cached_property
     def mgmt_class(self):
         from mgmtsystem.hawkular import Hawkular
         return Hawkular

--- a/cfme/middleware/provider/hawkular.py
+++ b/cfme/middleware/provider/hawkular.py
@@ -2,7 +2,6 @@ import re
 
 from cfme.common import TopologyMixin, TimelinesMixin
 from . import MiddlewareProvider
-from mgmtsystem.hawkular import Hawkular
 from utils.appliance import Navigatable
 from utils.db import cfmedb
 from utils.varmeth import variable
@@ -38,7 +37,11 @@ class HawkularProvider(MiddlewareBase, TopologyMixin, TimelinesMixin, Middleware
     property_tuples = MiddlewareProvider.property_tuples +\
         [('name', 'Name'), ('hostname', 'Host Name'), ('port', 'Port'), ('provider_type', 'Type')]
     type_name = "hawkular"
-    mgmt_class = Hawkular
+
+    @property
+    def mgmt_class(self):
+        from mgmtsystem.hawkular import Hawkular
+        return Hawkular
 
     def __init__(self, name=None, hostname=None, port=None, credentials=None, key=None,
             appliance=None, **kwargs):

--- a/cfme/middleware/provider/hawkular.py
+++ b/cfme/middleware/provider/hawkular.py
@@ -1,9 +1,10 @@
 import re
 
+from cached_property import cached_property
+
 from cfme.common import TopologyMixin, TimelinesMixin
 from . import MiddlewareProvider
 from utils.appliance import Navigatable
-from utils.cached_property import cached_property
 from utils.db import cfmedb
 from utils.varmeth import variable
 from . import _get_providers_page, _db_select_query

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -13,8 +13,6 @@ Required YAML keys:
 import fauxfactory
 import pytest
 
-import mgmtsystem
-
 from cfme.common.provider import cleanup_vm
 from cfme.common.vm import VM
 from cfme.control.explorer import actions, policies, policy_profiles
@@ -22,6 +20,8 @@ from cfme.configure import tasks
 from cfme.configure.tasks import Tasks
 from cfme.infrastructure import host
 from cfme.services import requests
+from cfme.infrastructure.provider.scvmm import SCVMMProvider
+from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.web_ui import toolbar as tb
 from datetime import datetime
 from fixtures.pytest_store import store
@@ -92,7 +92,7 @@ pytestmark = [
     pytest.mark.meta(blockers=[
         BZ(
             1149128,
-            unblock=lambda provider: not isinstance(provider.mgmt, mgmtsystem.scvmm.SCVMMSystem))
+            unblock=lambda provider: not isinstance(provider, SCVMMProvider))
     ]),
     pytest.mark.meta(server_roles="+automate +smartproxy +smartstate"),
     pytest.mark.tier(2),
@@ -631,7 +631,7 @@ def test_action_initiate_smartstate_analysis(
         test_flag: actions, provision
     """
     # Set host credentials for VMWare
-    if isinstance(vm.provider, mgmtsystem.virtualcenter.VMWareSystem):
+    if isinstance(vm.provider, VMwareProvider):
         set_host_credentials(request, vm.provider, vm)
 
     # Set up the policy and prepare finalizer

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -92,7 +92,7 @@ pytestmark = [
     pytest.mark.meta(blockers=[
         BZ(
             1149128,
-            unblock=lambda provider: not isinstance(provider, SCVMMProvider))
+            unblock=lambda provider: not provider.one_of(SCVMMProvider))
     ]),
     pytest.mark.meta(server_roles="+automate +smartproxy +smartstate"),
     pytest.mark.tier(2),
@@ -631,7 +631,7 @@ def test_action_initiate_smartstate_analysis(
         test_flag: actions, provision
     """
     # Set host credentials for VMWare
-    if isinstance(vm.provider, VMwareProvider):
+    if vm.provider.one_of(VMwareProvider):
         set_host_credentials(request, vm.provider, vm)
 
     # Set up the policy and prepare finalizer

--- a/cfme/tests/infrastructure/test_provisioning.py
+++ b/cfme/tests/infrastructure/test_provisioning.py
@@ -3,6 +3,7 @@ import pytest
 
 from cfme import test_requirements
 from cfme.common.provider import cleanup_vm
+from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.provisioning import do_vm_provisioning
 from cfme.services import requests
 from cfme.web_ui import fill
@@ -10,7 +11,6 @@ from utils import normalize_text, testgen
 from utils.blockers import BZ
 from utils.generators import random_vm_name
 from utils.log import logger
-from utils.mgmt_system import RHEVMSystem
 from utils.wait import wait_for
 
 pytestmark = [
@@ -19,7 +19,7 @@ pytestmark = [
     pytest.mark.meta(blockers=[
         BZ(
             1265466,
-            unblock=lambda provider: not isinstance(provider.mgmt, RHEVMSystem))
+            unblock=lambda provider: not isinstance(provider, RHEVMProvider))
     ]),
     pytest.mark.tier(2),
     test_requirements.provision

--- a/cfme/tests/infrastructure/test_provisioning.py
+++ b/cfme/tests/infrastructure/test_provisioning.py
@@ -19,7 +19,7 @@ pytestmark = [
     pytest.mark.meta(blockers=[
         BZ(
             1265466,
-            unblock=lambda provider: not isinstance(provider, RHEVMProvider))
+            unblock=lambda provider: not provider.one_of(RHEVMProvider))
     ]),
     pytest.mark.tier(2),
     test_requirements.provision

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -28,7 +28,7 @@ pytestmark = [
     pytest.mark.meta(blockers=[
         BZ(
             1265466,
-            unblock=lambda provider: not isinstance(provider, RHEVMProvider))
+            unblock=lambda provider: not provider.one_of(RHEVMProvider))
     ]),
     pytest.mark.tier(3)
 ]

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -8,10 +8,11 @@ import pytest
 from cfme import test_requirements
 from cfme.common.provider import cleanup_vm
 from cfme.infrastructure.virtual_machines import Vm
+from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.provisioning import provisioning_form
 from cfme.services import requests
 from cfme.web_ui import InfoBlock, fill, flash
-from utils import mgmt_system, testgen
+from utils import testgen
 from utils.appliance.implementations.ui import navigate_to
 from utils.blockers import BZ
 from utils.generators import random_vm_name
@@ -27,7 +28,7 @@ pytestmark = [
     pytest.mark.meta(blockers=[
         BZ(
             1265466,
-            unblock=lambda provider: not isinstance(provider.mgmt, mgmt_system.RHEVMSystem))
+            unblock=lambda provider: not isinstance(provider, RHEVMProvider))
     ]),
     pytest.mark.tier(3)
 ]

--- a/cfme/tests/infrastructure/test_provisioning_rest.py
+++ b/cfme/tests/infrastructure/test_provisioning_rest.py
@@ -55,7 +55,7 @@ def provision_data(rest_api_modscope, provider, small_template_modscope):
         "ems_custom_attributes": {},
         "miq_custom_attributes": {}
     }
-    if isinstance(provider, RHEVMProvider):
+    if provider.one_of(RHEVMProvider):
         result["vm_fields"]["provision_type"] = "native_clone"
     return result
 

--- a/cfme/tests/infrastructure/test_provisioning_rest.py
+++ b/cfme/tests/infrastructure/test_provisioning_rest.py
@@ -2,10 +2,10 @@ import fauxfactory
 import pytest
 
 from cfme import test_requirements
-from cfme.infrastructure.provider.rhevm import RHEVMProvider
-from cfme.infrastructure.provider.virtualcenter import VMwareProvider
+from cfme.providers.rhevm import RHEVMProvider
+from cfme.providers.virtualcenter import VMwareProvider
 from utils.wait import wait_for
-from utils import mgmt_system, testgen
+from utils import testgen
 
 
 pytestmark = [test_requirements.provision]
@@ -55,7 +55,7 @@ def provision_data(rest_api_modscope, provider, small_template_modscope):
         "ems_custom_attributes": {},
         "miq_custom_attributes": {}
     }
-    if isinstance(provider.mgmt, mgmt_system.RHEVMSystem):
+    if isinstance(provider, RHEVMProvider):
         result["vm_fields"]["provision_type"] = "native_clone"
     return result
 

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -21,8 +21,6 @@ import requests
 import traceback
 
 from sentaku import ImplementationContext
-from utils.mgmt_system import RHEVMSystem
-from mgmtsystem.virtualcenter import VMWareSystem
 
 from fixtures import ui_coverage
 from fixtures.pytest_store import store
@@ -2189,7 +2187,8 @@ class Appliance(IPAppliance):
     def destroy(self):
         """Destroys the VM this appliance is running as
         """
-        if isinstance(self.provider, RHEVMSystem):
+        from cfme.infrastructure.provider.rhevm import RHEVMProvider
+        if isinstance(self.provider, RHEVMProvider):
             # if rhev, try to remove direct_lun just in case it is detach
             self.remove_rhev_direct_lun_disk()
         self.provider.delete_vm(self.vm_name)
@@ -2230,11 +2229,13 @@ class Appliance(IPAppliance):
 
     @property
     def is_on_rhev(self):
-        return isinstance(self.provider, RHEVMSystem)
+        from cfme.infrastructure.provider.rhevm import RHEVMProvider
+        return isinstance(self.provider, RHEVMProvider)
 
     @property
     def is_on_vsphere(self):
-        return isinstance(self.provider, VMWareSystem)
+        from cfme.infrastructure.provider.virtualcenter import VMwareProvider
+        return isinstance(self.provider, VMwareProvider)
 
     def add_rhev_direct_lun_disk(self, log_callback=None):
         if log_callback is None:

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -2188,7 +2188,7 @@ class Appliance(IPAppliance):
         """Destroys the VM this appliance is running as
         """
         from cfme.infrastructure.provider.rhevm import RHEVMProvider
-        if isinstance(self.provider, RHEVMProvider):
+        if self.provider.one_of(RHEVMProvider):
             # if rhev, try to remove direct_lun just in case it is detach
             self.remove_rhev_direct_lun_disk()
         self.provider.delete_vm(self.vm_name)
@@ -2230,12 +2230,12 @@ class Appliance(IPAppliance):
     @property
     def is_on_rhev(self):
         from cfme.infrastructure.provider.rhevm import RHEVMProvider
-        return isinstance(self.provider, RHEVMProvider)
+        return self.provider.one_of(RHEVMProvider)
 
     @property
     def is_on_vsphere(self):
         from cfme.infrastructure.provider.virtualcenter import VMwareProvider
-        return isinstance(self.provider, VMwareProvider)
+        return self.provider.one_of(VMwareProvider)
 
     def add_rhev_direct_lun_disk(self, log_callback=None):
         if log_callback is None:

--- a/utils/virtual_machines.py
+++ b/utils/virtual_machines.py
@@ -2,14 +2,6 @@
 """
 import pytest
 
-from mgmtsystem.virtualcenter import VMWareSystem
-from mgmtsystem.scvmm import SCVMMSystem
-from mgmtsystem.azure import AzureSystem
-from mgmtsystem.ec2 import EC2System
-from mgmtsystem.google import GoogleCloudSystem
-from mgmtsystem.openstack import OpenstackSystem
-from mgmtsystem.rhevm import RHEVMSystem
-
 from utils.providers import get_crud
 from fixtures.pytest_store import store
 from novaclient.exceptions import OverLimit as OSOverLimit
@@ -60,52 +52,30 @@ def deploy_template(provider_key, vm_name, template_name=None, timeout=900,
         callable_mapping = {}
     provider_crud = get_crud(provider_key)
 
-    mgmt = provider_crud.get_mgmt_system()
-    data = provider_crud.get_yaml_data()
-
     deploy_args.update(vm_name=vm_name)
 
     if template_name is None:
         try:
-            deploy_args.update(template=data['small_template'])
+            deploy_args.update(template=provider_crud.data['small_template'])
         except KeyError:
             raise ValueError('small_template not defined for Provider {} in cfme_data.yaml'.format(
                 provider_key))
     else:
         deploy_args.update(template=template_name)
 
-    if isinstance(mgmt, RHEVMSystem):
-        if 'default_cluster' not in deploy_args:
-            deploy_args.update(cluster=data['default_cluster'])
-    elif isinstance(mgmt, VMWareSystem):
-        if "allowed_datastores" not in deploy_args and "allowed_datastores" in data:
-            deploy_args.update(allowed_datastores=data['allowed_datastores'])
-    elif isinstance(mgmt, SCVMMSystem):
-        if 'host_group' not in deploy_args:
-            deploy_args.update(host_group=data.get("host_group", "All Hosts"))
-    elif isinstance(mgmt, EC2System):
-        pass
-    elif isinstance(mgmt, GoogleCloudSystem):
-        pass
-    elif isinstance(mgmt, AzureSystem):
-        deploy_args.update(data['provisioning'])
-    elif isinstance(mgmt, OpenstackSystem):
-        if ('network_name' not in deploy_args) and data.get('network'):
-            deploy_args.update(network_name=data['network'])
-    else:
-        raise Exception("Unsupported provider type: {}".format(type(mgmt).__name__))
+    deploy_args.update(provider_crud.deployment_helper(deploy_args))
 
     logger.info("Getting ready to deploy VM/instance %s from template %s on provider %s",
-        vm_name, deploy_args['template'], data['name'])
+        vm_name, deploy_args['template'], provider_crud.data['name'])
     try:
         try:
             logger.debug("Deploy args: %s", deploy_args)
-            vm_name = mgmt.deploy_template(timeout=timeout, **deploy_args)
+            vm_name = provider_crud.mgmt.deploy_template(timeout=timeout, **deploy_args)
             logger.info("Provisioned VM/instance %s", vm_name)  # instance ID in case of EC2
         except Exception as e:
             logger.error('Could not provisioning VM/instance %s (%s: %s)',
                 vm_name, type(e).__name__, str(e))
-            _vm_cleanup(mgmt, vm_name)
+            _vm_cleanup(provider_crud.mgmt, vm_name)
             raise
     except skip_exceptions as e:
         e_c = type(e)


### PR DESCRIPTION
* Many cases where we were comparing to a mgmt_system object, instead of the provider object itself
* Deferred the loading of mgmtsystem classes until needed
* Moved some deployment args into a deployment_helper function, making the code in utils generic