### PR TITLE
[1LP][RFR]cloud timelines. missed changes

### DIFF
--- a/cfme/cloud/availability_zone.py
+++ b/cfme/cloud/availability_zone.py
@@ -5,6 +5,7 @@ from functools import partial
 from navmazing import NavigateToSibling, NavigateToAttribute
 
 from cfme import BaseLoggedInPage
+import cfme.fixtures.pytest_selenium as sel
 from cfme.web_ui import PagedTable, CheckboxTable, toolbar as tb, match_location
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import CFMENavigateStep, navigator
@@ -55,9 +56,9 @@ class AvailabilityZoneDetails(CFMENavigateStep):
 
     def step(self, *args, **kwargs):
         tb.select('List View')
-        listview_pagetable.find_row_by_cell_on_all_pages(
+        sel.click(listview_pagetable.find_row_by_cell_on_all_pages(
             {'Name': self.obj.name,
-             'Cloud Provider': self.obj.provider.name})
+             'Cloud Provider': self.obj.provider.name}))
 
 
 @navigator.register(AvailabilityZone, 'EditTags')

--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -4,6 +4,7 @@ import pytest
 from cfme.cloud.availability_zone import AvailabilityZone
 from cfme.cloud.instance import Instance
 from cfme.cloud.provider.azure import AzureProvider
+from cfme.cloud.provider.openstack import OpenStackProvider
 from utils import testgen, version
 from utils.appliance.implementations.ui import navigate_to
 from utils.generators import random_vm_name
@@ -14,7 +15,7 @@ from utils.wait import wait_for
 pytestmark = [pytest.mark.tier(2),
               pytest.mark.uncollectif(lambda: version.current_version() < '5.7'),
               pytest.mark.usefixtures("setup_provider_modscope")]
-pytest_generate_tests = testgen.generate([AzureProvider], scope="module")
+pytest_generate_tests = testgen.generate([AzureProvider, OpenStackProvider], scope="module")
 
 
 @pytest.fixture(scope="module")
@@ -44,11 +45,11 @@ def count_events(target, vm):
     found_events = []
     for evt in timelines_view.chart.get_events():
         # BZ(1428797)
-        if not hasattr(evt, 'source_vm'):
+        if not hasattr(evt, 'source_instance'):
             logger.warn("event {evt!r} doesn't have source_vm field. "
                         "Probably issue".format(evt=evt))
             continue
-        elif evt.source_vm == vm.name:
+        elif evt.source_instance == vm.name:
             found_events.append(evt)
 
     logger.info("found events: {evt}".format(evt="\n".join([repr(e) for e in found_events])))


### PR DESCRIPTION
1. fixed typo in cloud_timelines test
2. fixed azone issue, when Details destination didn't select appropriate azone
3. added OpenStack provider

{{pytest: --use-provider=azure cfme/tests/cloud/test_cloud_timelines.py}}