### PR TITLE
[1LP][RFR] test_rest_services fixes and refactoring

### DIFF
--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -452,4 +452,5 @@ def blueprints(request, rest_api, num=2):
                 'chart_data_model': {}
             }
         })
+
     return _creating_skeleton(request, rest_api, 'blueprints', data)

--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -436,3 +436,20 @@ def arbitration_rules(request, rest_api, num=2):
         })
 
     return _creating_skeleton(request, rest_api, 'arbitration_rules', data)
+
+
+def blueprints(request, rest_api, num=2):
+    data = []
+    for _ in range(num):
+        uniq = fauxfactory.gen_alphanumeric(5)
+        data.append({
+            'name': 'test_blueprint_{}'.format(uniq),
+            'description': 'Test Blueprint {}'.format(uniq),
+            'ui_properties': {
+                'service_catalog': {},
+                'service_dialog': {},
+                'automate_entrypoints': {},
+                'chart_data_model': {}
+            }
+        })
+    return _creating_skeleton(request, rest_api, 'blueprints', data)

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -150,7 +150,7 @@ class TestServiceRESTAPI(object):
             service.reload()
             assert service.name == new_names[i]
 
-    @pytest.mark.meta(blockers=[BZ(1414852, forced_streams=['5.7', 'upstream'])])
+    @pytest.mark.meta(blockers=[BZ(1414852, forced_streams=['5.7', '5.8', 'upstream'])])
     def test_delete_service_post(self, rest_api, services):
         """Tests deleting services from detail using POST method.
 
@@ -311,14 +311,14 @@ class TestServiceRESTAPI(object):
             assert rest_api.response.status_code == 200
             wait_for_vm_power_state(vm, resulting_state)
 
-        _action_and_check('start', 'on')
+        wait_for_vm_power_state(vm, 'on')
         _action_and_check('stop', 'off')
         _action_and_check('start', 'on')
         _action_and_check('suspend', 'suspended')
         _action_and_check('start', 'on')
 
-    @pytest.mark.meta(blockers=[BZ(1416146, forced_streams=['5.7', 'upstream'])])
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
+    @pytest.mark.meta(blockers=[BZ(1416146, forced_streams=['5.7', '5.8', 'upstream'])])
     def test_create_service_from_parent(self, request, rest_api):
         """Tests creation of new service that reference existing service.
 
@@ -376,8 +376,8 @@ class TestServiceRESTAPI(object):
         child.reload()
         assert child.ancestry == str(parent.id)
 
-    @pytest.mark.meta(blockers=[BZ(1416903, forced_streams=['5.7', 'upstream'])])
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
+    @pytest.mark.meta(blockers=[BZ(1416903, forced_streams=['5.7', '5.8', 'upstream'])])
     def test_power_parent_service(self, request, rest_api, service_data):
         """Tests that power operations triggered on service parent affects child service.
 
@@ -400,7 +400,7 @@ class TestServiceRESTAPI(object):
             assert rest_api.response.status_code == 200
             wait_for_vm_power_state(vm, resulting_state)
 
-        _action_and_check('start', 'on')
+        wait_for_vm_power_state(vm, 'on')
         _action_and_check('stop', 'off')
         _action_and_check('start', 'on')
         _action_and_check('suspend', 'suspended')
@@ -489,7 +489,7 @@ class TestServiceTemplateRESTAPI(object):
             rest_api.collections.service_templates.action.delete(*service_templates)
         assert rest_api.response.status_code == 404
 
-    @pytest.mark.meta(blockers=[BZ(1427338, forced_streams=['5.7', 'upstream'])])
+    @pytest.mark.meta(blockers=[BZ(1427338, forced_streams=['5.6', '5.7', '5.8', 'upstream'])])
     def test_delete_service_template_post(self, rest_api, service_templates):
         """Tests deleting service templates from detail using POST method.
 
