### PR TITLE
[1LP][RFR] Cloud Instance Widget Conversion (Part 1)

### DIFF
--- a/cfme/cloud/instance/azure.py
+++ b/cfme/cloud/instance/azure.py
@@ -1,8 +1,7 @@
+# -*- coding: utf-8 -*-
 from cfme.exceptions import OptionNotAvailable
-from cfme.web_ui import fill, flash
-from cfme.fixtures import pytest_selenium as sel
 from utils import version, deferred_verpick
-from . import Instance, select_provision_image
+from . import Instance
 
 
 class AzureInstance(Instance):
@@ -41,50 +40,18 @@ class AzureInstance(Instance):
             'on': [self.START],
             'off': [self.STOP, self.SUSPEND, self.SOFT_REBOOT]}
 
-    def create(self, email=None, first_name=None, last_name=None, availability_zone=None,
-               security_groups=None, instance_type=None, guest_keypair=None, cancel=False,
-               **prov_fill_kwargs):
+    def create(self, cancel=False, **prov_fill_kwargs):
         """Provisions an Azure instance with the given properties through CFME
 
         Args:
-            email: Email of the requester
-            first_name: Name of the requester
-            last_name: Surname of the requester
-            availability_zone: Name of the zone the instance should belong to
-            security_groups: List of security groups the instance should belong to
-                             (currently, only the first one will be used)
-            instance_type: Type of the instance
-            guest_keypair: Name of the key pair used to access the instance
             cancel: Clicks the cancel button if `True`, otherwise clicks the submit button
                     (Defaults to `False`)
+            prov_fill_kwargs: dictionary of provisioning field/value pairs
         Note:
             For more optional keyword arguments, see
-            :py:data:`cfme.cloud.provisioning.provisioning_form`
+            :py:data:`cfme.cloud.provisioning.ProvisioningForm`
         """
-        from cfme.provisioning import provisioning_form
-        select_provision_image(template_name=self.template_name, provider=self.provider)
-
-        fill(provisioning_form, dict(
-            email=email,
-            first_name=first_name,
-            last_name=last_name,
-            instance_name=self.name,
-            availability_zone=availability_zone,
-            # not supporting multiselect now, just take first value
-            security_groups=security_groups,
-            instance_type=instance_type,
-            guest_keypair=guest_keypair,
-            **prov_fill_kwargs
-        ))
-
-        if cancel:
-            sel.click(provisioning_form.cancel_button)
-            flash.assert_success_message(
-                "Add of new VM Provision Request was cancelled by the user")
-        else:
-            sel.click(provisioning_form.submit_button)
-            flash.assert_success_message(
-                "VM Provision Request was Submitted, you will be notified when your VMs are ready")
+        super(AzureInstance, self).create(form_values=prov_fill_kwargs, cancel=cancel)
 
     def power_control_from_provider(self, option):
         """Power control the instance from the provider

--- a/cfme/cloud/instance/ec2.py
+++ b/cfme/cloud/instance/ec2.py
@@ -1,8 +1,6 @@
-from utils import version, deferred_verpick
+# -*- coding: utf-8 -*-
 from cfme.exceptions import OptionNotAvailable
-from cfme.web_ui import fill, flash
-from cfme.fixtures import pytest_selenium as sel
-from . import Instance, select_provision_image
+from . import Instance
 
 
 class EC2Instance(Instance):
@@ -11,10 +9,7 @@ class EC2Instance(Instance):
     POWER_ON = START  # For compatibility with the infra objects.
     STOP = "Stop"
     DELETE = "Delete"
-    TERMINATE = deferred_verpick({
-        version.LOWEST: 'Terminate',
-        '5.6.1': 'Delete',
-    })
+    TERMINATE = 'Delete'
     # CFME-only power control options
     SOFT_REBOOT = "Soft Reboot"
     # Provider-only power control options
@@ -40,51 +35,18 @@ class EC2Instance(Instance):
             'on': [self.START],
             'off': [self.STOP, self.SOFT_REBOOT]}
 
-    def create(self, email=None, first_name=None, last_name=None, availability_zone=None,
-               security_groups=None, instance_type=None, guest_keypair=None, cancel=False,
-               **prov_fill_kwargs):
+    def create(self, cancel=False, **prov_fill_kwargs):
         """Provisions an EC2 instance with the given properties through CFME
 
         Args:
