### PR TITLE
[WIP] Add storage provider volumes navigations & tests (Openstack only)

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -225,7 +225,7 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
         return False
 
     @variable(alias='rest')
-    def is_refreshed(self, refresh_timer=None):
+    def is_refreshed(self, refresh_timer=None, refresh_delta=600):
         if refresh_timer:
             if refresh_timer.is_it_time():
                 logger.info(' Time for a refresh!')
@@ -235,7 +235,7 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
         if not rdate:
             return False
         td = self.appliance.utc_time() - rdate
-        if td > datetime.timedelta(0, 600):
+        if td > datetime.timedelta(0, refresh_delta):
             self.refresh_provider_relationships()
             return False
         else:

--- a/cfme/storage/volume.py
+++ b/cfme/storage/volume.py
@@ -4,9 +4,26 @@ from functools import partial
 from navmazing import NavigateToSibling
 
 import cfme.fixtures.pytest_selenium as sel
-from cfme.web_ui import match_location, PagedTable, toolbar as tb
+from cfme.web_ui import Form, Input, match_location, PagedTable, Select, toolbar as tb
+from cfme.web_ui.form_buttons import add_ng
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
+
+
+creation_form = Form([
+    ('volume_name', "//input[@name='name']"),
+    ('volume_size', "//input[@name='size']"),
+    ('cloud_tenant', Select("//select[@id='cloud_tenant_id']"))
+])
+
+_device_input = ('device_path', Input('device_path'))
+_select_vm = ('select_vm', Select("//select[@id='vm_id']"))
+_select_volume = ('select_volume', Select("//select[@id='volume_id']"))
+
+attach_inst_page_form = Form([_device_input, _select_volume])
+attach_vlm_page_form = Form([_device_input, _select_vm])
+detach_inst_page_form = Form([_select_volume])
+detach_vlm_page_form = Form([_select_vm])
 
 match_volumes = partial(match_location, controller='cloud_volume', title='Cloud Volumes')
 match_provider = partial(match_location, controller='ems_cloud', title='Cloud Providers')
@@ -19,6 +36,26 @@ class Volume(Navigatable):
         Navigatable.__init__(self, appliance=appliance)
         self.name = name
         self.provider = provider
+
+    def create(self, volume_size):
+        """
+        Creates cloud volume
+        :param volume_size: int value of volume size to be created in GB
+        """
+        navigate_to(Volume, 'All')
+        tb.select('Configuration', 'Add a new Cloud Volume')
+        volume_data = dict(volume_name=self.name, volume_size=volume_size,
+                           cloud_tenant=self.provider.mgmt.list_tenant()[0])
+        creation_form.fill(volume_data)
+        sel.click(add_ng)
+
+    def delete(self):
+        """Deletes volume"""
+        navigate_to(Volume, 'All')
+        params = {'Status': 'available', 'Name': self.name, 'Cloud Provider': self.provider.name}
+        list_tbl.click_row_by_cells(params, 'Name')
+        tb.select('Configuration', 'Delete this Cloud Volume', invokes_alert=True)
+        sel.handle_alert(cancel=False)
 
 
 @navigator.register(Volume, 'All')

--- a/cfme/storage/volume.py
+++ b/cfme/storage/volume.py
@@ -4,8 +4,7 @@ from functools import partial
 from navmazing import NavigateToSibling
 
 import cfme.fixtures.pytest_selenium as sel
-from cfme.exceptions import DestinationNotFound
-from cfme.web_ui import match_location, InfoBlock, PagedTable, toolbar as tb
+from cfme.web_ui import match_location, PagedTable, toolbar as tb
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
 
@@ -25,30 +24,16 @@ class Volume(Navigatable):
 @navigator.register(Volume, 'All')
 class All(CFMENavigateStep):
     def prerequisite(self):
-        if self.obj.appliance.version >= '5.7':
-            raise DestinationNotFound('Cloud Volumes does not exist in CFME 5.7+')
         navigate_to(self.obj.appliance.server, 'LoggedIn')
 
     def am_i_here(self):
         return match_volumes(summary='Cloud Volumes')
 
-    def step(self, *args, **kwargs):
-        self.prerequisite_view.navigation.select('Compute', 'Clouds', 'Volumes')
-
-
-@navigator.register(Volume, 'AllByProvider')
-class AllByProvider(CFMENavigateStep):
-    def prerequisite(self):
-        if self.obj.appliance.version >= '5.7':
-            raise DestinationNotFound('Cloud Volumes does not exist in CFME 5.7+')
-        navigate_to(self.obj.appliance.server, 'LoggedIn')
-
-    def am_i_here(self):
-        return match_provider(summary='{} (All Cloud Volumes)'.format(self.obj.provider.name))
-
     def step(self):
