### PR TITLE
[1LP][RFR] Convert AnalysisProfile to Widgetastic

### DIFF
--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -279,6 +279,7 @@ class ConfigurationView(BaseLoggedInPage):
         @View.nested
         class settings(Accordion):  # noqa
             ACCORDION_NAME = "Settings"
+            INDIRECT = True
             tree = ManageIQTree()
 
         @View.nested

--- a/cfme/configure/configuration/analysis_profile.py
+++ b/cfme/configure/configuration/analysis_profile.py
@@ -1,0 +1,440 @@
+# -*- coding: utf-8 -*-
+from copy import deepcopy
+
+from navmazing import NavigateToSibling, NavigateToObject, NavigationDestinationNotFound
+from widgetastic.widget import View, Text, ConditionalSwitchableView
+from widgetastic.utils import Fillable
+from widgetastic_patternfly import Dropdown, Button, CandidateNotFound, TextInput, Tab
+from widgetastic_manageiq import (
+    Table, PaginationPane, SummaryFormItem, Checkbox, CheckboxSelect, DynamicTable)
+
+from cfme.base.login import BaseLoggedInPage
+from cfme.base.ui import Server, ConfigurationView
+from utils.appliance import Navigatable
+from utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
+from utils.pretty import Pretty
+from utils.update import Updateable
+
+
+table_button_classes = [Button.DEFAULT, Button.SMALL, Button.BLOCK]
+
+
+class AnalysisProfileToolbar(View):
+    """Toolbar on the analysis profiles configuration page
+    Works for both all page and details page
+    """
+    configuration = Dropdown('Configuration')
+
+
+class AnalysisProfileEntities(View):
+    """Main content on the analysis profiles configuration page, title and table"""
+    title = Text('//div[@id="main-content"]//h1[@id="explorer_title"]'
+                 '/span[@id="explorer_title_text"]')
+    table = Table('//div[@id="records_div"]//table')
+
+
+class AnalysisProfileDetailsEntities(View):
+    """Main content on an analysis profile details page"""
+    title = Text('//div[@id="main-content"]//h1[@id="explorer_title"]'
+                 '/span[@id="explorer_title_text"]')
+    info_name = SummaryFormItem(group_title='Info', item_name='Name')
+    info_description = SummaryFormItem(group_title='Info', item_name='Description')
+    info_type = SummaryFormItem(group_title='Info', item_name='Type')
+    table = Table('//h3[normalize-space(.)="File Items"]/following-sibling::table')
+    # TODO 'Event Log Items' below the table doesn't have a label, SummaryFormItem doesn't work
+
+
+class AnalysisProfileAllView(BaseLoggedInPage):
+    """View for the Analysis Profile collection page"""
+    @property
+    def is_displayed(self):
+        return (self.logged_in_as_current_user and
+                self.sidebar.accordions.settings.tree.selected_item.text == 'Analysis Profiles' and
+                self.entities.title.text == 'Settings Analysis Profiles')
+
+    toolbar = View.nested(AnalysisProfileToolbar)
+    sidebar = View.nested(ConfigurationView)
+    entities = View.nested(AnalysisProfileEntities)
+    paginator = View.nested(PaginationPane)
+
+
+class AnalysisProfileDetailsView(BaseLoggedInPage):
+    """View for an analysis profile details page"""
+    @property
+    def is_displayed(self):
+        return (
+            self.logged_in_as_current_user and
+            self.entities.title.text == 'Settings Analysis Profile "{}"'
+                                        .format(self.context['object'].name))
+
+    toolbar = View.nested(AnalysisProfileToolbar)
+    sidebar = View.nested(ConfigurationView)
+    entities = View.nested(AnalysisProfileDetailsEntities)
+
+
+class AnalysisProfileBaseAddForm(View):
+    """View for the common elements of the two AP forms"""
+    name = TextInput(id='name')
+    description = TextInput(id='description')
+
+    @View.nested
+    class files(Tab):  # noqa
+        TAB_NAME = 'File'
+        tab_form = DynamicTable(
+            locator='.//h3[normalize-space(.)="File Entry"]/following-sibling::table',
+            column_widgets={
+                'Name': TextInput(id='entry_fname'),
+                'Collect Contents?': Checkbox(id='entry_content'),
+                'Actions': Button(title='Add this entry', classes=table_button_classes)},
+            assoc_column='Name', rows_ignore_top=1, action_row=0)
+
+    @View.nested
+    class events(Tab):  # noqa
+        TAB_NAME = 'Event Log'
+        tab_form = DynamicTable(
+            locator='.//h3[normalize-space(.)="Event Log Entry"]/following-sibling::table',
+            column_widgets={
+                'Name': TextInput(id='entry_name'),
+                'Filter Message': TextInput(id='entry_message'),
+                'Level': TextInput(id='entry_level'),
+                'Source': TextInput(id='entry_source'),
+                '# of Days': TextInput(id='entry_num_days'),
+                'Actions': Button(title='Add this entry', classes=table_button_classes)},
+            assoc_column='Name', rows_ignore_top=1, action_row=0)
+
+
+class AnalysisProfileAddView(BaseLoggedInPage):
+    """View for the add form, switches between host/vm based on object type
+    Uses a switchable view based on the profile type widget
+    """
+    @property
+    def is_displayed(self):
+        return (
+            self.title.text == 'Adding a new Analysis Profile' and
+            self.profile_type.text == self.context['object'].profile_type)
+    title = Text('//div[@id="main-content"]//h1[@id="explorer_title"]'
+                 '/span[@id="explorer_title_text"]')
+    # This is a ALMOST a SummaryFormItem, but there's no div to wrap the items so it doesn't work
+    # instead I have this nasty xpath to hack around that
+    profile_type = Text(
+        locator='.//h3[normalize-space(.)="Basic Information"]'
+                '/following-sibling::div[@class="form-group"]'
+                '/label[normalize-space(.)="Type"]'
+                '/following-sibling::div')
+    form = ConditionalSwitchableView(reference='profile_type')
+    # to avoid dynamic table buttons use title + alt + classes
+    add = Button(title='Add', classes=[Button.PRIMARY], alt='Add')
+    cancel = Button(title='Cancel', classes=[Button.DEFAULT], alt='Cancel')
+
+    @form.register('Host')
+    class AnalysisProfileAddHost(AnalysisProfileBaseAddForm):
+        """View for the host profile add form"""
+        pass
+
+    @form.register('Vm')
+    class AnalysisProfileAddVm(AnalysisProfileBaseAddForm):
+        """View for the vm profile add form"""
+        @View.nested
+        class categories(Tab):  # noqa
+            TAB_NAME = 'Category'
+            tab_form = CheckboxSelect(search_root='form_div')
+
+        @View.nested
+        class registry(Tab):  # noqa
+            TAB_NAME = 'Registry'
+            tab_form = DynamicTable(
+                locator='.//h3[normalize-space(.)="Registry Entry"]/following-sibling::table',
+                column_widgets={
+                    'Registry Hive': Text('.//tr[@id="new_tr"]/td[normalize-space(.)="HKLM"]'),
+                    'Registry Key': TextInput(id='entry_kname'),
+                    'Registry Value': TextInput(id='entry_value'),
+                    'Actions': Button(title='Add this entry', classes=table_button_classes)},
+                assoc_column='Registry Key', rows_ignore_top=1, action_row=0)
+
+
+class AnalysisProfileEditView(AnalysisProfileAddView):
+    """View for the edit form, extends add view since all fields are the same and editable"""
+    @property
+    def is_displayed(self):
+        expected_title = 'Editing Analysis Profile "{}"'.format(self.context['object'].name)
+        return (
+            self.title.text == expected_title and
+            self.profile_type.text == self.context['object'].profile_type)
+
+    # to avoid dynamic table buttons use title + alt + classes
+    save = Button(title='Save Changes', classes=[Button.PRIMARY])
+    reset = Button(title='Reset Changes', classes=[Button.DEFAULT], alt='Save Changes')
+
+
+class AnalysisProfileCopyView(AnalysisProfileAddView):
+    """View for the copy form is the same as an add
+
+    The name field is by default set with 'Copy of [profile name of copy source]
+    Don't want to assert against this field to separately verify the view is displayed
+    If is_displayed is called after the form is changed it will be false negative"""
+    pass
+
+
+class AnalysisProfile(Pretty, Updateable, Fillable, Navigatable):
+    """Analysis profiles, Vm and Host type
+
+    Example: Note the keys for files, events, registry should match UI columns
+
+        .. code-block:: python
+
+            p = AnalysisProfile(name, description, profile_type='VM')
+            p.files = [
+                {"Name": "/some/anotherfile", "Collect_Contents?": True},
+            ]
+            p.events = [
+                {"Name": name, "Filter Message": msg, "Level": lvl, "Source": src, "# of Days": 1},
+            ]
+            p.registry = [
+                {"Registry Key": key, "Registry Value": value},
+            ]
+            p.categories = ["System", "Software"]  # Use the checkbox text name
+            p.create()
+            p2 = p.copy(new_name="updated AP")
+            with update(p):
+                p.files = [{"Name": "/changed". "Collect_Contents?": False}]
+            p.delete()
+
+    """
+    CREATE_LOC = None
+    pretty_attrs = "name", "description", "files", "events"
+    VM_TYPE = 'Vm'
+    HOST_TYPE = 'Host'
+
+    def __init__(self, name, description, profile_type, files=None, events=None, categories=None,
+                 registry=None, appliance=None):
+        Navigatable.__init__(self, appliance=appliance)
+        self.name = name
+        self.description = description
+        self.files = files if isinstance(files, (list, type(None))) else [files]
+        self.events = events if isinstance(events, (list, type(None))) else [events]
+        self.categories = categories if isinstance(categories, (list, type(None))) else [categories]
+        self.registry = registry if isinstance(registry, (list, type(None))) else [registry]
+        if profile_type in (self.VM_TYPE, self.HOST_TYPE):
+            self.profile_type = profile_type
+        else:
+            raise ValueError("Profile Type is incorrect")
+
+    def create(self, cancel=False):
+        """Add Analysis Profile to appliance"""
+        # The tab form values have to be dictionaries with the root key matching the tab widget name
+        form_values = self.form_fill_args()
+
+        view = navigate_to(self, 'Add')
+        view.form.fill(form_values)
+
+        if cancel:
+            view.cancel.click()
+        else:
+            view.add.click()
+
+        view = self.create_view(AnalysisProfileAllView)
+        view.flush_widget_cache()
+        assert view.is_displayed
+        view.flash.assert_no_error()
+        view.flash.assert_success_message(
+            'Add of new Analysis Profile was cancelled by the user'
+            if cancel
+            else 'Analysis Profile "{}" was saved'.format(self.name))
+
+    def update(self, updates, cancel=False):
+        """Update the existing Analysis Profile with given updates dict
+        Make use of Updateable and use `with` to update object as well
+        Note the updates dict should take the structure below if called directly
+
+            .. code-block:: python
+                updates = {
+                    'name': self.name,
+                    'description': self.description,
+                    'files': {
+                        'tab_form': ['/example/file']},
+                    'events': {
+                        'tab_form': ['example_event']},
+                    'categories': {
+                        'tab_form': ['Example']},
+                    'registry': {
+                        'tab_form': ['example_registry']}
+                }
+
+            Args:
+                updates (dict): Dictionary of values to change in the object.
+                cancel (boolean): whether to cancel the update
+        """
+        # hack to work around how updates are passed when used in context mgr
+        # TODO revisit this method when BZ is fixed:
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1485953
+        form_fill_args = self.form_fill_args(updates=updates)
+        view = navigate_to(self, 'Edit')
+        changed = view.form.fill(form_fill_args)
+
+        if changed and not cancel:  # save button won't be enabled if nothing was changed
+            view.save.click()
+        else:
+            view.cancel.click()
+
+        view = self.create_view(AnalysisProfileDetailsView)  # edited through details
+        view.flush_widget_cache()
+        # Can't assert view.is_displayed because the name may have changed and object hasn't
+        # been updated yet
+        assert (view.entities.title.text == 'Settings Analysis Profile "{}"'
+                                            .format(updates.get('name', self.name)))
+        view.flash.assert_no_error()
+        view.flash.assert_success_message(
+            'Edit of Analysis Profile "{}" was cancelled by the user'.format(self.name)
+            if cancel or not changed
+            else 'Analysis Profile "{}" was saved'.format(updates.get('name', self.name)))
+
+    def delete(self, cancel=False):
+        """Delete self via details page"""
+        view = navigate_to(self, 'Details')
+        view.toolbar.configuration.item_select("Delete this Analysis Profile",
+                                               handle_alert=not cancel)
+        view = self.create_view(
+            AnalysisProfileDetailsView if cancel else AnalysisProfileAllView)
+        view.flush_widget_cache()
+        assert view.is_displayed
+        if not cancel:
+            view.flash.assert_success_message('Analysis Profile "{}": Delete successful'
+                                              .format(self.description))
+        else:
+            assert view.flash.messages == []
+
+    def copy(self, new_name=None, cancel=False):
+        """Copy the Analysis Profile"""
+        # Create a new object to return in addition to running copy in the UI
+        # TODO revisit this method when BZ is fixed:
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1485953
+        profile_args = self.__dict__.copy()
+        profile_args['name'] = new_name or self.name + "-copy"
+        new_profile = AnalysisProfile(**profile_args)
+
+        # actually run copy in the UI, fill the form
+        view = navigate_to(self, 'Copy')
+        form_args = self.form_fill_args(updates={'name': new_profile.name})
+        view.form.fill(form_args)
+        if cancel:
+            view.cancel.click()
+        else:
+            view.add.click()
+
+        # check the result
+        view = self.create_view(
+            AnalysisProfileDetailsView if cancel else AnalysisProfileAllView)
+        view.flush_widget_cache()
+        assert view.is_displayed
+        view.flash.assert_no_error()
+        view.flash.assert_success_message(
+            'Add of new Analysis Profile was cancelled by the user'  # yep, not copy specific
+            if cancel
+            else 'Analysis Profile "{}" was saved'.format(new_profile.name))
+
+        return new_profile
+
+    @property
+    def exists(self):
+        try:
+            navigate_to(self, 'Details')
+        except (NavigationDestinationNotFound, CandidateNotFound):
+            return False
+        else:
+            return True
+
+    def as_fill_value(self):
+        """String representation of an Analysis Profile in CFME UI"""
+        return self.name
+
+    def form_fill_args(self, updates=None):
+        """Build a dictionary of nested tab_forms for assoc_fill from a flat object dictionary
+        If updates dictionary is passed, it is used instead of `self`
+        This should work for create or update form fill args
+        """
+        fill_args = {'profile_type': None}  # this can't be set when adding or editing
+        for key in ['name', 'description']:
+            arg = updates[key] if updates and key in updates else getattr(self, key)
+            fill_args[key] = arg
+
+        for key in ['files', 'events', 'registry']:
+            data = deepcopy(updates[key] if updates and key in updates else getattr(self, key))
+            if isinstance(data, list):
+                # It would be much better to not have these hardcoded, but I can't get them
+                # statically from the form (ConditionalSwitchWidget)
+                assoc_column = 'Name' if key in ['files', 'events'] else 'Registry Key'
+                values_dict = {}
+                for item in data:
+                    name = item.pop(assoc_column)
+                    values_dict[name] = item
+
+                fill_args[key] = {'tab_form': values_dict}
+
+        for key in ['categories']:
+            # No assoc_fill for checkbox select, just tab_form mapping here
+            arg = deepcopy(updates[key] if updates and key in updates else getattr(self, key))
+            fill_args[key] = {'tab_form': arg}
+
+        return fill_args
+
+    def __str__(self):
+        return self.as_fill_value()
+
+    def __enter__(self):
+        self.create()
+
+    def __exit__(self, type, value, traceback):
+        self.delete()
+
+
+@navigator.register(AnalysisProfile, 'All')
+class AnalysisProfileAll(CFMENavigateStep):
+    VIEW = AnalysisProfileAllView
+    prerequisite = NavigateToObject(Server, 'Configuration')
+
+    def step(self):
+        server_region = self.obj.appliance.server_region_string()
+        self.prerequisite_view.accordions.settings.tree.click_path(
+            server_region, "Analysis Profiles")
+
+
+@navigator.register(AnalysisProfile, 'Add')
+class AnalysisProfileAdd(CFMENavigateStep):
+    VIEW = AnalysisProfileAddView
+    prerequisite = NavigateToSibling('All')
+
+    def step(self):
+        # stupid capitalization inconsistencies, just wait until there's a 3rd option...
+        profile_type = self.obj.profile_type if self.obj.profile_type == 'Host' else 'VM'
+        self.prerequisite_view.toolbar.configuration.item_select(
+            "Add {} Analysis Profile".format(profile_type))
+
+
+@navigator.register(AnalysisProfile, 'Details')
+class AnalysisProfileDetails(CFMENavigateStep):
+    VIEW = AnalysisProfileDetailsView
+    prerequisite = NavigateToSibling('All')
+
+    def step(self):
+        server_region = self.obj.appliance.server_region_string()
+        self.prerequisite_view.sidebar.accordions.settings.tree.click_path(
+            server_region, "Analysis Profiles", str(self.obj))
+
+
+@navigator.register(AnalysisProfile, 'Edit')
+class AnalysisProfileEdit(CFMENavigateStep):
+    VIEW = AnalysisProfileEditView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        self.prerequisite_view.toolbar.configuration.item_select("Edit this Analysis Profile")
+
+
+@navigator.register(AnalysisProfile, 'Copy')
+class AnalysisProfileCopy(CFMENavigateStep):
+    VIEW = AnalysisProfileCopyView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        self.prerequisite_view.toolbar.configuration.item_select(
+            'Copy this selected Analysis Profile')

