### PR TITLE
[1LP][RFR] Remove providers through rest & fix provider exists check for renamed providers

### DIFF
--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -143,6 +143,7 @@ class CloudProvider(Pretty, CloudInfraProvider):
     vm_name = "Instances"
     template_name = "Images"
     _properties_region = prop_region  # This will get resolved in common to a real form
+    db_types = ["CloudManager"]
     # Specific Add button
     add_provider_button = deferred_verpick(
         {version.LOWEST: form_buttons.FormButton("Add this Cloud Provider"),

--- a/cfme/cloud/provider/azure.py
+++ b/cfme/cloud/provider/azure.py
@@ -6,6 +6,7 @@ from mgmtsystem.azure import AzureSystem
 class AzureProvider(CloudProvider):
     type_name = "azure"
     mgmt_class = AzureSystem
+    db_types = ["Azure::CloudManager"]
 
     def __init__(self, name=None, credentials=None, zone=None, key=None, region=None,
                  tenant_id=None, subscription_id=None, appliance=None):

--- a/cfme/cloud/provider/ec2.py
+++ b/cfme/cloud/provider/ec2.py
@@ -6,6 +6,7 @@ from mgmtsystem.ec2 import EC2System
 class EC2Provider(CloudProvider):
     type_name = "ec2"
     mgmt_class = EC2System
+    db_types = ["Amazon::CloudManager"]
 
     def __init__(
             self, name=None, credentials=None, zone=None, key=None, region=None, appliance=None):

--- a/cfme/cloud/provider/gce.py
+++ b/cfme/cloud/provider/gce.py
@@ -6,6 +6,7 @@ from mgmtsystem.google import GoogleCloudSystem
 class GCEProvider(CloudProvider):
     type_name = "gce"
     mgmt_class = GoogleCloudSystem
+    db_types = ["Google::CloudManager"]
 
     def __init__(
             self, name=None, project=None, zone=None, region=None, credentials=None, key=None,

--- a/cfme/cloud/provider/openstack.py
+++ b/cfme/cloud/provider/openstack.py
@@ -7,6 +7,7 @@ from . import CloudProvider
 class OpenStackProvider(CloudProvider):
     type_name = "openstack"
     mgmt_class = OpenstackSystem
+    db_types = ["Openstack::CloudManager"]
 
     def __init__(self, name=None, credentials=None, zone=None, key=None, hostname=None,
                  ip_address=None, api_port=None, sec_protocol=None, amqp_sec_protocol=None,

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -85,6 +85,7 @@ class ContainersProvider(BaseProvider, Pretty):
     edit_page_suffix = 'provider_edit_detail'
     refresh_text = "Refresh items and relationships"
     quad_name = None
+    db_types = ["ContainerManager"]
     _properties_region = prop_region  # This will get resolved in common to a real form
     add_provider_button = deferred_verpick(
         {version.LOWEST: form_buttons.FormButton("Add this Containers Provider"),

--- a/cfme/containers/provider/kubernetes.py
+++ b/cfme/containers/provider/kubernetes.py
@@ -5,6 +5,7 @@ from mgmtsystem.kubernetes import Kubernetes
 class KubernetesProvider(ContainersProvider):
     type_name = "kubernetes"
     mgmt_class = Kubernetes
+    db_types = ["Kubernetes::ContainerManager"]
 
     def __init__(self, name=None, credentials=None, key=None,
                  zone=None, hostname=None, port=None, provider_data=None, appliance=None):

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -17,6 +17,7 @@ class OpenshiftProvider(ContainersProvider):
     STATS_TO_MATCH = ContainersProvider.STATS_TO_MATCH + num_route
     type_name = "openshift"
     mgmt_class = Openshift
+    db_types = ["Openshift::ContainerManager"]
 
     def __init__(self, name=None, credentials=None, key=None,
                  zone=None, hostname=None, port=None, provider_data=None, appliance=None):

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -136,6 +136,7 @@ class InfraProvider(Pretty, CloudInfraProvider):
     templates_destination_name = "Templates"
     quad_name = "infra_prov"
     _properties_region = prop_region  # This will get resolved in common to a real form
+    db_types = ["InfraManager"]
     add_provider_button = deferred_verpick({
         version.LOWEST: form_buttons.FormButton("Add this Infrastructure Provider"),
         '5.6': form_buttons.add

--- a/cfme/infrastructure/provider/openstack_infra.py
+++ b/cfme/infrastructure/provider/openstack_infra.py
@@ -23,6 +23,7 @@ class OpenstackInfraProvider(InfraProvider):
     _properties_region = prop_region
     type_name = "openstack_infra"
     mgmt_class = OpenstackInfraSystem
+    db_types = ["Openstack::InfraManager"]
 
     def __init__(self, name=None, credentials=None, key=None, hostname=None,
                  ip_address=None, start_ip=None, end_ip=None, provider_data=None,

--- a/cfme/infrastructure/provider/rhevm.py
+++ b/cfme/infrastructure/provider/rhevm.py
@@ -7,6 +7,7 @@ class RHEVMProvider(InfraProvider):
     _properties_region = prop_region
     type_name = "rhevm"
     mgmt_class = RHEVMSystem
+    db_types = ["Redhat::InfraManager"]
 
     def __init__(self, name=None, credentials=None, zone=None, key=None, hostname=None,
                  ip_address=None, api_port=None, start_ip=None, end_ip=None,

--- a/cfme/infrastructure/provider/scvmm.py
+++ b/cfme/infrastructure/provider/scvmm.py
@@ -6,6 +6,7 @@ class SCVMMProvider(InfraProvider):
     STATS_TO_MATCH = ['num_template', 'num_vm']
     type_name = "scvmm"
     mgmt_class = SCVMMSystem
+    db_types = ["Microsoft::InfraManager"]
 
     def __init__(self, name=None, credentials=None, key=None, zone=None, hostname=None,
                  ip_address=None, start_ip=None, end_ip=None, sec_protocol=None, sec_realm=None,

--- a/cfme/infrastructure/provider/virtualcenter.py
+++ b/cfme/infrastructure/provider/virtualcenter.py
@@ -5,6 +5,7 @@ from mgmtsystem.virtualcenter import VMWareSystem
 class VMwareProvider(InfraProvider):
     type_name = "virtualcenter"
     mgmt_class = VMWareSystem
+    db_types = ["Vmware::InfraManager"]
 
     def __init__(self, name=None, credentials=None, key=None, zone=None, hostname=None,
                  ip_address=None, start_ip=None, end_ip=None, provider_data=None, appliance=None):

--- a/cfme/middleware/provider/__init__.py
+++ b/cfme/middleware/provider/__init__.py
@@ -76,6 +76,7 @@ class MiddlewareProvider(BaseProvider):
     add_provider_button = form_buttons.FormButton("Add")
     save_button = form_buttons.FormButton("Save changes")
     taggable_type = 'ExtManagementSystem'
+    db_types = ["MiddlewareManager"]
 
 
 @navigator.register(MiddlewareProvider, 'All')

--- a/cfme/middleware/provider/hawkular.py
+++ b/cfme/middleware/provider/hawkular.py
@@ -38,6 +38,7 @@ class HawkularProvider(MiddlewareBase, TopologyMixin, TimelinesMixin, Middleware
         [('name', 'Name'), ('hostname', 'Host Name'), ('port', 'Port'), ('provider_type', 'Type')]
     type_name = "hawkular"
     mgmt_class = Hawkular
+    db_types = ["Hawkular::MiddlewareManager"]
 
     def __init__(self, name=None, hostname=None, port=None, credentials=None, key=None,
             appliance=None, **kwargs):

--- a/cfme/tests/infrastructure/test_provider_discovery.py
+++ b/cfme/tests/infrastructure/test_provider_discovery.py
@@ -3,7 +3,6 @@ from itertools import combinations
 
 from utils import testgen
 from utils.providers import get_crud
-from cfme.common.provider import BaseProvider
 from cfme.infrastructure.provider import discover, InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
@@ -83,7 +82,7 @@ def pytest_generate_tests(metafunc):
 @pytest.yield_fixture(scope='function')
 def delete_providers_after_test():
     yield
-    BaseProvider.clear_providers_by_class(InfraProvider)
+    InfraProvider.clear_providers()
 
 
 @pytest.mark.tier(2)

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -9,7 +9,6 @@ from manageiq_client.api import APIException
 import cfme.web_ui.flash as flash
 import utils.error as error
 import cfme.fixtures.pytest_selenium as sel
-from cfme.common.provider import BaseProvider
 from cfme.exceptions import FlashMessageException
 from cfme.infrastructure.provider import discover, wait_for_a_provider, InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
@@ -182,7 +181,7 @@ def test_providers_discovery(request, provider):
     """
     provider.discover()
     flash.assert_message_match('Infrastructure Providers: Discovery successfully initiated')
-    request.addfinalizer(lambda: BaseProvider.clear_providers_by_class(InfraProvider))
+    request.addfinalizer(InfraProvider.clear_providers)
     wait_for_a_provider()
 
 

--- a/cfme/tests/test_db_restore.py
+++ b/cfme/tests/test_db_restore.py
@@ -87,7 +87,7 @@ def test_db_restore(request, soft_assert, virtualcenter_provider_crud, ec2_provi
         ec2_provider_crud.setup()
         cloud_provider.wait_for_a_provider()
 
-        providers_appl1 = appl1.ipapp.managed_providers
+        providers_appl1 = appl1.ipapp.managed_known_providers
         appl1.ipapp.backup_database()
 
     # Fetch v2_key and DB backup from the first appliance
@@ -113,7 +113,7 @@ def test_db_restore(request, soft_assert, virtualcenter_provider_crud, ec2_provi
         cloud_provider.wait_for_a_provider()
 
         # Assert providers on the second appliance
-        providers_appl2 = appl2.ipapp.managed_providers
+        providers_appl2 = appl2.ipapp.managed_known_providers
         assert set(providers_appl2).issubset(providers_appl1),\
             'Restored DB is missing some providers'
 

--- a/fixtures/log.py
+++ b/fixtures/log.py
@@ -45,7 +45,8 @@ def pytest_runtest_logreport(report):
                 logger().info(
                     "Managed providers: {}".format(
                         ", ".join([
-                            prov.key for prov in pytest.store.current_appliance.managed_providers]))
+                            prov.key for prov in
+                            pytest.store.current_appliance.managed_known_providers]))
                 )
             except KeyError as ex:
                 if 'ext_management_systems' in ex.msg:

--- a/fixtures/provider.py
+++ b/fixtures/provider.py
@@ -186,7 +186,7 @@ def _generate_provider_fixtures():
             @pytest.fixture(scope='function')
             def _has_no_providers():
                 """ Clears all providers of given class from the appliance """
-                BaseProvider.clear_providers_by_class(prov_class, validate=True)
+                prov_class.clear_providers()
             return _has_no_providers
         fn_name = 'has_no_{}_providers'.format(prov_type)
         globals()[fn_name] = gen_has_no_providers(prov_class)

--- a/sprout/appliances/tasks.py
+++ b/sprout/appliances/tasks.py
@@ -1415,7 +1415,7 @@ def scavenge_managed_providers_from_appliance(self, appliance_id):
     except ObjectDoesNotExist:
         return None
     try:
-        managed_providers = appliance.ipapp.managed_providers
+        managed_providers = appliance.ipapp.managed_known_providers
         appliance.managed_providers = [prov.key for prov in managed_providers]
     except Exception as e:
         # To prevent single appliance messing up whole result

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -479,7 +479,7 @@ class IPAppliance(object):
                 yield ipaddress, hostname
 
     @property
-    def managed_providers(self):
+    def managed_known_providers(self):
         """Returns a set of provider crud objects of known providers managed by this appliance
 
         Note:
@@ -505,7 +505,12 @@ class IPAppliance(object):
 
     @property
     def managed_provider_names(self):
-        """Returns a list of names for all providers configured on the appliance"""
+        """Returns a list of names for all providers configured on the appliance
+
+        Note:
+            Unlike ``managed_known_providers``, this will also return names of providers that were
+            not recognized, but are present.
+        """
         return [ems.name for ems in self._list_ems()]
 
     def check_no_conflicting_providers(self):
@@ -555,10 +560,10 @@ class IPAppliance(object):
             return False
 
         prov_cruds = list_providers(use_global_filters=False)
-        managed_providers_names = [prov.name for prov in self.managed_providers]
+        managed_known_providers_names = [prov.name for prov in self.managed_known_providers]
         for ems in self._list_ems():
-            # EMS found among managed providers can be safely ignored; they are not conflicting
-            if ems.name in managed_providers_names:
+            # EMS found among managed known providers can be ignored; they are not conflicting
+            if ems.name in managed_known_providers_names:
                 continue
             # Otherwise, if the EMS matches a provider in our yamls by IP or credentials
             # but isn't among managed providers -> same provider with a different name

--- a/utils/appliance/implementations/ui.py
+++ b/utils/appliance/implementations/ui.py
@@ -222,8 +222,9 @@ class CFMENavigateStep(NavigateStep):
             logger.debug('Top Memory consumers:')
             logger.debug(store.current_appliance.ssh_client.run_command(
                 'top -c -b -n1 -o "%MEM" | head -30').output)  # noqa
-            logger.debug('Managed Providers:')
-            logger.debug('%r', [prov.key for prov in store.current_appliance.managed_providers])
+            logger.debug('Managed known Providers:')
+            logger.debug(
+                '%r', [prov.key for prov in store.current_appliance.managed_known_providers])
             self.appliance.browser.quit_browser()
             self.appliance.browser.open_browser()
             self.go(_tries, *args, **go_kwargs)

--- a/utils/tests/test_ipappliance.py
+++ b/utils/tests/test_ipappliance.py
@@ -31,7 +31,7 @@ def test_ipappliance_use_baseurl():
 
 def test_ipappliance_managed_providers(infra_provider):
     ip_a = IPAppliance()
-    assert infra_provider in ip_a.managed_providers
+    assert infra_provider in ip_a.managed_known_providers
 
 
 def test_context_hack(monkeypatch):


### PR DESCRIPTION
This adds mapping between our classes and MiQ classes so that when we call `clear_providers` to delete for example all `InfraProviders`, it will look for all `InfraManager` providers and remove them. Until now, we only deleted known managed providers (part of this PR is also renaming the method to make its function 100% clear from the name) which is not sufficient when those are renamed. Same with checking with `.exists`.
It also removes `clear_providers_by_class` and keeps only `clear_providers` which becomes a `classmethod` -> the providers removed depend on which class you call it from. `InfraProvider.clear_providers()` will remove all infra providers, `CloudProvider.clear_providers()` will remove all cloud providers...

{{pytest: -k test_provider}}