### PR TITLE
[RFR] Fixed the open_edit method for instances

### DIFF
--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -84,6 +84,8 @@ class Instance(VM, Navigatable):
     REMOVE_SINGLE = {'5.6': 'Remove from the VMDB',
                      '5.7': 'Remove Instance'}
 
+    TO_OPEN_EDIT = "Edit this Instance"
+
     def __init__(self, name, provider, template_name=None, appliance=None):
         super(Instance, self).__init__(name=name, provider=provider, template_name=template_name)
         Navigatable.__init__(self, appliance=appliance)


### PR DESCRIPTION
* Instances were inheriting the base VM class' None for the TO_OPEN_EDIT
  configuration step and hence were never getting to the right page
* This commit makes the link work, however an issue has been opened to
  replace all this with the navmazing step