### PR TITLE
[1LP][RFR] Update test_retirement, remove existing_vm fixture

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -157,7 +157,7 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable, SummaryMixin
                      '5.6.2.2': 'Remove from the VMDB',
                      '5.7': 'Remove Virtual Machine'}
     RETIRE_DATE_FMT = {version.LOWEST: parsetime.american_date_only_format,
-                       '5.7': parsetime.american_minutes_wit_utc}
+                       '5.7': parsetime.american_minutes_with_utc}
 
     ###
     # Shared behaviour

--- a/cfme/tests/cloud_infra_common/test_retirement.py
+++ b/cfme/tests/cloud_infra_common/test_retirement.py
@@ -112,7 +112,8 @@ def test_retirement_now(test_vm):
 
 @test_requirements.retirement
 @pytest.mark.tier(2)
-@pytest.mark.meta(blockers=[BZ(1419150, forced_streams='5.6')])
+@pytest.mark.meta(blockers=[BZ(1419150, forced_streams='5.6',
+                               unblock=lambda: current_version() >= '5.7')])
 def test_set_retirement_date(test_vm):
     """Tests setting retirement date and verifies configured date is reflected in UI
 

--- a/cfme/tests/cloud_infra_common/test_retirement.py
+++ b/cfme/tests/cloud_infra_common/test_retirement.py
@@ -1,16 +1,19 @@
 # -*- coding: utf-8 -*-
-import datetime
 import pytest
+from datetime import date, timedelta, datetime
 
 from cfme import test_requirements
 from cfme.common.provider import CloudInfraProvider
 from cfme.common.vm import VM
+from cfme.web_ui import toolbar as tb
 from utils import testgen
+from utils.blockers import BZ
 from utils.generators import random_vm_name
 from utils.log import logger
 from utils.providers import ProviderFilter
 from utils.timeutil import parsetime
 from utils.wait import wait_for
+from utils.version import pick, current_version
 
 
 pytest_generate_tests = testgen.generate(
@@ -27,78 +30,113 @@ pytestmark = [
 
 
 @pytest.yield_fixture(scope="function")
-def vm(small_template, provider):
-    vm_obj = VM.factory(random_vm_name('retire'), provider, template_name=small_template)
-    vm_obj.create_on_provider(find_in_cfme=True, allow_skip="default")
-    yield vm_obj
+def test_vm(small_template, provider):
+    test_vm = VM.factory(random_vm_name('retire'), provider, template_name=small_template)
+    test_vm.create_on_provider(find_in_cfme=True, allow_skip="default")
+    yield test_vm
 
     try:
-        if provider.mgmt.does_vm_exist(vm_obj.name):
-            provider.mgmt.delete_vm(vm_obj.name)
+        if provider.mgmt.does_vm_exist(test_vm.name):
+            provider.mgmt.delete_vm(test_vm.name)
     except Exception:
-        logger.warning('Failed to delete vm from provider: {}'.format(vm_obj.name))
+        logger.warning('Failed to delete vm from provider: {}'.format(test_vm.name))
 
 
-@pytest.yield_fixture(scope="function")
-def existing_vm(provider):
-    """ Fixture will be using for set\unset retirement date for existing vm instead of
-    creation a new one
-    """
-    all_vms = provider.mgmt.list_vm()
-    need_to_create_vm = True
-    for virtual_machine in all_vms:
-        if provider.mgmt.is_vm_running(virtual_machine):
-            vm_obj = VM.factory(virtual_machine, provider)
-            need_to_create_vm = False
-            break
-    if need_to_create_vm:
-        machine_name = random_vm_name('retire')
-        vm_obj = VM.factory(machine_name, provider)
-        vm_obj.create_on_provider(find_in_cfme=True, allow_skip="default")
-
-    yield vm_obj
-
-    try:
-        if need_to_create_vm and provider.mgmt.does_vm_exist(vm_obj.name):
-            provider.mgmt.delete_vm(vm_obj.name)
-    except Exception:
-        logger.warning('Failed to delete vm from provider: {}'.format(vm_obj.name))
-
-
-def verify_retirement(vm):
+def verify_retirement_state(test_vm):
     # wait for the info block showing a date as retired date
-    wait_for(lambda: vm.is_retired, delay=15, num_sec=10 * 60,
-             message="Wait until VM {} will be retired".format(vm.name))
+    # Use lambda for is_retired since its a property
+    assert wait_for(lambda: test_vm.is_retired, delay=5, num_sec=10 * 60, fail_func=tb.refresh,
+             message="Wait for VM '{}' to enter retired state".format(test_vm.name))
 
-    assert vm.summary.power_management.power_state.text_value in {'off', 'suspended', 'unknown'}
+    # TODO: remove dependency on SummaryMixin and use widgetastic when available
+    assert test_vm.summary.power_management.power_state.text_value in ['off', 'suspended',
+                                                                       'unknown']
 
-    # make sure retirement date is today
-    retirement_date = vm.retirement_date
-    today = parsetime.now().to_american_date_only()
-    assert retirement_date == today
+
+def verify_retirement_date(test_vm, expected_date='Never'):
+    """Verify the retirement date for a variety of situations
+
+    Args:
+        expected_date: a :py:class: `str` or :py:class: `parsetime` date
+            or a dict of :py:class: `parsetime` dates with 'start' and 'end' keys.
+    """
+    if isinstance(expected_date, list):
+        # convert to a parsetime object for comparsion, function depends on version
+        if 'UTC' in pick(VM.RETIRE_DATE_FMT):
+            convert_func = parsetime.from_american_minutes_with_utc
+        else:
+            convert_func = parsetime.from_american_date_only
+        expected_date.update({'retire': convert_func(test_vm.retirement_date)})
+        logger.info('Asserting retire date "%s" is between "%s" and "%s"',
+                    expected_date['retire'],
+                    expected_date['start'],
+                    expected_date['end'])
+
+        assert expected_date['start'] <= expected_date['retire'] <= expected_date['end']
+
+    elif isinstance(expected_date, (parsetime, datetime, date)):
+        test_vm.retirement_date == expected_date.strftime(pick(VM.RETIRE_DATE_FMT))
+    else:
+        test_vm.retirement_date == expected_date
+
+
+def generate_retirement_date(delta=None):
+    gen_date = date.today()
+    if delta:
+        gen_date += timedelta(days=delta)
+    return gen_date
+
+
+def generate_retirement_date_now():
+    return datetime.utcnow()
 
 
 @test_requirements.retirement
-def test_retirement_now(vm):
+@pytest.mark.tier(2)
+def test_retirement_now(test_vm):
     """Tests on-demand retirement of an instance/vm
     """
-    vm.retire()
-    verify_retirement(vm)
+    # For 5.7 capture two times to assert the retire time is within a window.
+    # Too finicky to get it down to minute precision, nor is it really needed here
+    retire_times = dict()
+    retire_times['start'] = generate_retirement_date_now() + timedelta(minutes=-1)
+    test_vm.retire()
+    verify_retirement_state(test_vm)
+    retire_times['end'] = generate_retirement_date_now() + timedelta(minutes=1)
+    if current_version() < '5.7':
+        verify_retirement_date(test_vm,
+                               expected_date=parsetime.now().to_american_date_only())
+    else:
+        verify_retirement_date(test_vm, expected_date=retire_times)
 
 
 @test_requirements.retirement
-def test_set_retirement_date(vm):
-    """Tests retirement by setting a date
+@pytest.mark.tier(2)
+@pytest.mark.meta(blockers=[BZ(1419150, forced_streams='5.6')])
+def test_set_retirement_date(test_vm):
+    """Tests setting retirement date and verifies configured date is reflected in UI
+
+    Note we cannot control the retirement time, just day, so we cannot wait for the VM to retire
     """
