### PR TITLE
[1LP][RFR]Tag filter combination tests

### DIFF
--- a/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
+++ b/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
@@ -25,25 +25,26 @@ def a_provider(request):
     return setup_one_or_skip(request, filters=[prov_filter])
 
 
-@pytest.fixture(params=test_items, ids=[str(test_id[0]) for test_id in test_items],
+@pytest.fixture(params=test_items, ids=[collection_type for collection_type, __ in test_items],
                 scope='function')
 def testing_vis_object(request, a_provider, appliance):
     """ Fixture creates class object for tag visibility test
+
     Returns: class object of certain type
     """
     collection_name, param_class = request.param
-    test_items = getattr(appliance.rest_api.collections, collection_name)
+    collection_rest = getattr(appliance.rest_api.collections, collection_name)
 
     if not test_items:
         pytest.skip('No content found for test!')
 
     if collection_name == 'templates':
         item_type = a_provider.data['provisioning']['catalog_item_type'].lower()
-        for test_item_value in test_items:
-            if test_item_value.vendor == item_type:
-                return param_class(name=test_item_value.name, provider=a_provider)
+        for resource in collection_rest:
+            if resource.vendor == item_type:
+                return param_class(name=resource.name, provider=a_provider)
     else:
-        return param_class(name=test_items[0].name, provider=a_provider)
+        return param_class(name=collection_rest[0].name, provider=a_provider)
 
 
 @pytest.fixture(scope='module')
@@ -56,6 +57,7 @@ def group_tag_datacenter_combination(group_with_tag, a_provider):
 def test_tagvis_tag_datacenter_combination(testing_vis_object, group_tag_datacenter_combination,
                                 check_item_visibility, visibility):
     """ Tests template visibility with combination  of tag and selected
+
         datacenter filters in the group
         Prerequisites:
             Catalog, tag, role, group and restricted user should be created

--- a/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
+++ b/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
@@ -1,147 +1,69 @@
-import fauxfactory
 import pytest
 
 from cfme import test_requirements
 from cfme.infrastructure.cluster import Cluster
-from cfme.configure.access_control import User
-from cfme.infrastructure.provider.virtualcenter import VMwareProvider
+from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.virtual_machines import Vm, Template
-from cfme.web_ui import mixins
 from fixtures.provider import setup_one_or_skip
-from utils.appliance.implementations.ui import navigate_to
-from utils.log import logger
 from utils.providers import ProviderFilter
 from utils.update import update
 
 
 pytestmark = [test_requirements.tag, pytest.mark.tier(2)]
 
+test_items = [
+    ('clusters', Cluster),
+    ('vms', Vm),
+    ('templates', Template)
+]
+
 
 @pytest.fixture(scope='module')
 def a_provider(request):
-    prov_filter = ProviderFilter(classes=[VMwareProvider])
+    prov_filter = ProviderFilter(classes=[InfraProvider],
+                                 required_fields=['datacenters', 'clusters'])
     return setup_one_or_skip(request, filters=[prov_filter])
 
 
-@pytest.fixture(scope='function')
-def cluster(a_provider):
-    clusters = a_provider.get_clusters()
-    if not clusters:
-        pytest.skip('No content found for test!')
-    return Cluster(name=clusters[0].name, provider=a_provider)
-
-
-@pytest.fixture(scope='function')
-def vm(a_provider):
-    vms_list = a_provider.mgmt.list_vm()
-    return Vm(vms_list[0], a_provider)
-
-
-@pytest.fixture(scope='function')
-def template(a_provider):
-    templates_list = a_provider.mgmt.list_template()
-    return Template(templates_list[0], a_provider)
-
-
-@pytest.yield_fixture(scope='function')
-def restricted_user(group, new_credential):
-    user = User(
-        name='user{}'.format(fauxfactory.gen_alphanumeric()),
-        credential=new_credential,
-        email='xyz@redhat.com',
-        group=group)
-    user.create()
-    yield user
-    user.delete()
-
-
-@pytest.fixture(scope='function')
-def check_item_visibility(tag, user_restricted):
-    def _check_item_visibility(visibility_result, testing_vis_object):
-        """
-        Args:
-            visibility_result: pass 'True' is item should be visible,
-                               'False' if not
-        """
-        navigate_to(testing_vis_object, 'Details')
-        if visibility_result:
-            mixins.add_tag(tag)
-        else:
-            mixins.remove_tag(tag)
-        with user_restricted:
-            try:
-                navigate_to(testing_vis_object, 'Details')
-                actual_visibility = True
-            except Exception:
-                logger.debug('Tagged item is not visible')
-                actual_visibility = False
-        assert actual_visibility == visibility_result
-    return _check_item_visibility
-
-
-def test_tagvis_tag_cluster_combination(a_provider, group, cluster, check_item_visibility,
-                                        category, tag):
-    """ Tests cluster visibility with combination of tag and cluster filters in the group
-    Prerequisites:
-        Catalog, tag, role, group and restricted user should be created
-
-    Steps:
-        1. As admin add tag
-        2. Login as restricted user, item is visible for user
-        3. As admin remove tag
-        4. Login as restricted user, item is not visible for user
+@pytest.fixture(params=test_items, ids=[str(test_id[0]) for test_id in test_items],
+                scope='function')
+def testing_vis_object(request, a_provider, appliance):
+    """ Fixture creates class object for tag visibility test
+    Returns: class object of certain type
     """
-    # Admin adds a tag, user should see item
+    collection_name, param_class = request.param
+    test_items = getattr(appliance.rest_api.collections, collection_name)
 
-    with update(group):
-        group.tag = [category.display_name, tag.display_name]
-        group.vm_template = [a_provider.data['name'], a_provider.data['datacenters'][0],
-                             'Discovered virtual machine']
-    check_item_visibility(True, cluster)
-    # Admin removes a tag, user should not see item
-    check_item_visibility(False, cluster)
+    if not test_items:
+        pytest.skip('No content found for test!')
 
-
-def test_tagvis_tag_vm_combination(vm, group, category, tag, a_provider, check_item_visibility):
-    """ Tests vm visibility with combination of tag and datacenter filters in the group
-      Prerequisites:
-          Catalog, tag, role, group and restricted user should be created
-
-      Steps:
-          1. As admin add tag
-          2. Login as restricted user, item is visible for user
-          3. As admin remove tag
-          4. Login as restricted user, iten is not visible for user
-      """
-    with update(group):
-        group.tag = [category.display_name, tag.display_name]
-        group.vm_template = [a_provider.data['name'], a_provider.data['datacenters'][0],
-                             'Discovered virtual machine']
-    # Admin adds a tag, user should see item
-    check_item_visibility(True, vm)
-    # Admin removes a tag, user should not see item
-    check_item_visibility(False, vm)
+    if collection_name == 'templates':
+        item_type = a_provider.data['provisioning']['catalog_item_type'].lower()
+        for test_item_value in test_items:
+            if test_item_value.vendor == item_type:
+                return param_class(name=test_item_value.name, provider=a_provider)
+    else:
+        return param_class(name=test_items[0].name, provider=a_provider)
 
 
-@pytest.mark.parametrize("test", [vm, template], ids=['vm', 'template'])
-def test_tagvis_tag_template_combination(test, group, category, tag,
-                                         a_provider, check_item_visibility):
-    """ Tests template visibility with combination of tag and selected
+@pytest.fixture(scope='module')
+def group_tag_datacenter_combination(group_with_tag, a_provider):
+    with update(group_with_tag):
+        group_with_tag.host_cluster = [a_provider.data['name'], a_provider.data['datacenters'][0]]
+
+
+@pytest.mark.parametrize('visibility', [True, False], ids=['visible', 'notVisible'])
+def test_tagvis_tag_datacenter_combination(testing_vis_object, group_tag_datacenter_combination,
+                                check_item_visibility, visibility):
+    """ Tests template visibility with combination  of tag and selected
         datacenter filters in the group
-         Prerequisites:
-             Catalog, tag, role, group and restricted user should be created
+        Prerequisites:
+            Catalog, tag, role, group and restricted user should be created
 
-         Steps:
-             1. As admin add tag
-             2. Login as restricted user, item is visible for user
-             3. As admin remove tag
-             4. Login as restricted user, iten is not visible for user
-         """
-    with update(group):
-        group.tag = [category.display_name, tag.display_name]
-        group.vm_template = [a_provider.data['name'], a_provider.data['datacenters'][0],
-                             'Discovered virtual machine']
-    # Admin adds a tag, user should see item
-    check_item_visibility(True, test)
-    # Admin removes a tag, user should not see item
-    check_item_visibility(False, test)
+        Steps:
+            1. As admin add tag
+            2. Login as restricted user, item is visible for user
+            3. As admin remove tag
+            4. Login as restricted user, iten is not visible for user
+    """
+    check_item_visibility(testing_vis_object, visibility)

--- a/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
+++ b/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
@@ -1,0 +1,147 @@
+import fauxfactory
+import pytest
+
+from cfme import test_requirements
+from cfme.infrastructure.cluster import Cluster
+from cfme.configure.access_control import User
+from cfme.infrastructure.provider.virtualcenter import VMwareProvider
+from cfme.infrastructure.virtual_machines import Vm, Template
+from cfme.web_ui import mixins
+from fixtures.provider import setup_one_or_skip
+from utils.appliance.implementations.ui import navigate_to
+from utils.log import logger
+from utils.providers import ProviderFilter
+from utils.update import update
+
+
+pytestmark = [test_requirements.tag, pytest.mark.tier(2)]
+
+
+@pytest.fixture(scope='module')
+def a_provider(request):
+    prov_filter = ProviderFilter(classes=[VMwareProvider])
+    return setup_one_or_skip(request, filters=[prov_filter])
+
+
+@pytest.fixture(scope='function')
+def cluster(a_provider):
+    clusters = a_provider.get_clusters()
+    if not clusters:
+        pytest.skip('No content found for test!')
+    return Cluster(name=clusters[0].name, provider=a_provider)
+
+
+@pytest.fixture(scope='function')
+def vm(a_provider):
+    vms_list = a_provider.mgmt.list_vm()
+    return Vm(vms_list[0], a_provider)
+
+
+@pytest.fixture(scope='function')
+def template(a_provider):
+    templates_list = a_provider.mgmt.list_template()
+    return Template(templates_list[0], a_provider)
+
+
+@pytest.yield_fixture(scope='function')
+def restricted_user(group, new_credential):
+    user = User(
+        name='user' + fauxfactory.gen_alphanumeric(),
+        credential=new_credential,
+        email='xyz@redhat.com',
+        group=group)
+    user.create()
+    yield user
+    user.delete()
+
+
+@pytest.fixture(scope='function')
+def check_item_visibility(tag, user_restricted):
+    def _check_item_visibility(visibility_result, testing_vis_object):
+        """
+        Args:
+            visibility_result: pass 'True' is item should be visible,
+                               'False' if not
+        """
+        navigate_to(testing_vis_object, 'Details')
+        if visibility_result:
+            mixins.add_tag(tag)
+        else:
+            mixins.remove_tag(tag)
+        with user_restricted:
+            try:
+                navigate_to(testing_vis_object, 'Details')
+                actual_visibility = True
+            except Exception:
+                logger.debug('Tagged item is not visible')
+                actual_visibility = False
+        assert actual_visibility == visibility_result
+    return _check_item_visibility
+
+
+def test_tagvis_tag_cluster_combination(a_provider, group, cluster, check_item_visibility,
+                                        category, tag):
+    """ Tests cluster visibility with combination of tag and cluster filters in the group
+    Prerequisites:
+        Catalog, tag, role, group and restricted user should be created
+
+    Steps:
+        1. As admin add tag
+        2. Login as restricted user, item is visible for user
+        3. As admin remove tag
+        4. Login as restricted user, item is not visible for user
+    """
+    # Admin adds a tag, user should see item
+
+    with update(group):
+        group.tag = [category.display_name, tag.display_name]
+        group.vm_template = [a_provider.data['name'], a_provider.data['datacenters'][0],
+                             'Discovered virtual machine']
+    check_item_visibility(True, cluster)
+    # Admin removes a tag, user should not see item
+    check_item_visibility(False, cluster)
+
+
+def test_tagvis_tag_vm_combination(vm, group, category, tag, a_provider, check_item_visibility):
+    """ Tests vm visibility with combination of tag and datacenter filters in the group
+      Prerequisites:
+          Catalog, tag, role, group and restricted user should be created
+
+      Steps:
+          1. As admin add tag
+          2. Login as restricted user, item is visible for user
+          3. As admin remove tag
+          4. Login as restricted user, iten is not visible for user
+      """
+    with update(group):
+        group.tag = [category.display_name, tag.display_name]
+        group.vm_template = [a_provider.data['name'], a_provider.data['datacenters'][0],
+                             'Discovered virtual machine']
+    # Admin adds a tag, user should see item
+    check_item_visibility(True, vm)
+    # Admin removes a tag, user should not see item
+    check_item_visibility(False, vm)
+
+
+@pytest.mark.parametrize("test", [vm, template], ids=['vm', 'template'])
+def test_tagvis_tag_template_combination(test, group, category, tag,
+                                         a_provider, check_item_visibility):
+    """ Tests template visibility with combination of tag and selected
+        datacenter filters in the group
+         Prerequisites:
+             Catalog, tag, role, group and restricted user should be created
+
+         Steps:
+             1. As admin add tag
+             2. Login as restricted user, item is visible for user
+             3. As admin remove tag
+             4. Login as restricted user, iten is not visible for user
+         """
+    with update(group):
+        group.tag = [category.display_name, tag.display_name]
+        group.vm_template = [a_provider.data['name'], a_provider.data['datacenters'][0],
+                             'Discovered virtual machine']
+    # Admin adds a tag, user should see item
+    check_item_visibility(True, test)
+    # Admin removes a tag, user should not see item
+    check_item_visibility(False, test)

--- a/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
+++ b/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
@@ -53,7 +53,7 @@ def group_tag_datacenter_combination(group_with_tag, a_provider):
         group_with_tag.host_cluster = [a_provider.data['name'], a_provider.data['datacenters'][0]]
 
 
-@pytest.mark.parametrize('visibility', [True, False], ids=['visible', 'notVisible'])
+@pytest.mark.parametrize('visibility', [True, False], ids=['visible', 'not_visible'])
 def test_tagvis_tag_datacenter_combination(testing_vis_object, group_tag_datacenter_combination,
                                 check_item_visibility, visibility):
     """ Tests template visibility with combination  of tag and selected

--- a/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
+++ b/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
@@ -46,7 +46,7 @@ def template(a_provider):
 @pytest.yield_fixture(scope='function')
 def restricted_user(group, new_credential):
     user = User(
-        name='user' + fauxfactory.gen_alphanumeric(),
+        name='user{}'.format(fauxfactory.gen_alphanumeric()),
         credential=new_credential,
         email='xyz@redhat.com',
         group=group)


### PR DESCRIPTION
Purpose or Intent
=================
New tests cover group tag filters cases for tag visibility
{{pytest: cfme/tests/infrastructure/test_infra_tag_filters_combination.py -v -k test_tagvis --long-running}} 
