### PR TITLE
[1LP][RFR] appliance's configuration_details workaroud for openstack

### DIFF
--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -1945,12 +1945,13 @@ class IPAppliance(object):
                     # If there's only one server, it's the one we want
                     server = all_servers[0]
                 else:
-                    # Otherwise, filter based on id and guid
+                    # Otherwise, filter based on id and ip/guid
                     def server_filter(server):
                         return all([
                             server.id >= reg_min,
                             server.id < reg_max,
-                            server.guid == self.guid
+                            # second check because of openstack ip addresses
+                            server.ipaddress == self.db.hostname or server.guid == self.guid
                         ])
                     servers = filter(server_filter, all_servers)
                     if servers:

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -1945,13 +1945,12 @@ class IPAppliance(object):
                     # If there's only one server, it's the one we want
                     server = all_servers[0]
                 else:
-                    # Otherwise, filter based on id and ip address
+                    # Otherwise, filter based on id and guid
                     def server_filter(server):
                         return all([
                             server.id >= reg_min,
                             server.id < reg_max,
-                            # XXX: This currently fails due to public/private addresses on openstack
-                            server.ipaddress == self.db.hostname
+                            server.guid == self.guid
                         ])
                     servers = filter(server_filter, all_servers)
                     if servers:


### PR DESCRIPTION
Previously configuration_details returns (None, None, None, None) if two appliances were provisioned from openstack because  server.ipaddress equal to 192.168.x.x

self.guid takes info from /var/www/miq/vmdb/GUID and server.guid from db 

Example with two appliances: 
You can see error in PRT run #12105 for 5.6
And no such error in PRT run with this fix #12110 for 5.6
