### PR TITLE
[RFR] Added support for Container based servers in standalone mode.

### DIFF
--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -379,6 +379,13 @@ class MiddlewareServerNotFound(CFMEException):
     pass
 
 
+class MiddlewareServerGroupNotFound(CFMEException):
+    """
+    Raised if a specific Middleware Server Group cannot be found.
+    """
+    pass
+
+
 class MiddlewareDomainNotFound(CFMEException):
     """
     Raised if a specific Middleware Domain cannot be found.

--- a/cfme/middleware/provider/__init__.py
+++ b/cfme/middleware/provider/__init__.py
@@ -30,7 +30,7 @@ auth_btn = partial(tb.select, 'Authentication')
 jdbc_btn = partial(tb.select, 'JDBC Drivers')
 datasources_btn = partial(tb.select, 'Datasources')
 
-LIST_TABLE_LOCATOR = "//div[@id='list_grid']/table"
+LIST_TABLE_LOCATOR = "//div[@id='gtl_div']//table"
 
 
 details_page = Region(infoblock_type='detail')
@@ -91,7 +91,7 @@ class MiddlewareProvider(BaseProvider):
     detail_page_suffix = 'provider_detail'
     edit_page_suffix = 'provider_edit_detail'
     refresh_text = "Refresh items and relationships"
-    quad_name = None
+    quad_name = 'middleware'
     _properties_region = prop_region  # This will get resolved in common to a real form
     add_provider_button = form_buttons.FormButton("Add")
     save_button = form_buttons.FormButton("Save")
@@ -109,8 +109,9 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         tb.select("Grid View")
-        sel.check(paginator.check_all())
-        sel.uncheck(paginator.check_all())
+        if paginator.page_controls_exist():
+            sel.check(paginator.check_all())
+            sel.uncheck(paginator.check_all())
 
 
 @navigator.register(MiddlewareProvider, 'Add')
@@ -255,6 +256,7 @@ jdbc_driver_form = Form(
         ("jdbc_driver_name", Input("jdbc_driver_name_input")),
         ("jdbc_module_name", Input("jdbc_module_name_input")),
         ("jdbc_driver_class", Input("jdbc_driver_class_input")),
+        ("driver_xa_datasource_class", Input("driver_xa_datasource_class_name_input")),
         ("major_version", Input("major_version_input")),
         ("minor_version", Input("minor_version_input")),
         ('deploy_button', form_buttons.FormButton("Deploy", ng_click="addJdbcDriver()")),
@@ -352,7 +354,7 @@ class Container(SummaryMixin):
         flash.assert_success_message(self.deployment_message
                     .format(runtime_name if runtime_name else os.path.basename(filename)))
 
-    def add_jdbc_driver(self, filename, driver_name, module_name, driver_class,
+    def add_jdbc_driver(self, filename, driver_name, module_name, driver_class, xa_class=None,
                         major_version=None, minor_version=None, cancel=False):
         """Clicks to "Add JDBC Driver" button, in opened window fills fields by provided parameters,
         and deploys.
@@ -374,6 +376,7 @@ class Container(SummaryMixin):
                 "jdbc_driver_name": driver_name,
                 "jdbc_module_name": module_name,
                 "jdbc_driver_class": driver_class,
+                "driver_xa_datasource_class": xa_class,
                 "major_version": major_version,
                 "minor_version": minor_version
             })

--- a/cfme/middleware/server_group.py
+++ b/cfme/middleware/server_group.py
@@ -238,6 +238,12 @@ class MiddlewareServerGroup(MiddlewareBase, Taggable, Container, Navigatable):
         )
         sel.click(timeout_form.cancel_button if cancel else timeout_form.stop_button)
 
+    def is_immutable(self):
+        return not (tb.exists("Power") or
+                    tb.exists("Deployments") or
+                    tb.exists("JDBC Drivers") or
+                    tb.exists("Datasources"))
+
 
 @navigator.register(MiddlewareServerGroup, 'Details')
 class Details(CFMENavigateStep):

