### PR TITLE
[1LP][RFR] Update class.exists() methods to be properties

### DIFF
--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -1222,6 +1222,7 @@ class ZoneCANDUGapCollection(CFMENavigateStep):
 
 
 @Zone.exists.external_getter_implemented_for(ViaUI)
+@property
 def exists(self):
     try:
         navigate_to(self, 'Details')

--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -1222,7 +1222,6 @@ class ZoneCANDUGapCollection(CFMENavigateStep):
 
 
 @Zone.exists.external_getter_implemented_for(ViaUI)
-@property
 def exists(self):
     try:
         navigate_to(self, 'Details')

--- a/cfme/cloud/tenant.py
+++ b/cfme/cloud/tenant.py
@@ -63,7 +63,7 @@ class Tenant(Navigatable):
 
     def wait_for_disappear(self, timeout=300):
         try:
-            return wait_for(self.exists,
+            return wait_for(lambda: self.exists,
                             fail_condition=True,
                             timeout=timeout,
                             message='Wait for cloud tenant to disappear',
@@ -73,8 +73,8 @@ class Tenant(Navigatable):
             logger.error('Timed out waiting for tenant to disappear, continuing')
 
     def wait_for_appear(self, timeout=600):
-        return wait_for(self.exists, timeout=timeout, message='Wait for cloud tenant to appear',
-                        delay=10)
+        return wait_for(lambda: self.exists, timeout=timeout, delay=10,
+                        message='Wait for cloud tenant to appear')
 
     def update(self, updates, wait=True):
         navigate_to(self, 'Edit')
@@ -82,7 +82,7 @@ class Tenant(Navigatable):
         create_tenant_form.fill({'name': updated_name})
         sel.click(create_tenant_form.save_button)
         self.provider.refresh_provider_relationships()
-        return wait_for(self.exists, fail_condition=False, timeout=600,
+        return wait_for(lambda: self.exists, fail_condition=False, timeout=600,
                         message="Wait for cloud tenant to appear", delay=10,
                         fail_func=sel.refresh)
 
@@ -122,7 +122,7 @@ class Tenant(Navigatable):
             sel.handle_alert(cancel=cancel)
 
         if cancel:
-            return self.exists()
+            return self.exists
         else:
             # Flash message is the same whether deleted from details or by selection
             result = flash.assert_success_message('Delete initiated for 1 Cloud Tenant.')
@@ -131,6 +131,7 @@ class Tenant(Navigatable):
                 result = self.wait_for_disappear(600)
                 return result
 
+    @property
     def exists(self):
         try:
             navigate_to(self, 'Details')

--- a/cfme/infrastructure/pxe.py
+++ b/cfme/infrastructure/pxe.py
@@ -167,6 +167,7 @@ class PXEServer(Updateable, Pretty, Navigatable):
             flash.assert_message_match('Add of new PXE Server was cancelled by the user')
 
     @variable(alias="db")
+    @property
     def exists(self):
         """
         Checks if the PXE server already exists
@@ -176,6 +177,7 @@ class PXEServer(Updateable, Pretty, Navigatable):
         return self.name in [s.name for s in candidates]
 
     @exists.variant('ui')
+    @property
     def exists_ui(self):
         """
         Checks if the PXE server already exists
@@ -360,6 +362,7 @@ class CustomizationTemplate(Updateable, Pretty, Navigatable):
                 'Add of new Customization Template was cancelled by the user')
 
     @variable(alias='db')
+    @property
     def exists(self):
         """
         Checks if the Customization template already exists
@@ -369,6 +372,7 @@ class CustomizationTemplate(Updateable, Pretty, Navigatable):
         return self.name in [s.name for s in candidates]
 
     @exists.variant('ui')
+    @property
     def exists_ui(self):
         """
         Checks if the Customization template already exists
@@ -608,6 +612,7 @@ class ISODatastore(Updateable, Pretty, Navigatable):
             self.refresh(timeout=refresh_timeout)
 
     @variable(alias='db')
+    @property
     def exists(self):
         """
         Checks if the ISO Datastore already exists via db

--- a/cfme/services/myservice.py
+++ b/cfme/services/myservice.py
@@ -198,6 +198,7 @@ class MyService(Updateable, Navigatable):
         view = self.create_view(MyServiceDetailView, override=updates)
         assert view.is_displayed
 
+    @property
     def exists(self):
         try:
             navigate_to(self, 'Details')

--- a/cfme/tests/cloud/test_cloud_init_provisioning.py
+++ b/cfme/tests/cloud/test_cloud_init_provisioning.py
@@ -27,7 +27,7 @@ pytest_generate_tests = testgen.generate(
 def setup_ci_template(provider):
     cloud_init_template_name = provider.data['provisioning']['ci-template']
     cloud_init_template = get_template_from_config(cloud_init_template_name)
-    if not cloud_init_template.exists():
+    if not cloud_init_template.exists:
         cloud_init_template.create()
 
 

--- a/cfme/tests/cloud/test_tenant.py
+++ b/cfme/tests/cloud/test_tenant.py
@@ -18,7 +18,7 @@ def tenant(provider, setup_provider):
     yield tenant
 
     try:
-        if tenant.exists():
+        if tenant.exists:
             tenant.delete()
 
     except Exception:
@@ -38,23 +38,23 @@ def test_tenant_crud(tenant):
     """
 
     tenant.create(cancel=True)
-    assert not tenant.exists()
+    assert not tenant.exists
 
     tenant.create()
 
     tenant.wait_for_appear()
-    assert tenant.exists()
+    assert tenant.exists
 
     with update(tenant):
         tenant.name = fauxfactory.gen_alphanumeric(8)
     tenant.wait_for_appear()
-    assert tenant.exists()
+    assert tenant.exists
 
     tenant.delete(from_details=False, cancel=True)
-    assert tenant.exists()
+    assert tenant.exists
 
     tenant.delete(from_details=True, cancel=False)
     # BZ#1411112 Delete/update cloud tenant
     #  not reflected in UI in cloud tenant list
     tenant.provider.refresh_provider_relationships()
-    assert not tenant.exists()
+    assert not tenant.exists

--- a/cfme/tests/infrastructure/test_cloud_init_provisioning.py
+++ b/cfme/tests/infrastructure/test_cloud_init_provisioning.py
@@ -32,7 +32,7 @@ def pytest_generate_tests(metafunc):
 def setup_ci_template(provisioning):
     cloud_init_template_name = provisioning['ci-template']
     cloud_init_template = get_template_from_config(cloud_init_template_name)
-    if not cloud_init_template.exists():
+    if not cloud_init_template.exists:
         cloud_init_template.create()
 
 

--- a/cfme/tests/infrastructure/test_host_provisioning.py
+++ b/cfme/tests/infrastructure/test_host_provisioning.py
@@ -72,11 +72,11 @@ def pytest_generate_tests(metafunc):
 
 @pytest.fixture(scope="module")
 def setup_pxe_servers_host_prov(pxe_server, pxe_cust_template, host_provisioning):
-    if not pxe_server.exists():
+    if not pxe_server.exists:
         pxe_server.create()
         pxe_server.set_pxe_image_type(host_provisioning['pxe_image'],
                                       host_provisioning['pxe_image_type'])
-    if not pxe_cust_template.exists():
+    if not pxe_cust_template.exists:
         pxe_cust_template.create()
 
 

--- a/cfme/tests/infrastructure/test_iso_datastore.py
+++ b/cfme/tests/infrastructure/test_iso_datastore.py
@@ -15,7 +15,7 @@ pytest_generate_tests = testgen.generate([InfraProvider], required_fields=['iso_
 @pytest.fixture()
 def no_iso_dss(provider):
     template_crud = pxe.ISODatastore(provider.name)
-    if template_crud.exists():
+    if template_crud.exists:
         template_crud.delete(cancel=False)
 
 

--- a/cfme/tests/infrastructure/test_iso_provisioning.py
+++ b/cfme/tests/infrastructure/test_iso_provisioning.py
@@ -53,11 +53,11 @@ def pytest_generate_tests(metafunc):
 
 @pytest.fixture
 def datastore_init(iso_cust_template, iso_datastore, provisioning):
-    if not iso_datastore.exists():
+    if not iso_datastore.exists:
         iso_datastore.create()
     # Fails on upstream, BZ1109256
     iso_datastore.set_iso_image_type(provisioning['iso_file'], provisioning['iso_image_type'])
-    if not iso_cust_template.exists():
+    if not iso_cust_template.exists:
         iso_cust_template.create()
 
 

--- a/cfme/tests/infrastructure/test_pxe_provisioning.py
+++ b/cfme/tests/infrastructure/test_pxe_provisioning.py
@@ -60,10 +60,10 @@ def pytest_generate_tests(metafunc):
 
 @pytest.fixture(scope="function")
 def setup_pxe_servers_vm_prov(pxe_server, pxe_cust_template, provisioning):
-    if not pxe_server.exists():
+    if not pxe_server.exists:
         pxe_server.create()
     pxe_server.set_pxe_image_type(provisioning['pxe_image'], provisioning['pxe_image_type'])
-    if not pxe_cust_template.exists():
+    if not pxe_cust_template.exists:
         pxe_cust_template.create()
 
 

--- a/cfme/tests/intelligence/reports/test_crud.py
+++ b/cfme/tests/intelligence/reports/test_crud.py
@@ -23,7 +23,7 @@ schedules_crud_dir = data_path.join("schedules_crud")
 
 def crud_files_reports():
     result = []
-    if not report_crud_dir.exists():
+    if not report_crud_dir.exists:
         report_crud_dir.mkdir()
     for file_name in report_crud_dir.listdir():
         if file_name.isfile() and file_name.basename.endswith(".yaml"):
@@ -33,7 +33,7 @@ def crud_files_reports():
 
 def crud_files_schedules():
     result = []
-    if not schedules_crud_dir.exists():
+    if not schedules_crud_dir.exists:
         schedules_crud_dir.mkdir()
     for file_name in schedules_crud_dir.listdir():
         if file_name.isfile() and file_name.basename.endswith(".yaml"):

--- a/cfme/tests/services/test_iso_service_catalogs.py
+++ b/cfme/tests/services/test_iso_service_catalogs.py
@@ -58,10 +58,10 @@ def pytest_generate_tests(metafunc):
 
 @pytest.fixture(scope="function")
 def setup_iso_datastore(setup_provider_modscope, iso_cust_template, iso_datastore, provisioning):
-    if not iso_datastore.exists():
+    if not iso_datastore.exists:
         iso_datastore.create()
     iso_datastore.set_iso_image_type(provisioning['iso_file'], provisioning['iso_image_type'])
-    if not iso_cust_template.exists():
+    if not iso_cust_template.exists:
         iso_cust_template.create()
 
 

--- a/cfme/tests/services/test_pxe_service_catalogs.py
+++ b/cfme/tests/services/test_pxe_service_catalogs.py
@@ -66,10 +66,10 @@ def pytest_generate_tests(metafunc):
 
 @pytest.fixture(scope="function")
 def setup_pxe_servers_vm_prov(pxe_server, pxe_cust_template, provisioning):
-    if not pxe_server.exists():
+    if not pxe_server.exists:
         pxe_server.create()
     pxe_server.set_pxe_image_type(provisioning['pxe_image'], provisioning['pxe_image_type'])
-    if not pxe_cust_template.exists():
+    if not pxe_cust_template.exists:
         pxe_cust_template.create()
 
 


### PR DESCRIPTION
most were, just making it consistent.
Fixed all the calls using .exists() for .exists

Not including sentaku implementations here because of: 
https://github.com/RonnyPfannschmidt/Sentaku/issues/12

If Sentaku PR is merged to fix ContextualProperty, Zone.exists can be implemented as a property as well. https://github.com/RonnyPfannschmidt/Sentaku/pull/14/files

FIXES RHCFQE-3249

PRT might be a bit crazy because I'm not intending to fix any modified tests that may not be working, limiting scope to just fixing the exists calls.

# PRT Results
Failures, but nothing to do with any of the calls to exists properties that I've modified here.