### PR TITLE
[1LP][RFR]Provider reload button/data_integrity image registry fix

### DIFF
--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -97,8 +97,8 @@ class ContainersProvider(BaseProvider, Pretty):
         'num_replication_controller',
         'num_pod',
         'num_node',
-        'num_container',
-        'num_image_registry']
+        'num_image_registry',
+        'num_container']
     # TODO add 'num_volume'
     string_name = "Containers"
     page_name = "containers"
@@ -217,8 +217,7 @@ class ContainersProvider(BaseProvider, Pretty):
 
     @variable(alias='db')
     def num_container(self):
-        # Containers are linked to providers through container definitions and
-        # then through pods
+        # Containers are linked to providers through container definitions and then through pods
         res = self.appliance.db.engine.execute(
             "SELECT count(*) "
             "FROM ext_management_systems, container_groups, container_definitions, containers "
@@ -258,8 +257,7 @@ class All(CFMENavigateStep):
     prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
 
     def step(self):
-        self.prerequisite_view.navigation.select(
-            'Compute', 'Containers', 'Providers')
+        self.prerequisite_view.navigation.select('Compute', 'Containers', 'Providers')
 
     def resetter(self):
         # Reset view and selection
@@ -348,7 +346,6 @@ class TopologyFromDetails(CFMENavigateStep):
 class ContainersTestItem(object):
     """This is a generic test item. Especially used for parametrized functions
     """
-
     def __init__(self, obj, polarion_id):
         """Args:
             * obj: The container object in this test (e.g. Image)

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -100,7 +100,7 @@ class ContainersProvider(BaseProvider, Pretty):
         'num_node',
         'num_container',
         'num_image_registry']
-    # TODO add 'num_volume', 'num_image_registry'
+    # TODO add 'num_volume'
     string_name = "Containers"
     page_name = "containers"
     detail_page_suffix = 'provider_detail'

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -72,7 +72,6 @@ properties_form_58 = TabStripForm(
     })
 
 
-
 prop_region = Region(
     locators={
         'properties_form': {

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -72,6 +72,7 @@ properties_form_58 = TabStripForm(
     })
 
 
+
 prop_region = Region(
     locators={
         'properties_form': {
@@ -97,7 +98,8 @@ class ContainersProvider(BaseProvider, Pretty):
         'num_replication_controller',
         'num_pod',
         'num_node',
-        'num_container']
+        'num_container',
+        'num_image_registry']
     # TODO add 'num_volume', 'num_image_registry'
     string_name = "Containers"
     page_name = "containers"
@@ -216,7 +218,8 @@ class ContainersProvider(BaseProvider, Pretty):
 
     @variable(alias='db')
     def num_container(self):
-        # Containers are linked to providers through container definitions and then through pods
+        # Containers are linked to providers through container definitions and
+        # then through pods
         res = self.appliance.db.engine.execute(
             "SELECT count(*) "
             "FROM ext_management_systems, container_groups, container_definitions, containers "
@@ -256,7 +259,8 @@ class All(CFMENavigateStep):
     prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
 
     def step(self):
-        self.prerequisite_view.navigation.select('Compute', 'Containers', 'Providers')
+        self.prerequisite_view.navigation.select(
+            'Compute', 'Containers', 'Providers')
 
     def resetter(self):
         # Reset view and selection
@@ -345,6 +349,7 @@ class TopologyFromDetails(CFMENavigateStep):
 class ContainersTestItem(object):
     """This is a generic test item. Especially used for parametrized functions
     """
+
     def __init__(self, obj, polarion_id):
         """Args:
             * obj: The container object in this test (e.g. Image)

--- a/cfme/tests/containers/test_overview_data_integrity.py
+++ b/cfme/tests/containers/test_overview_data_integrity.py
@@ -9,6 +9,7 @@ from cfme.containers.service import Service
 from cfme.containers.project import Project
 from cfme.containers.route import Route
 from cfme.containers.container import Container
+from cfme.containers.image_registry import ImageRegistryAll
 from cfme.containers.overview import ContainersOverview
 from cfme.web_ui import StatusBox
 from utils import testgen, version
@@ -32,6 +33,7 @@ DATA_SETS = [
     DataSet(Pod, 'Pods'),
     DataSet(Service, 'Services'),
     DataSet(Route, 'Routes'),
+    DataSet(ImageRegistryAll, 'Registries'),
     DataSet(ContainersProvider, 'Providers')
 ]
 
@@ -45,6 +47,7 @@ def get_api_object_counts(providers):
         Service: 0,
         Project: 0,
         Route: 0,
+        ImageRegistryAll: 0
     }
     for provider in providers:
         out[ContainersProvider] += 1
@@ -54,6 +57,7 @@ def get_api_object_counts(providers):
         out[Service] += len(provider.mgmt.list_service())
         out[Project] += len(provider.mgmt.list_project())
         out[Route] += len(provider.mgmt.list_route())
+        out[ImageRegistryAll] += len(provider.mgmt.list_image_registry())
     return out
 
 
@@ -72,7 +76,7 @@ def test_containers_overview_data_integrity(provider):
     # (until we find a better solution)
     # Since we collect images from Openshift and from the pods,
     # images are tested separately
-    # image registries are also tested separately
+
     time.sleep(2)
     statusbox_values = {data_set.object: int(StatusBox(data_set.name).value())
                         for data_set in DATA_SETS}
