### PR TITLE
[RFR] Fix scope mismatch err

### DIFF
--- a/cfme/tests/test_utilization.py
+++ b/cfme/tests/test_utilization.py
@@ -44,10 +44,10 @@ def enable_candu():
 
 
 # Blow away all providers when done - collecting metrics for all of them is too much
-@pytest.yield_fixture
+@pytest.yield_fixture(scope="module")
 def clean_setup_provider(request, provider):
     BaseProvider.clear_providers()
-    setup_or_skip(provider)
+    setup_or_skip(request, provider)
     yield
     BaseProvider.clear_providers()
 

--- a/cfme/tests/test_utilization_metrics.py
+++ b/cfme/tests/test_utilization_metrics.py
@@ -56,10 +56,10 @@ def enable_candu():
         set_server_roles(**original_roles)
 
 
-@pytest.yield_fixture
+@pytest.yield_fixture(scope="module")
 def clean_setup_provider(request, provider):
     BaseProvider.clear_providers()
-    setup_or_skip(provider)
+    setup_or_skip(request, provider)
     yield
     BaseProvider.clear_providers()
 


### PR DESCRIPTION
Fixes the tests and should also speed them up, as a by-product, since it's no longer going to run `clean_setup_provider` in func scope.

Tested locally; there were some skips and some failures but no more fixture setup errors.