### PR TITLE
[RFR] Update template_upload and trackerbot for streams

### DIFF
--- a/scripts/template_upload_all.py
+++ b/scripts/template_upload_all.py
@@ -23,9 +23,9 @@ import datetime
 import sys
 import utils
 from contextlib import closing
-from utils import path
-
 from urllib2 import urlopen, HTTPError
+
+from utils import path, trackerbot
 from utils.conf import cfme_data
 
 CFME_BREW_ID = "cfme"
@@ -375,6 +375,12 @@ def main():
                 checksum_url,
                 get_version(url)
             )
+            if not stream:
+                # Stream is none, using automatic naming strategy, parse stream from template name
+                template_parser = trackerbot.parse_template(kwargs['template_name'])
+                if template_parser.stream:
+                    kwargs['stream'] = template_parser.group_name
+
         print("TEMPLATE_UPLOAD_ALL:-----Start of {} upload on: {}--------".format(
             kwargs['template_name'], provider_type))
 

--- a/utils/trackerbot.py
+++ b/utils/trackerbot.py
@@ -29,8 +29,10 @@ stream_matchers = (
     (get_stream('5.8'), r'^cfme-58.*-(?P<month>\d{2})(?P<day>\d{2})'),
     # Nightly builds have potentially multiple version streams bound to them so we
     # cannot use get_stream()
-    ('upstream_stable', r'^miq-stable-(?P<release>[-\w]*?)'
+    ('upstream_stable', r'^miq-stable-(?P<release>fine[-\w]*?)'
                         r'-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})'),
+    ('upstream_euwe', r'^miq-stable-(?P<release>euwe[-\w]*?)'
+                      r'-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})'),
     ('downstream-nightly', r'^cfme-nightly-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})'),
     # new format
     ('downstream-nightly', r'^cfme-nightly-\d*-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})'),


### PR DESCRIPTION
Updated regex matchers in utils.trackerbot, missed this regex update when I re-enabled the upstream_euwe stream.

Added block to template upload to set stream name automatically from template name if the stream wasn't provided.  This is so that when templates are added to trackerbot for the first time, they have a stream set.