-    vm.set_retirement_date(datetime.datetime.now(), warn="1 Week before retirement")
-    verify_retirement(vm)
+    num_days = 2
+    retire_date = generate_retirement_date(delta=num_days)
+    test_vm.set_retirement_date(retire_date, warn="1 Week before retirement")
+    verify_retirement_date(test_vm, expected_date=retire_date)
 
 
 @test_requirements.retirement
-def test_unset_retirement_date(existing_vm):
+@pytest.mark.tier(2)
+def test_unset_retirement_date(test_vm):
     """Tests cancelling a scheduled retirement by removing the set date
     """
-    tomorrow = datetime.date.today() + datetime.timedelta(days=1)
-    existing_vm.set_retirement_date(tomorrow)
-    existing_vm.set_retirement_date(None)
-    assert existing_vm.get_detail(properties=["Lifecycle", "Retirement Date"]) == "Never"
+    num_days = 3
+    retire_date = generate_retirement_date(delta=num_days)
+    test_vm.set_retirement_date(retire_date)
+    if BZ(1419150, forced_streams='5.6').blocks:
+        # The date is wrong, but we can still test unset
+        logger.warning('Skipping test step verification for BZ 1419150')
+    else:
+        verify_retirement_date(test_vm, expected_date=retire_date)
+
+    test_vm.set_retirement_date(None)
+    verify_retirement_date(test_vm, expected_date='Never')

