### PR TITLE
[1LP][RFR] Optimizing navigation in infra VMs

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -16,7 +16,6 @@ from cfme.web_ui import (
 from utils import version
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigate_to
-from utils.blockers import BZ
 from utils.log import logger
 from utils.pretty import Pretty
 from utils.timeutil import parsetime
@@ -301,9 +300,9 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable, SummaryMixin
                 # TODO implement as navigate_to when cfme.infra.virtual_machines has destination
                 navigate_to(self, 'All')
             elif self.is_vm:
-                self.provider.load_all_provider_vms()
+                navigate_to(self, 'AllForProvider', use_resetter=False)
             else:
-                self.provider.load_all_provider_templates()
+                navigate_to(self, 'AllForProvider', use_resetter=False)
             toolbar.select('Grid View')
         else:
             # Search requires navigation, we shouldn't use it then
@@ -320,12 +319,11 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable, SummaryMixin
         if use_search:
             try:
                 if not search.has_quick_search_box():
-                    # We don't use provider-specific page (vm_templates_provider_branch) here
-                    # as those don't list archived/orphaned VMs
+                    # TODO rework search for archived/orphaned VMs
                     if self.is_vm:
-                        navigate_to(self.provider, 'Instances')
+                        navigate_to(self, 'AllForProvider', use_resetter=False)
                     else:
-                        navigate_to(self.provider, self.provider.templates_destination_name)
+                        navigate_to(self, 'AllForProvider', use_resetter=False)
                 search.normal_search(self.name)
             except Exception as e:
                 logger.warning("Failed to use search: %s", str(e))
@@ -384,15 +382,9 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable, SummaryMixin
             VmOrInstanceNotFound:
                 When unable to find the VM passed
         """
-        navigate_to(self, 'Details')
-        sel.click(self.find_quadicon())
+        navigate_to(self, 'Details', use_resetter=False)
         if refresh:
-            # bz1389299 for 5.7, should be fixed in 5.7.1 - dajo
-            reload_bug = BZ(1329299)
-            if reload_bug.bugzilla.get_bug(1329299).is_opened:
-                sel.click(self.find_quadicon())
-            else:
-                toolbar.refresh()
+            toolbar.refresh()
 
     def open_edit(self):
         """Loads up the edit page of the object."""

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -18,8 +18,9 @@ import cfme.web_ui.toolbar as tb
 from cfme.web_ui import (
     CheckboxTree, Form, InfoBlock, Region, Quadicon, Tree, accordion, fill, flash, form_buttons,
     paginator, toolbar, Calendar, Select, Input, CheckboxTable, DriftGrid, match_location,
-    BootstrapTreeview, summary_title, Table
+    BootstrapTreeview, summary_title, Table, search
 )
+from cfme.web_ui.search import search_box
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
 from utils.conf import cfme_data
 from utils.log import logger
@@ -78,6 +79,8 @@ match_page = partial(match_location, controller='vm_infra', title='Virtual Machi
 
 def reset_page():
     tb.select("Grid View")
+    if sel.is_displayed(search_box.search_field):
+        search.ensure_normal_search_empty()
     if paginator.page_controls_exist():
         # paginator.results_per_page(1000)
         sel.check(paginator.check_all())

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -135,14 +135,13 @@ class TestControlOnQuadicons(object):
         soft_assert(
             testing_vm.provider.mgmt.is_vm_running(testing_vm.name), "vm not running")
 
-    def test_power_off(self, testing_vm, verify_vm_running, soft_assert, register_event):
+    def test_power_off(self, testing_vm, verify_vm_running, soft_assert):
         """Tests power off
 
         Metadata:
             test_flag: power_control, provision
         """
         testing_vm.wait_for_vm_state_change(desired_state=testing_vm.STATE_ON, timeout=720)
-        register_event('VmOrTemplate', testing_vm.name, ['request_vm_poweroff', 'vm_poweroff'])
         testing_vm.power_control_from_cfme(option=testing_vm.POWER_OFF, cancel=False)
         flash.assert_message_contain("Stop initiated")
         if_scvmm_refresh_provider(testing_vm.provider)
@@ -166,14 +165,13 @@ class TestControlOnQuadicons(object):
             not testing_vm.provider.mgmt.is_vm_running(testing_vm.name), "vm running")
 
     @pytest.mark.tier(1)
-    def test_power_on(self, testing_vm, verify_vm_stopped, soft_assert, register_event):
+    def test_power_on(self, testing_vm, verify_vm_stopped, soft_assert):
         """Tests power on
 
         Metadata:
             test_flag: power_control, provision
         """
         testing_vm.wait_for_vm_state_change(desired_state=testing_vm.STATE_OFF, timeout=720)
-        register_event('VmOrTemplate', testing_vm.name, ['request_vm_start', 'vm_start'])
         testing_vm.power_control_from_cfme(option=testing_vm.POWER_ON, cancel=False)
         flash.assert_message_contain("Start initiated")
         if_scvmm_refresh_provider(testing_vm.provider)
@@ -185,7 +183,7 @@ class TestControlOnQuadicons(object):
 
 class TestVmDetailsPowerControlPerProvider(object):
 
-    def test_power_off(self, testing_vm, verify_vm_running, soft_assert, register_event):
+    def test_power_off(self, testing_vm, verify_vm_running, soft_assert):
         """Tests power off
 
         Metadata:
@@ -194,7 +192,6 @@ class TestVmDetailsPowerControlPerProvider(object):
         testing_vm.wait_for_vm_state_change(
             desired_state=testing_vm.STATE_ON, timeout=720, from_details=True)
         last_boot_time = testing_vm.get_detail(properties=("Power Management", "Last Boot Time"))
-        register_event('VmOrTemplate', testing_vm.name, ['request_vm_poweroff', 'vm_poweroff'])
         testing_vm.power_control_from_cfme(option=testing_vm.POWER_OFF, cancel=False,
                                            from_details=True)
         flash.assert_message_contain("Stop initiated")
@@ -210,7 +207,7 @@ class TestVmDetailsPowerControlPerProvider(object):
             soft_assert(new_last_boot_time == last_boot_time,
                         "ui: {} should ==  orig: {}".format(new_last_boot_time, last_boot_time))
 
-    def test_power_on(self, testing_vm, verify_vm_stopped, soft_assert, register_event):
+    def test_power_on(self, testing_vm, verify_vm_stopped, soft_assert):
         """Tests power on
 
         Metadata:
@@ -218,7 +215,6 @@ class TestVmDetailsPowerControlPerProvider(object):
         """
         testing_vm.wait_for_vm_state_change(
             desired_state=testing_vm.STATE_OFF, timeout=720, from_details=True)
-        register_event('VmOrTemplate', testing_vm.name, ['request_vm_start', 'vm_start'])
         testing_vm.power_control_from_cfme(option=testing_vm.POWER_ON, cancel=False,
                                            from_details=True)
         flash.assert_message_contain("Start initiated")
@@ -228,7 +224,7 @@ class TestVmDetailsPowerControlPerProvider(object):
         soft_assert(
             testing_vm.provider.mgmt.is_vm_running(testing_vm.name), "vm not running")
 
-    def test_suspend(self, testing_vm, verify_vm_running, soft_assert, register_event):
+    def test_suspend(self, testing_vm, verify_vm_running, soft_assert):
         """Tests suspend
 
         Metadata:
@@ -237,7 +233,6 @@ class TestVmDetailsPowerControlPerProvider(object):
         testing_vm.wait_for_vm_state_change(
             desired_state=testing_vm.STATE_ON, timeout=720, from_details=True)
         last_boot_time = testing_vm.get_detail(properties=("Power Management", "Last Boot Time"))
-        register_event('VmOrTemplate', testing_vm.name, ['request_vm_suspend', 'vm_suspend'])
         testing_vm.power_control_from_cfme(option=testing_vm.SUSPEND, cancel=False,
                                            from_details=True)
         flash.assert_message_contain("Suspend initiated")
@@ -261,7 +256,7 @@ class TestVmDetailsPowerControlPerProvider(object):
                         "ui: {} should ==  orig: {}".format(new_last_boot_time, last_boot_time))
 
     def test_start_from_suspend(
-            self, testing_vm, verify_vm_suspended, soft_assert, register_event):
+            self, testing_vm, verify_vm_suspended, soft_assert):
         """Tests start from suspend
 
         Metadata:
@@ -276,7 +271,6 @@ class TestVmDetailsPowerControlPerProvider(object):
                 logger.warning('working around bz1174858, ignoring timeout')
             else:
                 raise
-        register_event('VmOrTemplate', testing_vm.name, ['request_vm_start', 'vm_start'])
         last_boot_time = testing_vm.get_detail(properties=("Power Management", "Last Boot Time"))
         testing_vm.power_control_from_cfme(option=testing_vm.POWER_ON, cancel=False,
                                            from_details=True)


### PR DESCRIPTION
__Fixing__ excessive navigation

+ __removin__ register_event as it's causing huge issues with testing machine performance and slowdowns test run in general. Events are not the main thing of this tests and without them tests run ~5times faster
{{pytest: cfme/tests/infrastructure/test_vm_power_control.py  "-k not test_power_options_from and not test_guest" --use-provider vsphere55  --long-running}}