### PR TITLE
[1LP][RFR] Update cfme.infra.host, add provider arg

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Module containing classes with common behaviour for both VMs and Instances of all types."""
-from contextlib import contextmanager
 from datetime import date
 from functools import partial
 
@@ -124,6 +123,10 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable, SummaryMixin
         """
         # Ensure the classes are loaded:
         import cfme.cloud.instance  # NOQA
+        from cfme.cloud.instance.azure import AzureInstance  # NOQA
+        from cfme.cloud.instance.ec2 import EC2Instance  # NOQA
+        from cfme.cloud.instance.gce import GCEInstance  # NOQA
+        from cfme.cloud.instance.openstack import OpenStackInstance  # NOQA
         import cfme.infrastructure.virtual_machines  # NOQA
         try:
             return (

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -123,7 +123,7 @@ class Host(Updateable, Pretty, Navigatable):
 
     def __init__(self, name=None, hostname=None, ip_address=None, custom_ident=None,
                  host_platform=None, ipmi_address=None, mac_address=None, credentials=None,
-                 ipmi_credentials=None, interface_type='lan', appliance=None):
+                 ipmi_credentials=None, interface_type='lan', provider=None, appliance=None):
         Navigatable.__init__(self, appliance=appliance)
         self.name = name
         self.quad_name = 'host'
@@ -137,6 +137,7 @@ class Host(Updateable, Pretty, Navigatable):
         self.ipmi_credentials = ipmi_credentials
         self.interface_type = interface_type
         self.db_id = None
