### PR TITLE
[1LP][RFR]Extending cloud provisioning asserts + removing unused ldap setup

### DIFF
--- a/cfme/tests/infrastructure/test_provisioning.py
+++ b/cfme/tests/infrastructure/test_provisioning.py
@@ -41,8 +41,8 @@ def vm_name():
 
 
 @pytest.mark.tier(1)
-def test_provision_from_template(rbac_role, configure_ldap_auth_mode, setup_provider, provider,
-        vm_name, smtp_test, request, provisioning):
+def test_provision_from_template(rbac_role, setup_provider, provider, vm_name, smtp_test,
+                                 request, provisioning):
     """ Tests provisioning from a template
 
     Metadata:


### PR DESCRIPTION
Purpose or Intent
=================
__Extending__ cloud provisioning asserts to check request status because wasn't doing that

and

__Removing__  LDAP auth setup as it's unused during these tests, which saves time

{{pytest: cfme/tests/ "-k test_provision_from_template" --use-provider ec2west --use-provider azure  --long-running}}