### PR TITLE
[1LP][RFR] Fixed EditPolicyEventAssignments view

### DIFF
--- a/cfme/control/explorer/policies.py
+++ b/cfme/control/explorer/policies.py
@@ -1,19 +1,20 @@
 # -*- coding: utf-8 -*-
 """Page model for Control / Explorer"""
 from navmazing import NavigateToAttribute
-
-from widgetastic.widget import Text, Checkbox, TextInput
-from widgetastic_manageiq import SummaryFormItem, CheckboxSelect, MultiBoxSelect
 from widgetastic_patternfly import Button, Input
-from cfme.web_ui.expression_editor_widgetastic import ExpressionEditor
+from widgetastic.utils import Version, VersionPick
+from widgetastic.widget import Text, Checkbox, TextInput
 
 from . import ControlExplorerView
 from actions import Action
+from cfme.web_ui.expression_editor_widgetastic import ExpressionEditor
 from utils import ParamClassName
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, navigate_to, CFMENavigateStep
 from utils.pretty import Pretty
 from utils.update import Updateable
+from widgetastic_manageiq import (BootstrapSwitchSelect, CheckboxSelect, MultiBoxSelect,
+    SummaryFormItem)
 
 
 class PoliciesAllView(ControlExplorerView):
@@ -33,7 +34,10 @@ class PoliciesAllView(ControlExplorerView):
 class EditPolicyEventAssignments(ControlExplorerView):
     title = Text("#explorer_title_text")
 
-    events = CheckboxSelect("policy_info_div")
+    events = VersionPick({
+        Version.lowest: CheckboxSelect("policy_info_div"),
+        "5.8.1": BootstrapSwitchSelect("policy_info_div")
+    })
 
     cancel_button = Button("Cancel")
     save_button = Button("Save")

--- a/cfme/control/explorer/policies.py
+++ b/cfme/control/explorer/policies.py
@@ -35,7 +35,7 @@ class EditPolicyEventAssignments(ControlExplorerView):
     title = Text("#explorer_title_text")
 
     events = VersionPick({
-        Version.lowest: CheckboxSelect("policy_info_div"),
+        Version.lowest(): CheckboxSelect("policy_info_div"),
         "5.8.1": BootstrapSwitchSelect("policy_info_div")
     })
 

--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -188,7 +188,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.12.2
 widgetastic.core==0.9.0
-widgetastic.patternfly==0.0.7
+widgetastic.patternfly==0.0.8
 widgetsnbextension==2.0.0
 wrapanapi==2.1.4
 wrapt==1.10.10

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -35,7 +35,9 @@ from widgetastic.widget import (
 from widgetastic.xpath import quote
 from widgetastic_patternfly import (
     Accordion as PFAccordion, CandidateNotFound, BootstrapSwitch, BootstrapTreeview, Button, Input,
-    BootstrapSelect, CheckableBootstrapTreeview)
+    BootstrapSelect, CheckableBootstrapTreeview, FlashMessages)
+
+from cfme.exceptions import ItemNotFound, ManyEntitiesFound
 
 
 class DynaTree(Widget):

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -600,17 +600,24 @@ class CheckboxSelect(Widget):
 
 
 class BootstrapSwitchSelect(CheckboxSelect):
-    """This view is very similar to parent CheckboxSelect view. BootstrapSwitches used instead of
+    """BootstrapSwitchSelect view.
+
+    This view is very similar to parent CheckboxSelect view. BootstrapSwitches used instead of
     usual Checkboxes. It can be found in the same policy's events assignment screen since
     CFME 5.8.1.
