### PR TITLE
[1LP][RFR] Fixed failing tests according to new UI changes.

### DIFF
--- a/cfme/middleware/domain.py
+++ b/cfme/middleware/domain.py
@@ -1,3 +1,4 @@
+import re
 from navmazing import NavigateToSibling, NavigateToAttribute
 from cfme.common import Taggable
 from cfme.exceptions import MiddlewareDomainNotFound
@@ -123,8 +124,7 @@ class MiddlewareDomain(MiddlewareBase, Navigatable, Taggable):
         rows = provider.mgmt.inventory.list_domain()
         for row in rows:
             domains.append(MiddlewareDomain(
-                name=row.data['Local Host Name']
-                if row.data['Local Host Name'] != 'master' else 'Unnamed Domain',
+                name=re.sub(r'master\.', '', re.sub(r'%20', ' ', row.path.feed_id)),
                 feed=row.path.feed_id,
                 product=row.data['Product Name']
                 if 'Product Name' in row.data else None,

--- a/cfme/tests/middleware/test_middleware_provider.py
+++ b/cfme/tests/middleware/test_middleware_provider.py
@@ -109,7 +109,10 @@ def test_required_fields_validation(provider, soft_assert):
 @pytest.mark.usefixtures('setup_provider')
 def test_duplicite_provider_creation(provider):
     """Tests that creation of already existing provider fails."""
-    with error.expected('Host Name has already been taken'):
+    message = 'Name has already been taken, Host Name has already been taken'
+    if current_version() >= '5.8':
+        message = 'Name has already been taken, Host Name has to be unique per provider type'
+    with error.expected(message):
         provider.create(cancel=False, validate_credentials=True)
 # TODO - this checks only hostname err msgs, we need two providers to check name err msg as well
 


### PR DESCRIPTION
changed displaying domain name, add provider error message fix
{{pytest: cfme/tests/middleware/test_middleware_provider.py::test_duplicite_provider_creation -v --use-provider hawkular}}