### PR TITLE
[RFR] - Fix testgen refs

### DIFF
--- a/cfme/tests/cloud/test_cloud_init_provisioning.py
+++ b/cfme/tests/cloud/test_cloud_init_provisioning.py
@@ -18,17 +18,13 @@ from utils.wait import wait_for
 pytestmark = [pytest.mark.meta(server_roles="+automate")]
 
 
-def pytest_generate_tests(metafunc):
-    # Filter out providers without templates defined
-    argnames, argvalues, idlist = testgen.providers_by_class(metafunc, [CloudProvider],
-        required_fields=[
-            ['provisioning', 'ci-template'],
-            ['provisioning', 'ci-username'],
-            ['provisioning', 'ci-pass'],
-            ['provisioning', 'image']]
-    )
-
-    testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope="module")
+pytest_generate_tests = testgen.generate(
+    testgen.providers_by_class, [CloudProvider], required_fields=[
+        ['provisioning', 'ci-template'],
+        ['provisioning', 'ci-username'],
+        ['provisioning', 'ci-pass'],
+        ['provisioning', 'image']],
+    scope="module")
 
 
 @pytest.fixture(scope="module")

--- a/cfme/tests/cloud/test_cloud_init_provisioning.py
+++ b/cfme/tests/cloud/test_cloud_init_provisioning.py
@@ -9,6 +9,7 @@ from cfme.cloud.instance.openstack import OpenStackInstance  # NOQA
 from cfme.cloud.instance.ec2 import EC2Instance  # NOQA
 from cfme.cloud.instance.azure import AzureInstance  # NOQA
 from cfme.cloud.instance.gce import GCEInstance  # NOQA
+from cfme.cloud.provider import CloudProvider
 from cfme.infrastructure.pxe import get_template_from_config
 from utils import testgen, ssh
 from utils.log import logger
@@ -19,13 +20,13 @@ pytestmark = [pytest.mark.meta(server_roles="+automate")]
 
 def pytest_generate_tests(metafunc):
     # Filter out providers without templates defined
-    argnames, argvalues, idlist = testgen.cloud_providers(metafunc,
+    argnames, argvalues, idlist = testgen.providers_by_class(metafunc, [CloudProvider],
         required_fields=[
             ['provisioning', 'ci-template'],
             ['provisioning', 'ci-username'],
             ['provisioning', 'ci-pass'],
-            ['provisioning', 'image']
-        ])
+            ['provisioning', 'image']]
+    )
 
     testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope="module")
 

--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -2,6 +2,7 @@
 import fauxfactory
 import pytest
 from cfme.cloud.instance import Instance
+from cfme.cloud.provider import CloudProvider
 from cfme.web_ui import InfoBlock, toolbar, jstimelines
 from cfme.exceptions import ToolbarOptionGreyedOrUnavailable
 from utils import testgen
@@ -12,7 +13,7 @@ from utils.log import logger
 from utils.wait import wait_for
 
 
-pytest_generate_tests = testgen.generate(testgen.cloud_providers, scope="module")
+pytest_generate_tests = testgen.generate(testgen.providers_by_class(CloudProvider), scope="module")
 
 pytestmark = [pytest.mark.tier(2)]
 

--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -13,7 +13,8 @@ from utils.log import logger
 from utils.wait import wait_for
 
 
-pytest_generate_tests = testgen.generate(testgen.providers_by_class(CloudProvider), scope="module")
+pytest_generate_tests = testgen.generate(
+    testgen.providers_by_class, [CloudProvider], scope="module")
 
 pytestmark = [pytest.mark.tier(2)]
 

--- a/cfme/tests/cloud/test_delete_cloud_object.py
+++ b/cfme/tests/cloud/test_delete_cloud_object.py
@@ -3,6 +3,7 @@ import pytest
 
 from cfme import test_requirements
 from cfme.cloud.instance.image import Image
+from cfme.cloud.provider import CloudProvider
 from cfme.cloud.stack import Stack
 from cfme.common.vm import VM
 from cfme.fixtures import pytest_selenium as sel
@@ -12,10 +13,8 @@ from utils.appliance.implementations.ui import navigate_to
 from utils.version import current_version
 
 
-def pytest_generate_tests(metafunc):
-    # Filter out providers without templates defined
-    argnames, argvalues, idlist = testgen.cloud_providers(metafunc, required_fields=['remove_test'])
-    testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope="module")
+pytest_generate_tests = testgen.generate(
+    testgen.providers_by_class, [CloudProvider], required_fields=['remove_test'], scope="module")
 
 
 pytestmark = [pytest.mark.tier(2),

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -23,7 +23,8 @@ from utils.appliance.implementations.ui import navigate_to
 from utils.update import update
 from utils.log import logger
 
-pytest_generate_tests = testgen.generate(testgen.cloud_providers, scope="function")
+pytest_generate_tests = testgen.generate(
+    testgen.providers_by_class, [CloudProvider], scope="function")
 
 
 @pytest.fixture(scope="module")

--- a/cfme/tests/cloud/test_provisioning.py
+++ b/cfme/tests/cloud/test_provisioning.py
@@ -13,6 +13,7 @@ from cfme.cloud.instance.openstack import OpenStackInstance  # NOQA
 from cfme.cloud.instance.ec2 import EC2Instance  # NOQA
 from cfme.cloud.instance.azure import AzureInstance  # NOQA
 from cfme.cloud.instance.gce import GCEInstance  # NOQA
+from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.cloud.provider.openstack import OpenStackProvider
@@ -27,10 +28,8 @@ pytestmark = [pytest.mark.meta(server_roles="+automate"),
               test_requirements.provision, pytest.mark.tier(2)]
 
 
-def pytest_generate_tests(metafunc):
-    argnames, argvalues, idlist = testgen.cloud_providers(metafunc,
-        required_fields=[['provisioning', 'image']])
-    testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope="function")
+pytest_generate_tests = testgen.generate(testgen.providers_by_class, [CloudProvider],
+    required_fields=[['provisioning', 'image']], scope="function")
 
 
 @pytest.fixture(scope="function")

