### PR TITLE
[RFR][1LP] browser wharf: actually stop the renew thread if docker_id is None

### DIFF
--- a/utils/browser.py
+++ b/utils/browser.py
@@ -109,6 +109,7 @@ class Wharf(object):
                 return
             if self.docker_id is None:
                 log.debug("renew done, docker id %s", self.docker_id)
+                return
             expiry_info = self._get('renew', self.docker_id)
             self.config.update(expiry_info)
             log.info('Renewed webdriver container %s', self.docker_id)


### PR DESCRIPTION
that return was forgotten in the original code and it took until now to actually hit the condition

fortunately it only exits the thread that was supposed to exit graceful