### PR TITLE
[1LP][RFR] Widgetastic Elements for Configure.tasks

### DIFF
--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -7,6 +7,7 @@ from widgetastic_patternfly import (Accordion, Input, Button, Dropdown,
 from widgetastic.widget import View, Table, Text
 
 from cfme import BaseLoggedInPage
+from cfme.configure.tasks import TasksView
 from cfme.dashboard import DashboardView
 from cfme.intelligence.rss import RSSView
 from cfme.exceptions import ZoneNotFound, DestinationNotFound
@@ -156,6 +157,7 @@ class Documentation(CFMENavigateStep):
 
 @navigator.register(Server)
 class Tasks(CFMENavigateStep):
+    VIEW = TasksView
     prerequisite = NavigateToSibling('LoggedIn')
 
     def step(self):

--- a/cfme/configure/tasks.py
+++ b/cfme/configure/tasks.py
@@ -2,13 +2,16 @@
 
 """ Module dealing with Configure/Tasks section.
 """
+from functools import partial
 
 from navmazing import NavigateToAttribute
+from widgetastic.widget import View
+from widgetastic_manageiq import BootstrapSelect, Button, CheckboxSelect, Table
+from widgetastic_patternfly import Dropdown, Tab, FlashMessages
 
-from cfme import web_ui as ui
+from cfme import web_ui as ui, BaseLoggedInPage
 import cfme.fixtures.pytest_selenium as sel
-import cfme.web_ui.tabstrip as tabs
-from cfme.web_ui import Form, Region, CheckboxTable, fill, toolbar, match_location
+from cfme.web_ui import Form, Region, CheckboxTable, fill, match_location
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
 from utils.wait import wait_for, TimedOutError
@@ -36,12 +39,17 @@ filter_form = Form(
     ]
 )
 
+table_loc = '//div[@id="records_div"]/table'
+
+match_page = partial(match_location, controller='miq_task')
+
 tasks_table = CheckboxTable(
     table_locator='//div[@id="records_div"]/table[thead]',
     header_checkbox_locator="//div[@id='records_div']//input[@id='masterToggle']"
 )
 
 
+# TODO move these into Task class
 def _filter(
         zone=None,
         user=None,
@@ -88,22 +96,18 @@ def is_cluster_analysis_finished(name, **kwargs):
 
 
 def is_task_finished(tab_destination, task_name, expected_status, clear_tasks_after_success=True):
-    navigate_to(Tasks, tab_destination)
-    el = tasks_table.find_row_by_cells({
-        'task_name': task_name,
-        'state': expected_status
-    })
-    if el is None:
+    view = navigate_to(Tasks, tab_destination)
+    row = view.tabs.tab_destination.table.row(task_name=task_name, state=expected_status)
+    if row is None:
         return False
 
     # throw exception if status is error
-    if 'Error' in sel.get_attribute(sel.element('.//td/img', root=el), 'title'):
+    if 'Error' in row.title:
         raise Exception("Task {} errored".format(task_name))
 
     if clear_tasks_after_success:
         # Remove all finished tasks so they wouldn't poison other tests
-        toolbar.select('Delete Tasks', 'Delete All', invokes_alert=True)
-        sel.handle_alert(cancel=False)
+        view.delete('Delete All', handle_alert=True)
 
     return True
 
@@ -113,7 +117,7 @@ def is_analysis_finished(name, task_type='vm', clear_tasks_after_success=True):
 
     tabs_data = {
         'vm': {
-            'tab': 'AllVMContainerAnalysis',
+            'tab': 'AllTasks',
             'task': '{}',
             'state': 'finished'
         },
@@ -124,13 +128,11 @@ def is_analysis_finished(name, task_type='vm', clear_tasks_after_success=True):
         },
         'datastore': {
             'tab': 'MyOther',
-            'page': 'tasks_my_other_ui',
             'task': 'SmartState Analysis for [{}]',
             'state': "Finished"
         },
         'cluster': {
             'tab': 'MyOther',
-            'page': 'tasks_my_other_ui',
             'task': 'SmartState Analysis for [{}]',
             'state': "Finished"}
     }[task_type]
