### PR TITLE
[WIP]Add Providers with SSL Fixes

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -1,6 +1,7 @@
 import datetime
 from functools import partial
 
+
 from manageiq_client.api import APIException
 
 from cfme.base.credential import Credential, EventsCredential, TokenCredential, SSHCredential, \
@@ -20,6 +21,7 @@ from utils.appliance.implementations.ui import navigate_to
 from utils.browser import ensure_browser_open
 from utils.log import logger
 from utils.stats import tol_check
+from utils.ssh import SSHClient
 from utils.update import Updateable
 from utils.varmeth import variable
 from utils.wait import wait_for, RefreshTimer
@@ -724,3 +726,26 @@ def cleanup_vm(vm_name, provider):
     except:
         # The mgmt_sys classes raise Exception :\
         logger.warning('Failed to clean up VM %s on provider %s', vm_name, provider.key)
+
+
+# def get_provider_certificate(self, sec_protocol=None, cert_source=None, prov_config=None):
+#     creds = conf.credentials['openshift-3']
+#     provider_user = self.get_credentials_from_config(credential_config_name='openshift-3', cred_type='token')
+#     provider_pass = self.get_credentials_from_config(credential_config_name='openshift-3', cred_type='token')
+#     # provider_user = OpenshiftProvider.process_credential_yaml_key(prov_config['credentials']).principal
+#     # provider_user = OpenshiftProvider.process_credential_yaml_key(prov_config['credentials'], cred_type='token')
+#     # provider_pass = OpenshiftProvider.process_credential_yaml_key(prov_config['credentials']).secret
+#     # The Hawkular Cert part will probably change. Awaiting details on Hawkular certs
+#     if sec_protocol != 'SSL trusting custom CA':
+#         return None
+#     else:
+#         ip = cert_source
+#         ssh_kwargs = {
+#             'username': provider_user,
+#             'password': provider_pass,
+#             'hostname': ip \
+#             }
+#         ssh = SSHClient(**ssh_kwargs)
+#         cert = ssh.run_command('cat /etc/origin/master/ca.crt')
+#         assert cert
+#         return str(cert)

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -728,24 +728,20 @@ def cleanup_vm(vm_name, provider):
         logger.warning('Failed to clean up VM %s on provider %s', vm_name, provider.key)
 
 
-# def get_provider_certificate(self, sec_protocol=None, cert_source=None, prov_config=None):
-#     creds = conf.credentials['openshift-3']
-#     provider_user = self.get_credentials_from_config(credential_config_name='openshift-3', cred_type='token')
-#     provider_pass = self.get_credentials_from_config(credential_config_name='openshift-3', cred_type='token')
-#     # provider_user = OpenshiftProvider.process_credential_yaml_key(prov_config['credentials']).principal
-#     # provider_user = OpenshiftProvider.process_credential_yaml_key(prov_config['credentials'], cred_type='token')
-#     # provider_pass = OpenshiftProvider.process_credential_yaml_key(prov_config['credentials']).secret
-#     # The Hawkular Cert part will probably change. Awaiting details on Hawkular certs
-#     if sec_protocol != 'SSL trusting custom CA':
-#         return None
-#     else:
-#         ip = cert_source
-#         ssh_kwargs = {
-#             'username': provider_user,
-#             'password': provider_pass,
-#             'hostname': ip \
-#             }
-#         ssh = SSHClient(**ssh_kwargs)
-#         cert = ssh.run_command('cat /etc/origin/master/ca.crt')
-#         assert cert
-#         return str(cert)
+def get_certificate(provider, sec_protocol=None, cert_source=None):
+    provider_user = conf.credentials[provider.key].username
+    provider_pass = conf.credentials[provider.key].password
+    # The Hawkular Cert part will probably change. Awaiting details on Hawkular certs
+    if sec_protocol != 'SSL trusting custom CA':
+        return None
+    else:
+        ip = cert_source
+        ssh_kwargs = {
+            'username': provider_user,
+            'password': provider_pass,
+            'hostname': ip
+        }
+        ssh = SSHClient(**ssh_kwargs)
+        cert = ssh.run_command('cat /etc/origin/master/ca.crt')
+        assert cert
+        return str(cert)

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -124,6 +124,8 @@ class ContainersProvider(BaseProvider, Pretty):
             hostname=None,
             port=None,
             sec_protocol=None,
+            hawkular_hostname=None,
+            hawkular_api_port=None,
             hawkular_sec_protocol=None,
             provider_data=None,
             appliance=None):
