### PR TITLE
[1LP] [RFR] prepare refactoring script to do the providers move

### DIFF
--- a/cfme/containers/container.py
+++ b/cfme/containers/container.py
@@ -9,7 +9,7 @@ from cfme.web_ui import CheckboxTable, toolbar as tb, paginator, match_location,
 from utils import version
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
-from .provider import details_page, pol_btn, mon_btn
+from cfme.containers.provider import details_page, pol_btn, mon_btn
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
 

--- a/cfme/containers/image_registry.py
+++ b/cfme/containers/image_registry.py
@@ -8,7 +8,7 @@ from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import CheckboxTable, toolbar as tb, paginator, match_location
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
-from .provider import pol_btn
+from cfme.containers.provider import pol_btn
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
 

--- a/cfme/containers/node.py
+++ b/cfme/containers/node.py
@@ -8,7 +8,7 @@ from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import CheckboxTable, toolbar as tb, paginator, InfoBlock, match_location
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
-from .provider import pol_btn, mon_btn
+from cfme.containers.provider import pol_btn, mon_btn
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
 

--- a/cfme/containers/pod.py
+++ b/cfme/containers/pod.py
@@ -4,7 +4,7 @@ from functools import partial
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import toolbar as tb, CheckboxTable, paginator, match_location
-from .provider import details_page
+from cfme.containers.provider import details_page
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep,\
     navigate_to

--- a/cfme/containers/project.py
+++ b/cfme/containers/project.py
@@ -3,7 +3,7 @@
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import toolbar as tb, CheckboxTable, paginator, match_location
-from .provider import details_page
+from cfme.containers.provider import details_page
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import CFMENavigateStep, navigator,\
     navigate_to

--- a/cfme/containers/replicator.py
+++ b/cfme/containers/replicator.py
@@ -3,7 +3,7 @@
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import toolbar as tb, CheckboxTable, paginator, match_location
-from .provider import details_page
+from cfme.containers.provider import details_page
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep,\
     navigate_to

--- a/cfme/containers/route.py
+++ b/cfme/containers/route.py
@@ -2,7 +2,7 @@
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import CheckboxTable, toolbar as tb, paginator, match_location
-from .provider import details_page
+from cfme.containers.provider import details_page
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep,\
     navigate_to
 from navmazing import NavigateToAttribute, NavigateToSibling

--- a/cfme/containers/service.py
+++ b/cfme/containers/service.py
@@ -3,7 +3,7 @@
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import toolbar as tb, CheckboxTable, paginator, match_location
-from .provider import details_page
+from cfme.containers.provider import details_page
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep,\
     navigate_to

--- a/cfme/middleware/datasource.py
+++ b/cfme/middleware/datasource.py
@@ -12,7 +12,8 @@ from utils.appliance.implementations.ui import navigator, CFMENavigateStep, navi
 from utils.db import cfmedb
 from utils.providers import get_crud_by_name, list_providers_by_class
 from utils.varmeth import variable
-from .provider import LIST_TABLE_LOCATOR, MiddlewareBase, download, get_server_name, operations_btn
+from cfme.middleware.provider import (
+    LIST_TABLE_LOCATOR, MiddlewareBase, download, get_server_name, operations_btn)
 
 
 list_tbl = CheckboxTable(table_locator=LIST_TABLE_LOCATOR)

--- a/cfme/middleware/deployment.py
+++ b/cfme/middleware/deployment.py
@@ -12,7 +12,7 @@ from utils.appliance.implementations.ui import navigator, CFMENavigateStep, navi
 from utils.db import cfmedb
 from utils.providers import get_crud_by_name, list_providers_by_class
 from utils.varmeth import variable
-from .provider import LIST_TABLE_LOCATOR, MiddlewareBase, download, get_server_name
+from cfme.middleware.provider import LIST_TABLE_LOCATOR, MiddlewareBase, download, get_server_name
 
 list_tbl = CheckboxTable(table_locator=LIST_TABLE_LOCATOR)
 

--- a/cfme/middleware/domain.py
+++ b/cfme/middleware/domain.py
@@ -12,7 +12,7 @@ from utils.appliance.implementations.ui import navigator, CFMENavigateStep, navi
 from utils.db import cfmedb
 from utils.providers import get_crud_by_name, list_providers_by_class
 from utils.varmeth import variable
