### PR TITLE
[1LP][RFR] new tests for copying orchestration templates using REST API

### DIFF
--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -792,13 +792,12 @@ class TestOrchestrationTemplatesRESTAPI(object):
             test_flag: rest
         """
         num_orch_templates = len(orchestration_templates)
-        content_template = "{ 'Description' : '@s' }\n"
         new = []
         for _ in range(num_orch_templates):
             uniq = fauxfactory.gen_alphanumeric(5)
             new.append({
                 "name": "test_copied_{}".format(uniq),
-                "content": content_template.replace('@s', uniq)
+                "content": "{{ 'Description' : '{}' }}\n".format(uniq)
             })
         if from_detail:
             copied = []

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -792,13 +792,13 @@ class TestOrchestrationTemplatesRESTAPI(object):
             test_flag: rest
         """
         num_orch_templates = len(orchestration_templates)
-        content_template = "{ 'Description' : '%S' }\n"
+        content_template = "{ 'Description' : '@s' }\n"
         new = []
         for _ in range(num_orch_templates):
             uniq = fauxfactory.gen_alphanumeric(5)
             new.append({
                 "name": "test_copied_{}".format(uniq),
-                "content": content_template.replace('%S', uniq)
+                "content": content_template.replace('@s', uniq)
             })
         if from_detail:
             copied = []

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -778,3 +778,77 @@ class TestOrchestrationTemplatesRESTAPI(object):
             assert edited[i].description == new[i]['description']
             orchestration_templates[i].reload()
             assert orchestration_templates[i].description == new[i]['description']
+
+    @pytest.mark.tier(3)
+    @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
+    @pytest.mark.parametrize(
+        "from_detail", [True, False],
+        ids=["from_detail", "from_collection"])
+    def test_copy_orchestration_templates(self, request, rest_api, orchestration_templates,
+            from_detail):
+        """Tests copying of orchestration templates.
+
+        Metadata:
+            test_flag: rest
+        """
+        response_len = len(orchestration_templates)
+        new = []
+        for _ in range(response_len):
+            uniq = fauxfactory.gen_alphanumeric(5)
+            new.append({
+                "name": "test_copied_{}".format(uniq),
+                "content": "{ 'Description' : " + "'{}'".format(uniq) + "}\n"
+            })
+        if from_detail:
+            copied = []
+            for i in range(response_len):
+                copied.append(orchestration_templates[i].action.copy(**new[i]))
+                assert rest_api.response.status_code == 200
+        else:
+            for i in range(response_len):
+                new[i].update(orchestration_templates[i]._ref_repr())
+            copied = rest_api.collections.orchestration_templates.action.copy(*new)
+            assert rest_api.response.status_code == 200
+
+        request.addfinalizer(
+            lambda: rest_api.collections.orchestration_templates.action.delete(*copied))
+
+        assert len(copied) == response_len
+        for i in range(response_len):
+            orchestration_templates[i].reload()
+            assert copied[i].name == new[i]['name']
+            assert orchestration_templates[i].id != copied[i].id
+            assert orchestration_templates[i].name != copied[i].name
+            assert orchestration_templates[i].description == copied[i].description
+            new_record = rest_api.collections.orchestration_templates.get(id=copied[i].id)
+            assert new_record.name == copied[i].name
+
+    @pytest.mark.tier(3)
+    @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
+    @pytest.mark.parametrize(
+        "from_detail", [True, False],
+        ids=["from_detail", "from_collection"])
+    def test_invalid_copy_orchestration_templates(self, rest_api, orchestration_templates,
+            from_detail):
+        """Tests copying of orchestration templates without changing content.
+
+        Metadata:
+            test_flag: rest
+        """
+        response_len = len(orchestration_templates)
+        new = []
+        for _ in range(response_len):
+            new.append({
+                "name": "test_copied_{}".format(fauxfactory.gen_alphanumeric(5))
+            })
+        if from_detail:
+            for i in range(response_len):
+                with error.expected("content must be unique"):
+                    orchestration_templates[i].action.copy(**new[i])
+                assert rest_api.response.status_code == 400
+        else:
+            for i in range(response_len):
+                new[i].update(orchestration_templates[i]._ref_repr())
+            with error.expected("content must be unique"):
+                rest_api.collections.orchestration_templates.action.copy(*new)
+            assert rest_api.response.status_code == 400

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -791,21 +791,22 @@ class TestOrchestrationTemplatesRESTAPI(object):
         Metadata:
             test_flag: rest
         """
-        response_len = len(orchestration_templates)
+        CONTENT_TEMPLATE = "{ 'Description' : '%s' }\n"
+        num_orch_templates = len(orchestration_templates)
         new = []
-        for _ in range(response_len):
+        for _ in range(num_orch_templates):
             uniq = fauxfactory.gen_alphanumeric(5)
             new.append({
                 "name": "test_copied_{}".format(uniq),
-                "content": "{ 'Description' : " + "'{}'".format(uniq) + "}\n"
+                "content": CONTENT_TEMPLATE.replace('%s', uniq)
             })
         if from_detail:
             copied = []
-            for i in range(response_len):
+            for i in range(num_orch_templates):
                 copied.append(orchestration_templates[i].action.copy(**new[i]))
                 assert rest_api.response.status_code == 200
         else:
-            for i in range(response_len):
+            for i in range(num_orch_templates):
                 new[i].update(orchestration_templates[i]._ref_repr())
             copied = rest_api.collections.orchestration_templates.action.copy(*new)
             assert rest_api.response.status_code == 200
@@ -813,8 +814,8 @@ class TestOrchestrationTemplatesRESTAPI(object):
         request.addfinalizer(
             lambda: rest_api.collections.orchestration_templates.action.delete(*copied))
 
-        assert len(copied) == response_len
-        for i in range(response_len):
+        assert len(copied) == num_orch_templates
+        for i in range(num_orch_templates):
             orchestration_templates[i].reload()
             assert copied[i].name == new[i]['name']
             assert orchestration_templates[i].id != copied[i].id
@@ -835,19 +836,19 @@ class TestOrchestrationTemplatesRESTAPI(object):
         Metadata:
             test_flag: rest
         """
