### PR TITLE
[1LP][RFR] Update cloud_infra_common.test_retirement, ProviderFilter

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -530,8 +530,10 @@ class VM(BaseVM):
         self.load_details(refresh=True)
         lcl_btn(self.TO_RETIRE, invokes_alert=True)
         sel.handle_alert()
-        flash.assert_success_message('Retirement initiated for 1 VM and Instance from the CFME '
-                                     'Database')
+        flash.assert_success_message(
+            'Retirement initiated for 1 VM and Instance from the {} Database'.format(version.pick({
+                version.LOWEST: 'CFME',
+                'upstream': 'ManageIQ'})))
 
     def power_control_from_provider(self):
         raise NotImplementedError("You have to implement power_control_from_provider!")

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -522,7 +522,7 @@ class VM(BaseVM):
 
     retire_form = Form(fields=[
         ('date_retire', AngularCalendarInput(
-            "retirement_date", "//label[contains(normalize-space(.), 'Retirement')]")),
+            "retirement_date", "//label[contains(normalize-space(.), 'Retirement Date')]")),
         ('warn', AngularSelect('retirementWarning'))
     ])
 

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Module containing classes with common behaviour for both VMs and Instances of all types."""
-from contextlib import contextmanager
 from datetime import date
 from functools import partial
 
@@ -522,10 +521,8 @@ class VM(BaseVM):
     TO_RETIRE = None
 
     retire_form = Form(fields=[
-        ('date_retire', {
-            version.LOWEST: date_retire_element,
-            "5.5": AngularCalendarInput(
-                "retirement_date", "//label[contains(normalize-space(.), 'Retirement Date')]")}),
+        ('date_retire', AngularCalendarInput(
+            "retirement_date", "//label[contains(normalize-space(.), 'Retirement')]")),
         ('warn', AngularSelect('retirementWarning'))
     ])
 
@@ -533,9 +530,8 @@ class VM(BaseVM):
         self.load_details(refresh=True)
         lcl_btn(self.TO_RETIRE, invokes_alert=True)
         sel.handle_alert()
-        flash.assert_success_message({
-            version.LOWEST: "Retire initiated for 1 VM and Instance from the CFME Database",
-            "5.5": "Retirement initiated for 1 VM and Instance from the CFME Database"})
+        flash.assert_success_message('Retirement initiated for 1 VM and Instance from the CFME '
+                                     'Database')
 
     def power_control_from_provider(self):
         raise NotImplementedError("You have to implement power_control_from_provider!")

--- a/cfme/tests/cloud_infra_common/test_retirement.py
+++ b/cfme/tests/cloud_infra_common/test_retirement.py
@@ -67,7 +67,7 @@ def existing_vm(provider):
 
 def verify_retirement(vm):
     # wait for the info block showing a date as retired date
-    wait_for(lambda: vm.is_retired, delay=30, num_sec=720,
+    wait_for(lambda: vm.is_retired, delay=15, num_sec=10 * 60,
              message="Wait until VM {} will be retired".format(vm.name))
 
     assert vm.summary.power_management.power_state.text_value in {'off', 'suspended', 'unknown'}

--- a/cfme/tests/cloud_infra_common/test_retirement.py
+++ b/cfme/tests/cloud_infra_common/test_retirement.py
@@ -7,88 +7,80 @@ from cfme.common.provider import CloudInfraProvider
 from cfme.common.vm import VM
 from utils import testgen
 from utils.generators import random_vm_name
-from utils.providers import setup_a_provider_by_class
+from utils.log import logger
+from utils.providers import ProviderFilter
 from utils.timeutil import parsetime
 from utils.wait import wait_for
-from utils.version import current_version
+
+
+pytest_generate_tests = testgen.generate(
+    gen_func=testgen.providers,
+    filters=[ProviderFilter(classes=[CloudInfraProvider], required_flags=['provision', 'retire'])],
+    scope='module')
+
 
 pytestmark = [
-    pytest.mark.usefixtures('uses_infra_providers', 'uses_cloud_providers'),
-    pytest.mark.tier(2)
+    pytest.mark.usefixtures('setup_provider_modscope'),
+    pytest.mark.tier(2),
+    pytest.mark.long_running
 ]
 
 
-def pytest_generate_tests(metafunc):
-    argnames, argvalues, idlist = testgen.all_providers(metafunc)
-    testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope="module")
-
-
-@pytest.fixture(scope="function")
-def vm(request, provider, setup_provider, small_template):
+@pytest.yield_fixture(scope="function")
+def vm(small_template, provider):
     vm_obj = VM.factory(random_vm_name('retire'), provider, template_name=small_template)
+    vm_obj.create_on_provider(find_in_cfme=True, allow_skip="default")
+    yield vm_obj
 
-    @request.addfinalizer
-    def _delete_vm():
+    try:
         if provider.mgmt.does_vm_exist(vm_obj.name):
             provider.mgmt.delete_vm(vm_obj.name)
-    vm_obj.create_on_provider(find_in_cfme=True, allow_skip="default")
-    return vm_obj
+    except Exception:
+        logger.warning('Failed to delete vm from provider: {}'.format(vm_obj.name))
 
 
-@pytest.fixture(scope="function")
-def test_provider(request):
-    return setup_a_provider_by_class(CloudInfraProvider)
-
-
-@pytest.fixture(scope="function")
-def existing_vm(request, test_provider):
+@pytest.yield_fixture(scope="function")
+def existing_vm(provider):
     """ Fixture will be using for set\unset retirement date for existing vm instead of
     creation a new one
     """
-    all_vms = test_provider.mgmt.list_vm()
+    all_vms = provider.mgmt.list_vm()
     need_to_create_vm = True
     for virtual_machine in all_vms:
-        if test_provider.mgmt.is_vm_running(virtual_machine):
-            need_vm = VM.factory(virtual_machine, test_provider)
+        if provider.mgmt.is_vm_running(virtual_machine):
+            vm_obj = VM.factory(virtual_machine, provider)
             need_to_create_vm = False
             break
     if need_to_create_vm:
         machine_name = random_vm_name('retire')
-        need_vm = VM.factory(machine_name, test_provider)
-        need_vm.create_on_provider(find_in_cfme=True, allow_skip="default")
+        vm_obj = VM.factory(machine_name, provider)
+        vm_obj.create_on_provider(find_in_cfme=True, allow_skip="default")
 
-    @request.addfinalizer
-    def _delete_vm():
-        if need_to_create_vm:
-            test_provider.mgmt.delete_vm(need_vm.name)
-    return need_vm
+    yield vm_obj
+
+    try:
+        if need_to_create_vm and provider.mgmt.does_vm_exist(vm_obj.name):
+            provider.mgmt.delete_vm(vm_obj.name)
+    except Exception:
+        logger.warning('Failed to delete vm from provider: {}'.format(vm_obj.name))
 
 
 def verify_retirement(vm):
-    # add condition because of differ behaviour between 5.5 and 5.6
-    if current_version() < "5.6":
-        wait_for(lambda: vm.exists is False, delay=30, num_sec=360,
-                 message="Wait for VM {} removed from provider".format(vm.name))
-    else:
-        # wait for the info block showing a date as retired date
-        wait_for(lambda: vm.is_retired, delay=30, num_sec=720,
-                 message="Wait until VM {} will be retired".format(vm.name))
+    # wait for the info block showing a date as retired date
+    wait_for(lambda: vm.is_retired, delay=30, num_sec=720,
+             message="Wait until VM {} will be retired".format(vm.name))
 
-        assert vm.summary.power_management.power_state.text_value in {'off', 'suspended', 'unknown'}
+    assert vm.summary.power_management.power_state.text_value in {'off', 'suspended', 'unknown'}
 
-        # make sure retirement date is today
-        retirement_date = vm.retirement_date
-        today = parsetime.now().to_american_date_only()
-        assert retirement_date == today
+    # make sure retirement date is today
+    retirement_date = vm.retirement_date
+    today = parsetime.now().to_american_date_only()
+    assert retirement_date == today
 
 
 @test_requirements.retirement
-@pytest.mark.meta(blockers=[1337697])
 def test_retirement_now(vm):
-    """Tests retirement
-
-    Metadata:
-        test_flag: retire, provision
+    """Tests on-demand retirement of an instance/vm
     """
     vm.retire()
     verify_retirement(vm)
