### PR TITLE
[1LP][RFR] Refactor parallelization data source handling

### DIFF
--- a/cfme/fixtures/base.py
+++ b/cfme/fixtures/base.py
@@ -3,13 +3,11 @@ import pytest
 from utils.appliance import get_or_create_current_appliance
 from utils.appliance import ApplianceException
 from cfme.configure import configuration
-from urlparse import urlparse
 
 from fixtures.artifactor_plugin import fire_art_hook
 
 from utils.log import logger
 from utils.path import data_path
-from utils.conf import env
 
 
 def pytest_sessionstart(session):
@@ -56,7 +54,10 @@ def fix_merkyl_workaround(request, appliance):
         remote_file = "/etc/init.d/merkyl"
         ssh_client.put_file(local_file.strpath, remote_file)
         ssh_client.run_command("service merkyl restart")
-        fire_art_hook(request.config, 'setup_merkyl', ip=urlparse(env['base_url']).netloc)
+        fire_art_hook(
+            request.config,
+            'setup_merkyl',
+            ip=appliance.address)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/cfme/test_framework/sprout/plugin.py
+++ b/cfme/test_framework/sprout/plugin.py
@@ -16,16 +16,12 @@ from utils.wait import wait_for
 _appliance_help = '''specify appliance URLs to use for distributed testing.
 this option can be specified more than once, and must be specified at least two times'''
 
-# Todo: hack taken from parallelizer, restructure
-env_base_urls = conf.env.get('parallel_base_urls', [])
-if env_base_urls:
-    conf.runtime['env']['base_url'] = env_base_urls[0]
-
 
 def pytest_addoption(parser):
     group = parser.getgroup("cfme")
-    group._addoption('--appliance', dest='appliances', action='append',
-        default=env_base_urls, metavar='base_url', help=_appliance_help)
+    group._addoption(
+        '--appliance', dest='appliances', action='append', metavar='base_url', help=_appliance_help,
+        default=[])
     group._addoption('--use-sprout', dest='use_sprout', action='store_true',
         default=False, help="Use Sprout for provisioning appliances.")
     group._addoption('--sprout-appliances', dest='sprout_appliances', type=int,

--- a/conf/env.yaml.template
+++ b/conf/env.yaml.template
@@ -1,4 +1,5 @@
-base_url: https://10.11.12.13
+appliances:
+    - base_url: https://10.11.12.13
 browser:
     webdriver: Remote
     webdriver_options:

--- a/fixtures/merkyl.py
+++ b/fixtures/merkyl.py
@@ -1,9 +1,8 @@
 import pytest
 
-from urlparse import urlparse
 from fixtures.artifactor_plugin import fire_art_test_hook
 
-from utils.conf import env
+from utils.appliance import get_or_create_current_appliance
 
 
 class MerkylInspector(object):
@@ -16,7 +15,7 @@ class MerkylInspector(object):
         and does nothing special.
         """
         self.node = request.node
-        self.ip = urlparse(env['base_url']).netloc
+        self.ip = get_or_create_current_appliance().address
 
     def get_log(self, log_name):
         """ A simple getter for log files.

--- a/scripts/apishow.py
+++ b/scripts/apishow.py
@@ -15,6 +15,7 @@ import warnings
 
 from collections import namedtuple
 from utils import conf
+from utils.appliances import get_or_create_current_appliance
 from utils.path import log_path
 from manageiq_client.api import ManageIQClient as MiqApi
 
@@ -222,7 +223,7 @@ if __name__ == '__main__':
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument(
         '--address',
-        default=conf.env.get('base_url'),
+        default=None,
         help="hostname or ip address of target appliance, "
              "default pulled from local environment conf")
     parser.add_argument(
@@ -232,16 +233,18 @@ if __name__ == '__main__':
         help="path to cfme log file, default: %(default)s")
     args = parser.parse_args()
 
+    address = args.address or get_or_create_current_appliance().address
+
     # we are really not interested in any warnings and "warnings.simplefilter('ignore')"
     # doesn't work when it's redefined later in the REST API client
     warnings.showwarning = lambda *args, **kwargs: None
 
     api = MiqApi(
-        '{}/api'.format(args.address.rstrip('/')),
+        '{}/api'.format(address.rstrip('/')),
         (conf.credentials['default']['username'], conf.credentials['default']['password']),
         verify_ssl=False)
 
-    print("Appliance IP: {}".format(args.address))
+    print("Appliance IP: {}".format(address))
 
     store = {}
 

--- a/scripts/install_netapp_lib.py
+++ b/scripts/install_netapp_lib.py
@@ -5,15 +5,8 @@
 
 import argparse
 from urlparse import urlparse
-from utils.appliance import IPAppliance
-from utils.conf import cfme_data, env
-
-
-def parse_if_not_none(o):
-    if o is None:
-        return None
-    url = urlparse(o)
-    return url.netloc or url.path  # If you pass a plain IP, it will get in the .path
+from utils.appliance import IPAppliance, get_or_create_current_appliance
+from utils.conf import cfme_data
 
 
 def log(s):
@@ -26,7 +19,7 @@ def main():
     parser.add_argument(
         '--address',
         help='hostname or ip address of target appliance',
-        default=parse_if_not_none(env.get("base_url")))
+        default=None)
     parser.add_argument(
         '--sdk_url',
         help='url to download sdk pkg',
@@ -35,11 +28,14 @@ def main():
         '(required for proper operation)', action="store_true")
 
     args = parser.parse_args()
