### PR TITLE
[1LP][RFR] new REST API test for vms service subcollection; removing support for versions < 5.7

### DIFF
--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -323,6 +323,17 @@ class TestServiceRESTAPI(object):
         _action_and_check('start', 'on')
 
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
+    def test_service_vm_subcollection(self, appliance, service_data):
+        """Tests /api/services/:id/vms.
+
+        Metadata:
+            test_flag: rest
+        """
+        service = appliance.rest_api.collections.services.get(name=service_data['service_name'])
+        vm = appliance.rest_api.collections.vms.get(name=service_data['vm_name'])
+        assert service.vms[0].id == vm.id
+
+    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     def test_create_service_from_parent(self, request, appliance):
         """Tests creation of new service that reference existing service.
 

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -4,7 +4,6 @@ import fauxfactory
 import pytest
 
 from cfme.rest.gen_data import dialog as _dialog
-from cfme.rest.gen_data import services as _services
 from cfme.rest.gen_data import service_data as _service_data
 from cfme.rest.gen_data import service_catalogs as _service_catalogs
 from cfme.rest.gen_data import service_templates as _service_templates
@@ -80,25 +79,21 @@ def service_catalogs(request, appliance):
 
 @pytest.fixture(scope="function")
 def services(request, appliance, a_provider):
-    if version.current_version() >= '5.7':
-        # create simple service using REST API
-        bodies = [service_body() for _ in range(3)]
-        collection = appliance.rest_api.collections.services
-        new_services = collection.action.create(*bodies)
-        assert appliance.rest_api.response.status_code == 200
+    # create simple service using REST API
+    bodies = [service_body() for _ in range(3)]
+    collection = appliance.rest_api.collections.services
+    new_services = collection.action.create(*bodies)
+    assert appliance.rest_api.response.status_code == 200
 
-        @request.addfinalizer
-        def _finished():
-            collection.reload()
-            ids = [service.id for service in new_services]
-            delete_entities = [service for service in collection if service.id in ids]
-            if delete_entities:
-                collection.action.delete(*delete_entities)
+    @request.addfinalizer
+    def _finished():
+        collection.reload()
+        ids = [service.id for service in new_services]
+        delete_entities = [service for service in collection if service.id in ids]
+        if delete_entities:
+            collection.action.delete(*delete_entities)
 
-        return new_services
-    else:
-        # create full-blown service using UI
-        return _services(request, appliance.rest_api, a_provider)
+    return new_services
 
 
 @pytest.fixture(scope="function")
@@ -291,7 +286,6 @@ class TestServiceRESTAPI(object):
             assert hasattr(service, "evm_owner_id")
             assert service.evm_owner_id == user.id
 
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     @pytest.mark.parametrize(
         "from_detail", [True, False],
         ids=["from_detail", "from_collection"])
@@ -322,7 +316,6 @@ class TestServiceRESTAPI(object):
         _action_and_check('suspend', 'suspended')
         _action_and_check('start', 'on')
 
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     def test_service_vm_subcollection(self, appliance, service_data):
         """Tests /api/services/:id/vms.
 
@@ -333,7 +326,6 @@ class TestServiceRESTAPI(object):
         vm = appliance.rest_api.collections.vms.get(name=service_data['vm_name'])
         assert service.vms[0].id == vm.id
 
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     def test_create_service_from_parent(self, request, appliance):
         """Tests creation of new service that reference existing service.
 
@@ -355,7 +347,6 @@ class TestServiceRESTAPI(object):
         for ent in response:
             assert ent.ancestry == str(service.id)
 
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     def test_delete_parent_service(self, appliance):
         """Tests that when parent service is deleted, child service is deleted automatically.
 
@@ -379,7 +370,6 @@ class TestServiceRESTAPI(object):
             with error.expected("ActiveRecord::RecordNotFound"):
                 gen.action.delete()
 
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     def test_add_service_parent(self, request, appliance):
         """Tests adding parent reference to already existing service.
 
@@ -395,7 +385,6 @@ class TestServiceRESTAPI(object):
         child.reload()
         assert child.ancestry == str(parent.id)
 
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     @pytest.mark.meta(blockers=[BZ(1416903, forced_streams=['5.7', '5.8', 'upstream'])])
     def test_power_parent_service(self, request, appliance, service_data):
         """Tests that power operations triggered on service parent affects child service.