-        navigate_to(self.obj.provider, 'Details')
-        sel.click(InfoBlock('Relationships', 'Cloud volumes').element)
+        if self.obj.appliance.version < '5.7':
+            self.prerequisite_view.navigation.select('Compute', 'Clouds', 'Volumes')
+        else:
+            self.prerequisite_view.navigation.select('Storage', 'Volumes')
 
 
 @navigator.register(Volume, 'Details')
@@ -58,7 +43,7 @@ class Details(CFMENavigateStep):
     def am_i_here(self):
         return match_volumes(summary='{} (Summary)'.format(self.obj.name))
 
-    def step(self, *args, **kwargs):
+    def step(self):
         tb.select('List View')
         sel.click(list_tbl.find_row_by_cell_on_all_pages(
             {'Name': self.obj.name, 'Cloud Provider': self.obj.provider.name}))

--- a/cfme/tests/configure/test_visual_cloud.py
+++ b/cfme/tests/configure/test_visual_cloud.py
@@ -11,7 +11,7 @@ from cfme.cloud.instance import Instance
 from cfme.cloud.keypairs import KeyPair
 from cfme.cloud.stack import Stack
 from cfme.cloud.tenant import Tenant
-from cfme.cloud.volume import Volume
+from cfme.storage.volume import Volume
 from cfme.web_ui import paginator, toolbar as tb, match_location
 from utils.appliance.implementations.ui import navigate_to
 from utils import version