+
     """
+
     BS_TEXT = '/../../following-sibling::text()[1]'
 
     def _get_bs_description(self, bs):
-        """Returns text description of the BootstrapSwitch widget. We have to use such hack with
-        the script execution, because Selenium cannot return text of a text node itself.
+        """Returns text description of the BootstrapSwitch widget.
+
+        We have to use such hack with the script execution, because Selenium cannot return text of a
+        text node itself.
 
         Returns: str
+
         """
         return bs._label or self.browser.execute_script(
             "{script} return xpath(null, {arg}).textContent;".format(

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -34,10 +34,8 @@ from widgetastic.widget import (
     do_not_read_this_widget)
 from widgetastic.xpath import quote
 from widgetastic_patternfly import (
-    Accordion as PFAccordion, CandidateNotFound, BootstrapTreeview, Button, Input, BootstrapSelect,
-    CheckableBootstrapTreeview, FlashMessages)
-
-from cfme.exceptions import ItemNotFound, ManyEntitiesFound
+    Accordion as PFAccordion, CandidateNotFound, BootstrapSwitch, BootstrapTreeview, Button, Input,
+    BootstrapSelect, ViewChangeButton, CheckableBootstrapTreeview)
 
 
 class DynaTree(Widget):
@@ -599,6 +597,40 @@ class CheckboxSelect(Widget):
     def read(self):
         """Only selected checkboxes."""
         return [cb for cb in self.checkboxes if cb.selected]
+
+
+class BootstrapSwitchSelect(CheckboxSelect):
+    """This view is very similar to parent CheckboxSelect view. BootstrapSwitches used instead of
+    usual Checkboxes. It can be found in the same policy's events assignment screen since
+    CFME 5.8.1.
+    """
+    @property
+    def checkboxes(self):
+        """All bootstrap switches."""
+        return {BootstrapSwitch(self, id=el.get_attribute("id")) for el in self.browser.elements(
+            ".//input[@type='checkbox']", parent=self)}
+
+    def checkbox_by_id(self, id):
+        """Finds bootstrap switch by id."""
+        return BootstrapSwitch(self, id=id)
+
+    @property
+    def selected_text(self):
+        """Only selected bootstrap switches' text descriptions."""
+        return {bs.text for bs in self.selected_checkboxes}
+
+    def checkbox_by_text(self, text):
+        """Returns bootstrap switch searched by its text."""
+        if self._access_func is not None:
+            for cb in self.checkboxes:
+                txt = self._access_func(cb)
+                if txt == text:
+                    return cb
+            else:
+                raise NameError("Bootstrap switch with text {} not found!".format(text))
+        else:
+            # Has to be only single
+            return BootstrapSwitch(self, label=text)
 
 
 # ManageIQ table objects definition

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -35,7 +35,7 @@ from widgetastic.widget import (
 from widgetastic.xpath import quote
 from widgetastic_patternfly import (
     Accordion as PFAccordion, CandidateNotFound, BootstrapSwitch, BootstrapTreeview, Button, Input,
-    BootstrapSelect, ViewChangeButton, CheckableBootstrapTreeview)
+    BootstrapSelect, CheckableBootstrapTreeview)
 
 
 class DynaTree(Widget):
@@ -604,6 +604,20 @@ class BootstrapSwitchSelect(CheckboxSelect):
     usual Checkboxes. It can be found in the same policy's events assignment screen since
     CFME 5.8.1.
     """
+    BS_TEXT = '/../../following-sibling::text()[1]'
+
+    def _get_bs_description(self, bs):
+        """Returns text description of the BootstrapSwitch widget. We have to use such hack with
+        the script execution, because Selenium cannot return text of a text node itself.
+
+        Returns: str
+        """
+        return bs._label or self.browser.execute_script(
+            "{script} return xpath(null, {arg}).textContent;".format(
+                script=DynaTree.XPATH,
+                arg=quote(bs.ROOT.locator + self.BS_TEXT)
+            )).strip()
+
     @property
     def checkboxes(self):
         """All bootstrap switches."""
@@ -617,7 +631,7 @@ class BootstrapSwitchSelect(CheckboxSelect):
     @property
     def selected_text(self):
         """Only selected bootstrap switches' text descriptions."""
-        return {bs.text for bs in self.selected_checkboxes}
+        return {self._get_bs_description(bs) for bs in self.selected_checkboxes}
 
     def checkbox_by_text(self, text):
         """Returns bootstrap switch searched by its text."""


### PR DESCRIPTION
Purpose
=================

__Fixing__ events assignment in CFME 5.8.1. Checkboxes are replaced by BootstrapSwitches. BootstrapswitchSelect has been implemented. Requires https://github.com/RedHatQE/widgetastic.patternfly/pull/9

{{pytest: -v -k "test_assign_two_random_events_to_control_policy" --long-running}}