### PR TITLE
[1LP][RFR] test_delete_notifications_from_detail - add 5.8 to forced_streams for BZ1420872

### DIFF
--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -659,7 +659,7 @@ class TestNotificationsRESTAPI(object):
         Metadata:
             test_flag: rest
         """
-        if method == 'delete' and BZ('1420872', forced_streams=['5.7', 'upstream']).blocks:
+        if method == 'delete' and BZ('1420872', forced_streams=['5.7', '5.8', 'upstream']).blocks:
             pytest.skip("Affected by BZ1420872, cannot test.")
         collection = appliance.rest_api.collections.notifications
         collection.reload()


### PR DESCRIPTION
The BZ 1420872 should be blocker on 5.8 as well.

{{pytest: -v -k test_delete_notifications_from_detail}}