### PR TITLE
[RFR] remove rest_api fixture from test_tag

### DIFF
--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -74,7 +74,7 @@ def tags(request, rest_api, categories):
             'category': refs[index % 3]
         })
 
-    return _creating_skeleton(request, rest_api, 'tags', tags)
+    return _creating_skeleton(request, rest_api, 'tags', tags, substr_search=True)
 
 
 def dialog():
@@ -368,7 +368,8 @@ def users(request, rest_api, num=1):
     return users
 
 
-def _creating_skeleton(request, rest_api, col_name, col_data, col_action='create'):
+def _creating_skeleton(request, rest_api, col_name, col_data, col_action='create',
+        substr_search=False):
     collection = getattr(rest_api.collections, col_name)
     try:
         action = getattr(collection.action, col_action)
@@ -378,13 +379,15 @@ def _creating_skeleton(request, rest_api, col_name, col_data, col_action='create
 
     entities = action(*col_data)
     action_status = rest_api.response.status_code
+    search_str = '%{}%' if substr_search else '{}'
     for entity in col_data:
         if entity.get('name', None):
             wait_for(lambda: collection.find_by(
-                name=entity.get('name')) or False, num_sec=180, delay=10)
+                name=search_str.format(entity.get('name'))) or False, num_sec=180, delay=10)
         elif entity.get('description', None):
             wait_for(lambda: collection.find_by(
-                description=entity.get('description')) or False, num_sec=180, delay=10)
+                description=search_str.format(entity.get('description'))) or False,
+                num_sec=180, delay=10)
         else:
             raise NotImplementedError
 

--- a/cfme/tests/configure/test_tag.py
+++ b/cfme/tests/configure/test_tag.py
@@ -42,34 +42,34 @@ class TestTagsViaREST(object):
     COLLECTIONS_BULK_TAGS = ("services", "vms")
 
     @pytest.fixture(scope="function")
-    def categories(self, request, rest_api, num=3):
-        return _categories(request, rest_api, num)
+    def categories(self, request, appliance, num=3):
+        return _categories(request, appliance.rest_api, num)
 
     @pytest.fixture(scope="function")
-    def tags(self, request, rest_api, categories):
-        return _tags(request, rest_api, categories)
+    def tags(self, request, appliance, categories):
+        return _tags(request, appliance.rest_api, categories)
 
     @pytest.fixture(scope="module")
-    def categories_mod(self, request, rest_api_modscope, num=3):
-        return _categories(request, rest_api_modscope, num)
+    def categories_mod(self, request, appliance, num=3):
+        return _categories(request, appliance.rest_api, num)
 
     @pytest.fixture(scope="module")
-    def tags_mod(self, request, rest_api_modscope, categories_mod):
-        return _tags(request, rest_api_modscope, categories_mod)
+    def tags_mod(self, request, appliance, categories_mod):
+        return _tags(request, appliance.rest_api, categories_mod)
 
     @pytest.fixture(scope="module")
-    def tenants(self, request, rest_api_modscope):
-        return _tenants(request, rest_api_modscope, num=1)
+    def tenants(self, request, appliance):
+        return _tenants(request, appliance.rest_api, num=1)
 
     @pytest.fixture(scope="module")
     def a_provider(self, request):
         return _a_provider(request)
 
     @pytest.fixture(scope="module")
-    def services(self, request, rest_api_modscope, a_provider):
+    def services(self, request, appliance, a_provider):
         try:
-            return _services(request, rest_api_modscope, a_provider)
-        except:
+            return _services(request, appliance.rest_api, a_provider)
+        except Exception:
             pass
 
     def service_body(self, **kwargs):
@@ -82,77 +82,82 @@ class TestTagsViaREST(object):
         return body
 
     @pytest.fixture(scope="module")
-    def dummy_services(self, request, rest_api_modscope):
+    def dummy_services(self, request, appliance):
         # create simple service using REST API
         bodies = [self.service_body() for _ in range(3)]
-        collection = rest_api_modscope.collections.services
+        collection = appliance.rest_api.collections.services
         new_services = collection.action.create(*bodies)
