### PR TITLE
[1LP][RFR] remove rest_api fixture from test_rest_services

### DIFF
--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -72,20 +72,20 @@ def dialog():
 
 
 @pytest.fixture(scope="function")
-def service_catalogs(request, rest_api):
-    response = _service_catalogs(request, rest_api)
-    assert rest_api.response.status_code == 200
+def service_catalogs(request, appliance):
+    response = _service_catalogs(request, appliance.rest_api)
+    assert appliance.rest_api.response.status_code == 200
     return response
 
 
 @pytest.fixture(scope="function")
-def services(request, rest_api, a_provider):
+def services(request, appliance, a_provider):
     if version.current_version() >= '5.7':
         # create simple service using REST API
         bodies = [service_body() for _ in range(3)]
-        collection = rest_api.collections.services
+        collection = appliance.rest_api.collections.services
         new_services = collection.action.create(*bodies)
-        assert rest_api.response.status_code == 200
+        assert appliance.rest_api.response.status_code == 200
 
         @request.addfinalizer
         def _finished():
@@ -98,23 +98,23 @@ def services(request, rest_api, a_provider):
         return new_services
     else:
         # create full-blown service using UI
-        return _services(request, rest_api, a_provider)
+        return _services(request, appliance.rest_api, a_provider)
 
 
 @pytest.fixture(scope="function")
-def service_templates(request, rest_api):
-    response = _service_templates(request, rest_api)
-    assert rest_api.response.status_code == 200
+def service_templates(request, appliance):
+    response = _service_templates(request, appliance.rest_api)
+    assert appliance.rest_api.response.status_code == 200
     return response
 
 
 @pytest.fixture(scope="function")
-def service_data(request, rest_api, a_provider):
-    return _service_data(request, rest_api, a_provider)
+def service_data(request, appliance, a_provider):
+    return _service_data(request, appliance.rest_api, a_provider)
 
 
 class TestServiceRESTAPI(object):
-    def test_edit_service(self, rest_api, services):
+    def test_edit_service(self, appliance, services):
         """Tests editing a service.
         Prerequisities:
             * An appliance with ``/api`` available.
@@ -127,12 +127,12 @@ class TestServiceRESTAPI(object):
         for service in services:
             new_name = fauxfactory.gen_alphanumeric()
             response = service.action.edit(name=new_name)
-            assert rest_api.response.status_code == 200
+            assert appliance.rest_api.response.status_code == 200
             assert response.name == new_name
             service.reload()
             assert service.name == new_name
 
-    def test_edit_multiple_services(self, rest_api, services):
+    def test_edit_multiple_services(self, appliance, services):
         """Tests editing multiple services at a time.
         Prerequisities:
             * An appliance with ``/api`` available.
@@ -151,8 +151,8 @@ class TestServiceRESTAPI(object):
                 "href": service.href,
                 "name": new_name,
             })
-        response = rest_api.collections.services.action.edit(*services_data_edited)
-        assert rest_api.response.status_code == 200
+        response = appliance.rest_api.collections.services.action.edit(*services_data_edited)
+        assert appliance.rest_api.response.status_code == 200
         for i, resource in enumerate(response):
             assert resource.name == new_names[i]
             service = services[i]
@@ -161,7 +161,7 @@ class TestServiceRESTAPI(object):
 
     # POST method is not available on < 5.8, as described in BZ 1414852
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
-    def test_delete_service_post(self, rest_api, services):
+    def test_delete_service_post(self, appliance, services):
         """Tests deleting services from detail using POST method.
 
         Metadata:
@@ -169,12 +169,12 @@ class TestServiceRESTAPI(object):
         """
         for service in services:
             service.action.delete(force_method="post")
-            assert rest_api.response.status_code == 200
+            assert appliance.rest_api.response.status_code == 200
             with error.expected("ActiveRecord::RecordNotFound"):
                 service.action.delete(force_method="post")
-            assert rest_api.response.status_code == 404
+            assert appliance.rest_api.response.status_code == 404
 
-    def test_delete_service_delete(self, rest_api, services):
+    def test_delete_service_delete(self, appliance, services):
         """Tests deleting services from detail using DELETE method.
 
         Metadata:
@@ -182,42 +182,42 @@ class TestServiceRESTAPI(object):
         """
         for service in services:
             service.action.delete(force_method="delete")
