### PR TITLE
[RFR][1LP] Update test_appliance_console, grep for MIQ+CFME

### DIFF
--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -10,12 +10,15 @@ TimedCommand = namedtuple('TimedCommand', ['command', 'timeout'])
 @pytest.mark.smoke
 def test_black_console(appliance):
     """'exec > >(tee /tmp/opt.txt)' saves stdout to file, 'ap' launch appliance_console."""
-
+    appliance_title = 'CFME' if version.appliance_is_downstream() else 'ManageIQ'
     command_set = ('exec > >(tee /tmp/opt.txt)', 'ap')
     appliance.appliance_console.run_commands(command_set)
-    assert appliance.ssh_client.run_command("cat /tmp/opt.txt | grep 'CFME Virtual Appliance'")
-    assert appliance.ssh_client.run_command("cat /tmp/opt.txt | grep 'CFME Database:'")
-    assert appliance.ssh_client.run_command("cat /tmp/opt.txt | grep 'CFME Version:'")
+    assert appliance.ssh_client.run_command("cat /tmp/opt.txt | egrep '{} Virtual Appliance'"
+                                            .format(appliance_title))
+    assert appliance.ssh_client.run_command("cat /tmp/opt.txt | egrep '{} Database:'"
+                                            .format(appliance_title))
+    assert appliance.ssh_client.run_command("cat /tmp/opt.txt | egrep '{} Version:'"
+                                            .format(appliance_title))
 
 
 def test_black_console_set_hostname(appliance):


### PR DESCRIPTION
This is causing failures in template testing for upstream.

@lcouzens should check this out

# PRT
{{ pytest: cfme/tests -m smoke --use-provider default }}