### PR TITLE
[WIPTEST] ManageIQForm Prototype to reduce button re-definition

### DIFF
--- a/cfme/provisioning.py
+++ b/cfme/provisioning.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 
 from widgetastic.widget import View
 from widgetastic_patternfly import Tab, BootstrapSelect, Input, BootstrapTreeview
-from widgetastic_manageiq import VersionPick, Version, CheckboxSelect, Table, Calendar
+from widgetastic_manageiq import VersionPick, Version, CheckboxSelect, Table, Calendar, ManageIQForm
 
 from cfme import web_ui as ui
 from cfme import BaseLoggedInPage
@@ -26,7 +26,7 @@ def select_security_group(sg):
     sel.sleep(1)
 
 
-class ProvisioningForm(BaseLoggedInPage):
+class ProvisioningForm(BaseLoggedInPage, ManageIQForm):
     @View.nested
     class request(Tab):  # noqa
         TAB_NAME = 'Request'

--- a/widgetastic_manageiq.py
+++ b/widgetastic_manageiq.py
@@ -1589,3 +1589,19 @@ class TimelinesView(View):
     @property
     def is_displayed(self):
         return self.title.text == 'Timelines'
+
+
+class ManageIQForm(View):
+    """Generic form view with common action buttons
+
+    .. code-block:: python
+
+        class PageWithFormView(View):
+            @View.nested
+            class form(ManageIQForm):
+                # widgets
+    """
+    continue_button = Button('Continue')
+    submit_button = Button('Submit')
+    reset_button = Button('Reset')
+    cancel_button = Button('Cancel')


### PR DESCRIPTION
Provide a generic ManageIQForm view that defines the basic form buttons. To be inherited/composited into form views to prevent defining these form buttons hundreds of times across the page models.