@@ -147,61 +149,110 @@ def wait_analysis_finished(task_name, task_type, delay=5, timeout='5M'):
              delay=delay, timeout=timeout, fail_func=requests.reload)
 
 
+class TasksView(BaseLoggedInPage):
+    flash = FlashMessages('.//div[starts-with(@id, "flash_text_div")]')
+    # Toolbar
+    delete = Dropdown('Delete Tasks')  # dropdown just has icon, use element title
+    reload = Button(title='Reload the current display')
+
+    @View.nested
+    class tabs(View):  # noqa
+        # Extra Toolbar
+        # Only on 'All' type tabs, but for access it doesn't make sense to access the tab for a
+        # toolbar button
+        cancel = Button(title='Cancel the selected task')
+
+        # Form Buttons
+        apply = Button('Apply')
+        reset = Button('Reset')
+        default = Button('Default')
+
+        # Filters
+        zone = BootstrapSelect(id='chosen_zone')
+        period = BootstrapSelect(id='time_period')
+        user = BootstrapSelect(id='user_choice')
+        # This checkbox search_root captures all the filter options
+        # It will break for status if/when there is second checkbox selection field added
+        # It's the lowest level div with an id that captures the status checkboxes
+        status = CheckboxSelect(search_root='tasks_options_div')
+        state = BootstrapSelect(id='state_choice')
+
+        @View.nested
+        class mytasks(Tab):  # noqa
+            TAB_NAME = "My VM and Container Analysis Tasks"
+            table = Table(table_loc)
+
+        @View.nested
+        class myothertasks(Tab):  # noqa
+            TAB_NAME = "My Other UI Tasks"
+            table = Table(table_loc)
+
+        @View.nested
+        class alltasks(Tab):  # noqa
+            TAB_NAME = "All VM and Container Analysis Tasks"
+            table = Table(table_loc)
+
+        @View.nested
+        class allothertasks(Tab):  # noqa
+            TAB_NAME = "All Other Tasks"
+            table = Table(table_loc)
+
+    @property
+    def is_displayed(self):
+        return (
+            self.tabs.mytasks.is_displayed and
+            self.tabs.myothertasks.is_displayed and
+            self.tabs.alltasks.is_displayed and
+            self.tabs.allothertasks.is_displayed)
+
+
 class Tasks(Navigatable):
     pass
 
 
-@navigator.register(Tasks, 'MyVMContainerAnalysis')
-class MyVMContainerAnalysis(CFMENavigateStep):
+@navigator.register(Tasks, 'MyTasks')
+class MyTasks(CFMENavigateStep):
+    VIEW = TasksView
     prerequisite = NavigateToAttribute('appliance.server', 'Tasks')
 
-    tab_name = 'My VM and Container Analysis Tasks'
-
     def step(self, *args, **kwargs):
-        tabs.select_tab(self.tab_name)
+        self.view.tabs.mytasks.select()
 
     def am_i_here(self):
-        return match_location(controller='miq_task', title='My Tasks') and \
-            tabs.is_tab_selected(self.tab_name)
+        return match_page(title='My Tasks') and self.view.tabs.mytasks.is_active()
 
 
-@navigator.register(Tasks, 'MyOther')
-class MyOther(CFMENavigateStep):
+@navigator.register(Tasks, 'MyOtherTasks')
+class MyOtherTasks(CFMENavigateStep):
+    VIEW = TasksView
     prerequisite = NavigateToAttribute('appliance.server', 'Tasks')
 
-    tab_name = 'My Other UI Tasks'
-
     def step(self, *args, **kwargs):
-        tabs.select_tab(self.tab_name)
+        self.view.tabs.myothertasks.select()
 
     def am_i_here(self):
