### PR TITLE
[RFR][1LP] Added Labels test

### DIFF
--- a/cfme/containers/container.py
+++ b/cfme/containers/container.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from functools import partial
+import random
 
 from navmazing import NavigateToSibling, NavigateToAttribute
 
@@ -42,6 +43,23 @@ class Container(Taggable, SummaryMixin, Navigatable):
         """
         self.load_details(refresh=True)
         return details_page.infoblock.text(*ident)
+
+    @property
+    def project_name(self):
+        return self.pod.project_name
+
+    @classmethod
+    def get_random_instances(cls, provider, count=1, appliance=None):
+        """Generating random instances."""
+        containers_list = provider.mgmt.list_container()
+        instances = []
+        random.shuffle(containers_list)
+        while containers_list and len(instances) < count:
+            chosen = containers_list.pop()
+            instances.append(
+                cls(chosen.name, chosen.cg_name, appliance=appliance)
+            )
+        return instances
 
 
 @navigator.register(Container, 'All')

--- a/cfme/containers/image_registry.py
+++ b/cfme/containers/image_registry.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from functools import partial
+import random
 
 from navmazing import NavigateToSibling, NavigateToAttribute
 
@@ -34,6 +35,19 @@ class ImageRegistry(Taggable, SummaryMixin, Navigatable):
     @property
     def name(self):
         return self.host
+
+    @classmethod
+    def get_random_instances(cls, provider, count=1, appliance=None):
+        """Generating random instances."""
+        ir_list = provider.mgmt.list_image_registry()
+        instances = []
+        random.shuffle(ir_list)
+        while ir_list and len(instances) < count:
+            chosen = ir_list.pop()
+            instances.append(
+                cls(chosen.host, provider, appliance=appliance)
+            )
+        return instances
 
 
 @navigator.register(ImageRegistry, 'All')

--- a/cfme/containers/node.py
+++ b/cfme/containers/node.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # added new list_tbl definition
 from functools import partial
+import random
+
 from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.widget import View, Text
 from widgetastic_manageiq import (
@@ -9,7 +11,7 @@ from widgetastic_patternfly import Dropdown
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.common import Taggable, SummaryMixin
-from cfme.containers.provider import ContainersProvider
+from cfme.containers.provider import ContainersProvider, Labelable
 from cfme.exceptions import NodeNotFound
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import CheckboxTable, toolbar as tb, InfoBlock, match_location
@@ -75,7 +77,7 @@ class NodeAllView(NodeView):
     paginator = PaginationPane()
 
 
-class Node(Taggable, SummaryMixin, Navigatable):
+class Node(Taggable, Labelable, SummaryMixin, Navigatable):
     def __init__(self, name, provider, collection=None, appliance=None):
         self.name = name
         self.provider = provider
@@ -97,6 +99,19 @@ class Node(Taggable, SummaryMixin, Navigatable):
         """
         self.load_details()
         return InfoBlock.text(*ident)
+
+    @classmethod
+    def get_random_instances(cls, provider, count=1, appliance=None):
+        """Generating random instances."""
+        node_list = provider.mgmt.list_node()
+        instances = []
+        random.shuffle(node_list)
+        while node_list and len(instances) < count:
+            chosen = node_list.pop()
+            instances.append(
+                cls(chosen.name, provider, appliance=appliance)
+            )
+        return instances
 
 
 # Still registering Node to keep on consistency on container objects navigations

--- a/cfme/containers/project.py
+++ b/cfme/containers/project.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
+import random
+
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import toolbar as tb, paginator, match_location,\
     PagedTable, CheckboxTable
-from cfme.containers.provider import details_page
+from cfme.containers.provider import details_page, Labelable
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import CFMENavigateStep, navigator,\
     navigate_to
@@ -16,7 +18,7 @@ paged_tbl = PagedTable(table_locator="//div[@id='list_grid']//table")
 match_page = partial(match_location, controller='container_projects', title='Projects')
 
 
-class Project(Taggable, SummaryMixin, Navigatable):
+class Project(Taggable, Labelable, SummaryMixin, Navigatable):
 
     def __init__(self, name, provider, appliance=None):
         self.name = name
