### PR TITLE
[1LP][RFR] Updating the doc with information about how to use latest selenium server

### DIFF
--- a/docs/guides/vnc_selenium.rst
+++ b/docs/guides/vnc_selenium.rst
@@ -85,7 +85,7 @@ Here's an example script that does those things:
 Important things:
 * The script **MUST** start with `#!/bin/sh` (or your shell shebang of choice).
 * The script **MUST** be executable (`chmod +x ~/.vnc/xstartup`)
-* The "-ensureCleanSession -trustAllSSLCertificates"  won't work with the latest selenium-server which is 3.4.0. 
+* The "-ensureCleanSession -trustAllSSLCertificates"  won't work with the selenium-server which is 3.x.x onward.
 Start the server
 ^^^^^^^^^^^^^^^^
 
@@ -149,7 +149,7 @@ An example of the yaml is below:
            desired_capabilities:
                platform: LINUX
                browserName: 'chrome'
-               # for the selenium-server version 3.4.0 you will need to use 
+               # for the selenium-server version 3.x.x onward you will need to use
                # following capabilities instead of using CLI arguments (uncomment next 2 lines)
                # and do not use '-ensureCleanSession -trustAllSSLCertificates' in java -jar command
                # which is used to launch selenium-server in xstartup script as shown 

--- a/docs/guides/vnc_selenium.rst
+++ b/docs/guides/vnc_selenium.rst
@@ -150,15 +150,19 @@ An example of the yaml is below:
                platform: LINUX
                browserName: 'chrome'
                # for the selenium-server version 3.4.0 you will need to use 
-               # following capabilities if you have written 'firefox' in browserName
-               acceptInsecureCerts: true
-               ensureCleanSession: true
+               # following capabilities instead of using CLI arguments (uncomment next 2 lines)
+               # and do not use '-ensureCleanSession -trustAllSSLCertificates' in java -jar command
+               # which is used to launch selenium-server in xstartup script as shown 
+               # in 'Configure the startup script' section
+               # acceptInsecureCerts: true
+               # ensureCleanSession: true
 
 
 Note: 
-You might see issue related 'mouseMoveTo' which is open on GitHub:
- * https://github.com/SeleniumHQ/selenium/issues/4008
- * https://github.com/SeleniumHQ/selenium/issues/3808
+If you are using selenium server 3.4.0 then you might see issue related 'mouseMoveTo' which is open on GitHub:
+* https://github.com/SeleniumHQ/selenium/issues/4008
+* https://github.com/SeleniumHQ/selenium/issues/3808
+
 
 Security
 --------

--- a/docs/guides/vnc_selenium.rst
+++ b/docs/guides/vnc_selenium.rst
@@ -85,7 +85,7 @@ Here's an example script that does those things:
 Important things:
 * The script **MUST** start with `#!/bin/sh` (or your shell shebang of choice).
 * The script **MUST** be executable (`chmod +x ~/.vnc/xstartup`)
-
+* The "-ensureCleanSession -trustAllSSLCertificates"  won't work with the latest selenium-server which is 3.4.0. 
 Start the server
 ^^^^^^^^^^^^^^^^
 
@@ -149,6 +149,16 @@ An example of the yaml is below:
            desired_capabilities:
                platform: LINUX
                browserName: 'chrome'
+               # for the selenium-server version 3.4.0 you will need to use 
+               # following capabilities if you have written 'firefox' in browserName
+               acceptInsecureCerts: true
+               ensureCleanSession: true
+
+
+Note: 
+You might see issue related 'mouseMoveTo' which is open on GitHub:
+ * https://github.com/SeleniumHQ/selenium/issues/4008
+ * https://github.com/SeleniumHQ/selenium/issues/3808
 
 Security
 --------


### PR DESCRIPTION


Purpose or Intent
=================

__Fixing__ vnc_selenium.rst because it currently does not show how to use the setup with the latest selenium server. Latest version of selenium server (3.4.0) does not take arguments "-ensureCleanSession -trustAllSSLCertificates" hence need to update those as capabilities in the env.yaml or env.local.yaml, whichever you are using. 