### PR TITLE
[1LP][RFR] Add container object to smart mgmt test suite

### DIFF
--- a/cfme/tests/containers/test_smart_management.py
+++ b/cfme/tests/containers/test_smart_management.py
@@ -21,9 +21,9 @@ pytestmark = [
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
 
-# TODO: fix polarion ID for Container object
+
 TEST_ITEMS = [
-    pytest.mark.polarion('CMP-10320')(ContainersTestItem(Container, 'CMP-10320')),
+    pytest.mark.polarion('CMP-9948')(ContainersTestItem(Container, 'CMP-9948')),
     pytest.mark.polarion('CMP-10320')(ContainersTestItem(Template, 'CMP-10320')),
     pytest.mark.polarion('CMP-9992')(ContainersTestItem(ImageRegistry, 'CMP-9992')),
     pytest.mark.polarion('CMP-9981')(ContainersTestItem(Image, 'CMP-9981')),
@@ -65,7 +65,7 @@ def obj_factory(obj_creator, row, provider):
                "Pod": lambda row: {"name": row.name.text, "provider": provider},
                "Node": lambda row: {"name": row.name.text, "provider": provider},
                "Template": lambda row: {"name": row.name.text, "provider": provider},
-               "Container": lambda row: {"name": row.name.text, "pod": row.pod.text},
+               "Container": lambda row: {"name": row.name.text, "pod": row.pod_name.text},
                "Image": lambda row: {"name": row.name.text,
                                      "tag": row.tag.text, "provider": provider},
                "Image_Registry": lambda row: {"host": row.host.text, "provider": provider}}

--- a/cfme/tests/containers/test_smart_management.py
+++ b/cfme/tests/containers/test_smart_management.py
@@ -58,21 +58,6 @@ def set_random_tag(instance):
     return Tag(display_name=random_tag.text, category=random_cat.text)
 
 
-def obj_factory(obj_creator, row, provider):
-
-    factory = {"Provider": lambda row: {"name": row.name.text},
-               "Project": lambda row: {"name": row.name.text, "provider": provider},
-               "Pod": lambda row: {"name": row.name.text, "provider": provider},
-               "Node": lambda row: {"name": row.name.text, "provider": provider},
-               "Template": lambda row: {"name": row.name.text, "provider": provider},
-               "Container": lambda row: {"name": row.name.text, "pod": row.pod_name.text},
-               "Image": lambda row: {"name": row.name.text,
-                                     "tag": row.tag.text, "provider": provider},
-               "Image_Registry": lambda row: {"host": row.host.text, "provider": provider}}
-
-    return obj_creator(**factory[get_object_name(obj_creator)](row))
-
-
 @pytest.mark.parametrize('test_item',
                          TEST_ITEMS, ids=[item.args[1].pretty_id() for item in TEST_ITEMS])
 def test_smart_management_add_tag(provider, test_item):

--- a/cfme/tests/containers/test_smart_management.py
+++ b/cfme/tests/containers/test_smart_management.py
@@ -8,6 +8,7 @@ from cfme.web_ui import toolbar, AngularSelect, form_buttons
 from cfme.configure.configuration import Tag
 from cfme.containers.provider import ContainersProvider, ContainersTestItem
 from cfme.containers.image import Image
+from cfme.containers.container import Container
 from cfme.containers.project import Project
 from cfme.containers.node import Node
 from cfme.containers.image_registry import ImageRegistry
@@ -20,7 +21,9 @@ pytestmark = [
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
 
+# TODO: fix polarion ID for Container object
 TEST_ITEMS = [
+    pytest.mark.polarion('CMP-10320')(ContainersTestItem(Container, 'CMP-10320')),
     pytest.mark.polarion('CMP-10320')(ContainersTestItem(Template, 'CMP-10320')),
     pytest.mark.polarion('CMP-9992')(ContainersTestItem(ImageRegistry, 'CMP-9992')),
     pytest.mark.polarion('CMP-9981')(ContainersTestItem(Image, 'CMP-9981')),
@@ -53,6 +56,21 @@ def set_random_tag(instance):
     form_buttons.save()
 
     return Tag(display_name=random_tag.text, category=random_cat.text)
+
+
+def obj_factory(obj_creator, row, provider):
+
+    factory = {"Provider": lambda row: {"name": row.name.text},
+               "Project": lambda row: {"name": row.name.text, "provider": provider},
+               "Pod": lambda row: {"name": row.name.text, "provider": provider},
+               "Node": lambda row: {"name": row.name.text, "provider": provider},
+               "Template": lambda row: {"name": row.name.text, "provider": provider},
+               "Container": lambda row: {"name": row.name.text, "pod": row.pod.text},
+               "Image": lambda row: {"name": row.name.text,
+                                     "tag": row.tag.text, "provider": provider},
+               "Image_Registry": lambda row: {"host": row.host.text, "provider": provider}}
+
+    return obj_creator(**factory[get_object_name(obj_creator)](row))
 
 
 @pytest.mark.parametrize('test_item',


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_smart_management.py -v --use-provider cm-env1 }}

When I automated Smart Management test suite i forgotten to add container object to test suite
in this PR i added the missing object.