-            email: Email of the requester
-            first_name: Name of the requester
-            last_name: Surname of the requester
-            availability_zone: Name of the zone the instance should belong to
-            security_groups: List of security groups the instance should belong to
-                             (currently, only the first one will be used)
-            instance_type: Type of the instance
-            guest_keypair: Name of the key pair used to access the instance
             cancel: Clicks the cancel button if `True`, otherwise clicks the submit button
                     (Defaults to `False`)
+            prov_fill_kwargs: dictionary of provisioning field/value pairs
         Note:
             For more optional keyword arguments, see
-            :py:data:`cfme.cloud.provisioning.provisioning_form`
+            :py:data:`cfme.cloud.provisioning.ProvisioningForm`
         """
-        from cfme.provisioning import provisioning_form
-        # Nav to provision form and select image
-        select_provision_image(template_name=self.template_name, provider=self.provider)
-
-        fill(provisioning_form, dict(
-            email=email,
-            first_name=first_name,
-            last_name=last_name,
-            instance_name=self.name,
-            availability_zone=availability_zone,
-            # not supporting multiselect now, just take first value
-            security_groups=security_groups,
-            instance_type=instance_type,
-            guest_keypair=guest_keypair,
-            **prov_fill_kwargs
-        ))
-
-        if cancel:
-            sel.click(provisioning_form.cancel_button)
-            flash.assert_success_message(
-                "Add of new VM Provision Request was cancelled by the user")
-        else:
-            sel.click(provisioning_form.submit_button)
-            flash.assert_success_message(
-                "VM Provision Request was Submitted, you will be notified when your VMs are ready")
+        super(EC2Instance, self).create(form_values=prov_fill_kwargs, cancel=cancel)
 
     def power_control_from_provider(self, option):
         """Power control the instance from the provider

--- a/cfme/cloud/instance/gce.py
+++ b/cfme/cloud/instance/gce.py
@@ -1,8 +1,7 @@
-from utils import version, deferred_verpick
+# -*- coding: utf-8 -*-
 from cfme.exceptions import OptionNotAvailable
-from cfme.web_ui import fill, flash
-from cfme.fixtures import pytest_selenium as sel
-from . import Instance, select_provision_image
+from utils import version, deferred_verpick
+from . import Instance
 
 
 class GCEInstance(Instance):
@@ -40,49 +39,18 @@ class GCEInstance(Instance):
             'on': [self.START],
             'off': [self.STOP, self.SOFT_REBOOT]}
 
-    def create(self, email=None, first_name=None, last_name=None, availability_zone=None,
-               instance_type=None, cloud_network=None, boot_disk_size=None, cancel=False,
-               **prov_fill_kwargs):
+    def create(self, cancel=False, **prov_fill_kwargs):
         """Provisions an GCE instance with the given properties through CFME
 
         Args:
-            email: Email of the requester
-            first_name: Name of the requester
-            last_name: Surname of the requester
-            availability_zone: zone to deploy instance
-            cloud_network: Name of the cloud network the instance should belong to
-            instance_type: Type of the instance
-            boot_disk_size: size of root disk
             cancel: Clicks the cancel button if `True`, otherwise clicks the submit button
                     (Defaults to `False`)
+            prov_fill_kwargs: dictionary of provisioning field/value pairs
         Note:
             For more optional keyword arguments, see
-            :py:data:`cfme.cloud.provisioning.provisioning_form`
+            :py:data:`cfme.cloud.provisioning.ProvisioningForm`
         """
