### PR TITLE
[WIPTEST] fix for test_compliance

### DIFF
--- a/cfme/tests/control/test_compliance.py
+++ b/cfme/tests/control/test_compliance.py
@@ -16,6 +16,7 @@ from fixtures.pytest_store import store
 from utils import testgen, version
 from utils.appliance import Appliance, ApplianceException, provision_appliance
 from utils.log import logger
+from utils.providers import setup_a_provider_by_class
 from utils.update import update
 from utils.wait import wait_for
 from urlparse import urlparse
@@ -23,12 +24,18 @@ from cfme import test_requirements
 
 PREFIX = "test_compliance_"
 
+
+@pytest.fixture(scope="module")
+def setup_a_provider():
+    setup_a_provider_by_class(InfraProvider)
+
 pytestmark = [
     # TODO: Problems with fleecing configuration - revisit later
     pytest.mark.ignore_stream("upstream"),
     pytest.mark.meta(server_roles=["+automate", "+smartstate", "+smartproxy"]),
     pytest.mark.uncollectif(lambda provider: provider.type in {"scvmm"}),
     pytest.mark.tier(3),
+    pytest.mark.usefixtures("setup_a_provider"),
     test_requirements.control
 ]
 

--- a/cfme/tests/control/test_compliance.py
+++ b/cfme/tests/control/test_compliance.py
@@ -3,8 +3,6 @@ import diaper
 import fauxfactory
 import pytest
 
-from mgmtsystem import exceptions
-
 from cfme.common.vm import VM
 from cfme.control.explorer.policies import VMCompliancePolicy, HostCompliancePolicy
 from cfme.control.explorer.conditions import VMCondition
@@ -12,14 +10,11 @@ from cfme.control.explorer.policy_profiles import PolicyProfile
 from cfme.infrastructure.provider import InfraProvider
 from cfme.configure.configuration import AnalysisProfile
 from cfme.web_ui import flash, toolbar
-from fixtures.pytest_store import store
 from utils import testgen, version
-from utils.appliance import Appliance, ApplianceException, provision_appliance
 from utils.log import logger
 from utils.providers import setup_a_provider_by_class
 from utils.update import update
 from utils.wait import wait_for
-from urlparse import urlparse
 from cfme import test_requirements
 
 PREFIX = "test_compliance_"

--- a/fixtures/appliance.py
+++ b/fixtures/appliance.py
@@ -18,7 +18,7 @@ from cfme.test_framework.sprout.client import SproutClient
 
 
 @contextmanager
-def temp_appliances(count=1, preconfigured=True, lease_time=180):
+def temp_appliances(count=1, preconfigured=True, provider=None, lease_time=180):
     """ Provisions one or more appliances for testing
 
     Args:
@@ -29,7 +29,7 @@ def temp_appliances(count=1, preconfigured=True, lease_time=180):
     try:
         sprout_client = SproutClient.from_config()
         apps, request_id = sprout_client.provision_appliances(
-            count=count, lease_time=lease_time, preconfigured=preconfigured)
+            count=count, lease_time=lease_time, preconfigured=preconfigured, provider=provider)
         yield apps
     finally:
         sprout_client.destroy_pool(request_id)
@@ -39,6 +39,12 @@ def temp_appliances(count=1, preconfigured=True, lease_time=180):
 @pytest.yield_fixture(scope="module")
 def temp_appliance_preconfig(temp_appliance_preconfig_modscope):
     yield temp_appliance_preconfig_modscope
+
+
+@pytest.yield_fixture(scope="module")
+def temp_appliance_for_cur_provider(provider):
+    with temp_appliances(preconfigured=True, provider=provider.key) as appliances:
+        yield appliances[0]
 
 
 @pytest.yield_fixture(scope="module")


### PR DESCRIPTION
Yaml fix: cfme-qe-yamls/MR\#97
It will probably requre adding a template to new vsphere55.

{{pytest: --use-provider=vsphere55 cfme/tests/control/test_compliance.py}}