### PR TITLE
[1LP][RFR] Optimize yaml config

### DIFF
--- a/cfme/configure/configuration/__init__.py
+++ b/cfme/configure/configuration/__init__.py
@@ -1516,18 +1516,17 @@ def get_server_roles(navigate=True, db=True):
         accepts as kwargs.
     """
     if db:
-        asr = cfmedb()['assigned_server_roles']
-        sr = cfmedb()['server_roles']
-        cfg = store.current_appliance.get_yaml_config('vmdb')
-        roles = list(cfmedb().session.query(sr.name))
-        roles_set = list(cfmedb().session.query(sr.name)
+        asr = store.current_appliance.db['assigned_server_roles']
+        sr = store.current_appliance.db['server_roles']
+        roles = list(store.current_appliance.db.session.query(sr.name))
+        roles_set = list(store.current_appliance.db.session.query(sr.name)
                          .join(asr, asr.server_role_id == sr.id))
         role_set = [role_set[0] for role_set in roles_set]
         roles_with_bool = {role[0]: role[0] in role_set for role in roles}
 
         dead_keys = ['database_owner', 'vdi_inventory']
         for key in roles_with_bool:
-            if 'storage' not in cfg.get('product', {}):
+            if not store.current_appliance.is_storage_enabled:
                 if key.startswith('storage'):
                     dead_keys.append(key)
                 if key == 'vmdb_storage_bridge':

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -1662,6 +1662,7 @@ class IPAppliance(object):
             else:
                 log_callback(
                     'Appliance must be restarted before the netapp functionality can be used.')
+        del self.is_storage_enabled
 
     def wait_for_db(self, timeout=600):
         """Waits for appliance database to be ready
@@ -1890,6 +1891,10 @@ class IPAppliance(object):
     @cached_property
     def host_id(self, hostname):
         return db_queries.get_host_id(hostname, db=self.db)
+
+    @cached_property
+    def is_storage_enabled(self):
+        return 'storage' in self.get_yaml_config('vmdb').get('product', {})
 
     def get_yaml_config(self, config_name):
         if config_name == 'vmdb':

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -1662,7 +1662,7 @@ class IPAppliance(object):
             else:
                 log_callback(
                     'Appliance must be restarted before the netapp functionality can be used.')
-        del self.is_storage_enabled
+        clear_property_cache(self, 'is_storage_enabled')
 
     def wait_for_db(self, timeout=600):
         """Waits for appliance database to be ready


### PR DESCRIPTION
* It appeared as if the get_yaml_config was being called way too often
  in multiple places however it now looks it was just the role matching
  calls that were the predominant cause. Everything else appears to be
  cached already.
* Added a new is_storage_enabled method on the appliance object
* Use this when getting the roles