@@ -702,7 +702,7 @@ class TestOrchestrationTemplatesRESTAPI(object):
 
     @pytest.mark.tier(3)
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
-    @pytest.mark.meta(blockers=[BZ(1414881, forced_streams=['5.7', 'upstream'])])
+    @pytest.mark.meta(blockers=[BZ(1414881, forced_streams=['5.7', '5.8', 'upstream'])])
     def test_delete_orchestration_templates_from_detail_post(self, orchestration_templates,
             rest_api):
         """Tests deleting orchestration templates from detail using POST method.

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -3,21 +3,19 @@ import datetime
 import fauxfactory
 import pytest
 
-from manageiq_client.api import APIException
-
 from cfme.rest.gen_data import dialog as _dialog
 from cfme.rest.gen_data import services as _services
 from cfme.rest.gen_data import service_data as _service_data
 from cfme.rest.gen_data import service_catalogs as _service_catalogs
 from cfme.rest.gen_data import service_templates as _service_templates
 from cfme.rest.gen_data import orchestration_templates as _orchestration_templates
+from cfme.rest.gen_data import blueprints as _blueprints
 from cfme import test_requirements
 from cfme.infrastructure.provider import InfraProvider
 from fixtures.provider import setup_one_or_skip
 from utils import error, version
 from utils.providers import ProviderFilter
 from utils.wait import wait_for
-from utils.log import logger
 from utils.blockers import BZ
 
 
@@ -39,31 +37,6 @@ def a_provider(request):
     return setup_one_or_skip(request, filters=[pf])
 
 
-@pytest.fixture(scope="function")
-def dialog():
-    return _dialog()
-
-
-@pytest.fixture(scope="function")
-def service_catalogs(request, rest_api):
-    return _service_catalogs(request, rest_api)
-
-
-@pytest.fixture(scope="function")
-def services(request, rest_api, a_provider, dialog, service_catalogs):
-    return _services(request, rest_api, a_provider, dialog, service_catalogs)
-
-
-@pytest.fixture(scope='function')
-def service_templates(request, rest_api, dialog):
-    return _service_templates(request, rest_api, dialog)
-
-
-@pytest.fixture(scope='function')
-def service_data(request, rest_api, a_provider, dialog, service_catalogs):
-    return _service_data(request, rest_api, a_provider, dialog, service_catalogs)
-
-
 def wait_for_vm_power_state(vm, resulting_state):
     wait_for(
         lambda: vm.power_state == resulting_state,
@@ -82,6 +55,55 @@ def service_body(**kwargs):
     return body
 
 
+@pytest.fixture(scope="function")
+def dialog():
+    return _dialog()
+
+
+@pytest.fixture(scope="function")
+def service_catalogs(request, rest_api):
+    response = _service_catalogs(request, rest_api)
+    assert rest_api.response.status_code == 200
+    return response
+
+
+@pytest.fixture(scope="function")
+def services(request, rest_api, a_provider):
+    if version.current_version() >= '5.7':
+        # create simple service using REST API
+        bodies = [service_body() for _ in range(3)]
+        collection = rest_api.collections.services
+        new_services = collection.action.create(*bodies)
+        assert rest_api.response.status_code == 200
+
+        @request.addfinalizer
+        def _finished():
+            collection.reload()
+            ids = [service.id for service in new_services]
+            delete_entities = [service for service in collection if service.id in ids]
+            if len(delete_entities) != 0:
+                collection.action.delete(*delete_entities)
+
+        return new_services
+    else:
+        # create full-blown service using UI
+        s_dialog = _dialog()
+        s_catalogs = _service_catalogs(request, rest_api)
+        return _services(request, rest_api, a_provider, s_dialog, s_catalogs)
+
+
+@pytest.fixture(scope="function")
+def service_templates(request, rest_api, dialog):
+    response = _service_templates(request, rest_api, dialog)
+    assert rest_api.response.status_code == 200
+    return response
+
+
+@pytest.fixture(scope="function")
+def service_data(request, rest_api, a_provider, dialog, service_catalogs):
+    return _service_data(request, rest_api, a_provider, dialog, service_catalogs)
+
+
 class TestServiceRESTAPI(object):
     def test_edit_service(self, rest_api, services):
         """Tests editing a service.
@@ -93,14 +115,13 @@ class TestServiceRESTAPI(object):
         Metadata:
             test_flag: rest
         """
-        ser = services[0]
-        new_name = fauxfactory.gen_alphanumeric()
-        ser.action.edit(name=new_name)
-        wait_for(
-            lambda: rest_api.collections.services.find_by(name=new_name),
-            num_sec=180,
-            delay=10,
-        )
+        for service in services:
+            new_name = fauxfactory.gen_alphanumeric()
+            response = service.action.edit(name=new_name)
+            assert rest_api.response.status_code == 200
+            assert response.name == new_name
+            service.reload()
+            assert service.name == new_name
 
     def test_edit_multiple_services(self, rest_api, services):
         """Tests editing multiple service catalogs at time.
