### PR TITLE
[RFR][1LP] Update cleanup_old_vms, detailed reporting

### DIFF
--- a/scripts/cleanup_old_vms.py
+++ b/scripts/cleanup_old_vms.py
@@ -279,7 +279,7 @@ def cleanup_vms(texts, max_hours=24, providers=None, prompt=True):
     for thread in thread_queue:
         thread.join()
 
-    with open(args.outfile, 'a') as report:
+    with open(args.outfile, 'w') as report:
         report.write('## VM/Instances deleted via:\n'
                      '##   text matches: {}\n'
                      '##   age matches: {}\n'

--- a/scripts/cleanup_old_vms.py
+++ b/scripts/cleanup_old_vms.py
@@ -97,7 +97,7 @@ def get_vm_config_modified_time(host_name, vm_name, datastore_url, provider_key)
             'hostname': hostname
         }
         datastore_path = re.findall(r'([^ds:`/*].*)', str(datastore_url))
-        command = 'find ~/{} -name {}.vmx | xargs  date -r'.format(
+        command = 'find ~/{} -exec date -r {} \; -name {}.vmx | xargs  date -r'.format(
             pathjoin(datastore_path[0], vm_name),
             vm_name)
 
@@ -166,7 +166,7 @@ def process_provider_vms(provider_key, matchers, delta, vms_to_delete):
                 continue
 
         with lock:
-            print('{} finished'.format(provider_key))
+            print('{} finished processing for matches'.format(provider_key))
     except Exception as ex:
         with lock:
             # Print out the error message too because logs in the job get deleted
@@ -204,7 +204,7 @@ def delete_provider_vms(provider_key, provider_mgmt, names_ages):
             with lock:
                 deleted_vms_list.append([provider_key, vm_name, age, status, result])
     with lock:
-        print("{} is done!".format(provider_key))
+        print("{} is done deleting vms".format(provider_key))
 
 
 def cleanup_vms(texts, max_hours=24, providers=None, prompt=True):
@@ -289,8 +289,9 @@ def cleanup_vms(texts, max_hours=24, providers=None, prompt=True):
                            tablefmt='orgtbl')
         report.write(message)
     print(message)
-
     print("Deleting finished")
+
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/cleanup_old_vms.py
+++ b/scripts/cleanup_old_vms.py
@@ -279,7 +279,7 @@ def cleanup_vms(texts, max_hours=24, providers=None, prompt=True):
     for thread in thread_queue:
         thread.join()
 
