### PR TITLE
[1LP][RFR] check response status code in test_provision_from_template_using_rest

### DIFF
--- a/cfme/tests/cloud/test_provisioning.py
+++ b/cfme/tests/cloud/test_provisioning.py
@@ -191,7 +191,9 @@ def test_provision_from_template_using_rest(
 
     request.addfinalizer(
         lambda: provider.mgmt.delete_vm(vm_name) if provider.mgmt.does_vm_exist(vm_name) else None)
+
     request = rest_api.collections.provision_requests.action.create(**provision_data)[0]
+    assert rest_api.response.status_code == 200
 
     def _finished():
         request.reload()


### PR DESCRIPTION
Adding check that the http status code of the REST API response was "200".

{{pytest: cfme/tests/cloud/test_provisioning.py --use-provider gce_central -v -k test_provision_from_template_using_rest}}