### PR TITLE
[1LP][RFR] test diagnostic timelines

### DIFF
--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -5,7 +5,8 @@ from selenium.webdriver.common.keys import Keys
 import re
 from navmazing import NavigateToSibling, NavigateToAttribute
 
-from widgetastic_manageiq import ManageIQTree, Checkbox, AttributeValueForm, SummaryFormItem
+from widgetastic_manageiq import (ManageIQTree, Checkbox, AttributeValueForm, SummaryFormItem,
+                                  TimelinesView)
 from widgetastic_patternfly import (Accordion, Input, Button, Dropdown,
     FlashMessages, BootstrapSelect, Tab)
 from widgetastic.utils import Version, VersionPick
@@ -532,7 +533,7 @@ class ServerDiagnosticsView(ConfigurationView):
         TAB_NAME = "Utilization"
 
     @View.nested
-    class timelines(Tab):  # noqa
+    class timelines(Tab, TimelinesView):  # noqa
         TAB_NAME = "Timelines"
 
     configuration = Dropdown('Configuration')

--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -10,7 +10,7 @@ from widgetastic_manageiq import (
     ItemsToolBarViewSelector, Search)
 
 from cfme.base.login import BaseLoggedInPage
-from cfme.common.vm import VM
+from cfme.common.vm import VM, EditServerRelationShipView
 from cfme.exceptions import InstanceNotFound, DestinationNotFound, TemplateNotFound
 from cfme.fixtures import pytest_selenium as sel
 from cfme.provisioning import ProvisioningForm
@@ -549,3 +549,12 @@ class Timelines(CFMENavigateStep):
 
     def step(self, *args, **kwargs):
         self.prerequisite_view.toolbar.monitoring.item_select('Timelines')
+
+
+@navigator.register(Instance, 'EditManagementEngineRelationship')
+class VmEngineRelationship(CFMENavigateStep):
+    VIEW = EditServerRelationShipView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        self.prerequisite_view.configuration.item_select('Edit Management Engine Relationship')

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -6,6 +6,7 @@ from functools import partial
 from wrapanapi import exceptions
 
 from cfme import js
+from cfme.base.login import BaseLoggedInPage
 from cfme.exceptions import (
     VmOrInstanceNotFound, TemplateNotFound, OptionNotAvailable, UnknownProviderType)
 from cfme.fixtures import pytest_selenium as sel
@@ -24,6 +25,9 @@ from utils.timeutil import parsetime
 from utils.update import Updateable
 from utils.virtual_machines import deploy_template
 from utils.wait import wait_for, TimedOutError
+
+from widgetastic.widget import Text
+from widgetastic_patternfly import Button, BootstrapSelect
 
 from . import PolicyProfileAssignable, Taggable, SummaryMixin
 
@@ -72,6 +76,20 @@ def all_types(template=False):
 
 class _TemplateMixin(object):
     pass
+
+
+class EditServerRelationShipView(BaseLoggedInPage):
+    title = Text('//div[@id="main-content"]//h1')
+    server = BootstrapSelect(id='server_id')
+
+    save = Button('Save')
+    reset = Button('Reset')
+    cancel = Button('Cancel')
+
+    @property
+    def is_displayed(self):
+        title_name = 'Edit CFME Server Relationship for Virtual Machine'
+        return title_name in self.title.text
 
 
 class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable, SummaryMixin, Navigatable):

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -146,6 +146,20 @@ class InfraVmReconfigureView(BaseLoggedInPage):
     is_displayed = False
 
 
