### PR TITLE
[1LP][RFR]fix for azure provision

### DIFF
--- a/cfme/tests/cloud/test_provisioning.py
+++ b/cfme/tests/cloud/test_provisioning.py
@@ -98,6 +98,7 @@ def testing_instance(request, setup_provider, provider, provisioning, vm_name):
         # Azure uses different provisioning keys for some reason
         recursive_update(inst_args, {
             'environment': {
+                'automatic_placement': auto,
                 'cloud_network': None if auto else provisioning['virtual_net'],
                 'cloud_subnet': None if auto else provisioning['subnet_range'],
                 'security_groups': None if auto else [provisioning['network_nsg']],


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ auto_placement provision for azure - one argument was missed

{{pytest: --long-running --use-provider azure  -k "azure-Auto"}}