### PR TITLE
[1LP][RFR] Action tests refactoring

### DIFF
--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -128,7 +128,13 @@ class Host(Updateable, Pretty, Navigatable, PolicyProfileAssignable):
         """
 
         view = navigate_to(self, "Edit")
-        changed = view.fill(updates)
+        changed = view.fill({
+            "name": updates.get("name"),
+            "hostname": updates.get("hostname") or updates.get("ip_address"),
+            "custom_ident": updates.get("custom_ident"),
+            "ipmi_address": updates.get("ipmi_address"),
+            "mac_address": updates.get("mac_address")
+        })
         credentials = updates.get("credentials")
         ipmi_credentials = updates.get("ipmi_credentials")
         credentials_changed = False

--- a/cfme/tests/control/__init__.py
+++ b/cfme/tests/control/__init__.py
@@ -1,7 +1,7 @@
-from utils import conf, version
-from utils.wait import wait_for
-from utils.log import logger
 from cfme.web_ui import flash, toolbar
+from utils import conf, version
+from utils.log import logger
+from utils.wait import wait_for
 
 vddk_url_map = {
     "5.5": conf.cfme_data.get("basic_info", {}).get("vddk_url").get("v5_5"),

--- a/cfme/tests/control/__init__.py
+++ b/cfme/tests/control/__init__.py
@@ -10,6 +10,12 @@ vddk_url_map = {
 }
 
 
+def wait_for_ssa_enabled():
+    wait_for(
+        lambda: not toolbar.is_greyed('Configuration', 'Perform SmartState Analysis'),
+        delay=10, handle_exception=True, num_sec=600, fail_func=lambda: toolbar.select("Reload"))
+
+
 def do_scan(vm, additional_item_check=None):
     if vm.rediscover_if_analysis_data_present():
         # policy profile assignment is lost so reassign

--- a/cfme/tests/control/__init__.py
+++ b/cfme/tests/control/__init__.py
@@ -1,13 +1,6 @@
 from cfme.web_ui import flash, toolbar
-from utils import conf
 from utils.log import logger
 from utils.wait import wait_for
-
-vddk_url_map = {
-    "5.5": conf.cfme_data.get("basic_info", {}).get("vddk_url").get("v5_5"),
-    "6": conf.cfme_data.get("basic_info", {}).get("vddk_url").get("v6_0"),
-    "6.5": conf.cfme_data.get("basic_info", {}).get("vddk_url").get("v6_5")
-}
 
 
 def wait_for_ssa_enabled():

--- a/cfme/tests/control/__init__.py
+++ b/cfme/tests/control/__init__.py
@@ -1,5 +1,5 @@
 from cfme.web_ui import flash, toolbar
-from utils import conf, version
+from utils import conf
 from utils.log import logger
 from utils.wait import wait_for
 
@@ -27,9 +27,7 @@ def do_scan(vm, additional_item_check=None):
     if additional_item_check is not None:
         original_item = vm.get_detail(properties=additional_item_check)
     vm.smartstate_scan(cancel=False, from_details=True)
-    flash.assert_message_contain(version.pick({
-        version.LOWEST: "Smart State Analysis initiated",
-        "5.5": "Analysis initiated for 1 VM and Instance from the CFME Database"}))
+    flash.assert_message_contain("Analysis initiated for 1 VM and Instance from the CFME Database")
     logger.info("Scan initiated")
     wait_for(
         lambda: _scan() != original,

--- a/cfme/tests/control/__init__.py
+++ b/cfme/tests/control/__init__.py
@@ -1,0 +1,35 @@
+from utils import conf, version
+from utils.wait import wait_for
+from utils.log import logger
+from cfme.web_ui import flash, toolbar
+
+vddk_url_map = {
+    "5.5": conf.cfme_data.get("basic_info", {}).get("vddk_url").get("v5_5"),
+    "6": conf.cfme_data.get("basic_info", {}).get("vddk_url").get("v6_0"),
+    "6.5": conf.cfme_data.get("basic_info", {}).get("vddk_url").get("v6_5")
+}
+
+
+def do_scan(vm, additional_item_check=None):
+    if vm.rediscover_if_analysis_data_present():
+        # policy profile assignment is lost so reassign
+        vm.assign_policy_profiles(*vm.assigned_policy_profiles)
+
+    def _scan():
+        return vm.get_detail(properties=("Lifecycle", "Last Analyzed")).lower()
+    original = _scan()
+    if additional_item_check is not None:
+        original_item = vm.get_detail(properties=additional_item_check)
+    vm.smartstate_scan(cancel=False, from_details=True)
+    flash.assert_message_contain(version.pick({
+        version.LOWEST: "Smart State Analysis initiated",
+        "5.5": "Analysis initiated for 1 VM and Instance from the CFME Database"}))
+    logger.info("Scan initiated")
+    wait_for(
+        lambda: _scan() != original,
+        num_sec=600, delay=5, fail_func=lambda: toolbar.select("Reload"))
+    if additional_item_check is not None:
+        wait_for(
+            lambda: vm.get_detail(properties=additional_item_check) != original_item,
+            num_sec=120, delay=5, fail_func=lambda: toolbar.select("Reload"))
+    logger.info("Scan finished")

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -171,14 +171,15 @@ def _get_vm(request, appliance, provider, template_name, vm_name):
     return VMWrapper(provider, vm_name, api)
 
 
-@pytest.fixture(scope="function")
-def vm(request, appliance, has_no_providers, provider, setup_provider, small_template, vm_name):
-    return _get_vm(request, appliance, provider, small_template, vm_name)
+@pytest.fixture(scope="module")
+def vm(request, appliance, provider, setup_one_provider_modscope, small_template_modscope, vm_name):
+    return _get_vm(request, appliance, provider, small_template_modscope, vm_name)
 
 
-@pytest.fixture(scope="function")
-def vm_big(request, appliance, has_no_providers, provider, setup_provider, big_template, vm_name):
-    return _get_vm(request, appliance, provider, big_template, vm_name)
+@pytest.fixture(scope="module")
+def vm_big(request, appliance, provider, setup_one_provider_modscope, big_template_modscope,
+        vm_name):
+    return _get_vm(request, appliance, provider, big_template_modscope, vm_name)
 
 
 @pytest.fixture(scope="module")

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """ Tests used to check whether assigned actions really do what they're supposed to do. Events are
-note supported by ec2, gce, scvmm and openstack providers. Tests are uncollected for these
+note supported by ec2, gc and scvmm providers. Tests are uncollected for these
 providers. When the support will be implemented these tests can enabled for them.
 
 Required YAML keys:
