### PR TITLE
[WIPTEST]Fix Add button in cfme/tests/intelligence/test_chargeback.py

### DIFF
--- a/cfme/intelligence/chargeback.py
+++ b/cfme/intelligence/chargeback.py
@@ -80,7 +80,7 @@ rate_form = Form(
         ('storage_fixed_2_var', _mkitem("variable_rate", 1)),
         ('storage_alloc_var', _mkitem("variable_rate", 2)),
         ('storage_used_var', _mkitem("variable_rate", 3)),
-        ('add_button', form_buttons.add),
+        ('add_button', form_buttons.FormButton('Add', by_alt_only=True)),
         ('save_button', form_buttons.save),
         ('reset_button', form_buttons.reset),
         ('cancel_button', form_buttons.cancel)])

--- a/cfme/web_ui/form_buttons.py
+++ b/cfme/web_ui/form_buttons.py
@@ -48,15 +48,19 @@ class FormButton(Pretty):
 
     def __init__(
             self, alt, dimmed_alt=None, force_click=False, partial_alt=False, ng_click=None,
-            classes=None):
+            classes=None, by_alt_only=False):
         self._alt = alt
         self._dimmed_alt = dimmed_alt
         self._force = force_click
         self._partial = partial_alt
         self._ng_click = ng_click
         self._classes = classes or []
+        self._by_alt_only = by_alt_only
 
     def alt_expr(self, dimmed=False):
+        if self._by_alt_only:
+            return ("normalize-space(@alt)={alt}".format(
+                alt=quoteattr((self._dimmed_alt or self._alt) if dimmed else self._alt)))
         if self._partial:
             if self._ng_click is None:
                 return (


### PR DESCRIPTION
{{ pytest: cfme/tests/intelligence/test_chargeback.py }}

In chargeback's page there are few "Add" buttons

![image](https://cloud.githubusercontent.com/assets/20817708/24403736/eba4eed6-13c6-11e7-9445-1c0118fa47d6.png)
