### PR TITLE
[1LP][RFR]Cockpit button accessibility/cockpit login

### DIFF
--- a/cfme/tests/containers/test_cockpit.py
+++ b/cfme/tests/containers/test_cockpit.py
@@ -17,11 +17,12 @@ pytest_generate_tests = testgen.generate(
 
 
 @pytest.mark.polarion('CMP-10255')
-def test_cockpit_button_access(provider):
+def test_cockpit_button_access(provider, soft_assert):
     """ The test verifies the existence of cockpit "Web Console"
         button on each node
 
     """
+
     navigate_to(NodeCollection, 'All')
     tb.select('List View')
 
@@ -31,6 +32,8 @@ def test_cockpit_button_access(provider):
     for name in names:
         obj = Node(name, provider)
         obj.load_details()
-        assert tb.exists(
-            'Open a new browser window with Cockpit for this '
-            'VM.  This requires that Cockpit is pre-configured on the VM.')
+        soft_assert(
+            tb.exists(
+                'Open a new browser window with Cockpit for this '
+                'VM.  This requires that Cockpit is pre-configured on the VM.'),
+            'Cockpit "Web Console" button is not found on details page.'.format(name))

--- a/cfme/tests/containers/test_cockpit.py
+++ b/cfme/tests/containers/test_cockpit.py
@@ -36,4 +36,4 @@ def test_cockpit_button_access(provider, soft_assert):
             tb.exists(
                 'Open a new browser window with Cockpit for this '
                 'VM.  This requires that Cockpit is pre-configured on the VM.'),
-            'Cockpit "Web Console" button is not found on details page.'.format(name))
+            'Cockpit "Web Console" button {} is not found on details page.'.format(name))

--- a/cfme/tests/containers/test_cockpit.py
+++ b/cfme/tests/containers/test_cockpit.py
@@ -1,10 +1,10 @@
 import pytest
 
-from cfme.containers.node import NodeCollection, Node
-from utils import testgen, version
-from cfme.web_ui import CheckboxTable, toolbar as tb
-from utils.appliance.implementations.ui import navigate_to
+from cfme.containers.node import Node, NodeCollection
 from cfme.containers.provider import ContainersProvider
