### PR TITLE
[RFR] Add NodeNotFound to cfme.exceptions

### DIFF
--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -245,6 +245,11 @@ class HostNotFound(CFMEException):
     pass
 
 
+class NodeNotFound(CFMEException):
+    """Raised if a specific container node cannot be found int he UI"""
+    pass
+
+
 class StackNotFound(CFMEException):
     """
     Raised if a specific stack cannot be found.

--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -246,7 +246,7 @@ class HostNotFound(CFMEException):
 
 
 class NodeNotFound(CFMEException):
-    """Raised if a specific container node cannot be found int he UI"""
+    """Raised if a specific container node cannot be found in the UI"""
     pass
 
 


### PR DESCRIPTION
Going to use this in container.node widgetastic refactor

Not used anywhere yet, PRT results are pretty irrelevant.