### PR TITLE
[1LP][RFR] Container reports tests

### DIFF
--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -354,7 +354,9 @@ class ContainersTestItem(object):
         self.polarion_id = polarion_id
 
     def pretty_id(self):
-        return '{} ({})'.format(self.obj.__name__, self.polarion_id)
+        name = (self.obj.__name__ if hasattr(self.obj, '__name__')
+                else str(self.obj))
+        return '{} ({})'.format(name, self.polarion_id)
 
 
 def navigate_and_get_rows(provider, obj, count, table_class=CheckboxTable):

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -354,9 +354,9 @@ class ContainersTestItem(object):
         self.polarion_id = polarion_id
 
     def pretty_id(self):
-        name = (self.obj.__name__ if hasattr(self.obj, '__name__')
-                else str(self.obj))
-        return '{} ({})'.format(name, self.polarion_id)
+        return '{} ({})'.format(
+            getattr(self.obj, '__name__', str(self.obj)),
+            self.polarion_id)
 
 
 def navigate_and_get_rows(provider, obj, count, table_class=CheckboxTable):

--- a/cfme/fixtures/vporizer.py
+++ b/cfme/fixtures/vporizer.py
@@ -1,0 +1,97 @@
+from datetime import datetime
+import re
+from collections import namedtuple
+from random import random
+from cfme.fixtures.base import appliance
+
+import pytest
+
+
+vpor_values_pattern = """---
+:avg:
+  :cpu_usagemhz_rate_average: {}
+  :derived_memory_used: {}
+  :max_cpu_usage_rate_average: {}
+  :max_mem_usage_absolute_average: {}
+:dev:
+  :cpu_usagemhz_rate_average: {}
+  :derived_memory_used: {}
+  :max_cpu_usage_rate_average: {}
+  :max_mem_usage_absolute_average: {}
+"""
+
+vpor_data_instance = namedtuple('vpor_data_instance',
+                                [
+                                    'resource_type',
+                                    'resource_id',
+                                    'resource_name',
+                                    'cpu_usagemhz_rate_average',
+                                    'derived_memory_used',
+                                    'max_cpu_usage_rate_average',
+                                    'max_mem_usage_absolute_average'
+                                ])
+
+
+@pytest.yield_fixture(scope='module')
+def vporizer():
+
+    """Grabbing vim_performance_operating_ranges table data for nodes and projects.
+    In case that no such data exists, inserting fake rows"""
+
+    db = appliance().db
+    vpor = db.get('vim_performance_operating_ranges')
+
+    def gen_vpor_values():
+        return vpor_values_pattern.format(
+            random(), random() * 8000,
+            random() * 100, random() * 100,
+            random(), random() * 8000,
+            random() * 100, random() * 100
+        )
+
+    container_nodes = db.get('container_nodes')
+    container_pods = db.get('container_groups')
+    container_projects = db.get('container_projects')
+    created_at = datetime.now()
+    vpor_data_list = []
+
+    for table, resource_type in zip(
+        (container_nodes, container_projects, container_pods),
+        ('ContainerNode', 'ContainerProject', 'ContainerGroup')
+    ):
+
+        for resource in table.__table__.select() \
+                .where(True).execute().fetchall():
+            def get_resource_vpor_data():
+                return vpor.__table__.select().where(
+                    (vpor.resource_id == resource.id) &
+                    (vpor.resource_type == resource_type)
+                ).execute().fetchone()
+            # Checking whether values has already inserted to the table for this resource.
+            # Should be True only in case that the appliance age is greater than 24h
+            # if there isn't such row, insert...
+            if not get_resource_vpor_data():
+                vpor.__table__.insert().values(
+                    resource_type=resource_type, resource_id=resource.id,
+                    created_at=created_at, days=30, updated_at=datetime.now(),
+                    time_profile_id=1, values=gen_vpor_values()
+                ).execute()
+            # now, collecting the values from the table
+            resource_vpor_data = get_resource_vpor_data()
+            vpor_values_match = re.search(vpor_values_pattern.replace('{}', '([\d\.]+)'),
+                                          resource_vpor_data['values'])
+            if not vpor_values_match:
+                raise Exception('Could not parse VPOR values from row: values={}'
+                                .format(resource_vpor_data['values']))
+            vpor_values = [float(v) for v in vpor_values_match.groups()]
+            vpor_data_list.append(
+                vpor_data_instance(
+                    resource_vpor_data['resource_type'],
+                    resource_vpor_data['resource_id'], resource.name,
+                    vpor_values[0], vpor_values[1], vpor_values[2], vpor_values[3]
+                )
+            )
+
+    yield vpor_data_list
+
+    vpor.__table__.delete().where(vpor.created_at == created_at).execute()