@@ -137,6 +139,8 @@ class ContainersProvider(BaseProvider, Pretty):
         self.hostname = hostname
         self.port = port
         self.sec_protocol = sec_protocol
+        self.hawkular_hostname = hawkular_hostname
+        self.hawkular_api_port = hawkular_api_port
         self.hawkular_sec_protocol = hawkular_sec_protocol
         self.provider_data = provider_data
 

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -1,4 +1,8 @@
 from . import ContainersProvider
+from utils.providers import get_crud
+from utils import conf
+from utils.ssh import SSHClient
+
 from utils.varmeth import variable
 from os import path
 from mgmtsystem.openshift import Openshift
@@ -19,10 +23,12 @@ class OpenshiftProvider(ContainersProvider):
     mgmt_class = Openshift
     db_types = ["Openshift::ContainerManager"]
 
-    def __init__(self, name=None, credentials=None, key=None, zone=None, hostname=None, port=None,
-                 sec_protocol=None, hawkular_sec_protocol=None, provider_data=None, appliance=None):
+    def __init__(self, name=None, credentials=None, key=None, zone=None, hostname=None, hawkular_hostname=None,
+                 port=None, hawkular_api_port=None, sec_protocol=None, hawkular_sec_protocol=None,
+                 provider_data=None, appliance=None):
         super(OpenshiftProvider, self).__init__(
-            name=name, credentials=credentials, key=key, zone=zone, hostname=hostname, port=port,
+            name=name, credentials=credentials, key=key, zone=zone, hostname=hostname,
+            hawkular_hostname=hawkular_hostname, port=port, hawkular_api_port=hawkular_api_port,
             sec_protocol=sec_protocol, hawkular_sec_protocol=hawkular_sec_protocol,
             provider_data=provider_data, appliance=appliance)
 
@@ -33,16 +39,19 @@ class OpenshiftProvider(ContainersProvider):
     def _form_mapping(self, create=None, hawkular=False, **kwargs):
         if self.appliance.version > '5.8.0.3' and hawkular:
             sec_protocol = kwargs.get('sec_protocol'),
-            hawkular_hostname = kwargs.get('hostname')
+            hawkular_hostname = kwargs.get('hawkular_hostname')
+            hawkular_api_port = kwargs.get('hawkular_api_port')
             hawkular_sec_protocol = kwargs.get('hawkular_sec_protocol')
         elif self.appliance.version > '5.8.0.3' and not hawkular:
             sec_protocol = kwargs.get('sec_protocol')
             hawkular_hostname = None
             hawkular_sec_protocol = None
+            hawkular_api_port = None
         else:
             sec_protocol = None
             hawkular_hostname = None
             hawkular_sec_protocol = None
+            hawkular_api_port = None
         return {'name_text': kwargs.get('name'),
                 'type_select': create and 'OpenShift',
                 'hostname_text': kwargs.get('hostname'),
@@ -50,6 +59,7 @@ class OpenshiftProvider(ContainersProvider):
                 'sec_protocol': sec_protocol,
                 'zone_select': kwargs.get('zone'),
                 'hawkular_hostname': hawkular_hostname,
+                'hawkular_api_port': hawkular_api_port,
                 'hawkular_sec_protocol': hawkular_sec_protocol}
 
     @variable(alias='db')
@@ -72,13 +82,17 @@ class OpenshiftProvider(ContainersProvider):
     def from_config(prov_config, prov_key, appliance=None):
         token_creds = OpenshiftProvider.process_credential_yaml_key(
             prov_config['credentials'], cred_type='token')
+        # provider_user = OpenshiftProvider.process_credential_yaml_key(prov_config['credentials']).principal
+        # provider_pass = OpenshiftProvider.process_credential_yaml_key(prov_config['credentials']).secret
         return OpenshiftProvider(
             name=prov_config['name'],
             credentials={'token': token_creds},
             key=prov_key,
             zone=prov_config['server_zone'],
             hostname=prov_config.get('hostname', None) or prov_config['ip_address'],
+            hawkular_hostname=prov_config.get('hawkular_hostname'),
             port=prov_config['port'],
+            hawkular_api_port=prov_config['hawkular_api_port'],
             sec_protocol=prov_config.get('sec_protocol', None),
             hawkular_sec_protocol=prov_config.get('hawkular_sec_protocol'),
             provider_data=prov_config,
@@ -174,3 +188,22 @@ class OpenshiftProvider(ContainersProvider):
             } for attr in attribs if attr.name in names]}
         return self.appliance.rest_api.post(
             path.join(self.href(), 'custom_attributes'), **payload)
