### PR TITLE
[1LP][RFR]Patch for image comparison in cfme/tests/containers/test_containers_overv…

### DIFF
--- a/cfme/tests/containers/test_containers_overview_data_integrity.py
+++ b/cfme/tests/containers/test_containers_overview_data_integrity.py
@@ -93,11 +93,13 @@ def test_containers_overview_data_integrity(provider):
     list_img_from_openshift_parsed = [i[7:].split(
         '@sha256:')[-1] for i in list_img_from_openshift_splitted]
 
-    list_img_from_openshift_parsed.extend([item for item in list_img_from_registry_splitted
-                                           if item not in list_img_from_openshift_parsed])
+    list_img_from_registry_splitted_new = set(list_img_from_registry_splitted)
+    list_img_from_openshift_parsed_new = set(list_img_from_openshift_parsed)
+
+    list_img_from_openshift_parsed_new.update(list_img_from_registry_splitted_new)
 
     num_img_cfme_56 = len(provider.mgmt.list_image())
-    num_img_cfme_57 = len(list_img_from_openshift_parsed)
+    num_img_cfme_57 = len(list_img_from_openshift_parsed_new)
 
     assert StatusBox('images').value() == version.pick({version.LOWEST:
                                                         num_img_cfme_56, '5.7': num_img_cfme_57})

--- a/cfme/tests/containers/test_containers_overview_data_integrity.py
+++ b/cfme/tests/containers/test_containers_overview_data_integrity.py
@@ -84,7 +84,7 @@ def test_containers_overview_data_integrity(provider):
         list_providers_by_class(ContainersProvider))
 
     list_img_from_registry = provider.mgmt.list_image()
