### PR TITLE
[RFR][1LP] fix KeyError: 'username' in virtualcenter.py

### DIFF
--- a/cfme/infrastructure/provider/virtualcenter.py
+++ b/cfme/infrastructure/provider/virtualcenter.py
@@ -28,9 +28,8 @@ class VMwareProvider(InfraProvider):
         """ Used in utils.virtual_machines """
         # Called within a dictionary update. Since we want to remove key/value pairs, return the
         # entire dictionary
-        for key in ['username', 'password']:
-            if key in deploy_args:
-                del deploy_args[key]
+        deploy_args.pop('username', None)
+        deploy_args.pop('password', None)
         if "allowed_datastores" not in deploy_args and "allowed_datastores" in self.data:
             deploy_args['allowed_datastores'] = self.data['allowed_datastores']
 

--- a/cfme/infrastructure/provider/virtualcenter.py
+++ b/cfme/infrastructure/provider/virtualcenter.py
@@ -28,8 +28,9 @@ class VMwareProvider(InfraProvider):
         """ Used in utils.virtual_machines """
         # Called within a dictionary update. Since we want to remove key/value pairs, return the
         # entire dictionary
-        del deploy_args['username']
-        del deploy_args['password']
+        for key in ['username', 'password']:
+            if key in deploy_args:
+                del deploy_args[key]
         if "allowed_datastores" not in deploy_args and "allowed_datastores" in self.data:
             deploy_args['allowed_datastores'] = self.data['allowed_datastores']
 


### PR DESCRIPTION
Many tests are now failing with
```
>       del deploy_args['username']
E       KeyError: 'username'

cfme/infrastructure/provider/virtualcenter.py:31: KeyError
```