### PR TITLE
[RFR] Jenkins Template Tester script updates

### DIFF
--- a/scripts/template_upload_all.py
+++ b/scripts/template_upload_all.py
@@ -96,7 +96,7 @@ def template_name(image_link, image_ts, checksum_link, version=None):
         elif "stable" in image_link:
             # Handle named MIQ releases, dropping provider and capturing release and date
             if 'master' not in image_link:
-                pattern = re.compile(r'manageiq-[^\d]*?-(?P<release>[-\w]*?)'
+                pattern = re.compile(r'manageiq-[^\d]*?-(?P<release>[-.\w]*?)'
                                      r'-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})')
                 # Use match so we can use regex group names
                 result = pattern.match(image_name)
@@ -321,7 +321,8 @@ def main():
             if key != stream:
                 continue
         if upload_url:
-            if url != upload_url:
+            # strip trailing slashes just in case
+            if url.rstrip('/') != upload_url.rstrip('/'):
                 continue
         dir_files = browse_directory(url)
         if not dir_files:

--- a/scripts/template_upload_rhevm.py
+++ b/scripts/template_upload_rhevm.py
@@ -162,11 +162,11 @@ def template_from_ova(api, username, password, rhevip, edomain, ovaname, ssh_cli
                 command = ['engine-image-uploader']
         command.append("-u {}".format(username))
         command.append("-p {}".format(password))
+        command.append("-v -m --insecure")
         command.append("-r {}:443".format(rhevip))
         command.append("-N {}".format(temp_template_name))
         command.append("-e {}".format(edomain))
         command.append("upload {}".format(ovaname))
-        command.append("-m --insecure")
         command = ' '.join(command)
         print(
             'RHEVM:{} Executing command: {}'.format(

--- a/utils/version.py
+++ b/utils/version.py
@@ -173,7 +173,7 @@ class Version(object):
             vstring = ".".join(map(str, vstring))
         elif vstring:
             vstring = str(vstring).strip()
-        if vstring in ('master', 'latest', 'upstream') or 'fine' in vstring:
+        if vstring in ('master', 'latest', 'upstream') or 'fine' in vstring or 'euwe' in vstring:
             vstring = 'master'
         # TODO These aren't used anywhere - remove?
         if vstring == 'darga-3':


### PR DESCRIPTION
Fix template_upload_all regex to capture build filenames with '.' in the version.

Also strip the trailing slash when comparing build URL's, to avoid silly failures.

Add verbosity to engine_image_uploader call in template_upload_rhevm to get more status information from the script in the event of a failure.

Changes tested locally against the euwe-2.1 build.