@@ -114,121 +135,156 @@ class TestServiceRESTAPI(object):
         """
         new_names = []
         services_data_edited = []
-        for ser in services:
+        for service in services:
             new_name = fauxfactory.gen_alphanumeric()
             new_names.append(new_name)
             services_data_edited.append({
-                "href": ser.href,
+                "href": service.href,
                 "name": new_name,
             })
-        rest_api.collections.services.action.edit(*services_data_edited)
-        for new_name in new_names:
+        response = rest_api.collections.services.action.edit(*services_data_edited)
+        assert rest_api.response.status_code == 200
+        for i, resource in enumerate(response):
+            assert resource.name == new_names[i]
+            service = services[i]
+            service.reload()
+            assert service.name == new_names[i]
+
+    @pytest.mark.meta(blockers=[BZ(1414852, forced_streams=['5.7', 'upstream'])])
+    def test_delete_service_post(self, rest_api, services):
+        """Tests deleting services from detail using POST method.
+
+        Metadata:
+            test_flag: rest
+        """
+        for service in services:
+            service.action.delete(force_method="post")
+            assert rest_api.response.status_code == 200
+            with error.expected("ActiveRecord::RecordNotFound"):
+                service.action.delete(force_method="post")
+            assert rest_api.response.status_code == 404
+
+    def test_delete_service_delete(self, rest_api, services):
+        """Tests deleting services from detail using DELETE method.
+
+        Metadata:
+            test_flag: rest
+        """
+        for service in services:
+            service.action.delete(force_method="delete")
+            assert rest_api.response.status_code == 204
+            with error.expected("ActiveRecord::RecordNotFound"):
+                service.action.delete(force_method="delete")
+            assert rest_api.response.status_code == 404
+
+    def test_delete_services(self, rest_api, services):
+        """Tests deleting services from collection.
+
+        Metadata:
+            test_flag: rest
+        """
+        rest_api.collections.services.action.delete(*services)
+        assert rest_api.response.status_code == 200
+        with error.expected("ActiveRecord::RecordNotFound"):
+            rest_api.collections.services.action.delete(*services)
+        assert rest_api.response.status_code == 404
+
+    @pytest.mark.parametrize(
+        "from_detail", [True, False],
+        ids=["from_detail", "from_collection"])
+    def test_retire_service_now(self, rest_api, services, from_detail):
+        """Test retiring a service now.
+
+        Metadata:
+            test_flag: rest
+        """
+        if from_detail:
+            for service in services:
+                service.action.retire()
+                assert rest_api.response.status_code == 200
+        else:
+            rest_api.collections.services.action.retire(*services)
+            assert rest_api.response.status_code == 200
+
+        for service in services:
             wait_for(
-                lambda: rest_api.collections.service_templates.find_by(name=new_name),
-                num_sec=180,
+                lambda: not rest_api.collections.services.find_by(name=service.name),
+                num_sec=600,
                 delay=10,
             )
 
-    def test_delete_service(self, rest_api, services):
-        service = rest_api.collections.services[0]
-        service.action.delete()
-        with error.expected("ActiveRecord::RecordNotFound"):
-            service.action.delete()
+    @pytest.mark.parametrize(
+        "from_detail", [True, False],
+        ids=["from_detail", "from_collection"])
+    def test_retire_service_future(self, rest_api, services, from_detail):
+        """Test retiring a service in future.
 
-    def test_delete_services(self, rest_api, services):
-        rest_api.collections.services.action.delete(*services)
-        with error.expected("ActiveRecord::RecordNotFound"):
-            rest_api.collections.services.action.delete(*services)
-
-    def test_retire_service_now(self, rest_api, services):
-        """Test retiring a service
-        Prerequisities:
-            * An appliance with ``/api`` available.
-        Steps:
-            * Retrieve list of entities using GET /api/services , pick the first one
-            * POST /api/service/<id> (method ``retire``)
         Metadata:
             test_flag: rest
         """
-        assert "retire" in rest_api.collections.services.action.all
-        retire_service = services[0]
-        retire_service.action.retire()
-        wait_for(
-            lambda: not rest_api.collections.services.find_by(name=retire_service.name),
-            num_sec=600,
-            delay=10,
-        )
-
-    def test_retire_service_future(self, rest_api, services):
-        """Test retiring a service
-        Prerequisities:
-            * An appliance with ``/api`` available.
-        Steps:
-            * Retrieve list of entities using GET /api/services , pick the first one
-            * POST /api/service/<id> (method ``retire``) with the ``retire_date``
-        Metadata:
-            test_flag: rest
-        """
-        assert "retire" in rest_api.collections.services.action.all
-
-        retire_service = services[0]
-        date = (datetime.datetime.now() + datetime.timedelta(days=5)).strftime('%m/%d/%y')
+        date = (datetime.datetime.now() + datetime.timedelta(days=5)).strftime("%Y/%m/%d")
         future = {
             "date": date,
             "warn": "4",
         }
-        date_before = retire_service.updated_at
-        retire_service.action.retire(future)
 