--- a/cfme/tests/cloud_infra_common/test_retirement.py
+++ b/cfme/tests/cloud_infra_common/test_retirement.py
@@ -60,7 +60,7 @@ def verify_retirement_date(test_vm, expected_date='Never'):
         expected_date: a :py:class: `str` or :py:class: `parsetime` date
             or a dict of :py:class: `parsetime` dates with 'start' and 'end' keys.
     """
-    if isinstance(expected_date, list):
+    if isinstance(expected_date, dict):
         # convert to a parsetime object for comparsion, function depends on version
         if 'UTC' in pick(VM.RETIRE_DATE_FMT):
             convert_func = parsetime.from_american_minutes_with_utc
@@ -75,9 +75,9 @@ def verify_retirement_date(test_vm, expected_date='Never'):
         assert expected_date['start'] <= expected_date['retire'] <= expected_date['end']
 
     elif isinstance(expected_date, (parsetime, datetime, date)):
-        test_vm.retirement_date == expected_date.strftime(pick(VM.RETIRE_DATE_FMT))
+        assert test_vm.retirement_date == expected_date.strftime(pick(VM.RETIRE_DATE_FMT))
     else:
-        test_vm.retirement_date == expected_date
+        assert test_vm.retirement_date == expected_date
 
 
 def generate_retirement_date(delta=None):

--- a/cfme/tests/cloud_infra_common/test_retirement.py
+++ b/cfme/tests/cloud_infra_common/test_retirement.py
@@ -31,15 +31,15 @@ pytestmark = [
 
 @pytest.yield_fixture(scope="function")
 def test_vm(small_template, provider):
-    test_vm = VM.factory(random_vm_name('retire'), provider, template_name=small_template)
-    test_vm.create_on_provider(find_in_cfme=True, allow_skip="default")
-    yield test_vm
+    vm = VM.factory(random_vm_name('retire'), provider, template_name=small_template)
+    vm.create_on_provider(find_in_cfme=True, allow_skip="default")
+    yield vm
 
     try:
-        if provider.mgmt.does_vm_exist(test_vm.name):
-            provider.mgmt.delete_vm(test_vm.name)
+        if provider.mgmt.does_vm_exist(vm.name):
+            provider.mgmt.delete_vm(vm.name)
     except Exception:
-        logger.warning('Failed to delete vm from provider: {}'.format(test_vm.name))
+        logger.warning('Failed to delete vm from provider: {}'.format(vm.name))
 
 
 def verify_retirement_state(test_vm):
@@ -67,7 +67,7 @@ def verify_retirement_date(test_vm, expected_date='Never'):
         else:
             convert_func = parsetime.from_american_date_only
         expected_date.update({'retire': convert_func(test_vm.retirement_date)})
-        logger.info('Asserting retire date "%s" is between "%s" and "%s"',
+        logger.info('Asserting retire date "%s" is between "%s" and "%s"',  # noqa
                     expected_date['retire'],
                     expected_date['start'],
                     expected_date['end'])

--- a/utils/timeutil.py
+++ b/utils/timeutil.py
@@ -15,14 +15,14 @@ class parsetime(_datetime):  # NOQA
     """ Modified class with loaders for our datetime formats.
 
     """
-    _american_with_utc_format = "%m/%d/%y %H:%M:%S UTC"
-    _iso_with_utc_format = "%Y-%m-%d %H:%M:%S UTC"
-    _american_minutes = "%m/%d/%y %H:%M"
-    _american_minutes_wit_utc = "%m/%d/%y %H:%M UTC"
-    _american_date_only_format = "%m/%d/%y"
-    _iso_date_only_format = "%Y-%m-%d"
-    _request_format = "%Y-%m-%d-%H-%M-%S"
-    _long_date_format = "%B %d, %Y %H:%M"
+    american_with_utc_format = "%m/%d/%y %H:%M:%S UTC"
+    iso_with_utc_format = "%Y-%m-%d %H:%M:%S UTC"
+    american_minutes = "%m/%d/%y %H:%M"
+    american_minutes_wit_utc = "%m/%d/%y %H:%M UTC"
+    american_date_only_format = "%m/%d/%y"
+    iso_date_only_format = "%Y-%m-%d"
+    request_format = "%Y-%m-%d-%H-%M-%S"
+    long_date_format = "%B %d, %Y %H:%M"
 
     @classmethod
     def _parse(cls, fmt, time_string):
@@ -45,7 +45,7 @@ class parsetime(_datetime):  # NOQA
             time_string: String with time to parse
         Returns: :py:class`utils.timeutil.datetime()` object
         """