-    print('Address: {}'.format(args.address))
+    if not args.address:
+        appliance = get_or_create_current_appliance()
+    else:
+        appliance = IPAppliance(address=args.address)
+    print('Address: {}'.format(appliance.address))
     print('SDK URL: {}'.format(args.sdk_url))
     print('Restart: {}'.format(args.restart))
 
-    appliance = IPAppliance(address=args.address)
     appliance.install_netapp_sdk(sdk_url=args.sdk_url, reboot=args.restart, log_callback=log)
 
 

--- a/scripts/install_vddk.py
+++ b/scripts/install_vddk.py
@@ -6,8 +6,7 @@
 import argparse
 import sys
 from urlparse import urlparse
-from utils.appliance import IPAppliance
-from utils.conf import env
+from utils.appliance import IPAppliance, get_or_create_current_appliance
 
 
 def log(message):
@@ -19,7 +18,7 @@ def main():
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument(
         '--address',
-        help='hostname or ip address of target appliance', default=env.get("base_url"))
+        help='hostname or ip address of target appliance', default=None)
     parser.add_argument('--vddk_url', help='url to download vddk pkg')
     parser.add_argument('--reboot', help='reboot after installation ' +
                         '(required for proper operation)', action="store_true")
@@ -28,9 +27,11 @@ def main():
 
     args = parser.parse_args()
 
-    address = urlparse(args.address).netloc
+    if not args.address:
+        appliance = get_or_create_current_appliance()
+    else:
+        appliance = IPAppliance(address=urlparse(args.address).netloc)
 
-    appliance = IPAppliance(address=address)
     appliance.install_vddk(
         reboot=args.reboot, force=args.force, vddk_url=args.vddk_url, log_callback=log)
 

--- a/utils/db.py
+++ b/utils/db.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import Pool
 
 from fixtures.pytest_store import store
-from utils import conf, ports
+from utils import conf
 from utils.log import logger
 
 
