### PR TITLE
[RFR] sprout: setup time sync in appliances after provisioning

### DIFF
--- a/sprout/appliances/tasks.py
+++ b/sprout/appliances/tasks.py
@@ -894,6 +894,8 @@ def appliance_power_on(self, appliance_id):
                 # VM is running now.
                 sync_appliance_hw.delay(appliance.id)
                 sync_provider_hw.delay(appliance.template.provider.id)
+                # fixes time synchronization
+                appliance.ipapp.fix_ntp_clock()
                 return
             else:
                 # IP not present yet
@@ -907,9 +909,6 @@ def appliance_power_on(self, appliance_id):
             appliance.set_status("Powering on.")
             appliance.provider_api.start_vm(appliance.name)
             self.retry(args=(appliance_id, ), countdown=20, max_retries=40)
-
-        # fixes time synchronization
-        appliance.ipapp.fix_ntp_clock()
     except Exception as e:
         provider_error_logger().error("Exception {}: {}".format(type(e).__name__, str(e)))
         self.retry(args=(appliance_id, ), exc=e, countdown=20, max_retries=30)

--- a/sprout/appliances/tasks.py
+++ b/sprout/appliances/tasks.py
@@ -907,6 +907,10 @@ def appliance_power_on(self, appliance_id):
             appliance.set_status("Powering on.")
             appliance.provider_api.start_vm(appliance.name)
             self.retry(args=(appliance_id, ), countdown=20, max_retries=40)
+
+        # fixes time synchronization
+        cfme_appliance = CFMEAppliance(appliance.provider_name, appliance.name)
+        cfme_appliance.fix_ntp_clock()
     except Exception as e:
         provider_error_logger().error("Exception {}: {}".format(type(e).__name__, str(e)))
         self.retry(args=(appliance_id, ), exc=e, countdown=20, max_retries=30)

--- a/sprout/appliances/tasks.py
+++ b/sprout/appliances/tasks.py
@@ -909,8 +909,7 @@ def appliance_power_on(self, appliance_id):
             self.retry(args=(appliance_id, ), countdown=20, max_retries=40)
 
         # fixes time synchronization
-        cfme_appliance = CFMEAppliance(appliance.provider_name, appliance.name)
-        cfme_appliance.fix_ntp_clock()
+        appliance.ipapp.fix_ntp_clock()
     except Exception as e:
         provider_error_logger().error("Exception {}: {}".format(type(e).__name__, str(e)))
         self.retry(args=(appliance_id, ), exc=e, countdown=20, max_retries=30)


### PR DESCRIPTION
Purpose or Intent
=================
CFME experiences different issues when system time is incorrect.
Sprout currently doesn't fix time sync daemon after provisioning appliances. 
This PR will make sprout run setup for time sync daemon after provisioning.