### PR TITLE
[RFR] Containers Summary Test, possible fix for objects duplication problem

### DIFF
--- a/cfme/tests/containers/test_containers_summary.py
+++ b/cfme/tests/containers/test_containers_summary.py
@@ -9,7 +9,6 @@ from utils.version import current_version
 pytestmark = [
     pytest.mark.uncollectif(
         lambda: current_version() < "5.6"),
-    pytest.mark.usefixtures('has_no_containers_providers'),
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_containers_summary.py -v --use-provider cm-env1 }}

Purpose or Intent
=================
This should fix the objects duplication problem we have that is caused by successive providers removal and addition