### PR TITLE
[1LP][RFR] Update Advanced Search buttons, BZ1380430

### DIFF
--- a/cfme/tests/infrastructure/test_advanced_search_host.py
+++ b/cfme/tests/infrastructure/test_advanced_search_host.py
@@ -120,7 +120,6 @@ def test_filter_save_cancel(hosts, hosts_with_vm_count, host_with_median_vm):
         search.load_filter(filter_name)  # does not exist
 
 
-@pytest.mark.meta(blockers=[1283554, 1320244])
 @pytest.mark.requires("test_can_open_advanced_search")
 def test_filter_save_and_load(request, hosts, hosts_with_vm_count, host_with_median_vm):
     navigate_to(Host, 'All')
@@ -140,7 +139,6 @@ def test_filter_save_and_load(request, hosts, hosts_with_vm_count, host_with_med
     assert len(more_than_median_hosts) == len(host.get_all_hosts(do_not_navigate=True))
 
 
-@pytest.mark.meta(blockers=[1283554, 1320244])
 @pytest.mark.requires("test_can_open_advanced_search")
 def test_filter_save_and_cancel_load(request, hosts, hosts_with_vm_count, host_with_median_vm):
     navigate_to(Host, 'All')
@@ -163,7 +161,6 @@ def test_filter_save_and_cancel_load(request, hosts, hosts_with_vm_count, host_w
     assert_no_cfme_exception()
 
 
-@pytest.mark.meta(blockers=[1283554, 1320244])
 @pytest.mark.requires("test_can_open_advanced_search")
 def test_filter_save_and_load_cancel(request, hosts, hosts_with_vm_count, host_with_median_vm):
     navigate_to(Host, 'All')
@@ -220,7 +217,6 @@ def test_quick_search_with_filter(request, hosts, hosts_with_vm_count, host_with
     assert len(all_hosts_visible) == 1 and median_host in all_hosts_visible
 
 
-@pytest.mark.meta(blockers=[1283554, 1320244])
 def test_can_delete_filter():
     navigate_to(Host, 'All')
     filter_name = fauxfactory.gen_alphanumeric()
@@ -235,7 +231,6 @@ def test_can_delete_filter():
     assert_no_cfme_exception()
 
 
-@pytest.mark.meta(blockers=[1097150, 1283554, 1320244])
 def test_delete_button_should_appear_after_save(request):
     """Delete button appears only after load, not after save"""
     navigate_to(Host, 'All')
@@ -252,7 +247,6 @@ def test_delete_button_should_appear_after_save(request):
         pytest.fail("Could not delete filter right after saving!")
 
 
-@pytest.mark.meta(blockers=[1097150, 1283554, 1320244])
 def test_cannot_delete_more_than_once(request, nuke_browser_after_test):
     """When Delete button appars, it does not want to go away"""
     navigate_to(Host, 'All')

--- a/cfme/tests/infrastructure/test_advanced_search_providers.py
+++ b/cfme/tests/infrastructure/test_advanced_search_providers.py
@@ -200,7 +200,6 @@ def test_can_delete_filter():
     assert_no_cfme_exception()
 
 
-@pytest.mark.meta(blockers=[1097150, 1320244])
 def test_delete_button_should_appear_after_save(rails_delete_filter):
     """Delete button appears only after load, not after save"""
     # bind filter_name to the function for fixture cleanup
@@ -212,7 +211,6 @@ def test_delete_button_should_appear_after_save(rails_delete_filter):
         pytest.fail("Could not delete filter right after saving!")
 
 
-@pytest.mark.meta(blockers=[1097150, 1320244])
 def test_cannot_delete_more_than_once():
     """When Delete button appars, it does not want to go away"""
     filter_name = fauxfactory.gen_alphanumeric()

--- a/cfme/tests/infrastructure/test_advanced_search_vms.py
+++ b/cfme/tests/infrastructure/test_advanced_search_vms.py
@@ -122,7 +122,6 @@ def test_filter_save_cancel(vms, subset_of_vms, expression_for_vms_subset):
 
 
 @pytest.mark.requires("test_can_open_advanced_search")
-@pytest.mark.meta(blockers=[1273032])
 def test_filter_save_and_load(request, vms, subset_of_vms, expression_for_vms_subset):
     navigate_to(Vm, 'VMsOnly')
     filter_name = fauxfactory.gen_alphanumeric()
@@ -139,7 +138,6 @@ def test_filter_save_and_load(request, vms, subset_of_vms, expression_for_vms_su
 
 
 @pytest.mark.requires("test_can_open_advanced_search")
-@pytest.mark.meta(blockers=[1273032])
 def test_filter_save_and_cancel_load(request):
     navigate_to(Vm, 'VMsOnly')
     filter_name = fauxfactory.gen_alphanumeric()
@@ -160,7 +158,6 @@ def test_filter_save_and_cancel_load(request):
 
 
 @pytest.mark.requires("test_can_open_advanced_search")
-@pytest.mark.meta(blockers=[1273032])
 def test_filter_save_and_load_cancel(request, vms, subset_of_vms):
     navigate_to(Vm, 'VMsOnly')
     filter_name = fauxfactory.gen_alphanumeric()
@@ -216,7 +213,6 @@ def test_quick_search_with_filter(request, vms, subset_of_vms, expression_for_vm
     assert len(all_vms_visible) == 1 and chosen_vm in all_vms_visible
 
 
-@pytest.mark.meta(blockers=[1273032, 1320244])
 def test_can_delete_filter():
     navigate_to(Vm, 'VMsOnly')
     filter_name = fauxfactory.gen_alphanumeric()
@@ -231,7 +227,6 @@ def test_can_delete_filter():
     assert_no_cfme_exception()
 
 
-@pytest.mark.meta(blockers=[1097150, 1273032, 1320244])
 def test_delete_button_should_appear_after_save(request):
     """Delete button appears only after load, not after save"""
     navigate_to(Vm, 'VMsOnly')
@@ -248,7 +243,6 @@ def test_delete_button_should_appear_after_save(request):
         pytest.fail("Could not delete filter right after saving!")
 
 
-@pytest.mark.meta(blockers=[1097150, 1273032, 1320244])
 def test_cannot_delete_more_than_once(request, nuke_browser_after_test):
     """When Delete button appars, it does not want to go away"""
     navigate_to(Vm, 'VMsOnly')

--- a/cfme/web_ui/expression_editor.py
+++ b/cfme/web_ui/expression_editor.py
@@ -7,7 +7,6 @@ from selenium.common.exceptions import NoSuchElementException
 from multimethods import singledispatch
 
 from utils.wait import wait_for, TimedOutError
-from utils import version
 import cfme.fixtures.pytest_selenium as sel
 from cfme.web_ui import Anything, Calendar, Form, Input, Region, AngularSelect, fill
 import re
@@ -36,17 +35,15 @@ def _expressions_root():
 # Buttons container
 buttons = Region(
     locators=dict(
-        commit={version.LOWEST: "//img[@alt='Commit expression element changes']",
-                '5.7': "//button[@title='Commit expression element changes']"},
-        discard={version.LOWEST: "//img[@alt='Discard expression element changes']",
-                 '5.7': "//button[@title='Discard expression element changes']"},
-        remove="//span[not(contains(@style, 'none'))]//img[@alt='Remove this expression element']",
+        commit="//button[@title='Commit expression element changes']",
+        discard="//button[@title='Discard expression element changes']",
+        remove="//span[@id='exp_buttons_on']//*[@title='Remove this expression element']",
         NOT="//span[not(contains(@style, 'none'))]" +
             "//img[@alt='Wrap this expression element with a NOT']",
         OR="//span[not(contains(@style, 'none'))]//img[@alt='OR with a new expression element']",
         AND="//span[not(contains(@style, 'none'))]//img[@alt='AND with a new expression element']",
-        redo="//img[@alt='Redo']",
-        undo="//img[@alt='Undo']",
+        redo="(//button | //a)[@title='Re-apply the previous change']",
+        undo="(//button | //a)[@title='Undo the last change']",
         select_specific="//img[@alt='Click to change to a specific Date/Time format']",
         select_relative="//img[@alt='Click to change to a relative Date/Time format']",
     )
@@ -251,7 +248,7 @@ def fill_count(count=None, key=None, value=None):
             type="Count of",
             count=count,
             key=key,
-            value=int(value),
+            value=int(value) if value is not None else value,
         ),
     )
     # In case of advanced search box


### PR DESCRIPTION
alt-text for the advanced search buttons will be fixed here:
https://github.com/ManageIQ/manageiq-ui-classic/pull/367

The required bug has been fixed in 57z and 58z cloudforms, and is in upstream MIQ. With the announcement of EOL of version support of CFME 56z, this can now be merged.
https://bugzilla.redhat.com/show_bug.cgi?id=1380430

This fulfills the 'automate_bug' flag in the BZ and reverts to previous design using FormButton instead of specific locators for advanced search buttons.


## Pytest Results
Marginally better than current master/downstream-stable results against 58z.  Failures well outside the scope of what I'm trying to accomplish here, that should be addressed by focus area owner of CFME QE.

* 57z: 73% overall passing rate, test_adv_search_vms failing because search widget isn't rendered on page (35% pass)
* 58z: 76% overall passing rate, test_adv_search_vms failing because search widget isn't rendered on page (35% pass)

{{ pytest: -k "advanced_search" }}