### PR TITLE
[WIPTEST] dockerbot: rewrite dockerbot image construction and orchestration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ conf/README
 
 # custom imports
 conf/miq_python_startup.py
+
+# temporaries to support docker image building
+scripts/dockerbot/pytestbase/temporary_git_repo/

--- a/cfme/scripting/ci.py
+++ b/cfme/scripting/ci.py
@@ -26,6 +26,7 @@ def qe_yaml_path(path):
 
 
 def appliances_configured():
+    """check if the appliances config was taken in from sprout"""
     return 'appliances:' in path.conf_path.join('env.local.yaml').read()
 
 
@@ -47,6 +48,7 @@ def managed_miq_sprout_checkout():
 
 @click.group(help='Functions for test and ci related actions')
 def main():
+    """command group for the ci commands"""
     pass
 
 
@@ -141,6 +143,8 @@ def verify_commit(commit):
 @click.option('--verify/--no-verify', default=True)
 def prepare_workdir_checkout(ctx, cfme_repo, cfme_pr,
                              branch, base_branch, verify):
+    """prepare the current checkout
+    """
     secho("preparing checkout", fg="yellow")
     extra_env = {
         'CFME_PR': cfme_pr,
@@ -257,6 +261,7 @@ def full(ctx,
          cfme_repo, cfme_pr, branch, base_branch, verify,
          browser, wharf, appliance, json, smtp,
          pytest_command, use_sprout):
+    """runs each component of the ci in order"""
     ctx.invoke(fetch_credentials,
                credentials_repo=credentials_repo)
     ctx.invoke(prepare_workdir_checkout,
@@ -291,6 +296,7 @@ def run_quickstart():
 @click.argument('extra_args', nargs=-1)
 @click.option('--post-task', default=None, envvar="POST_TASK")
 def run_logged(logfile, extra_args, post_task):
+    """backward compatibility hack to ensure legacy logging and result posting"""
     tee = subprocess.Popen(
         ['tee', '-a', logfile],
         stdin=subprocess.PIPE,

--- a/cfme/scripting/ci.py
+++ b/cfme/scripting/ci.py
@@ -50,7 +50,7 @@ def main():
     pass
 
 
-def do(command, cwd=None, extra_env=None,  shell=False, **kwargs):
+def do(command, cwd=None, extra_env=None, shell=False, **kwargs):
     """convenience to invoke subprocesses
 
     Args:
@@ -73,9 +73,8 @@ def do(command, cwd=None, extra_env=None,  shell=False, **kwargs):
 
 
 @main.command()
-@click.pass_context
 @click.option("--credentials-repo", envvar="CFME_CRED_REPO")
-def fetch_credentials(ctx, credentials_repo):
+def fetch_credentials(credentials_repo):
     """
     fetch the yaml credentials based on the config repo
     """

--- a/cfme/scripting/ci.py
+++ b/cfme/scripting/ci.py
@@ -4,15 +4,17 @@ click commands for ci testing
 import sys
 import os
 import subprocess
+import contextlib
 from functools import partial
 import re
 
 import click
 from click import secho
-from utils import conf
-from utils import path
-from utils import safe_string
-from utils.trackerbot import post_task_result
+from cfme.utils import conf
+from cfme.utils import path
+from cfme.utils import safe_string
+from cfme.utils.trackerbot import post_task_result
+from cfme.utils.wait import wait_for
 
 from . import quickstart
 
@@ -21,6 +23,18 @@ GIT_NO_SSL = dict(GIT_SSL_NO_VERIFY='true')
 
 def qe_yaml_path(path):
     return path.dirpath().join('cfme-qe-yamls')
+
+
+def appliances_configured():
+    return 'appliances:' in path.conf_path.join('env.local.yaml')
+
+
+@contextlib.contextmanager
+def managed_miq_sprout_checkout():
+    checkout_process = Popen(['miq', 'sprout', 'checkout'])
+    try:
+        wait_for(appliances_configured):
+)
 
 
 @click.group(help='Functions for test and ci related actions')
@@ -233,6 +247,7 @@ def run_tests(pytest_command):
 @click.option('--appliance', envvar="APPLIANCE")
 @click.option('--json', envvar="JSON")
 @click.option('--smtp', envvar="SMTP")
+@click.option('--use-sprout', envvar="USE_SPROUT", default="no", choices=)
 @click.argument('pytest_command', envvar='PYTEST')
 @click.pass_context
 def full(ctx,

--- a/cfme/scripting/ci.py
+++ b/cfme/scripting/ci.py
@@ -1,0 +1,287 @@
+"""
+click commands for ci testing
+"""
+import sys
+import os
+import subprocess
+from functools import partial
+import re
+
+import click
+from click import secho
+from utils import conf
+from utils import path
+from utils import safe_string
+from utils.trackerbot import post_task_result
+
+from . import quickstart
+
+GIT_NO_SSL = dict(GIT_SSL_NO_VERIFY='true')
+
+
+def qe_yaml_path(path):
+    return path.dirpath().join('cfme-qe-yamls')
+
+
+@click.group(help='Functions for test and ci related actions')
+def main():
+    pass
+
+
+def do(command, cwd=None, extra_env=None,  shell=False, **kwargs):
+    """convenience to invoke subprocesses
+
+    Args:
+        command: the command to invoke
+        cwd: the expected working directory
+        extra_env: overrides for environment variables
+        shell: same as for call
+    """
+    if extra_env:
+        extra_env = {k: str(v) for k, v in extra_env.items() if v is not None}
+        kwargs['env'] = dict(kwargs.get('env') or os.environ, **extra_env)
+    if not shell:
+        command = list(map(str, command))
+
+    secho(str(command))
+    ret = subprocess.call(command, cwd=cwd and str(cwd), shell=shell, **kwargs)
+    if ret:
+        click.echo("{!r} failed with {!r}".format(command, ret))
+        sys.exit(ret)
+
+
+@main.command()
+@click.pass_context
+@click.option("--credentials-repo", envvar="CFME_CRED_REPO")
+def fetch_credentials(ctx, credentials_repo):
+    """
+    fetch the yaml credentials based on the config repo
+    """
+    credentials_path = qe_yaml_path(path.project_path)
+    secho("updating credentials", fg="yellow")
+    try:
+        if credentials_path.check(dir=True):
+            return do(
+                ['git', 'pull'],
+                cwd=credentials_path,
+                extra_env=GIT_NO_SSL,
+            )
+        else:
+            if credentials_repo is None:
+                sys.exit("without an existing repo the credentials repo "
+                         "needs to be passed explicitly")
+            return do(
+                ['git', 'clone', credentials_repo, credentials_path],
+                extra_env=GIT_NO_SSL,
+            )
+    finally:
+        quickstart.link_config_files('../cfme-qe-yamls/complete/', 'conf')
+
+
+@main.command()
+@click.argument('commit')
+def verify_commit(commit):
+    """
+    fetches the configured pgp keys and verifies a git commit against them
+
+    args:
+        commit: the git commit to be verified
+    """
+
+    conf.clear()  # reload config
+    key_list = [key.replace(' ', '') for key in conf.gpg['allowed_keys']]
+    # TODO: getthe blunt work of this somewhere else
+    do(['gpg2', '--recv-keys'] + key_list)
+    logfile = path.log_path.join('gpg_verify.log')
+    secho("verify commit")
+    try:
+        with logfile.open('wb') as fp:
+            do(['git', 'verify-commit', commit, '--raw'], stderr=fp)
+        output = logfile.read()
+    finally:  # ensure we print  on failure
+        output = logfile.read()
+        secho(output)
+    if 'GOODSIG' in output:
+        gpg = re.findall('VALIDSIG ([A-F0-9]+)', output)[0]
+        click.echo(gpg)
+        if gpg in key_list:
+            secho("Good sig and match for {}".format(gpg))
+            return
+    secho("Bad Sig")
+    sys.exit(127)
+
+
+@main.command()
+@click.pass_context
+@click.option("--cfme-repo", envvar="CFME_REPO", required=True)
+@click.option("--cfme-pr", envvar="CFME_PR", default=None)
+@click.option('--branch', envvar="BRANCH", default=None)
+@click.option('--base-branch', envvar='BASE_BRANCH', default='master')
+@click.option('--verify/--no-verify', default=True)
+def prepare_workdir_checkout(ctx, cfme_repo, cfme_pr,
+                             branch, base_branch, verify):
+    secho("preparing checkout", fg="yellow")
+    extra_env = {
+        'CFME_PR': cfme_pr,
+        'CFME_REPO': cfme_repo,
+        'BASE_BRANCH': base_branch,
+        'BRANCH': branch,
+    }
+    for k, v in extra_env.items():
+        if v is not None:
+            secho("  {}: {}".format(k, v))
+    pdo = partial(do, shell=True, extra_env=extra_env)
+
+    if not cfme_repo:
+        ctx.fail("missing repo, failing")
+    pdo('git remote add repo_under_test "$CFME_REPO"')
+    if cfme_pr is not None:
+        secho("preparing pr merge", fg="yellow")
+        pdo('git fetch repo_under_test'
+            ' "+refs/heads/$BASE_BRANCH:refs/repo_under_test/$BASE_BRANCH"')
+        pdo('git fetch repo_under_test'
+            ' +refs/pull/"$CFME_PR"/head:refs/heads/pr-"$CFME_PR"')
+        if verify:
+            ctx.invoke(verify_commit, commit='pr-{}'.format(cfme_pr))
+        pdo('git checkout pr-$CFME_PR')
+        pdo('git merge --no-ff --no-edit repo_under_test/$BASE_BRANCH')
+
+    elif branch is not None:
+        secho("preparing branch under test", fg="yellow")
+        pdo('git fetch repo_under_test "+refs/heads/$BRANCH:refs/repo_under_test/$BRANCH"')
+        pdo('git checkout "repo_under_test/$BRANCH"')
+    else:
+        ctx.fail("branch or pr needed to prep workdir")
+
+
+CONFIGFILE_TEMPLATE = """
+base_url: {appliance}
+browser:
+    webdriver_wharf: {wharf}
+    webdriver_options:
+        keep_alive: True
+        desired_capabilities:
+            platform: LINUX
+            browserName: {browser}
+artifactor:
+    per_run: test #test, run, None
+    reuse_dir: True
+    squash_exceptions: True
+    threaded: True
+    server_address: 127.0.0.1
+    server_enabled: True
+    plugins:
+        logger:
+            enabled: True
+            plugin: logger
+            level: DEBUG
+        filedump:
+            enabled: True
+            plugin: filedump
+        reporter:
+            enabled: True
+            plugin: reporter
+            only_failed: True
+
+mail_collector:
+    ports:
+        smtp: {smtp}
+        json: {json}
+
+"""
+
+
+@main.command()
+@click.option("--browser", envvar="BROWSER")
+@click.option("--wharf", envvar="WHARF", required=True)
+@click.option('--appliance', envvar="APPLIANCE", required=True)
+@click.option('--json', envvar="JSON", required=True)
+@click.option('--smtp', envvar="SMTP", required=True)
+def prepare_workdir_configfiles(browser, wharf, appliance, json, smtp):
+    configfile = path.conf_path.join('env.local.yaml')
+    if configfile.check(file=True):
+        sys.exit("env.local.yaml exists - aborting automated overwrite")
+
+    configfile.write(CONFIGFILE_TEMPLATE.format(
+        browser=browser,
+        wharf=wharf,
+        json=json,
+        smtp=smtp,
+        appliance=appliance,
+    ), ensure=True)
+
+
+@main.command()
+def run_tests(pytest_command):
+    quickstart.run_for_current_env()
+    import sys
+    sys.stdout.flush()
+    sys.stderr.flush()
+
+    sys.exit(subprocess.call(pytest_command, shell=True))
+
+
+@main.command()
+@click.option("--credentials-repo", envvar="CFME_CRED_REPO")
+@click.option("--cfme-repo", envvar="CFME_REPO", required=True)
+@click.option("--cfme-pr", envvar="CFME_PR", default=None)
+@click.option('--branch', envvar="BRANCH", default=None)
+@click.option('--base-branch', envvar='BASE_BRANCH', default='master')
+@click.option('--verify/--no-verify', default=True)
+@click.option("--browser", envvar="BROWSER")
+@click.option("--wharf", envvar="WHARF")
+@click.option('--appliance', envvar="APPLIANCE")
+@click.option('--json', envvar="JSON")
+@click.option('--smtp', envvar="SMTP")
+@click.argument('pytest_command', envvar='PYTEST')
+@click.pass_context
+def full(ctx,
+         credentials_repo,
+         cfme_repo, cfme_pr, branch, base_branch, verify,
+         browser, wharf, appliance, json, smtp,
+         pytest_command):
+    ctx.invoke(fetch_credentials,
+               credentials_repo=credentials_repo)
+    ctx.invoke(prepare_workdir_checkout,
+               cfme_pr=cfme_pr, cfme_repo=cfme_repo,
+               branch=branch, base_branch=base_branch,
+               verify=verify)
+    ctx.invoke(prepare_workdir_configfiles,
+               browser=browser, wharf=wharf,
+               appliance=appliance,
+               json=json, smtp=smtp)
+    ctx.invoke(run_tests, pytest_command=pytest_command)
+
+
+@main.command()
+@click.option('--logfile', default=str(path.log_path / 'setup.txt'))
+@click.argument('extra_args', nargs=-1)
+@click.option('--post-task', default=None, envvar="POST_TASK")
+def run_logged(logfile, extra_args, post_task):
+    tee = subprocess.Popen(
+        ['tee', '-a', logfile],
+        stdin=subprocess.PIPE,
+    )
+    result = subprocess.call(
+        ['miq', 'ci', 'full'] + list(extra_args),
+        stdout=tee.stdin,
+        stderr=tee.stdin,
+    )
+    result_name = 'passed' if result in (0, 5) else 'failed'
+
+    if post_task:
+        with open(logfile) as fp:
+            setup_data = fp.read()
+
+        try:
+
+            with path.log_path.join("coverage_result.txt").open() as f:
+                coverage_data = f.read().strip("\n")
+            coverage = float(coverage_data)
+        except Exception:
+            coverage = 0.0
+        conf.clear()  # reset all configuration
+        post_task_result(
+            post_task, result_name,
+            safe_string(setup_data), coverage)
+    sys.exit(0 if result_name == 'passed' else 1)

--- a/cfme/scripting/ci_trampoline.sh
+++ b/cfme/scripting/ci_trampoline.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+. /cfme_venv/bin/activate
+exec miq  ci run_logged

--- a/cfme/scripting/miq.py
+++ b/cfme/scripting/miq.py
@@ -7,6 +7,7 @@ from cfme.scripting.setup_env import main as setup_main
 from cfme.scripting.sprout import main as sprout_main
 from scripts.dockerbot.sel_container import main as sel_con_main
 from scripts.release import main as rel_main
+from cfme.scripting.ci import main as ci_main
 
 
 @click.group()
@@ -22,6 +23,8 @@ cli.add_command(shell_main, name="shell")
 cli.add_command(conf_main, name="conf")
 cli.add_command(sprout_main, name="sprout")
 cli.add_command(setup_main, name="setup-env")
+cli.add_command(ci_main, name="ci")
+
 
 if __name__ == '__main__':
     cli()

--- a/cfme/scripting/quickstart.py
+++ b/cfme/scripting/quickstart.py
@@ -271,5 +271,9 @@ def main(args):
         print("      .", os.path.join(args.mk_virtualenv, 'bin/activate'))
 
 
+def run_for_current_env(mk_virtualenv=sys.prefix,):
+    main(parser.parse_args(['--mk-virtualenv', sys.prefix]))
+
+
 if IS_SCRIPT:
     main(parser.parse_args())

--- a/cfme/scripting/tests/test_own_ci.py
+++ b/cfme/scripting/tests/test_own_ci.py
@@ -1,0 +1,150 @@
+from __future__ import print_function
+import pytest
+from utils import path
+from commands import getoutput
+from .. import ci
+from click.testing import CliRunner
+
+TEST_BRANCH_NAME = 'miq-test-branch'
+PULL_REQUEST = 1337
+
+
+@pytest.fixture
+def fake_repo(request, tmpdir):
+    repo = tmpdir / 'repo'
+    ci.do(['git', 'clone', path.project_path, repo, '--bare'])
+    if request.node.get_marker('create_history'):
+        branch_wd = tmpdir / 'branch-for-wd'
+        ci.do(['git', 'clone', repo, branch_wd])
+        with branch_wd.as_cwd():
+            ci.do(['git', 'checkout', '-b', TEST_BRANCH_NAME])
+            file = branch_wd.join('setup.py')
+            file.write_binary(file.read_binary() + b'\n# extra')
+            ci.do(['git', 'commit', '-a', '-m', 'test commit'])
+            ci.do(['git', 'push', 'origin', TEST_BRANCH_NAME])
+
+            ci.do(['git', 'push', 'origin',
+                   '{}:refs/pull/{}/head'.format(TEST_BRANCH_NAME, PULL_REQUEST),
+                   ])
+    return repo
+
+
+@pytest.fixture
+def ci_checkout(request, monkeypatch, fake_repo, tmpdir):
+
+    co = tmpdir.join('checkout')
+    ci.do(['git', 'clone', fake_repo, co])
+    ci.do([
+        'git', 'clone',
+        ci.qe_yaml_path(path.project_path),
+        ci.qe_yaml_path(co),
+    ])
+
+    # todo: undo the need ofr this evil
+    monkeypatch.setattr(path, 'original_project_path',
+                        path.project_path, raising=False)
+    monkeypatch.setattr(path, 'project_path', co)
+    if request.node.get_marker('chdir'):
+        monkeypatch.chdir(co)
+    return co
+
+
+@pytest.fixture
+def _runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def invoke(_runner):
+
+    def invoke(*k, **kw):
+        result = _runner.invoke(
+            *k, **kw)
+        print(result.output_bytes)
+        return result
+    return invoke
+
+
+@pytest.mark.chdir
+def test_ci_fetch_credentials(ci_checkout, invoke):
+    invoke(ci.fetch_credentials)
+
+
+@pytest.mark.chdir
+def test_fetch_credentials_fails_when_missing(ci_checkout, invoke):
+    ci.qe_yaml_path(ci_checkout).remove()
+    result = invoke(ci.fetch_credentials)
+    assert isinstance(result.exception, SystemExit)
+
+
+@pytest.mark.chdir
+def test_fetch_credentials_clone_when_given(ci_checkout, invoke):
+    ci.qe_yaml_path(ci_checkout).remove()
+    result = invoke(ci.fetch_credentials, [
+        '--credentials-repo', path.original_project_path.strpath])
+    assert result.exception is None
+    assert ci.qe_yaml_path(ci_checkout).isdir()
+
+
+@pytest.mark.parametrize('commit, verified', [
+    ("b08d0396d798626ce3f07050cfc5c0cd2a54ce28", True),
+    ("39dbccaafe392d1a75900055c24088c2cafca8e0", False),
+])
+def test_verify_commit(invoke, commit, verified):
+    result = invoke(ci.verify_commit, [commit])
+    if verified:
+        print(result.exception)
+        assert result.exception is None
+    else:
+        assert isinstance(result.exception, SystemExit)
+
+
+@pytest.mark.chdir
+def test_prepare_workdir_checkout_needs_repo(invoke):
+    result = invoke(ci.prepare_workdir_checkout)
+    assert b'--cfme-repo' in result.output_bytes
+    assert result.exception
+
+
+@pytest.mark.chdir
+def test_prepare_workdir_checkout_needs_work(invoke, ci_checkout):
+    result = invoke(ci.prepare_workdir_checkout, [
+        '--cfme-repo', str(ci_checkout)
+    ])
+    assert b'branch or pr needed' in result.output_bytes
+    assert result.exception
+
+
+@pytest.mark.chdir
+@pytest.mark.create_history
+def test_prepare_workdir_for_branch_prepares_branch(invoke, ci_checkout, fake_repo):
+    result = invoke(ci.prepare_workdir_checkout, [
+        '--cfme-repo', str(fake_repo),
+        '--branch', TEST_BRANCH_NAME,
+    ])
+    assert result.exception is None
+    assert ('* ' + TEST_BRANCH_NAME) in getoutput("git branch")
+
+
+@pytest.mark.chdir
+@pytest.mark.create_history
+def test_prepare_workdir_for_pr_prepares_branch(invoke, ci_checkout, fake_repo):
+    result = invoke(ci.prepare_workdir_checkout, [
+        '--cfme-repo', str(fake_repo),
+        '--cfme-pr', PULL_REQUEST,
+        '--no-verify',
+    ])
+    assert result.exception is None
+    assert '* pr-{}'.format(PULL_REQUEST) in getoutput("git branch")
+
+
+@pytest.mark.chdir
+def test_prepare_configfiles(invoke, ci_checkout, monkeypatch):
+    conf_path = ci_checkout.join('conf')
+    monkeypatch.setattr(path, "conf_path", conf_path)
+    result = invoke(ci.prepare_workdir_configfiles, [
+        '--appliance', 'https://example.com',
+    ])
+    assert not result.exception
+
+    assert conf_path.join("env.local.yaml").isfile()

--- a/cfme/utils/trackerbot.py
+++ b/cfme/utils/trackerbot.py
@@ -9,7 +9,7 @@ import slumber
 import requests
 import time
 
-from cfme.utils.conf import env
+from cfme.utils import conf
 from cfme.utils.providers import providers_data
 from cfme.utils.version import get_stream
 
@@ -43,7 +43,6 @@ generic_matchers = (
     ('sprout', r'^sprout_template'),
     ('rhevm-internal', r'^auto-tmp'),
 )
-conf = env.get('trackerbot', {})
 _active_streams = None
 
 TemplateInfo = namedtuple('TemplateInfo', ['group_name', 'datestamp', 'stream'])
@@ -73,7 +72,7 @@ def cmdline_parser():
 def api(trackerbot_url=None):
     """Return an API object authenticated to the given trackerbot api"""
     if trackerbot_url is None:
-        trackerbot_url = conf['url']
+        trackerbot_url = conf.env.trackerbot.url
 
     return slumber.API(trackerbot_url)
 
@@ -310,9 +309,9 @@ def depaginate(api, result):
 
 def composite_uncollect(build, source='jenkins'):
     """Composite build function"""
-    since = env.get('ts', time.time())
+    since = conf.env.get('ts', time.time())
     url = "{0}?build={1}&source={2}&since={3}".format(
-        conf['ostriz'], urllib.quote(build), urllib.quote(source), urllib.quote(since))
+        conf.env['ostriz'], urllib.quote(build), urllib.quote(source), urllib.quote(since))
     try:
         resp = requests.get(url, timeout=10)
         return resp.json()

--- a/scripts/dockerbot/README.md
+++ b/scripts/dockerbot/README.md
@@ -22,15 +22,7 @@ you are using SELinux.
 `sudo chcon -Rt svirt_sandbox_file_t /path/to/log_depot/`
 
 ### Building the pytestbase image
-
-We then need to build the pytest docker container. To do this we need to change directory to the
-pytestbase folder which is contained in this repo and run the following.
-
-`docker build -t py_test_base .`
-
-This can be run multiple times if required to update the pip requirements from master.
-You may need to use the `--no-cache=true` to tell the build not to use the cached versions
-of the previous steps.
+`python scripts/dockerbot/build-container.py`
 
 ### Obtaining the sel_ff_chrome image
 

--- a/scripts/dockerbot/build-container.py
+++ b/scripts/dockerbot/build-container.py
@@ -1,10 +1,71 @@
+from __future__ import print_function, absolute_import
 import subprocess
 import py
 import sys
 
-here = py.path.local(__file__).dirpath()
+HERE = py.path.local(__file__).dirpath()
+BASE = HERE.join('pytestbase')
+
+REPO = BASE.join('temporary_git_repo/integration_tests')
+CWD = py.path.local()
 
 
-sys.exit(subprocess.call([
-    'docker', 'build', '-t', 'py_test_base', str(here / 'pytestbase')
-]))
+def cwdstr(maybe_path):
+    if isinstance(maybe_path, py.path.local):
+        return maybe_path.relto(CWD) or '.'  # fragile
+    else:
+        return str(maybe_path)
+
+
+def call(*command_parts, **kw):
+    cwd = kw.get('cwd')
+    if cwd is not None:
+        cwd = str(cwd)
+    command = []
+    for elements in command_parts:
+        if isinstance(elements, (list, tuple)):
+            command.extend(map(cwdstr, elements))
+        else:
+            command.append(cwdstr(elements))
+    res = subprocess.call(command, cwd=cwd)
+    print(res, 'from', command)
+    return res
+
+
+def build_image(dockerfile, context_dir, tag=None, no_cache=False):
+    assert tag
+    command = [
+        'docker', 'build',
+        '-t', tag + ':latest',
+        '-t', tag,
+    ]
+
+    if no_cache:
+        command.append('--no-cache')
+    return call(command, [context_dir, '-f', dockerfile])
+
+
+def re_setup_repo():
+    if REPO.check(dir=True):
+        REPO.remove()
+    return call(
+        ['git', 'clone', HERE.dirpath().dirpath(), REPO]
+    ) or call(
+        ['git', 'checkout', '-b', 'master'],
+        cwd=REPO,
+    )
+
+
+sys.exit(
+    re_setup_repo() or
+
+    build_image(
+        BASE / "Dockerfile.base", context_dir=BASE,
+        tag='cfmeqe/dockerbot-base') or
+    build_image(
+        BASE / "Dockerfile.checkouts",
+        context_dir=BASE, tag='cfmeqe/dockerbot-checkouts', no_cache=True) or
+    build_image(
+        BASE / "Dockerfile",
+        context_dir=BASE, tag='py_test_base', no_cache=True)
+)

--- a/scripts/dockerbot/pytestbase/Dockerfile
+++ b/scripts/dockerbot/pytestbase/Dockerfile
@@ -1,10 +1,4 @@
-FROM fedora:23
-RUN dnf install -y gcc postgresql-devel libxml2-devel libxslt-devel zeromq3-devel git nano python-devel gnupg gnupg2 libcurl-devel redhat-rpm-config findutils libffi-devel openssl-devel tesseract freetype-devel gcc-c++
-RUN git clone https://github.com/RedHatQE/cfme_tests.git
-RUN dnf -y install python-setuptools; easy_install pip
-RUN pip install -U pip
-RUN cd /cfme_tests && PYCURL_SSL_LIBRARY=nss pip install -U -r /cfme_tests/requirements/frozen.txt --no-cache-dir
-ADD setup.sh /setup.sh
-ADD post_result.py /post_result.py
-ADD get_keys.py /get_keys.py
-ADD verify_commit.py /verify_commit.py
+FROM cfmeqe/dockerbot-checkouts
+VOLUME ["/integration_tests/logt"]
+WORKDIR /integration_tests
+ENTRYPOINT ["bash", "/integration_tests/cfme/scripting/ci_trampoline.sh"]

--- a/scripts/dockerbot/pytestbase/Dockerfile.base
+++ b/scripts/dockerbot/pytestbase/Dockerfile.base
@@ -1,0 +1,9 @@
+FROM fedora:25
+RUN dnf install -y \
+		gcc-c++ postgresql-devel libxml2-devel libxslt-devel zeromq3-devel git nano python-devel gnupg gnupg2 \
+		libcurl-devel redhat-rpm-config findutils libffi-devel openssl-devel python-virtualenv && dnf clean all
+
+RUN git config --global user.email "me@dockerbot" && \
+    git config --global user.name "DockerBot" &&  \
+    git config --global gpg.program gpg2
+

--- a/scripts/dockerbot/pytestbase/Dockerfile.checkouts
+++ b/scripts/dockerbot/pytestbase/Dockerfile.checkouts
@@ -1,0 +1,5 @@
+FROM cfmeqe/dockerbot-base
+ADD ./temporary_git_repo/integration_tests /integration_tests
+RUN cd /integration_tests && \
+	python -m cfme.scripting.quickstart && \
+	dnf clean all


### PR DESCRIPTION
* the complete test run is now managed by a miq command
* the repo is included and quickstart is used
* the local repo is used instead of going for gh
* gpg2 is used consistently
* trackerbot reporting is still done in-image
* container construction happens as multipart process
  (there is room for optimization there)

{pytest: --confcutdir=cfme cfme/scripting}