### PR TITLE
[1LP] [RFR] fix test_delete_orchestration_templates test

### DIFF
--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -67,11 +67,6 @@ def service_data(request, rest_api, a_provider, dialog, service_catalogs):
     return _service_data(request, rest_api, a_provider, dialog, service_catalogs)
 
 
-@pytest.fixture(scope='function')
-def orchestration_templates(request, rest_api):
-    return _orchestration_templates(request, rest_api, num=2)
-
-
 class TestServiceRESTAPI(object):
     def test_edit_service(self, rest_api, services):
         """Tests editing a service.
@@ -457,6 +452,12 @@ class TestBlueprintsRESTAPI(object):
 
 
 class TestOrchestrationTemplatesRESTAPI(object):
+    @pytest.fixture(scope='function')
+    def orchestration_templates(self, request, rest_api):
+        response = _orchestration_templates(request, rest_api, num=2)
+        assert len(response) == 2
+        return response
+
     @pytest.mark.tier(3)
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     def test_create_orchestration_templates(self, rest_api, orchestration_templates):
@@ -465,7 +466,6 @@ class TestOrchestrationTemplatesRESTAPI(object):
         Metadata:
             test_flag: rest
         """
-        assert len(orchestration_templates) == 2
         for template in orchestration_templates:
             record = rest_api.collections.orchestration_templates.get(id=template.id)
             assert record.name == template.name
@@ -474,29 +474,33 @@ class TestOrchestrationTemplatesRESTAPI(object):
 
     @pytest.mark.tier(3)
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
-    @pytest.mark.parametrize(
-        "from_detail", [True, False],
-        ids=["from_detail", "from_collection"])
-    def test_delete_orchestration_templates(self, rest_api, orchestration_templates, from_detail):
-        """Tests delete orchestration templates.
+    def test_delete_orchestration_templates_from_collection(
+            self, rest_api, orchestration_templates):
+        """Tests delete orchestration templates from collection.
 
         Metadata:
             test_flag: rest
         """
-        assert len(orchestration_templates) > 0
         collection = rest_api.collections.orchestration_templates
-        if from_detail:
-            methods = ['post', 'delete']
-            if BZ('1414881', forced_streams=['5.7', 'upstream']).blocks:
-                methods[0] = 'delete'  # because the 'post' method fails
-            for i, ent in enumerate(orchestration_templates):
-                ent.action.delete(force_method=methods[i % 2])
-                with error.expected("ActiveRecord::RecordNotFound"):
-                    ent.action.delete()
-        else:
+        collection.action.delete(*orchestration_templates)
+        with error.expected("ActiveRecord::RecordNotFound"):
             collection.action.delete(*orchestration_templates)
+
+    @pytest.mark.tier(3)
+    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
+    @pytest.mark.parametrize('method', ['post', 'delete'])
+    def test_delete_orchestration_templates_from_detail(self, orchestration_templates, method):
+        """Tests delete orchestration templates from detail.
+
+        Metadata:
+            test_flag: rest
+        """
+        if method == 'post' and BZ('1414881', forced_streams=['5.7', 'upstream']).blocks:
+            pytest.skip("Affected by BZ1414881, cannot test.")
+        for ent in orchestration_templates:
+            ent.action.delete(force_method=method)
             with error.expected("ActiveRecord::RecordNotFound"):
-                collection.action.delete(*orchestration_templates)
+                ent.action.delete()
 
     @pytest.mark.tier(3)
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
@@ -510,7 +514,6 @@ class TestOrchestrationTemplatesRESTAPI(object):
             test_flag: rest
         """
         response_len = len(orchestration_templates)
-        assert response_len > 0
         new = []
         for _ in range(response_len):
             new.append({

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -17,6 +17,7 @@ from utils import error, version, testgen
 from utils.providers import setup_a_provider as _setup_a_provider
 from utils.wait import wait_for
 from utils.log import logger
+from utils.blockers import BZ
 
 
 pytestmark = [
@@ -486,6 +487,8 @@ class TestOrchestrationTemplatesRESTAPI(object):
         collection = rest_api.collections.orchestration_templates
         if from_detail:
             methods = ['post', 'delete']
+            if BZ('1414881', forced_streams=['5.7', 'upstream']).blocks:
+                methods[0] = 'delete'  # because the 'post' method fails
             for i, ent in enumerate(orchestration_templates):
                 ent.action.delete(force_method=methods[i % 2])
                 with error.expected("ActiveRecord::RecordNotFound"):


### PR DESCRIPTION
Adding BZ check to workaround the issue reported in https://bugzilla.redhat.com/show_bug.cgi?id=1414881 and leaving the test useful.

{{pytest: cfme/tests/services/test_rest_services.py -v -k TestOrchestrationTemplatesRESTAPI --long-running}}