### PR TITLE
[1LP][WIP] Cloud provider widgetastic conversion -  rest of views

### DIFF
--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -220,7 +220,7 @@ def get_all_providers():
     return [item.name for item in view.items.get_all(surf_pages=True)]
 
 
-def discover(credential, cancel=False, d_type="Amazon"):
+def discover(credential, cancel=False, d_type="Amazon EC2"):
     """
     Discover cloud providers. Note: only starts discovery, doesn't
     wait for it to finish.
@@ -231,10 +231,19 @@ def discover(credential, cancel=False, d_type="Amazon"):
       d_type: provider name which will be discovered
     """
     view = navigate_to(CloudProvider, 'Discover')
-    view.fill({'discover_type': d_type,
-               'username': credential.principal,
-               'password': credential.secret,
-               'password_verify': credential.verify_secret})
+    view.fill({'discover_type': d_type})
+    if d_type == 'Amazon EC2':
+        view.fields.fill({'username': getattr(credential, 'principal', None),
+                          'password': getattr(credential, 'secret', None),
+                          'password_verify': getattr(credential, 'verify_secret', None)})
+    elif d_type == 'Azure':
+        view.fields.fill({'client_id': getattr(credential, 'principal', None),
+                          'client_key': getattr(credential, 'secret', None),
+                          'tenant_id': getattr(credential, 'tenant_id', None),
+                          'subscription': getattr(credential, 'subscription_id', None)})
+    else:
+        raise ValueError('Wrong provider type or credential')
+
     if cancel:
         view.cancel.click()
     else:

--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -18,103 +18,23 @@ from cfme.base.login import BaseLoggedInPage
 from cfme.common.provider_views import (CloudProviderAddView,
                                         CloudProviderEditView,
                                         CloudProviderDetailsView,
-                                        CloudProvidersView)
+                                        CloudProvidersView,
+                                        CloudProvidersDiscoverView,
+                                        ProvidersManagePoliciesView,
+                                        ProvidersEditTagsView)
 import cfme.fixtures.pytest_selenium as sel
 from cfme.common.provider import CloudInfraProvider
-from cfme.web_ui import form_buttons, CFMECheckbox
+from cfme.web_ui import form_buttons
 from cfme.web_ui import toolbar as tb
-from cfme.web_ui import Region, Quadicon, Form, Select, fill, paginator, AngularSelect, Radio, \
-    InfoBlock, match_location
-from cfme.web_ui import Input
-from cfme.web_ui.tabstrip import TabStripForm
+from cfme.web_ui import Region, fill, paginator, InfoBlock, match_location
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, navigate_to, CFMENavigateStep
 from utils.log import logger
 from utils.wait import wait_for
-from utils import version, deferred_verpick
 from utils.pretty import Pretty
 
 