@@ -99,12 +103,6 @@ def test_containers_overview_data_integrity(provider):
 
     assert StatusBox('images').value() == version.pick({version.LOWEST: num_img_cfme_56,
                                                         '5.7': num_img_cfme_57})
-
-    list_all_rgstr = provider.mgmt.list_image_registry()
-    list_all_rgstr_revised = [i.host for i in list_all_rgstr]
-    list_all_rgstr_new = filter(lambda ch: 'openshift3' not in ch, list_all_rgstr_revised)
-
-    assert len(list_all_rgstr_new) == StatusBox('registries').value()
 
     results = {}
     for cls in DATA_SETS:

--- a/cfme/tests/containers/test_reload_button_provider.py
+++ b/cfme/tests/containers/test_reload_button_provider.py
@@ -11,8 +11,7 @@ pytestmark = [
         lambda: version.current_version() < "5.6"),
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(2)]
-pytest_generate_tests = testgen.generate(
-    [ContainersProvider], scope='function')
+pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
 
 
 @pytest.mark.polarion('CMP-9878')
@@ -44,8 +43,7 @@ def test_reload_button_provider(provider):
     list_img_from_registry_splitted_new = set(list_img_from_registry_splitted)
     list_img_from_openshift_parsed_new = set(list_img_from_openshift_parsed)
 
-    list_img_from_openshift_parsed_new.update(
-        list_img_from_registry_splitted_new)
+    list_img_from_openshift_parsed_new.update(list_img_from_registry_splitted_new)
 
     num_img_in_cfme = provider.num_image()
     # TODO Fix num_image_ui()

--- a/cfme/tests/containers/test_reload_button_provider.py
+++ b/cfme/tests/containers/test_reload_button_provider.py
@@ -52,9 +52,6 @@ def test_reload_button_provider(provider):
 
     num_img_cfme_56 = len(provider.mgmt.list_image())
     num_img_cfme_57 = len(list_img_from_openshift_parsed_new)
-    num_img_cfme_58 = len(list_img_from_openshift_parsed_new)
 
     assert num_img_in_cfme == version.pick({version.LOWEST: num_img_cfme_56,
-                                            '5.7': num_img_cfme_57,
-                                            '5.8': num_img_cfme_58
-                                            })
+                                            '5.7': num_img_cfme_57})

--- a/cfme/tests/containers/test_reload_button_provider.py
+++ b/cfme/tests/containers/test_reload_button_provider.py
@@ -1,8 +1,8 @@
 import pytest
 
 from cfme.containers.provider import ContainersProvider
-from utils import testgen, version
 from cfme.web_ui import toolbar as tb
+from utils import testgen, version
 from utils.appliance.implementations.ui import navigate_to
 
 
@@ -11,7 +11,8 @@ pytestmark = [
         lambda: version.current_version() < "5.6"),
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(2)]
-pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
+pytest_generate_tests = testgen.generate(
+    [ContainersProvider], scope='function')
 
 
 @pytest.mark.polarion('CMP-9878')
@@ -19,11 +20,12 @@ def test_reload_button_provider(provider):
     """ This test verifies the data integrity of the fields in
         the Relationships table after clicking the "reload"
         button. Fields that are being verified as part of provider.validate.stats():
-        Projects, Routes, Container Services, Replicators, Pods, Containers, and Nodes.
+        Projects, Routes, Container Services, Replicators, Pods, Image Registries,
+        Containers, and Nodes.
         Images are being validated separately, since the total
-        number of images in CFME 5.7 includes all images from the OSE registry as well
+        number of images in CFME 5.7 and CFME 5.8 includes all images from the OSE registry as well
         as the images that are being created from the running pods. The images are searched
-        according to the @sha. Image Registries are also validated separately.
+        according to the @sha.
     """
 
     navigate_to(provider, 'Details')
@@ -42,22 +44,17 @@ def test_reload_button_provider(provider):
     list_img_from_registry_splitted_new = set(list_img_from_registry_splitted)
     list_img_from_openshift_parsed_new = set(list_img_from_openshift_parsed)
 
-    list_img_from_openshift_parsed_new.update(list_img_from_registry_splitted_new)
+    list_img_from_openshift_parsed_new.update(
+        list_img_from_registry_splitted_new)
 
     num_img_in_cfme = provider.num_image()
     # TODO Fix num_image_ui()
 
     num_img_cfme_56 = len(provider.mgmt.list_image())
     num_img_cfme_57 = len(list_img_from_openshift_parsed_new)
+    num_img_cfme_58 = len(list_img_from_openshift_parsed_new)
 
     assert num_img_in_cfme == version.pick({version.LOWEST: num_img_cfme_56,
-                                            '5.7': num_img_cfme_57})
-
-    # validate the number of image registries
-    list_all_rgstr = provider.mgmt.list_image_registry()
-    list_all_rgstr_revised = [i.host for i in list_all_rgstr]
-    list_all_rgstr_new = filter(lambda ch: 'openshift3' not in ch, list_all_rgstr_revised)
-
-    num_rgstr_in_cfme = provider.summary.relationships.image_registries.value
-
-    assert len(list_all_rgstr_new) == num_rgstr_in_cfme
+                                            '5.7': num_img_cfme_57,
+                                            '5.8': num_img_cfme_58
+                                            })


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_reload_button_provider.py -v --use-provider cm-env1}}

{{pytest: cfme/tests/containers/test_overview_data_integrity.py -v --use-provider cm-env1}}

Fixed the image registry issue for CFME 5.7 and 5.8. Image Registry is now included in validate_stats() function, along with other objects. The images are still tested separately. 