-    list_img_from_registry_splitted = [i[2].split(
+    list_img_from_registry_splitted = [i.id.split(
         '@sha256:')[-1] for i in list_img_from_registry]
 
     list_img_from_openshift = provider.mgmt.list_image_openshift()
@@ -102,10 +102,7 @@ def test_containers_overview_data_integrity(provider):
 
     results = {}
     for cls in DATA_SETS:
-        results[
-            cls.object] = api_values[
-            cls.object] == statusbox_values[
-            cls.object]
+        results[cls.object] = api_values[cls.object] == statusbox_values[cls.object]
     if not all(results.values()):
         pytest.fail('There is a mismatch between API and UI values:\n{}'.format(
             '\n'.join(['{}: {} (API) != {} (UI)'.format(

--- a/cfme/tests/containers/test_containers_overview_data_integrity.py
+++ b/cfme/tests/containers/test_containers_overview_data_integrity.py
@@ -1,12 +1,11 @@
 import pytest
+
 from utils import testgen
 from utils.version import current_version
 from cfme.containers.provider import ContainersProvider
 from cfme.containers.node import Node
 from cfme.containers.pod import Pod
 from cfme.containers.service import Service
-from cfme.containers.image_registry import ImageRegistry
-from cfme.containers.image import Image
 from cfme.containers.project import Project
 from cfme.containers.route import Route
 from collections import namedtuple
@@ -17,12 +16,14 @@ from utils.providers import list_providers_by_class
 from utils.appliance.implementations.ui import navigate_to
 from cfme.containers.overview import ContainersOverview
 
+
 pytestmark = [
     pytest.mark.uncollectif(
         lambda provider: current_version() < "5.6"),
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1)]
-pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
+pytest_generate_tests = testgen.generate(
+    [ContainersProvider], scope='function')
 
 
 DataSet = namedtuple('DataSet', ['object', 'name'])
@@ -33,10 +34,8 @@ DATA_SETS = [
     DataSet(Project, 'Projects'),
     DataSet(Pod, 'Pods'),
     DataSet(Service, 'Services'),
-    DataSet(Image, 'Images'),
     DataSet(Route, 'Routes'),
-    DataSet(ContainersProvider, 'Providers'),
-    DataSet(ImageRegistry, 'Registries')
+    DataSet(ContainersProvider, 'Providers')
 ]
 
 
@@ -47,8 +46,6 @@ def get_api_object_counts(providers):
         Node: 0,
         Pod: 0,
         Service: 0,
-        ImageRegistry: 0,
-        Image: 0,
         Project: 0,
         Route: 0,
     }
@@ -58,8 +55,6 @@ def get_api_object_counts(providers):
         out[Node] += len(provider.mgmt.list_node())
         out[Pod] += len(provider.mgmt.list_container_group())
         out[Service] += len(provider.mgmt.list_service())
-        out[ImageRegistry] += len(provider.mgmt.list_image_registry())
-        out[Image] += len(provider.mgmt.list_image())
         out[Project] += len(provider.mgmt.list_project())
         out[Route] += len(provider.mgmt.list_route())
     return out
@@ -68,8 +63,7 @@ def get_api_object_counts(providers):
 # CMP-9521
 
 
-@pytest.mark.meta(blockers=[1369359])
-def test_containers_overview_data_integrity():
+def test_containers_overview_data_integrity(provider):
     """Test data integrity of status boxes in containers dashboard.
     Steps:
         * Go to Containers / Overview
@@ -81,15 +75,39 @@ def test_containers_overview_data_integrity():
     navigate_to(ContainersOverview, 'All')
     # We should wait ~2 seconds for the StatusBox population
     # (until we find a better solution)
+    # Since we collect images from Openshift and from the pods,
+    # images are tested separately
     time.sleep(2)
     statusbox_values = {data_set.object: int(StatusBox(data_set.name).value())
                         for data_set in DATA_SETS}
-    api_values = get_api_object_counts(list_providers_by_class(ContainersProvider))
+    api_values = get_api_object_counts(
+        list_providers_by_class(ContainersProvider))
+
+    list_img_from_registry = provider.mgmt.list_image()
+    list_img_from_registry_splitted = [i[2].split(
+        '@sha256:')[-1] for i in list_img_from_registry]
+
+    list_img_from_openshift = provider.mgmt.list_image_openshift()
+    list_img_from_openshift_splitted = [d['name']
+                                        for d in list_img_from_openshift]
+    list_img_from_openshift_parsed = [i[7:].split(
+        '@sha256:')[-1] for i in list_img_from_openshift_splitted]
+
+    for s in list_img_from_openshift_parsed:
+        for item in list_img_from_registry_splitted:
+            if item not in list_img_from_openshift_parsed:
+                list_img_from_openshift_parsed.append(item)
+
+    assert len(list_img_from_openshift_parsed) == StatusBox('images').value()
+
     results = {}
     for cls in DATA_SETS:
-        results[cls.object] = api_values[cls.object] == statusbox_values[cls.object]
+        results[
+            cls.object] = api_values[
+            cls.object] == statusbox_values[
+            cls.object]
     if not all(results.values()):
         pytest.fail('There is a mismatch between API and UI values:\n{}'.format(
-                    '\n'.join(['{}: {} (API) != {} (UI)'.format(
-                        obj.__name__, api_values[obj], statusbox_values[obj])
-                        for obj, is_pass in results.items() if not is_pass])))
+            '\n'.join(['{}: {} (API) != {} (UI)'.format(
+                obj.__name__, api_values[obj], statusbox_values[obj])
+                for obj, is_pass in results.items() if not is_pass])))

--- a/cfme/tests/containers/test_containers_overview_data_integrity.py
+++ b/cfme/tests/containers/test_containers_overview_data_integrity.py
@@ -77,6 +77,7 @@ def test_containers_overview_data_integrity(provider):
     # (until we find a better solution)
     # Since we collect images from Openshift and from the pods,
     # images are tested separately
+    # image registries are also tested separately
     time.sleep(2)
     statusbox_values = {data_set.object: int(StatusBox(data_set.name).value())
                         for data_set in DATA_SETS}

--- a/cfme/tests/containers/test_containers_overview_data_integrity.py
+++ b/cfme/tests/containers/test_containers_overview_data_integrity.py
@@ -100,6 +100,12 @@ def test_containers_overview_data_integrity(provider):
 
     assert len(list_img_from_openshift_parsed) == StatusBox('images').value()
 
+    list_all_rgstr = provider.mgmt.list_image_registry()
+    list_all_rgstr_revised = [i.host for i in list_all_rgstr]
+    list_all_rgstr_new = filter(lambda ch: 'openshift3' not in ch, list_all_rgstr_revised)
+
+    assert len(list_all_rgstr_new) == StatusBox('registries').value()
+
     results = {}
     for cls in DATA_SETS:
         results[cls.object] = api_values[cls.object] == statusbox_values[cls.object]

--- a/cfme/tests/containers/test_containers_overview_data_integrity.py
+++ b/cfme/tests/containers/test_containers_overview_data_integrity.py
@@ -93,10 +93,8 @@ def test_containers_overview_data_integrity(provider):
     list_img_from_openshift_parsed = [i[7:].split(
         '@sha256:')[-1] for i in list_img_from_openshift_splitted]
 
-    for s in list_img_from_openshift_parsed:
-        for item in list_img_from_registry_splitted:
-            if item not in list_img_from_openshift_parsed:
-                list_img_from_openshift_parsed.append(item)
+    list_img_from_openshift_parsed.extend([item for item in list_img_from_registry_splitted
+                                           if item not in list_img_from_openshift_parsed])
 
     assert len(list_img_from_openshift_parsed) == StatusBox('images').value()
 

--- a/cfme/tests/containers/test_containers_overview_data_integrity.py
+++ b/cfme/tests/containers/test_containers_overview_data_integrity.py
@@ -1,7 +1,6 @@
 import pytest
 
-from utils import testgen
-from utils.version import current_version
+from utils import testgen, version
 from cfme.containers.provider import ContainersProvider
 from cfme.containers.node import Node
 from cfme.containers.pod import Pod
@@ -19,7 +18,7 @@ from cfme.containers.overview import ContainersOverview
 
 pytestmark = [
     pytest.mark.uncollectif(
-        lambda provider: current_version() < "5.6"),
+        lambda provider: version.current_version() < "5.6"),
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate(
@@ -97,7 +96,11 @@ def test_containers_overview_data_integrity(provider):
     list_img_from_openshift_parsed.extend([item for item in list_img_from_registry_splitted
                                            if item not in list_img_from_openshift_parsed])
 
-    assert len(list_img_from_openshift_parsed) == StatusBox('images').value()
+    num_img_cfme_56 = len(provider.mgmt.list_image())
+    num_img_cfme_57 = len(list_img_from_openshift_parsed)
+
+    assert StatusBox('images').value() == version.pick({version.LOWEST:
+                                                        num_img_cfme_56, '5.7': num_img_cfme_57})
 
     list_all_rgstr = provider.mgmt.list_image_registry()
     list_all_rgstr_revised = [i.host for i in list_all_rgstr]


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_containers_overview_data_integrity.py -v --use-provider cm-env1 }}

Fixed functionality to collect images from the Openshift, as well as the images from other registries if they don't already exist in the list of images collected from the Openshift.
