### PR TITLE
[RFR] General fixes

### DIFF
--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -3,7 +3,6 @@ from random import sample
 import re
 import json
 
-import fauxfactory
 from navmazing import NavigateToSibling, NavigateToAttribute
 
 from cfme.common.provider import BaseProvider
@@ -485,20 +484,14 @@ class Labelable(object):
                 return False
             else:
                 raise exceptions.LabelNotFoundException(failure_signature)
-        del json_content['metadata']['labels'][name]
-        temp_filename = fauxfactory.gen_alpha()
         self.provider.cli.run_command(
-            'echo \'{}\' > {}'.format(
-                json.dumps(json_content), temp_filename))
-        self.provider.cli.run_command(
-            'oc edit {} {} -f \'{}\''.format(
+            'oc label {} {} {}-'.format(
                 self._cli_resource_type,
-                ('sha256:{}'.format(self.sha256) if
-                 (self.__class__.__name__ == 'Image') else self.name),
-                temp_filename
+                ('sha256:{}'.format(self.sha256)
+                 if (self.__class__.__name__ == 'Image') else self.name),
+                name
             )
         )
-        self.provider.cli.run_command('rm {}'.format(temp_filename))
         return True
 
 

--- a/cfme/tests/containers/test_configurable_menus.py
+++ b/cfme/tests/containers/test_configurable_menus.py
@@ -61,13 +61,6 @@ def test_monitoring_invisible(appliance):
     assert not is_menu_visible(appliance, 'Monitor')
 
 
-@pytest.mark.meta(blockers=[BZ(1444935, forced_streams=["5.8"])])
-@pytest.mark.polarion('CMP-10650')
-def test_datawarehouse_visible(appliance, config_menus_visible):
-    assert is_menu_visible(appliance, 'Datawarehouse'), \
-        'Datawarehouse menu should be visible (currently invisible)'
-
-
 @pytest.mark.meta(blockers=[BZ(1444939, forced_streams=["5.8"])])
 @pytest.mark.polarion('CMP-10649')
 def test_monitoring_visible(appliance, config_menus_visible):

--- a/cfme/tests/containers/test_labels.py
+++ b/cfme/tests/containers/test_labels.py
@@ -17,14 +17,12 @@ from cfme.containers.template import Template
 from cfme.exceptions import SetLabelException
 
 from utils import testgen
-from utils.version import current_version
 from utils.wait import wait_for
 from utils.log import logger
 from utils.blockers import BZ
 
 
 pytestmark = [
-    pytest.mark.uncollectif(lambda provider: current_version() < "5.6"),
     pytest.mark.usefixtures('setup_provider_modscope'),
     pytest.mark.tier(1)]
 pytest_generate_tests = testgen.generate([ContainersProvider], scope='module')

--- a/cfme/tests/containers/test_ssl_providers.py
+++ b/cfme/tests/containers/test_ssl_providers.py
@@ -16,9 +16,11 @@ alphanumeric_name = gen_alphanumeric(10)
 long_alphanumeric_name = gen_alphanumeric(100)
 integer_name = str(gen_integer(0, 100000000))
 provider_names = alphanumeric_name, integer_name, long_alphanumeric_name
-DEFAULT_SEC_PROTOCOLS = (pytest.mark.polarion('CMP-10598')('SSL trusting custom CA'),
-                  pytest.mark.polarion('CMP-10597')('SSL without validation'),
-                  pytest.mark.polarion('CMP-10599')('SSL'))
+DEFAULT_SEC_PROTOCOLS = (
+    pytest.mark.polarion('CMP-10598')('SSL trusting custom CA'),
+    pytest.mark.polarion('CMP-10597')('SSL without validation'),
+    pytest.mark.polarion('CMP-10599')('SSL')
+)
 
 checked_item = namedtuple('TestItem', ['default_sec_protocol', 'hawkular_sec_protocol'])
 TEST_ITEMS = (
@@ -43,6 +45,7 @@ TEST_ITEMS = (
 )
 
 
+@pytest.mark.polarion('CMP-9836')
 @pytest.mark.usefixtures('has_no_containers_providers')
 def test_add_provider_naming_conventions(provider, soft_assert):
     """" This test is checking ability to add Providers with different names:
@@ -64,7 +67,7 @@ def test_add_provider_naming_conventions(provider, soft_assert):
             credentials=provider.credentials
         )
         try:
-            prov.create()
+            prov.setup()
             flash.assert_message_contain('Containers Providers "' + provider_name + '" was saved')
         except FlashMessageException:
             soft_assert(False, provider_name + ' wasn\'t added successfully')
@@ -93,7 +96,7 @@ def test_add_provider_ssl(provider, default_sec_protocols, soft_assert):
         credentials=provider.credentials
     )
     try:
-        prov.create()
+        prov.setup()
         flash.assert_message_contain('Containers Providers "' + provider.name + '" was saved')
     except FlashMessageException:
         soft_assert(False, provider.name + ' wasn\'t added successfully using ' +
@@ -128,7 +131,7 @@ def test_add_hawkular_provider_ssl(provider, test_item, soft_assert):
         credentials=provider.credentials
     )
     try:
-        prov.create()
+        prov.setup()
         flash.assert_message_contain('Containers Providers "' + provider.name + '" was saved')
     except FlashMessageException:
         soft_assert(False, provider.name + ' wasn\'t added successfully using ' +

--- a/utils/ocp_cli.py
+++ b/utils/ocp_cli.py
@@ -1,4 +1,4 @@
-from utils import conf
+from utils.conf import credentials
 from utils.log import logger
 from utils.ssh import SSHClient
 
@@ -10,19 +10,22 @@ class OcpCli(object):
 
         provider_cfme_data = provider.get_yaml_data()
         self.hostname = provider_cfme_data['hostname']
-        creds = conf.configuration.yaycl_config.credentials
-        if hasattr(creds, provider.key):
-            prov_creds = getattr(creds, provider.key)
-            self.username = prov_creds.username
-            self.password = prov_creds.password
-            self.ssh_client = SSHClient(hostname=self.hostname,
-                                        username=self.username,
-                                        password=self.password)
+        creds = provider_cfme_data.get('ssh_creds')
+
+        if not creds:
+            raise Exception('Could not find ssh_creds in provider\'s cfme data.')
+        if isinstance(creds, dict):
+            self.username = creds.get('username')
+            self.password = creds.get('password')
         else:
-            # Try with known hosts
-            self.ssh_client = SSHClient()
+            self.username = credentials[creds].get('username')
+            self.password = credentials[creds].get('password')
+
+        with SSHClient(hostname=self.hostname, username=self.username,
+                       password=self.password, look_for_keys=True) as ssh_client:
+            self.ssh_client = ssh_client
             self.ssh_client.load_system_host_keys()
-            self.ssh_client.connect(self.hostname)
+
         self._command_counter = 0
         self.log_line_limit = 500
 


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_basic_metrics.py cfme/tests/containers/test_labels.py -v --use-provider cm-env2}}

Removed test: test_configurable_menus::test_datawarehouse_visible
Fixes: text_basic_metrics, test_ssl_providers
Modified utils/ocp_cli to use ssh_creds instead of ocp credentials
Modified label removal