### PR TITLE
[1LP][RFR] remove rest_api fixture from test_tag_category

### DIFF
--- a/cfme/tests/configure/test_tag_category.py
+++ b/cfme/tests/configure/test_tag_category.py
@@ -22,67 +22,63 @@ def test_category_crud():
 
 class TestCategoriesViaREST(object):
     @pytest.fixture(scope="function")
-    def categories(self, request, rest_api):
-        response = _categories(request, rest_api, num=5)
-        assert rest_api.response.status_code == 200
+    def categories(self, request, appliance):
+        response = _categories(request, appliance.rest_api, num=5)
+        assert appliance.rest_api.response.status_code == 200
         assert len(response) == 5
         return response
 
     @pytest.mark.tier(3)
-    def test_create_categories(self, rest_api, categories):
+    def test_create_categories(self, appliance, categories):
         """Tests creating categories.
 
         Metadata:
             test_flag: rest
         """
         for ctg in categories:
-            record = rest_api.collections.categories.get(id=ctg.id)
-            assert rest_api.response.status_code == 200
+            record = appliance.rest_api.collections.categories.get(id=ctg.id)
+            assert appliance.rest_api.response.status_code == 200
             assert record.name == ctg.name
 
     @pytest.mark.tier(3)
     @pytest.mark.parametrize(
         "multiple", [False, True],
         ids=["one_request", "multiple_requests"])
-    def test_edit_categories(self, rest_api, categories, multiple):
+    def test_edit_categories(self, appliance, categories, multiple):
         """Tests editing categories.
 
         Metadata:
             test_flag: rest
         """
+        collection = appliance.rest_api.collections.categories
+        categories_len = len(categories)
+        new = []
+        for _ in range(categories_len):
+            new.append(
+                {'description': 'test_category_{}'.format(fauxfactory.gen_alphanumeric().lower())})
         if multiple:
-            new_descriptions = []
-            ctgs_data_edited = []
-            for ctg in categories:
-                new_description = "test_category_{}".format(fauxfactory.gen_alphanumeric().lower())
-                new_descriptions.append(new_description)
-                ctg.reload()
-                ctgs_data_edited.append({
-                    "href": ctg.href,
-                    "description": new_description,
-                })
-            rest_api.collections.categories.action.edit(*ctgs_data_edited)
-            assert rest_api.response.status_code == 200
-            for new_description in new_descriptions:
-                wait_for(
-                    lambda: rest_api.collections.categories.find_by(description=new_description),
-                    num_sec=180,
-                    delay=10,
-                )
+            for index in range(categories_len):
+                new[index].update(categories[index]._ref_repr())
+            edited = collection.action.edit(*new)
+            assert appliance.rest_api.response.status_code == 200
         else:
-            ctg = rest_api.collections.categories.get(description=categories[0].description)
-            new_description = "test_category_{}".format(fauxfactory.gen_alphanumeric().lower())
-            ctg.action.edit(description=new_description)
-            assert rest_api.response.status_code == 200
-            wait_for(
-                lambda: rest_api.collections.categories.find_by(description=new_description),
+            edited = []
+            for index in range(categories_len):
+                edited.append(categories[index].action.edit(**new[index]))
+                assert appliance.rest_api.response.status_code == 200
+        assert categories_len == len(edited)
+        for index in range(categories_len):
+            record, _ = wait_for(
+                lambda: collection.find_by(description=new[index]['description']),
                 num_sec=180,
                 delay=10,
             )
+            assert record[0].id == edited[index].id
+            assert record[0].description == edited[index].description
 
     @pytest.mark.tier(3)
     @pytest.mark.parametrize("method", ["post", "delete"], ids=["POST", "DELETE"])
-    def test_delete_categories_from_detail(self, rest_api, categories, method):
+    def test_delete_categories_from_detail(self, appliance, categories, method):
         """Tests deleting categories from detail.
 
         Metadata:
@@ -91,20 +87,20 @@ class TestCategoriesViaREST(object):
         status = 204 if method == "delete" else 200
         for ctg in categories:
             ctg.action.delete(force_method=method)
-            assert rest_api.response.status_code == status
+            assert appliance.rest_api.response.status_code == status
             with error.expected("ActiveRecord::RecordNotFound"):
                 ctg.action.delete(force_method=method)
-            assert rest_api.response.status_code == 404
+            assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
-    def test_delete_categories_from_collection(self, rest_api, categories):
+    def test_delete_categories_from_collection(self, appliance, categories):
         """Tests deleting categories from collection.
 
         Metadata:
             test_flag: rest
         """
-        rest_api.collections.categories.action.delete(*categories)
-        assert rest_api.response.status_code == 200
+        appliance.rest_api.collections.categories.action.delete(*categories)
+        assert appliance.rest_api.response.status_code == 200
         with error.expected("ActiveRecord::RecordNotFound"):
-            rest_api.collections.categories.action.delete(*categories)
-        assert rest_api.response.status_code == 404
+            appliance.rest_api.collections.categories.action.delete(*categories)
+        assert appliance.rest_api.response.status_code == 404


### PR DESCRIPTION
* replacing the ``rest_api`` fixture with ``appliance.rest_api``
* ``test_edit_categories`` enhancements

{{pytest: -v -k TestCategoriesViaREST}}