### PR TITLE
[RFR] fixes for service_catalogs

### DIFF
--- a/cfme/tests/automate/test_service_dialog.py
+++ b/cfme/tests/automate/test_service_dialog.py
@@ -20,12 +20,13 @@ def test_create_service_dialog():
         'default_text_box': "Default text"
     }
     dialog = ServiceDialog(label=fauxfactory.gen_alphanumeric(),
+                           element_data=element_data,
                            description="my dialog", submit=True, cancel=True,
                            tab_label="tab_" + fauxfactory.gen_alphanumeric(),
                            tab_desc="my tab desc",
                            box_label="box_" + fauxfactory.gen_alphanumeric(),
                            box_desc="my box desc")
-    dialog.create(element_data)
+    dialog.create()
 
 
 def test_update_service_dialog():
@@ -37,12 +38,13 @@ def test_update_service_dialog():
         'default_text_box': "Default text"
     }
     dialog = ServiceDialog(label=fauxfactory.gen_alphanumeric(),
+                           element_data=element_data,
                            description="my dialog", submit=True, cancel=True,
                            tab_label="tab_" + fauxfactory.gen_alphanumeric(),
                            tab_desc="my tab desc",
                            box_label="box_" + fauxfactory.gen_alphanumeric(),
                            box_desc="my box desc")
-    dialog.create(element_data)
+    dialog.create()
     with update(dialog):
         dialog.description = "my edited description"
 
@@ -56,12 +58,13 @@ def test_delete_service_dialog():
         'default_text_box': "Default text"
     }
     dialog = ServiceDialog(label=fauxfactory.gen_alphanumeric(),
+                           element_data=element_data,
                            description="my dialog", submit=True, cancel=True,
                            tab_label="tab_" + fauxfactory.gen_alphanumeric(),
                            tab_desc="my tab desc",
                            box_label="box_" + fauxfactory.gen_alphanumeric(),
                            box_desc="my box desc")
-    dialog.create(element_data)
+    dialog.create()
     dialog.delete()
 
 
@@ -74,14 +77,15 @@ def test_service_dialog_duplicate_name():
         'default_text_box': "Default text"
     }
     dialog = ServiceDialog(label=fauxfactory.gen_alphanumeric(),
+                           element_data=element_data,
                            description="my dialog", submit=True, cancel=True,
                            tab_label="tab_" + fauxfactory.gen_alphanumeric(),
                            tab_desc="my tab desc",
                            box_label="box_" + fauxfactory.gen_alphanumeric(),
                            box_desc="my box desc")
-    dialog.create(element_data)
+    dialog.create()
     with error.expected("Label has already been taken"):
-        dialog.create(element_data)
+        dialog.create()
 
 
 def test_checkbox_dialog_element():
@@ -94,12 +98,13 @@ def test_checkbox_dialog_element():
         'field_required': True
     }
     dialog = ServiceDialog(label=fauxfactory.gen_alphanumeric(),
+                           element_data=element_data,
                            description="my dialog", submit=True, cancel=True,
                            tab_label="tab_" + fauxfactory.gen_alphanumeric(),
                            tab_desc="my tab desc",
                            box_label="box_" + fauxfactory.gen_alphanumeric(),
                            box_desc="my box desc")
-    dialog.create(element_data)
+    dialog.create()
 
 
 def test_datecontrol_dialog_element():
@@ -111,12 +116,13 @@ def test_datecontrol_dialog_element():
         'field_past_dates': True
     }
     dialog = ServiceDialog(label=fauxfactory.gen_alphanumeric(),
+                           element_data=element_data,
                            description="my dialog", submit=True, cancel=True,
                            tab_label="tab_" + fauxfactory.gen_alphanumeric(),
                            tab_desc="my tab desc",
                            box_label="box_" + fauxfactory.gen_alphanumeric(),
                            box_desc="my box desc")
-    dialog.create(element_data)
+    dialog.create()
 
 
 def test_dropdownlist_dialog_element():
