### PR TITLE
[1LP][WIP] add 'action_exists' function for usage in REST API tests

### DIFF
--- a/utils/rest.py
+++ b/utils/rest.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""Helper functions for tests using REST API."""
+
+
+def action_exists(collection, name, method='post'):
+    """Check if action is present for given collection/subcollection.
+
+    You can do following:
+
+    .. code-block:: python
+
+        assert action_exists(rest_api.collections.providers[0], 'delete', 'delete')
+
+    """
+    try:
+        collection_actions = collection._actions
+    except AttributeError:
+        return False
+
+    for action in collection_actions:
+        if action['method'] == method and action['name'] == name:
+            return True
+    return False


### PR DESCRIPTION
There's at least one REST API collection where there is an action available, but is not listed in "actions". See https://bugzilla.redhat.com/show_bug.cgi?id=1422596

For REST API tests that are deleting items, I usually test "delete" with both DELETE and POST methods. In case of the bug above, the DELETE action is not listed, but is available, so the test would pass silently. For that reason I want to add this simple function for checking if action is listed in the collection and use it (mainly) in delete tests.

I'm not sure what's the best location for such function, `utils/rest.py` or `rest/utils.py`?