### PR TITLE
[RFR] Fix in credentials.py

### DIFF
--- a/cfme/base/credential.py
+++ b/cfme/base/credential.py
@@ -2,6 +2,7 @@
 from cfme.web_ui import FileInput, Input, Radio, form_buttons
 from cfme.web_ui.tabstrip import TabStripForm
 from utils import conf
+from copy import deepcopy
 from utils.pretty import Pretty
 from utils.update import Updateable
 
@@ -9,7 +10,7 @@ from utils.update import Updateable
 class FromConfigMixin(object):
     @classmethod
     def from_config(cls, key):
-        creds = conf.credentials[key]
+        creds = deepcopy(conf.credentials[key])
 
         # todo: fix this along with other credential fixes. code or credentials conf ?
         to_rename = [('password', 'secret'), ('username', 'principal')]


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ credentials.py Without `deepcopy` of the `conf.credentials` it's possible to change original object which will affect in other places where `conf.credentials` called with the same key.