+
+
+def get_certificate(provider, sec_protocol=None, cert_source=None):
+    provider_user = conf.credentials[provider.key].username
+    provider_pass = conf.credentials[provider.key].password
+    # The Hawkular Cert part will probably change. Awaiting details on Hawkular certs
+    if sec_protocol != 'SSL trusting custom CA':
+        return None
+    else:
+        ip = cert_source
+        ssh_kwargs = {
+            'username': provider_user,
+            'password': provider_pass,
+            'hostname': ip
+        }
+        ssh = SSHClient(**ssh_kwargs)
+        cert = ssh.run_command('cat /etc/origin/master/ca.crt')
+        assert cert
+        return str(cert)

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -1,8 +1,4 @@
 from . import ContainersProvider
-from utils.providers import get_crud
-from utils import conf
-from utils.ssh import SSHClient
-
 from utils.varmeth import variable
 from os import path
 from mgmtsystem.openshift import Openshift
@@ -189,21 +185,3 @@ class OpenshiftProvider(ContainersProvider):
         return self.appliance.rest_api.post(
             path.join(self.href(), 'custom_attributes'), **payload)
 
-
-def get_certificate(provider, sec_protocol=None, cert_source=None):
-    provider_user = conf.credentials[provider.key].username
-    provider_pass = conf.credentials[provider.key].password
-    # The Hawkular Cert part will probably change. Awaiting details on Hawkular certs
-    if sec_protocol != 'SSL trusting custom CA':
-        return None
-    else:
-        ip = cert_source
-        ssh_kwargs = {
-            'username': provider_user,
-            'password': provider_pass,
-            'hostname': ip
-        }
-        ssh = SSHClient(**ssh_kwargs)
-        cert = ssh.run_command('cat /etc/origin/master/ca.crt')
-        assert cert
-        return str(cert)

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -78,8 +78,6 @@ class OpenshiftProvider(ContainersProvider):
     def from_config(prov_config, prov_key, appliance=None):
         token_creds = OpenshiftProvider.process_credential_yaml_key(
             prov_config['credentials'], cred_type='token')
