### PR TITLE
[1LP][RFR] Snapshots tests adoption for RHV.

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -353,10 +353,8 @@ class Vm(BaseVM):
         def does_snapshot_exist(self):
             self._nav_to_snapshot_mgmt()
             try:
-                if self.name is not None:
-                    self.snapshot_tree.find_path_to(re.compile(r"{}.*?".format(self.name)))
-                else:
-                    self.snapshot_tree.find_path_to(re.compile(r"{}.*?".format(self.description)))
+                self.snapshot_tree.find_path_to(
+                    re.compile(r"{}.*?".format(self.name or self.description)))
                 return True
             except CandidateNotFound:
                 return False
@@ -364,8 +362,7 @@ class Vm(BaseVM):
                 return False
 
         def _snapshot_click_helper(self, prop):
-            """
-            Helper method to reduce code duplication.
+            """Helper method to reduce code duplication.
 
             Args:
                 prop (str): Property to check (name or description).
@@ -377,8 +374,7 @@ class Vm(BaseVM):
                 *self.snapshot_tree.find_path_to(re.compile(prop)))
 
         def _snapshot_is_active_helper(self, prop):
-            """
-            Helper for a wait_for_snapshot_active method to reduce code duplication.
+            """Helper for a wait_for_snapshot_active method to reduce code duplication.
 
             Args:
                 prop (str): Property to check (name or description).
@@ -433,10 +429,8 @@ class Vm(BaseVM):
 
         def revert_to(self, cancel=False):
             self._nav_to_snapshot_mgmt()
-            if self.name is not None:
-                self._snapshot_click_helper(self.name)
-            else:
-                self._snapshot_click_helper(self.description)
+
+            self._snapshot_click_helper(self.name or self.description)
 
             toolbar.select('Revert to selected snapshot', invokes_alert=True)
             sel.handle_alert(cancel=cancel)

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -391,10 +391,7 @@ class Vm(BaseVM):
 
         def wait_for_snapshot_active(self):
             self._nav_to_snapshot_mgmt()
-            if self.name is not None:
-                return self._snapshot_is_active_helper(self.name)
-            else:
-                return self._snapshot_is_active_helper(self.description)
+            return self._snapshot_is_active_helper(self.name or self.description)
 
         def create(self):
             snapshot_dict = {

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -12,7 +12,6 @@ from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.infrastructure.virtual_machines import Vm  # For Vm.Snapshot
 from utils import testgen
-from utils.appliance.implementations.ui import navigate_to
 from utils.conf import credentials
 from utils.log import logger
 from utils.path import data_path
@@ -142,7 +141,6 @@ def test_verify_revert_snapshot(test_vm, provider, soft_assert, register_event, 
 
     if provider.one_of(RHEVMProvider):
         test_vm.power_control_from_cfme(option=test_vm.POWER_OFF, cancel=False)
-        navigate_to(test_vm.provider, 'Details')
         test_vm.wait_for_vm_state_change(
             desired_state=test_vm.STATE_OFF, timeout=900)
 
@@ -153,7 +151,6 @@ def test_verify_revert_snapshot(test_vm, provider, soft_assert, register_event, 
     wait_for(lambda: snapshot1.active, num_sec=300, delay=20, fail_func=sel.refresh)
     test_vm.wait_for_vm_state_change(desired_state=test_vm.STATE_OFF, timeout=720)
     test_vm.power_control_from_cfme(option=test_vm.POWER_ON, cancel=False)
-    navigate_to(test_vm.provider, 'Details')
     test_vm.wait_for_vm_state_change(desired_state=test_vm.STATE_ON, timeout=900)
     current_state = test_vm.find_quadicon().state
     soft_assert(current_state.startswith('currentstate-on'),

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -65,9 +65,9 @@ def new_snapshot(test_vm, has_name=True):
     return new_snapshot
 
 
-@pytest.mark.uncollectif(
-    lambda provider: provider.type != 'virtualcenter' and
-    provider.type != 'rhevm' or provider.type == 'rhevm' and provider.version < 4)
+@pytest.mark.uncollectif(lambda provider:
+    (provider.type != 'virtualcenter' and provider.type != 'rhevm') or
+    (provider.type == 'rhevm' and provider.version < 4))
 def test_snapshot_crud(test_vm, provider):
     """Tests snapshot crud
 
@@ -96,9 +96,9 @@ def test_delete_all_snapshots(test_vm, provider):
     snapshot2.delete_all()
 
 
-@pytest.mark.uncollectif(
-    lambda provider: provider.type != 'virtualcenter' and
-    provider.type != 'rhevm' or provider.type == 'rhevm' and provider.version < 4)
+@pytest.mark.uncollectif(lambda provider:
+    (provider.type != 'virtualcenter' and provider.type != 'rhevm') or
+    (provider.type == 'rhevm' and provider.version < 4))
 def test_verify_revert_snapshot(test_vm, provider, soft_assert, register_event, request):
     """Tests revert snapshot
 


### PR DESCRIPTION
Hi!

I've took https://github.com/ManageIQ/integration_tests/pull/4562
pull request and it wasn't working properly. As far as I understood
it's because of RHV VM's quadicon state could be not just
'currentstate-on' but 'currentstate-on-<some_hash_here>'.

So I've changed soft assertion's condition and now it's fine.

Thanks.

{{pytest: -v --long-running cfme/tests/infrastructure/test_snapshot.py --use-provider rhv41}}

Signed-off-by: Aleksei Slaikovskii <aslaikov@redhat.com>