### PR TITLE
[1LP][RFR] remove rest_api fixture from test_rest_templates

### DIFF
--- a/cfme/tests/infrastructure/test_rest_templates.py
+++ b/cfme/tests/infrastructure/test_rest_templates.py
@@ -8,7 +8,7 @@ from cfme.rest.gen_data import vm as _vm
 from utils import error
 from utils.blockers import BZ
 
-pytestmark = [pytest.mark.ignore_stream("5.4"), test_requirements.rest]
+pytestmark = [test_requirements.rest]
 
 
 @pytest.fixture(scope="module")
@@ -17,34 +17,34 @@ def a_provider(request):
 
 
 @pytest.fixture(scope="function")
-def vm(request, a_provider, rest_api_modscope):
-    return _vm(request, a_provider, rest_api_modscope)
+def vm(request, a_provider, appliance):
+    return _vm(request, a_provider, appliance.rest_api)
 
 
 @pytest.fixture(scope="function")
-def template(request, rest_api, a_provider, vm):
-    template = mark_vm_as_template(rest_api, provider=a_provider, vm_name=vm)
+def template(request, appliance, a_provider, vm):
+    template = mark_vm_as_template(appliance.rest_api, provider=a_provider, vm_name=vm)
 
     @request.addfinalizer
     def _finished():
-        if template.id in rest_api.collections.templates:
-            rest_api.collections.templates.action.delete(*template)
+        if template.id in appliance.rest_api.collections.templates:
+            appliance.rest_api.collections.templates.action.delete(*template)
 
     return template
 
 
 @pytest.mark.tier(3)
 @pytest.mark.parametrize("from_detail", [True, False], ids=["from_detail", "from_collection"])
-def test_set_ownership(rest_api, template, from_detail):
+def test_set_ownership(appliance, template, from_detail):
     """Tests setting of template ownership.
 
     Metadata:
         test_flag: rest
     """
-    if "set_ownership" not in rest_api.collections.templates.action.all:
+    if "set_ownership" not in appliance.rest_api.collections.templates.action.all:
         pytest.skip("set_ownership action for templates is not implemented in this version")
-    group = rest_api.collections.groups.get(description='EvmGroup-super_administrator')
-    user = rest_api.collections.users.get(userid='admin')
+    group = appliance.rest_api.collections.groups.get(description='EvmGroup-super_administrator')
+    user = appliance.rest_api.collections.users.get(userid='admin')
     data = {
         "owner": {"href": user.href},
         "group": {"href": group.href}
@@ -53,8 +53,8 @@ def test_set_ownership(rest_api, template, from_detail):
         template.action.set_ownership(**data)
     else:
         data["href"] = template.href
-        rest_api.collections.templates.action.set_ownership(**data)
-    assert rest_api.response.status_code == 200
+        appliance.rest_api.collections.templates.action.set_ownership(**data)
+    assert appliance.rest_api.response.status_code == 200
     template.reload()
     assert hasattr(template, "evm_owner_id")
     assert template.evm_owner_id == user.id
@@ -63,43 +63,43 @@ def test_set_ownership(rest_api, template, from_detail):
 
 
 @pytest.mark.tier(2)
-@pytest.mark.meta(blockers=[BZ(1422807, forced_streams=["5.6", "5.7", "upstream"])])
-def test_delete_template_from_detail_post(rest_api, template):
+@pytest.mark.meta(blockers=[BZ(1422807, forced_streams=["5.7"])])
+def test_delete_template_from_detail_post(appliance, template):
     """Tests deletion of template from detail using POST method.
 
     Metadata:
         test_flag: rest
     """
     template.action.delete(force_method="post")
-    assert rest_api.response.status_code == 200
+    assert appliance.rest_api.response.status_code == 200
     with error.expected("ActiveRecord::RecordNotFound"):
         template.action.delete(force_method="post")
-    assert rest_api.response.status_code == 404
+    assert appliance.rest_api.response.status_code == 404
 
 
 @pytest.mark.tier(2)
-def test_delete_template_from_detail_delete(rest_api, template):
+def test_delete_template_from_detail_delete(appliance, template):
     """Tests deletion of template from detail using DELETE method.
 
     Metadata:
         test_flag: rest
     """
     template.action.delete(force_method="delete")
-    assert rest_api.response.status_code == 204
+    assert appliance.rest_api.response.status_code == 204
     with error.expected("ActiveRecord::RecordNotFound"):
         template.action.delete(force_method="delete")
-    assert rest_api.response.status_code == 404
+    assert appliance.rest_api.response.status_code == 404
 
 
 @pytest.mark.tier(2)
-def test_delete_template_from_collection(rest_api, template):
+def test_delete_template_from_collection(appliance, template):
     """Tests deletion of template from collection.
 
     Metadata:
         test_flag: rest
     """
-    rest_api.collections.templates.action.delete(template)
-    assert rest_api.response.status_code == 200
+    appliance.rest_api.collections.templates.action.delete(template)
+    assert appliance.rest_api.response.status_code == 200
     with error.expected("ActiveRecord::RecordNotFound"):
-        rest_api.collections.templates.action.delete(template)
-    assert rest_api.response.status_code == 404
+        appliance.rest_api.collections.templates.action.delete(template)
+    assert appliance.rest_api.response.status_code == 404

--- a/cfme/tests/infrastructure/test_rest_templates.py
+++ b/cfme/tests/infrastructure/test_rest_templates.py
@@ -6,7 +6,7 @@ from cfme.rest.gen_data import a_provider as _a_provider
 from cfme.rest.gen_data import mark_vm_as_template
 from cfme.rest.gen_data import vm as _vm
 from utils import error
-from utils.blockers import BZ
+from utils.version import current_version
 
 pytestmark = [test_requirements.rest]
 
@@ -63,7 +63,8 @@ def test_set_ownership(appliance, template, from_detail):
 
 
 @pytest.mark.tier(2)
-@pytest.mark.meta(blockers=[BZ(1422807, forced_streams=["5.7"])])
+# BZ1422807 that was fixed only in 5.8
+@pytest.mark.uncollectif(lambda: current_version() < '5.8')
 def test_delete_template_from_detail_post(appliance, template):
     """Tests deletion of template from detail using POST method.
 


### PR DESCRIPTION
removing the `res_api` fixture + old cruft

{{pytest: -v cfme/tests/infrastructure/test_rest_templates.py}}