### PR TITLE
[1LP][RFR] Generify the cloud discovery

### DIFF
--- a/cfme/cloud/provider/azure.py
+++ b/cfme/cloud/provider/azure.py
@@ -30,6 +30,7 @@ class AzureProvider(CloudProvider):
     mgmt_class = AzureSystem
     db_types = ["Azure::CloudManager"]
     endpoints_form = AzureEndpointForm
+    discover_name = "Azure"
 
     def __init__(self, name=None, endpoints=None, zone=None, key=None, region=None,
                  tenant_id=None, subscription_id=None, appliance=None):
@@ -41,6 +42,7 @@ class AzureProvider(CloudProvider):
 
     @property
     def view_value_mapping(self):
+        """Maps values to view attrs"""
         region = pick(self.region) if isinstance(self.region, dict) else self.region
         return {
             'name': self.name,
@@ -67,3 +69,13 @@ class AzureProvider(CloudProvider):
             endpoints={endpoint.name: endpoint},
             key=prov_key,
             appliance=appliance)
+
+    @staticmethod
+    def discover_dict(credential):
+        """Returns the discovery credentials dictionary"""
+        return {
+            'client_id': getattr(credential, 'principal', None),
+            'client_key': getattr(credential, 'secret', None),
+            'tenant_id': getattr(credential, 'tenant_id', None),
+            'subscription': getattr(credential, 'subscription_id', None)
+        }

--- a/cfme/cloud/provider/ec2.py
+++ b/cfme/cloud/provider/ec2.py
@@ -29,6 +29,7 @@ class EC2Provider(CloudProvider):
     mgmt_class = EC2System
     db_types = ["Amazon::CloudManager"]
     endpoints_form = EC2EndpointForm
+    discover_name = "Amazon EC2"
 
     def __init__(
             self, name=None, endpoints=None, zone=None, key=None, region=None, region_name=None,
@@ -40,6 +41,7 @@ class EC2Provider(CloudProvider):
 
     @property
     def view_value_mapping(self):
+        """Maps values to view attrs"""
         return {
             'name': self.name,
             'prov_type': 'Amazon EC2',
@@ -48,6 +50,7 @@ class EC2Provider(CloudProvider):
 
     @classmethod
     def from_config(cls, prov_config, prov_key, appliance=None):
+        """Returns the EC" object from configuration"""
         endpoint = EC2Endpoint(**prov_config['endpoints']['default'])
         return cls(name=prov_config['name'],
                    region=prov_config['region'],
@@ -56,3 +59,12 @@ class EC2Provider(CloudProvider):
                    zone=prov_config['server_zone'],
                    key=prov_key,
                    appliance=appliance)
+
+    @staticmethod
+    def discover_dict(credential):
+        """Returns the discovery credentials dictionary"""
+        return {
+            'username': getattr(credential, 'principal', None),
+            'password': getattr(credential, 'secret', None),
+            'password_verify': getattr(credential, 'verify_secret', None)
+        }

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -31,7 +31,7 @@ pytest_generate_tests = testgen.generate([CloudProvider], scope="function")
 @test_requirements.discovery
 def test_empty_discovery_form_validation(appliance):
     """ Tests that the flash message is correct when discovery form is empty."""
-    discover(None, d_type="Amazon EC2")
+    discover(None, EC2Provider)
     view = appliance.browser.create_view(CloudProvidersDiscoverView)
     view.flash.assert_message('Username is required')
 
@@ -40,7 +40,7 @@ def test_empty_discovery_form_validation(appliance):
 @test_requirements.discovery
 def test_discovery_cancelled_validation(appliance):
     """ Tests that the flash message is correct when discovery is cancelled."""
-    discover(None, cancel=True, d_type="Amazon EC2")
+    discover(None, EC2Provider, cancel=True)
     view = appliance.browser.create_view(CloudProvidersView)
     view.flash.assert_success_message('Cloud Providers Discovery was cancelled by the user')
 
@@ -63,7 +63,7 @@ def test_password_mismatch_validation(appliance):
         secret=fauxfactory.gen_alphanumeric(5),
         verify_secret=fauxfactory.gen_alphanumeric(7))
 
-    discover(cred, d_type="Amazon EC2")
+    discover(cred, EC2Provider)
     view = appliance.browser.create_view(CloudProvidersView)
     view.flash.assert_message('Password/Verify Password do not match')
 
@@ -76,7 +76,7 @@ def test_providers_discovery_amazon(appliance):
     # This test was being uncollected anyway, and needs to be parametrized and not directory call
     # out to specific credential keys
     # amazon_creds = get_credentials_from_config('cloudqe_amazon')
-    # discover(amazon_creds, d_type="Amazon EC2")
+    # discover(amazon_creds, EC2Provider)
 
     view = appliance.browser.create_view(CloudProvidersView)
     view.flash.assert_success_message('Amazon Cloud Providers: Discovery successfully initiated')
@@ -217,7 +217,7 @@ def test_api_port_blank_validation(request):
 @pytest.mark.tier(3)
 def test_user_id_max_character_validation():
     cred = Credential(principal=fauxfactory.gen_alphanumeric(51), secret='')
-    discover(cred, d_type="Amazon EC2")
+    discover(cred, EC2Provider)
 
 
 @pytest.mark.tier(3)
@@ -227,7 +227,7 @@ def test_password_max_character_validation():
         principal=fauxfactory.gen_alphanumeric(5),
         secret=password,
         verify_secret=password)
-    discover(cred, d_type="Amazon EC2")
+    discover(cred, EC2Provider)
 
 
 @pytest.mark.tier(3)


### PR DESCRIPTION
Previously, the discovery function, which is in common, had knowledge
about providers baked in. This means that when adding a new provider,
we had to modify the common file. This changes means that shouldn't be
necessary.

* Created a new discover_dict() function that will take a credential
  and return the correct field dict to be filled in.
* Created the same function on CloudProvider to act as a default and
  prevent people trying to use discover on a provider that doesn't
  support it.
* Modified all tests to now supply the class and not a string type

{{pytest: cfme/tests/cloud/test_providers.py}}