-        response_len = len(orchestration_templates)
+        num_orch_templates = len(orchestration_templates)
         new = []
-        for _ in range(response_len):
+        for _ in range(num_orch_templates):
             new.append({
                 "name": "test_copied_{}".format(fauxfactory.gen_alphanumeric(5))
             })
         if from_detail:
-            for i in range(response_len):
+            for i in range(num_orch_templates):
                 with error.expected("content must be unique"):
                     orchestration_templates[i].action.copy(**new[i])
                 assert rest_api.response.status_code == 400
         else:
-            for i in range(response_len):
+            for i in range(num_orch_templates):
                 new[i].update(orchestration_templates[i]._ref_repr())
             with error.expected("content must be unique"):
                 rest_api.collections.orchestration_templates.action.copy(*new)

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -791,14 +791,14 @@ class TestOrchestrationTemplatesRESTAPI(object):
         Metadata:
             test_flag: rest
         """
-        CONTENT_TEMPLATE = "{ 'Description' : '%s' }\n"
         num_orch_templates = len(orchestration_templates)
+        content_template = "{ 'Description' : '%S' }\n"
         new = []
         for _ in range(num_orch_templates):
             uniq = fauxfactory.gen_alphanumeric(5)
             new.append({
                 "name": "test_copied_{}".format(uniq),
-                "content": CONTENT_TEMPLATE.replace('%s', uniq)
+                "content": content_template.replace('%S', uniq)
             })
         if from_detail:
             copied = []


### PR DESCRIPTION
New tests for copying orchestration templates using REST API.

{{pytest: -v --long-running -k copy_orchestration_templates}}