### PR TITLE
[1LP][RFR] Fixed failing middleware tests, caused by UI changes.

### DIFF
--- a/cfme/middleware/domain.py
+++ b/cfme/middleware/domain.py
@@ -124,7 +124,8 @@ class MiddlewareDomain(MiddlewareBase, Navigatable, Taggable):
         rows = provider.mgmt.inventory.list_domain()
         for row in rows:
             domains.append(MiddlewareDomain(
-                name=row.data['Local Host Name'],
+                name=row.data['Local Host Name']
+                if row.data['Local Host Name'] != 'master' else 'Unnamed Domain',
                 feed=row.path.feed_id,
                 product=row.data['Product Name']
                 if 'Product Name' in row.data else None,

--- a/cfme/tests/middleware/server_methods.py
+++ b/cfme/tests/middleware/server_methods.py
@@ -70,10 +70,10 @@ def get_hawkular_server(provider):
 
 
 def get_domain_server(provider):
-    return _get_server_by_name(provider, EAP_PRODUCT_NAME, 'EAP7-server-one|server-one')
+    return _get_server_by_name(provider=provider, name='EAP7-server-one|server-one')
 
 
-def _get_server_by_name(provider, product, name=None):
+def _get_server_by_name(provider, product=None, name=None):
     """
     Return server by given provider, product and server name.
 

--- a/cfme/web_ui/mixins.py
+++ b/cfme/web_ui/mixins.py
@@ -2,6 +2,7 @@
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import fill, Form, AngularSelect, Table, toolbar, form_buttons, flash
 from xml.sax.saxutils import quoteattr
+from utils.version import current_version
 
 tag_form = Form(
     fields=[
@@ -47,9 +48,9 @@ def remove_tag(tag):
 
 def get_tags(tag="My Company Tags"):
     tags = []
-    for row in sel.elements(
-            "//*[(self::th or self::td) and normalize-space(.)={}]/../.."
-            "//td[img[contains(@src, 'smarttag')]]".format(
-                quoteattr(tag))):
+    tagpath = "//*[(self::th or self::td) and normalize-space(.)={}]/../.."\
+        "//td[img[contains(@src, 'smarttag')]]" if current_version() < '5.8'\
+        else "//td[i[contains(@class, 'fa-tag')]]"
+    for row in sel.elements(tagpath.format(quoteattr(tag))):
         tags.append(sel.text(row).strip())
     return tags


### PR DESCRIPTION
* Domain name is shown "Unnamed Domain" if not configured.
* Stopped Domain mode servers do not have Product field.
* There are UI element structure changes for Tags.

{{pytest: cfme/tests/middleware/test_middleware_tags.py -v --use-provider hawkular}}