### PR TITLE
[1LP][RFR] ensure utils.path is independent of its own location

### DIFF
--- a/utils/path.py
+++ b/utils/path.py
@@ -7,14 +7,14 @@ Paths rendered below will be different in your local environment.
 .. _py.path.local: http://pylib.readthedocs.org/en/latest/path.html
 """
 
-import os
-
+import imp
 from py.path import local
 
-_this_file = os.path.abspath(__file__)
+_cfme_package_dir = local(imp.find_module('cfme')[1])
 
 #: The project root, ``cfme_tests/``
-project_path = local(_this_file).new(basename='..')
+project_path = _cfme_package_dir.dirpath()
+
 
 #: conf yaml storage, ``cfme_tests/conf/``
 conf_path = project_path.join('conf')


### PR DESCRIPTION
this is part of the utils move preparation,
by using imp.find_module we get independent of paths