-        from cfme.provisioning import provisioning_form
-        # Nav to provision form and select image
-        select_provision_image(template_name=self.template_name, provider=self.provider)
-
-        fill(provisioning_form, dict(
-            email=email,
-            first_name=first_name,
-            last_name=last_name,
-            instance_name=self.name,
-            availability_zone=availability_zone,
-            instance_type=instance_type,
-            cloud_network=cloud_network,
-            boot_disk_size=boot_disk_size,
-            **prov_fill_kwargs
-        ))
-
-        if cancel:
-            sel.click(provisioning_form.cancel_button)
-            flash.assert_success_message(
-                "Add of new VM Provision Request was cancelled by the user")
-        else:
-            sel.click(provisioning_form.submit_button)
-            flash.assert_success_message(
-                "VM Provision Request was Submitted, you will be notified when your VMs are ready")
+        super(GCEInstance, self).create(form_values=prov_fill_kwargs, cancel=cancel)
 
     def power_control_from_provider(self, option):
         """Power control the instance from the provider

--- a/cfme/cloud/instance/openstack.py
+++ b/cfme/cloud/instance/openstack.py
@@ -1,8 +1,7 @@
-from utils import version, deferred_verpick
+# -*- coding: utf-8 -*-
 from cfme.exceptions import OptionNotAvailable
-from cfme.web_ui import fill, flash
-from cfme.fixtures import pytest_selenium as sel
-from . import Instance, select_provision_image
+from utils import version, deferred_verpick
+from . import Instance
 
 
 class OpenStackInstance(Instance):
@@ -50,49 +49,18 @@ class OpenStackInstance(Instance):
             'on': [self.START],
             'off': [self.SUSPEND, self.SOFT_REBOOT, self.HARD_REBOOT]}
 
-    def create(self, email=None, first_name=None, last_name=None, cloud_network=None,
-               instance_type=None, cancel=False, **prov_fill_kwargs):
+    def create(self, cancel=False, **prov_fill_kwargs):
         """Provisions an OpenStack instance with the given properties through CFME
 
         Args:
-            email: Email of the requester
-            first_name: Name of the requester
-            last_name: Surname of the requester
-            cloud_network: Name of the cloud network the instance should belong to
-            instance_type: Type of the instance
             cancel: Clicks the cancel button if `True`, otherwise clicks the submit button
                     (Defaults to `False`)
+            prov_fill_kwargs: dictionary of provisioning field/value pairs
         Note:
             For more optional keyword arguments, see
-            :py:data:`cfme.cloud.provisioning.provisioning_form`
+            :py:data:`cfme.cloud.provisioning.ProvisioningForm`
         """
-        from cfme.provisioning import provisioning_form
-        # Nav to provision form and select image
-        select_provision_image(template_name=self.template_name, provider=self.provider)
-
-        # not supporting multiselect now, just take first value
-        security_groups = prov_fill_kwargs.pop('security_groups', None)
-        if security_groups:
-            prov_fill_kwargs['security_groups'] = security_groups[0]
-
-        fill(provisioning_form, dict(
-            email=email,
-            first_name=first_name,
-            last_name=last_name,
-            instance_name=self.name,
-            instance_type=instance_type,
-            cloud_network=cloud_network,
-            **prov_fill_kwargs
-        ))
-
-        if cancel:
-            sel.click(provisioning_form.cancel_button)
-            flash.assert_success_message(
-                "Add of new VM Provision Request was cancelled by the user")
-        else:
-            sel.click(provisioning_form.submit_button)
-            flash.assert_success_message(
-                "VM Provision Request was Submitted, you will be notified when your VMs are ready")
+        super(OpenStackInstance, self).create(form_values=prov_fill_kwargs, cancel=cancel)
 
     def power_control_from_provider(self, option):
         """Power control the instance from the provider

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -446,11 +446,11 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable, SummaryMixin
 
         Args:
             timeout: time (in seconds) to wait for it to appear
-            from_details: when found, should it load the vm details
+            load_details: when found, should it load the vm details
         """
         wait_for(
             lambda: self.exists,
-            num_sec=timeout, delay=30, fail_func=sel.refresh,
+            num_sec=timeout, delay=30, fail_func=self.provider.refresh_provider_relationships,
             message="wait for vm to appear")
         if load_details:
             self.load_details()
@@ -662,6 +662,7 @@ class VM(BaseVM):
                 :py:class:`datetime.datetime` or :py:class:`utils.timeutil.parsetime`.
             warn: When to warn, fills the select in the form in case the ``when`` is specified.
         """
