### PR TITLE
[1LP] [RFR] REST API tests for /api/requests

### DIFF
--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -283,8 +283,9 @@ def service_templates(request, rest_api, dialog):
     return s_tpls
 
 
-def automation_requests_data(vm):
-    return [{
+def automation_requests_data(vm, requests_collection=False, approve=True):
+    # for creating automation request using /api/automation_requests
+    automation_requests_col = {
         "uri_parts": {
             "namespace": "System",
             "class": "Request",
@@ -295,9 +296,29 @@ def automation_requests_data(vm):
             "vm_name": vm,
         },
         "requester": {
-            "auto_approve": True
+            "auto_approve": approve
         }
-    } for index in range(1, 5)]
+    }
+    # for creating automation request using /api/requests
+    requests_col = {
+        "options": {
+            "request_type": "automation",
+            "message": "create",
+            "namespace": "System",
+            "class_name": "Request",
+            "instance_name": "InspectME",
+            "attrs": {
+                "vm_name": vm,
+                "userid": "admin"
+            }
+        },
+        "requester": {
+            "user_name": "admin"
+        },
+        "auto_approve": approve
+    }
+    data = requests_col if requests_collection else automation_requests_col
+    return [data for _ in range(4)]
 
 
 def groups(request, rest_api, role, tenant, num=1):

--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -16,6 +16,7 @@ from utils.version import current_version
 from utils.wait import wait_for
 from utils import testgen
 from utils.log import logger
+from utils.blockers import BZ
 
 
 pytestmark = [test_requirements.rest]
@@ -33,19 +34,24 @@ def vm(request, a_provider, rest_api):
     return _vm(request, a_provider, rest_api)
 
 
+def wait_for_requests(requests):
+    def _finished():
+        for request in requests:
+            request.reload()
+            if request.request_state != 'finished':
+                return False
+        return True
+
+    wait_for(_finished, num_sec=45, delay=5, message="requests finished")
+
+
 @pytest.fixture(scope="function")
 def generate_notifications(rest_api):
     requests_data = automation_requests_data('nonexistent_vm')
     requests = rest_api.collections.automation_requests.action.create(*requests_data[:2])
+    assert len(requests) == 2
 
-    def _finished():
-        for resource in requests:
-            resource.reload()
-            if resource.request_state != 'finished':
-                return False
-        return True
-
-    wait_for(_finished, num_sec=45, delay=5, message="notifications generation")
+    wait_for_requests(requests)
 
 
 @pytest.yield_fixture(scope="function")
@@ -410,3 +416,103 @@ def test_delete_notifications(rest_api, generate_notifications, from_detail):
         collection.action.delete(*notifications)
         with error.expected("ActiveRecord::RecordNotFound"):
             collection.action.delete(*notifications)
+
+
+class TestRequestsRESTAPI(object):
+    @pytest.fixture(scope="function")
+    def pending_requests(self, rest_api):
+        requests_data = automation_requests_data(
+            'nonexistent_vm', requests_collection=True, approve=False)
+        response = rest_api.collections.requests.action.create(*requests_data[:2])
+        assert len(response) == 2
+        for resource in response:
+            assert resource.request_state == 'pending'
+        return response
+
+    @pytest.mark.uncollectif(lambda: current_version() < '5.7')
+    @pytest.mark.tier(3)
+    def test_create_automation_requests(self, rest_api, pending_requests):
+        """Tests creating automation requests using /api/requests.
+
+        Metadata:
+            test_flag: rest
+        """
+        for request in pending_requests:
+            resource = rest_api.collections.requests.get(id=request.id)
+            assert resource.type == 'AutomationRequest'
+
+    @pytest.mark.uncollectif(lambda: current_version() < '5.7')
+    @pytest.mark.tier(3)
+    @pytest.mark.parametrize(
+        'from_detail', [True, False],
+        ids=['from_detail', 'from_collection'])
+    def test_approve_requests(self, rest_api, pending_requests, from_detail):
+        """Tests approving requests.
+
+        Metadata:
+            test_flag: rest
+        """
+        if from_detail:
+            for request in pending_requests:
+                request.action.approve(reason="I said so")
+        else:
+            rest_api.collections.requests.action.approve(reason="I said so", *pending_requests)
+
+        wait_for_requests(pending_requests)
+
+        for request in pending_requests:
+            request.reload()
+            assert request.approval_state == 'approved'
+
+    @pytest.mark.uncollectif(lambda: current_version() < '5.7')
+    @pytest.mark.tier(3)
+    @pytest.mark.parametrize(
+        'from_detail', [True, False],
+        ids=['from_detail', 'from_collection'])
+    def test_deny_requests(self, rest_api, pending_requests, from_detail):
+        """Tests denying requests.
+
+        Metadata:
+            test_flag: rest
+        """
+        if from_detail:
+            for request in pending_requests:
+                request.action.deny(reason="I said so")
+        else:
+            rest_api.collections.requests.action.deny(reason="I said so", *pending_requests)
+
+        wait_for_requests(pending_requests)
+
+        for request in pending_requests:
+            request.reload()
+            assert request.approval_state == 'denied'
+
+    @pytest.mark.uncollectif(lambda: current_version() < '5.7')
+    @pytest.mark.tier(3)
+    @pytest.mark.parametrize(
+        'from_detail', [True, False],
+        ids=['from_detail', 'from_collection'])
+    def test_edit_requests(self, rest_api, pending_requests, from_detail):
+        """Tests editing requests.
+
+        Metadata:
+            test_flag: rest
+        """
+        collection = rest_api.collections.requests
+        body = {'options': {'arbitrary_key_allowed': 'test_rest'}}
+
+        if from_detail:
+            if BZ('1418331', forced_streams=['5.7', 'upstream']).blocks:
+                pytest.skip("Affected by BZ1418331, cannot test.")
+            for request in pending_requests:
+                request.action.edit(**body)
+        else:
+            identifiers = []
+            for i, resource in enumerate(pending_requests):
+                loc = ({'id': resource.id}, {'href': '{}/{}'.format(collection._href, resource.id)})
+                identifiers.append(loc[i % 2])
+            collection.action.edit(*identifiers, **body)
+
+        for request in pending_requests:
+            request.reload()
+            assert request.options['arbitrary_key_allowed'] == 'test_rest'


### PR DESCRIPTION
Adding tests for /api/requests collection.

{{pytest:  cfme/tests/test_rest.py -v -k TestRequestsRESTAPI}}
