### PR TITLE
[1LP][RFR] Fixed test_check_compliance_history

### DIFF
--- a/cfme/tests/control/test_bugs.py
+++ b/cfme/tests/control/test_bugs.py
@@ -123,7 +123,7 @@ items = [
 ]
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def vmware_vm(request, virtualcenter_provider):
     vm = VM.factory(random_vm_name("control"), virtualcenter_provider)
     vm.create_on_provider(find_in_cfme=True)


### PR DESCRIPTION
{{pytest: -v -k 'test_check_compliance_history' --long-running}}

Purpose or Intent
=================

__Fixed__ scope mismatch in  test_check_compliance_history