### PR TITLE
[1LP][RFR] Add default server_zone to rhev providers

### DIFF
--- a/cfme/infrastructure/provider/rhevm.py
+++ b/cfme/infrastructure/provider/rhevm.py
@@ -56,7 +56,7 @@ class RHEVMProvider(InfraProvider):
             ip_address=prov_config['ipaddress'],
             api_port='',
             credentials=credentials,
-            zone=prov_config['server_zone'],
+            zone=prov_config.get('server_zone', 'default'),
             key=prov_key,
             start_ip=start_ip,
             end_ip=end_ip)


### PR DESCRIPTION
This is to fix the failing rhev template tester job (where we sed in a provider without server_zone in yaml set). It shouldn't be pulled from yamls anyway - eventually, we should pull it from the appliance attached to the crud object - but this is a quickfix.