### PR TITLE
Add list_all_provider_keys

### DIFF
--- a/scripts/sync_template_tracker.py
+++ b/scripts/sync_template_tracker.py
@@ -9,7 +9,7 @@ from slumber.exceptions import SlumberHttpBaseException
 
 from utils import trackerbot, net
 from utils.conf import cfme_data
-from utils.providers import list_providers, get_mgmt
+from utils.providers import list_all_provider_keys, get_mgmt
 
 
 def main(trackerbot_url, mark_usable=None):
@@ -18,7 +18,7 @@ def main(trackerbot_url, mark_usable=None):
     thread_q = []
     thread_lock = Lock()
     template_providers = defaultdict(list)
-    all_providers = set(list_providers())
+    all_providers = set(list_all_provider_keys())
     unresponsive_providers = set()
     # Queue up list_template calls
     for provider_key in all_providers:

--- a/utils/providers.py
+++ b/utils/providers.py
@@ -254,6 +254,13 @@ def list_providers(allowed_types=None, use_global_filters=False):
     return [prov.key for prov in provs]
 
 
+def list_all_provider_keys():
+    try:
+        return conf.cfme_data.management_systems.keys()
+    except:
+        return []
+
+
 def setup_provider(provider_key, validate=True, check_existing=True):
     provider = get_crud(provider_key)
     provider.create(validate_credentials=True, validate_inventory=validate,


### PR DESCRIPTION
...to fix sync template tracker and any other scripts that might require all provider keys (wihtout filtering) with no access to an appliance.