### PR TITLE
[RFR] New test coverage for Timezones

### DIFF
--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -11,6 +11,20 @@ import yaml
 
 TimedCommand = namedtuple('TimedCommand', ['command', 'timeout'])
 LoginOption = namedtuple('LoginOption', ['name', 'option', 'index'])
+TZ = namedtuple('TimeZone', ['name', 'option'])
+tzs = [
+    TZ('Africa/Abidjan', ('1', '1')),
+    TZ('America/Argentina/Buenos_Aires', ('2', '6', '1')),
+    TZ('Antarctica/Casey', ('3', 'q', '1')),
+    TZ('Arctic/Longyearbyen', ('4', 'q', '1')),
+    TZ('Asia/Aden', ('5', '1')),
+    TZ('Atlantic/Azores', ('6', 'q', '1')),
+    TZ('Australia/Adelaide', ('7', 'q', '1')),
+    TZ('Europe/Amsterdam', ('8', '1')),
+    TZ('Indian/Antananarivo', ('9', 'q', '1')),
+    TZ('Pacific/Apia', ('10', '1')),
+    TZ('UTC', ('11',))
+]
 
 
 @pytest.mark.smoke
@@ -46,13 +60,12 @@ def test_black_console_set_hostname(appliance):
     assert return_code == 0
 
 
-@pytest.mark.parametrize('timezone', [('3', 'Antarctica/Casey'), ('4', 'Arctic/Longyearbyen'),
-    ('6', 'Atlantic/Azores'), ('7', 'Australia/Adelaide'), ('9', 'Indian/Antananarivo')])
+@pytest.mark.parametrize('timezone', tzs, ids=[tz.name for tz in tzs])
 def test_black_console_set_timezone(request, timezone, temp_appliance_preconfig_modscope):
     """'ap' launch appliance_console, '' clear info screen, '2/5' set timezone, 'opt' select
-    region, 'timezone' selects zone, '1' selects local area, 'y' confirm slection, '' finish."""
+    region, 'timezone' selects zone, 'y' confirm slection, '' finish."""
     opt = '2' if temp_appliance_preconfig_modscope.version >= "5.8" else '5'
-    command_set = ('ap', '', opt, timezone[0], '1', 'y', '')
+    command_set = ('ap', '', opt) + timezone[1] + ('y', '')
     temp_appliance_preconfig_modscope.appliance_console.run_commands(command_set)
 
     temp_appliance_preconfig_modscope.appliance_console.timezone_check(timezone)

--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -46,6 +46,18 @@ def test_black_console_set_hostname(appliance):
     assert return_code == 0
 
 
+@pytest.mark.parametrize('timezone', [('3', 'Antarctica/Casey'), ('4', 'Arctic/Longyearbyen'),
+    ('6', 'Atlantic/Azores'), ('7', 'Australia/Adelaide'), ('9', 'Indian/Antananarivo')])
+def test_black_console_set_timezone(request, timezone, temp_appliance_preconfig_modscope):
+    """'ap' launch appliance_console, '' clear info screen, '2/5' set timezone, 'opt' select
+    region, 'timezone' selects zone, '1' selects local area, 'y' confirm slection, '' finish."""
+    opt = '2' if temp_appliance_preconfig_modscope.version >= "5.8" else '5'
+    command_set = ('ap', '', opt, timezone[0], '1', 'y', '')
+    temp_appliance_preconfig_modscope.appliance_console.run_commands(command_set)
+
+    temp_appliance_preconfig_modscope.appliance_console.timezone_check(timezone)
+
+
 def test_black_console_internal_db(app_creds, temp_appliance_unconfig_funcscope):
     """'ap' launch appliance_console, '' clear info screen, '5/8' setup db, '1' Creates v2_key,
     '1' selects internal db, 'y' continue, '1' use partition, 'n' don't create dedicated db, '0'

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -74,6 +74,20 @@ class ApplianceConsole(object):
     def __init__(self, appliance):
         self.appliance = appliance
 
+    def timezone_check(self, timezone):
+        channel = self.appliance.ssh_client.invoke_shell()
+        channel.settimeout(20)
+        channel.send("ap")
+        result = ''
+        try:
+            while True:
+                result += channel.recv(1)
+                if ("{}".format(timezone[1])) in result:
+                    break
+        except socket.timeout:
+            pass
+        logger.debug(result)
+
     def run_commands(self, commands, autoreturn=True, timeout=20, channel=None):
         if not channel:
             channel = self.appliance.ssh_client.invoke_shell()

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -82,7 +82,7 @@ class ApplianceConsole(object):
         try:
             while True:
                 result += channel.recv(1)
-                if ("{}".format(timezone[1])) in result:
+                if ("{}".format(timezone[0])) in result:
                     break
         except socket.timeout:
             pass


### PR DESCRIPTION
New test coverage for timezone setting through appliance_console
{{pytest: -k test_black_console_set_timezone}}