### PR TITLE
fix version float

### DIFF
--- a/utils/version.py
+++ b/utils/version.py
@@ -41,7 +41,7 @@ def get_version(obj=None):
     If obj is None, the version will be retrieved from the current appliance
 
     """
-    if isinstance(obj, Version):
+    if isinstance(obj, Version) or isinstance(obj, float):
         return obj
     if obj.startswith('master'):
         return Version.latest()

--- a/utils/version.py
+++ b/utils/version.py
@@ -3,6 +3,7 @@ import re
 from cached_property import cached_property
 from collections import namedtuple
 from datetime import date, datetime
+from six import string_types
 
 import multimethods as mm
 
@@ -41,8 +42,10 @@ def get_version(obj=None):
     If obj is None, the version will be retrieved from the current appliance
 
     """
-    if isinstance(obj, Version) or isinstance(obj, float):
+    if isinstance(obj, Version):
         return obj
+    if not isinstance(obj, string_types):
+        obj = str(obj)
     if obj.startswith('master'):
         return Version.latest()
     return Version(obj)


### PR DESCRIPTION
This is a fix for get_version when 'obj' is float.

During my testing an error occurred with get_version function. For whatever reason it was getting a float number on input (obj == 5.7) and it did not expect that to happen. My fix propagates this number through the function and fixes the tests for both 5.7 and 5.8.