### PR TITLE
[1LP][RFR] utils/providers.py: Accept and propagate appliance= param

### DIFF
--- a/cfme/cloud/provider/azure.py
+++ b/cfme/cloud/provider/azure.py
@@ -9,9 +9,9 @@ class AzureProvider(CloudProvider):
     mgmt_class = AzureSystem
 
     def __init__(self, name=None, credentials=None, zone=None, key=None, region=None,
-                 tenant_id=None, subscription_id=None):
+                 tenant_id=None, subscription_id=None, appliance=None):
         super(AzureProvider, self).__init__(name=name, credentials=credentials,
-                                            zone=zone, key=key)
+                                            zone=zone, key=key, appliance=appliance)
         self.region = region  # Region can be a string or a dict for version pick
         self.tenant_id = tenant_id
         self.subscription_id = subscription_id
@@ -32,7 +32,7 @@ class AzureProvider(CloudProvider):
         return self.data['provisioning']
 
     @classmethod
-    def from_config(cls, prov_config, prov_key):
+    def from_config(cls, prov_config, prov_key, appliance=None):
         credentials_key = prov_config['credentials']
         credentials = cls.process_credential_yaml_key(credentials_key)
         # HACK: stray domain entry in credentials, so ensure it is not there
@@ -43,4 +43,5 @@ class AzureProvider(CloudProvider):
             tenant_id=prov_config['tenant_id'],
             subscription_id=prov_config['subscription_id'],
             credentials={'default': credentials},
-            key=prov_key)
+            key=prov_key,
+            appliance=appliance)

--- a/cfme/cloud/provider/ec2.py
+++ b/cfme/cloud/provider/ec2.py
@@ -8,9 +8,10 @@ class EC2Provider(CloudProvider):
     type_name = "ec2"
     mgmt_class = EC2System
 
-    def __init__(self, name=None, credentials=None, zone=None, key=None, region=None):
+    def __init__(
+            self, name=None, credentials=None, zone=None, key=None, region=None, appliance=None):
         super(EC2Provider, self).__init__(name=name, credentials=credentials,
-                                          zone=zone, key=key)
+                                          zone=zone, key=key, appliance=appliance)
         self.region = region
 
     def _form_mapping(self, create=None, **kwargs):
@@ -19,11 +20,12 @@ class EC2Provider(CloudProvider):
                 'region_select': sel.ByValue(kwargs.get('region'))}
 
     @classmethod
-    def from_config(cls, prov_config, prov_key):
+    def from_config(cls, prov_config, prov_key, appliance=None):
         credentials_key = prov_config['credentials']
         credentials = cls.process_credential_yaml_key(credentials_key)
         return cls(name=prov_config['name'],
             region=prov_config['region'],
             credentials={'default': credentials},
             zone=prov_config['server_zone'],
-            key=prov_key)
+            key=prov_key,
+            appliance=appliance)

--- a/cfme/cloud/provider/gce.py
+++ b/cfme/cloud/provider/gce.py
@@ -8,8 +8,11 @@ class GCEProvider(CloudProvider):
     type_name = "gce"
     mgmt_class = GoogleCloudSystem
 
-    def __init__(self, name=None, project=None, zone=None, region=None, credentials=None, key=None):
-        super(GCEProvider, self).__init__(name=name, zone=zone, key=key, credentials=credentials)
+    def __init__(
+            self, name=None, project=None, zone=None, region=None, credentials=None, key=None,
+            appliance=None):
+        super(GCEProvider, self).__init__(
+            name=name, zone=zone, key=key, credentials=credentials, appliance=appliance)
         self.region = region
         self.project = project
 
@@ -20,7 +23,7 @@ class GCEProvider(CloudProvider):
                 'google_project_text': kwargs.get('project')}
 
     @classmethod