-            assert rest_api.response.status_code == 204
+            assert appliance.rest_api.response.status_code == 204
             with error.expected("ActiveRecord::RecordNotFound"):
                 service.action.delete(force_method="delete")
-            assert rest_api.response.status_code == 404
+            assert appliance.rest_api.response.status_code == 404
 
-    def test_delete_services(self, rest_api, services):
+    def test_delete_services(self, appliance, services):
         """Tests deleting services from collection.
 
         Metadata:
             test_flag: rest
         """
-        rest_api.collections.services.action.delete(*services)
-        assert rest_api.response.status_code == 200
+        appliance.rest_api.collections.services.action.delete(*services)
+        assert appliance.rest_api.response.status_code == 200
         with error.expected("ActiveRecord::RecordNotFound"):
-            rest_api.collections.services.action.delete(*services)
-        assert rest_api.response.status_code == 404
+            appliance.rest_api.collections.services.action.delete(*services)
+        assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.parametrize(
         "from_detail", [True, False],
         ids=["from_detail", "from_collection"])
-    def test_retire_service_now(self, rest_api, service_data, from_detail):
+    def test_retire_service_now(self, appliance, service_data, from_detail):
         """Test retiring a service now.
 
         Metadata:
             test_flag: rest
         """
-        collection = rest_api.collections.services
+        collection = appliance.rest_api.collections.services
         service = collection.get(name=service_data['service_name'])
-        vm = rest_api.collections.vms.get(name=service_data['vm_name'])
+        vm = appliance.rest_api.collections.vms.get(name=service_data['vm_name'])
 
         if from_detail:
             service.action.retire()
-            assert rest_api.response.status_code == 200
+            assert appliance.rest_api.response.status_code == 200
         else:
             collection.action.retire(service)
-            assert rest_api.response.status_code == 200
+            assert appliance.rest_api.response.status_code == 200
 
         wait_for(lambda: is_retired(service), num_sec=600, delay=10)
         wait_for(lambda: is_retired(vm), num_sec=1000, delay=10)
@@ -225,7 +225,7 @@ class TestServiceRESTAPI(object):
     @pytest.mark.parametrize(
         "from_detail", [True, False],
         ids=["from_detail", "from_collection"])
-    def test_retire_service_future(self, rest_api, services, from_detail):
+    def test_retire_service_future(self, appliance, services, from_detail):
         """Test retiring a service in future.
 
         Metadata:
@@ -240,10 +240,10 @@ class TestServiceRESTAPI(object):
         if from_detail:
             for service in services:
                 service.action.retire(**future)
-                assert rest_api.response.status_code == 200
+                assert appliance.rest_api.response.status_code == 200
         else:
-            rest_api.collections.services.action.retire(*services, **future)
-            assert rest_api.response.status_code == 200
+            appliance.rest_api.collections.services.action.retire(*services, **future)
+            assert appliance.rest_api.response.status_code == 200
 
         def _finished(service):
             service.reload()
@@ -256,36 +256,36 @@ class TestServiceRESTAPI(object):
                 delay=5
             )
 
-    def test_set_service_owner(self, rest_api, services):
+    def test_set_service_owner(self, appliance, services):
         """Tests set_ownership action on /api/services/:id.
 
         Metadata:
             test_flag: rest
         """
-        user = rest_api.collections.users.get(userid="admin")
+        user = appliance.rest_api.collections.users.get(userid="admin")
         data = {
             "owner": {"href": user.href}
         }
         for service in services:
             service.action.set_ownership(**data)
-            assert rest_api.response.status_code == 200
+            assert appliance.rest_api.response.status_code == 200
             service.reload()
             assert hasattr(service, "evm_owner_id")
             assert service.evm_owner_id == user.id
 
-    def test_set_services_owner(self, rest_api, services):
+    def test_set_services_owner(self, appliance, services):
         """Tests set_ownership action on /api/services collection.
 
         Metadata:
             test_flag: rest
         """
-        user = rest_api.collections.users.get(userid="admin")
+        user = appliance.rest_api.collections.users.get(userid="admin")
         requests = [{
             "href": service.href,
             "owner": {"href": user.href}
         } for service in services]
-        rest_api.collections.services.action.set_ownership(*requests)
-        assert rest_api.response.status_code == 200
+        appliance.rest_api.collections.services.action.set_ownership(*requests)
+        assert appliance.rest_api.response.status_code == 200
         for service in services:
             service.reload()
             assert hasattr(service, "evm_owner_id")
@@ -295,7 +295,7 @@ class TestServiceRESTAPI(object):
     @pytest.mark.parametrize(
         "from_detail", [True, False],
         ids=["from_detail", "from_collection"])
-    def test_power_service(self, rest_api, service_data, from_detail):
+    def test_power_service(self, appliance, service_data, from_detail):
         """Tests power operations on /api/services and /api/services/:id.
 
         * start, stop and suspend actions
