### PR TITLE
[RFR] added some logging to debug tricky credentials case

### DIFF
--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -544,6 +544,8 @@ def _fill_credential(form, cred, validate=None):
 
 def get_credentials_from_config(credential_config_name):
     creds = conf.credentials[credential_config_name]
+    logger.info('credential name: {cred}'.format(cred=credential_config_name))
+    logger.info('credentials itself: {cred}'.format(cred=creds))
     return Host.Credential(principal=creds['username'],
                            secret=creds['password'])
 


### PR DESCRIPTION
Some tests fail in jenkins with error KeyError: 'username'.
I cannot reproduce this locally. 
So, I'd like to temporarily add some logging in order to figure out where the issue is.