--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -5,7 +5,7 @@ Extensively uses :py:mod:`cfme.intelligence.reports.ui_elements`
 """
 from functools import partial
 from cached_property import cached_property
-from navmazing import NavigateToSibling, NavigateToAttribute, NavigateToObject
+from navmazing import NavigateToSibling, NavigateToObject
 
 from . import Report
 from cfme.fixtures import pytest_selenium as sel

--- a/cfme/tests/containers/test_reports.py
+++ b/cfme/tests/containers/test_reports.py
@@ -1,0 +1,201 @@
+# -*- coding: utf-8 -*-
+import re
+
+import pytest
+
+from cfme.containers.provider import ContainersProvider
+from cfme.intelligence.reports.reports import CannedSavedReport
+from cfme.fixtures.base import appliance
+from utils import testgen
+from utils.blockers import BZ
+
+
+pytestmark = [
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.meta(
+        server_roles='+ems_metrics_coordinator +ems_metrics_collector +ems_metrics_processor'),
+    pytest.mark.tier(1)]
+pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
+
+
+@pytest.fixture(scope='module')
+def node_hardwares_db_data():
+
+    """Grabbing hardwares table data for nodes"""
+
+    db = appliance().db
+    hardwares_table = db.get('hardwares')
+    container_nodes = db.get('container_nodes')
+
+    out = {}
+    for node in container_nodes.__table__.select().where(True).execute().fetchall():
+
+        out[node.name] = hardwares_table.__table__.select().where(
+            hardwares_table.id == node.id
+        ).execute().fetchone()
+
+    return out
+
+
+@pytest.fixture(scope='function')
+def pods_per_ready_status(provider):
+    """Grabing the pods and their ready status from API"""
+    entities_j = provider.mgmt.api.get('pod')[1]['items']
+    out = {}
+    for entity_j in entities_j:
+        out[entity_j['metadata']['name']] = next(
+            (True if condition['status'].lower() == 'true' else False)
+            for condition in entity_j['status']['conditions']
+            if condition['type'].lower() == 'ready'
+        )
+
+    return out
+
+
+def get_report(menu_name):
+    """Queue a report by menu name , wait for finish and return it"""
+    path_to_report = ['Configuration Management', 'Containers', menu_name]
+    run_at = CannedSavedReport.queue_canned_report(path_to_report)
+    return CannedSavedReport(path_to_report, run_at)
+
+
+# @pytest.mark.meta(blockers=[BZ(1435958, forced_streams=["5.8"])])
+@pytest.mark.polarion('CMP-9533')
+def test_pods_per_ready_status(soft_assert, pods_per_ready_status):
+
+    report = get_report('Pods per Ready Status')
+    for row in report.data.rows:
+        name = row['# Pods per Ready Status']
+        readiness_ui = (True if row['Ready Condition Status'].lower() == 'true'
+                        else False)
+        if name not in pods_per_ready_status:  # this check based on BZ#1435958
+            soft_assert(False,
+                        'Could not find pod "{}" in openshift.'
+                        .format(name))
+            continue
+        soft_assert(pods_per_ready_status[name] == readiness_ui,
+                    'For pod "{}" expected readiness is "{}" got "{}"'
+                    .format(name, pods_per_ready_status[name], readiness_ui))
+
+
+@pytest.mark.meta(blockers=[BZ(1435970, forced_streams=["5.8"])])
+@pytest.mark.polarion('CMP-9536')
+def test_report_nodes_by_capacity(appliance, soft_assert, node_hardwares_db_data):
+
+    report = get_report('Nodes By Capacity')
+    for row in report.data.rows:
+
+        hw = node_hardwares_db_data[row['Name']]
+
+        soft_assert(hw.cpu_total_cores == int(row['CPU Cores']),
+                    'Number of CPU cores is wrong: expected {}'
+                    ' got {}'.format(hw.cpu_total_cores, row['CPU Cores']))
+
+        # The following block is to convert whatever we have to MB
+        memory_ui = float(re.sub(r'[a-zA-Z,]', '', row['Memory']))
+        if 'gb' in row['Memory'].lower():
+            memory_mb_ui = memory_ui * 1024
+            # Shift hw.memory_mb to GB, round to the number of decimals of memory_mb_db
+            # and shift back to MB:
+            memory_mb_db = round(hw.memory_mb / 1024.0,
+                                 len(str(memory_mb_ui).split('.')[1])) * 1024
+        else:  # Assume it's MB
+            memory_mb_ui = memory_ui
+            memory_mb_db = hw.memory_mb
+
+        soft_assert(memory_mb_ui == memory_mb_db,
+                    'Memory (MB) is wrong for node "{}": expected {} got {}'
+                    .format(row['Name'], memory_mb_ui, memory_mb_db))
+
+
+@pytest.mark.polarion('CMP-10034')
+def test_report_nodes_by_cpu_usage(appliance, soft_assert, vporizer):
+
+    report = get_report('Nodes By CPU Usage')
+    for row in report.data.rows:
+
+        vpor_values = [vals for vals in vporizer if vals.resource_name == row["Name"]][0]
+        usage_db = round(vpor_values.max_cpu_usage_rate_average, 2)
+        usage_report = round(float(row['CPU Usage (%)']), 2)
+
+        soft_assert(usage_db == usage_report,
+                    'CPU usage is wrong for node "{}": expected {} got {}'
+                    .format(row['Name'], usage_db, usage_report))
+
+
+@pytest.mark.polarion('CMP-10033')
+def test_report_nodes_by_memory_usage(appliance, soft_assert, vporizer):
+
+    report = get_report('Nodes By Memory Usage')
+    for row in report.data.rows:
+
+        vpor_values = [vals for vals in vporizer if vals.resource_name == row["Name"]][0]
+        usage_db = round(vpor_values.max_mem_usage_absolute_average, 2)
+        usage_report = round(float(row['Memory Usage (%)']), 2)
+
+        soft_assert(usage_db == usage_report,
+                    'CPU usage is wrong for node "{}": expected {} got {}.'
+                    .format(row['Name'], usage_db, usage_report))
+
+
+@pytest.mark.meta(blockers=[BZ(1436698, forced_streams=["5.6", "5.7"])])
+@pytest.mark.polarion('CMP-10033')
+def test_report_nodes_by_number_of_cpu_cores(soft_assert, node_hardwares_db_data):
+
+    report = get_report('Number of Nodes per CPU Cores')
+    for row in report.data.rows:
+
+        hw = node_hardwares_db_data[row['Name']]
+
+        soft_assert(hw.cpu_total_cores == int(row['Hardware Number of CPU Cores']),
+                    'Hardware Number of CPU Cores is wrong for node "{}": expected {} got {}.'
+                    .format(row['Name'], hw.cpu_total_cores, row['Hardware Number of CPU Cores']))
+
+
+@pytest.mark.polarion('CMP-10008')
+def test_report_projects_by_number_of_pods(appliance, soft_assert):
+
+    container_projects = appliance.db.get('container_projects')
+    container_pods = appliance().db.get('container_groups')
+
+    report = get_report('Projects by Number of Pods')
+    for row in report.data.rows:
+        pods_count = len(container_pods.__table__.select().where(
+            container_pods.container_project_id ==
+            container_projects.__table__.select().where(
+                container_projects.name == row['Project Name']).execute().fetchone().id
+        ).execute().fetchall())
+
+        soft_assert(pods_count == int(row['Number of Pods']),
+                    'Number of pods is wrong for project "{}". expected {} got {}.'
+                    .format(row['Project Name'], pods_count, row['Number of Pods']))
+
+
+@pytest.mark.polarion('CMP-10009')
+def test_report_projects_by_cpu_usage(soft_assert, vporizer):
+
+    report = get_report('Projects By CPU Usage')
+    for row in report.data.rows:
+
+        vpor_values = [vals for vals in vporizer if vals.resource_name == row["Name"]][0]
+        usage_db = round(vpor_values.max_cpu_usage_rate_average, 2)
+        usage_report = round(float(row['CPU Usage (%)']), 2)
+
+        soft_assert(usage_db == usage_report,
+                    'CPU usage is wrong for project "{}": expected {} got {}'
+                    .format(row['Name'], usage_db, usage_report))
+
+
+@pytest.mark.polarion('CMP-10010')
+def test_report_projects_by_memory_usage(soft_assert, vporizer):
+
+    report = get_report('Projects By Memory Usage')
+    for row in report.data.rows:
+
+        vpor_values = [vals for vals in vporizer if vals.resource_name == row["Name"]][0]
+        usage_db = round(vpor_values.max_mem_usage_absolute_average, 2)
+        usage_report = round(float(row['Memory Usage (%)']), 2)
+
+        soft_assert(usage_db == usage_report,
+                    'CPU usage is wrong for project "{}": expected {} got {}.'
+                    .format(row['Name'], usage_db, usage_report))

--- a/cfme/tests/containers/test_reports.py
+++ b/cfme/tests/containers/test_reports.py
@@ -39,6 +39,7 @@ def node_hardwares_db_data(appliance):
 @pytest.fixture(scope='function')
 def pods_per_ready_status(provider):
     """Grabing the pods and their ready status from API"""
+    #  TODO: Add later this logic to mgmtsystem
     entities_j = provider.mgmt.api.get('pod')[1]['items']
     out = {}
     for entity_j in entities_j:
@@ -51,6 +52,10 @@ def pods_per_ready_status(provider):
     return out
 
 
+def get_vpor_data_by_name(vporizer_, name):
+    return [vals for vals in vporizer_ if vals.resource_name == name]
+
+
 def get_report(menu_name):
     """Queue a report by menu name , wait for finish and return it"""
     path_to_report = ['Configuration Management', 'Containers', menu_name]
@@ -58,7 +63,7 @@ def get_report(menu_name):
     return CannedSavedReport(path_to_report, run_at)
 
 
-# @pytest.mark.meta(blockers=[BZ(1435958, forced_streams=["5.8"])])
+@pytest.mark.meta(blockers=[BZ(1435958, forced_streams=["5.8"])])
 @pytest.mark.polarion('CMP-9533')
 def test_pods_per_ready_status(soft_assert, pods_per_ready_status):
 
@@ -111,7 +116,7 @@ def test_report_nodes_by_cpu_usage(appliance, soft_assert, vporizer):
     report = get_report('Nodes By CPU Usage')
     for row in report.data.rows:
 
-        vpor_values = [vals for vals in vporizer if vals.resource_name == row["Name"]][0]
+        vpor_values = get_vpor_data_by_name(vporizer, row["Name"])[0]
         usage_db = round(vpor_values.max_cpu_usage_rate_average, 2)
         usage_report = round(float(row['CPU Usage (%)']), 2)
 
@@ -126,7 +131,7 @@ def test_report_nodes_by_memory_usage(appliance, soft_assert, vporizer):
     report = get_report('Nodes By Memory Usage')
     for row in report.data.rows:
 
-        vpor_values = [vals for vals in vporizer if vals.resource_name == row["Name"]][0]
+        vpor_values = get_vpor_data_by_name(vporizer, row["Name"])[0]
         usage_db = round(vpor_values.max_mem_usage_absolute_average, 2)
         usage_report = round(float(row['Memory Usage (%)']), 2)
 
@@ -174,7 +179,7 @@ def test_report_projects_by_cpu_usage(soft_assert, vporizer):
     report = get_report('Projects By CPU Usage')
     for row in report.data.rows:
 
-        vpor_values = [vals for vals in vporizer if vals.resource_name == row["Name"]][0]
+        vpor_values = get_vpor_data_by_name(vporizer, row["Name"])[0]
         usage_db = round(vpor_values.max_cpu_usage_rate_average, 2)
         usage_report = round(float(row['CPU Usage (%)']), 2)
 
@@ -189,7 +194,7 @@ def test_report_projects_by_memory_usage(soft_assert, vporizer):
     report = get_report('Projects By Memory Usage')
     for row in report.data.rows:
 
-        vpor_values = [vals for vals in vporizer if vals.resource_name == row["Name"]][0]
+        vpor_values = get_vpor_data_by_name(vporizer, row["Name"])[0]
         usage_db = round(vpor_values.max_mem_usage_absolute_average, 2)
         usage_report = round(float(row['Memory Usage (%)']), 2)
 

--- a/conftest.py
+++ b/conftest.py
@@ -200,6 +200,7 @@ pytest_plugins = (
     'cfme.fixtures.smtp',
     'cfme.fixtures.tag',
     'cfme.fixtures.vm_name',
+    'cfme.fixtures.vporizer',
 
     'metaplugins',
 )


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_reports.py -v --use-provider cm-env1}}

Added Container reports tests

- Added fixture vporizer to grabbing and manipulating VPOR db table. will be used later in more tests.
- Fix ContainerTestItem.pretty_id so support also objects without __name__ attrribute