### PR TITLE
[RFR][1LP] Fix exception in containers.provider.openshift

### DIFF
--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -73,7 +73,7 @@ class OpenshiftProvider(ContainersProvider):
             zone=prov_config['server_zone'],
             hostname=prov_config.get('hostname', None) or prov_config['ip_address'],
             port=prov_config['port'],
-            sec_protocol=prov_config['sec_protocol'],
+            sec_protocol=prov_config.get('sec_protocol', None),
             provider_data=prov_config,
             appliance=appliance)
 


### PR DESCRIPTION
Provide a default for sec_protocol from prov_config in case the key doesn't exist.

This is causing exceptions in upstream tests on Jenkins at the moment. Missing a YAML update @jkrocil?

# PRT
upstream failure is an ssh_client assertion that's not at all related to this. all other smoke tests pass