-# Forms
-discover_form = Form(
-    fields=[
-        ('discover_select', AngularSelect("discover_type_selected"), {"appeared_in": "5.5"}),
-        ('username', "#userid"),
-        ('password', "#password"),
-        ('password_verify', "#verify"),
-        ('start_button', form_buttons.FormButton("Start the Host Discovery"))
-    ])
-
-properties_form_55 = Form(
-    fields=[
-        ('type_select', {version.LOWEST: Select('select#server_emstype'),
-            '5.5': AngularSelect("emstype")}),
-        ('azure_tenant_id', Input("azure_tenant_id")),
-        ('name_text', Input("name")),
-        ('hostname_text', Input("hostname")),
-        ('ipaddress_text', Input("ipaddress"), {"removed_since": "5.4.0.0.15"}),
-        ('region_select', {version.LOWEST: Select("select#provider_region"),
-            "5.5": AngularSelect("provider_region")}),
-        ('api_port', Input(
-            {
-                version.LOWEST: "port",
-                "5.5": "api_port",
-            }
-        )),
-        ('azure_subscription_id', Input("subscription"), {'appeared_in', '5.6'}),
-        ('api_version', AngularSelect("api_version"), {"appeared_in": "5.5"}),
-        ('sec_protocol', AngularSelect("security_protocol", exact=True), {"appeared_in": "5.5"}),
-        ('infra_provider', {
-            version.LOWEST: None,
-            "5.4": Select("select#provider_id"),
-            "5.5": AngularSelect("provider_id")}),
-    ])
-
-properties_form_56 = TabStripForm(
-    fields=[
-        ('type_select', AngularSelect("ems_type")),
-        ('name_text', Input("name")),
-        ('tenant_mapping', CFMECheckbox("ems_tenant_mapping_enabled"), {"appeared_in": "5.7"}),
-        ('region_select', {
-            version.LOWEST: AngularSelect("ems_region"),
-            '5.7': AngularSelect('provider_region')}),
-        ('google_region_select', {
-            version.LOWEST: AngularSelect("ems_preferred_region"),
-            '5.7': AngularSelect('provider_region')}),
-        ('api_version', AngularSelect("ems_api_version")),
-        ('infra_provider', AngularSelect("ems_infra_provider_id")),
-        ('google_project_text', Input("project")),
-        ('azure_tenant_id', Input("azure_tenant_id")),
-        ('azure_subscription_id', Input("subscription")),
-    ],
-    tab_fields={
-        "Default": [
-            ('hostname_text', Input("default_hostname")),
-            ('sec_protocol', AngularSelect("default_security_protocol", exact=True)),
-            ('api_port', Input("default_api_port")),
-        ],
-        "Events": [
-            ('event_selection', Radio('event_stream_selection')),
-            ('amqp_hostname_text', Input("amqp_hostname")),
-            ('amqp_api_port', Input("amqp_api_port")),
-            ('amqp_sec_protocol', AngularSelect("amqp_security_protocol", exact=True)),
-        ]
-    })
-
-prop_region = Region(
-    locators={
-        'properties_form': {
-            version.LOWEST: properties_form_55,
-            '5.6': properties_form_56,
-        }
-    }
-)
-
 details_page = Region(infoblock_type='detail')
-
-cfg_btn = partial(tb.select, 'Configuration')
-pol_btn = partial(tb.select, 'Policy')
-mon_btn = partial(tb.select, 'Monitoring')
 
 match_page = partial(match_location, controller='ems_cloud', title='Cloud Providers')
 
