### PR TITLE
[1LP][RFR] fix for python-bugzilla API change

### DIFF
--- a/utils/bz.py
+++ b/utils/bz.py
@@ -328,7 +328,7 @@ class BugWrapper(object):
         # With these states, the change is in upstream
         if self.status not in {"POST", "MODIFIED", "ON_QA", "VERIFIED", "RELEASE_PENDING"}:
             return False
-        history = self.get_history()["bugs"][0]["history"]
+        history = self.get_history_raw()["bugs"][0]["history"]
         changes = []
         # We look for status changes in the history
         for event in history:


### PR DESCRIPTION
This fixes BZ blockers on upstream. It's failing with
```
>       raise AttributeError(msg)
E       AttributeError: Bug object has no attribute 'can_test_on_upstream'.
E       If 'can_test_on_upstream' is a bugzilla attribute, it may not have been cached when the bug was fetched. You may want to adjust your include_fields for getbug/query.
```

It's caused by API change - ``Bug.get_history()`` is now ``Bug.get_history_raw()`` - see e.g. http://blog.wikichoon.com/2016/06/python-bugzilla-api-changes-in-git.html

This one was tricky to find, ``Bug.get_history()`` is called in ``can_test_on_upstream`` property and since it fails with attribute error, the ``can_test_on_upstream`` is passed to ``__getattr__``, hence this misleading error.