### PR TITLE
[1LP][RFR] Refactored orchestration templates, fixed azure issues

### DIFF
--- a/cfme/services/catalogs/orchestration_template.py
+++ b/cfme/services/catalogs/orchestration_template.py
@@ -138,10 +138,14 @@ class OrchestrationTemplate(Updateable, Pretty, Navigatable):
 
     def create(self, content):
         view = navigate_to(self, "AddTemplate")
-        if(self.template_type == "CloudFormation Templates"):
+        if self.template_type == "CloudFormation Templates":
             temp_type = "Amazon CloudFormation"
-        else:
+        elif self.template_type == "Heat Templates":
             temp_type = "OpenStack Heat"
+        elif self.template_type == "Azure Templates":
+            temp_type = "Microsoft Azure"
+        else:
+            raise Exception("ERROR template_type needs to be one of the above")
         view.fill({'name': self.template_name,
                    'description': self.description,
                    'template_type': temp_type,

--- a/cfme/services/catalogs/service_catalogs.py
+++ b/cfme/services/catalogs/service_catalogs.py
@@ -32,6 +32,8 @@ stack_form = Form(
         ('vm_user', Input("param_adminUserName")),
         ('vm_password', Input("param_adminPassword__protected")),
         ('vm_size', Select("//select[@id='param_virtualMachineSize']")),
+        ('user_image', Select("//select[@id='param_userImageName']")),
+        ('os_type', Select("//select[@id='param_operatingSystemType']")),
         ('key_name', Input("param_KeyName")),
         ('ssh_location', Input("param_SSHLocation"))
     ])

--- a/cfme/tests/services/test_provision_stack.py
+++ b/cfme/tests/services/test_provision_stack.py
@@ -12,6 +12,8 @@ from cfme.cloud.provider import CloudProvider
 from cfme.cloud.stack import Stack
 from cfme import test_requirements
 from utils import testgen
+from utils.path import orchestration_path
+from utils.datafile import load_data_file
 from utils.log import logger
 from utils.wait import wait_for
 
@@ -22,169 +24,6 @@ pytestmark = [
     test_requirements.stack,
     pytest.mark.tier(2)
 ]
-
-AWS_TEMPLATE = """
-{
-  "AWSTemplateFormatVersion" : "2010-09-09",
-  "Description" : "AWS CloudFormation Sample Template EC2InstanceWithSecurityGroupSample:",
-  "Parameters" : {
-    "KeyName": {
-      "Description" : "Name of an existing EC2 KeyPair to enable SSH access to the instance",
-      "Type": "AWS::EC2::KeyPair::KeyName",
-      "ConstraintDescription" : "must be the name of an existing EC2 KeyPair."
-    },
-    "virtualMachineName" : {
-      "Description" : "Name of the Virtual Machine",
-      "Type" : "String",
-      "ConstraintDescription" : "must be a valid EC2 instance name."
-    },
-    "InstanceType" : {
-      "Description" : "WebServer EC2 instance type",
-      "Type" : "String",
-      "Default" : "m1.small",
-      "AllowedValues" : ["m1.small", "t1.micro", "t2.nano", "t2.micro", "t2.small", "t2.large"],
-      "ConstraintDescription" : "must be a valid EC2 instance type."
-    },
-    "SSHLocation" : {
-      "Description" : "The IP address range that can be used to SSH to the EC2 instances",
-      "Type": "String",
-      "MinLength": "9",
-      "MaxLength": "18",
-      "Default": "0.0.0.0/0",
-      "ConstraintDescription": "must be a valid IP CIDR range of the form x.x.x.x/x."
-   }
-  },
-  "Mappings" : {
-    "AWSInstanceType2Arch" : {
-      "m1.small"    : { "Arch" : "PV64"   },
-      "t1.micro"    : { "Arch" : "PV64"   },
-      "t2.nano"     : { "Arch" : "HVM64"  },
-      "t2.micro"    : { "Arch" : "HVM64"  },
-      "t2.small"    : { "Arch" : "HVM64"  },
-      "t2.large"    : { "Arch" : "HVM64"  }
-    },
-    "AWSInstanceType2NATArch" : {
-      "m1.small"    : { "Arch" : "NATPV64"   },
-      "t1.micro"    : { "Arch" : "NATPV64"   },
-      "t2.nano"     : { "Arch" : "NATHVM64"  },
-      "t2.micro"    : { "Arch" : "NATHVM64"  },
-      "t2.small"    : { "Arch" : "NATHVM64"  },
-      "t2.large"    : { "Arch" : "NATHVM64"  }
-    }
-,
-    "AWSRegionArch2AMI" : {
-      "us-east-1"        : {
-      "PV64" : "ami-2a69aa47", "HVM64" : "ami-6869aa05", "HVMG2" : "ami-2e5e9c43"},
-      "us-west-2"        : {
-      "PV64" : "ami-7f77b31f", "HVM64" : "ami-7172b611", "HVMG2" : "ami-83b770e3"},
-      "us-west-1"        : {
-      "PV64" : "ami-a2490dc2", "HVM64" : "ami-31490d51", "HVMG2" : "ami-fd76329d"},
-      "eu-west-1"        : {
-      "PV64" : "ami-4cdd453f", "HVM64" : "ami-f9dd458a", "HVMG2" : "ami-b9bd25ca"},
-      "eu-central-1"     : {
-      "PV64" : "ami-6527cf0a", "HVM64" : "ami-ea26ce85", "HVMG2" : "ami-7f04ec10"},
-      "ap-northeast-1"   : {
-      "PV64" : "ami-3e42b65f", "HVM64" : "ami-374db956", "HVMG2" : "ami-e0ee1981"},
-      "ap-northeast-2"   : {
-      "PV64" : "NOT_SUPPORTED", "HVM64" : "ami-2b408b45", "HVMG2" : "NOT_SUPPORTED"},
-      "ap-southeast-1"   : {
-      "PV64" : "ami-df9e4cbc", "HVM64" : "ami-a59b49c6", "HVMG2" : "ami-0cb5676f"},
-      "ap-southeast-2"   : {
-      "PV64" : "ami-63351d00", "HVM64" : "ami-dc361ebf", "HVMG2" : "ami-a71c34c4"},
-      "ap-south-1"       : {
-      "PV64" : "NOT_SUPPORTED", "HVM64" : "ami-ffbdd790", "HVMG2" : "ami-f5b2d89a"},
-      "sa-east-1"        : {
-      "PV64" : "ami-1ad34676", "HVM64" : "ami-6dd04501", "HVMG2" : "NOT_SUPPORTED"},
-      "cn-north-1"       : {
-      "PV64" : "ami-77559f1a", "HVM64" : "ami-8e6aa0e3", "HVMG2" : "NOT_SUPPORTED"}
-    }
-  },
-  "Resources" : {
-    "EC2Instance" : {
-      "Type" : "AWS::EC2::Instance",
-      "Properties" : {
-        "InstanceType" : { "Ref" : "InstanceType" },
-        "SecurityGroups" : [ { "Ref" : "InstanceSecurityGroup" } ],
-        "KeyName" : { "Ref" : "KeyName" },
-        "ImageId" : { "Fn::FindInMap" : [ "AWSRegionArch2AMI", { "Ref" : "AWS::Region" },
-                          { "Fn::FindInMap" : [ "AWSInstanceType2Arch",
-                          { "Ref" : "InstanceType" }, "Arch" ] } ] },
-        "Tags" : [{"Key" : "Name", "Value" : { "Ref" : "virtualMachineName" }}]
-      }
-    },
-    "InstanceSecurityGroup" : {
-      "Type" : "AWS::EC2::SecurityGroup",
-      "Properties" : {
-        "GroupDescription" : "Enable SSH access via port 22",
-        "SecurityGroupIngress" : [ {
-          "IpProtocol" : "tcp",
-          "FromPort" : "22",
-          "ToPort" : "22",
-          "CidrIp" : { "Ref" : "SSHLocation"}
-        } ]
-      }
-    }
-  },
-  "Outputs" : {
-    "InstanceId" : {
-      "Description" : "InstanceId of the newly created EC2 instance",
-      "Value" : { "Ref" : "EC2Instance" }
-    },
-    "AZ" : {
-      "Description" : "Availability Zone of the newly created EC2 instance",
-      "Value" : { "Fn::GetAtt" : [ "EC2Instance", "AvailabilityZone" ] }
-    },
-    "PublicDNS" : {
-      "Description" : "Public DNSName of the newly created EC2 instance",
-      "Value" : { "Fn::GetAtt" : [ "EC2Instance", "PublicDnsName" ] }
-    },
-    "PublicIP" : {
-      "Description" : "Public IP address of the newly created EC2 instance",
-      "Value" : { "Fn::GetAtt" : [ "EC2Instance", "PublicIp" ] }
-    }
-  }
-}
-"""
-
-
-HEAT_TEMPLATE = """
-heat_template_version: 2013-05-23
-description: Simple template to deploy a single compute instance
-parameters:
-  image:
-    type: string
-    label: Image name or ID
-    description: Image to be used for compute instance
-    default: cirros
-  flavor:
-    type: string
-    label: Flavor
-    description: Type of instance (flavor) to be used
-    default: m1.small
-  key:
-    type: string
-    label: Key name
-    description: Name of key-pair to be used for compute instance
-    default: psav
-  private_network:
-    type: string
-    label: Private network name or ID
-    description: Network to attach instance to.
-    default: c0f0db9c-846f-4d4e-b058-0db5bfb2cb90
-resources:
-  my_instance:
-    type: OS::Nova::Server
-    properties:
-      image: { get_param: image }
-      flavor: { get_param: flavor }
-      key_name: { get_param: key }
-      networks:
-        - uuid: { get_param: private_network }
-outputs:
-  instance_ip:
-    description: IP address of the instance
-    value: { get_attr: [my_instance, first_address]}
-"""
 
 
 pytest_generate_tests = testgen.generate(
@@ -197,21 +36,18 @@ pytest_generate_tests = testgen.generate(
 @pytest.yield_fixture(scope="function")
 def template(provider, provisioning, dialog_name):
     template_type = provisioning['stack_provisioning']['template_type']
-    if provider.type == 'azure':
-        template_name = 'azure-single-vm-from-user-image'
-    else:
-        template_name = fauxfactory.gen_alphanumeric()
-
+    template_name = fauxfactory.gen_alphanumeric()
     template = OrchestrationTemplate(template_type=template_type,
                                      template_name=template_name)
 
     if provider.type == "ec2":
-        method = AWS_TEMPLATE.replace('CloudFormation', random_desc())
+        data_file = load_data_file(str(orchestration_path.join('aws_vm_template.json')))
     elif provider.type == "openstack":
-        method = HEAT_TEMPLATE.replace('Simple', random_desc())
+        data_file = load_data_file(str(orchestration_path.join('openstack_vm_template.data')))
+    elif provider.type == "azure":
+        data_file = load_data_file(str(orchestration_path.join('azure_vm_template.json')))
 
-    template.create(method)
-
+    template.create(data_file.read().replace('CFMETemplateName', template_name))
     if provider.type != "azure":
         template.create_service_dialog_from_template(dialog_name, template.template_name)
 
@@ -272,6 +108,8 @@ def prepare_stack_data(provider, provisioning):
             'mode': mode,
             'vm_user': vm_user,
             'vm_password': vm_password,
+            'user_image': user_image,
+            'os_type': os_type,
             'vm_size': vm_size
         }
         return stack_data
@@ -304,8 +142,10 @@ def test_provision_stack(setup_provider, provider, provisioning, catalog, catalo
             if provider.mgmt.stack_exist(stack_data['stack_name']):
                 wait_for(lambda: provider.mgmt.delete_stack(stack_data['stack_name']),
                          delay=10, num_sec=800, message="wait for stack delete")
-            stack_data['vm_name'].delete_from_provider()
             catalog_item.orch_template.delete()
+            if provider.type == 'azure' and provider.mgmt.vm_exist(stack_data['vm_name']):
+                wait_for(lambda: provider.mgmt.delete_vm(stack_data['vm_name']),
+                         delay=10, num_sec=800, message="wait for vm delete")
         except Exception as ex:
             logger.warning('Exception while checking/deleting stack, continuing: {}'
                            .format(ex.message))
@@ -337,7 +177,6 @@ def test_reconfigure_service(provider, provisioning, catalog, catalog_item, requ
             if provider.mgmt.stack_exist(stack_data['stack_name']):
                 wait_for(lambda: provider.mgmt.delete_stack(stack_data['stack_name']),
                  delay=10, num_sec=800, message="wait for stack delete")
-            stack_data['vm_name'].delete_from_provider()
             catalog_item.orch_template.delete()
         except Exception as ex:
             logger.warning('Exception while checking/deleting stack, continuing: {}'
@@ -405,7 +244,6 @@ def test_retire_stack(provider, provisioning, catalog, catalog_item, request):
     @request.addfinalizer
     def _cleanup_templates():
         try:
-            stack_data['vm_name'].delete_from_provider()
             catalog_item.orch_template.delete()
         except Exception as ex:
             logger.warning('Exception while checking/deleting stack, continuing: {}'

--- a/data/orchestration/aws_vm_template.json
+++ b/data/orchestration/aws_vm_template.json
@@ -1,0 +1,118 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Description" : "AWS CFMETemplateName Template EC2InstanceWithSecurityGroupSample:",
+  "Parameters" : {
+
+    "KeyName": {
+      "Description" : "Name of an existing EC2 KeyPair to enable SSH access",
+      "Type": "AWS::EC2::KeyPair::KeyName",
+      "ConstraintDescription" : "must be the name of an existing EC2 KeyPair."
+    },
+    "virtualMachineName" : {
+      "Description" : "Name of the Virtual Machine",
+      "Type" : "String",
+      "ConstraintDescription" : "must be a valid EC2 instance name."
+    },
+    "InstanceType" : {
+      "Description" : "WebServer EC2 instance type",
+      "Type" : "String",
+      "Default" : "m1.small",
+      "AllowedValues" : ["m1.small", "t1.micro", "t2.micro", "t2.small", "t2.large"],
+      "ConstraintDescription" : "must be a valid EC2 instance type."
+    },
+    "SSHLocation" : {
+      "Description" : "The IP address for SSH to the EC2 instances",
+      "Type": "String",
+      "MinLength": "9",
+      "MaxLength": "18",
+      "Default": "0.0.0.0/0",
+      "ConstraintDescription": "must be a valid IP CIDR range of the form x.x.x.x/x."
+   }
+  },
+  "Mappings" : {
+    "AWSInstanceType2Arch" : {
+      "m1.small"    : { "Arch" : "PV64"   },
+      "t1.micro"    : { "Arch" : "PV64"   },
+      "t2.micro"    : { "Arch" : "HVM64"  },
+      "t2.small"    : { "Arch" : "HVM64"  },
+      "t2.large"    : { "Arch" : "HVM64"  }
+    },
+    "AWSInstanceType2NATArch" : {
+      "m1.small"    : { "Arch" : "NATPV64"   },
+      "t1.micro"    : { "Arch" : "NATPV64"   },
+      "t2.micro"    : { "Arch" : "NATHVM64"  },
+      "t2.small"    : { "Arch" : "NATHVM64"  },
+      "t2.large"    : { "Arch" : "NATHVM64"  }
+    },
+    "AWSRegionArch2AMI" : {
+      "us-east-1"        : {
+      "PV64" : "ami-2a69aa47", "HVM64" : "ami-6869aa05", "HVMG2" : "ami-2e5e9c43"},
+      "us-west-2"        : {
+      "PV64" : "ami-7f77b31f", "HVM64" : "ami-7172b611", "HVMG2" : "ami-83b770e3"},
+      "us-west-1"        : {
+      "PV64" : "ami-a2490dc2", "HVM64" : "ami-31490d51", "HVMG2" : "ami-fd76329d"},
+      "eu-west-1"        : {
+      "PV64" : "ami-4cdd453f", "HVM64" : "ami-f9dd458a", "HVMG2" : "ami-b9bd25ca"},
+      "eu-central-1"     : {
+      "PV64" : "ami-6527cf0a", "HVM64" : "ami-ea26ce85", "HVMG2" : "ami-7f04ec10"},
+      "ap-northeast-1"   : {
+      "PV64" : "ami-3e42b65f", "HVM64" : "ami-374db956", "HVMG2" : "ami-e0ee1981"},
+      "ap-northeast-2"   : {
+      "PV64" : "NOT_SUPPORTED", "HVM64" : "ami-2b408b45", "HVMG2" : "NOT_SUPPORTED"},
+      "ap-southeast-1"   : {
+      "PV64" : "ami-df9e4cbc", "HVM64" : "ami-a59b49c6", "HVMG2" : "ami-0cb5676f"},
+      "ap-southeast-2"   : {
+      "PV64" : "ami-63351d00", "HVM64" : "ami-dc361ebf", "HVMG2" : "ami-a71c34c4"},
+      "ap-south-1"       : {
+      "PV64" : "NOT_SUPPORTED", "HVM64" : "ami-ffbdd790", "HVMG2" : "ami-f5b2d89a"},
+      "sa-east-1"        : {
+      "PV64" : "ami-1ad34676", "HVM64" : "ami-6dd04501", "HVMG2" : "NOT_SUPPORTED"},
+      "cn-north-1"       : {
+      "PV64" : "ami-77559f1a", "HVM64" : "ami-8e6aa0e3", "HVMG2" : "NOT_SUPPORTED"}
+    }
+  },
+  "Resources" : {
+    "EC2Instance" : {
+      "Type" : "AWS::EC2::Instance",
+      "Properties" : {
+        "InstanceType" : { "Ref" : "InstanceType" },
+        "SecurityGroups" : [ { "Ref" : "InstanceSecurityGroup" } ],
+        "KeyName" : { "Ref" : "KeyName" },
+        "ImageId" : { "Fn::FindInMap" : [ "AWSRegionArch2AMI", { "Ref" : "AWS::Region" },
+                          { "Fn::FindInMap" : [ "AWSInstanceType2Arch",
+                          { "Ref" : "InstanceType" }, "Arch" ] } ] },
+        "Tags" : [{"Key" : "Name", "Value" : { "Ref" : "virtualMachineName" }}]
+      }
+    },
+    "InstanceSecurityGroup" : {
+      "Type" : "AWS::EC2::SecurityGroup",
+      "Properties" : {
+        "GroupDescription" : "Enable SSH access via port 22",
+        "SecurityGroupIngress" : [ {
+          "IpProtocol" : "tcp",
+          "FromPort" : "22",
+          "ToPort" : "22",
+          "CidrIp" : { "Ref" : "SSHLocation"}
+        } ]
+      }
+    }
+  },
+  "Outputs" : {
+    "InstanceId" : {
+      "Description" : "InstanceId of the newly created EC2 instance",
+      "Value" : { "Ref" : "EC2Instance" }
+    },
+    "AZ" : {
+      "Description" : "Availability Zone of the newly created EC2 instance",
+      "Value" : { "Fn::GetAtt" : [ "EC2Instance", "AvailabilityZone" ] }
+    },
+    "PublicDNS" : {
+      "Description" : "Public DNSName of the newly created EC2 instance",
+      "Value" : { "Fn::GetAtt" : [ "EC2Instance", "PublicDnsName" ] }
+    },
+    "PublicIP" : {
+      "Description" : "Public IP address of the newly created EC2 instance",
+      "Value" : { "Fn::GetAtt" : [ "EC2Instance", "PublicIp" ] }
+    }
+  }
+}

--- a/data/orchestration/azure_vm_template.json
+++ b/data/orchestration/azure_vm_template.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "virtualMachineName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the virtual machine template is CFMETemplateName"
+      }
+    },
+    "adminUserName": {
+      "type": "string",
+      "metadata": {
+        "description": "Administrator user name for the virtual machine"
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Password for the administrator"
+      }
+    },
+    "userImageName": {
+      "type": "string",
+      "metadata": {
+        "description": "The image used to provision the virtual machine"
+      }
+    },
+    "operatingSystemType": {
+      "type": "string",
+      "allowedValues": [
+        "windows",
+        "linux"
+      ],
+      "metadata": {
+        "description": "Operating system of the virtual machine"
+      }
+    },
+    "virtualMachineSize": {
+      "type": "string",
+      "metadata": {
+        "description": "Standard size of the virtual machine"
+      }
+    }
+  },
+  "variables": {
+    "location": "[resourceGroup().location]",
+    "virtualNetworkName": "myVNET",
+    "nicName": "[concat(parameters('virtualMachineName'),'-nic')]",
+    "addressPrefix": "10.0.0.0/16",
+    "subnet1Name": "Subnet-1",
+    "subnet1Prefix": "10.0.0.0/24",
+    "publicIPAddressType": "Dynamic",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+    "subnet1Ref": "[concat(variables('vnetID'),'/subnets/',variables('subnet1Name'))]",
+    "storageAccount": "[split(parameters('userImageName'),'.')[0]]",
+    "osDiskVhdName": "[concat(variables('storageAccount'),'.blob.core.windows.net/vhds/',parameters('virtualMachineName'),'-osDisk.vhd')]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('addressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('subnet1Name')]",
+            "properties": {
+              "addressPrefix": "[variables('subnet1Prefix')]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('nicName')]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('subnet1Ref')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[parameters('virtualMachineName')]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('virtualMachineSize')]"
+        },
+        "osProfile": {
+          "computername": "[parameters('virtualMachineName')]",
+          "adminUsername": "[parameters('adminUserName')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "osDisk": {
+            "name": "[concat(parameters('virtualMachineName'),'-osDisk')]",
+            "osType": "[parameters('operatingSystemType')]",
+            "caching": "ReadWrite",
+            "createOption": "FromImage",
+            "image": {
+              "uri": "[parameters('userImageName')]"
+            },
+            "vhd": {
+              "uri": "[variables('osDiskVhdName')]"
+            }
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+            }
+          ]
+        },
+        "diagnosticsProfile": {
+          "bootDiagnostics": {
+             "enabled": "true",
+             "storageUri": "[concat(variables('storageAccount'),'.blob.core.windows.net')]"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/data/orchestration/openstack_vm_template.data
+++ b/data/orchestration/openstack_vm_template.data
@@ -1,0 +1,36 @@
+heat_template_version: 2013-05-23
+description: Simple template CFMETemplateName to deploy a single compute instance
+parameters:
+  image:
+    type: string
+    label: Image name or ID
+    description: Image to be used for compute instance
+    default: cirros
+  flavor:
+    type: string
+    label: Flavor
+    description: Type of instance (flavor) to be used
+    default: m1.small
+  key:
+    type: string
+    label: Key name
+    description: Name of key-pair to be used for compute instance
+    default: psav
+  private_network:
+    type: string
+    label: Private network name or ID
+    description: Network to attach instance to.
+    default: c0f0db9c-846f-4d4e-b058-0db5bfb2cb90
+resources:
+  my_instance:
+    type: OS::Nova::Server
+    properties:
+      image: { get_param: image }
+      flavor: { get_param: flavor }
+      key_name: { get_param: key }
+      networks:
+        - uuid: { get_param: private_network }
+outputs:
+  instance_ip:
+    description: IP address of the instance
+    value: { get_attr: [my_instance, first_address]}

--- a/utils/path.py
+++ b/utils/path.py
@@ -40,6 +40,9 @@ scripts_data_path = scripts_path.join('data')
 #: jinja2 templates, use with ``jinja2.FileSystemLoader``
 template_path = data_path.join('templates')
 
+#: orchestration datafile storage, ``cfme_tests/data/orchestration``
+orchestration_path = data_path.join('orchestration')
+
 #: resource files root directory, ``cfme_tests/data/resources``
 resources_path = data_path.join('resources')
 


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ 
https://projects.engineering.redhat.com/browse/RHCFQE-1693
Cleanup was busted.  Someone was trying to run a method on a string

https://projects.engineering.redhat.com/browse/RHCFQE-1712
Azure dying at template create

and

__Extending__ 
https://projects.engineering.redhat.com/browse/RHCFQE-1750
Extracted data to separate files as request in PR

Fixed all the missing Azure stack data entries
Fixed all the missing form field entries.

{{pytest: cfme/tests/services/test_provision_stack.py::test_provision_stack -v --use-provider azure }}