### PR TITLE
[RFR][1LP] automation request REST API - make sure approval_state is not changed

### DIFF
--- a/cfme/tests/infrastructure/test_rest_automation_request.py
+++ b/cfme/tests/infrastructure/test_rest_automation_request.py
@@ -64,7 +64,9 @@ def create_requests(collection, rest_api, automation_requests_data, multiple):
 
 
 def create_pending_requests(collection, rest_api, requests_pending):
-    # Wait to see that the `approval_state` does NOT change.
+    # The `approval_state` is `pending_approval`. Wait to see that
+    # it does NOT change - that would mean the request was auto-approved.
+    # The `wait_for` is expected to fail.
     # It's enough to wait just for the first request, it gives
     # other requests the same amount of time to change state.
     waiting_request = requests_pending[0]

--- a/cfme/tests/infrastructure/test_rest_automation_request.py
+++ b/cfme/tests/infrastructure/test_rest_automation_request.py
@@ -64,7 +64,20 @@ def create_requests(collection, rest_api, automation_requests_data, multiple):
 
 
 def create_pending_requests(collection, rest_api, requests_pending):
+    # Wait to see that the `approval_state` does NOT change.
+    # It's enough to wait just for the first request, it gives
+    # other requests the same amount of time to change state.
+    waiting_request = requests_pending[0]
+    wait_for(
+        lambda: waiting_request.approval_state != 'pending_approval',
+        fail_func=waiting_request.reload,
+        num_sec=30,
+        delay=10,
+        silent_failure=True)
+
     for request in requests_pending:
+        request.reload()
+        assert request.approval_state == 'pending_approval'
         resource = collection.get(id=request.id)
         assert rest_api.response.status_code == 200
         assert resource.type == 'AutomationRequest'


### PR DESCRIPTION
Enhancement to make sure that approval_state is not changed (request is automatically approved) for pending requests.

**PRT:** (before comment change)
http://10.16.4.32/trackerbot/pr/run/11691

{{pytest: -v -k test_create_pending_requests}}