### PR TITLE
[RFR] restore conf.runtime property that is used in sprout/artifactor

### DIFF
--- a/cfme/test_framework/config.py
+++ b/cfme/test_framework/config.py
@@ -64,6 +64,10 @@ class DeprecatedConfigWrapper(object):
             )
         return self.configuration.get_config(key)
 
+    @property
+    def runtime(self):
+        return self.configuration.runtime
+
     def __getitem__(self, key):
         if self._warn:
             warnings.warn(


### PR DESCRIPTION
local test pending, can we print it and put it into a hall of shame