@@ -279,7 +279,7 @@ def assign_policy_for_testing_vm_big(policy_for_testing_for_vm_big, provider, po
 
 
 @pytest.mark.uncollectif(lambda provider: not provider.one_of(VMwareProvider, RHEVMProvider,
-    AzureProvider))
+    OpenStackProvider, AzureProvider))
 def test_action_start_virtual_machine_after_stopping(request, vm, vm_on, vm_crud_refresh,
         assign_policy_for_testing):
     """ This test tests action 'Start Virtual Machine'
@@ -305,7 +305,7 @@ def test_action_start_virtual_machine_after_stopping(request, vm, vm_on, vm_crud
 
 
 @pytest.mark.uncollectif(lambda provider: not provider.one_of(VMwareProvider, RHEVMProvider,
-    AzureProvider))
+    OpenStackProvider, AzureProvider))
 def test_action_stop_virtual_machine_after_starting(request, vm, vm_off, vm_crud_refresh,
         assign_policy_for_testing):
     """ This test tests action 'Stop Virtual Machine'
@@ -331,7 +331,7 @@ def test_action_stop_virtual_machine_after_starting(request, vm, vm_off, vm_crud
 
 
 @pytest.mark.uncollectif(lambda provider: not provider.one_of(VMwareProvider, RHEVMProvider,
-    AzureProvider))
+    OpenStackProvider, AzureProvider))
 def test_action_suspend_virtual_machine_after_starting(request, vm, vm_off, vm_crud_refresh,
         assign_policy_for_testing):
     """ This test tests action 'Suspend Virtual Machine'
@@ -357,7 +357,7 @@ def test_action_suspend_virtual_machine_after_starting(request, vm, vm_off, vm_c
 
 @pytest.mark.meta(blockers=[1142875])
 @pytest.mark.uncollectif(lambda provider: not provider.one_of(VMwareProvider, RHEVMProvider,
-    AzureProvider))
+    OpenStackProvider, AzureProvider))
 def test_action_prevent_event(request, vm, vm_off, vm_crud_refresh, assign_policy_for_testing):
     """ This test tests action 'Prevent current event from proceeding'
 
