### PR TITLE
[RFR] parallelizer: handle messages from terminated workers

### DIFF
--- a/fixtures/parallelizer/__init__.py
+++ b/fixtures/parallelizer/__init__.py
@@ -239,6 +239,10 @@ class ParallelSession(object):
         slaveid, _, event_json = self.sock.recv_multipart(flags=zmq.NOBLOCK)
         event_data = json.loads(event_json)
         event_name = event_data.pop('_event_name')
+        if slaveid not in self.slaves:
+            self.log.error("message from terminated worker %s %s %s",
+                           slaveid, event_name, event_data)
+            return None, None, None
         return self.slaves[slaveid], event_data, event_name
 
     def print_message(self, message, prefix='master', **markup):


### PR DESCRIPTION
i couldn't locally replicate the conditions

this pr is in order to handle messages from workers we already disengaged with
