### PR TITLE
[1LP] [RFR] widgetastic view control

### DIFF
--- a/widgetastic_manageiq.py
+++ b/widgetastic_manageiq.py
@@ -1047,7 +1047,8 @@ class BreadCrumb(Widget):
 class ToolBarViewSelector(View):
     """ represents toolbar's view selector control ("Grid View", "Tile View", etc)
 
-        .. code-block:: python
+    .. code-block:: python
+
         @View.nested
         class view_selector(ToolBarViewSelector):  # NOQA
 

--- a/widgetastic_manageiq.py
+++ b/widgetastic_manageiq.py
@@ -1044,25 +1044,26 @@ class BreadCrumb(Widget):
         return result
 
 
-class ToolBarViewSelector(View):
-    """ represents toolbar's view selector control ("Grid View", "Tile View", etc)
+class ItemsToolBarViewSelector(View):
+    """ represents toolbar's view selector control
+        it is present at pages with items like Infra or Cloud Providers pages
 
     .. code-block:: python
 
         @View.nested
-        class view_selector(ToolBarViewSelector):  # NOQA
+        class view_selector(ItemsToolBarViewSelector):  # NOQA
 
         some_view.view_selector.select('Tile View')
         some_view.view_selector.selected
     """
     ROOT = './/div[contains(@class, "toolbar-pf-view-selector")]'
-    BUTTONS = './/button'
+    grid_button = Button(title='Grid View')
+    tile_button = Button(title='Tile View')
+    list_button = Button(title='List View')
 
     @property
     def _view_buttons(self):
-        br = self.browser
-        return [Button(self, title=br.get_attribute('title', btn)) for btn
-                in br.elements(self.BUTTONS)]
+        return self.grid_button, self.tile_button, self.list_button
 
     def select(self, title):
         for button in self._view_buttons:
@@ -1073,7 +1074,36 @@ class ToolBarViewSelector(View):
 
     @property
     def selected(self):
-        """
-        Returns: title of currently selected view
-        """
+        return next(btn.title for btn in self._view_buttons if btn.active)
+
+
+class DetailsToolBarViewSelector(View):
+    """ represents toolbar's view selector control
+        it is present at pages with items like Infra or Cloud Providers pages
+
+    .. code-block:: python
+
+        @View.nested
+        class view_selector(DetailsToolBarViewSelector):  # NOQA
+
+        some_view.view_selector.select('Dashboard View')
+        some_view.view_selector.selected
+    """
+    ROOT = './/div[contains(@class, "toolbar-pf-view-selector")]'
+    summary_button = Button(title='Summary View')
+    dashboard_button = Button(title='Dashboard View')
+
+    @property
+    def _view_buttons(self):
+        return self.dashboard_button, self.summary_button
+
+    def select(self, title):
+        for button in self._view_buttons:
+            if button.title == title:
+                return button.click()
+        else:
+            raise ValueError("The view with title {title} isn't present".format(title=title))
+
+    @property
+    def selected(self):
         return next(btn.title for btn in self._view_buttons if btn.active)

--- a/widgetastic_manageiq.py
+++ b/widgetastic_manageiq.py
@@ -1042,3 +1042,37 @@ class BreadCrumb(Widget):
             self.browser.handle_alert(wait=2.0, squash=True)
             self.browser.plugin.ensure_page_safe()
         return result
+
+
+class ToolBarViewSelector(View):
+    """ represents toolbar's view selector control ("Grid View", "Tile View", etc)
+
+        .. code-block:: python
+        @View.nested
+        class view_selector(ToolBarViewSelector):  # NOQA
+
+        some_view.view_selector.select('Tile View')
+        some_view.view_selector.selected
+    """
+    ROOT = './/div[contains(@class, "toolbar-pf-view-selector")]'
+    BUTTONS = './/button'
+
+    @property
+    def _view_buttons(self):
+        br = self.browser
+        return [Button(self, title=br.get_attribute('title', btn)) for btn
+                in br.elements(self.BUTTONS)]
+
+    def select(self, title):
+        for button in self._view_buttons:
+            if button.title == title:
+                return button.click()
+        else:
+            raise ValueError("The view with title {title} isn't present".format(title=title))
+
+    @property
+    def selected(self):
+        """
+        Returns: title of currently selected view
+        """
+        return next(btn.title for btn in self._view_buttons if btn.active)

--- a/widgetastic_manageiq.py
+++ b/widgetastic_manageiq.py
@@ -1046,15 +1046,14 @@ class BreadCrumb(Widget):
 
 class ItemsToolBarViewSelector(View):
     """ represents toolbar's view selector control
-        it is present at pages with items like Infra or Cloud Providers pages
+        it is present on pages with items like Infra or Cloud Providers pages
 
     .. code-block:: python
 
-        @View.nested
-        class view_selector(ItemsToolBarViewSelector):  # NOQA
+        view_selector = View.nested(ItemsToolBarViewSelector)
 
-        some_view.view_selector.select('Tile View')
-        some_view.view_selector.selected
+        view_selector.select('Tile View')
+        view_selector.selected
     """
     ROOT = './/div[contains(@class, "toolbar-pf-view-selector")]'
     grid_button = Button(title='Grid View')
@@ -1063,7 +1062,9 @@ class ItemsToolBarViewSelector(View):
 
     @property
     def _view_buttons(self):
-        return self.grid_button, self.tile_button, self.list_button
+        yield self.grid_button
+        yield self.tile_button
+        yield self.list_button
 
     def select(self, title):
         for button in self._view_buttons:
@@ -1079,15 +1080,14 @@ class ItemsToolBarViewSelector(View):
 
 class DetailsToolBarViewSelector(View):
     """ represents toolbar's view selector control
-        it is present at pages with items like Infra or Cloud Providers pages
+        it is present on pages like Infra Providers Details page
 
     .. code-block:: python
 
-        @View.nested
-        class view_selector(DetailsToolBarViewSelector):  # NOQA
+        view_selector = View.nested(DetailsToolBarViewSelector)
 
-        some_view.view_selector.select('Dashboard View')
-        some_view.view_selector.selected
+        view_selector.select('Dashboard View')
+        view_selector.selected
     """
     ROOT = './/div[contains(@class, "toolbar-pf-view-selector")]'
     summary_button = Button(title='Summary View')
@@ -1095,7 +1095,8 @@ class DetailsToolBarViewSelector(View):
 
     @property
     def _view_buttons(self):
-        return self.dashboard_button, self.summary_button
+        yield self.dashboard_button
+        yield self.summary_button
 
     def select(self, title):
         for button in self._view_buttons:

--- a/widgetastic_patternfly.py
+++ b/widgetastic_patternfly.py
@@ -88,6 +88,10 @@ class Button(Widget, ClickableMixin):
     def __repr__(self):
         return '{}{}'.format(type(self).__name__, call_sig(self.args, self.kwargs))
 
+    @property
+    def title(self):
+        return self.browser.get_attribute('title', self)
+
 
 class Input(TextInput):
     """Patternfly input


### PR DESCRIPTION
Purpose or Intent
=================
1. Two widgetastic views representing View Selector control are prepared. These are used to change view on many pages like Provider, Provider Details, VMs, etc.
One view ItemsToolBarViewSelector consists of buttons ("Grid View", "Tile View", "List View") and present on such pages like Infrastructure Providers.
Second view DetailsToolBarViewSelector contains two buttons ('Summary View', 'Dashboard View') and can be found on Provider Details page.
I haven't seen any other View Selector except there two.

I tested the views on Infra Providers and Infra Provider Details pages.