### PR TITLE
[1LP][RFR]Fix tree navigation in test_myservice.py tests

### DIFF
--- a/cfme/services/catalogs/service_catalogs.py
+++ b/cfme/services/catalogs/service_catalogs.py
@@ -135,7 +135,7 @@ class ServiceCatalogDetails(CFMENavigateStep):
     def step(self):
         try:
             self.prerequisite_view.service_catalogs.tree.click_path("All Services",
-                self.obj.catalog.name, self.obj.name)
+                    self.obj.catalog, self.obj.name)
         except:
             raise NoSuchElementException()
 

--- a/cfme/services/catalogs/service_catalogs.py
+++ b/cfme/services/catalogs/service_catalogs.py
@@ -135,7 +135,7 @@ class ServiceCatalogDetails(CFMENavigateStep):
     def step(self):
         try:
             self.prerequisite_view.service_catalogs.tree.click_path("All Services",
-                 self.obj.catalog, self.obj.name)
+                self.obj.catalog.name, self.obj.name)
         except:
             raise NoSuchElementException()
 

--- a/cfme/services/catalogs/service_catalogs.py
+++ b/cfme/services/catalogs/service_catalogs.py
@@ -135,7 +135,7 @@ class ServiceCatalogDetails(CFMENavigateStep):
     def step(self):
         try:
             self.prerequisite_view.service_catalogs.tree.click_path("All Services",
-                self.obj.catalog.name, self.obj.name)
+                 self.obj.catalog, self.obj.name)
         except:
             raise NoSuchElementException()
 

--- a/cfme/services/catalogs/service_catalogs.py
+++ b/cfme/services/catalogs/service_catalogs.py
@@ -135,7 +135,7 @@ class ServiceCatalogDetails(CFMENavigateStep):
     def step(self):
         try:
             self.prerequisite_view.service_catalogs.tree.click_path("All Services",
-                    self.obj.catalog, self.obj.name)
+                 self.obj.catalog.name, self.obj.name)
         except:
             raise NoSuchElementException()
 

--- a/cfme/services/myservice.py
+++ b/cfme/services/myservice.py
@@ -202,25 +202,27 @@ class MyService(Updateable, Navigatable):
         navigate_to(self, 'All')
         down_btn("Download as " + extension)
 
+    @property
+    def label_all_services(self):
+        if self.appliance.version < '5.8':
+            return 'All Services'
+        else:
+            return 'Active Services'
+
 
 @navigator.register(MyService, 'All')
 class MyServiceAll(CFMENavigateStep):
     prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
 
     def am_i_here(self):
-        if self.obj.appliance.version > '5.8':
-            return match_page(summary='Active Services')
-        else:
-            return match_page(summary='All Services')
+        return match_page(summary=self.obj.label_all_services)
 
     def step(self, *args, **kwargs):
         self.prerequisite_view.navigation.select('Services', 'My Services')
 
     def resetter(self, *args, **kwargs):
-        if self.obj.appliance.version > '5.8':
-            my_service_tree().click_path('Active Services')
-        else:
-            my_service_tree().click_path('All Services')
+        if self.obj.appliance.version < '5.7':
+            my_service_tree().click_path(self.obj.label_all_services)
         tb.refresh()
 
 
@@ -233,10 +235,7 @@ class MyServiceDetails(CFMENavigateStep):
 
     def step(self, *args, **kwargs):
         logger.debug('Clicking tree for service: {}'.format(self.obj.service_name))
-        if self.obj.appliance.version > '5.8':
-            my_service_tree().click_path('Active Services', self.obj.service_name)
-        else:
-            my_service_tree().click_path('All Services', self.obj.service_name)
+        my_service_tree().click_path(self.obj.label_all_services, self.obj.service_name)
 
     def resetter(self, *args, **kwargs):
         tb.refresh()

--- a/cfme/services/myservice.py
+++ b/cfme/services/myservice.py
@@ -202,20 +202,27 @@ class MyService(Updateable, Navigatable):
         navigate_to(self, 'All')
         down_btn("Download as " + extension)
 
+    @property
+    def label_all_services(self):
+        if self.appliance.version < '5.8':
+            return 'All Services'
+        else:
+            return 'Active Services'
+
 
 @navigator.register(MyService, 'All')
 class MyServiceAll(CFMENavigateStep):
     prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
 
     def am_i_here(self):
-        return match_page(summary='All Services')
+        return match_page(summary=self.obj.label_all_services)
 
     def step(self, *args, **kwargs):
         self.prerequisite_view.navigation.select('Services', 'My Services')
 
     def resetter(self, *args, **kwargs):
         if self.obj.appliance.version < '5.7':
-            my_service_tree().click_path('All Services')
+            my_service_tree().click_path(self.obj.label_all_services)
         tb.refresh()
 
 
@@ -228,7 +235,7 @@ class MyServiceDetails(CFMENavigateStep):
 
     def step(self, *args, **kwargs):
         logger.debug('Clicking tree for service: {}'.format(self.obj.service_name))
