### PR TITLE
[1LP][RFR] Requirements are now sent to Ostriz

### DIFF
--- a/artifactor/plugins/reporter.py
+++ b/artifactor/plugins/reporter.py
@@ -362,13 +362,14 @@ class Reporter(ArtifactorBasePlugin, ReporterBase):
         return None, {'artifacts': {test_ident: {'skipped': skip_data}}}
 
     @ArtifactorBasePlugin.check_configured
-    def start_test(self, test_location, test_name, slaveid, tier=None, param_dict=None):
+    def start_test(
+            self, test_location, test_name, slaveid, tier=None, param_dict=None, requirement=None):
         if not param_dict:
             param_dict = {}
         test_ident = "{}/{}".format(test_location, test_name)
         return None, {'artifacts': {test_ident: {
             'start_time': time.time(), 'slaveid': slaveid, 'tier': tier or "N/A",
-            'params': param_dict}}
+            'params': param_dict, 'requirement': requirement or "None"}}
         }
 
     @ArtifactorBasePlugin.check_configured

--- a/cfme/tests/test_login.py
+++ b/cfme/tests/test_login.py
@@ -1,5 +1,5 @@
 import pytest
-from cfme import BaseLoggedInPage, login, Credential
+from cfme import BaseLoggedInPage, login, Credential, test_requirements
 from cfme.configure.access_control import User
 from utils import conf, error
 from utils.appliance.implementations.ui import navigate_to
@@ -7,7 +7,7 @@ from utils.appliance.implementations.ui import navigate_to
 pytestmark = pytest.mark.usefixtures('browser')
 
 
-@pytest.mark.requirement('drift')
+@test_requirements.drift
 @pytest.mark.tier(1)
 @pytest.mark.sauce
 @pytest.mark.smoke
@@ -25,7 +25,7 @@ def test_login(method, appliance):
     assert login_page.is_displayed
 
 
-@pytest.mark.requirement('drift')
+@test_requirements.drift
 @pytest.mark.tier(1)
 @pytest.mark.sauce
 @pytest.mark.smoke
@@ -50,6 +50,7 @@ def test_re_login(appliance):
     assert login_page.is_displayed
 
 
+@test_requirements.drift
 @pytest.mark.tier(2)
 @pytest.mark.sauce
 def test_bad_password(request, appliance):

--- a/fixtures/artifactor_plugin.py
+++ b/fixtures/artifactor_plugin.py
@@ -174,6 +174,10 @@ def pytest_runtest_protocol(item):
     if tier:
         tier = tier.args[0]
 
+    requirement = item.get_marker('requirement')
+    if requirement:
+        requirement = requirement.args[0]
+
     try:
         params = item.callspec.params
         param_dict = {p: get_name(v) for p, v in params.iteritems()}
@@ -189,7 +193,7 @@ def pytest_runtest_protocol(item):
     fire_art_test_hook(
         item, 'start_test',
         slaveid=store.slaveid, ip=ip,
-        tier=tier, param_dict=param_dict)
+        tier=tier, requirement=requirement, param_dict=param_dict)
     yield
 
 


### PR DESCRIPTION
This ensures requirements are sent to Ostriz
Test are marked with requirements, until now these were not being sent to Ostriz, we need this to be able to start grouping tests in reporting.