### PR TITLE
[1LP][RFR] remove rest_api fixture from test_instance_power_control

### DIFF
--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -31,7 +31,7 @@ def testing_instance(setup_provider, provider):
     """
     instance = Instance.factory(random_vm_name('pwr-c'), provider)
     if not provider.mgmt.does_vm_exist(instance.name):
-        instance.create_on_provider(timeout=1000, allow_skip="default", find_in_cfme=True)
+        instance.create_on_provider(timeout=2000, allow_skip="default", find_in_cfme=True)
     elif instance.provider.type == "ec2" and \
             provider.mgmt.is_vm_state(instance.name, provider.mgmt.states['deleted']):
         provider.mgmt.set_name(


### PR DESCRIPTION
* remove `rest_api` fixture
* minor cleanups

{{pytest: -v -k TestInstanceRESTAPI --use-provider ec2west --long-running cfme/tests/cloud/test_instance_power_control.py}}