### PR TITLE
[1LP][RFR] manual timelines tests

### DIFF
--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -107,3 +107,8 @@ def test_cloud_instance_event(gen_events, new_instance):
     """
     wait_for(count_events, [new_instance, new_instance], timeout='5m', fail_condition=0,
              message="events to appear")
+
+
+@pytest.mark.manual
+def test_policy_events():
+    pass

--- a/cfme/tests/configure/test_diagnostic_timelines.py
+++ b/cfme/tests/configure/test_diagnostic_timelines.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+
+@pytest.mark.manual
+def test_diagnostic_timelines():
+    pass

--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -201,3 +201,8 @@ class TestInfraVmEventRESTAPI(object):
             lifecycle_events.event == event["event"],
         ))
         assert events_list, "Could not find the lifecycle event in the database"
+
+
+@pytest.mark.manual
+def test_policy_events():
+    pass

--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -206,3 +206,8 @@ class TestInfraVmEventRESTAPI(object):
 @pytest.mark.manual
 def test_policy_events():
     pass
+
+
+@pytest.mark.manual
+def test_timelines_ui():
+    pass

--- a/cfme/tests/intelligence/test_reports_with_timelines.py
+++ b/cfme/tests/intelligence/test_reports_with_timelines.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+timelines_reports = ('hosts', 'vm_operation', 'policy_events', 'policy_events2')
+
+
+@pytest.mark.manual
+@pytest.mark.parametrize('report', timelines_reports)
+def test_default_reports_with_timelines(report):
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.parametrize('report', timelines_reports)
+def test_custom_reports_with_timelines(report):
+    pass

--- a/markers/manual.py
+++ b/markers/manual.py
@@ -15,17 +15,8 @@ def pytest_addoption(parser):
 
 def pytest_collection_modifyitems(session, config, items):
     len_collected = len(items)
-
-    new_items = []
-    for item in items:
-        if config.getvalue('manual'):
-            if not item.get_marker('manual'):
-                continue
-        else:
-            if item.get_marker('manual'):
-                continue
-        new_items.append(item)
-    items[:] = new_items
+    is_manual = config.getvalue('manual')
+    items[:] = [item for item in items if bool(item.get_marker('manual')) == is_manual]
 
     len_filtered = len(items)
     filtered_count = len_collected - len_filtered

--- a/markers/manual.py
+++ b/markers/manual.py
@@ -18,10 +18,13 @@ def pytest_collection_modifyitems(session, config, items):
 
     new_items = []
     for item in items:
-        if config.getvalue('manual') and not item.get_marker('manual'):
-            continue
+        if config.getvalue('manual'):
+            if not item.get_marker('manual'):
+                continue
         else:
-            new_items.append(item)
+            if item.get_marker('manual'):
+                continue
+        new_items.append(item)
     items[:] = new_items
 
     len_filtered = len(items)


### PR DESCRIPTION
1. Added manual timelines tests.
There should be much more tests but the rest will be added later.
2. Fixed manual py test plugin to correctly collect/uncollect manual test cases.
The collection works in the following way now:
If --manual argument is added then pytest collects only manual test cases.
If --manual argument isn't added then pytest ignores all manual test cases.
