### PR TITLE
[1LP][RFR] remove rest_api fixture from test_rest.py

### DIFF
--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -28,8 +28,8 @@ def a_provider(request):
 
 
 @pytest.fixture(scope="function")
-def vm(request, a_provider, rest_api):
-    return _vm(request, a_provider, rest_api)
+def vm(request, a_provider, appliance):
+    return _vm(request, a_provider, appliance.rest_api)
 
 
 def wait_for_requests(requests):
@@ -47,13 +47,13 @@ def wait_for_requests(requests):
 @pytest.mark.parametrize(
     "from_detail", [True, False],
     ids=["from_detail", "from_collection"])
-def test_vm_scan(rest_api, vm, from_detail):
-    rest_vm = rest_api.collections.vms.get(name=vm)
+def test_vm_scan(appliance, vm, from_detail):
+    rest_vm = appliance.rest_api.collections.vms.get(name=vm)
     if from_detail:
         response = rest_vm.action.scan()
     else:
-        response, = rest_api.collections.vms.action.scan(rest_vm)
-    assert rest_api.response.status_code == 200
+        response, = appliance.rest_api.collections.vms.action.scan(rest_vm)
+    assert appliance.rest_api.response.status_code == 200
 
     @pytest.wait_for(timeout="5m", delay=5, message="REST running scanning vm finishes")
     def _finished():
@@ -107,7 +107,7 @@ COLLECTIONS_OMMITED = {"settings"}
         (collection_name in COLLECTIONS_ADDED_IN_57 and current_version() < "5.7") or
         (collection_name in COLLECTIONS_ADDED_IN_58 and current_version() < "5.8")
 )
-def test_query_simple_collections(rest_api, collection_name):
+def test_query_simple_collections(appliance, collection_name):
     """This test tries to load each of the listed collections. 'Simple' collection means that they
     have no usable actions that we could try to run
     Steps:
@@ -115,8 +115,8 @@ def test_query_simple_collections(rest_api, collection_name):
     Metadata:
         test_flag: rest
     """
-    collection = getattr(rest_api.collections, collection_name)
-    assert rest_api.response.status_code == 200
+    collection = getattr(appliance.rest_api.collections, collection_name)
+    assert appliance.rest_api.response.status_code == 200
     collection.reload()
     list(collection)
 
@@ -134,15 +134,16 @@ COLLECTIONS_BUGGY_ATTRS = {"results", "service_catalogs", "automate", "categorie
         (collection_name in COLLECTIONS_BUGGY_ATTRS and
             BZ(1437201, forced_streams=["5.6", "5.7", "5.8", "upstream"]).blocks)
 )
-def test_select_attributes(rest_api, collection_name):
+def test_select_attributes(appliance, collection_name):
     """Tests that it's possible to limit returned attributes.
 
     Metadata:
         test_flag: rest
     """
-    collection = getattr(rest_api.collections, collection_name)
-    response = rest_api.get('{}{}'.format(collection._href, '?expand=resources&attributes=id'))
-    assert rest_api.response.status_code == 200
+    collection = getattr(appliance.rest_api.collections, collection_name)
+    response = appliance.rest_api.get(
+        '{}{}'.format(collection._href, '?expand=resources&attributes=id'))
+    assert appliance.rest_api.response.status_code == 200
     for resource in response['resources']:
         assert 'id' in resource
         expected_len = 2 if 'href' in resource else 1
@@ -150,146 +151,146 @@ def test_select_attributes(rest_api, collection_name):
 
 
 @pytest.mark.uncollectif(lambda: current_version() < '5.7')
-def test_add_picture(rest_api):
+def test_add_picture(appliance):
     """Tests adding picture.
 
     Metadata:
         test_flag: rest
     """
-    collection = rest_api.collections.pictures
+    collection = appliance.rest_api.collections.pictures
     count = collection.count
     collection.action.create({
         "extension": "png",
         "content": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcS"
                    "JAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="})
-    assert rest_api.response.status_code == 200
+    assert appliance.rest_api.response.status_code == 200
     collection.reload()
     assert collection.count == count + 1
 
 
 @pytest.mark.uncollectif(lambda: current_version() < '5.8')
-def test_add_picture_invalid_extension(rest_api):
+def test_add_picture_invalid_extension(appliance):
     """Tests adding picture with invalid extension.
 
     Metadata:
         test_flag: rest
     """