@@ -425,7 +414,6 @@ class TestServiceRESTAPI(object):
         _action_and_check('suspend', 'suspended')
         _action_and_check('start', 'on')
 
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     @pytest.mark.meta(blockers=[BZ(1441412, forced_streams=['5.8', 'upstream'])])
     def test_retire_parent_service_now(self, appliance, service_data):
         """Tests that child service is retired together with a parent service.
@@ -448,7 +436,6 @@ class TestServiceRESTAPI(object):
 
 
 class TestServiceDialogsRESTAPI(object):
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     @pytest.mark.parametrize("method", ["post", "delete"])
     def test_delete_service_dialog(self, appliance, dialog, method):
         """Tests deleting service dialogs from detail.
@@ -464,7 +451,6 @@ class TestServiceDialogsRESTAPI(object):
             service_dialog.action.delete(force_method=method)
         assert appliance.rest_api.response.status_code == 404
 
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     def test_delete_service_dialogs(self, appliance, dialog):
         """Tests deleting service dialogs from collection.
 
@@ -619,7 +605,6 @@ class TestBlueprintsRESTAPI(object):
         return response
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     def test_create_blueprints(self, appliance, blueprints):
         """Tests creation of blueprints.
 
@@ -633,7 +618,6 @@ class TestBlueprintsRESTAPI(object):
             assert record.ui_properties == blueprint.ui_properties
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     @pytest.mark.parametrize("method", ["post", "delete"], ids=["POST", "DELETE"])
     def test_delete_blueprints_from_detail(self, appliance, blueprints, method):
         """Tests deleting blueprints from detail.
@@ -650,7 +634,6 @@ class TestBlueprintsRESTAPI(object):
             assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     def test_delete_blueprints_from_collection(self, appliance, blueprints):
         """Tests deleting blueprints from collection.
 
@@ -665,7 +648,6 @@ class TestBlueprintsRESTAPI(object):
         assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     @pytest.mark.parametrize(
         "from_detail", [True, False],
         ids=["from_detail", "from_collection"])
@@ -708,7 +690,6 @@ class TestOrchestrationTemplatesRESTAPI(object):
         return response
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     def test_create_orchestration_templates(self, appliance, orchestration_templates):
         """Tests creation of orchestration templates.
 
@@ -722,7 +703,6 @@ class TestOrchestrationTemplatesRESTAPI(object):
             assert record.type == template.type
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     def test_delete_orchestration_templates_from_collection(
             self, appliance, orchestration_templates):
         """Tests deleting orchestration templates from collection.
@@ -738,7 +718,6 @@ class TestOrchestrationTemplatesRESTAPI(object):
         assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     @pytest.mark.meta(blockers=[BZ(1414881, forced_streams=['5.7', '5.8', 'upstream'])])
     def test_delete_orchestration_templates_from_detail_post(self, orchestration_templates,
             appliance):
@@ -755,7 +734,6 @@ class TestOrchestrationTemplatesRESTAPI(object):
             assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     def test_delete_orchestration_templates_from_detail_delete(self, orchestration_templates,
             appliance):
         """Tests deleting orchestration templates from detail using DELETE method.
@@ -771,7 +749,6 @@ class TestOrchestrationTemplatesRESTAPI(object):
             assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     @pytest.mark.parametrize(
         "from_detail", [True, False],
         ids=["from_detail", "from_collection"])


### PR DESCRIPTION
* new test checking that VM added to service is also accessible using VMs subcollection.

Tested locally. This test depends on manageiq-client==0.3.0 which is in requirements/frozen.txt, but for some reason is not installed on PRT. It seems requirements are not being installed at all.

* also removing support for versions < 5.7

{{pytest: -v -k test_service_vm_subcollection --long-running}}