### PR TITLE
[WIPTEST] Allow use of CFME_TESTS_KEY env var to store yaml encryption key

### DIFF
--- a/cfme/test_framework/config.py
+++ b/cfme/test_framework/config.py
@@ -15,13 +15,16 @@ class Configuration(object):
     def __init__(self):
         self.yaycl_config = None
 
-    def configure(self, config_dir, crypt_key_file=None):
+    def configure(self, config_dir, crypt_key_file=None, crypt_key_env_var='CFME_TESTS_KEY'):
         """
         do the defered initial loading of the configuration
 
         :param config_dir: path to the folder with configuration files
         :param crypt_key_file: optional name of a file holding the key for encrypted
             configuration files
+        :param crypt_key_env_var: optional name of the environment variable holding
+            the key for encrypted configuration files. If this environment variable
+            exists, it will override the key specified by crypt_key_file
 
         :raises: AssertionError if called more than once
 
@@ -29,7 +32,11 @@ class Configuration(object):
         """
 
         assert self.yaycl_config is None
-        if crypt_key_file and os.path.exists(crypt_key_file):
+        if crypt_key_env_var in os.environ:
+            self.yaycl_config = yaycl.Config(
+                config_dir=config_dir,
+                crypt_key=os.environ[crypt_key_env_var])
+        elif crypt_key_file and os.path.exists(crypt_key_file):
             self.yaycl_config = yaycl.Config(
                 config_dir=config_dir,
                 crypt_key_file=crypt_key_file)

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -18,8 +18,9 @@ If the target appliance you will be testing is a container, you might like to co
 Setup
 -----
 You can use this shortcut to install the system and python dependencies which will leave you only
-with the need to copy the yamls and putting the ``.yaml_key`` in place. Copy this to an executable
-file, place it in the ``cfme_tests`` repository (along ``conftest.py``):
+with the need to copy the yamls and storing the key for the encrypted yaml files. Copy the code
+segment below to an executable file, place it in the ``cfme_tests`` repository
+(along ``conftest.py``):
 
 .. code-block:: bash
 
@@ -49,12 +50,14 @@ Detailed steps (manual environment setup):
     needs finishing touches.
 
 * Fork and Clone this repository
-* Get the shared encryption key (``.yaml_key``) for credentials. Ask in CFME QE.
+* Get the shared encryption key for credentials (``*.eyaml``). Ask in CFME QE.
 * Make sure you set the shared secret for the credentials files encryption. There are two ways:
 
-  * add ``export CFME_TESTS_KEY="our shared key"`` into the activate script
   * create ``.yaml_key`` file in project root containing the key
-
+    ``echo 'our shared key' > .yaml_key``
+    --OR--
+  * add ``export CFME_TESTS_KEY="our shared key"`` into the activate script. 
+    If the environment variable ``CFME_TESTS_KEY`` exists, it will override any key in ``.yaml_key``
 
 * Ensure the following devel packages are installed (for building python dependencies):
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -17,10 +17,10 @@ If the target appliance you will be testing is a container, you might like to co
 
 Setup
 -----
-You can use this shortcut to install the system and python dependencies which will leave you only
-with the need to copy the yamls and storing the key for the encrypted yaml files. Copy the code
-segment below to an executable file, place it in the ``cfme_tests`` repository
-(along ``conftest.py``):
+You can use this shortcut to install the system and python dependencies which will leave you with
+only the need to copy the yamls and store the key for the encrypted yaml files. Copy the code
+segment below to an executable file and place it in the ``cfme_tests`` repository root
+(along with ``conftest.py``):
 
 .. code-block:: bash
 
@@ -50,14 +50,15 @@ Detailed steps (manual environment setup):
     needs finishing touches.
 
 * Fork and Clone this repository
-* Get the shared encryption key for credentials (``*.eyaml``). Ask in CFME QE.
-* Make sure you set the shared secret for the credentials files encryption. There are two ways:
+* Get the shared encryption key for the credentials yaml (``*.eyaml``). Ask in CFME QE.
+* Set the shared secret for the encrypted credentials files used in automation.
+  This can be accomplished two ways:
 
   * create ``.yaml_key`` file in project root containing the key
     ``echo 'our shared key' > .yaml_key``
-    --OR--
-  * add ``export CFME_TESTS_KEY="our shared key"`` into the activate script. 
+  * add ``export CFME_TESTS_KEY="our shared key"`` into the virtualenv activate script. 
     If the environment variable ``CFME_TESTS_KEY`` exists, it will override any key in ``.yaml_key``
+
 
 * Ensure the following devel packages are installed (for building python dependencies):
 

--- a/scripts/dockerbot/dockerbot.py
+++ b/scripts/dockerbot/dockerbot.py
@@ -408,13 +408,26 @@ class DockerBot(object):
             self.args['pytest'] += ' --dev-branch {} --dev-repo {}'.format(branch, repo)
         print("  PYTEST Command: {}".format(self.args['pytest']))
 
-    def enc_key(self):
+    def enc_key(self, enc_key_file='.yaml_key', enc_key_env_var='CFME_TESTS_KEY'):
+        """
+        Retrieve the yaml encryption key from enc_key_file OR
+        the environment variable CFME_TESTS_KEY
+
+        :param enc_key_file: optional name of a file holding the key for encrypted
+            configuration files
+        :param enc_key_env_var: optional name of the environment variable holding
+            the key for encrypted configuration files. If this environment variable
+            exists, it will override the key specified in enc_key_file
+        """
+
         try:
-            with open('.yaml_key') as f:
+            with open(enc_key_file) as f:
                 key = f.read()
         except:
             key = None
-        return key
+
+        # Environment variable overrides the .yaml_key
+        return os.environ.get(enc_key_env_var) or key
 
     def create_pytest_envvars(self):
         self.env_details = {'BROWSER': self.args['browser'],


### PR DESCRIPTION
Fix for storing the yaml encryption key in the CFME_TESTS_KEY environment variable instead of .yaml_key. 

Getting started guide states that the yaml encryption can be stored in .yaml_key OR  CFME_TESTS_KEY but the environment variable is never read and automation fails when .yaml_key doesn't exist.  This will allow either method to be used and CFME_TEST_KEY will override .yaml_key if it exists. Update affects pytest and dockerbot automation.

This is a quality of life fix and can be disregarded if you want to settle on using .yaml_key only (w/ update to docs).
