### PR TITLE
[1LP][RFR] Support for F26 devenv.

### DIFF
--- a/cfme/scripting/quickstart.py
+++ b/cfme/scripting/quickstart.py
@@ -47,11 +47,19 @@ REDHAT_PACKAGES_F25 = (
     " redhat-rpm-config gcc-c++ openssl-devel"
     " libffi-devel python2-devel")
 
+REDHAT_PACKAGES_F26 = (
+    " python2-virtualenv gcc postgresql-devel libxml2-devel"
+    " libxslt-devel zeromq-devel libcurl-devel"
+    " redhat-rpm-config gcc-c++ openssl-devel"
+    " libffi-devel python2-devel")
+
 
 if REDHAT_BASED:
     os.environ['PYCURL_SSL_LIBRARY'] = 'nss'
     if DISTRO_DATA == ("Fedora", "25"):
         REDHAT_PACKAGES = REDHAT_PACKAGES_F25
+    elif DISTRO_DATA == ("Fedora", "26"):
+        REDHAT_PACKAGES = REDHAT_PACKAGES_F26
     else:
         REDHAT_PACKAGES = REDHAT_PACKAGES_OLD
 


### PR DESCRIPTION
As Fedora 26 has no zeromq3-devel package, `python -m cfme.scripting.quickstart` command from getting started guide will fail.

So I've added REDHAT_PACKAGES_F26 variable with valid packages set.

Cheers.

Signed-off-by: Aleksei Slaikovskii <aslaikov@redhat.com>