### PR TITLE
[1LP][RFR] Canned reports tests

### DIFF
--- a/cfme/tests/intelligence/reports/test_canned_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_canned_corresponds.py
@@ -146,6 +146,8 @@ def test_operations_vm_on(soft_assert):
 @test_requirements.report
 @pytest.mark.usefixtures('setup_provider')
 def test_datastores_summary(soft_assert):
+    """Checks Datastores Summary report with DB data. Checks all data in report, even rounded
+    storage sizes."""
 
     appliance = get_or_create_current_appliance()
     adb = appliance.db

--- a/cfme/tests/intelligence/reports/test_canned_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_canned_corresponds.py
@@ -164,7 +164,9 @@ def test_datastores_summary(soft_assert):
     assert len(storages_in_db) == len(list(report.data.rows))
     for store in storages_in_db:
 
-        number_of_vms = adb.session.query(vms.id).filter(vms.storage_id == store.id).count()
+        number_of_vms = adb.session.query(vms.id).filter(
+            vms.storage_id == store.id).filter(
+                vms.template == 'f').count()
         number_of_hosts = adb.session.query(host_storages.host_id).filter(
             host_storages.storage_id == store.id).count()
 

--- a/cfme/tests/intelligence/reports/test_canned_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_canned_corresponds.py
@@ -6,16 +6,25 @@ from cfme.infrastructure.provider import InfraProvider, details_page
 from cfme.intelligence.reports.reports import CannedSavedReport
 from utils.appliance.implementations.ui import navigate_to
 from utils.net import ip_address, resolve_hostname
-from utils.providers import get_crud_by_name
+from utils.providers import get_crud_by_name, setup_a_provider as _setup_a_provider, ProviderFilter
+from utils.appliance import get_or_create_current_appliance
 from utils import version
 from cfme import test_requirements
 
 provider_props = partial(details_page.infoblock.text, "Properties")
 
 
+@pytest.fixture(scope="module")
+def setup_a_provider():
+    try:
+        _setup_a_provider(filters=[ProviderFilter(classes=[InfraProvider])])
+    except Exception:
+        pytest.skip("It's not possible to set up any providers, therefore skipping")
+
+
 @pytest.mark.tier(3)
 @test_requirements.report
-def test_providers_summary(soft_assert, infra_provider):
+def test_providers_summary(soft_assert, setup_a_provider):
     """Checks some informations about the provider. Does not check memory/frequency as there is
     presence of units and rounding."""
     path = ["Configuration Management", "Providers", "Providers Summary"]
@@ -48,7 +57,7 @@ def test_providers_summary(soft_assert, infra_provider):
 
 @pytest.mark.tier(3)
 @test_requirements.report
-def test_cluster_relationships(soft_assert, infra_provider):
+def test_cluster_relationships(soft_assert, setup_a_provider):
     path = ["Relationships", "Virtual Machines, Folders, Clusters", "Cluster Relationships"]
     report = CannedSavedReport.new(path)
     for relation in report.data.rows:
@@ -88,3 +97,86 @@ def test_cluster_relationships(soft_assert, infra_provider):
                     break
         else:
             soft_assert(False, "Hostname {} not found in {}".format(host_name, provider_name))