@@ -304,16 +304,16 @@ class TestServiceRESTAPI(object):
         Metadata:
             test_flag: rest
         """
-        collection = rest_api.collections.services
+        collection = appliance.rest_api.collections.services
         service = collection.get(name=service_data['service_name'])
-        vm = rest_api.collections.vms.get(name=service_data['vm_name'])
+        vm = appliance.rest_api.collections.vms.get(name=service_data['vm_name'])
 
         def _action_and_check(action, resulting_state):
             if from_detail:
                 getattr(service.action, action)()
             else:
                 getattr(collection.action, action)(service)
-            assert rest_api.response.status_code == 200
+            assert appliance.rest_api.response.status_code == 200
             wait_for_vm_power_state(vm, resulting_state)
 
         wait_for_vm_power_state(vm, 'on')
@@ -323,13 +323,13 @@ class TestServiceRESTAPI(object):
         _action_and_check('start', 'on')
 
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
-    def test_create_service_from_parent(self, request, rest_api):
+    def test_create_service_from_parent(self, request, appliance):
         """Tests creation of new service that reference existing service.
 
         Metadata:
             test_flag: rest
         """
-        collection = rest_api.collections.services
+        collection = appliance.rest_api.collections.services
         service = collection.action.create(service_body())[0]
         request.addfinalizer(service.action.delete)
         bodies = []
@@ -340,27 +340,27 @@ class TestServiceRESTAPI(object):
         for ref in references:
             bodies.append(service_body(parent_service=ref))
         response = collection.action.create(*bodies)
-        assert rest_api.response.status_code == 200
+        assert appliance.rest_api.response.status_code == 200
         for ent in response:
             assert ent.ancestry == str(service.id)
 
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
-    def test_delete_parent_service(self, rest_api):
+    def test_delete_parent_service(self, appliance):
         """Tests that when parent service is deleted, child service is deleted automatically.
 
         Metadata:
             test_flag: rest
         """
-        collection = rest_api.collections.services
+        collection = appliance.rest_api.collections.services
         grandparent = collection.action.create(service_body())[0]
         parent = collection.action.create(service_body(parent_service={'id': grandparent.id}))[0]
         child = collection.action.create(service_body(parent_service={'id': parent.id}))[0]
         assert parent.ancestry == str(grandparent.id)
         assert child.ancestry == '{}/{}'.format(grandparent.id, parent.id)
         grandparent.action.delete()
-        assert rest_api.response.status_code in (200, 204)
+        assert appliance.rest_api.response.status_code in (200, 204)
         wait_for(
-            lambda: not rest_api.collections.services.find_by(name=grandparent.name),
+            lambda: not appliance.rest_api.collections.services.find_by(name=grandparent.name),
             num_sec=600,
             delay=10,
         )
@@ -369,24 +369,24 @@ class TestServiceRESTAPI(object):
                 gen.action.delete()
 
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
-    def test_add_service_parent(self, request, rest_api):
+    def test_add_service_parent(self, request, appliance):
         """Tests adding parent reference to already existing service.
 
         Metadata:
             test_flag: rest
         """
-        collection = rest_api.collections.services
+        collection = appliance.rest_api.collections.services
         parent = collection.action.create(service_body())[0]
         request.addfinalizer(parent.action.delete)
         child = collection.action.create(service_body())[0]
         child.action.edit(ancestry=str(parent.id))
-        assert rest_api.response.status_code == 200
+        assert appliance.rest_api.response.status_code == 200
         child.reload()
         assert child.ancestry == str(parent.id)
 
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     @pytest.mark.meta(blockers=[BZ(1416903, forced_streams=['5.7', '5.8', 'upstream'])])
-    def test_power_parent_service(self, request, rest_api, service_data):
+    def test_power_parent_service(self, request, appliance, service_data):
         """Tests that power operations triggered on service parent affects child service.
 
         * start, stop and suspend actions
