### PR TITLE
[1LP][RFR][NOTEST]Refactor cleanup_old_vms

### DIFF
--- a/scripts/list_provider_vms.py
+++ b/scripts/list_provider_vms.py
@@ -137,9 +137,8 @@ if __name__ == "__main__":
     # Stacking the generator this way is equivalent to using list.extend instead of list.append
     # Need to check queue.empty since a call to get will raise an Empty exception
     output_data = []
-    for _ in proc_list:
-        while not queue.empty():
-            output_data.extend(queue.get())
+    while not queue.empty():
+        output_data.extend(queue.get())
 
     header = '''## VM/Instances on providers matching:
 ## providers: {}

--- a/scripts/list_provider_vms.py
+++ b/scripts/list_provider_vms.py
@@ -136,11 +136,15 @@ if __name__ == "__main__":
     # Now pull all the results off of the queue
     # Stacking the generator this way is equivalent to using list.extend instead of list.append
     # Need to check queue.empty since a call to get will raise an Empty exception
-    output_data = [data for _ in proc_list if not queue.empty() for data in queue.get()]
+    output_data = []
+    for _ in proc_list:
+        while not queue.empty():
+            output_data.extend(queue.get())
 
     header = '''## VM/Instances on providers matching:
 ## providers: {}
-## tags: {}'''.format(args.provider, args.tag)
+## tags: {}
+'''.format(args.provider, args.tag)  # don't forget trailing newline...
 
     with open(args.outfile, 'w') as output_file:
         # stdout and the outfile


### PR DESCRIPTION
Depends on: ~~https://github.com/ManageIQ/wrapanapi/pull/151~~

vsphere no longer requires connecting to the host to get
vm_creation_date for a powered off VM, greatly simplifies this script,
removing the need for a separate method for these vm types.

Converted to using MultiProcessing Process + Queue instead of threads
and global dicts

MP applied to delete with a process for each prov+vm tuple, instead of
threaded per-provider which is really slow (vm deletes were sequential)

FIXES RHCFQE-3256