### PR TITLE
[1LP][RFR] Entrypoints addition

### DIFF
--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -14,7 +14,7 @@ from functools import partial
 from navmazing import NavigateToSibling, NavigateToAttribute
 
 import cfme.fixtures.pytest_selenium as sel
-from cfme.common.provider import CloudInfraProvider, import_all_modules_of
+from cfme.common.provider import CloudInfraProvider
 from cfme.web_ui import form_buttons, CFMECheckbox
 from cfme.web_ui import toolbar as tb
 from cfme.web_ui import Region, Quadicon, Form, Select, fill, paginator, AngularSelect, Radio, \
@@ -113,7 +113,6 @@ mon_btn = partial(tb.select, 'Monitoring')
 match_page = partial(match_location, controller='ems_cloud', title='Cloud Providers')
 
 
-@CloudInfraProvider.add_base_type
 class CloudProvider(Pretty, CloudInfraProvider):
     """
     Abstract model of a cloud provider in cfme. See EC2Provider or OpenStackProvider.
@@ -321,6 +320,3 @@ def wait_for_a_provider():
     logger.info('Waiting for a provider to appear...')
     wait_for(paginator.rec_total, fail_condition=None, message="Wait for any provider to appear",
              num_sec=1000, fail_func=sel.refresh)
-
-
-import_all_modules_of('cfme.cloud.provider')

--- a/cfme/cloud/provider/azure.py
+++ b/cfme/cloud/provider/azure.py
@@ -3,7 +3,6 @@ from utils.version import pick
 from mgmtsystem.azure import AzureSystem
 
 
-@CloudProvider.add_provider_type
 class AzureProvider(CloudProvider):
     type_name = "azure"
     mgmt_class = AzureSystem

--- a/cfme/cloud/provider/ec2.py
+++ b/cfme/cloud/provider/ec2.py
@@ -3,7 +3,6 @@ import cfme.fixtures.pytest_selenium as sel
 from mgmtsystem.ec2 import EC2System
 
 
-@CloudProvider.add_provider_type
 class EC2Provider(CloudProvider):
     type_name = "ec2"
     mgmt_class = EC2System

--- a/cfme/cloud/provider/gce.py
+++ b/cfme/cloud/provider/gce.py
@@ -3,7 +3,6 @@ import cfme.fixtures.pytest_selenium as sel
 from mgmtsystem.google import GoogleCloudSystem
 
 
-@CloudProvider.add_provider_type
 class GCEProvider(CloudProvider):
     type_name = "gce"
     mgmt_class = GoogleCloudSystem

--- a/cfme/cloud/provider/openstack.py
+++ b/cfme/cloud/provider/openstack.py
@@ -4,7 +4,6 @@ from mgmtsystem.openstack import OpenstackSystem
 from . import CloudProvider
 
 
-@CloudProvider.add_provider_type
 class OpenStackProvider(CloudProvider):
     type_name = "openstack"
     mgmt_class = OpenstackSystem

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -3,7 +3,7 @@ from random import sample
 
 from navmazing import NavigateToSibling, NavigateToAttribute
 
-from cfme.common.provider import BaseProvider, import_all_modules_of
+from cfme.common.provider import BaseProvider
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import (
     Quadicon, Form, AngularSelect, form_buttons, Input, toolbar as tb,
@@ -66,7 +66,6 @@ match_page = partial(match_location, controller='ems_container',
                      title='Containers Providers')
 
 
-@BaseProvider.add_base_type
 class ContainersProvider(BaseProvider, Pretty):
     provider_types = {}
     in_version = ('5.5', version.LATEST)
@@ -313,11 +312,7 @@ class TopologyFromDetails(CFMENavigateStep):
         sel.click(InfoBlock('Overview', 'Topology'))
 
 
-import_all_modules_of('cfme.containers.provider')
-
-
 # Common methods:
-
 def navigate_and_get_rows(provider, obj, table, count):
     """Get <count> random rows from the obj list table,
     if <count> is greater that the number of rows, return number of rows.

--- a/cfme/containers/provider/kubernetes.py
+++ b/cfme/containers/provider/kubernetes.py
@@ -2,7 +2,6 @@ from . import ContainersProvider
 from mgmtsystem.kubernetes import Kubernetes
 
 
