### PR TITLE
[1LP][RFR] More containers tests

### DIFF
--- a/cfme/containers/pod.py
+++ b/cfme/containers/pod.py
@@ -14,7 +14,7 @@ list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
 paged_tbl = PagedTable(table_locator="//div[@id='list_grid']//table")
 
 
-match_page = partial(match_location, controller='container_pods', title='Pods')
+match_page = partial(match_location, controller='container_group', title='Pods')
 
 
 class Pod(Taggable, SummaryMixin, Navigatable):

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -256,6 +256,9 @@ class ContainersProvider(BaseProvider, Pretty):
 class All(CFMENavigateStep):
     prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
 
+    def am_i_here(self):
+        return match_page(summary='Pods')
+
     def step(self):
         self.prerequisite_view.navigation.select('Compute', 'Containers', 'Providers')
 

--- a/cfme/containers/service.py
+++ b/cfme/containers/service.py
@@ -13,7 +13,7 @@ from functools import partial
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
 paged_tbl = PagedTable(table_locator="//div[@id='list_grid']//table")
 
-match_page = partial(match_location, controller='container_services', title='Services')
+match_page = partial(match_location, controller='container_service', title='Services')
 
 
 class Service(Taggable, SummaryMixin, Navigatable):

--- a/cfme/tests/containers/test_configurable_menus.py
+++ b/cfme/tests/containers/test_configurable_menus.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from cfme.containers.provider import ContainersProvider
+from cfme import BaseLoggedInPage
+from utils import testgen
+from utils.version import current_version
+from utils.appliance.implementations.ui import navigate_to
+from utils.blockers import BZ
+
+
+pytestmark = [pytest.mark.uncollectif(lambda: current_version() < "5.8")]
+pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
+
+
+def config_menus_visibility(appliance, is_visible):
+    # Configure the menus visibility parameters in config/settings.yaml
+    yaml_config = appliance.get_yaml_config()
+
+    if (yaml_config['product']['datawarehouse_manager'] == is_visible) and \
+            (yaml_config['prototype']['monitoring'] == is_visible):
+        return  # If this is already the state, return
+
+    yaml_config['product']['datawarehouse_manager'] = is_visible
+    yaml_config['prototype']['monitoring'] = is_visible
+
+    appliance.set_yaml_config(yaml_config)
+    appliance.reboot()
+
+
+def is_menu_visible(appliance, link_text):
+    navigate_to(ContainersProvider, 'All')
+    logged_in_page = appliance.browser.create_view(BaseLoggedInPage)
+    return link_text in logged_in_page.navigation.nav_links()
+
+
+@pytest.yield_fixture(scope='module')
+def config_menus_visible(appliance):
+    config_menus_visibility(appliance, True)
+    yield
+    config_menus_visibility(appliance, False)
+
+
+@pytest.mark.polarion('CMP-10614')
+def test_datawarehouse_invisible(appliance):
+    # This should be the default state
+    yaml_config = appliance.get_yaml_config()
+    assert not yaml_config['product']['datawarehouse_manager'], \
+        'Datawarehouse menu should be configured as invisible by default ' \
+        '(currently configured as visible)'
+    assert not is_menu_visible(appliance, 'Datawarehouse')
+
+
+@pytest.mark.polarion('CMP-10613')
+def test_monitoring_invisible(appliance):
+    # This should be the default state
+    yaml_config = appliance.get_yaml_config()
+    assert not yaml_config['prototype']['monitoring'], \
+        'Monitor menu should be configured as invisible by default ' \
+        '(currently configured as visible)'
+    assert not is_menu_visible(appliance, 'Monitor')
+
+
+@pytest.mark.meta(blockers=[BZ(1444935, forced_streams=["5.8"])])
+@pytest.mark.polarion('CMP-10650')
+def test_datawarehouse_visible(appliance, config_menus_visible):
+    assert is_menu_visible(appliance, 'Datawarehouse'), \
+        'Datawarehouse menu should be visible (currently invisible)'
+
+
+@pytest.mark.meta(blockers=[BZ(1444939, forced_streams=["5.8"])])
+@pytest.mark.polarion('CMP-10649')
+def test_monitoring_visible(appliance, config_menus_visible):
+    assert is_menu_visible(appliance, 'Monitor'), \
+        'Monitor menu should be visible (currently invisible)'

--- a/cfme/tests/containers/test_start_page.py
+++ b/cfme/tests/containers/test_start_page.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+from collections import namedtuple
+
+import pytest
+
+from cfme.configure import settings
+from cfme.containers.overview import match_page as match_page_containersoverview
+from cfme.containers.node import match_page as match_page_node
+from cfme.containers.pod import match_page as match_page_pod
+from cfme.containers.service import match_page as match_page_service
+from cfme.containers.container import match_page as match_page_container
+from cfme.containers.provider import ContainersProvider, \
+    match_page as match_page_containersprovider
+from cfme.web_ui import browser_title
+from utils import testgen
+from utils.appliance.implementations.ui import navigate_to
+from utils.version import current_version
+from utils.blockers import BZ
+
+
+pytestmark = [pytest.mark.uncollectif(lambda: current_version() < "5.8")]
+pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
+
+
+DataSet = namedtuple('DataSet', ['match_page', 'start_page_name'])
+data_sets = (
+    DataSet(match_page_containersoverview, 'Containers / Overview'),
+    DataSet(match_page_containersprovider, 'Containers / Providers'),
+    DataSet(match_page_node, 'Containers / Nodes'),
+    DataSet(match_page_pod, 'Containers / Pods'),
+    DataSet(match_page_service, 'Containers / Services'),
+    DataSet(match_page_container, 'Containers / Explorer')
+)
+
+
+@pytest.mark.meta(blockers=[BZ(1446265, forced_streams=["5.8", "upstream"])])
+@pytest.mark.polarion('CMP-10601')
+def test_start_page(appliance, soft_assert):
+
+    for data_set in data_sets:
+        settings.visual.login_page = data_set.start_page_name
+        login_page = navigate_to(appliance.server, 'LoginScreen')
+        login_page.login_admin()
+        soft_assert(
+            data_set.match_page(),
+            'Configured start page is "{}", but the start page now'
+            ' is "{}" instead of "{}"'.format(
+                data_set.start_page_name, data_set.match_page.keywords['title'],
+                browser_title()
+            )
+        )


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_start_page.py  cfme/tests/containers/test_reports.py cfme/tests/containers/test_configurable_menus.py -v --use-provider cm-env1 }}

- Added cfme/tests/containers/test_start_page.py - test_start_page
- Added cfme/tests/containers/test_reports.py - test_container_reports_base_on_options
- Few page match fixes