### PR TITLE
[1LP][RFR] Smart Management test

### DIFF
--- a/cfme/tests/containers/test_smart_management.py
+++ b/cfme/tests/containers/test_smart_management.py
@@ -75,6 +75,7 @@ def test_smart_management_add_tag(provider, test_item):
 
     # validate no tag set to project
     obj_inst = obj_factory(test_item.obj, chosen_row, provider)
+
     regex = r"([\w\s|\-|\*]+:([\w\s|\-|\*])+)|(No.*assigned)"
     try:
         # Remove all previous configured tags for given object
@@ -96,8 +97,8 @@ def test_smart_management_add_tag(provider, test_item):
     actual_tags_on_instance = obj_inst.get_tags()
 
     # Validate tag seted successfully
-    assert len(actual_tags_on_instance) == 1, \
-        "Fail to set a tag for {type}".format(type=test_item.obj.__module__.title().split(".")[-1])
+    assert len(actual_tags_on_instance) == 1, "Fail to set a tag for {obj_type}".format(
+        obj_type=test_item.obj.__module__.title().split(".")[-1])
     actual_tags_on_instance = actual_tags_on_instance.pop()
 
     # Validate tag value

--- a/cfme/tests/containers/test_smart_management.py
+++ b/cfme/tests/containers/test_smart_management.py
@@ -13,6 +13,7 @@ from cfme.containers.pod import Pod
 from cfme.containers.template import Template
 from cfme.containers.provider import navigate_and_get_rows
 import random
+import re
 
 pytestmark = [
     pytest.mark.uncollectif(
@@ -77,11 +78,20 @@ def test_smart_management_add_tag(provider, test_item):
     # validate no tag set to project
     obj_inst = obj_factory(test_item.obj, chosen_row, provider)
 
+    # Validate old tags formating (my not do anything besause no tag was set)
+    regex = r"(\w+:([\w\s|\-|\*])+)|(No.*assigned)"
+    assert re.match(regex, obj_inst.summary.smart_management.my_company_tags.text_value), \
+        "Tag formmting is invalid!"
+
     # Remove all previous configured tags for given object
     obj_inst.remove_tags(obj_inst.get_tags())
 
     # Config random tag for object\
     random_tag_setted = set_random_tag(obj_inst)
+
+    # validate new tag format
+    assert re.match(regex, obj_inst.summary.smart_management.my_company_tags.text_value), \
+        "Tag formmting is invalid!"
     actual_tags_on_instance = obj_inst.get_tags()
 
     # Validate tag seted successfully

--- a/cfme/tests/containers/test_smart_management.py
+++ b/cfme/tests/containers/test_smart_management.py
@@ -52,6 +52,8 @@ def set_random_tag(instance):
     return Tag(display_name=random_tag.text, category=random_cat.text)
 
 
+get_object_name = lambda obj:obj.__module__.title().split(".")[-1]
+
 def obj_factory(obj_creator, row, provider):
 
     factory = {"Provider": lambda row: {"name": row.name.text},
@@ -63,11 +65,11 @@ def obj_factory(obj_creator, row, provider):
                                      "tag": row.tag.text, "provider": provider},
                "Image_Registry": lambda row: {"host": row.host.text, "provider": provider}}
 
-    return obj_creator(**factory[obj_creator.__module__.title().split(".")[-1]](row))
+    return obj_creator(**factory[get_object_name(obj_creator)](row))
 
 
 @pytest.mark.parametrize('test_item',
-                         TEST_ITEMS, ids=[testItem.args[1].pretty_id() for testItem in TEST_ITEMS])
+                         TEST_ITEMS, ids=[test_item.args[1].pretty_id() for test_item in TEST_ITEMS])
 def test_smart_management_add_tag(provider, test_item):
 
     # Select random instanse from instanse table
@@ -98,7 +100,7 @@ def test_smart_management_add_tag(provider, test_item):
 
     # Validate tag seted successfully
     assert len(actual_tags_on_instance) == 1, "Fail to set a tag for {obj_type}".format(
-        obj_type=test_item.obj.__module__.title().split(".")[-1])
+        obj_type=get_object_name(test_item))
     actual_tags_on_instance = actual_tags_on_instance.pop()
 
     # Validate tag value

--- a/cfme/tests/containers/test_smart_management.py
+++ b/cfme/tests/containers/test_smart_management.py
@@ -32,6 +32,10 @@ TEST_ITEMS = [
 ]
 
 
+def get_object_name(obj):
+    return obj.__module__.title().split(".")[-1]
+
+
 def set_random_tag(instance):
     navigate_to(instance, 'Details')
     toolbar.select('Policy', 'Edit Tags')
@@ -52,8 +56,6 @@ def set_random_tag(instance):
     return Tag(display_name=random_tag.text, category=random_cat.text)
 
 