@@ -146,25 +66,15 @@ class CloudProvider(Pretty, CloudInfraProvider):
 
     """
     provider_types = {}
-    in_version = (version.LOWEST, version.LATEST)
     category = "cloud"
     pretty_attrs = ['name', 'credentials', 'zone', 'key']
     STATS_TO_MATCH = ['num_template', 'num_vm']
     string_name = "Cloud"
     page_name = "clouds"
     templates_destination_name = "Images"
-    quad_name = "cloud_prov"
     vm_name = "Instances"
     template_name = "Images"
-    _properties_region = prop_region  # This will get resolved in common to a real form
     db_types = ["CloudManager"]
-    # Specific Add button
-    add_provider_button = deferred_verpick(
-        {version.LOWEST: form_buttons.FormButton("Add this Cloud Provider"),
-         '5.5': form_buttons.add})
-    save_button = deferred_verpick(
-        {version.LOWEST: form_buttons.save,
-         '5.5': form_buttons.angular_save})
 
     def __init__(self, name=None, endpoints=None, zone=None, key=None, appliance=None):
         Navigatable.__init__(self, appliance=appliance)
@@ -210,10 +120,11 @@ class New(CFMENavigateStep):
 
 @navigator.register(CloudProvider, 'Discover')
 class Discover(CFMENavigateStep):
+    VIEW = CloudProvidersDiscoverView
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        cfg_btn('Discover Cloud Providers')
+        self.prerequisite_view.toolbar.configuration.item_select('Discover Cloud Providers')
 
 
 @navigator.register(CloudProvider, 'Details')
@@ -241,41 +152,45 @@ class EditFromDetails(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        cfg_btn('Edit this Cloud Provider')
+        self.prerequisite_view.toolbar.configuration.item_select('Edit this Cloud Provider')
 
 
 @navigator.register(CloudProvider, 'ManagePolicies')
 class ManagePolicies(CFMENavigateStep):
+    VIEW = ProvidersManagePoliciesView
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        sel.check(Quadicon(self.obj.name, self.obj.quad_name).checkbox())
-        pol_btn('Manage Policies')
+        self.prerequisite_view.items.get_item(by_name=self.obj.name).check()
+        self.prerequisite_view.toolbar.policy.item_select('Manage Policies')
 
 
 @navigator.register(CloudProvider, 'ManagePoliciesFromDetails')
 class ManagePoliciesFromDetails(CFMENavigateStep):
+    VIEW = ProvidersManagePoliciesView
     prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        pol_btn('Manage Policies')
+        self.prerequisite_view.toolbar.policy.item_select('Manage Policies')
 
 
 @navigator.register(CloudProvider, 'EditTags')
 class EditTags(CFMENavigateStep):
+    VIEW = ProvidersEditTagsView
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        sel.check(Quadicon(self.obj.name, self.obj.quad_name).checkbox())
-        pol_btn('Edit Tags')
+        self.prerequisite_view.items.get_item(by_name=self.obj.name).check()
+        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
 
 
 @navigator.register(CloudProvider, 'EditTagsFromDetails')
 class EditTagsFromDetails(CFMENavigateStep):
+    VIEW = ProvidersEditTagsView
     prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        pol_btn('Edit Tags')
+        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
 
 
 @navigator.register(CloudProvider, 'Timelines')
@@ -284,7 +199,8 @@ class Timelines(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        mon_btn('Timelines')
+        mon = self.prerequisite_view.toolbar.monitoring
+        mon.item_select('Timelines')
 
 
 @navigator.register(CloudProvider, 'Instances')
@@ -330,20 +246,22 @@ def discover(credential, cancel=False, d_type="Amazon"):
     Args:
       credential (cfme.base.credential.Credential):  Amazon discovery credentials.
       cancel (boolean):  Whether to cancel out of the discover UI.
+      d_type: provider name which will be discovered
     """
-    navigate_to(CloudProvider, 'Discover')
-    form_data = {'discover_select': d_type}
-    if credential:
-        form_data.update({'username': credential.principal,
-                          'password': credential.secret,
-                          'password_verify': credential.verify_secret})
-    fill(discover_form, form_data,
-         action=form_buttons.cancel if cancel else discover_form.start_button,
-         action_always=True)
+    view = navigate_to(CloudProvider, 'Discover')
+    view.fill({'discover_type': d_type,
+               'username': credential.principal,
+               'password': credential.secret,
+               'password_verify': credential.verify_secret})
+    if cancel:
+        view.cancel.click()
+    else:
+        view.start.click()
 
 
 def wait_for_a_provider():
-    navigate_to(CloudProvider, 'All')
+    view = navigate_to(CloudProvider, 'All')
     logger.info('Waiting for a provider to appear...')
-    wait_for(paginator.rec_total, fail_condition=None, message="Wait for any provider to appear",
-             num_sec=1000, fail_func=sel.refresh)
+    wait_for(lambda: int(view.paginator.items_amount), fail_condition=0,
+             message="Wait for any provider to appear", num_sec=1000,
+             fail_func=view.browser.selenium.refresh)

--- a/cfme/cloud/provider/gce.py
+++ b/cfme/cloud/provider/gce.py
@@ -36,11 +36,12 @@ class GCEProvider(CloudProvider):
     db_types = ["Google::CloudManager"]
     endpoints_form = GCEEndpointForm
 
-    def __init__(self, name=None, project=None, zone=None, region=None, endpoints=None, key=None,
-                 appliance=None):
+    def __init__(self, name=None, project=None, zone=None, region=None, region_name=None,
+                 endpoints=None, key=None, appliance=None):
         super(GCEProvider, self).__init__(name=name, zone=zone, key=key, endpoints=endpoints,
                                           appliance=appliance)
         self.region = region
+        self.region_name = region_name
         self.project = project
 
     @property