@@ -382,7 +382,7 @@ def test_action_prevent_event(request, vm, vm_off, vm_crud_refresh, assign_polic
 
 
 @pytest.mark.uncollectif(lambda provider: not provider.one_of(VMwareProvider, RHEVMProvider,
-    AzureProvider))
+    OpenStackProvider, AzureProvider))
 def test_action_power_on_logged(request, vm, vm_off, appliance, vm_crud_refresh,
         assign_policy_for_testing):
     """ This test tests action 'Generate log message'.
@@ -421,7 +421,7 @@ def test_action_power_on_logged(request, vm, vm_off, appliance, vm_crud_refresh,
 
 
 @pytest.mark.uncollectif(lambda provider: not provider.one_of(VMwareProvider, RHEVMProvider,
-    AzureProvider))
+    OpenStackProvider, AzureProvider))
 def test_action_power_on_audit(request, vm, vm_off, appliance, vm_crud_refresh,
         assign_policy_for_testing):
     """ This test tests action 'Generate Audit Event'.
@@ -623,7 +623,7 @@ def test_action_initiate_smartstate_analysis(request, configure_fleecing, vm, vm
 
 # Purely custom actions
 @pytest.mark.uncollectif(lambda provider: not provider.one_of(VMwareProvider, RHEVMProvider,
-    AzureProvider))
+    OpenStackProvider, AzureProvider))
 def test_action_tag(request, vm, vm_off, vm_crud_refresh, assign_policy_for_testing):
     """ Tests action tag
 
@@ -661,7 +661,7 @@ def test_action_tag(request, vm, vm_off, vm_crud_refresh, assign_policy_for_test
 
 @pytest.mark.meta(blockers=[1205496])
 @pytest.mark.uncollectif(lambda provider: not provider.one_of(VMwareProvider, RHEVMProvider,
-    AzureProvider))
+    OpenStackProvider, AzureProvider))
 def test_action_untag(request, vm, vm_off, vm_crud_refresh, assign_policy_for_testing):
     """ Tests action untag
 

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -107,7 +107,7 @@ def vm_name_big(provider):
 @pytest.yield_fixture(scope="function")
 def configure_fleecing(request, appliance, provider, vm):
     setup_host_creds(provider.key, vm.api.host.name)
-    appliance.install_vddk(vddk_url=vddk_url_map[str(provider.version)])
+    appliance.install_vddk(reboot=False, vddk_url=vddk_url_map[str(provider.version)])
     yield
     appliance.uninstall_vddk()
     setup_host_creds(provider.key, vm.api.host.name, remove_creds=True)
