### PR TITLE
[RFR][1LP] Update test_html5_ssl_files_present

### DIFF
--- a/cfme/tests/test_appliance.py
+++ b/cfme/tests/test_appliance.py
@@ -156,9 +156,6 @@ def test_html5_ssl_files_present(appliance, soft_assert):
         # Test for files existance
         assert appliance.ssh_client.run_command("test -f '{}'".format(ssl_file)) == 0
 
-        # Test if the file is different from what was delivered via RPM.
-        assert appliance.ssh_client.run_command("rpm -V cfme|grep '{}$'".format(ssl_file)) == 0
-
 
 @pytest.mark.ignore_stream("upstream")
 def test_db_connection(appliance):


### PR DESCRIPTION
The validation against rpm isn't necessary as far as I can tell, those ssl files are generated by the IPappliance object's configuration methods on deployment. Found during template testing of CFME, will fail against MIQ because it isn't delivered via rpm.

Didn't really mean to create this branch on the main repo, but its here now. I can delete now, or after we merge...

@jamesooden Thoughts?

{{ pytest: -m smoke }}