### PR TITLE
[RFR][1LP] Added a mandatory Hawkular provider

### DIFF
--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -43,8 +43,8 @@ class OpenshiftProvider(ContainersProvider):
             .find_by(name=self.name).resources[0].href
 
     def _form_mapping(self, create=None, **kwargs):
-        hawkular = kwargs.get('hawkular')
         sec_protocol = kwargs.get('sec_protocol')
+        hawkular = kwargs.get('hawkular')
         hawkular_hostname = kwargs.get('hawkular_hostname')
         hawkular_sec_protocol = kwargs.get('hawkular_sec_protocol')
         default_ca_certificate = self.get_cert()
@@ -98,6 +98,12 @@ class OpenshiftProvider(ContainersProvider):
     def from_config(prov_config, prov_key, appliance=None):
         token_creds = OpenshiftProvider.process_credential_yaml_key(
             prov_config['credentials'], cred_type='token')
+	hawkular_hostname = prov_config['endpoints']['hawkular'].hostname
+	hawkular_api_port = prov_config['endpoints']['hawkular'].api_port
+	if hawkular_hostname and hawkular_api_port:
+	    hawkular = True
+	else:
+	    hawkular = False
         return OpenshiftProvider(
             name=prov_config['name'],
             credentials={'token': token_creds},
@@ -109,7 +115,8 @@ class OpenshiftProvider(ContainersProvider):
             hawkular_sec_protocol=prov_config['endpoints']['hawkular'].sec_protocol,
             hawkular_hostname=prov_config['endpoints']['hawkular'].hostname,
             hawkular_api_port=prov_config['endpoints']['hawkular'].api_port,
-            provider_data=prov_config,
+            hawkular=hawkular,
+	    provider_data=prov_config,
             appliance=appliance)
 
     def custom_attributes(self):

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -100,9 +100,12 @@ class OpenshiftProvider(ContainersProvider):
             prov_config['credentials'], cred_type='token')
         try:
             hawkular_hostname = prov_config['endpoints']['hawkular'].hostname
+            hawkular_api_port = prov_config['endpoints']['hawkular'].api_port
+            hawkular_sec_protocol = prov_config['endpoints']['hawkular'].sec_protocol
         except:
             hawkular_hostname = None
             hawkular_api_port = None
+            hawkular_sec_protocol = None
         if hawkular_hostname and hawkular_api_port:
             hawkular = True
         else:
@@ -115,7 +118,7 @@ class OpenshiftProvider(ContainersProvider):
             hostname=prov_config['endpoints']['default'].hostname or prov_config['ipaddress'],
             api_port=prov_config['endpoints']['default'].api_port,
             sec_protocol=prov_config['endpoints']['default'].sec_protocol,
-            hawkular_sec_protocol=prov_config['endpoints']['hawkular'].sec_protocol,
+            hawkular_sec_protocol=hawkular_sec_protocol,
             hawkular_hostname=hawkular_hostname,
             hawkular_api_port=hawkular_api_port,
             hawkular=hawkular,

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -44,8 +44,8 @@ class OpenshiftProvider(ContainersProvider):
 
     def _form_mapping(self, create=None, **kwargs):
         sec_protocol = kwargs.get('sec_protocol')
-        hawkular = kwargs.get('hawkular')
         hawkular_hostname = kwargs.get('hawkular_hostname')
+        hawkular = kwargs.get('hawkular')
         hawkular_sec_protocol = kwargs.get('hawkular_sec_protocol')
         default_ca_certificate = self.get_cert()
         hawkular_ca_certificate = default_ca_certificate
@@ -98,12 +98,12 @@ class OpenshiftProvider(ContainersProvider):
     def from_config(prov_config, prov_key, appliance=None):
         token_creds = OpenshiftProvider.process_credential_yaml_key(
             prov_config['credentials'], cred_type='token')
-	hawkular_hostname = prov_config['endpoints']['hawkular'].hostname
-	hawkular_api_port = prov_config['endpoints']['hawkular'].api_port
-	if hawkular_hostname and hawkular_api_port:
-	    hawkular = True
-	else:
-	    hawkular = False
+        hawkular_hostname = prov_config['endpoints']['hawkular'].hostname
+        hawkular_api_port = prov_config['endpoints']['hawkular'].api_port
+        if hawkular_hostname and hawkular_api_port:
+            hawkular = True
+        else:
+            hawkular = False
         return OpenshiftProvider(
             name=prov_config['name'],
             credentials={'token': token_creds},
@@ -113,10 +113,10 @@ class OpenshiftProvider(ContainersProvider):
             api_port=prov_config['endpoints']['default'].api_port,
             sec_protocol=prov_config['endpoints']['default'].sec_protocol,
             hawkular_sec_protocol=prov_config['endpoints']['hawkular'].sec_protocol,
-            hawkular_hostname=prov_config['endpoints']['hawkular'].hostname,
-            hawkular_api_port=prov_config['endpoints']['hawkular'].api_port,
+            hawkular_hostname=hawkular_hostname,
+            hawkular_api_port=hawkular_api_port,
             hawkular=hawkular,
-	    provider_data=prov_config,
+            provider_data=prov_config,
             appliance=appliance)
 
     def custom_attributes(self):

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -98,8 +98,11 @@ class OpenshiftProvider(ContainersProvider):
     def from_config(prov_config, prov_key, appliance=None):
         token_creds = OpenshiftProvider.process_credential_yaml_key(
             prov_config['credentials'], cred_type='token')
-        hawkular_hostname = prov_config['endpoints']['hawkular'].hostname
-        hawkular_api_port = prov_config['endpoints']['hawkular'].api_port
+        try:
+            hawkular_hostname = prov_config['endpoints']['hawkular'].hostname
+        except:
+            hawkular_hostname = None
+            hawkular_api_port = None
         if hawkular_hostname and hawkular_api_port:
             hawkular = True
         else:


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_relationships.py -v --use-provider cm-env2 }}

We'd like a Hawkular endpoint added with every Openshift Containers Provider we add for the tests