### PR TITLE
[1LP][RFR] Call robust setup_a_provider in fixtures.provider._setup_provider

### DIFF
--- a/fixtures/provider.py
+++ b/fixtures/provider.py
@@ -45,7 +45,7 @@ def _setup_provider(provider_key, request=None):
         skip(provider_key, previous_fail=True)
 
     try:
-        providers.setup_provider(provider_key)
+        providers.setup_a_provider(filters=[providers.ProviderFilter(keys=[provider_key])])
     except Exception as ex:
         logger.error('Error setting up provider %s', provider_key)
         logger.exception(ex)


### PR DESCRIPTION
@jkrocil is currently working on a more complete revising of the provider fixtures. This is just a 'small' change that would make setup_a_provider the default, which would impact all tests using the setup_provider[_(modscope|clsscope|funcscope)] fixtures.

It still relies on the provider_key being passed.

Jan will be enlightening the team next week on his designs for provider and testgen!

{{ pytest: cfme/tests/cloud/test_provisioning.py --long-running -k "test_provision_from_template" --use-provider ec2west }}


