### PR TITLE
[RFR] reenable pytest output

### DIFF
--- a/fixtures/templateloader.py
+++ b/fixtures/templateloader.py
@@ -16,6 +16,7 @@ def pytest_addoption(parser):
         default=False, help="Use a cached version of the templates and not redownload them")
 
 
+@pytest.mark.trylast
 def pytest_configure(config):
     if store.parallelizer_role == 'master' or trackerbot.conf.get('url') is None:
         return


### PR DESCRIPTION
tracker-bot output would set this misbehavior off ,
making it last prevents a race-condition

the current theory is that initialization happens while early plugin-manager capture suspension happens but the terminal-writer is not initialized