-get_object_name = lambda obj:obj.__module__.title().split(".")[-1]
-
 def obj_factory(obj_creator, row, provider):
 
     factory = {"Provider": lambda row: {"name": row.name.text},
@@ -69,7 +71,7 @@ def obj_factory(obj_creator, row, provider):
 
 
 @pytest.mark.parametrize('test_item',
-                         TEST_ITEMS, ids=[test_item.args[1].pretty_id() for test_item in TEST_ITEMS])
+                         TEST_ITEMS, ids=[item.args[1].pretty_id() for item in TEST_ITEMS])
 def test_smart_management_add_tag(provider, test_item):
 
     # Select random instanse from instanse table
@@ -100,7 +102,7 @@ def test_smart_management_add_tag(provider, test_item):
 
     # Validate tag seted successfully
     assert len(actual_tags_on_instance) == 1, "Fail to set a tag for {obj_type}".format(
-        obj_type=get_object_name(test_item))
+        obj_type=get_object_name(test_item.obj))
     actual_tags_on_instance = actual_tags_on_instance.pop()
 
     # Validate tag value

--- a/cfme/tests/containers/test_smart_management.py
+++ b/cfme/tests/containers/test_smart_management.py
@@ -22,27 +22,13 @@ pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
 
 
 TEST_ITEMS = [
-    pytest.mark.polarion('CMP-10320')(
-        ContainersTestItem(Template, 'CMP-10320')
-    ),
-    pytest.mark.polarion('CMP-9992')(
-        ContainersTestItem(ImageRegistry, 'CMP-9992')
-    ),
-    pytest.mark.polarion('CMP-9981')(
-        ContainersTestItem(Image, 'CMP-9981')
-    ),
-    pytest.mark.polarion('CMP-9964')(
-        ContainersTestItem(Node, 'CMP-9964')
-    ),
-    pytest.mark.polarion('CMP-9932')(
-        ContainersTestItem(Pod, 'CMP-9932')
-    ),
-    pytest.mark.polarion('CMP-9870')(
-        ContainersTestItem(Project, 'CMP-9870')
-    ),
-    pytest.mark.polarion('CMP-9854')(
-        ContainersTestItem(ContainersProvider, 'CMP-9854')
-    )
+    pytest.mark.polarion('CMP-10320')(ContainersTestItem(Template, 'CMP-10320', additinal_params={})),
+    pytest.mark.polarion('CMP-9992')(ContainersTestItem(ImageRegistry, 'CMP-9992', additinal_params={})),
+    pytest.mark.polarion('CMP-9981')(ContainersTestItem(Image, 'CMP-9981', additinal_params={"tag":None})),
+    pytest.mark.polarion('CMP-9964')(ContainersTestItem(Node, 'CMP-9964', additinal_params={})),
+    pytest.mark.polarion('CMP-9932')(ContainersTestItem(Pod, 'CMP-9932', additinal_params={})),
+    pytest.mark.polarion('CMP-9870')(ContainersTestItem(Project, 'CMP-9870', additinal_params={})),
+    pytest.mark.polarion('CMP-9854')(ContainersTestItem(ContainersProvider, 'CMP-9854', additinal_params={}))
 ]
 
 
@@ -60,7 +46,7 @@ def set_random_tag(instance):
     random_tag = random.choice(tag_selector.all_options).text
     tag_selector.select_by_visible_text(random_tag)
 
-    # Save tog configuration
+    # Save tag conig
     form_buttons.save()
 
     return Tag(display_name=random_tag, category=random_cat)
@@ -72,18 +58,19 @@ def test_smart_management_add_tag(provider, test_item):
 
     # Select random project
     navigate_to(test_item.obj, 'All')
+    toolbar.select('List View')
     chosen_row = random.choice(paged_tbl.rows_as_list())
 
     # validate no tag set to project
-    obj_inst = test_item.obj(chosen_row.name.text, provider)
+    obj_inst = test_item.obj(name=chosen_row.name.text, provider=provider, **test_item.additinal_params)
 
     # Remove all previous configured tags for given object
     obj_inst.remove_tags(obj_inst.get_tags())
 
     # Config random tag for object
-    random_sag_setted = set_random_tag(obj_inst)
+    random_tag_setted = set_random_tag(obj_inst)
     actual_tags_on_instance = obj_inst.get_tags().pop()
 
     # Validate tag configuration
-    assert actual_tags_on_instance.display_name == random_sag_setted.display_name, \
+    assert actual_tags_on_instance.display_name == random_tag_setted.display_name, \
         "Display name not correctly configured"