--- a/cfme/tests/middleware/jdbc_driver_methods.py
+++ b/cfme/tests/middleware/jdbc_driver_methods.py
@@ -79,10 +79,11 @@ def download_jdbc_driver(database_name):
 
 
 def deploy_jdbc_driver(provider, server, file_path, driver_name, module_name,
-                       driver_class, major_version=None, minor_version=None):
+                       driver_class, xa_class=None,
+                       major_version=None, minor_version=None):
     """Deploys JDBC driver file into provided server.
     Refreshes the provider relationships via REST call.
     """
     server.add_jdbc_driver(file_path, driver_name, module_name, driver_class,
-                           major_version, minor_version)
+                           xa_class, major_version, minor_version)
     provider.refresh_provider_relationships()

--- a/cfme/tests/middleware/test_middleware_deployment.py
+++ b/cfme/tests/middleware/test_middleware_deployment.py
@@ -252,9 +252,10 @@ def test_undeploy_disabled(provider, archive_name):
     check_deployment_not_listed(provider, server, runtime_name)
 
 
+@pytest.mark.uncollect
 def test_redeploy_fail(provider):
     """Tests Redeployment of already deployed archive into EAP7 server
-
+    @TODO enable when "alert-warning" notifications are handled.
     Steps:
         * Get servers list from UI
         * Chooses JBoss EAP server from list

--- a/cfme/tests/middleware/test_middleware_drivers.py
+++ b/cfme/tests/middleware/test_middleware_drivers.py
@@ -47,5 +47,6 @@ def test_deploy_driver(provider, driver):
                        driver_name=driver.driver_name,
                        module_name=driver.module_name,
                        driver_class=driver.driver_class,
+                       xa_class=driver.xa_class,
                        major_version=driver.major_version,
                        minor_version=driver.minor_version)

--- a/cfme/tests/middleware/test_middleware_provider.py
+++ b/cfme/tests/middleware/test_middleware_provider.py
@@ -95,7 +95,7 @@ def test_provider_add_with_bad_hostname(provider):
 def test_required_fields_validation(provider, soft_assert):
     """Test to validate all required fields while adding a provider"""
     navigate_to(provider, 'Add')
-    cred = Credential()
+    cred = Credential('', '')
     fill(provider.properties_form, {"type_select": "Hawkular"})
     soft_assert(not provider.add_provider_button.can_be_clicked)
     soft_assert(not form_buttons.validate.can_be_clicked)

--- a/cfme/tests/middleware/test_middleware_server_group.py
+++ b/cfme/tests/middleware/test_middleware_server_group.py
@@ -18,6 +18,7 @@ from deployment_methods import deploy
 from deployment_methods import RESOURCE_JAR_NAME, RESOURCE_WAR_NAME
 from deployment_methods import WAR_EXT, RESOURCE_WAR_NAME_NEW
 from deployment_methods import RESOURCE_WAR_CONTENT, RESOURCE_WAR_CONTENT_NEW
+from server_methods import get_domain_container_server
 
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
@@ -237,6 +238,22 @@ def test_redeploy_overwrite(provider, main_server_group):
     check_group_deployment_enabled(provider, main_server_group, runtime_name)
     check_group_deployment_content(provider, main_server_group, runtime_name.replace(WAR_EXT, ''),
                              RESOURCE_WAR_CONTENT_NEW)
+
+
+@pytest.mark.uncollect
+def test_container_server_group_immutability(provider):
+    """Tests container based EAP server group immutability on UI
+
+    Steps:
+        * Select container based EAP domain server details in UI
+        * Click on Relationships Middleware Server Group
+        * Verify that all menu items are disabled and server group is immutable
+    """
+    server = get_domain_container_server(provider)
+    srv_ui = server.server(method='ui')
+    assert srv_ui, "Server was not found in UI"
+    srv_group_ui = srv_ui.server_group(method='ui')
+    assert srv_group_ui.is_immutable(), "Server Group in container should be immutable"
 
 
 def get_server_group_set(server_groups):


### PR DESCRIPTION
Fixed failing Datasource tests because of UI changes. Disabled unnecessary tests.

{{pytest: cfme/tests/middleware/test_middleware_server.py -v --use-provider hawkular}}