### PR TITLE
[RFR] Cleanup: remove property or none

### DIFF
--- a/fixtures/pytest_store.py
+++ b/fixtures/pytest_store.py
@@ -27,7 +27,7 @@ from _pytest.terminal import TerminalReporter
 from cached_property import cached_property
 from py.io import TerminalWriter
 
-from utils import diaper, property_or_none
+from utils import diaper
 
 
 class FlexibleTerminalReporter(TerminalReporter):
@@ -89,51 +89,51 @@ class Store(object):
             else, the base_url from the config is returned."""
         return self.current_appliance.url
 
+    def _maybe_get_plugin(self, name):
+        """ returns the plugin if the pluginmanager is availiable and the plugin exists"""
+        return self.pluginmanager and self.pluginmanager.getplugin(name)
+
     @property
     def in_pytest_session(self):
         return self.session is not None
 
-    @property_or_none
+    @property
     def fixturemanager(self):
         # "publicize" the fixturemanager
-        return self.session._fixturemanager
+        return self.session and self.session._fixturemanager
 
-    @property_or_none
+    @property
     def capturemanager(self):
-        return self.pluginmanager.getplugin('capturemanager')
+        return self._maybe_get_plugin('capturemanager')
 
-    @property_or_none
+    @property
     def pluginmanager(self):
         # Expose this directly on the store for convenience in getting/setting plugins
-        return self.config.pluginmanager
+        return self.config and self.config.pluginmanager
 
-    @property_or_none
+    @property
     def terminalreporter(self):
         if self._terminalreporter is not None:
             return self._terminalreporter
 
-        if self.pluginmanager is not None:
-            reporter = self.pluginmanager.getplugin('terminalreporter')
-            if reporter and isinstance(reporter, TerminalReporter):
-                self._terminalreporter = reporter
-                return reporter
+        reporter = self._maybe_get_plugin('terminalreporter')
+        if reporter and isinstance(reporter, TerminalReporter):
+            self._terminalreporter = reporter
+            return reporter
 
         return FlexibleTerminalReporter(self.config)
 
-    @property_or_none
+    @property
     def terminaldistreporter(self):
-        if self.pluginmanager is not None:
-            reporter = self.pluginmanager.getplugin('terminaldistreporter')
-            if reporter:
-                return reporter
+        return self._maybe_get_plugin('terminaldistreporter')
 
-    @property_or_none
+    @property
     def parallel_session(self):
-        return self.pluginmanager.getplugin('parallel_session')
+        return self._maybe_get_plugin('parallel_session')
 
-    @property_or_none
+    @property
     def slave_manager(self):
-        return self.pluginmanager.getplugin('slave_manager')
+        return self._maybe_get_plugin('slave_manager')
 
     @cached_property
     def my_ip_address(self):

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -26,26 +26,6 @@ def fakeobject_or_object(obj, attr, default=None):
         return obj
 
 
-def property_or_none(wrapped, *args, **kwargs):
-    """property_or_none([fget[, fset[, fdel[, doc]]]])
-    Property decorator that turns AttributeErrors into None returns
-
-    Useful for chained attr lookups where some links in the chain are None
-
-    Note:
-
-        This delegates back to the :py:func:`property <python:property>` builtin and inherits
-        its signature; thus it can be used interchangeably with ``property``.
-
-    """
-    def wrapper(store):
-        try:
-            return wrapped(store)
-        except AttributeError:
-            pass
-    return property(wrapper, *args, **kwargs)
-
-
 def clear_property_cache(obj, *names):
     """
     clear a cached property regardess of if it was cached priority


### PR DESCRIPTION
its abstraction was based on hiding errors and the only usages have better direct implementations