@@ -526,7 +526,7 @@ def test_action_initiate_smartstate_analysis(request, configure_fleecing, vm, vm
     # Set up the policy and prepare finalizer
     policy_for_testing.assign_actions_to_event("VM Power On",
         ["Initiate SmartState Analysis for VM"])
-    request.addfinalizer(lambda: policy_for_testing.assign_events())
+    request.addfinalizer(policy_for_testing.assign_events)
     # Start the VM
     vm.crud.power_control_from_cfme(option=vm.crud.POWER_ON, cancel=False, from_details=True)
     vm.crud.load_details()

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -23,7 +23,6 @@ from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.web_ui import toolbar as tb
 from datetime import datetime
-from fixtures.pytest_store import store
 from functools import partial
 from utils import testgen
 from utils.appliance.implementations.ui import navigate_to
@@ -99,7 +98,7 @@ pytestmark = [
 ]
 
 
-def get_vm_object(vm_name):
+def get_vm_object(appliance, vm_name):
     """Looks up the CFME database for the VM.
 
     Args:
@@ -110,7 +109,7 @@ def get_vm_object(vm_name):
         If not, `None`
     """
     try:
-        return pytest.store.current_appliance.rest_api.collections.vms.find_by(name=vm_name)[0]
+        return appliance.rest_api.collections.vms.find_by(name=vm_name)[0]
     except IndexError:
         return None
 
@@ -145,10 +144,10 @@ def set_host_credentials(request, provider, vm):
 
 
 @pytest.fixture(scope="module")
-def local_setup_provider(request, setup_provider_modscope, provider):
+def local_setup_provider(request, appliance, setup_provider_modscope, provider):
     if provider.type == 'virtualcenter':
-        store.current_appliance.install_vddk(reboot=True)
-        store.current_appliance.wait_for_web_ui()
+        appliance.install_vddk(reboot=True)
+        appliance.wait_for_web_ui()
         try:
             pytest.sel.refresh()
         except AttributeError:

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -108,7 +108,7 @@ def configure_fleecing(request, appliance, provider, vm):
     setup_host_creds(provider.key, vm.api.host.name, remove_creds=True)
 
 
-def _get_vm(request, appliance, provider, template_name, vm_name):
+def _get_vm(request, provider, template_name, vm_name):
     if provider.one_of(RHEVMProvider):
         kwargs = {"cluster": provider.data["default_cluster"]}
     elif provider.one_of(OpenStackProvider):
@@ -161,7 +161,7 @@ def _get_vm(request, appliance, provider, template_name, vm_name):
 
     # Get the REST API object
     api = wait_for(
-        lambda: get_vm_object(appliance, vm_name),
+        lambda: get_vm_object(provider.appliance, vm_name),
         message="VM object {} appears in CFME".format(vm_name),
         fail_condition=None,
         num_sec=600,
@@ -172,14 +172,13 @@ def _get_vm(request, appliance, provider, template_name, vm_name):
 
 
 @pytest.fixture(scope="module")
-def vm(request, appliance, provider, setup_one_provider_modscope, small_template_modscope, vm_name):
-    return _get_vm(request, appliance, provider, small_template_modscope, vm_name)
+def vm(request, provider, setup_one_provider_modscope, small_template_modscope, vm_name):
+    return _get_vm(request, provider, small_template_modscope, vm_name)
 
 
 @pytest.fixture(scope="module")
-def vm_big(request, appliance, provider, setup_one_provider_modscope, big_template_modscope,
-        vm_name):
-    return _get_vm(request, appliance, provider, big_template_modscope, vm_name)
+def vm_big(request, provider, setup_one_provider_modscope, big_template_modscope, vm_name):
+    return _get_vm(request, provider, big_template_modscope, vm_name)
 
 
 @pytest.fixture(scope="module")

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -12,6 +12,8 @@ Required YAML keys:
 """
 import fauxfactory
 import pytest
+from datetime import datetime
+from functools import partial
 
 from cfme.common.provider import cleanup_vm
 from cfme.common.vm import VM
@@ -22,8 +24,6 @@ from cfme.services import requests
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.web_ui import toolbar as tb
-from datetime import datetime
-from functools import partial
 from utils import testgen
 from utils.appliance.implementations.ui import navigate_to
 from utils.blockers import BZ
@@ -242,23 +242,6 @@ def policy_name(name_suffix):
 @pytest.fixture(scope="module")
 def policy_profile_name(name_suffix):
     return "action_testing: policy profile {}".format(name_suffix)
-
-
-@pytest.yield_fixture(scope="module")
-def automate_role_set(request):
-    """ Sets the Automate role that the VM can be provisioned.
-
-    Sets the Automate role state back when finished the module tests.
-    """
-    from cfme.configure import configuration
-    roles = configuration.get_server_roles()
-    old_roles = dict(roles)
-    roles["automate"] = True
-    roles["smartproxy"] = True
-    roles["smartstate"] = True
-    configuration.set_server_roles(**roles)
-    yield
-    configuration.set_server_roles(**old_roles)
 
 
 @pytest.fixture(scope="module")

--- a/cfme/tests/control/test_compliance.py
+++ b/cfme/tests/control/test_compliance.py
@@ -9,13 +9,14 @@ from cfme.control.explorer.conditions import VMCondition
 from cfme.control.explorer.policy_profiles import PolicyProfile
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.configure.configuration import AnalysisProfile
-from cfme.web_ui import flash, toolbar
-from cfme import test_requirements
-from utils import testgen, version, conf
-from utils.hosts import setup_providers_hosts_credentials
+from fixtures.pytest_store import store
+from utils import testgen, version
+from utils.appliance import Appliance, ApplianceException, provision_appliance
 from utils.log import logger
 from utils.update import update
-from utils.wait import wait_for
+from urlparse import urlparse
+from cfme import test_requirements
+from . import do_scan, wait_for_ssa_enabled
 
 vddk_url_map = {
     "5.5": conf.cfme_data.get("basic_info", {}).get("vddk_url").get("v5_5"),
@@ -32,12 +33,6 @@ pytestmark = [
 
 
 pytest_generate_tests = testgen.generate([VMwareProvider], scope="module")
-
-
-def wait_for_ssa_enabled():
-    wait_for(
-        lambda: not toolbar.is_greyed('Configuration', 'Perform SmartState Analysis'),
-        delay=10, handle_exception=True, num_sec=600, fail_func=lambda: toolbar.select("Reload"))
 
 
 @pytest.fixture

--- a/fixtures/provider.py
+++ b/fixtures/provider.py
@@ -253,6 +253,13 @@ def setup_provider_modscope(request, provider):
     return setup_or_skip(request, provider)
 
 
+@pytest.fixture(scope='module')
+def setup_one_provider_modscope(request, provider):
+    """Module-scoped fixture to remove all existing providers and set up one"""
+    BaseProvider.clear_providers()
+    return setup_or_skip(request, provider)
+
+
 @pytest.fixture(scope='class')
 def setup_provider_clsscope(request, provider):
     """Module-scoped fixture to set up a provider"""

--- a/fixtures/provider.py
+++ b/fixtures/provider.py
@@ -253,13 +253,6 @@ def setup_provider_modscope(request, provider):
     return setup_or_skip(request, provider)
 
 
-@pytest.fixture(scope='module')
-def setup_one_provider_modscope(request, provider):
-    """Module-scoped fixture to remove all existing providers and set up one"""
-    BaseProvider.clear_providers()
-    return setup_or_skip(request, provider)
-
-
 @pytest.fixture(scope='class')
 def setup_provider_clsscope(request, provider):
     """Module-scoped fixture to set up a provider"""

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -1456,7 +1456,7 @@ class IPAppliance(object):
 
     @logger_wrap("Uninstall VDDK: {}")
     def uninstall_vddk(self, log_callback=None):
-        """Uninstall the vddk from a appliance"""
+        """Uninstall the vddk from an appliance"""
         with self.ssh_client as client:
             is_installed = client.run_command('test -d /usr/lib/vmware-vix-disklib/lib64').success
             if is_installed:

--- a/utils/hosts.py
+++ b/utils/hosts.py
@@ -7,10 +7,8 @@ import socket
 
 from utils import conf
 from utils.log import logger
-from utils.wait import wait_for
 from utils.update import update
 from cfme.infrastructure import host
-import cfme.fixtures.pytest_selenium as sel
 
 
 def get_host_data_by_name(provider_key, host_name):
@@ -30,12 +28,6 @@ def setup_host_creds(provider_key, host_name, remove_creds=False, ignore_errors=
                 if test_host.ip_address is None:
                     test_host.ip_address = socket.gethostbyname_ex(host_name)[2][0]
                 test_host.credentials = host.get_credentials_from_config(host_data['credentials'])
-            wait_for(
-                lambda: test_host.has_valid_credentials,
-                delay=10,
-                num_sec=120,
-                fail_func=sel.refresh
-            )
         elif test_host.has_valid_credentials and remove_creds:
             with update(test_host):
                 test_host.credentials = host.Host.Credential(principal="", secret="",

--- a/utils/hosts.py
+++ b/utils/hosts.py
@@ -18,7 +18,7 @@ def get_host_data_by_name(provider_key, host_name):
     return None
 
 
-def setup_host_creds(provider_key, host_name, ignore_errors=False):
+def setup_host_creds(provider_key, host_name, remove_creds=False, ignore_errors=False):
     try:
         host_data = get_host_data_by_name(provider_key, host_name)
         test_host = host.Host(name=host_name)
@@ -39,6 +39,13 @@ def setup_host_creds(provider_key, host_name, ignore_errors=False):
                 delay=10,
                 num_sec=120,
                 fail_func=sel.refresh
+            )
+        elif test_host.has_valid_credentials and remove_creds:
+            test_host.update(
+                updates={'credentials': host.Host.Credential(
+                    principal="", secret="", verify_secret="")
+                },
+                validate_credentials=False
             )
     except Exception as e:
         if not ignore_errors:

--- a/utils/hosts.py
+++ b/utils/hosts.py
@@ -40,7 +40,6 @@ def setup_host_creds(provider_key, host_name, remove_creds=False, ignore_errors=
             with update(test_host):
                 test_host.credentials = host.Host.Credential(principal="", secret="",
                     verify_secret="")
-                test_host.validate_credentials = False
     except Exception as e:
         if not ignore_errors:
             raise e


### PR DESCRIPTION
Purpose
=======

__Refactoring tests__  in test_actions.py. There are several deprecated objects and functions.
* Instead of strings comparing `provider.key` we should check the instance of the provider object `provider.one_of()`
* Removed fixtures: `vm_crud_refresh`, `automate_role_set`
* Enabled tests for openstack and azure providers
* `pytest.store.appliance` replaced by `appliance` fixture

{{pytest: -v -k 'test_action and not test_action_crud' --long-running --use-provider vsphere6-nested}}

test_action_cancel_clone failed due the template absence. 58z failed because of testing vm is deleted for some reason during test run.
