### PR TITLE
[1LP][RFR] Provider setup consolidation

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -590,7 +590,6 @@ def get_paginator_value():
 class CloudInfraProvider(BaseProvider, PolicyProfileAssignable):
     vm_name = ""
     template_name = ""
-    category = "core"
     detail_page_suffix = 'provider'
     edit_page_suffix = 'provider_edit'
     refresh_text = "Refresh Relationships and Power States"

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -45,6 +45,13 @@ def provider_types(category):
     }
 
 
+def all_types():
+    all_types = base_types()
+    for category in all_types.keys():
+        all_types.update(provider_types(category))
+    return all_types
+
+
 class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
     # List of constants that every non-abstract subclass must have defined
     STATS_TO_MATCH = []
@@ -583,6 +590,7 @@ def get_paginator_value():
 class CloudInfraProvider(BaseProvider, PolicyProfileAssignable):
     vm_name = ""
     template_name = ""
+    category = "core"
     detail_page_suffix = 'provider'
     edit_page_suffix = 'provider_edit'
     refresh_text = "Refresh Relationships and Power States"

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -265,6 +265,13 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
                 'Delete initiated for 1 {} Provider from the {} Database'.format(
                     self.string_name, self.appliance.product_name))
 
+    def setup(self):
+        """
+        Sets up the provider robustly
+        """
+        return self.create(
+            cancel=False, validate_credentials=True, check_existing=True, validate_inventory=True)
+
     def delete_if_exists(self, *args, **kwargs):
         """Combines ``.exists`` and ``.delete()`` as a shortcut for ``request.addfinalizer``
 

--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -7,7 +7,7 @@ from cfme.infrastructure.provider import InfraProvider
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
 from cfme.services import requests
-from utils.providers import setup_a_provider_by_class
+from fixture.provider import setup_one_by_class_or_skip
 from utils.virtual_machines import deploy_template
 from utils.wait import wait_for
 from utils.log import logger
@@ -179,7 +179,7 @@ def rates(request, rest_api, num=3):
 
 
 def a_provider():
-    return setup_a_provider_by_class(InfraProvider)
+    return setup_one_by_class_or_skip(InfraProvider)
 
 
 def vm(request, a_provider, rest_api):

--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -178,8 +178,8 @@ def rates(request, rest_api, num=3):
     return _creating_skeleton(request, rest_api, 'rates', data)
 
 
-def a_provider():
-    return setup_one_by_class_or_skip(InfraProvider)
+def a_provider(request):
+    return setup_one_by_class_or_skip(request, InfraProvider)
 
 
 def vm(request, a_provider, rest_api):

--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -7,7 +7,7 @@ from cfme.infrastructure.provider import InfraProvider
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
 from cfme.services import requests
-from fixture.provider import setup_one_by_class_or_skip
+from fixtures.provider import setup_one_by_class_or_skip
 from utils.virtual_machines import deploy_template
 from utils.wait import wait_for
 from utils.log import logger

--- a/cfme/tests/cloud/test_keypairs.py
+++ b/cfme/tests/cloud/test_keypairs.py
@@ -2,18 +2,12 @@ import fauxfactory
 import pytest
 from cfme.cloud.keypairs import KeyPair
 from cfme.cloud.provider.openstack import OpenStackProvider
-from fixtures.provider import setup_one_by_class_or_skip
 from utils import testgen
 from utils.version import current_version
 
 pytestmark = [
     pytest.mark.uncollectif(lambda: current_version() > '5.7')
 ]
-
-
-@pytest.fixture(scope="module")
-def rhos_provider(request):
-    return setup_one_by_class_or_skip(request, OpenStackProvider)
 
 
 def pytest_generate_tests(metafunc):

--- a/cfme/tests/cloud/test_keypairs.py
+++ b/cfme/tests/cloud/test_keypairs.py
@@ -17,7 +17,7 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.mark.tier(3)
-def test_keypair_crud(rhos_provider):
+def test_keypair_crud(openstack_provider):
     """ This will test whether it will create new Keypair and then deletes it.
 
     Prerequisites:
@@ -28,6 +28,6 @@ def test_keypair_crud(rhos_provider):
         * Select Cloud Provider.
         * Also delete it.
     """
-    keypair = KeyPair(name=fauxfactory.gen_alphanumeric(), provider=rhos_provider)
+    keypair = KeyPair(name=fauxfactory.gen_alphanumeric(), provider=openstack_provider)
     keypair.create()
     keypair.delete()

--- a/cfme/tests/cloud/test_keypairs.py
+++ b/cfme/tests/cloud/test_keypairs.py
@@ -2,9 +2,9 @@ import fauxfactory
 import pytest
 from cfme.cloud.keypairs import KeyPair
 from cfme.cloud.provider.openstack import OpenStackProvider
+from fixtures.provider import setup_one_by_class_or_skip
 from utils import testgen
 from utils.version import current_version
-from utils.providers import setup_a_provider_by_class
 
 pytestmark = [
     pytest.mark.uncollectif(lambda: current_version() > '5.7')
@@ -12,8 +12,8 @@ pytestmark = [
 
 
 @pytest.fixture(scope="module")
-def a_provider():
-    return setup_a_provider_by_class(OpenStackProvider)
+def rhos_provider(request):
+    return setup_one_by_class_or_skip(request, OpenStackProvider)
 
 
 def pytest_generate_tests(metafunc):
@@ -23,7 +23,7 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.mark.tier(3)
-def test_keypair_crud(a_provider):
+def test_keypair_crud(rhos_provider):
     """ This will test whether it will create new Keypair and then deletes it.
 
     Prerequisites:
