### PR TITLE
[RFR][NOTEST] switch dockerbot to use an actual docker entrypoint

### DIFF
--- a/scripts/dockerbot/dockerbot.py
+++ b/scripts/dockerbot/dockerbot.py
@@ -384,7 +384,7 @@ class DockerBot(object):
         if self.args['auto_gen_test'] and self.args['pr']:
             self.pr_metadata = self.get_pr_metadata(self.args['pr'])
             pytest = self.pr_metadata.get('pytest', None)
-            sprout_appliances = self.pr_metadata.get('sprouts', 1)
+            self.args['sprout_appliances'] = self.pr_metadata.get('sprouts', 1)
             if pytest:
                 self.args['pytest'] = "py.test {}".format(pytest)
             else:
@@ -394,10 +394,12 @@ class DockerBot(object):
                                            "--perf").format(" ".join(files))
                 else:
                     self.args['pytest'] = "py.test -v --use-provider default -m smoke"
+
         if self.args['pr']:
             self.base_branch = self.get_base_branch(self.args['pr']) or self.base_branch
         if self.args['sprout']:
-            self.args['pytest'] += ' --use-sprout --sprout-appliances {}'.format(sprout_appliances)
+            self.args['pytest'] += ' --use-sprout --sprout-appliances {}'.format(
+                self.args['sprout_appliances'])
             self.args['pytest'] += ' --sprout-group {}'.format(self.args['sprout_stream'])
             self.args['pytest'] += ' --sprout-desc {}'.format(self.args['sprout_description'])
         if not self.args['capture']:

--- a/scripts/dockerbot/dockerbot.py
+++ b/scripts/dockerbot/dockerbot.py
@@ -102,7 +102,6 @@ class PytestDocker(DockerInstance):
             pt_name = name
             pt_create_info = dc.create_container(pytest_con, tty=True,
                                                  name=pt_name, environment=env,
-                                                 command='sh /setup.sh',
                                                  volumes=[artifactor_dir],
                                                  ports=self.ports)
             self.container_id = _dgci(pt_create_info, 'id')

--- a/scripts/dockerbot/pytestbase/Dockerfile
+++ b/scripts/dockerbot/pytestbase/Dockerfile
@@ -8,3 +8,4 @@ ADD setup.sh /setup.sh
 ADD post_result.py /post_result.py
 ADD get_keys.py /get_keys.py
 ADD verify_commit.py /verify_commit.py
+ENTRYPOINT ["sh", "setup.sh"]


### PR DESCRIPTION
this pr uses the docker entry-point to declare the ci command, this will decouple evolution of the docker image from the image executor

i need some idea to test this without affecting live trackerbot data