-    def from_config(cls, prov_config, prov_key):
+    def from_config(cls, prov_config, prov_key, appliance=None):
         ser_acc_creds = cls.get_credentials_from_config(
             prov_config['credentials'], cred_type='service_account')
         return cls(name=prov_config['name'],
@@ -28,7 +31,8 @@ class GCEProvider(CloudProvider):
             zone=prov_config['zone'],
             region=prov_config['region'],
             credentials={'default': ser_acc_creds},
-            key=prov_key)
+            key=prov_key,
+            appliance=appliance)
 
     @classmethod
     def get_credentials(cls, credential_dict, cred_type=None):

--- a/cfme/cloud/provider/openstack.py
+++ b/cfme/cloud/provider/openstack.py
@@ -11,9 +11,9 @@ class OpenStackProvider(CloudProvider):
 
     def __init__(self, name=None, credentials=None, zone=None, key=None, hostname=None,
                  ip_address=None, api_port=None, sec_protocol=None, amqp_sec_protocol=None,
-                 tenant_mapping=None, infra_provider=None):
+                 tenant_mapping=None, infra_provider=None, appliance=None):
         super(OpenStackProvider, self).__init__(name=name, credentials=credentials,
-                                                zone=zone, key=key)
+                                                zone=zone, key=key, appliance=appliance)
         self.hostname = hostname
         self.ip_address = ip_address
         self.api_port = api_port
@@ -67,7 +67,7 @@ class OpenStackProvider(CloudProvider):
         return {}
 
     @classmethod
-    def from_config(cls, prov_config, prov_key):
+    def from_config(cls, prov_config, prov_key, appliance=None):
         from utils.providers import get_crud
         credentials_key = prov_config['credentials']
         credentials = cls.process_credential_yaml_key(credentials_key)
@@ -77,7 +77,7 @@ class OpenStackProvider(CloudProvider):
                 prov_config['amqp_credentials'], cred_type='amqp')
             creds['amqp'] = amqp_credentials
         infra_prov_key = prov_config.get('infra_provider_key')
-        infra_provider = get_crud(infra_prov_key) if infra_prov_key else None
+        infra_provider = get_crud(infra_prov_key, appliance=appliance) if infra_prov_key else None
         return cls(name=prov_config['name'],
             hostname=prov_config['hostname'],
             ip_address=prov_config['ipaddress'],
@@ -87,4 +87,5 @@ class OpenStackProvider(CloudProvider):
             key=prov_key,
             sec_protocol=prov_config.get('sec_protocol', "Non-SSL"),
             tenant_mapping=prov_config.get('tenant_mapping', False),
-            infra_provider=infra_provider)
+            infra_provider=infra_provider,
+            appliance=appliance)

--- a/cfme/containers/provider/kubernetes.py
+++ b/cfme/containers/provider/kubernetes.py
@@ -8,10 +8,10 @@ class KubernetesProvider(ContainersProvider):
     mgmt_class = Kubernetes
 
     def __init__(self, name=None, credentials=None, key=None,
-                 zone=None, hostname=None, port=None, provider_data=None):
+                 zone=None, hostname=None, port=None, provider_data=None, appliance=None):
         super(KubernetesProvider, self).__init__(
             name=name, credentials=credentials, key=key, zone=zone, hostname=hostname, port=port,
-            provider_data=provider_data)
+            provider_data=provider_data, appliance=None)
 
     def _form_mapping(self, create=None, **kwargs):
         return {'name_text': kwargs.get('name'),
@@ -21,7 +21,7 @@ class KubernetesProvider(ContainersProvider):
                 'zone_select': kwargs.get('zone')}
 
     @staticmethod
