### PR TITLE
[1LP][RFR]Fix 57z test_provider_discovery

### DIFF
--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -503,6 +503,11 @@ class IPAppliance(object):
                 "Unrecognized managed providers: {}".format(','.join(unrecognized_ems_names)))
         return list(found_cruds)
 
+    @property
+    def managed_provider_names(self):
+        """Returns a list of names for all providers configured on the appliance"""
+        return [ems.name for ems in self._list_ems()]
+
     def check_no_conflicting_providers(self):
         """ Checks that there are no conflicting providers set up on the appliance
 


### PR DESCRIPTION
The provider.exists call was always false because the discovered provider doesn't have a matching name.

Added IPAppliance.managed_provider_names and used it to validate that each discovered provider's IP address was in a managed provider's name.

Tested locally against 5.6.4 and 5.7.1.1