### PR TITLE
[WIPTEST] Fix for test failures in access_control

### DIFF
--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -737,15 +737,18 @@ class Tenant(Updateable, Pretty, Navigatable):
         return self.tree_path[:-1]
 
     def create(self, cancel=False):
+        flash_tenant_success_msg = 'Tenant "{}" was saved'.format(self.name)
+        flash_project_success_msg = 'Project "{}" was saved'.format(self.name)
+
         if self._default:
             raise ValueError("Cannot create the root tenant {}".format(self.name))
 
         navigate_to(self, 'Add')
         fill(self.tenant_form, self, action=form_buttons.add)
         if type(self) is Tenant:
-            flash.assert_success_message('Tenant "{}" was saved'.format(self.name))
+            flash.assert_success_message(flash_tenant_success_msg)
         elif type(self) is Project:
-            flash.assert_success_message('Project "{}" was saved'.format(self.name))
+            flash.assert_success_message(flash_project_success_msg)
         else:
             raise TypeError(
                 'No Tenant or Project class passed to create method{}'.format(
@@ -811,10 +814,11 @@ class TenantAdd(CFMENavigateStep):
         navigate_to(self.obj.parent_tenant, 'Details')
 
     def step(self, *args, **kwargs):
-        if isinstance(self.obj, Tenant):
-            add_selector = 'Add child Tenant to this Tenant'
-        elif isinstance(self.obj, Project):
+        # Check for Project before Tenant since isinstance returns True for base classes
+        if isinstance(self.obj, Project):
             add_selector = 'Add Project to this Tenant'
+        elif isinstance(self.obj, Tenant):
+            add_selector = 'Add child Tenant to this Tenant'
         else:
             raise OptionNotAvailable('Object type unsupported for Tenant Add: {}'
                                      .format(type(self.obj).__name__))

--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -390,6 +390,11 @@ class Group(Updateable, Pretty, Navigatable):
             RBACOperationBlocked - If the delete operation is disabled
         """
         flash_success_msg = "EVM Group \"{}\": Delete successful".format(self.description)
+        flash_blocked_assigned_user_msg = version.pick({
+            '5.6': ("EVM Group \"{}\": Error during delete: Still has users assigned.".format(
+                self.description)),
+            '5.5': ("EVM Group \"{}\": Error during \'destroy\': Still has users assigned".format(
+                self.description))})
         delete_result = False
 
         if all_group_selection:
@@ -408,6 +413,12 @@ class Group(Updateable, Pretty, Navigatable):
                 delete_result = True
             except FlashMessageException:
                 pass
+
+        try:
+            flash.assert_message_match(flash_blocked_assigned_user_msg)
+            raise RBACOperationBlocked
+        except FlashMessageException:
+            pass
 
         return delete_result
 

--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -241,8 +241,7 @@ class Group(Updateable, Pretty, Navigatable):
     def create(self):
         flash_blocked_msg = version.pick({
             '5.8': ("Description is not unique within region {}".format(self.region)),
-            '5.7': ("Description has already been taken"),
-            })
+            '5.7': ("Description has already been taken"), })
 
         navigate_to(self, 'Add')
         fill(self.group_form, {'description_txt': self.description,
@@ -297,7 +296,7 @@ class Group(Updateable, Pretty, Navigatable):
 
     def _update_using_all_selection(self):
         flash_blocked_msg = 'Read Only EVM Group "{}" can not be edited'.format(
-                self.description)
+            self.description)
 
         #TODO: this functionality should be moved to edit navigate step
         navigate_to(Group, 'All')

--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -326,11 +326,23 @@ class Group(Updateable, Pretty, Navigatable):
 
         return False
 
-    def delete(self):
+    def delete(self, all_group_selection=False):
+        """
+        Delete the group referenced by this object
+
+        Args:
+            all_group_selection: Attempt to use the selection list by clicking
+                on the Access Control "Groups" header
+
+        Returns: True if group was deleted successfully
+
+        Exception:
+            RBACOperationBlocked - If the delete operation is disabled
+        """
         flash_success_msg = "EVM Group \"{}\": Delete successful".format(self.description)
         delete_result = False
 
-        if self.appliance.version < "5.7":
+        if all_group_selection:
             delete_result = self._delete_using_all_selection()
         else:
             navigate_to(self, 'Details')
@@ -339,6 +351,7 @@ class Group(Updateable, Pretty, Navigatable):
                 raise RBACOperationBlocked
 
             tb_select('Delete this Group', invokes_alert=True)
+            sleep(10)
             sel.handle_alert()
             try:
                 flash.assert_message_match(flash_success_msg)

--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -89,7 +89,7 @@ class User(Updateable, Pretty, Navigatable):
             '5.8': ("Userid is not unique within region {}".format(self.region)),
             '5.7': ("Userid has already been taken"), })
         flash_success_msg = version.pick({
-            '5.6' : ('User "{}" was saved'.format(self.name)), })
+            '5.6': ('User "{}" was saved'.format(self.name)), })
 
         navigate_to(self, 'Add')
         fill(self.user_form, {'name_txt': self.name,
@@ -111,7 +111,7 @@ class User(Updateable, Pretty, Navigatable):
 
     def update(self, updates):
         flash_success_msg = version.pick({
-            '5.6' : 'User "{}" was saved'.format(updates.get('name', self.name)), })
+            '5.6': 'User "{}" was saved'.format(updates.get('name', self.name)), })
 
         navigate_to(self, 'Edit')
         change_stored_password()

--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -653,8 +653,7 @@ class Tenant(Updateable, Pretty, Navigatable):
         description: Description of the tenant
         parent_tenant: Parent tenant, can be None, can be passed as string or object
     """
-    save_changes = deferred_verpick({'5.7': form_buttons.angular_save,
-                   '5.8': form_buttons.simple_save})
+    save_changes = deferred_verpick({'5.6': form_buttons.simple_save})
 
     # TODO:
     # Temporary defining elements with "//input" as Input() is not working.Seems to be

--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -89,7 +89,7 @@ class User(Updateable, Pretty, Navigatable):
             '5.8': ("Userid is not unique within region {}".format(self.region)),
             '5.7': ("Userid has already been taken"), })
         flash_success_msg = version.pick({
-            '5.5': ('User "{}" was saved'.format(self.name)), })
+            '5.6' : ('User "{}" was saved'.format(self.name)), })
 
         navigate_to(self, 'Add')
         fill(self.user_form, {'name_txt': self.name,
@@ -110,6 +110,9 @@ class User(Updateable, Pretty, Navigatable):
         flash.assert_success_message(flash_success_msg)
 
     def update(self, updates):
+        flash_success_msg = version.pick({
+            '5.6' : 'User "{}" was saved'.format(updates.get('name', self.name)), })
+
         navigate_to(self, 'Edit')
         change_stored_password()
         new_updates = {}
@@ -129,8 +132,7 @@ class User(Updateable, Pretty, Navigatable):
                 'description', None)
         })
         fill(self.user_form, new_updates, action=form_buttons.save)
