### PR TITLE
[1LP][RFR] fix test_order_catalog_item_via_rest

### DIFF
--- a/cfme/tests/services/test_service_catalogs.py
+++ b/cfme/tests/services/test_service_catalogs.py
@@ -61,7 +61,7 @@ def test_order_catalog_item_via_rest(
     request.addfinalizer(lambda: cleanup_vm(vm_name, provider))
     catalog_item.create()
     request.addfinalizer(catalog_item.delete)
-    catalog = rest_api.collections.service_catalogs.find_by(name=catalog)
+    catalog = rest_api.collections.service_catalogs.find_by(name=catalog.name)
     assert len(catalog) == 1
     catalog, = catalog
     template = catalog.service_templates.find_by(name=catalog_item.name)


### PR DESCRIPTION
Fixing how catalog name is obtained in test_order_catalog_item_via_rest.

PRT is not cooperating, tests are failing or skipped there for various unrelated reasons, tested localy:

cfme/tests/services/test_service_catalogs.py::test_order_catalog_item_via_rest[vsphere6-nested] PASSED

====================================================================== 1 passed in 648.23 seconds



{{pytest: '''cfme/tests/services/test_service_catalogs.py::test_order_catalog_item_via_rest'' --runxfail --long-running -v'}}
