### PR TITLE
[1LP][RFR] Custom attributes - new tests

### DIFF
--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -241,6 +241,7 @@ class SummaryTable(object):
         self._object = o
         self._text = text
         self._entry = entry
+        self._raw_keys = []
         self._keys = []
         self.load()
 
@@ -250,6 +251,7 @@ class SummaryTable(object):
             " ".join("{}={}".format(key, repr(getattr(self, key))) for key in self._keys))
 
     def load(self):
+        self._raw_keys = []
         self._keys = []
         key_values = []
         if sel.is_displayed(self.MULTIKEY_LOC, root=self._entry):
@@ -277,6 +279,7 @@ class SummaryTable(object):
         for key, key_id, value in key_values:
             value_object = process_field(value)
             setattr(self, key_id, value_object)
+            self._raw_keys.append(sel.text_sane(key))
             self._keys.append(key_id)
 
     def reload(self):
@@ -287,6 +290,10 @@ class SummaryTable(object):
             except AttributeError:
                 pass
         return self.load()
+
+    @property
+    def raw_keys(self):
+        return self._raw_keys
 
     @property
     def keys(self):

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -30,7 +30,7 @@ class OpenshiftProvider(ContainersProvider):
         # probably a js wait issue, not reproducible manually
         super(OpenshiftProvider, self).create(validate_credentials=validate_credentials, **kwargs)
 
-    def _href(self):
+    def href(self):
         return self.appliance.rest_api.collections.providers\
             .find_by(name=self.name).resources[0].href
 
@@ -73,7 +73,7 @@ class OpenshiftProvider(ContainersProvider):
     def custom_attributes(self):
         """returns custom attributes"""
         response = self.appliance.rest_api.get(
-            path.join(self._href(), 'custom_attributes'))
+            path.join(self.href(), 'custom_attributes'))
         out = []
         for attr_dict in response['resources']:
             attr = self.appliance.rest_api.get(attr_dict['href'])
@@ -109,7 +109,7 @@ class OpenshiftProvider(ContainersProvider):
             if fld_tp:
                 payload['resources'][i]['field_type'] = fld_tp
         return self.appliance.rest_api.post(
-            path.join(self._href(), 'custom_attributes'), **payload)
+            path.join(self.href(), 'custom_attributes'), **payload)
 
     def edit_custom_attributes(self, *custom_attributes):
         """Editing static custom attributes in provider.
@@ -132,18 +132,24 @@ class OpenshiftProvider(ContainersProvider):
                 "value": ca.value
             } for ca in custom_attributes]}
         return self.appliance.rest_api.post(
-            path.join(self._href(), 'custom_attributes'), **payload)
+            path.join(self.href(), 'custom_attributes'), **payload)
 
-    def delete_custom_attributes(self, *names):
+    def delete_custom_attributes(self, *custom_attributes):
         """Deleting static custom attributes from provider.
         Args:
-            names: The names of the custom attributes to delete.
+            custom_attributes: The custom attributes to delete.
+                               (Could be also names (str))
         returns: response.
         """
-        for name in names:
-            if type(name) is not str:
-                raise TypeError('Type of names should be {}. ({} != {})'
-                                .format(str, type(name), str))
+        names = []
+        for attr in custom_attributes:
+            attr_type = type(attr)
+            if attr_type in (str, CustomAttribute):
+                names.append(attr if attr_type is str else attr.name)
+            else:
+                raise TypeError('Type of arguments should be either'
+                                'str or CustomAttribute. ({} not in [str, CustomAttribute])'
+                                .format(type(attr)))
         attribs = self.custom_attributes()
         if not names:
             names = [attr.name for attr in attribs]
@@ -153,4 +159,4 @@ class OpenshiftProvider(ContainersProvider):
                 "href": attr.href,
             } for attr in attribs if attr.name in names]}
         return self.appliance.rest_api.post(
-            path.join(self._href(), 'custom_attributes'), **payload)
+            path.join(self.href(), 'custom_attributes'), **payload)

--- a/cfme/tests/containers/test_static_custom_attributes.py
+++ b/cfme/tests/containers/test_static_custom_attributes.py
@@ -1,5 +1,7 @@
 from string import digits, ascii_letters
 from random import choice
+from traceback import format_exception_only
+from os import path
 import sys
 import inspect
 import re
@@ -11,8 +13,6 @@ from utils.version import current_version
 from utils import testgen
 from cfme.containers.provider import ContainersProvider
 from cfme.containers.provider.openshift import CustomAttribute
-from traceback import format_exception_only
-from os import path
 
 pytestmark = [
     pytest.mark.uncollectif(

--- a/cfme/tests/containers/test_static_custom_attributes.py
+++ b/cfme/tests/containers/test_static_custom_attributes.py
@@ -10,6 +10,7 @@ from utils.version import current_version
 from utils import testgen
 from cfme.containers.provider import ContainersProvider
 from cfme.containers.provider.openshift import CustomAttribute
+from utils.blockers import BZ
 
 pytestmark = [
     pytest.mark.uncollectif(
@@ -166,7 +167,7 @@ def test_delete_non_exist_attribute(provider):
 
 # CMP-10542
 
-@pytest.mark.meta(blockers=[1416797])
+@pytest.mark.meta(blockers=[BZ(1416797, forced_streams=['5.7'])])
 def test_add_already_exist_attribute(provider):
     ca = choice(ATTRIBUTES_DATASET)
     with pytest.raises(APIException):

--- a/cfme/tests/containers/test_static_custom_attributes.py
+++ b/cfme/tests/containers/test_static_custom_attributes.py
@@ -131,14 +131,12 @@ def test_add_attribute_with_empty_name(provider):
         * You should get an error
         * You should not see this attribute in the custom  attributes table
     """
-    try:
+    with pytest.raises(APIException):
         provider.add_custom_attributes(
             CustomAttribute('', "17")
         )
         pytest.fail('You have added custom attribute with empty name'
                     'and didn\'t get an error!')
-    except APIException:
-        pass
 
     if hasattr(provider.summary, 'custom_attributes'):
         assert "" not in provider.summary.custom_attributes
@@ -148,13 +146,11 @@ def test_add_attribute_with_empty_name(provider):
 
 def test_add_date_value_with_wrong_value(provider):
     ca = CustomAttribute('nondate', "koko", 'Date')
-    try:
+    with pytest.raises(APIException):
         provider.add_custom_attributes(ca)
         pytest.fail('You have added custom attribute of type'
                     '{} with value of {} and didn\'t get an error!'
                     .format(ca.field_type, ca.value))
-    except APIException:
-        pass
 
     if hasattr(provider.summary, 'custom_attributes'):
         assert 'nondate' not in provider.summary.custom_attributes
@@ -166,7 +162,7 @@ def test_edit_non_exist_attribute(provider):
     setup_dataset(provider, verify_exists=False)
 
     ca = choice(ATTRIBUTES_DATASET)
-    try:
+    with pytest.raises(APIException):
         # Note: we need to implement it inside the test instead of using
         #       the API (provider.edit_custom_attributes) in order to
         #       specify the href and yield the exception
@@ -182,8 +178,6 @@ def test_edit_non_exist_attribute(provider):
         pytest.fail('You tried to edit a non-exist custom attribute'
                     '({}) and didn\'t get an error!'
                     .format(ca.value))
-    except APIException:
-        pass
 
 
 # CMP-10543
@@ -192,13 +186,11 @@ def test_delete_non_exist_attribute(provider):
     setup_dataset(provider, verify_exists=False)
 
     ca = choice(ATTRIBUTES_DATASET)
-    try:
+    with pytest.raises(APIException):
         provider.delete_custom_attributes(ca)
         pytest.fail('You tried to delete a non-exist custom attribute'
                     '({}) and didn\'t get an error!'
                     .format(ca.value))
-    except APIException:
-        pass
 
 
 # CMP-10542
@@ -207,13 +199,11 @@ def test_delete_non_exist_attribute(provider):
 def test_add_already_exist_attribute(provider):
     setup_dataset(provider, verify_exists=True)
     ca = choice(ATTRIBUTES_DATASET)
-    try:
+    with pytest.raises(APIException):
         provider.add_custom_attributes(ca)
         pytest.fail('You tried to add a custom attribute that already exists'
                     '({}) and didn\'t get an error!'
                     .format(ca.value))
-    except APIException:
-        pass
 
 
 # CMP-10540


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_static_custom_attributes.py -v --use-provider cm-env1 }}