### PR TITLE
[1LP][RFR]Fix and resetter for InfraProvider Details 

### DIFF
--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -314,9 +314,11 @@ class All(CFMENavigateStep):
 
     def resetter(self):
         # Reset view and selection
-        tb.select("Grid View")
-        sel.check(paginator.check_all())
-        sel.uncheck(paginator.check_all())
+        if tb.exists("Grid View"):
+            tb.select("Grid View")
+        if paginator.page_controls_exist():
+            sel.check(paginator.check_all())
+            sel.uncheck(paginator.check_all())
 
 
 @navigator.register(InfraProvider, 'Add')
@@ -341,6 +343,11 @@ class Details(CFMENavigateStep):
 
     def step(self):
         sel.click(Quadicon(self.obj.name, self.obj.quad_name))
+
+    def resetter(self):
+        # Reset view and selection
+        if tb.exists("Summary View"):
+            tb.select("Summary View")
 
 
 @navigator.register(InfraProvider, 'ManagePolicies')


### PR DESCRIPTION
adding checks for paginator to avoid BZ 1422449 block and adding 'Summary View' to Details (it was added in 5.8)

This is mainly for 5.8 - as InfraProviders received Dashboard/Summary views in provider details.
There's a NEEDINFO regarding CloudProviders in that BZ .  It is always good to have  additional checks