### PR TITLE
[WIPTEST] Get metrics hostname from openshift and check it is up.

### DIFF
--- a/cfme/tests/containers/test_basic_metrics.py
+++ b/cfme/tests/containers/test_basic_metrics.py
@@ -1,8 +1,9 @@
+import kubeshift
+import requests
 import pytest
-import re
+
 from cfme.containers.provider import ContainersProvider
 from utils import testgen
-from utils import conf
 from utils.version import current_version
 
 
@@ -18,11 +19,23 @@ def test_basic_metrics(provider, ssh_client):
         This test checks that the Metrics service is up
         Curls the hawkular status page and checks if it's up
         """
-    username, password = provider.credentials['token'].principal,\
-        provider.credentials['token'].secret
-    hostname = conf.cfme_data.get('management_systems', {})[provider.key]\
-        .get('hostname', [])
-    host_url = 'https://' + hostname + '/hawkular/metrics/'
-    command = 'curl -X GET ' + host_url + ' --insecure'
-    ssh_client = ssh_client(hostname=hostname, username=username, password=password)
-    assert re.search("Hawkular[ -]Metrics", str(ssh_client.run_command(command)))
+
+    os_api_url = "{0.rest_protocol}://{0.hostname}:{0.port}".format(
+        provider.provider_data)
+
+    # Prepare the creds for the kubeshift. Note we don't need to store
+    # need to store the credentials in any file, hence /dev/null is used.
+    # This means that the creds_name is also unimportant as it is thrown away.
+    creds_name = "some-creds-identifier-that-doesnt't-mean-a-thing"
+    kubeshift_config = kubeshift.Config.from_params(api=os_api_url,
+                                                    verify=False,
+                                                    filepath="/dev/null",
+                                                    username=creds_name)
+    kubeshift_config.set_credentials(creds_name,
+                                     token=provider.credentials["token"].token)
+
+    client = kubeshift.OpenshiftClient(kubeshift_config)
+    hm_api = client.routes(namespace="openshift-infra").by_name("hawkular-metrics")["spec"]["host"]
+    status_url = 'https://' + hm_api + '/hawkular/metrics/status'
+    response = requests.get(status_url, verify=False)
+    assert response.json().get("MetricsService") == "STARTED"

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ Jinja2
 jsmin
 jupyter
 kwargify
+git+https://github.com/cdrage/kubeshift.git@971e69f8b29a9a4#egg=kubeshift
 # 15.8.1 breaks yaycl: https://github.com/mk-fg/layered-yaml-attrdict-config/commit/ea12fbf31b96abf15543c7b436272d8854b5d324
 layered-yaml-attrdict-config
 mgmtsystem>0.0.15


### PR DESCRIPTION
Fixes #3934

Test assumed the metrics to be running on the master which may not be the case. I also think that if we need to test metrics in cfme_tests, we should be using the DNS route. This can be discovered by asking the openshift using the kubeshift client in the test running time to avoid the need to configure it.

Patch is adding a yet another dependency -- on kubeshift. I think though that the kubeshift may be used in other tests to get the information about the provider to compare it with the CFME UI / API which could justify it's addition.

{{ pytest: cfme/tests/containers/test_basic_metrics.py --use-provider cm-env1 }}