+        # TODO: refactor for retirement nav destinations and widget form fill when child classes
         self.load_details()
         lcl_btn("Set Retirement Date")
         if callable(self.retire_form.date_retire):

--- a/cfme/provisioning.py
+++ b/cfme/provisioning.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from collections import OrderedDict
 
-from widgetastic.widget import View
+from widgetastic.widget import View, Checkbox
 from widgetastic_patternfly import Tab, BootstrapSelect, Input, BootstrapTreeview
 from widgetastic_manageiq import VersionPick, Version, CheckboxSelect, Table, Calendar
 
@@ -62,7 +62,7 @@ class ProvisioningForm(BaseLoggedInPage):
     class environment(Tab):  # noqa
         TAB_NAME = 'Environment'
 
-        automatic_placement = Input(name='environment__placement_auto')
+        automatic_placement = Checkbox(id='environment__placement_auto')
         # Cloud
         availability_zone = BootstrapSelect('environment__placement_availability_zone')
         cloud_network = BootstrapSelect('environment__cloud_network')

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -15,14 +15,12 @@ from utils.log import logger
 from utils.wait import wait_for, TimedOutError, RefreshTimer
 
 
-def pytest_generate_tests(metafunc):
-    argnames, argvalues, idlist = testgen.providers_by_class(
-        metafunc, [CloudProvider],
-        required_fields=[('test_power_control', True)])
-    testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope="function")
+pytest_generate_tests = testgen.generate([CloudProvider], scope='function',
+                                         required_fields=['test_power_control'])
 
-
-pytestmark = [pytest.mark.tier(2), pytest.mark.long_running, test_requirements.power]
+pytestmark = [pytest.mark.tier(2),
+              pytest.mark.long_running,
+              test_requirements.power]
 
 
 @pytest.yield_fixture(scope="function")
@@ -37,9 +35,7 @@ def testing_instance(setup_provider, provider):
         provider.mgmt.set_name(
             instance.name, 'test_terminated_{}'.format(fauxfactory.gen_alphanumeric(8)))
         instance.create_on_provider(allow_skip="default", find_in_cfme=True)
-
     provider.refresh_provider_relationships()
-    instance.wait_to_appear()
 
     yield instance
 

--- a/cfme/tests/cloud/test_provisioning.py
+++ b/cfme/tests/cloud/test_provisioning.py
@@ -3,6 +3,7 @@
 # in selenium (the group is selected then immediately reset)
 import fauxfactory
 import pytest
+from riggerlib import recursive_update
 
 from textwrap import dedent
 
@@ -30,7 +31,7 @@ pytest_generate_tests = testgen.generate(
     [CloudProvider], required_fields=[['provisioning', 'image']], scope="function")
 
 
-@pytest.fixture(scope="function")
+@pytest.yield_fixture(scope="function")
 def testing_instance(request, setup_provider, provider, provisioning, vm_name):
     """ Fixture to prepare instance parameters for provisioning
     """
@@ -40,62 +41,91 @@ def testing_instance(request, setup_provider, provider, provisioning, vm_name):
 
     instance = Instance.factory(vm_name, provider, image)
 
-    request.addfinalizer(instance.delete_from_provider)
+    inst_args = dict()
 
