### PR TITLE
[WIPTEST] Pod condition table test

### DIFF
--- a/cfme/cloud/keypairs.py
+++ b/cfme/cloud/keypairs.py
@@ -194,7 +194,7 @@ class KeyPair(Taggable, SummaryMixin, Navigatable):
         view = self.create_view(KeyPairAllView)
         # TODO BZ 1444520 causing ridiculous redirection times after submitting the form
         wait_for(lambda: view.is_displayed, fail_condition=False, num_sec=120, delay=3,
-                 fail_func=lambda: view.flush_widget_cache())
+                 fail_func=lambda: view.flush_widget_cache(), handle_exception=True)
         view = self.create_view(KeyPairAllView)
         view.entities.flash.assert_no_error()
         view.entities.flash.assert_success_message(flash_message)

--- a/cfme/cloud/keypairs.py
+++ b/cfme/cloud/keypairs.py
@@ -1,26 +1,122 @@
 # -*- coding: utf-8 -*-
-import cfme.fixtures.pytest_selenium as sel
-from navmazing import NavigateToAttribute
+from navmazing import NavigateToAttribute, NavigateToSibling
+from widgetastic.widget import View
+from widgetastic.utils import VersionPick, Version
+from widgetastic.exceptions import NoSuchElementException
+from widgetastic_patternfly import Dropdown, Button, FlashMessages
+
+from cfme.base.ui import BaseLoggedInPage
 from cfme.common import SummaryMixin, Taggable
+from cfme.exceptions import KeyPairNotFound
+from cfme.web_ui import match_location
 from utils.appliance.implementations.ui import navigate_to, navigator, CFMENavigateStep
 from utils.appliance import Navigatable
-from cfme.web_ui import (Quadicon, flash, Form, Input, form_buttons, fill, AngularSelect,
-                         CheckboxTable)
-from functools import partial
-from cfme.web_ui import toolbar as tb
 from utils.wait import wait_for
+from widgetastic_manageiq import (
+    ItemsToolBarViewSelector, Text, TextInput, Table, Search, PaginationPane, Accordion,
+    ManageIQTree, BreadCrumb, SummaryTable, BootstrapSelect)
 
 
-cfg_btn = partial(tb.select, "Configuration")
-keypair_form = Form(
-    fields=[
-        ('name', Input("name")),
-        ('public_key', Input("public_key")),
-        ('provider', AngularSelect('ems_id')),
-        ('save_button', form_buttons.add)
-    ])
+class KeyPairToolbar(View):
+    policy = Dropdown('Policy')
+    configuration = Dropdown('Configuration')
+    download = Dropdown('Download')
 
-keypair_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
+    view_selector = View.nested(ItemsToolBarViewSelector)
+
+
+class KeyPairDetailsToolbar(View):
+    policy = Dropdown('Policy')
+    configuration = Dropdown('Configuration')
+    download = Button(title='Download summary in PDF format')
+
+
+class KeyPairDetailsAccordion(View):
+    @View.nested
+    class properties(Accordion):  # noqa
+        tree = ManageIQTree()
+
+    @View.nested
+    class relationships(Accordion):  # noqa
+        tree = ManageIQTree()
+
+
+class KeyPairEntities(View):
+    title = Text('//div[@id="main-content"]//h1')
+    table = Table("//div[@id='list_grid']//table")
+    search = View.nested(Search)
+    # element attributes changed from id to class in upstream-fine+, capture both with locator
+    flash = FlashMessages('.//div[@id="flash_msg_div"]'
+                          '/div[@id="flash_text_div" or contains(@class, "flash_text_div")]')
+
+
+class KeyPairDetailsEntities(View):
+    breadcrumb = BreadCrumb()
+    title = Text('//div[@id="main-content"]//h1')
+    properties = SummaryTable(title='Properties')
+    relationships = SummaryTable(title='Relationships')
+    smart_management = SummaryTable(title='Smart Management')
+
+
+class KeyPairAddEntities(View):
+    breadcrumb = BreadCrumb()
+    title = Text('//div[@id="main-content"]//h1')
+
+
+class KeyPairAddForm(View):
+    name = TextInput(id='name')
+    public_key = TextInput(id='public_key')
+    provider = BootstrapSelect(id='ems_id')
+    add = Button('Add')
+    cancel = Button('Cancel')
+
+
+class KeyPairView(BaseLoggedInPage):
+    """Base view for header and nav checking, navigatable views should inherit this"""
+    @property
+    def in_keypair(self):
+        return(
+            self.logged_in_as_current_user and
+            self.navigation.currently_selected == ['Compute', 'Clouds', 'Key Pairs'] and
+            match_location(controller='auth_key_pair_cloud', title='Key Pairs'))
+
+
+class KeyPairAllView(KeyPairView):
+    @property
+    def is_displayed(self):
+        return (
+            self.in_keypair and
+            self.entities.title.text == 'Key Pairs')
+
+    toolbar = View.nested(KeyPairToolbar)
+    entities = View.nested(KeyPairEntities)
+    paginator = View.nested(PaginationPane)
+
+
+class KeyPairDetailsView(KeyPairView):
+    @property
+    def is_displayed(self):
+        expected_title = '{} (Summary)'.format(self.context['object'].name)
+        return (
+            self.in_keypair and
+            self.entities.title.text == expected_title and
+            self.entities.breadcrumb.active_location == expected_title)
+
+    toolbar = View.nested(KeyPairDetailsToolbar)
+    sidebar = View.nested(KeyPairDetailsAccordion)
+    entities = View.nested(KeyPairDetailsEntities)
+
+
+class KeyPairAddView(KeyPairView):
+    @property
+    def is_displayed(self):
+        return (
+            self.in_keypair and
+            self.entities.breadcrumb.active_location == 'Add New Key Pair' and
+            self.entities.title.text == 'Add New Key Pair')
+
+    entities = View.nested(KeyPairAddEntities)
+    form = View.nested(KeyPairAddForm)
 
 
 class KeyPair(Taggable, SummaryMixin, Navigatable):
@@ -31,39 +127,111 @@ class KeyPair(Taggable, SummaryMixin, Navigatable):
     """
     _param_name = "KeyPair"
 
-    def __init__(self, name, provider, appliance=None):
+    def __init__(self, name, provider, public_key=None, appliance=None):
         Navigatable.__init__(self, appliance=appliance)
         self.name = name
         self.provider = provider
+        self.public_key = public_key
 
-    def delete(self):
-        navigate_to(self, 'All')
-        keypair_tbl.select_row_by_cells({'Name': self.name})
-        cfg_btn('Remove selected Key Pairs', invokes_alert=True)
-        sel.handle_alert(cancel=False)
-        flash.assert_message_match('Delete initiated for 1 Key Pair')
+    def delete(self, cancel=False, wait=False):
+        view = navigate_to(self, 'Details')
+        view.toolbar.configuration.item_select('Remove this Key Pair',
+                                               handle_alert=not cancel)
+        # cancel doesn't redirect, confirmation does
+        view.flush_widget_cache()
+        if cancel:
+            view = self.create_view(KeyPairDetailsView)
+        else:
+            view = self.create_view(KeyPairAllView)
+        wait_for(lambda: view.is_displayed, fail_condition=False, num_sec=10, delay=1)
+
+        # flash message only displayed if it was deleted
+        if not cancel:
+            view.entities.flash.assert_no_error()
+            view.entities.flash.assert_success_message('Delete initiated for 1 Key Pair')
+
+        if wait:
+            self.wait_for_delete()
 
     def wait_for_delete(self):
-        navigate_to(self, 'All')
-        quad = Quadicon(self.name, 'keypairs')
-        wait_for(lambda: not sel.is_displayed(quad), fail_condition=False,
-            message="Wait keypairs to disappear", num_sec=500, fail_func=sel.refresh)
+        def refresh():
+            self.provider.refresh_provider_relationships()
+            view.browser.selenium.refresh()
+            view.flush_widget_cache()
+        view = navigate_to(self, 'All')
+        # look for the row, call is_displayed on it to get boolean
+        # find_row_on_pages is going to raise NoSuchElement when the row disappears
+        try:
+            wait_for(lambda: view.paginator.find_row_on_pages(view.entities.table,
+                                                              name=self.name).is_displayed,
+                     fail_condition=True, message="Wait keypairs to disappear", num_sec=500,
+                     delay=5, fail_func=refresh)
+        except NoSuchElementException:
+            # The row doesn't exist anymore, success
+            pass
 
     def create(self, cancel=False):
         """Create new keypair"""
-        navigate_to(self, 'All')
-        cfg_btn('Add a new Key Pair')
-        fill(keypair_form, {'name': self.name, 'provider': self.provider.name},
-             action=keypair_form.save_button)
-        if not cancel:
-            flash.assert_message_match('Creating Key Pair {}'.format(self.name))
+        def refresh():
+            self.provider.refresh_provider_relationships()
+            view.browser.selenium.refresh()
+            view.flush_widget_cache()
+
+        view = navigate_to(self, 'Add')
+        view.form.fill({'name': self.name,
+                        'public_key': self.public_key,
+                        'provider': self.provider.name})
+        if cancel:
+            view.form.cancel.click()
+            flash_message = 'Add of new Key Pair was cancelled by the user'
         else:
-            flash.assert_message_match('Add of new Key Pair was cancelled by the user')
+            view.form.add.click()
+            flash_message = VersionPick({
+                Version.lowest(): 'Creating Key Pair {}'.format(self.name),
+                '5.8': 'Key Pair "{}" created'.format(self.name)}).pick(self.appliance.version)
+
+        # add/cancel should redirect, new view
+        view = self.create_view(KeyPairAllView)
+        # TODO BZ 1444520 causing ridiculous redirection times after submitting the form
+        wait_for(lambda: view.is_displayed, fail_condition=False, num_sec=120, delay=3,
+                 fail_func=lambda: view.flush_widget_cache())
+        view = self.create_view(KeyPairAllView)
+        view.entities.flash.assert_no_error()
+        view.entities.flash.assert_success_message(flash_message)
 
 
 @navigator.register(KeyPair, 'All')
 class All(CFMENavigateStep):
+    VIEW = KeyPairAllView
     prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
 
-    def step(self):
+    def step(self, *args, **kwargs):
         self.prerequisite_view.navigation.select('Compute', 'Clouds', 'Key Pairs')
+
+
+@navigator.register(KeyPair, 'Details')
+class Details(CFMENavigateStep):
+    VIEW = KeyPairDetailsView
+    prerequisite = NavigateToSibling('All')
+
+    def step(self, *args, **kwargs):
+        self.prerequisite_view.toolbar.view_selector.select('List View')
+        try:
+            row = self.prerequisite_view.paginator.find_row_on_pages(
+                self.prerequisite_view.entities.table,
+                name=self.obj.name
+            )
+        except NoSuchElementException:
+            raise KeyPairNotFound
+
+        row.click()
+
+
+@navigator.register(KeyPair, 'Add')
+class Add(CFMENavigateStep):
+    VIEW = KeyPairAddView
+    prerequisite = NavigateToSibling('All')
+
+    def step(self, *args, **kwargs):
+        """Raises DropdownItemDisabled from widgetastic_patternfly if no RHOS provider present"""
+        self.prerequisite_view.toolbar.configuration.item_select('Add a new Key Pair')

--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -248,9 +248,9 @@ class SummaryTable(object):
 
     def __repr__(self):
         if self._multitable:
-            "<SummaryTable {main_table_name} {sub_tables}>".format(
+            return "<SummaryTable {main_table_name}:\n\t {sub_tables}>".format(
                 main_table_name=self._text,
-                sub_tables="\n\t".join([repr(getattr(self, key)) for key in self._keys]))
+                sub_tables='\n\t'.join([repr(getattr(self, key)) for key in self._keys]))
 
         return "<SummaryTable {} {}>".format(
             repr(self._text),
@@ -267,13 +267,14 @@ class SummaryTable(object):
 
             # parsing table titels
             table_titles = sel.elements('./td', root=table_rows[0])
-            table_titles_text = [el.text for el in table_titles]
+            table_titles_text = [el.text.replace(" ", "_") for el in table_titles]
 
             # match each line values with the relevant title
             for row in table_rows[1:]:
                 # creating mapping between titel and row values
                 row_mapping = dict(zip(table_titles_text,
                                        [el.text for el in sel.elements('./td', root=row)]))
+
                 # set the value of the "name" colume to be the key of the entier table,
                 # if "name" is not avliable setting themost left element to be the key
                 row_key = row_mapping.get("Name", row_mapping.keys()[0])

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -17,6 +17,7 @@ from cfme.web_ui import toolbar as tb
 from utils import conf
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigate_to
+from utils.blockers import BZ
 from utils.browser import ensure_browser_open
 from utils.log import logger
 from utils.stats import tol_check
@@ -188,6 +189,9 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
         self._submit(cancel, self.save_button)
         name = updates.get('name', self.name)
         if not cancel:
+            if BZ.bugzilla.get_bug(1436341).is_opened and version.current_version() > '5.8':
+                logger.warning('Skipping flash message verification because of BZ 1436341')
+                return
             flash.assert_message_match(
                 '{} Provider "{}" was saved'.format(self.string_name, name))
 

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -364,7 +364,8 @@ class ContainersTestItem(object):
             self.polarion_id)
 
 
-def navigate_and_get_rows(provider, obj, count, table_class=CheckboxTable):
+def navigate_and_get_rows(provider, obj, count, table_class=CheckboxTable,
+                          silent_failure=False):
     """Get <count> random rows from the obj list table,
     if <count> is greater that the number of rows, return number of rows.
 