-    def from_config(prov_config, prov_key):
+    def from_config(prov_config, prov_key, appliance=None):
         token_creds = KubernetesProvider.process_credential_yaml_key(
             prov_config['credentials'], cred_type='token')
         return KubernetesProvider(
@@ -31,4 +31,5 @@ class KubernetesProvider(ContainersProvider):
             zone=prov_config['server_zone'],
             hostname=prov_config.get('hostname', None) or prov_config['ip_address'],
             port=prov_config['port'],
-            provider_data=prov_config)
+            provider_data=prov_config,
+            appliance=appliance)

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -20,10 +20,10 @@ class OpenshiftProvider(ContainersProvider):
     mgmt_class = Openshift
 
     def __init__(self, name=None, credentials=None, key=None,
-                 zone=None, hostname=None, port=None, provider_data=None):
+                 zone=None, hostname=None, port=None, provider_data=None, appliance=None):
         super(OpenshiftProvider, self).__init__(
             name=name, credentials=credentials, key=key, zone=zone, hostname=hostname, port=port,
-            provider_data=provider_data)
+            provider_data=provider_data, appliance=appliance)
 
     def create(self, validate_credentials=True, **kwargs):
         # Workaround - randomly fails on 5.5.0.8 with no validation
@@ -58,7 +58,7 @@ class OpenshiftProvider(ContainersProvider):
         return int(self.get_detail("Relationships", "Container Templates"))
 
     @staticmethod
-    def from_config(prov_config, prov_key):
+    def from_config(prov_config, prov_key, appliance=None):
         token_creds = OpenshiftProvider.process_credential_yaml_key(
             prov_config['credentials'], cred_type='token')
         return OpenshiftProvider(
@@ -68,7 +68,8 @@ class OpenshiftProvider(ContainersProvider):
             zone=prov_config['server_zone'],
             hostname=prov_config.get('hostname', None) or prov_config['ip_address'],
             port=prov_config['port'],
-            provider_data=prov_config)
+            provider_data=prov_config,
+            appliance=appliance)
 
     def custom_attributes(self):
         """returns custom attributes"""

--- a/cfme/infrastructure/datastore.py
+++ b/cfme/infrastructure/datastore.py
@@ -58,7 +58,7 @@ class Datastore(Pretty, Navigatable):
         self.type = type
         self.quad_name = 'datastore'
         if provider_key:
-            self.provider = get_crud(provider_key)
+            self.provider = get_crud(provider_key, appliance=appliance)
         else:
             self.provider = None
 

--- a/cfme/infrastructure/provider/openstack_infra.py
+++ b/cfme/infrastructure/provider/openstack_infra.py
@@ -22,9 +22,10 @@ class OpenstackInfraProvider(InfraProvider):
 
     def __init__(self, name=None, credentials=None, key=None, hostname=None,
                  ip_address=None, start_ip=None, end_ip=None, provider_data=None,
-                 sec_protocol=None):
-        super(OpenstackInfraProvider, self).__init__(name=name, credentials=credentials,
-                                             key=key, provider_data=provider_data)
+                 sec_protocol=None, appliance=None):
+        super(OpenstackInfraProvider, self).__init__(
+            name=name, credentials=credentials, key=key, provider_data=provider_data,
+            appliance=appliance)
 
         self.hostname = hostname
         self.ip_address = ip_address
@@ -51,7 +52,7 @@ class OpenstackInfraProvider(InfraProvider):
         return data_dict
 
     @classmethod
-    def from_config(cls, prov_config, prov_key):
+    def from_config(cls, prov_config, prov_key, appliance=None):
         credentials_key = prov_config['credentials']
         credentials = cls.process_credential_yaml_key(credentials_key)
         credential_dict = {'default': credentials}
@@ -74,7 +75,8 @@ class OpenstackInfraProvider(InfraProvider):
             credentials=credential_dict,
             key=prov_key,
             start_ip=start_ip,