@@ -395,17 +395,17 @@ class TestServiceRESTAPI(object):
         Metadata:
             test_flag: rest
         """
-        collection = rest_api.collections.services
+        collection = appliance.rest_api.collections.services
         service = collection.action.create(service_body())[0]
         request.addfinalizer(service.action.delete)
         child = collection.get(name=service_data['service_name'])
-        vm = rest_api.collections.vms.get(name=service_data['vm_name'])
+        vm = appliance.rest_api.collections.vms.get(name=service_data['vm_name'])
         child.action.edit(ancestry=str(service.id))
         child.reload()
 
         def _action_and_check(action, resulting_state):
             getattr(service.action, action)()
-            assert rest_api.response.status_code == 200
+            assert appliance.rest_api.response.status_code == 200
             wait_for_vm_power_state(vm, resulting_state)
 
         wait_for_vm_power_state(vm, 'on')
@@ -416,21 +416,21 @@ class TestServiceRESTAPI(object):
 
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     @pytest.mark.meta(blockers=[BZ(1441412, forced_streams=['5.8', 'upstream'])])
-    def test_retire_parent_service_now(self, rest_api, service_data):
+    def test_retire_parent_service_now(self, appliance, service_data):
         """Tests that child service is retired together with a parent service.
 
         Metadata:
             test_flag: rest
         """
-        collection = rest_api.collections.services
+        collection = appliance.rest_api.collections.services
         parent = collection.action.create(service_body())[0]
         child = collection.get(name=service_data['service_name'])
-        vm = rest_api.collections.vms.get(name=service_data['vm_name'])
+        vm = appliance.rest_api.collections.vms.get(name=service_data['vm_name'])
         child.action.edit(ancestry=str(parent.id))
         child.reload()
 
         parent.action.retire()
-        assert rest_api.response.status_code == 200
+        assert appliance.rest_api.response.status_code == 200
 
         wait_for(lambda: is_retired(child), num_sec=600, delay=10)
         wait_for(lambda: is_retired(vm), num_sec=1000, delay=10)
@@ -439,37 +439,37 @@ class TestServiceRESTAPI(object):
 class TestServiceDialogsRESTAPI(object):
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     @pytest.mark.parametrize("method", ["post", "delete"])
-    def test_delete_service_dialog(self, rest_api, dialog, method):
+    def test_delete_service_dialog(self, appliance, dialog, method):
         """Tests deleting service dialogs from detail.
 
         Metadata:
             test_flag: rest
         """
         status = 204 if method == "delete" else 200
-        service_dialog = rest_api.collections.service_dialogs.get(label=dialog.label)
+        service_dialog = appliance.rest_api.collections.service_dialogs.get(label=dialog.label)
         service_dialog.action.delete(force_method=method)
-        assert rest_api.response.status_code == status
+        assert appliance.rest_api.response.status_code == status
         with error.expected("ActiveRecord::RecordNotFound"):
             service_dialog.action.delete(force_method=method)
-        assert rest_api.response.status_code == 404
+        assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
-    def test_delete_service_dialogs(self, rest_api, dialog):
+    def test_delete_service_dialogs(self, appliance, dialog):
         """Tests deleting service dialogs from collection.
 
         Metadata:
             test_flag: rest
         """
-        service_dialog = rest_api.collections.service_dialogs.get(label=dialog.label)
-        rest_api.collections.service_dialogs.action.delete(service_dialog)
-        assert rest_api.response.status_code == 200
+        service_dialog = appliance.rest_api.collections.service_dialogs.get(label=dialog.label)
+        appliance.rest_api.collections.service_dialogs.action.delete(service_dialog)
+        assert appliance.rest_api.response.status_code == 200
         with error.expected("ActiveRecord::RecordNotFound"):
-            rest_api.collections.service_dialogs.action.delete(service_dialog)
-        assert rest_api.response.status_code == 404
+            appliance.rest_api.collections.service_dialogs.action.delete(service_dialog)
+        assert appliance.rest_api.response.status_code == 404
 
 
 class TestServiceTemplateRESTAPI(object):
-    def test_edit_service_template(self, rest_api, service_templates):
+    def test_edit_service_template(self, appliance, service_templates):
         """Tests editing a service template.
         Prerequisities:
             * An appliance with ``/api`` available.