@@ -40,6 +42,19 @@ class Project(Taggable, SummaryMixin, Navigatable):
         """
         self.load_details(refresh=True)
         return details_page.infoblock.text(*ident)
+
+    @classmethod
+    def get_random_instances(cls, provider, count=1, appliance=None):
+        """Generating random instances."""
+        project_list = provider.mgmt.list_project()
+        instances = []
+        random.shuffle(project_list)
+        while project_list and len(instances) < count:
+            chosen = project_list.pop()
+            instances.append(
+                cls(chosen.name, provider, appliance=appliance)
+            )
+        return instances
 
 
 @navigator.register(Project, 'All')

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -1,7 +1,10 @@
+from cached_property import cached_property
+
 from . import ContainersProvider
 from utils.varmeth import variable
 from os import path
 from mgmtsystem.openshift import Openshift
+from utils.ocp_cli import OcpCli
 
 
 class CustomAttribute(object):
@@ -25,6 +28,10 @@ class OpenshiftProvider(ContainersProvider):
             name=name, credentials=credentials, key=key, zone=zone, hostname=hostname, port=port,
             sec_protocol=sec_protocol, hawkular_sec_protocol=hawkular_sec_protocol,
             provider_data=provider_data, appliance=appliance)
+
+    @cached_property
+    def cli(self):
+        return OcpCli(self)
 
     def href(self):
         return self.appliance.rest_api.collections.providers\

--- a/cfme/containers/replicator.py
+++ b/cfme/containers/replicator.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
+import random
+
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import toolbar as tb, paginator, match_location,\
     PagedTable, CheckboxTable
-from cfme.containers.provider import details_page
+from cfme.containers.provider import details_page, Labelable
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep,\
     navigate_to
@@ -16,10 +18,11 @@ paged_tbl = PagedTable(table_locator="//div[@id='list_grid']//table")
 match_page = partial(match_location, controller='container_replicators', title='Replicators')
 
 
-class Replicator(Taggable, SummaryMixin, Navigatable):
+class Replicator(Taggable, Labelable, SummaryMixin, Navigatable):
 
-    def __init__(self, name, provider, appliance=None):
+    def __init__(self, name, project_name, provider, appliance=None):
         self.name = name
+        self.project_name = project_name
         self.provider = provider
         Navigatable.__init__(self, appliance=appliance)
 
@@ -41,6 +44,19 @@ class Replicator(Taggable, SummaryMixin, Navigatable):
         """
         self.load_details(refresh=True)
         return details_page.infoblock.text(*ident)
+
+    @classmethod
+    def get_random_instances(cls, provider, count=1, appliance=None):
+        """Generating random instances."""
+        rc_list = provider.mgmt.list_replication_controller()
+        instances = []
+        random.shuffle(rc_list)
+        while rc_list and len(instances) < count:
+            chosen = rc_list.pop()
+            instances.append(
+                cls(chosen.name, chosen.project_name, provider, appliance=appliance)
+            )
+        return instances
 
 
 @navigator.register(Replicator, 'All')
@@ -66,4 +82,5 @@ class Details(CFMENavigateStep):
 
     def step(self):
         tb.select('List View')
-        sel.click(paged_tbl.find_row_by_cell_on_all_pages({'Name': self.obj.name}))
+        sel.click(paged_tbl.find_row_by_cell_on_all_pages({'Name': self.obj.name,
+                                                           'Project Name': self.obj.project_name}))

--- a/cfme/containers/route.py
+++ b/cfme/containers/route.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
+import random
+
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import toolbar as tb, paginator, match_location,\
     PagedTable, CheckboxTable
-from cfme.containers.provider import details_page
+from cfme.containers.provider import details_page, Labelable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep,\
     navigate_to
 from navmazing import NavigateToAttribute, NavigateToSibling
@@ -16,10 +18,11 @@ paged_tbl = PagedTable(table_locator="//div[@id='list_grid']//table")
 match_page = partial(match_location, controller='container_routes', title='Routes')
 
 
-class Route(Taggable, SummaryMixin, Navigatable):
+class Route(Taggable, Labelable, SummaryMixin, Navigatable):
 
-    def __init__(self, name, provider, appliance=None):
+    def __init__(self, name, project_name, provider, appliance=None):
         self.name = name
+        self.project_name = project_name
         self.provider = provider
         Navigatable.__init__(self, appliance=appliance)
 
