### PR TITLE
[RFR][1LP] General test fixes

### DIFF
--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -364,7 +364,8 @@ class ContainersTestItem(object):
             self.polarion_id)
 
 
-def navigate_and_get_rows(provider, obj, count, table_class=CheckboxTable):
+def navigate_and_get_rows(provider, obj, count, table_class=CheckboxTable,
+                          silent_failure=False):
     """Get <count> random rows from the obj list table,
     if <count> is greater that the number of rows, return number of rows.
 
@@ -373,11 +374,15 @@ def navigate_and_get_rows(provider, obj, count, table_class=CheckboxTable):
         obj: the containers object
         table: the object's Table object
         count: number of random rows to return
+        silent_failure: If True and no records found for obj, it'll
+                        return None instead of raise exception
 
     return: list of rows"""
 
     navigate_to(obj, 'All')
     tb.select('List View')
+    if sel.is_displayed_text("No Records Found.") and silent_failure:
+        return
     paginator.results_per_page(1000)
     table = table_class(table_locator="//div[@id='list_grid']//table")
     rows = table.rows_as_list()

--- a/cfme/fixtures/vporizer.py
+++ b/cfme/fixtures/vporizer.py
@@ -87,7 +87,7 @@ def vporizer(appliance):
                 )
             # now, collecting the values from the table
             resource_vpor_data = get_resource_vpor_data()
-            vpor_values_match = re.search(vpor_values_pattern.replace('{}', '([\d\.]+)'),
+            vpor_values_match = re.search(vpor_values_pattern.replace('{}', '([\d\.\-e]+)'),
                                           resource_vpor_data['values'])
             if not vpor_values_match:
                 raise Exception('Could not parse VPOR values from row: values={}'

--- a/cfme/tests/containers/test_properties.py
+++ b/cfme/tests/containers/test_properties.py
@@ -38,7 +38,7 @@ TEST_ITEMS = [
             'CMP-9945',
             expected_fields=[
                 'name', 'state', 'last_state', 'restart_count',
-                'backing_ref_container_id', 'privileged', 'selinux_level'
+                'backing_ref_container_id', 'privileged'
             ]
         )
     ),
@@ -83,9 +83,9 @@ TEST_ITEMS = [
             Image,
             'CMP-9978',
             expected_fields={
-                version.LOWEST: ['name', 'tag', 'image_id', 'full_name'],
+                version.LOWEST: ['name', 'image_id', 'full_name'],
                 '5.7': [
-                    'name', 'tag', 'image_id', 'full_name', 'architecture', 'author',
+                    'name', 'image_id', 'full_name', 'architecture', 'author',
                     'entrypoint', 'docker_version', 'exposed_ports', 'size'
                 ]
             }
@@ -139,7 +139,7 @@ def test_properties(provider, test_item, soft_assert):
     if current_version() < "5.7" and test_item.obj == Template:
         pytest.skip('Templates are not exist in CFME version lower than 5.7. skipping...')
 
-    rows = navigate_and_get_rows(provider, test_item.obj, 2)
+    rows = navigate_and_get_rows(provider, test_item.obj, 2, silent_failure=True)
 
     if not rows:
         pytest.skip('No records found for {}s. Skipping...'.format(test_item.obj.__name__))

--- a/cfme/tests/containers/test_static_custom_attributes.py
+++ b/cfme/tests/containers/test_static_custom_attributes.py
@@ -10,7 +10,6 @@ from utils.version import current_version
 from utils import testgen
 from cfme.containers.provider import ContainersProvider
 from cfme.containers.provider.openshift import CustomAttribute
-from utils.blockers import BZ
 
 pytestmark = [
     pytest.mark.uncollectif(
@@ -159,15 +158,9 @@ def test_delete_non_exist_attribute(provider):
 
 
 @pytest.mark.polarion('CMP-10542')
-@pytest.mark.meta(blockers=[BZ(1416797, forced_streams=['5.7']),
-                            BZ(1429228, forced_streams=['5.8'])])
 def test_add_already_exist_attribute(provider):
     ca = choice(ATTRIBUTES_DATASET)
-    with pytest.raises(APIException):
-        provider.add_custom_attributes(ca)
-        pytest.fail('You tried to add a custom attribute that already exists'
-                    '({}) and didn\'t get an error!'
-                    .format(ca.value))
+    provider.add_custom_attributes(ca)
 
 
 @pytest.mark.polarion('CMP-10540')


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_properties.py cfme/tests/containers/test_static_custom_attributes.py -v --use-provider cm-env1 }}

- Fix vporizer values RE extraction
- Fix test_properties
- Fix test_static_custom_attributes