-        return match_location(controller='miq_task', title='My UI Tasks') and \
-            tabs.is_tab_selected()
+        return match_page(title='My UI Tasks') and self.view.tabs.myothertasks.is_active()
 
 
-@navigator.register(Tasks, 'AllVMContainerAnalysis')
-class AllVMContainerAnalysis(CFMENavigateStep):
+@navigator.register(Tasks, 'AllTasks')
+class AllTasks(CFMENavigateStep):
+    VIEW = TasksView
     prerequisite = NavigateToAttribute('appliance.server', 'Tasks')
 
-    tab_name = "All VM and Container Analysis Tasks"
-
     def step(self, *args, **kwargs):
-        tabs.select_tab(self.tab_name)
+        self.view.tabs.alltasks.select()
 
     def am_i_here(self):
-        return match_location(controller='miq_task', title='All Tasks') and \
-            tabs.is_tab_selected(self.tab_name)
+        return match_page(title='All Tasks') and self.view.tabs.alltasks.is_active()
 
 
-@navigator.register(Tasks, 'AllOther')
-class AllOther(CFMENavigateStep):
+@navigator.register(Tasks, 'AllOtherTasks')
+class AllOtherTasks(CFMENavigateStep):
+    VIEW = TasksView
     prerequisite = NavigateToAttribute('appliance.server', 'Tasks')
 
-    tab_name = 'All Other Tasks'
-
     def step(self, *args, **kwargs):
-        tabs.select_tab(self.tab_name)
+        self.view.tabs.allothertasks.select()
 
     def am_i_here(self):
-        return match_location(controller='miq_task', title='All UI Tasks') and \
-            tabs.is_tab_selected(self.tab_name)
+        return match_page(title='All UI Tasks') and self.view.tabs.allothertasks.is_active()

--- a/cfme/tests/containers/test_containers_smartstate_analysis.py
+++ b/cfme/tests/containers/test_containers_smartstate_analysis.py
@@ -32,9 +32,8 @@ RESULT_DETAIL_FIELDS = {'Packages': lambda val: int(val) > 0,
 
 def delete_all_vm_tasks():
     # delete all tasks
-    navigate_to(Tasks, 'AllVMContainerAnalysis')
-    tb.select('Delete Tasks', 'Delete All', invokes_alert=True)
-    sel.handle_alert()
+    view = navigate_to(Tasks, 'AllTasks')
+    view.delete.item_select('Delete All', handle_alert=True)
 
 
 def check_log(log, verify_tags):

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -16,7 +16,6 @@ import pytest
 from cfme.common.provider import cleanup_vm
 from cfme.common.vm import VM
 from cfme.control.explorer import actions, policies, policy_profiles
-from cfme.configure import tasks
 from cfme.configure.tasks import Tasks
 from cfme.infrastructure import host
 from cfme.services import requests
@@ -661,12 +660,10 @@ def test_action_initiate_smartstate_analysis(
     def is_vm_analysis_finished():
         """ Check if analysis is finished - if not, reload page
         """
-        navigate_to(Tasks, 'AllVMContainerAnalysis')
-        vm_analysis_finished = tasks.tasks_table.find_row_by_cells({
-            'task_name': "Scan from Vm {}".format(vm.name),
-            'state': 'finished'
-        })
-        return vm_analysis_finished is not None
+        view = navigate_to(Tasks, 'AllTasks')
+        vm_analysis_row = view.tabs.alltasks.table.row(task_name="Scan from Vm {}"
+                                                                 .format(vm.name))
+        return vm_analysis_row.state.text == 'Finished'
 
     # Wait for VM analysis to finish
     def wait_analysis_finished():


### PR DESCRIPTION
This is working navigation and widget interaction for the tasks filters on each tab.

I would like to keep the scope of this PR small, and do Collections and moving all of the methods into proper TasksCollection & Tasks classes in another.

## PRT Results

_Can ignore failures_

There is a failure in `test_host_drift_analysis` that occurs at a soft_assert on `test_host.equal_drift_results`.  The fix isn't obvious to me, and after spending a bit of time trying to debug I'm going to leave it off this PR. 3 failures, none to do with tasks widget changes.

The fix for the test failures here are in PR #4265, thanks @niyazRedhat 