### PR TITLE
[1LP][RFR] update test_query_simple_collections with collections new in 5.8

### DIFF
--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -65,14 +65,14 @@ def test_vm_scan(rest_api, vm, from_detail):
         return response.task.state.lower() == 'finished'
 
 
-COLLECTIONS_IGNORED_56 = {
+COLLECTIONS_ADDED_IN_57 = {
     "arbitration_profiles", "arbitration_rules", "arbitration_settings", "automate",
     "automate_domains", "blueprints", "cloud_networks", "container_deployments", "currencies",
     "measures", "notifications", "orchestration_templates", "virtual_templates",
 }
 
 
-COLLECTIONS_IGNORED_57 = {
+COLLECTIONS_ADDED_IN_58 = {
     "actions", "alert_definitions", "alerts", "authentications", "configuration_script_payloads",
     "configuration_script_sources", "load_balancers",
 }
@@ -99,8 +99,8 @@ COLLECTIONS_IGNORED_57 = {
      "vms", "zones"])
 @pytest.mark.uncollectif(
     lambda collection_name:
-        (collection_name in COLLECTIONS_IGNORED_56 and current_version() < "5.7") or
-        (collection_name in COLLECTIONS_IGNORED_57 and current_version() < "5.8")
+        (collection_name in COLLECTIONS_ADDED_IN_57 and current_version() < "5.7") or
+        (collection_name in COLLECTIONS_ADDED_IN_58 and current_version() < "5.8")
 )
 def test_query_simple_collections(rest_api, collection_name):
     """This test tries to load each of the listed collections. 'Simple' collection means that they

--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -72,22 +72,36 @@ COLLECTIONS_IGNORED_56 = {
 }
 
 
+COLLECTIONS_IGNORED_57 = {
+    "actions", "alert_definitions", "alerts", "authentications", "configuration_script_payloads",
+    "configuration_script_sources", "load_balancers",
+}
+
+
 @pytest.mark.tier(3)
 @pytest.mark.parametrize(
     "collection_name",
-    ["arbitration_profiles", "arbitration_rules", "arbitration_settings", "automate",
-     "automate_domains", "automation_requests", "availability_zones", "blueprints", "categories",
-     "chargebacks", "cloud_networks", "clusters", "conditions", "container_deployments",
-     "currencies", "data_stores", "events", "features", "flavors", "groups", "hosts", "instances",
-     "measures", "notifications", "orchestration_templates", "pictures", "policies",
-     "policy_actions", "policy_profiles", "providers", "provision_dialogs", "provision_requests",
-     "rates", "reports", "request_tasks", "requests", "resource_pools", "results", "roles",
-     "security_groups", "servers", "service_catalogs", "service_dialogs", "service_orders",
-     "service_requests", "service_templates", "services", "tags", "tasks", "templates", "tenants",
-     "users", "virtual_templates", "vms", "zones"])
+    ["actions", "alert_definitions", "alerts", "arbitration_profiles",
+     "arbitration_rules", "arbitration_settings", "authentications",
+     "automate", "automate_domains", "automation_requests",
+     "availability_zones", "blueprints", "categories", "chargebacks",
+     "cloud_networks", "clusters", "conditions",
+     "configuration_script_payloads", "configuration_script_sources",
+     "container_deployments", "currencies", "data_stores", "events",
+     "features", "flavors", "groups", "hosts", "instances", "load_balancers",
+     "measures", "notifications", "orchestration_templates", "pictures",
+     "policies", "policy_actions", "policy_profiles", "providers",
+     "provision_dialogs", "provision_requests", "rates", "reports",
+     "request_tasks", "requests", "resource_pools", "results", "roles",
+     "security_groups", "servers", "service_catalogs", "service_dialogs",
+     "service_orders", "service_requests", "service_templates", "services",
+     "tags", "tasks", "templates", "tenants", "users", "virtual_templates",
+     "vms", "zones"])
 @pytest.mark.uncollectif(
-    lambda collection_name: (
-        collection_name in COLLECTIONS_IGNORED_56 and current_version() < "5.7"))
+    lambda collection_name:
+        (collection_name in COLLECTIONS_IGNORED_56 and current_version() < "5.7") or
+        (collection_name in COLLECTIONS_IGNORED_57 and current_version() < "5.8")
+)
 def test_query_simple_collections(rest_api, collection_name):
     """This test tries to load each of the listed collections. 'Simple' collection means that they
     have no usable actions that we could try to run


### PR DESCRIPTION
The test_query_simple_collections updated with collections added in 5.8.

{{pytest: -v -k test_query_simple_collections}} 