### PR TITLE
[1LP][RFR] DynaTree fix to click checkbox if leaf contains checkbox

### DIFF
--- a/widgetastic_manageiq.py
+++ b/widgetastic_manageiq.py
@@ -320,15 +320,17 @@ class DynaTree(Widget):
 
         """
         leaf = self.expand_path(*path, **kwargs)
-        checkbox = self.browser.element('./span[contains(@class, '
-                                        '"dynatree-checkbox")]', parent=leaf)
         title = self.browser.element('./a', parent=leaf)
 
         self.logger.info("Path %r yielded menuitem %r", path, self.browser.text(title))
         if title is not None:
             self.browser.plugin.ensure_page_safe()
             self.browser.click(title)
-            self.browser.click(checkbox)
+
+            checkbox_locator = './span[contains(@class, "dynatree-checkbox")]'
+            if self.browser.is_displayed(checkbox_locator, parent=leaf):
+                checkbox = self.browser.element(checkbox_locator, parent=leaf)
+                self.browser.click(checkbox)
 
         return leaf
 

--- a/widgetastic_manageiq.py
+++ b/widgetastic_manageiq.py
@@ -305,7 +305,7 @@ class DynaTree(Widget):
         if node is not None:
             self.expand_id(last_id)
 
-        return self.browser.element('./span/a', parent=node)
+        return self.browser.element('./span', parent=node)
 
     def click_path(self, *path, **kwargs):
         """ Exposes a path and then clicks it.
@@ -320,10 +320,16 @@ class DynaTree(Widget):
 
         """
         leaf = self.expand_path(*path, **kwargs)
-        self.logger.info("Path %r yielded menuitem %r", path, self.browser.text(leaf))
-        if leaf is not None:
+        checkbox = self.browser.element('./span[contains(@class, '
+                                        '"dynatree-checkbox")]', parent=leaf)
+        title = self.browser.element('./a', parent=leaf)
+
+        self.logger.info("Path %r yielded menuitem %r", path, self.browser.text(title))
+        if title is not None:
             self.browser.plugin.ensure_page_safe()
-            self.browser.click(leaf)
+            self.browser.click(title)
+            self.browser.click(checkbox)
+
         return leaf
 
 


### PR DESCRIPTION
Purpose or Intent
=================
Some views like Manage Policies have DynaTree control with checkbox in 5.6.
Currently checkbox is not clicked when DynaTree's fill is called.
This small patch fixes that.
I didn't spend time implementing methods like check/uncheck/is_checked/etc since DynaTree is deprecated. I can make a better fix if it makes sense.

Limitation: fill doesn't check whether checkbox is already checked/not checked.
