### PR TITLE
[RFR] fix for check_no_conflicting_providers which fails on gce

### DIFF
--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -564,6 +564,7 @@ class IPAppliance(object):
          automation issues.
         """
         from utils.providers import list_providers
+        from cfme.base.credential import ServiceAccountCredential
 
         def _recognized_by_ip(provider, ems):
             if any(p_type in ems.type for p_type in RECOGNIZED_BY_IP):
@@ -585,6 +586,10 @@ class IPAppliance(object):
                     # TODO: fix this when all providers are moved to endpoints
                     if hasattr(provider, 'default_endpoint'):
                         default_creds = provider.default_endpoint.credentials
+                        if isinstance(default_creds, ServiceAccountCredential):
+                            # TODO: ask providers about gce private key format in authentications
+                            # table and add gce support
+                            return False
                     else:
                         default_creds = provider.credentials['default']
                 except KeyError:


### PR DESCRIPTION
It turned out that appliance.check_no_conflicting_providers didn't check existance of gce properly.
When GCE was converted to endpoints/widgetastic  + some consequent changes, that method started to fail.
This PR makes check_no_conflicting_providers ignore gce providers.
I expect to fix checking for existance of gce providers a bit later when I figure out how to compare gce providers.

{{pytest: -v cfme/tests/cloud/test_providers.py cfme/tests/infrastructure/test_providers.py}}