### PR TITLE
[1LP][RFR] RHCFQE-2646 VMware Console Type config

### DIFF
--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -13,6 +13,30 @@ class CFMEException(Exception):
     pass
 
 
+class ConsoleNotSupported(CFMEException):
+    """Raised by functions in :py:mod:`cfme.configure.configuration` when an invalid
+    console type is given"""
+    def __init__(self, product_name, version):
+        self.product_name = product_name
+        self.version = version
+
+    def __str__(self):
+        return "Console not supported on current version: {} {}".format(
+            self.product_name,
+            self.version
+        )
+
+
+class ConsoleTypeNotSupported(CFMEException):
+    """Raised by functions in :py:mod:`cfme.configure.configuration` when an invalid
+    console type is given"""
+    def __init__(self, console_type):
+        self.console_type = console_type
+
+    def __str__(self):
+        return "Console type not supported: {}".format(self.console_type)
+
+
 class FlashMessageException(CFMEException):
     """Raised by functions in :py:mod:`cfme.web_ui.flash`"""
 

--- a/cfme/tests/configure/test_vmware_console_settings.py
+++ b/cfme/tests/configure/test_vmware_console_settings.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from cfme.configure.configuration import VMwareConsoleSupport
+from utils.appliance.implementations.ui import navigate_to
+from utils.version import current_version
+
+
+@pytest.mark.tier(3)
+@pytest.mark.sauce
+@pytest.mark.uncollectif(lambda: current_version() < '5.8')
+def test_vmware_console_support(appliance):
+    """Tests that the VMware Console Support setting may be changed."""
+    navigate_to(appliance.server, 'Server')
+
+    console_type_loc = VMwareConsoleSupport.vmware_console_form.console_type
+    old_vm_console_type = console_type_loc.first_selected_option_text
+    assert old_vm_console_type, "The default VMware console type should not be empty"
+
+    for new_vm_console_type in VMwareConsoleSupport.CONSOLE_TYPES:
+        vmware_console_settings = VMwareConsoleSupport(
+            appliance=appliance,
+            console_type=new_vm_console_type
+        )
+        vmware_console_settings.update()
+
+        cur_vm_console_type = console_type_loc.first_selected_option_text
+        assert cur_vm_console_type == new_vm_console_type
+
+    # Set back to original console type
+    vmware_console_settings = VMwareConsoleSupport(
+        appliance=appliance,
+        console_type=old_vm_console_type
+    )
+    vmware_console_settings.update()


### PR DESCRIPTION
Purpose or Intent
=================

Provide CRUD class for modifying VMware Console settings, and a test to test it.   These settings are under the main configuration page for CFME.

Note, this PR is based on PR:

  https://github.com/ManageIQ/integration_tests/pull/4594 (Merged)

So the only thing to be reviewed is the stuff in the "Add support for configuring VMware Console Type" commit.   When PR 4594 gets merged and this PR rebased off of master, this will no longer be an issue.