-    with open(args.outfile, 'w') as report:
+    with open(args.outfile, 'a') as report:
         report.write('## VM/Instances deleted via:\n'
                      '##   text matches: {}\n'
                      '##   age matches: {}\n'
@@ -287,7 +287,7 @@ def cleanup_vms(texts, max_hours=24, providers=None, prompt=True):
         message = tabulate(deleted_vms_list,
                            headers=['Provider', 'Name', 'Age', 'Status', 'Delete RC'],
                            tablefmt='orgtbl')
-        report.write(message)
+        report.write(message + '\n')
     print(message)
     print("Deleting finished")
 

--- a/scripts/cleanup_old_vms.py
+++ b/scripts/cleanup_old_vms.py
@@ -5,22 +5,33 @@ import datetime
 import pytz
 import re
 import sys
-from collections import defaultdict
+from os.path import join as pathjoin
+from collections import defaultdict, namedtuple
 from dateutil import parser
 from tabulate import tabulate
 from threading import Lock, Thread
 from tzlocal import get_localzone
+from mgmtsystem.virtualcenter import VMWareSystem
 
 from utils import net
 from utils.log import logger
-from utils.conf import cfme_data
-from utils.conf import credentials
+from utils.conf import cfme_data, credentials
 from utils.path import log_path
 from utils.ssh import SSHClient
 from utils.providers import list_provider_keys, get_mgmt
 
 lock = Lock()
-providers_vm_list = []
+# Hold all the deleted vm's as a list, add in from all the threads with lock
+# Each items is a list containing: ['Provider', 'Name', 'Age', 'Status From Provider', 'Delete RC']
+deleted_vms_list = []
+
+# Constant strings for the report
+PASS = 'PASS'
+FAIL = 'FAIL'
+NULL = '--'
+
+NameAge = namedtuple('NameAge', 'name, age')
+HostCreds = namedtuple('HostCreds', 'hostname, cred_key')
 
 
 def parse_cmd_line():
@@ -33,16 +44,18 @@ def parse_cmd_line():
     parser.add_argument('--provider', dest='providers', action='append', default=None,
                         help='Provider(s) to inspect, can be used multiple times',
                         metavar='PROVIDER')
-    parser.add_argument('text_to_match', nargs='*', default=['^test_', '^jenkins', '^i-'],
-                        help='Regex in the name of vm to be affected, can be use multiple times'
-                             ' (Defaults to "^test_" and "^jenkins")')
     parser.add_argument('-l', '--list', default=False, action='store_true', dest='list_vms',
                         help='list vms of the specified "provider_type"')
     parser.add_argument('--provider-type', dest='provider_type', default='ec2, gce, azure',
                         help='comma separated list of the provider type, useful in case of gce,'
                              'azure, ec2 to get the insight into cost/vm listing')
-    parser.add_argument('--outfile', dest='outfile', default=log_path.join(
-        'cleanup_old_vms.log').strpath, help='outfile to list ')
+    parser.add_argument('--outfile', dest='outfile',
+                        default=log_path.join('cleanup_old_vms.log').strpath,
+                        help='outfile to list ')
+    parser.add_argument('text_to_match', nargs='*', default=['^test_', '^jenkins', '^i-'],
+                        help='Regex in the name of vm to be affected, can be use multiple times'
+                             ' (Defaults to "^test_" and "^jenkins")')
+
     args = parser.parse_args()
     return args
 
@@ -55,51 +68,59 @@ def match(matchers, vm_name):
         return False
 
 
-def get_vm_config_modified_time(name, vm_name, datastore_url, provider_key):
+def get_vm_config_modified_time(host_name, vm_name, datastore_url, provider_key):
+    """
+    SSH to provider and find modified date for VMX file
+    :param host_name: string the host to connect to
+    :param vm_name: string name of the vm
+    :param datastore_url: string datastore url in format ds:
+    :param provider_key: string provider key
+    :return:
+    """
     try:
         providers_data = cfme_data.get("management_systems", {})
-        hosts = providers_data[provider_key]['hosts']
-        host_creds = providers_data[provider_key].get('host_credentials', 'host_default')
-        hostname = [host['name'] for host in hosts if name in host['name']]
-        if not hostname:
-            hostname = re.findall(r'[0-9]+(?:\.[0-9]+){3}', name)
+        yaml_hosts = providers_data[provider_key]['hosts']
+        # pull host name and credentials from yaml, may be multiple hosts defined
+        hostname, host_cred_key = None, None  # Init in case not found in yaml
+        for host in yaml_hosts:
+            # Some of the vsphere environments are configured with IP as the host's name
+            if host_name in [host['name'], host.get('ipaddress')]:
+                hostname, host_cred_key = host['name'], host['credentials']
+                break
+
+        if not hostname or not host_cred_key:
+            raise KeyError('Could not find host {} and credentials for {} in yaml'
+                           .format(host_name, provider_key))
         connect_kwargs = {
-            'username': credentials[host_creds]['username'],
-            'password': credentials[host_creds]['password'],
-            'hostname': hostname[0]
+            'username': credentials[host_cred_key]['username'],
+            'password': credentials[host_cred_key]['password'],
+            'hostname': hostname
         }
         datastore_path = re.findall(r'([^ds:`/*].*)', str(datastore_url))
-        ssh_client = SSHClient(**connect_kwargs)
-        command = 'find ~/{}/{} -name {} | xargs  date -r'.format(
-            datastore_path[0], str(vm_name), str(vm_name) + '.vmx')
-        exit_status, output = ssh_client.run_command(command)
-        ssh_client.close()
-        modified_time = parser.parse(output.rstrip())
-        modified_time = modified_time.astimezone(pytz.timezone(str(get_localzone())))
-        return modified_time.replace(tzinfo=None)
+        command = 'find ~/{} -name {}.vmx | xargs  date -r'.format(
+            pathjoin(datastore_path[0], vm_name),
+            vm_name)
+
+        with SSHClient(**connect_kwargs) as ssh_client:
+            result = ssh_client.run_command(command)
+        parsed_time = parser.parse(str(result).rstrip())
+        return parsed_time.astimezone(pytz.timezone(str(get_localzone()))).replace(tzinfo=None)
     except Exception as e:
         logger.error(e)
         return False
 
 
-def list_provider_vms(provider_key):
-    try:
-        provider = get_mgmt(provider_key)
-        vm_list = provider.list_vm()
-        provider_type = cfme_data.get("management_systems", {})[provider_key].get('type')
-        now = datetime.datetime.now()
-        for vm_name in vm_list:
-            creation = provider.vm_creation_time(vm_name)
-            providers_vm_list.append([provider_type, provider_key, vm_name,
-                                      (now - creation), provider.vm_type(vm_name),
-                                      provider.vm_status(vm_name)])
-    except Exception as e:
-        logger.error('failed to list vms from provider {}'.format(provider_key))
-        logger.exception(e)
+def process_provider_vms(provider_key, matchers, delta, vms_to_delete):
+    """
+    Process the VMs on a given provider, comparing name and creation time.
+    Append vms meeting criteria to vms_to_delete
 
-
-def process_provider_vms(provider_key, provider_type, matchers,
-                         delta, vms_to_delete, list_vms=None):
+    :param provider_key: string provider key
+    :param matchers: matching strings
+    :param delta: time delta
+    :param vms_to_delete: the list of vms that should be deleted
+    :return: modifies vms_to_delete
+    """
     with lock:
         print('{} processing'.format(provider_key))
     try:
@@ -108,15 +129,14 @@ def process_provider_vms(provider_key, provider_type, matchers,
             # Known conf issue :)
             provider = get_mgmt(provider_key)
         vm_list = provider.list_vm()
-        if list_vms:
-            list_provider_vms(provider_key)
 
         for vm_name in vm_list:
             try:
                 if not match(matchers, vm_name):
                     continue
 
-                if provider_type == 'virtualcenter' and provider.vm_status(vm_name) == 'poweredOff':
+                if (isinstance(provider, VMWareSystem) and
+                        provider.vm_status(vm_name) == 'poweredOff'):
                     hostname = provider.get_vm_host_name(vm_name)
                     vm_config_datastore = provider.get_vm_config_files_path(vm_name)
                     datastore_url = provider.get_vm_datastore_path(vm_name, vm_config_datastore)
@@ -124,6 +144,16 @@ def process_provider_vms(provider_key, provider_type, matchers,
                                                                    datastore_url, provider_key)
                 else:
                     vm_creation_time = provider.vm_creation_time(vm_name)
+
+                if vm_creation_time is False:
+                    # This VM must have some problem, include in report even though we can't delete
+                    status = provider.vm_status(vm_name)
+                    deleted_vms_list.append([provider_key,
+                                             vm_name,
+                                             NULL,  # can't know age, failed getting creation date
+                                             status,
+                                             FAIL])
+                    raise Exception  # the except block message is accurate in this case
 
                 if vm_creation_time + delta < now:
                     vm_delta = now - vm_creation_time
@@ -145,54 +175,72 @@ def process_provider_vms(provider_key, provider_type, matchers,
         logger.exception(ex)
 
 
-def delete_provider_vms(provider_key, vm_names):
+def delete_provider_vms(provider_key, provider_mgmt, names_ages):
+    """
+    lock, lock, more locking. Need to convert caller to Process+Queue
+
+    :param provider_key: string provider name/key, for easy logging
+    :param provider_mgmt: provider mgmtsystem object
+    :param names_ages: list of NameAge namedtuples
+    :return: none
+    """
     with lock:
         print('Deleting VMs from {} ...'.format(provider_key))
 
-    try:
-        with lock:
-            provider = get_mgmt(provider_key)
-    except Exception as e:
-        with lock:
-            print("Could not retrieve the provider {}'s mgmt system ({}: {})".format(
-                provider_key, type(e).__name__, str(e)))
-            logger.exception(e)
-
-    for vm_name in vm_names:
+    for vm_name, age in names_ages:
         with lock:
             print("Deleting {} from {}".format(vm_name, provider_key))
         try:
-            provider.delete_vm(vm_name)
+            provider_mgmt.delete_vm(vm_name)
+            status = NULL
+            result = PASS
         except Exception as e:
+            status = provider_mgmt.vm_status(vm_name)
+            result = FAIL
             with lock:
                 print('Failed to delete {} on {}'.format(vm_name, provider_key))
                 logger.exception(e)
+        finally:
+            with lock:
+                deleted_vms_list.append([provider_key, vm_name, age, status, result])
     with lock:
         print("{} is done!".format(provider_key))
 
 
 def cleanup_vms(texts, max_hours=24, providers=None, prompt=True):
+    """
+    Main method for the cleanup process
+    Generates regex match objects
+    Checks providers for cleanup boolean in yaml
+    Checks provider connectivity (using ping)
+    Threads process_provider_vms to build list of vms to delete
+    Prompts user to continue with delete
+    Threads deleting of the vms
+
+    :param texts: list of strings to match against
+    :param max_hours: integer maximum number of hours that the VM can exist for
+    :param providers: list of provider keys
+    :param prompt: boolean, whether or not to prompt the user for each delete
+    :return: 0 if user declines delete when prompt is True
+    """
     providers = providers or list_provider_keys()
-    providers_data = cfme_data.get("management_systems", {})
     delta = datetime.timedelta(hours=int(max_hours))
     vms_to_delete = defaultdict(set)
     thread_queue = []
     # precompile regexes
     matchers = [re.compile(text, re.IGNORECASE) for text in texts]
+    print('Matching VM names against the following case-insensitive strings: {}'.format(texts))
 
     for provider_key in providers:
         # check for cleanup boolean
         if not cfme_data['management_systems'][provider_key].get('cleanup', False):
-            print('Skipping {}, cleanup set to false in yaml'.format(provider_key))
+            print('Skipping {}, cleanup map set to false or missing in yaml'.format(provider_key))
             continue
         ipaddress = cfme_data['management_systems'][provider_key].get('ipaddress')
         if ipaddress and not net.is_pingable(ipaddress):
             continue
-        provider_type = providers_data[provider_key].get('type')
-        list_vms = args.list_vms and provider_type in args.provider_type
         thread = Thread(target=process_provider_vms,
-                        args=(provider_key, provider_type, matchers,
-                              delta, vms_to_delete, list_vms))
+                        args=(provider_key, matchers, delta, vms_to_delete))
         # Mark as daemon thread for easy-mode KeyboardInterrupt handling
         thread.daemon = True
         thread_queue.append(thread)
@@ -201,22 +249,6 @@ def cleanup_vms(texts, max_hours=24, providers=None, prompt=True):
     # Join the queued calls
     for thread in thread_queue:
         thread.join()
-
-    if providers_vm_list:
-        with open(args.outfile, 'a+') as report:
-                message = tabulate(
-                    providers_vm_list, headers=['ProviderType', 'ProviderKey',
-                                                'InstanceName', 'CreatedSince',
-                                                'InstanceType', 'InstanceStatus'],
-                    tablefmt='orgtbl')
-                report.write(message)
-        print(message)
-
-    for provider_key, vm_set in vms_to_delete.items():
-        print('{}:'.format(provider_key))
-        for vm_name, vm_delta in vm_set:
-            days, hours = vm_delta.days, vm_delta.seconds / 3600
-            print(' {} is {} days, {} hours old'.format(vm_name, days, hours))
 
     if vms_to_delete and prompt:
         yesno = raw_input('Delete these VMs? [y/N]: ')
@@ -229,8 +261,16 @@ def cleanup_vms(texts, max_hours=24, providers=None, prompt=True):
 
     thread_queue = []
     for provider_key, vm_set in vms_to_delete.items():
+        provider_mgmt = get_mgmt(provider_key)
+
+        names_ages = []
+        for vm_name, vm_delta in vm_set:
+            days, hours = vm_delta.days, vm_delta.seconds / 3600
+            age = '{} days, {} hours old'.format(days, hours)
+            names_ages.append(NameAge(vm_name, age))
+
         thread = Thread(target=delete_provider_vms,
-            args=(provider_key, [name for name, t_delta in vm_set]))
+                        args=(provider_key, provider_mgmt, names_ages))
         # Mark as daemon thread for easy-mode KeyboardInterrupt handling
         thread.daemon = True
         thread_queue.append(thread)
@@ -239,10 +279,20 @@ def cleanup_vms(texts, max_hours=24, providers=None, prompt=True):
     for thread in thread_queue:
         thread.join()
 
+    with open(args.outfile, 'a') as report:
+        report.write('## VM/Instances deleted via:\n'
+                     '##   text matches: {}\n'
+                     '##   age matches: {}\n'
+                     .format(texts, max_hours))
+        message = tabulate(deleted_vms_list,
+                           headers=['Provider', 'Name', 'Age', 'Status', 'Delete RC'],
+                           tablefmt='orgtbl')
+        report.write(message)
+    print(message)
+
     print("Deleting finished")
 
 
 if __name__ == "__main__":
     args = parse_cmd_line()
-    sys.exit(cleanup_vms(args.text_to_match, args.max_hours,
-                         args.providers, args.prompt))
+    sys.exit(cleanup_vms(args.text_to_match, args.max_hours, args.providers, args.prompt))


### PR DESCRIPTION
Refactor the cleanup_old_vms script to:
* Remove list mode - to be replaced by separate script
* Collect report data for deleted VMs, and write that to outfile

This way the script is more focused on cleanup, and reporting cleanup actions/results, and its use/function doesn't get convoluted.

I've been testing locally with combinations of singular and multiple text matchers with no issues so far, other than uncovering problem VM's that are in bad states and can't be cleaned up via normal calls.