@@ -48,7 +49,7 @@ class GCEProvider(CloudProvider):
         return {
             'name': self.name,
             'prov_type': 'Google Compute Engine',
-            'region': self.region,
+            'region': self.region_name,
             'project_id': self.project
         }
 
@@ -59,6 +60,7 @@ class GCEProvider(CloudProvider):
                    project=prov_config['project'],
                    zone=prov_config['zone'],
                    region=prov_config['region'],
+                   region_name=prov_config['region_name'],
                    endpoints={endpoint.name: endpoint},
                    key=prov_key,
                    appliance=appliance)

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -361,8 +361,12 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
                     logger.warning('Skipping flash message verification because of BZ 1436341')
                     return
 
-                if details_view.is_displayed:
-                    success_text = '{} Provider "{}" was saved'.format(self.string_name, self.name)
+                success_text = '{} Provider "{}" was saved'.format(self.string_name, self.name)
+                if main_view.is_displayed:
+                    # since 5.8.1 main view is displayed when edit starts from main view
+                    main_view.flash.assert_message(success_text)
+                elif details_view.is_displayed:
+                    # details view is always displayed up to 5.8.1
                     details_view.flash.assert_message(success_text)
                 else:
                     edit_view.flash.assert_no_error()

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -103,7 +103,9 @@ class ProviderDetailsView(BaseLoggedInPage):
 
         title = '{name} ({subtitle})'.format(name=self.context['object'].name,
                                              subtitle=subtitle)
-        return self.logged_in_as_current_user and self.breadcrumb.active_location == title
+        return (self.logged_in_as_current_user and
+                self.breadcrumb.is_displayed and
+                self.breadcrumb.active_location == title)
 
 
 class InfraProviderDetailsView(ProviderDetailsView):

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from widgetastic.utils import VersionPick, Version
-from widgetastic.widget import View, Text
+from widgetastic.widget import View, Text, ConditionalSwitchableView
 from widgetastic_patternfly import Dropdown, BootstrapSelect, FlashMessages
 
 from cfme.base.login import BaseLoggedInPage
@@ -170,9 +170,21 @@ class CloudProvidersDiscoverView(BaseLoggedInPage):
     title = Text('//div[@id="main-content"]//h1')
 
     discover_type = BootstrapSelect('discover_type_selected')
-    username = Input(name='userid')
-    password = Input(name='password')
-    confirm_password = Input(name='verify')
+
+    fields = ConditionalSwitchableView(reference='discover_type')
+
+    @fields.register('Amazon EC2', default=True)
+    class Amazon(View):
+        username = Input(name='userid')
+        password = Input(name='password')
+        confirm_password = Input(name='verify')
+
+    @fields.register('Azure')
+    class Azure(View):
+        client_id = Input(name='client_id')
+        client_key = Input(name='client_key')
+        tenant_id = Input(name='azure_tenant_id')
+        subscription = Input(name='subscription')
 
     start = Button('Start')
     cancel = Button('Cancel')
@@ -397,7 +409,6 @@ class ProviderAddView(BaseLoggedInPage):
     title = Text('//div[@id="main-content"]//h1')
     name = Input('name')
     prov_type = BootstrapSelect(id='emstype')