@@ -482,26 +482,26 @@ class TestServiceTemplateRESTAPI(object):
         for service_template in service_templates:
             new_name = fauxfactory.gen_alphanumeric()
             response = service_template.action.edit(name=new_name)
-            assert rest_api.response.status_code == 200
+            assert appliance.rest_api.response.status_code == 200
             assert response.name == new_name
             service_template.reload()
             assert service_template.name == new_name
 
-    def test_delete_service_templates(self, rest_api, service_templates):
+    def test_delete_service_templates(self, appliance, service_templates):
         """Tests deleting service templates from collection.
 
         Metadata:
             test_flag: rest
         """
-        rest_api.collections.service_templates.action.delete(*service_templates)
-        assert rest_api.response.status_code == 200
+        appliance.rest_api.collections.service_templates.action.delete(*service_templates)
+        assert appliance.rest_api.response.status_code == 200
         with error.expected("ActiveRecord::RecordNotFound"):
-            rest_api.collections.service_templates.action.delete(*service_templates)
-        assert rest_api.response.status_code == 404
+            appliance.rest_api.collections.service_templates.action.delete(*service_templates)
+        assert appliance.rest_api.response.status_code == 404
 
     # POST method is not available on < 5.8, as described in BZ 1427338
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
-    def test_delete_service_template_post(self, rest_api, service_templates):
+    def test_delete_service_template_post(self, appliance, service_templates):
         """Tests deleting service templates from detail using POST method.
 
         Metadata:
@@ -509,12 +509,12 @@ class TestServiceTemplateRESTAPI(object):
         """
         for service_template in service_templates:
             service_template.action.delete(force_method="post")
-            assert rest_api.response.status_code == 200
+            assert appliance.rest_api.response.status_code == 200
             with error.expected("ActiveRecord::RecordNotFound"):
                 service_template.action.delete(force_method="post")
-            assert rest_api.response.status_code == 404
+            assert appliance.rest_api.response.status_code == 404
 
-    def test_delete_service_template_delete(self, rest_api, service_templates):
+    def test_delete_service_template_delete(self, appliance, service_templates):
         """Tests deleting service templates from detail using DELETE method.
 
         Metadata:
@@ -522,12 +522,12 @@ class TestServiceTemplateRESTAPI(object):
         """
         for service_template in service_templates:
             service_template.action.delete(force_method="delete")
-            assert rest_api.response.status_code == 204
+            assert appliance.rest_api.response.status_code == 204
             with error.expected("ActiveRecord::RecordNotFound"):
                 service_template.action.delete(force_method="delete")
-            assert rest_api.response.status_code == 404
+            assert appliance.rest_api.response.status_code == 404
 
-    def test_assign_unassign_service_template_to_service_catalog(self, rest_api, service_catalogs,
+    def test_assign_unassign_service_template_to_service_catalog(self, appliance, service_catalogs,
             service_templates):
         """Tests assigning and unassigning the service templates to service catalog.
         Prerequisities:
@@ -549,25 +549,26 @@ class TestServiceTemplateRESTAPI(object):
         # if the template is already assigned, unassign it first
         stpl.reload()
         if hasattr(stpl, 'service_template_catalog_id'):
-            scl_a = rest_api.collections.service_catalogs.get(id=stpl.service_template_catalog_id)
+            scl_a = appliance.rest_api.collections.service_catalogs.get(
+                id=stpl.service_template_catalog_id)
             scl_a.service_templates.action.unassign(stpl)
 
         scl.service_templates.action.assign(stpl)
-        assert rest_api.response.status_code == 200
+        assert appliance.rest_api.response.status_code == 200
         scl.reload()
         stpl.reload()
         assert stpl.id in [st.id for st in scl.service_templates.all]
         assert stpl.service_template_catalog_id == scl.id
 
         scl.service_templates.action.unassign(stpl)
-        assert rest_api.response.status_code == 200
+        assert appliance.rest_api.response.status_code == 200
         scl.reload()
         assert stpl.id not in [st.id for st in scl.service_templates.all]
         # load data again so we get rid of attributes that are no longer there
-        stpl = rest_api.collections.service_templates.get(id=stpl.id)
+        stpl = appliance.rest_api.collections.service_templates.get(id=stpl.id)
         assert not hasattr(stpl, 'service_template_catalog_id')
 
-    def test_edit_multiple_service_templates(self, rest_api, service_templates):
+    def test_edit_multiple_service_templates(self, appliance, service_templates):
         """Tests editing multiple service catalogs at time.
         Prerequisities:
             * An appliance with ``/api`` available.
@@ -587,8 +588,9 @@ class TestServiceTemplateRESTAPI(object):
                 "href": tpl.href,
                 "name": new_name,
             })
