### PR TITLE
[1LP] [RFR] Fix provider selection in test_rest_services.py

### DIFF
--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -133,9 +133,9 @@ def service_data(request, rest_api, a_provider, dialog, service_catalogs):
     """
     The attempt to add the service entities via web
     """
-    template, host, datastore, iso_file, vlan, catalog_item_type = map(
-        a_provider.data.get("provisioning").get,
-        ('template', 'host', 'datastore', 'iso_file', 'vlan', 'catalog_item_type'))
+    template, host, datastore, vlan, catalog_item_type = map(
+        a_provider.data.get('provisioning').get,
+        ('template', 'host', 'datastore', 'vlan', 'catalog_item_type'))
 
     provisioning_data = {
         'vm_name': 'test_rest_{}'.format(fauxfactory.gen_alphanumeric()),
@@ -146,7 +146,7 @@ def service_data(request, rest_api, a_provider, dialog, service_catalogs):
     if a_provider.type == 'rhevm':
         provisioning_data['provision_type'] = 'Native Clone'
         provisioning_data['vlan'] = vlan
-        catalog_item_type = "RHEV"
+        catalog_item_type = 'RHEV'
     elif a_provider.type == 'virtualcenter':
         provisioning_data['provision_type'] = 'VMware'
         provisioning_data['vlan'] = vlan
@@ -158,7 +158,7 @@ def service_data(request, rest_api, a_provider, dialog, service_catalogs):
     catalog = service_catalogs[0].name
     item_name = fauxfactory.gen_alphanumeric()
     catalog_item = CatalogItem(item_type=catalog_item_type, name=item_name,
-                               description="my catalog", display_in=True,
+                               description='my catalog', display_in=True,
                                catalog=catalog,
                                dialog=dialog.label,
                                catalog_name=template,

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -13,8 +13,8 @@ from cfme.rest.gen_data import service_templates as _service_templates
 from cfme.rest.gen_data import orchestration_templates as _orchestration_templates
 from cfme import test_requirements
 from cfme.infrastructure.provider import InfraProvider
-from utils import error, version, testgen
-from utils.providers import setup_a_provider as _setup_a_provider
+from utils import error, version
+from utils.providers import new_setup_a_provider, ProviderFilter
 from utils.wait import wait_for
 from utils.log import logger
 
@@ -26,19 +26,18 @@ pytestmark = [
 ]
 
 
-pytest_generate_tests = testgen.generate([InfraProvider], required_fields=[
-    ['provisioning', 'template'],
-    ['provisioning', 'host'],
-    ['provisioning', 'datastore'],
-    ['provisioning', 'iso_file'],
-    ['provisioning', 'vlan'],
-    ['provisioning', 'catalog_item_type']
-], scope='module')
-
-
 @pytest.fixture(scope="module")
 def a_provider():
-    return _setup_a_provider("infra")
+    try:
+        pf = ProviderFilter(classes=[InfraProvider], required_fields=[
+            ['provisioning', 'template'],
+            ['provisioning', 'host'],
+            ['provisioning', 'datastore'],
+            ['provisioning', 'vlan'],
+            ['provisioning', 'catalog_item_type']])
+        return new_setup_a_provider(filters=[pf])
+    except Exception:
+        pytest.skip("It's not possible to set up any providers, therefore skipping")
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Fixing provider selection in `test_rest_services.py` to avoid fails like
```
    def service_data(request, rest_api, a_provider, dialog, service_catalogs):
        """
        The attempt to add the service entities via web
        """
        template, host, datastore, iso_file, vlan, catalog_item_type = map(
>           a_provider.data.get("provisioning").get,
            ('template', 'host', 'datastore', 'iso_file', 'vlan', 'catalog_item_type'))
E       AttributeError: 'NoneType' object has no attribute 'get'

cfme/rest/gen_data.py:137: AttributeError
```
See https://github.com/ManageIQ/integration_tests/issues/4114

I hope I understood how `testgen` is working and that it's not necessary to use it in this module as no tests are parameterized with provider.