+class EditServerRelationShipView(BaseLoggedInPage):
+    title = Text('//div[@id="main-content"]//h1')
+    server = Dropdown('server_id')
+
+    save = Button('Save')
+    reset = Button('Reset')
+    cancel = Button('Cancel')
+
+    @property
+    def is_displayed(self):
+        title_name = 'Edit CFME Server Relationship for Virtual Machine "{vm}"'
+        return title_name in self.title.text
+
+
 class VMDisk(
         namedtuple('VMDisk', ['filename', 'size', 'size_unit', 'type', 'mode'])):
     """Represents a single VM disk
@@ -1170,3 +1184,12 @@ class VmReconfigure(CFMENavigateStep):
 
     def step(self):
         self.prerequisite_view.configuration.item_select('Reconfigure this VM')
+
+
+@navigator.register(Vm, 'EditManagementEngineRelationship')
+class VmEngineRelationship(CFMENavigateStep):
+    VIEW = EditServerRelationShipView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        self.prerequisite_view.configuration.item_select('Edit Management Engine Relationship')

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -12,7 +12,7 @@ from selenium.common.exceptions import NoSuchElementException
 from navmazing import NavigateToSibling, NavigateToAttribute
 
 from cfme.base.login import BaseLoggedInPage
-from cfme.common.vm import VM as BaseVM, Template as BaseTemplate
+from cfme.common.vm import VM as BaseVM, Template as BaseTemplate, EditServerRelationShipView
 from cfme.exceptions import (CandidateNotFound, VmNotFound, OptionNotAvailable,
                              DestinationNotFound, TemplateNotFound)
 from cfme.fixtures import pytest_selenium as sel
@@ -144,20 +144,6 @@ class InfraVmReconfigureView(BaseLoggedInPage):
 
     # The page doesn't contain enough info to ensure that it's the right VM -> always navigate
     is_displayed = False
-
-
-class EditServerRelationShipView(BaseLoggedInPage):
-    title = Text('//div[@id="main-content"]//h1')
-    server = BootstrapSelect(id='server_id')
-
-    save = Button('Save')
-    reset = Button('Reset')
-    cancel = Button('Cancel')
-
-    @property
-    def is_displayed(self):
-        title_name = 'Edit CFME Server Relationship for Virtual Machine'
-        return title_name in self.title.text
 
 
 class VMDisk(

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -148,7 +148,7 @@ class InfraVmReconfigureView(BaseLoggedInPage):
 
 class EditServerRelationShipView(BaseLoggedInPage):
     title = Text('//div[@id="main-content"]//h1')
-    server = Dropdown('server_id')
+    server = BootstrapSelect(id='server_id')
 
     save = Button('Save')
     reset = Button('Reset')
@@ -156,7 +156,7 @@ class EditServerRelationShipView(BaseLoggedInPage):
 
     @property
     def is_displayed(self):
-        title_name = 'Edit CFME Server Relationship for Virtual Machine "{vm}"'
+        title_name = 'Edit CFME Server Relationship for Virtual Machine'
         return title_name in self.title.text
 
 

--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -2,6 +2,7 @@
 import pytest
 from time import sleep
 
+from cfme.base.ui import Server
 from cfme.cloud.availability_zone import AvailabilityZone
 from cfme.cloud.instance import Instance
 from cfme.cloud.provider.azure import AzureProvider
@@ -57,6 +58,8 @@ def gen_events(new_instance):
 
 def count_events(target, vm):
     timelines_view = navigate_to(target, 'Timelines')
+    if isinstance(target, Server):
+        timelines_view = timelines_view.timelines
     timelines_view.filter.time_position.select_by_visible_text('centered')
     timelines_view.filter.apply.click()
     found_events = []

--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -10,6 +10,7 @@ from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.cloud.provider.ec2 import EC2Provider
 from utils import testgen, version
 from utils.appliance.implementations.ui import navigate_to
+from utils.blockers import BZ
 from utils.generators import random_vm_name
 from utils.log import logger
 from utils.wait import wait_for
@@ -126,6 +127,7 @@ def test_cloud_instance_event(gen_events, new_instance):
              message="events to appear")
 
 
+@pytest.mark.meta(blockers=[BZ(1429962, forced_streams=["5.7"])])
 def test_cloud_diagnostic_timelines(gen_events, new_instance, mark_vm_as_appliance, appliance):
     """Tests timelines on settings->diagnostics page
 

--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -2,7 +2,6 @@
 import fauxfactory
 import pytest
 
-from cfme.base import Server
 from cfme.common.vm import VM
 
 from cfme.infrastructure.host import Host
@@ -40,15 +39,16 @@ def new_vm(request, provider):
 
 
 @pytest.yield_fixture(scope="module")
-def mark_vm_as_appliance(new_vm):
+def mark_vm_as_appliance(new_vm, appliance):
     # set diagnostics vm
     relations_view = navigate_to(new_vm, 'EditManagementEngineRelationship')
-    relations_view.server.item_select()
+    server_name = "{name} ({sid})".format(name=appliance.server.name, sid=appliance.server.sid)
+    relations_view.server.select_by_visible_text(server_name)
     relations_view.save.click()
     yield
     # unset diagnostics vm
     relations_view = navigate_to(new_vm, 'EditManagementEngineRelationship')
-    relations_view.server.item_select()
+    relations_view.server.select_by_visible_text('<Not a Server>')
     relations_view.save.click()
 
 
@@ -124,14 +124,14 @@ def test_infra_cluster_event(gen_events, new_vm):
              fail_condition=0, message="events to appear")
 
 
-def test_infra_vm_diagnostic_timelines(gen_events, new_vm, mark_vm_as_appliance):
-    """Tests timelines on diagnostics page
+def test_infra_vm_diagnostic_timelines(gen_events, new_vm, mark_vm_as_appliance, appliance):
+    """Tests timelines on settings->diagnostics page
 
     Metadata:
-        test_flag: timelines, provision, diagnostics
+        test_flag: timelines, provision
     """
     # go diagnostic timelines
-    wait_for(count_events, [Server, new_vm], timeout='5m',
+    wait_for(count_events, [appliance.server, new_vm], timeout='5m',
              fail_condition=0, message="events to appear")
 
 

--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -3,7 +3,7 @@ import fauxfactory
 import pytest
 
 from cfme.common.vm import VM
-
+from cfme.base.ui import Server
 from cfme.infrastructure.host import Host
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
@@ -62,6 +62,8 @@ def gen_events(new_vm):
 
 def count_events(target, vm):
     timelines_view = navigate_to(target, 'Timelines')
+    if isinstance(target, Server):
+        timelines_view = timelines_view.timelines
     timelines_view.filter.time_position.select_by_visible_text('centered')
     timelines_view.filter.apply.click()
     found_events = []

--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -12,6 +12,7 @@ from cfme.rest.gen_data import vm as _vm
 from cfme.web_ui import InfoBlock
 from utils import testgen
 from utils.appliance.implementations.ui import navigate_to
+from utils.blockers import BZ
 from utils.generators import random_vm_name
 from utils.log import logger
 from utils.providers import ProviderFilter
@@ -126,6 +127,7 @@ def test_infra_cluster_event(gen_events, new_vm):
              fail_condition=0, message="events to appear")
 
 
+@pytest.mark.meta(blockers=[BZ(1429962, forced_streams=["5.7"])])
 def test_infra_vm_diagnostic_timelines(gen_events, new_vm, mark_vm_as_appliance, appliance):
     """Tests timelines on settings->diagnostics page
 


### PR DESCRIPTION
new timelines test 

{{pytest: -k test_infra_vm_diagnostic_timelines  --use-provider=rhevm36 cfme/tests/infrastructure/test_timelines.py}}
cfme/tests/cloud/test_cloud_timelines.py 