-        def _finished():
-            retire_service.reload()
-            if retire_service.updated_at > date_before:
-                return True
-            return False
+        if from_detail:
+            for service in services:
+                service.action.retire(**future)
+                assert rest_api.response.status_code == 200
+        else:
+            rest_api.collections.services.action.retire(*services, **future)
+            assert rest_api.response.status_code == 200
 
-        wait_for(_finished, num_sec=600, delay=5, message="REST automation_request finishes")
+        def _finished(ser):
+            ser.reload()
+            if not hasattr(ser, "retires_on"):
+                return False
+            if not hasattr(ser, "retirement_warn"):
+                return False
+            return True
 
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.5')
+        for service in services:
+            wait_for(
+                lambda: _finished(service),
+                num_sec=60,
+                delay=5
+            )
+
     def test_set_service_owner(self, rest_api, services):
         """Tests set_ownership action on /api/services/:id.
 
         Metadata:
             test_flag: rest
         """
-        if "set_ownership" not in rest_api.collections.services.action.all:
-            pytest.skip("Set owner action for service is not implemented in this version")
-        service = services[0]
-        user = rest_api.collections.users.get(userid='admin')
+        user = rest_api.collections.users.get(userid="admin")
         data = {
             "owner": {"href": user.href}
         }
-        service.action.set_ownership(data)
-        service.reload()
-        assert hasattr(service, "evm_owner")
-        assert service.evm_owner.userid == user.userid
+        for service in services:
+            service.action.set_ownership(**data)
+            service.reload()
+            assert rest_api.response.status_code == 200
+            assert hasattr(service, "evm_owner_id")
+            assert service.evm_owner_id == user.id
 
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.5')
     def test_set_services_owner(self, rest_api, services):
         """Tests set_ownership action on /api/services collection.
 
         Metadata:
             test_flag: rest
         """
-        if "set_ownership" not in rest_api.collections.services.action.all:
-            pytest.skip("Set owner action for service is not implemented in this version")
-        data = []
-        user = rest_api.collections.users.get(userid='admin')
-        for service in services:
-            tmp_data = {
-                "href": service.href,
-                "owner": {"href": user.href}
-            }
-            data.append(tmp_data)
-        rest_api.collections.services.action.set_ownership(*data)
+        user = rest_api.collections.users.get(userid="admin")
+        requests = [{
+            "href": service.href,
+            "owner": {"href": user.href}
+        } for service in services]
+        rest_api.collections.services.action.set_ownership(*requests)
+        assert rest_api.response.status_code == 200
         for service in services:
             service.reload()
