### PR TITLE
[RFR][1LP] Test alerts refactoring

### DIFF
--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -139,7 +139,7 @@ def vm_name():
 
 
 @pytest.yield_fixture(scope="function")
-def vm(vm_name, full_template, provider, setup_one_provider_modscope):
+def vm(vm_name, full_template, provider, setup_provider):
     vm_obj = VM.factory(vm_name, provider, template_name=full_template["name"])
     vm_obj.create_on_provider(allow_skip="default")
     provider.mgmt.start_vm(vm_obj.name)

--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -173,7 +173,7 @@ def ssh(provider, full_template, vm_name):
 
 
 @pytest.yield_fixture(scope="module")
-def snmp(appliance):
+def setup_snmp(appliance):
     appliance.ssh_client.run_command("echo 'disableAuthorization yes' >> /etc/snmp/snmptrapd.conf")
     appliance.ssh_client.run_command("systemctl start snmptrapd.service")
     yield
@@ -304,7 +304,7 @@ def test_alert_timeline_cpu(request, vm, set_performance_capture_threshold, prov
 
 
 @pytest.mark.uncollectif(lambda provider: not provider.one_of(*CANDU_PROVIDER_TYPES))
-def test_alert_snmp(request, vm, snmp, provider, appliance, setup_candu):
+def test_alert_snmp(request, appliance, provider, setup_snmp, setup_candu, vm):
     """ Tests a custom alert that uses C&U data to trigger an alert. Since the threshold is set to
     zero, it will start firing mails as soon as C&U data are available. It uses SNMP to catch the
     alerts. It uses SNMP v2.

--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -3,6 +3,7 @@ import fauxfactory
 import pytest
 from datetime import datetime, timedelta
 
+from cfme import test_requirements
 from cfme.common.vm import VM
 from cfme.configure.configuration import server_roles_enabled, candu
 from cfme.control.explorer import actions, alert_profiles, alerts, policies, policy_profiles
@@ -11,14 +12,13 @@ from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from utils import ports, testgen
 from utils.conf import credentials
+from utils.generators import random_vm_name
 from utils.log import logger
 from utils.net import net_check
+from utils.providers import ProviderFilter
 from utils.ssh import SSHClient
 from utils.update import update
 from utils.wait import wait_for
-from utils.providers import ProviderFilter
-from utils.generators import random_vm_name
-from cfme import test_requirements
 
 pytestmark = [
     pytest.mark.long_running,

--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -124,10 +124,11 @@ def set_performance_capture_threshold(appliance):
 
 
 @pytest.yield_fixture(scope="function")
-def setup_candu():
+def setup_candu(vm):
     candu.enable_all()
     with server_roles_enabled('ems_metrics_coordinator', 'ems_metrics_collector',
             'ems_metrics_processor'):
+        vm.wait_candu_data_available(timeout=20 * 60)
         yield
     candu.disable_all()
 
@@ -153,8 +154,6 @@ def vm(vm_name, full_template, provider, setup_one_provider_modscope):
     if not vm_obj.exists:
         provider.refresh_provider_relationships()
         vm_obj.wait_to_appear()
-    if provider.one_of(*CANDU_PROVIDER_TYPES):
-        vm_obj.wait_candu_data_available(timeout=20 * 60)
     yield vm_obj
     try:
         if provider.mgmt.does_vm_exist(vm_obj.name):

--- a/fixtures/provider.py
+++ b/fixtures/provider.py
@@ -253,6 +253,13 @@ def setup_provider_modscope(request, provider):
     return setup_or_skip(request, provider)
 
 
+@pytest.fixture(scope='module')
+def setup_one_provider_modscope(request, provider):
+    """Module-scoped fixture to remove all existing providers and set up one"""
+    BaseProvider.clear_providers()
+    return setup_or_skip(request, provider)
+
+
 @pytest.fixture(scope='class')
 def setup_provider_clsscope(request, provider):
     """Module-scoped fixture to set up a provider"""

--- a/fixtures/provider.py
+++ b/fixtures/provider.py
@@ -253,13 +253,6 @@ def setup_provider_modscope(request, provider):
     return setup_or_skip(request, provider)
 
 
-@pytest.fixture(scope='module')
-def setup_one_provider_modscope(request, provider):
-    """Module-scoped fixture to remove all existing providers and set up one"""
-    BaseProvider.clear_providers()
-    return setup_or_skip(request, provider)
-
-
 @pytest.fixture(scope='class')
 def setup_provider_clsscope(request, provider):
     """Module-scoped fixture to set up a provider"""


### PR DESCRIPTION
Intent
=====

__Refactoring__ test_alerts.py.

* Removed redundant fixtures
* Refactored pytest_generate_tests
* `provider.type` strings comparison replaced by `provider.one_of()`
* Renamed test VMs to `test-alert-`

{{py.test: -v -k 'test_alert' --long-running --use-provider vsphere65-nested}}