### PR TITLE
[1LP][RFR] Creds + Endpoints + Add/Edit Infra Providers

### DIFF
--- a/cfme/infrastructure/provider/openstack_infra.py
+++ b/cfme/infrastructure/provider/openstack_infra.py
@@ -1,49 +1,81 @@
 from navmazing import NavigateToSibling
-
-from . import InfraProvider, prop_region
-from cfme.common.provider_views import ProviderNodesView, ProviderRegisterNodesView
-from cfme.exceptions import DestinationNotFound
+from widgetastic.widget import View, Text
+from widgetastic_patternfly import Tab, Input, BootstrapSelect, Button
+from widgetastic_manageiq import RadioGroup, FileInput
 from mgmtsystem.openstack_infra import OpenstackInfraSystem
+
+from cfme.infrastructure.provider import InfraProvider
+from cfme.common.provider import EventsEndpoint, SSHEndpoint, DefaultEndpoint, DefaultEndpointForm
+from cfme.common.provider_views import ProviderNodesView, ProviderRegisterNodesView, BeforeFillMixin
+from cfme.exceptions import DestinationNotFound
 from utils.appliance.implementations.ui import navigate_to, CFMENavigateStep, navigator
+
+
+class RHOSEndpoint(DefaultEndpoint):
+    @property
+    def view_value_mapping(self):
+        return {'hostname': self.hostname,
+                'api_port': self.api_port,
+                'security_protocol': self.security_protocol,
+                }
+
+
+class OpenStackInfraEndpointForm(View):
+    @View.nested
+    class default(Tab, DefaultEndpointForm, BeforeFillMixin):  # NOQA
+        TAB_NAME = 'Default'
+        api_port = Input('default_api_port')
+        security_protocol = BootstrapSelect('default_security_protocol')
+
+    @View.nested
+    class events(Tab, BeforeFillMixin):  # NOQA
+        TAB_NAME = 'Events'
+        event_stream = RadioGroup(locator='//div[@id="amqp"]')
+        # below controls which appear only if amqp is chosen
+        hostname = Input('amqp_hostname')
+        api_port = Input('amqp_api_port')
+        security_protocol = BootstrapSelect('amqp_security_protocol')
+        change_password = Text(locator='.//a[normalize-space(.)="Change stored password"]')
+
+        username = Input('amqp_userid')
+        password = Input('amqp_password')
+        confirm_password = Input('amqp_verify')
+
+        validate = Button('Validate')
+
+    @View.nested
+    class rsa_keypair(Tab, BeforeFillMixin):  # NOQA
+        TAB_NAME = 'RSA key pair'
+
+        username = Input('ssh_keypair_userid')
+        private_key = FileInput(locator='.//input[@id="ssh_keypair_password"]')
+        change_key = Text(locator='.//a[normalize-space(.)="Change stored private key"]')
 
 
 class OpenstackInfraProvider(InfraProvider):
     STATS_TO_MATCH = ['num_template', 'num_host']
-    _properties_region = prop_region
     type_name = "openstack_infra"
     mgmt_class = OpenstackInfraSystem
     db_types = ["Openstack::InfraManager"]
+    endpoints_form = OpenStackInfraEndpointForm
 
-    def __init__(self, name=None, credentials=None, key=None, hostname=None,
-                 ip_address=None, start_ip=None, end_ip=None, provider_data=None,
-                 sec_protocol=None, appliance=None):
-        super(OpenstackInfraProvider, self).__init__(
-            name=name, credentials=credentials, key=key, provider_data=provider_data,
-            appliance=appliance)
-
+    def __init__(self, name=None, endpoints=None, key=None, hostname=None, ip_address=None,
+                 start_ip=None, end_ip=None, provider_data=None, appliance=None):
+        super(OpenstackInfraProvider, self).__init__(name=name, endpoints=endpoints, key=key,
+                                                     provider_data=provider_data,
+                                                     appliance=appliance)
         self.hostname = hostname
-        self.ip_address = ip_address
         self.start_ip = start_ip
         self.end_ip = end_ip
-        self.sec_protocol = sec_protocol
+        if ip_address:
+            self.ip_address = ip_address
 
