### PR TITLE
[RFR] Changed default/ssh passwords for credentials.yaml

### DIFF
--- a/conf/credentials.yaml.template
+++ b/conf/credentials.yaml.template
@@ -1,6 +1,6 @@
 default:
     username: admin
-    password: password
+    password: smartvm
     email: admin@example.com
 bugzilla:
     username: john.doe@company.test
@@ -28,7 +28,7 @@ hawkular:
     password: password
 ssh:
     username: root
-    password: password
+    password: smartvm
 netapp-storage:
     username: root
     password: letmein


### PR DESCRIPTION

Purpose or Intent
=================
Changed default and ssh password in the credentials file. This will be beneficial for dockerized integration tests (#3254), where we can use this yaml template file without modification. Without specifying custom yaml credential file, we will be able to run basic test (test_login.py).

