### PR TITLE
[1LP][RFR] Revisited test_pull_splitter_persistence

### DIFF
--- a/cfme/infrastructure/datastore.py
+++ b/cfme/infrastructure/datastore.py
@@ -194,8 +194,9 @@ class All(CFMENavigateStep):
             # for existing tests
             pass
         tb.select("Grid View")
-        sel.check(paginator.check_all())
-        sel.uncheck(paginator.check_all())
+        if paginator.page_controls_exist():
+            sel.check(paginator.check_all())
+            sel.uncheck(paginator.check_all())
 
 
 @navigator.register(Datastore, 'Details')

--- a/cfme/infrastructure/networking.py
+++ b/cfme/infrastructure/networking.py
@@ -1,0 +1,21 @@
+from utils.appliance import Navigatable
+from navmazing import NavigateToAttribute
+from utils.appliance.implementations.ui import navigator, CFMENavigateStep
+from cfme.web_ui import toolbar as tb
+
+
+class InfraNetworking(Navigatable):
+    def __init__(self, appliance=None):
+        Navigatable.__init__(self, appliance)
+
+
+@navigator.register(InfraNetworking, 'All')
+class All(CFMENavigateStep):
+    prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
+
+    def step(self):
+        self.prerequisite_view.navigation.select('Compute', 'Infrastructure', 'Networking')
+
+    def resetter(self):
+        # Reset view and selection
+        tb.select("Grid View")

--- a/cfme/optimize/utilization.py
+++ b/cfme/optimize/utilization.py
@@ -1,0 +1,16 @@
+from utils.appliance import Navigatable
+from navmazing import NavigateToAttribute
+from utils.appliance.implementations.ui import navigator, CFMENavigateStep
+
+
+class Utilization(Navigatable):
+    def __init__(self, appliance=None):
+        Navigatable.__init__(self, appliance)
+
+
+@navigator.register(Utilization, 'All')
+class All(CFMENavigateStep):
+    prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
+
+    def step(self):
+        self.prerequisite_view.navigation.select('Optimize', 'Utilization')

--- a/cfme/services/catalogs/service_catalogs.py
+++ b/cfme/services/catalogs/service_catalogs.py
@@ -6,6 +6,7 @@ from utils.update import Updateable
 from utils.pretty import Pretty
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
+from cfme.base import Server
 
 from . import ServicesCatalogView
 
@@ -46,6 +47,17 @@ class ServiceCatalogsView(ServicesCatalogView):
             self.title.text == 'All Services' and
             self.service_catalogs.is_opened and
             self.service_catalogs.tree.currently_selected == ["All Services"])
+
+
+class ServiceCatalogsDefaultView(ServicesCatalogView):
+    title = Text("#explorer_title_text")
+
+    @property
+    def is_displayed(self):
+        return (
+            self.in_explorer and
+            self.title.text == 'All Services' and
+            self.service_catalogs.is_opened)
 
 
 class DetailsServiceCatalogView(ServicesCatalogView):
@@ -91,6 +103,16 @@ class ServiceCatalogs(Updateable, Pretty, Navigatable):
         view.submit_button.click()
         # Request page is displayed after this hence not asserting for view
         view.flash.assert_success_message("Order Request was Submitted")
+
+
+@navigator.register(Server)
+class ServiceCatalogsDefault(CFMENavigateStep):
+    VIEW = ServiceCatalogsDefaultView
+
+    prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
+
+    def step(self):
+        self.prerequisite_view.navigation.select('Services', 'Catalogs')
 
 
 @navigator.register(ServiceCatalogs, 'All')

--- a/cfme/services/workloads.py
+++ b/cfme/services/workloads.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 """ A model of Workloads page in CFME
 """
-from navmazing import NavigateToAttribute
+from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.widget import View, Text
 from widgetastic_manageiq import Accordion, ManageIQTree, Search
 
 from cfme import BaseLoggedInPage
 from utils.appliance import Navigatable
+from cfme.base import Server
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep
 
 
@@ -55,12 +56,22 @@ class WorkloadsVM(WorkloadsView):
     @property
     def is_displayed(self):
         return (
-            super(WorkloadsVM, self).in_workloads and
+            self.in_workloads and
             self.title.text == 'All VMs & Instances' and
             self.vms.is_opened and
             self.vms.tree.currently_selected == [
                 "All VMs & Instances"])
 
+
+class WorkloadsDefaultView(WorkloadsView):
+    title = Text("#explorer_title_text")
+
+    @property
+    def is_displayed(self):
+        return (
+            self.in_workloads and
+            self.title.text == 'All VMs & Instances' and
+            self.vms.is_opened)
 
 class WorkloadsTemplate(WorkloadsView):
     title = Text("#explorer_title_text")
