### PR TITLE
[RFR] Update utils trackerbot and version for cfme 58

### DIFF
--- a/utils/trackerbot.py
+++ b/utils/trackerbot.py
@@ -26,6 +26,7 @@ stream_matchers = (
     (get_stream('5.5'), r'^cfme-55.*-(?P<month>\d{2})(?P<day>\d{2})'),
     (get_stream('5.6'), r'^cfme-56.*-(?P<month>\d{2})(?P<day>\d{2})'),
     (get_stream('5.7'), r'^cfme-57.*-(?P<month>\d{2})(?P<day>\d{2})'),
+    (get_stream('5.8'), r'^cfme-58.*-(?P<month>\d{2})(?P<day>\d{2})'),
     # Nightly builds have potentially multiple version streams bound to them so we
     # cannot use get_stream()
     ('upstream_stable', r'^miq-stable-darga-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})'),

--- a/utils/version.py
+++ b/utils/version.py
@@ -345,6 +345,7 @@ version_stream_product_mapping = {
     '5.5': SPTuple('downstream-55z', '4.0'),
     '5.6': SPTuple('downstream-56z', '4.1'),
     '5.7': SPTuple('downstream-57z', '4.2'),
+    '5.8': SPTuple('downstream-58z', '4.5'),
     LATEST: SPTuple('upstream', 'master')
 }
 


### PR DESCRIPTION
Support 5.8 in trackerbot and version utils.