-@ContainersProvider.add_provider_type
 class KubernetesProvider(ContainersProvider):
     type_name = "kubernetes"
     mgmt_class = Kubernetes

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -12,7 +12,6 @@ class CustomAttribute(object):
         self.href = href
 
 
-@ContainersProvider.add_provider_type
 class OpenshiftProvider(ContainersProvider):
     num_route = ['num_route']
     STATS_TO_MATCH = ContainersProvider.STATS_TO_MATCH + num_route

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -13,7 +13,7 @@ from functools import partial
 from navmazing import NavigateToSibling, NavigateToAttribute
 
 from cached_property import cached_property
-from cfme.common.provider import CloudInfraProvider, import_all_modules_of
+from cfme.common.provider import CloudInfraProvider
 from cfme.fixtures import pytest_selenium as sel
 from cfme.infrastructure.host import Host
 from cfme.infrastructure.cluster import Cluster
@@ -107,7 +107,6 @@ pol_btn = partial(tb.select, 'Policy')
 mon_btn = partial(tb.select, 'Monitoring')
 
 
-@CloudInfraProvider.add_base_type
 class InfraProvider(Pretty, CloudInfraProvider):
     """
     Abstract model of an infrastructure provider in cfme. See VMwareProvider or RHEVMProvider.
@@ -451,6 +450,3 @@ def wait_for_a_provider():
     logger.info('Waiting for a provider to appear...')
     wait_for(paginator.rec_total, fail_condition=None, message="Wait for any provider to appear",
              num_sec=1000, fail_func=sel.refresh)
-
-
-import_all_modules_of('cfme.infrastructure.provider')

--- a/cfme/infrastructure/provider/openstack_infra.py
+++ b/cfme/infrastructure/provider/openstack_infra.py
@@ -18,7 +18,6 @@ register_nodes_form = Form(
     ])
 
 
-@InfraProvider.add_provider_type
 class OpenstackInfraProvider(InfraProvider):
     STATS_TO_MATCH = ['num_template', 'num_host']
     _properties_region = prop_region

--- a/cfme/infrastructure/provider/rhevm.py
+++ b/cfme/infrastructure/provider/rhevm.py
@@ -3,7 +3,6 @@ from . import InfraProvider, prop_region
 from mgmtsystem.rhevm import RHEVMSystem
 
 
-@InfraProvider.add_provider_type
 class RHEVMProvider(InfraProvider):
     _properties_region = prop_region
     type_name = "rhevm"

--- a/cfme/infrastructure/provider/scvmm.py
+++ b/cfme/infrastructure/provider/scvmm.py
@@ -2,7 +2,6 @@ from . import InfraProvider
 from mgmtsystem.scvmm import SCVMMSystem
 
 
-@InfraProvider.add_provider_type
 class SCVMMProvider(InfraProvider):
     STATS_TO_MATCH = ['num_template', 'num_vm']
     type_name = "scvmm"

--- a/cfme/infrastructure/provider/virtualcenter.py
+++ b/cfme/infrastructure/provider/virtualcenter.py
@@ -2,7 +2,6 @@ from . import InfraProvider
 from mgmtsystem.virtualcenter import VMWareSystem
 
 
-@InfraProvider.add_provider_type
 class VMwareProvider(InfraProvider):
     type_name = "virtualcenter"
     mgmt_class = VMWareSystem

--- a/cfme/middleware/provider/__init__.py
+++ b/cfme/middleware/provider/__init__.py
@@ -6,7 +6,6 @@ import os
 import re
 
 from cfme.common import Validatable, SummaryMixin
-from cfme.common.provider import import_all_modules_of
 from cfme.common.provider import BaseProvider
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import (
@@ -61,7 +60,6 @@ properties_form = Form(
     ])
 
 
-@BaseProvider.add_base_type
 class MiddlewareProvider(BaseProvider):
     in_version = ('5.7', version.LATEST)
     category = "middleware"
@@ -448,6 +446,3 @@ class Deployable(SummaryMixin):
         operations_btn("Enable", invokes_alert=True)
         sel.handle_alert()
         flash.assert_success_message('Enable initiated for selected deployment(s)')
-
-
-import_all_modules_of('cfme.middleware.provider')

--- a/cfme/middleware/provider/hawkular.py
+++ b/cfme/middleware/provider/hawkular.py
@@ -11,7 +11,6 @@ from utils.appliance.implementations.ui import navigate_to
 from mgmtsystem.hawkular import Hawkular
 
 
-@MiddlewareProvider.add_provider_type
 class HawkularProvider(MiddlewareBase, TopologyMixin, TimelinesMixin, MiddlewareProvider):
     """
     HawkularProvider class holds provider data. Used to perform actions on hawkular provider page

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -14,7 +14,7 @@ from cfme.configure.access_control import set_group_order
 from cfme.control.explorer import ControlExplorer # NOQA
 from cfme.infrastructure.provider import InfraProvider
 from cfme.exceptions import OptionNotAvailable
