### PR TITLE
[1LP][RFR] Update widgetastic_miq, CheckboxSelect.checkboxes

### DIFF
--- a/widgetastic_manageiq.py
+++ b/widgetastic_manageiq.py
@@ -446,7 +446,7 @@ class CheckboxSelect(Widget):
     def checkboxes(self):
         """All checkboxes."""
         return {Checkbox(self, id=el.get_attribute("id")) for el in self.browser.elements(
-            ".//input[@type='checkbox']")}
+            ".//input[@type='checkbox']", parent=self)}
 
     @property
     def selected_checkboxes(self):


### PR DESCRIPTION
Pass parent attribute to browser.elements so that only checkboxes under
the given search_root parameter are discovered.

FIXES #4303 

Note that selected_text() has an issue as well that this does not resolve (at least specific to the Configure/Tasks screen)