-from .provider import LIST_TABLE_LOCATOR, MiddlewareBase, download
+from cfme.middleware.provider import LIST_TABLE_LOCATOR, MiddlewareBase, download
 
 list_tbl = CheckboxTable(table_locator=LIST_TABLE_LOCATOR)
 

--- a/cfme/middleware/messaging.py
+++ b/cfme/middleware/messaging.py
@@ -12,7 +12,7 @@ from utils.appliance.implementations.ui import navigator, CFMENavigateStep, navi
 from utils.db import cfmedb
 from utils.providers import get_crud_by_name, list_providers_by_class
 from utils.varmeth import variable
-from .provider import LIST_TABLE_LOCATOR, MiddlewareBase, download, get_server_name
+from cfme.middleware.provider import LIST_TABLE_LOCATOR, MiddlewareBase, download, get_server_name
 
 list_tbl = CheckboxTable(table_locator=LIST_TABLE_LOCATOR)
 

--- a/cfme/middleware/server.py
+++ b/cfme/middleware/server.py
@@ -17,7 +17,7 @@ from utils.appliance.implementations.ui import navigator, CFMENavigateStep, navi
 from utils.db import cfmedb
 from utils.providers import get_crud_by_name, list_providers_by_class
 from utils.varmeth import variable
-from .provider import LIST_TABLE_LOCATOR, pwr_btn, MiddlewareBase, download
+from cfme.middleware.provider import LIST_TABLE_LOCATOR, pwr_btn, MiddlewareBase, download
 
 list_tbl = CheckboxTable(table_locator=LIST_TABLE_LOCATOR)
 

--- a/cfme/middleware/server_group.py
+++ b/cfme/middleware/server_group.py
@@ -11,8 +11,8 @@ from utils.db import cfmedb
 from utils.varmeth import variable
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
-from .provider import LIST_TABLE_LOCATOR, MiddlewareBase, download
-from .domain import MiddlewareDomain
+from cfme.middleware.provider import LIST_TABLE_LOCATOR, MiddlewareBase, download
+from cfme.middleware.domain import MiddlewareDomain
 from cfme.exceptions import MiddlewareDomainNotFound
 
 list_tbl = CheckboxTable(table_locator=LIST_TABLE_LOCATOR)

--- a/scripts/refactoring/provider_move.py
+++ b/scripts/refactoring/provider_move.py
@@ -1,0 +1,40 @@
+from rope.base import project
+from rope.refactor.move import MoveModule
+from rope.refactor.rename import Rename
+
+my_project = project.Project('.')
+
+providers_dest = my_project.get_folder('cfme/providers')
+if not providers_dest.exists():
+    providers_dest.create()
+
+if not providers_dest.get_children():
+    providers_dest.create_file('__init__.py')
+
+
+folders_to_process = ['infrastructure', 'cloud', 'middleware', 'containers']
+
+for folder in folders_to_process:
+    def find(fmt):
+        return my_project.find_module(fmt.format(folder=folder))
+
+    print(folder)
+    print(" append name")
+    res = find('cfme.{folder}.provider')
+    Rename(my_project, res).get_changes('provider_' + folder).do()
+    print(" move")
+    res = find('cfme.{folder}.provider_{folder}')
+    MoveModule(my_project, res).get_changes(providers_dest).do()
+    print(" fix_name")
+    res = find('cfme.providers.provider_{folder}')
+    Rename(my_project, res).get_changes(folder).do()
+    print(" push up elements")
+    res = find('cfme.providers.{folder}')
+    for item in res.get_children():
+        if item.name == '__init__.py':
+            continue
+        print("  push up " + item.name)
+        MoveModule(my_project, item).get_changes(res.parent).do()
+    print(" meshing up __init__.py")
+    res.get_child('__init__.py').move(
+        'cfme/providers/{folder}.py'.format(folder=folder))


### PR DESCRIPTION
this is about moving `cfme.*.provider{,.*}' over to `cfme.provider.*`

the change was implemented by letting rope lose on the codebase