### PR TITLE
[1LP][RFR] Uniquely renaming test cases for infra and cloud test cases.

### DIFF
--- a/cfme/tests/configure/test_default_views_cloud.py
+++ b/cfme/tests/configure/test_default_views_cloud.py
@@ -49,17 +49,17 @@ def set_and_test_default_view(group_name, view, page):
 
 
 @pytest.mark.parametrize('key', gtl_params, scope="module")
-def test_tile_defaultview(request, key):
+def test_cloud_tile_defaultview(request, key):
     set_and_test_default_view(key, 'Tile View', gtl_params[key])
 
 
 @pytest.mark.parametrize('key', gtl_params, scope="module")
-def test_list_defaultview(request, key):
+def test_cloud_list_defaultview(request, key):
     set_and_test_default_view(key, 'List View', gtl_params[key])
 
 
 @pytest.mark.parametrize('key', gtl_params, scope="module")
-def test_grid_defaultview(request, key):
+def test_cloud_grid_defaultview(request, key):
     set_and_test_default_view(key, 'Grid View', gtl_params[key])
 
 

--- a/cfme/tests/configure/test_default_views_infra.py
+++ b/cfme/tests/configure/test_default_views_infra.py
@@ -55,17 +55,17 @@ def set_and_test_default_view(group_name, view, page):
 
 
 @pytest.mark.parametrize('key', gtl_params, scope="module")
-def test_tile_defaultview(request, key):
+def test_infra_tile_defaultview(request, key):
     set_and_test_default_view(key, 'Tile View', gtl_params[key])
 
 
 @pytest.mark.parametrize('key', gtl_params, scope="module")
-def test_list_defaultview(request, key):
+def test_infra_list_defaultview(request, key):
     set_and_test_default_view(key, 'List View', gtl_params[key])
 
 
 @pytest.mark.parametrize('key', gtl_params, scope="module")
-def test_grid_defaultview(request, key):
+def test_infra_grid_defaultview(request, key):
     set_and_test_default_view(key, 'Grid View', gtl_params[key])
 
 


### PR DESCRIPTION
Renamed the name of the test cases uniquely.


{{pytest: -v -k 'test_cloud_tile_defaultview or test_cloud_list_defaultview or test_cloud_grid_defaultview or test_infra_list_defaultview or test_infra_grid_defaultview or test_infra_tile_defaultview' }}