-        assert rest_api_modscope.response.status_code == 200
+        assert appliance.rest_api.response.status_code == 200
 
         @request.addfinalizer
         def _finished():
             collection.reload()
             ids = [service.id for service in new_services]
             delete_entities = [service for service in collection if service.id in ids]
-            if len(delete_entities) != 0:
+            if delete_entities:
                 collection.action.delete(*delete_entities)
 
         return new_services
 
     @pytest.fixture(scope="module")
-    def service_templates(self, request, rest_api_modscope):
-        return _service_templates(request, rest_api_modscope)
+    def service_templates(self, request, appliance):
+        return _service_templates(request, appliance.rest_api)
 
     @pytest.fixture(scope="module")
-    def vm(self, request, a_provider, rest_api_modscope):
-        return _vm(request, a_provider, rest_api_modscope)
+    def vm(self, request, a_provider, appliance):
+        return _vm(request, a_provider, appliance.rest_api)
 
     @pytest.mark.tier(2)
-    def test_edit_tags(self, rest_api, tags):
+    def test_edit_tags(self, appliance, tags):
         """Tests tags editing from collection.
 
         Metadata:
             test_flag: rest
         """
-        new_names = []
+        collection = appliance.rest_api.collections.tags
+        tags_len = len(tags)
         tags_data_edited = []
         for tag in tags:
-            new_name = "test_tag_{}".format(fauxfactory.gen_alphanumeric().lower())
-            new_names.append(new_name)
-            tag.reload()
             tags_data_edited.append({
                 "href": tag.href,
-                "name": new_name,
+                "name": "test_tag_{}".format(fauxfactory.gen_alphanumeric().lower()),
             })
-        rest_api.collections.tags.action.edit(*tags_data_edited)
-        assert rest_api.response.status_code == 200
-        for new_name in new_names:
-            wait_for(
-                lambda: rest_api.collections.tags.find_by(name=new_name),
+        edited = collection.action.edit(*tags_data_edited)
+        assert appliance.rest_api.response.status_code == 200
+        assert len(edited) == tags_len
+        for index in range(tags_len):
+            record, _ = wait_for(lambda:
+                collection.find_by(name="%/{}".format(tags_data_edited[index]["name"])) or False,
                 num_sec=180,
-                delay=10,
-            )
+                delay=10)
+            assert record[0].id == edited[index].id
+            assert record[0].name == edited[index].name
 
     @pytest.mark.tier(2)
-    def test_edit_tag(self, rest_api, tags):
+    def test_edit_tag(self, appliance, tags):
         """Tests tag editing from detail.
 
         Metadata:
             test_flag: rest
         """
-        tag = rest_api.collections.tags.get(name=tags[0].name)
-        new_name = 'test_tag_{}'.format(fauxfactory.gen_alphanumeric())
-        tag.action.edit(name=new_name)
-        assert rest_api.response.status_code == 200
-        wait_for(
-            lambda: rest_api.collections.tags.find_by(name=new_name),
-            num_sec=180,
-            delay=10,
-        )
+        edited = []
+        new_names = []
+        for tag in tags:
+            new_name = 'test_tag_{}'.format(fauxfactory.gen_alphanumeric())
+            new_names.append(new_name)
+            edited.append(tag.action.edit(name=new_name))
+            assert appliance.rest_api.response.status_code == 200
+        for index, name in enumerate(new_names):
+            record, _ = wait_for(lambda:
+                appliance.rest_api.collections.tags.find_by(name="%/{}".format(name)) or False,
+                num_sec=180,
+                delay=10)
+            assert record[0].id == edited[index].id
+            assert record[0].name == edited[index].name
 
     @pytest.mark.tier(3)
     @pytest.mark.parametrize("method", ["post", "delete"], ids=["POST", "DELETE"])
