### PR TITLE
[RFR][1LP] Pod condition test

### DIFF
--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -248,9 +248,9 @@ class SummaryTable(object):
 
     def __repr__(self):
         if self._multitable:
-            "<SummaryTable {main_table_name} {sub_tables}>".format(
+            return "<SummaryTable {main_table_name}:\n\t {sub_tables}>".format(
                 main_table_name=self._text,
-                sub_tables="\n\t".join([repr(getattr(self, key)) for key in self._keys]))
+                sub_tables='\n\t'.join([repr(getattr(self, key)) for key in self._keys]))
 
         return "<SummaryTable {} {}>".format(
             repr(self._text),
@@ -267,13 +267,14 @@ class SummaryTable(object):
 
             # parsing table titels
             table_titles = sel.elements('./td', root=table_rows[0])
-            table_titles_text = [el.text for el in table_titles]
+            table_titles_text = [el.text.replace(" ", "_") for el in table_titles]
 
             # match each line values with the relevant title
             for row in table_rows[1:]:
                 # creating mapping between titel and row values
                 row_mapping = dict(zip(table_titles_text,
                                        [el.text for el in sel.elements('./td', root=row)]))
+
                 # set the value of the "name" colume to be the key of the entier table,
                 # if "name" is not avliable setting themost left element to be the key
                 row_key = row_mapping.get("Name", row_mapping.keys()[0])

--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import aliased
 from utils import attributize_string, version, deferred_verpick
 from utils.units import Unit
 from utils.varmeth import variable
+from utils.log import logger
 
 pol_btn = partial(toolbar.select, "Policy")
 
@@ -245,6 +246,11 @@ class SummaryTable(object):
         self._multitable = False
         if not skip_load:
             self.load()
+        else:
+            logger.warning(
+                "Child SummaryTable created for {table_name}, "
+                "this table wasn't initialized due to skip_load value".format(
+                    table_name=self._text))
 
     def __repr__(self):
         if self._multitable:
@@ -261,6 +267,10 @@ class SummaryTable(object):
         self._keys = []
         key_values = []
         if sel.is_displayed(self.MULTIKEY_LOC, root=self._entry):
+            logger.warning(
+                "Parent SummaryTable created for {talbe_name}, "
+                "it might create few un-inilized SummaryTable".format(
+                    talbe_name=self._text))
             self._multitable = True
             # get all table rows (include titles)
             table_rows = sel.elements(self.ROWS, root=self._entry)

--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -268,25 +268,25 @@ class SummaryTable(object):
         key_values = []
         if sel.is_displayed(self.MULTIKEY_LOC, root=self._entry):
             logger.warning(
-                "Parent SummaryTable created for {talbe_name}, "
-                "it might create few un-inilized SummaryTable".format(
-                    talbe_name=self._text))
+                "Parent SummaryTable created for {table_name}, "
+                "it might create few un-initialized SummaryTable".format(
+                    table_name=self._text))
             self._multitable = True
             # get all table rows (include titles)
             table_rows = sel.elements(self.ROWS, root=self._entry)
 
-            # parsing table titels
+            # parsing table titles
             table_titles = sel.elements('./td', root=table_rows[0])
             table_titles_text = [el.text.replace(" ", "_") for el in table_titles]
 
             # match each line values with the relevant title
             for row in table_rows[1:]:
-                # creating mapping between titel and row values
+                # creating mapping between title and row values
                 row_mapping = dict(zip(table_titles_text,
                                        [el.text for el in sel.elements('./td', root=row)]))
 
-                # set the value of the "name" colume to be the key of the entier table,
-                # if "name" is not avliable setting themost left element to be the key
+                # set the value of the "name" column to be the key of the entire table,
+                # if "name" is not available setting the most left element to be the key
                 row_key = row_mapping.get("Name", row_mapping.keys()[0])
 
                 # creating empty table to populate the row data as regular table
@@ -300,7 +300,7 @@ class SummaryTable(object):
                 for key in row_mapping.keys():
                     setattr(table, key, row_mapping[key])
 