@@ -127,12 +133,13 @@ def test_dropdownlist_dialog_element():
         'choose_type': "Drop Down List"
     }
     dialog = ServiceDialog(label=fauxfactory.gen_alphanumeric(),
+                           element_data=element_data,
                            description="my dialog", submit=True, cancel=True,
                            tab_label="tab_" + fauxfactory.gen_alphanumeric(),
                            tab_desc="my tab desc",
                            box_label="box_" + fauxfactory.gen_alphanumeric(),
                            box_desc="my box desc")
-    dialog.create(element_data)
+    dialog.create()
 
 
 def test_radiobutton_dialog_element():
@@ -143,12 +150,13 @@ def test_radiobutton_dialog_element():
         'choose_type': "Radio Button"
     }
     dialog = ServiceDialog(label=fauxfactory.gen_alphanumeric(),
+                           element_data=element_data,
                            description="my dialog", submit=True, cancel=True,
                            tab_label="tab_" + fauxfactory.gen_alphanumeric(),
                            tab_desc="my tab desc",
                            box_label="box_" + fauxfactory.gen_alphanumeric(),
                            box_desc="my box desc")
-    dialog.create(element_data)
+    dialog.create()
 
 
 def test_tagcontrol_dialog_element():
@@ -161,12 +169,13 @@ def test_tagcontrol_dialog_element():
         'field_required': True
     }
     dialog = ServiceDialog(label=fauxfactory.gen_alphanumeric(),
+                           element_data=element_data,
                            description="my dialog", submit=True, cancel=True,
                            tab_label="tab_" + fauxfactory.gen_alphanumeric(),
                            tab_desc="my tab desc",
                            box_label="box_" + fauxfactory.gen_alphanumeric(),
                            box_desc="my box desc")
-    dialog.create(element_data)
+    dialog.create()
 
 
 def test_textareabox_dialog_element():
@@ -178,12 +187,13 @@ def test_textareabox_dialog_element():
         'field_required': True
     }
     dialog = ServiceDialog(label=fauxfactory.gen_alphanumeric(),
+                           element_data=element_data,
                            description="my dialog", submit=True, cancel=True,
                            tab_label="tab_" + fauxfactory.gen_alphanumeric(),
                            tab_desc="my tab desc",
                            box_label="box_" + fauxfactory.gen_alphanumeric(),
                            box_desc="my box desc")
-    dialog.create(element_data)
+    dialog.create()
 
 
 def test_reorder_elements():
@@ -203,12 +213,13 @@ def test_reorder_elements():
         'field_required': True
     }
     dialog = ServiceDialog(label=fauxfactory.gen_alphanumeric(),
+                           element_data=(element_1_data, element_2_data),
                            description="my dialog", submit=True, cancel=True,
                            tab_label="tab_" + fauxfactory.gen_alphanumeric(),
                            tab_desc="my tab desc",
                            box_label="box_" + fauxfactory.gen_alphanumeric(),
                            box_desc="my box desc")
-    dialog.create(element_1_data, element_2_data)
+    dialog.create()
     dialog.reorder_elements(dialog.tab_label, dialog.box_label, element_1_data, element_2_data)
 
 
@@ -230,10 +241,11 @@ def test_reorder_unsaved_elements():
         'field_required': True
     }
     dialog = ServiceDialog(label=fauxfactory.gen_alphanumeric(),
+                           element_data=element_1_data,
                            description="my dialog", submit=True, cancel=True,
                            tab_label="tab_" + fauxfactory.gen_alphanumeric(),
                            tab_desc="my tab desc",
                            box_label="box_" + fauxfactory.gen_alphanumeric(),
                            box_desc="my box desc")
-    dialog.create(element_1_data)
+    dialog.create()
     dialog.update_element(element_2_data, element_1_data)

--- a/cfme/tests/infrastructure/test_vm_clone.py
+++ b/cfme/tests/infrastructure/test_vm_clone.py
@@ -38,10 +38,11 @@ def dialog():
         default_text_box="default value"
     )
     service_dialog = ServiceDialog(label=dialog, description="my dialog",
+                     element_data=element_data,
                      submit=True, cancel=True,
                      tab_label="tab_" + fauxfactory.gen_alphanumeric(), tab_desc="my tab desc",
                      box_label="box_" + fauxfactory.gen_alphanumeric(), box_desc="my box desc")
-    service_dialog.create(element_data)
+    service_dialog.create()
     flash.assert_success_message('Dialog "{}" was added'.format(dialog))
     yield dialog
 