-    def test_delete_tags_from_detail(self, rest_api, tags, method):
+    def test_delete_tags_from_detail(self, appliance, tags, method):
         """Tests deleting tags from detail.
 
         Metadata:
@@ -161,26 +166,26 @@ class TestTagsViaREST(object):
         status = 204 if method == "delete" else 200
         for tag in tags:
             tag.action.delete(force_method=method)
-            assert rest_api.response.status_code == status
+            assert appliance.rest_api.response.status_code == status
             with error.expected("ActiveRecord::RecordNotFound"):
                 tag.action.delete(force_method=method)
-            assert rest_api.response.status_code == 404
+            assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
-    def test_delete_tags_from_collection(self, rest_api, tags):
+    def test_delete_tags_from_collection(self, appliance, tags):
         """Tests deleting tags from collection.
 
         Metadata:
             test_flag: rest
         """
-        rest_api.collections.tags.action.delete(*tags)
-        assert rest_api.response.status_code == 200
+        appliance.rest_api.collections.tags.action.delete(*tags)
+        assert appliance.rest_api.response.status_code == 200
         with error.expected("ActiveRecord::RecordNotFound"):
-            rest_api.collections.tags.action.delete(*tags)
-        assert rest_api.response.status_code == 404
+            appliance.rest_api.collections.tags.action.delete(*tags)
+        assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
-    def test_create_tag_with_wrong_arguments(self, rest_api):
+    def test_create_tag_with_wrong_arguments(self, appliance):
         """Tests creating tags with missing category "id", "href" or "name".
 
         Metadata:
@@ -191,32 +196,32 @@ class TestTagsViaREST(object):
             "description": "test_tag_{}".format(fauxfactory.gen_alphanumeric().lower())
         }
         with error.expected("BadRequestError: Category id, href or name needs to be specified"):
-            rest_api.collections.tags.action.create(data)
-        assert rest_api.response.status_code == 400
+            appliance.rest_api.collections.tags.action.create(data)
+        assert appliance.rest_api.response.status_code == 400
 
     @pytest.mark.tier(3)
     @pytest.mark.parametrize(
         "collection_name", ["clusters", "hosts", "data_stores", "providers", "resource_pools",
         "services", "service_templates", "tenants", "vms"])
