### PR TITLE
[RFR] Update Stack use, include provider for __init__

### DIFF
--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -337,8 +337,8 @@ class InstanceAll(CFMENavigateStep):
         accordion.tree('Instances', 'All Instances')
 
 
-@navigator.register(Instance, 'ProviderAll')
-class InstanceProviderAll(CFMENavigateStep):
+@navigator.register(Instance, 'AllForProvider')
+class InstanceAllForProvider(CFMENavigateStep):
     prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
 
     def am_i_here(self):

--- a/cfme/cloud/instance/image.py
+++ b/cfme/cloud/instance/image.py
@@ -77,6 +77,20 @@ class ImageAll(CFMENavigateStep):
         accordion.tree('Images', 'All Images')
 
 
+@navigator.register(Image, 'AllForProvider')
+class ImageAllForProvider(CFMENavigateStep):
+    prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
+
+    def am_i_here(self):
+        return match_page(summary='Images under Provider "{}"'.format(self.obj.provider.name))
+
+    def step(self, *args, **kwargs):
+        self.prerequisite_view.navigation.select('Compute', 'Clouds', 'Instances')
+
+        # use accordion
+        accordion.tree('Images by Provider', 'Images by Provider', self.obj.provider.name)
+
+
 @navigator.register(Image, 'Details')
 class ImageDetails(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')

--- a/cfme/tests/cloud/test_delete_cloud_object.py
+++ b/cfme/tests/cloud/test_delete_cloud_object.py
@@ -10,8 +10,6 @@ from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import toolbar, Quadicon
 from utils import testgen
 from utils.appliance.implementations.ui import navigate_to
-from utils.version import current_version
-
 
 pytest_generate_tests = testgen.generate(
     [CloudProvider], required_fields=['remove_test'], scope="module")
@@ -71,14 +69,13 @@ def test_delete_image(setup_provider, provider, set_grid, request):
     request.addfinalizer(reset)
 
 
-@pytest.mark.uncollectif(lambda: current_version() < "5.4")
 def test_delete_stack(setup_provider, provider, provisioning, request):
     """ Tests delete stack
 
     Metadata:
         test_flag: delete_object
     """
-    stack = Stack(provisioning['stack'])
+    stack = Stack(provisioning['stack'], provider=provider)
     refresh_and_wait(provider, stack)
     stack.delete()
     navigate_to(stack, 'All')

--- a/cfme/tests/cloud/test_delete_cloud_object.py
+++ b/cfme/tests/cloud/test_delete_cloud_object.py
@@ -58,8 +58,6 @@ def test_delete_image(setup_provider, provider, set_grid, request):
     Metadata:
         test_flag: delete_object
     """
-    # TODO as of 5.6+ clouds_images is no longer in the menu tree
-    # Refactor to navigate via clouds instances accordion
     image_name = provider.data['remove_test']['image']
     test_image = VM.factory(image_name, provider, template=True)
     test_image.delete(from_details=False)

--- a/cfme/tests/services/test_provision_stack.py
+++ b/cfme/tests/services/test_provision_stack.py
@@ -11,7 +11,7 @@ from cfme.services import requests
 from cfme.cloud.provider import CloudProvider
 from cfme.cloud.stack import Stack
 from cfme import test_requirements
-from utils import testgen, version
+from utils import testgen
 from utils.log import logger
 from utils.wait import wait_for
 
@@ -251,7 +251,7 @@ def test_provision_stack(setup_provider, provider, provisioning, catalog, catalo
 
     service_catalogs = ServiceCatalogs(item_name, stack_data)
     service_catalogs.order()
-    logger.info('Waiting for cfme provision request for service %s', item_name)
+    logger.info('Waiting for cfme provision request for service {}'.format(item_name))
     row_description = item_name
     cells = {'Description': row_description}
     row, __ = wait_for(requests.wait_for_request, [cells, True],
@@ -260,7 +260,6 @@ def test_provision_stack(setup_provider, provider, provisioning, catalog, catalo
     assert 'Provisioned Successfully' in row.last_message.text
 
 
-@pytest.mark.uncollectif(lambda: version.current_version() <= '5.5')
 def test_reconfigure_service(provider, provisioning, catalog, catalog_item, request):
     """Tests stack provisioning
 
@@ -285,7 +284,7 @@ def test_reconfigure_service(provider, provisioning, catalog, catalog_item, requ
 
     service_catalogs = ServiceCatalogs(item_name, stack_data)
     service_catalogs.order()
-    logger.info('Waiting for cfme provision request for service %s', item_name)
+    logger.info('Waiting for cfme provision request for service {}'.format(item_name))
     row_description = item_name
     cells = {'Description': row_description}
     row, __ = wait_for(requests.wait_for_request, [cells, True],
@@ -317,7 +316,6 @@ def test_remove_template_provisioning(provider, provisioning, catalog, catalog_i
     assert row.last_message.text == 'Service_Template_Provisioning failed'
 
 
-@pytest.mark.uncollectif(lambda: version.current_version() < '5.5')
 def test_retire_stack(provider, provisioning, catalog, catalog_item, request):
     """Tests stack provisioning
 
@@ -330,7 +328,7 @@ def test_retire_stack(provider, provisioning, catalog, catalog_item, request):
     stack_data = prepare_stack_data(provider, provisioning)
     service_catalogs = ServiceCatalogs(item_name, stack_data)
     service_catalogs.order()
-    logger.info('Waiting for cfme provision request for service %s', item_name)
+    logger.info('Waiting for cfme provision request for service {}'.format(item_name))
     row_description = item_name
     cells = {'Description': row_description}
     row, __ = wait_for(requests.wait_for_request, [cells, True],
@@ -338,7 +336,7 @@ def test_retire_stack(provider, provisioning, catalog, catalog_item, request):
 
     assert 'Provisioned Successfully' in row.last_message.text
 
-    stack = Stack(stack_data['stack_name'])
+    stack = Stack(stack_data['stack_name'], provider=provider)
     stack.wait_for_appear()
     stack.retire_stack()
 


### PR DESCRIPTION
Missed this in PR #4117 

# PRT
Run 10177 - failures from ec2west failing to provision, or tests running without the provider actually being configured. Runs locally.
* 56z: 72% pass, unrelated bugs
* 57z: 54% pass, unrelated bugs
* Upstream: 67% pass, unrelated bug