### PR TITLE
[RFR] test_config_management fix

### DIFF
--- a/cfme/infrastructure/config_management.py
+++ b/cfme/infrastructure/config_management.py
@@ -466,7 +466,7 @@ class MgrAll(CFMENavigateStep):
             page = 'All Ansible Tower Providers'
         else:
             page = 'All Configuration Manager Providers'
-        return match_page(page)
+        return match_page(summary=page)
 
 
 @navigator.register(ConfigManager, 'Add')


### PR DESCRIPTION
There are ~ 7 tests failing in jenkins with NavigationError error.
This PR fixes those tests

{{pytest: cfme/tests/infrastructure/test_config_management.py}}