@@ -40,6 +43,19 @@ class Route(Taggable, SummaryMixin, Navigatable):
         """
         self.load_details(refresh=True)
         return details_page.infoblock.text(*ident)
+
+    @classmethod
+    def get_random_instances(cls, provider, count=1, appliance=None):
+        """Generating random instances."""
+        route_list = provider.mgmt.list_route()
+        instances = []
+        random.shuffle(route_list)
+        while route_list and len(instances) < count:
+            chosen = route_list.pop()
+            instances.append(
+                cls(chosen.name, chosen.project_name, provider, appliance=appliance)
+            )
+        return instances
 
 
 @navigator.register(Route, 'All')
@@ -65,4 +81,5 @@ class Details(CFMENavigateStep):
 
     def step(self):
         tb.select('List View')
-        sel.click(paged_tbl.find_row_by_cell_on_all_pages({'Name': self.obj.name}))
+        sel.click(paged_tbl.find_row_by_cell_on_all_pages({'Name': self.obj.name,
+                                                           'Project Name': self.obj.project_name}))

--- a/cfme/containers/service.py
+++ b/cfme/containers/service.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
+import random
+
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import toolbar as tb, paginator, match_location,\
     PagedTable, CheckboxTable
-from cfme.containers.provider import details_page
+from cfme.containers.provider import details_page, Labelable
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep,\
     navigate_to
@@ -16,11 +18,12 @@ paged_tbl = PagedTable(table_locator="//div[@id='list_grid']//table")
 match_page = partial(match_location, controller='container_service', title='Services')
 
 
-class Service(Taggable, SummaryMixin, Navigatable):
+class Service(Taggable, Labelable, SummaryMixin, Navigatable):
 
-    def __init__(self, name, provider, appliance=None):
+    def __init__(self, name, project_name, provider, appliance=None):
         self.name = name
         self.provider = provider
+        self.project_name = project_name
         Navigatable.__init__(self, appliance=appliance)
 
     def load_details(self, refresh=False):
@@ -40,6 +43,19 @@ class Service(Taggable, SummaryMixin, Navigatable):
         """
         self.load_details(refresh=True)
         return details_page.infoblock.text(*ident)
+
+    @classmethod
+    def get_random_instances(cls, provider, count=1, appliance=None):
+        """Generating random instances."""
+        service_list = provider.mgmt.list_service()
+        instances = []
+        random.shuffle(service_list)
+        while service_list and len(instances) < count:
+            chosen = service_list.pop()
+            instances.append(
+                cls(chosen.name, chosen.project_name, provider, appliance=appliance)
+            )
+        return instances
 
 
 @navigator.register(Service, 'All')
@@ -65,4 +81,5 @@ class Details(CFMENavigateStep):
 
     def step(self):
         tb.select('List View')
-        sel.click(paged_tbl.find_row_by_cell_on_all_pages({'Name': self.obj.name}))
+        sel.click(paged_tbl.find_row_by_cell_on_all_pages({'Name': self.obj.name,
+                                                           'Project Name': self.obj.project_name}))

--- a/cfme/containers/template.py
+++ b/cfme/containers/template.py
@@ -1,5 +1,11 @@
 # -*- coding: utf-8 -*-
+import random
+from functools import partial
+
+from navmazing import NavigateToAttribute, NavigateToSibling
+
 from cfme.common import SummaryMixin, Taggable
+from cfme.containers.provider import Labelable
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import toolbar as tb, paginator, match_location,\
     PagedTable, CheckboxTable
@@ -7,8 +13,6 @@ from .provider import details_page
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep,\
     navigate_to
-from navmazing import NavigateToAttribute, NavigateToSibling
-from functools import partial
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
 paged_tbl = PagedTable(table_locator="//div[@id='list_grid']//table")
@@ -16,10 +20,11 @@ paged_tbl = PagedTable(table_locator="//div[@id='list_grid']//table")
 match_page = partial(match_location, controller='container_templates', title='Container Templates')
 
 
-class Template(Taggable, SummaryMixin, Navigatable):
+class Template(Taggable, Labelable, SummaryMixin, Navigatable):
 
-    def __init__(self, name, provider, appliance=None):
+    def __init__(self, name, project_name, provider, appliance=None):
         self.name = name
+        self.project_name = project_name
         self.provider = provider
         Navigatable.__init__(self, appliance=appliance)
 