--- a/cfme/tests/services/test_cloud_service_catalogs.py
+++ b/cfme/tests/services/test_cloud_service_catalogs.py
@@ -3,6 +3,7 @@ import fauxfactory
 import pytest
 
 from cfme.common.provider import cleanup_vm
+from cfme.cloud.provider import CloudProvider
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.automate.service_dialogs import ServiceDialog
 from cfme.services.catalogs.catalog import Catalog
@@ -22,12 +23,8 @@ pytestmark = [
 ]
 
 
-def pytest_generate_tests(metafunc):
-    # Filter out providers without templates defined
-    argnames, argvalues, idlist = testgen.cloud_providers(
-        metafunc, required_fields=[['provisioning', 'image']]
-    )
-    testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope="module")
+pytest_generate_tests = testgen.generate(testgen.providers_by_class, [CloudProvider],
+    required_fields=[['provisioning', 'image']], scope="module")
 
 
 @pytest.yield_fixture(scope="function")

--- a/cfme/tests/services/test_orchestration_template.py
+++ b/cfme/tests/services/test_orchestration_template.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import fauxfactory
 import pytest
+from cfme.cloud.provider import CloudProvider
 from cfme.services.catalogs.orchestration_template import OrchestrationTemplate
 from utils import testgen, error
 from utils.update import update
@@ -42,12 +43,11 @@ METHOD_TORSO_copied = """
 """
 
 
-def pytest_generate_tests(metafunc):
-    # Filter out providers without templates defined
-    argnames, argvalues, idlist = testgen.cloud_providers(metafunc, required_fields=[
+pytest_generate_tests = testgen.generate(
+    testgen.providers_by_class, [CloudProvider],
+    required_fields=[
         ['provisioning', 'stack_provisioning']
-    ])
-    testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope="module")
+    ], scope="module")
 
 
 @pytest.yield_fixture(scope="function")

--- a/cfme/tests/services/test_provision_stack.py
+++ b/cfme/tests/services/test_provision_stack.py
@@ -134,7 +134,7 @@ outputs:
 
 
 pytest_generate_tests = testgen.generate(
-    testgen.cloud_providers, [CloudProvider],
+    testgen.providers_by_class, [CloudProvider],
     required_fields=[
         ['provisioning', 'stack_provisioning']
     ],

--- a/cfme/tests/services/test_provision_stack.py
+++ b/cfme/tests/services/test_provision_stack.py
@@ -8,6 +8,7 @@ from cfme.services.catalogs.orchestration_template import OrchestrationTemplate
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
 from cfme.services.myservice import MyService
 from cfme.services import requests
+from cfme.cloud.provider import CloudProvider
 from cfme.cloud.stack import Stack
 from cfme import test_requirements
 from utils import testgen, version
@@ -132,12 +133,12 @@ outputs:
 """
 
 
-def pytest_generate_tests(metafunc):
-    # Filter out providers without templates defined
-    argnames, argvalues, idlist = testgen.cloud_providers(metafunc, required_fields=[
+pytest_generate_tests = testgen.generate(
+    testgen.cloud_providers, [CloudProvider],
+    required_fields=[
         ['provisioning', 'stack_provisioning']
-    ])
-    testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope="module")
+    ],
+    scope="module")
 
 
 @pytest.yield_fixture(scope="function")

--- a/utils/testgen.py
+++ b/utils/testgen.py
@@ -86,7 +86,6 @@ More information on ``parametrize`` can be found in pytest's documentation:
 """
 import pytest
 
-from cfme.cloud.provider import CloudProvider
 from cfme.common.provider import BaseProvider
 from cfme.containers.provider import ContainersProvider
 from cfme.infrastructure.config_management import get_config_manager_from_config
@@ -249,11 +248,6 @@ def providers_by_class(metafunc, classes, required_fields=None):
 def all_providers(metafunc, **options):
     """ Returns providers of all types """
     return providers_by_class(metafunc, [BaseProvider], **options)
-
-
-def cloud_providers(metafunc, **options):
-    """ Returns only cloud providers """
-    return providers_by_class(metafunc, [CloudProvider], **options)
 
 
 def containers_providers(metafunc, **options):


### PR DESCRIPTION
Starting to obliterate the class calls

{{pytest: --collect-only --use-provider complete}}