### PR TITLE
[1LP][RFR] Fix Automate tests for 5.8

### DIFF
--- a/cfme/automate/__init__.py
+++ b/cfme/automate/__init__.py
@@ -54,27 +54,3 @@ class AutomateCustomization(CFMENavigateStep):
 
     def step(self):
         self.view.navigation.select(*automate_menu_name(self.obj.appliance) + ['Customization'])
-
-
-class AutomateExplorerView(BaseLoggedInPage):
-    @property
-    def is_displayed(self):
-        return (
-            self.logged_in_as_current_user and
-            self.navigation.currently_selected == automate_menu_name(
-                self.context['object'].appliance) + ['Explorer'])
-
-    @View.nested
-    class datastore(Accordion):  # noqa
-        tree = ManageIQTree()
-
-    configuration = Dropdown('Configuration')
-
-
-@navigator.register(Server)
-class AutomateExplorer(CFMENavigateStep):
-    VIEW = AutomateExplorerView
-    prerequisite = NavigateToSibling('LoggedIn')
-
-    def step(self):
-        self.view.navigation.select(*automate_menu_name(self.obj.appliance) + ['Explorer'])

--- a/cfme/automate/explorer/__init__.py
+++ b/cfme/automate/explorer/__init__.py
@@ -1,11 +1,15 @@
 # -*- coding: utf-8 -*-
 import re
 
+from navmazing import NavigateToSibling
 from widgetastic.widget import View
 from widgetastic_manageiq import Accordion, ManageIQTree
 from widgetastic_patternfly import Dropdown, FlashMessages
 
 from cfme import BaseLoggedInPage
+from cfme.base import Server
+from cfme.base.ui import automate_menu_name
+from utils.appliance.implementations.ui import navigator, CFMENavigateStep
 
 
 class AutomateExplorerView(BaseLoggedInPage):
@@ -15,7 +19,8 @@ class AutomateExplorerView(BaseLoggedInPage):
     def in_explorer(self):
         return (
             self.logged_in_as_current_user and
-            self.navigation.currently_selected == ['Automate', 'Explorer'])
+            self.navigation.currently_selected == automate_menu_name(
+                self.context['object'].appliance) + ['Explorer'])
 
     @property
     def is_displayed(self):
@@ -27,6 +32,15 @@ class AutomateExplorerView(BaseLoggedInPage):
         tree = ManageIQTree()
 
     configuration = Dropdown('Configuration')
+
+
+@navigator.register(Server)
+class AutomateExplorer(CFMENavigateStep):
+    VIEW = AutomateExplorerView
+    prerequisite = NavigateToSibling('LoggedIn')
+
+    def step(self):
+        self.view.navigation.select(*automate_menu_name(self.obj.appliance) + ['Explorer'])
 
 
 def check_tree_path(actual, desired):

--- a/cfme/tests/automate/test_class.py
+++ b/cfme/tests/automate/test_class.py
@@ -75,6 +75,7 @@ def test_schema_crud(request, namespace):
 
 
 @pytest.mark.tier(2)
+@pytest.mark.meta(blockers=[1428424])
 def test_duplicate_class_disallowed(namespace):
     name = fauxfactory.gen_alphanumeric()
     namespace.classes.create(name=name)

--- a/cfme/tests/automate/test_domain.py
+++ b/cfme/tests/automate/test_domain.py
@@ -5,6 +5,7 @@ import pytest
 from cfme.automate.explorer.domain import DomainCollection
 
 from utils import error
+from utils.appliance.implementations.ui import navigate_to
 from utils.update import update
 
 
@@ -18,10 +19,16 @@ def test_domain_crud(request, enabled):
         enabled=enabled)
     request.addfinalizer(domain.delete_if_exists)
     assert domain.exists
-    # TODO: Verify details
+    view = navigate_to(domain, 'Details')
+    if enabled:
+        assert 'Disabled' not in view.title.text
+    else:
+        assert 'Disabled' in view.title.text
     updated_description = "editdescription{}".format(fauxfactory.gen_alpha())
     with update(domain):
         domain.description = updated_description