--- a/cfme/tests/storage/test_volume.py
+++ b/cfme/tests/storage/test_volume.py
@@ -1,0 +1,163 @@
+"""Tests for cloud provider's volumes"""
+
+import cfme.web_ui.flash as flash
+import pytest
+from fauxfactory import gen_alphanumeric
+from cfme.cloud.instance import Instance
+from cfme.cloud.provider.openstack import OpenStackProvider
+from cfme.storage.volume import (attach_inst_page_form, attach_vlm_page_form,
+                               detach_inst_page_form, detach_vlm_page_form,
+                               get_volume_name, list_tbl, Volume)
+from cfme.fixtures import pytest_selenium as sel
+from cfme.web_ui import InfoBlock, toolbar as tb
+from cfme.web_ui.form_buttons import (attach_volume, detach_volume,
+                                      submit_changes)
+from random import choice
+from utils import testgen
+from utils.appliance.implementations.ui import navigate_to
+from utils.wait import wait_for
+
+pytest_generate_tests = testgen.generate(testgen.providers_by_class,
+                                         [OpenStackProvider], scope='module')
+
+
+pytestmark = [pytest.mark.tier(3),
+              pytest.mark.usefixtures("setup_provider_modscope")]
+
+
+def test_create_volume(provider):
+    """Creates a volume for given cloud provider"""
+    volume = Volume(gen_alphanumeric(), provider)
+    vsize = 1
+    volume.create(vsize)
+    flash.assert_message_contain('Create Cloud Volume')
+
+    wait_for(provider.is_refreshed, [None, 10], delay=5)
+    sel.refresh()
+    params = {'Name': volume.name, 'Size': '{} GB'.format(vsize), 'Status': 'available'}
+    res = list_tbl.find_rows_by_cells(params)
+    assert res, 'Newly created volume doesn\'t appear in UI'
+
+
+def test_list_volumes_provider_details(provider, soft_assert):
+    """Verifies that all provider's volumes are present on details page"""
+    # Gather all provider's volumes name
+    volumes = []
+    for volume in provider.mgmt.list_volume():
+        vname = provider.mgmt.get_volume(volume).to_dict()['display_name']
+        volumes.append(vname)
+    navigate_to(provider, 'Details')
+    clv_el = provider.get_detail('Relationships')
+    assert len(volumes) == clv_el.value
+
+    clv_el.click()
+    for volume in volumes:
+        soft_assert(list_tbl.find_cell('Name', volume), 'Volume {} is not displayed'.format(volume))
+
+
+def test_attach_volume_from_instance_page(provider):
+    """Attaches pre-created volume to an instance from Instance page"""
+    vms = filter(lambda vm: vm.power_state == 'ACTIVE', provider.mgmt.all_vms())
+    instance_name = choice(vms).name
+    # Find available volume
+    volume = Volume('', provider).find_free_volume()
+    assert volume, "Can't find free volume to attach"
+
+    Instance(instance_name, provider).load_details()
+    tb.select('Configuration', 'Attach a Cloud Volume to this Instance')
+    assert len(attach_inst_page_form.select_volume.all_options) > 0
+
+    attach_inst_page_form.fill(dict(select_volume=volume.name,
+                                    device_path='/dev/vdb'))
+    sel.click(submit_changes)
+    flash.assert_message_contain('Attaching Cloud Volume')
+
+    wait_for(provider.is_refreshed, [None, 10], delay=5)
+    info_el = InfoBlock.element('Relationships', 'Cloud Volumes')
+    sel.click(info_el)
+    params = {'Name': volume.name, 'Status': 'in-use'}
+    res = list_tbl.find_rows_by_cells(params)
+    assert res, 'Volume does not appear in instance relationships'
+
+
+def test_detach_volume_from_instance_page(provider):
+    """Detaches volume from instance from Instance page"""
+    vm_name = None
+    # Find an instance with attached volumes
+    for instance in provider.mgmt._get_all_instances():
+        info = instance.to_dict()
+        if info['os-extended-volumes:volumes_attached']:
+            vm_name = info['name']
+            break
+    assert vm_name, "Can't find any instance with attached volume"
+
+    Instance(vm_name, provider).load_details()
+    tb.select('Configuration', 'Detach a Cloud Volume from this Instance')
+    v_option = choice(detach_inst_page_form.select_volume.all_options[1:])
+    detach_inst_page_form.select_volume.select_by_value(v_option[1])
+    sel.click(submit_changes)
+    flash.assert_message_contain('Detaching Cloud Volume')
+
+    wait_for(provider.is_refreshed, [None, 10], delay=5)
+    info_el = InfoBlock.element('Relationships', 'Cloud Volumes')
+    sel.click(info_el)
+    res = list_tbl.find_cell('Name', v_option[0])
+    assert not res, 'Volume does not disappear from instance relationships'
+
+
+def test_attach_volume_from_volume_page(provider):
+    """Attaches pre-created volume to an instance from Volume page"""
+    vms = filter(lambda vm: vm.power_state == 'ACTIVE', provider.mgmt.all_vms())
+    inst_name = choice(vms).name
+    navigate_to(Volume, 'All')
+    params = {'Status': 'available',
+              'Cloud Provider': provider.get_yaml_data()['name']}
+    list_tbl.click_row_by_cells(params, 'Name')
+    vname = get_volume_name()
+    tb.select('Configuration', 'Attach this Cloud Volume to an Instance')
+    assert len(attach_vlm_page_form.select_vm.all_options) > 0
+
+    attach_vlm_page_form.fill(dict(select_vm=inst_name, device_path='/dev/vdb'))
+    sel.click(attach_volume)
+    flash.assert_message_contain('Attaching Cloud Volume')
+
+    wait_for(provider.is_refreshed, [None, 10], delay=5)
+    navigate_to(Volume, 'All')
+    params = {'Name': vname, 'Status': 'in-use'}
+    res = list_tbl.find_rows_by_cells(params)
+    assert res, 'Volume does not marked as in-use'
+
+
+def test_detach_volume_from_volume_page(provider):
+    """Detaches volume from instance from Volume page"""
+    navigate_to(Volume, 'All')
+    params = {'Status': 'in-use',
+              'Cloud Provider': provider.get_yaml_data()['name']}
+    list_tbl.click_row_by_cells(params, 'Name')
+    vname = get_volume_name()
+    tb.select('Configuration', 'Detach this Cloud Volume from an Instance')
+    assert len(detach_vlm_page_form.select_vm.all_options) > 0
+    detach_vlm_page_form.select_vm.select_by_index(1)
+    sel.click(detach_volume)
+    flash.assert_message_contain('Detaching Cloud Volume')
+
+    wait_for(provider.is_refreshed, [None, 10], delay=5)
+    navigate_to(Volume, 'All')
+    params = {'Name': vname, 'Status': 'available'}
+    res = list_tbl.find_rows_by_cells(params)
+    assert res, 'Volume does not marked as available'
+
+
+def test_delete_volume(provider):
+    """Deletes volume"""
+    volume = Volume('', provider).find_free_volume()
+    assert volume, "Can't find free volume to attach"
+
+    volume.delete()
+    flash.assert_message_contain('Delete initiated for 1 Cloud Volume.')
+
+    wait_for(provider.is_refreshed, [None, 10], delay=5)
+    navigate_to(Volume, 'All')
+    params = {'Name': volume.name}
+    res = list_tbl.find_rows_by_cells(params)
+    assert not res, 'Volume does not disappear from volume list'

--- a/cfme/web_ui/form_buttons.py
+++ b/cfme/web_ui/form_buttons.py
@@ -145,6 +145,7 @@ class FormButton(Pretty):
 
 
 add = FormButton("Add")
+add_ng = FormButton('Add', ng_click='addClicked()')
 save = FormButton("Save Changes", dimmed_alt="Save", ng_click="saveClicked()")
 angular_save = FormButton("Save changes", ng_click="saveClicked()")
 cancel = FormButton("Cancel")


### PR DESCRIPTION
Moving cfme/cloud/volume.py to cfme/storage/volume.py
adding navigations for storage provider's volumes (CF 5.7+)
adding some tests for volumes (Openstack provider only)