-            end_ip=end_ip)
+            end_ip=end_ip,
+            appliance=appliance)
 
     def register(self, file_path):
         """Register new nodes (Openstack)

--- a/cfme/infrastructure/provider/rhevm.py
+++ b/cfme/infrastructure/provider/rhevm.py
@@ -11,9 +11,10 @@ class RHEVMProvider(InfraProvider):
 
     def __init__(self, name=None, credentials=None, zone=None, key=None, hostname=None,
                  ip_address=None, api_port=None, start_ip=None, end_ip=None,
-                 provider_data=None):
-        super(RHEVMProvider, self).__init__(name=name, credentials=credentials,
-                                            zone=zone, key=key, provider_data=provider_data)
+                 provider_data=None, appliance=None):
+        super(RHEVMProvider, self).__init__(
+            name=name, credentials=credentials, zone=zone, key=key, provider_data=provider_data,
+            appliance=appliance)
 
         self.hostname = hostname
         self.ip_address = ip_address
@@ -40,7 +41,7 @@ class RHEVMProvider(InfraProvider):
         return {}
 
     @classmethod
-    def from_config(cls, prov_config, prov_key):
+    def from_config(cls, prov_config, prov_key, appliance=None):
         credentials_key = prov_config['credentials']
         credentials = {
             # The default credentials for controlling the provider
@@ -63,4 +64,5 @@ class RHEVMProvider(InfraProvider):
             zone=prov_config.get('server_zone', 'default'),
             key=prov_key,
             start_ip=start_ip,
-            end_ip=end_ip)
+            end_ip=end_ip,
+            appliance=appliance)

--- a/cfme/infrastructure/provider/scvmm.py
+++ b/cfme/infrastructure/provider/scvmm.py
@@ -10,9 +10,10 @@ class SCVMMProvider(InfraProvider):
 
     def __init__(self, name=None, credentials=None, key=None, zone=None, hostname=None,
                  ip_address=None, start_ip=None, end_ip=None, sec_protocol=None, sec_realm=None,
-                 provider_data=None):
-        super(SCVMMProvider, self).__init__(name=name, credentials=credentials,
-            zone=zone, key=key, provider_data=provider_data)
+                 provider_data=None, appliance=None):
+        super(SCVMMProvider, self).__init__(
+            name=name, credentials=credentials, zone=zone, key=key, provider_data=provider_data,
+            appliance=appliance)
 
         self.hostname = hostname
         self.ip_address = ip_address
@@ -48,7 +49,7 @@ class SCVMMProvider(InfraProvider):
         return values
 
     @classmethod
-    def from_config(cls, prov_config, prov_key):
+    def from_config(cls, prov_config, prov_key, appliance=None):
         credentials_key = prov_config['credentials']
         credentials = cls.process_credential_yaml_key(credentials_key)
         if prov_config.get('discovery_range', None):
@@ -65,4 +66,5 @@ class SCVMMProvider(InfraProvider):
             start_ip=start_ip,
             end_ip=end_ip,
             sec_protocol=prov_config['sec_protocol'],
-            sec_realm=prov_config['sec_realm'])
+            sec_realm=prov_config['sec_realm'],
+            appliance=appliance)

--- a/cfme/infrastructure/provider/virtualcenter.py
+++ b/cfme/infrastructure/provider/virtualcenter.py
@@ -8,9 +8,10 @@ class VMwareProvider(InfraProvider):
     mgmt_class = VMWareSystem
 
     def __init__(self, name=None, credentials=None, key=None, zone=None, hostname=None,
-                 ip_address=None, start_ip=None, end_ip=None, provider_data=None):
-        super(VMwareProvider, self).__init__(name=name, credentials=credentials,
-                                             zone=zone, key=key, provider_data=provider_data)
+                 ip_address=None, start_ip=None, end_ip=None, provider_data=None, appliance=None):
+        super(VMwareProvider, self).__init__(
+            name=name, credentials=credentials, zone=zone, key=key, provider_data=provider_data,
+            appliance=appliance)
 
         self.hostname = hostname
         self.ip_address = ip_address
@@ -30,7 +31,7 @@ class VMwareProvider(InfraProvider):
         return {}
 
     @classmethod
-    def from_config(cls, prov_config, prov_key):
+    def from_config(cls, prov_config, prov_key, appliance=None):
         credentials_key = prov_config['credentials']
         credentials = cls.process_credential_yaml_key(credentials_key)
         if prov_config.get('discovery_range', None):
@@ -45,4 +46,5 @@ class VMwareProvider(InfraProvider):
             zone=prov_config['server_zone'],
             key=prov_key,
             start_ip=start_ip,
-            end_ip=end_ip)
+            end_ip=end_ip,
+            appliance=appliance)

--- a/cfme/infrastructure/resource_pool.py
+++ b/cfme/infrastructure/resource_pool.py
@@ -43,7 +43,7 @@ class ResourcePool(Pretty, Navigatable):
         self.quad_name = 'resource_pool'
         self.name = name
         if provider_key:
-            self.provider = get_crud(provider_key)
+            self.provider = get_crud(provider_key, appliance=appliance)
         else:
             self.provider = None
 

--- a/cfme/middleware/provider/hawkular.py
+++ b/cfme/middleware/provider/hawkular.py
@@ -154,7 +154,7 @@ class HawkularProvider(MiddlewareBase, TopologyMixin, TimelinesMixin, Middleware
         mon_btn("Timelines")
 
     @staticmethod
-    def from_config(prov_config, prov_key):
+    def from_config(prov_config, prov_key, appliance=None):
         credentials_key = prov_config['credentials']
         credentials = HawkularProvider.process_credential_yaml_key(credentials_key)
         return HawkularProvider(
@@ -162,4 +162,5 @@ class HawkularProvider(MiddlewareBase, TopologyMixin, TimelinesMixin, Middleware
             key=prov_key,
             hostname=prov_config['hostname'],
             port=prov_config['port'],
-            credentials={'default': credentials})
+            credentials={'default': credentials},
+            appliance=appliance)

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -461,7 +461,7 @@ class IPAppliance(object):
             Recognized by name only.
         """
         from utils.providers import list_providers
