### PR TITLE
[RFR] fix for providers which don't have ipaddress or hostname

### DIFF
--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -570,7 +570,7 @@ class IPAppliance(object):
                 try:
                     prov_ip = getattr(provider, 'ip_address', None) \
                         or resolve_hostname(provider.hostname)
-                except AttributeError:
+                except (AttributeError, TypeError):
                     # Provider has no IP nor hostname; it should be looked up by credentials,
                     # not by IP address
                     return False


### PR DESCRIPTION
it turned out that my changes in Cloud providers break  appliance.check_no_conflicting_providers in some cases. This is the fix for that issue.