@@ -41,6 +46,19 @@ class Template(Taggable, SummaryMixin, Navigatable):
         """
         self.load_details(refresh=True)
         return details_page.infoblock.text(*ident)
+
+    @classmethod
+    def get_random_instances(cls, provider, count=1, appliance=None):
+        """Generating random instances."""
+        template_list = provider.mgmt.list_template()
+        instances = []
+        random.shuffle(template_list)
+        while template_list and len(instances) < count:
+            chosen = template_list.pop()
+            instances.append(
+                cls(chosen.name, chosen.project_name, provider, appliance=appliance)
+            )
+        return instances
 
 
 @navigator.register(Template, 'All')
@@ -66,4 +84,5 @@ class Details(CFMENavigateStep):
 
     def step(self):
         tb.select('List View')
-        sel.click(paged_tbl.find_row_by_cell_on_all_pages({'Name': self.obj.name}))
+        sel.click(paged_tbl.find_row_by_cell_on_all_pages({'Name': self.obj.name,
+                                                           'Project Name': self.obj.project_name}))

--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -387,6 +387,16 @@ class DbAllocatorConfigNotFound(CFMEException):
     """Raised when cdme_data.yaml file does not contain configuration of 'db_allocator'."""
 
 
+class SetLabelException(Exception):
+    "Raised when failed to set label to an object via cli"
+    pass
+
+
+class LabelNotFoundException(Exception):
+    "Raises when failed to remove label from object via cli"
+    pass
+
+
 class UsingSharedTables(CFMEException):
     """Raised if the :py:class:`cfme.web_ui.Table` suspects there is a use of shared tables."""
 

--- a/cfme/tests/containers/test_labels.py
+++ b/cfme/tests/containers/test_labels.py
@@ -1,0 +1,115 @@
+import random
+from traceback import format_exc
+from collections import namedtuple
+
+import pytest
+import fauxfactory
+
+from cfme.containers.provider import ContainersProvider
+from cfme.containers.pod import Pod
+from cfme.containers.service import Service
+from cfme.containers.node import Node
+from cfme.containers.replicator import Replicator
+from cfme.containers.image import Image
+from cfme.containers.project import Project
+from cfme.containers.route import Route
+from cfme.containers.template import Template
+from cfme.exceptions import SetLabelException
+
+from utils import testgen
+from utils.version import current_version
+from utils.wait import wait_for
+from utils.log import logger
+from utils.blockers import BZ
+
+
+pytestmark = [
+    pytest.mark.uncollectif(lambda provider: current_version() < "5.6"),
+    pytest.mark.usefixtures('setup_provider_modscope'),
+    pytest.mark.tier(1)]
+pytest_generate_tests = testgen.generate([ContainersProvider], scope='module')
+
+
+TEST_OBJECTS = (Pod, Service, Route, Template, Node, Replicator, Image, Project)
+
+
+def check_labels_in_ui(instance, name, expected_value):
+    if hasattr(instance.summary, 'labels') and \
+            hasattr(instance.summary.labels, name.lower()):
+        return getattr(instance.summary.labels, name.lower()).text_value == str(expected_value)
+    return False
+
+
+@pytest.fixture(scope='module')
+def random_labels(provider, appliance):
+    # Creating random instance for each object in TEST_OBJECTS and create a random label for it.
+    label_data = namedtuple('label_data', ['instance', 'label_name', 'label_value',
+                                           'result_status', 'result_message'])
+    data_collection = []  # Collected data in the form:
+    #                <instance>, <label_name>, <label_value>, <results_status>
+    # Adding label to each object:
+    for test_obj in TEST_OBJECTS:
+        instance = test_obj.get_random_instances(provider, count=1, appliance=appliance).pop()
+        name = fauxfactory.gen_alpha(1) + fauxfactory.gen_alphanumeric(random.randrange(1, 62))
+        value = fauxfactory.gen_alphanumeric(random.randrange(1, 63))
+        try:
+            results = test_obj.set_label(instance, name, value)
+            result_status, result_message = results.success, str(results)
+        except SetLabelException:
+            result_status, result_message = False, format_exc()
+
+        data_collection.append(
+            label_data(instance, name, value, result_status, result_message)
+        )
+    return data_collection
+
+
+@pytest.mark.polarion('CMP-10572')
+def test_labels_create(provider, soft_assert, random_labels):
+
+    provider.refresh_provider_relationships()
+    # Verify that the labels appear in the UI:
+    for instance, label_name, label_value, results_status, results_message in random_labels:
+        if soft_assert(results_status, results_message):
+            soft_assert(
+                wait_for(
+                    lambda: check_labels_in_ui(instance, label_name, label_value),
+                    num_sec=120, delay=10,
+                    fail_func=instance.summary.reload,
+                    message='Verifying label ({} = {}) for {} {} exists'
+                            .format(label_name, label_value,
+                                    instance.__class__.__name__, instance.name),
+                    silent_failure=True),
+                'Could not find label ({} = {}) for {} {} in UI.'
+                .format(label_name, label_value, instance.__class__.__name__, instance.name)
+            )
+
+
+@pytest.mark.meta(blockers=[BZ(1451832, forced_streams=['5.7', '5.8', 'upstream'])])
+@pytest.mark.polarion('CMP-10572')
+def test_labels_remove(provider, soft_assert, random_labels):
+    # Removing the labels
+    for instance, label_name, label_value, results_status, _ in random_labels:
+        if results_status:
+            instance.remove_label(label_name)
+        else:
+            logger.warning('Cannot remove label ({} = {}) for {} {}. (failed to add it previously)'
+                           .format(label_name, label_value,
+                                   instance.__class__.__name__, instance.name))
+
+    provider.refresh_provider_relationships()
+    # Verify that the labels removed successfully from UI:
+    for instance, label_name, label_value, results_status, _ in random_labels:
+        if results_status:
+            soft_assert(
+                wait_for(
+                    lambda: not check_labels_in_ui(instance, label_name, label_value),
+                    num_sec=120, delay=10,
+                    fail_func=instance.summary.reload,
+                    message='Verifying label ({} = {}) for {} {} removed'
+                            .format(label_name, label_value,
+                                    instance.__class__.__name__, instance.name),
+                    silent_failure=True),
+                'Label ({} = {}) for {} {} found in UI (but should be removed).'
+                .format(label_name, label_value, instance.__class__.__name__, instance.name)
+            )

--- a/cfme/tests/containers/test_relationships.py
+++ b/cfme/tests/containers/test_relationships.py
@@ -109,10 +109,9 @@ def test_container_status_relationships_data_integrity(provider):
     rows = navigate_and_get_rows(provider, Pod, 3)
     if not rows:
         pytest.skip('No containers found to test. skipping...')
-    pod_names = [r.name.text for r in rows]
 
-    for name in pod_names:
-        obj = Pod(name, provider)
+    for row in rows:
+        obj = Pod(row.name.text, row.project_name.text, provider)
         assert obj.summary.relationships.containers.value == \
             obj.summary.container_statuses_summary.running.value + \
             obj.summary.container_statuses_summary.waiting.value + \

--- a/utils/ocp_cli.py
+++ b/utils/ocp_cli.py
@@ -1,0 +1,44 @@
+from utils import conf
+from utils.log import logger
+from utils.ssh import SSHClient
+
+
+class OcpCli(object):
+    """This class provides CLI functionality for Openshift provider.
+    """
+    def __init__(self, provider):
+
+        provider_cfme_data = provider.get_yaml_data()
+        self.hostname = provider_cfme_data['hostname']
+        creds = conf.configuration.yaycl_config.credentials
+        if hasattr(creds, provider.key):
+            prov_creds = getattr(creds, provider.key)
+            self.username = prov_creds.username
+            self.password = prov_creds.password
+            self.ssh_client = SSHClient(hostname=self.hostname,
+                                        username=self.username,
+                                        password=self.password)
+        else:
+            # Try with known hosts
+            self.ssh_client = SSHClient()
+            self.ssh_client.load_system_host_keys()
+            self.ssh_client.connect(self.hostname)
+        self._command_counter = 0
+        self.log_line_limit = 500
+
+    def run_command(self, *args, **kwargs):
+        logger.info('{} - Running SSH Command#{} : {}'
+                    .format(self.hostname, self._command_counter, args[0]))
+        results = self.ssh_client.run_command(*args, **kwargs)
+        results_short = results[:max((self.log_line_limit, len(results)))]
+        if results.success:
+            logger.info('{} - Command#{} - Succeed: {}'
+                        .format(self.hostname, self._command_counter, results_short))
+        else:
+            logger.warning('{} - Command#{} - Failed: {}'
+                           .format(self.hostname, self._command_counter, results_short))
+        self._command_counter += 1
+        return results
+
+    def close(self):
+        self.ssh_client.close()


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_labels.py -v --use-provider cm-env1}}

- Added label tests
- Changed Pod, Replicator, Route, Service constructors to get project name as argument (Required to differentiate among objects with the same name)
- Added utils/ocp_cli.py util which provide ssh access to openshift provider
- Added functionality to get random instances of each containers object
- Added Labalable class to provide label CRUD functionality for containers objects
- Get image from table by ID instead of name/tag