### PR TITLE
[NOTEST] Update template_upload_all for rhevm.ova image

### DIFF
--- a/scripts/template_upload_all.py
+++ b/scripts/template_upload_all.py
@@ -245,7 +245,7 @@ def browse_directory(dir_url):
         print("Skipping: {}".format(dir_url))
         return None
 
-    rhevm_pattern = re.compile(r'<a href="?\'?([^"\']*(?:rhevm|ovirt)[^"\'>]*)')
+    rhevm_pattern = re.compile(r'<a href="?\'?([^"\']*(?:rhevm\.ova|ovirt)[^"\'>]*)')
     rhevm_image_name = rhevm_pattern.findall(string_from_url)
     rhos_pattern = re.compile(r'<a href="?\'?([^"\']*(?:rhos|openstack|rhelosp)[^"\'>]*)')
     rhos_image_name = rhos_pattern.findall(string_from_url)


### PR DESCRIPTION
CFME 5.8 brings rhevm qcow2 images, which were erroneously matching this pattern, causing template upload to fail.

Explicitly match the rhevm.ova file, tested locally and the regex matches the correct image for 5.8.