### PR TITLE
[RFR] Skip unstable tests

### DIFF
--- a/cfme/tests/containers/test_containers_smartstate_analysis.py
+++ b/cfme/tests/containers/test_containers_smartstate_analysis.py
@@ -7,7 +7,6 @@ from cfme.containers.image import Image
 from cfme.containers.provider import ContainersProvider, ContainersTestItem
 
 from utils import testgen
-from utils.blockers import BZ
 from utils.wait import wait_for
 from cfme.configure.tasks import delete_all_tasks
 
@@ -65,9 +64,8 @@ def test_check_compliance(random_image_instance):
     random_image_instance.check_compliance()
 
 
-@pytest.mark.meta(blockers=[BZ(1382326), BZ(1408255), BZ(1371896),
-                            BZ(1447655, forced_streams=['5.7', '5.8', 'upstream'])])
 @pytest.mark.parametrize(('test_item'), TEST_ITEMS)
+@pytest.mark.skip(reason="This test is currently skipped due to instability issues. ")
 def test_containers_smartstate_analysis(provider, test_item, soft_assert,
                                         delete_all_container_tasks,
                                         random_image_instance):

--- a/cfme/tests/containers/test_properties.py
+++ b/cfme/tests/containers/test_properties.py
@@ -156,6 +156,7 @@ def test_properties(provider, test_item, soft_assert):
                                    .format(test_item.obj.__name__, instance.name, field))
 
 
+@pytest.mark.skip(reason="This test is currently skipped due to instability issues. ")
 def test_pods_conditions(provider, appliance, soft_assert):
 
     #  TODO: Add later this logic to mgmtsystem

--- a/cfme/tests/containers/test_reload_button_provider.py
+++ b/cfme/tests/containers/test_reload_button_provider.py
@@ -15,6 +15,7 @@ pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
 
 
 @pytest.mark.polarion('CMP-9878')
+@pytest.mark.skip(reason="This test is currently skipped due to instability issues. ")
 def test_reload_button_provider(provider):
     """ This test verifies the data integrity of the fields in
         the Relationships table after clicking the "reload"

--- a/cfme/tests/containers/test_reports.py
+++ b/cfme/tests/containers/test_reports.py
@@ -93,6 +93,7 @@ def test_container_reports_base_on_options(soft_assert):
 
 @pytest.mark.meta(blockers=[BZ(1435958, forced_streams=["5.8"])])
 @pytest.mark.polarion('CMP-9533')
+@pytest.mark.skip(reason="This test is currently skipped due to instability issues. ")
 def test_pods_per_ready_status(soft_assert, pods_per_ready_status):
     """Testing 'Pods per Ready Status' report, see polarion case for more info"""
     report = get_report('Pods per Ready Status')

--- a/cfme/tests/containers/test_smart_management.py
+++ b/cfme/tests/containers/test_smart_management.py
@@ -64,6 +64,7 @@ def test_smart_management_add_tag(provider, test_item):
 
     # validate no tag set to project
     if test_item.obj is ContainersProvider:
+        pytest.skip("This test is currently skipped due to instability issues. ")
         obj_inst = provider
     else:
         obj_inst = test_item.obj.get_random_instances(provider, count=1).pop()


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_containers_smartstate_analysis.py cfme/tests/containers/test_properties.py cfme/tests/containers/test_reload_button_provider.py cfme/tests/containers/test_reports.py cfme/tests/containers/test_smart_management.py -v --use-provider cm-env2}}
- Skipping unstable tests