### PR TITLE
[1LP][RFR] remove import time requirement for appliance objects

### DIFF
--- a/cfme/tests/automate/test_buttons.py
+++ b/cfme/tests/automate/test_buttons.py
@@ -3,7 +3,6 @@ import fauxfactory
 import pytest
 from cfme import test_requirements
 from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import flash
 from cfme.automate.buttons import Button, ButtonGroup
 from cfme.automate.service_dialogs import ServiceDialog
 from cfme.infrastructure import host

--- a/cfme/tests/configure/test_visual_cloud.py
+++ b/cfme/tests/configure/test_visual_cloud.py
@@ -21,24 +21,17 @@ pytestmark = [pytest.mark.tier(3),
               pytest.mark.usefixtures("openstack_provider")]
 
 # TODO When all of these classes have widgets and views use them in the tests
-grid_pages = version.pick({
-    version.LOWEST: [CloudProvider,
-                     AvailabilityZone,
-                     Tenant,
-                     Volume,
-                     Flavor,
-                     Instance,
-                     Stack,
-                     KeyPair],
-    # Volume was removed in 5.7
-    '5.7': [CloudProvider,
-            AvailabilityZone,
-            Tenant,
-            Flavor,
-            Instance,
-            Stack,
-            KeyPair]
-})
+grid_pages = [
+    CloudProvider,
+    AvailabilityZone,
+    Tenant,
+    # TODO: use pytest.marked after pytest 3.1
+    pytest.mark.uncollectif(Volume, lambda: version.current_version() >= "5.7"),
+    Flavor,
+    Instance,
+    Stack,
+    KeyPair,
+]
 
 # Dict values are kwargs for cfme.web_ui.match_location
 landing_pages = {

--- a/cfme/tests/infrastructure/test_vm_clone.py
+++ b/cfme/tests/infrastructure/test_vm_clone.py
@@ -105,7 +105,7 @@ def create_vm(provider, setup_provider, catalog_item, request):
 
 @pytest.mark.meta(blockers=[1255190])
 @pytest.mark.usefixtures("setup_provider")
-@pytest.mark.uncollectif(version.appliance_is_downstream())
+@pytest.mark.uncollectif(lambda: version.appliance_is_downstream())
 @pytest.mark.long_running
 def test_vm_clone(provider, clone_vm_name, request, create_vm):
     vm_name = create_vm + "_0001"

--- a/cfme/tests/test_appliance.py
+++ b/cfme/tests/test_appliance.py
@@ -9,45 +9,18 @@ from utils import conf, version
 pytestmark = [pytest.mark.smoke, pytest.mark.tier(1)]
 
 
-def _rpms_present_packages():
-    # autogenerate the rpms to test based on the current appliance version
-    # and the list of possible packages that can be installed
-    current_version = version.current_version()
-    possible_packages = [
-        'cfme',
-        'cfme-appliance',
-        'cfme-lib',
-        'nfs-utils',
-        'nfs-utils-lib',
-        'libnfsidmap',
-        'mingw32-cfme-host',
-        'ipmitool',
-        'prince',
-        'netapp-manageability-sdk',
-        'rhn-client-tools',
-        'rhn-check',
-        'rhnlib'
-    ]
-
-    def package_filter(package):
-        package_tests = [
-            # stopped shipping this with 5.4
-            package == 'mingw32-cfme-host' and current_version >= '5.4',
-            # stopped shipping these with 5.5
-            package in ('cfme-lib', 'netapp-manageability-sdk') and current_version >= 5.5,
-            # nfs-utils-lib was superseded by libnfsidmap in el7/cfme 5.5
-            # so filter out nfs-utils-lib on 5.5 and up, and libnfsidmap below 5.5
-            package == 'nfs-utils-lib' and current_version >= '5.5',
-            package == 'libnfsidmap' and current_version < '5.5',
-        ]
-        # If any of the package tests eval'd to true, filter this package out
-        return not any(package_tests)
-
-    return filter(package_filter, possible_packages)
-
-
 @pytest.mark.ignore_stream("upstream")
-@pytest.mark.parametrize('package', _rpms_present_packages())
+@pytest.mark.parametrize('package', [
+    'cfme',
+    'cfme-appliance',
+    'nfs-utils',
+    'libnfsidmap',
+    'ipmitool',
+    'prince',
+    'rhn-client-tools',
+    'rhn-check',
+    'rhnlib',
+])
 @pytest.mark.uncollectif(
     lambda package: "rhn" in package and store.current_appliance.is_pod)
 def test_rpms_present(appliance, package):

--- a/fixtures/pytest_store.py
+++ b/fixtures/pytest_store.py
@@ -61,6 +61,8 @@ class Store(object):
     def current_appliance(self):
         # layz import due to loops and loops and loops
         from utils import appliance
+        # TODO: concieve a better way to detect/log import-time missuse
+        # assert self.config is not None, 'current appliance not in scope'
         return appliance.current_appliance
 
     def __init__(self):

--- a/fixtures/templateloader.py
+++ b/fixtures/templateloader.py
@@ -2,7 +2,7 @@
 """Preloads all templates on all providers that were selected for testing. Useful for test collect.
 """
 import pytest
-from fixtures.pytest_store import store, write_line
+from fixtures.pytest_store import store
 from utils import trackerbot
 from utils.providers import list_provider_keys
 

--- a/markers/uncollect.py
+++ b/markers/uncollect.py
@@ -52,6 +52,17 @@ Note:
 
 """
 import inspect
+import pytest
+
+MARKDECORATOR_TYPE = type(pytest.mark.slip)
+
+
+# work around https://github.com/pytest-dev/pytest/issues/2400
+def get_uncollect_function(marker_or_markdecorator):
+    if isinstance(marker_or_markdecorator, MARKDECORATOR_TYPE):
+        return marker_or_markdecorator.args[0]
+    else:
+        return list(marker_or_markdecorator)[0].args[0]
 
 
 def uncollectif(item):
@@ -70,7 +81,7 @@ def uncollectif(item):
             marker.kwargs.get('reason', 'No reason given'))
 
         try:
-            arg_names = inspect.getargspec(marker._arglist[0][0][0]).args
+            arg_names = inspect.getargspec(get_uncollect_function(marker)).args
         except TypeError:
             logger.debug(log_msg)
             return not bool(marker.args[0])

--- a/scripts/refactoring/checkallimports.py
+++ b/scripts/refactoring/checkallimports.py
@@ -1,0 +1,12 @@
+from __future__ import print_function
+import importscan
+
+to_check = 'cfme artifactor fixtures markers utils'
+
+if __name__ == '__main__':
+    for name in to_check.split():
+        base = __import__(name)
+
+        def handle_error(name, error):
+            print(name, error)
+        importscan.scan(base, handle_error=handle_error)


### PR DESCRIPTION
also fail if one tries to use store before the config is loaded

{{pytest:  --composite-uncollect --collect-only}}

```
cfme/tests/configure/test_visual_cloud.py  cfme/tests/infrastructure/test_vm_clone.py cfme/tests/intelligence/test_chargeback.py cfme/tests/test_appliance.py
```