-    collection = rest_api.collections.pictures
+    collection = appliance.rest_api.collections.pictures
     count = collection.count
     with error.expected('Extension must be'):
         collection.action.create({
             "extension": "xcf",
             "content": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcS"
             "JAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="})
-    assert rest_api.response.status_code == 400
+    assert appliance.rest_api.response.status_code == 400
     collection.reload()
     assert collection.count == count
 
 
 @pytest.mark.uncollectif(lambda: current_version() < '5.8')
 @pytest.mark.meta(blockers=[BZ(1438587, forced_streams=['5.8', 'upstream'])])
-def test_add_picture_invalid_data(rest_api):
+def test_add_picture_invalid_data(appliance):
     """Tests adding picture with invalid content.
 
     Metadata:
         test_flag: rest
     """
-    collection = rest_api.collections.pictures
+    collection = appliance.rest_api.collections.pictures
     count = collection.count
     with error.expected('Invalid content'):  # change once the BZ1438587 is fixed
         collection.action.create({
             "extension": "png",
             "content": "invalid"})
-    assert rest_api.response.status_code == 400
+    assert appliance.rest_api.response.status_code == 400
     collection.reload()
     assert collection.count == count
 
 
 @pytest.mark.uncollectif(lambda: current_version() < '5.7')
-def test_http_options(rest_api):
+def test_http_options(appliance):
     """Tests OPTIONS http method.
 
     Metadata:
         test_flag: rest
     """
-    assert 'boot_time' in rest_api.collections.vms.options()['attributes']
-    assert rest_api.response.status_code == 200
+    assert 'boot_time' in appliance.rest_api.collections.vms.options()['attributes']
+    assert appliance.rest_api.response.status_code == 200
 
 
 @pytest.mark.uncollectif(lambda: current_version() < '5.8')
 @pytest.mark.parametrize("collection_name", ["hosts", "clusters"])
-def test_http_options_node_types(rest_api, collection_name):
+def test_http_options_node_types(appliance, collection_name):
     """Tests that OPTIONS http method on Hosts and Clusters collection returns node_types.
 
     Metadata:
         test_flag: rest
     """
-    collection = getattr(rest_api.collections, collection_name)
+    collection = getattr(appliance.rest_api.collections, collection_name)
     assert 'node_types' in collection.options()['data']
-    assert rest_api.response.status_code == 200
+    assert appliance.rest_api.response.status_code == 200
 
 
 @pytest.mark.uncollectif(lambda: current_version() < '5.8')
-def test_http_options_subcollections(rest_api):
+def test_http_options_subcollections(appliance):
     """Tests that OPTIONS returns supported subcollections.
 
     Metadata:
         test_flag: rest
     """
-    assert 'tags' in rest_api.collections.vms.options()['subcollections']
-    assert rest_api.response.status_code == 200
+    assert 'tags' in appliance.rest_api.collections.vms.options()['subcollections']
+    assert appliance.rest_api.response.status_code == 200
 
 
 @pytest.mark.uncollectif(lambda: current_version() < '5.7')
-def test_server_info(rest_api):
+def test_server_info(appliance):
     """Check that server info is present.
 
     Metadata:
         test_flag: rest
     """
-    assert all(item in rest_api.server_info for item in ('appliance', 'build', 'version'))
+    assert all(item in appliance.rest_api.server_info for item in ('appliance', 'build', 'version'))
 
 
 @pytest.mark.uncollectif(lambda: current_version() < '5.7')
-def test_product_info(rest_api):
+def test_product_info(appliance):
     """Check that product info is present.
 
     Metadata:
         test_flag: rest
     """