@@ -68,7 +79,7 @@ class WorkloadsTemplate(WorkloadsView):
     @property
     def is_displayed(self):
         return (
-            super(WorkloadsTemplate, self).in_workloads and
+            self.in_workloads and
             self.title.text == 'All Templates & Images' and
             self.templates.is_opened and
             self.templates.tree.currently_selected == [
@@ -92,6 +103,15 @@ class TemplatesImages(Navigatable):
 
     def __init__(self, appliance=None):
         Navigatable.__init__(self, appliance)
+
+
+@navigator.register(Server)
+class WorkloadsDefault(CFMENavigateStep):
+    VIEW = WorkloadsDefaultView
+    prerequisite = NavigateToSibling("LoggedIn")
+
+    def step(self):
+        self.view.navigation.select("Services", "Workloads")
 
 
 @navigator.register(VmsInstances, 'All')

--- a/cfme/tests/webui/test_splitter.py
+++ b/cfme/tests/webui/test_splitter.py
@@ -1,11 +1,10 @@
 import pytest
 from xml.sax.saxutils import quoteattr, unescape
 
+from cfme.control import explorer  # noqa
 from cfme.exceptions import CannotScrollException
 from cfme.base.ui import Server
-from cfme import automate  # noqa
 from cfme.cloud.instance import Instance
-from cfme.control.explorer import ControlExplorer  # noqa
 from cfme.infrastructure.config_management import ConfigManager
 from cfme.infrastructure.datastore import Datastore
 from cfme.infrastructure.pxe import ISODatastore
@@ -14,7 +13,10 @@ from cfme.intelligence.chargeback import ComputeRate
 from cfme.intelligence.reports.reports import CustomReport
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
 from cfme.services.myservice import MyService
-from cfme.services.workloads import VmsInstances, TemplatesImages
+from cfme.services import workloads  # noqa
+from cfme.optimize.utilization import Utilization
+from cfme.optimize.bottlenecks import Bottlenecks
+from cfme.infrastructure.networking import InfraNetworking
 from cfme.web_ui.splitter import pull_splitter_left, pull_splitter_right
 from utils import version
 from utils.appliance import current_appliance
@@ -22,13 +24,11 @@ from utils.appliance.implementations.ui import navigate_to
 from utils.blockers import BZ
 
 LOCATIONS = [
-    # Bottlenecks missing
-    # infra_networking missing
     (Server, 'ControlExplorer'), (Server, 'AutomateExplorer'), (Server, 'AutomateCustomization'),
-    (MyService, 'All'), (ServiceCatalogs, 'All'), (CustomReport, 'All'), (ComputeRate, 'All'),
-    (Instance, 'All'), (Vm, 'VMsOnly'), (ISODatastore, 'All'), (Server, 'Configuration'),
-    (Datastore, 'All'), (ConfigManager, 'All'), (Server, 'Utilization'), (VmsInstances, 'All'),
-    (TemplatesImages, 'All')
+    (MyService, 'All'), (ServiceCatalogs, 'All'), (Server, 'WorkloadsDefault'),
+    (CustomReport, 'All'), (ComputeRate, 'All'), (Instance, 'All'), (Vm, 'VMsOnly'),
+    (ISODatastore, 'All'), (Server, 'Configuration'), (Datastore, 'All'), (ConfigManager, 'All'),
+    (Utilization, 'All'), (InfraNetworking, 'All'), (Bottlenecks, 'All')
 ]
 
 
@@ -37,13 +37,15 @@ pytestmark = [
         "location", LOCATIONS, ids=[
             "{}-{}".format(loc[0].__name__, loc[1]) for loc in LOCATIONS]
     ),
-    pytest.mark.uncollectif(lambda
-        location: location == "infrastructure_networking" and version.current_version() < '5.7')]
+    pytest.mark.uncollectif(lambda location: location[0] == InfraNetworking and
+        version.current_version() < '5.7')
+]
 
 
 @pytest.mark.meta(
     blockers=[
-        BZ('1380443', unblock=lambda location: location != "bottlenecks")  # Leaving this for later
+        BZ(1380443, forced_streams=['5.6', '5.7', '5.8'], unblock=lambda location: location[0] !=
+            Bottlenecks)
     ]
 )
 @pytest.mark.requirement('general_ui')

--- a/cfme/tests/webui/test_splitter.py
+++ b/cfme/tests/webui/test_splitter.py
@@ -11,9 +11,10 @@ from cfme.infrastructure.pxe import ISODatastore
 from cfme.infrastructure.virtual_machines import Vm
 from cfme.intelligence.chargeback import ComputeRate
 from cfme.intelligence.reports.reports import CustomReport
-from cfme.services.catalogs.service_catalogs import ServiceCatalogs
+from cfme.services.catalogs import service_catalogs # noqa
 from cfme.services.myservice import MyService
 from cfme.services import workloads  # noqa
+from cfme.automate import explorer # noqa
 from cfme.optimize.utilization import Utilization
 from cfme.optimize.bottlenecks import Bottlenecks
 from cfme.infrastructure.networking import InfraNetworking
@@ -25,7 +26,7 @@ from utils.blockers import BZ
 
 LOCATIONS = [
     (Server, 'ControlExplorer'), (Server, 'AutomateExplorer'), (Server, 'AutomateCustomization'),
-    (MyService, 'All'), (ServiceCatalogs, 'All'), (Server, 'WorkloadsDefault'),
+    (MyService, 'All'), (Server, 'ServiceCatalogsDefault'), (Server, 'WorkloadsDefault'),
     (CustomReport, 'All'), (ComputeRate, 'All'), (Instance, 'All'), (Vm, 'VMsOnly'),
     (ISODatastore, 'All'), (Server, 'Configuration'), (Datastore, 'All'), (ConfigManager, 'All'),
     (Utilization, 'All'), (InfraNetworking, 'All'), (Bottlenecks, 'All')


### PR DESCRIPTION
Added Utilization, InfraNetworking navigate_to.
Fixed uncollectif and blockers for test_pull_splitter_persistence
Added parametrized Bottlenecks, Utilization, InfraNetworking and deleted TemplatesImages.
Fixed Datastore navigate_to when there are no items in datastore and paginator is hidden.