+    view = navigate_to(domain, 'Edit')
+    assert view.description.value == updated_description
     assert domain.exists
     domain.delete(cancel=True)
     assert domain.exists
@@ -59,3 +66,27 @@ def test_duplicate_domain_disallowed(request):
             name=domain.name,
             description=domain.description,
             enabled=domain.enabled)
+
+
+@pytest.mark.tier(2)
+def test_cannot_delete_builtin():
+    domains = DomainCollection()
+    manageiq_domain = domains.instantiate(name='ManageIQ')
+    details_view = navigate_to(manageiq_domain, 'Details')
+    if domains.appliance.version < '5.7':
+        assert details_view.configuration.is_displayed
+        assert 'Remove this Domain' not in details_view.configuration.items
+    else:
+        assert not details_view.configuration.is_displayed
+
+
+@pytest.mark.tier(2)
+def test_cannot_edit_builtin():
+    domains = DomainCollection()
+    manageiq_domain = domains.instantiate(name='ManageIQ')
+    details_view = navigate_to(manageiq_domain, 'Details')
+    if domains.appliance.version < '5.7':
+        assert details_view.configuration.is_displayed
+        assert not details_view.configuration.item_enabled('Edit this Domain')
+    else:
+        assert not details_view.configuration.is_displayed


### PR DESCRIPTION
Automation results:
```
Appliance's streams: [5.8, downstream]

cfme/tests/automate/test_domain.py::test_domain_crud[enabled] PASSED
cfme/tests/automate/test_domain.py::test_domain_crud[disabled] PASSED
cfme/tests/automate/test_domain.py::test_domain_delete_from_table PASSED
cfme/tests/automate/test_domain.py::test_duplicate_domain_disallowed PASSED
cfme/tests/automate/test_class.py::test_class_crud[plain] PASSED
cfme/tests/automate/test_class.py::test_class_crud[nested_existing] PASSED
cfme/tests/automate/test_class.py::test_schema_crud[plain] PASSED
cfme/tests/automate/test_class.py::test_schema_crud[nested_existing] PASSED
cfme/tests/automate/test_class.py::test_duplicate_class_disallowed[plain] FAILED
cfme/tests/automate/test_class.py::test_duplicate_class_disallowed[nested_existing] FAILED
cfme/tests/automate/test_class.py::test_same_class_name_different_namespace PASSED
cfme/tests/automate/test_class.py::test_display_name_unset_from_ui[plain] PASSED
cfme/tests/automate/test_class.py::test_display_name_unset_from_ui[nested_existing] PASSED
cfme/tests/automate/test_namespace.py::test_namespace_crud[plain] PASSED
cfme/tests/automate/test_namespace.py::test_namespace_delete_from_table[plain] PASSED
cfme/tests/automate/test_namespace.py::test_duplicate_namespace_disallowed[plain] PASSED
cfme/tests/automate/test_namespace.py::test_namespace_crud[nested_existing] PASSED
cfme/tests/automate/test_namespace.py::test_namespace_delete_from_table[nested_existing] PASSED
cfme/tests/automate/test_namespace.py::test_duplicate_namespace_disallowed[nested_existing] PASSED
cfme/tests/automate/test_instance.py::test_instance_crud PASSED
cfme/tests/automate/test_instance.py::test_duplicate_disallowed PASSED
cfme/tests/automate/test_instance.py::test_display_name_unset_from_ui PASSED
cfme/tests/automate/test_method.py::test_method_crud PASSED
cfme/tests/automate/test_method.py::test_duplicate_method_disallowed PASSED
```

The two fails are due to a BZ.

{{pytest: cfme/tests/automate/test_domain.py cfme/tests/automate/test_class.py cfme/tests/automate/test_namespace.py cfme/tests/automate/test_instance.py cfme/tests/automate/test_method.py -v}}