### PR TITLE
[1LP][RFR] remove report_safe_longrepr in favour of report.longreprtext #pytest3

### DIFF
--- a/fixtures/artifactor_plugin.py
+++ b/fixtures/artifactor_plugin.py
@@ -35,7 +35,6 @@ from utils.blockers import BZ, Blocker
 from utils.conf import env, credentials
 from utils.net import random_port, net_check
 from utils.wait import wait_for
-from utils.pytest_shortcuts import report_safe_longrepr
 from utils import version
 
 UNDER_TEST = False  # set to true for artifactor using tests
@@ -241,11 +240,11 @@ def pytest_runtest_logreport(report):
 
     if hasattr(report, 'skipped'):
         if report.skipped:
-            contents = report_safe_longrepr(report)
             fire_art_hook(
                 config, 'filedump',
                 test_location=location, test_name=name,
-                description="Short traceback", contents=contents,
+                description="Short traceback",
+                contents=report.longreprtext,
                 file_type="short_tb", group_id="skipped")
     fire_art_hook(
         config, 'report_test',

--- a/fixtures/browser.py
+++ b/fixtures/browser.py
@@ -32,7 +32,6 @@ def pytest_exception_interact(node, call, report):
     from fixtures.pytest_store import store
     from httplib import BadStatusLine
     from socket import error
-    from utils.pytest_shortcuts import report_safe_longrepr
     import urllib2
 
     val = safe_string(call.excinfo.value.message).decode('utf-8', 'ignore')
@@ -44,10 +43,9 @@ def pytest_exception_interact(node, call, report):
 
     short_tb = '{}\n{}'.format(
         call.excinfo.type.__name__, val.encode('ascii', 'xmlcharrefreplace'))
-    longrepr = report_safe_longrepr(report)
     fire_art_test_hook(
         node, 'filedump',
-        description="Traceback", contents=longrepr, file_type="traceback",
+        description="Traceback", contents=report.longreprtext, file_type="traceback",
         display_type="danger", display_glyph="align-justify", group_id="pytest-exception",
         slaveid=store.slaveid)
     fire_art_test_hook(
@@ -57,7 +55,7 @@ def pytest_exception_interact(node, call, report):
         slaveid=store.slaveid)
 
     # base64 encoded to go into a data uri, same for screenshots
-    full_tb = longrepr.encode('base64').strip()
+    full_tb = report.longreprtext.encode('base64').strip()
     # errors are when exceptions are thrown outside of the test call phase
     report.when = getattr(report, 'when', 'setup')
     is_error = report.when != 'call'

--- a/fixtures/log.py
+++ b/fixtures/log.py
@@ -3,7 +3,6 @@ import collections
 import pytest
 
 from utils import log
-from utils.pytest_shortcuts import report_safe_longrepr
 
 #: A dict of tests, and their state at various test phases
 test_tracking = collections.defaultdict(dict)
@@ -57,7 +56,7 @@ def pytest_runtest_logreport(report):
                 test_status)),
             extra={'source_file': path, 'source_lineno': lineno})
     if report.outcome == "skipped":
-        logger().info(log.format_marker(report_safe_longrepr(report)))
+        logger().info(log.format_marker(report.longreprtext))
 
 
 def pytest_exception_interact(node, call, report):

--- a/utils/pytest_shortcuts.py
+++ b/utils/pytest_shortcuts.py
@@ -16,21 +16,3 @@ def extract_fixtures_values(item):
         # This can cause some problems if the fixtures are used in the guards in this case, but
         # that will tell use where is the problem and we can then find it out properly.
         return {}
-
-
-def report_safe_longrepr(report):
-    """savely extract the longrepr text of a test report
-
-    Args:
-        report: a test report
-    Returns:
-        :py:class:`str` with the long repr text extracted
-    """
-    # Usualy longrepr's a tuple, other times it isn't... :(
-    try:
-        longrepr = report.longrepr[-1]
-    except (AttributeError, TypeError):
-        # type error for python 3 and pytest > 3
-        # Attributeerror for old style classes on python2
-        longrepr = str(report.longrepr)
-    return longrepr


### PR DESCRIPTION
i believe this should fix an error we started to see - unfortunately i don't have a direct way to replicate it