-        return cls._parse(cls._american_with_utc_format, time_string)
+        return cls._parse(cls.american_with_utc_format, time_string)
 
     def to_american_with_utc(self):
         """ Convert the this object to string representation in american with UTC.
@@ -54,7 +54,7 @@ class parsetime(_datetime):  # NOQA
 
         Returns: :py:class`str` object
         """
-        return self.strftime(self._american_with_utc_format)
+        return self.strftime(self.american_with_utc_format)
 
     @classmethod
     def from_iso_with_utc(cls, time_string):
@@ -66,7 +66,7 @@ class parsetime(_datetime):  # NOQA
             time_string: String with time to parse
         Returns: :py:class`utils.timeutil.datetime()` object
         """
-        return cls._parse(cls._iso_with_utc_format, time_string)
+        return cls._parse(cls.iso_with_utc_format, time_string)
 
     def to_iso_with_utc(self):
         """ Convert the this object to string representation in american with UTC.
@@ -75,7 +75,7 @@ class parsetime(_datetime):  # NOQA
 
         Returns: :py:class`str` object
         """
-        return self.strftime(self._iso_with_utc_format)
+        return self.strftime(self.iso_with_utc_format)
 
     @classmethod
     def from_american_minutes(cls, time_string):
@@ -87,7 +87,7 @@ class parsetime(_datetime):  # NOQA
             time_string: String with time to parse
         Returns: :py:class`utils.timeutil.datetime()` object
         """
-        return cls._parse(cls._american_minutes, time_string)
+        return cls._parse(cls.american_minutes, time_string)
 
     def to_american_minutes(self):
         """ Convert the this object to string representation in american with just minutes.
@@ -96,7 +96,7 @@ class parsetime(_datetime):  # NOQA
 
         Returns: :py:class`str` object
         """
-        return self.strftime(self._american_minutes)
+        return self.strftime(self.american_minutes)
 
     @classmethod
     def from_american_minutes_with_utc(cls, time_string):
@@ -108,7 +108,7 @@ class parsetime(_datetime):  # NOQA
             time_string: String with time to parse
         Returns: :py:class`utils.timeutil.datetime()` object
         """
-        return cls._parse(cls._american_minutes_wit_utc, time_string)
+        return cls._parse(cls.american_minutes_wit_utc, time_string)
 
     def to_american_minutes_with_utc(self):
         """ Convert the this object to string representation in american with just minutes.
@@ -117,7 +117,7 @@ class parsetime(_datetime):  # NOQA
 
         Returns: :py:class`str` object
         """
-        return self.strftime(self._american_minutes_wit_utc)
+        return self.strftime(self.american_minutes_wit_utc)
 
     @classmethod
     def from_american_date_only(cls, time_string):
@@ -129,7 +129,7 @@ class parsetime(_datetime):  # NOQA
             time_string: String with time to parse
         Returns: :py:class`utils.timeutil.datetime()` object
         """
-        return cls._parse(cls._american_date_only_format, time_string)
+        return cls._parse(cls.american_date_only_format, time_string)
 
     def to_american_date_only(self):
         """ Convert the this object to string representation in american date only format.
@@ -138,7 +138,7 @@ class parsetime(_datetime):  # NOQA
 
         Returns: :py:class`str` object
         """
-        return self.strftime(self._american_date_only_format)
+        return self.strftime(self.american_date_only_format)
 
     @classmethod
     def from_iso_date(cls, time_string):