-        response = rest_api.collections.service_templates.action.edit(*service_tpls_data_edited)
-        assert rest_api.response.status_code == 200
+        response = appliance.rest_api.collections.service_templates.action.edit(
+            *service_tpls_data_edited)
+        assert appliance.rest_api.response.status_code == 200
         for i, resource in enumerate(response):
             assert resource.name == new_names[i]
             service_template = service_templates[i]
@@ -598,23 +600,23 @@ class TestServiceTemplateRESTAPI(object):
 
 class TestBlueprintsRESTAPI(object):
     @pytest.fixture(scope="function")
-    def blueprints(self, request, rest_api):
+    def blueprints(self, request, appliance):
         num = 2
-        response = _blueprints(request, rest_api, num=num)
-        assert rest_api.response.status_code == 200
+        response = _blueprints(request, appliance.rest_api, num=num)
+        assert appliance.rest_api.response.status_code == 200
         assert len(response) == num
         return response
 
     @pytest.mark.tier(3)
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
-    def test_create_blueprints(self, rest_api, blueprints):
+    def test_create_blueprints(self, appliance, blueprints):
         """Tests creation of blueprints.
 
         Metadata:
             test_flag: rest
         """
         for blueprint in blueprints:
-            record = rest_api.collections.blueprints.get(id=blueprint.id)
+            record = appliance.rest_api.collections.blueprints.get(id=blueprint.id)
             assert record.name == blueprint.name
             assert record.description == blueprint.description
             assert record.ui_properties == blueprint.ui_properties
@@ -622,7 +624,7 @@ class TestBlueprintsRESTAPI(object):
     @pytest.mark.tier(3)
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     @pytest.mark.parametrize("method", ["post", "delete"], ids=["POST", "DELETE"])
-    def test_delete_blueprints_from_detail(self, rest_api, blueprints, method):
+    def test_delete_blueprints_from_detail(self, appliance, blueprints, method):
         """Tests deleting blueprints from detail.
 
         Metadata:
@@ -631,32 +633,32 @@ class TestBlueprintsRESTAPI(object):
         status = 204 if method == "delete" else 200
         for blueprint in blueprints:
             blueprint.action.delete(force_method=method)
-            assert rest_api.response.status_code == status
+            assert appliance.rest_api.response.status_code == status
             with error.expected("ActiveRecord::RecordNotFound"):
                 blueprint.action.delete(force_method=method)
-            assert rest_api.response.status_code == 404
+            assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
-    def test_delete_blueprints_from_collection(self, rest_api, blueprints):
+    def test_delete_blueprints_from_collection(self, appliance, blueprints):
         """Tests deleting blueprints from collection.
 
         Metadata:
             test_flag: rest
         """
-        collection = rest_api.collections.blueprints
+        collection = appliance.rest_api.collections.blueprints
         collection.action.delete(*blueprints)
-        assert rest_api.response.status_code == 200
+        assert appliance.rest_api.response.status_code == 200
         with error.expected("ActiveRecord::RecordNotFound"):
             collection.action.delete(*blueprints)
-        assert rest_api.response.status_code == 404
+        assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     @pytest.mark.parametrize(
         "from_detail", [True, False],
         ids=["from_detail", "from_collection"])
-    def test_edit_blueprints(self, rest_api, blueprints, from_detail):
+    def test_edit_blueprints(self, appliance, blueprints, from_detail):
         """Tests editing of blueprints.
 
         Metadata:
@@ -672,12 +674,12 @@ class TestBlueprintsRESTAPI(object):
             edited = []
             for i in range(response_len):
                 edited.append(blueprints[i].action.edit(**new[i]))
-                assert rest_api.response.status_code == 200
+                assert appliance.rest_api.response.status_code == 200
         else:
             for i in range(response_len):
                 new[i].update(blueprints[i]._ref_repr())
