### PR TITLE
[RFR] extracting BaseItem and BaseItems widgets

### DIFF
--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -128,7 +128,7 @@ class Details(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.items.get_entity(by_name=self.obj.name).click()
+        self.prerequisite_view.entities.get_entity(by_name=self.obj.name).click()
 
 
 @navigator.register(CloudProvider, 'Edit')
@@ -137,7 +137,7 @@ class Edit(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.items.get_entity(by_name=self.obj.name).check()
+        self.prerequisite_view.entities.get_entity(by_name=self.obj.name).check()
         self.prerequisite_view.toolbar.configuration.item_select('Edit Selected Cloud Provider')
 
 
@@ -156,7 +156,7 @@ class ManagePolicies(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.items.get_entity(by_name=self.obj.name).check()
+        self.prerequisite_view.entities.get_entity(by_name=self.obj.name).check()
         self.prerequisite_view.toolbar.policy.item_select('Manage Policies')
 
 
@@ -175,7 +175,7 @@ class EditTags(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.items.get_entity(by_name=self.obj.name).check()
+        self.prerequisite_view.entities.get_entity(by_name=self.obj.name).check()
         self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
 
 
@@ -223,7 +223,7 @@ class Images(CFMENavigateStep):
 def get_all_providers():
     """Returns list of all providers"""
     view = navigate_to(CloudProvider, 'All')
-    return [item.name for item in view.items.get_all(surf_pages=True)]
+    return [item.name for item in view.entities.get_all(surf_pages=True)]
 
 
 def discover(credential, discover_cls, cancel=False):
@@ -237,8 +237,9 @@ def discover(credential, discover_cls, cancel=False):
       discover_cls: class of the discovery item
     """
     view = navigate_to(CloudProvider, 'Discover')
-    view.fill({'discover_type': discover_cls.discover_name})
-    view.fields.fill(discover_cls.discover_dict(credential))
+    if discover_cls:
+        view.fill({'discover_type': discover_cls.discover_name})
+        view.fields.fill(discover_cls.discover_dict(credential))
 
     if cancel:
         view.cancel.click()

--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -96,7 +96,7 @@ class All(CFMENavigateStep):
 
     def resetter(self):
         tb = self.view.toolbar
-        paginator = self.view.paginator
+        paginator = self.view.entities.paginator
         if 'Grid View' not in tb.view_selector.selected:
             tb.view_selector.select('Grid View')
         if paginator.exists:
@@ -128,7 +128,7 @@ class Details(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.items.get_item(by_name=self.obj.name).click()
+        self.prerequisite_view.items.get_entity(by_name=self.obj.name).click()
 
 
 @navigator.register(CloudProvider, 'Edit')
@@ -137,7 +137,7 @@ class Edit(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.items.get_item(by_name=self.obj.name).check()
+        self.prerequisite_view.items.get_entity(by_name=self.obj.name).check()
         self.prerequisite_view.toolbar.configuration.item_select('Edit Selected Cloud Provider')
 
 
@@ -156,7 +156,7 @@ class ManagePolicies(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.items.get_item(by_name=self.obj.name).check()
+        self.prerequisite_view.items.get_entity(by_name=self.obj.name).check()
         self.prerequisite_view.toolbar.policy.item_select('Manage Policies')
 
 
@@ -175,7 +175,7 @@ class EditTags(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.items.get_item(by_name=self.obj.name).check()
+        self.prerequisite_view.items.get_entity(by_name=self.obj.name).check()
         self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
 
 
@@ -249,6 +249,6 @@ def discover(credential, discover_cls, cancel=False):
 def wait_for_a_provider():
     view = navigate_to(CloudProvider, 'All')
     logger.info('Waiting for a provider to appear...')
-    wait_for(lambda: int(view.paginator.items_amount), fail_condition=0,
+    wait_for(lambda: int(view.entities.paginator.items_amount), fail_condition=0,
              message="Wait for any provider to appear", num_sec=1000,
              fail_func=view.browser.refresh)

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -3,7 +3,7 @@ from collections import Iterable
 from functools import partial
 
 from manageiq_client.api import APIException
-from widgetastic.widget import View, Text
+from widgetastic.widget import View, Text, ParametrizedView
 from widgetastic_patternfly import Input, Button
 
 from cfme.base.credential import (
@@ -30,6 +30,7 @@ from utils.stats import tol_check
 from utils.update import Updateable
 from utils.varmeth import variable
 from utils.wait import wait_for, RefreshTimer
+from widgetastic_manageiq import BaseQuadIconItem, BaseTileIconItem, BaseListItem, BaseItem
 from . import PolicyProfileAssignable, Taggable, SummaryMixin
 
 cfg_btn = partial(tb.select, 'Configuration')
@@ -999,3 +1000,29 @@ class DefaultEndpointForm(View):
     change_password = Text(locator='.//a[normalize-space(.)="Change stored password"]')
 
     validate = Button('Validate')
+
+
+class ProviderQuadIconItem(BaseQuadIconItem):
+    @property
+    def data(self):
+        br = self.browser
+        return {
+            "no_host": br.text(self.QUADRANT.format(pos='a')),
+            "vendor": br.get_attribute('src', self.QUADRANT.format(pos='c')),
+            "creds": br.get_attribute('src', self.QUADRANT.format(pos='d')),
+        }
+
+
+class ProviderTileIconItem(BaseTileIconItem):
+    quad_icon = ParametrizedView.nested(ProviderQuadIconItem)
+    pass
+
+
+class ProviderListItem(BaseListItem):
+    pass
+
+
+class ProviderItem(BaseItem):
+    quad_item = ProviderQuadIconItem
+    list_item = ProviderListItem
+    tile_item = ProviderTileIconItem

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -210,14 +210,14 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
                     cancel_text = ('Add of {} Provider was '
                                    'cancelled by the user'.format(self.string_name))
 
-                    main_view.items.flash.assert_message(cancel_text)
-                    main_view.items.flash.assert_no_error()
+                    main_view.entities.flash.assert_message(cancel_text)
+                    main_view.entities.flash.assert_no_error()
                 else:
                     add_view.add.click()
                     if main_view.is_displayed:
                         success_text = '{} Providers "{}" was saved'.format(self.string_name,
                                                                             self.name)
-                        main_view.items.flash.assert_message(success_text)
+                        main_view.entities.flash.assert_message(success_text)
                     else:
                         add_view.flash.assert_no_error()
                         raise AssertionError("Provider wasn't added. It seems form isn't accurately"
@@ -326,8 +326,8 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
                 cancel_text = 'Edit of {type} Provider "{name}" ' \
                               'was cancelled by the user'.format(type=self.string_name,
                                                                  name=self.name)
-                main_view.items.flash.assert_message(cancel_text)
-                main_view.items.flash.assert_no_error()
+                main_view.entities.flash.assert_message(cancel_text)
+                main_view.entities.flash.assert_no_error()
             else:
                 edit_view.save.click()
                 if endpoints:

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -3,9 +3,10 @@ from collections import Iterable
 from functools import partial
 
 from manageiq_client.api import APIException
-from widgetastic.widget import View, Text, ParametrizedView
+from widgetastic.widget import View, Text
 from widgetastic_patternfly import Input, Button
 
+import cfme.fixtures.pytest_selenium as sel
 from cfme.base.credential import (
     Credential, EventsCredential, TokenCredential, SSHCredential, CANDUCredential, AzureCredential,
     ServiceAccountCredential)
@@ -13,7 +14,6 @@ from cfme.common.provider_views import (InfraProvidersView,
                                         CloudProvidersView,
                                         InfraProviderDetailsView,
                                         CloudProviderDetailsView)
-import cfme.fixtures.pytest_selenium as sel
 from cfme.exceptions import (
     ProviderHasNoKey, HostStatsNotContains, ProviderHasNoProperty, FlashMessageException)
 from cfme.web_ui import (
@@ -30,7 +30,6 @@ from utils.stats import tol_check
 from utils.update import Updateable
 from utils.varmeth import variable
 from utils.wait import wait_for, RefreshTimer
-from widgetastic_manageiq import BaseQuadIconItem, BaseTileIconItem, BaseListItem, BaseItem
 from . import PolicyProfileAssignable, Taggable, SummaryMixin
 
 cfg_btn = partial(tb.select, 'Configuration')
@@ -1000,29 +999,3 @@ class DefaultEndpointForm(View):
     change_password = Text(locator='.//a[normalize-space(.)="Change stored password"]')
 
     validate = Button('Validate')
-
-
-class ProviderQuadIconItem(BaseQuadIconItem):
-    @property
-    def data(self):
-        br = self.browser
-        return {
-            "no_host": br.text(self.QUADRANT.format(pos='a')),
-            "vendor": br.get_attribute('src', self.QUADRANT.format(pos='c')),
-            "creds": br.get_attribute('src', self.QUADRANT.format(pos='d')),
-        }
-
-
-class ProviderTileIconItem(BaseTileIconItem):
-    quad_icon = ParametrizedView.nested(ProviderQuadIconItem)
-    pass
-
-
-class ProviderListItem(BaseListItem):
-    pass
-
-
-class ProviderItem(BaseItem):
-    quad_item = ProviderQuadIconItem
-    list_item = ProviderListItem
-    tile_item = ProviderTileIconItem

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -15,9 +15,10 @@ from widgetastic_manageiq import (BreadCrumb,
                                   Table,
                                   PaginationPane,
                                   FileInput,
-                                  BaseItemsView,
+                                  BaseEntitiesView,
                                   DynaTree,
-                                  BootstrapTreeview)
+                                  BootstrapTreeview,
+                                  ProviderItem)
 
 
 class ProviderDetailsToolBar(View):
@@ -258,8 +259,7 @@ class ProviderNodesView(BaseLoggedInPage):
     """
     title = Text('//div[@id="main-content"]//h1')
     toolbar = View.nested(NodesToolBar)
-    contents = View.nested(View)  # left it for future
-    paginator = View.nested(PaginationPane)
+    entities = View.nested(View)  # left it for future
 
     @property
     def is_displayed(self):
@@ -287,6 +287,10 @@ class ProviderSideBar(View):
     pass
 
 
+class ProviderItemsView(BaseEntitiesView):
+    entity_class = ProviderItem
+
+
 class ProvidersView(BaseLoggedInPage):
     """
      represents Main view displaying all providers
@@ -297,7 +301,7 @@ class ProvidersView(BaseLoggedInPage):
 
     toolbar = View.nested(ProviderToolBar)
     sidebar = View.nested(ProviderSideBar)
-    items = View.nested(BaseItemsView)
+    items = View.nested(ProviderItemsView)
 
 
 class InfraProvidersView(ProvidersView):

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -303,7 +303,7 @@ class ProvidersView(BaseLoggedInPage):
 
     toolbar = View.nested(ProviderToolBar)
     sidebar = View.nested(ProviderSideBar)
-    entities = View.nested(ProviderEntitiesView)
+    including_entities = View.include(ProviderEntitiesView)
 
 
 class InfraProvidersView(ProvidersView):

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -290,7 +290,9 @@ class ProviderEntitiesView(BaseEntitiesView):
     """
      represents child class of Entities view for Provider entities
     """
-    entity_class = ProviderEntity
+    @property
+    def entity_class(self):
+        return ProviderEntity
 
 
 class ProvidersView(BaseLoggedInPage):

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -13,12 +13,11 @@ from widgetastic_manageiq import (BreadCrumb,
                                   Checkbox,
                                   Input,
                                   Table,
-                                  PaginationPane,
                                   FileInput,
                                   BaseEntitiesView,
                                   DynaTree,
                                   BootstrapTreeview,
-                                  ProviderItem)
+                                  ProviderEntity)
 
 
 class ProviderDetailsToolBar(View):
@@ -287,8 +286,11 @@ class ProviderSideBar(View):
     pass
 
 
-class ProviderItemsView(BaseEntitiesView):
-    entity_class = ProviderItem
+class ProviderEntitiesView(BaseEntitiesView):
+    """
+     represents child class of Entities view for Provider entities
+    """
+    entity_class = ProviderEntity
 
 
 class ProvidersView(BaseLoggedInPage):
@@ -301,7 +303,7 @@ class ProvidersView(BaseLoggedInPage):
 
     toolbar = View.nested(ProviderToolBar)
     sidebar = View.nested(ProviderSideBar)
-    items = View.nested(ProviderItemsView)
+    entities = View.nested(ProviderEntitiesView)
 
 
 class InfraProvidersView(ProvidersView):
@@ -312,7 +314,7 @@ class InfraProvidersView(ProvidersView):
     def is_displayed(self):
         return (super(InfraProvidersView, self).is_displayed and
                 self.navigation.currently_selected == ['Compute', 'Infrastructure', 'Providers'] and
-                self.items.title.text == 'Infrastructure Providers')
+                self.entities.title.text == 'Infrastructure Providers')
 
 
 class CloudProvidersView(ProvidersView):
@@ -323,7 +325,7 @@ class CloudProvidersView(ProvidersView):
     def is_displayed(self):
         return (super(CloudProvidersView, self).is_displayed and
                 self.navigation.currently_selected == ['Compute', 'Clouds', 'Providers'] and
-                self.items.title.text == 'Cloud Providers')
+                self.entities.title.text == 'Cloud Providers')
 
 
 class BeforeFillMixin(object):

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -4,7 +4,6 @@ from widgetastic.widget import View, Text, ConditionalSwitchableView
 from widgetastic_patternfly import Dropdown, BootstrapSelect, FlashMessages
 
 from cfme.base.login import BaseLoggedInPage
-from cfme.exceptions import ItemNotFound, ManyItemsFound
 from widgetastic_manageiq import (BreadCrumb,
                                   SummaryTable,
                                   Button,
@@ -16,10 +15,9 @@ from widgetastic_manageiq import (BreadCrumb,
                                   Table,
                                   PaginationPane,
                                   FileInput,
-                                  Search,
+                                  BaseItemsView,
                                   DynaTree,
                                   BootstrapTreeview)
-from cfme.common.provider import ProviderItem
 
 
 class ProviderDetailsToolBar(View):
@@ -282,76 +280,6 @@ class ProviderToolBar(View):
     view_selector = View.nested(ItemsToolBarViewSelector)
 
 
-class ProviderItems(View):
-    """
-    should represent the view with different items like providers
-    """
-    title = Text('//div[@id="main-content"]//h1')
-    search = View.nested(Search)
-    flash = FlashMessages('.//div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
-                          'contains(@class, "flash_text_div")]')
-    _quadicons = '//tr[./td/div[@class="quadicon"]]/following-sibling::tr/td/a'
-    _listitems = Table(locator='//div[@id="list_grid"]/table')
-
-    def _get_item_names(self):
-        if self.parent.toolbar.view_selector.selected == 'List View':
-            return [row.name.text for row in self._listitems.rows()]
-        else:
-            br = self.browser
-            return [br.get_attribute('title', el) for el in br.elements(self._quadicons)]
-
-    def get_all(self, surf_pages=False):
-        """
-        obtains all items like QuadIcon displayed by view
-        Args:
-            surf_pages (bool): current page items if False, all items otherwise
-
-        Returns: all items (QuadIcon/etc.) displayed by view
-        """
-        if not surf_pages:
-            return [ProviderItem(parent=self, name=name) for name in self._get_item_names()]
-        else:
-            items = []
-            for _ in self.parent.paginator.pages():
-                items.extend([ProviderItem(parent=self, name=name)
-                              for name in self._get_item_names()])
-            return items
-
-    def get_items(self, by_name=None, surf_pages=False):
-        """
-        obtains all matched items like QuadIcon displayed by view
-        Args:
-            by_name (str): only items which match to by_name will be returned
-            surf_pages (bool): current page items if False, all items otherwise
-
-        Returns: all matched items (QuadIcon/etc.) displayed by view
-        """
-        items = self.get_all(surf_pages)
-        remaining_items = []
-        for item in items:
-            if by_name and by_name in item.name:
-                remaining_items.append(item)
-            # todo: by_type and by_regexp will be implemented later if needed
-        return remaining_items
-
-    def get_item(self, by_name=None, surf_pages=False):
-        """
-        obtains one item matched to by_name
-        raises exception if no items or several items were found
-        Args:
-            by_name (str): only item which match to by_name will be returned
-            surf_pages (bool): current page items if False, all items otherwise
-
-        Returns: matched item (QuadIcon/etc.)
-        """
-        items = self.get_items(by_name=by_name, surf_pages=surf_pages)
-        if len(items) == 0:
-            raise ItemNotFound("Item {name} isn't found on this page".format(name=by_name))
-        elif len(items) > 1:
-            raise ManyItemsFound("Several items with {name} were found".format(name=by_name))
-        return items[0]
-
-
 class ProviderSideBar(View):
     """
     represents left side bar. it usually contains navigation, filters, etc
@@ -369,8 +297,7 @@ class ProvidersView(BaseLoggedInPage):
 
     toolbar = View.nested(ProviderToolBar)
     sidebar = View.nested(ProviderSideBar)
-    items = View.nested(ProviderItems)
-    paginator = View.nested(PaginationPane)
+    items = View.nested(BaseItemsView)
 
 
 class InfraProvidersView(ProvidersView):

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -305,7 +305,7 @@ class ProvidersView(BaseLoggedInPage):
 
     toolbar = View.nested(ProviderToolBar)
     sidebar = View.nested(ProviderSideBar)
-    including_entities = View.include(ProviderEntitiesView)
+    including_entities = View.include(ProviderEntitiesView, use_parent=True)
 
 
 class InfraProvidersView(ProvidersView):

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -18,8 +18,8 @@ from widgetastic_manageiq import (BreadCrumb,
                                   FileInput,
                                   Search,
                                   DynaTree,
-                                  BootstrapTreeview,
-                                  ProviderItem)
+                                  BootstrapTreeview)
+from cfme.common.provider import ProviderItem
 
 
 class ProviderDetailsToolBar(View):

--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -432,5 +432,5 @@ class ItemNotFound(CFMEException):
     """Raised when an item is not found in general."""
 
 
-class ManyItemsFound(CFMEException):
+class ManyEntitiesFound(CFMEException):
     """Raised when one or no items were expected but several/many items were obtained instead."""

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -220,7 +220,7 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         tb = self.view.toolbar
-        paginator = self.view.paginator
+        paginator = self.view.entities.paginator
         if 'Grid View' not in tb.view_selector.selected:
             tb.view_selector.select('Grid View')
         if paginator.exists:
@@ -254,7 +254,7 @@ class Details(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.items.get_item(by_name=self.obj.name).click()
+        self.prerequisite_view.items.get_entity(by_name=self.obj.name).click()
 
     def resetter(self):
         # Reset view and selection
@@ -270,7 +270,7 @@ class ManagePolicies(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.items.get_item(by_name=self.obj.name).check()
+        self.prerequisite_view.items.get_entity(by_name=self.obj.name).check()
         self.prerequisite_view.toolbar.policy.item_select('Manage Policies')
 
 
@@ -289,7 +289,7 @@ class EditTags(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.items.get_item(by_name=self.obj.name).check()
+        self.prerequisite_view.items.get_entity(by_name=self.obj.name).check()
         self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
 
 
@@ -308,7 +308,7 @@ class Edit(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.items.get_item(by_name=self.obj.name).check()
+        self.prerequisite_view.items.get_entity(by_name=self.obj.name).check()
         self.prerequisite_view.toolbar.configuration.item_select('Edit Selected '
                                                                  'Infrastructure Providers')
 
@@ -388,6 +388,6 @@ def discover(discover_cls, cancel=False, start_ip=None, end_ip=None):
 def wait_for_a_provider():
     view = navigate_to(InfraProvider, 'All')
     logger.info('Waiting for a provider to appear...')
-    wait_for(lambda: int(view.paginator.items_amount), fail_condition=0,
+    wait_for(lambda: int(view.entitites.paginator.items_amount), fail_condition=0,
              message="Wait for any provider to appear", num_sec=1000,
              fail_func=view.browser.refresh)

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -254,7 +254,7 @@ class Details(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.items.get_entity(by_name=self.obj.name).click()
+        self.prerequisite_view.entities.get_entity(by_name=self.obj.name).click()
 
     def resetter(self):
         # Reset view and selection
@@ -270,7 +270,7 @@ class ManagePolicies(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.items.get_entity(by_name=self.obj.name).check()
+        self.prerequisite_view.entities.get_entity(by_name=self.obj.name).check()
         self.prerequisite_view.toolbar.policy.item_select('Manage Policies')
 
 
@@ -289,7 +289,7 @@ class EditTags(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.items.get_entity(by_name=self.obj.name).check()
+        self.prerequisite_view.entities.get_entity(by_name=self.obj.name).check()
         self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
 
 
@@ -308,7 +308,7 @@ class Edit(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.items.get_entity(by_name=self.obj.name).check()
+        self.prerequisite_view.entities.get_entity(by_name=self.obj.name).check()
         self.prerequisite_view.toolbar.configuration.item_select('Edit Selected '
                                                                  'Infrastructure Providers')
 
@@ -350,7 +350,7 @@ class Templates(CFMENavigateStep):
 def get_all_providers():
     """Returns list of all providers"""
     view = navigate_to(InfraProvider, 'All')
-    return [item.name for item in view.items.get_all(surf_pages=True)]
+    return [item.name for item in view.entities.get_all(surf_pages=True)]
 
 
 def discover(discover_cls, cancel=False, start_ip=None, end_ip=None):
@@ -367,7 +367,8 @@ def discover(discover_cls, cancel=False, start_ip=None, end_ip=None):
         end_ip: String end of the IP range for discovery
     """
     form_data = {}
-    form_data.update(discover_cls.discover_dict)
+    if discover_cls:
+        form_data.update(discover_cls.discover_dict)
 
     if start_ip:
         for idx, octet in enumerate(start_ip.split('.'), start=1):
@@ -388,6 +389,6 @@ def discover(discover_cls, cancel=False, start_ip=None, end_ip=None):
 def wait_for_a_provider():
     view = navigate_to(InfraProvider, 'All')
     logger.info('Waiting for a provider to appear...')
-    wait_for(lambda: int(view.entitites.paginator.items_amount), fail_condition=0,
+    wait_for(lambda: int(view.entities.paginator.items_amount), fail_condition=0,
              message="Wait for any provider to appear", num_sec=1000,
              fail_func=view.browser.refresh)

--- a/cfme/tests/openstack/infrastructure/test_provider.py
+++ b/cfme/tests/openstack/infrastructure/test_provider.py
@@ -19,7 +19,7 @@ def test_api_port(provider):
 
 def test_credentials_quads(provider):
     view = navigate_to(provider, 'All')
-    prov_item = view.items.get_entity(by_name=provider.name)
+    prov_item = view.entities.get_entity(by_name=provider.name)
     assert prov_item.data.get('creds') and 'checkmark' in prov_item.data['creds']
 
 
@@ -27,4 +27,4 @@ def test_delete_provider(provider):
     provider.delete(cancel=False)
     provider.wait_for_delete()
     view = navigate_to(provider, 'All')
-    assert provider.name not in [item.name for item in view.items.get_all(surf_pages=True)]
+    assert provider.name not in [item.name for item in view.entities.get_all(surf_pages=True)]

--- a/cfme/tests/openstack/infrastructure/test_provider.py
+++ b/cfme/tests/openstack/infrastructure/test_provider.py
@@ -19,7 +19,7 @@ def test_api_port(provider):
 
 def test_credentials_quads(provider):
     view = navigate_to(provider, 'All')
-    prov_item = view.items.get_item(by_name=provider.name)
+    prov_item = view.items.get_entity(by_name=provider.name)
     assert prov_item.data.get('creds') and 'checkmark' in prov_item.data['creds']
 
 

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -1975,7 +1975,6 @@ class EntitiesConditionalView(View):
 
     """
     elements = '//tr[./td/div[@class="quadicon"]]/following-sibling::tr/td/a'
-    entity_class = BaseEntity
     title = Text('//div[@id="main-content"]//h1')
     search = View.nested(Search)
     paginator = View.nested(PaginationPane)
@@ -1999,11 +1998,11 @@ class EntitiesConditionalView(View):
         Returns: all entities (QuadIcon/etc.) displayed by view
         """
         if not surf_pages:
-            return [self.entity_class(parent=self, name=name) for name in self.entity_names]
+            return [self.parent.entity_class(parent=self, name=name) for name in self.entity_names]
         else:
             items = []
             for _ in self.parent.paginator.pages():
-                items.extend([item(parent=self, name=name)
+                items.extend([self.parent.entity_class(parent=self, name=name)
                               for name in self.entity_names])
             return items
 
@@ -2048,8 +2047,8 @@ class EntitiesConditionalView(View):
         Returns: matched entity (QuadIcon/etc.)
         """
         for _ in self.parent.paginator.pages():
-            found_items = [self.entity_class(parent=self, name=name) for name in self.entity_names
-                           if by_name == name]
+            found_items = [self.parent.entity_class(parent=self, name=name)
+                           for name in self.entity_names if by_name == name]
             if found_items:
                 return found_items[0]
 
@@ -2060,7 +2059,7 @@ class BaseEntitiesView(View):
     """
     should represent the view with different entities like providers
     """
-    some_text = Text(locator='blabla')
+    entity_class = BaseEntity
     entities = ConditionalSwitchableView(reference='parent.toolbar.view_selector',
                                          ignore_bad_reference=True)
 

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -1309,7 +1309,10 @@ class ItemsToolBarViewSelector(View):
 
     @property
     def selected(self):
-        return next(btn.title for btn in self._view_buttons if btn.active)
+        if self.is_displayed:
+            return next(btn.title for btn in self._view_buttons if btn.active)
+        else:
+            return None
 
     def read(self):
         return self.selected
@@ -1348,7 +1351,7 @@ class DetailsToolBarViewSelector(View):
 
     @property
     def selected(self):
-        return next(btn.title for btn in self._view_buttons if btn.active)
+        return next(btn.title for btn in self._view_buttons if btn.is_displayed and btn.active)
 
     @property
     def is_displayed(self):

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -1351,7 +1351,10 @@ class DetailsToolBarViewSelector(View):
 
     @property
     def selected(self):
-        return next(btn.title for btn in self._view_buttons if btn.is_displayed and btn.active)
+        if self.is_displayed:
+            return next(btn.title for btn in self._view_buttons if btn.active)
+        else:
+            return None
 
     @property
     def is_displayed(self):

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -1290,15 +1290,9 @@ class ItemsToolBarViewSelector(View):
         view_selector.selected
     """
     ROOT = './/div[contains(@class, "toolbar-pf-view-selector")]'
-    grid_button = VersionPick({
-        Version.lowest(): ViewChangeButton(title='Grid View'),
-        '5.7.0': Button(title='Grid View')})
-    tile_button = VersionPick({
-        Version.lowest(): ViewChangeButton(title='Tile View'),
-        '5.7.0': Button(title='Tile View')})
-    list_button = VersionPick({
-        Version.lowest(): ViewChangeButton(title='List View'),
-        '5.7.0': Button(title='List View')})
+    grid_button = Button(title='Grid View')
+    tile_button = Button(title='Tile View')
+    list_button = Button(title='List View')
 
     @property
     def _view_buttons(self):
@@ -1320,6 +1314,10 @@ class ItemsToolBarViewSelector(View):
     def read(self):
         return self.selected
 
+    @property
+    def is_displayed(self):
+        return self.grid_button.is_displayed
+
 
 class DetailsToolBarViewSelector(View):
     """ represents toolbar's view selector control
@@ -1333,12 +1331,8 @@ class DetailsToolBarViewSelector(View):
         view_selector.selected
     """
     ROOT = './/div[contains(@class, "toolbar-pf-view-selector")]'
-    summary_button = VersionPick({
-        Version.lowest(): ViewChangeButton(title='Summary View'),
-        '5.7.0': Button(title='Summary View')})
-    dashboard_button = VersionPick({
-        Version.lowest(): ViewChangeButton(title='Dashboard View'),
-        '5.7.0': Button(title='Dashboard View')})
+    summary_button = Button(title='Summary View')
+    dashboard_button = Button(title='Dashboard View')
 
     @property
     def _view_buttons(self):

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -1989,7 +1989,7 @@ class EntitiesConditionalView(View):
 
         Returns: all entities (QuadIcon/etc.) displayed by view
         """
-        item = self.parent.item_class
+        item = self.parent.entity_class
         if not surf_pages:
             return [item(parent=self, name=name) for name in self.entity_names]
         else:
@@ -2039,7 +2039,7 @@ class EntitiesConditionalView(View):
 
         Returns: matched entity (QuadIcon/etc.)
         """
-        item = self.parent.item_class
+        item = self.parent.entity_class
         for _ in self.parent.paginator.pages():
             found_items = [item(parent=self, name=name) for name in self.entity_names
                            if by_name == name]
@@ -2060,7 +2060,7 @@ class BaseEntitiesView(View):
     flash = FlashMessages('.//div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
                           'contains(@class, "flash_text_div")]')
 
-    entities = ConditionalSwitchableView(reference='parent.toolbar.view_selector',
+    entities = ConditionalSwitchableView(reference='self.parent.toolbar.view_selector',
                                          ignore_bad_reference=True)
 
     @entities.register('Grid View', default=True)

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -2059,7 +2059,10 @@ class BaseEntitiesView(View):
     """
     should represent the view with different entities like providers
     """
-    entity_class = BaseEntity
+    @property
+    def entity_class(self):
+        return BaseEntity
+
     entities = ConditionalSwitchableView(reference='parent.toolbar.view_selector',
                                          ignore_bad_reference=True)
 


### PR DESCRIPTION
This PR is going to extact BaseItem widget which will be used everywhere as a replacement for QuadIcon, etc. Additionally, BaseItems view will be extracted and refactored.

requires:[widgetastic.core->View.include fix]( https://github.com/RedHatQE/widgetastic.core/pull/42)
{{pytest: cfme/tests/infrastructure/test_providers.py cfme/tests/cloud/test_providers.py}}