-            assert hasattr(service, "evm_owner")
-            assert service.evm_owner.userid == user.userid
+            assert hasattr(service, "evm_owner_id")
+            assert service.evm_owner_id == user.id
 
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     @pytest.mark.parametrize(
@@ -252,6 +308,7 @@ class TestServiceRESTAPI(object):
                 getattr(service.action, action)()
             else:
                 getattr(collection.action, action)(service)
+            assert rest_api.response.status_code == 200
             wait_for_vm_power_state(vm, resulting_state)
 
         assert vm.power_state == 'on'
@@ -275,6 +332,7 @@ class TestServiceRESTAPI(object):
         for ref in {'id': service.id}, {'href': service.href}:
             bodies.append(service_body(parent_service=ref))
         response = collection.action.create(*bodies)
+        assert rest_api.response.status_code == 200
         for ent in response:
             assert ent.ancestry == str(service.id)
 
@@ -292,7 +350,13 @@ class TestServiceRESTAPI(object):
         assert parent.ancestry == str(grandparent.id)
         assert child.ancestry == '{}/{}'.format(grandparent.id, parent.id)
         grandparent.action.delete()
-        for gen in parent, child:
+        assert rest_api.response.status_code in (200, 204)
+        wait_for(
+            lambda: not rest_api.collections.services.find_by(name=grandparent.name),
+            num_sec=600,
+            delay=10,
+        )
+        for gen in child, parent, grandparent:
             with error.expected("ActiveRecord::RecordNotFound"):
                 gen.action.delete()
 
@@ -308,6 +372,7 @@ class TestServiceRESTAPI(object):
         request.addfinalizer(parent.action.delete)
         child = collection.action.create(service_body())[0]
         child.action.edit(ancestry=str(parent.id))
+        assert rest_api.response.status_code == 200
         child.reload()
         assert child.ancestry == str(parent.id)
 
@@ -332,6 +397,7 @@ class TestServiceRESTAPI(object):
 
         def _action_and_check(action, resulting_state):
             getattr(service.action, action)()
+            assert rest_api.response.status_code == 200
             wait_for_vm_power_state(vm, resulting_state)
 
         assert vm.power_state == 'on'
@@ -341,7 +407,7 @@ class TestServiceRESTAPI(object):
         _action_and_check('start', 'on')
 
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
-    def test_retire_parent_service_now(self, rest_api, service_data):
+    def test_retire_parent_service_now(self, rest_api):
         """Tests that child service is retired together with a parent service.
 
         Metadata:
@@ -352,6 +418,7 @@ class TestServiceRESTAPI(object):
         child = collection.action.create(service_body(parent_service={'id': parent.id}))[0]
 
         parent.action.retire()
+        assert rest_api.response.status_code == 200
         wait_for(
             lambda: not collection.find_by(name=child.name),
             num_sec=600,
@@ -363,17 +430,32 @@ class TestServiceDialogsRESTAPI(object):
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     @pytest.mark.parametrize("method", ["post", "delete"])
     def test_delete_service_dialog(self, rest_api, dialog, method):
-        service_dialog = rest_api.collections.service_dialogs.find_by(label=dialog.label)[0]
+        """Tests deleting service dialogs from detail.
+
+        Metadata:
+            test_flag: rest
+        """
+        status = 204 if method == "delete" else 200
+        service_dialog = rest_api.collections.service_dialogs.get(label=dialog.label)
         service_dialog.action.delete(force_method=method)
+        assert rest_api.response.status_code == status
         with error.expected("ActiveRecord::RecordNotFound"):
-            service_dialog.action.delete()
+            service_dialog.action.delete(force_method=method)
+        assert rest_api.response.status_code == 404
 
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     def test_delete_service_dialogs(self, rest_api, dialog):
-        service_dialog = rest_api.collections.service_dialogs.find_by(label=dialog.label)[0]
+        """Tests deleting service dialogs from collection.
+
+        Metadata:
+            test_flag: rest
+        """
+        service_dialog = rest_api.collections.service_dialogs.get(label=dialog.label)
         rest_api.collections.service_dialogs.action.delete(service_dialog)
+        assert rest_api.response.status_code == 200
         with error.expected("ActiveRecord::RecordNotFound"):
             rest_api.collections.service_dialogs.action.delete(service_dialog)
+        assert rest_api.response.status_code == 404
 
 
 class TestServiceTemplateRESTAPI(object):
@@ -387,28 +469,54 @@ class TestServiceTemplateRESTAPI(object):
         Metadata:
             test_flag: rest
         """
-        scl = rest_api.collections.service_templates[0]
-        new_name = fauxfactory.gen_alphanumeric()
-        scl.action.edit(name=new_name)
-        wait_for(
-            lambda: rest_api.collections.service_catalogs.find_by(name=new_name),
-            num_sec=180,
-            delay=10,
-        )
+        for service_template in service_templates:
+            new_name = fauxfactory.gen_alphanumeric()
+            response = service_template.action.edit(name=new_name)
+            assert rest_api.response.status_code == 200
+            assert response.name == new_name
+            service_template.reload()
+            assert service_template.name == new_name
 
     def test_delete_service_templates(self, rest_api, service_templates):
+        """Tests deleting service templates from collection.
+
+        Metadata:
+            test_flag: rest
+        """
         rest_api.collections.service_templates.action.delete(*service_templates)
+        assert rest_api.response.status_code == 200
         with error.expected("ActiveRecord::RecordNotFound"):
             rest_api.collections.service_templates.action.delete(*service_templates)
+        assert rest_api.response.status_code == 404
 
-    def test_delete_service_template(self, rest_api, service_templates):
-        s_tpl = rest_api.collections.service_templates[0]
-        s_tpl.action.delete()
-        with error.expected("ActiveRecord::RecordNotFound"):
-            s_tpl.action.delete()
+    @pytest.mark.meta(blockers=[BZ(1427338, forced_streams=['5.7', 'upstream'])])
+    def test_delete_service_template_post(self, rest_api, service_templates):
+        """Tests deleting service templates from detail using POST method.
 
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.5')
-    def test_assign_unassign_service_template_to_service_catalog(self, service_catalogs,
+        Metadata:
+            test_flag: rest
+        """
+        for service_template in service_templates:
+            service_template.action.delete(force_method="post")
+            assert rest_api.response.status_code == 200
+            with error.expected("ActiveRecord::RecordNotFound"):
+                service_template.action.delete(force_method="post")
+            assert rest_api.response.status_code == 404
+
+    def test_delete_service_template_delete(self, rest_api, service_templates):
+        """Tests deleting service templates from detail using DELETE method.
+
+        Metadata:
+            test_flag: rest
+        """
+        for service_template in service_templates:
+            service_template.action.delete(force_method="delete")
+            assert rest_api.response.status_code == 204
+            with error.expected("ActiveRecord::RecordNotFound"):
+                service_template.action.delete(force_method="delete")
+            assert rest_api.response.status_code == 404
+
+    def test_assign_unassign_service_template_to_service_catalog(self, rest_api, service_catalogs,
             service_templates):
         """Tests assigning and unassigning the service templates to service catalog.
         Prerequisities:
@@ -427,9 +535,11 @@ class TestServiceTemplateRESTAPI(object):
         scl = service_catalogs[0]
         stpl = service_templates[0]
         scl.service_templates.action.assign(stpl)
+        assert rest_api.response.status_code == 200
         scl.reload()
         assert stpl.id in [st.id for st in scl.service_templates.all]
         scl.service_templates.action.unassign(stpl)
+        assert rest_api.response.status_code == 200
         scl.reload()
         assert stpl.id not in [st.id for st in scl.service_templates.all]
 
@@ -453,40 +563,23 @@ class TestServiceTemplateRESTAPI(object):
                 "href": tpl.href,
                 "name": new_name,
             })
-        rest_api.collections.service_templates.action.edit(*service_tpls_data_edited)
-        for new_name in new_names:
-            wait_for(
-                lambda: rest_api.collections.service_templates.find_by(name=new_name),
-                num_sec=180,
-                delay=10,
-            )
+        response = rest_api.collections.service_templates.action.edit(*service_tpls_data_edited)
+        assert rest_api.response.status_code == 200
+        for i, resource in enumerate(response):
+            assert resource.name == new_names[i]
+            service_template = service_templates[i]
+            service_template.reload()
+            assert service_template.name == new_names[i]
 
 
 class TestBlueprintsRESTAPI(object):
-    @pytest.yield_fixture(scope="function")
-    def blueprints(self, rest_api):
-        body = []
-        for _ in range(2):
-            uid = fauxfactory.gen_alphanumeric(5)
-            body.append({
-                'name': 'test_blueprint_{}'.format(uid),
-                'description': 'Test Blueprint {}'.format(uid),
-                'ui_properties': {
-                    'service_catalog': {},
-                    'service_dialog': {},
-                    'automate_entrypoints': {},
-                    'chart_data_model': {}
-                }
-            })
-        response = rest_api.collections.blueprints.action.create(*body)
-
-        yield response
-
-        try:
-            rest_api.collections.blueprints.action.delete(*response)
-        except APIException:
-            # blueprints can be deleted by tests, just log warning
-            logger.warning("Failed to delete blueprints.")
+    @pytest.fixture(scope="function")
+    def blueprints(self, request, rest_api):
+        num = 2
+        response = _blueprints(request, rest_api, num=num)
+        assert rest_api.response.status_code == 200
+        assert len(response) == num
+        return response
 
     @pytest.mark.tier(3)
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
@@ -496,35 +589,43 @@ class TestBlueprintsRESTAPI(object):
         Metadata:
             test_flag: rest
         """
-        assert len(blueprints) > 0
-        record = rest_api.collections.blueprints.get(id=blueprints[0].id)
-        assert record.name == blueprints[0].name
-        assert record.description == blueprints[0].description
-        assert record.ui_properties == blueprints[0].ui_properties
+        for blueprint in blueprints:
+            record = rest_api.collections.blueprints.get(id=blueprint.id)
+            assert record.name == blueprint.name
+            assert record.description == blueprint.description
+            assert record.ui_properties == blueprint.ui_properties
 
     @pytest.mark.tier(3)
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
-    @pytest.mark.parametrize(
-        "from_detail", [True, False],
-        ids=["from_detail", "from_collection"])
-    def test_delete_blueprints(self, rest_api, blueprints, from_detail):
-        """Tests delete blueprints.
+    @pytest.mark.parametrize("method", ["post", "delete"], ids=["POST", "DELETE"])
+    def test_delete_blueprints_from_detail(self, rest_api, blueprints, method):
+        """Tests deleting blueprints from detail.
 
         Metadata:
             test_flag: rest
         """
-        assert len(blueprints) > 0
-        collection = rest_api.collections.blueprints
-        if from_detail:
-            methods = ['post', 'delete']
-            for i, ent in enumerate(blueprints):
-                ent.action.delete(force_method=methods[i % 2])
-                with error.expected("ActiveRecord::RecordNotFound"):
-                    ent.action.delete()
-        else:
-            collection.action.delete(*blueprints)
+        status = 204 if method == "delete" else 200
+        for blueprint in blueprints:
+            blueprint.action.delete(force_method=method)
+            assert rest_api.response.status_code == status
             with error.expected("ActiveRecord::RecordNotFound"):
-                collection.action.delete(*blueprints)
+                blueprint.action.delete(force_method=method)
+            assert rest_api.response.status_code == 404
+
+    @pytest.mark.tier(3)
+    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
+    def test_delete_blueprints_from_collection(self, rest_api, blueprints):
+        """Tests deleting blueprints from collection.
+
+        Metadata:
+            test_flag: rest
+        """
+        collection = rest_api.collections.blueprints
+        collection.action.delete(*blueprints)
+        assert rest_api.response.status_code == 200
+        with error.expected("ActiveRecord::RecordNotFound"):
+            collection.action.delete(*blueprints)
+        assert rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
@@ -538,32 +639,35 @@ class TestBlueprintsRESTAPI(object):
             test_flag: rest
         """
         response_len = len(blueprints)
-        assert response_len > 0
-        new = []
-        for _ in range(response_len):
-            new.append({
-                'ui_properties': {
-                    'automate_entrypoints': {'Reconfigure': 'foo'}
-                }
-            })
+        new = [{
+            'ui_properties': {
+                'automate_entrypoints': {'Reconfigure': 'foo'}
+            }
+        } for _ in range(response_len)]
         if from_detail:
             edited = []
             for i in range(response_len):
                 edited.append(blueprints[i].action.edit(**new[i]))
+                assert rest_api.response.status_code == 200
         else:
             for i in range(response_len):
                 new[i].update(blueprints[i]._ref_repr())
             edited = rest_api.collections.blueprints.action.edit(*new)
+            assert rest_api.response.status_code == 200
         assert len(edited) == response_len
         for i in range(response_len):
             assert edited[i].ui_properties == new[i]['ui_properties']
+            blueprints[i].reload()
+            assert blueprints[i].ui_properties == new[i]['ui_properties']
 
 
 class TestOrchestrationTemplatesRESTAPI(object):
     @pytest.fixture(scope='function')
     def orchestration_templates(self, request, rest_api):
-        response = _orchestration_templates(request, rest_api, num=2)
-        assert len(response) == 2
+        num = 2
+        response = _orchestration_templates(request, rest_api, num=num)
+        assert rest_api.response.status_code == 200
+        assert len(response) == num
         return response
 
     @pytest.mark.tier(3)
@@ -584,31 +688,50 @@ class TestOrchestrationTemplatesRESTAPI(object):
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     def test_delete_orchestration_templates_from_collection(
             self, rest_api, orchestration_templates):
-        """Tests delete orchestration templates from collection.
+        """Tests deleting orchestration templates from collection.
 
         Metadata:
             test_flag: rest
         """
         collection = rest_api.collections.orchestration_templates
         collection.action.delete(*orchestration_templates)
+        assert rest_api.response.status_code == 200
         with error.expected("ActiveRecord::RecordNotFound"):
             collection.action.delete(*orchestration_templates)
+        assert rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
-    @pytest.mark.parametrize('method', ['post', 'delete'])
-    def test_delete_orchestration_templates_from_detail(self, orchestration_templates, method):
-        """Tests delete orchestration templates from detail.
+    @pytest.mark.meta(blockers=[BZ(1414881, forced_streams=['5.7', 'upstream'])])
+    def test_delete_orchestration_templates_from_detail_post(self, orchestration_templates,
+            rest_api):
+        """Tests deleting orchestration templates from detail using POST method.
 
         Metadata:
             test_flag: rest
         """
-        if method == 'post' and BZ('1414881', forced_streams=['5.7', 'upstream']).blocks:
-            pytest.skip("Affected by BZ1414881, cannot test.")
         for ent in orchestration_templates:
-            ent.action.delete(force_method=method)
+            ent.action.delete(force_method="post")
+            assert rest_api.response.status_code == 200
             with error.expected("ActiveRecord::RecordNotFound"):
-                ent.action.delete()
+                ent.action.delete(force_method="post")
+            assert rest_api.response.status_code == 404
+
+    @pytest.mark.tier(3)
+    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
+    def test_delete_orchestration_templates_from_detail_delete(self, orchestration_templates,
+            rest_api):
+        """Tests deleting orchestration templates from detail using DELETE method.
+
+        Metadata:
+            test_flag: rest
+        """
+        for ent in orchestration_templates:
+            ent.action.delete(force_method="delete")
+            assert rest_api.response.status_code == 204
+            with error.expected("ActiveRecord::RecordNotFound"):
+                ent.action.delete(force_method="delete")
+            assert rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
@@ -622,19 +745,21 @@ class TestOrchestrationTemplatesRESTAPI(object):
             test_flag: rest
         """
         response_len = len(orchestration_templates)
-        new = []
-        for _ in range(response_len):
-            new.append({
-                'description': 'Updated Test Template {}'.format(fauxfactory.gen_alphanumeric(5))
-            })
+        new = [{
+            'description': 'Updated Test Template {}'.format(fauxfactory.gen_alphanumeric(5))
+        } for _ in range(response_len)]
         if from_detail:
             edited = []
             for i in range(response_len):
                 edited.append(orchestration_templates[i].action.edit(**new[i]))
+                assert rest_api.response.status_code == 200
         else:
             for i in range(response_len):
                 new[i].update(orchestration_templates[i]._ref_repr())
             edited = rest_api.collections.orchestration_templates.action.edit(*new)
+            assert rest_api.response.status_code == 200
         assert len(edited) == response_len
         for i in range(response_len):
             assert edited[i].description == new[i]['description']
+            orchestration_templates[i].reload()
+            assert orchestration_templates[i].description == new[i]['description']

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -124,7 +124,7 @@ class TestServiceRESTAPI(object):
             assert service.name == new_name
 
     def test_edit_multiple_services(self, rest_api, services):
-        """Tests editing multiple service catalogs at time.
+        """Tests editing multiple services at a time.
         Prerequisities:
             * An appliance with ``/api`` available.
         Steps:
@@ -236,13 +236,9 @@ class TestServiceRESTAPI(object):
             rest_api.collections.services.action.retire(*services, **future)
             assert rest_api.response.status_code == 200
 
-        def _finished(ser):
-            ser.reload()
-            if not hasattr(ser, "retires_on"):
-                return False
-            if not hasattr(ser, "retirement_warn"):
-                return False
-            return True
+        def _finished(service):
+            service.reload()
+            return hasattr(service, "retires_on") and hasattr(service, "retirement_warn")
 
         for service in services:
             wait_for(
@@ -263,8 +259,8 @@ class TestServiceRESTAPI(object):
         }
         for service in services:
             service.action.set_ownership(**data)
-            service.reload()
             assert rest_api.response.status_code == 200
+            service.reload()
             assert hasattr(service, "evm_owner_id")
             assert service.evm_owner_id == user.id
 

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -150,7 +150,8 @@ class TestServiceRESTAPI(object):
             service.reload()
             assert service.name == new_names[i]
 
-    @pytest.mark.meta(blockers=[BZ(1414852, forced_streams=['5.7', '5.8', 'upstream'])])
+    # POST method is not available on < 5.8, as described in BZ 1414852
+    @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
     def test_delete_service_post(self, rest_api, services):
         """Tests deleting services from detail using POST method.
 
@@ -485,7 +486,8 @@ class TestServiceTemplateRESTAPI(object):
             rest_api.collections.service_templates.action.delete(*service_templates)
         assert rest_api.response.status_code == 404
 
-    @pytest.mark.meta(blockers=[BZ(1427338, forced_streams=['5.6', '5.7', '5.8', 'upstream'])])
+    # POST method is not available on < 5.8, as described in BZ 1427338
+    @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
     def test_delete_service_template_post(self, rest_api, service_templates):
         """Tests deleting service templates from detail using POST method.
 

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -311,7 +311,7 @@ class TestServiceRESTAPI(object):
             assert rest_api.response.status_code == 200
             wait_for_vm_power_state(vm, resulting_state)
 
-        assert vm.power_state == 'on'
+        _action_and_check('start', 'on')
         _action_and_check('stop', 'off')
         _action_and_check('start', 'on')
         _action_and_check('suspend', 'suspended')
@@ -400,7 +400,7 @@ class TestServiceRESTAPI(object):
             assert rest_api.response.status_code == 200
             wait_for_vm_power_state(vm, resulting_state)
 
-        assert vm.power_state == 'on'
+        _action_and_check('start', 'on')
         _action_and_check('stop', 'off')
         _action_and_check('start', 'on')
         _action_and_check('suspend', 'suspended')


### PR DESCRIPTION
* tests fixes
* refactoring
* check HTTP response statuses

**PRT:**
(updated 14:17 10.3.2017)
See run http://10.16.4.32/trackerbot/pr/run/11160
The only failed test is "TestServiceTemplateRESTAPI.test_delete_service_template_post" because BZ 1427338 is no longer blocker but the fix is not available in the tested version - this was solved by last commit.

{{pytest: cfme/tests/services/test_rest_services.py -v --long-running --use-provider vsphere6-nested}}