-            edited = rest_api.collections.blueprints.action.edit(*new)
-            assert rest_api.response.status_code == 200
+            edited = appliance.rest_api.collections.blueprints.action.edit(*new)
+            assert appliance.rest_api.response.status_code == 200
         assert len(edited) == response_len
         for i in range(response_len):
             assert edited[i].ui_properties == new[i]['ui_properties']
@@ -687,23 +689,23 @@ class TestBlueprintsRESTAPI(object):
 
 class TestOrchestrationTemplatesRESTAPI(object):
     @pytest.fixture(scope='function')
-    def orchestration_templates(self, request, rest_api):
+    def orchestration_templates(self, request, appliance):
         num = 2
-        response = _orchestration_templates(request, rest_api, num=num)
-        assert rest_api.response.status_code == 200
+        response = _orchestration_templates(request, appliance.rest_api, num=num)
+        assert appliance.rest_api.response.status_code == 200
         assert len(response) == num
         return response
 
     @pytest.mark.tier(3)
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
-    def test_create_orchestration_templates(self, rest_api, orchestration_templates):
+    def test_create_orchestration_templates(self, appliance, orchestration_templates):
         """Tests creation of orchestration templates.
 
         Metadata:
             test_flag: rest
         """
         for template in orchestration_templates:
-            record = rest_api.collections.orchestration_templates.get(id=template.id)
+            record = appliance.rest_api.collections.orchestration_templates.get(id=template.id)
             assert record.name == template.name
             assert record.description == template.description
             assert record.type == template.type
@@ -711,24 +713,24 @@ class TestOrchestrationTemplatesRESTAPI(object):
     @pytest.mark.tier(3)
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     def test_delete_orchestration_templates_from_collection(
-            self, rest_api, orchestration_templates):
+            self, appliance, orchestration_templates):
         """Tests deleting orchestration templates from collection.
 
         Metadata:
             test_flag: rest
         """
-        collection = rest_api.collections.orchestration_templates
+        collection = appliance.rest_api.collections.orchestration_templates
         collection.action.delete(*orchestration_templates)
-        assert rest_api.response.status_code == 200
+        assert appliance.rest_api.response.status_code == 200
         with error.expected("ActiveRecord::RecordNotFound"):
             collection.action.delete(*orchestration_templates)
-        assert rest_api.response.status_code == 404
+        assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     @pytest.mark.meta(blockers=[BZ(1414881, forced_streams=['5.7', '5.8', 'upstream'])])
     def test_delete_orchestration_templates_from_detail_post(self, orchestration_templates,
-            rest_api):
+            appliance):
         """Tests deleting orchestration templates from detail using POST method.
 
         Metadata:
@@ -736,15 +738,15 @@ class TestOrchestrationTemplatesRESTAPI(object):
         """
         for ent in orchestration_templates:
             ent.action.delete(force_method="post")
-            assert rest_api.response.status_code == 200
+            assert appliance.rest_api.response.status_code == 200
             with error.expected("ActiveRecord::RecordNotFound"):
                 ent.action.delete(force_method="post")
-            assert rest_api.response.status_code == 404
+            assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     def test_delete_orchestration_templates_from_detail_delete(self, orchestration_templates,
-            rest_api):
+            appliance):
         """Tests deleting orchestration templates from detail using DELETE method.
 
         Metadata:
@@ -752,17 +754,17 @@ class TestOrchestrationTemplatesRESTAPI(object):
         """
         for ent in orchestration_templates:
             ent.action.delete(force_method="delete")
-            assert rest_api.response.status_code == 204
+            assert appliance.rest_api.response.status_code == 204
             with error.expected("ActiveRecord::RecordNotFound"):
                 ent.action.delete(force_method="delete")
-            assert rest_api.response.status_code == 404
+            assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     @pytest.mark.parametrize(
         "from_detail", [True, False],
         ids=["from_detail", "from_collection"])
