### PR TITLE
[1LP][RFR] fix vm_name identifier string

### DIFF
--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -167,7 +167,7 @@ class InfraProvider(Pretty, CloudInfraProvider):
         return version.pick({
             version.LOWEST: "VMs",
             '5.5': "VMs and Instances",
-            '5.8': "Virtual Machines"})  # TODO: If it lands in some 5.7.x, change this version!
+            '5.7': "Virtual Machines"})
 
     @variable(alias='db')
     def num_datastore(self):


### PR DESCRIPTION
Fix test that are using `vm_name` identifier string from `cfme/infrastructure/provider/__init__.py` and are failing with
`NoSuchElementException: Message: Element .//table/tbody/tr/td[1][@class="label"][normalize-space(.)="VMs and Instances"]/.. not found on page.`

**PRT results:**
relevant PASSED tests on 5.7:
cfme/tests/cloud_infra_common/test_power_control_rest.py::test_stop[vsphere55-cfrom_detail] PASSED
cfme/tests/cloud_infra_common/test_power_control_rest.py::test_start[vsphere55-from_detail] PASSED
cfme/tests/cloud_infra_common/test_power_control_rest.py::test_suspend[vsphere55-from_detail] PASSED
cfme/tests/cloud_infra_common/test_power_control_rest.py::test_reset_vm[vsphere55-from_detail] PASSED
cfme/tests/cloud_infra_common/test_power_control_rest.py::test_stop[vsphere55-from_collection] PASSED
cfme/tests/cloud_infra_common/test_power_control_rest.py::test_start[vsphere55-from_collection] PASSED
cfme/tests/cloud_infra_common/test_power_control_rest.py::test_suspend[vsphere55-from_collection] PASSED
cfme/tests/cloud_infra_common/test_power_control_rest.py::test_reset_vm[vsphere55-from_collection] PASSED

http://10.16.4.32/trackerbot/pr/run/10001#ZkpUMF3U

{{pytest: cfme/tests/cloud_infra_common/test_power_control_rest.py -v}}