--- a/cfme/configure/configuration/analysis_profile.py
+++ b/cfme/configure/configuration/analysis_profile.py
@@ -112,6 +112,7 @@ class AnalysisProfileAddView(BaseLoggedInPage):
         return (
             self.title.text == 'Adding a new Analysis Profile' and
             self.profile_type.text == self.context['object'].profile_type)
+
     title = Text('//div[@id="main-content"]//h1[@id="explorer_title"]'
                  '/span[@id="explorer_title_text"]')
     # This is a ALMOST a SummaryFormItem, but there's no div to wrap the items so it doesn't work
@@ -235,7 +236,6 @@ class AnalysisProfile(Pretty, Updateable, Fillable, Navigatable):
         view = self.create_view(AnalysisProfileAllView)
         view.flush_widget_cache()
         assert view.is_displayed
-        view.flash.assert_no_error()
         view.flash.assert_success_message(
             'Add of new Analysis Profile was cancelled by the user'
             if cancel
@@ -276,13 +276,10 @@ class AnalysisProfile(Pretty, Updateable, Fillable, Navigatable):
         else:
             view.cancel.click()
 
-        view = self.create_view(AnalysisProfileDetailsView)  # edited through details
-        view.flush_widget_cache()
-        # Can't assert view.is_displayed because the name may have changed and object hasn't
-        # been updated yet
-        assert (view.entities.title.text == 'Settings Analysis Profile "{}"'
-                                            .format(updates.get('name', self.name)))
-        view.flash.assert_no_error()
+        # redirects to details if edited from there
+        view = self.create_view(AnalysisProfileDetailsView, override=updates)
+        assert view.is_displayed
+
         view.flash.assert_success_message(
             'Edit of Analysis Profile "{}" was cancelled by the user'.format(self.name)
             if cancel or not changed
@@ -326,7 +323,6 @@ class AnalysisProfile(Pretty, Updateable, Fillable, Navigatable):
             AnalysisProfileDetailsView if cancel else AnalysisProfileAllView)
         view.flush_widget_cache()
         assert view.is_displayed
-        view.flash.assert_no_error()
         view.flash.assert_success_message(
             'Add of new Analysis Profile was cancelled by the user'  # yep, not copy specific
             if cancel

--- a/cfme/tests/configure/test_analysis_profiles.py
+++ b/cfme/tests/configure/test_analysis_profiles.py
@@ -2,107 +2,213 @@
 import fauxfactory
 import pytest
 
-import cfme.fixtures.pytest_selenium as sel
-from cfme.configure.configuration import AnalysisProfile
-from cfme.web_ui import Table, flash, toolbar as tb, form_buttons
+from cfme.configure.configuration.analysis_profile import AnalysisProfile, AnalysisProfileAddView
+from utils.blockers import BZ
 from utils.appliance.implementations.ui import navigate_to
-from utils import error
 from utils.update import update
-
-
-records_table = Table("//div[@id='records_div']/table")
 
 
 pytestmark = [pytest.mark.tier(3)]
 
+# TODO parametrize this with some data fuzzing
+files_list = [{'Name': '/etc/test/true', 'Collect Contents?': True},
+              {'Name': '/etc/test/false', 'Collect Contents?': False}]
+categories_list = ['System', 'User Accounts']
+registry_list = [{'Registry Key': 'test-reg-key',
+                  'Registry Value': 'test-reg-value'}]
+events_list = [{'Name': 'test-event',
+                'Filter Message': 'test-msg',
+                'Source': 'test-src',
+                '# of Days': '5'}]
+
+updated_files = [
+    {'Name': files_list[0]['Name'],
+     'Collect Contents?': not files_list[0]['Collect Contents?']}]
+
+
+def events_check(updates=False):
+    form_bug = BZ(1485953, forced_streams=['5.7', '5.8', 'upstream'])
+    if updates:
+        return updated_files if not form_bug.blocks else None
+    else:
+        return events_list if not form_bug.blocks else None
+
+
+@pytest.yield_fixture(scope='module')
+def vm_profile():
+    return AnalysisProfile(name=fauxfactory.gen_alphanumeric(),
+                           description=fauxfactory.gen_alphanumeric(),
+                           profile_type=AnalysisProfile.VM_TYPE,
+                           files=files_list, categories=categories_list, registry=registry_list,
+                           events=events_check())
+
+
+@pytest.yield_fixture(scope='module')
+def host_profile():
+    return AnalysisProfile(name=fauxfactory.gen_alphanumeric(),
+                           description=fauxfactory.gen_alphanumeric(),
+                           profile_type=AnalysisProfile.HOST_TYPE,
+                           files=files_list, events=events_check())
+
 
 @pytest.mark.tier(2)
-def test_vm_analysis_profile_crud():
+def test_vm_analysis_profile_crud(soft_assert, vm_profile):
     """CRUD for VM analysis profiles."""
-    p = AnalysisProfile(name=fauxfactory.gen_alphanumeric(),
-                        description=fauxfactory.gen_alphanumeric(),
-                        profile_type='VM', files=["asdf", "dfg"])
-    p.create()
-    with update(p):
-        p.files = ["qwer"]
-    with update(p):
-        p.categories = ["check_system"]
-    p.delete()
+    vm_profile.create()
+    assert vm_profile.exists
+
+    files_updates = events_check(updates=True)
+    with update(vm_profile):
+        vm_profile.files = files_updates
+    soft_assert(vm_profile.files == files_updates,
+                'Files update failed on profile: {}, {}'.format(vm_profile.name, vm_profile.files))
+
+    with update(vm_profile):
+        vm_profile.categories = ['System']
+    soft_assert(vm_profile.categories == ['System'],
+                'Categories update failed on profile: {}'.format(vm_profile.name))
+
+    copied_profile = vm_profile.copy(new_name='copied-{}'.format(vm_profile.name))
+    assert copied_profile.exists
+
+    copied_profile.delete()
+    assert not copied_profile.exists
+
+    vm_profile.delete()
+    assert not vm_profile.exists
 
 
 @pytest.mark.tier(2)
-def test_host_analysis_profile_crud():
+def test_host_analysis_profile_crud(soft_assert, host_profile):
     """CRUD for Host analysis profiles."""
-    p = AnalysisProfile(name=fauxfactory.gen_alphanumeric(),
-                        description=fauxfactory.gen_alphanumeric(), profile_type='Host',
-                        files=["asdf", "dfg"])
-    p.create()
-    with update(p):
-        p.files = ["qwer"]
-    copied_profile = p.copy()
+    host_profile.create()
+    assert host_profile.exists
+
+    files_updates = events_check(updates=True)
+    with update(host_profile):
+        host_profile.files = files_updates
+    soft_assert(host_profile.files == files_updates,
+                'Files update failed on profile: {}, {}'
+                .format(host_profile.name, host_profile.files))
+
+    copied_profile = host_profile.copy(new_name='copied-{}'.format(host_profile.name))
+    assert copied_profile.exists
+
     copied_profile.delete()
-    p.delete()
+    assert not copied_profile.exists
+
+    host_profile.delete()
+    assert not host_profile.exists
 
 
+# TODO Combine and parametrize VM + Host validation tests
+# Parametrize VM/Host, and (name/description/no item + flash) message as namedtuple
 def test_vmanalysis_profile_description_validation():
     """ Test to validate description in vm profiles"""
-    p = AnalysisProfile(name=fauxfactory.gen_alphanumeric(), description=None, profile_type='VM',
-                        categories=["check_system"])
-    with error.expected("Description can't be blank"):
-        p.create()
+    profile = AnalysisProfile(name=fauxfactory.gen_alphanumeric(), description=None,
+                              profile_type=AnalysisProfile.VM_TYPE,
+                              categories=categories_list)
+    with pytest.raises(AssertionError):
+        profile.create()
+
+    # Should still be on the form page after create method raises exception
+    view = profile.create_view(AnalysisProfileAddView)
+    assert view.is_displayed
+    view.flash.assert_message("Description can't be blank")
+    view.cancel.click()
 
 
 def test_analysis_profile_duplicate_name():
     """ Test to validate duplicate profiles name."""
-    p = AnalysisProfile(name=fauxfactory.gen_alphanumeric(),
-                        description=fauxfactory.gen_alphanumeric(), profile_type='VM',
-                        categories=["check_system"])
-    p.create()
-    with error.expected("Name has already been taken"):
-        p.create()
-    sel.click(form_buttons.cancel)
+    profile = AnalysisProfile(name=fauxfactory.gen_alphanumeric(),
+                              description=fauxfactory.gen_alphanumeric(),
+                              profile_type=AnalysisProfile.VM_TYPE,
+                              categories=categories_list)
+    profile.create()
+
+    with pytest.raises(AssertionError):
+        profile.create()
+
+    # Should still be on the form page after create method raises exception
+    view = profile.create_view(AnalysisProfileAddView)
+    assert view.is_displayed
+    view.flash.assert_message("Name has already been taken")
+    view.cancel.click()
 
 
 def test_delete_default_analysis_profile():
     """ Test to validate delete default profiles."""
-    p = AnalysisProfile(name="host sample", description=None, profile_type='Host')
-    navigate_to(p, 'All')
-    row = records_table.find_row_by_cells({'Name': p.name})
-    sel.check(sel.element(".//input[@type='checkbox']", root=row[0]))
-    tb.select('Configuration', 'Delete the selected Analysis Profiles', invokes_alert=True)
-    sel.handle_alert()
-    flash.assert_message_match('Default Analysis Profile "{}" can not be deleted' .format(p.name))
+    profile = AnalysisProfile(name="host sample", description='Host Sample',
+                              profile_type=AnalysisProfile.HOST_TYPE)
+    # Option disabled from details
+    view = navigate_to(profile, 'Details')
+    assert not view.toolbar.configuration.item_enabled('Delete this Analysis Profile')
+
+    # Flash error from collection
+    view = navigate_to(profile, 'All')
+    row = view.entities.table.row(name=profile.name, description=profile.description)
+    row[0].check()
+    view.toolbar.configuration.item_select('Delete the selected Analysis Profiles',
+                                           handle_alert=True)
+    view.flash.assert_message('Default Analysis Profile "{}" can not be deleted'
+                              .format(profile.name))
 
 
 def test_edit_default_analysis_profile():
     """ Test to validate edit default profiles."""
-    p = AnalysisProfile(name="host sample", description=None, profile_type='Host')
-    navigate_to(p, 'All')
-    row = records_table.find_row_by_cells({'Name': p.name})
-    sel.check(sel.element(".//input[@type='checkbox']", root=row[0]))
-    tb.select('Configuration', 'Edit the selected Analysis Profiles')
-    flash.assert_message_match('Sample Analysis Profile "{}" can not be edited' .format(p.name))
+    profile = AnalysisProfile(name="host sample", description='Host Sample',
+                              profile_type=AnalysisProfile.HOST_TYPE)
+    # Option disabled from details
+    view = navigate_to(profile, 'Details')
+    assert not view.toolbar.configuration.item_enabled('Edit this Analysis Profile')
+
+    # Flash error from collection
+    view = navigate_to(profile, 'All')
+    row = view.entities.table.row(name=profile.name, description=profile.description)
+    row[0].check()
+    view.toolbar.configuration.item_select('Edit the selected Analysis Profiles')
+    view.flash.assert_message('Sample Analysis Profile "{}" can not be edited'.format(profile.name))
 
 
 def test_analysis_profile_item_validation():
     """ Test to validate analysis profile items."""
-    p = AnalysisProfile(name=fauxfactory.gen_alphanumeric(),
-                        description=fauxfactory.gen_alphanumeric(), profile_type='Host')
-    with error.expected("At least one item must be entered to create Analysis Profile"):
-        p.create()
+    profile_name = fauxfactory.gen_alphanumeric()
+    profile = AnalysisProfile(name=profile_name, description=profile_name,
+                              profile_type=AnalysisProfile.HOST_TYPE)
+
+    with pytest.raises(AssertionError):
+        profile.create()
+
+    # Should still be on the form page after create method raises exception
+    view = profile.create_view(AnalysisProfileAddView)
+    assert view.is_displayed
+    view.flash.assert_message("At least one item must be entered to create Analysis Profile")
+    view.cancel.click()
 
 
 def test_analysis_profile_name_validation():
     """ Test to validate profile name."""
-    p = AnalysisProfile(name="", description=fauxfactory.gen_alphanumeric(),
-                        profile_type='Host', files=["asdf", "dfg"])
-    with error.expected("Name can't be blank"):
-        p.create()
+    profile = AnalysisProfile(name="", description=fauxfactory.gen_alphanumeric(),
+                              profile_type=AnalysisProfile.HOST_TYPE, files=files_list)
+    with pytest.raises(AssertionError):
+        profile.create()
+
+    # Should still be on the form page after create method raises exception
+    view = profile.create_view(AnalysisProfileAddView)
+    assert view.is_displayed
+    view.flash.assert_message("Name can't be blank")
+    view.cancel.click()
 
 
 def test_analysis_profile_description_validation():
     """ Test to validate profile description."""
-    p = AnalysisProfile(name=fauxfactory.gen_alphanumeric(), description="", profile_type='Host',
-                        files=["asdf", "dfg"])
-    with error.expected("Description can't be blank"):
-        p.create()
+    profile = AnalysisProfile(name=fauxfactory.gen_alphanumeric(), description="",
+                              profile_type=AnalysisProfile.HOST_TYPE, files=files_list)
+    with pytest.raises(AssertionError):
+        profile.create()
+
+    # Should still be on the form page after create method raises exception
+    view = profile.create_view(AnalysisProfileAddView)
+    assert view.is_displayed
+    view.flash.assert_message("Description can't be blank")
+    view.cancel.click()

--- a/cfme/tests/control/test_compliance.py
+++ b/cfme/tests/control/test_compliance.py
@@ -8,8 +8,8 @@ from cfme.control.explorer.policies import VMCompliancePolicy, HostCompliancePol
 from cfme.control.explorer.conditions import VMCondition
 from cfme.control.explorer.policy_profiles import PolicyProfile
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
-from cfme.configure.configuration import AnalysisProfile
-from utils import conf, testgen
+from cfme.configure.configuration.analysis_profile import AnalysisProfile
+from utils import testgen, conf
 from utils.hosts import setup_providers_hosts_credentials
 from utils.update import update
 from cfme import test_requirements
@@ -105,7 +105,7 @@ def analysis_profile():
     ap = AnalysisProfile(
         name="default",
         description="ap-desc",
-        profile_type="VM",
+        profile_type=AnalysisProfile.VM_TYPE,
         categories=[
             "check_services",
             "check_accounts",

--- a/cfme/tests/infrastructure/test_instance_analysis.py
+++ b/cfme/tests/infrastructure/test_instance_analysis.py
@@ -9,6 +9,7 @@ from cfme.common.vm import VM, Template
 from cfme.common.provider import cleanup_vm
 from cfme.cloud.provider import CloudProvider
 from cfme.configure import configuration
+from cfme.configure.configuration.analysis_profile import AnalysisProfile
 from cfme.configure.tasks import is_vm_analysis_finished
 from cfme.control.explorer.policy_profiles import PolicyProfile
 from cfme.control.explorer.policies import VMControlPolicy
@@ -277,15 +278,15 @@ def instance(request, local_setup_provider, provider, vm_name, vm_analysis_data,
 def policy_profile(request, instance):
     collected_files = [
         {"Name": "/etc/redhat-access-insights/machine-id", "Collect Contents?": True},
-        {"Name": ssa_expect_file, "Collect Contents?": True},
+        {"Name": ssa_expect_file, "Collect Contents?": True}
     ]
 
     analysis_profile_name = 'ssa_analysis_{}'.format(fauxfactory.gen_alphanumeric())
-    analysis_profile = configuration.AnalysisProfile(name=analysis_profile_name,
-                                                     description=analysis_profile_name,
-                                                     profile_type='VM',
-                                                     categories=["check_system"],
-                                                     files=collected_files)
+    analysis_profile = AnalysisProfile(name=analysis_profile_name,
+                                       description=analysis_profile_name,
+                                       profile_type=AnalysisProfile.VM_TYPE,
+                                       categories=["System"],
+                                       files=collected_files)
     if analysis_profile.exists:
         analysis_profile.delete()
     analysis_profile.create()


### PR DESCRIPTION
Separate AnalysisProfile into its own module
Widgetastic conversion of the pages and CRUD

## PRT Results
### Included tests
All tests in `cfme/tests/configure/test_analysis_profiles.py` should pass.

NOT Including test_compliance.py and test_instance_analysis.py because I slightly changed the yield_fixture there for an AnalysisProfile object, and the tests pretty much completely failed for unrelated reasons.


{{ pytest: -v --long-running cfme/tests/configure/test_analysis_profiles.py }}