### PR TITLE
[1LP][RFR] new REST API test - OPTIONS returns supported subcollections

### DIFF
--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -229,6 +229,17 @@ def test_http_options_node_types(rest_api, collection_name):
     assert rest_api.response.status_code == 200
 
 
+@pytest.mark.uncollectif(lambda: current_version() < '5.8')
+def test_http_options_subcollections(rest_api):
+    """Tests that OPTIONS returns supported subcollections.
+
+    Metadata:
+        test_flag: rest
+    """
+    assert 'tags' in rest_api.collections.vms.options()['subcollections']
+    assert rest_api.response.status_code == 200
+
+
 @pytest.mark.uncollectif(lambda: current_version() < '5.7')
 def test_server_info(rest_api):
     """Check that server info is present.


### PR DESCRIPTION
new REST API test for checking that OPTIONS http method returns supported subcollections for given collection.

{{pytest: -v -k test_http_options_subcollections cfme/tests/test_rest.py}}