### PR TITLE
[1LP][RFR] Excluding SCVMM from timelines tests

### DIFF
--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -6,6 +6,7 @@ from cfme.common.vm import VM
 
 from cfme.infrastructure.host import Host
 from cfme.infrastructure.provider import InfraProvider
+from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.rest.gen_data import a_provider as _a_provider
 from cfme.rest.gen_data import vm as _vm
 from cfme.web_ui import InfoBlock
@@ -13,12 +14,16 @@ from utils import version, testgen
 from utils.appliance.implementations.ui import navigate_to
 from utils.generators import random_vm_name
 from utils.log import logger
+from utils.providers import ProviderFilter
 from utils.wait import wait_for
 
 
 pytestmark = [pytest.mark.tier(2),
               pytest.mark.usefixtures("setup_provider_modscope")]
-pytest_generate_tests = testgen.generate([InfraProvider], scope='module')
+not_scvmm = ProviderFilter(classes=[SCVMMProvider], inverted=True)  # scvmm doesn't provide events
+all_prov = ProviderFilter(classes=[InfraProvider])
+pytest_generate_tests = testgen.generate(gen_func=testgen.providers,
+                                         filters=[not_scvmm, all_prov], scope='module')
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
SCVMM doesn't provide events to CFME. So, timelines tests always fail against it.

Shriver: Adding pytest line, default provider tag doesn't include scvmm
{{ pytest: cfme/tests/infrastructure/test_timelines.py --use-provider complete --long-running -v --collect-only}}