### PR TITLE
[1LP][RFR] Fixed SSH closing on one test

### DIFF
--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -169,12 +169,14 @@ def vm_name(request, initialize_provider, full_template):
     return name
 
 
-@pytest.fixture(scope="function")
+@pytest.yield_fixture(scope="function")
 def ssh(provider, full_template, vm_name):
-    return SSHClient(
+    conn = SSHClient(
         username=credentials[full_template['creds']]['username'],
         password=credentials[full_template['creds']]['password'],
         hostname=provider.mgmt.get_ip_address(vm_name))
+    yield conn
+    conn.close()
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Close of SSH on finishing of test

#### mshriver: limiting PRT to the test that uses the ssh fixture
{{ pytest: cfme/tests/control/test_alerts.py -k  test_alert_timeline_cpu --long-running --use-provider vsphere6-nested }}