-    assert all(item in rest_api.product_info for item in
+    assert all(item in appliance.rest_api.product_info for item in
                ('copyright', 'name', 'name_full', 'support_website', 'support_website_text'))
 
 
 @pytest.mark.uncollectif(lambda: current_version() < '5.7')
-def test_identity(rest_api):
+def test_identity(appliance):
     """Check that user's identity is present.
 
     Metadata:
         test_flag: rest
     """
-    assert all(item in rest_api.identity for item in
+    assert all(item in appliance.rest_api.identity for item in
                ('userid', 'name', 'group', 'role', 'tenant', 'groups'))
 
 
 @pytest.mark.uncollectif(lambda: current_version() < '5.7')
-def test_user_settings(rest_api):
+def test_user_settings(appliance):
     """Check that user's settings are returned.
 
     Metadata:
         test_flag: rest
     """
-    assert isinstance(rest_api.settings, dict)
+    assert isinstance(appliance.rest_api.settings, dict)
 
 
 @pytest.mark.uncollectif(lambda: current_version() < '5.8')
-def test_datetime_filtering(rest_api, a_provider):
+def test_datetime_filtering(appliance, a_provider):
     """Tests support for DateTime filtering with timestamps in YYYY-MM-DDTHH:MM:SSZ format.
 
     Metadata:
         test_flag: rest
     """
-    collection = rest_api.collections.vms
+    collection = appliance.rest_api.collections.vms
     url_string = '{}{}'.format(
         collection._href,
         '?expand=resources&attributes=created_on&sort_by=created_on&sort_order=asc'
@@ -300,14 +301,14 @@ def test_datetime_filtering(rest_api, a_provider):
     baseline_datetime = baseline_vm._data['created_on']  # YYYY-MM-DDTHH:MM:SSZ
 
     def _get_filtered_resources(operator):
-        return rest_api.get(url_string.format(operator, baseline_datetime))['resources']
+        return appliance.rest_api.get(url_string.format(operator, baseline_datetime))['resources']
 
     older_resources = _get_filtered_resources('<')
     newer_resources = _get_filtered_resources('>')
     matching_resources = _get_filtered_resources('=')
     # this will fail once BZ1437529 is fixed
-    # should be: ``assert len(matching_resources)``
-    assert len(matching_resources) == 0
+    # should be: ``assert matching_resources``
+    assert not matching_resources
     if older_resources:
         last_older = collection.get(id=older_resources[-1]['id'])
         assert last_older.created_on < baseline_vm.created_on
@@ -319,13 +320,13 @@ def test_datetime_filtering(rest_api, a_provider):
 
 
 @pytest.mark.uncollectif(lambda: current_version() < '5.8')
-def test_date_filtering(rest_api, a_provider):
+def test_date_filtering(appliance, a_provider):
     """Tests support for DateTime filtering with timestamps in YYYY-MM-DD format.
 
     Metadata:
         test_flag: rest
     """
-    collection = rest_api.collections.vms
+    collection = appliance.rest_api.collections.vms
     url_string = '{}{}'.format(
         collection._href,
         '?expand=resources&attributes=created_on&sort_by=created_on&sort_order=desc'
@@ -336,12 +337,12 @@ def test_date_filtering(rest_api, a_provider):
     baseline_date, _ = baseline_vm._data['created_on'].split('T')  # YYYY-MM-DD
 
     def _get_filtered_resources(operator):
-        return rest_api.get(url_string.format(operator, baseline_date))['resources']
+        return appliance.rest_api.get(url_string.format(operator, baseline_date))['resources']
 
     older_resources = _get_filtered_resources('<')
     newer_resources = _get_filtered_resources('>')
     matching_resources = _get_filtered_resources('=')
-    assert len(matching_resources)
+    assert matching_resources
     if newer_resources:
         last_newer = collection.get(id=newer_resources[-1]['id'])
         assert last_newer.created_on > baseline_vm.created_on
@@ -351,37 +352,38 @@ def test_date_filtering(rest_api, a_provider):
 
 
 @pytest.mark.uncollectif(lambda: current_version() < '5.8')
-def test_resources_hiding(rest_api):
+def test_resources_hiding(appliance):
     """Test that it's possible to hide resources in response.
 
     Metadata:
         test_flag: rest
     """
-    roles = rest_api.collections.roles
-    resources_visible = rest_api.get(roles._href + '?filter[]=read_only=true')
-    assert rest_api.response.status_code == 200
+    roles = appliance.rest_api.collections.roles
+    resources_visible = appliance.rest_api.get(roles._href + '?filter[]=read_only=true')
+    assert appliance.rest_api.response.status_code == 200
     assert 'resources' in resources_visible
-    resources_hidden = rest_api.get(roles._href + '?filter[]=read_only=true&hide=resources')
-    assert rest_api.response.status_code == 200
+    resources_hidden = appliance.rest_api.get(
+        roles._href + '?filter[]=read_only=true&hide=resources')
+    assert appliance.rest_api.response.status_code == 200
     assert 'resources' not in resources_hidden
     assert resources_hidden['subcount'] == resources_visible['subcount']
 
 
 @pytest.mark.uncollectif(lambda: current_version() < '5.8')
-def test_sorting_by_attributes(rest_api):
+def test_sorting_by_attributes(appliance):
     """Test that it's possible to sort resources by attributes.
 
     Metadata:
         test_flag: rest
     """
     url_string = '{}{}'.format(
-        rest_api.collections.groups._href,
+        appliance.rest_api.collections.groups._href,
         '?expand=resources&attributes=id&sort_by=id&sort_order={}')
-    response_asc = rest_api.get(url_string.format('asc'))
-    assert rest_api.response.status_code == 200
+    response_asc = appliance.rest_api.get(url_string.format('asc'))
+    assert appliance.rest_api.response.status_code == 200
     assert 'resources' in response_asc
-    response_desc = rest_api.get(url_string.format('desc'))
-    assert rest_api.response.status_code == 200
+    response_desc = appliance.rest_api.get(url_string.format('desc'))
+    assert appliance.rest_api.response.status_code == 200
     assert 'resources' in response_desc
     assert response_asc['subcount'] == response_desc['subcount']
 
@@ -397,90 +399,90 @@ def test_sorting_by_attributes(rest_api):
 
 class TestBulkQueryRESTAPI(object):
     @pytest.mark.uncollectif(lambda: current_version() < '5.7')
-    def test_bulk_query(self, rest_api):
+    def test_bulk_query(self, appliance):
         """Tests bulk query referencing resources by attributes id, href and guid
 
         Metadata:
             test_flag: rest
         """
-        collection = rest_api.collections.events
+        collection = appliance.rest_api.collections.events
         data0, data1, data2 = collection[0]._data, collection[1]._data, collection[2]._data
-        response = rest_api.collections.events.action.query(
+        response = appliance.rest_api.collections.events.action.query(
             {'id': data0['id']}, {'href': data1['href']}, {'guid': data2['guid']})
-        assert rest_api.response.status_code == 200
+        assert appliance.rest_api.response.status_code == 200
         assert len(response) == 3
         assert (data0 == response[0]._data and
                 data1 == response[1]._data and
                 data2 == response[2]._data)
 
     @pytest.mark.uncollectif(lambda: current_version() < '5.7')
-    def test_bulk_query_users(self, rest_api):
+    def test_bulk_query_users(self, appliance):
         """Tests bulk query on 'users' collection
 
         Metadata:
             test_flag: rest
         """
-        data = rest_api.collections.users[0]._data
-        response = rest_api.collections.users.action.query(
+        data = appliance.rest_api.collections.users[0]._data
+        response = appliance.rest_api.collections.users.action.query(
             {'name': data['name']}, {'userid': data['userid']})
-        assert rest_api.response.status_code == 200
+        assert appliance.rest_api.response.status_code == 200
         assert len(response) == 2
         assert data['id'] == response[0]._data['id'] == response[1]._data['id']
 
     @pytest.mark.uncollectif(lambda: current_version() < '5.7')
-    def test_bulk_query_roles(self, rest_api):
+    def test_bulk_query_roles(self, appliance):
         """Tests bulk query on 'roles' collection
 
         Metadata:
             test_flag: rest
         """
-        collection = rest_api.collections.roles
+        collection = appliance.rest_api.collections.roles
         data0, data1 = collection[0]._data, collection[1]._data
-        response = rest_api.collections.roles.action.query(
+        response = appliance.rest_api.collections.roles.action.query(
             {'name': data0['name']}, {'name': data1['name']})
-        assert rest_api.response.status_code == 200
+        assert appliance.rest_api.response.status_code == 200
         assert len(response) == 2
         assert data0 == response[0]._data and data1 == response[1]._data
 
     @pytest.mark.uncollectif(lambda: current_version() < '5.7')
-    def test_bulk_query_groups(self, rest_api):
+    def test_bulk_query_groups(self, appliance):
         """Tests bulk query on 'groups' collection
 
         Metadata:
             test_flag: rest
         """
-        collection = rest_api.collections.groups
+        collection = appliance.rest_api.collections.groups
         data0, data1 = collection[0]._data, collection[1]._data
-        response = rest_api.collections.groups.action.query(
+        response = appliance.rest_api.collections.groups.action.query(
             {'description': data0['description']}, {'description': data1['description']})
-        assert rest_api.response.status_code == 200
+        assert appliance.rest_api.response.status_code == 200
         assert len(response) == 2
         assert data0 == response[0]._data and data1 == response[1]._data
 
 
 class TestArbitrationSettingsRESTAPI(object):
     @pytest.fixture(scope='function')
-    def arbitration_settings(self, request, rest_api):
+    def arbitration_settings(self, request, appliance):
         num_settings = 2
-        response = _arbitration_settings(request, rest_api, num=num_settings)
-        assert rest_api.response.status_code == 200
+        response = _arbitration_settings(request, appliance.rest_api, num=num_settings)
+        assert appliance.rest_api.response.status_code == 200
         assert len(response) == num_settings
         return response
 
     @pytest.mark.uncollectif(lambda: current_version() < '5.7')
-    def test_create_arbitration_settings(self, rest_api, arbitration_settings):
+    def test_create_arbitration_settings(self, appliance, arbitration_settings):
         """Tests create arbitration settings.
 
         Metadata:
             test_flag: rest
         """
         for setting in arbitration_settings:
-            record = rest_api.collections.arbitration_settings.get(id=setting.id)
+            record = appliance.rest_api.collections.arbitration_settings.get(id=setting.id)
             assert record._data == setting._data
 
     @pytest.mark.uncollectif(lambda: current_version() < '5.7')
     @pytest.mark.parametrize('method', ['post', 'delete'])
-    def test_delete_arbitration_settings_from_detail(self, rest_api, arbitration_settings, method):
+    def test_delete_arbitration_settings_from_detail(self, appliance, arbitration_settings, method):
         """Tests delete arbitration settings from detail.
 
         Metadata:
@@ -489,30 +491,30 @@ class TestArbitrationSettingsRESTAPI(object):
         status = 204 if method == 'delete' else 200
         for setting in arbitration_settings:
             setting.action.delete(force_method=method)
-            assert rest_api.response.status_code == status
+            assert appliance.rest_api.response.status_code == status
             with error.expected('ActiveRecord::RecordNotFound'):
                 setting.action.delete(force_method=method)
-            assert rest_api.response.status_code == 404
+            assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.uncollectif(lambda: current_version() < '5.7')
-    def test_delete_arbitration_settings_from_collection(self, rest_api, arbitration_settings):
+    def test_delete_arbitration_settings_from_collection(self, appliance, arbitration_settings):
         """Tests delete arbitration settings from collection.
 
         Metadata:
             test_flag: rest
         """
-        collection = rest_api.collections.arbitration_settings
+        collection = appliance.rest_api.collections.arbitration_settings
         collection.action.delete(*arbitration_settings)
-        assert rest_api.response.status_code == 200
+        assert appliance.rest_api.response.status_code == 200
         with error.expected('ActiveRecord::RecordNotFound'):
             collection.action.delete(*arbitration_settings)
-        assert rest_api.response.status_code == 404
+        assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.uncollectif(lambda: current_version() < '5.7')
     @pytest.mark.parametrize(
         "from_detail", [True, False],
         ids=["from_detail", "from_collection"])
-    def test_edit_arbitration_settings(self, rest_api, arbitration_settings, from_detail):
+    def test_edit_arbitration_settings(self, appliance, arbitration_settings, from_detail):
         """Tests edit arbitration settings.
 
         Metadata:
@@ -526,12 +528,12 @@ class TestArbitrationSettingsRESTAPI(object):
             edited = []
             for i in range(num_settings):
                 edited.append(arbitration_settings[i].action.edit(**new[i]))
-                assert rest_api.response.status_code == 200
+                assert appliance.rest_api.response.status_code == 200
         else:
             for i in range(num_settings):
                 new[i].update(arbitration_settings[i]._ref_repr())
-            edited = rest_api.collections.arbitration_settings.action.edit(*new)
-            assert rest_api.response.status_code == 200
+            edited = appliance.rest_api.collections.arbitration_settings.action.edit(*new)
+            assert appliance.rest_api.response.status_code == 200
         assert len(edited) == num_settings
         for i in range(num_settings):
             assert (edited[i].name == new[i]['name'] and
@@ -540,27 +542,27 @@ class TestArbitrationSettingsRESTAPI(object):
 
 class TestArbitrationRulesRESTAPI(object):
     @pytest.fixture(scope='function')
-    def arbitration_rules(self, request, rest_api):
+    def arbitration_rules(self, request, appliance):
         num_rules = 2
-        response = _arbitration_rules(request, rest_api, num=num_rules)
-        assert rest_api.response.status_code == 200
+        response = _arbitration_rules(request, appliance.rest_api, num=num_rules)
+        assert appliance.rest_api.response.status_code == 200
         assert len(response) == num_rules
         return response
 
     @pytest.mark.uncollectif(lambda: current_version() < '5.7')
-    def test_create_arbitration_rules(self, arbitration_rules, rest_api):
+    def test_create_arbitration_rules(self, arbitration_rules, appliance):
         """Tests create arbitration rules.
 
         Metadata:
             test_flag: rest
         """
         for rule in arbitration_rules:
-            record = rest_api.collections.arbitration_rules.get(id=rule.id)
+            record = appliance.rest_api.collections.arbitration_rules.get(id=rule.id)
             assert record.description == rule.description
 
     @pytest.mark.uncollectif(lambda: current_version() < '5.7')
     @pytest.mark.parametrize('method', ['post', 'delete'])
-    def test_delete_arbitration_rules_from_detail(self, arbitration_rules, rest_api, method):
+    def test_delete_arbitration_rules_from_detail(self, arbitration_rules, appliance, method):
         """Tests delete arbitration rules from detail.
 
         Metadata:
@@ -569,30 +571,30 @@ class TestArbitrationRulesRESTAPI(object):
         status = 204 if method == 'delete' else 200
         for entity in arbitration_rules:
             entity.action.delete(force_method=method)
-            assert rest_api.response.status_code == status
+            assert appliance.rest_api.response.status_code == status
             with error.expected('ActiveRecord::RecordNotFound'):
                 entity.action.delete(force_method=method)
-            assert rest_api.response.status_code == 404
+            assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.uncollectif(lambda: current_version() < '5.7')
-    def test_delete_arbitration_rules_from_collection(self, arbitration_rules, rest_api):
+    def test_delete_arbitration_rules_from_collection(self, arbitration_rules, appliance):
         """Tests delete arbitration rules from collection.
 
         Metadata:
             test_flag: rest
         """
-        collection = rest_api.collections.arbitration_rules
+        collection = appliance.rest_api.collections.arbitration_rules
         collection.action.delete(*arbitration_rules)
-        assert rest_api.response.status_code == 200
+        assert appliance.rest_api.response.status_code == 200
         with error.expected('ActiveRecord::RecordNotFound'):
             collection.action.delete(*arbitration_rules)
-        assert rest_api.response.status_code == 404
+        assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.uncollectif(lambda: current_version() < '5.7')
     @pytest.mark.parametrize(
         'from_detail', [True, False],
         ids=['from_detail', 'from_collection'])
-    def test_edit_arbitration_rules(self, arbitration_rules, rest_api, from_detail):
+    def test_edit_arbitration_rules(self, arbitration_rules, appliance, from_detail):
         """Tests edit arbitration rules.
 
         Metadata:
@@ -605,12 +607,12 @@ class TestArbitrationRulesRESTAPI(object):
             edited = []
             for i in range(num_rules):
                 edited.append(arbitration_rules[i].action.edit(**new[i]))
-                assert rest_api.response.status_code == 200
+                assert appliance.rest_api.response.status_code == 200
         else:
             for i in range(num_rules):
                 new[i].update(arbitration_rules[i]._ref_repr())
-            edited = rest_api.collections.arbitration_rules.action.edit(*new)
-            assert rest_api.response.status_code == 200
+            edited = appliance.rest_api.collections.arbitration_rules.action.edit(*new)
+            assert appliance.rest_api.response.status_code == 200
         assert len(edited) == num_rules
         for i in range(num_rules):
             assert edited[i].description == new[i]['description']
@@ -618,9 +620,10 @@ class TestArbitrationRulesRESTAPI(object):
 
 class TestNotificationsRESTAPI(object):
     @pytest.fixture(scope='function')
-    def generate_notifications(self, rest_api):
+    def generate_notifications(self, appliance):
         requests_data = automation_requests_data('nonexistent_vm')
-        requests = rest_api.collections.automation_requests.action.create(*requests_data[:2])
+        requests = appliance.rest_api.collections.automation_requests.action.create(
+            *requests_data[:2])
         assert len(requests) == 2
         wait_for_requests(requests)
 
@@ -628,22 +631,22 @@ class TestNotificationsRESTAPI(object):
     @pytest.mark.parametrize(
         'from_detail', [True, False],
         ids=['from_detail', 'from_collection'])
-    def test_mark_notifications(self, rest_api, generate_notifications, from_detail):
+    def test_mark_notifications(self, appliance, generate_notifications, from_detail):
         """Tests marking notifications as seen.
 
         Metadata:
             test_flag: rest
         """
-        unseen = rest_api.collections.notifications.find_by(seen=False)
+        unseen = appliance.rest_api.collections.notifications.find_by(seen=False)
         notifications = [unseen[-i] for i in range(1, 3)]
 
         if from_detail:
             for ent in notifications:
                 ent.action.mark_as_seen()
-                assert rest_api.response.status_code == 200
+                assert appliance.rest_api.response.status_code == 200
         else:
-            rest_api.collections.notifications.action.mark_as_seen(*notifications)
-            assert rest_api.response.status_code == 200
+            appliance.rest_api.collections.notifications.action.mark_as_seen(*notifications)
+            assert appliance.rest_api.response.status_code == 200
 
         for ent in notifications:
             ent.reload()
@@ -651,7 +654,7 @@ class TestNotificationsRESTAPI(object):
 
     @pytest.mark.uncollectif(lambda: current_version() < '5.7')
     @pytest.mark.parametrize('method', ['post', 'delete'])
-    def test_delete_notifications_from_detail(self, rest_api, generate_notifications, method):
+    def test_delete_notifications_from_detail(self, appliance, generate_notifications, method):
         """Tests delete notifications from detail.
 
         Metadata:
@@ -659,31 +662,31 @@ class TestNotificationsRESTAPI(object):
         """
         if method == 'delete' and BZ('1420872', forced_streams=['5.7', 'upstream']).blocks:
             pytest.skip("Affected by BZ1420872, cannot test.")
-        collection = rest_api.collections.notifications
+        collection = appliance.rest_api.collections.notifications
         collection.reload()
         notifications = [collection[-i] for i in range(1, 3)]
         status = 204 if method == 'delete' else 200
 
         for entity in notifications:
             entity.action.delete(force_method=method)
-            assert rest_api.response.status_code == status
+            assert appliance.rest_api.response.status_code == status
             with error.expected('ActiveRecord::RecordNotFound'):
                 entity.action.delete(force_method=method)
-            assert rest_api.response.status_code == 404
+            assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.uncollectif(lambda: current_version() < '5.7')
-    def test_delete_notifications_from_collection(self, rest_api, generate_notifications):
+    def test_delete_notifications_from_collection(self, appliance, generate_notifications):
         """Tests delete notifications from collection.
 
         Metadata:
             test_flag: rest
         """
-        collection = rest_api.collections.notifications
+        collection = appliance.rest_api.collections.notifications
         collection.reload()
         notifications = [collection[-i] for i in range(1, 3)]
 
         collection.action.delete(*notifications)
-        assert rest_api.response.status_code == 200
+        assert appliance.rest_api.response.status_code == 200
         with error.expected("ActiveRecord::RecordNotFound"):
             collection.action.delete(*notifications)
-        assert rest_api.response.status_code == 404
+        assert appliance.rest_api.response.status_code == 404

--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -188,7 +188,6 @@ def test_add_picture_invalid_extension(appliance):
 
 
 @pytest.mark.uncollectif(lambda: current_version() < '5.8')
-@pytest.mark.meta(blockers=[BZ(1438587, forced_streams=['5.8', 'upstream'])])
 def test_add_picture_invalid_data(appliance):
     """Tests adding picture with invalid content.
 
@@ -197,7 +196,7 @@ def test_add_picture_invalid_data(appliance):
     """
     collection = appliance.rest_api.collections.pictures
     count = collection.count
-    with error.expected('Invalid content'):  # change once the BZ1438587 is fixed
+    with error.expected('invalid base64'):
         collection.action.create({
             "extension": "png",
             "content": "invalid"})


### PR DESCRIPTION
Replacing the ``rest_api`` fixture with ``appliance.rest_api``

{{pytest: cfme/tests/test_rest.py -v}}