### PR TITLE
[1LP][RFR] Fix the coverage hook setup

### DIFF
--- a/fixtures/ui_coverage.py
+++ b/fixtures/ui_coverage.py
@@ -72,7 +72,8 @@ appliance_coverage_root = rails_root.join('coverage')
 
 # local
 coverage_data = scripts_data_path.join('coverage')
-gemfile = coverage_data.join('Gemfile.dev.rb')
+gemfile = coverage_data.join('coverage_gem.rb')
+bundler_d = rails_root.join('bundler.d')
 coverage_hook_lowest = coverage_data.join('coverage_hook_lowest.rb')
 coverage_hook_55 = coverage_data.join('coverage_hook_55.rb')
 coverage_hook_out_fn = 'coverage_hook.rb'
@@ -169,7 +170,7 @@ class CoverageManager(object):
 
     def _install_simplecov(self):
         self.log.info('Installing coverage gem on appliance')
-        self.ipapp.ssh_client.put_file(gemfile.strpath, rails_root.strpath)
+        self.ipapp.ssh_client.put_file(gemfile.strpath, bundler_d.strpath)
 
         # gem install for more recent downstream builds
         def _gem_install():
@@ -183,7 +184,6 @@ class CoverageManager(object):
         version.pick({
             version.LOWEST: _bundle_install,
             '5.4': _gem_install,
-            '5.5': _gem_install,
             version.LATEST: _bundle_install,
         })()
 
@@ -198,9 +198,9 @@ class CoverageManager(object):
         })
         # Put the coverage hook in the miq lib path
         self.ipapp.ssh_client.put_file(coverage_hook.strpath, rails_root.join(
-            '..', 'lib', coverage_hook_out_fn).strpath)
+            'lib', coverage_hook_out_fn).strpath)
         replacements = {
-            'require': r"require 'coverage_hook'",
+            'require': r"require_relative '../lib/coverage_hook'",
             'config': rails_root.join('config').strpath
         }
         # grep/echo to try to add the require line only once

--- a/scripts/data/coverage/Gemfile.dev.rb
+++ b/scripts/data/coverage/Gemfile.dev.rb
@@ -1,2 +1,0 @@
-# goes into the rails root, next to the other Gemfiles
-gem 'simplecov'

--- a/scripts/data/coverage/coverage_gem.rb
+++ b/scripts/data/coverage/coverage_gem.rb
@@ -1,0 +1,2 @@
+# goes into vmdb/bundler.d/
+gem 'simplecov'

--- a/scripts/data/coverage/thing_toucher.rb
+++ b/scripts/data/coverage/thing_toucher.rb
@@ -3,7 +3,6 @@
 
 # INCLUDE_GLOBS is eager, and tries to get all the rubies
 INCLUDE_GLOBS = [
-  '../lib/**/*.rb',
   'lib/**/*.rb',
   'app/**/*.rb',
 ]
@@ -13,8 +12,7 @@ INCLUDE_GLOBS = [
 # appliance console.
 # Models are loaded separately, so they're also excluded here.
 EXCLUDE_GLOBS = [
-  '../lib/appliance_console*',
-  '../lib/coverage_hook*',
+  'lib/coverage_hook*',
   'lib/extensions/**',
   'lib/db_administration/**',
   'lib/miq_automation_engine/**',
@@ -32,9 +30,7 @@ def touch_all_the_things
   excludes = Dir.glob(EXCLUDE_GLOBS)
 
   includes.each do |file|
-    if excludes.include?(file)
-      next
-    end
+    next if excludes.include?(file)
     begin
       require File.basename(file, ".rb")
       puts "#{file} touched"

--- a/utils/ssh.py
+++ b/utils/ssh.py
@@ -309,13 +309,13 @@ class SSHClient(paramiko.SSHClient):
 
     def run_rails_command(self, command, timeout=RUNCMD_TIMEOUT, **kwargs):
         logger.info("Running rails command %r", command)
-        return self.run_command('/var/www/miq/vmdb/bin/rails runner {command}'.format(
+        return self.run_command('cd /var/www/miq/vmdb; bin/rails runner {command}'.format(
             command=command), timeout=timeout, **kwargs)
 
     def run_rake_command(self, command, timeout=RUNCMD_TIMEOUT, **kwargs):
         logger.info("Running rake command %r", command)
         return self.run_command(
-            '/var/www/miq/vmdb/bin/rake -f /var/www/miq/vmdb/Rakefile {command}'.format(
+            'cd /var/www/miq/vmdb; bin/rake -f /var/www/miq/vmdb/Rakefile {command}'.format(
                 command=command), timeout=timeout, **kwargs)
 
     def put_file(self, local_file, remote_file='.', **kwargs):


### PR DESCRIPTION
The miq/lib/ directory was removed, making the installation of coverage hook fail.

Moved the installation into vmdb/lib/ and modified the preinitializer to require_relative.

{{pytest: -v -m smoke --ui-coverage}}