### PR TITLE
[RFR][1LP] fix for test_default_views  tests

### DIFF
--- a/cfme/configure/settings.py
+++ b/cfme/configure/settings.py
@@ -351,7 +351,7 @@ class DefaultView(Updateable, Navigatable):
         Navigatable.__init__(self, appliance=appliance)
 
     @classmethod
-    def set_default_view(cls, button_group_names, defaults):
+    def set_default_view(cls, button_group_names, defaults, fieldset=None):
 
         """This function sets default views for the objects.
         Args:
@@ -381,7 +381,7 @@ class DefaultView(Updateable, Navigatable):
 
         is_something_changed = False
         for button_group_name, default in zip(button_group_names, defaults):
-            bg = ButtonGroup(button_group_name)
+            bg = ButtonGroup(button_group_name, fieldset=fieldset)
             navigate_to(cls, 'All')
             if bg.active != default:
                 bg.choose(default)
@@ -391,8 +391,8 @@ class DefaultView(Updateable, Navigatable):
             sel.click(form_buttons.save)
 
     @classmethod
-    def get_default_view(cls, button_group_name):
-        bg = ButtonGroup(button_group_name)
+    def get_default_view(cls, button_group_name, fieldset=None):
+        bg = ButtonGroup(button_group_name, fieldset=fieldset)
         navigate_to(cls, 'All')
         return bg.active
 

--- a/cfme/tests/configure/test_default_views_cloud.py
+++ b/cfme/tests/configure/test_default_views_cloud.py
@@ -37,12 +37,12 @@ def select_two_quads():
 
 
 def set_and_test_default_view(group_name, view, page):
-    old_default = DefaultView.get_default_view(group_name)
-    DefaultView.set_default_view(group_name, view)
+    old_default = DefaultView.get_default_view(group_name, fieldset='Clouds')
+    DefaultView.set_default_view(group_name, view, fieldset='Clouds')
     navigate_to(page, 'All', use_resetter=False)
     # TODO replace view detection with widgets when all tested classes have them
     assert tb.is_active(view), "{} view setting failed".format(view)
-    DefaultView.set_default_view(group_name, old_default)
+    DefaultView.set_default_view(group_name, old_default, fieldset='Clouds')
 
 # BZ 1283118 written against 5.5 has a mix of what default views do and don't work on different
 # pages in different releases

--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -3464,7 +3464,7 @@ class DriftGrid(Pretty):
 
 
 class ButtonGroup(object):
-    def __init__(self, key):
+    def __init__(self, key, fieldset=None):
         """ A ButtonGroup is a set of buttons next to each other, as is used on the DefaultViews
         page.
 
@@ -3472,6 +3472,7 @@ class ButtonGroup(object):
             key: The name of the key field text before the button group.
         """
         self.key = key
+        self.fieldset = fieldset
 
     @property
     def _icon_tag(self):
@@ -3490,12 +3491,12 @@ class ButtonGroup(object):
     @property
     def locator(self):
         attr = re.sub(r"&amp;", "&", quoteattr(self.key))  # We don't need it in xpath
-        if version.current_version() < "5.5":
-            return '//td[@class="key" and normalize-space(.)={}]/..'.format(attr)
-        else:
-            return (
-                '//label[contains(@class, "control-label") and normalize-space(.)={}]/..'
-                .format(attr))
+        path = './/label[contains(@class, "control-label") and ' \
+               'normalize-space(.)={}]/..'.format(attr)
+        if self.fieldset:
+            fieldset = quoteattr(self.fieldset)
+            path = '//fieldset[./h3[normalize-space(.)={}]]/'.format(fieldset) + path
+        return path
 
     def locate(self):
         """ Moves to the element """


### PR DESCRIPTION
ButtonGroups control doesn't take into accout that settings page can have several labels with the same name. I've added fieldset property to make those tests work with buttons from correct fieldset
{{pytest: cfme/tests/configure/test_default_views_cloud.py}}