-        flash.assert_success_message(
-            'User "{}" was saved'.format(updates.get('name', self.name)))
+        flash.assert_success_message(flash_success_msg)
 
     def copy(self):
         navigate_to(self, 'Details')

--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -405,3 +405,7 @@ class ItemNotFound(CFMEException):
 
 class ManyItemsFound(CFMEException):
     """Raised when one or no items were expected but several/many items were obtained instead."""
+
+
+class RBACOperationBlocked(CFMEException):
+    """Raised when a Role Based Access Control operation is blocked""" 

--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -408,4 +408,4 @@ class ManyItemsFound(CFMEException):
 
 
 class RBACOperationBlocked(CFMEException):
-    """Raised when a Role Based Access Control operation is blocked""" 
+    """Raised when a Role Based Access Control operation is blocked"""

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -95,7 +95,8 @@ def test_user_login():
 def test_user_duplicate_name():
     nu = new_user()
     nu.create()
-    with error.expected("Userid has already been taken"):
+
+    with pytest.raises(RBACOperationBlocked):
         nu.create()
 
 

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -286,7 +286,8 @@ def test_delete_default_group():
     with pytest.raises(RBACOperationBlocked):
         all_group_selection = False
 
-        if version.current_version() < "5.7": all_group_selection = True
+        if version.current_version() < "5.7":
+            all_group_selection = True
 
         group.delete(all_group_selection=all_group_selection)
 

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -294,14 +294,11 @@ def test_delete_default_group():
 
 @pytest.mark.tier(3)
 def test_delete_group_with_assigned_user():
-    flash_msg = version.pick({
-        '5.6': ("EVM Group \"{}\": Error during delete: Still has users assigned"),
-        '5.5': ("EVM Group \"{}\": Error during \'destroy\': Still has users assigned")})
     group = new_group()
     group.create()
     user = new_user(group=group)
     user.create()
-    with error.expected(flash_msg.format(group.description)):
+    with pytest.raises(RBACOperationBlocked):
         group.delete()
 
 

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -285,8 +285,7 @@ def test_delete_default_group():
     with pytest.raises(RBACOperationBlocked):
         all_group_selection = False
 
