### PR TITLE
[1LP] [RFR] Ensures we use default ram and cpu values unless explicitly ove…

### DIFF
--- a/cfme/infrastructure/provider/scvmm.py
+++ b/cfme/infrastructure/provider/scvmm.py
@@ -38,9 +38,14 @@ class SCVMMProvider(InfraProvider):
 
     def deployment_helper(self, deploy_args):
         """ Used in utils.virtual_machines """
+        values = {}
         if 'host_group' not in deploy_args:
-            return {'host_group': self.data.get("host_group", "All Hosts")}
-        return {}
+            values['host_group'] = self.data.get("host_group", "All Hosts")
+        if 'cpu' not in deploy_args:
+            values['cpu'] = self.data.get("cpu", 0)
+        if 'ram' not in deploy_args:
+            values['ram'] = self.data.get("ram", 0)
+        return values
 
     @classmethod
     def from_config(cls, prov_config, prov_key):


### PR DESCRIPTION
…rridden.

Purpose or Intent
=================

__Extending__ SCVMM initialization by making absolutely sure we use the template default values for cpu and ram unless explicitly overridden.  Use primarily for implementing mfalesni's request to customize scvmm deployments from sprout.  The management system PR is needed as well, but this change has no impact on any tests.

py.test cfme/tests/infrastructure/test_vm_power_control.py -k "test_power_off_cancel" --long-running --use-provider scvmm