+
+
+@pytest.mark.tier(3)
+@test_requirements.report
+def test_operations_vm_on(soft_assert, setup_a_provider):
+
+    appliance = get_or_create_current_appliance()
+    adb = appliance.db
+    vms = adb['vms']
+    hosts = adb['hosts']
+    storages = adb['storages']
+
+    path = ["Operations", "Virtual Machines", "Online VMs (Powered On)"]
+    report = CannedSavedReport.new(path)
+
+    vms_in_db = adb.session.query(
+        vms.name.label('vm_name'),
+        vms.location.label('vm_location'),
+        vms.last_scan_on.label('vm_last_scan'),
+        storages.name.label('storages_name'),
+        hosts.name.label('hosts_name')).join(
+            hosts, vms.host_id == hosts.id).join(
+                storages, vms.storage_id == storages.id).filter(
+                    vms.power_state == 'on').order_by(vms.name).all()
+
+    if len(vms_in_db) == len(list(report.data.rows)):
+        for vm in vms_in_db:
+            store_path = '{}/{}'.format(vm.storages_name.encode('utf8'),
+                                        vm.vm_location.encode('utf8'))
+            for item in report.data.rows:
+                if vm.vm_name.encode('utf8') == item['VM Name']:
+                    if (vm.hosts_name.encode('utf8') == item['Host'] and
+                        vm.storages_name.encode('utf8') == item['Datastore'] and
+                        store_path == item['Datastore Path'] and
+                        (str(vm.vm_last_scan).encode('utf8') == item['Last Analysis Time'] or
+                            (str(vm.vm_last_scan).encode('utf8') == 'None' and
+                             item['Last Analysis Time'] == '')
+                         )):
+                            continue
+                    else:
+                        pytest.fail("Found not matching items. db:{} report:{}".format(vm, item))
+    else:
+        pytest.fail("Lenghts of report and BD do not match. db count:{} report count:{}".format(
+            len(vms_in_db), len(list(report.data.rows))))
+
+
+@pytest.mark.tier(3)
+@test_requirements.report
+def test_datastores_summary(soft_assert, setup_a_provider):
+
+    appliance = get_or_create_current_appliance()
+    adb = appliance.db
+    storages = adb['storages']
+    vms = adb['vms']
+    host_storages = adb['host_storages']
+
+    path = ["Configuration Management", "Storage", "Datastores Summary"]
+    report = CannedSavedReport.new(path)
+
+    storages_in_db = adb.session.query(storages.store_type, storages.free_space,
+                                       storages.total_space, storages.name, storages.id).all()
+
+    if len(storages_in_db) == len(list(report.data.rows)):
+        for store in storages_in_db:
+
+            number_of_vms = adb.session.query(vms.id).filter(vms.storage_id == store.id).count()
+            number_of_hosts = adb.session.query(host_storages.host_id).filter(
+                host_storages.storage_id == store.id).count()
+
+            for item in report.data.rows:
+                if store.name.encode('utf8') == item['Datastore Name']:
+                    if (store.store_type.encode('utf8') == item['Type'] and
+                     extract_gb(store.free_space) == float(item['Free Space'].split(' ')[0]) and
+                      extract_gb(store.total_space) == float(item['Total Space'].split(' ')[0]) and
+                       int(number_of_hosts) == int(item['Number of Hosts']) and
+                       int(number_of_vms) == int(item['Number of VMs'])):
+                        continue
+                    else:
+                        pytest.fail("Found not matching items. db:{} report:{}".format(store, item))
+
+
+def extract_gb(column):
+    return round((float(column) / 1073741824), 1)

--- a/cfme/tests/intelligence/reports/test_canned_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_canned_corresponds.py
@@ -109,7 +109,7 @@ def test_cluster_relationships(soft_assert, setup_a_provider):
 @pytest.mark.tier(3)
 @test_requirements.report
 @pytest.mark.usefixtures('setup_provider')
-def test_operations_vm_on(soft_assert, setup_a_provider):
+def test_operations_vm_on(soft_assert):
 
     appliance = get_or_create_current_appliance()
     adb = appliance.db
@@ -171,24 +171,38 @@ def test_datastores_summary(soft_assert):
         for item in report.data.rows:
             if store.name.encode('utf8') == item['Datastore Name']:
                 assert store.store_type.encode('utf8') == item['Type']
-                print item['Free Space']
-                assert round_gb(store.free_space) == extract_gb(item['Free Space'])
-                assert round_gb(store.total_space) == extract_gb(item['Total Space'])
+                assert round_num(store.free_space) == extract_num(item['Free Space'])
+                assert round_num(store.total_space) == extract_num(item['Total Space'])
                 assert int(number_of_hosts) == int(item['Number of Hosts'])
                 assert int(number_of_vms) == int(item['Number of VMs'])
 
 
