### PR TITLE
[1LP] [RFR] New test test_control_identical_descriptions

### DIFF
--- a/cfme/control/explorer/actions.py
+++ b/cfme/control/explorer/actions.py
@@ -12,8 +12,6 @@ from . import ControlExplorerView
 from utils.appliance import Navigatable
 from utils.update import Updateable
 
-from utils.db import cfmedb
-
 
 class ActionsAllView(ControlExplorerView):
     title = Text("#explorer_title_text")
@@ -212,8 +210,12 @@ class Action(Updateable, Navigatable, Pretty):
 
     @property
     def exists(self):
-        actions = cfmedb()["miq_actions"]
-        return cfmedb().session\
+        """Check existence of this Action.
+
+        Returns: :py:class:`bool` signalizing the presence of the Action in the database.
+        """
+        actions = self.appliance.db["miq_actions"]
+        return self.appliance.db.session\
             .query(actions.description)\
             .filter(actions.description == self.description)\
             .count() > 0

--- a/cfme/control/explorer/alert_profiles.py
+++ b/cfme/control/explorer/alert_profiles.py
@@ -95,7 +95,7 @@ class BaseAlertProfile(Updateable, Navigatable, Pretty):
         view.fill({
             "description": self.description,
             "notes": self.notes,
-            "alerts": self.alerts
+            "alerts": [str(alert) for alert in self.alerts]
         })
         view.add_button.click()
         view = self.create_view(AlertProfileDetailsView)
@@ -146,6 +146,18 @@ class BaseAlertProfile(Updateable, Navigatable, Pretty):
             view.flash.assert_no_error()
             view.flash.assert_message(
                 'Alert Profile "{}": Delete successful'.format(self.description))
+
+    @property
+    def exists(self):
+        """Check existence of this Alert Profile.
+
+        Returns: :py:class:`bool` signalizing the presence of the Alert Profile in the database.
+        """
+        miq_sets = self.appliance.db["miq_sets"]
+        return self.appliance.db.session.query(miq_sets.description)\
+            .filter(
+                miq_sets.description == self.description and miq_sets.set_type == "MiqAlertSet")\
+            .count() > 0
 
 
 @navigator.register(BaseAlertProfile, "Add")

--- a/cfme/control/explorer/alerts.py
+++ b/cfme/control/explorer/alerts.py
@@ -262,6 +262,18 @@ class Alert(Updateable, Navigatable, Pretty):
                 fill_details["snmp_trap"] = self.snmp_trap
         view.fill(fill_details)
 
+    @property
+    def exists(self):
+        """Check existence of this Alert.
+
+        Returns: :py:class:`bool` signalizing the presence of the Alert in the database.
+        """
+        alerts = self.appliance.db["miq_alerts"]
+        return self.appliance.db.session\
+            .query(alerts.description)\
+            .filter(alerts.description == self.description)\
+            .count() > 0
+
 
 @navigator.register(Alert, "Add")
 class AlertNew(CFMENavigateStep):

--- a/cfme/control/explorer/conditions.py
+++ b/cfme/control/explorer/conditions.py
@@ -200,6 +200,18 @@ class BaseCondition(Updateable, Navigatable, Pretty):
         assert view.is_displayed
         return view.scope.read()
 
+    @property
+    def exists(self):
+        """Check existence of this Condition.
+
+        Returns: :py:class:`bool` signalizing the presence of the Condition in the database.
+        """
+        conditions = self.appliance.db["conditions"]
+        return self.appliance.db.session\
+            .query(conditions.description)\
+            .filter(conditions.description == self.description)\
+            .count() > 0
+
 
 @navigator.register(BaseCondition, "Add")
 class ConditionNew(CFMENavigateStep):

--- a/cfme/tests/control/test_bugs.py
+++ b/cfme/tests/control/test_bugs.py
@@ -7,6 +7,9 @@ from cfme.common.vm import VM
 from cfme.control.explorer.policy_profiles import PolicyProfile
 from cfme.control.explorer.policies import VMCompliancePolicy, VMControlPolicy
 from cfme.control.explorer.actions import Action
