### PR TITLE
[RFR][1LP] replace pytest.wait_for with wait_for_decorator

### DIFF
--- a/cfme/tests/cli/test_evmserverd.py
+++ b/cfme/tests/cli/test_evmserverd.py
@@ -3,6 +3,7 @@
 import pytest
 import re
 from utils import version
+from utils.wait import wait_for_decorator
 
 
 @pytest.yield_fixture(scope="module")
@@ -39,7 +40,7 @@ def test_evmserverd_stop(appliance):
     server_names = {server[server_name_key] for server in appliance.ssh_client.status["servers"]}
     assert appliance.ssh_client.run_command("systemctl stop evmserverd").rc == 0
 
-    @pytest.wait_for(timeout="2m", delay=5)
+    @wait_for_decorator(timeout="2m", delay=5)
     def servers_stopped():
         status = {
             server[server_name_key]: server for server in appliance.ssh_client.status["servers"]

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -33,7 +33,7 @@ from utils.generators import random_vm_name
 from utils.log import logger
 from utils.version import current_version
 from utils.virtual_machines import deploy_template
-from utils.wait import wait_for, TimedOutError
+from utils.wait import wait_for, wait_for_decorator, TimedOutError
 from utils.pretty import Pretty
 from cfme import test_requirements
 
@@ -656,7 +656,7 @@ def test_action_initiate_smartstate_analysis(
 
     # Check that analyse job has appeared in the list
     # Wait for the task to finish
-    @pytest.wait_for(delay=15, timeout="8m", fail_func=lambda: tb.refresh())
+    @wait_for_decorator(delay=15, timeout="8m", fail_func=lambda: tb.refresh())
     def is_vm_analysis_finished():
         """ Check if analysis is finished - if not, reload page
         """

--- a/cfme/tests/infrastructure/test_instance_analysis.py
+++ b/cfme/tests/infrastructure/test_instance_analysis.py
@@ -20,7 +20,7 @@ from cfme.web_ui import InfoBlock, DriftGrid, toolbar
 from utils import testgen, ssh, safe_string, error
 from utils.conf import cfme_data
 from utils.log import logger
-from utils.wait import wait_for
+from utils.wait import wait_for, wait_for_decorator
 
 pytestmark = [pytest.mark.tier(3), test_requirements.smartstate]
 
@@ -226,7 +226,7 @@ def instance(request, local_setup_provider, provider, vm_name, vm_analysis_data,
 
     mgmt_system = provider.get_mgmt_system()
 
-    @pytest.wait_for(timeout="20m", delay=5)
+    @wait_for_decorator(timeout="20m", delay=5)
     def get_ip_address():
         logger.info("Power state for {} vm: {}, is_vm_stopped: {}".format(
             vm_name, mgmt_system.vm_status(vm_name), mgmt_system.is_vm_stopped(vm_name)))

--- a/cfme/tests/infrastructure/test_provider_discovery.py
+++ b/cfme/tests/infrastructure/test_provider_discovery.py
@@ -3,6 +3,7 @@ from itertools import combinations
 
 from utils import testgen
 from utils.providers import get_crud
+from utils.wait import wait_for_decorator
 from cfme.infrastructure.provider import discover, InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
@@ -102,7 +103,7 @@ def test_discover_infra(providers_for_discover, start_ip, max_range):
 
     discover(rhevm, virtualcenter, scvmm, False, start_ip, max_range)
 
-    @pytest.wait_for(num_sec=count_timeout(start_ip, max_range), delay=5)
+    @wait_for_decorator(num_sec=count_timeout(start_ip, max_range), delay=5)
     def _wait_for_all_providers():
         for provider in providers_for_discover:
             # When the provider is discovered, its name won't match what would be expected from

--- a/cfme/tests/intelligence/reports/test_crud.py
+++ b/cfme/tests/intelligence/reports/test_crud.py
@@ -14,6 +14,8 @@ from utils.blockers import BZ
 from utils import version
 from cfme import test_requirements
 
+from utils.wait import wait_for_decorator
+
 
 report_crud_dir = data_path.join("reports_crud")
 schedules_crud_dir = data_path.join("schedules_crud")
@@ -188,7 +190,7 @@ def test_run_report(appliance):
     response = report.action.run()
     assert appliance.rest_api.response.status_code == 200
 
-    @pytest.wait_for(timeout="5m", delay=5)
+    @wait_for_decorator(timeout="5m", delay=5)
     def rest_running_report_finishes():
         response.task.reload()
         if "error" in response.task.status.lower():

--- a/cfme/tests/services/test_service_catalogs.py
+++ b/cfme/tests/services/test_service_catalogs.py
@@ -11,7 +11,7 @@ from cfme.services import requests
 from cfme.web_ui import flash
 from cfme import test_requirements
 from utils.log import logger
-from utils.wait import wait_for
+from utils.wait import wait_for, wait_for_decorator
 from utils import testgen, error
 
 
@@ -73,7 +73,7 @@ def test_order_catalog_item_via_rest(
     req = template.action.order()
     assert rest_api.response.status_code == 200
 
-    @pytest.wait_for(timeout="15m", delay=5)
+    @wait_for_decorator(timeout="15m", delay=5)
     def request_finished():
         req.reload()
         logger.info("Request status: {}, Request state: {}, Request message: {}".format(

--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -14,7 +14,7 @@ from cfme.rest.gen_data import automation_requests_data
 from fixtures.provider import setup_one_or_skip
 from utils.providers import ProviderFilter
 from utils.version import current_version
-from utils.wait import wait_for
+from utils.wait import wait_for, wait_for_decorator
 from utils.blockers import BZ
 
 
@@ -55,7 +55,7 @@ def test_vm_scan(appliance, vm, from_detail):
         response, = appliance.rest_api.collections.vms.action.scan(rest_vm)
     assert appliance.rest_api.response.status_code == 200
 
-    @pytest.wait_for(timeout="5m", delay=5, message="REST running scanning vm finishes")
+    @wait_for_decorator(timeout="5m", delay=5, message="REST running scanning vm finishes")
     def _finished():
         response.task.reload()
         if response.task.status.lower() in {"error"}:

--- a/utils/wait.py
+++ b/utils/wait.py
@@ -1,6 +1,7 @@
-from wait_for import wait_for as wait_for_mod
+from wait_for import wait_for as wait_for_mod, wait_for_decorator as wait_for_decorator_mod
 from wait_for import RefreshTimer, TimedOutError  # NOQA
 from utils.log import logger
 from functools import partial
 
 wait_for = partial(wait_for_mod, logger=logger)
+wait_for_decorator = partial(wait_for_decorator_mod, logger=logger)


### PR DESCRIPTION
{{pytest: cfme/tests/cli/test_evmserverd.py cfme/tests/control/test_actions.py cfme/tests/infrastructure/test_instance_analysis.py cfme/tests/infrastructure/test_provider_discovery.py cfme/tests/intelligence/reports/test_crud.py cfme/tests/services/test_service_catalogs.py cfme/tests/test_rest.py}}