+        self.provider = provider
 
     def _form_mapping(self, create=None, **kwargs):
         return {'name_text': kwargs.get('name'),
@@ -495,7 +496,7 @@ def get_from_config(provider_config_name):
 
     Returns: A Host object that has methods that operate on CFME
     """
-
+    # TODO: Include provider key in YAML and include provider object when creating
     prov_config = conf.cfme_data.get('management_hosts', {})[provider_config_name]
     credentials = get_credentials_from_config(prov_config['credentials'])
     ipmi_credentials = get_credentials_from_config(prov_config['ipmi_credentials'])

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -286,7 +286,9 @@ class InfraProvider(Pretty, CloudInfraProvider):
                 secret=creds["password"],
                 verify_secret=creds["password"],
             )
-            result.append(Host(name=host["name"], credentials=cred))
+            result.append(Host(name=host["name"],
+                               credentials=cred,
+                               provider=self))
         return result
 
     def get_clusters(self):

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -124,7 +124,7 @@ def vm_name(provider):
 def set_host_credentials(request, provider, vm):
     # Add credentials to host
     host_name = vm.api.host.name
-    test_host = host.Host(name=host_name)
+    test_host = host.Host(name=host_name, provider=provider)
 
     host_list = cfme_data.get('management_systems', {})[vm._prov.key].get('hosts', [])
     host_data = [x for x in host_list if x.name == host_name][0]

--- a/cfme/tests/infrastructure/test_datastore_analysis.py
+++ b/cfme/tests/infrastructure/test_datastore_analysis.py
@@ -94,7 +94,7 @@ def test_run_datastore_analysis(request, setup_provider, provider, datastore, so
                 continue
 
             found_host = True
-            test_host = host.Host(name=host_name)
+            test_host = host.Host(name=host_name, provider=provider)
 
             # Add them to the host
             wait_for(lambda: test_host.exists, delay=10, num_sec=120, fail_func=sel.refresh)

--- a/cfme/tests/infrastructure/test_delete_infra_object.py
+++ b/cfme/tests/infrastructure/test_delete_infra_object.py
@@ -39,7 +39,7 @@ def test_delete_host(setup_provider, provider):
         test_flag: delete_object
     """
     host_name = provider.data['remove_test']['host']
-    test_host = host.Host(name=host_name)
+    test_host = host.Host(name=host_name, provider=provider)
     test_host.delete(cancel=False)
     host.wait_for_host_delete(test_host)
     provider.refresh_provider_relationships()

--- a/cfme/tests/infrastructure/test_host_analysis.py
+++ b/cfme/tests/infrastructure/test_host_analysis.py
@@ -65,7 +65,7 @@ def test_run_host_analysis(request, setup_provider, provider, host_type, host_na
     """
     # Add credentials to host
     host_data = get_host_data_by_name(provider.key, host_name)
-    test_host = host.Host(name=host_name)
+    test_host = host.Host(name=host_name, provider=provider)
 
     wait_for(lambda: test_host.exists, delay=10, num_sec=120)
 

--- a/cfme/tests/infrastructure/test_host_drift_analysis.py
+++ b/cfme/tests/infrastructure/test_host_drift_analysis.py
@@ -48,7 +48,7 @@ def test_host_drift_analysis(request, setup_provider, provider, host, soft_asser
     Metadata:
         test_flag: host_drift_analysis
     """
-    test_host = host_obj.Host(name=host['name'])
+    test_host = host_obj.Host(name=host['name'], provider=provider)
 
     wait_for(lambda: test_host.exists, delay=10, num_sec=120, fail_func=sel.refresh,
              message="hosts_exists")

--- a/cfme/tests/infrastructure/test_host_provisioning.py
+++ b/cfme/tests/infrastructure/test_host_provisioning.py
@@ -124,11 +124,11 @@ def test_host_provisioning(setup_provider, cfme_data, host_provisioning, provide
                 test_host.delete(cancel=False)
                 host.wait_for_host_delete(test_host)
             elif renamed_host_name1 in host_list_ui:
-                host_renamed_obj1 = host.Host(name=renamed_host_name1)
+                host_renamed_obj1 = host.Host(name=renamed_host_name1, provider=provider)
                 host_renamed_obj1.delete(cancel=False)
                 host.wait_for_host_delete(host_renamed_obj1)
             elif renamed_host_name2 in host_list_ui:
-                host_renamed_obj2 = host.Host(name=renamed_host_name2)
+                host_renamed_obj2 = host.Host(name=renamed_host_name2, provider=provider)
                 host_renamed_obj2.delete(cancel=False)
                 host.wait_for_host_delete(host_renamed_obj2)
         except:

--- a/cfme/tests/infrastructure/test_individual_host_creds.py
+++ b/cfme/tests/infrastructure/test_individual_host_creds.py
@@ -39,7 +39,7 @@ def test_host_good_creds(request, setup_provider, provider):
     """
     test_host = random.choice(provider.get_yaml_data()["hosts"])
     host_data = get_host_data_by_name(provider.key, test_host.name)
-    host_obj = host.Host(name=test_host.name)
+    host_obj = host.Host(name=test_host.name, provider=provider)
 
     # Remove creds after test
     @request.addfinalizer
@@ -60,7 +60,7 @@ def test_host_bad_creds(request, setup_provider, provider):
     Tests host credentialing  with bad credentials
     """
     test_host = random.choice(provider.get_yaml_data()["hosts"])
-    host_obj = host.Host(name=test_host.name)
+    host_obj = host.Host(name=test_host.name, provider=provider)
 
     with error.expected(msgs[provider.type]):
         with update(host_obj, validate_credentials=True):

--- a/cfme/tests/infrastructure/test_instance_analysis.py
+++ b/cfme/tests/infrastructure/test_instance_analysis.py
@@ -144,7 +144,7 @@ def local_setup_provider(request, setup_provider_modscope, provider, vm_analysis
 
 def set_host_credentials(request, provider, vm_analysis_data):
     # Add credentials to host
-    test_host = host.Host(name=vm_analysis_data['host'])
+    test_host = host.Host(name=vm_analysis_data['host'], provider=provider)
     wait_for(lambda: test_host.exists, delay=10, num_sec=120)
 
     host_list = cfme_data.get('management_systems', {})[provider.key].get('hosts', [])
@@ -353,7 +353,7 @@ def test_ssa_template(request, local_setup_provider, provider, soft_assert, vm_a
         host_list = cfme_data.get('management_systems', {})[provider.key].get('hosts', [])
         host_names = test_datastore.get_hosts()
         for host_name in host_names:
-            test_host = host.Host(name=host_name)
+            test_host = host.Host(name=host_name, provider=provider)
             hosts_data = [x for x in host_list if x.name == host_name]
             if len(hosts_data) > 0:
                 host_data = hosts_data[0]

--- a/cfme/tests/openstack/infrastructure/test_hosts.py
+++ b/cfme/tests/openstack/infrastructure/test_hosts.py
@@ -21,7 +21,7 @@ def test_host_configuration(provider, soft_assert):
     my_quads = list(Quadicon.all())
     assert len(my_quads) > 0
     for quad in my_quads:
-        host = Host(name=quad.name)
+        host = Host(name=quad.name, provider=provider)
         host.run_smartstate_analysis()
         wait_for(is_host_analysis_finished, [host.name], delay=15,
                  timeout="10m", fail_func=toolbar.refresh)
@@ -37,7 +37,7 @@ def test_host_cpu_resources(provider, soft_assert):
     my_quads = list(Quadicon.all())
     assert len(my_quads) > 0
     for quad in my_quads:
-        host = Host(name=quad.name)
+        host = Host(name=quad.name, provider=provider)
         fields = ['Number of CPUs', 'Number of CPU Cores',
                   'CPU Cores Per Socket']
         for field in fields:
@@ -51,7 +51,7 @@ def test_host_devices(provider):
     my_quads = list(Quadicon.all())
     assert len(my_quads) > 0
     for quad in my_quads:
-        host = Host(name=quad.name)
+        host = Host(name=quad.name, provider=provider)
         assert int(host.get_detail("Properties", "Devices")) > 0
 
 
@@ -60,7 +60,7 @@ def test_host_hostname(provider, soft_assert):
     my_quads = list(Quadicon.all())
     assert len(my_quads) > 0
     for quad in my_quads:
-        host = Host(name=quad.name)
+        host = Host(name=quad.name, provider=provider)
         result = host.get_detail("Properties", "Hostname")
         soft_assert(result, "Missing hostname in: " + str(result))
 
@@ -71,7 +71,7 @@ def test_host_memory(provider):
     my_quads = list(Quadicon.all())
     assert len(my_quads) > 0
     for quad in my_quads:
-        host = Host(name=quad.name)
+        host = Host(name=quad.name, provider=provider)
         result = int(host.get_detail("Properties", "Memory").split()[0])
         assert result > 0
 
@@ -82,7 +82,7 @@ def test_host_security(provider, soft_assert):
     my_quads = list(Quadicon.all())
     assert len(my_quads) > 0
     for quad in my_quads:
-        host = Host(name=quad.name)
+        host = Host(name=quad.name, provider=provider)
         soft_assert(
             int(host.get_detail("Security", "Users")) > 0,
             'Nodes number of Users is 0')
@@ -100,6 +100,6 @@ def test_host_zones_assigned(provider):
     my_quads = filter(lambda q: True if 'Compute' in q.name else False,
                       my_quads)
     for quad in my_quads:
-        host = Host(name=quad.name)
+        host = Host(name=quad.name, provider=provider)
         result = host.get_detail('Relationships', 'Availability Zone')
         assert result, "Availability zone doesn't specified"


### PR DESCRIPTION
Modify calls to instantiate to include a provider object if available

Intent is not to modify behavior at this point but to add provider as an argument for Host constructor and to pass it where available in the current code.

# PRT Results
Failures unrelated to this specific change, but in general a very low pass rate for the included tests.

FIXES #4137 