### PR TITLE
[RFR] Update util.app.implem.ui, navigation logging

### DIFF
--- a/cfme/services/requests.py
+++ b/cfme/services/requests.py
@@ -46,7 +46,7 @@ class Request(Navigatable):
 class RequestAll(CFMENavigateStep):
     prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
 
-    def am_i_here(self):
+    def am_i_here(self, *args, **kwargs):
         return match_page(summary='Requests')
 
     def step(self, *args, **kwargs):

--- a/utils/appliance/implementations/ui.py
+++ b/utils/appliance/implementations/ui.py
@@ -2,6 +2,7 @@
 import json
 import time
 from jsmin import jsmin
+from inspect import isclass
 
 from utils.log import logger, create_sublogger
 from cfme import exceptions
@@ -354,7 +355,8 @@ class CFMENavigateStep(NavigateStep):
         pass
 
     def log_message(self, msg, level="debug"):
-        str_msg = "[UI-NAV/{}/{}]: {}".format(self.obj.__class__.__name__, self._name, msg)
+        class_name = self.obj.__name__ if isclass(self.obj) else self.obj.__class__.__name__
+        str_msg = "[UI-NAV/{}/{}]: {}".format(class_name, self._name, msg)
         getattr(logger, level)(str_msg)
 
     def construst_message(self, here, resetter, view, duration):


### PR DESCRIPTION
~~Try/except for class name vs object name when logging navigation~~

@mfalesni suggested using `inspect.isclass`, this is way better.

~~Maybe there's a more elegant way of handling this?~~

RHCFQE-2753

