### PR TITLE
[1LP][RFR] Uncollect tests that are not valid on a pod deployment

### DIFF
--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -189,6 +189,7 @@ class IPAppliance(object):
         self.context = ImplementationContext.from_instances(
             [self.browser])
         self._server = None
+        self.is_pod = False
 
     def get(self, cls, *args, **kwargs):
         """A generic getter for instantiation of Collection classes
@@ -786,6 +787,7 @@ class IPAppliance(object):
                 'container': self.container,
                 'is_pod': True,
             }
+            self.is_pod = True
         else:
             connect_kwargs = {
                 'hostname': self.hostname,


### PR DESCRIPTION
Some tests should not be run against the podified image as they are not valid... this PR uncollects such tests.  I am sure there are more, this is a quick first past. 

This will not work in PRT as PRT has not podified appliance backing... so here are the results...

17:13:19 Appliance's streams: [5.8, downstream]
17:13:19 ============================= Running smoke tests ==============================
17:13:21 
17:14:11 cfme/tests/test_appliance.py::test_rpms_present[cfme] PASSED
17:14:12 cfme/tests/test_appliance.py::test_rpms_present[cfme-appliance] PASSED
17:14:14 cfme/tests/test_appliance.py::test_rpms_present[nfs-utils] PASSED
17:14:15 cfme/tests/test_appliance.py::test_rpms_present[libnfsidmap] PASSED
17:14:16 cfme/tests/test_appliance.py::test_rpms_present[ipmitool] PASSED
17:14:18 cfme/tests/test_appliance.py::test_rpms_present[prince] PASSED
17:14:19 cfme/tests/test_appliance.py::test_evm_running PASSED
17:14:21 cfme/tests/test_appliance.py::test_service_enabled[evmserverd] PASSED
17:14:23 cfme/tests/test_appliance.py::test_service_enabled[evminit] PASSED
17:14:24 cfme/tests/test_appliance.py::test_memory_total PASSED
17:14:25 cfme/tests/test_appliance.py::test_cpu_total PASSED
17:14:36 cfme/tests/test_appliance.py::test_certificates_present PASSED
17:14:39 cfme/tests/test_appliance.py::test_db_connection PASSED
17:14:40 cfme/tests/test_appliance.py::test_asset_precompiled PASSED
17:14:44 cfme/tests/test_appliance.py::test_keys_included PASSED
17:14:44 -------------------- 15 smoke tests passed in 84.35 seconds --------------------