@@ -34,6 +34,6 @@ def test_keypair_crud(a_provider):
         * Select Cloud Provider.
         * Also delete it.
     """
-    keypair = KeyPair(name=fauxfactory.gen_alphanumeric(), provider=a_provider)
+    keypair = KeyPair(name=fauxfactory.gen_alphanumeric(), provider=rhos_provider)
     keypair.create()
     keypair.delete()

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -261,11 +261,11 @@ def test_password_max_character_validation():
 @pytest.mark.tier(3)
 @test_requirements.discovery
 def test_name_max_character_validation(request, cloud_provider):
-    """Test to validate max character for name field"""
+    """Test to validate that provider can have up to 255 characters in name"""
     request.addfinalizer(lambda: cloud_provider.delete_if_exists(cancel=False))
     name = fauxfactory.gen_alphanumeric(255)
-    cloud_provider.update({'name': name})
-    cloud_provider.name = name
+    with update(cloud_provider):
+        cloud_provider.name = name
     assert cloud_provider.exists
 
 

--- a/cfme/tests/cloud_infra_common/test_tag_objects.py
+++ b/cfme/tests/cloud_infra_common/test_tag_objects.py
@@ -14,14 +14,12 @@ from cfme.infrastructure.host import Host
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.virtual_machines import Vm, Template
 from cfme.web_ui import Quadicon, mixins, toolbar as tb
-from utils import providers
 from utils.appliance.implementations.ui import navigate_to
 
 
 @pytest.fixture(scope="module")
-def setup_first_provider():
-    providers.setup_a_provider_by_class(InfraProvider)
-    providers.setup_a_provider_by_class(CloudProvider)
+def cloud_and_infra_provider(cloud_provider, infra_provider):
+    pass
 
 
 param_classes = {
@@ -41,7 +39,7 @@ param_classes = {
 
 pytestmark = [
     pytest.mark.parametrize("location", param_classes),
-    pytest.mark.usefixtures("setup_first_provider"),
+    pytest.mark.usefixtures("cloud_and_infra_provider"),
     pytest.mark.tier(3)
 ]
 

--- a/cfme/tests/cloud_infra_common/test_tag_objects.py
+++ b/cfme/tests/cloud_infra_common/test_tag_objects.py
@@ -97,18 +97,18 @@ def _tag_item_through_details(request, location, tag):
 @pytest.mark.usefixtures('has_no_providers', scope='class')
 class TestCloudTagVisibility():
 
-    def test_cloud_tag_item_through_selecting(request, cloud_provider, location, tag):
+    def test_cloud_tag_item_through_selecting(self, request, cloud_provider, location, tag):
         _tag_item_through_selecting(request, location, tag)
 
-    def test_cloud_tag_item_through_details(request, cloud_provider, location, tag):
+    def test_cloud_tag_item_through_details(self, request, cloud_provider, location, tag):
         _tag_item_through_details(request, location, tag)
 
 
 @pytest.mark.usefixtures('has_no_providers', scope='class')
 class TestInfraTagVisibility():
 
-    def test_infra_tag_item_through_selecting(request, infra_provider, location, tag):
+    def test_infra_tag_item_through_selecting(self, request, infra_provider, location, tag):
         _tag_item_through_selecting(request, location, tag)
 
-    def test_infra_tag_item_through_details(request, infra_provider, location, tag):
+    def test_infra_tag_item_through_details(self, request, infra_provider, location, tag):
         _tag_item_through_details(request, location, tag)

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -12,7 +12,6 @@ from cfme.automate import AutomateExplorer # NOQA
 from cfme.base import Server
 from cfme.configure.access_control import set_group_order
 from cfme.control.explorer import ControlExplorer # NOQA
-from cfme.infrastructure.provider import InfraProvider
 from cfme.exceptions import OptionNotAvailable
 from cfme.common.provider import base_types
 from cfme.infrastructure import virtual_machines as vms
@@ -22,7 +21,6 @@ from cfme.configure import tasks
 from utils.appliance.implementations.ui import navigate_to
 from utils.blockers import BZ
 from utils.log import logger
-from utils.providers import setup_a_provider_by_class
 from utils.update import update
 from utils import version
 
@@ -32,15 +30,10 @@ usergrp = Group(description='EvmGroup-user')
 group_table = Table("//div[@id='main_div']//table")
 
 
-@pytest.fixture(scope="module")
-def setup_first_provider():
-    setup_a_provider_by_class(InfraProvider)
-
-
 # due to pytest.mark.meta(blockers=[1035399]), non admin users can't login
 # with no providers added
 pytestmark = [test_requirements.rbac,
-              pytest.mark.usefixtures("setup_first_provider")]
+              pytest.mark.usefixtures("infra_provider")]
 
 
 def new_credential():
@@ -604,7 +597,7 @@ def test_permissions_vm_provisioning():
 #    # Ensure VMs exist
 #    if not vms.get_number_of_vms():
 #        logger.debug("Setting up providers")
-#        setup_first_provider()
+#        infra_provider()
 #        logger.debug("Providers setup")
 #    single_task_permission_test(
 #        [

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -597,7 +597,7 @@ def test_permissions_vm_provisioning():
 #    # Ensure VMs exist
 #    if not vms.get_number_of_vms():
 #        logger.debug("Setting up providers")
-#        infra_provider()
+#        infra_provider
 #        logger.debug("Providers setup")
 #    single_task_permission_test(
 #        [

--- a/cfme/tests/configure/test_default_filters.py
+++ b/cfme/tests/configure/test_default_filters.py
@@ -4,9 +4,7 @@ import pytest
 from cfme import test_requirements
 from cfme.configure import settings as st
 from cfme.fixtures import pytest_selenium as sel
-from cfme.infrastructure.provider import InfraProvider
 from utils.blockers import BZ
-from utils.providers import setup_a_provider_by_class
 from cfme.cloud.instance.image import Image
 from cfme.cloud.instance import Instance
 from cfme.infrastructure import virtual_machines as vms
@@ -15,15 +13,11 @@ from utils.appliance.implementations.ui import navigate_to
 from cfme.infrastructure.host import Host
 
 pytestmark = [pytest.mark.tier(3),
-              test_requirements.settings]
+              test_requirements.settings,
+              pytest.mark.use_fixtures("infra_provider")]
 
 
-@pytest.fixture(scope="module")
-def setup_first_provider():
-    setup_a_provider_by_class(InfraProvider)
-
-
-def test_cloudimage_defaultfilters(setup_first_provider):
+def test_cloudimage_defaultfilters():
     filters = [['Cloud', 'Instances', 'Images', 'Platform / Amazon']]
     df = st.DefaultFilter(name='Platform / Amazon')
     df.update({'filters': [(k, True) for k in filters]})
@@ -31,7 +25,7 @@ def test_cloudimage_defaultfilters(setup_first_provider):
     assert sel.is_displayed_text(df.name), "Default Filter settings Failed!"
 
 
-def test_cloudinstance_defaultfilters(setup_first_provider):
+def test_cloudinstance_defaultfilters():
     filters = [['Cloud', 'Instances', 'Instances', 'Platform / Openstack']]
     df = st.DefaultFilter(name='Platform / Openstack')
     df.update({'filters': [(k, True) for k in filters]})
@@ -39,7 +33,7 @@ def test_cloudinstance_defaultfilters(setup_first_provider):
     assert sel.is_displayed_text(df.name), "Default Filter settings Failed!"
 
 
-def test_infrastructurehost_defaultfilters(setup_first_provider):
+def test_infrastructurehost_defaultfilters():
     filters = [['Infrastructure', 'Hosts', 'Platform / HyperV']]
     df = st.DefaultFilter(name='Platform / HyperV')
     df.update({'filters': [(k, True) for k in filters]})
@@ -47,7 +41,7 @@ def test_infrastructurehost_defaultfilters(setup_first_provider):
     assert sel.is_displayed_text(df.name), "Default Filter settings Failed!"
 
 
-def test_infrastructurevms_defaultfilters(setup_first_provider):
+def test_infrastructurevms_defaultfilters():
     filters = [['Infrastructure', 'Virtual Machines', 'VMs', 'Platform / VMware']]
     df = st.DefaultFilter(name='Platform / VMware')
     df.update({'filters': [(k, True) for k in filters]})
@@ -55,7 +49,7 @@ def test_infrastructurevms_defaultfilters(setup_first_provider):
     assert sel.is_displayed_text(df.name), "Default Filter settings Failed!"
 
 
-def test_infrastructuretemplates_defaultfilters(setup_first_provider):
+def test_infrastructuretemplates_defaultfilters():
     filters = [['Infrastructure', 'Virtual Machines', 'Templates', 'Platform / Redhat']]
     df = st.DefaultFilter(name='Platform / Redhat')
     df.update({'filters': [(k, True) for k in filters]})
@@ -64,7 +58,7 @@ def test_infrastructuretemplates_defaultfilters(setup_first_provider):
 
 
 @pytest.mark.meta(blockers=[BZ(1290300, forced_streams=["upstream"])])
-def test_servicetemplateandimages_defaultfilters(setup_first_provider):
+def test_servicetemplateandimages_defaultfilters():
     filters = [['Services', 'Workloads', 'Templates & Images', 'Platform / Microsoft']]
     df = st.DefaultFilter(name='Platform / Microsoft')
     df.update({'filters': [(k, True) for k in filters]})
@@ -76,7 +70,7 @@ def test_servicetemplateandimages_defaultfilters(setup_first_provider):
         df.update({'filters': [(k, False) for k in filters]})
 
 
-def test_servicevmsandinstances_defaultfilters(setup_first_provider):
+def test_servicevmsandinstances_defaultfilters():
     filters = [['Services', 'Workloads', 'VMs & Instances', 'Platform / Openstack']]
     df = st.DefaultFilter(name='Platform / Openstack')
     df.update({'filters': [(k, True) for k in filters]})

--- a/cfme/tests/configure/test_default_filters.py
+++ b/cfme/tests/configure/test_default_filters.py
@@ -14,7 +14,7 @@ from cfme.infrastructure.host import Host
 
 pytestmark = [pytest.mark.tier(3),
               test_requirements.settings,
-              pytest.mark.use_fixtures("infra_provider")]
+              pytest.mark.usefixtures("infra_provider")]
 
 
 def test_cloudimage_defaultfilters():

--- a/cfme/tests/configure/test_default_views_cloud.py
+++ b/cfme/tests/configure/test_default_views_cloud.py
@@ -10,12 +10,12 @@ from cfme.cloud.instance import Instance
 from cfme.cloud.instance.image import Image
 from cfme.configure.settings import DefaultView
 from cfme.web_ui import Quadicon, fill, toolbar as tb
+from fixtures.provider import setup_one_by_class_or_skip
 from utils.appliance.implementations.ui import navigate_to
-from utils.providers import setup_a_provider_by_class
 
 pytestmark = [pytest.mark.tier(3),
               test_requirements.settings,
-              pytest.mark.usefixtures('setup_a_provider')]
+              pytest.mark.usefixtures('rhos_provider')]
 
 gtl_params = {
     'Cloud Providers': CloudProvider,
@@ -28,8 +28,8 @@ gtl_params = {
 
 # TODO refactor for setup_provider parametrization with new 'latest' tag
 @pytest.fixture(scope="module")
-def setup_a_provider():
-    setup_a_provider_by_class(OpenStackProvider)
+def rhos_provider():
+    setup_one_by_class_or_skip(OpenStackProvider)
 
 
 def select_two_quads():

--- a/cfme/tests/configure/test_default_views_cloud.py
+++ b/cfme/tests/configure/test_default_views_cloud.py
@@ -3,14 +3,12 @@ import pytest
 
 from cfme import test_requirements
 from cfme.cloud.provider import CloudProvider
-from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.cloud.availability_zone import AvailabilityZone
 from cfme.cloud.flavor import Flavor
 from cfme.cloud.instance import Instance
 from cfme.cloud.instance.image import Image
 from cfme.configure.settings import DefaultView
 from cfme.web_ui import Quadicon, fill, toolbar as tb
-from fixtures.provider import setup_one_by_class_or_skip
 from utils.appliance.implementations.ui import navigate_to
 
 pytestmark = [pytest.mark.tier(3),
@@ -27,9 +25,6 @@ gtl_params = {
 
 
 # TODO refactor for setup_provider parametrization with new 'latest' tag
-@pytest.fixture(scope="module")
-def rhos_provider():
-    setup_one_by_class_or_skip(OpenStackProvider)
 
 
 def select_two_quads():

--- a/cfme/tests/configure/test_default_views_cloud.py
+++ b/cfme/tests/configure/test_default_views_cloud.py
@@ -13,7 +13,7 @@ from utils.appliance.implementations.ui import navigate_to
 
 pytestmark = [pytest.mark.tier(3),
               test_requirements.settings,
-              pytest.mark.usefixtures('rhos_provider')]
+              pytest.mark.usefixtures('openstack_provider')]
 
 gtl_params = {
     'Cloud Providers': CloudProvider,

--- a/cfme/tests/configure/test_default_views_infra.py
+++ b/cfme/tests/configure/test_default_views_infra.py
@@ -4,27 +4,20 @@ import pytest
 from cfme import test_requirements
 from cfme.configure.settings import DefaultView
 from cfme.infrastructure.provider import InfraProvider
-from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.infrastructure.virtual_machines import Vm
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.myservice import MyService
 from cfme.services.workloads import VmsInstances, TemplatesImages
 from cfme.web_ui import Quadicon, fill, toolbar as tb
 from utils.appliance.implementations.ui import navigate_to
-from utils.providers import setup_a_provider_by_class
 
 
 pytestmark = [pytest.mark.tier(3),
               test_requirements.settings,
-              pytest.mark.usefixtures('setup_a_provider')]
+              pytest.mark.usefixtures('vmware_provider')]
 
 
 # TODO refactor for setup_provider parametrization with new 'latest' tag
-@pytest.fixture(scope="module")
-def setup_a_provider():
-    setup_a_provider_by_class(VMwareProvider)
-
-
 # TODO: infrastructure hosts, pools, stores, clusters are removed
 # due to navmazing. all items have to be put back once navigation change is fully done
 

--- a/cfme/tests/configure/test_default_views_infra.py
+++ b/cfme/tests/configure/test_default_views_infra.py
@@ -14,7 +14,7 @@ from utils.appliance.implementations.ui import navigate_to
 
 pytestmark = [pytest.mark.tier(3),
               test_requirements.settings,
-              pytest.mark.usefixtures('vmware_provider')]
+              pytest.mark.usefixtures('virtualcenter_provider')]
 
 
 # TODO refactor for setup_provider parametrization with new 'latest' tag

--- a/cfme/tests/configure/test_tag.py
+++ b/cfme/tests/configure/test_tag.py
@@ -64,8 +64,8 @@ class TestTagsViaREST(object):
         return _tenants(request, rest_api_modscope, num=1)
 
     @pytest.fixture(scope="module")
-    def a_provider(self):
-        return _a_provider()
+    def a_provider(self, request):
+        return _a_provider(request)
 
     @pytest.fixture(scope="module")
     def dialog(self):

--- a/cfme/tests/configure/test_visual_cloud.py
+++ b/cfme/tests/configure/test_visual_cloud.py
@@ -18,7 +18,7 @@ from utils import version
 
 pytestmark = [pytest.mark.tier(3),
               test_requirements.settings,
-              pytest.mark.usefixtures("rhos_provider")]
+              pytest.mark.usefixtures("openstack_provider")]
 
 grid_pages = version.pick({
     version.LOWEST: [CloudProvider,

--- a/cfme/tests/configure/test_visual_cloud.py
+++ b/cfme/tests/configure/test_visual_cloud.py
@@ -14,12 +14,13 @@ from cfme.cloud.stack import Stack
 from cfme.cloud.tenant import Tenant
 from cfme.cloud.volume import Volume
 from cfme.web_ui import paginator, toolbar as tb, match_location
+from fixtures.provider import setup_one_by_class_or_skip
 from utils.appliance.implementations.ui import navigate_to
-from utils.providers import setup_a_provider_by_class
 from utils import version
 
 pytestmark = [pytest.mark.tier(3),
-              test_requirements.settings]
+              test_requirements.settings,
+              pytest.mark.use_fixtures("rhos_provider")]
 
 grid_pages = version.pick({
     version.LOWEST: [CloudProvider,
@@ -61,8 +62,8 @@ landing_pages = {
 
 
 @pytest.fixture(scope="module")
-def setup_a_provider():
-    setup_a_provider_by_class(OpenStackProvider)
+def rhos_provider():
+    setup_one_by_class_or_skip(OpenStackProvider)
 
 
 @pytest.yield_fixture(scope="module")
@@ -106,7 +107,7 @@ def set_cloud_provider_quad():
 
 
 @pytest.mark.parametrize('page', grid_pages, scope="module")
-def test_grid_page_per_item(request, setup_a_provider, page, set_grid):
+def test_grid_page_per_item(request, page, set_grid):
     """ Tests grid items per page
 
     Metadata:
@@ -123,7 +124,7 @@ def test_grid_page_per_item(request, setup_a_provider, page, set_grid):
 
 
 @pytest.mark.parametrize('page', grid_pages, scope="module")
-def test_tile_page_per_item(request, setup_a_provider, page, set_tile):
+def test_tile_page_per_item(request, page, set_tile):
     """ Tests tile items per page
 
     Metadata:
@@ -140,7 +141,7 @@ def test_tile_page_per_item(request, setup_a_provider, page, set_tile):
 
 
 @pytest.mark.parametrize('page', grid_pages, scope="module")
-def test_list_page_per_item(request, setup_a_provider, page, set_list):
+def test_list_page_per_item(request, page, set_list):
     """ Tests list items per page
 
     Metadata:
@@ -157,7 +158,7 @@ def test_list_page_per_item(request, setup_a_provider, page, set_list):
 
 
 @pytest.mark.parametrize('start_page', landing_pages, scope="module")
-def test_start_page(request, setup_a_provider, start_page):
+def test_start_page(request, start_page):
     """ Tests start page
 
     Metadata:
@@ -171,6 +172,6 @@ def test_start_page(request, setup_a_provider, start_page):
     assert match_location(**match_args), "Landing Page Failed"
 
 
-def test_cloudprovider_noquads(request, setup_a_provider, set_cloud_provider_quad):
+def test_cloudprovider_noquads(request, set_cloud_provider_quad):
     navigate_to(CloudProvider, 'All')
     assert visual.check_image_exists, "Image View Failed!"

--- a/cfme/tests/configure/test_visual_cloud.py
+++ b/cfme/tests/configure/test_visual_cloud.py
@@ -6,7 +6,6 @@ from cfme import test_requirements
 from cfme.configure.settings import visual
 from cfme.cloud.availability_zone import AvailabilityZone
 from cfme.cloud.provider import CloudProvider
-from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.cloud.flavor import Flavor
 from cfme.cloud.instance import Instance
 from cfme.cloud.keypairs import KeyPair
@@ -14,13 +13,12 @@ from cfme.cloud.stack import Stack
 from cfme.cloud.tenant import Tenant
 from cfme.cloud.volume import Volume
 from cfme.web_ui import paginator, toolbar as tb, match_location
-from fixtures.provider import setup_one_by_class_or_skip
 from utils.appliance.implementations.ui import navigate_to
 from utils import version
 
 pytestmark = [pytest.mark.tier(3),
               test_requirements.settings,
-              pytest.mark.use_fixtures("rhos_provider")]
+              pytest.mark.usefixtures("rhos_provider")]
 
 grid_pages = version.pick({
     version.LOWEST: [CloudProvider,
@@ -59,11 +57,6 @@ landing_pages = {
                                     'title': 'Availability Zones',
                                     'summary': 'Availability Zones'},
 }
-
-
-@pytest.fixture(scope="module")
-def rhos_provider():
-    setup_one_by_class_or_skip(OpenStackProvider)
 
 
 @pytest.yield_fixture(scope="module")

--- a/cfme/tests/configure/test_visual_infra.py
+++ b/cfme/tests/configure/test_visual_infra.py
@@ -8,7 +8,6 @@ from cfme import test_requirements
 from cfme.configure.settings import visual
 from cfme.intelligence.reports.reports import CannedSavedReport
 from cfme.web_ui import paginator, toolbar as tb
-from utils.providers import setup_a_provider_by_class
 from cfme.infrastructure import virtual_machines as vms  # NOQA
 from cfme.infrastructure.provider import InfraProvider
 from utils.appliance.implementations.ui import navigate_to
@@ -16,7 +15,8 @@ from cfme.infrastructure.host import Host
 from cfme.infrastructure.datastore import Datastore
 
 pytestmark = [pytest.mark.tier(3),
-              test_requirements.settings]
+              test_requirements.settings,
+              pytest.mark.use_fixtures("infra_provider")]
 
 # todo: infrastructure hosts, pools, stores, cluster are removed due to changing
 # navigation to navmazing. all items have to be put back once navigation change is fully done
@@ -45,11 +45,6 @@ landing_pages = [
     'Optimize / Planning',
     'Optimize / Bottlenecks',
 ]
-
-
-@pytest.fixture(scope="module")
-def setup_a_provider():
-    return setup_a_provider_by_class(InfraProvider)
 
 
 @pytest.yield_fixture(scope="module")
@@ -130,7 +125,7 @@ def set_template_quad():
 
 @pytest.mark.meta(blockers=[1267148])
 @pytest.mark.parametrize('page', grid_pages, scope="module")
-def test_grid_page_per_item(request, setup_a_provider, page, set_grid):
+def test_grid_page_per_item(request, page, set_grid):
     """ Tests grid items per page
 
     Metadata:
@@ -146,7 +141,7 @@ def test_grid_page_per_item(request, setup_a_provider, page, set_grid):
 
 @pytest.mark.meta(blockers=[1267148])
 @pytest.mark.parametrize('page', grid_pages, scope="module")
-def test_tile_page_per_item(request, setup_a_provider, page, set_tile):
+def test_tile_page_per_item(request, page, set_tile):
     """ Tests tile items per page
 
     Metadata:
@@ -162,7 +157,7 @@ def test_tile_page_per_item(request, setup_a_provider, page, set_tile):
 
 @pytest.mark.meta(blockers=[1267148])
 @pytest.mark.parametrize('page', grid_pages, scope="module")
-def test_list_page_per_item(request, setup_a_provider, page, set_list):
+def test_list_page_per_item(request, page, set_list):
     """ Tests list items per page
 
     Metadata:
@@ -177,7 +172,7 @@ def test_list_page_per_item(request, setup_a_provider, page, set_list):
 
 
 @pytest.mark.meta(blockers=[1267148, 1273529])
-def test_report_page_per_item(setup_a_provider, set_report):
+def test_report_page_per_item(set_report):
     """ Tests report items per page
 
     Metadata:
@@ -194,7 +189,7 @@ def test_report_page_per_item(setup_a_provider, set_report):
 @pytest.mark.uncollect('Needs to be fixed after menu removed')
 @pytest.mark.meta(blockers=[1267148])
 @pytest.mark.parametrize('start_page', landing_pages, scope="module")
-def test_start_page(request, setup_a_provider, start_page):
+def test_start_page(request, start_page):
     """ Tests start page
 
     Metadata:
@@ -214,27 +209,27 @@ def test_start_page(request, setup_a_provider, start_page):
     # assert nav.is_page_active(*steps) or nav.is_page_active(*longer_steps), "Landing Page Failed"
 
 
-def test_infraprovider_noquads(request, setup_a_provider, set_infra_provider_quad):
-    navigate_to(setup_a_provider, 'All')
+def test_infraprovider_noquads(request, infra_provider, set_infra_provider_quad):
+    navigate_to(infra_provider, 'All')
     assert visual.check_image_exists, "Image View Failed!"
 
 
-def test_host_noquads(request, setup_a_provider, set_host_quad):
+def test_host_noquads(request, set_host_quad):
     navigate_to(Host, 'All')
     assert visual.check_image_exists, "Image View Failed!"
 
 
-def test_datastore_noquads(request, setup_a_provider, set_datastore_quad):
+def test_datastore_noquads(request, set_datastore_quad):
     navigate_to(Datastore, 'All')
     assert visual.check_image_exists, "Image View Failed!"
 
 
-def test_vm_noquads(request, setup_a_provider, set_vm_quad):
+def test_vm_noquads(request, set_vm_quad):
     navigate_to(vms.Vm, 'All')
     assert visual.check_image_exists, "Image View Failed!"
 
 
 @pytest.mark.meta(blockers=['GH#ManageIQ/manageiq:11215'])
-def test_template_noquads(request, setup_a_provider, set_template_quad):
+def test_template_noquads(request, set_template_quad):
     navigate_to(vms.Template, 'TemplatesOnly')
     assert visual.check_image_exists, "Image View Failed!"

--- a/cfme/tests/configure/test_visual_infra.py
+++ b/cfme/tests/configure/test_visual_infra.py
@@ -209,8 +209,8 @@ def test_start_page(request, start_page):
     # assert nav.is_page_active(*steps) or nav.is_page_active(*longer_steps), "Landing Page Failed"
 
 
-def test_infraprovider_noquads(request, infra_provider, set_infra_provider_quad):
-    navigate_to(infra_provider, 'All')
+def test_infraprovider_noquads(request, set_infra_provider_quad):
+    navigate_to(InfraProvider, 'All')
     assert visual.check_image_exists, "Image View Failed!"
 
 

--- a/cfme/tests/configure/test_visual_infra.py
+++ b/cfme/tests/configure/test_visual_infra.py
@@ -16,7 +16,7 @@ from cfme.infrastructure.datastore import Datastore
 
 pytestmark = [pytest.mark.tier(3),
               test_requirements.settings,
-              pytest.mark.use_fixtures("infra_provider")]
+              pytest.mark.usefixtures("infra_provider")]
 
 # todo: infrastructure hosts, pools, stores, cluster are removed due to changing
 # navigation to navmazing. all items have to be put back once navigation change is fully done

--- a/cfme/tests/control/test_bugs.py
+++ b/cfme/tests/control/test_bugs.py
@@ -127,8 +127,8 @@ items = [
 
 
 @pytest.fixture(scope="module")
-def vmware_vm(request, vmware_provider):
-    vm = VM.factory(random_vm_name("control"), vmware_provider)
+def vmware_vm(request, virtualcenter_provider):
+    vm = VM.factory(random_vm_name("control"), virtualcenter_provider)
     vm.create_on_provider(find_in_cfme=True)
     request.addfinalizer(vm.delete_from_provider)
     return vm
@@ -163,7 +163,7 @@ def test_scope_windows_registry_stuck(request, infra_provider):
 
 @pytest.mark.meta(blockers=[1209538], automates=[1209538])
 @pytest.mark.skipif(current_version() > "5.5", reason="requires cfme 5.5 and lower")
-def test_folder_field_scope(request, vmware_provider, vmware_vm):
+def test_folder_field_scope(request, virtualcenter_provider, vmware_vm):
     """This test tests the bug that makes the folder filter in expression not work.
 
     Prerequisities:
@@ -218,13 +218,13 @@ def test_folder_field_scope(request, vmware_provider, vmware_vm):
     request.addfinalizer(profile.delete)
 
     # Assign policy profile to the provider
-    vmware_provider.assign_policy_profiles(profile.description)
-    request.addfinalizer(lambda: vmware_provider.unassign_policy_profiles(profile.description))
+    virtualcenter_provider.assign_policy_profiles(profile.description)
+    request.addfinalizer(lambda: virtualcenter_provider.unassign_policy_profiles(profile.description))
 
     # Delete and rediscover the VM
     vmware_vm.delete()
     vmware_vm.wait_for_delete()
-    vmware_provider.refresh_provider_relationships()
+    virtualcenter_provider.refresh_provider_relationships()
     vmware_vm.wait_to_appear()
 
     # Wait for the tag to appear
@@ -271,7 +271,7 @@ def test_invoke_custom_automation(request):
 
 
 @pytest.mark.meta(blockers=[1375093], automates=[1375093])
-def test_check_compliance_history(request, vmware_provider, vmware_vm):
+def test_check_compliance_history(request, virtualcenter_provider, vmware_vm):
     """This test checks if compliance history link in a VM details screen work.
 
     Steps:
@@ -298,8 +298,8 @@ def test_check_compliance_history(request, vmware_provider, vmware_vm):
     )
     request.addfinalizer(lambda: policy_profile.delete() if policy_profile.exists else None)
     policy_profile.create()