@@ -150,7 +150,7 @@ class parsetime(_datetime):  # NOQA
             time_string: String with time to parse
         Returns: :py:class`utils.timeutil.datetime()` object
         """
-        return cls._parse(cls._iso_date_only_format, time_string)
+        return cls._parse(cls.iso_date_only_format, time_string)
 
     def to_iso_date(self):
         """ Convert the this object to string representation in ISO format.
@@ -159,7 +159,7 @@ class parsetime(_datetime):  # NOQA
 
         Returns: :py:class`str` object
         """
-        return self.strftime(self._iso_date_only_format)
+        return self.strftime(self.iso_date_only_format)
 
     @classmethod
     def from_request_format(cls, time_string):
@@ -171,7 +171,7 @@ class parsetime(_datetime):  # NOQA
             time_string: String with time to parse
         Returns: :py:class`utils.timeutil.datetime()` object
         """
-        return cls._parse(cls._request_format, time_string)
+        return cls._parse(cls.request_format, time_string)
 
     def to_request_format(self):
         """ Convert the this object to string representation in http request.
@@ -180,7 +180,7 @@ class parsetime(_datetime):  # NOQA
 
         Returns: :py:class`str` object
         """
-        return self.strftime(self._request_format)
+        return self.strftime(self.request_format)
 
     @classmethod
     def from_long_date_format(cls, time_string):
@@ -192,7 +192,7 @@ class parsetime(_datetime):  # NOQA
                     time_string: String with time to parse
                 Returns: :py:class`utils.timeutil.datetime()` object
                 """
-        return cls._parse(cls._long_date_format, time_string)
+        return cls._parse(cls.long_date_format, time_string)
 
     def to_long_date_format(self):
         """ Convert the this object to string representation in http request.
@@ -201,7 +201,7 @@ class parsetime(_datetime):  # NOQA
 
                 Returns: :py:class`str` object
                 """
-        return self.strftime(self._long_date_format)
+        return self.strftime(self.long_date_format)
 
 
 def nice_seconds(t_s):

--- a/utils/timeutil.py
+++ b/utils/timeutil.py
@@ -18,7 +18,7 @@ class parsetime(_datetime):  # NOQA
     american_with_utc_format = "%m/%d/%y %H:%M:%S UTC"
     iso_with_utc_format = "%Y-%m-%d %H:%M:%S UTC"
     american_minutes = "%m/%d/%y %H:%M"
-    american_minutes_wit_utc = "%m/%d/%y %H:%M UTC"
+    american_minutes_with_utc = "%m/%d/%y %H:%M UTC"
     american_date_only_format = "%m/%d/%y"
     iso_date_only_format = "%Y-%m-%d"
     request_format = "%Y-%m-%d-%H-%M-%S"
@@ -108,7 +108,7 @@ class parsetime(_datetime):  # NOQA
             time_string: String with time to parse
         Returns: :py:class`utils.timeutil.datetime()` object
         """
-        return cls._parse(cls.american_minutes_wit_utc, time_string)
+        return cls._parse(cls.american_minutes_with_utc, time_string)
 
     def to_american_minutes_with_utc(self):
         """ Convert the this object to string representation in american with just minutes.
@@ -117,7 +117,7 @@ class parsetime(_datetime):  # NOQA
 
         Returns: :py:class`str` object
         """
-        return self.strftime(self.american_minutes_wit_utc)
+        return self.strftime(self.american_minutes_with_utc)
 
     @classmethod
     def from_american_date_only(cls, time_string):


### PR DESCRIPTION
Some fairly heavy refactoring of the existing tests to fix some versioning issues, some assertion/verification issues, and to remove a really-bad-idea:tm:  `existing_vm` fixture.

* Make util.timeutil.parsetime format strings public
* Use the public parsetime format strings to define a version-picked class constant `RETIRE_DATE_FMT`
* Modify common.vm.BaseVM.retirement_date to not parse the retirement date in the UI and return as-is so that tests may verify it
* Use the classes's constant in test methods to generate a correctly formatted date for given offset
* Separate methods for verifying retirement state and retirement date
* Add tier marking to test cases

## PRT

Re-running with set_retirement_date unblocked for 5.7.  Last run was successful with an unrelated upstream failure.

{{ pytest: cfme/tests/cloud_infra_common/test_retirement.py cfme/tests/automate/test_common_methods.py --long-running --use-provider rhevm36 }}