-        if version.current_version() < "5.7":
-            all_group_selection = True
+        if version.current_version() < "5.7": all_group_selection = True
 
         group.delete(all_group_selection=all_group_selection)
 
@@ -306,13 +305,14 @@ def test_delete_group_with_assigned_user():
 
 @pytest.mark.tier(3)
 def test_edit_default_group():
-    flash_msg = 'Read Only EVM Group "{}" can not be edited'
     group = Group(description='EvmGroup-approver')
-    navigate_to(Group, 'All')
-    row = group_table.find_row_by_cells({'Name': group.description})
-    sel.check(sel.element(".//input[@type='checkbox']", root=row[0]))
-    tb.select('Configuration', 'Edit the selected Group')
-    flash.assert_message_match(flash_msg.format(group.description))
+    all_group_selection = False
+
+    if version.current_version() < "5.7":
+        all_group_selection = True
+
+    with pytest.raises(RBACOperationBlocked):
+        group.update(None, all_group_selection)
 
 
 @pytest.mark.tier(3)
@@ -377,24 +377,17 @@ def test_delete_default_roles():
 def test_edit_default_roles():
     role = Role(name='EvmRole-auditor')
 
-    #navigate_to(role, 'Edit')
-    #flash.assert_message_match("Read Only Role \"{}\" can not be edited" .format(role.name))
     with pytest.raises(RBACOperationBlocked):
         role.update(None)
 
 
 @pytest.mark.tier(3)
 def test_delete_roles_with_assigned_group():
-    #flash_msg = version.pick({
-    #    '5.6': ("Role \"{}\": Error during delete: Cannot delete record "
-    #        "because of dependent entitlements"),
-    #    '5.5': ("Role \"{}\": Error during \'destroy\': Cannot delete record "
-    #        "because of dependent miq_groups")})
     role = new_role()
     role.create()
     group = new_group(role=role.name)
     group.create()
-    #with error.expected(flash_msg.format(role.name)):
+
     with pytest.raises(RBACOperationBlocked):
         role.delete()
 

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -283,7 +283,12 @@ def test_group_description_required_error_validation():
 def test_delete_default_group():
     group = Group(description='EvmGroup-administrator')
     with pytest.raises(RBACOperationBlocked):
-        group.delete()
+        all_group_selection = False
+
+        if version.current_version() < "5.7":
+            all_group_selection = True
+
+        group.delete(all_group_selection=all_group_selection)
 
 
 @pytest.mark.tier(3)

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -281,25 +281,7 @@ def test_group_description_required_error_validation():
 
 @pytest.mark.tier(3)
 def test_delete_default_group():
-    flash_msg = "EVM Group \"{}\": Error during delete: A read only group cannot be deleted."
     group = Group(description='EvmGroup-administrator')
-    #navigate_to(Group, 'All')
-    #row = group_table.find_row_by_cells({'Name': group.description})
-    #sel.check(sel.element(".//input[@type='checkbox']", root=row[0]))
-    #sleep(10)  # todo: temporary fix of js issue, to remove when switch to widgetastic
-    #tb.select('Configuration', 'Delete selected Groups', invokes_alert=True)
-    sel.handle_alert()
-    flash.assert_message_match(flash_msg.format(group.description))
-
-def test_delete_default_group_landon():
-    from cfme.exceptions import FlashMessageException
-    flash_msg = "EVM Group \"{}\": Error during delete: A read only group cannot be deleted."
-    ############################################################################
-    #DELETE THIS
-    #pytest.set_trace()
-    ############################################################################
-    group = Group(description='EvmGroup-administrator')
-    #group = Group(description='FooGroup-administrator')
     with pytest.raises(RBACOperationBlocked):
         group.delete()
 

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -368,13 +368,8 @@ def test_rolename_duplicate_validation():
 
 @pytest.mark.tier(3)
 def test_delete_default_roles():
-    flash_msg = version.pick({
-        '5.6': ("Role \"{}\": Error during delete: Cannot delete record "
-            "because of dependent entitlements"),
-        '5.5': ("Role \"{}\": Error during \'destroy\': Cannot delete record "
-            "because of dependent miq_groups")})
     role = Role(name='EvmRole-approver')
-    with error.expected(flash_msg.format(role.name)):
+    with pytest.raises(RBACOperationBlocked):
         role.delete()
 
 

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -246,7 +246,7 @@ def test_group_crud():
 def test_group_duplicate_name():
     group = new_group()
     group.create()
