### PR TITLE
[RFR] Pass args and kwargs in SummaryTable init

### DIFF
--- a/widgetastic_manageiq.py
+++ b/widgetastic_manageiq.py
@@ -645,8 +645,8 @@ class SummaryTable(VanillaTable):
     BASELOC = './/table[./thead/tr/th[contains(@align, "left") and normalize-space(.)={}]]'
     Image = namedtuple('Image', ['alt', 'title', 'src'])
 
-    def __init__(self, parent, title):
-        VanillaTable.__init__(self, parent, self.BASELOC.format(quote(title)))
+    def __init__(self, parent, title, *args, **kwargs):
+        VanillaTable.__init__(self, parent, self.BASELOC.format(quote(title)), *args, **kwargs)
 
     @property
     def fields(self):


### PR DESCRIPTION
Found that when using SummaryTable for cloud.instances widgetastic refactor, and exception was raised because of logger being passed as a kwarg.