-        prov_cruds = list_providers(use_global_filters=False)
+        prov_cruds = list_providers(use_global_filters=False, appliance=self)
 
         found_cruds = set()
         unrecognized_ems_names = set()

--- a/utils/providers.py
+++ b/utils/providers.py
@@ -218,12 +218,14 @@ global_filters['enabled_only'] = ProviderFilter(required_tags=['disabled'], inve
 global_filters['restrict_version'] = ProviderFilter(restrict_version=True)
 
 
-def list_providers(filters=None, use_global_filters=True):
+def list_providers(filters=None, use_global_filters=True, appliance=None):
     """ Lists provider crud objects, global filter optional
 
     Args:
         filters: List if :py:class:`ProviderFilter` or None
         use_global_filters: Will apply global filters as well if `True`, will not otherwise
+        appliance: Optional :py:class:`utils.appliance.IPAppliance` to be passed to provider CRUD
+            objects
 
     Note: Requires the framework to be pointed at an appliance to succeed.
 
@@ -232,25 +234,27 @@ def list_providers(filters=None, use_global_filters=True):
     filters = filters or []
     if use_global_filters:
         filters = filters + global_filters.values()
-    providers = [get_crud(prov_key) for prov_key in providers_data]
+    providers = [get_crud(prov_key, appliance=appliance) for prov_key in providers_data]
     for prov_filter in filters:
         providers = filter(prov_filter, providers)
     return providers
 
 
-def list_providers_by_class(prov_class, use_global_filters=True):
+def list_providers_by_class(prov_class, use_global_filters=True, appliance=None):
     """ Lists provider crud objects of a specific class (or its subclasses), global filter optional
 
     Args:
         prov_class: Provider class to apply for filtering
         use_global_filters: See :py:func:`list_providers`
+        appliance: Optional :py:class:`utils.appliance.IPAppliance` to be passed to provider CRUD
+            objects
 
     Note: Requires the framework to be pointed at an appliance to succeed.
 
     Returns: List of provider crud objects.
     """
     pf = ProviderFilter(classes=[prov_class])
-    return list_providers(filters=[pf], use_global_filters=use_global_filters)
+    return list_providers(filters=[pf], use_global_filters=use_global_filters, appliance=appliance)
 
 
 def list_provider_keys(provider_type=None):
@@ -278,14 +282,15 @@ def list_provider_keys(provider_type=None):
         return all_keys
 
 
-def setup_provider(provider_key, validate=True, check_existing=True):
-    provider = get_crud(provider_key)
+def setup_provider(provider_key, validate=True, check_existing=True, appliance=None):
+    provider = get_crud(provider_key, appliance=appliance)
     provider.create(validate_credentials=True, validate_inventory=validate,
                     check_existing=check_existing)
     return provider
 
 
-def setup_a_provider(filters=None, use_global_filters=True, validate=True, check_existing=True):
+def setup_a_provider(
+        filters=None, use_global_filters=True, validate=True, check_existing=True, appliance=None):
     """ Sets up a single provider robustly.
 
     Does some counter-badness measures.
@@ -295,10 +300,13 @@ def setup_a_provider(filters=None, use_global_filters=True, validate=True, check
         use_global_filters: Will apply global filters as well if `True`, will not otherwise
         validate: Whether to validate the provider.
         check_existing: Whether to check if the provider already exists.
+        appliance: Optional :py:class:`utils.appliance.IPAppliance` to be passed to provider CRUD
+            objects
     """
     filters = filters or []
 
-    providers = list_providers(filters=filters, use_global_filters=use_global_filters)
+    providers = list_providers(
+        filters=filters, use_global_filters=use_global_filters, appliance=appliance)
     if not providers:
         raise Exception("All providers have been filtered out, cannot setup any providers")
 
@@ -365,9 +373,10 @@ def setup_a_provider(filters=None, use_global_filters=True, validate=True, check
     return provider
 
 
-def setup_a_provider_by_class(prov_class, validate=True, check_existing=True):
+def setup_a_provider_by_class(prov_class, validate=True, check_existing=True, appliance=None):
     pf = ProviderFilter(classes=[prov_class])
-    return setup_a_provider(filters=[pf], validate=validate, check_existing=check_existing)
+    return setup_a_provider(
+        filters=[pf], validate=validate, check_existing=check_existing, appliance=appliance)
 
 
 def get_class_from_type(prov_type):
@@ -381,7 +390,7 @@ def get_class_from_type(prov_type):
         raise UnknownProviderType("Unknown provider type: {}!".format(prov_type))
 
 
-def get_crud(provider_key):
+def get_crud(provider_key, appliance=None):
     """ Creates a Provider object given a management_system key in cfme_data.
 
     Usage:
@@ -392,10 +401,11 @@ def get_crud(provider_key):
     prov_config = providers_data[provider_key]
     prov_type = prov_config.get('type')
 
-    return get_class_from_type(prov_type).from_config(prov_config, provider_key)
+    return get_class_from_type(prov_type).from_config(
+        prov_config, provider_key, appliance=appliance)
 
 
-def get_crud_by_name(provider_name):
+def get_crud_by_name(provider_name, appliance=None):
     """ Creates a Provider object given a management_system name in cfme_data.
 
     Usage:
@@ -405,7 +415,7 @@ def get_crud_by_name(provider_name):
     """
     for provider_key, provider_data in providers_data.items():
         if provider_data.get("name") == provider_name:
-            return get_crud(provider_key)
+            return get_crud(provider_key, appliance=appliance)
     raise NameError("Could not find provider {}".format(provider_name))
 
 

--- a/utils/providers.py
+++ b/utils/providers.py
@@ -231,6 +231,10 @@ def list_providers(filters=None, use_global_filters=True, appliance=None):
 
     Returns: List of provider crud objects.
     """
+    if isinstance(filters, six.string_types):
+        raise TypeError(
+            'You are probably using the old-style invocation of provider setup functions! '
+            'You need to change it appropriately.')
     filters = filters or []
     if use_global_filters:
         filters = filters + global_filters.values()


### PR DESCRIPTION
This is required for Sprout provider scaenging functioning again, because managed_providers now returns crud objects which do not work by default on Sprout because Sprout's base_url is None, therefore get_or_create_current_appliance does not work.