### PR TITLE
[WIPTEST] Ad-Hoc matrix basic test 

### DIFF
--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -367,6 +367,24 @@ class ContainersTestItem(object):
             self.polarion_id)
 
 
+def get_object_name(obj):
+    return obj.__module__.title().split(".")[-1]
+
+
+def obj_factory(obj_creator, row, provider):
+
+    factory = {"Provider": lambda row: {"name": row.name.text},
+               "Project": lambda row: {"name": row.name.text, "provider": provider},
+               "Pod": lambda row: {"name": row.name.text, "provider": provider},
+               "Node": lambda row: {"name": row.name.text, "provider": provider},
+               "Template": lambda row: {"name": row.name.text, "provider": provider},
+               "Image": lambda row: {"name": row.name.text,
+                                     "tag": row.tag.text, "provider": provider},
+               "Image_Registry": lambda row: {"host": row.host.text, "provider": provider}}
+
+    return obj_creator(**factory[get_object_name(obj_creator)](row))
+
+
 def navigate_and_get_rows(provider, obj, count, table_class=CheckboxTable,
                           silent_failure=False):
     """Get <count> random rows from the obj list table,

--- a/cfme/tests/containers/test_ad_hoc_matrix.py
+++ b/cfme/tests/containers/test_ad_hoc_matrix.py
@@ -1,5 +1,6 @@
 import pytest
 from utils import testgen
+from utils.log import logger
 from cfme.containers.provider import ContainersProvider, navigate_and_get_rows, obj_factory
 from utils.version import current_version
 from cfme.web_ui import toolbar, tabstrip, form_buttons
@@ -21,7 +22,7 @@ def matrics_up_and_running(provider):
     response = requests.get("https://{url}:443".format(url=hawkular_url), verify=False)
     if not response.ok:
         raise Exception("hawkular failed started!")
-    print "hawkular started successfully"
+    logger.info("hawkular started successfully")
 
 
 def set_hawkular_without_validation(provider_object):
@@ -48,18 +49,3 @@ def test_ad_hoc_metrics_overview(provider):
     set_hawkular_without_validation(provider_object)
 
     navigate_to_ad_hoc_page(provider_object)
-
-
-@pytest.mark.polarion('CMP-10645')
-def test_ad_hoc_metrics_select_filter(provider):
-    matrics_up_and_running(provider)
-
-    chosen_provider = navigate_and_get_rows(provider, ContainersProvider, 1).pop()
-    provider_object = obj_factory(ContainersProvider, chosen_provider, provider)
-
-    # TODO: replace with pavelz code if marged
-    set_hawkular_without_validation(provider_object)
-
-    navigate_to_ad_hoc_page(provider_object)
-
-    # TODO: implementat for steps of entering a filter by pressing the button

--- a/cfme/tests/containers/test_ad_hoc_matrix.py
+++ b/cfme/tests/containers/test_ad_hoc_matrix.py
@@ -3,7 +3,9 @@ import re
 from cfme.containers.provider import ContainersProvider
 from utils import testgen
 from utils import conf
+import httplib
 from utils.ssh import SSHClient
+from utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
 from utils.version import current_version
 
 
@@ -13,7 +15,29 @@ pytestmark = [
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
 
+def access_https(url):
+    c = httplib.HTTPSConnection(url)
+    c.request("GET", "/")
+    response = c.getresponse()
+    data = response.read()
+    status = response.status
+    return {"status": status, "data": data}
 
-@pytest.mark.polarion('CMP-10643'):
-def test_basic_metrics(provider):
+def matrics_up_and_running(provider):
+        routers = [router for router in provider.mgmt.o_api.get('route')[1]['items'] if
+                   router["metadata"]["name"] == "hawkular-metrics"]
+        hawkular_urls = [router["status"]["ingress"][0]["host"] for router in routers]
+        responses = [access_https(url) for url in hawkular_urls]
+        if not all(["A time series metrics engine based on Cassandra" in response.get("data") and
+                    response.get("status") == 200 for response in responses]):
+            raise Exception("matrices not started")
+        print "Matrix started successfully"
+
+@pytest.mark.polarion('CMP-10643')
+def test_ad_hoc_metrics_overview(provider):
     pass
+
+@pytest.mark.polarion('CMP-10645')
+def test_ad_hoc_metrics_select_filter(provider):
+    pass
+

--- a/cfme/tests/containers/test_ad_hoc_matrix.py
+++ b/cfme/tests/containers/test_ad_hoc_matrix.py
@@ -2,7 +2,7 @@ import pytest
 from utils import testgen
 from cfme.containers.provider import ContainersProvider, navigate_and_get_rows, obj_factory
 from utils.version import current_version
-from cfme.web_ui import toolbar
+from cfme.web_ui import toolbar, tabstrip, form_buttons
 from utils.appliance.implementations.ui import navigate_to
 
 pytestmark = [
@@ -24,19 +24,42 @@ def matrics_up_and_running(provider):
     print "hawkular started successfully"
 
 
+def set_hawkular_without_validation(provider_object):
+    navigate_to(provider_object, 'Details')
+    toolbar.select('Configurations', 'Edit this Containers Provider')
+    tabstrip.select_tab("Hawkular")
+    form_buttons.validate()
+
+
+def navigate_to_ad_hoc_page(provider_object):
+    navigate_to(provider_object, 'Details')
+    is_greyed = toolbar.is_greyed('Monitoring', 'Ad hoc Metrics')
+    assert not is_greyed, "Monitoring --> Ad hoc Metrics not activated despite provider was set"
+
+
 @pytest.mark.polarion('CMP-10643')
 def test_ad_hoc_metrics_overview(provider):
     matrics_up_and_running(provider)
+
     chosen_provider = navigate_and_get_rows(provider, ContainersProvider, 1).pop()
     provider_object = obj_factory(ContainersProvider, chosen_provider, provider)
-    navigate_to(provider_object, 'Details')
-    try:
-        toolbar.select('Monitoring', 'Ad hoc Metrics')
-    except Exception as ex:
-        print "args:\n{args}".format(args=ex.args)
-        print "message:\n{message}".format(message=ex.message)
-        raise Exception("naviation to Ad hoc Metrics failed!")
 
-# @pytest.mark.polarion('CMP-10645')
-# def test_ad_hoc_metrics_select_filter(provider):
-#     pass
+    # TODO: replace with pavelz code if marged
+    set_hawkular_without_validation(provider_object)
+
+    navigate_to_ad_hoc_page(provider_object)
+
+
+@pytest.mark.polarion('CMP-10645')
+def test_ad_hoc_metrics_select_filter(provider):
+    matrics_up_and_running(provider)
+
+    chosen_provider = navigate_and_get_rows(provider, ContainersProvider, 1).pop()
+    provider_object = obj_factory(ContainersProvider, chosen_provider, provider)
+
+    # TODO: replace with pavelz code if marged
+    set_hawkular_without_validation(provider_object)
+
+    navigate_to_ad_hoc_page(provider_object)
+
+    # TODO: implementat for steps of entering a filter by pressing the button

--- a/cfme/tests/containers/test_ad_hoc_matrix.py
+++ b/cfme/tests/containers/test_ad_hoc_matrix.py
@@ -1,0 +1,19 @@
+import pytest
+import re
+from cfme.containers.provider import ContainersProvider
+from utils import testgen
+from utils import conf
+from utils.ssh import SSHClient
+from utils.version import current_version
+
+
+pytestmark = [
+    pytest.mark.uncollectif(lambda provider: current_version() < "5.6"),
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.tier(1)]
+pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
+
+
+@pytest.mark.polarion('CMP-10643'):
+def test_basic_metrics(provider):
+    pass


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_ad_hoc_matrix.py -v --use-provider cm-env1 }}

# summary
This PR contains new ad hoc test and adding factory function to common functions

## Ad-Hoc test:
The test validating that ad hoc matrix is available when OSE provider is set on the system.

## Common function:
Many times we have to get random instance (using navigate_and_get_rows) and create python object from the selected instance. the factory function actual get the selected row and return the required object.
