### PR TITLE
[1LP][RFR]Fixed timeprofile tests for 5.8 version

### DIFF
--- a/cfme/configure/settings.py
+++ b/cfme/configure/settings.py
@@ -35,10 +35,12 @@ class Timeprofile(Updateable, Navigatable):
             ("hours", CFMECheckbox("all_hours")),
         ]
     )
-    save_edit_button = form_buttons.FormButton('Save changes')
+    save_edit_button = deferred_verpick({'5.7': form_buttons.FormButton('Save changes'),
+                                         '5.8': form_buttons.FormButton('Save')})
     save_button = deferred_verpick({
         version.LOWEST: form_buttons.FormButton("Add this Time Profile"),
-        '5.7': form_buttons.FormButton('Add')
+        '5.7': form_buttons.FormButton('Add'),
+        '5.8': form_buttons.FormButton('Save')
     })
 
     def __init__(self, description=None, scope=None, days=None, hours=None, timezone=None,

--- a/cfme/tests/configure/test_timeprofile.py
+++ b/cfme/tests/configure/test_timeprofile.py
@@ -3,7 +3,6 @@ import fauxfactory
 import cfme.configure.settings as st
 import pytest
 import utils.error as error
-from utils.blockers import BZ
 from utils.update import update
 from utils import version
 from cfme import test_requirements
@@ -32,8 +31,8 @@ def test_timeprofile_crud():
     timeprofile.delete()
 
 
-@pytest.mark.meta(blockers=[BZ(1394833, forced_streams=["5.7", "upstream"])])
 @pytest.mark.sauce
+@pytest.mark.uncollectif(lambda: version.current_version() > '5.7')
 def test_timeprofile_duplicate_name():
     nt = new_timeprofile()
     nt.create()
@@ -65,7 +64,10 @@ def test_days_required_error_validation():
         tp.create(cancel=True)
         assert "At least one day needs to be selected" == \
                tp.timeprofile_form.days.angular_help_block
-        assert form_buttons.add.is_dimmed
+        if version.current_version() > "5.8":
+            assert form_buttons.save.is_dimmed
+        else:
+            assert form_buttons.add.is_dimmed
     else:
         with error.expected("At least one Day must be selected"):
             tp.create()
@@ -83,7 +85,10 @@ def test_hours_required_error_validation():
         tp.create(cancel=True)
         assert "At least one hour needs to be selected" == \
                tp.timeprofile_form.days.angular_help_block
-        assert form_buttons.add.is_dimmed
+        if version.current_version() > "5.8":
+            assert form_buttons.save.is_dimmed
+        else:
+            assert form_buttons.add.is_dimmed
     else:
         with error.expected("At least one Hour must be selected"):
             tp.create()
@@ -98,7 +103,10 @@ def test_description_required_error_validation():
     if version.current_version() > "5.7":
         tp.create(cancel=True)
         assert tp.timeprofile_form.description.angular_help_block == "Required"
-        assert form_buttons.add.is_dimmed
+        if version.current_version() > "5.8":
+            assert form_buttons.save.is_dimmed
+        else:
+            assert form_buttons.add.is_dimmed
     else:
         with error.expected("Description is required"):
             tp.create()


### PR DESCRIPTION
Add button was changed with Save button in 5.8 so this is fix for it.