### PR TITLE
[1LP][RFR] check response status code for test_order_catalog_item_via_rest

### DIFF
--- a/cfme/tests/services/test_service_catalogs.py
+++ b/cfme/tests/services/test_service_catalogs.py
@@ -49,7 +49,7 @@ def test_order_catalog_item(provider, setup_provider, catalog_item, request, reg
 
     service_catalogs = ServiceCatalogs(catalog_item.name)
     service_catalogs.order()
-    logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
+    logger.info("Waiting for cfme provision request for service {}".format(catalog_item.name))
     row_description = catalog_item.name
     cells = {'Description': row_description}
     row, __ = wait_for(requests.wait_for_request, [cells, True],
@@ -75,12 +75,13 @@ def test_order_catalog_item_via_rest(
     assert len(template) == 1
     template, = template
     req = template.action.order()
+    assert rest_api.response.status_code == 200
 
     @pytest.wait_for(timeout="15m", delay=5)
     def request_finished():
         req.reload()
-        logger.info("Request status: %s, Request state: %s, Request message: %s",
-            req.status, req.request_state, req.message)
+        logger.info("Request status: {}, Request state: {}, Request message: {}".format(
+            req.status, req.request_state, req.message))
         return req.status.lower() == "ok" and req.request_state.lower() == "finished"
 
 
@@ -101,7 +102,7 @@ def test_order_catalog_bundle(provider, setup_provider, catalog_item, request):
     catalog_bundle.create([catalog_item.name])
     service_catalogs = ServiceCatalogs(catalog_bundle.name)
     service_catalogs.order()
-    logger.info('Waiting for cfme provision request for service %s', bundle_name)
+    logger.info("Waiting for cfme provision request for service {}".format(bundle_name))
     row_description = bundle_name
     cells = {'Description': row_description}
     row, __ = wait_for(requests.wait_for_request, [cells, True],
@@ -151,7 +152,7 @@ def test_request_with_orphaned_template(provider, setup_provider, catalog_item):
     catalog_item.create()
     service_catalogs = ServiceCatalogs(catalog_item.name)
     service_catalogs.order()
-    logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
+    logger.info("Waiting for cfme provision request for service {}".format(catalog_item.name))
     row_description = catalog_item.name
     cells = {'Description': row_description}
     provider.delete(cancel=False)


### PR DESCRIPTION
check HTTP response status code

PRT:
on 5.8 and upstream, in cfme/services/catalogs/catalog.py:168 the `navigate_to(self, 'Add')` is not navigating to 'Add' for some reason. In any case it's not an issue that is supposed to be solved in this PR.

{{pytest:  cfme/tests/services/test_service_catalogs.py -v -k rest --long-running}}