-    def test_edit_orchestration_templates(self, rest_api, orchestration_templates, from_detail):
+    def test_edit_orchestration_templates(self, appliance, orchestration_templates, from_detail):
         """Tests editing of orchestration templates.
 
         Metadata:
@@ -776,12 +778,12 @@ class TestOrchestrationTemplatesRESTAPI(object):
             edited = []
             for i in range(response_len):
                 edited.append(orchestration_templates[i].action.edit(**new[i]))
-                assert rest_api.response.status_code == 200
+                assert appliance.rest_api.response.status_code == 200
         else:
             for i in range(response_len):
                 new[i].update(orchestration_templates[i]._ref_repr())
-            edited = rest_api.collections.orchestration_templates.action.edit(*new)
-            assert rest_api.response.status_code == 200
+            edited = appliance.rest_api.collections.orchestration_templates.action.edit(*new)
+            assert appliance.rest_api.response.status_code == 200
         assert len(edited) == response_len
         for i in range(response_len):
             assert edited[i].description == new[i]['description']
@@ -793,7 +795,7 @@ class TestOrchestrationTemplatesRESTAPI(object):
     @pytest.mark.parametrize(
         "from_detail", [True, False],
         ids=["from_detail", "from_collection"])
-    def test_copy_orchestration_templates(self, request, rest_api, orchestration_templates,
+    def test_copy_orchestration_templates(self, request, appliance, orchestration_templates,
             from_detail):
         """Tests copying of orchestration templates.
 
@@ -812,15 +814,15 @@ class TestOrchestrationTemplatesRESTAPI(object):
             copied = []
             for i in range(num_orch_templates):
                 copied.append(orchestration_templates[i].action.copy(**new[i]))
-                assert rest_api.response.status_code == 200
+                assert appliance.rest_api.response.status_code == 200
         else:
             for i in range(num_orch_templates):
                 new[i].update(orchestration_templates[i]._ref_repr())
-            copied = rest_api.collections.orchestration_templates.action.copy(*new)
-            assert rest_api.response.status_code == 200
+            copied = appliance.rest_api.collections.orchestration_templates.action.copy(*new)
+            assert appliance.rest_api.response.status_code == 200
 
         request.addfinalizer(
-            lambda: rest_api.collections.orchestration_templates.action.delete(*copied))
+            lambda: appliance.rest_api.collections.orchestration_templates.action.delete(*copied))
 
         assert len(copied) == num_orch_templates
         for i in range(num_orch_templates):
@@ -829,7 +831,7 @@ class TestOrchestrationTemplatesRESTAPI(object):
             assert orchestration_templates[i].id != copied[i].id
             assert orchestration_templates[i].name != copied[i].name
             assert orchestration_templates[i].description == copied[i].description
-            new_record = rest_api.collections.orchestration_templates.get(id=copied[i].id)
+            new_record = appliance.rest_api.collections.orchestration_templates.get(id=copied[i].id)
             assert new_record.name == copied[i].name
 
     @pytest.mark.tier(3)
@@ -837,7 +839,7 @@ class TestOrchestrationTemplatesRESTAPI(object):
     @pytest.mark.parametrize(
         "from_detail", [True, False],
         ids=["from_detail", "from_collection"])
-    def test_invalid_copy_orchestration_templates(self, rest_api, orchestration_templates,
+    def test_invalid_copy_orchestration_templates(self, appliance, orchestration_templates,
             from_detail):
         """Tests copying of orchestration templates without changing content.
 
@@ -854,10 +856,10 @@ class TestOrchestrationTemplatesRESTAPI(object):
             for i in range(num_orch_templates):
                 with error.expected("content must be unique"):
                     orchestration_templates[i].action.copy(**new[i])
-                assert rest_api.response.status_code == 400
+                assert appliance.rest_api.response.status_code == 400
         else:
             for i in range(num_orch_templates):
                 new[i].update(orchestration_templates[i]._ref_repr())
             with error.expected("content must be unique"):
-                rest_api.collections.orchestration_templates.action.copy(*new)
-            assert rest_api.response.status_code == 400
+                appliance.rest_api.collections.orchestration_templates.action.copy(*new)
+            assert appliance.rest_api.response.status_code == 400

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -40,7 +40,7 @@ def a_provider(request):
 def wait_for_vm_power_state(vm, resulting_state):
     wait_for(
         lambda: vm.power_state == resulting_state,
-        num_sec=600, delay=20, fail_func=vm.reload,
+        num_sec=1200, delay=45, fail_func=vm.reload,
         message='Wait for VM to {} (current state: {})'.format(
             resulting_state, vm.power_state))
 


### PR DESCRIPTION
Replacing the rest_api fixture with appliance.rest_api in test_rest_services.

{{pytest: -v --long-running cfme/tests/services/test_rest_services.py}}