@@ -96,21 +88,15 @@ def test_retirement_now(vm):
 
 @test_requirements.retirement
 def test_set_retirement_date(vm):
-    """Tests retirement
-
-    Metadata:
-        test_flag: retire, provision
+    """Tests retirement by setting a date
     """
     vm.set_retirement_date(datetime.datetime.now(), warn="1 Week before retirement")
     verify_retirement(vm)
 
 
 @test_requirements.retirement
-def test_set_unset_retirement_date_tomorrow(existing_vm):
-    """Tests retirement
-
-    Metadata:
-        test_flag: retire, provision
+def test_unset_retirement_date(existing_vm):
+    """Tests cancelling a scheduled retirement by removing the set date
     """
     tomorrow = datetime.date.today() + datetime.timedelta(days=1)
     existing_vm.set_retirement_date(tomorrow)


### PR DESCRIPTION
Update test_retirement.test_set_and_unset_retirement_date_tomorrow, move to test_unset_retirement_date.

I'm scoping this commit for the changes that I would like to make to the test generation and fixtures.

I will address test updates, additions, fixes, etc in a separate commit to keep them reasonable in size. That being said I'm testing against all providers here for a baseline.

# PRT
Various failures from timeouts during wait, azure missing a template, VM not found on provider.
Increased wait time for retirement in new commit, and covered an upstream change to the flash message. Otherwise I would prefer to leave additional test fixes to a 2nd PR to limit size/scope.

{{ pytest: cfme/tests/cloud_infra_common/test_retirement.py -v --long-running --use-provider complete }}