### PR TITLE
[1LP][RFR] fix creating templates in test_rest_templates

### DIFF
--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -411,9 +411,9 @@ def mark_vm_as_template(rest_api, provider, vm_name):
     """
     t_vm = rest_api.collections.vms.get(name=vm_name)
     t_vm.action.stop()
-    provider.mgmt.wait_vm_stopped(vm_name=vm_name, num_sec=600)
+    provider.mgmt.wait_vm_stopped(vm_name=vm_name, num_sec=900)
 
-    provider.mgmt.mark_as_template(vm_name, delete=False)
+    provider.mgmt.mark_as_template(vm_name)
 
     wait_for(
         lambda: rest_api.collections.templates.find_by(name=vm_name).subcount != 0,

--- a/cfme/tests/infrastructure/test_rest_templates.py
+++ b/cfme/tests/infrastructure/test_rest_templates.py
@@ -63,7 +63,7 @@ def test_set_ownership(rest_api, template, from_detail):
 
 
 @pytest.mark.tier(2)
-@pytest.mark.meta(blockers=[BZ(1422807, forced_streams=["5.7", "upstream"])])
+@pytest.mark.meta(blockers=[BZ(1422807, forced_streams=["5.6", "5.7", "upstream"])])
 def test_delete_template_from_detail_post(rest_api, template):
     """Tests deletion of template from detail using POST method.
 

--- a/cfme/tests/infrastructure/test_rest_templates.py
+++ b/cfme/tests/infrastructure/test_rest_templates.py
@@ -6,6 +6,7 @@ from cfme.rest.gen_data import a_provider as _a_provider
 from cfme.rest.gen_data import mark_vm_as_template
 from cfme.rest.gen_data import vm as _vm
 from utils import error
+from utils.blockers import BZ
 
 pytestmark = [pytest.mark.ignore_stream("5.4"), test_requirements.rest]
 
@@ -15,7 +16,7 @@ def a_provider():
     return _a_provider()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def vm(request, a_provider, rest_api_modscope):
     return _vm(request, a_provider, rest_api_modscope)
 
@@ -35,6 +36,11 @@ def template(request, rest_api, a_provider, vm):
 @pytest.mark.tier(3)
 @pytest.mark.parametrize("from_detail", [True, False], ids=["from_detail", "from_collection"])
 def test_set_ownership(rest_api, template, from_detail):
+    """Tests setting of template ownership.
+
+    Metadata:
+        test_flag: rest
+    """
     if "set_ownership" not in rest_api.collections.templates.action.all:
         pytest.skip("set_ownership action for templates is not implemented in this version")
     group = rest_api.collections.groups.get(description='EvmGroup-super_administrator')
@@ -48,6 +54,7 @@ def test_set_ownership(rest_api, template, from_detail):
     else:
         data["href"] = template.href
         rest_api.collections.templates.action.set_ownership(**data)
+    assert rest_api.response.status_code == 200
     template.reload()
     assert hasattr(template, "evm_owner_id")
     assert template.evm_owner_id == user.id
@@ -56,13 +63,43 @@ def test_set_ownership(rest_api, template, from_detail):
 
 
 @pytest.mark.tier(2)
-@pytest.mark.parametrize("multiple", [False, True], ids=["one_request", "multiple_requests"])
-def test_delete_template(rest_api, template, multiple):
-    if multiple:
+@pytest.mark.meta(blockers=[BZ(1422807, forced_streams=["5.7", "upstream"])])
+def test_delete_template_from_detail_POST(rest_api, template):
+    """Tests deletion of template from detail using POST method.
+
+    Metadata:
+        test_flag: rest
+    """
+    template.action.delete(force_method="post")
+    assert rest_api.response.status_code == 200
+    with error.expected("ActiveRecord::RecordNotFound"):
+        template.action.delete(force_method="post")
+    assert rest_api.response.status_code == 404
+
+
+@pytest.mark.tier(2)
+def test_delete_template_from_detail_DELETE(rest_api, template):
+    """Tests deletion of template from detail using DELETE method.
+
+    Metadata:
+        test_flag: rest
+    """
+    template.action.delete(force_method="delete")
+    assert rest_api.response.status_code == 204
+    with error.expected("ActiveRecord::RecordNotFound"):
+        template.action.delete(force_method="delete")
+    assert rest_api.response.status_code == 404
+
+
+@pytest.mark.tier(2)
+def test_delete_template_from_collection(rest_api, template):
+    """Tests deletion of template from collection.
+
+    Metadata:
+        test_flag: rest
+    """
+    rest_api.collections.templates.action.delete(template)
+    assert rest_api.response.status_code == 200
+    with error.expected("ActiveRecord::RecordNotFound"):
         rest_api.collections.templates.action.delete(template)
-        with error.expected("ActiveRecord::RecordNotFound"):
-            rest_api.collections.templates.action.delete(template)
-    else:
-        template.action.delete()
-        with error.expected("ActiveRecord::RecordNotFound"):
-            template.action.delete()
+    assert rest_api.response.status_code == 404

--- a/cfme/tests/infrastructure/test_rest_templates.py
+++ b/cfme/tests/infrastructure/test_rest_templates.py
@@ -64,7 +64,7 @@ def test_set_ownership(rest_api, template, from_detail):
 
 @pytest.mark.tier(2)
 @pytest.mark.meta(blockers=[BZ(1422807, forced_streams=["5.7", "upstream"])])
-def test_delete_template_from_detail_POST(rest_api, template):
+def test_delete_template_from_detail_post(rest_api, template):
     """Tests deletion of template from detail using POST method.
 
     Metadata:
@@ -78,7 +78,7 @@ def test_delete_template_from_detail_POST(rest_api, template):
 
 
 @pytest.mark.tier(2)
-def test_delete_template_from_detail_DELETE(rest_api, template):
+def test_delete_template_from_detail_delete(rest_api, template):
     """Tests deletion of template from detail using DELETE method.
 
     Metadata:


### PR DESCRIPTION
* tests fix:
These tests often failed with errors like
`E           ValueError: No such 'vms' matching query {'name': 'test_rest_vm_CwrY'}!`
The reason is that the `mark_vm_as_template` function tried to preserved the original vm, which doesn't work on some providers and the vm is destroyed.

* "delete" tests expanded to test both POST and DELETE methods
There is a bug that prevents testing of delete with POST. I created two separate tests instead of one with parameters, because this way I'm able to block the test before fixtures are resolved (as opposed to `if BZ(...): pytest.skip(...)` for the affected test variant).

* add http response status checks

**PRT:**
tested on vsphere55 because of timeouts on rhevm36

{{pytest: cfme/tests/infrastructure/test_rest_templates.py -v --use-provider vsphere55}}