### PR TITLE
[1LP][RFR] Removed older option and simplified codebase

### DIFF
--- a/cfme/configure/configuration/__init__.py
+++ b/cfme/configure/configuration/__init__.py
@@ -1496,13 +1496,13 @@ def set_server_roles(db=True, **roles):
     Args:
         **roles: Roles specified as in server_roles Form in this module. Set to True or False
     """
-    yaml = store.current_appliance.get_yaml_config("vmdb")
+    yaml = store.current_appliance.get_yaml_config()
     if get_server_roles() == roles:
         logger.debug(' Roles already match, returning...')
         return
     if db:
         yaml['server']['role'] = ','.join([role for role, boolean in roles.iteritems() if boolean])
-        store.current_appliance.set_yaml_config("vmdb", yaml)
+        store.current_appliance.set_yaml_config(yaml)
         wait_for(lambda: get_server_roles() == roles, num_sec=60)
     else:
         navigate_to(current_appliance.server, 'Server')

--- a/cfme/tests/configure/test_ntp_server.py
+++ b/cfme/tests/configure/test_ntp_server.py
@@ -95,13 +95,13 @@ def test_ntp_server_check(request):
         # Configuring the ntp server and restarting the appliance
         # checking if ntp property is available, adding if it is not available
         configuration.set_ntp_servers(*cfme_data['clock_servers'])
-        yaml_config = store.current_appliance.get_yaml_config("vmdb")
+        yaml_config = store.current_appliance.get_yaml_config()
         ntp = yaml_config.get("ntp", None)
         if not ntp:
             yaml_config["ntp"] = {}
         # adding the ntp interval to 1 minute and updating the configuration
         yaml_config["ntp"]["interval"] = '1.minutes'
-        store.current_appliance.set_yaml_config("vmdb", yaml_config)
+        store.current_appliance.set_yaml_config(yaml_config)
         # restarting the evmserverd for NTP to work
         store.current_appliance.restart_evm_service(rude=True)
         store.current_appliance.wait_for_web_ui(timeout=1200)

--- a/utils/perf.py
+++ b/utils/perf.py
@@ -95,14 +95,14 @@ def set_rails_loglevel(level, validate_against_worker='MiqUiWorker'):
     ui_worker_pid = '#{}'.format(get_worker_pid(validate_against_worker))
 
     logger.info('Setting log level_rails on appliance to {}'.format(level))
-    yaml = store.current_appliance.get_yaml_config('vmdb')
+    yaml = store.current_appliance.get_yaml_config()
     if not str(yaml['log']['level_rails']).lower() == level.lower():
         logger.info('Opening /var/www/miq/vmdb/log/evm.log for tail')
         evm_tail = SSHTail('/var/www/miq/vmdb/log/evm.log')
         evm_tail.set_initial_file_end()
 
         yaml['log']['level_rails'] = level
-        store.current_appliance.set_yaml_config("vmdb", yaml)
+        store.current_appliance.set_yaml_config(yaml)
 
         attempts = 0
         detected = False


### PR DESCRIPTION
Removing an older option that is no longer present in 5.6+
Removed get_yaml_file() as it is no longer used