### PR TITLE
[RFR] refactoring; check response status code for test_tag

### DIFF
--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -84,11 +84,12 @@ def categories(request, rest_api, num=1):
 def tags(request, rest_api, categories):
     # Category id, href or name needs to be specified for creating a new tag resource
     tags = []
-    for ctg in categories:
+    for i, ctg in enumerate(categories):
+        refs = [{'id': ctg.id}, {'href': ctg.href}, {'name': ctg.name}]
         data = {
             'name': 'test_tag_{}'.format(fauxfactory.gen_alphanumeric().lower()),
             'description': 'test_tag_{}'.format(fauxfactory.gen_alphanumeric().lower()),
-            'category': {'href': ctg.href}
+            'category': refs[i % 3]
         }
         tags.append(data)
     tags = rest_api.collections.tags.action.create(*tags)

--- a/cfme/tests/configure/test_tag.py
+++ b/cfme/tests/configure/test_tag.py
@@ -169,8 +169,7 @@ class TestTagsViaREST(object):
             "name": "test_tag_{}".format(fauxfactory.gen_alphanumeric().lower()),
             "description": "test_tag_{}".format(fauxfactory.gen_alphanumeric().lower())
         }
-        with error.expected("Api::BadRequestError: "
-                "Category id, href or name needs to be specified"):
+        with error.expected("BadRequestError: Category id, href or name needs to be specified"):
             rest_api.collections.tags.action.create(data)
         assert rest_api.response.status_code == 400
 

--- a/cfme/tests/configure/test_tag.py
+++ b/cfme/tests/configure/test_tag.py
@@ -2,8 +2,6 @@
 import fauxfactory
 import pytest
 
-from manageiq_client.api import APIException
-
 from cfme.configure.configuration import Category, Tag
 from cfme.rest.gen_data import a_provider as _a_provider
 from cfme.rest.gen_data import categories as _categories
@@ -14,10 +12,9 @@ from cfme.rest.gen_data import service_templates as _service_templates
 from cfme.rest.gen_data import tenants as _tenants
 from cfme.rest.gen_data import tags as _tags
 from cfme.rest.gen_data import vm as _vm
-from utils.blockers import BZ
 from utils.update import update
 from utils.wait import wait_for
-from utils import error, version
+from utils import error
 
 
 @pytest.yield_fixture
@@ -41,9 +38,7 @@ def test_tag_crud(category):
     tag.delete(cancel=False)
 
 
-@pytest.mark.uncollectif(lambda: version.current_version() < '5.5')
 class TestTagsViaREST(object):
-
     @pytest.fixture(scope="function")
     def categories(self, request, rest_api, num=3):
         return _categories(request, rest_api, num)
@@ -93,17 +88,23 @@ class TestTagsViaREST(object):
 
     @pytest.mark.tier(2)
     def test_edit_tags(self, rest_api, tags):
+        """Tests tags editing from collection.
+
+        Metadata:
+            test_flag: rest
+        """
         new_names = []
         tags_data_edited = []
         for tag in tags:
-            new_name = fauxfactory.gen_alphanumeric().lower()
+            new_name = "test_tag_{}".format(fauxfactory.gen_alphanumeric().lower())
             new_names.append(new_name)
             tag.reload()
             tags_data_edited.append({
                 "href": tag.href,
-                "name": "test_tag_{}".format(new_name),
+                "name": new_name,
             })
         rest_api.collections.tags.action.edit(*tags_data_edited)