-    api_version = BootstrapSelect(id='api_version')  # only for OpenStack
     keystone_v3_domain_id = Input('keystone_v3_domain_id')  # OpenStack only
     zone = Input('zone')
     flash = FlashMessages('.//div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
@@ -419,6 +430,8 @@ class ProviderAddView(BaseLoggedInPage):
 
 
 class InfraProviderAddView(ProviderAddView):
+    api_version = BootstrapSelect(id='api_version')  # only for OpenStack
+
     @property
     def is_displayed(self):
         return (super(InfraProviderAddView, self).is_displayed and
@@ -436,6 +449,8 @@ class CloudProviderAddView(ProviderAddView):
     tenant_id = Input('azure_tenant_id')  # only for Azure
     subscription = Input('subscription')  # only for Azure
     project_id = Input('project')  # only for Azure
+    # bug in cfme this field has different ids for cloud and infra add views
+    api_version = BootstrapSelect(id='ems_api_version')  # only for OpenStack
     infra_provider = BootstrapSelect(id='ems_infra_provider_id')  # OpenStack only
     tenant_mapping = Checkbox(name='tenant_mapping_enabled')  # OpenStack only
 

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -137,7 +137,7 @@ class ProviderTimelinesView(TimelinesView, BaseLoggedInPage):
                 TimelinesView.is_displayed)
 
 
-class ProvidersDiscoverView(BaseLoggedInPage):
+class InfraProvidersDiscoverView(BaseLoggedInPage):
     """
      Discover View from Infrastructure Providers page
     """
@@ -161,6 +161,27 @@ class ProvidersDiscoverView(BaseLoggedInPage):
         return (self.logged_in_as_current_user and
                 self.navigation.currently_selected == ['Compute', 'Infrastructure', 'Providers'] and
                 self.title.text == 'Infrastructure Providers Discovery')
+
+
+class CloudProvidersDiscoverView(BaseLoggedInPage):
+    """
+     Discover View from Infrastructure Providers page
+    """
+    title = Text('//div[@id="main-content"]//h1')
+
+    discover_type = BootstrapSelect('discover_type_selected')
+    username = Input(name='userid')
+    password = Input(name='password')
+    confirm_password = Input(name='verify')
+
+    start = Button('Start')
+    cancel = Button('Cancel')
+
+    @property
+    def is_displayed(self):
+        return (self.logged_in_as_current_user and
+                self.navigation.currently_selected == ['Compute', 'Clouds', 'Providers'] and
+                self.title.text == 'Cloud Providers Discovery')
 
 
 class ProvidersManagePoliciesView(BaseLoggedInPage):

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -402,4 +402,4 @@ def wait_for_a_provider():
     logger.info('Waiting for a provider to appear...')
     wait_for(lambda: int(view.paginator.items_amount), fail_condition=0,
              message="Wait for any provider to appear", num_sec=1000,
-             fail_func=view.browser.selenium.refresh)
+             fail_func=view.browser.refresh)

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -12,7 +12,7 @@ from cfme.common.provider_views import (InfraProviderAddView,
                                         InfraProviderEditView,
                                         InfraProviderDetailsView,
                                         ProviderTimelinesView,
-                                        ProvidersDiscoverView,
+                                        InfraProvidersDiscoverView,
                                         ProvidersManagePoliciesView,
                                         ProvidersEditTagsView,
                                         InfraProvidersView)
