### PR TITLE
[1LP][RFR] fix for AttributeError: 'FakeObject' object has no attribute 'label'

### DIFF
--- a/cfme/services/catalogs/catalog_item.py
+++ b/cfme/services/catalogs/catalog_item.py
@@ -126,7 +126,7 @@ class CatalogItem(Updateable, Pretty, Navigatable):
 
         sel.wait_for_element(basic_info_form.name_text)
         catalog = fakeobject_or_object(self.catalog, "name", "Unassigned")
-        dialog = fakeobject_or_object(self.dialog, "name", "No Dialog")
+        dialog = fakeobject_or_object(self.dialog, "label", "No Dialog")
 
         # Need to provide the (optional) provider name to the form, not the object
         provider_name = None


### PR DESCRIPTION
Some tests that are using `CatalogItem.create()` fails with
``E       AttributeError: 'FakeObject' object has no attribute 'label'``
or
``E           NoSuchElementException: Message: Element //select[@id='st_prov_type'] not found on page.`` (caused by not being at the correct page as a result of this bug)

Due to recent change in https://github.com/sshveta/cfme_tests/blob/0cced52f9442538272a2d503424422a1c2c18bcd/cfme/services/catalogs/catalog_item.py#L147
this needs to be changed as well.