+        assert rest_api.response.status_code == 200
         for new_name in new_names:
             wait_for(
                 lambda: rest_api.collections.tags.find_by(name=new_name),
@@ -113,9 +114,15 @@ class TestTagsViaREST(object):
 
     @pytest.mark.tier(2)
     def test_edit_tag(self, rest_api, tags):
+        """Tests tag editing from detail.
+
+        Metadata:
+            test_flag: rest
+        """
         tag = rest_api.collections.tags.get(name=tags[0].name)
         new_name = 'test_tag_{}'.format(fauxfactory.gen_alphanumeric())
         tag.action.edit(name=new_name)
+        assert rest_api.response.status_code == 200
         wait_for(
             lambda: rest_api.collections.tags.find_by(name=new_name),
             num_sec=180,
@@ -123,47 +130,72 @@ class TestTagsViaREST(object):
         )
 
     @pytest.mark.tier(3)
-    @pytest.mark.meta(blockers=[BZ(1290783, forced_streams=["5.5"])])
-    @pytest.mark.parametrize(
-        "multiple", [False, True],
-        ids=["one_request", "multiple_requests"])
-    def test_delete_tags(self, rest_api, tags, multiple):
-        if multiple:
+    @pytest.mark.parametrize("method", ["post", "delete"], ids=["POST", "DELETE"])
+    def test_delete_tags_from_detail(self, rest_api, tags, method):
+        """Tests deleting tags from detail.
+
+        Metadata:
+            test_flag: rest
+        """
+        status = 204 if method == "delete" else 200
+        for tag in tags:
+            tag.action.delete(force_method=method)
+            assert rest_api.response.status_code == status
+            with error.expected("ActiveRecord::RecordNotFound"):
+                tag.action.delete(force_method=method)
+            assert rest_api.response.status_code == 404
+
+    @pytest.mark.tier(3)
+    def test_delete_tags_from_collection(self, rest_api, tags):
+        """Tests deleting tags from collection.
+
+        Metadata:
+            test_flag: rest
+        """
+        rest_api.collections.tags.action.delete(*tags)
+        assert rest_api.response.status_code == 200
+        with error.expected("ActiveRecord::RecordNotFound"):
             rest_api.collections.tags.action.delete(*tags)
-            with error.expected("ActiveRecord::RecordNotFound"):
-                rest_api.collections.tags.action.delete(*tags)
-        else:
-            tag = tags[0]
-            tag.action.delete()
-            with error.expected("ActiveRecord::RecordNotFound"):
-                tag.action.delete()
+        assert rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
     def test_create_tag_with_wrong_arguments(self, rest_api):
+        """Tests creating tags with missing category "id", "href" or "name".
+
+        Metadata:
+            test_flag: rest
+        """
         data = {
-            'name': 'test_tag_{}'.format(fauxfactory.gen_alphanumeric().lower()),
-            'description': 'test_tag_{}'.format(fauxfactory.gen_alphanumeric().lower())
+            "name": "test_tag_{}".format(fauxfactory.gen_alphanumeric().lower()),
+            "description": "test_tag_{}".format(fauxfactory.gen_alphanumeric().lower())
         }
-        try:
+        with error.expected("Api::BadRequestError: "
+                "Category id, href or name needs to be specified"):
             rest_api.collections.tags.action.create(data)
-        except APIException as e:
-            assert "Category id, href or name needs to be specified" in e.args[0]
+        assert rest_api.response.status_code == 400
 
     @pytest.mark.tier(3)
     @pytest.mark.parametrize(
-        "collection_name", ['clusters', 'hosts', 'data_stores', 'providers', 'resource_pools',
-        'services', 'service_templates', 'tenants', 'vms'])
+        "collection_name", ["clusters", "hosts", "data_stores", "providers", "resource_pools",
+        "services", "service_templates", "tenants", "vms"])
     def test_assign_and_unassign_tag(self, rest_api, tags_mod, a_provider, services,
             service_templates, tenants, vm, collection_name):
-        col = getattr(rest_api.collections, collection_name)
-        col.reload()
-        if len(col.all) == 0:
+        """Tests assigning and unassigning tags.
+
+        Metadata:
+            test_flag: rest
+        """
+        collection = getattr(rest_api.collections, collection_name)
+        collection.reload()
+        if len(collection.all) == 0:
             pytest.skip("No available entity in {} to assign tag".format(collection_name))
-        collection = col[-1]
+        entity = collection[-1]
         tag = tags_mod[0]
-        collection.tags.action.assign(tag)
-        collection.reload()
-        assert tag.id in [t.id for t in collection.tags.all]
-        collection.tags.action.unassign(tag)
-        collection.reload()
-        assert tag.id not in [t.id for t in collection.tags.all]
+        entity.tags.action.assign(tag)
+        assert rest_api.response.status_code == 200
+        entity.reload()
+        assert tag.id in [t.id for t in entity.tags.all]
+        entity.tags.action.unassign(tag)
+        assert rest_api.response.status_code == 200
+        entity.reload()
+        assert tag.id not in [t.id for t in entity.tags.all]


### PR DESCRIPTION
* check HTTP response status code
* refactoring
* test also DELETE method
* reference categories with all supported means (id, href, name)
* add metadata where missing

{{pytest: cfme/tests/configure/test_tag.py -v -k TestTagsViaREST --use-provider rhevm36}}