### PR TITLE
[1LP][RFR] Deployment Roles workaround

### DIFF
--- a/cfme/infrastructure/deployment_roles.py
+++ b/cfme/infrastructure/deployment_roles.py
@@ -4,7 +4,7 @@ from functools import partial
 from navmazing import NavigateToAttribute, NavigateToSibling
 from selenium.common.exceptions import NoSuchElementException
 
-from cfme.exceptions import DestinationNotFound
+from cfme.exceptions import ListAccordionLinkNotFound
 from cfme.fixtures import pytest_selenium as sel
 from cfme.infrastructure.provider.openstack_infra import OpenstackInfraProvider
 from utils.appliance import Navigatable
@@ -20,8 +20,7 @@ details_page = Region(infoblock_type='detail')
 
 cfg_btn = partial(tb.select, 'Configuration')
 pol_btn = partial(tb.select, 'Policy')
-match_page = partial(match_location, controller='ems_cluster',
-                     title='Deployment Roles')
+match_page = partial(match_location, controller='ems_cluster')
 
 
 class DeploymentRoles(Pretty, Navigatable):
@@ -66,14 +65,18 @@ class All(CFMENavigateStep):
     prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
 
     def step(self):
-        nav_path = ('Compute', 'Infrastructure', 'Deployment Roles')
         try:
-            self.prerequisite_view.navigation.select(*nav_path)
+            self.prerequisite_view.navigation.select('Compute', 'Infrastructure',
+                                                     'Deployment Roles')
         except NoSuchElementException:
-            raise DestinationNotFound('Navigation {} not found'.format(nav_path))
+            self.prerequisite_view.navigation.select('Compute', 'Infrastructure',
+                                                     'Clusters / Deployment Roles')
 
     def am_i_here(self):
-        return match_page(summary='Deployment Roles')
+        option1 = match_page(title='Deployment Roles', summary='Deployment Roles')
+        option2 = match_page(title='Clusers / Deployment Roles',
+                             summary='Clusers / Deployment Roles')
+        return option1 or option2
 
 
 @navigator.register(DeploymentRoles, 'AllForProvider')
@@ -83,12 +86,20 @@ class AllForProvider(CFMENavigateStep):
         navigate_to(self.obj.provider, 'Details')
 
     def step(self):
-        list_acc.select('Relationships', 'Show all managed Deployment Roles',
-                        by_title=True, partial=False)
+        try:
+            list_acc.select('Relationships', 'Show all managed Deployment Roles',
+                            by_title=True, partial=False)
+        except ListAccordionLinkNotFound:
+            list_acc.select('Relationships', 'Show all managed Clusters / Deployment Roles',
+                            by_title=True, partial=False)
 
     def am_i_here(self):
-        summary = "{} (All Deployment Roles)".format(self.obj.provider.name)
-        return match_page(summary=summary)
+        def match(option):
+            summary_ptrn = "{} (All {})"
+            return match_page(summary=summary_ptrn.format(self.obj.provider.name, option),
+                              title=option)
+
+        return match('Deployment Roles') or match('Clusters / Deployment Roles')
 
 
 @navigator.register(DeploymentRoles, 'Details')

--- a/cfme/infrastructure/deployment_roles.py
+++ b/cfme/infrastructure/deployment_roles.py
@@ -65,18 +65,17 @@ class All(CFMENavigateStep):
     prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
 
     def step(self):
+        nav_select = partial(self.prerequisite_view.navigation.select, 'Compute', 'Infrastructure')
         try:
-            self.prerequisite_view.navigation.select('Compute', 'Infrastructure',
-                                                     'Deployment Roles')
+            nav_select('Deployment Roles')
         except NoSuchElementException:
-            self.prerequisite_view.navigation.select('Compute', 'Infrastructure',
-                                                     'Clusters / Deployment Roles')
+            nav_select('Clusters / Deployment Roles')
 
     def am_i_here(self):
-        option1 = match_page(title='Deployment Roles', summary='Deployment Roles')
-        option2 = match_page(title='Clusers / Deployment Roles',
-                             summary='Clusers / Deployment Roles')
-        return option1 or option2
+        def match(option):
+            return match_page(title=option, summary=option)
+
+        return match('Clusters / Deployment Roles') or match('Deployment Roles')
 
 
 @navigator.register(DeploymentRoles, 'AllForProvider')
@@ -86,12 +85,14 @@ class AllForProvider(CFMENavigateStep):
         navigate_to(self.obj.provider, 'Details')
 
     def step(self):
+        def list_acc_select(option):
+            list_acc.select('Relationships', 'Show all managed {}'.format(option), by_title=True,
+                            partial=False)
+
         try:
-            list_acc.select('Relationships', 'Show all managed Deployment Roles',
-                            by_title=True, partial=False)
+            list_acc_select('Deployment Roles')
         except ListAccordionLinkNotFound:
-            list_acc.select('Relationships', 'Show all managed Clusters / Deployment Roles',
-                            by_title=True, partial=False)
+            list_acc_select('Clusters / Deployment Roles')
 
     def am_i_here(self):
         def match(option):

--- a/cfme/tests/openstack/infrastructure/test_relationships.py
+++ b/cfme/tests/openstack/infrastructure/test_relationships.py
@@ -6,6 +6,7 @@ results of the relationships
 import pytest
 
 import cfme.fixtures.pytest_selenium as sel
+from selenium.common.exceptions import NoSuchElementException
 from cfme.infrastructure.provider.openstack_infra import OpenstackInfraProvider
 from cfme.web_ui import InfoBlock, Table
 from utils import testgen
@@ -21,7 +22,11 @@ pytest_generate_tests = testgen.generate([OpenstackInfraProvider], scope='module
 
 def test_assigned_roles(provider):
     navigate_to(provider, 'Details')
-    assert int(provider.get_detail('Relationships', 'Deployment Roles')) > 0
+    try:
+        res = provider.get_detail('Relationships', 'Deployment Roles')
+    except NoSuchElementException:
+        res = provider.get_detail('Relationships', 'Clusters / Deployment Roles')
+    assert int(res) > 0
 
 
 def test_nodes(provider):

--- a/cfme/tests/openstack/infrastructure/test_roles.py
+++ b/cfme/tests/openstack/infrastructure/test_roles.py
@@ -1,5 +1,6 @@
 import pytest
 from random import choice
+from selenium.common.exceptions import NoSuchElementException
 
 from cfme.configure.tasks import is_host_analysis_finished
 from cfme.infrastructure.deployment_roles import DeploymentRoles
@@ -31,7 +32,10 @@ def test_host_role_association(provider, soft_assert):
         navigate_to(host, 'Details')
         role_name = summary_title().split()[1].translate(None, '()')
         role_name = 'Compute' if role_name == 'NovaCompute' else role_name
-        role_assoc = host.get_detail('Relationships', 'Deployment Role')
+        try:
+            role_assoc = host.get_detail('Relationships', 'Deployment Role')
+        except NoSuchElementException:
+            role_assoc = host.get_detail('Relationships', 'Cluster / Deployment Role')
         soft_assert(role_name in role_assoc, 'Deployment roles misconfigured')
 
 


### PR DESCRIPTION
Added an option to use DeploymentRoles class on applications with different Infra providers connected (Openstack, VMWare etc.)
{{ pytest: cfme/tests/openstack/infrastructure/test_roles.py --use-provider=rhos_uc }}