-    def test_assign_and_unassign_tag(self, rest_api, tags_mod, a_provider, services,
+    def test_assign_and_unassign_tag(self, appliance, tags_mod, a_provider, services,
             service_templates, tenants, vm, collection_name):
         """Tests assigning and unassigning tags.
 
         Metadata:
             test_flag: rest
         """
-        collection = getattr(rest_api.collections, collection_name)
+        collection = getattr(appliance.rest_api.collections, collection_name)
         collection.reload()
-        if len(collection.all) == 0:
+        if not collection.all:
             pytest.skip("No available entity in {} to assign tag".format(collection_name))
         entity = collection[-1]
         tag = tags_mod[0]
         entity.tags.action.assign(tag)
-        assert rest_api.response.status_code == 200
+        assert appliance.rest_api.response.status_code == 200
         entity.reload()
         assert tag.id in [t.id for t in entity.tags.all]
         entity.tags.action.unassign(tag)
-        assert rest_api.response.status_code == 200
+        assert appliance.rest_api.response.status_code == 200
         entity.reload()
         assert tag.id not in [t.id for t in entity.tags.all]
 
@@ -224,14 +229,14 @@ class TestTagsViaREST(object):
     @pytest.mark.tier(3)
     @pytest.mark.parametrize(
         "collection_name", COLLECTIONS_BULK_TAGS)
-    def test_bulk_assign_and_unassign_tag(self, rest_api, tags_mod, dummy_services, vm,
+    def test_bulk_assign_and_unassign_tag(self, appliance, tags_mod, dummy_services, vm,
             collection_name):
         """Tests bulk assigning and unassigning tags.
 
         Metadata:
             test_flag: rest
         """
-        collection = getattr(rest_api.collections, collection_name)
+        collection = getattr(appliance.rest_api.collections, collection_name)
         collection.reload()
         if len(collection) > 1:
             entities = [collection[-2], collection[-1]]  # slice notation doesn't work here
@@ -247,13 +252,15 @@ class TestTagsViaREST(object):
         new_tags.append({'category': 'department', 'name': 'finance'})
         new_tags.append({'name': '/managed/department/presales'})
         tags_ids = set([t.id for t in tags_mod])
-        tags_ids.add(rest_api.collections.tags.get(name='/managed/department/finance').id)
-        tags_ids.add(rest_api.collections.tags.get(name='/managed/department/presales').id)
+        tags_ids.add(
+            appliance.rest_api.collections.tags.get(name='/managed/department/finance').id)
+        tags_ids.add(
+            appliance.rest_api.collections.tags.get(name='/managed/department/presales').id)
         tags_count = len(new_tags) * len(entities)
 
         def _verify_action_result():
-            assert rest_api.response.status_code == 200
-            response = rest_api.response.json()
+            assert appliance.rest_api.response.status_code == 200
+            response = appliance.rest_api.response.json()
             assert len(response['results']) == tags_count
             num_success = 0
             for result in response['results']:
@@ -277,14 +284,14 @@ class TestTagsViaREST(object):
     @pytest.mark.tier(3)
     @pytest.mark.parametrize(
         "collection_name", COLLECTIONS_BULK_TAGS)
-    def test_bulk_assign_and_unassign_invalid_tag(self, rest_api, dummy_services, vm,
+    def test_bulk_assign_and_unassign_invalid_tag(self, appliance, dummy_services, vm,
             collection_name):
         """Tests bulk assigning and unassigning invalid tags.
 
         Metadata:
             test_flag: rest
         """
-        collection = getattr(rest_api.collections, collection_name)
+        collection = getattr(appliance.rest_api.collections, collection_name)
         collection.reload()
         if len(collection) > 1:
             entities = [collection[-2], collection[-1]]  # slice notation doesn't work here
@@ -299,8 +306,8 @@ class TestTagsViaREST(object):
             tags_per_entities_count.append(entity.tags.subcount)
 
         def _verify_action_result():
-            assert rest_api.response.status_code == 200
-            response = rest_api.response.json()
+            assert appliance.rest_api.response.status_code == 200
+            response = appliance.rest_api.response.json()
             assert len(response['results']) == tags_count
             num_fail = 0
             for result in response['results']:

--- a/cfme/tests/configure/test_tag.py
+++ b/cfme/tests/configure/test_tag.py
@@ -13,6 +13,7 @@ from cfme.rest.gen_data import vm as _vm
 from utils.update import update
 from utils.wait import wait_for
 from utils.version import current_version
+from utils.blockers import BZ
 from utils import error
 
 
@@ -200,6 +201,7 @@ class TestTagsViaREST(object):
         assert appliance.rest_api.response.status_code == 400
 
     @pytest.mark.tier(3)
+    @pytest.mark.meta(blockers=[BZ(1451025)])
     @pytest.mark.parametrize(
         "collection_name", ["clusters", "hosts", "data_stores", "providers", "resource_pools",
         "services", "service_templates", "tenants", "vms"])

--- a/cfme/tests/configure/test_tag.py
+++ b/cfme/tests/configure/test_tag.py
@@ -68,10 +68,7 @@ class TestTagsViaREST(object):
 
     @pytest.fixture(scope="module")
     def services(self, request, appliance, a_provider):
-        try:
-            return _services(request, appliance.rest_api, a_provider)
-        except Exception:
-            pass
+        return _services(request, appliance.rest_api, a_provider)
 
     def service_body(self, **kwargs):
         uid = fauxfactory.gen_alphanumeric(5)
@@ -201,7 +198,7 @@ class TestTagsViaREST(object):
         assert appliance.rest_api.response.status_code == 400
 
     @pytest.mark.tier(3)
-    @pytest.mark.meta(blockers=[BZ(1451025)])
+    @pytest.mark.meta(blockers=[BZ(1451025, forced_streams=['5.7'])])
     @pytest.mark.parametrize(
         "collection_name", ["clusters", "hosts", "data_stores", "providers", "resource_pools",
         "services", "service_templates", "tenants", "vms"])


### PR DESCRIPTION
* replacing the rest_api fixture with appliance.rest_api
* edit tests enhancements

{{pytest: -v --use-provider vsphere6-nested -k TestTagsViaREST}}
