### PR TITLE
[RFR] Fix the param_getter

### DIFF
--- a/fixtures/artifactor_plugin.py
+++ b/fixtures/artifactor_plugin.py
@@ -57,12 +57,7 @@ def get_test_idents(item):
 
 
 def get_name(obj):
-    if hasattr(obj, '_param_name'):
-        return getattr(obj, obj._param_name)
-    elif hasattr(obj, 'name'):
-        return obj.name
-    else:
-        return str(obj)
+    return getattr(obj, '_param_name', None) or getattr(obj, 'name', None) or str(obj)
 
 
 class DummyClient(object):


### PR DESCRIPTION
I made a mistake - this fixes it, _param_name returns the param_name of the object, not the name of what the parameter should be to access the param_name