### PR TITLE
[WIPTEST] update blockers on REST API tests

### DIFF
--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -603,7 +603,7 @@ class TestOrchestrationTemplatesRESTAPI(object):
         Metadata:
             test_flag: rest
         """
-        if method == 'post' and BZ('1414881', forced_streams=['5.7', 'upstream']).blocks:
+        if method == 'post' and BZ('1414881', forced_streams=['5.7', '5.8', 'upstream']).blocks:
             pytest.skip("Affected by BZ1414881, cannot test.")
         for ent in orchestration_templates:
             ent.action.delete(force_method=method)

--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -570,7 +570,7 @@ class TestRequestsRESTAPI(object):
         body = {'options': {'arbitrary_key_allowed': 'test_rest'}}
 
         if from_detail:
-            if BZ('1418331', forced_streams=['5.7', 'upstream']).blocks:
+            if BZ('1418331', forced_streams=['5.7', '5.8', 'upstream']).blocks:
                 pytest.skip("Affected by BZ1418331, cannot test.")
             for request in pending_requests:
                 request.action.edit(**body)


### PR DESCRIPTION
Update blockers for bugs that are filled for 5.7 and affects also 5.8.