-                # add the entier table to parent table keys
+                # add the entire table to parent table keys
                 self._keys.append(row_key)
 
                 # add attr to parent table

--- a/cfme/tests/containers/test_properties.py
+++ b/cfme/tests/containers/test_properties.py
@@ -179,6 +179,8 @@ def test_pods_conditions(provider, soft_assert):
 
     for pod_name in selected_pods_cfme:
         cfme_pod = selected_pods_cfme[pod_name]
+        s = cfme_pod.summary
+        print s.conditions
         ose_pod = selected_pods_ose[pod_name]
 
         ose_pod_condition = {cond["type"]: cond["status"] for cond in

--- a/cfme/tests/containers/test_properties.py
+++ b/cfme/tests/containers/test_properties.py
@@ -166,3 +166,26 @@ def test_properties(provider, test_item, soft_assert):
             except AttributeError:
                 soft_assert(False, '{} "{}" properties table has missing field - "{}"'
                                    .format(test_item.obj.__name__, name, field))
+
+
+def test_pods_conditions(provider, soft_assert):
+
+    #  TODO: Add later this logic to mgmtsystem
+    selected_pods_cfme = {row.name.text: Pod(name=row.name.text, provider=provider) for row in
+                          navigate_and_get_rows(provider, Pod, 3)}
+    selected_pods_ose = {pod["metadata"]["name"]: pod for pod in
+                         provider.mgmt.api.get('pod')[1]['items'] if pod["metadata"]["name"] in
+                         selected_pods_cfme}
+
+    for pod_name in selected_pods_cfme:
+        cfme_pod = selected_pods_cfme[pod_name]
+        ose_pod = selected_pods_ose[pod_name]
+
+        ose_pod_condition = {cond["type"]: cond["status"] for cond in
+                             ose_pod['status']['conditions']}
+        cfme_pod_condition = {}
+
+        for item in cfme_pod_condition.items():
+            # Just using the vars for flake8 test will pass
+            # line have to change to real assestion
+            soft_assert(cfme_pod, ose_pod_condition)

--- a/cfme/tests/containers/test_properties.py
+++ b/cfme/tests/containers/test_properties.py
@@ -179,15 +179,13 @@ def test_pods_conditions(provider, soft_assert):
 
     for pod_name in selected_pods_cfme:
         cfme_pod = selected_pods_cfme[pod_name]
-        s = cfme_pod.summary
-        print s.conditions
+
         ose_pod = selected_pods_ose[pod_name]
 
         ose_pod_condition = {cond["type"]: cond["status"] for cond in
                              ose_pod['status']['conditions']}
-        cfme_pod_condition = {}
+        cfme_pod_condition = {type: getattr(getattr(cfme_pod.summary.conditions, type), "Status")
+                              for type in ose_pod_condition}
 
-        for item in cfme_pod_condition.items():
-            # Just using the vars for flake8 test will pass
-            # line have to change to real assestion
-            soft_assert(cfme_pod, ose_pod_condition)
+        for item in cfme_pod_condition:
+            soft_assert(ose_pod_condition[item], cfme_pod_condition[item])


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_properties.py::test_pods_conditions -v --use-provider cm-env1 }}

# Pod condition test automation

## summery

In this PR I automated test id 9914 from Polarion, the test compare the values of each type of pod condition between openshift and CFME.

To make this test works i had to add new infa code on multi key summery tables.

## Multi key summery table load implementation:

For each multi-key table I set parent table and few child tables, the parent table will be the original table and each row of it will represented as child table. the parent table will have properties with the value of the name column of each line, in case on name column exist we get the most left value in each line and set it to be the property name.

### Example:

for the following table:

table name: connection
|Name| IP | status |
|A |1.2.3.4 |Up |
|B |5.6.7.8 |Up |
|V |9.10.11.12|Down |

multi key table will be something like this:
parent table: connection (properties A,B,C):
child: A (name:A, IP:1.2.3.4,status:UP)
child: B (name:B, IP:5.6.7.8,status:UP)
child: C (name:C, IP:9.10.11.12,status:Down)

it possible to something like <parent_table>.<child_table>.<child_property>