--- a/cfme/tests/containers/test_smart_management.py
+++ b/cfme/tests/containers/test_smart_management.py
@@ -1,0 +1,89 @@
+import pytest
+from utils import testgen
+from utils.appliance.implementations.ui import navigate_to
+from utils.version import current_version
+from cfme.web_ui import toolbar, AngularSelect, form_buttons
+from cfme.configure.configuration import Tag
+from cfme.containers.provider import ContainersProvider, ContainersTestItem
+from cfme.containers.image import Image
+from cfme.containers.project import Project, paged_tbl
+from cfme.containers.node import Node
+from cfme.containers.image_registry import ImageRegistry
+from cfme.containers.pod import Pod
+from cfme.containers.template import Template
+import random
+
+pytestmark = [
+    pytest.mark.uncollectif(
+        lambda: current_version() < "5.6"),
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.tier(1)]
+pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
+
+
+TEST_ITEMS = [
+    pytest.mark.polarion('CMP-10320')(
+        ContainersTestItem(Template, 'CMP-10320')
+    ),
+    pytest.mark.polarion('CMP-9992')(
+        ContainersTestItem(ImageRegistry, 'CMP-9992')
+    ),
+    pytest.mark.polarion('CMP-9981')(
+        ContainersTestItem(Image, 'CMP-9981')
+    ),
+    pytest.mark.polarion('CMP-9964')(
+        ContainersTestItem(Node, 'CMP-9964')
+    ),
+    pytest.mark.polarion('CMP-9932')(
+        ContainersTestItem(Pod, 'CMP-9932')
+    ),
+    pytest.mark.polarion('CMP-9870')(
+        ContainersTestItem(Project, 'CMP-9870')
+    ),
+    pytest.mark.polarion('CMP-9854')(
+        ContainersTestItem(ContainersProvider, 'CMP-9854')
+    )
+]
+
+
+def set_random_tag(instance):
+    navigate_to(instance, 'Details')
+    toolbar.select('Policy', 'Edit Tags')
+
+    # select random tag category
+    cat_selector = AngularSelect("tag_cat")
+    random_cat = random.choice(cat_selector.all_options).text
+    cat_selector.select_by_visible_text(random_cat)
+
+    # select random tag tag
+    tag_selector = AngularSelect("tag_add")
+    random_tag = random.choice(tag_selector.all_options).text
+    tag_selector.select_by_visible_text(random_tag)
+
+    # Save tog configuration
+    form_buttons.save()
+
+    return Tag(display_name=random_tag, category=random_cat)
+
+
+@pytest.mark.parametrize('test_item',
+                         TEST_ITEMS, ids=[testItem.args[1].pretty_id() for testItem in TEST_ITEMS])
+def test_smart_management_add_tag(provider, test_item):
+
+    # Select random project
+    navigate_to(test_item.obj, 'All')
+    chosen_row = random.choice(paged_tbl.rows_as_list())
+
+    # validate no tag set to project
+    obj_inst = test_item.obj(chosen_row.name.text, provider)
+
+    # Remove all previous configured tags for given object
+    obj_inst.remove_tags(obj_inst.get_tags())
+
+    # Config random tag for object
+    random_sag_setted = set_random_tag(obj_inst)
+    actual_tags_on_instance = obj_inst.get_tags().pop()
+
+    # Validate tag configuration
+    assert actual_tags_on_instance.display_name == random_sag_setted.display_name, \
+        "Display name not correctly configured"

--- a/cfme/tests/containers/test_smart_management.py
+++ b/cfme/tests/containers/test_smart_management.py
@@ -11,6 +11,7 @@ from cfme.containers.node import Node
 from cfme.containers.image_registry import ImageRegistry
 from cfme.containers.pod import Pod
 from cfme.containers.template import Template
