### PR TITLE
[NOMERGE] Request class/views/navigation updates

### DIFF
--- a/cfme/configure/tasks.py
+++ b/cfme/configure/tasks.py
@@ -11,13 +11,13 @@ from widgetastic_patternfly import Dropdown, Tab, FlashMessages
 
 from cfme import web_ui as ui
 from cfme.base.login import BaseLoggedInPage
+from cfme.web_ui import toolbar as tb
 import cfme.fixtures.pytest_selenium as sel
 from cfme.web_ui import Form, Region, CheckboxTable, fill, match_location
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
 from utils.log import logger
 from utils.wait import wait_for, TimedOutError
-from cfme.services import requests
 
 buttons = Region(
     locators={
@@ -165,7 +165,7 @@ def is_analysis_finished(name, task_type='vm', clear_tasks_after_success=True):
 def wait_analysis_finished(task_name, task_type, delay=5, timeout='5M'):
     """ Wait until analysis is finished (or timeout exceeded)"""
     wait_for(lambda: is_analysis_finished(task_name, task_type),
-             delay=delay, timeout=timeout, fail_func=requests.reload)
+             delay=delay, timeout=timeout, fail_func=tb.refresh())
 
 
 class TasksView(BaseLoggedInPage):

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -17,7 +17,7 @@ from cfme.exceptions import (CandidateNotFound, VmNotFound, OptionNotAvailable,
                              DestinationNotFound, TemplateNotFound)
 from cfme.fixtures import pytest_selenium as sel
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
-from cfme.services import requests
+from cfme.services.requests import Request
 import cfme.web_ui.toolbar as tb
 from cfme.web_ui import (
     CheckboxTree, Form, InfoBlock, Region, Quadicon, Tree, accordion, fill, flash, form_buttons,
@@ -517,8 +517,9 @@ class Vm(BaseVM):
         from cfme.provisioning import provisioning_form
         fill(provisioning_form, provisioning_data, action=provisioning_form.submit_button)
         cells = {'Description': 'Publish from [{}] to [{}]'.format(self.name, template_name)}
-        row, __ = wait_for(
-            requests.wait_for_request, [cells], fail_func=requests.reload, num_sec=900, delay=20)
+        request_row = Request(cells=cells)
+        wait_for(
+            request_row.is_finished, fail_func=request_row.reload, num_sec=900, delay=20)
         return Template(template_name, self.provider)
 
     @property

--- a/cfme/provisioning.py
+++ b/cfme/provisioning.py
@@ -317,7 +317,7 @@ def do_vm_provisioning(template_name, provider, vm_name, provisioning_data, requ
     try:
         wait_for(request_row.is_finished, fail_func=request_row.reload, num_sec=num_sec, delay=20)
     except Exception as e:
-        request_row.debug_requests()
+        request_row.debug_request()
         raise e
     assert request_row.if_succeeded(), \
         "Provisioning failed with the message {}".format(request_row.row.last_message.text)

--- a/cfme/provisioning.py
+++ b/cfme/provisioning.py
@@ -9,7 +9,7 @@ from cfme import web_ui as ui
 from cfme.base.login import BaseLoggedInPage
 from cfme.fixtures import pytest_selenium as sel
 from cfme.infrastructure.virtual_machines import Vm
-from cfme.services import requests
+from cfme.services.requests import Request
 from cfme.web_ui import AngularSelect, fill, flash, form_buttons, tabstrip
 from utils import version
 from utils import normalize_text
@@ -313,17 +313,14 @@ def do_vm_provisioning(template_name, provider, vm_name, provisioning_data, requ
     # Provision Re important in this test
     logger.info('Waiting for cfme provision request for vm %s', vm_name)
     row_description = 'Provision from [{}] to [{}]'.format(template_name, vm_name)
-    cells = {'Description': row_description}
+    request_row = Request(row_description)
     try:
-        row, __ = wait_for(requests.wait_for_request, [cells],
-                           fail_func=requests.reload, num_sec=num_sec, delay=20)
+        wait_for(request_row.is_finished, fail_func=request_row.reload, num_sec=num_sec, delay=20)
     except Exception as e:
-        requests.debug_requests()
+        request_row.debug_requests()
         raise e
-    assert normalize_text(row.status.text) == 'ok' \
-                                              and normalize_text(
-        row.request_state.text) == 'finished', \
-        "Provisioning failed with the message {}".format(row.last_message.text)
+    assert request_row.if_succeeded(), \
+        "Provisioning failed with the message {}".format(request_row.row.last_message.text)
 
     # Wait for the VM to appear on the provider backend before proceeding to ensure proper cleanup
     logger.info('Waiting for vm %s to appear on provider %s', vm_name, provider.key)
@@ -343,7 +340,8 @@ def do_vm_provisioning(template_name, provider, vm_name, provisioning_data, requ
 
 
 def copy_request(cells, modifications):
-    with requests.copy_request(cells):
+    request_row = Request(cells=cells)
+    with request_row.copy_request():
         fill(provisioning_form, modifications)
 
 
@@ -356,4 +354,5 @@ def copy_request_by_vm_and_template_name(vm_name, template_name, modifications, 
 def go_to_request_by_vm_and_template_name(vm_name, template_name, multi=False):
     multistr = "###" if multi else ""
     row_description = "Provision from [{}] to [{}{}]".format(template_name, vm_name, multistr)
-    return requests.go_to_request({'Description': row_description})
+    request_row = Request(row_description)
+    return request_row.load_details()

--- a/cfme/services/requests.py
+++ b/cfme/services/requests.py
@@ -1,18 +1,22 @@
 # -*- coding: utf-8 -*-
 from contextlib import contextmanager
 from functools import partial
-from navmazing import NavigateToAttribute
+from navmazing import NavigateToAttribute, NavigateToSibling
+from widgetastic.widget import Text, Table
+from widgetastic_manageiq import BreadCrumb
+from widgetastic_patternfly import Button, View, Input, Tab
 
+from cfme import BaseLoggedInPage
 from cfme.exceptions import RequestException
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import (
-    Input, Region, Table, fill, flash, paginator, toolbar, match_location)
+    Region, PagedTable, flash, paginator, toolbar, match_location)
 from utils.log import logger
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
 
-REQUEST_FINISHED_STATES = {'Migrated', 'Finished'}
 
+"""
 buttons = Region(
     locators=dict(
         approve="//*[@title='Approve this Request']",
@@ -24,8 +28,9 @@ buttons = Region(
         cancel="//a[@title='Cancel']",
     )
 )
+"""
+request_table = PagedTable(table_locator='//*[@id="list_grid"]/table')
 
-request_table = Table('//*[@id="list_grid"]/table')
 fields = Region(
     locators=dict(
         reason=Input("reason"),
@@ -34,163 +39,6 @@ fields = Region(
 )
 
 match_page = partial(match_location, controller='miq_request', title='Requests')
-
-
-# TODO Refactor these module methods and their callers for a proper request class
-class Request(Navigatable):
-    def __init__(self, appliance=None):
-        Navigatable.__init__(self, appliance=appliance)
-
-
-@navigator.register(Request, 'All')
-class RequestAll(CFMENavigateStep):
-    prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
-
-    def am_i_here(self, *args, **kwargs):
-        return match_page(summary='Requests')
-
-    def step(self, *args, **kwargs):
-        self.prerequisite_view.navigation.select('Services', 'Requests')
-
-
-def reload():
-    toolbar.refresh()
-
-
-def approve(reason, cancel=False):
-    """Approve currently opened request
-
-    Args:
-        reason: Reason for approving the request.
-        cancel: Whether to cancel the approval.
-    """
-    sel.wait_for_element(buttons.approve)
-    sel.click(buttons.approve)
-    sel.wait_for_element(fields.reason)
-    fill(fields.reason, reason)
-    sel.click(buttons.submit if not cancel else buttons.cancel)
-    flash.assert_no_errors()
-
-
-def approve_request(cells, reason, cancel=False):
-    """Open the specified request and approve it.
-
-    Args:
-        cells: Search data for the requests table.
-        reason: Reason for approving the request.
-        cancel: Whether to cancel the approval.
-
-    Raises:
-        RequestException: :py:class:`cfme.exceptions.RequestException` if the request was not found
-    """
-    if not go_to_request(cells=cells, partial_check=True):
-        raise RequestException("Request with identification {} not found!".format(str(cells)))
-    approve(reason, cancel)
-
-
-def deny(reason, cancel=False):
-    """Deny currently opened request
-
-    Args:
-        reason: Reason for denying the request.
-        cancel: Whether to cancel the denial.
-    """
-    sel.click(buttons.deny)
-    fill(fields.reason, reason)
-    sel.click(buttons.submit if not cancel else buttons.cancel)
-    flash.assert_no_errors()
-
-
-def deny_request(cells, reason, cancel=False):
-    """Open the specified request and deny it.
-
-    Args:
-        cells: Search data for the requests table.
-        reason: Reason for denying the request.
-        cancel: Whether to cancel the denial.
-
-    Raises:
-        RequestException: :py:class:`cfme.exceptions.RequestException` if the request was not found
-    """
-    if not go_to_request(cells):
-        raise RequestException("Request with identification {} not found!".format(str(cells)))
-    deny(reason, cancel)
-
-
-def delete(cancel=False):
-    """Delete currently opened request
-
-    Args:
-        cancel: Whether to cancel the deletion.
-    """
-    sel.wait_for_element(buttons.delete)
-    sel.click(buttons.delete, wait_ajax=False)
-    sel.handle_alert(cancel)
-    sel.wait_for_ajax()
-    flash.assert_no_errors()
-
-
-def delete_request(cells, cancel=False):
-    """Open the specified request and delete it.
-
-    Args:
-        cells: Search data for the requests table.
-        cancel: Whether to cancel the deletion.
-
-    Raises:
-        RequestException: :py:class:`cfme.exceptions.RequestException` if the request was not found
-    """
-    if not go_to_request(cells):
-        raise RequestException("Request with identification {} not found!".format(str(cells)))
-    delete(cancel)
-
-
-def wait_for_request(cells, partial_check=False):
-    """helper function checks if a request is complete
-
-    After finding the request's row using the ``cells`` argument, this will wait for a request to
-    reach the 'Finished' state and return it. In the event of an 'Error' state, it will raise an
-    AssertionError, for use with ``pytest.raises``, if desired.
-
-    Args:
-        cells: A dict of cells use to identify the request row to inspect in the
-            :py:attr:`request_list` Table. See :py:meth:`cfme.web_ui.Table.find_rows_by_cells`
-            for more.
-        partial_check: If to use the ``in`` operator rather than ``==`` in find_rows_by_cells().
-
-    Usage:
-
-        # Filter on the "Description" column
-        description = 'Provision from [%s] to [%s]' % (template_name, vm_name)
-        cells = {'Description': description}
-
-        # Filter on the "Request ID" column
-        # Text must match exactly, you can use "{:,}".format(request_id) to add commas if needed.
-        request_id = '{:,}'.format(1000000000001)  # Becomes '1,000,000,000,001', as in the table
-        cells = {'Request ID': request_id}
-
-        # However you construct the cells dict, pass it to wait_for_request
-        # Provisioning requests often take more than 5 minutes but less than 10.
-        wait_for(wait_for_request, [cells], num_sec=600)
-
-    Raises:
-        RequestException: if multiple matching requests were found
-
-    Returns:
-         The matching :py:class:`cfme.web_ui.Table.Row` if found, ``False`` otherwise.
-    """
-    row = find_request(cells, partial_check)
-    if row.request_state.text in REQUEST_FINISHED_STATES:
-        return row
-    else:
-        return False
-
-
-def debug_requests():
-    logger.debug('Outputting current requests')
-    for page in paginator.pages():
-        for row in fields.request_list.rows():
-            logger.debug(' %s', row)
 
 
 def find_request(cells, partial_check=False):
@@ -218,69 +66,270 @@ def find_request(cells, partial_check=False):
             logger.debug(' Request Message: %s', row.last_message.text)
             return row
     else:
-        # Request not found at all, can't continue
-        return False
-
-
-def go_to_request(cells, partial_check=False):
-    """Finds the request and opens the page
-
-    See :py:func:`wait_for_request` for futher details.
-
-    Args:
-        cells: Search data for the requests table.
-    Returns: Success of the action.
-    """
-    row = find_request(cells, partial_check)
-    if row:
-        sel.click(row)
-        return True
-    else:
-        return False
-
-
-@contextmanager
-def copy_request(cells):
-    """Context manager that opens the request for editing and saves or cancels depending on success.
-
-    Args:
-        cells: Search data for the requests table.
-    """
-    if not go_to_request(cells):
         raise Exception("The requst specified by {} not found!".format(str(cells)))
-    sel.wait_for_element(buttons.copy)  # It is glitching here ...
-    sel.click(buttons.copy)
-    try:
-        yield
-    except Exception:
-        sel.click(buttons.cancel)
-        raise
-    else:
+        return False
+
+
+# TODO Refactor these module methods and their callers for a proper request class
+class Request(Navigatable):
+    def __init__(self, row_description=None, cells=None, partial_check=False, appliance=None):
+        Navigatable.__init__(self, appliance=appliance)
+        self.row_description = row_description
+        self.cells = {'Description': self.row_description} if not cells else cells
+        self.partial_check = partial_check
+        self.REQUEST_FINISHED_STATES = {'Migrated', 'Finished'}
+        self.row = find_request(self.cells, self.partial_check)
+        self.request_id = self.row.request_id.text
+        self.description = self.row.description.text
+
+    @property
+    def if_exists(self):
+        return True if find_request(cells=self.cells, partial_check=self.partial_check) else False
+
+    def load_details(self):
+        return navigate_to(self, 'Details')
+
+    def reload(self):
+        toolbar.refresh()
+
+    def update_row(self):
+        self.row = find_request(self.cells, self.partial_check)
+
+    def approve_request(self, reason, cancel=False):
+        """Approves request with specified reason
+
+        Args:
+            reason: Reason for approving the request.
+            cancel: Whether to cancel the approval.
+
+        """
+        view = self.load_details()
+        view.approve(reason, cancel)
+
+    def deny_request(self, reason, cancel=False):
+        """Open the specified request and deny it.
+
+        Args:
+            reason: Reason for denying the request.
+            cancel: Whether to cancel the denial.
+
+        """
+        view = self.load_details()
+        view.deny(reason, cancel)
+
+    def delete_request(self, cancel=False):
+        """Open the specified request and delete it.
+
+        Args:
+            cancel: Whether to cancel the deletion.
+        """
+        view = self.load_details()
+        view.delete(cancel)
+
+    def is_finished(self):
+        """helper function checks if a request is complete
+
+        Raises:
+            RequestException: if multiple matching requests were found
+
+        Returns:
+             The matching :py:class:`cfme.web_ui.Table.Row` if found, ``False`` otherwise.
+        """
+        self.update_row()
+        self.row = find_request(self.cells, self.partial_check)
+        if self.row.request_state.text in self.REQUEST_FINISHED_STATES:
+            return True
+        else:
+            return False
+
+    def if_succeeded(self):
+        self.row = find_request(self.cells, self.partial_check)
+        if self.is_finished() and self.row.status.text == 'Ok':
+            return True
+        else:
+            return False
+
+    def debug_request(self):
+        self.row = find_request(self.cells, self.partial_check)
+        logger.debug('Last Message of request: {}', self.row.last_message.text)
+
+    @contextmanager
+    def copy_request(self):
+        """Context manager that opens the request for editing and saves or cancels depending on success.
+        """
+        view = self.load_details()
+        view.toolbar.copy.click()
+        try:
+            yield
+        except Exception:
+            view.cancel.click()
+            raise
+        else:
+            from cfme.provisioning import provisioning_form
+            btn = provisioning_form.submit_copy_button
+            sel.wait_for_element(btn)
+            sel.click(btn)
+            flash.assert_no_errors()
+
+    @contextmanager
+    def edit_request(self):
+        """Context manager that opens the request for editing and saves or cancels depending on success.
+        """
+        view = self.load_details()
+        view.toolbar.edit.click()
         from cfme.provisioning import provisioning_form
-        btn = provisioning_form.submit_copy_button
-        sel.wait_for_element(btn)
-        sel.click(btn)
+        try:
+            yield provisioning_form
+        except Exception as e:
+            logger.exception(e)
+            view.cancel.click()
+            raise
+        else:
+            sel.click(provisioning_form.submit_copy_button)
+            flash.assert_no_errors()
+
+
+class RequestView(BaseLoggedInPage):
+    title = Text('#explorer_title_text')
+    table = Table(locator='//*[@id="list_grid"]/table')
+
+    @property
+    def in_requests(self):
+        return (self.logged_in_as_current_user and
+                self.navigation.currently_selected == ['Services', 'Requests'])
+
+    def open_request(self, cells):
+        row = self.table.row(description=cells)
+        row.description.click()
+
+    @property
+    def is_displayed(self):
+        return self.in_requests
+
+
+class RequestDetailsToolBar(RequestView):
+    copy = Button(title='Copy original Request')
+    edit = Button(title='Edit the original Request')
+    delete = Button(title='Delete this Request')
+    reload = Button(title='Reload the current display')
+    approve = Button(title='Approve this Request')
+    deny = Button(title='Deny this Request')
+
+
+class RequestDetailsView(RequestView):
+    # TODO Add Request details elements
+    @View.nested
+    class details(View):
+        # Form ? or just test values
+        pass
+
+    @View.nested
+    class request(Tab):
+        pass
+
+    @View.nested
+    class purpose(Tab):
+        pass
+
+    @View.nested
+    class catalog(Tab):
+        pass
+
+    @View.nested
+    class environment(Tab):
+        pass
+
+    @View.nested
+    class hardware(Tab):
+        pass
+
+    @View.nested
+    class network(Tab):
+        pass
+
+    @View.nested
+    class properties(Tab):
+        pass
+
+    @View.nested
+    class customize(Tab):
+        pass
+
+    @View.nested
+    class schedule(Tab):
+        pass
+
+    breadcrumb = BreadCrumb()
+    toolbar = RequestDetailsToolBar()
+    reason = Input(name='reason')
+    submit = Button(title='Submit')
+    cancel = Button(title="Cancel this provisioning request")
+
+    def approve(self, reason_text, cancel=False):
+        """Approve currently opened request
+
+        Args:
+            reason_text: Reason for approving the request.
+            cancel: Cancel Approval and move to all request list
+        """
+        self.toolbar.approve.click()
+        self.reason.fill(reason_text)
+        if not cancel:
+            self.submit.click()
+        else:
+            self.breadcrumb.click_location(self.breadcrumb.locations[0])
+        flash.assert_no_errors()
+
+    def deny(self, reason_text, cancel=False):
+        """Deny currently opened request
+
+        Args:
+            reason_text: Reason for denying the request.
+            cancel:  Cancel Denial and move to all request list
+        """
+        self.toolbar.deny.click()
+        self.reason.fill(reason_text)
+        if not cancel:
+            self.submit.click()
+        else:
+            self.breadcrumb.click_location(self.breadcrumb.locations[0])
+        flash.assert_no_errors()
+
+    def delete(self, cancel=False):
+        """Delete currently opened request
+
+        Args:
+            cancel: Whether to cancel the deletion.
+        """
+        self.toolbar.delete.click()
+        sel.handle_alert(cancel)
+        sel.wait_for_ajax()
         flash.assert_no_errors()
 
 
-@contextmanager
-def edit_request(cells):
-    """Context manager that opens the request for editing and saves or cancels depending on success.
+@navigator.register(Request, 'All')
+class RequestAll(CFMENavigateStep):
+    VIEW = RequestView
+    prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
 
-    Args:
-        cells: Search data for the requests table.
-    """
-    if not go_to_request(cells):
-        raise Exception("The requst specified by {} not found!".format(str(cells)))
-    sel.wait_for_element(buttons.edit)  # It is glitching here ...
-    sel.click(buttons.edit)
-    from cfme.provisioning import provisioning_form
-    try:
-        yield provisioning_form
-    except Exception as e:
-        logger.exception(e)
-        sel.click(buttons.cancel)
-        raise
-    else:
-        sel.click(provisioning_form.submit_copy_button)
-        flash.assert_no_errors()
+    def am_i_here(self, *args, **kwargs):
+        return match_page(summary='Requests')
+
+    def step(self, *args, **kwargs):
+        self.prerequisite_view.navigation.select('Services', 'Requests')
+
+
+@navigator.register(Request, 'Details')
+class RequestDetails(CFMENavigateStep):
+    VIEW = RequestDetailsView
+    prerequisite = NavigateToSibling('All')
+
+    def am_i_here(self, *args, **kwargs):
+        return match_page(summary=self.obj.description)
+
+    def step(self, *args, **kwargs):
+        try:
+            return sel.click(request_table.find_row_by_cells(self.obj.cells,
+                                                             self.obj.partial_check))
+        except (NameError, TypeError):
+            logger.warning('Exception caught, could not match Request')

--- a/cfme/services/requests.py
+++ b/cfme/services/requests.py
@@ -219,44 +219,44 @@ class RequestDetailsToolBar(RequestView):
 class RequestDetailsView(RequestView):
     # TODO Add Request details elements
     @View.nested
-    class details(View):
+    class details(View): # noqa
         # Form ? or just test values
         pass
 
     @View.nested
-    class request(Tab):
+    class request(Tab):  # noqa
         pass
 
     @View.nested
-    class purpose(Tab):
+    class purpose(Tab): # noqa
         pass
 
     @View.nested
-    class catalog(Tab):
+    class catalog(Tab): # noqa
         pass
 
     @View.nested
-    class environment(Tab):
+    class environment(Tab): # noqa
         pass
 
     @View.nested
-    class hardware(Tab):
+    class hardware(Tab): # noqa
         pass
 
     @View.nested
-    class network(Tab):
+    class network(Tab): # noqa
         pass
 
     @View.nested
-    class properties(Tab):
+    class properties(Tab): # noqa
         pass
 
     @View.nested
-    class customize(Tab):
+    class customize(Tab): # noqa
         pass
 
     @View.nested
-    class schedule(Tab):
+    class schedule(Tab): # noqa
         pass
 
     breadcrumb = BreadCrumb()

--- a/cfme/tests/cloud/test_provisioning.py
+++ b/cfme/tests/cloud/test_provisioning.py
@@ -15,8 +15,8 @@ from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.openstack import OpenStackProvider
-from cfme.services import requests
-from utils import normalize_text, testgen
+from cfme.services.requests import Request
+from utils import testgen
 from utils.generators import random_vm_name
 from utils.log import logger
 from utils.update import update
@@ -135,16 +135,14 @@ def test_provision_from_template(provider, testing_instance, soft_assert):
     instance.create(**inst_args)
     logger.info('Waiting for cfme provision request for vm %s', instance.name)
     row_description = 'Provision from [{}] to [{}]'.format(image, instance.name)
-    cells = {'Description': row_description}
+    request_row = Request(row_description)
     try:
-        row, __ = wait_for(requests.wait_for_request, [cells],
-                           fail_func=requests.reload, num_sec=1500, delay=20)
+        wait_for(request_row.is_finished, fail_func=request_row.reload, num_sec=1500, delay=20)
     except Exception as e:
-        requests.debug_requests()
+        request_row.debug_requests()
         raise e
-    assert normalize_text(row.status.text) == 'ok' and \
-        normalize_text(row.request_state.text) == 'finished', \
-        "Provisioning failed with the message {}".format(row.last_message.text)
+    assert request_row.if_succeeded(), \
+        "Provisioning failed with the message {}".format(request_row.row.last_message.text)
     instance.wait_to_appear(timeout=800)
     provider.refresh_provider_relationships()
     logger.info("Refreshing provider relationships and power states")

--- a/cfme/tests/cloud/test_provisioning.py
+++ b/cfme/tests/cloud/test_provisioning.py
@@ -139,7 +139,7 @@ def test_provision_from_template(provider, testing_instance, soft_assert):
     try:
         wait_for(request_row.is_finished, fail_func=request_row.reload, num_sec=1500, delay=20)
     except Exception as e:
-        request_row.debug_requests()
+        request_row.debug_request()
         raise e
     assert request_row.if_succeeded(), \
         "Provisioning failed with the message {}".format(request_row.row.last_message.text)

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -18,7 +18,7 @@ from cfme.common.vm import VM
 from cfme.control.explorer import actions, policies, policy_profiles
 from cfme.configure.tasks import Tasks
 from cfme.infrastructure import host
-from cfme.services import requests
+from cfme.services.requests import Request
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.web_ui import toolbar as tb
@@ -810,6 +810,6 @@ def test_action_cancel_clone(request, provider, assign_policy_for_testing_vm_big
     request.addfinalizer(lambda: cleanup_vm(clone_vm_name, provider))
     vm_big.crud.clone_vm(fauxfactory.gen_email(), "first", "last", clone_vm_name, "VMware")
     cells = {"Description": clone_vm_name}
-    row, __ = wait_for(requests.wait_for_request, [cells, True],
-        fail_func=requests.reload, num_sec=4000, delay=20)
-    assert row.status.text == "Error"
+    request_row = Request(cells=cells, partial_check=True)
+    wait_for(request_row.is_finished, fail_func=request_row.reload, num_sec=4000, delay=20)
+    assert request_row.row.status.text == "Error"

--- a/cfme/tests/infrastructure/test_host_provisioning.py
+++ b/cfme/tests/infrastructure/test_host_provisioning.py
@@ -4,7 +4,7 @@ from cfme.infrastructure import host
 from cfme.infrastructure.pxe import get_pxe_server_from_config, get_template_from_config
 from cfme.infrastructure.provider import InfraProvider
 from cfme.provisioning import provisioning_form
-from cfme.services import requests
+from cfme.services.requests import Request
 from cfme.web_ui import flash, fill
 from utils.conf import cfme_data
 from utils.log import logger
@@ -165,12 +165,10 @@ def test_host_provisioning(setup_provider, cfme_data, host_provisioning, provide
         "Host Request was Submitted, you will be notified when your Hosts are ready")
 
     row_description = 'PXE install on [{}] from image [{}]'.format(prov_host_name, pxe_image)
-    cells = {'Description': row_description}
-
-    row, __ = wait_for(requests.wait_for_request, [cells],
-                       fail_func=requests.reload, num_sec=1500, delay=20)
-    assert row.last_message.text == 'Host Provisioned Successfully'
-    assert row.status.text != 'Error'
+    request_row = Request(row_description)
+    wait_for(request_row.is_finished, fail_func=request_row.reload, num_sec=1500, delay=20)
+    assert request_row.row.last_message.text == 'Host Provisioned Successfully'
+    assert request_row.row.status.text != 'Error'
 
     # Navigate to host details page and verify Provider and cluster names
     assert test_host.get_detail('Relationships', 'Infrastructure Provider') ==\

--- a/cfme/tests/infrastructure/test_vm_clone.py
+++ b/cfme/tests/infrastructure/test_vm_clone.py
@@ -9,7 +9,7 @@ from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.automate.service_dialogs import ServiceDialog
 from cfme.services.catalogs.catalog import Catalog
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
-from cfme.services import requests
+from cfme.services.requests import Request
 from cfme.web_ui import flash
 from utils.wait import wait_for
 from utils import testgen
@@ -96,10 +96,9 @@ def create_vm(provider, setup_provider, catalog_item, request):
     flash.assert_no_errors()
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     row_description = catalog_item.name
-    cells = {'Description': row_description}
-    row, __ = wait_for(requests.wait_for_request, [cells, True],
-        fail_func=requests.reload, num_sec=1400, delay=20)
-    assert row.last_message.text == 'Request complete'
+    request_row = Request(row_description, partial_check=True)
+    wait_for(request_row.is_finished, fail_func=request_row.reload, num_sec=1400, delay=20)
+    assert request_row.if_succeeded()
     return vm_name
 
 
@@ -118,7 +117,6 @@ def test_vm_clone(provider, clone_vm_name, request, create_vm):
         provision_type = 'VMware'
     vm.clone_vm("email@xyz.com", "first", "last", clone_vm_name, provision_type)
     row_description = clone_vm_name
-    cells = {'Description': row_description}
-    row, __ = wait_for(requests.wait_for_request, [cells, True],
-        fail_func=requests.reload, num_sec=4000, delay=20)
-    assert row.last_message.text == 'Vm Provisioned Successfully'
+    request_row = Request(row_description, partial_check=True)
+    wait_for(request_row.is_finished, fail_func=request_row.reload, num_sec=4000, delay=20)
+    assert request_row.if_succeeded()

--- a/cfme/tests/infrastructure/test_vm_migrate.py
+++ b/cfme/tests/infrastructure/test_vm_migrate.py
@@ -4,7 +4,7 @@ import pytest
 from cfme.common.vm import VM
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
-from cfme.services import requests
+from cfme.services.requests import Request
 from cfme.web_ui import flash
 from cfme import test_requirements
 
@@ -51,6 +51,6 @@ def test_vm_migrate(new_vm, provider):
     flash.assert_no_errors()
     row_description = new_vm.name
     cells = {'Description': row_description, 'Request Type': 'Migrate'}
-    row, __ = wait_for(requests.wait_for_request, [cells, True],
-        fail_func=requests.reload, num_sec=600, delay=20)
-    assert row.request_state.text == 'Migrated'
+    request_row = Request(row_description, cells=cells, partial_check=True)
+    wait_for(request_row.is_finished, fail_func=request_row.reload, num_sec=600, delay=20)
+    assert request_row.if_succeeded()

--- a/cfme/tests/services/test_add_remove_vm_to_service.py
+++ b/cfme/tests/services/test_add_remove_vm_to_service.py
@@ -6,7 +6,7 @@ from cfme.automate.explorer.domain import DomainCollection
 from cfme.automate.simulation import simulate
 from cfme.common.provider import cleanup_vm
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
-from cfme.services import requests
+from cfme.services.requests import Request
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
 from cfme.services.myservice import MyService
 from utils import testgen
@@ -48,10 +48,9 @@ def myservice(setup_provider, provider, catalog_item, request):
     service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     row_description = catalog_item.name
-    cells = {'Description': row_description}
-    row, __ = wait_for(requests.wait_for_request, [cells, True],
-                       fail_func=requests.reload, num_sec=900, delay=20)
-    assert row.request_state.text == 'Finished'
+    request_row = Request(row_description, partial_check=True)
+    wait_for(request_row.is_finished, fail_func=request_row.reload, num_sec=900, delay=20)
+    assert request_row.is_finished()
     service = MyService(catalog_item.name, vm_name)
     yield service
 

--- a/cfme/tests/services/test_cloud_service_catalogs.py
+++ b/cfme/tests/services/test_cloud_service_catalogs.py
@@ -8,7 +8,7 @@ from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.automate.service_dialogs import ServiceDialog
 from cfme.services.catalogs.catalog import Catalog
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
-from cfme.services import requests
+from cfme.services.requests import Request
 from cfme.web_ui import flash
 from cfme import test_requirements
 from utils import testgen
@@ -104,7 +104,6 @@ def test_cloud_catalog_item(setup_provider, provider, dialog, catalog, request, 
     flash.assert_no_errors()
     logger.info('Waiting for cfme provision request for service %s', item_name)
     row_description = item_name
-    cells = {'Description': row_description}
-    row, __ = wait_for(requests.wait_for_request, [cells, True],
-                       fail_func=requests.reload, num_sec=1200, delay=20)
-    assert row.request_state.text == 'Finished'
+    request_row = Request(row_description, partial_check=True)
+    wait_for(request_row.is_finished, fail_func=request_row.reload, num_sec=1200, delay=20)
+    assert request_row.if_succeeded()

--- a/cfme/tests/services/test_config_provider_servicecatalogs.py
+++ b/cfme/tests/services/test_config_provider_servicecatalogs.py
@@ -2,7 +2,7 @@ import pytest
 
 from cfme import test_requirements
 from cfme.configure.settings import DefaultView
-from cfme.services import requests
+from cfme.services.requests import Request
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
 from cfme.services.myservice import MyService
 from cfme.services.catalogs.catalog_item import CatalogItem
@@ -80,9 +80,9 @@ def test_order_tower_catalog_item(catalog_item, request):
     service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     cells = {'Description': catalog_item.name}
-    row, __ = wait_for(requests.wait_for_request, [cells, True],
-        fail_func=requests.reload, num_sec=1400, delay=20)
-    assert 'Provisioned Successfully' in row.last_message.text
+    request_row = Request(cells=cells, partial_check=True)
+    wait_for(request_row.is_finished, fail_func=request_row.reload, num_sec=1400, delay=20)
+    assert request_row.if_succeeded()
     DefaultView.set_default_view("Configuration Management Providers", "List View")
 
 
@@ -98,8 +98,8 @@ def test_retire_ansible_service(catalog_item, request):
     service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     cells = {'Description': catalog_item.name}
-    row, __ = wait_for(requests.wait_for_request, [cells, True],
-        fail_func=requests.reload, num_sec=1400, delay=20)
-    assert 'Provisioned Successfully' in row.last_message.text
+    request_row = Request(cells=cells, partial_check=True)
+    wait_for(request_row.is_finished, fail_func=request_row.reload, num_sec=1400, delay=20)
+    assert request_row.if_succeeded()
     myservice = MyService(catalog_item.name)
     myservice.retire()

--- a/cfme/tests/services/test_different_dialogs_in_catalogs.py
+++ b/cfme/tests/services/test_different_dialogs_in_catalogs.py
@@ -9,7 +9,7 @@ from cfme.services.catalogs.catalog import Catalog
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.infrastructure.provider import InfraProvider
 from cfme.common.provider import cleanup_vm
-from cfme.services import requests
+from cfme.services.requests import Request
 from utils import testgen
 from utils.log import logger
 from utils.wait import wait_for
@@ -104,7 +104,6 @@ def test_tagdialog_catalog_item(provider, setup_provider, catalog_item, request)
     service_catalogs.order()
     logger.info('Waiting for cfme provision request for service {}'.format(catalog_item.name))
     row_description = catalog_item.name
-    cells = {'Description': row_description}
-    row, __ = wait_for(requests.wait_for_request, [cells, True],
-        fail_func=requests.reload, num_sec=1400, delay=20)
-    assert row.request_state.text == 'Finished'
+    request_row = Request(row_description, partial_check=True)
+    wait_for(request_row.is_finished, fail_func=request_row.reload, num_sec=1400, delay=20)
+    assert request_row.if_succeeded()

--- a/cfme/tests/services/test_generic_service_catalogs.py
+++ b/cfme/tests/services/test_generic_service_catalogs.py
@@ -7,7 +7,7 @@ from cfme.rest.gen_data import service_catalogs as _service_catalogs
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
 from cfme.services.catalogs.catalog_item import CatalogBundle
-from cfme.services import requests
+from cfme.services.requests import Request
 from cfme.web_ui import flash
 from cfme import test_requirements
 from selenium.common.exceptions import NoSuchElementException
@@ -81,14 +81,9 @@ def test_service_generic_catalog_bundle(catalog_item):
     flash.assert_no_errors()
     logger.info('Waiting for cfme provision request for service %s', bundle_name)
     row_description = bundle_name
-    cells = {'Description': row_description}
-    row, __ = wait_for(requests.wait_for_request, [cells, True],
-        fail_func=requests.reload, num_sec=900, delay=20)
-    # Success message differs between 5.6 and 5.7
-    if version.current_version() >= '5.7':
-        assert 'Provisioned Successfully' in row.last_message.text
-    else:
-        assert row.last_message.text == 'Request complete'
+    request_row = Request(row_description, partial_check=True)
+    wait_for(request_row.is_finished, fail_func=request_row.reload, num_sec=900, delay=20)
+    assert request_row.if_succeeded()
 
 
 def test_bundles_in_bundle(catalog_item):
@@ -112,14 +107,9 @@ def test_bundles_in_bundle(catalog_item):
     flash.assert_no_errors()
     logger.info('Waiting for cfme provision request for service %s', bundle_name)
     row_description = third_bundle_name
-    cells = {'Description': row_description}
-    row, __ = wait_for(requests.wait_for_request, [cells, True],
-        fail_func=requests.reload, num_sec=900, delay=20)
-    # Success message differs between 5.6 and 5.7
-    if version.current_version() >= '5.7':
-        assert 'Provisioned Successfully' in row.last_message.text
-    else:
-        assert row.last_message.text == 'Request complete'
+    request_row = Request(row_description, partial_check=True)
+    wait_for(request_row.is_finished, fail_func=request_row.reload, num_sec=900, delay=20)
+    assert request_row.if_succeeded()
 
 
 def test_delete_dialog_before_parent_item(catalog_item):

--- a/cfme/tests/services/test_iso_service_catalogs.py
+++ b/cfme/tests/services/test_iso_service_catalogs.py
@@ -7,7 +7,7 @@ from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.pxe import get_template_from_config, ISODatastore
-from cfme.services import requests
+from cfme.services.requests import Request
 from cfme import test_requirements
 from utils import testgen
 from utils.log import logger
@@ -107,7 +107,6 @@ def test_rhev_iso_servicecatalog(setup_provider, provider, catalog_item, request
     # nav to requests page happens on successful provision
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     row_description = catalog_item.name
-    cells = {'Description': row_description}
-    row, __ = wait_for(requests.wait_for_request, [cells, True],
-        fail_func=requests.reload, num_sec=3100, delay=20)
-    assert row.last_message.text == 'Request complete'
+    request_row = Request(row_description, partial_check=True)
+    wait_for(request_row.is_finished, fail_func=request_row.reload, num_sec=3100, delay=20)
+    assert request_row.if_succeeded()

--- a/cfme/tests/services/test_myservice.py
+++ b/cfme/tests/services/test_myservice.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from cfme import test_requirements
 from cfme.common.provider import cleanup_vm
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
-from cfme.services import requests
+from cfme.services.requests import Request
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
 from cfme.services.myservice import MyService
 from cfme.web_ui import toolbar as tb
@@ -55,10 +55,9 @@ def myservice(setup_provider, provider, catalog_item, request):
     service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     row_description = catalog_item.name
-    cells = {'Description': row_description}
-    row, __ = wait_for(requests.wait_for_request, [cells, True],
-                       fail_func=tb.refresh, num_sec=2000, delay=60)
-    assert row.request_state.text == 'Finished'
+    service_request = Request(row_description, partial_check=True)
+    wait_for(service_request.is_finished, fail_func=tb.refresh, num_sec=2000, delay=60)
+    assert service_request.if_succeeded()
 
     yield MyService(catalog_item.name, vm_name)
 

--- a/cfme/tests/services/test_operations.py
+++ b/cfme/tests/services/test_operations.py
@@ -8,7 +8,7 @@ from cfme import test_requirements
 from cfme.infrastructure.virtual_machines import Vm
 from cfme.fixtures import pytest_selenium as sel
 from cfme.provisioning import provisioning_form
-from cfme.services import requests
+from cfme.services.requests import Request
 from cfme.web_ui import flash, fill
 from utils.appliance.implementations.ui import navigate_to
 from utils.browser import browser
@@ -88,19 +88,21 @@ def generated_request(appliance,
     request_cells = {
         "Description": "Provision from [{}] to [{}###]".format(template_name, vm_name),
     }
-    yield request_cells
+    request_row = Request(cells=request_cells)
+    yield request_row
 
     browser().get(store.base_url)
     appliance.server.login_admin()
 
-    requests.delete_request(request_cells)
+    request_row.delete_request()
     flash.assert_no_errors()
 
 
 @pytest.mark.tier(3)
 def test_services_request_direct_url(generated_request):
     """Go to the request page, save the url and try to access it directly."""
-    assert requests.go_to_request(generated_request), "could not find the request!"
+
+    assert generated_request.load_details(), "could not find the request!"
     request_url = sel.current_url()
     sel.get(sel.base_url())    # I need to flip it with something different here
     sel.get(request_url)        # Ok, direct access now.
@@ -118,8 +120,6 @@ def test_copy_request(request, generated_request, vm_name, template_name):
     new_vm_name = fauxfactory.gen_alphanumeric(length=16)
     cfme.provisioning.copy_request_by_vm_and_template_name(
         vm_name, template_name, {"vm_name": new_vm_name}, multi=True)
-    request.addfinalizer(lambda: requests.delete_request({
-        "Description": "Provision from [{}] to [{}###]".format(template_name, new_vm_name),
-    }))
-    assert cfme.provisioning.go_to_request_by_vm_and_template_name(
-        new_vm_name, template_name, multi=True)
+    request_row = Request(row_description=new_vm_name, partial_check=True)
+    request.addfinalizer(request_row.delete_request())
+    assert request_row.load_details()

--- a/cfme/tests/services/test_pxe_service_catalogs.py
+++ b/cfme/tests/services/test_pxe_service_catalogs.py
@@ -119,7 +119,7 @@ def test_pxe_servicecatalog(setup_provider, provider, catalog_item, request):
     # nav to requests page happens on successful provision
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     row_description = catalog_item.name
-    request = Request(row_description, partial_check=True)
-    wait_for(request.is_finished, fail_func=request.reload, num_sec=3100, delay=20,
+    request_row = Request(row_description, partial_check=True)
+    wait_for(request_row.is_finished, fail_func=request_row.reload, num_sec=3100, delay=20,
              message='Waiting for request to finish')
-    assert request.row.last_message.text == 'Request complete'
+    assert request_row.if_succeeded()

--- a/cfme/tests/services/test_pxe_service_catalogs.py
+++ b/cfme/tests/services/test_pxe_service_catalogs.py
@@ -7,7 +7,7 @@ from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.pxe import get_pxe_server_from_config, get_template_from_config
-from cfme.services import requests
+from cfme.services.requests import Request
 from cfme import test_requirements
 from utils import testgen
 from utils.log import logger
@@ -119,7 +119,7 @@ def test_pxe_servicecatalog(setup_provider, provider, catalog_item, request):
     # nav to requests page happens on successful provision
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     row_description = catalog_item.name
-    cells = {'Description': row_description}
-    row, __ = wait_for(requests.wait_for_request, [cells, True],
-        fail_func=requests.reload, num_sec=3100, delay=20)
-    assert row.last_message.text == 'Request complete'
+    request = Request(row_description, partial_check=True)
+    wait_for(request.is_finished, fail_func=request.reload, num_sec=3100, delay=20,
+             message='Waiting for request to finish')
+    assert request.row.last_message.text == 'Request complete'

--- a/cfme/tests/services/test_request.py
+++ b/cfme/tests/services/test_request.py
@@ -4,7 +4,7 @@ import pytest
 from cfme.common.provider import cleanup_vm
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
-from cfme.services import requests
+from cfme.services.requests import Request
 from cfme import test_requirements
 from utils import testgen
 from utils.wait import wait_for
@@ -29,7 +29,6 @@ def test_copy_request(setup_provider, provider, catalog_item, request):
     service_catalogs = ServiceCatalogs(catalog_item.catalog, catalog_item.name)
     service_catalogs.order()
     row_description = catalog_item.name
-    cells = {'Description': row_description}
-    row, __ = wait_for(requests.wait_for_request, [cells, True],
-        fail_func=requests.reload, num_sec=1800, delay=20)
-    requests.go_to_request(cells)
+    request_row = Request(row_description, partial_check=True)
+    wait_for(request_row.is_finished, fail_func=request_row.reload, num_sec=1800, delay=20)
+    request_row.load_details()

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -402,8 +402,8 @@ def ManageIQTree(tree_id=None):  # noqa
 class SummaryFormItem(Widget):
     """The UI item that shows the values for objects that are NOT VMs, Providers and such ones."""
     LOCATOR = (
-        './/h3[normalize-space(.)={}]/following-sibling::div[1]/div'
-        '/label[normalize-space(.)={}]/following-sibling::div')
+        './/h3[normalize-space(.)={}]/following-sibling::div/div'
+        '//label[normalize-space(.)={}]/following-sibling::div')
 
     def __init__(self, parent, group_title, item_name, text_filter=None, logger=None):
         Widget.__init__(self, parent, logger=logger)


### PR DESCRIPTION
Rhcfqe 2701

Purpose or Intent
=================

__Fixing__ some test had deprecated asserts in requests which was check for last_message == "Request completed" which was removed starting from 5.6

__Extending__ Requests Navmazing a bit + adding Views for widgetastic

and

__Updating tests__ that were using request to use Request class object and it's methods

{{pytest: -v -k "test_provision" --long-running --use-provider vsphere6-nested --use-provider vsphere65-nested}}