-    def _form_mapping(self, create=None, **kwargs):
-        data_dict = {
-            'name_text': kwargs.get('name'),
-            'type_select': create and 'OpenStack Platform Director',
-            'hostname_text': kwargs.get('hostname'),
-            'api_port': kwargs.get('api_port'),
-            'ipaddress_text': kwargs.get('ip_address'),
-            'sec_protocol': kwargs.get('sec_protocol'),
-            'amqp_sec_protocol': kwargs.get('amqp_sec_protocol')}
-        if 'amqp' in self.credentials:
-            data_dict.update({
-                'event_selection': 'amqp',
-                'amqp_hostname_text': kwargs.get('hostname'),
-                'amqp_api_port': kwargs.get('amqp_api_port', '5672'),
-                'amqp_sec_protocol': kwargs.get('amqp_sec_protocol', "Non-SSL")
-            })
-        return data_dict
+    @property
+    def view_value_mapping(self):
+        return {
+            'name': self.name,
+            'prov_type': 'OpenStack Platform Director',
+        }
 
     def has_nodes(self):
         details_view = navigate_to(self, 'Details')
@@ -55,26 +87,20 @@ class OpenstackInfraProvider(InfraProvider):
 
     @classmethod
     def from_config(cls, prov_config, prov_key, appliance=None):
-        credentials_key = prov_config['credentials']
-        credentials = cls.process_credential_yaml_key(credentials_key)
-        credential_dict = {'default': credentials}
+        endpoints = []
+        for endp in prov_config['endpoints']:
+            for expected_endpoint in (RHOSEndpoint, EventsEndpoint, SSHEndpoint):
+                if expected_endpoint.name == endp:
+                    endpoints.append(expected_endpoint(**prov_config['endpoints'][endp]))
+
         if prov_config.get('discovery_range', None):
             start_ip = prov_config['discovery_range']['start']
             end_ip = prov_config['discovery_range']['end']
         else:
             start_ip = end_ip = prov_config.get('ipaddress')