@@ -69,12 +69,10 @@ class Db(Mapping):
         tables, like the mapping interface or :py:meth:`values`.
 
     """
-    def __init__(self, hostname=None, credentials=None):
+    def __init__(self, hostname=None, credentials=None, port=None):
         self._table_cache = {}
-        if hostname is None:
-            self.hostname = store.current_appliance.db.address
-        else:
-            self.hostname = hostname
+        self.hostname = hostname or store.current_appliance.db.address
+        self.port = port or store.current_appliance.db_port
 
         self.credentials = credentials or conf.credentials['database']
 
@@ -194,7 +192,7 @@ class Db(Mapping):
     def db_url(self):
         """The connection URL for this database, including credentials"""
         template = "postgresql://{username}:{password}@{host}:{port}/vmdb_production"
-        result = template.format(host=self.hostname, port=ports.DB, **self.credentials)
+        result = template.format(host=self.hostname, port=self.port, **self.credentials)
         logger.info("[DB] db_url is %s", result)
         return result
 

--- a/utils/ssh.py
+++ b/utils/ssh.py
@@ -130,7 +130,7 @@ class SSHClient(paramiko.SSHClient):
             default_connect_kwargs['username'] = conf.credentials['ssh']['username']
             default_connect_kwargs['password'] = conf.credentials['ssh']['password']
             default_connect_kwargs['hostname'] = parsed_url.hostname
-        default_connect_kwargs["port"] = ports.SSH
+        default_connect_kwargs["port"] = connect_kwargs.pop('port', ports.SSH)
 
         # Overlay defaults with any passed-in kwargs and store
         default_connect_kwargs.update(connect_kwargs)


### PR DESCRIPTION
Requesting review and comments on this even though it is WIP

- Added a couple of functions in utils/appliance.py which handle configuration data and turn them into lists of appliances.
- This one is used in the parallelizer setup to process the appliances
- get_or_create_current_appliance uses it as well.
- IPAppliance can (de)serialize itself as json
- SlaveDetail uses appliance instead of url and passes the appliance into slave as serialized json instead of just URL
- SSHClient and Db accept port as well
- IPAppliance passes the port into SSHClient and Db as well
- Things that were refering directly to env.base_url were converted to get_or_create_appliance().(url|address) based on the use case

Samples:

Multiple appliances in env.yaml
```
$ py.test -v -m smoke --long-running --use-template-cache
Using templates from cache...
  Loaded 1624 templates successfully!
no test annotation found in None
Retrieved these appliances from the conf.env
* IPAppliance(address='10.0.0.1', container=None, db_host=None, db_port=5432, ssh_port=22)
* IPAppliance(address='10.0.0.2', container=None, db_host=None, db_port=5432, ssh_port=22)
* IPAppliance(address='10.0.0.3', container=None, db_host='10.0.0.3', db_port=5432, ssh_port=22)

(slave00)[20170503 15:13:56] using appliance https://10.0.0.1/
(slave01)[20170503 15:13:56] using appliance https://10.0.0.2/
(slave02)[20170503 15:13:56] using appliance https://10.0.0.3/
As a parallelizer master kicking off parallel session for these 3 appliances
================================================ test session starts =================================================
platform linux2 -- Python 2.7.11, pytest-3.0.7, py-1.4.33, pluggy-0.4.0 -- /home/mfalesni/.virtualenvs/cfme_tests/bin/python2
...
...
```
For this case, env.yaml contained this:
```
appliances:
    - base_url: https://10.0.0.1/
      ssh_port: 22
    - base_url: https://10.0.0.2/
      db_port: 5432
    - base_url: https://10.0.0.3/
      db_host: 10.0.0.3
```

Single appliance in conf.env (two of them commented out)
Same result when used with old-style base_url in env.yaml root
```
$ py.test -v -m smoke --long-running --use-template-cache
Using templates from cache...
  Loaded 1624 templates successfully!
no test annotation found in None
Retrieved these appliances from the conf.env
* IPAppliance(address='10.0.0.1', container=None, db_host=None, db_port=5432, ssh_port=22)
No parallelization required
...
...
```

When using `--appliance`
```
$ py.test -v -m smoke --long-running --use-template-cache --appliance https://10.0.0.1/
Using templates from cache...
  Loaded 1624 templates successfully!
no test annotation found in None
Retrieved these appliances from the --appliance parameters
* IPAppliance(address='10.0.0.1', container=None, db_host=None, db_port=5432, ssh_port=22)
No parallelization required
...
...
```

If you specify db_port, ssh_port or any of such options in root of env.yaml, then those will be used for all appliances passed that do not specify those values themselves. So for example the most obvious is the use case of --appliance, where you can only pass the base_url, but you can have some global settings in env.yaml that will be used.