### PR TITLE
[RFR] Fix to appliance provisioning errors

### DIFF
--- a/cfme/test_framework/sprout/client.py
+++ b/cfme/test_framework/sprout/client.py
@@ -111,7 +111,8 @@ class SproutClient(object):
             group=stream, provider=provider, lease_time=lease_time, ram=ram, cpu=cpu, count=count
         )
         wait_for(
-            lambda: self.call_method('request_check', str(request_id))['finished'], num_sec=300)
+            lambda: self.call_method('request_check', str(request_id))['finished'], num_sec=300,
+            message='provision {} appliance(s) from sprout'.format(count))
         data = self.call_method('request_check', str(request_id))
         logger.debug(data)
         appliances = []

--- a/fixtures/appliance.py
+++ b/fixtures/appliance.py
@@ -14,7 +14,6 @@ from contextlib import contextmanager
 
 import pytest
 
-from utils.log import logger
 from cfme.test_framework.sprout.client import SproutClient
 
 
@@ -27,18 +26,16 @@ def temp_appliances(count=1, preconfigured=True, lease_time=180):
         preconfigured: True if the appliance should be already configured, False otherwise
         lease_time: Lease time in minutes (3 hours by default)
     """
-    apps = None
+    apps = []
     try:
         sprout_client = SproutClient.from_config()
         apps, request_id = sprout_client.provision_appliances(
             count=count, lease_time=lease_time, preconfigured=preconfigured)
         yield apps
-        logger.exception('Error detected during appliance provision')
     finally:
-        if apps:
-            for app in apps:
-                app.ssh_client.close()
-            sprout_client.destroy_pool(request_id)
+        for app in apps:
+            app.ssh_client.close()
+        sprout_client.destroy_pool(request_id)
 
 
 # Single appliance, configured

--- a/fixtures/appliance.py
+++ b/fixtures/appliance.py
@@ -33,8 +33,7 @@ def temp_appliances(count=1, preconfigured=True, lease_time=180):
         apps, request_id = sprout_client.provision_appliances(
             count=count, lease_time=lease_time, preconfigured=preconfigured)
         yield apps
-    except Exception as e:
-        logger.info('Exception detected: %s', str(e))
+        logger.exception('Error detected during appliance provision')
     finally:
         if apps:
             for app in apps:

--- a/fixtures/appliance.py
+++ b/fixtures/appliance.py
@@ -26,15 +26,14 @@ def temp_appliances(count=1, preconfigured=True, lease_time=180):
         preconfigured: True if the appliance should be already configured, False otherwise
         lease_time: Lease time in minutes (3 hours by default)
     """
-    try:
-        sprout_client = SproutClient.from_config()
-        apps, request_id = sprout_client.provision_appliances(
-            count=count, lease_time=lease_time, preconfigured=preconfigured)
-        yield apps
-    finally:
-        for app in apps:
-            app.ssh_client.close()
-        sprout_client.destroy_pool(request_id)
+    sprout_client = SproutClient.from_config()
+    apps, request_id = sprout_client.provision_appliances(
+        count=count, lease_time=lease_time, preconfigured=preconfigured)
+    yield apps
+
+    for app in apps:
+        app.ssh_client.close()
+    sprout_client.destroy_pool(request_id)
 
 
 # Single appliance, configured

--- a/fixtures/appliance.py
+++ b/fixtures/appliance.py
@@ -36,9 +36,10 @@ def temp_appliances(count=1, preconfigured=True, lease_time=180):
     except Exception as e:
         logger.info('Exception detected: %s', str(e))
     finally:
-        for app in apps:
-            app.ssh_client.close()
-        sprout_client.destroy_pool(request_id)
+        if apps:
+            for app in apps:
+                app.ssh_client.close()
+            sprout_client.destroy_pool(request_id)
 
 
 # Single appliance, configured


### PR DESCRIPTION
Changes to appliance.py, removed try/finally as it would throw errors 'apps referenced before assignment' if no provisions where available. 

Also changed client.py to improve error message when no provisions are available from sprout.