### PR TITLE
[1LP][RFR] Implement instance ui_powerstates_* as properties

### DIFF
--- a/cfme/cloud/instance/azure.py
+++ b/cfme/cloud/instance/azure.py
@@ -29,14 +29,17 @@ class AzureInstance(Instance):
     STATE_UNKNOWN = "unknown"
     STATE_ARCHIVED = "archived"
 
-    UI_POWERSTATES_AVAILABLE = {
-        'on': [STOP, SUSPEND, SOFT_REBOOT, TERMINATE],
-        'off': [START, TERMINATE]
-    }
-    UI_POWERSTATES_UNAVAILABLE = {
-        'on': [START],
-        'off': [STOP, SUSPEND, SOFT_REBOOT]
-    }
+    @property
+    def ui_powerstates_available(self):
+        return {
+            'on': [self.STOP, self.SUSPEND, self.SOFT_REBOOT, self.TERMINATE],
+            'off': [self.START, self.TERMINATE]}
+
+    @property
+    def ui_powerstates_unavailable(self):
+        return {
+            'on': [self.START],
+            'off': [self.STOP, self.SUSPEND, self.SOFT_REBOOT]}
 
     def create(self, email=None, first_name=None, last_name=None, availability_zone=None,
                security_groups=None, instance_type=None, guest_keypair=None, cancel=False,

--- a/cfme/cloud/instance/ec2.py
+++ b/cfme/cloud/instance/ec2.py
@@ -27,14 +27,18 @@ class EC2Instance(Instance):
     STATE_TERMINATED = "terminated"
     STATE_ARCHIVED = "archived"
     STATE_UNKNOWN = "unknown"
-    UI_POWERSTATES_AVAILABLE = {
-        'on': [STOP, SOFT_REBOOT, TERMINATE],
-        'off': [START, TERMINATE]
-    }
-    UI_POWERSTATES_UNAVAILABLE = {
-        'on': [START],
-        'off': [STOP, SOFT_REBOOT]
-    }
+
+    @property
+    def ui_powerstates_available(self):
+        return {
+            'on': [self.STOP, self.SOFT_REBOOT, self.TERMINATE],
+            'off': [self.START, self.TERMINATE]}
+
+    @property
+    def ui_powerstates_unavailable(self):
+        return {
+            'on': [self.START],
+            'off': [self.STOP, self.SOFT_REBOOT]}
 
     def create(self, email=None, first_name=None, last_name=None, availability_zone=None,
                security_groups=None, instance_type=None, guest_keypair=None, cancel=False,

--- a/cfme/cloud/instance/gce.py
+++ b/cfme/cloud/instance/gce.py
@@ -28,14 +28,17 @@ class GCEInstance(Instance):
     STATE_ARCHIVED = "archived"
     STATE_UNKNOWN = "unknown"
 
-    UI_POWERSTATES_AVAILABLE = {
-        'on': [STOP, SOFT_REBOOT, TERMINATE],
-        'off': [START, TERMINATE]
-    }
-    UI_POWERSTATES_UNAVAILABLE = {
-        'on': [START],
-        'off': [STOP, SOFT_REBOOT]
-    }
+    @property
+    def ui_powerstates_available(self):
+        return {
+            'on': [self.STOP, self.SOFT_REBOOT, self.TERMINATE],
+            'off': [self.START, self.TERMINATE]}
+
+    @property
+    def ui_powerstates_unavailable(self):
+        return {
+            'on': [self.START],
+            'off': [self.STOP, self.SOFT_REBOOT]}
 
     def create(self, email=None, first_name=None, last_name=None, availability_zone=None,
                instance_type=None, cloud_network=None, boot_disk_size=None, cancel=False,

--- a/cfme/cloud/instance/openstack.py
+++ b/cfme/cloud/instance/openstack.py
@@ -38,14 +38,17 @@ class OpenStackInstance(Instance):
     STATE_ARCHIVED = "archived"
     STATE_TERMINATED = "terminated"
 
-    UI_POWERSTATES_AVAILABLE = {
-        'on': [SUSPEND, SOFT_REBOOT, HARD_REBOOT, TERMINATE],
-        'off': [START, TERMINATE]
-    }
-    UI_POWERSTATES_UNAVAILABLE = {
-        'on': [START],
-        'off': [SUSPEND, SOFT_REBOOT, HARD_REBOOT]
-    }
+    @property
+    def ui_powerstates_available(self):
+        return {
+            'on': [self.SUSPEND, self.SOFT_REBOOT, self.HARD_REBOOT, self.TERMINATE],
+            'off': [self.START, self.TERMINATE]}
+
+    @property
+    def ui_powerstates_unavailable(self):
+        return {
+            'on': [self.START],
+            'off': [self.SUSPEND, self.SOFT_REBOOT, self.HARD_REBOOT]}
 
     def create(self, email=None, first_name=None, last_name=None, cloud_network=None,
                instance_type=None, cancel=False, **prov_fill_kwargs):

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -111,11 +111,11 @@ def wait_for_termination(provider, instance):
 def check_power_options(soft_assert, instance, power_state):
     """ Checks if power options match given power state ('on', 'off')
     """
-    for pwr_option in instance.UI_POWERSTATES_AVAILABLE[power_state]:
+    for pwr_option in instance.ui_powerstates_available[power_state]:
         soft_assert(
             instance.is_pwr_option_available_in_cfme(option=pwr_option, from_details=True),
             "{} must be available in current power state - {} ".format(pwr_option, power_state))
-    for pwr_option in instance.UI_POWERSTATES_UNAVAILABLE[power_state]:
+    for pwr_option in instance.ui_powerstates_unavailable[power_state]:
         soft_assert(
             not instance.is_pwr_option_available_in_cfme(option=pwr_option, from_details=True),
             "{} must not be available in current power state - {} ".format(pwr_option, power_state))


### PR DESCRIPTION
The power control tests fail when a deferred_verpick isn't picked on access because its defined for a class constant.

Thanks @mfalesni for the help brainstorming this change!

{{ pytest: cfme/tests/cloud/test_instance_power_control.py --long-running --use-provider azure -k test_power_options_from }}

## PRT
Failures are either provider setup (GCE and EC2 access down at the moment, rhos7-ga+rhos8 unstable) or a VM not hitting the desired power state in time.

There is an Azure softassert failure against the available power options. Need to consult with FA owner for this. Its outside the scope of my intended fixes here.