### PR TITLE
[RFR][1LP] adding BZ import to fix NameError

### DIFF
--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -14,6 +14,7 @@ from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from utils import testgen, version
 from utils.update import update
+from utils.blockers import BZ
 from cfme import test_requirements
 
 pytest_generate_tests = testgen.generate([InfraProvider], scope="function")


### PR DESCRIPTION
Fixing error when running pytests due to missing import:
```
================================================================================ ERRORS ================================================================================
________________________________________ ERROR at setup of Source/repos/cfme_tests/cfme/tests/infrastructure/test_providers.py _________________________________________
cfme/tests/infrastructure/test_providers.py:213: in <module>
    @pytest.mark.meta(blockers=[BZ(1450527, unblock=lambda provider: provider.type != 'scvmm')])
E   NameError: name 'BZ' is not defined
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
======================================================================== 1076 tests deselected =========================================================================
============================================================== 1076 deselected, 1 error in 37.51 seconds ===============================================================
```


Introduced by https://github.com/ManageIQ/integration_tests/pull/4674

{{pytest: -v -k test_provider_crud cfme/tests/infrastructure/test_providers.py}}