-from cfme.common.provider import BaseProvider
+from cfme.common.provider import base_types
 from cfme.infrastructure import virtual_machines as vms
 from cfme.services.myservice import MyService
 from cfme.web_ui import flash, Table, InfoBlock, toolbar as tb
@@ -511,16 +511,16 @@ cat_name = "Settings"
       {
           'my services': _go_to(MyService),
           'chargeback': _go_to(Server, 'Chargeback'),
-          'clouds providers': _go_to(BaseProvider.base_types['cloud']),
-          'infrastructure providers': _go_to(BaseProvider.base_types['infra']),
+          'clouds providers': _go_to(base_types()['cloud']),
+          'infrastructure providers': _go_to(base_types()['infra']),
           'control explorer': _go_to(Server, 'ControlExplorer'),
           'automate explorer': _go_to(Server, 'AutomateExplorer')}],
      [_mk_role(product_features=[[['Everything'], True]]),  # full permissions
       {
           'my services': _go_to(MyService),
           'chargeback': _go_to(Server, 'Chargeback'),
-          'clouds providers': _go_to(BaseProvider.base_types['cloud']),
-          'infrastructure providers': _go_to(BaseProvider.base_types['infra']),
+          'clouds providers': _go_to(base_types()['cloud']),
+          'infrastructure providers': _go_to(base_types()['infra']),
           'control explorer': _go_to(Server, 'ControlExplorer'),
           'automate explorer': _go_to(Server, 'AutomateExplorer')},
       {}]])

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,36 @@ else:
 
 setup(
     name='manageiq-integration-tests',
+
     entry_points={
         'console_scripts': [
             'cfme-release = scripts.release:main',
+        ],
+        'manageiq.provider_categories':
+        [
+            'infra = cfme.infrastructure.provider:InfraProvider',
+            'cloud = cfme.cloud.provider:CloudProvider',
+            'middleware = cfme.middleware.provider:MiddlewareProvider',
+            'containers = cfme.containers.provider:ContainersProvider',
+        ],
+        'manageiq.provider_types.infra': [
+            'virtualcenter = cfme.infrastructure.provider.virtualcenter:VMwareProvider',
+            'scvmm = cfme.infrastructure.provider.scvmm:SCVMMProvider',
+            'rhevm = cfme.infrastructure.provider.rhevm:RHEVMProvider',
+            'openstack_infra = cfme.infrastructure.provider.openstack_infra:OpenstackInfraProvider',
+        ],
+        'manageiq.provider_types.cloud': [
+            'ec2 = cfme.cloud.provider.ec2:EC2Provider',
+            'openstack = cfme.cloud.provider.openstack:OpenStackProvider',
+            'azure = cfme.cloud.provider.azure:AzureProvider',
+            'gce = cfme.cloud.provider.gce:GCEProvider',
+        ],
+        'manageiq.provider_types.middleware': [
+            'hawkular = cfme.middleware.provider.hawkular:HawkularProvider',
+        ],
+        'manageiq.provider_types.containers': [
+            'kubernetes = cfme.containers.provider.kubernetes:KubernetesProvider',
+            'openshift = cfme.containers.provider.openshift:OpenshiftProvider',
         ],
     },
     packages=find_packages(),


### PR DESCRIPTION
This is a large change to the way providers are registered now

* Removed the add_provider_type method from the BaseProvider class
* Removed the add_base_type method from the BaseProvider class
* Added base_types as a function to the cfme.common.provider module
* Added provider_types as a function to the cfme.common.provider module
* Added entrypoints to the setup.py file
* Added load_setuptools_entrypoints to the utils.providers module