+from cfme.control.explorer.alerts import Alert
+from cfme.control.explorer.conditions import VMCondition
+from cfme.control.explorer.alert_profiles import VMInstanceAlertProfile
 from cfme.infrastructure.virtual_machines import Vm
 from utils.appliance.implementations.ui import navigate_to
 from utils.version import current_version
@@ -23,6 +26,104 @@ from utils.blockers import BZ
 pytestmark = [
     test_requirements.control,
     pytest.mark.tier(3)
+]
+
+
+def create_policy_profile(request):
+    random_string = fauxfactory.gen_alpha()
+    policy = VMControlPolicy(random_string)
+    policy.create()
+    policy_profile = PolicyProfile(random_string, [policy])
+    policy_profile.create()
+
+    @request.addfinalizer
+    def _delete():
+        while policy_profile.exists:
+            policy_profile.delete()
+        if policy.exists:
+            policy.delete()
+
+    return policy_profile
+
+
+def create_policy(request):
+    policy = VMControlPolicy(fauxfactory.gen_alpha())
+    policy.create()
+
+    @request.addfinalizer
+    def _delete():
+        while policy.exists:
+            policy.delete()
+
+    return policy
+
+
+def create_condition(request):
+    condition = VMCondition(
+        fauxfactory.gen_alpha(),
+        "fill_field(VM and Instance : Boot Time, BEFORE, Today)"
+    )
+    condition.create()
+
+    @request.addfinalizer
+    def _delete():
+        while condition.exists:
+            condition.delete()
+
+    return condition
+
+
+def create_action(request):
+    action = Action(
+        fauxfactory.gen_alpha(),
+        action_type="Tag",
+        action_values={"tag": ("My Company Tags", "Department", "Accounting")}
+    )
+    action.create()
+
+    @request.addfinalizer
+    def _delete():
+        while action.exists:
+            action.delete()
+
+    return action
+
+
+def create_alert_profile(request):
+    alert = Alert("VM CD Drive or Floppy Connected")
+    alert_profile = VMInstanceAlertProfile(fauxfactory.gen_alpha(), [alert])
+    alert_profile.create()
+
+    @request.addfinalizer
+    def _delete():
+        while alert_profile.exists:
+            alert_profile.delete()
+
+    return alert_profile
+
+
+def create_alert(request):
+    random_string = fauxfactory.gen_alpha()
+    alert = Alert(
+        random_string, timeline_event=True, driving_event="Hourly Timer"
+    )
+    alert.create()
+
+    @request.addfinalizer
+    def _delete():
+        while alert.exists:
+            alert.delete()
+
+    return alert
+
+
+items = [
+    ("Policy profiles", create_policy_profile),
+    ("Policies", create_policy),
+    ("Conditions", create_condition),
+    ("Actions", create_action),
+    ("Alert profiles", create_alert_profile),
+    ("Alerts", create_alert)
 ]
 
 
@@ -242,3 +343,22 @@ def test_delete_all_actions_from_compliance_policy(request):
     policy.create()
     with pytest.raises(AssertionError):
         policy.assign_actions_to_event("VM Compliance Check", [])
+
+
+@pytest.mark.parametrize("item_type,create_function", items, ids=[item[0] for item in items])
+@pytest.mark.uncollectif(lambda item_type: item_type in ["Policy profiles", "Alert profiles"] and
+    BZ(1304396, forced_streams=["5.6", "5.7"]).blocks)
+def test_control_identical_descriptions(request, item_type, create_function):
+    """CFME should not allow to create policy, alerts, profiles, actions and others to be created
+    if the item with the same description already exists.
+
+    Steps:
+        * Create an item
+        * Create the same item again
+
+    Result:
+        The item shouldn't be created.
+    """
+    item = create_function(request)
+    with pytest.raises(AssertionError):
+        item.create()


### PR DESCRIPTION
{{pytest: -v -k "test_control_identical_description"}}

Purpose or Intent
=================

__New test__ for Control. CFME should not allow to create policy, alerts, profiles, actions and others to be created if the item with the same description already exists.

Steps:
 * Create an item
 * Create the same item again

Result:  the item shouldn't be created.