-    with error.expected("Description has already been taken"):
+    with pytest.raises(RBACOperationBlocked):
         group.create()
 
 

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -376,22 +376,26 @@ def test_delete_default_roles():
 @pytest.mark.tier(3)
 def test_edit_default_roles():
     role = Role(name='EvmRole-auditor')
-    navigate_to(role, 'Edit')
-    flash.assert_message_match("Read Only Role \"{}\" can not be edited" .format(role.name))
+
+    #navigate_to(role, 'Edit')
+    #flash.assert_message_match("Read Only Role \"{}\" can not be edited" .format(role.name))
+    with pytest.raises(RBACOperationBlocked):
+        role.update(None)
 
 
 @pytest.mark.tier(3)
 def test_delete_roles_with_assigned_group():
-    flash_msg = version.pick({
-        '5.6': ("Role \"{}\": Error during delete: Cannot delete record "
-            "because of dependent entitlements"),
-        '5.5': ("Role \"{}\": Error during \'destroy\': Cannot delete record "
-            "because of dependent miq_groups")})
+    #flash_msg = version.pick({
+    #    '5.6': ("Role \"{}\": Error during delete: Cannot delete record "
+    #        "because of dependent entitlements"),
+    #    '5.5': ("Role \"{}\": Error during \'destroy\': Cannot delete record "
+    #        "because of dependent miq_groups")})
     role = new_role()
     role.create()
     group = new_group(role=role.name)
     group.create()
-    with error.expected(flash_msg.format(role.name)):
+    #with error.expected(flash_msg.format(role.name)):
+    with pytest.raises(RBACOperationBlocked):
         role.delete()
 
 

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -313,7 +313,7 @@ def test_edit_default_group():
         all_group_selection = True
 
     with pytest.raises(RBACOperationBlocked):
-        group.update(None, all_group_selection)
+        group.update({}, all_group_selection)
 
 
 @pytest.mark.tier(3)
@@ -379,7 +379,7 @@ def test_edit_default_roles():
     role = Role(name='EvmRole-auditor')
 
     with pytest.raises(RBACOperationBlocked):
-        role.update(None)
+        role.update({})
 
 
 @pytest.mark.tier(3)

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -13,7 +13,7 @@ from cfme.automate.explorer import AutomateExplorer # NOQA
 from cfme.base import Server
 from cfme.configure.access_control import set_group_order
 from cfme.control.explorer import ControlExplorer # NOQA
-from cfme.exceptions import OptionNotAvailable
+from cfme.exceptions import OptionNotAvailable, RBACOperationBlocked
 from cfme.common.provider import base_types
 from cfme.infrastructure import virtual_machines as vms
 from cfme.services.myservice import MyService
@@ -283,13 +283,25 @@ def test_group_description_required_error_validation():
 def test_delete_default_group():
     flash_msg = "EVM Group \"{}\": Error during delete: A read only group cannot be deleted."
     group = Group(description='EvmGroup-administrator')
-    navigate_to(Group, 'All')
-    row = group_table.find_row_by_cells({'Name': group.description})
-    sel.check(sel.element(".//input[@type='checkbox']", root=row[0]))
-    sleep(10)  # todo: temporary fix of js issue, to remove when switch to widgetastic
-    tb.select('Configuration', 'Delete selected Groups', invokes_alert=True)
+    #navigate_to(Group, 'All')
+    #row = group_table.find_row_by_cells({'Name': group.description})
+    #sel.check(sel.element(".//input[@type='checkbox']", root=row[0]))
+    #sleep(10)  # todo: temporary fix of js issue, to remove when switch to widgetastic
+    #tb.select('Configuration', 'Delete selected Groups', invokes_alert=True)
     sel.handle_alert()
     flash.assert_message_match(flash_msg.format(group.description))
+
+def test_delete_default_group_landon():
+    from cfme.exceptions import FlashMessageException
+    flash_msg = "EVM Group \"{}\": Error during delete: A read only group cannot be deleted."
+    ############################################################################
+    #DELETE THIS
+    #pytest.set_trace()
+    ############################################################################
+    group = Group(description='EvmGroup-administrator')
+    #group = Group(description='FooGroup-administrator')
+    with pytest.raises(RBACOperationBlocked):
+        group.delete()
 
 
 @pytest.mark.tier(3)


### PR DESCRIPTION
Updating test for deleting default groups due to the change vers > 5.7

Updating tests that are failing in cfme version >= 5.7. Also updating access_control module and test to move selenium automation out of the tests in into the access_control module.  Widgetastic and navmazing updates are still needed but will be implemented in separate PR's