-        my_service_tree().click_path('All Services', self.obj.service_name)
+        my_service_tree().click_path(self.obj.label_all_services, self.obj.service_name)
 
     def resetter(self, *args, **kwargs):
         tb.refresh()

--- a/cfme/services/myservice.py
+++ b/cfme/services/myservice.py
@@ -203,7 +203,7 @@ class MyService(Updateable, Navigatable):
         down_btn("Download as " + extension)
 
     @property
-    def label_all_services(self):
+    def all_services_label(self):
         if self.appliance.version < '5.8':
             return 'All Services'
         else:
@@ -215,14 +215,14 @@ class MyServiceAll(CFMENavigateStep):
     prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
 
     def am_i_here(self):
-        return match_page(summary=self.obj.label_all_services)
+        return match_page(summary=self.obj.all_services_label)
 
     def step(self, *args, **kwargs):
         self.prerequisite_view.navigation.select('Services', 'My Services')
 
     def resetter(self, *args, **kwargs):
         if self.obj.appliance.version < '5.7':
-            my_service_tree().click_path(self.obj.label_all_services)
+            my_service_tree().click_path(self.obj.all_services_label)
         tb.refresh()
 
 
@@ -235,7 +235,7 @@ class MyServiceDetails(CFMENavigateStep):
 
     def step(self, *args, **kwargs):
         logger.debug('Clicking tree for service: {}'.format(self.obj.service_name))
-        my_service_tree().click_path(self.obj.label_all_services, self.obj.service_name)
+        my_service_tree().click_path(self.obj.all_services_label, self.obj.service_name)
 
     def resetter(self, *args, **kwargs):
         tb.refresh()

--- a/cfme/services/myservice.py
+++ b/cfme/services/myservice.py
@@ -202,27 +202,20 @@ class MyService(Updateable, Navigatable):
         navigate_to(self, 'All')
         down_btn("Download as " + extension)
 
-    @property
-    def label_all_services(self):
-        if self.appliance.version < '5.8':
-            return 'All Services'
-        else:
-            return 'Active Services'
-
 
 @navigator.register(MyService, 'All')
 class MyServiceAll(CFMENavigateStep):
     prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
 
     def am_i_here(self):
-        return match_page(summary=self.obj.label_all_services)
+        return match_page(summary='All Services')
 
     def step(self, *args, **kwargs):
         self.prerequisite_view.navigation.select('Services', 'My Services')
 
     def resetter(self, *args, **kwargs):
         if self.obj.appliance.version < '5.7':
-            my_service_tree().click_path(self.obj.label_all_services)
+            my_service_tree().click_path('All Services')
         tb.refresh()
 
 
@@ -235,7 +228,7 @@ class MyServiceDetails(CFMENavigateStep):
 
     def step(self, *args, **kwargs):
         logger.debug('Clicking tree for service: {}'.format(self.obj.service_name))
-        my_service_tree().click_path(self.obj.label_all_services, self.obj.service_name)
+        my_service_tree().click_path('All Services', self.obj.service_name)
 
     def resetter(self, *args, **kwargs):
         tb.refresh()

--- a/cfme/tests/services/test_myservice.py
+++ b/cfme/tests/services/test_myservice.py
@@ -48,7 +48,7 @@ def myservice(setup_provider, provider, catalog_item, request):
         version.LOWEST: catalog_item.provisioning_data["vm_name"] + '_0001',
         '5.7': catalog_item.provisioning_data["vm_name"] + '0001'})
     catalog_item.create()
-    service_catalogs = ServiceCatalogs(catalog_item.catalog.name, catalog_item.name)
+    service_catalogs = ServiceCatalogs(catalog_item.name)
     service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     row_description = catalog_item.name

--- a/cfme/tests/services/test_myservice.py
+++ b/cfme/tests/services/test_myservice.py
@@ -48,7 +48,7 @@ def myservice(setup_provider, provider, catalog_item, request):
         version.LOWEST: catalog_item.provisioning_data["vm_name"] + '_0001',
         '5.7': catalog_item.provisioning_data["vm_name"] + '0001'})
     catalog_item.create()
-    service_catalogs = ServiceCatalogs(catalog_item.name)
+    service_catalogs = ServiceCatalogs(catalog_item.catalog.name, catalog_item.name)
     service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     row_description = catalog_item.name

--- a/cfme/tests/services/test_myservice.py
+++ b/cfme/tests/services/test_myservice.py
@@ -48,7 +48,7 @@ def myservice(setup_provider, provider, catalog_item, request):
         version.LOWEST: catalog_item.provisioning_data["vm_name"] + '_0001',
         '5.7': catalog_item.provisioning_data["vm_name"] + '0001'})
     catalog_item.create()
-    service_catalogs = ServiceCatalogs(catalog_item.catalog.name, catalog_item.name)
+    service_catalogs = ServiceCatalogs(catalog_item.catalog, catalog_item.name)
     service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     row_description = catalog_item.name


### PR DESCRIPTION
Fixed tree navigation, edited path label for finding 'All services' for 5.8 , and also add catalog step to find service in the tree.   

{{ pytest: cfme/tests/services/test_myservice.py -k test_download_file --long-running}}