-def round_gb(column):
-    return round((float(column) / 1073741824), 1)
+def round_num(column):
+    ret = float(column)
+    by = 1024
+    kb = pow(1024, 2)
+    mb = pow(1024, 3)
+    gb = pow(1024, 4)
+    tb = pow(1024, 5)
+
+    if ret < by:
+        return ret
+
+    if ret > by and ret < kb:
+        return round((ret / by), 1)
+
+    if ret > kb and ret < mb:
+        return round((ret / kb), 1)
+
+    if ret > mb and ret < gb:
+        return round((ret / mb), 1)
+
+    if ret > gb and ret < tb:
+        return round((ret / gb), 1)
+
+    if ret > tb:
+        return round((ret / tb), 1)
 
 
-def extract_gb(column):
-    count = float(column.split(' ')[0])
-    power = column.split(' ')[1]
-
-    if power == 'GB':
-        return count
-    elif power == 'MB':
-        return round((count / 1024), 1)
-    elif power == 'Bytes':
-        return round((count / 1073741824), 1)
+def extract_num(column):
+    return float(column.split(' ')[0])

--- a/cfme/tests/intelligence/reports/test_canned_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_canned_corresponds.py
@@ -25,11 +25,10 @@ def setup_or_skip_provider(request, provider):
     yield
 
 
-
 @pytest.mark.tier(3)
 @pytest.mark.usefixtures('setup_provider')
 @test_requirements.report
-def test_providers_summary(soft_assert, setup_a_provider):
+def test_providers_summary(soft_assert):
     """Checks some informations about the provider. Does not check memory/frequency as there is
     presence of units and rounding."""
     path = ["Configuration Management", "Providers", "Providers Summary"]
@@ -63,7 +62,7 @@ def test_providers_summary(soft_assert, setup_a_provider):
 @pytest.mark.tier(3)
 @pytest.mark.usefixtures('setup_provider')
 @test_requirements.report
-def test_cluster_relationships(soft_assert, setup_a_provider):
+def test_cluster_relationships(soft_assert):
     path = ["Relationships", "Virtual Machines, Folders, Clusters", "Cluster Relationships"]
     report = CannedSavedReport.new(path)
     for relation in report.data.rows:
@@ -145,7 +144,7 @@ def test_operations_vm_on(soft_assert):
 
 @pytest.mark.tier(3)
 @test_requirements.report
-@pytest.mark.usefixtures('setup_or_skip_provider')
+@pytest.mark.usefixtures('setup_provider')
 def test_datastores_summary(soft_assert):
 
     appliance = get_or_create_current_appliance()

--- a/cfme/tests/intelligence/reports/test_canned_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_canned_corresponds.py
@@ -7,7 +7,6 @@ from cfme.intelligence.reports.reports import CannedSavedReport
 from utils.appliance.implementations.ui import navigate_to
 from utils.net import ip_address, resolve_hostname
 from utils.providers import get_crud_by_name
-from utils.appliance import get_or_create_current_appliance
 from utils import version, testgen
 from cfme import test_requirements
 
@@ -98,9 +97,8 @@ def test_cluster_relationships(soft_assert):
 @pytest.mark.tier(3)
 @test_requirements.report
 @pytest.mark.usefixtures('setup_provider')
-def test_operations_vm_on(soft_assert):
+def test_operations_vm_on(soft_assert, appliance):
 
-    appliance = get_or_create_current_appliance()
     adb = appliance.db
     vms = adb['vms']
     hosts = adb['hosts']
@@ -136,11 +134,10 @@ def test_operations_vm_on(soft_assert):
 @pytest.mark.tier(3)
 @test_requirements.report
 @pytest.mark.usefixtures('setup_provider')
-def test_datastores_summary(soft_assert):
+def test_datastores_summary(soft_assert, appliance):
     """Checks Datastores Summary report with DB data. Checks all data in report, even rounded
     storage sizes."""
 
-    appliance = get_or_create_current_appliance()
     adb = appliance.db
     storages = adb['storages']
     vms = adb['vms']
@@ -181,19 +178,19 @@ def round_num(column):
     if ret < by:
         return ret
 
-    if ret > by and ret < kb:
+    if ret >= by and ret < kb:
         return round((ret / by), 1)
 
-    if ret > kb and ret < mb:
+    if ret >= kb and ret < mb:
         return round((ret / kb), 1)
 
-    if ret > mb and ret < gb:
+    if ret >= mb and ret < gb:
         return round((ret / mb), 1)
 
-    if ret > gb and ret < tb:
+    if ret >= gb and ret < tb:
         return round((ret / gb), 1)
 
-    if ret > tb:
+    if ret >= tb:
         return round((ret / tb), 1)
 
 

