### PR TITLE
[1LP][RFR] Fix infra.provider.rhevm, TLS support in create

### DIFF
--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -20,8 +20,8 @@ from cfme.fixtures import pytest_selenium as sel
 from cfme.infrastructure.host import Host
 from cfme.infrastructure.cluster import Cluster
 from cfme.web_ui import (
-    Region, Quadicon, Form, Select, CheckboxTree, fill, form_buttons, paginator, Input,
-    AngularSelect, toolbar as tb, Radio, InfoBlock, match_location
+    Region, Quadicon, Form, CheckboxTree, fill, form_buttons, paginator, Input,
+    AngularSelect, toolbar as tb, Radio, InfoBlock, match_location, BootstrapSwitch
 )
 from cfme.web_ui.form_buttons import FormButton
 from cfme.web_ui.tabstrip import TabStripForm
@@ -51,23 +51,8 @@ discover_form = Form(
         ('start_button', FormButton("Start the Host Discovery"))
     ])
 
-properties_form = Form(
-    fields=[
-        ('type_select', {
-            version.LOWEST: Select('select#server_emstype'),
-            '5.5': AngularSelect("server_emstype")
-        }),
-        ('name_text', Input("name")),
-        ('hostname_text', {version.LOWEST: Input("hostname")}),
-        ('ipaddress_text', Input("ipaddress"), {"removed_since": "5.4.0.0.15"}),
-        ('api_port', Input("port")),
-        ('sec_protocol', {version.LOWEST: Select("select#security_protocol"),
-            '5.5': AngularSelect("security_protocol", exact=True)}),
-        ('sec_realm', Input("realm"))
-    ])
 
-
-properties_form_56 = TabStripForm(
+properties_form = TabStripForm(
     fields=[
         ('type_select', AngularSelect("emstype")),
         ('name_text', Input("name")),
@@ -78,6 +63,8 @@ properties_form_56 = TabStripForm(
             ('hostname_text', Input("default_hostname")),
             ('api_port', Input("default_api_port")),
             ('sec_protocol', AngularSelect("default_security_protocol", exact=True)),
+            ('verify_tls_switch', BootstrapSwitch(input_id="default_tls_verify")),
+            ('ca_certs', Input('default_tls_ca_certs')),
         ],
         "Events": [
             ('event_selection', Radio('event_stream_selection')),
@@ -91,15 +78,7 @@ properties_form_56 = TabStripForm(
         ]
     })
 
-
-prop_region = Region(
-    locators={
-        'properties_form': {
-            version.LOWEST: properties_form,
-            '5.6': properties_form_56,
-        }
-    }
-)
+prop_region = Region(locators={'properties_form': properties_form})
 
 manage_policies_tree = CheckboxTree("//div[@id='protect_treebox']/ul")
 

--- a/cfme/infrastructure/provider/rhevm.py
+++ b/cfme/infrastructure/provider/rhevm.py
@@ -10,7 +10,8 @@ class RHEVMProvider(InfraProvider):
     db_types = ["Redhat::InfraManager"]
 
     def __init__(self, name=None, credentials=None, zone=None, key=None, hostname=None,
-                 ip_address=None, api_port=None, start_ip=None, end_ip=None,
+                 ip_address=None, api_port=None, verify_tls=False, ca_certs=None, start_ip=None,
+                 end_ip=None,
                  provider_data=None, appliance=None):
         super(RHEVMProvider, self).__init__(
             name=name, credentials=credentials, zone=zone, key=key, provider_data=provider_data,
@@ -19,6 +20,8 @@ class RHEVMProvider(InfraProvider):
         self.hostname = hostname
         self.ip_address = ip_address
         self.api_port = api_port
+        self.verify_tls = verify_tls
+        self.ca_certs = ca_certs
         self.start_ip = start_ip
         self.end_ip = end_ip
 
@@ -26,10 +29,18 @@ class RHEVMProvider(InfraProvider):
         provider_name = version.pick({
             version.LOWEST: 'Red Hat Enterprise Virtualization Manager',
             '5.7.1': 'Red Hat Virtualization Manager'})
+        verify_tls = version.pick({
+            version.LOWEST: None,
+            '5.8': kwargs.get('verify_tls', False)})
+        ca_certs = version.pick({
+            version.LOWEST: None,
+            '5.8': kwargs.get('ca_certs', None)})
         return {'name_text': kwargs.get('name'),
                 'type_select': create and provider_name,
                 'hostname_text': kwargs.get('hostname'),
                 'api_port': kwargs.get('api_port'),
+                'verify_tls_switch': verify_tls,
+                'ca_certs': ca_certs,
                 'ipaddress_text': kwargs.get('ip_address'),
                 'candu_hostname_text':
                 kwargs.get('hostname') if self.credentials.get('candu', None) else None}


### PR DESCRIPTION
Latest MIQ release adds two new form elements when configuring a rhevm infra provider:
* Verify TLS
* CA Certs

Cleanup some old form definitions that aren't needed for CFME 56z+, and support new fields.  Use 'None' values for versions lower than CFME 5.8 so that the form fill ignores them and doesn't generate exceptions for missing fields.

Tested locally against 56z, 57z, 58z

{{ pytest: cfme/tests/infrastructure/test_providers.py -k test_provider_crud --use-provider rhevm36 --long-running  }}

## PRT Comments
56z: Passed rhevm CRUD
57z: Passed rhevm CRUD
upstream: failed after the create, provider was added to appliance successfully.  outside of this scope. 

FIXES RHCFQE-2208