### PR TITLE
[1LP][RFR] logging: start to use one logfile per parallel worker

### DIFF
--- a/fixtures/parallelizer/remote.py
+++ b/fixtures/parallelizer/remote.py
@@ -184,7 +184,7 @@ if __name__ == '__main__':
     # overwrite the default logger before anything else is imported,
     # to get our best chance at having everything import the replaced logger
     import utils.log
-    utils.log.add_prefix.prefix = "({}) ".format(args.slaveid)
+    utils.log.setup_for_worker(args.slaveid)
 
     from fixtures import terminalreporter
     from fixtures.pytest_store import store

--- a/utils/log.py
+++ b/utils/log.py
@@ -479,7 +479,6 @@ def setup_for_worker(workername, loggers=('cfme', 'py.warnings')):
         log.debug("worker log started")  # directly reopens the file
 
 
-
 _configure_warnings()
 
 # Register a custom excepthook to log unhandled exceptions

--- a/utils/log.py
+++ b/utils/log.py
@@ -465,6 +465,21 @@ def _configure_warnings():
     wlog.propagate = False
 
 
+def setup_for_worker(workername, loggers=('cfme', 'py.warnings')):
+    # this function is a bad hack, at some point we want a more ballanced setup
+    for logger in loggers:
+        log = logging.getLogger(logger)
+        handler = next(x for x in log.handlers
+                       if isinstance(x, logging.FileHandler))
+        handler.close()
+        base, name = os.path.split(handler.baseFilename)
+        add_prefix.prefix = "({})".format(workername)
+        handler.baseFilename = os.path.join(
+            base, "{worker}-{name}".format(worker=workername, name=name))
+        log.debug("worker log started")  # directly reopens the file
+
+
+
 _configure_warnings()
 
 # Register a custom excepthook to log unhandled exceptions


### PR DESCRIPTION
this switches logging in the worker processes to use a logfile prefixed with the process name

while a hack this allows much better comprehension of the logfiles