### PR TITLE
[1LP][RFR] Added new field 'sec_protocol' for Middleware Provider for 5.8 and upstream versions.

### DIFF
--- a/cfme/middleware/provider/__init__.py
+++ b/cfme/middleware/provider/__init__.py
@@ -55,9 +55,29 @@ properties_form = Form(
     fields=[
         ('type_select', AngularSelect('emstype')),
         ('name_text', Input('name')),
+        ('sec_protocol', AngularSelect('default_security_protocol', exact=True)),
         ('hostname_text', Input('default_hostname')),
         ('port_text', Input('default_api_port'))
     ])
+
+properties_form_57 = Form(
+    fields=[
+        ('type_select', AngularSelect('emstype')),
+        ('name_text', Input('name')),
+        ('hostname_text', Input('default_hostname')),
+        ('port_text', Input('default_api_port'))
+    ])
+
+
+prop_region = Region(
+    locators={
+        'properties_form': {
+            version.UPSTREAM: properties_form,
+            '5.8': properties_form,
+            '5.7': properties_form_57,
+        }
+    }
+)
 
 
 class MiddlewareProvider(BaseProvider):
@@ -72,7 +92,7 @@ class MiddlewareProvider(BaseProvider):
     edit_page_suffix = 'provider_edit_detail'
     refresh_text = "Refresh items and relationships"
     quad_name = None
-    _properties_form = properties_form
+    _properties_region = prop_region  # This will get resolved in common to a real form
     add_provider_button = form_buttons.FormButton("Add")
     save_button = form_buttons.FormButton("Save")
     taggable_type = 'ExtManagementSystem'

--- a/cfme/middleware/provider/hawkular.py
+++ b/cfme/middleware/provider/hawkular.py
@@ -40,7 +40,7 @@ class HawkularProvider(MiddlewareBase, TopologyMixin, TimelinesMixin, Middleware
     db_types = ["Hawkular::MiddlewareManager"]
 
     def __init__(self, name=None, hostname=None, port=None, credentials=None, key=None,
-            appliance=None, **kwargs):
+            appliance=None, sec_protocol=None, **kwargs):
         Navigatable.__init__(self, appliance=appliance)
         self.name = name
         self.hostname = hostname
@@ -50,11 +50,13 @@ class HawkularProvider(MiddlewareBase, TopologyMixin, TimelinesMixin, Middleware
             credentials = {}
         self.credentials = credentials
         self.key = key
+        self.sec_protocol = sec_protocol if sec_protocol else 'Non-SSL'
         self.db_id = kwargs['db_id'] if 'db_id' in kwargs else None
 
     def _form_mapping(self, create=None, **kwargs):
         return {'name_text': kwargs.get('name'),
                 'type_select': create and 'Hawkular',
+                'sec_protocol': kwargs.get('sec_protocol'),
                 'hostname_text': kwargs.get('hostname'),
                 'port_text': kwargs.get('port')}
 
@@ -160,6 +162,7 @@ class HawkularProvider(MiddlewareBase, TopologyMixin, TimelinesMixin, Middleware
             name=prov_config['name'],
             key=prov_key,
             hostname=prov_config['hostname'],
+            sec_protocol=prov_config.get('sec_protocol', None),
             port=prov_config['port'],
             credentials={'default': credentials},
             appliance=appliance)


### PR DESCRIPTION
{{pytest: cfme/tests/middleware/test_middleware_provider.py::test_hawkular_crud -v --use-provider hawkular}}