### PR TITLE
[RFR][1LP] py.test --setup-plan fix

### DIFF
--- a/fixtures/log.py
+++ b/fixtures/log.py
@@ -94,7 +94,7 @@ def _test_status(test_name):
         return 'skipped'
     # Otherwise, report the call phase outcome (passed, skipped, or failed)
     else:
-        return test_phase['call']
+        return test_phase.get('call', 'skipped')
 
 
 def _format_nodeid(nodeid, strip_filename=True):


### PR DESCRIPTION
Purpose or Intent
=================
currently py.test --setup-plan fail in log.py fixture because test_phase['call'] isn't defined.
This PR fixes that fixture to return 'skipped' if call isn't defined