### PR TITLE
[WIPTEST] Login functionality of cockpit. 

### DIFF
--- a/cfme/tests/containers/test_webconsole_node.py
+++ b/cfme/tests/containers/test_webconsole_node.py
@@ -1,0 +1,33 @@
+import pytest
+
+from cfme.containers.provider import ContainersProvider
+from utils import testgen, version
+from cfme.web_ui import CheckboxTable, toolbar as tb
+from utils.appliance.implementations.ui import navigate_to
+from cfme.containers.node import Node
+from cfme.fixtures import pytest_selenium as sel
+from utils.blockers import BZ
+
+# CMP-10469
+
+
+pytestmark = [
+    pytest.mark.uncollectif(
+        lambda: version.current_version() < "5.6"),
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.tier(1)]
+pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
+
+
+@pytest.mark.meta(blockers=[BZ(1406772)])
+def test_webconsole_node():
+    """ Verify single sign-on to cockpit from master
+    """
+    navigate_to(Node, 'All')
+    tb.select('List View')
+    list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
+    nodes_instances = [r for r in list_tbl.rows()]
+    nodes_instances[0].row_element.click()
+    tb.select('Open a new browser window with Cockpit for this '
+              'VM.  This requires that Cockpit is pre-configured on the VM.')
+    assert sel.title() == 'Cockpit'

--- a/cfme/tests/containers/test_webconsole_node.py
+++ b/cfme/tests/containers/test_webconsole_node.py
@@ -20,7 +20,7 @@ pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
 
 
 @pytest.mark.meta(blockers=[BZ(1406772)])
-def test_webconsole_node():
+def test_webconsole_node(provider):
     """ Verify single sign-on to cockpit from master
     """
     navigate_to(Node, 'All')
@@ -30,4 +30,7 @@ def test_webconsole_node():
     nodes_instances[0].row_element.click()
     tb.select('Open a new browser window with Cockpit for this '
               'VM.  This requires that Cockpit is pre-configured on the VM.')
+    port_num = ':9090/system'
+    url_cockpit = provider.hostname + port_num
+    sel.get(url_cockpit)
     assert sel.title() == 'Cockpit'


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_webconsole_node.py -v --use-provider cm-env1 }}

Test the cockpit single sign-on functionality.
