### PR TITLE
[RFR][1LP] Support for customized ipython launcher.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ conf/README
 
 # virtual env
 .cfme/
+
+# custom imports
+conf/miq_python_startup.py

--- a/cfme/scripting/ipyshell.py
+++ b/cfme/scripting/ipyshell.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+import sys
+from . import quickstart
+
+from IPython.terminal.interactiveshell import TerminalInteractiveShell
+
+IMPORTS = [
+    'from utils import conf',
+    'from fixtures.pytest_store import store',
+    'from utils.appliance.implementations.ui import navigate_to',
+    'from utils import providers'
+]
+
+
+def main():
+    """Use quickstart to ensure we have correct env, then execute imports in ipython and done."""
+    quickstart.main(quickstart.parser.parse_args(['--mk-virtualenv', sys.prefix]))
+    print('Welcome to IPython designed for running CFME QE code.')
+    ipython = TerminalInteractiveShell.instance()
+    for code_import in IMPORTS:
+        print('> {}'.format(code_import))
+        ipython.run_cell(code_import)
+    from utils.path import conf_path
+    custom_import_path = conf_path.join('miq_python_startup.py')
+    if custom_import_path.exists():
+        with open(custom_import_path.strpath, 'r') as custom_import_file:
+            custom_import_code = custom_import_file.read()
+        print('Importing custom code:\n{}'.format(custom_import_code.strip()))
+        ipython.run_cell(custom_import_code)
+    else:
+        print(
+            'You can create your own python file with imports you use frequently. '
+            'Just create a conf/miq_python_startup.py file in your repo. '
+            'This file can contain arbitrary python code that is executed in this context.')
+    ipython.interact()
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
             'miq-release = scripts.release:main',
             'miq-artifactor-server = artifactor.__main__:main',
             'miq-runtest = cfme.scripting.runtest:main',
+            'miq-ipython = cfme.scripting.ipyshell:main',
         ],
         'manageiq.provider_categories':
         [


### PR DESCRIPTION
You can run a customized and "ensured" ipython by:
* miq-ipython
* python -m cfme.scripting.ipyshell

That ensures the env is correct and then launches ipython and imports some of the most common things.