+from cfme.containers.provider import navigate_and_get_rows
 import random
 
 pytestmark = [
@@ -22,13 +23,13 @@ pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
 
 
 TEST_ITEMS = [
-    pytest.mark.polarion('CMP-10320')(ContainersTestItem(Template, 'CMP-10320', additinal_params={})),
-    pytest.mark.polarion('CMP-9992')(ContainersTestItem(ImageRegistry, 'CMP-9992', additinal_params={})),
-    pytest.mark.polarion('CMP-9981')(ContainersTestItem(Image, 'CMP-9981', additinal_params={"tag":None})),
-    pytest.mark.polarion('CMP-9964')(ContainersTestItem(Node, 'CMP-9964', additinal_params={})),
-    pytest.mark.polarion('CMP-9932')(ContainersTestItem(Pod, 'CMP-9932', additinal_params={})),
-    pytest.mark.polarion('CMP-9870')(ContainersTestItem(Project, 'CMP-9870', additinal_params={})),
-    pytest.mark.polarion('CMP-9854')(ContainersTestItem(ContainersProvider, 'CMP-9854', additinal_params={}))
+    #pytest.mark.polarion('CMP-10320')(ContainersTestItem(Template, 'CMP-10320')),
+    #pytest.mark.polarion('CMP-9992')(ContainersTestItem(ImageRegistry,'CMP-9992')),
+    pytest.mark.polarion('CMP-9981')(ContainersTestItem(Image, 'CMP-9981'))#,
+    #pytest.mark.polarion('CMP-9964')(ContainersTestItem(Node, 'CMP-9964')),
+    #pytest.mark.polarion('CMP-9932')(ContainersTestItem(Pod,'CMP-9932')),
+    #pytest.mark.polarion('CMP-9870')(ContainersTestItem(Project, 'CMP-9870')),
+    #pytest.mark.polarion('CMP-9854')(ContainersTestItem(ContainersProvider, 'CMP-9854'))
 ]
 
 
@@ -38,39 +39,62 @@ def set_random_tag(instance):
 
     # select random tag category
     cat_selector = AngularSelect("tag_cat")
-    random_cat = random.choice(cat_selector.all_options).text
-    cat_selector.select_by_visible_text(random_cat)
+    random_cat = random.choice(cat_selector.all_options)
+    print "Random cat: {cat}".format(cat=random_cat.text)
+    cat_selector.select_by_value(random_cat.value)
 
     # select random tag tag
     tag_selector = AngularSelect("tag_add")
-    random_tag = random.choice(tag_selector.all_options).text
-    tag_selector.select_by_visible_text(random_tag)
+    random_tag = random.choice(filter(lambda op: op.value != "select", tag_selector.all_options))
+    print "Random tag: {tag}".format(tag=random_tag)
+    tag_selector.select_by_value(random_tag.value)
 
     # Save tag conig
     form_buttons.save()
 
-    return Tag(display_name=random_tag, category=random_cat)
+    return Tag(display_name=random_tag.text, category=random_cat.text)
+
+def objFactory(Type, row, provider):
+
+    factory = {"Provider": {"name": row.name.text},
+               "Project": {"name": row.name.text, "provider": provider},
+               "Pod": {"name": row.name.text, "provider": provider},
+               "Node": {"name": row.name.text, "provider": provider},
+               "Template": {"name": row.name.text, "provider": provider},
+               "Image": {"name": row.name.text, "provider": provider, "tag": row.tag},
+               "Image_Registry": {"host": row.name.text, "provider": provider}}
+    return Type(**factory[Type.__module__.title().split(".")[-1]])
 
 
 @pytest.mark.parametrize('test_item',
                          TEST_ITEMS, ids=[testItem.args[1].pretty_id() for testItem in TEST_ITEMS])
 def test_smart_management_add_tag(provider, test_item):
 
+
     # Select random project
-    navigate_to(test_item.obj, 'All')
-    toolbar.select('List View')
-    chosen_row = random.choice(paged_tbl.rows_as_list())
+    #navigate_to(test_item.obj, 'All')
+    #toolbar.select('List View')
+    #chosen_row = random.choice(paged_tbl.rows_as_list())
+
+    chosen_row = navigate_and_get_rows(provider, test_item.obj, 1).pop()
 
     # validate no tag set to project
-    obj_inst = test_item.obj(name=chosen_row.name.text, provider=provider, **test_item.additinal_params)
-
+    obj_inst = objFactory(test_item.obj, chosen_row, provider)
+    print "Chosen instance, {inst}".format(inst=chosen_row.name.text)
     # Remove all previous configured tags for given object
-    obj_inst.remove_tags(obj_inst.get_tags())
+
+    all_instance_tags = obj_inst.get_tags()
+    obj_inst.remove_tags(all_instance_tags)
 
     # Config random tag for object
     random_tag_setted = set_random_tag(obj_inst)
-    actual_tags_on_instance = obj_inst.get_tags().pop()
+    actual_tags_on_instance = obj_inst.get_tags()
 
-    # Validate tag configuration
+    # Validate tag seted successfully
+    assert len(actual_tags_on_instance) == 1, \
+        "Fail to set a tag for {type}".format(type=test_item.obj.__module__.title().split(".")[-1])
+    actual_tags_on_instance = actual_tags_on_instance.pop()
+
+    # Validate tag value
     assert actual_tags_on_instance.display_name == random_tag_setted.display_name, \
         "Display name not correctly configured"


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_smart_management.py -v --use-provider cm-env1 }}

Before the test starts the code remove all the previous smart management configuration

Add Smart management test for the following objects:
1) Template
2) Image Registry
3) Image
4) Node
5) Pod
6) Project
7) Containers Provider

The test choose random instance of object and do the following for each:
1) Navigate to smart management view
2) choose random category and tag
3) save configuration
4) verify configuration
