### PR TITLE
[RFR] Unexpected Alert Change

### DIFF
--- a/utils/browser.py
+++ b/utils/browser.py
@@ -272,13 +272,8 @@ class BrowserManager(object):
         try:
             self.browser.current_url
         except UnexpectedAlertPresentException:
-            # Try to handle an open alert, restart the browser if possible
-            log.info("browser hangs on alert, dismissing")
-            try:
-                self.browser.switch_to_alert().dismiss()
-            except:
-                log.exception("browser died on alert")
-                return False
+            # We shouldn't think that an Unexpected alert means the browser is dead
+            return True
         except Exception:
             log.exception("browser in unknown state, considering dead")
             return False


### PR DESCRIPTION
* browser _is_alive function was silently killing the alert this left
  some navigations on the wrong page, we shouldn't assume we can just
  close the alert without creating some kind of havoc. Raising a new
  kind of havoc just seems silly, so for now, we just let the original
  havoc wreak.

{{pytest: cfme/tests/infrastructure/test_infra_quota.py --long-running --use-provider complete}}