### PR TITLE
[1LP][RFR] Fixed login method

### DIFF
--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -177,8 +177,10 @@ def login(self, user=None, submit_method=LOGIN_METHODS[-1]):
         login_view.log_in(user, method=submit_method)
         logged_in_view.flush_widget_cache()
         user.name = logged_in_view.current_fullname
-        assert logged_in_view.logged_in_as_user
-        logged_in_view.flash.assert_no_error()
+        try:
+            assert logged_in_view.logged_in_as_user
+        except AssertionError:
+            login_view.flash.assert_no_error()
         self.appliance.user = user
 
 


### PR DESCRIPTION
* Login method was trying to assert a flash message on a page that it
  shouldn't be on if the previous statement passed

{{pytest: cfme/tests/configure/test_access_control.py -k test_user_login}}