### PR TITLE
[WIPTEST] Fix for deployment_helper()

### DIFF
--- a/cfme/infrastructure/provider/virtualcenter.py
+++ b/cfme/infrastructure/provider/virtualcenter.py
@@ -28,8 +28,11 @@ class VMwareProvider(InfraProvider):
         """ Used in utils.virtual_machines """
         # Called within a dictionary update. Since we want to remove key/value pairs, return the
         # entire dictionary
-        del deploy_args['username']
-        del deploy_args['password']
+        try:
+            del deploy_args['username']
+            del deploy_args['password']
+        except KeyError:
+            pass
         if "allowed_datastores" not in deploy_args and "allowed_datastores" in self.data:
             deploy_args['allowed_datastores'] = self.data['allowed_datastores']
 


### PR DESCRIPTION
{{pytest: -v -k 'test_action_cancel_clone' --long-running --use-provider=vpshere6-nested}}

Purpose or Intent
=================

__Fixing__ `deployment_helper()` in cfme/infrastructure/provider/virtualcenter.py, because `test_action_cancel_clone` caught `KeyError` in that method.