-        if 'ssh_credentials' in prov_config:
-            credential_dict['ssh'] = OpenstackInfraProvider.process_credential_yaml_key(
-                prov_config['ssh_credentials'], cred_type='ssh')
-        if 'amqp_credentials' in prov_config:
-            credential_dict['amqp'] = OpenstackInfraProvider.process_credential_yaml_key(
-                prov_config['amqp_credentials'], cred_type='amqp')
         return cls(
             name=prov_config['name'],
-            sec_protocol=prov_config.get('sec_protocol', "Non-SSL"),
-            hostname=prov_config['hostname'],
-            ip_address=prov_config['ipaddress'],
-            credentials=credential_dict,
+            endpoints=endpoints,
             key=prov_key,
             start_ip=start_ip,
             end_ip=end_ip,

--- a/cfme/infrastructure/provider/rhevm.py
+++ b/cfme/infrastructure/provider/rhevm.py
@@ -1,53 +1,74 @@
+from widgetastic.widget import View, Text
+from widgetastic_patternfly import Tab, Input, BootstrapSwitch, Button
+
+from cfme.common.provider_views import BeforeFillMixin
 from utils import version
-from . import InfraProvider, prop_region
+from . import InfraProvider
+from cfme.common.provider import CANDUEndpoint, DefaultEndpoint, DefaultEndpointForm
 from mgmtsystem.rhevm import RHEVMSystem
 
 
+class RHEVMEndpoint(DefaultEndpoint):
+    @property
+    def view_value_mapping(self):
+        return {'hostname': self.hostname,
+                'api_port': self.api_port,
+                'verify_tls': version.pick({version.LOWEST: None,
+                                            '5.8': self.verify_tls}),
+                'ca_certs': version.pick({version.LOWEST: None,
+                                          '5.8': self.ca_certs})
+                }
+
+
+class RHEVMEndpointForm(View):
+    @View.nested
+    class default(Tab, DefaultEndpointForm, BeforeFillMixin):  # NOQA
+        TAB_NAME = 'Default'
+        api_port = Input('default_api_port')
+        verify_tls = BootstrapSwitch(id='default_tls_verify')
+        ca_certs = Input('default_tls_ca_certs')
+
+    @View.nested
+    class candu(Tab, BeforeFillMixin):  # NOQA
+        TAB_NAME = 'C & U Database'
+        hostname = Input('metrics_hostname')
+        api_port = Input('metrics_api_port')
+        database_name = Input('metrics_database_name')
+        username = Input('metrics_userid')
+        password = Input('metrics_password')
+        confirm_password = Input('metrics_verify')
+        change_password = Text(locator='.//a[normalize-space(.)="Change stored password"]')
+
+        validate = Button('Validate')
+
+
 class RHEVMProvider(InfraProvider):
-    _properties_region = prop_region
     type_name = "rhevm"
     mgmt_class = RHEVMSystem
     db_types = ["Redhat::InfraManager"]
+    endpoints_form = RHEVMEndpointForm
 
-    def __init__(self, name=None, credentials=None, zone=None, key=None, hostname=None,
-                 ip_address=None, api_port=None, verify_tls=False, ca_certs=None, start_ip=None,
-                 end_ip=None,
-                 provider_data=None, appliance=None):
+    def __init__(self, name=None, endpoints=None, zone=None, key=None, hostname=None,
+                 ip_address=None, start_ip=None, end_ip=None, provider_data=None, appliance=None):
         super(RHEVMProvider, self).__init__(
-            name=name, credentials=credentials, zone=zone, key=key, provider_data=provider_data,
+            name=name, endpoints=endpoints, zone=zone, key=key, provider_data=provider_data,
             appliance=appliance)
-
         self.hostname = hostname
-        self.ip_address = ip_address
-        self.api_port = api_port
-        self.verify_tls = verify_tls
-        self.ca_certs = ca_certs
         self.start_ip = start_ip
         self.end_ip = end_ip
+        if ip_address:
+            self.ip_address = ip_address
 
-    def _form_mapping(self, create=None, **kwargs):
-        provider_name = version.pick({
-            version.LOWEST: 'Red Hat Enterprise Virtualization Manager',
-            '5.7.1': 'Red Hat Virtualization Manager',
-            '5.7.3': 'Red Hat Virtualization',
-            '5.8': 'Red Hat Virtualization Manager',
-            '5.8.0.10': 'Red Hat Virtualization'
-        })
-        verify_tls = version.pick({
-            version.LOWEST: None,
-            '5.8': kwargs.get('verify_tls', False)})
-        ca_certs = version.pick({
-            version.LOWEST: None,
-            '5.8': kwargs.get('ca_certs', None)})
-        return {'name_text': kwargs.get('name'),
-                'type_select': create and provider_name,
-                'hostname_text': kwargs.get('hostname'),
-                'api_port': kwargs.get('api_port'),
-                'verify_tls_switch': verify_tls,
-                'ca_certs': ca_certs,
-                'ipaddress_text': kwargs.get('ip_address'),
-                'candu_hostname_text':
-                kwargs.get('hostname') if self.credentials.get('candu', None) else None}
+    @property
+    def view_value_mapping(self):
+        return {
+            'name': self.name,
+            'prov_type': version.pick({version.LOWEST: 'Red Hat Enterprise Virtualization Manager',
+                                       '5.7.1': 'Red Hat Virtualization Manager',
+                                       '5.7.3': 'Red Hat Virtualization',
+                                       '5.8': 'Red Hat Virtualization Manager',
+                                       '5.8.0.10': 'Red Hat Virtualization'}),
+        }
 
     def deployment_helper(self, deploy_args):
         """ Used in utils.virtual_machines """
@@ -57,25 +78,19 @@ class RHEVMProvider(InfraProvider):
 
     @classmethod
     def from_config(cls, prov_config, prov_key, appliance=None):
-        credentials_key = prov_config['credentials']
-        credentials = {
-            # The default credentials for controlling the provider
-            'default': cls.process_credential_yaml_key(credentials_key),
-        }
+        endpoints = []
+        for endp in prov_config['endpoints']:
+            for expected_endpoint in (RHEVMEndpoint, CANDUEndpoint):
+                if expected_endpoint.name == endp:
+                    endpoints.append(expected_endpoint(**prov_config['endpoints'][endp]))
+
         if prov_config.get('discovery_range', None):
             start_ip = prov_config['discovery_range']['start']
             end_ip = prov_config['discovery_range']['end']
         else:
             start_ip = end_ip = prov_config.get('ipaddress')
-        if prov_config.get('candu_credentials', None):
-            # Insert C&U credentials if those are present
-            credentials['candu'] = RHEVMProvider.process_credential_yaml_key(
-                prov_config['candu_credentials'], cred_type='candu')
         return cls(name=prov_config['name'],
-                   hostname=prov_config['hostname'],
-                   ip_address=prov_config['ipaddress'],
-                   api_port='',
-                   credentials=credentials,
+                   endpoints=endpoints,
                    zone=prov_config.get('server_zone', 'default'),
                    key=prov_key,
                    start_ip=start_ip,

--- a/cfme/infrastructure/provider/scvmm.py
+++ b/cfme/infrastructure/provider/scvmm.py
@@ -1,5 +1,22 @@
+from widgetastic_patternfly import BootstrapSelect, Input
+
+from cfme.common.provider import DefaultEndpoint, DefaultEndpointForm
 from . import InfraProvider
 from mgmtsystem.scvmm import SCVMMSystem
+
+
+class SCVMMEndpoint(DefaultEndpoint):
+    @property
+    def view_value_mapping(self):
+        return {'hostname': self.hostname,
+                'security_protocol': self.security_protocol,
+                'realm': self.security_realm
+                }
+
+
+class SCVMMEndpointForm(DefaultEndpointForm):
+    security_protocol = BootstrapSelect(id='default_security_protocol')
+    realm = Input('realm')  # appears when Kerberos is chosen in security_protocol
 
 
 class SCVMMProvider(InfraProvider):
@@ -7,35 +24,25 @@ class SCVMMProvider(InfraProvider):
     type_name = "scvmm"
     mgmt_class = SCVMMSystem
     db_types = ["Microsoft::InfraManager"]
+    endpoints_form = SCVMMEndpointForm
 
-    def __init__(self, name=None, credentials=None, key=None, zone=None, hostname=None,
-                 ip_address=None, start_ip=None, end_ip=None, sec_protocol=None, sec_realm=None,
-                 provider_data=None, appliance=None):
+    def __init__(self, name=None, endpoints=None, key=None, zone=None, hostname=None,
+                 ip_address=None, start_ip=None, end_ip=None, provider_data=None, appliance=None):
         super(SCVMMProvider, self).__init__(
-            name=name, credentials=credentials, zone=zone, key=key, provider_data=provider_data,
+            name=name, endpoints=endpoints, zone=zone, key=key, provider_data=provider_data,
             appliance=appliance)
-
         self.hostname = hostname
-        self.ip_address = ip_address
         self.start_ip = start_ip
         self.end_ip = end_ip
-        self.sec_protocol = sec_protocol
-        self.sec_realm = sec_realm
+        if ip_address:
+            self.ip_address = ip_address
 
-    def _form_mapping(self, create=None, **kwargs):
-
-        values = {
-            'name_text': kwargs.get('name'),
-            'type_select': create and 'Microsoft System Center VMM',
-            'hostname_text': kwargs.get('hostname'),
-            'ipaddress_text': kwargs.get('ip_address'),
-            'sec_protocol': kwargs.get('sec_protocol')
+    @property
+    def view_value_mapping(self):
+        return {
+            'name': self.name,
+            'prov_type': 'Microsoft System Center VMM',
         }
-
-        if 'sec_protocol' in values and values['sec_protocol'] is 'Kerberos':
-            values['sec_realm'] = kwargs.get('sec_realm')
-
-        return values
 
     def deployment_helper(self, deploy_args):
         """ Used in utils.virtual_machines """
@@ -50,8 +57,8 @@ class SCVMMProvider(InfraProvider):
 
     @classmethod
     def from_config(cls, prov_config, prov_key, appliance=None):
-        credentials_key = prov_config['credentials']
-        credentials = cls.process_credential_yaml_key(credentials_key)
+        endpoint = SCVMMEndpoint(**prov_config['endpoints']['default'])
+
         if prov_config.get('discovery_range', None):
             start_ip = prov_config['discovery_range']['start']
             end_ip = prov_config['discovery_range']['end']
@@ -59,12 +66,8 @@ class SCVMMProvider(InfraProvider):
             start_ip = end_ip = prov_config.get('ipaddress')
         return cls(
             name=prov_config['name'],
-            hostname=prov_config['hostname'],
-            ip_address=prov_config['ipaddress'],
-            credentials={'default': credentials},
+            endpoints=endpoint,
             key=prov_key,
             start_ip=start_ip,
             end_ip=end_ip,
-            sec_protocol=prov_config['sec_protocol'],
-            sec_realm=prov_config['sec_realm'],
             appliance=appliance)

--- a/cfme/tests/infrastructure/test_esx_direct_host.py
+++ b/cfme/tests/infrastructure/test_esx_direct_host.py
@@ -5,10 +5,9 @@ not be difficult to extend the parametrizer.
 """
 import pytest
 
-from cfme.base.credential import Credential
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
+from cfme.common.provider import DefaultEndpoint
 from utils import testgen
-from utils.conf import credentials
 from utils.net import resolve_hostname
 from utils.version import Version
 
@@ -39,20 +38,14 @@ def pytest_generate_tests(metafunc):
             continue
 
         host = hosts[0]
-        creds = credentials[host["credentials"]]
         ip_address = resolve_hostname(host["name"])
-        cred = Credential(
-            principal=creds["username"],
-            secret=creds["password"],
-            verify_secret=creds["password"]
-        )
+        endpoint = DefaultEndpoint(credentials=host["credentials"], hostname=host["name"])
         # Mock provider data
         provider_data = {}
         provider_data.update(args['provider'].data)
         provider_data["name"] = host["name"]
         provider_data["hostname"] = host["name"]
         provider_data["ipaddress"] = ip_address
-        provider_data["credentials"] = host["credentials"]
         provider_data.pop("host_provisioning", None)
         provider_data["hosts"] = [host]
         provider_data["discovery_range"] = {}
@@ -60,11 +53,9 @@ def pytest_generate_tests(metafunc):
         provider_data["discovery_range"]["end"] = ip_address
         host_provider = VMwareProvider(
             name=host["name"],
-            hostname=host["name"],
             ip_address=ip_address,
-            credentials={'default': cred},
-            provider_data=provider_data,
-        )
+            endpoints=endpoint,
+            provider_data=provider_data)
         argvalues[i].append(host_provider)
         idlist[i] = "{}/{}".format(args['provider'].key, host["name"])
         new_idlist.append(idlist[i])

--- a/utils/providers.py
+++ b/utils/providers.py
@@ -354,7 +354,11 @@ def get_mgmt(provider_key, providers=None, credentials=None):
 
     if credentials is None:
         # We need to handle the in-place credentials
-        credentials = provider_data['credentials']
+
+        if provider_data.get('endpoints'):
+            credentials = provider_data['endpoints']['default']['credentials']
+        else:
+            credentials = provider_data['credentials']
         # If it is not a mapping, it most likely points to a credentials yaml (as by default)
         if not isinstance(credentials, Mapping):
             credentials = conf.credentials[credentials]
@@ -364,6 +368,11 @@ def get_mgmt(provider_key, providers=None, credentials=None):
     # Let the provider do whatever they need with them
     provider_kwargs = provider_data.copy()
     provider_kwargs.update(credentials)
+
+    if not provider_kwargs.get('username') and provider_kwargs.get('principal'):
+        provider_kwargs['username'] = provider_kwargs['principal']
+        provider_kwargs['password'] = provider_kwargs['secret']
+
     if isinstance(provider_key, six.string_types):
         provider_kwargs['provider_key'] = provider_key
     provider_kwargs['logger'] = logger


### PR DESCRIPTION
This PR contains 3 major changes.
1. I've moved Provider Credentials out of BaseProvider class and splitted them up to the bunch of Credentials classes. This change is introduced by PR #4511 (merged).
2. This PR introduces provider's endpoints approach. Part of provider's data belonging to endpoints was moved to appropriate Endpoints classes. Related data PR - cfme-qe-yamls/merge_requests/127
3. This PR also contains widgetastic Add and Edit views for Infrastructure providers and all related changes.
it also has related cfme data update request - PR 149
{{pytest: cfme/tests/infrastructure/test_esx_direct_host.py cfme/tests/cloud/test_providers.py cfme/tests/infrastructure/test_providers.py }}

**note:** these changes are related only to infrastructure providers. cloud providers tests kicked off only for checking that those aren't broken.