### PR TITLE
[1LP][RFR] Fixed and refactored test_compliance.py

### DIFF
--- a/cfme/configure/configuration/__init__.py
+++ b/cfme/configure/configuration/__init__.py
@@ -3,6 +3,7 @@ from navmazing import (NavigateToAttribute,
                        NavigateToSibling,
                        NavigateToObject,
                        NavigationDestinationNotFound)
+from widgetastic_patternfly import CandidateNotFound
 
 from contextlib import contextmanager
 from fixtures.pytest_store import store
@@ -245,7 +246,7 @@ class AnalysisProfile(Pretty, Updateable, Navigatable):
     def exists(self):
         try:
             navigate_to(self, 'Details')
-        except NavigationDestinationNotFound:
+        except (NavigationDestinationNotFound, CandidateNotFound):
             return False
         else:
             return True

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -544,8 +544,6 @@ def _fill_credential(form, cred, validate=None):
 
 def get_credentials_from_config(credential_config_name):
     creds = conf.credentials[credential_config_name]
-    logger.info('credential name: {cred}'.format(cred=credential_config_name))
-    logger.info('credentials itself: {cred}'.format(cred=creds))
     return Host.Credential(principal=creds['username'],
                            secret=creds['password'])
 

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -944,7 +944,7 @@ class VmAllWithTemplates(CFMENavigateStep):
         reset_page()
 
     def am_i_here(self, *args, **kwargs):
-            return match_page(summary='All VMs & Templates')
+        return match_page(summary='All VMs & Templates')
 
 
 @navigator.register(Template, 'AllForProvider')

--- a/cfme/tests/control/test_compliance.py
+++ b/cfme/tests/control/test_compliance.py
@@ -76,8 +76,9 @@ def assign_policy_for_testing(policy_for_testing, host, policy_profile_name):
 @pytest.yield_fixture(scope="module")
 def configure_fleecing(appliance, has_no_providers_modscope, provider, setup_provider_modscope):
     setup_providers_hosts_credentials(provider.key)
-    appliance.install_vddk(reboot=False, vddk_url=vddk_url_map[str(provider.version)])
-    appliance.reboot(quit_browser=True)
+    appliance.install_vddk(reboot=True, vddk_url=vddk_url_map[str(provider.version)])
+    appliance.reboot()
+    appliance.browser.quit_browser()
     yield
     appliance.uninstall_vddk()
 
@@ -113,8 +114,9 @@ def analysis_profile():
     )
     if ap.exists:
         ap.delete()
-    with ap:
-        yield ap
+    ap.create()
+    yield ap
+    ap.delete()
 
 
 def do_scan(vm, additional_item_check=None):

--- a/fixtures/provider.py
+++ b/fixtures/provider.py
@@ -229,6 +229,11 @@ def has_no_providers(request):
     BaseProvider.clear_providers()
 
 
+@pytest.fixture(scope="module")
+def has_no_providers_modscope(request):
+    BaseProvider.clear_providers()
+
+
 @pytest.fixture(scope="function")
 def setup_only_one_provider(request, has_no_providers):
     return setup_one_or_skip(request)

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -1633,7 +1633,7 @@ class IPAppliance(object):
         return result
 
     @logger_wrap("Rebooting Appliance: {}")
-    def reboot(self, wait_for_web_ui=True, quit_browser=False, log_callback=None):
+    def reboot(self, wait_for_web_ui=True, log_callback=None):
         log_callback('Rebooting appliance')
         client = self.ssh_client
 
@@ -1645,8 +1645,6 @@ class IPAppliance(object):
 
         if wait_for_web_ui:
             self.wait_for_web_ui()
-        if quit_browser:
-            self.browser.quit_browser()
 
     @logger_wrap("Waiting for web_ui: {}")
     def wait_for_web_ui(self, timeout=900, running=True, log_callback=None):


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ tests in cfme/tests/control/test_compliance.py.  Some core enhancements is required. After appliance rebooting the navigation is broken. I found a workaround in which you need just to close the browser to start the navigation cycle from the beginning.

{{pytest: -v -k 'test_check_package_presence' --long-running --use-provider vsphere6-nested}}