-    vmware_provider.assign_policy_profiles(policy_profile.description)
-    request.addfinalizer(lambda: vmware_provider.unassign_policy_profiles(
+    virtualcenter_provider.assign_policy_profiles(policy_profile.description)
+    request.addfinalizer(lambda: virtualcenter_provider.unassign_policy_profiles(
         policy_profile.description))
     vmware_vm.check_compliance()
     vmware_vm.open_details(["Compliance", "History"])

--- a/cfme/tests/control/test_bugs.py
+++ b/cfme/tests/control/test_bugs.py
@@ -219,7 +219,8 @@ def test_folder_field_scope(request, virtualcenter_provider, vmware_vm):
 
     # Assign policy profile to the provider
     virtualcenter_provider.assign_policy_profiles(profile.description)
-    request.addfinalizer(lambda: virtualcenter_provider.unassign_policy_profiles(profile.description))
+    request.addfinalizer(
+        lambda: virtualcenter_provider.unassign_policy_profiles(profile.description))
 
     # Delete and rediscover the VM
     vmware_vm.delete()

--- a/cfme/tests/control/test_bugs.py
+++ b/cfme/tests/control/test_bugs.py
@@ -10,9 +10,7 @@ from cfme.control.explorer.actions import Action
 from cfme.control.explorer.alerts import Alert
 from cfme.control.explorer.conditions import VMCondition
 from cfme.control.explorer.alert_profiles import VMInstanceAlertProfile
-from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.infrastructure.virtual_machines import Vm
-from cfme.fixtures import setup_one_by_class_or_skip
 from utils.appliance.implementations.ui import navigate_to
 from utils.version import current_version
 from utils.log import logger
@@ -126,11 +124,6 @@ items = [
     ("Alert profiles", create_alert_profile),
     ("Alerts", create_alert)
 ]
-
-
-@pytest.fixture(scope="module")
-def vmware_provider(request):
-    return setup_one_by_class_or_skip(request, VMwareProvider)
 
 
 @pytest.fixture(scope="module")

--- a/cfme/tests/distributed/test_appliance_replication.py
+++ b/cfme/tests/distributed/test_appliance_replication.py
@@ -116,17 +116,17 @@ def vm_name():
 
 
 @pytest.fixture(scope="module")
-def test_vm(request, vmware_provider, vm_name):
+def test_vm(request, virtualcenter_provider, vm_name):
     """Fixture to provision appliance to the provider being tested if necessary"""
-    vm = VM.factory(vm_name, vmware_provider)
+    vm = VM.factory(vm_name, virtualcenter_provider)
 
     request.addfinalizer(vm.delete_from_provider)
 
-    if not vmware_provider.mgmt.does_vm_exist(vm_name):
-        logger.info("deploying %s on provider %s", vm_name, vmware_provider.key)
+    if not virtualcenter_provider.mgmt.does_vm_exist(vm_name):
+        logger.info("deploying %s on provider %s", vm_name, virtualcenter_provider.key)
         vm.create_on_provider(allow_skip="default")
     else:
-        logger.info("recycling deployed vm %s on provider %s", vm_name, vmware_provider.key)
+        logger.info("recycling deployed vm %s on provider %s", vm_name, virtualcenter_provider.key)
     vm.provider.refresh_provider_relationships()
     vm.wait_to_appear()
     return vm
@@ -134,7 +134,7 @@ def test_vm(request, vmware_provider, vm_name):
 
 @pytest.mark.tier(2)
 @pytest.mark.ignore_stream("upstream", "5.7")  # no config->diagnostics->replication tab in 5.7
-def test_appliance_replicate_between_regions(request, vmware_provider):
+def test_appliance_replicate_between_regions(request, virtualcenter_provider):
     """Tests that a provider added to an appliance in one region
         is replicated to the parent appliance in another region.
 
@@ -150,18 +150,18 @@ def test_appliance_replicate_between_regions(request, vmware_provider):
     appl1.ipapp.browser_steal = True
     with appl1.ipapp:
         configure_db_replication(appl2.address)
-        vmware_provider.create()
+        virtualcenter_provider.create()
         wait_for_a_provider()
 
     appl2.ipapp.browser_steal = True
     with appl2.ipapp:
         wait_for_a_provider()
-        assert vmware_provider.exists
+        assert virtualcenter_provider.exists
 
 
 @pytest.mark.tier(2)
 @pytest.mark.ignore_stream("upstream")
-def test_external_database_appliance(request, vmware_provider):
+def test_external_database_appliance(request, virtualcenter_provider):
     """Tests that one appliance can externally
        connect to the database of another appliance.
 
@@ -176,18 +176,18 @@ def test_external_database_appliance(request, vmware_provider):
     request.addfinalizer(finalize)
     appl1.ipapp.browser_steal = True
     with appl1.ipapp:
-        vmware_provider.create()
+        virtualcenter_provider.create()
         wait_for_a_provider()
 
     appl2.ipapp.browser_steal = True
     with appl2.ipapp:
         wait_for_a_provider()
-        assert vmware_provider.exists
+        assert virtualcenter_provider.exists
 
 
 @pytest.mark.tier(2)
 @pytest.mark.ignore_stream("upstream", "5.7")  # no config->diagnostics->replication tab in 5.7
-def test_appliance_replicate_sync_role_change(request, vmware_provider):
+def test_appliance_replicate_sync_role_change(request, virtualcenter_provider):
     """Tests that a role change is replicated
 
     Metadata:
@@ -212,18 +212,18 @@ def test_appliance_replicate_sync_role_change(request, vmware_provider):
         wait_for(lambda: conf.get_replication_status(navigate=False), fail_condition=False,
                  num_sec=360, delay=10, fail_func=sel.refresh, message="get_replication_status")
         assert conf.get_replication_status()
-        vmware_provider.create()
+        virtualcenter_provider.create()
         wait_for_a_provider()
 
     appl2.ipapp.browser_steal = True
     with appl2.ipapp:
         wait_for_a_provider()
-        assert vmware_provider.exists
+        assert virtualcenter_provider.exists
 
 
 @pytest.mark.tier(2)
 @pytest.mark.ignore_stream("upstream", "5.7")  # no config->diagnostics->replication tab in 5.7
-def test_appliance_replicate_sync_role_change_with_backlog(request, vmware_provider):
+def test_appliance_replicate_sync_role_change_with_backlog(request, virtualcenter_provider):
     """Tests that a role change is replicated with backlog
 
     Metadata:
@@ -239,7 +239,7 @@ def test_appliance_replicate_sync_role_change_with_backlog(request, vmware_provi
     with appl1.ipapp:
         configure_db_replication(appl2.address)
         # Replication is up and running, now disable DB sync role
-        vmware_provider.create()
+        virtualcenter_provider.create()
         conf.set_server_roles(database_synchronization=False)
         navigate_to(current_appliance.server.zone.region, 'Replication')
         wait_for(lambda: conf.get_replication_status(navigate=False), fail_condition=True,
@@ -254,12 +254,12 @@ def test_appliance_replicate_sync_role_change_with_backlog(request, vmware_provi
     appl2.ipapp.browser_steal = True
     with appl2.ipapp:
         wait_for_a_provider()
-        assert vmware_provider.exists
+        assert virtualcenter_provider.exists
 
 
 @pytest.mark.tier(2)
 @pytest.mark.ignore_stream("upstream", "5.7")  # no config->diagnostics->replication tab in 5.7
-def test_appliance_replicate_database_disconnection(request, vmware_provider):
+def test_appliance_replicate_database_disconnection(request, virtualcenter_provider):
     """Tests a database disconnection
 
     Metadata:
@@ -282,18 +282,18 @@ def test_appliance_replicate_database_disconnection(request, vmware_provider):
         wait_for(lambda: conf.get_replication_status(navigate=False), fail_condition=False,
                  num_sec=360, delay=10, fail_func=sel.refresh, message="get_replication_status")
         assert conf.get_replication_status()
-        vmware_provider.create()
+        virtualcenter_provider.create()
         wait_for_a_provider()
 
     appl2.ipapp.browser_steal = True
     with appl2.ipapp:
         wait_for_a_provider()
-        assert vmware_provider.exists
+        assert virtualcenter_provider.exists
 
 
 @pytest.mark.tier(2)
 @pytest.mark.ignore_stream("upstream", "5.7")  # no config->diagnostics->replication tab in 5.7
-def test_appliance_replicate_database_disconnection_with_backlog(request, vmware_provider):
+def test_appliance_replicate_database_disconnection_with_backlog(request, virtualcenter_provider):
     """Tests a database disconnection with backlog
 
     Metadata:
@@ -309,7 +309,7 @@ def test_appliance_replicate_database_disconnection_with_backlog(request, vmware
     with appl1.ipapp:
         configure_db_replication(appl2.address)
         # Replication is up and running, now stop the DB on the replication parent
-        vmware_provider.create()
+        virtualcenter_provider.create()
         stop_db_process(appl2.address)
         sleep(60)
         start_db_process(appl2.address)
@@ -322,12 +322,12 @@ def test_appliance_replicate_database_disconnection_with_backlog(request, vmware
     appl2.ipapp.browser_steal = True
     with appl2.ipapp:
         wait_for_a_provider()
-        assert vmware_provider.exists
+        assert virtualcenter_provider.exists
 
 
 @pytest.mark.tier(2)
 @pytest.mark.ignore_stream("upstream", "5.7")  # no config->diagnostics->replication tab in 5.7
-def test_distributed_vm_power_control(request, test_vm, vmware_provider, verify_vm_running,
+def test_distributed_vm_power_control(request, test_vm, virtualcenter_provider, verify_vm_running,
                                       register_event, soft_assert):
     """Tests that a replication parent appliance can control the power state of a
     VM being managed by a replication child appliance.
@@ -344,7 +344,7 @@ def test_distributed_vm_power_control(request, test_vm, vmware_provider, verify_
     appl1.ipapp.browser_steal = True
     with appl1.ipapp:
         configure_db_replication(appl2.address)
-        vmware_provider.create()
+        virtualcenter_provider.create()
         wait_for_a_provider()
 
     appl2.ipapp.browser_steal = True

--- a/cfme/tests/distributed/test_appliance_replication.py
+++ b/cfme/tests/distributed/test_appliance_replication.py
@@ -10,7 +10,6 @@ import cfme.web_ui.flash as flash
 from cfme.common.vm import VM
 from cfme.configure import configuration as conf
 from cfme.infrastructure.provider import wait_for_a_provider
-from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 import cfme.fixtures.pytest_selenium as sel
 
 from utils import db, version
@@ -19,22 +18,17 @@ from utils.appliance.implementations.ui import navigate_to
 from utils.conf import credentials
 from utils.events import EventBuilder
 from utils.log import logger
-from utils.providers import setup_a_provider_by_class
 from utils.ssh import SSHClient
 from utils.wait import wait_for
 
 from cfme import test_requirements
+
 
 pytestmark = [
     pytest.mark.long_running,
     test_requirements.distributed,
     pytest.mark.uncollect(reason="test framework broke browser_steal"),
 ]
-
-
-@pytest.fixture(scope="module")
-def vmware_provider():
-    return setup_a_provider_by_class(VMwareProvider)
 
 
 def get_ssh_client(hostname):

--- a/cfme/tests/infrastructure/test_advanced_search_host.py
+++ b/cfme/tests/infrastructure/test_advanced_search_host.py
@@ -6,8 +6,6 @@ from itertools import dropwhile
 
 from cfme.infrastructure import host
 from cfme.infrastructure.host import Host
-from cfme.infrastructure.provider import InfraProvider
-from utils.providers import setup_a_provider_by_class
 from cfme.web_ui import search
 from cfme.web_ui.cfme_exception import (assert_no_cfme_exception,
     is_cfme_exception, cfme_exception_text)
@@ -16,12 +14,7 @@ from utils.appliance.implementations.ui import navigate_to
 
 
 @pytest.fixture(scope="module")
-def hosts():
-    """Ensure the infra providers are set up and get list of hosts"""
-    try:
-        setup_a_provider_by_class(InfraProvider)
-    except Exception:
-        pytest.skip("It's not possible to set up any providers, therefore skipping")
+def hosts(infra_provider):
     navigate_to(Host, 'All')
     search.ensure_no_filter_applied()
     return host.get_all_hosts()

--- a/cfme/tests/infrastructure/test_advanced_search_providers.py
+++ b/cfme/tests/infrastructure/test_advanced_search_providers.py
@@ -6,11 +6,8 @@ import fauxfactory
 import pytest
 from selenium.common.exceptions import NoSuchElementException
 
-from cfme.infrastructure import host
 from cfme.infrastructure.provider import InfraProvider
-# TODO: we should not call out to utils here, but maybe rather have an infra setup provider fixture
 from fixtures.pytest_store import store
-from utils.providers import setup_a_provider_by_class
 from utils.appliance.implementations.ui import navigate_to
 from utils.log import logger
 from cfme.web_ui import search
@@ -19,25 +16,8 @@ from cfme.web_ui.cfme_exception import (assert_no_cfme_exception,
     is_cfme_exception, cfme_exception_text)
 
 
-pytestmark = [pytest.mark.usefixtures("setup_cleanup_search"), pytest.mark.tier(3)]
-
-
-@pytest.fixture(scope="module")
-def single_provider():
-    """Ensure the infra provider is setup"""
-    try:
-        return setup_a_provider_by_class(InfraProvider)
-    except Exception as ex:
-        pytest.skip("Exception while setting up providers, therefore skipping: {}".format(ex))
-
-
-@pytest.fixture(scope="module")
-def hosts_with_vm_count(hosts):
-    """Returns a list of tuples (hostname, vm_count)"""
-    hosts_with_vm_count = []
-    for host_name in hosts:
-        hosts_with_vm_count.append((host_name, int(host.find_quadicon(host_name, True).no_vm)))
-    return sorted(hosts_with_vm_count, key=lambda tup: tup[1])
+pytestmark = [
+    pytest.mark.usefixtures("setup_cleanup_search", "infra_provider"), pytest.mark.tier(3)]
 
 
 @pytest.yield_fixture(scope="function")
@@ -72,26 +52,26 @@ def rails_delete_filter(request):
         logger.warning('rails_delete_filter: failed to get filter_name')
 
 
-def test_can_do_advanced_search(single_provider):
+def test_can_do_advanced_search():
     navigate_to(InfraProvider, 'All')
     assert search.is_advanced_search_possible(), "Cannot do advanced search here!"
 
 
 @pytest.mark.requires("test_can_do_advanced_search")
-def test_can_open_advanced_search(single_provider):
+def test_can_open_advanced_search():
     navigate_to(InfraProvider, 'All')
     search.ensure_advanced_search_open()
 
 
 @pytest.mark.requires("test_can_open_advanced_search")
-def test_filter_without_user_input(single_provider):
+def test_filter_without_user_input():
     # Set up the filter
     search.fill_and_apply_filter("fill_count(Infrastructure Provider.VMs, >=, 0)")
     assert_no_cfme_exception()
 
 
 @pytest.mark.requires("test_can_open_advanced_search")
-def test_filter_with_user_input(single_provider):
+def test_filter_with_user_input():
     # Set up the filter
     logger.debug('DEBUG: test_with_user_input: fill and apply')
     search.fill_and_apply_filter("fill_count(Infrastructure Provider.VMs, >=)",
@@ -100,7 +80,7 @@ def test_filter_with_user_input(single_provider):
 
 
 @pytest.mark.requires("test_can_open_advanced_search")
-def test_filter_with_user_input_and_cancellation(single_provider):
+def test_filter_with_user_input_and_cancellation():
     # Set up the filter
     search.fill_and_apply_filter(
         "fill_count(Infrastructure Provider.VMs, >=)", fill_callback={"COUNT": 0},
@@ -110,7 +90,7 @@ def test_filter_with_user_input_and_cancellation(single_provider):
 
 
 @pytest.mark.requires("test_can_open_advanced_search")
-def test_filter_save_cancel(single_provider, rails_delete_filter):
+def test_filter_save_cancel(rails_delete_filter):
     # bind filter_name to the function for fixture cleanup
     test_filter_save_cancel.filter_name = fauxfactory.gen_alphanumeric()
     logger.debug('Set filter_name to: {}'.format(test_filter_save_cancel.filter_name))
@@ -127,7 +107,7 @@ def test_filter_save_cancel(single_provider, rails_delete_filter):
 
 
 @pytest.mark.requires("test_can_open_advanced_search")
-def test_filter_save_and_load(single_provider, rails_delete_filter):
+def test_filter_save_and_load(rails_delete_filter):
     # bind filter_name to the function for fixture cleanup
     test_filter_save_and_load.filter_name = fauxfactory.gen_alphanumeric()
     logger.debug('Set filter_name to: {}'.format(test_filter_save_and_load.filter_name))
@@ -146,7 +126,7 @@ def test_filter_save_and_load(single_provider, rails_delete_filter):
 
 
 @pytest.mark.requires("test_can_open_advanced_search")
-def test_filter_save_and_cancel_load(single_provider, rails_delete_filter):
+def test_filter_save_and_cancel_load(rails_delete_filter):
     # bind filter_name to the function for fixture cleanup
     test_filter_save_and_cancel_load.filter_name = fauxfactory.gen_alphanumeric()
     logger.debug('Set filter_name to: {}'.format(test_filter_save_and_cancel_load.filter_name))
@@ -165,7 +145,7 @@ def test_filter_save_and_cancel_load(single_provider, rails_delete_filter):
 
 
 @pytest.mark.requires("test_can_open_advanced_search")
-def test_filter_save_and_cancel_load_with_user_input(single_provider, rails_delete_filter):
+def test_filter_save_and_cancel_load_with_user_input(rails_delete_filter):
     # bind filter_name to the function for fixture cleanup
     test_filter_save_and_cancel_load_with_user_input.filter_name = fauxfactory.gen_alphanumeric()
     logger.debug('Set filter_name to: {}'.format(
@@ -187,7 +167,7 @@ def test_filter_save_and_cancel_load_with_user_input(single_provider, rails_dele
     assert_no_cfme_exception()
 
 
-def test_quick_search_without_filter(request, single_provider):
+def test_quick_search_without_filter(request):
     assert_no_cfme_exception()
     # Make sure that we empty the regular search field after the test
     request.addfinalizer(search.ensure_normal_search_empty)
@@ -196,7 +176,7 @@ def test_quick_search_without_filter(request, single_provider):
     assert_no_cfme_exception()
 
 
-def test_quick_search_with_filter(request, single_provider):
+def test_quick_search_with_filter(request):
     search.fill_and_apply_filter("fill_count(Infrastructure Provider.VMs, >=, 0)")
     assert_no_cfme_exception()
     # Make sure that we empty the regular search field after the test
@@ -206,7 +186,7 @@ def test_quick_search_with_filter(request, single_provider):
     assert_no_cfme_exception()
 
 
-def test_can_delete_filter(single_provider):
+def test_can_delete_filter():
     filter_name = fauxfactory.gen_alphanumeric()
     logger.debug('Set filter_name to: {}'.format(filter_name))
     assert search.save_filter("fill_count(Infrastructure Provider.VMs, >, 0)", filter_name)
@@ -221,7 +201,7 @@ def test_can_delete_filter(single_provider):
 
 
 @pytest.mark.meta(blockers=[1097150, 1320244])
-def test_delete_button_should_appear_after_save(single_provider, rails_delete_filter):
+def test_delete_button_should_appear_after_save(rails_delete_filter):
     """Delete button appears only after load, not after save"""
     # bind filter_name to the function for fixture cleanup
     test_delete_button_should_appear_after_save.filter_name = fauxfactory.gen_alphanumeric()
@@ -233,7 +213,7 @@ def test_delete_button_should_appear_after_save(single_provider, rails_delete_fi
 
 
 @pytest.mark.meta(blockers=[1097150, 1320244])
-def test_cannot_delete_more_than_once(single_provider):
+def test_cannot_delete_more_than_once():
     """When Delete button appars, it does not want to go away"""
     filter_name = fauxfactory.gen_alphanumeric()
     assert search.save_filter("fill_count(Infrastructure Provider.VMs, >, 0)", filter_name)

--- a/cfme/tests/infrastructure/test_advanced_search_vms.py
+++ b/cfme/tests/infrastructure/test_advanced_search_vms.py
@@ -9,23 +9,20 @@ from cfme.infrastructure import virtual_machines
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.virtual_machines import Vm
 from cfme.web_ui import search
+from fixtures.provider import setup_one_or_skip
 from utils.appliance.implementations.ui import navigate_to
 from cfme.web_ui.cfme_exception import (assert_no_cfme_exception,
     is_cfme_exception, cfme_exception_text)
-from utils.providers import setup_a_provider as _setup_a_provider, ProviderFilter
+from utils.providers import ProviderFilter
+
+
+def large_template_infra_provider(request):
+    pf = ProviderFilter(classes=[InfraProvider], required_fields=['large'])
+    setup_one_or_skip(request, filters=[pf])
 
 
 @pytest.fixture(scope="module")
-def setup_a_provider():
-    try:
-        pf = ProviderFilter(classes=[InfraProvider], required_fields=['large'])
-        _setup_a_provider(filters=[pf])
-    except Exception:
-        pytest.skip("It's not possible to set up any providers, therefore skipping")
-
-
-@pytest.fixture(scope="module")
-def vms(setup_a_provider):
+def vms(large_template_infra_provider):
     """Ensure the infra providers are set up and get list of vms"""
     navigate_to(Vm, 'VMsOnly')
     search.ensure_no_filter_applied()

--- a/cfme/tests/infrastructure/test_advanced_search_vms.py
+++ b/cfme/tests/infrastructure/test_advanced_search_vms.py
@@ -16,13 +16,13 @@ from cfme.web_ui.cfme_exception import (assert_no_cfme_exception,
 from utils.providers import ProviderFilter
 
 
-def large_template_infra_provider(request):
+def a_provider(request):
     pf = ProviderFilter(classes=[InfraProvider], required_fields=['large'])
     setup_one_or_skip(request, filters=[pf])
 
 
 @pytest.fixture(scope="module")
-def vms(large_template_infra_provider):
+def vms(a_provider):
     """Ensure the infra providers are set up and get list of vms"""
     navigate_to(Vm, 'VMsOnly')
     search.ensure_no_filter_applied()

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -14,17 +14,12 @@ from cfme.exceptions import FlashMessageException
 from cfme.infrastructure.provider import discover, wait_for_a_provider, InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
-from utils import testgen, providers, version
+from utils import testgen, version
 from utils.update import update
 from utils.log import logger
 from cfme import test_requirements
 
 pytest_generate_tests = testgen.generate([InfraProvider], scope="function")
-
-
-@pytest.fixture(scope="module")
-def setup_a_provider():
-    return providers.setup_a_provider_by_class(InfraProvider)
 
 
 @pytest.mark.tier(3)
@@ -134,14 +129,13 @@ def test_ip_required_validation():
 
 @pytest.mark.tier(3)
 @test_requirements.provider_discovery
-def test_name_max_character_validation(request, setup_a_provider):
+def test_name_max_character_validation(request, infra_provider):
     """Test to validate max character for name field"""
-    provider = setup_a_provider
-    request.addfinalizer(lambda: provider.delete_if_exists(cancel=False))
+    request.addfinalizer(lambda: infra_provider.delete_if_exists(cancel=False))
     name = fauxfactory.gen_alphanumeric(255)
-    provider.update({'name': name})
-    provider.name = name
-    assert provider.exists
+    infra_provider.update({'name': name})
+    infra_provider.name = name
+    assert infra_provider.exists
 
 
 @pytest.mark.tier(3)
@@ -248,8 +242,8 @@ def test_provider_crud(provider):
 
 class TestProvidersRESTAPI(object):
     @pytest.yield_fixture(scope="function")
-    def custom_attributes(self, rest_api, setup_a_provider):
-        provider = rest_api.collections.providers.get(name=setup_a_provider.name)
+    def custom_attributes(self, rest_api, infra_provider):
+        provider = rest_api.collections.providers.get(name=infra_provider.name)
         body = []
         attrs_num = 2
         for _ in range(attrs_num):

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -400,14 +400,14 @@ class TestProvidersRESTAPI(object):
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     @pytest.mark.tier(3)
     @test_requirements.rest
-    def test_add_custom_attributes_bad_section(self, rest_api, setup_a_provider):
+    def test_add_custom_attributes_bad_section(self, rest_api, infra_provider):
         """Test that adding custom attributes with invalid section
         to provider using REST API fails.
 
         Metadata:
             test_flag: rest
         """
-        provider = rest_api.collections.providers.get(name=setup_a_provider.name)
+        provider = rest_api.collections.providers.get(name=infra_provider.name)
         uid = fauxfactory.gen_alphanumeric(5)
         body = {
             'name': 'ca_name_{}'.format(uid),

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -133,8 +133,8 @@ def test_name_max_character_validation(request, infra_provider):
     """Test to validate max character for name field"""
     request.addfinalizer(lambda: infra_provider.delete_if_exists(cancel=False))
     name = fauxfactory.gen_alphanumeric(255)
-    infra_provider.update({'name': name})
-    infra_provider.name = name
+    with update(infra_provider):
+        infra_provider.name = name
     assert infra_provider.exists
 
 

--- a/cfme/tests/infrastructure/test_rest_automation_request.py
+++ b/cfme/tests/infrastructure/test_rest_automation_request.py
@@ -10,8 +10,8 @@ pytestmark = [test_requirements.rest]
 
 
 @pytest.fixture(scope="module")
-def a_provider():
-    return _a_provider()
+def a_provider(request):
+    return _a_provider(request)
 
 
 @pytest.fixture(scope="module")

--- a/cfme/tests/infrastructure/test_rest_providers.py
+++ b/cfme/tests/infrastructure/test_rest_providers.py
@@ -14,8 +14,8 @@ pytestmark = [test_requirements.rest]
 
 
 @pytest.fixture(scope='module')
-def a_provider():
-    return _a_provider()
+def a_provider(request):
+    return _a_provider(request)
 
 
 @pytest.fixture(scope="function")

--- a/cfme/tests/infrastructure/test_rest_templates.py
+++ b/cfme/tests/infrastructure/test_rest_templates.py
@@ -12,8 +12,8 @@ pytestmark = [pytest.mark.ignore_stream("5.4"), test_requirements.rest]
 
 
 @pytest.fixture(scope="module")
-def a_provider():
-    return _a_provider()
+def a_provider(request):
+    return _a_provider(request)
 
 
 @pytest.fixture(scope="function")

--- a/cfme/tests/infrastructure/test_set_default_filter.py
+++ b/cfme/tests/infrastructure/test_set_default_filter.py
@@ -13,7 +13,7 @@ from cfme.infrastructure.host import Host
 from cfme.infrastructure.datastore import Datastore
 
 
-pytestmark = [pytest.mark.tier(3), pytest.mark.usefixtures("vmware_provider")]
+pytestmark = [pytest.mark.tier(3), pytest.mark.usefixtures("virtualcenter_provider")]
 
 
 def test_set_default_host_filter(request):

--- a/cfme/tests/infrastructure/test_set_default_filter.py
+++ b/cfme/tests/infrastructure/test_set_default_filter.py
@@ -4,20 +4,13 @@ from functools import partial
 import pytest
 
 from cfme.infrastructure import host, datastore
-from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.login import login_admin, logout
 from cfme.web_ui.search import search_box
-from fixtures.provider import setup_one_by_class_or_skip
 from utils import version
 from cfme.web_ui import accordion, listaccordion as list_acc
 from utils.appliance.implementations.ui import navigate_to
 from cfme.infrastructure.host import Host
 from cfme.infrastructure.datastore import Datastore
-
-
-@pytest.fixture(scope="module")
-def vmware_provider(request):
-    return setup_one_by_class_or_skip(request, VMwareProvider)
 
 
 pytestmark = [pytest.mark.tier(3), pytest.mark.usefixtures("vmware_provider")]

--- a/cfme/tests/infrastructure/test_set_default_filter.py
+++ b/cfme/tests/infrastructure/test_set_default_filter.py
@@ -7,7 +7,7 @@ from cfme.infrastructure import host, datastore
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.login import login_admin, logout
 from cfme.web_ui.search import search_box
-from utils.providers import setup_a_provider_by_class
+from fixtures.provider import setup_one_by_class_or_skip
 from utils import version
 from cfme.web_ui import accordion, listaccordion as list_acc
 from utils.appliance.implementations.ui import navigate_to
@@ -16,14 +16,14 @@ from cfme.infrastructure.datastore import Datastore
 
 
 @pytest.fixture(scope="module")
-def provider():
-    return setup_a_provider_by_class(VMwareProvider)
+def vmware_provider(request):
+    return setup_one_by_class_or_skip(request, VMwareProvider)
 
 
-pytestmark = [pytest.mark.tier(3)]
+pytestmark = [pytest.mark.tier(3), pytest.mark.usefixtures("vmware_provider")]
 
 
-def test_set_default_host_filter(provider, request):
+def test_set_default_host_filter(request):
     """ Test for setting default filter for hosts."""
 
     # Add cleanup finalizer
@@ -43,7 +43,7 @@ def test_set_default_host_filter(provider, request):
         'Status / Running filter not set as default'
 
 
-def test_clear_host_filter_results(provider):
+def test_clear_host_filter_results():
     """ Test for clearing filter results for hosts."""
 
     navigate_to(Host, 'All')
@@ -54,7 +54,7 @@ def test_clear_host_filter_results(provider):
 
 
 @pytest.mark.uncollectif(lambda: version.current_version() >= "5.6")
-def test_set_default_datastore_filter(provider, request):
+def test_set_default_datastore_filter(request):
     """ Test for setting default filter for datastores."""
 
     # Add cleanup finalizer
@@ -74,7 +74,7 @@ def test_set_default_datastore_filter(provider, request):
         'Store Type / NFS not set as default'
 
 
-def test_clear_datastore_filter_results(provider):
+def test_clear_datastore_filter_results():
     """ Test for clearing filter results for datastores."""
 
     if version.current_version() >= 5.6:

--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -165,8 +165,8 @@ def test_cluster_event(provider, gen_events, test_vm):
 
 class TestVmEventRESTAPI(object):
     @pytest.fixture(scope="module")
-    def a_provider(self):
-        return _a_provider()
+    def a_provider(self, request):
+        return _a_provider(request)
 
     @pytest.fixture(scope="module")
     def vm(self, request, a_provider, rest_api_modscope):

--- a/cfme/tests/infrastructure/test_vm_ownership.py
+++ b/cfme/tests/infrastructure/test_vm_ownership.py
@@ -14,8 +14,8 @@ pytestmark = [
 @pytest.mark.uncollectif(lambda: version.current_version() < '5.5')
 class TestVmOwnershipRESTAPI(object):
     @pytest.fixture(scope="module")
-    def a_provider(self):
-        return _a_provider()
+    def a_provider(self, request):
+        return _a_provider(request)
 
     @pytest.fixture(scope="module")
     def vm(self, request, a_provider, rest_api_modscope):

--- a/cfme/tests/infrastructure/test_vm_rest.py
+++ b/cfme/tests/infrastructure/test_vm_rest.py
@@ -12,8 +12,8 @@ pytestmark = [test_requirements.provision]
 
 
 @pytest.fixture(scope="function")
-def a_provider():
-    return _a_provider()
+def a_provider(request):
+    return _a_provider(request)
 
 
 @pytest.fixture(scope="function")

--- a/cfme/tests/infrastructure/test_vm_retirement_rest.py
+++ b/cfme/tests/infrastructure/test_vm_retirement_rest.py
@@ -12,8 +12,8 @@ pytestmark = [test_requirements.retirement]
 
 
 @pytest.fixture(scope="function")
-def a_provider():
-    return _a_provider()
+def a_provider(request):
+    return _a_provider(request)
 
 
 @pytest.fixture(scope="function")

--- a/cfme/tests/integration/test_aws_iam_auth_and_roles.py
+++ b/cfme/tests/integration/test_aws_iam_auth_and_roles.py
@@ -1,25 +1,18 @@
 import pytest
 
 from cfme.configure.access_control import simple_user
-from cfme.infrastructure.provider import InfraProvider
 from cfme.login import login, login_admin
 from utils.conf import credentials
 from utils.testgen import auth_groups, generate
 from utils import version
-from utils.providers import setup_a_provider_by_class
 
 pytest_generate_tests = generate(gen_func=auth_groups, auth_mode='aws_iam')
-
-
-@pytest.fixture(scope="module")
-def setup_first_provider():
-    setup_a_provider_by_class(InfraProvider)
 
 
 @pytest.mark.uncollect('Needs to be fixed after menu removed')
 @pytest.mark.tier(2)
 def test_group_roles(
-        request, configure_aws_iam_auth_mode, group_name, group_data, setup_first_provider):
+        request, configure_aws_iam_auth_mode, group_name, group_data, infra_provider):
     """Basic default AWS_IAM group role RBAC test
 
     Validates expected menu and submenu names are present for default

--- a/cfme/tests/integration/test_ldap_auth_and_roles.py
+++ b/cfme/tests/integration/test_ldap_auth_and_roles.py
@@ -1,25 +1,18 @@
 import pytest
 
 from cfme.configure.access_control import simple_user
-from cfme.infrastructure.provider import InfraProvider
 from cfme.login import login, login_admin
 from utils.conf import credentials
 from utils.testgen import auth_groups, generate
 from utils import version
-from utils.providers import setup_a_provider_by_class
 
 pytest_generate_tests = generate(gen_func=auth_groups, auth_mode='ldap')
-
-
-@pytest.fixture(scope="module")
-def setup_first_provider():
-    setup_a_provider_by_class(InfraProvider)
 
 
 @pytest.mark.uncollect('Needs to be fixed after menu removed')
 @pytest.mark.tier(2)
 def test_group_roles(
-        request, configure_ldap_auth_mode, group_name, group_data, setup_first_provider):
+        request, configure_ldap_auth_mode, group_name, group_data, infra_provider):
     """Basic default LDAP group role RBAC test
 
     Validates expected menu and submenu names are present for default

--- a/cfme/tests/intelligence/reports/test_canned_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_canned_corresponds.py
@@ -6,21 +6,16 @@ from cfme.infrastructure.provider import InfraProvider, details_page
 from cfme.intelligence.reports.reports import CannedSavedReport
 from utils.appliance.implementations.ui import navigate_to
 from utils.net import ip_address, resolve_hostname
-from utils.providers import get_crud_by_name, setup_a_provider_by_class
+from utils.providers import get_crud_by_name
 from utils import version
 from cfme import test_requirements
 
 provider_props = partial(details_page.infoblock.text, "Properties")
 
 
-@pytest.fixture(scope="module")
-def setup_a_provider():
-    setup_a_provider_by_class(InfraProvider)
-
-
 @pytest.mark.tier(3)
 @test_requirements.report
-def test_providers_summary(soft_assert, setup_a_provider):
+def test_providers_summary(soft_assert, infra_provider):
     """Checks some informations about the provider. Does not check memory/frequency as there is
     presence of units and rounding."""
     path = ["Configuration Management", "Providers", "Providers Summary"]
@@ -53,7 +48,7 @@ def test_providers_summary(soft_assert, setup_a_provider):
 
 @pytest.mark.tier(3)
 @test_requirements.report
-def test_cluster_relationships(soft_assert, setup_a_provider):
+def test_cluster_relationships(soft_assert, infra_provider):
     path = ["Relationships", "Virtual Machines, Folders, Clusters", "Cluster Relationships"]
     report = CannedSavedReport.new(path)
     for relation in report.data.rows:

--- a/cfme/tests/intelligence/reports/test_report_chargeback.py
+++ b/cfme/tests/intelligence/reports/test_report_chargeback.py
@@ -3,17 +3,10 @@ import fauxfactory
 import pytest
 import cfme.web_ui.flash as flash
 
-from cfme.infrastructure.provider import InfraProvider
 from cfme.intelligence.reports.reports import CustomReport
-from utils.providers import setup_a_provider_by_class
 from utils.log import logger
 
 pytestmark = [pytest.mark.tier(3)]
-
-
-@pytest.fixture(scope="module")
-def setup_first_provider():
-    setup_a_provider_by_class(InfraProvider)
 
 
 def _cleanup_report(report):
@@ -25,7 +18,7 @@ def _cleanup_report(report):
 
 
 # These tests are meant to catch issues such as BZ 1203022
-def test_charge_report_filter_owner(setup_first_provider, request):
+def test_charge_report_filter_owner(infra_provider, request):
     """Tests creation of chargeback report that is filtered by owner
 
     """
@@ -58,7 +51,7 @@ def test_charge_report_filter_owner(setup_first_provider, request):
     report.queue(wait_for_finish=True)
 
 
-def test_charge_report_filter_tag(setup_first_provider, request):
+def test_charge_report_filter_tag(infra_provider, request):
     """Tests creation of chargeback report that is filtered by tag
 
     """

--- a/cfme/tests/intelligence/reports/test_report_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_report_corresponds.py
@@ -4,20 +4,14 @@ import pytest
 from random import sample
 
 import utils
-from cfme.infrastructure.provider import InfraProvider
 from cfme.intelligence.reports.reports import CustomReport
-from utils.providers import get_crud_by_name, setup_a_provider_by_class
+from utils.providers import get_crud_by_name
 from utils.version import since_date_or_version
 from cfme import test_requirements
 
 
-@pytest.fixture(scope="module")
-def setup_first_provider():
-    setup_a_provider_by_class(InfraProvider)
-
-
 @pytest.yield_fixture(scope="function")
-def report_vms(setup_first_provider):
+def report_vms(infra_provider):
     report = CustomReport(
         menu_name=fauxfactory.gen_alphanumeric(),
         title=fauxfactory.gen_alphanumeric(),

--- a/cfme/tests/intelligence/test_chargeback_assignments.py
+++ b/cfme/tests/intelligence/test_chargeback_assignments.py
@@ -16,7 +16,7 @@ pytestmark = [
 
 
 @pytest.mark.meta(blockers=[1273654])
-def test_assign_compute_enterprise(vmware_provider):
+def test_assign_compute_enterprise(virtualcenter_provider):
     enterprise = cb.Assign(
         assign_to="The Enterprise",
         selections={
@@ -31,22 +31,22 @@ def test_assign_compute_enterprise(vmware_provider):
     assert selected_option == "Default", 'Selection does not match'
 
 
-def test_assign_compute_provider(vmware_provider):
+def test_assign_compute_provider(virtualcenter_provider):
     compute_provider = cb.Assign(
         assign_to="Selected Cloud/Infrastructure Providers",
         selections={
-            vmware_provider.name: "Default"
+            virtualcenter_provider.name: "Default"
         })
     compute_provider.computeassign()
 
     flash.assert_message_match('Rate Assignments saved')
     selected_option = sel.text(
-        cb.assign_form.selections.select_by_name(vmware_provider.name).first_selected_option)
+        cb.assign_form.selections.select_by_name(virtualcenter_provider.name).first_selected_option)
     assert selected_option == "Default", 'Selection does not match'
 
 
-def test_assign_compute_cluster(vmware_provider):
-    cluster_name = random.choice(vmware_provider.get_yaml_data()["clusters"])
+def test_assign_compute_cluster(virtualcenter_provider):
+    cluster_name = random.choice(virtualcenter_provider.get_yaml_data()["clusters"])
 
     cluster = cb.Assign(
         assign_to=version.pick({version.LOWEST: 'Selected Clusters',
@@ -62,7 +62,7 @@ def test_assign_compute_cluster(vmware_provider):
     assert selected_option == "Default", 'Selection does not match'
 
 
-def test_assign_compute_taggedvm(vmware_provider):
+def test_assign_compute_taggedvm(virtualcenter_provider):
     tagged_vm = cb.Assign(
         assign_to="Tagged VMs and Instances",
         tag_category="Location",
@@ -78,7 +78,7 @@ def test_assign_compute_taggedvm(vmware_provider):
 
 
 @pytest.mark.meta(blockers=[1273654])
-def test_assign_storage_enterprise(vmware_provider):
+def test_assign_storage_enterprise(virtualcenter_provider):
     enterprise = cb.Assign(
         assign_to="The Enterprise",
         selections={
@@ -93,8 +93,8 @@ def test_assign_storage_enterprise(vmware_provider):
     assert selected_option == "Default", 'Selection does not match'
 
 
-def test_assign_storage_datastores(vmware_provider):
-    datastore = random.choice(vmware_provider.get_yaml_data()["datastores"])["name"]
+def test_assign_storage_datastores(virtualcenter_provider):
+    datastore = random.choice(virtualcenter_provider.get_yaml_data()["datastores"])["name"]
 
     sel_datastore = cb.Assign(
         assign_to="Selected Datastores",
@@ -109,7 +109,7 @@ def test_assign_storage_datastores(vmware_provider):
     assert selected_option == "Default", 'Selection does not match'
 
 
-def test_assign_storage_tagged_datastores(vmware_provider):
+def test_assign_storage_tagged_datastores(virtualcenter_provider):
     tagged_datastore = cb.Assign(
         assign_to="Tagged Datastores",
         tag_category="Location",

--- a/cfme/tests/intelligence/test_chargeback_assignments.py
+++ b/cfme/tests/intelligence/test_chargeback_assignments.py
@@ -6,8 +6,6 @@ import pytest
 import random
 
 from cfme import test_requirements
-from cfme.infrastructure.provider.virtualcenter import VMwareProvider
-from utils.providers import setup_a_provider_by_class
 from utils import version
 
 
@@ -17,13 +15,8 @@ pytestmark = [
 ]
 
 
-@pytest.fixture(scope="module")
-def provider():
-    return setup_a_provider_by_class(VMwareProvider)
-
-
 @pytest.mark.meta(blockers=[1273654])
-def test_assign_compute_enterprise(provider):
+def test_assign_compute_enterprise(vmware_provider):
     enterprise = cb.Assign(
         assign_to="The Enterprise",
         selections={
@@ -38,22 +31,22 @@ def test_assign_compute_enterprise(provider):
     assert selected_option == "Default", 'Selection does not match'
 
 
-def test_assign_compute_provider(provider):
+def test_assign_compute_provider(vmware_provider):
     compute_provider = cb.Assign(
         assign_to="Selected Cloud/Infrastructure Providers",
         selections={
-            provider.name: "Default"
+            vmware_provider.name: "Default"
         })
     compute_provider.computeassign()
 
     flash.assert_message_match('Rate Assignments saved')
     selected_option = sel.text(
-        cb.assign_form.selections.select_by_name(provider.name).first_selected_option)
+        cb.assign_form.selections.select_by_name(vmware_provider.name).first_selected_option)
     assert selected_option == "Default", 'Selection does not match'
 
 
-def test_assign_compute_cluster(provider):
-    cluster_name = random.choice(provider.get_yaml_data()["clusters"])
+def test_assign_compute_cluster(vmware_provider):
+    cluster_name = random.choice(vmware_provider.get_yaml_data()["clusters"])
 
     cluster = cb.Assign(
         assign_to=version.pick({version.LOWEST: 'Selected Clusters',
@@ -69,7 +62,7 @@ def test_assign_compute_cluster(provider):
     assert selected_option == "Default", 'Selection does not match'
 
 
-def test_assign_compute_taggedvm(provider):
+def test_assign_compute_taggedvm(vmware_provider):
     tagged_vm = cb.Assign(
         assign_to="Tagged VMs and Instances",
         tag_category="Location",
@@ -85,7 +78,7 @@ def test_assign_compute_taggedvm(provider):
 
 
 @pytest.mark.meta(blockers=[1273654])
-def test_assign_storage_enterprise(provider):
+def test_assign_storage_enterprise(vmware_provider):
     enterprise = cb.Assign(
         assign_to="The Enterprise",
         selections={
@@ -100,8 +93,8 @@ def test_assign_storage_enterprise(provider):
     assert selected_option == "Default", 'Selection does not match'
 
 
-def test_assign_storage_datastores(provider):
-    datastore = random.choice(provider.get_yaml_data()["datastores"])["name"]
+def test_assign_storage_datastores(vmware_provider):
+    datastore = random.choice(vmware_provider.get_yaml_data()["datastores"])["name"]
 
     sel_datastore = cb.Assign(
         assign_to="Selected Datastores",
@@ -116,7 +109,7 @@ def test_assign_storage_datastores(provider):
     assert selected_option == "Default", 'Selection does not match'
 
 
-def test_assign_storage_tagged_datastores(provider):
+def test_assign_storage_tagged_datastores(vmware_provider):
     tagged_datastore = cb.Assign(
         assign_to="Tagged Datastores",
         tag_category="Location",

--- a/cfme/tests/intelligence/test_download_report.py
+++ b/cfme/tests/intelligence/test_download_report.py
@@ -2,9 +2,7 @@
 import pytest
 import os
 import shutil
-from cfme.infrastructure.provider import InfraProvider
 from cfme.intelligence.reports.reports import CannedSavedReport
-from utils.providers import setup_a_provider_by_class
 from utils.wait import wait_for
 from utils import browser
 
@@ -18,11 +16,6 @@ def clean_temp_directory():
             os.unlink(os.path.join(root, f))
         for d in dirs:
             shutil.rmtree(os.path.join(root, d))
-
-
-@pytest.fixture(scope="module")
-def setup_a_provider():
-    setup_a_provider_by_class(InfraProvider)
 
 
 @pytest.fixture
@@ -46,7 +39,7 @@ def report():
 # Files download is unsolved, since the browser runs in a separate container
 @pytest.mark.skip
 @pytest.mark.parametrize("filetype", ["txt", "csv"])
-def test_download_report_firefox(needs_firefox, setup_a_provider, report, filetype):
+def test_download_report_firefox(needs_firefox, infra_provider, report, filetype):
     """ Download the report as a file and check whether it was downloaded. """
     extension = "." + filetype
     clean_temp_directory()

--- a/cfme/tests/services/test_operations.py
+++ b/cfme/tests/services/test_operations.py
@@ -6,7 +6,6 @@ import pytest
 import cfme.provisioning
 from cfme import test_requirements
 from cfme.infrastructure.virtual_machines import Vm
-from cfme.infrastructure.provider import InfraProvider
 from cfme.fixtures import pytest_selenium as sel
 from cfme.login import login_admin
 from cfme.provisioning import provisioning_form
@@ -14,7 +13,6 @@ from cfme.services import requests
 from cfme.web_ui import flash, fill
 from utils.appliance.implementations.ui import navigate_to
 from utils.browser import browser
-from utils.providers import setup_a_provider_by_class
 from utils.wait import wait_for
 from fixtures.pytest_store import store
 
@@ -26,13 +24,8 @@ pytestmark = [
 
 
 @pytest.fixture(scope="module")
-def provider():
-    return setup_a_provider_by_class(InfraProvider)
-
-
-@pytest.fixture(scope="module")
-def provider_data(provider):
-    return provider.get_yaml_data()
+def provider_data(infra_provider):
+    return infra_provider.get_yaml_data()
 
 
 @pytest.fixture(scope="module")
@@ -51,7 +44,7 @@ def vm_name():
 
 
 @pytest.yield_fixture(scope="module")
-def generated_request(provider, provider_data, provisioning, template_name, vm_name):
+def generated_request(infra_provider, provider_data, provisioning, template_name, vm_name):
     """Creates a provision request, that is not automatically approved, and returns the search data.
 
     After finishing the test, request should be automatically deleted.
@@ -63,7 +56,7 @@ def generated_request(provider, provider_data, provisioning, template_name, vm_n
     notes = fauxfactory.gen_alphanumeric()
     e_mail = "{}@{}.test".format(first_name, last_name)
     host, datastore = map(provisioning.get, ('host', 'datastore'))
-    vm = Vm(name=vm_name, provider=provider, template_name=template_name)
+    vm = Vm(name=vm_name, provider=infra_provider, template_name=template_name)
     navigate_to(vm, 'ProvisionVM')
 
     provisioning_data = {

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -13,8 +13,9 @@ from cfme.rest.gen_data import service_templates as _service_templates
 from cfme.rest.gen_data import orchestration_templates as _orchestration_templates
 from cfme import test_requirements
 from cfme.infrastructure.provider import InfraProvider
+from fixtures.provider import setup_one_or_skip
 from utils import error, version
-from utils.providers import setup_a_provider, ProviderFilter
+from utils.providers import ProviderFilter
 from utils.wait import wait_for
 from utils.log import logger
 from utils.blockers import BZ
@@ -28,17 +29,14 @@ pytestmark = [
 
 
 @pytest.fixture(scope="module")
-def a_provider():
-    try:
-        pf = ProviderFilter(classes=[InfraProvider], required_fields=[
-            ['provisioning', 'template'],
-            ['provisioning', 'host'],
-            ['provisioning', 'datastore'],
-            ['provisioning', 'vlan'],
-            ['provisioning', 'catalog_item_type']])
-        return setup_a_provider(filters=[pf])
-    except Exception:
-        pytest.skip("It's not possible to set up any providers, therefore skipping")
+def a_provider(request):
+    pf = ProviderFilter(classes=[InfraProvider], required_fields=[
+        ['provisioning', 'template'],
+        ['provisioning', 'host'],
+        ['provisioning', 'datastore'],
+        ['provisioning', 'vlan'],
+        ['provisioning', 'catalog_item_type']])
+    return setup_one_or_skip(request, filters=[pf])
 
 
 @pytest.fixture(scope="function")

--- a/cfme/tests/storage/test_object_store.py
+++ b/cfme/tests/storage/test_object_store.py
@@ -3,21 +3,13 @@ import pytest
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.storage import object_store
 from cfme.web_ui import mixins
-from utils.providers import setup_a_provider_by_class
 from utils import testgen
 
-pytestmark = [pytest.mark.usefixtures("setup_a_provider")]
+
+pytestmark = pytest.mark.usefixtures("setup_provider")
 
 
-@pytest.fixture(scope="module")
-def setup_a_provider():
-    setup_a_provider_by_class(OpenStackProvider)
-
-
-def pytest_generate_tests(metafunc):
-    argnames, argvalues, idlist = testgen.providers_by_class(
-        metafunc, [OpenStackProvider])
-    testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope='module')
+pytest_generate_tests = testgen.generate([OpenStackProvider], scope="module")
 
 
 @pytest.mark.tier(3)

--- a/cfme/tests/test_db_restore.py
+++ b/cfme/tests/test_db_restore.py
@@ -17,7 +17,7 @@ from utils import version
 
 
 @pytest.fixture
-def vmware_provider_crud():
+def virtualcenter_provider_crud():
     try:
         return list_providers_by_class(VMwareProvider)[0]
     except IndexError:
@@ -68,7 +68,7 @@ def get_appliances():
 @pytest.mark.uncollectif(
     lambda: not (store.current_appliance.is_downstream and
         store.current_appliance.version >= '5.4'))
-def test_db_restore(request, soft_assert, vmware_provider_crud, ec2_provider_crud):
+def test_db_restore(request, soft_assert, virtualcenter_provider_crud, ec2_provider_crud):
 
     appl1, appl2 = get_appliances()
 
@@ -82,7 +82,7 @@ def test_db_restore(request, soft_assert, vmware_provider_crud, ec2_provider_cru
         # Manage infra,cloud providers and set some roles before taking a DB backup
         config.set_server_roles(automate=True)
         roles = config.get_server_roles()
-        vmware_provider_crud.setup()
+        virtualcenter_provider_crud.setup()
         wait_for_a_provider()
         ec2_provider_crud.setup()
         cloud_provider.wait_for_a_provider()
@@ -118,7 +118,7 @@ def test_db_restore(request, soft_assert, vmware_provider_crud, ec2_provider_cru
             'Restored DB is missing some providers'
 
         # Verify that existing provider can detect new VMs on the second appliance
-        vm = provision_vm(request, vmware_provider_crud)
+        vm = provision_vm(request, virtualcenter_provider_crud)
         soft_assert(vm.find_quadicon().state == 'currentstate-on')
         soft_assert(vm.provider.mgmt.is_vm_running(vm.name),
             "vm running")

--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -25,9 +25,9 @@ pytestmark = [test_requirements.rest]
 
 
 @pytest.fixture(scope="module")
-def a_provider():
+def a_provider(request):
     pf = ProviderFilter(classes=[VMwareProvider, RHEVMProvider])
-    return setup_one_or_skip(filters=[pf])
+    return setup_one_or_skip(request, filters=[pf])
 
 
 @pytest.fixture(scope="function")

--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -13,7 +13,8 @@ from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.rest.gen_data import vm as _vm
 from cfme.rest.gen_data import arbitration_settings, automation_requests_data
-from utils.providers import setup_a_provider, ProviderFilter
+from fixtures.provider import setup_one_or_skip
+from utils.providers import ProviderFilter
 from utils.version import current_version
 from utils.wait import wait_for
 from utils.log import logger
@@ -25,11 +26,8 @@ pytestmark = [test_requirements.rest]
 
 @pytest.fixture(scope="module")
 def a_provider():
-    try:
-        pf = ProviderFilter(classes=[VMwareProvider, RHEVMProvider])
-        return setup_a_provider(filters=[pf])
-    except Exception:
-        pytest.skip("It's not possible to set up any providers, therefore skipping")
+    pf = ProviderFilter(classes=[VMwareProvider, RHEVMProvider])
+    return setup_one_or_skip(filters=[pf])
 
 
 @pytest.fixture(scope="function")

--- a/fixtures/provider.py
+++ b/fixtures/provider.py
@@ -1,41 +1,42 @@
 """ Fixtures to set up providers
 
-There are two ways to request a setup provider depending on what kind of test we create.
+Used to ensure that we have a provider set up on the appliance before running a test.
+
+There are two ways to request a setup provider depending on what kind of test we create:
 
 1. Test parametrized by provider (test is run once per each matching provider)
    For parametrized tests, provider is delivered by testgen. Testgen ensures that the requested
-   provider is available as the 'provider' parameter. It doesn't set the provider up, however, as
+   provider is available as the ``provider`` parameter. It doesn't set the provider up, however, as
    it will only provide you with the appropriate provider CRUD object.
    To get the provider set up, we need to add one of the following fixtures to parameters as well:
-     - setup_provider
-     - setup_provider_modscope
-     - setup_provider_clsscope
-     - setup_provider_funcscope (same as setup_provider)
+     - ``setup_provider``
+     - ``setup_provider_modscope``
+     - ``setup_provider_clsscope``
+     - ``setup_provider_funcscope`` (same as ``setup_provider``)
 
-   This ensures that whatever is currently hiding under the 'provider' parameter will be set up.
+   This ensures that whatever is currently hiding under the ``provider`` parameter will be set up.
 
 2. Test not parametrized by provider (test is run once and we just need some provider available)
    In this case, we don't really care about what sort of a provider we have available. Usually,
    we just want something to fill the UI with data so that we can test our provider non-specific
    functionality. For that, we can leverage one of the following fixtures:
-     - core_provider (infra + cloud)
-     - infra_provider
-     - cloud_provider
-     - middleware_provider
-     - containers_provider
+     - ``core_provider`` (infra or cloud)
+     - ``infra_provider``
+     - ``cloud_provider``
+     - ``middleware_provider``
+     - ``containers_provider``
      - ...and others
 
-   If these don't really fit your needs, you can implement your own module-local 'a_provider'
-   fixture using setup_one_by_class_or_skip or more adjustable setup_one_or_skip. These functions
-   do exactly what their names suggest - they setup one of the providers fitting given parameters
-   or skip the test. All of these fixtures are (and should be) module scoped - please keep that in
-   mind when defining your module-local ones.
+   If these don't really fit your needs, you can implement your own module-local ``a_provider``
+   fixture using ``setup_one_by_class_or_skip`` or more adjustable ``setup_one_or_skip``.
+   These functions do exactly what their names suggest - they setup one of the providers fitting
+   given parameters or skip the test. All of these fixtures are (and should be) module scoped.
+   Please keep that in mind when creating your module-local substitutes.
 
 If setting up a provider fails, the issue is logged and an internal counter is incremented
-as a result. If this counter reaches a predefined number of failures (see SETUP_FAIL_LIMIT),
-the provider will be added to a list of problematic providers and no further attempts to set it up
-will be made.
-
+as a result. If this counter reaches a predefined number of failures (see ``SETUP_FAIL_LIMIT``),
+the failing provider will be added to the list of problematic providers and no further attempts
+to set it up will be made.
 """
 import pytest
 import random

--- a/fixtures/provider.py
+++ b/fixtures/provider.py
@@ -166,7 +166,7 @@ def vmware_provider(request):
     return setup_one_by_class_or_skip(request, VMwareProvider)
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def setup_provider(request, provider):
     """Function-scoped fixture to set up a provider"""
     return setup_or_skip(request, provider)

--- a/fixtures/provider.py
+++ b/fixtures/provider.py
@@ -170,7 +170,7 @@ def setup_one_by_class_or_skip(request, prov_class, use_global_filters=True):
 def _generate_provider_fixtures():
     """ Generate provider setup and clear fixtures based on what classes are available
 
-    This will make fixtures like "cloud_provider" and "has_no_cloud_provider" available to tests.
+    This will make fixtures like "cloud_provider" and "has_no_cloud_providers" available to tests.
     """
     for prov_type, prov_class in all_types().iteritems():
         def gen_setup_provider(prov_class):

--- a/fixtures/provider.py
+++ b/fixtures/provider.py
@@ -174,7 +174,7 @@ def _generate_provider_fixtures():
     """
     for prov_type, prov_class in all_types().iteritems():
         def gen_setup_provider(prov_class):
-            @pytest.fixture(scope='module')
+            @pytest.fixture(scope='function')
             def _setup_provider(request):
                 """ Sets up one of the matching providers """
                 return setup_one_by_class_or_skip(request, prov_class)
@@ -183,7 +183,7 @@ def _generate_provider_fixtures():
         globals()[fn_name] = gen_setup_provider(prov_class)
 
         def gen_has_no_providers(prov_class):
-            @pytest.fixture
+            @pytest.fixture(scope='function')
             def _has_no_providers():
                 """ Clears all providers of given class from the appliance """
                 BaseProvider.clear_providers_by_class(prov_class, validate=True)
@@ -194,6 +194,16 @@ def _generate_provider_fixtures():
 
 # Let's generate all the provider setup and clear fixtures within the scope of this module
 _generate_provider_fixtures()
+
+
+@pytest.fixture(scope="function")
+def has_no_providers(request):
+    BaseProvider.clear_providers()
+
+
+@pytest.fixture(scope="function")
+def setup_only_one_provider(request, has_no_providers):
+    return setup_one_or_skip(request)
 
 
 # When we want to setup a provider provided by testgen
@@ -221,12 +231,6 @@ def setup_provider_funcscope(request, provider):
     """Function-scoped fixture to set up a provider"""
     return setup_or_skip(request, provider)
 # -----------------------------------------------
-
-
-@pytest.fixture(scope="session")
-def any_provider_session(request):
-    BaseProvider.clear_providers()
-    return setup_one_or_skip(request)
 
 
 @pytest.fixture(scope="function")

--- a/fixtures/provider.py
+++ b/fixtures/provider.py
@@ -29,7 +29,7 @@ There are two ways to request a setup provider depending on what kind of test we
    If these don't really fit your needs, you can implement your own module-local ``a_provider``
    fixture using ``setup_one_by_class_or_skip`` or more adjustable ``setup_one_or_skip``.
    These functions do exactly what their names suggest - they setup one of the providers fitting
-   given parameters or skip the test. All of these fixtures are (and should be) module scoped.
+   given parameters or skip the test. All of these fixtures are (and should be) function scoped.
    Please keep that in mind when creating your module-local substitutes.
 
 If setting up a provider fails, the issue is logged and an internal counter is incremented

--- a/fixtures/provider.py
+++ b/fixtures/provider.py
@@ -61,7 +61,7 @@ SETUP_FAIL_LIMIT = 3
 def _artifactor_skip_providers(request, providers, skip_msg):
     node = request.node
     name, location = get_test_idents(node)
-    skip_data = {'type': 'provider', 'reason': [p.key for p in providers].join(', ')}
+    skip_data = {'type': 'provider', 'reason': ', '.join([p.key for p in providers])}
     art_client.fire_hook('skip_test', test_location=location, test_name=name,
         skip_data=skip_data)
     pytest.skip(skip_msg)
@@ -188,7 +188,7 @@ def _generate_provider_fixtures():
                 """ Clears all providers of given class from the appliance """
                 BaseProvider.clear_providers_by_class(prov_class, validate=True)
             return _has_no_providers
-        fn_name = 'has_no_{}_provider'.format(prov_type)
+        fn_name = 'has_no_{}_providers'.format(prov_type)
         globals()[fn_name] = gen_has_no_providers(prov_class)
 
 

--- a/fixtures/widgets.py
+++ b/fixtures/widgets.py
@@ -8,7 +8,7 @@ from utils.appliance.implementations.ui import navigate_to
 
 
 @pytest.fixture(scope="session")
-def widgets_generated(any_provider_session):
+def widgets_generated(setup_only_one_provider):
     navigate_to(Server, 'Dashboard')
     widget_list = []
     for widget in Widget.all():

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -2175,7 +2175,6 @@ class Appliance(IPAppliance):
     @logger_wrap("Configure fleecing: {}")
     def configure_fleecing(self, log_callback=None):
         from cfme.configure.configuration import set_server_roles, get_server_roles
-        from utils.providers import setup_provider
         with self(browser_steal=True):
             if self.is_on_vsphere:
                 self.install_vddk(reboot=True, log_callback=log_callback)

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -2199,7 +2199,7 @@ class Appliance(IPAppliance):
 
             # add provider
             log_callback('Setting up provider...')
-            setup_provider(self._provider_key)
+            self.provider.setup()
 
             # credential hosts
             log_callback('Credentialing hosts...')

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -501,7 +501,7 @@ class IPAppliance(object):
                 unrecognized_ems_names.add(ems.name)
         if unrecognized_ems_names:
             self.log.warning(
-                "Unrecognized managed providers: {}".format(','.join(unrecognized_ems_names)))
+                "Unrecognized managed providers: {}".format(', '.join(unrecognized_ems_names)))
         return list(found_cruds)
 
     @property

--- a/utils/providers.py
+++ b/utils/providers.py
@@ -1,11 +1,10 @@
 """ Helper functions related to the creation, listing, filtering and destruction of providers
 
-The functions in this module that require the 'filters' parameter, such as list_providers,
-setup_a_provider etc depend on a (by default global) dict of filters by default.
-If you are writing tests or fixtures, you want to depend on those functions as de facto gateways.
+The list_providers function in this module depend on a (by default global) dict of filters.
+If you are writing tests or fixtures, you want to depend on this function as a de facto gateway.
 
-The rest of the functions, such as get_mgmt, get_crud etc ignore this global dict and will provide
-you with whatever you ask for with no limitations.
+The rest of the functions, such as get_mgmt, get_crud, get_provider_keys etc ignore this global
+dict and will provide you with whatever you ask for with no limitations.
 
 The main clue to know what is limited by the filters and what isn't is the 'filters' parameter.
 """

--- a/utils/providers.py
+++ b/utils/providers.py
@@ -13,7 +13,7 @@ import six
 from collections import Mapping, OrderedDict
 from copy import copy
 
-from cfme.common.provider import base_types, provider_types
+from cfme.common.provider import all_types
 
 from cfme.containers import provider as containers_providers  # NOQA
 from cfme.cloud import provider as cloud_providers  # NOQA
@@ -299,12 +299,8 @@ def list_provider_keys(provider_type=None):
 
 
 def get_class_from_type(prov_type):
-    """ Serves to translate both provider types and categories to actual classes """
-    all_classes_map = base_types().copy()
-    for base_type in base_types().keys():
-        all_classes_map.update(provider_types(base_type))
     try:
-        return all_classes_map[prov_type]
+        return all_types()[prov_type]
     except KeyError:
         raise UnknownProviderType("Unknown provider type: {}!".format(prov_type))
 

--- a/utils/testgen.py
+++ b/utils/testgen.py
@@ -200,7 +200,7 @@ def generate(*args, **kwargs):
 
     """
     # Pull out/default kwargs for this function and parametrize; any args and kwargs that are not
-    # pulled out here will be passed into gen_func withing pytest_generate_tests below
+    # pulled out here will be passed into gen_func within pytest_generate_tests below
     scope = kwargs.pop('scope', 'function')
     indirect = kwargs.pop('indirect', False)
     filter_unused = kwargs.pop('filter_unused', True)

--- a/utils/testgen.py
+++ b/utils/testgen.py
@@ -95,28 +95,69 @@ from utils.log import logger
 from utils.providers import ProviderFilter, list_providers
 
 
-def providers_by_class(metafunc, classes, required_fields=None):
-    """ Gets providers by their class
+def _param_check(metafunc, argnames, argvalues):
+    """Helper function to check if parametrizing is necessary
+
+    * If no argnames were specified, parametrization is unnecessary.
+    * If argvalues were generated, parametrization is necessary.
+    * If argnames were specified, but no values were generated, the test cannot run successfully,
+      and will be uncollected using the :py:mod:`markers.uncollect` mark.
+
+    See usage in :py:func:`parametrize`
 
     Args:
-        metafunc: Passed in by pytest
-        classes: List of classes to fetch
-        required_fields: See :py:class:`cfme.utils.provider.ProviderFilter`
+        metafunc: metafunc objects from pytest_generate_tests
+        argnames: argnames list for use in metafunc.parametrize
+        argvalues: argvalues list for use in metafunc.parametrize
 
-    Usage:
-        # In the function itself
-        def pytest_generate_tests(metafunc):
-            argnames, argvalues, idlist = testgen.providers_by_class(
-                [GCEProvider, AzureProvider], required_fields=['provisioning']
-            )
-        metafunc.parametrize(argnames, argvalues, ids=idlist, scope='module')
+    Returns:
+        * ``True`` if this test should be parametrized
+        * ``False`` if it shouldn't be parametrized
+        * ``None`` if the test will be uncollected
 
-        # Using the parametrize wrapper
-        pytest_generate_tests = testgen.parametrize(testgen.providers_by_class, [GCEProvider],
-            scope='module')
     """
-    pf = ProviderFilter(classes=classes, required_fields=required_fields)
-    return providers(metafunc, filters=[pf])
+    # If no parametrized args were named, don't parametrize
+    if not argnames:
+        return False
+    # If parametrized args were named and values were generated, parametrize
+    elif any(argvalues):
+        return True
+    # If parametrized args were named, but no values were generated, mark this test to be
+    # removed from the test collection. Otherwise, py.test will try to find values for the
+    # items in argnames by looking in its fixture pool, which will almost certainly fail.
+    else:
+        # module and class are optional, but function isn't
+        modname = getattr(metafunc.module, '__name__', None)
+        classname = getattr(metafunc.cls, '__name__', None)
+        funcname = metafunc.function.__name__
+
+        test_name = '.'.join(filter(None, (modname, classname, funcname)))
+        uncollect_msg = 'Parametrization for {} yielded no values,'\
+            ' marked for uncollection'.format(test_name)
+        logger.warning(uncollect_msg)
+
+        # apply the mark
+        pytest.mark.uncollect(reason=uncollect_msg)(metafunc.function)
+
+
+def parametrize(metafunc, argnames, argvalues, *args, **kwargs):
+    """parametrize wrapper that calls :py:func:`_param_check`, and only parametrizes when needed
+
+    This can be used in any place where conditional parametrization is used.
+
+    """
+    if _param_check(metafunc, argnames, argvalues):
+        metafunc.parametrize(argnames, argvalues, *args, **kwargs)
+    # if param check failed and the test was supposed to be parametrized around a provider
+    elif 'provider' in metafunc.fixturenames:
+        try:
+            # hack to pass trough in case of a failed param_check
+            # where it sets a custom message
+            metafunc.function.uncollect
+        except AttributeError:
+            pytest.mark.uncollect(
+                reason="provider was not parametrized did you forget --use-provider?"
+            )(metafunc.function)
 
 
 def generate(*args, **kwargs):
@@ -138,10 +179,16 @@ def generate(*args, **kwargs):
     Usage:
 
         # Abstract example:
-        pytest_generate_tests = testgen.generate(testgen.test_gen_func, arg1, arg2, kwarg1='a')
+        pytest_generate_tests = testgen.generate(arg1, arg2, kwarg1='a')
 
-        # Concrete example using infra_providers and scope
-        pytest_generate_tests = testgen.generate(testgen.infra_providers, scope="module")
+        # Concrete example using all infrastructure providers and module scope
+        pytest_generate_tests = testgen.generate([InfraProvider], scope="module")
+
+        # Another concrete example using only VMware and SCVMM providers with 'retire' flag
+        pf = ProviderFilter(
+            classes=[WMwareProvider, SCVMMProvider]), required_flags=['retire'])
+        pytest_generate_tests = testgen.generate(
+            gen_func=testgen.providers, filters=[pf], scope="module")
 
     Note:
 
@@ -152,14 +199,30 @@ def generate(*args, **kwargs):
         at least one common argname in every test signature to give pytest a clue in sorting tests.
 
     """
-    # Pull out/default kwargs for this function and parametrize
+    # Pull out/default kwargs for this function and parametrize; any args and kwargs that are not
+    # pulled out here will be passed into gen_func withing pytest_generate_tests below
     scope = kwargs.pop('scope', 'function')
     indirect = kwargs.pop('indirect', False)
     filter_unused = kwargs.pop('filter_unused', True)
     gen_func = kwargs.pop('gen_func', providers_by_class)
 
+    def fixture_filter(metafunc, argnames, argvalues):
+        """Filter fixtures based on fixturenames in the function represented by ``metafunc``"""
+        # Identify indeces of matches between argnames and fixturenames
+        keep_index = [e[0] for e in enumerate(argnames) if e[1] in metafunc.fixturenames]
+
+        # Keep items at indices in keep_index
+        def f(l):
+            return [e[1] for e in enumerate(l) if e[0] in keep_index]
+
+        # Generate the new values
+        argnames = f(argnames)
+        argvalues = map(f, argvalues)
+        return argnames, argvalues
+
     # If parametrize doesn't get you what you need, steal this and modify as needed
     def pytest_generate_tests(metafunc):
+        # Pass through of args and kwargs
         argnames, argvalues, idlist = gen_func(metafunc, *args, **kwargs)
         # Filter out argnames that aren't requested on the metafunc test item, so not all tests
         # need all fixtures to run, and tests not using gen_func's fixtures aren't parametrized.
@@ -167,42 +230,8 @@ def generate(*args, **kwargs):
             argnames, argvalues = fixture_filter(metafunc, argnames, argvalues)
         # See if we have to parametrize at all after filtering
         parametrize(metafunc, argnames, argvalues, indirect=indirect, ids=idlist, scope=scope)
+
     return pytest_generate_tests
-
-
-def parametrize(metafunc, argnames, argvalues, *args, **kwargs):
-    """parametrize wrapper that calls :py:func:`param_check`, and only parametrizes when needed
-
-    This can be used in any place where conditional parametrization is used.
-
-    """
-    if param_check(metafunc, argnames, argvalues):
-        metafunc.parametrize(argnames, argvalues, *args, **kwargs)
-    # if param check failed and the test was supposed to be parametrized around a provider
-    elif 'provider' in metafunc.fixturenames:
-        try:
-            # hack to pass trough in case of a failed param_check
-            # where it sets a custom message
-            metafunc.function.uncollect
-        except AttributeError:
-            pytest.mark.uncollect(
-                reason="provider was not parametrized did you forget --use-provider?"
-            )(metafunc.function)
-
-
-def fixture_filter(metafunc, argnames, argvalues):
-    """Filter fixtures based on fixturenames in the function represented by ``metafunc``"""
-    # Identify indeces of matches between argnames and fixturenames
-    keep_index = [e[0] for e in enumerate(argnames) if e[1] in metafunc.fixturenames]
-
-    # Keep items at indices in keep_index
-    def f(l):
-        return [e[1] for e in enumerate(l) if e[0] in keep_index]
-
-    # Generate the new values
-    argnames = f(argnames)
-    argvalues = map(f, argvalues)
-    return argnames, argvalues
 
 
 def providers(metafunc, filters=None):
@@ -241,6 +270,29 @@ def providers(metafunc, filters=None):
             argnames.append('provider')
 
     return argnames, argvalues, idlist
+
+
+def providers_by_class(metafunc, classes, required_fields=None):
+    """ Gets providers by their class
+
+    Args:
+        metafunc: Passed in by pytest
+        classes: List of classes to fetch
+        required_fields: See :py:class:`cfme.utils.provider.ProviderFilter`
+
+    Usage:
+        # In the function itself
+        def pytest_generate_tests(metafunc):
+            argnames, argvalues, idlist = testgen.providers_by_class(
+                [GCEProvider, AzureProvider], required_fields=['provisioning']
+            )
+        metafunc.parametrize(argnames, argvalues, ids=idlist, scope='module')
+
+        # Using the parametrize wrapper
+        pytest_generate_tests = testgen.parametrize([GCEProvider], scope='module')
+    """
+    pf = ProviderFilter(classes=classes, required_fields=required_fields)
+    return providers(metafunc, filters=[pf])
 
 
 def all_providers(metafunc, **options):
@@ -307,48 +359,3 @@ def pxe_servers(metafunc):
                           get_pxe_server_from_config(pxe_server)])
         idlist.append(pxe_server)
     return argnames, argvalues, idlist
-
-
-def param_check(metafunc, argnames, argvalues):
-    """Helper function to check if parametrizing is necessary
-
-    * If no argnames were specified, parametrization is unnecessary.
-    * If argvalues were generated, parametrization is necessary.
-    * If argnames were specified, but no values were generated, the test cannot run successfully,
-      and will be uncollected using the :py:mod:`markers.uncollect` mark.
-
-    See usage in :py:func:`parametrize`
-
-    Args:
-        metafunc: metafunc objects from pytest_generate_tests
-        argnames: argnames list for use in metafunc.parametrize
-        argvalues: argvalues list for use in metafunc.parametrize
-
-    Returns:
-        * ``True`` if this test should be parametrized
-        * ``False`` if it shouldn't be parametrized
-        * ``None`` if the test will be uncollected
-
-    """
-    # If no parametrized args were named, don't parametrize
-    if not argnames:
-        return False
-    # If parametrized args were named and values were generated, parametrize
-    elif any(argvalues):
-        return True
-    # If parametrized args were named, but no values were generated, mark this test to be
-    # removed from the test collection. Otherwise, py.test will try to find values for the
-    # items in argnames by looking in its fixture pool, which will almost certainly fail.
-    else:
-        # module and class are optional, but function isn't
-        modname = getattr(metafunc.module, '__name__', None)
-        classname = getattr(metafunc.cls, '__name__', None)
-        funcname = metafunc.function.__name__
-
-        test_name = '.'.join(filter(None, (modname, classname, funcname)))
-        uncollect_msg = 'Parametrization for {} yielded no values,'\
-            ' marked for uncollection'.format(test_name)
-        logger.warning(uncollect_msg)
-
-        # apply the mark
-        pytest.mark.uncollect(reason=uncollect_msg)(metafunc.function)

--- a/utils/tests/test_ipappliance.py
+++ b/utils/tests/test_ipappliance.py
@@ -2,10 +2,8 @@
 from urlparse import urlparse
 import pytest
 
-from cfme.infrastructure.provider import InfraProvider
 from fixtures.pytest_store import store
 from utils.appliance import IPAppliance
-from utils.providers import setup_a_provider_by_class
 
 
 def test_ipappliance_from_address():
@@ -31,10 +29,9 @@ def test_ipappliance_use_baseurl():
     assert ip_a.address in store.base_url
 
 
-def test_ipappliance_managed_providers():
+def test_ipappliance_managed_providers(infra_provider):
     ip_a = IPAppliance()
-    provider = setup_a_provider_by_class(InfraProvider)
-    assert provider in ip_a.managed_providers
+    assert infra_provider in ip_a.managed_providers
 
 
 def test_context_hack(monkeypatch):


### PR DESCRIPTION
Added `.setup()` to provider object
Added `setup_or_skip`, `setup_one_or_skip` and `setup_one_by_class_or_skip` to `fixtures.provider`
Added `infra_provider`, `cloud_provider` and others to `fixtures.provider`
Removed `setup_provider`, `setup_a_provider` and `setup_a_provider_by_class` from `utils.providers` - turns out it really has no place in there
Updated `utils.testgen` docs and moved things around to make more sense for a casual explorer, the docs do still need some more love though
Added dynamically-generated fixtures for provider setup to `fixtures.provider`

{{pytest: -k "test_provider or test_tag_objects" -v --use-provider complete}}