@@ -53,14 +53,12 @@ class InfraProvider(Pretty, CloudInfraProvider, Fillable):
 
     """
     provider_types = {}
-    in_version = (version.LOWEST, version.LATEST)
     category = "infra"
     pretty_attrs = ['name', 'key', 'zone']
     STATS_TO_MATCH = ['num_template', 'num_vm', 'num_datastore', 'num_host', 'num_cluster']
     string_name = "Infrastructure"
     page_name = "infrastructure"
     templates_destination_name = "Templates"
-    quad_name = "infra_prov"
     db_types = ["InfraManager"]
 
     def __init__(
@@ -249,7 +247,7 @@ class Add(CFMENavigateStep):
 
 @navigator.register(InfraProvider, 'Discover')
 class Discover(CFMENavigateStep):
-    VIEW = ProvidersDiscoverView
+    VIEW = InfraProvidersDiscoverView
     prerequisite = NavigateToSibling('All')
 
     def step(self):
@@ -403,4 +401,5 @@ def wait_for_a_provider():
     view = navigate_to(InfraProvider, 'All')
     logger.info('Waiting for a provider to appear...')
     wait_for(lambda: int(view.paginator.items_amount), fail_condition=0,
-             message="Wait for any provider to appear", num_sec=1000, fail_func=sel.refresh)
+             message="Wait for any provider to appear", num_sec=1000,
+             fail_func=view.browser.selenium.refresh)

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -8,7 +8,7 @@ import pytest
 
 from utils import error
 from cfme.base.credential import Credential
-from cfme.cloud.provider import (discover, wait_for_a_provider, CloudProvider)
+from cfme.cloud.provider import discover, wait_for_a_provider, CloudProvider
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.cloud.provider.ec2 import EC2Provider
@@ -31,7 +31,7 @@ pytest_generate_tests = testgen.generate([CloudProvider], scope="function")
 @test_requirements.discovery
 def test_empty_discovery_form_validation(appliance):
     """ Tests that the flash message is correct when discovery form is empty."""
-    discover(None, d_type="Amazon")
+    discover(None, d_type="Amazon EC2")
     view = appliance.browser.create_view(CloudProvidersDiscoverView)
     view.flash.assert_message('Username is required')
 
@@ -40,7 +40,7 @@ def test_empty_discovery_form_validation(appliance):
 @test_requirements.discovery
 def test_discovery_cancelled_validation(appliance):
     """ Tests that the flash message is correct when discovery is cancelled."""
-    discover(None, cancel=True, d_type="Amazon")
+    discover(None, cancel=True, d_type="Amazon EC2")
     view = appliance.browser.create_view(CloudProvidersView)
     view.flash.assert_success_message('Cloud Providers Discovery was cancelled by the user')
 
@@ -63,7 +63,7 @@ def test_password_mismatch_validation(appliance):
         secret=fauxfactory.gen_alphanumeric(5),
         verify_secret=fauxfactory.gen_alphanumeric(7))
 
-    discover(cred, d_type="Amazon")
+    discover(cred, d_type="Amazon EC2")
     view = appliance.browser.create_view(CloudProvidersView)
     view.flash.assert_message('Password/Verify Password do not match')
 
@@ -76,7 +76,7 @@ def test_providers_discovery_amazon(appliance):
     # This test was being uncollected anyway, and needs to be parametrized and not directory call
     # out to specific credential keys
     # amazon_creds = get_credentials_from_config('cloudqe_amazon')
-    # discover(amazon_creds, d_type="Amazon")
+    # discover(amazon_creds, d_type="Amazon EC2")
 
     view = appliance.browser.create_view(CloudProvidersView)
     view.flash.assert_success_message('Amazon Cloud Providers: Discovery successfully initiated')
@@ -217,7 +217,7 @@ def test_api_port_blank_validation(request):
 @pytest.mark.tier(3)
 def test_user_id_max_character_validation():
     cred = Credential(principal=fauxfactory.gen_alphanumeric(51), secret='')
-    discover(cred, d_type="Amazon")
+    discover(cred, d_type="Amazon EC2")
 
 
 @pytest.mark.tier(3)
@@ -227,7 +227,7 @@ def test_password_max_character_validation():
         principal=fauxfactory.gen_alphanumeric(5),
         secret=password,
         verify_secret=password)
-    discover(cred, d_type="Amazon")
+    discover(cred, d_type="Amazon EC2")
 
 
 @pytest.mark.tier(3)

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -546,6 +546,7 @@ class IPAppliance(object):
          automation issues.
         """
         from utils.providers import list_providers
+        from cfme.base.credential import ServiceAccountCredential
 
         def _recognized_by_ip(provider, ems):
             if any(p_type in ems.type for p_type in RECOGNIZED_BY_IP):
@@ -567,6 +568,10 @@ class IPAppliance(object):
                     # TODO: fix this when all providers are moved to endpoints
                     if hasattr(provider, 'default_endpoint'):
                         default_creds = provider.default_endpoint.credentials
+                        if isinstance(default_creds, ServiceAccountCredential):
+                            # TODO: ask providers about gce private key format in authentications
+                            # table and add gce support
+                            return False
                     else:
                         default_creds = provider.credentials['default']
                 except KeyError:


### PR DESCRIPTION
1. Converted rest of cloud provider views to widgetastic
2. fixed all broken tests
3. Removed old code from both cloud and infra providers
4. fixed various issues

{{pytest: -v cfme/tests/cloud/test_providers.py cfme/tests/infrastructure/test_providers.py cfme/tests/cloud_infra_common/test_discovery.py cfme/tests/cloud_infra_common/test_tag_objects.py cfme/tests/cloud_infra_common/test_tag_visibility.py }}