--- a/cfme/tests/services/test_cloud_service_catalogs.py
+++ b/cfme/tests/services/test_cloud_service_catalogs.py
@@ -92,13 +92,13 @@ def test_cloud_catalog_item(setup_provider, provider, dialog, catalog, request, 
                                name=item_name,
                                description="my catalog",
                                display_in=True,
-                               catalog=catalog.name,
+                               catalog=catalog,
                                dialog=dialog,
                                catalog_name=image,
                                provider=provider,
                                prov_data=provisioning_data)
     catalog_item.create()
-    service_catalogs = ServiceCatalogs(catalog_item.name)
+    service_catalogs = ServiceCatalogs(catalog_item.catalog, catalog_item.name)
     service_catalogs.order()
     flash.assert_no_errors()
     logger.info('Waiting for cfme provision request for service %s', item_name)

--- a/cfme/tests/services/test_cloud_service_catalogs.py
+++ b/cfme/tests/services/test_cloud_service_catalogs.py
@@ -38,12 +38,13 @@ def dialog():
         default_text_box="default value"
     )
     service_dialog = ServiceDialog(label=dialog, description="my dialog",
+                                   element_data=element_data,
                                    submit=True, cancel=True,
                                    tab_label="tab_" + fauxfactory.gen_alphanumeric(),
                                    tab_desc="my tab desc",
                                    box_label="box_" + fauxfactory.gen_alphanumeric(),
                                    box_desc="my box desc")
-    service_dialog.create(element_data)
+    service_dialog.create()
     flash.assert_success_message('Dialog "{}" was added'.format(dialog))
     yield dialog
 

--- a/cfme/tests/services/test_iso_service_catalogs.py
+++ b/cfme/tests/services/test_iso_service_catalogs.py
@@ -78,10 +78,11 @@ def dialog():
         default_text_box="default value"
     )
     service_dialog = ServiceDialog(label=dialog, description="my dialog",
+                     element_data=element_data,
                      submit=True, cancel=True,
                      tab_label="tab_" + fauxfactory.gen_alphanumeric(), tab_desc="tab_desc",
                      box_label="box_" + fauxfactory.gen_alphanumeric(), box_desc="box_desc")
-    service_dialog.create(element_data)
+    service_dialog.create()
     yield dialog
 
 

--- a/cfme/tests/services/test_pxe_service_catalogs.py
+++ b/cfme/tests/services/test_pxe_service_catalogs.py
@@ -86,10 +86,11 @@ def dialog():
         default_text_box="default value"
     )
     service_dialog = ServiceDialog(label=dialog, description="my dialog",
+                     element_data=element_data,
                      submit=True, cancel=True,
                      tab_label="tab_" + fauxfactory.gen_alphanumeric(), tab_desc="tab_desc",
                      box_label="box_" + fauxfactory.gen_alphanumeric(), box_desc="box_desc")
-    service_dialog.create(element_data)
+    service_dialog.create()
     yield dialog
 
 

--- a/cfme/tests/test_ui_problems.py
+++ b/cfme/tests/test_ui_problems.py
@@ -36,11 +36,11 @@ def test_broken_angular_select(request):
         name="Catitem_{}".format(fauxfactory.gen_alpha()),
         description=fauxfactory.gen_alpha(),
         display_in=True,
-        catalog=cat.name,
+        catalog=cat,
         dialog="azure-single-vm-from-user-image")
     item.create()
     request.addfinalizer(item.delete)
-    sc = service_catalogs.ServiceCatalogs(item.name)
+    sc = service_catalogs.ServiceCatalogs(item.catalog, item.name)
     navigate_to(sc, 'Order')
     # The check itself
     fill(the_select, "Linux")


### PR DESCRIPTION
UPDATE:
I included tests fixes from https://github.com/ManageIQ/integration_tests/pull/4492 into this PR.
Sorry for the mess, I figured it will be easier to review/merge the PRs if it would be just tests fixes vs framework fixes.

The purpose of this PR is to fix calls to ``CatalogItem()``, ``ServiceCatalogs()`` and ``ServiceDialog.create()``.

This PR fixes **just the calls**, not all the other things that may be broken == tests are not expected to pass in PRT