-    inst_args = {
+    # Base instance info
+    inst_args['request'] = {
         'email': 'image_provisioner@example.com',
         'first_name': 'Image',
         'last_name': 'Provisioner',
         'notes': note,
     }
     # TODO Move this into helpers on the provider classes
-    if not isinstance(provider, AzureProvider):
-        inst_args['instance_type'] = provisioning['instance_type']
-        inst_args['availability_zone'] = provisioning['availability_zone']
-        inst_args['security_groups'] = provisioning['security_group']
-        inst_args['guest_keypair'] = provisioning['guest_keypair']
 
-    if isinstance(provider, OpenStackProvider):
-        inst_args['cloud_network'] = provisioning['cloud_network']
+    recursive_update(inst_args, {'catalog': {'vm_name': vm_name}})
 
-    if isinstance(provider, GCEProvider):
-        inst_args['cloud_network'] = provisioning['cloud_network']
-        inst_args['boot_disk_size'] = provisioning['boot_disk_size']
-        inst_args['is_preemtible'] = True if current_version() >= "5.7" else None
-
-    if isinstance(provider, AzureProvider):
-        inst_args['cloud_network'] = provisioning['virtual_net']
-        inst_args['cloud_subnet'] = provisioning['subnet_range']
-        inst_args['security_groups'] = provisioning['network_nsg']
-        inst_args['resource_groups'] = provisioning['resource_group']
-        inst_args['instance_type'] = provisioning['vm_size'].lower()
-        inst_args['admin_username'] = provisioning['vm_user']
-        inst_args['admin_password'] = provisioning['vm_password']
-
+    # Check whether auto-selection of environment is passed
     try:
         auto = request.param
-        if auto:
-            inst_args['automatic_placement'] = True
-            inst_args['availability_zone'] = None
-            inst_args['virtual_private_cloud'] = None
-            inst_args['cloud_network'] = None
-            inst_args['cloud_subnet'] = None
-            inst_args['security_groups'] = None
-            inst_args['resource_groups'] = None
-            inst_args['public_ip_address'] = None
     except AttributeError:
         # in case nothing was passed just skip
-        pass
-    return instance, inst_args, image
+        auto = False
+
+    # All providers other than Azure
+    if not isinstance(provider, AzureProvider):
+        recursive_update(inst_args, {
+            'properties': {
+                'instance_type': provisioning['instance_type'],
+                'guest_keypair': provisioning['guest_keypair']},
+            'environment': {
+                'availability_zone': None if auto else provisioning['availability_zone'],
+                'security_groups': None if auto else provisioning['security_group'],
+                'automatic_placement': auto
+            }
+        })
+
+    # Openstack specific
+    if isinstance(provider, OpenStackProvider):
+        recursive_update(inst_args, {
+            'environment': {
+                'cloud_network': None if auto else provisioning['cloud_network']
+            }
+        })
+
+    # GCE specific
+    if isinstance(provider, GCEProvider):
+        recursive_update(inst_args, {
+            'environment': {
+                'cloud_network': None if auto else provisioning['cloud_network']
+            },
+            'properties': {
+                'boot_disk_size': provisioning['boot_disk_size'],
+                'is_preemptible': True if current_version() >= "5.7" else None}
+        })
+
+    # Azure specific
+    if isinstance(provider, AzureProvider):
+        # Azure uses different provisioning keys for some reason
+        recursive_update(inst_args, {
+            'environment': {
+                'cloud_network': None if auto else provisioning['virtual_net'],
+                'cloud_subnet': None if auto else provisioning['subnet_range'],
+                'security_groups': None if auto else [provisioning['network_nsg']],
+                'resource_groups': None if auto else provisioning['resource_group']
+            },
+            'properties': {
+                'instance_type': provisioning['vm_size'].lower()},
+            'customize': {
+                'admin_username': provisioning['vm_user'],
+                'admin_password': provisioning['vm_password']}})
+
+    yield instance, inst_args, image
+
+    try:
+        if instance.does_vm_exist_on_provider():
+            instance.delete_from_provider()
+    except Exception as ex:
+        logger.warning('Exception while deleting instance fixture, continuing: {}'
+                       .format(ex.message))
 
 
 @pytest.fixture(scope="function")
-def vm_name(request, provider):
+def vm_name(request):
     return random_vm_name('prov')
 
 
 @pytest.mark.parametrize('testing_instance', [True, False], ids=["Auto", "Manual"], indirect=True)
-def test_provision_from_template(request, setup_provider, provider, testing_instance, soft_assert):
+def test_provision_from_template(provider, testing_instance, soft_assert):
     """ Tests instance provision from template
 
     Metadata:
@@ -128,9 +158,10 @@ def test_provision_from_template(request, setup_provider, provider, testing_inst
     soft_assert(instance.does_vm_exist_on_provider(), "Instance wasn't provisioned")
 
 
-@pytest.mark.uncollectif(lambda provider: provider.type != 'gce' or current_version() < "5.7")
-def test_gce_preemtible_provision(request, setup_provider, provider, testing_instance, soft_assert):
-    instance, inst_args = testing_instance
+@pytest.mark.uncollectif(lambda provider: not provider.one_of(GCEProvider) or
+                         current_version() < "5.7")
+def test_gce_preemtible_provision(provider, testing_instance, soft_assert):
+    instance, inst_args, image = testing_instance
     instance.create(**inst_args)
     instance.wait_to_appear(timeout=800)
     provider.refresh_provider_relationships()
@@ -400,25 +431,26 @@ def copy_domains(original_request_class, domain):
 # Not collected for EC2 in generate_tests above
 @pytest.mark.meta(blockers=[1152737])
 @pytest.mark.parametrize("disks", [1, 2])
-@pytest.mark.uncollectif(lambda provider: provider.type != 'openstack')
-def test_provision_from_template_with_attached_disks(
-        request, setup_provider, provider, vm_name, provisioning,
-        disks, soft_assert, domain, modified_request_class, copy_domains):
+@pytest.mark.uncollectif(lambda provider: not provider.one_of(OpenStackProvider))
+def test_provision_from_template_with_attached_disks(request, testing_instance, provider, disks,
+                                                     soft_assert, domain, modified_request_class,
+                                                     copy_domains, provisioning):
     """ Tests provisioning from a template and attaching disks
 
     Metadata:
         test_flag: provision
     """
-    image = provisioning['image']['name']
-    note = ('Testing provisioning from image {} to vm {} on provider {}'.format(
-        image, vm_name, provider.key))
+    instance, inst_args, image = testing_instance
+    # Modify availiability_zone for Azure provider
+    if provider.one_of(AzureProvider):
+        recursive_update(inst_args, {'environment': {'availability_zone': provisioning("av_set")}})
 
-    DEVICE_NAME = "/dev/sd{}"
+    device_name = "/dev/sd{}"
     device_mapping = []
 
     with provider.mgmt.with_volumes(1, n=disks) as volumes:
         for i, volume in enumerate(volumes):
-            device_mapping.append((volume, DEVICE_NAME.format(chr(ord("b") + i))))
+            device_mapping.append((volume, device_name.format(chr(ord("b") + i))))
         # Set up automate
 
         method = modified_request_class.methods.instantiate(name="openstack_PreProvision")
@@ -433,22 +465,6 @@ def test_provision_from_template_with_attached_disks(
             with update(method):
                 method.script = """prov = $evm.root["miq_provision"]"""
         request.addfinalizer(_finish_method)
-        instance = Instance.factory(vm_name, provider, image)
-        request.addfinalizer(instance.delete_from_provider)
-        inst_args = {
-            'email': 'image_provisioner@example.com',
-            'first_name': 'Image',
-            'last_name': 'Provisioner',
-            'notes': note,
-            'instance_type': provisioning['instance_type'],
-            "availability_zone": provisioning["availability_zone"] if provider.type != "azure" else
-            provisioning["av_set"],
-            'security_groups': [provisioning['security_group']],
-            'guest_keypair': provisioning['guest_keypair']
-        }
-
-        if isinstance(provider, OpenStackProvider):
-            inst_args['cloud_network'] = provisioning['cloud_network']
 
         instance.create(**inst_args)
 
@@ -462,17 +478,15 @@ def test_provision_from_template_with_attached_disks(
 
 # Not collected for EC2 in generate_tests above
 @pytest.mark.meta(blockers=[1160342])
-@pytest.mark.uncollectif(lambda provider: provider.type != 'openstack')
-def test_provision_with_boot_volume(request, setup_provider, provider, vm_name,
-        soft_assert, domain, copy_domains, provisioning, modified_request_class):
+@pytest.mark.uncollectif(lambda provider: not provider.one_of(OpenStackProvider))
+def test_provision_with_boot_volume(request, testing_instance, provider, soft_assert, copy_domains,
+                                    modified_request_class):
     """ Tests provisioning from a template and attaching one booting volume.
 
     Metadata:
         test_flag: provision, volumes
     """
-    image = provisioning['image']['name']
-    note = ('Testing provisioning from image {} to vm {} on provider {}'.format(
-        image, vm_name, provider.key))
+    instance, inst_args, image = testing_instance
 
     with provider.mgmt.with_volume(1, imageRef=provider.mgmt.get_template_id(image)) as volume:
         # Set up automate
@@ -498,21 +512,6 @@ def test_provision_with_boot_volume(request, setup_provider, provider, vm_name,
         def _finish_method():
             with update(method):
                 method.script = """prov = $evm.root["miq_provision"]"""
-        instance = Instance.factory(vm_name, provider, image)
-        request.addfinalizer(instance.delete_from_provider)
-        inst_args = {
-            'email': 'image_provisioner@example.com',
-            'first_name': 'Image',
-            'last_name': 'Provisioner',
-            'notes': note,
-            'instance_type': provisioning['instance_type'],
-            "availability_zone": provisioning["availability_zone"],
-            'security_groups': [provisioning['security_group']],
-            'guest_keypair': provisioning['guest_keypair']
-        }
-
-        if isinstance(provider, OpenStackProvider):
-            inst_args['cloud_network'] = provisioning['cloud_network']
 
         instance.create(**inst_args)
 
@@ -524,18 +523,16 @@ def test_provision_with_boot_volume(request, setup_provider, provider, vm_name,
 
 # Not collected for EC2 in generate_tests above
 @pytest.mark.meta(blockers=[1186413])
-@pytest.mark.uncollectif(lambda provider: provider.type != 'openstack')
-def test_provision_with_additional_volume(request, setup_provider, provider, vm_name,
-        soft_assert, copy_domains, domain, provisioning, modified_request_class):
+@pytest.mark.uncollectif(lambda provider: not provider.one_of(OpenStackProvider))
+def test_provision_with_additional_volume(request, testing_instance, provider, soft_assert,
+                                          copy_domains, domain, modified_request_class):
     """ Tests provisioning with setting specific image from AE and then also making it create and
     attach an additional 3G volume.
 
     Metadata:
         test_flag: provision, volumes
     """
-    image = provisioning['image']['name']
-    note = ('Testing provisioning from image {} to vm {} on provider {}'.format(
-        image, vm_name, provider.key))
+    instance, inst_args, image = testing_instance
 
     # Set up automate
     method = modified_request_class.methods.instantiate(name="openstack_CustomizeRequest")
@@ -565,21 +562,6 @@ def test_provision_with_additional_volume(request, setup_provider, provider, vm_
         with update(method):
             method.script = """prov = $evm.root["miq_provision"]"""
     request.addfinalizer(_finish_method)
-    instance = Instance.factory(vm_name, provider, image)
-    request.addfinalizer(instance.delete_from_provider)
-    inst_args = {
-        'email': 'image_provisioner@example.com',
-        'first_name': 'Image',
-        'last_name': 'Provisioner',
-        'notes': note,
-        'instance_type': provisioning['instance_type'],
-        "availability_zone": provisioning["availability_zone"],
-        'security_groups': [provisioning['security_group']],
-        'guest_keypair': provisioning['guest_keypair']
-    }
-
-    if isinstance(provider, OpenStackProvider):
-        inst_args['cloud_network'] = provisioning['cloud_network']
 
     instance.create(**inst_args)
 


### PR DESCRIPTION
Convert the cloud instances class to widgetastic by defining new views and widgets.

Part 1 here provides All, AllForProvider, Details, and Provisioning views and widgets.

I have a lot more code ready to follow this for the other instance pages.

Local testing works for the destinations/widgets added, along with the 2 modified tests. Will update with PRT results > 12214

{{ pytest: cfme/tests/cloud/test_instance_power_control.py cfme/tests/cloud/test_provisioning.py --use-provider ec2west --use-provider gce_central --long-running -v -k "not RESTAPI" }}

## PRT Results
Run 12979 - 92% pass rate or better, 2 failing tests in 57z and 1 failing test in 58z. Not at all related to these changes.

Rebased recently, PRT re-running.