### PR TITLE
[RFR][1LP] move conftest into pytest plugin

### DIFF
--- a/cfme/test_framework/pytest_plugin.py
+++ b/cfme/test_framework/pytest_plugin.py
@@ -4,14 +4,19 @@ Top-level conftest.py does a couple of things:
 1) Add cfme_pages repo to the sys.path automatically
 2) Load a number of plugins and fixtures automatically
 """
-
 import pytest
 
 
-@pytest.mark.tryfirst
 def pytest_addoption(parser):
     # Create the cfme option group for use in other plugins
     parser.getgroup('cfme', 'cfme: options related to cfme/miq appliances')
+
+
+def pytest_plugin_registered(plugin, manager):
+    # work around pytest not running consider_module on setuptools loaded plugins
+    # https://github.com/pytest-dev/pytest/issues/2391
+    if getattr(plugin, '__name__', None) == __name__:
+        manager.consider_module(plugin)
 
 
 pytest_plugins = (

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,3 @@
+# inplace due to dockerbot not invoking editable installs
+# will be removed
+pytest_plugins = ('cfme.test_framework.pytest_plugin',)

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ setup(
             'miq-artifactor-server = artifactor.__main__:main',
             'miq-runtest = cfme.scripting.runtest:main',
         ],
+        'pytest11': [
+            'miq_testing = cfme.test_framework.pytest_plugin',
+        ],
         'manageiq.provider_categories':
         [
             'infra = cfme.infrastructure.provider:InfraProvider',


### PR DESCRIPTION
this has to work around a newly found pytest issue
this enables general use as package, currently editable installation is still needed