+from cfme.web_ui import CheckboxTable, toolbar as tb
+from utils import testgen, version
+from utils.appliance.implementations.ui import navigate_to
 
 
 pytestmark = [

--- a/cfme/tests/containers/test_cockpit.py
+++ b/cfme/tests/containers/test_cockpit.py
@@ -2,7 +2,7 @@ import pytest
 
 from cfme.containers.node import Node, NodeCollection
 from cfme.containers.provider import ContainersProvider
-from cfme.web_ui import CheckboxTable, toolbar as tb
+from cfme.web_ui import toolbar as tb
 from utils import testgen, version
 from utils.appliance.implementations.ui import navigate_to
 
@@ -23,11 +23,9 @@ def test_cockpit_button_access(provider, soft_assert):
 
     """
 
-    navigate_to(NodeCollection, 'All')
-    tb.select('List View')
+    view = navigate_to(NodeCollection, 'All')
 
-    list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
-    names = [r.name.text for r in list_tbl.rows()]
+    names = [r.name.text for r in view.nodes]
 
     for name in names:
         obj = Node(name, provider)

--- a/cfme/tests/containers/test_cockpit.py
+++ b/cfme/tests/containers/test_cockpit.py
@@ -15,9 +15,8 @@ pytestmark = [
 pytest_generate_tests = testgen.generate(
     [ContainersProvider], scope='function')
 
-# CMP-10255
 
-
+@pytest.mark.polarion('CMP-10255')
 def test_cockpit_button_access(provider):
     """ The test verifies the existence of cockpit "Web Console"
         button on each node in the cluster

--- a/cfme/tests/containers/test_cockpit.py
+++ b/cfme/tests/containers/test_cockpit.py
@@ -19,7 +19,7 @@ pytest_generate_tests = testgen.generate(
 @pytest.mark.polarion('CMP-10255')
 def test_cockpit_button_access(provider):
     """ The test verifies the existence of cockpit "Web Console"
-        button on each node in the cluster
+        button on each node
 
     """
     navigate_to(NodeCollection, 'All')

--- a/cfme/tests/containers/test_cockpit.py
+++ b/cfme/tests/containers/test_cockpit.py
@@ -1,37 +1,50 @@
 import pytest
 
-from cfme.containers.node import Node, NodeCollection
+from cfme.containers.node import NodeCollection
 from cfme.containers.provider import ContainersProvider
-from cfme.web_ui import toolbar as tb
+from cfme.fixtures import pytest_selenium as sel
+from cfme.web_ui import CheckboxTable, toolbar as tb
 from utils import testgen, version
 from utils.appliance.implementations.ui import navigate_to
+from utils.blockers import BZ
 
 
 pytestmark = [
     pytest.mark.uncollectif(
-        lambda provider: version.current_version() < "5.6"),
+        lambda provider: version.current_version() < "5.7"),
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate(
     [ContainersProvider], scope='function')
 
 
-@pytest.mark.polarion('CMP-10255')
+@pytest.mark.polarion('CMP-10469')
+@pytest.mark.meta(blockers=[BZ(1406772)])
 def test_cockpit_button_access(provider, soft_assert):
     """ The test verifies the existence of cockpit "Web Console"
-        button on each node
+        button on master node, then presses on the button and
+        opens up the cockpit main page in a new window. Then
+        we verify the title of the main cockpit page. The test
+        will not work until the single sign-on bug is fixed
 
     """
 
-    view = navigate_to(NodeCollection, 'All')
+    navigate_to(NodeCollection, 'All')
+    list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
+    names = [r for r in list_tbl.rows()]
 
-    names = [r.name.text for r in view.nodes]
+    names[0].row_element.click()
 
-    for name in names:
-        obj = Node(name, provider)
-        obj.load_details()
-        soft_assert(
-            tb.exists(
-                'Open a new browser window with Cockpit for this '
-                'VM.  This requires that Cockpit is pre-configured on the VM.'),
-            'Cockpit "Web Console" button {} is not found on details page.'.format(name))
+    soft_assert(
+        tb.exists(
+            'Open a new browser window with Cockpit for this '
+            'VM.  This requires that Cockpit is pre-configured on the VM.'),
+        'No "Web Console" button found')
+    tb.select('Open a new browser window with Cockpit for this '
+              'VM.  This requires that Cockpit is pre-configured on the VM.')
+
+    port_num = ':9090/system'
+    url_cockpit = provider.hostname + port_num
+    sel.get(url_cockpit)
+    title_pg = sel.title()
+    soft_assert(title_pg == 'Cockpit', 'Cockpit main page failed to open')

--- a/cfme/tests/containers/test_cockpit.py
+++ b/cfme/tests/containers/test_cockpit.py
@@ -3,7 +3,7 @@ import pytest
 from cfme.containers.node import NodeCollection
 from cfme.containers.provider import ContainersProvider
 from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import CheckboxTable, toolbar as tb
+from cfme.web_ui import toolbar as tb
 from utils import testgen, version
 from utils.appliance.implementations.ui import navigate_to
 from utils.blockers import BZ
@@ -29,11 +29,10 @@ def test_cockpit_button_access(provider, soft_assert):
 
     """
 
-    navigate_to(NodeCollection, 'All')
-    list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
-    names = [r for r in list_tbl.rows()]
-
-    names[0].row_element.click()
+    collection = NodeCollection()
+    nodes = collection.all()
+    node = [node for node in nodes if 'master' in node.name][0]
+    navigate_to(node, 'Details')
 
     soft_assert(
         tb.exists(

--- a/cfme/tests/containers/test_cockpit_button_access.py
+++ b/cfme/tests/containers/test_cockpit_button_access.py
@@ -1,0 +1,37 @@
+import pytest
+
+from cfme.containers.node import NodeCollection, Node
+from utils import testgen, version
+from cfme.web_ui import CheckboxTable, toolbar as tb
+from utils.appliance.implementations.ui import navigate_to
+from cfme.containers.provider import ContainersProvider
+
+
+pytestmark = [
+    pytest.mark.uncollectif(
+        lambda provider: version.current_version() < "5.6"),
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.tier(1)]
+pytest_generate_tests = testgen.generate(
+    [ContainersProvider], scope='function')
+
+# CMP-10255
+
+
+def test_cockpit_button_access(provider):
+    """ The test verifies the existence of cockpit "Web Console"
+        button on each node in the cluster
+
+    """
+    navigate_to(NodeCollection, 'All')
+    tb.select('List View')
+
+    list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
+    names = [r.name.text for r in list_tbl.rows()]
+
+    for name in names:
+        obj = Node(name, provider)
+        obj.load_details()
+        assert tb.exists(
+            'Open a new browser window with Cockpit for this '
+            'VM.  This requires that Cockpit is pre-configured on the VM.')


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_cockpit.py -v --use-provider cm-env1 }}

The test verifies the accessibility of the cockpit (Web Console) button on the master node, then logs in to cockpit. It will not work until the single sign-on bug is fixed. 