### PR TITLE
[1LP][RFR] fix test_power_control_rest for scvmm and make testing more robust

### DIFF
--- a/cfme/tests/cloud_infra_common/test_power_control_rest.py
+++ b/cfme/tests/cloud_infra_common/test_power_control_rest.py
@@ -48,7 +48,7 @@ def vm_obj(request, provider, setup_provider, small_template, vm_name):
 def wait_for_vm_state_change(vm_obj, state):
     vm = vm_obj.get_vm_via_rest()
     if vm_obj.provider.one_of(GCEProvider, EC2Provider, SCVMMProvider):
-        num_sec = 2400  # extra time for slow providers
+        num_sec = 4000  # extra time for slow providers
     else:
         num_sec = 1200
 

--- a/cfme/tests/cloud_infra_common/test_power_control_rest.py
+++ b/cfme/tests/cloud_infra_common/test_power_control_rest.py
@@ -41,7 +41,7 @@ def vm_obj(request, provider, setup_provider, small_template, vm_name):
         except Exception:
             logger.warning("Failed to delete vm `{}`.".format(vm_obj.name))
 
-    vm_obj.create_on_provider(find_in_cfme=True, allow_skip="default")
+    vm_obj.create_on_provider(timeout=2400, find_in_cfme=True, allow_skip="default")
     return vm_obj
 
 
@@ -102,12 +102,7 @@ def test_stop(rest_api, vm_obj, verify_vm_running, soft_assert, from_detail):
     else:
         rest_api.collections.vms.action.stop(vm)
     verify_action_result(rest_api)
-    wait_for(
-        lambda: vm_obj.provider.mgmt.is_vm_stopped(vm_obj.name),
-        num_sec=1200,
-        delay=20,
-        silent_failure=True,
-        message="mgmt system check - vm stopped")
+    wait_for_vm_state_change(vm_obj, vm_obj.STATE_OFF)
     soft_assert(not verify_vm_power_state(vm, vm_obj.STATE_ON), "vm still running")
 
 

--- a/cfme/tests/cloud_infra_common/test_power_control_rest.py
+++ b/cfme/tests/cloud_infra_common/test_power_control_rest.py
@@ -199,7 +199,7 @@ def test_reset_vm(rest_api, vm_obj, verify_vm_running, from_detail):
     else:
         rest_api.collections.vms.action.reset(vm)
     success, message = verify_action_result(rest_api, assert_success=False)
-    if current_version() < '5.8':
+    if current_version() < '5.7':
         unsupported_providers = (GCEProvider, EC2Provider, SCVMMProvider)
     else:
         unsupported_providers = (GCEProvider, EC2Provider)

--- a/cfme/tests/cloud_infra_common/test_power_control_rest.py
+++ b/cfme/tests/cloud_infra_common/test_power_control_rest.py
@@ -10,7 +10,6 @@ from utils.log import logger
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
-from utils.version import current_version
 
 
 pytestmark = [
@@ -172,7 +171,7 @@ def test_suspend(rest_api, vm_obj, verify_vm_running, soft_assert, from_detail):
 
 
 @pytest.mark.parametrize("from_detail", [True, False], ids=["from_detail", "from_collection"])
-def test_reset_vm(rest_api, vm_obj, verify_vm_running, from_detail):
+def test_reset_vm(rest_api, vm_obj, verify_vm_running, from_detail, appliance):
     """
     Test reset vm
 
@@ -199,7 +198,7 @@ def test_reset_vm(rest_api, vm_obj, verify_vm_running, from_detail):
     else:
         rest_api.collections.vms.action.reset(vm)
     success, message = verify_action_result(rest_api, assert_success=False)
-    if current_version() < '5.7':
+    if appliance.version < '5.7':
         unsupported_providers = (GCEProvider, EC2Provider, SCVMMProvider)
     else:
         unsupported_providers = (GCEProvider, EC2Provider)


### PR DESCRIPTION
* reset is supported on scvmm in 5.8
* more robust checking for power state changes
* make sure we are always using /api/vms and not /api/instances even for cloud providers

**PRT results**:
OK apart from failures to create vm on providers (not these tests faults) and semi-expected `SoftAssertionError`s (timeouts when waiting for change states - this is unreliable hence soft asserts).

{{pytest: cfme/tests/cloud_infra_common/test_power_control_rest.py -v --use-provider scvmm}}