### PR TITLE
[1LP][RFR] Patternfly ViewChangeButton widget for 56z

### DIFF
--- a/widgetastic_manageiq.py
+++ b/widgetastic_manageiq.py
@@ -27,7 +27,8 @@ from widgetastic.widget import (
 from widgetastic.utils import ParametrizedLocator, Parameter, attributize_string
 from widgetastic.xpath import quote
 from widgetastic_patternfly import (
-    Accordion as PFAccordion, CandidateNotFound, BootstrapTreeview, Button, Input, BootstrapSelect)
+    Accordion as PFAccordion, CandidateNotFound, BootstrapTreeview, Button, ViewChangeButton, Input,
+    BootstrapSelect)
 from cached_property import cached_property
 
 
@@ -1205,9 +1206,15 @@ class ItemsToolBarViewSelector(View):
         view_selector.selected
     """
     ROOT = './/div[contains(@class, "toolbar-pf-view-selector")]'
-    grid_button = Button(title='Grid View')
-    tile_button = Button(title='Tile View')
-    list_button = Button(title='List View')
+    grid_button = VersionPick({
+        Version.lowest(): ViewChangeButton(title='Grid View'),
+        '5.7.0': Button(title='Grid View')})
+    tile_button = VersionPick({
+        Version.lowest(): ViewChangeButton(title='Tile View'),
+        '5.7.0': Button(title='Tile View')})
+    list_button = VersionPick({
+        Version.lowest(): ViewChangeButton(title='List View'),
+        '5.7.0': Button(title='List View')})
 
     @property
     def _view_buttons(self):
@@ -1239,8 +1246,12 @@ class DetailsToolBarViewSelector(View):
         view_selector.selected
     """
     ROOT = './/div[contains(@class, "toolbar-pf-view-selector")]'
-    summary_button = Button(title='Summary View')
-    dashboard_button = Button(title='Dashboard View')
+    summary_button = VersionPick({
+        Version.lowest(): ViewChangeButton(title='Summary View'),
+        '5.7.0': Button(title='Summary View')})
+    dashboard_button = VersionPick({
+        Version.lowest(): ViewChangeButton(title='Dashboard View'),
+        '5.7.0': Button(title='Dashboard View')})
 
     @property
     def _view_buttons(self):

--- a/widgetastic_patternfly.py
+++ b/widgetastic_patternfly.py
@@ -93,6 +93,28 @@ class Button(Widget, ClickableMixin):
         return self.browser.get_attribute('title', self)
 
 
+class ViewChangeButton(Widget, ClickableMixin):
+    """A PatternFly/Bootstrap view selection button in CFME 56z
+
+        .. code-block:: python
+
+            ViewChangeButton(title='Grid View')
+            assert button.active
+    """
+    CHECK_VISIBILITY = True
+
+    def __init__(self, parent, title, **kwargs):
+        Widget.__init__(self, parent, logger=kwargs.pop('logger', None))
+        self.title = title
+
+    def __locator__(self):
+        return './/a[(@title={}) and i[contains(@class, "fa")]]'.format(quote(self.title))
+
+    @property
+    def active(self):
+        return 'active' in self.browser.classes(self.parent)
+
+
 class Input(TextInput):
     """Patternfly input
 


### PR DESCRIPTION
The view change buttons in cfme 56z don't have the proper patternfly markup. Add  Version picking to widgetastic_manageIQ's ItemsToolbarViewSelector 