@@ -373,11 +374,15 @@ def navigate_and_get_rows(provider, obj, count, table_class=CheckboxTable):
         obj: the containers object
         table: the object's Table object
         count: number of random rows to return
+        silent_failure: If True and no records found for obj, it'll
+                        return None instead of raise exception
 
     return: list of rows"""
 
     navigate_to(obj, 'All')
     tb.select('List View')
+    if sel.is_displayed_text("No Records Found.") and silent_failure:
+        return
     paginator.results_per_page(1000)
     table = table_class(table_locator="//div[@id='list_grid']//table")
     rows = table.rows_as_list()

--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -264,6 +264,13 @@ class FlavorNotFound(CFMEException):
     pass
 
 
+class KeyPairNotFound(CFMEException):
+    """
+    Raised if a specific cloud key pair cannot be found in the UI
+    """
+    pass
+
+
 class OptionNotAvailable(CFMEException):
     """
     Raised if a specified option is not available.

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -13,13 +13,18 @@ TimedCommand = namedtuple('TimedCommand', ['command', 'timeout'])
 
 @pytest.yield_fixture(scope="function")
 def dedicated_db_appliance(app_creds, appliance):
+    """'ap' launch appliance_console, '' clear info screen, '5/8' setup db, '1' Creates v2_key,
+    '1' selects internal db, 'y' continue, '1' use partition, 'y' create dedicated db, 'pwd'
+    db password, 'pwd' confirm db password + wait 360 secs and '' finish."""
     if appliance.version > '5.7':
         with temp_appliances(count=1, preconfigured=False) as apps:
             pwd = app_creds['password']
             if apps[0].version >= "5.8":
-                command_set = ('ap', '', '5', '1', '1', '1', 'y', pwd, TimedCommand(pwd, 45), '')
+                command_set = (
+                    'ap', '', '5', '1', '1', 'y', '1', 'y', pwd, TimedCommand(pwd, 360), '')
             else:
-                command_set = ('ap', '', '8', '1', '1', '1', 'y', pwd, TimedCommand(pwd, 45), '')
+                command_set = (
+                    'ap', '', '8', '1', '1', 'y', '1', 'y', pwd, TimedCommand(pwd, 360), '')
             apps[0].appliance_console.run_commands(command_set)
             wait_for(apps[0].is_dedicated_db_active)
             yield apps[0]

--- a/cfme/fixtures/vporizer.py
+++ b/cfme/fixtures/vporizer.py
@@ -87,7 +87,7 @@ def vporizer(appliance):
                 )
             # now, collecting the values from the table
             resource_vpor_data = get_resource_vpor_data()