-        # provider_user = OpenshiftProvider.process_credential_yaml_key(prov_config['credentials']).principal
-        # provider_pass = OpenshiftProvider.process_credential_yaml_key(prov_config['credentials']).secret
         return OpenshiftProvider(
             name=prov_config['name'],
             credentials={'token': token_creds},

--- a/cfme/tests/containers/test_ssl_providers.py
+++ b/cfme/tests/containers/test_ssl_providers.py
@@ -1,0 +1,103 @@
+import pytest
+from itertools import product
+from cfme.containers.provider import ContainersProvider
+from cfme.common.provider import get_certificate
+from utils import testgen
+from utils.version import current_version
+from utils.appliance.implementations.ui import navigate_to
+from cfme.web_ui import fill, flash
+from cfme.fixtures import pytest_selenium as sel
+
+
+pytestmark = [
+    pytest.mark.uncollectif(lambda provider: current_version() < "5.8.0.3")]
+pytest_generate_tests = testgen.generate([ContainersProvider], scope='module')
+
+DEFAULT_SEC_PROTOCOLS = 'SSL trusting custom CA', 'SSL without validation', 'SSL'
+HAWKULAR_SEC_PROTOCOLS = 'SSL trusting custom CA', 'SSL without validation', 'SSL'
+
+
+@pytest.mark.parametrize('default_sec_protocols', DEFAULT_SEC_PROTOCOLS)
+@pytest.mark.usefixtures('has_no_containers_providers')
+@pytest.mark.polarion('CMP-10586')
+def test_add_provider_ssl(provider, default_sec_protocols, soft_assert):
+    """ This test checks adding container providers with 3 different security protocols:
+    SSL trusting custom CA, SSL without validation and SSL
+        """
+    navigate_to(ContainersProvider, 'Add')
+    fill(provider.properties_form, form_data(provider, default_sec_protocol=default_sec_protocols))
+    for cred in provider.credentials:
+        try:
+            fill(provider.credentials[cred].form, provider.credentials[cred], validate=True)
+            provider._submit(False, provider.add_provider_button)
+            flash.assert_message_contain('Containers Providers "' + provider.name + '" was saved')
+        except:
+            # The refresh is a workaround for
+            # https://github.com/ManageIQ/integration_tests/issues/4478
+            sel.refresh()
+            soft_assert(False, provider.name + ' wasn\'t added successfully using ' +
+                        default_sec_protocols + ' security')
+
+
+@pytest.mark.parametrize(('default_sec_protocols', 'hawkular_sec_protocols'),
+                         product(DEFAULT_SEC_PROTOCOLS, HAWKULAR_SEC_PROTOCOLS))
+@pytest.mark.usefixtures('has_no_containers_providers')
+@pytest.mark.polarion('CMP-10586')
+def test_add_hawkular_provider_ssl(provider, default_sec_protocols,
+                                   hawkular_sec_protocols, soft_assert):
+    """This test checks adding container providers with 3 different security protocols:
+    SSL trusting custom CA, SSL without validation and SSL
+    The test checks the Default Endpoint as well as the Hawkular Endpoint
+        """
+    navigate_to(ContainersProvider, 'Add')
+    fill(provider.properties_form, form_data(provider, default_sec_protocol=default_sec_protocols,
+                                             hawkular_sec_protocol=hawkular_sec_protocols,
+                                             with_hawkular=True))
+    for cred in provider.credentials:
+        try:
+            fill(provider.credentials[cred].form, provider.credentials[cred], validate=True)
+            provider._submit(False, provider.add_provider_button)
+            flash.assert_message_contain('Containers Providers "' + provider.name + '" was saved')
+        except:
+            # The refresh is a workaround for
+            # https://github.com/ManageIQ/integration_tests/issues/4478
+            sel.refresh()
+            soft_assert(False, provider.name + ' wasn\'t added successfully using ' +
+                        default_sec_protocols + ' and ' +
+                        hawkular_sec_protocols + ' hawkular security protocol')
+
+
+def form_data(provider, default_sec_protocol, hawkular_sec_protocol=None, with_hawkular=False):
+    name_text = provider.name
+    type_select = 'OpenShift Container Platform'
+    hostname_text = str(provider.hostname)
+    hawkular_hostname = str(provider.hawkular_hostname)
+    hostname_port = provider.port
+    hawkular_api_port = provider.hawkular_api_port
+    zone_select = 'default'
+    default_ca_certificate = get_certificate(provider, sec_protocol=default_sec_protocol,
+                                             cert_source=hostname_text)
+    hawkular_ca_certificate = get_certificate(provider, sec_protocol=hawkular_sec_protocol,
+                                              cert_source=hawkular_hostname)
+    if with_hawkular:
+        return {'name_text': name_text,
+                'type_select': type_select,
+                'hostname_text': hostname_text,
+                'port_text': hostname_port,
+                'trusted_ca_certificates': default_ca_certificate,
+                'sec_protocol': default_sec_protocol,
+                'zone_select': zone_select,
+                'hawkular_hostname': hawkular_hostname,
+                'hawkular_api_port': hawkular_api_port,
+                'hawkular_sec_protocol': hawkular_sec_protocol,
+                'hawkular_ca_certificates': hawkular_ca_certificate,
+                }
+    else:
+        return {'name_text': name_text,
+                'type_select': type_select,
+                'hostname_text': hostname_text,
+                'port_text': hostname_port,
+                'trusted_ca_certificates': default_ca_certificate,
+                'sec_protocol': default_sec_protocol,
+                'zone_select': zone_select,
+                }

--- a/test_ssl_providers.py
+++ b/test_ssl_providers.py
@@ -1,0 +1,104 @@
+import pytest
+from itertools import product
+from cfme.containers.provider import ContainersProvider
+from cfme.containers.provider.openshift import get_certificate
+from utils import testgen
+from utils.version import current_version
+from utils.appliance.implementations.ui import navigate_to
+from cfme.web_ui import fill, flash
+from cfme.fixtures import pytest_selenium as sel
+
+pytestmark = [
+    pytest.mark.uncollectif(lambda provider: current_version() < "5.8.0.3")]
+pytest_generate_tests = testgen.generate([ContainersProvider], scope='module')
+
+DEFAULT_SEC_PROTOCOLS = 'SSL trusting custom CA', 'SSL without validation', 'SSL'
+HAWKULAR_SEC_PROTOCOLS = 'SSL trusting custom CA', 'SSL without validation', 'SSL'
+
+
+@pytest.mark.parametrize('default_sec_protocols', DEFAULT_SEC_PROTOCOLS)
+@pytest.mark.usefixtures('has_no_containers_providers')
+@pytest.mark.polarion('CMP-10586')
+def test_add_provider_ssl(provider, default_sec_protocols, soft_assert):
+    """ This test checks adding container providers with 3 different security protocols:
+    SSL trusting custom CA, SSL without validation and SSL
+        """
+    navigate_to(ContainersProvider, 'Add')
+    fill(provider.properties_form, form_data(provider, default_sec_protocol=default_sec_protocols))
+    fill(self.properties_form, self._form_mapping(True, hawkular=False, **self.__dict__))
+
+    for cred in provider.credentials:
+        try:
+            fill(provider.credentials[cred].form, provider.credentials[cred], validate=True)
+            provider._submit(False, provider.add_provider_button)
+            flash.assert_message_contain('Containers Providers "' + provider.name + '" was saved')
+        except:
+            # The refresh is a workaround for
+            # https://github.com/ManageIQ/integration_tests/issues/4478
+            sel.refresh()
+            soft_assert(False, provider.name + ' wasn\'t added successfully using ' +
+                        default_sec_protocols + ' security')
+
+
+@pytest.mark.parametrize(('default_sec_protocols', 'hawkular_sec_protocols'),
+                         product(DEFAULT_SEC_PROTOCOLS, HAWKULAR_SEC_PROTOCOLS))
+@pytest.mark.usefixtures('has_no_containers_providers')
+@pytest.mark.polarion('CMP-10586')
+def test_add_hawkular_provider_ssl(provider, default_sec_protocols,
+                                   hawkular_sec_protocols, soft_assert):
+    """This test checks adding container providers with 3 different security protocols:
+    SSL trusting custom CA, SSL without validation and SSL
+    The test checks the Default Endpoint as well as the Hawkular Endpoint
+        """
+    navigate_to(ContainersProvider, 'Add')
+    fill(provider.properties_form, form_data(provider, default_sec_protocol=default_sec_protocols,
+                                             hawkular_sec_protocol=hawkular_sec_protocols,
+                                             with_hawkular=True))
+    for cred in provider.credentials:
+        try:
+            fill(provider.credentials[cred].form, provider.credentials[cred], validate=True)
+            provider._submit(False, provider.add_provider_button)
+            flash.assert_message_contain('Containers Providers "' + provider.name + '" was saved')
+        except:
+            # The refresh is a workaround for
+            # https://github.com/ManageIQ/integration_tests/issues/4478
+            sel.refresh()
+            soft_assert(False, provider.name + ' wasn\'t added successfully using ' +
+                        default_sec_protocols + ' and ' +
+                        hawkular_sec_protocols + ' hawkular security protocol')
+
+
+def form_data(provider, default_sec_protocol, hawkular_sec_protocol=None, with_hawkular=False):
+    name_text = provider.name
+    type_select = 'OpenShift Container Platform'
+    hostname_text = str(provider.hostname)
+    hawkular_hostname = str(provider.hawkular_hostname)
+    hostname_port = provider.port
+    hawkular_api_port = provider.hawkular_api_port
+    zone_select = 'default'
+    default_ca_certificate = get_certificate(provider, sec_protocol=default_sec_protocol,
+                                             cert_source=hostname_text)
+    hawkular_ca_certificate = get_certificate(provider, sec_protocol=hawkular_sec_protocol,
+                                              cert_source=hawkular_hostname)
+    if with_hawkular:
+        return {'name_text': name_text,
+                'type_select': type_select,
+                'hostname_text': hostname_text,
+                'port_text': hostname_port,
+                'trusted_ca_certificates': default_ca_certificate,
+                'sec_protocol': default_sec_protocol,
+                'zone_select': zone_select,
+                'hawkular_hostname': hawkular_hostname,
+                'hawkular_api_port': hawkular_api_port,
+                'hawkular_sec_protocol': hawkular_sec_protocol,
+                'hawkular_ca_certificates': hawkular_ca_certificate,
+                }
+    else:
+        return {'name_text': name_text,
+                'type_select': type_select,
+                'hostname_text': hostname_text,
+                'port_text': hostname_port,
+                'trusted_ca_certificates': default_ca_certificate,
+                'sec_protocol': default_sec_protocol,
+                'zone_select': zone_select,
+                }


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_ssl_providers.py -v --use-provider cm-env2 }}
This test is testing the various Providers addition SSL protocols

This is a rewrite of the https://github.com/ManageIQ/integration_tests/pull/4405
For some reason I couldn't merge with the changes so I rewritten some stuff.