--- a/cfme/tests/intelligence/reports/test_canned_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_canned_corresponds.py
@@ -168,30 +168,12 @@ def test_datastores_summary(soft_assert, appliance):
 
 
 def round_num(column):
-    ret = float(column)
-    by = 1024
-    kb = pow(1024, 2)
-    mb = pow(1024, 3)
-    gb = pow(1024, 4)
-    tb = pow(1024, 5)
+    num = float(column)
 
-    if ret < by:
-        return ret
+    while num > 1024:
+        num /= 1024.0
 
-    if ret >= by and ret < kb:
-        return round((ret / by), 1)
-
-    if ret >= kb and ret < mb:
-        return round((ret / kb), 1)
-
-    if ret >= mb and ret < gb:
-        return round((ret / mb), 1)
-
-    if ret >= gb and ret < tb:
-        return round((ret / gb), 1)
-
-    if ret >= tb:
-        return round((ret / tb), 1)
+    return round(num, 1)
 
 
 def extract_num(column):

--- a/cfme/tests/intelligence/reports/test_canned_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_canned_corresponds.py
@@ -8,21 +8,12 @@ from utils.appliance.implementations.ui import navigate_to
 from utils.net import ip_address, resolve_hostname
 from utils.providers import get_crud_by_name
 from utils.appliance import get_or_create_current_appliance
-from fixtures.provider import setup_or_skip
 from utils import version, testgen
 from cfme import test_requirements
 
 provider_props = partial(details_page.infoblock.text, "Properties")
 
 pytest_generate_tests = testgen.generate(classes=[InfraProvider], scope='module')
-
-# pytestmark = [pytest.mark.usefixtures('setup_provider')]
-
-
-@pytest.yield_fixture(scope="module")
-def setup_or_skip_provider(request, provider):
-    setup_or_skip(request, provider)
-    yield
 
 
 @pytest.mark.tier(3)

--- a/cfme/tests/intelligence/reports/test_canned_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_canned_corresponds.py
@@ -8,6 +8,7 @@ from utils.appliance.implementations.ui import navigate_to
 from utils.net import ip_address, resolve_hostname
 from utils.providers import get_crud_by_name
 from utils.appliance import get_or_create_current_appliance
+from fixtures.provider import setup_or_skip
 from utils import version, testgen
 from cfme import test_requirements
 
@@ -15,16 +16,14 @@ provider_props = partial(details_page.infoblock.text, "Properties")
 
 pytest_generate_tests = testgen.generate(classes=[InfraProvider], scope='module')
 
-pytestmark = [pytest.mark.usefixtures('setup_provider')]
+# pytestmark = [pytest.mark.usefixtures('setup_provider')]
 
-'''
-@pytest.fixture(scope="module")
-def setup_a_provider():
-    try:
-        _setup_a_provider(filters=[ProviderFilter(classes=[InfraProvider])])
-    except Exception:
-        pytest.skip("It's not possible to set up any providers, therefore skipping")
-'''
+
+@pytest.yield_fixture(scope="module")
+def setup_or_skip_provider(request, provider):
+    setup_or_skip(request, provider)
+    yield
+
 
 
 @pytest.mark.tier(3)
@@ -146,7 +145,7 @@ def test_operations_vm_on(soft_assert):
 
 @pytest.mark.tier(3)
 @test_requirements.report
-@pytest.mark.usefixtures('infra_provider')
+@pytest.mark.usefixtures('setup_or_skip_provider')
 def test_datastores_summary(soft_assert):
 
     appliance = get_or_create_current_appliance()


### PR DESCRIPTION
Purpose or Intent
=================

__Adding tests__ for canned reports. At the moment, there are no tests checking content of canned reports.

Tests will be added continually to this PR.

Tests are suffering of __live environment changing__ too rapidly. That's why test won't pass checks. At the moment, we are in need of __static__ environment for testing this.

test_operations_vm_on:
Path to test: Operations > Virtual Machines > Online VMs (Powered On)
Queue report, get data from DB. Compare. _(suffering of moving sand on live providers)_

test_datastores_summary:
Path to test: Configuration Management > Storage > Datastores Summary
Queue report, get data from DB. Compare.

{{pytest: -k 'test_datastores_summary' --use-provider vsphere55 --use-provider scvmm --use-provider rhevm36 --use-provider  vsphere55 --use-provider scvmm -s -v}}