-            vpor_values_match = re.search(vpor_values_pattern.replace('{}', '([\d\.]+)'),
+            vpor_values_match = re.search(vpor_values_pattern.replace('{}', '([\d\.\-e]+)'),
                                           resource_vpor_data['values'])
             if not vpor_values_match:
                 raise Exception('Could not parse VPOR values from row: values={}'

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -27,6 +27,7 @@ from cfme.infrastructure.host import Host
 from cfme.web_ui import (
     Region, Quadicon, form_buttons, paginator, Input,
     AngularSelect, toolbar as tb, Radio, match_location, BootstrapSwitch)
+from cfme.web_ui.form_buttons import FormButton
 from cfme.web_ui.tabstrip import TabStripForm
 from utils import conf, version, deferred_verpick
 from utils.appliance import Navigatable

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -28,7 +28,7 @@ from cfme.web_ui import (
     Region, Quadicon, form_buttons, paginator, Input,
     AngularSelect, toolbar as tb, Radio, match_location, BootstrapSwitch)
 from cfme.web_ui.tabstrip import TabStripForm
-from utils import conf, version
+from utils import conf, version, deferred_verpick
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
 from utils.log import logger
@@ -102,7 +102,8 @@ class InfraProvider(Pretty, CloudInfraProvider):
     _properties_region = prop_region  # This will get resolved in common to a real form
     db_types = ["InfraManager"]
     add_provider_button = form_buttons.add
-    save_button = form_buttons.angular_save
+    save_button = deferred_verpick({version.LOWEST: form_buttons.angular_save,
+                   '5.8': FormButton('Save')})
 
     def __init__(
             self, name=None, credentials=None, key=None, zone=None, provider_data=None,

--- a/cfme/tests/automate/test_rest.py
+++ b/cfme/tests/automate/test_rest.py
@@ -10,7 +10,9 @@ pytestmark = [test_requirements.rest]
 
 
 @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
-def test_rest_search_automate(rest_api):
+def test_rest_search_automate(appliance):
+    rest_api = appliance.rest_api
+
     def _do_query(**kwargs):
         response = rest_api.collections.automate.query_string(**kwargs)
         assert rest_api.response.status_code == 200

--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -27,7 +27,7 @@ def test_black_console_set_hostname(appliance):
 
     hostname = 'test.example.com'
     if appliance.version >= "5.8":
-        command_set = ('ap', '', '1', '4', hostname)
+        command_set = ('ap', '', '1', '5', hostname)
     else:
         command_set = ('ap', '', '4', hostname)
     appliance.appliance_console.run_commands(command_set)
@@ -44,13 +44,13 @@ def test_black_console_set_hostname(appliance):
 def test_black_console_internal_db(app_creds, temp_appliance_unconfig_funcscope):
     """'ap' launch appliance_console, '' clear info screen, '5/8' setup db, '1' Creates v2_key,
     '1' selects internal db, 'y' continue, '1' use partition, 'n' don't create dedicated db, '0'
-    db region number, 'pwd' db password, 'pwd' confirm db password + wait 45 secs and '' finish."""
+    db region number, 'pwd' db password, 'pwd' confirm db password + wait 360 secs and '' finish."""
 
     pwd = app_creds['password']
     if temp_appliance_unconfig_funcscope.version >= "5.8":
-        command_set = ('ap', '', '5', '1', '1', 'y', '1', 'n', '0', pwd, TimedCommand(pwd, 45), '')
+        command_set = ('ap', '', '5', '1', '1', 'y', '1', 'n', '0', pwd, TimedCommand(pwd, 360), '')
     else:
-        command_set = ('ap', '', '8', '1', '1', 'y', '1', 'n', '0', pwd, TimedCommand(pwd, 45), '')
+        command_set = ('ap', '', '8', '1', '1', 'y', '1', 'n', '0', pwd, TimedCommand(pwd, 360), '')
     temp_appliance_unconfig_funcscope.appliance_console.run_commands(command_set)
     temp_appliance_unconfig_funcscope.wait_for_evm_service()
     temp_appliance_unconfig_funcscope.wait_for_web_ui()
@@ -59,14 +59,15 @@ def test_black_console_internal_db(app_creds, temp_appliance_unconfig_funcscope)
 @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
 def test_black_console_internal_db_reset(app_creds, temp_appliance_preconfig_funcscope):
     """'ap' launch appliance_console, '' clear info screen, '5/8' setup db, '4' reset db, 'y'
-    confirm db reset, '1' db region number + wait 90 secs, '' continue, '' clear info screen,
+    confirm db reset, '1' db region number + wait 360 secs, '' continue, '' clear info screen,
     '15/19' start evm and 'y' confirm start."""
 
     temp_appliance_preconfig_funcscope.ssh_client.run_command('systemctl stop evmserverd')
     if temp_appliance_preconfig_funcscope.version >= "5.8":
-        command_set = ('ap', '', '5', '4', 'y', TimedCommand('1', 90), '', '', '15', 'y')
+        command_set = ('ap', '', '5', '4', 'y', TimedCommand('1', 360), '')
     else:
-        command_set = ('ap', '', '8', '4', 'y', TimedCommand('1', 90), '', '', '19', 'y')
+        command_set = ('ap', '', '8', '4', 'y', TimedCommand('1', 360), '')
+    temp_appliance_preconfig_funcscope.ssh_client.run_command('systemctl start evmserverd')
     temp_appliance_preconfig_funcscope.appliance_console.run_commands(command_set)
     temp_appliance_preconfig_funcscope.wait_for_evm_service()
     temp_appliance_preconfig_funcscope.wait_for_web_ui()
@@ -75,14 +76,14 @@ def test_black_console_internal_db_reset(app_creds, temp_appliance_preconfig_fun
 @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
 def test_black_console_dedicated_db(temp_appliance_unconfig_funcscope, app_creds):
     """'ap' launch appliance_console, '' clear info screen, '5/8' setup db, '1' Creates v2_key,
-    '1' selects internal db, '1' use partition, 'y' create dedicated db, 'pwd' db password, 'pwd'
-    confirm db password + wait 45 secs and '' finish."""
+    '1' selects internal db, 'y' continue, '1' use partition, 'y' create dedicated db, 'pwd'
+    db password, 'pwd' confirm db password + wait 360 secs and '' finish."""
 
     pwd = app_creds['password']
     if temp_appliance_unconfig_funcscope.version >= "5.8":
-        command_set = ('ap', '', '5', '1', '1', '1', 'y', pwd, TimedCommand(pwd, 45), '')
+        command_set = ('ap', '', '5', '1', '1', 'y', '1', 'y', pwd, TimedCommand(pwd, 360), '')
     else:
-        command_set = ('ap', '', '8', '1', '1', '1', 'y', pwd, TimedCommand(pwd, 45), '')
+        command_set = ('ap', '', '8', '1', '1', 'y', '1', 'y', pwd, TimedCommand(pwd, 360), '')
     temp_appliance_unconfig_funcscope.appliance_console.run_commands(command_set)
     wait_for(temp_appliance_unconfig_funcscope.is_dedicated_db_active)
 
@@ -91,17 +92,17 @@ def test_black_console_external_db(temp_appliance_unconfig_funcscope, app_creds,
     """'ap' launch appliance_console, '' clear info screen, '5/8' setup db, '2' fetch v2_key,
     'ip' address to fetch from, '' default username, 'pwd' db password, '' default v2_key location,
     '3' join external region, 'ip' address of joining region, '' default port number, '' use defult
-    db name, '' default username, 'pwd' db password, 'pwd' confirm db password + wait 45 secs and
+    db name, '' default username, 'pwd' db password, 'pwd' confirm db password + wait 360 secs and
     '' finish."""
 
     ip = appliance.address
     pwd = app_creds['password']
     if temp_appliance_unconfig_funcscope.version >= "5.8":
         command_set = ('ap', '', '5', '2', ip, '', pwd, '', '3', ip, '', '', '',
-            pwd, TimedCommand(pwd, 45), '')
+            pwd, TimedCommand(pwd, 360), '')
     else:
         command_set = ('ap', '', '8', '2', ip, '', pwd, '', '3', ip, '', '',
-            pwd, TimedCommand(pwd, 45), '')
+            pwd, TimedCommand(pwd, 360), '')
     temp_appliance_unconfig_funcscope.appliance_console.run_commands(command_set)
     temp_appliance_unconfig_funcscope.wait_for_evm_service()
     temp_appliance_unconfig_funcscope.wait_for_web_ui()
@@ -113,16 +114,16 @@ def test_black_console_external_db_create(app_creds, dedicated_db_appliance,
     """'ap' launch appliance_console, '' clear info screen, '5/8' setup db, '1' create v2_key,
     '2' create region in external db, '0' db region number, 'y' confirm create region in external db
     'ip' address of dedicated db, '' default port number, '' use defult db name, '' default
-    username, 'pwd' db password, 'pwd' confirm db password + wait 45 secs and '' finish."""
+    username, 'pwd' db password, 'pwd' confirm db password + wait 360 secs and '' finish."""
 
     ip = dedicated_db_appliance.address
     pwd = app_creds['password']
     if temp_appliance_unconfig_funcscope.version >= "5.8":
         command_set = ('ap', '', '5', '1', '2', '0', 'y', ip, '', '', '', pwd,
-            TimedCommand(pwd, 45), '')
+            TimedCommand(pwd, 360), '')
     else:
         command_set = ('ap', '', '8', '1', '2', '0', 'y', ip, '', '', pwd,
-            TimedCommand(pwd, 45), '')
+            TimedCommand(pwd, 360), '')
     temp_appliance_unconfig_funcscope.appliance_console.run_commands(command_set)
     temp_appliance_unconfig_funcscope.wait_for_evm_service()
     temp_appliance_unconfig_funcscope.wait_for_web_ui()

--- a/cfme/tests/cloud_infra_common/test_power_control_rest.py
+++ b/cfme/tests/cloud_infra_common/test_power_control_rest.py
@@ -76,7 +76,7 @@ def verify_action_result(rest_api, assert_success=True):
 
 
 @pytest.mark.parametrize("from_detail", [True, False], ids=["cfrom_detail", "from_collection"])
-def test_stop(rest_api, vm_obj, verify_vm_running, soft_assert, from_detail):
+def test_stop(appliance, vm_obj, verify_vm_running, soft_assert, from_detail):
     """Test stop of vm
 
     Prerequisities:
@@ -93,6 +93,7 @@ def test_stop(rest_api, vm_obj, verify_vm_running, soft_assert, from_detail):
     Metadata:
         test_flag: rest
     """
+    rest_api = appliance.rest_api
     vm_obj.wait_for_vm_state_change(desired_state=vm_obj.STATE_ON)
     vm = rest_api.collections.vms.get(name=vm_obj.name)
 
@@ -106,7 +107,7 @@ def test_stop(rest_api, vm_obj, verify_vm_running, soft_assert, from_detail):
 
 
 @pytest.mark.parametrize("from_detail", [True, False], ids=["from_detail", "from_collection"])
-def test_start(rest_api, vm_obj, verify_vm_stopped, soft_assert, from_detail):
+def test_start(appliance, vm_obj, verify_vm_stopped, soft_assert, from_detail):
     """Test start vm
 
     Prerequisities:
@@ -123,6 +124,7 @@ def test_start(rest_api, vm_obj, verify_vm_stopped, soft_assert, from_detail):
     Metadata:
         test_flag: rest
     """
+    rest_api = appliance.rest_api
     vm_obj.wait_for_vm_state_change(desired_state=vm_obj.STATE_OFF, timeout=1200)
     vm = rest_api.collections.vms.get(name=vm_obj.name)
 
@@ -136,7 +138,7 @@ def test_start(rest_api, vm_obj, verify_vm_stopped, soft_assert, from_detail):
 
 
 @pytest.mark.parametrize("from_detail", [True, False], ids=["from_detail", "from_collection"])
-def test_suspend(rest_api, vm_obj, verify_vm_running, soft_assert, from_detail):
+def test_suspend(appliance, vm_obj, verify_vm_running, soft_assert, from_detail):
     """Test suspend vm
 
     Prerequisities:
@@ -153,6 +155,7 @@ def test_suspend(rest_api, vm_obj, verify_vm_running, soft_assert, from_detail):
     Metadata:
         test_flag: rest
     """
+    rest_api = appliance.rest_api
     vm_obj.wait_for_vm_state_change(desired_state=vm_obj.STATE_ON)
     vm = rest_api.collections.vms.get(name=vm_obj.name)
 
@@ -171,7 +174,7 @@ def test_suspend(rest_api, vm_obj, verify_vm_running, soft_assert, from_detail):
 
 
 @pytest.mark.parametrize("from_detail", [True, False], ids=["from_detail", "from_collection"])
-def test_reset_vm(rest_api, vm_obj, verify_vm_running, from_detail, appliance):
+def test_reset_vm(vm_obj, verify_vm_running, from_detail, appliance):
     """
     Test reset vm
 
@@ -189,6 +192,7 @@ def test_reset_vm(rest_api, vm_obj, verify_vm_running, from_detail, appliance):
     Metadata:
         test_flag: rest
     """
+    rest_api = appliance.rest_api
     vm_obj.wait_for_vm_state_change(desired_state=vm_obj.STATE_ON)
     vm = rest_api.collections.vms.get(name=vm_obj.name)
 

--- a/cfme/tests/configure/test_rest_access_control.py
+++ b/cfme/tests/configure/test_rest_access_control.py
@@ -20,66 +20,62 @@ pytestmark = [
 
 class TestTenantsViaREST(object):
     @pytest.fixture(scope="function")
-    def tenants(self, request, rest_api):
+    def tenants(self, request, appliance):
         num_tenants = 3
-        response = _tenants(request, rest_api, num=num_tenants)
-        assert rest_api.response.status_code == 200
+        response = _tenants(request, appliance.rest_api, num=num_tenants)
+        assert appliance.rest_api.response.status_code == 200
         assert len(response) == num_tenants
         return response
 
     @pytest.mark.tier(3)
-    def test_create_tenants(self, rest_api, tenants):
+    def test_create_tenants(self, appliance, tenants):
         """Tests creating tenants.
 
         Metadata:
             test_flag: rest
         """
         for tenant in tenants:
-            record = rest_api.collections.tenants.get(id=tenant.id)
-            assert rest_api.response.status_code == 200
+            record = appliance.rest_api.collections.tenants.get(id=tenant.id)
+            assert appliance.rest_api.response.status_code == 200
             assert record.name == tenant.name
 
     @pytest.mark.tier(2)
     @pytest.mark.parametrize("multiple", [False, True], ids=["one_request", "multiple_requests"])
-    def test_edit_tenants(self, rest_api, tenants, multiple):
+    def test_edit_tenants(self, appliance, tenants, multiple):
         """Tests editing tenants.
 
         Metadata:
             test_flag: rest
         """
+        collection = appliance.rest_api.collections.tenants
+        tenants_len = len(tenants)
+        new = []
+        for _ in range(tenants_len):
+            new.append(
+                {'name': 'test_tenants_{}'.format(fauxfactory.gen_alphanumeric().lower())})
         if multiple:
-            new_names = []
-            tenants_data_edited = []
-            for tenant in tenants:
-                new_name = "test_tenants_{}".format(fauxfactory.gen_alphanumeric().lower())
-                new_names.append(new_name)
-                tenant.reload()
-                tenants_data_edited.append({
-                    "href": tenant.href,
-                    "name": new_name,
-                })
-            rest_api.collections.tenants.action.edit(*tenants_data_edited)
-            assert rest_api.response.status_code == 200
-            for new_name in new_names:
-                wait_for(
-                    lambda: rest_api.collections.tenants.find_by(name=new_name),
-                    num_sec=180,
-                    delay=10,
-                )
+            for index in range(tenants_len):
+                new[index].update(tenants[index]._ref_repr())
+            edited = collection.action.edit(*new)
+            assert appliance.rest_api.response.status_code == 200
         else:
-            tenant = rest_api.collections.tenants.get(name=tenants[0].name)
-            new_name = "test_tenant_{}".format(fauxfactory.gen_alphanumeric().lower())
-            tenant.action.edit(name=new_name)
-            assert rest_api.response.status_code == 200
-            wait_for(
-                lambda: rest_api.collections.tenants.find_by(name=new_name),
+            edited = []
+            for index in range(tenants_len):
+                edited.append(tenants[index].action.edit(**new[index]))
+                assert appliance.rest_api.response.status_code == 200
+        assert tenants_len == len(edited)
+        for index in range(tenants_len):
+            record, _ = wait_for(
+                lambda: collection.find_by(name=new[index]['name']),
                 num_sec=180,
                 delay=10,
             )
+            assert record[0].id == edited[index].id
+            assert record[0].name == edited[index].name
 
     @pytest.mark.tier(3)
     @pytest.mark.parametrize("method", ["post", "delete"], ids=["POST", "DELETE"])
-    def test_delete_tenants_from_detail(self, rest_api, tenants, method):
+    def test_delete_tenants_from_detail(self, appliance, tenants, method):
         """Tests deleting tenants from detail.
 
         Metadata:
@@ -88,87 +84,83 @@ class TestTenantsViaREST(object):
         status = 204 if method == "delete" else 200
         for tenant in tenants:
             tenant.action.delete(force_method=method)
-            assert rest_api.response.status_code == status
+            assert appliance.rest_api.response.status_code == status
             with error.expected("ActiveRecord::RecordNotFound"):
                 tenant.action.delete(force_method=method)
-            assert rest_api.response.status_code == 404
+            assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
-    def test_delete_tenants_from_collection(self, rest_api, tenants):
+    def test_delete_tenants_from_collection(self, appliance, tenants):
         """Tests deleting tenants from collection.
 
         Metadata:
             test_flag: rest
         """
-        rest_api.collections.tenants.action.delete(*tenants)
-        assert rest_api.response.status_code == 200
+        appliance.rest_api.collections.tenants.action.delete(*tenants)
+        assert appliance.rest_api.response.status_code == 200
         with error.expected("ActiveRecord::RecordNotFound"):
-            rest_api.collections.tenants.action.delete(*tenants)
-        assert rest_api.response.status_code == 404
+            appliance.rest_api.collections.tenants.action.delete(*tenants)
+        assert appliance.rest_api.response.status_code == 404
 
 
 class TestRolesViaREST(object):
     @pytest.fixture(scope="function")
-    def roles(self, request, rest_api):
+    def roles(self, request, appliance):
         num_roles = 3
-        response = _roles(request, rest_api, num=num_roles)
-        assert rest_api.response.status_code == 200
+        response = _roles(request, appliance.rest_api, num=num_roles)
+        assert appliance.rest_api.response.status_code == 200
         assert len(response) == num_roles
         return response
 
     @pytest.mark.tier(3)
-    def test_create_roles(self, rest_api, roles):
+    def test_create_roles(self, appliance, roles):
         """Tests creating roles.
 
         Metadata:
             test_flag: rest
         """
         for role in roles:
-            record = rest_api.collections.roles.get(id=role.id)
-            assert rest_api.response.status_code == 200
+            record = appliance.rest_api.collections.roles.get(id=role.id)
+            assert appliance.rest_api.response.status_code == 200
             assert record.name == role.name
 
     @pytest.mark.tier(2)
     @pytest.mark.parametrize("multiple", [False, True], ids=["one_request", "multiple_requests"])
-    def test_edit_roles(self, rest_api, roles, multiple):
+    def test_edit_roles(self, appliance, roles, multiple):
         """Tests editing roles.
 
         Metadata:
             test_flag: rest
         """
+        collection = appliance.rest_api.collections.roles
+        roles_len = len(roles)
+        new = []
+        for _ in range(roles_len):
+            new.append(
+                {'name': 'test_role_{}'.format(fauxfactory.gen_alphanumeric())})
         if multiple:
-            new_names = []
-            roles_data_edited = []
-            for role in roles:
-                new_name = "role_name_{}".format(fauxfactory.gen_alphanumeric())
-                new_names.append(new_name)
-                role.reload()
-                roles_data_edited.append({
-                    "href": role.href,
-                    "name": new_name,
-                })
-            rest_api.collections.roles.action.edit(*roles_data_edited)
-            assert rest_api.response.status_code == 200
-            for new_name in new_names:
-                wait_for(
-                    lambda: rest_api.collections.roles.find_by(name=new_name),
-                    num_sec=180,
-                    delay=10,
-                )
+            for index in range(roles_len):
+                new[index].update(roles[index]._ref_repr())
+            edited = collection.action.edit(*new)
+            assert appliance.rest_api.response.status_code == 200
         else:
-            role = rest_api.collections.roles.get(name=roles[0].name)
-            new_name = "role_name_{}".format(fauxfactory.gen_alphanumeric())
-            role.action.edit(name=new_name)
-            assert rest_api.response.status_code == 200
-            wait_for(
-                lambda: rest_api.collections.roles.find_by(name=new_name),
+            edited = []
+            for index in range(roles_len):
+                edited.append(roles[index].action.edit(**new[index]))
+                assert appliance.rest_api.response.status_code == 200
+        assert roles_len == len(edited)
+        for index in range(roles_len):
+            record, _ = wait_for(
+                lambda: collection.find_by(name=new[index]['name']),
                 num_sec=180,
                 delay=10,
             )
+            assert record[0].id == edited[index].id
+            assert record[0].name == edited[index].name
 
     @pytest.mark.tier(3)
     @pytest.mark.parametrize("method", ["post", "delete"], ids=["POST", "DELETE"])
-    def test_delete_roles_from_detail(self, rest_api, roles, method):
+    def test_delete_roles_from_detail(self, appliance, roles, method):
         """Tests deleting roles from detail.
 
         Metadata:
@@ -177,139 +169,135 @@ class TestRolesViaREST(object):
         status = 204 if method == "delete" else 200
         for role in roles:
             role.action.delete(force_method=method)
-            assert rest_api.response.status_code == status
+            assert appliance.rest_api.response.status_code == status
             with error.expected("ActiveRecord::RecordNotFound"):
                 role.action.delete(force_method=method)
-            assert rest_api.response.status_code == 404
+            assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
-    def test_delete_roles_from_collection(self, rest_api, roles):
+    def test_delete_roles_from_collection(self, appliance, roles):
         """Tests deleting roles from collection.
 
         Metadata:
             test_flag: rest
         """
-        rest_api.collections.roles.action.delete(*roles)
-        assert rest_api.response.status_code == 200
+        appliance.rest_api.collections.roles.action.delete(*roles)
+        assert appliance.rest_api.response.status_code == 200
         with error.expected("ActiveRecord::RecordNotFound"):
-            rest_api.collections.roles.action.delete(*roles)
-        assert rest_api.response.status_code == 404
+            appliance.rest_api.collections.roles.action.delete(*roles)
+        assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
-    def test_add_delete_role(self, rest_api):
+    def test_add_delete_role(self, appliance):
         """Tests adding role using "add" action and deleting it.
 
         Metadata:
             test_flag: rest
         """
         role_data = {"name": "role_name_{}".format(format(fauxfactory.gen_alphanumeric()))}
-        role = rest_api.collections.roles.action.add(role_data)[0]
-        assert rest_api.response.status_code == 200
+        role = appliance.rest_api.collections.roles.action.add(role_data)[0]
+        assert appliance.rest_api.response.status_code == 200
         assert role.name == role_data["name"]
         wait_for(
-            lambda: rest_api.collections.roles.find_by(name=role.name),
+            lambda: appliance.rest_api.collections.roles.find_by(name=role.name),
             num_sec=180,
             delay=10,
         )
-        found_role = rest_api.collections.roles.get(name=role.name)
+        found_role = appliance.rest_api.collections.roles.get(name=role.name)
         assert found_role.name == role_data["name"]
         role.action.delete()
-        assert rest_api.response.status_code == 200
+        assert appliance.rest_api.response.status_code == 200
         with error.expected("ActiveRecord::RecordNotFound"):
             role.action.delete()
-        assert rest_api.response.status_code == 404
+        assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
-    def test_role_assign_and_unassign_feature(self, rest_api, roles):
+    def test_role_assign_and_unassign_feature(self, appliance, roles):
         """Tests assigning and unassigning feature to a role.
 
         Metadata:
             test_flag: rest
         """
-        feature = rest_api.collections.features.get(name="Everything")
+        feature = appliance.rest_api.collections.features.get(name="Everything")
         role = roles[0]
         role.reload()
         role.features.action.assign(feature)
-        assert rest_api.response.status_code == 200
+        assert appliance.rest_api.response.status_code == 200
         role.reload()
         # This verification works because the created roles don't have assigned features
         assert feature.id in [f.id for f in role.features.all]
         role.features.action.unassign(feature)
-        assert rest_api.response.status_code == 200
+        assert appliance.rest_api.response.status_code == 200
         role.reload()
         assert feature.id not in [f.id for f in role.features.all]
 
 
 class TestGroupsViaREST(object):
     @pytest.fixture(scope="function")
-    def tenants(self, request, rest_api):
-        return _tenants(request, rest_api, num=1)
+    def tenants(self, request, appliance):
+        return _tenants(request, appliance.rest_api, num=1)
 
     @pytest.fixture(scope="function")
-    def roles(self, request, rest_api):
-        return _roles(request, rest_api, num=1)
+    def roles(self, request, appliance):
+        return _roles(request, appliance.rest_api, num=1)
 
     @pytest.fixture(scope="function")
-    def groups(self, request, rest_api, roles, tenants):
+    def groups(self, request, appliance, roles, tenants):
         num_groups = 3
-        response = _groups(request, rest_api, roles, tenants, num=num_groups)
-        assert rest_api.response.status_code == 200
+        response = _groups(request, appliance.rest_api, roles, tenants, num=num_groups)
+        assert appliance.rest_api.response.status_code == 200
         assert len(response) == num_groups
         return response
 
     @pytest.mark.tier(3)
-    def test_create_groups(self, rest_api, groups):
+    def test_create_groups(self, appliance, groups):
         """Tests creating groups.
 
         Metadata:
             test_flag: rest
         """
         for group in groups:
-            record = rest_api.collections.groups.get(id=group.id)
-            assert rest_api.response.status_code == 200
+            record = appliance.rest_api.collections.groups.get(id=group.id)
+            assert appliance.rest_api.response.status_code == 200
             assert record.description == group.description
 
     @pytest.mark.tier(2)
     @pytest.mark.parametrize("multiple", [False, True], ids=["one_request", "multiple_requests"])
-    def test_edit_groups(self, rest_api, groups, multiple):
+    def test_edit_groups(self, appliance, groups, multiple):
         """Tests editing groups.
 
         Metadata:
             test_flag: rest
         """
+        collection = appliance.rest_api.collections.groups
+        groups_len = len(groups)
+        new = []
+        for _ in range(groups_len):
+            new.append(
+                {'description': 'group_description_{}'.format(fauxfactory.gen_alphanumeric())})
         if multiple:
-            new_descriptions = []
-            groups_data_edited = []
-            for group in groups:
-                new_description = "group_descripton_{}".format(fauxfactory.gen_alphanumeric())
-                new_descriptions.append(new_description)
-                group.reload()
-                groups_data_edited.append({
-                    "href": group.href,
-                    "description": new_description,
-                })
-            rest_api.collections.groups.action.edit(*groups_data_edited)
-            assert rest_api.response.status_code == 200
-            for description in new_descriptions:
-                wait_for(
-                    lambda: rest_api.collections.groups.find_by(description=description),
-                    num_sec=180,
-                    delay=10,
-                )
+            for index in range(groups_len):
+                new[index].update(groups[index]._ref_repr())
+            edited = collection.action.edit(*new)
+            assert appliance.rest_api.response.status_code == 200
         else:
-            group = rest_api.collections.groups.get(description=groups[0].description)
-            new_description = "group_description_{}".format(fauxfactory.gen_alphanumeric())
-            group.action.edit(description=new_description)
-            assert rest_api.response.status_code == 200
-            wait_for(
-                lambda: rest_api.collections.groups.find_by(description=new_description),
+            edited = []
+            for index in range(groups_len):
+                edited.append(groups[index].action.edit(**new[index]))
+                assert appliance.rest_api.response.status_code == 200
+        assert groups_len == len(edited)
+        for index in range(groups_len):
+            record, _ = wait_for(
+                lambda: collection.find_by(name=new[index]['description']),
                 num_sec=180,
                 delay=10,
             )
+            assert record[0].id == edited[index].id
+            assert record[0].description == edited[index].description
 
     @pytest.mark.tier(3)
     @pytest.mark.parametrize("method", ["post", "delete"], ids=["POST", "DELETE"])
-    def test_delete_groups_from_detail(self, rest_api, groups, method):
+    def test_delete_groups_from_detail(self, appliance, groups, method):
         """Tests deleting groups from detail.
 
         Metadata:
@@ -318,48 +306,48 @@ class TestGroupsViaREST(object):
         status = 204 if method == "delete" else 200
         for group in groups:
             group.action.delete(force_method=method)
-            assert rest_api.response.status_code == status
+            assert appliance.rest_api.response.status_code == status
             with error.expected("ActiveRecord::RecordNotFound"):
                 group.action.delete(force_method=method)
-            assert rest_api.response.status_code == 404
+            assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
-    def test_delete_groups_from_collection(self, rest_api, groups):
+    def test_delete_groups_from_collection(self, appliance, groups):
         """Tests deleting groups from collection.
 
         Metadata:
             test_flag: rest
         """
-        rest_api.collections.groups.action.delete(*groups)
-        assert rest_api.response.status_code == 200
+        appliance.rest_api.collections.groups.action.delete(*groups)
+        assert appliance.rest_api.response.status_code == 200
         with error.expected("ActiveRecord::RecordNotFound"):
-            rest_api.collections.groups.action.delete(*groups)
-        assert rest_api.response.status_code == 404
+            appliance.rest_api.collections.groups.action.delete(*groups)
+        assert appliance.rest_api.response.status_code == 404
 
 
 class TestUsersViaREST(object):
     @pytest.fixture(scope="function")
-    def users(self, request, rest_api):
+    def users(self, request, appliance):
         num_users = 3
-        response = _users(request, rest_api, num=num_users)
-        assert rest_api.response.status_code == 200
+        response = _users(request, appliance.rest_api, num=num_users)
+        assert appliance.rest_api.response.status_code == 200
         assert len(response) == 3
         return response
 
     @pytest.mark.tier(3)
-    def test_create_users(self, rest_api, users):
+    def test_create_users(self, appliance, users):
         """Tests creating users.
 
         Metadata:
             test_flag: rest
         """
         for user in users:
-            record = rest_api.collections.users.get(id=user.id)
-            assert rest_api.response.status_code == 200
+            record = appliance.rest_api.collections.users.get(id=user.id)
+            assert appliance.rest_api.response.status_code == 200
             assert record.name == user.name
 
     @pytest.mark.tier(2)
-    def test_edit_user_password(self, request, rest_api, users):
+    def test_edit_user_password(self, request, appliance, users):
         """Tests editing user password.
 
         Metadata:
@@ -369,52 +357,48 @@ class TestUsersViaREST(object):
         user = users[0]
         new_password = fauxfactory.gen_alphanumeric()
         user.action.edit(password=new_password)
-        assert rest_api.response.status_code == 200
+        assert appliance.rest_api.response.status_code == 200
         cred = Credential(principal=user.userid, secret=new_password)
         new_user = User(credential=cred)
         login(new_user)
 
     @pytest.mark.tier(3)
     @pytest.mark.parametrize("multiple", [False, True], ids=["one_request", "multiple_requests"])
-    def test_edit_user_name(self, rest_api, users, multiple):
+    def test_edit_user_name(self, appliance, users, multiple):
         """Tests editing user name.
 
         Metadata:
             test_flag: rest
         """
+        collection = appliance.rest_api.collections.users
+        users_len = len(users)
+        new = []
+        for _ in range(users_len):
+            new.append(
+                {'name': 'user_name_{}'.format(fauxfactory.gen_alphanumeric())})
         if multiple:
-            new_names = []
-            users_data_edited = []
-            for user in users:
-                new_name = "user_name_{}".format(fauxfactory.gen_alphanumeric())
-                new_names.append(new_name)
-                user.reload()
-                users_data_edited.append({
-                    "href": user.href,
-                    "name": new_name,
-                })
-            rest_api.collections.users.action.edit(*users_data_edited)
-            assert rest_api.response.status_code == 200
-            for new_name in new_names:
-                wait_for(
-                    lambda: rest_api.collections.users.find_by(name=new_name),
-                    num_sec=180,
-                    delay=10,
-                )
+            for index in range(users_len):
+                new[index].update(users[index]._ref_repr())
+            edited = collection.action.edit(*new)
+            assert appliance.rest_api.response.status_code == 200
         else:
-            user = users[0]
-            new_name = 'user_{}'.format(fauxfactory.gen_alphanumeric())
-            user.action.edit(name=new_name)
-            assert rest_api.response.status_code == 200
-            wait_for(
-                lambda: rest_api.collections.users.find_by(name=new_name),
+            edited = []
+            for index in range(users_len):
+                edited.append(users[index].action.edit(**new[index]))
+                assert appliance.rest_api.response.status_code == 200
+        assert users_len == len(edited)
+        for index in range(users_len):
+            record, _ = wait_for(
+                lambda: collection.find_by(name=new[index]['name']),
                 num_sec=180,
                 delay=10,
             )
+            assert record[0].id == edited[index].id
+            assert record[0].name == edited[index].name
 
     @pytest.mark.tier(3)
     @pytest.mark.parametrize("method", ["post", "delete"], ids=["POST", "DELETE"])
-    def test_delete_users_from_detail(self, rest_api, users, method):
+    def test_delete_users_from_detail(self, appliance, users, method):
         """Tests deleting users from detail.
 
         Metadata:
@@ -423,20 +407,20 @@ class TestUsersViaREST(object):
         status = 204 if method == "delete" else 200
         for user in users:
             user.action.delete(force_method=method)
-            assert rest_api.response.status_code == status
+            assert appliance.rest_api.response.status_code == status
             with error.expected("ActiveRecord::RecordNotFound"):
                 user.action.delete(force_method=method)
-            assert rest_api.response.status_code == 404
+            assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
-    def test_delete_users_from_collection(self, rest_api, users):
+    def test_delete_users_from_collection(self, appliance, users):
         """Tests deleting users from collection.
 
         Metadata:
             test_flag: rest
         """
-        rest_api.collections.users.action.delete(*users)
-        assert rest_api.response.status_code == 200
+        appliance.rest_api.collections.users.action.delete(*users)
+        assert appliance.rest_api.response.status_code == 200
         with error.expected("ActiveRecord::RecordNotFound"):
-            rest_api.collections.users.action.delete(*users)
-        assert rest_api.response.status_code == 404
+            appliance.rest_api.collections.users.action.delete(*users)
+        assert appliance.rest_api.response.status_code == 404

--- a/cfme/tests/configure/test_tag_category.py
+++ b/cfme/tests/configure/test_tag_category.py
@@ -22,67 +22,63 @@ def test_category_crud():
 
 class TestCategoriesViaREST(object):
     @pytest.fixture(scope="function")
-    def categories(self, request, rest_api):
-        response = _categories(request, rest_api, num=5)
-        assert rest_api.response.status_code == 200
+    def categories(self, request, appliance):
+        response = _categories(request, appliance.rest_api, num=5)
+        assert appliance.rest_api.response.status_code == 200
         assert len(response) == 5
         return response
 
     @pytest.mark.tier(3)
-    def test_create_categories(self, rest_api, categories):
+    def test_create_categories(self, appliance, categories):
         """Tests creating categories.
 
         Metadata:
             test_flag: rest
         """
         for ctg in categories:
-            record = rest_api.collections.categories.get(id=ctg.id)
-            assert rest_api.response.status_code == 200
+            record = appliance.rest_api.collections.categories.get(id=ctg.id)
+            assert appliance.rest_api.response.status_code == 200
             assert record.name == ctg.name
 
     @pytest.mark.tier(3)
     @pytest.mark.parametrize(
         "multiple", [False, True],
         ids=["one_request", "multiple_requests"])
-    def test_edit_categories(self, rest_api, categories, multiple):
+    def test_edit_categories(self, appliance, categories, multiple):
         """Tests editing categories.
 
         Metadata:
             test_flag: rest
         """
+        collection = appliance.rest_api.collections.categories
+        categories_len = len(categories)
+        new = []
+        for _ in range(categories_len):
+            new.append(
+                {'description': 'test_category_{}'.format(fauxfactory.gen_alphanumeric().lower())})
         if multiple:
-            new_descriptions = []
-            ctgs_data_edited = []
-            for ctg in categories:
-                new_description = "test_category_{}".format(fauxfactory.gen_alphanumeric().lower())
-                new_descriptions.append(new_description)
-                ctg.reload()
-                ctgs_data_edited.append({
-                    "href": ctg.href,
-                    "description": new_description,
-                })
-            rest_api.collections.categories.action.edit(*ctgs_data_edited)
-            assert rest_api.response.status_code == 200
-            for new_description in new_descriptions:
-                wait_for(
-                    lambda: rest_api.collections.categories.find_by(description=new_description),
-                    num_sec=180,
-                    delay=10,
-                )
+            for index in range(categories_len):
+                new[index].update(categories[index]._ref_repr())
+            edited = collection.action.edit(*new)
+            assert appliance.rest_api.response.status_code == 200
         else:
-            ctg = rest_api.collections.categories.get(description=categories[0].description)
-            new_description = "test_category_{}".format(fauxfactory.gen_alphanumeric().lower())
-            ctg.action.edit(description=new_description)
-            assert rest_api.response.status_code == 200
-            wait_for(
-                lambda: rest_api.collections.categories.find_by(description=new_description),
+            edited = []
+            for index in range(categories_len):
+                edited.append(categories[index].action.edit(**new[index]))
+                assert appliance.rest_api.response.status_code == 200
+        assert categories_len == len(edited)
+        for index in range(categories_len):
+            record, _ = wait_for(
+                lambda: collection.find_by(description=new[index]['description']),
                 num_sec=180,
                 delay=10,
             )
+            assert record[0].id == edited[index].id
+            assert record[0].description == edited[index].description
 
     @pytest.mark.tier(3)
     @pytest.mark.parametrize("method", ["post", "delete"], ids=["POST", "DELETE"])
-    def test_delete_categories_from_detail(self, rest_api, categories, method):
+    def test_delete_categories_from_detail(self, appliance, categories, method):
         """Tests deleting categories from detail.
 
         Metadata:
@@ -91,20 +87,20 @@ class TestCategoriesViaREST(object):
         status = 204 if method == "delete" else 200
         for ctg in categories:
             ctg.action.delete(force_method=method)
-            assert rest_api.response.status_code == status
+            assert appliance.rest_api.response.status_code == status
             with error.expected("ActiveRecord::RecordNotFound"):
                 ctg.action.delete(force_method=method)
-            assert rest_api.response.status_code == 404
+            assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
-    def test_delete_categories_from_collection(self, rest_api, categories):
+    def test_delete_categories_from_collection(self, appliance, categories):
         """Tests deleting categories from collection.
 
         Metadata:
             test_flag: rest
         """
-        rest_api.collections.categories.action.delete(*categories)
-        assert rest_api.response.status_code == 200
+        appliance.rest_api.collections.categories.action.delete(*categories)
+        assert appliance.rest_api.response.status_code == 200
         with error.expected("ActiveRecord::RecordNotFound"):
-            rest_api.collections.categories.action.delete(*categories)
-        assert rest_api.response.status_code == 404
+            appliance.rest_api.collections.categories.action.delete(*categories)
+        assert appliance.rest_api.response.status_code == 404

--- a/cfme/tests/containers/test_breadcrumbs.py
+++ b/cfme/tests/containers/test_breadcrumbs.py
@@ -46,7 +46,7 @@ DATA_SETS = [
 ]
 
 
-@pytest.mark.polarion('CMP-10567')
+@pytest.mark.polarion('CMP-10576')
 def test_breadcrumbs(provider, soft_assert):
 
     for dataset in DATA_SETS:

--- a/cfme/tests/containers/test_cockpit.py
+++ b/cfme/tests/containers/test_cockpit.py
@@ -18,7 +18,7 @@ pytest_generate_tests = testgen.generate(
     [ContainersProvider], scope='function')
 
 
-@pytest.mark.polarion('CMP-10469')
+@pytest.mark.polarion('CMP-10255')
 @pytest.mark.meta(blockers=[BZ(1406772, forced_streams=["5.7", "5.8"])])
 def test_cockpit_button_access(provider, soft_assert):
     """ The test verifies the existence of cockpit "Web Console"

--- a/cfme/tests/containers/test_properties.py
+++ b/cfme/tests/containers/test_properties.py
@@ -179,6 +179,8 @@ def test_pods_conditions(provider, soft_assert):
 
     for pod_name in selected_pods_cfme:
         cfme_pod = selected_pods_cfme[pod_name]
+        s = cfme_pod.summary
+        print s.conditions
         ose_pod = selected_pods_ose[pod_name]
 
         ose_pod_condition = {cond["type"]: cond["status"] for cond in

--- a/cfme/tests/containers/test_properties.py
+++ b/cfme/tests/containers/test_properties.py
@@ -38,7 +38,7 @@ TEST_ITEMS = [
             'CMP-9945',
             expected_fields=[
                 'name', 'state', 'last_state', 'restart_count',
-                'backing_ref_container_id', 'privileged', 'selinux_level'
+                'backing_ref_container_id', 'privileged'
             ]
         )
     ),
@@ -83,9 +83,9 @@ TEST_ITEMS = [
             Image,
             'CMP-9978',
             expected_fields={
-                version.LOWEST: ['name', 'tag', 'image_id', 'full_name'],
+                version.LOWEST: ['name', 'image_id', 'full_name'],
                 '5.7': [
-                    'name', 'tag', 'image_id', 'full_name', 'architecture', 'author',
+                    'name', 'image_id', 'full_name', 'architecture', 'author',
                     'entrypoint', 'docker_version', 'exposed_ports', 'size'
                 ]
             }
@@ -139,7 +139,7 @@ def test_properties(provider, test_item, soft_assert):
     if current_version() < "5.7" and test_item.obj == Template:
         pytest.skip('Templates are not exist in CFME version lower than 5.7. skipping...')
 
-    rows = navigate_and_get_rows(provider, test_item.obj, 2)
+    rows = navigate_and_get_rows(provider, test_item.obj, 2, silent_failure=True)
 
     if not rows:
         pytest.skip('No records found for {}s. Skipping...'.format(test_item.obj.__name__))

--- a/cfme/tests/containers/test_properties.py
+++ b/cfme/tests/containers/test_properties.py
@@ -166,3 +166,26 @@ def test_properties(provider, test_item, soft_assert):
             except AttributeError:
                 soft_assert(False, '{} "{}" properties table has missing field - "{}"'
                                    .format(test_item.obj.__name__, name, field))
+
+
+def test_pods_conditions(provider, soft_assert):
+
+    #  TODO: Add later this logic to mgmtsystem
+    selected_pods_cfme = {row.name.text: Pod(name=row.name.text, provider=provider) for row in
+                          navigate_and_get_rows(provider, Pod, 3)}
+    selected_pods_ose = {pod["metadata"]["name"]: pod for pod in
+                         provider.mgmt.api.get('pod')[1]['items'] if pod["metadata"]["name"] in
+                         selected_pods_cfme}
+
+    for pod_name in selected_pods_cfme:
+        cfme_pod = selected_pods_cfme[pod_name]
+        ose_pod = selected_pods_ose[pod_name]
+
+        ose_pod_condition = {cond["type"]: cond["status"] for cond in
+                             ose_pod['status']['conditions']}
+        cfme_pod_condition = {}
+
+        for item in cfme_pod_condition.items():
+            # Just using the vars for flake8 test will pass
+            # line have to change to real assestion
+            soft_assert(cfme_pod, ose_pod_condition)

--- a/cfme/tests/containers/test_properties.py
+++ b/cfme/tests/containers/test_properties.py
@@ -179,15 +179,13 @@ def test_pods_conditions(provider, soft_assert):
 
     for pod_name in selected_pods_cfme:
         cfme_pod = selected_pods_cfme[pod_name]
-        s = cfme_pod.summary
-        print s.conditions
+
         ose_pod = selected_pods_ose[pod_name]
 
         ose_pod_condition = {cond["type"]: cond["status"] for cond in
                              ose_pod['status']['conditions']}
-        cfme_pod_condition = {}
+        cfme_pod_condition = {type: getattr(getattr(cfme_pod.summary.conditions, type), "Status")
+                              for type in ose_pod_condition}
 
-        for item in cfme_pod_condition.items():
-            # Just using the vars for flake8 test will pass
-            # line have to change to real assestion
-            soft_assert(cfme_pod, ose_pod_condition)
+        for item in cfme_pod_condition:
+            soft_assert(ose_pod_condition[item], cfme_pod_condition[item])

--- a/cfme/tests/containers/test_static_custom_attributes.py
+++ b/cfme/tests/containers/test_static_custom_attributes.py
@@ -10,7 +10,6 @@ from utils.version import current_version
 from utils import testgen
 from cfme.containers.provider import ContainersProvider
 from cfme.containers.provider.openshift import CustomAttribute
-from utils.blockers import BZ
 
 pytestmark = [
     pytest.mark.uncollectif(
@@ -159,15 +158,9 @@ def test_delete_non_exist_attribute(provider):
 
 
 @pytest.mark.polarion('CMP-10542')
-@pytest.mark.meta(blockers=[BZ(1416797, forced_streams=['5.7']),
-                            BZ(1429228, forced_streams=['5.8'])])
 def test_add_already_exist_attribute(provider):
     ca = choice(ATTRIBUTES_DATASET)
-    with pytest.raises(APIException):
-        provider.add_custom_attributes(ca)
-        pytest.fail('You tried to add a custom attribute that already exists'
-                    '({}) and didn\'t get an error!'
-                    .format(ca.value))
+    provider.add_custom_attributes(ca)
 
 
 @pytest.mark.polarion('CMP-10540')

--- a/cfme/tests/containers/test_tables_fields.py
+++ b/cfme/tests/containers/test_tables_fields.py
@@ -36,7 +36,7 @@ TEST_ITEMS = [
     ),
     pytest.mark.polarion('CMP-9875')(
         ContainersTestItem(
-            Route, 'CMP-9875', fields_to_verify=['provider', 'project_name']
+            Route, 'CMP-10651', fields_to_verify=['provider', 'project_name']
         )
     ),
     pytest.mark.polarion('CMP-9943')(
@@ -84,7 +84,7 @@ TEST_ITEMS = [
             ImageRegistry, 'CMP-9985', fields_to_verify=['port', 'provider']
         )
     ),
-    pytest.mark.polarion('CMP-9886')(
+    pytest.mark.polarion('CMP-10652')(
         ContainersTestItem(
             Project, 'CMP-9886', fields_to_verify=[
                 'provider', 'container_routes', 'container_services',

--- a/cfme/tests/control/test_rest_control.py
+++ b/cfme/tests/control/test_rest_control.py
@@ -17,27 +17,27 @@ pytestmark = [
 
 class TestConditionsRESTAPI(object):
     @pytest.fixture(scope='function')
-    def conditions(self, request, rest_api):
+    def conditions(self, request, appliance):
         num_conditions = 2
-        response = _conditions(request, rest_api, num=num_conditions)
-        assert rest_api.response.status_code == 200
+        response = _conditions(request, appliance.rest_api, num=num_conditions)
+        assert appliance.rest_api.response.status_code == 200
         assert len(response) == num_conditions
         return response
 
     @pytest.mark.uncollectif(lambda: current_version() < '5.8')
-    def test_create_conditions(self, rest_api, conditions):
+    def test_create_conditions(self, appliance, conditions):
         """Tests create conditions.
 
         Metadata:
             test_flag: rest
         """
         for condition in conditions:
-            record = rest_api.collections.conditions.get(id=condition.id)
+            record = appliance.rest_api.collections.conditions.get(id=condition.id)
             assert record.description == condition.description
 
     @pytest.mark.uncollectif(lambda: current_version() < '5.8')
     @pytest.mark.parametrize('method', ['post', 'delete'], ids=['POST', 'DELETE'])
-    def test_delete_conditions_from_detail(self, conditions, rest_api, method):
+    def test_delete_conditions_from_detail(self, conditions, appliance, method):
         """Tests delete conditions from detail.
 
         Metadata:
@@ -46,30 +46,30 @@ class TestConditionsRESTAPI(object):
         status = 204 if method == 'delete' else 200
         for condition in conditions:
             condition.action.delete(force_method=method)
-            assert rest_api.response.status_code == status
+            assert appliance.rest_api.response.status_code == status
             with error.expected('ActiveRecord::RecordNotFound'):
                 condition.action.delete(force_method=method)
-            assert rest_api.response.status_code == 404
+            assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.uncollectif(lambda: current_version() < '5.8')
-    def test_delete_conditions_from_collection(self, conditions, rest_api):
+    def test_delete_conditions_from_collection(self, conditions, appliance):
         """Tests delete conditions from collection.
 
         Metadata:
             test_flag: rest
         """
-        collection = rest_api.collections.conditions
+        collection = appliance.rest_api.collections.conditions
         collection.action.delete(*conditions)
-        assert rest_api.response.status_code == 200
+        assert appliance.rest_api.response.status_code == 200
         with error.expected('ActiveRecord::RecordNotFound'):
             collection.action.delete(*conditions)
-        assert rest_api.response.status_code == 404
+        assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.uncollectif(lambda: current_version() < '5.8')
     @pytest.mark.parametrize(
         'from_detail', [True, False],
         ids=['from_detail', 'from_collection'])
-    def test_edit_conditions(self, conditions, rest_api, from_detail):
+    def test_edit_conditions(self, conditions, appliance, from_detail):
         """Tests edit conditions.
 
         Metadata:
@@ -82,12 +82,12 @@ class TestConditionsRESTAPI(object):
             edited = []
             for i in range(num_conditions):
                 edited.append(conditions[i].action.edit(**new[i]))
-                assert rest_api.response.status_code == 200
+                assert appliance.rest_api.response.status_code == 200
         else:
             for i in range(num_conditions):
                 new[i].update(conditions[i]._ref_repr())
-            edited = rest_api.collections.conditions.action.edit(*new)
-            assert rest_api.response.status_code == 200
+            edited = appliance.rest_api.collections.conditions.action.edit(*new)
+            assert appliance.rest_api.response.status_code == 200
         assert len(edited) == num_conditions
         for i in range(num_conditions):
             assert edited[i].description == new[i]['description']
@@ -95,26 +95,26 @@ class TestConditionsRESTAPI(object):
 
 class TestPoliciesRESTAPI(object):
     @pytest.fixture(scope='function')
-    def policies(self, request, rest_api):
+    def policies(self, request, appliance):
         num_policies = 2
-        response = _policies(request, rest_api, num=num_policies)
-        assert rest_api.response.status_code == 200
+        response = _policies(request, appliance.rest_api, num=num_policies)
+        assert appliance.rest_api.response.status_code == 200
         assert len(response) == num_policies
         return response
 
     @pytest.mark.uncollectif(lambda: current_version() < '5.8')
-    def test_create_policies(self, rest_api, policies):
+    def test_create_policies(self, appliance, policies):
         """Tests create policies.
 
         Metadata:
             test_flag: rest
         """
         for policy in policies:
-            record = rest_api.collections.policies.get(id=policy.id)
+            record = appliance.rest_api.collections.policies.get(id=policy.id)
             assert record.description == policy.description
 
     @pytest.mark.uncollectif(lambda: current_version() < '5.8')
-    def test_delete_policies_from_detail_post(self, policies, rest_api):
+    def test_delete_policies_from_detail_post(self, policies, appliance):
         """Tests delete policies from detail using POST method.
 
         Metadata:
@@ -122,14 +122,14 @@ class TestPoliciesRESTAPI(object):
         """
         for policy in policies:
             policy.action.delete(force_method='post')
-            assert rest_api.response.status_code == 200
+            assert appliance.rest_api.response.status_code == 200
             with error.expected('ActiveRecord::RecordNotFound'):
                 policy.action.delete(force_method='post')
-            assert rest_api.response.status_code == 404
+            assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.uncollectif(lambda: current_version() < '5.8')
     @pytest.mark.meta(blockers=[BZ(1435773, forced_streams=['5.8', 'upstream'])])
-    def test_delete_policies_from_detail_delete(self, policies, rest_api):
+    def test_delete_policies_from_detail_delete(self, policies, appliance):
         """Tests delete policies from detail using DELETE method.
 
         Metadata:
@@ -137,31 +137,31 @@ class TestPoliciesRESTAPI(object):
         """
         for policy in policies:
             policy.action.delete(force_method='delete')
-            assert rest_api.response.status_code == 204
+            assert appliance.rest_api.response.status_code == 204
             with error.expected('ActiveRecord::RecordNotFound'):
                 policy.action.delete(force_method='delete')
-            assert rest_api.response.status_code == 404
+            assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.uncollectif(lambda: current_version() < '5.8')
-    def test_delete_policies_from_collection(self, policies, rest_api):
+    def test_delete_policies_from_collection(self, policies, appliance):
         """Tests delete policies from collection.
 
         Metadata:
             test_flag: rest
         """
-        collection = rest_api.collections.policies
+        collection = appliance.rest_api.collections.policies
         collection.action.delete(*policies)
-        assert rest_api.response.status_code == 200
+        assert appliance.rest_api.response.status_code == 200
         with error.expected('ActiveRecord::RecordNotFound'):
             collection.action.delete(*policies)
-        assert rest_api.response.status_code == 404
+        assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.uncollectif(lambda: current_version() < '5.8')
     @pytest.mark.meta(blockers=[BZ(1435777, forced_streams=['5.8', 'upstream'])])
     @pytest.mark.parametrize(
         'from_detail', [True, False],
         ids=['from_detail', 'from_collection'])
-    def test_edit_policies(self, policies, rest_api, from_detail):
+    def test_edit_policies(self, policies, appliance, from_detail):
         """Tests edit policies.
 
         Metadata:
@@ -174,12 +174,12 @@ class TestPoliciesRESTAPI(object):
             edited = []
             for i in range(num_policies):
                 edited.append(policies[i].action.edit(**new[i]))
-                assert rest_api.response.status_code == 200
+                assert appliance.rest_api.response.status_code == 200
         else:
             for i in range(num_policies):
                 new[i].update(policies[i]._ref_repr())
-            edited = rest_api.collections.policies.action.edit(*new)
-            assert rest_api.response.status_code == 200
+            edited = appliance.rest_api.collections.policies.action.edit(*new)
+            assert appliance.rest_api.response.status_code == 200
         assert len(edited) == num_policies
         for i in range(num_policies):
             assert edited[i].description == new[i]['description']

--- a/cfme/tests/infrastructure/test_infra_quota.py
+++ b/cfme/tests/infrastructure/test_infra_quota.py
@@ -201,7 +201,7 @@ def test_group_quota_max_cpu_check_by_tagging(
             '(Group Allocated vCPUs 0 + Requested 8 \> Quota 2)'
 
 
-@pytest.mark.tier(1)
+@pytest.mark.tier(2)
 def test_tenant_quota_max_cpu_check(
         provisioner, prov_data, template_name, provider, request, vm_name, set_tenant_cpu, bug):
     """Test Tenant Quota-Max CPU by UI.
@@ -238,7 +238,7 @@ def test_tenant_quota_max_cpu_check(
     assert row.reason.text == "Quota Exceeded"
 
 
-@pytest.mark.tier(1)
+@pytest.mark.tier(2)
 def test_tenant_quota_max_memory_check(
         provisioner, prov_data, template_name, provider, request, vm_name, set_tenant_memory, bug):
     """Test Tenant Quota-Max Memory by UI.
@@ -271,7 +271,7 @@ def test_tenant_quota_max_memory_check(
     assert row.reason.text == "Quota Exceeded"
 
 
-@pytest.mark.tier(1)
+@pytest.mark.tier(2)
 def test_tenant_quota_max_storage_check(
         provisioner, prov_data, template_name, provider, request, vm_name, set_tenant_storage, bug):
     """Test Tenant Quota-Max Storage by UI.
@@ -303,7 +303,7 @@ def test_tenant_quota_max_storage_check(
     assert row.reason.text == "Quota Exceeded"
 
 
-@pytest.mark.tier(1)
+@pytest.mark.tier(2)
 def test_tenant_quota_max_num_vms_check(
         provisioner, prov_data, template_name, provider, request, vm_name, set_tenant_vm, bug):
     """Test Tenant Quota-Max number of vms by UI.

--- a/cfme/tests/optimize/test_bottlenecks.py
+++ b/cfme/tests/optimize/test_bottlenecks.py
@@ -62,7 +62,7 @@ def db_restore(temp_appliance_extended_db):
         app.wait_for_web_ui()
 
 
-@pytest.mark.tier(1)
+@pytest.mark.tier(2)
 def test_bottlenecks_event_groups(temp_appliance_extended_db, db_restore, db_tbl, db_events):
     with temp_appliance_extended_db:
         view = navigate_to(Bottlenecks, 'All')
@@ -77,7 +77,7 @@ def test_bottlenecks_event_groups(temp_appliance_extended_db, db_restore, db_tbl
         assert sum(1 for row in rows) == db_events.filter(db_tbl.event_type != 'DiskUsage').count()
 
 
-@pytest.mark.tier(1)
+@pytest.mark.tier(2)
 def test_bottlenecks_show_host_events(temp_appliance_extended_db, db_restore, db_events):
     with temp_appliance_extended_db:
         view = navigate_to(Bottlenecks, 'All')
@@ -91,7 +91,7 @@ def test_bottlenecks_show_host_events(temp_appliance_extended_db, db_restore, db
         assert sum(1 for row in rows) == db_events.count()
 
 
-@pytest.mark.tier(1)
+@pytest.mark.tier(2)
 def test_bottlenecks_time_zome(temp_appliance_extended_db, db_restore, db_tbl, db_events):
     with temp_appliance_extended_db:
         view = navigate_to(Bottlenecks, 'All')

--- a/cfme/tests/services/test_add_remove_vm_to_service.py
+++ b/cfme/tests/services/test_add_remove_vm_to_service.py
@@ -86,7 +86,7 @@ def test_add_vm_to_service(myservice, request, copy_domain):
     $evm.log("info", "===========================================")
 
     add_to_service
-    """.format(myservice.service_name)
+    """.format(myservice.name)
     method = copy_domain\
         .namespaces.instantiate(name='System')\
         .classes.instantiate(name='Request')\

--- a/scripts/dockerbot/pytestbase/Dockerfile
+++ b/scripts/dockerbot/pytestbase/Dockerfile
@@ -3,7 +3,7 @@ RUN dnf install -y gcc postgresql-devel libxml2-devel libxslt-devel zeromq3-deve
 RUN git clone https://github.com/RedHatQE/cfme_tests.git
 RUN dnf -y install python-setuptools; easy_install pip
 RUN pip install -U pip
-RUN cd /cfme_tests && PYCURL_SSL_LIBRARY=nss pip install -U -r /cfme_tests/requirements/frozen.txt --no-cache-dir
+RUN cd /cfme_tests && PYCURL_SSL_LIBRARY=nss pip install -U -r /cfme_tests/requirements/dev.txt --no-cache-dir
 ADD setup.sh /setup.sh
 ADD post_result.py /post_result.py
 ADD get_keys.py /get_keys.py

--- a/scripts/template_upload_rhevm.py
+++ b/scripts/template_upload_rhevm.py
@@ -66,6 +66,9 @@ def is_ovirt_engine_running(rhevm_ip, sshname, sshpass):
     try:
         ssh_client = make_ssh_client(rhevm_ip, sshname, sshpass)
         stdout = ssh_client.run_command('systemctl status ovirt-engine')[1]
+        # fallback to sysV commands if necessary
+        if 'command not found' in stdout:
+            stdout = ssh_client.run_command('service ovirt-engine status')[1]
         ssh_client.close()
         return 'running' in stdout
     except Exception:

--- a/sprout/appliances/models.py
+++ b/sprout/appliances/models.py
@@ -188,7 +188,11 @@ class Provider(MetadataMixin):
 
     @property
     def api(self):
-        return get_mgmt(self.id)
+        provider_data = self.metadata.get('provider_data', None)
+        if provider_data:
+            return get_mgmt(provider_data)
+        else:
+            return get_mgmt(self.id)
 
     @property
     def num_currently_provisioning(self):
@@ -268,7 +272,11 @@ class Provider(MetadataMixin):
 
     @property
     def provider_data(self):
-        return cfme_data.get("management_systems", {}).get(self.id, {})
+        data = self.metadata.get('provider_data', None)
+        if data:
+            return data
+        else:
+            return cfme_data.get("management_systems", {}).get(self.id, {})
 
     @property
     def ip_address(self):
@@ -887,7 +895,7 @@ class Appliance(MetadataMixin):
 
     @classmethod
     def unassigned(cls):
-        return cls.objects.filter(appliance_pool=None, ready=True)
+        return cls.objects.filter(appliance_pool=None, ready=True, marked_for_deletion=False)
 
     @classmethod
     def give_to_pool(cls, pool, custom_limit=None, cpu=None, ram=None):
@@ -934,7 +942,7 @@ class Appliance(MetadataMixin):
         return len(appliances)
 
     @classmethod
-    def kill(cls, appliance_or_id):
+    def kill(cls, appliance_or_id, force_delete=False):
         # Completely delete appliance from provider
         from appliances.tasks import kill_appliance
         if isinstance(appliance_or_id, cls):
@@ -945,7 +953,7 @@ class Appliance(MetadataMixin):
             with transaction.atomic():
                 self = type(self).objects.get(pk=self.pk)
                 self.class_logger(self.pk).info("Killing")
-                if not self.marked_for_deletion:
+                if not self.marked_for_deletion or force_delete:
                     self.marked_for_deletion = True
                     self.save()
                     return kill_appliance.delay(self.id)

--- a/sprout/appliances/tasks.py
+++ b/sprout/appliances/tasks.py
@@ -36,7 +36,6 @@ from sprout.log import create_logger
 from utils import conf
 from utils.appliance import Appliance as CFMEAppliance
 from utils.path import project_path
-from utils.providers import get_mgmt
 from utils.timeutil import parsetime
 from utils.trackerbot import api, depaginate, parse_template
 from utils.version import Version
@@ -328,6 +327,9 @@ def poke_trackerbot(self):
                     for appliance in Appliance.objects.filter(
                             template=template, marked_for_deletion=False,
                             appliance_pool=None):
+                        self.logger.info(
+                            'Killing an appliance {}/{} because its template was marked as unusable'
+                            .format(appliance.id, appliance.name))
                         Appliance.kill(appliance)
 
 
@@ -607,7 +609,9 @@ def apply_lease_times_after_pool_fulfilled(self, appliance_pool_id, time_minutes
             pool.save()
     else:
         # Look whether we can swap any provisioning appliance with some in shepherd
-        unfinished = list(Appliance.objects.filter(appliance_pool=pool, ready=False).all())
+        unfinished = list(
+            Appliance.objects.filter(
+                appliance_pool=pool, ready=False, marked_for_deletion=False).all())
         random.shuffle(unfinished)
         if len(unfinished) > 0:
             n = Appliance.give_to_pool(pool, len(unfinished))
@@ -656,7 +660,11 @@ def process_delayed_provision_tasks(self):
                         task.pool.appliance_container_q,
                         **task.pool.appliance_filter_params)
                     if appliances:
-                        Appliance.kill(random.choice(appliances))
+                        appl = random.choice(appliances)
+                        self.logger.info(
+                            'Freeing some space in provider by killing appliance {}/{}'
+                            .format(appl.id, appl.name))
+                        Appliance.kill(appl)
                         break  # Just one
         else:
             # There was a free appliance in shepherd, so we took it and we don't need this task more
@@ -1149,13 +1157,9 @@ def delete_nonexistent_appliances(self):
     # And now - if something happened during appliance deletion, call kill again
     for appliance in Appliance.objects.filter(
             marked_for_deletion=True, status_changed__lt=expiration_time).all():
-        with transaction.atomic():
-            appl = Appliance.objects.get(pk=appliance.pk)
-            appl.marked_for_deletion = False
-            appl.save()
         self.logger.info(
             "Trying to kill unkilled appliance {}/{}".format(appliance.id, appliance.name))
-        Appliance.kill(appl)
+        Appliance.kill(appliance, force_delete=True)
 
 
 def generic_shepherd(self, preconfigured):
@@ -1306,26 +1310,26 @@ def wait_appliance_ready(self, appliance_id):
 
 @singleton_task()
 def anyvm_power_on(self, provider, vm):
-    provider = get_mgmt(provider)
-    provider.start_vm(vm)
+    provider = Provider.objects.get(id=provider)
+    provider.api.start_vm(vm)
 
 
 @singleton_task()
 def anyvm_power_off(self, provider, vm):
-    provider = get_mgmt(provider)
-    provider.stop_vm(vm)
+    provider = Provider.objects.get(id=provider)
+    provider.api.stop_vm(vm)
 
 
 @singleton_task()
 def anyvm_suspend(self, provider, vm):
-    provider = get_mgmt(provider)
-    provider.suspend_vm(vm)
+    provider = Provider.objects.get(id=provider)
+    provider.api.suspend_vm(vm)
 
 
 @singleton_task()
 def anyvm_delete(self, provider, vm):
-    provider = get_mgmt(provider)
-    provider.delete_vm(vm)
+    provider = Provider.objects.get(id=provider)
+    provider.api.delete_vm(vm)
 
 
 @singleton_task()

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -84,6 +84,8 @@ class ApplianceConsole(object):
             try:
                 while True:
                     result += channel.recv(1)
+                    if 'Press any key to continue' in result:
+                        break
             except socket.timeout:
                 pass
             logger.debug(result)
@@ -99,32 +101,37 @@ class ApplianceConsoleCli(object):
             "appliance_console_cli {}".format(appliance_console_cli_command))
 
     def set_hostname(self, hostname):
-        self._run("-H {host}".format(host=hostname))
+        self._run("--host {host}".format(host=hostname))
 
     def configure_appliance_external_join(self, dbhostname,
             username, password, dbname, fetch_key, sshlogin, sshpass):
-        self._run("-h {dbhostname} -U {username} -p {password} -d {dbname} -v -K {fetch_key} "
-            "-s {sshlogin} -a {sshpass}".format(dbhostname=dbhostname, username=username,
+        self._run("--hostname {dbhostname} --username {username} --password {password}"
+            "--dbname {dbname} --verbose --fetch-key {fetch_key} --sshlogin {sshlogin}"
+            " --sshpassword {sshpass}".format(dbhostname=dbhostname, username=username,
                 password=password, dbname=dbname, fetch_key=fetch_key, sshlogin=sshlogin,
                 sshpass=sshpass))
 
     def configure_appliance_external_create(self, region, dbhostname,
             username, password, dbname, fetch_key, sshlogin, sshpass):
-        self._run("-r {region} -h {dbhostname} -U {username} -p {password} "
-            "-d {dbname} -v -K {fetch_key} -s {sshlogin} -a {sshpass}".format(
+        self._run("--region {region} --hostname {dbhostname} --username {username}"
+            " --password {password} --dbname {dbname} --verbose --fetch-key {fetch_key}"
+            " --sshlogin {sshlogin} --sshpassword {sshpass}".format(
                 region=region, dbhostname=dbhostname, username=username, password=password,
                 dbname=dbname, fetch_key=fetch_key, sshlogin=sshlogin, sshpass=sshpass))
 
     def configure_appliance_internal_fetch_key(self, region, dbhostname,
             username, password, dbname, fetch_key, sshlogin, sshpass):
-        self._run("-r {region} -i -h {dbhostname} -U {username} -p {password} "
-            "-d {dbname} -v -K {fetch_key} -s {sshlogin} -a {sshpass}".format(
+        self._run("--region {region} --internal --hostname {dbhostname} --username {username}"
+            " --password {password} --dbname {dbname} --verbose --fetch-key {fetch_key}"
+            " --sshlogin {sshlogin} --sshpassword {sshpass}".format(
                 region=region, dbhostname=dbhostname, username=username, password=password,
                 dbname=dbname, fetch_key=fetch_key, sshlogin=sshlogin, sshpass=sshpass))
 
     def configure_ipa(self, ipaserver, username, password, domain, realm):
-        self._run("-e {ipaserver} -n {username} -w {password} -o {domain} -l {realm}".format(
-            ipaserver=ipaserver, username=username, password=password, domain=domain, realm=realm))
+        self._run("--ipaserver {ipaserver} --ipaprincipal {username} --ipapassword {password}"
+            " --ipadomain {domain} --iparealm {realm}".format(
+                ipaserver=ipaserver, username=username, password=password, domain=domain,
+                realm=realm))
         assert self.appliance.ssh_client.run_command("systemctl status sssd | grep running")
         return_code, output = self.appliance.ssh_client.run_command(
             "cat /etc/ipa/default.conf | grep 'enable_ra = True'")


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_properties.py::test_pods_conditions -v --use-provider cm-env1 }}

# Pod condition test automation

## summery
In this test i automated test id 9914 from Polarion, the test compare the values of each type of pod condition  between openshift and CFME.

To make this test works i had to add new infa code on multi key summery tables.

## Multi key summery table load implementation:
For each multi-key table I set parent table and few child tables, the parent table will be the original table and each row of it will represented as child table. the parent table will have properties with the value of the name column of each line, in case on name column exist we get the most left value in each line and set it to be the property name.

#### Example:
for the following table:

table name: connection
|Name| IP            | status   |
|A      |1.2.3.4      |Up          |  
|B      |5.6.7.8      |Up          |  
|V      |9.10.11.12|Down      |  

multi key table will be something like this:
parent table: connection (properties A,B,C):
           child: A (name:A, IP:1.2.3.4,status:UP)
           child: B (name:B, IP:5.6.7.8,status:UP)
           child: C (name:C, IP:9.10.11.12,status:Down)

 it possible to something like <parent_table>.<child_table>.<child_property>
 
