### PR TITLE
[RFR][1LP] Use widgetastic automation for access control tests and resolve test failures on CFME default users/groups/roles

### DIFF
--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -3,7 +3,6 @@ from widgetastic_manageiq import UpDownSelect, PaginationPane, SummaryFormItem, 
 from widgetastic_patternfly import (
     BootstrapSelect, Button, Input, Tab, CheckableBootstrapTreeview,
     BootstrapSwitch, CandidateNotFound, Dropdown)
-from widgetastic.exceptions import NoSuchElementException
 from widgetastic.utils import VersionPick, Version
 from widgetastic.widget import Checkbox, View, Text
 
@@ -16,7 +15,6 @@ from cfme.utils.log import logger
 from cfme.utils.pretty import Pretty
 from cfme.utils.update import Updateable
 from cfme.utils.wait import wait_for
-
 
 
 def simple_user(userid, password):
@@ -701,7 +699,6 @@ class Group(Updateable, Pretty, Navigatable):
 
         view.flash.assert_message(flash_message)
         assert view.is_displayed
-
 
     def delete(self, cancel=True):
         """

--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -22,6 +22,12 @@ def simple_user(userid, password):
     return User(name=userid, credential=creds)
 
 
+class AccessControlToolbar(View):
+    """ Toolbar on the Access Control page """
+    configuration = Dropdown('Configuration')
+    policy = Dropdown('Policy')
+
+
 ####################################################################################################
 # RBAC USER METHODS
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -43,8 +49,7 @@ class UsersEntities(View):
 
 class AllUserView(ConfigurationView):
     """ All Users View."""
-    configuration = Dropdown('Configuration')
-    policy = Dropdown('Policy')
+    toolbar = View.nested(AccessControlToolbar)
     entities = View.nested(UsersEntities)
 
     @property
@@ -66,8 +71,7 @@ class AddUserView(UserForm):
 
 class DetailsUserView(ConfigurationView):
     """ User Details view."""
-    configuration = Dropdown('Configuration')
-    policy = Dropdown('Policy')
+    toolbar = View.nested(AccessControlToolbar)
 
     @property
     def is_displayed(self):
@@ -242,7 +246,7 @@ class User(Updateable, Pretty, Navigatable):
             return: User object of copied user
         """
         view = navigate_to(self, 'Details')
-        view.configuration.item_select('Copy this User to a new User')
+        view.toolbar.configuration.item_select('Copy this User to a new User')
         view = self.create_view(AddUserView)
         new_user = User(name="{}copy".format(self.name),
                         credential=Credential(principal='redhat', secret='redhat'))
@@ -275,11 +279,11 @@ class User(Updateable, Pretty, Navigatable):
 
         view = navigate_to(self, 'Details')
 
-        if not view.configuration.item_enabled(delete_user_txt):
+        if not view.toolbar.configuration.item_enabled(delete_user_txt):
             raise RBACOperationBlocked("Configuration action '{}' is not enabled".format(
                 delete_user_txt))
 
-        view.configuration.item_select(delete_user_txt, handle_alert=cancel)
+        view.toolbar.configuration.item_select(delete_user_txt, handle_alert=cancel)
         try:
             view.flash.assert_message(flash_blocked_msg)
             raise RBACOperationBlocked(flash_blocked_msg)
@@ -374,7 +378,7 @@ class UserAdd(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.configuration.item_select("Add a new User")
+        self.prerequisite_view.toolbar.configuration.item_select("Add a new User")
 
 
 @navigator.register(User, 'Details')
@@ -393,7 +397,7 @@ class UserEdit(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        self.prerequisite_view.configuration.item_select('Edit this User')
+        self.prerequisite_view.toolbar.configuration.item_select('Edit this User')
 
 
 @navigator.register(User, 'EditTags')
@@ -402,7 +406,8 @@ class UserTagsEdit(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        self.prerequisite_view.policy.item_select("Edit 'My Company' Tags for this User")
+        self.prerequisite_view.toolbar.policy.item_select(
+            "Edit 'My Company' Tags for this User")
 
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 # RBAC USER METHODS
@@ -464,8 +469,7 @@ class AddGroupView(GroupForm):
 
 class DetailsGroupView(ConfigurationView):
     """ Details Group View in CFME UI """
-    configuration = Dropdown('Configuration')
-    policy = Dropdown('Policy')
+    toolbar = View.nested(AccessControlToolbar)
 
     @property
     def is_displayed(self):
@@ -490,8 +494,7 @@ class EditGroupView(GroupForm):
 
 class AllGroupView(ConfigurationView):
     """ All Groups View in CFME UI """
-    configuration = Dropdown('Configuration')
-    policy = Dropdown('Policy')
+    toolbar = View.nested(AccessControlToolbar)
     table = Table("//div[@id='main_div']//table")
     paginator = PaginationPane()
 
@@ -671,7 +674,7 @@ class Group(Updateable, Pretty, Navigatable):
         edit_group_txt = 'Edit this Group'
 
         view = navigate_to(self, 'Details')
-        if not view.configuration.item_enabled(edit_group_txt):
+        if not view.toolbar.configuration.item_enabled(edit_group_txt):
             raise RBACOperationBlocked("Configuration action '{}' is not enabled".format(
                 edit_group_txt))
         view = navigate_to(self, 'Edit')
@@ -720,11 +723,11 @@ class Group(Updateable, Pretty, Navigatable):
 
         view = navigate_to(self, 'Details')
 
-        if not view.configuration.item_enabled(delete_group_txt):
+        if not view.toolbar.configuration.item_enabled(delete_group_txt):
             raise RBACOperationBlocked("Configuration action '{}' is not enabled".format(
                 delete_group_txt))
 
-        view.configuration.item_select(delete_group_txt, handle_alert=cancel)
+        view.toolbar.configuration.item_select(delete_group_txt, handle_alert=cancel)
         try:
             view.flash.assert_message(flash_blocked_msg)
             raise RBACOperationBlocked(flash_blocked_msg)
@@ -854,7 +857,7 @@ class GroupAdd(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.configuration.item_select("Add a new Group")
+        self.prerequisite_view.toolbar.configuration.item_select("Add a new Group")
 
 
 @navigator.register(Group, 'EditGroupSequence')
@@ -863,7 +866,7 @@ class EditGroupSequence(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.configuration.item_select(
+        self.prerequisite_view.toolbar.configuration.item_select(
             'Edit Sequence of User Groups for LDAP Look Up')
 
 
@@ -883,7 +886,7 @@ class GroupEdit(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        self.prerequisite_view.configuration.item_select('Edit this Group')
+        self.prerequisite_view.toolbar.configuration.item_select('Edit this Group')
 
 
 @navigator.register(Group, 'EditTags')
@@ -893,7 +896,8 @@ class GroupTagsEdit(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        self.prerequisite_view.policy.item_select("Edit 'My Company' Tags for this Group")
+        self.prerequisite_view.toolbar.policy.item_select(
+            "Edit 'My Company' Tags for this Group")
 
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 # END RBAC GROUP METHODS
@@ -939,8 +943,7 @@ class EditRoleView(RoleForm):
 
 class DetailsRoleView(RoleForm):
     """ Details Role View """
-    configuration = Dropdown('Configuration')
-    policy = Dropdown('Policy')
+    toolbar = View.nested(AccessControlToolbar)
 
     @property
     def is_displayed(self):
@@ -952,8 +955,7 @@ class DetailsRoleView(RoleForm):
 
 class AllRolesView(ConfigurationView):
     """ All Roles View """
-    configuration = Dropdown('Configuration')
-    policy = Dropdown('Policy')
+    toolbar = View.nested(AccessControlToolbar)
     table = Table("//div[@id='main_div']//table")
 
     @property
@@ -1029,7 +1031,7 @@ class Role(Updateable, Pretty, Navigatable):
         edit_role_txt = 'Edit this Role'
 
         view = navigate_to(self, 'Details')
-        if not view.configuration.item_enabled(edit_role_txt):
+        if not view.toolbar.configuration.item_enabled(edit_role_txt):
             raise RBACOperationBlocked("Configuration action '{}' is not enabled".format(
                 edit_role_txt))
 
@@ -1072,11 +1074,11 @@ class Role(Updateable, Pretty, Navigatable):
 
         view = navigate_to(self, 'Details')
 
-        if not view.configuration.item_enabled(delete_role_txt):
+        if not view.toolbar.configuration.item_enabled(delete_role_txt):
                 raise RBACOperationBlocked("Configuration action '{}' is not enabled".format(
                     delete_role_txt))
 
-        view.configuration.item_select(delete_role_txt, handle_alert=cancel)
+        view.toolbar.configuration.item_select(delete_role_txt, handle_alert=cancel)
         try:
             view.flash.assert_message(flash_blocked_msg)
             raise RBACOperationBlocked(flash_blocked_msg)
@@ -1100,7 +1102,7 @@ class Role(Updateable, Pretty, Navigatable):
         if name is None:
             name = "{}_copy".format(self.name)
         view = navigate_to(self, 'Details')
-        view.configuration.item_select('Copy this Role to a new Role')
+        view.toolbar.configuration.item_select('Copy this Role to a new Role')
         view = self.create_view(AddRoleView)
         new_role = Role(name=name)
         view.fill({'name_txt': new_role.name})
@@ -1144,7 +1146,7 @@ class RoleAdd(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.configuration.item_select("Add a new Role")
+        self.prerequisite_view.toolbar.configuration.item_select("Add a new Role")
 
 
 @navigator.register(Role, 'Details')
@@ -1163,7 +1165,7 @@ class RoleEdit(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        self.prerequisite_view.configuration.item_select('Edit this Role')
+        self.prerequisite_view.toolbar.configuration.item_select('Edit this Role')
 
 
 ####################################################################################################
@@ -1197,8 +1199,7 @@ class TenantQuotaView(ConfigurationView):
 
 class AllTenantView(ConfigurationView):
     """ All Tenants View """
-    configuration = Dropdown('Configuration')
-    policy = Dropdown('Policy')
+    toolbar = View.nested(AccessControlToolbar)
 
     @property
     def is_displayed(self):
@@ -1222,8 +1223,7 @@ class AddTenantView(TenantForm):
 
 class DetailsTenantView(ConfigurationView):
     """ Details Tenant View """
-    configuration = Dropdown('Configuration')
-    policy = Dropdown('Policy')
+    toolbar = View.nested(AccessControlToolbar)
 
     @property
     def is_displayed(self):
@@ -1388,7 +1388,8 @@ class Tenant(Updateable, Pretty, Navigatable):
                     'False' - deletion of role will be canceled
         """
         view = navigate_to(self, 'Details')
-        view.configuration.item_select('Delete this item', handle_alert=cancel)
+        view.toolbar.configuration.item_select(
+            'Delete this item', handle_alert=cancel)
         if cancel:
             view = self.create_view(ParentDetailsTenantView)
             view.flash.assert_success_message(
@@ -1455,7 +1456,7 @@ class TenantAdd(CFMENavigateStep):
         else:
             raise OptionNotAvailable('Object type unsupported for Tenant Add: {}'
                                      .format(type(self.obj).__name__))
-        self.prerequisite_view.configuration.item_select(add_selector)
+        self.prerequisite_view.toolbar.configuration.item_select(add_selector)
 
 
 @navigator.register(Tenant, 'Edit')
@@ -1464,7 +1465,7 @@ class TenantEdit(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        self.prerequisite_view.configuration.item_select('Edit this item')
+        self.prerequisite_view.toolbar.configuration.item_select('Edit this item')
 
 
 @navigator.register(Tenant, 'ManageQuotas')
@@ -1473,7 +1474,7 @@ class TenantManageQuotas(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        self.prerequisite_view.configuration.item_select('Manage Quotas')
+        self.prerequisite_view.toolbar.configuration.item_select('Manage Quotas')
 
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 # END TENANT METHODS

--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -1,14 +1,15 @@
 from navmazing import NavigateToSibling, NavigateToAttribute
-from widgetastic_manageiq import PaginationPane, SummaryFormItem, UpDownSelect
+from widgetastic_manageiq import UpDownSelect, PaginationPane, SummaryFormItem, Table
 from widgetastic_patternfly import (
     BootstrapSelect, Button, Input, Tab, CheckableBootstrapTreeview,
     BootstrapSwitch, CandidateNotFound, Dropdown)
+from widgetastic.exceptions import NoSuchElementException
 from widgetastic.utils import VersionPick, Version
-from widgetastic.widget import Checkbox, View, Table, Text
+from widgetastic.widget import Checkbox, View, Text
 
 from cfme.base.credential import Credential
 from cfme.base.ui import ConfigurationView
-from cfme.exceptions import OptionNotAvailable
+from cfme.exceptions import OptionNotAvailable, RBACOperationBlocked
 from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
 from cfme.utils.log import logger
@@ -17,11 +18,15 @@ from cfme.utils.update import Updateable
 from cfme.utils.wait import wait_for
 
 
+
 def simple_user(userid, password):
     creds = Credential(principal=userid, secret=password)
     return User(name=userid, credential=creds)
 
 
+####################################################################################################
+# RBAC USER METHODS
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 class UserForm(ConfigurationView):
     """ User Form View."""
     name_txt = Input(name='name')
@@ -43,6 +48,8 @@ class AllUserView(ConfigurationView):
     configuration = Dropdown('Configuration')
     policy = Dropdown('Policy')
     entities = View.nested(UsersEntities)
+    table = Table("//div[@id='main_div']//table")
+    paginator = PaginationPane()
 
     @property
     def is_displayed(self):
@@ -152,7 +159,18 @@ class User(Updateable, Pretty, Navigatable):
         Args:
             cancel: True - if you want to cancel user creation,
                     by defaul user will be created
+
+        Throws:
+            RBACOperationBlocked: If operation is blocked due to current user
+                not having appropriate permissions OR update is not allowed
+                for currently selected role
         """
+        if self.appliance.version < "5.8":
+            user_blocked_msg = ("Userid has already been taken")
+        else:
+            user_blocked_msg = ("Userid is not unique within region {}".format(
+                self.appliance.server_region()))
+
         view = navigate_to(self, 'Add')
         view.fill({
             'name_txt': self.name,
@@ -162,12 +180,20 @@ class User(Updateable, Pretty, Navigatable):
             'email_txt': self.email,
             'user_group_select': getattr(self.group, 'description', None)
         })
+
         if cancel:
             view.cancel_button.click()
             flash_message = 'Add of new User was cancelled by the user'
         else:
             view.add_button.click()
             flash_message = 'User "{}" was saved'.format(self.name)
+
+        try:
+            view.flash.assert_message(user_blocked_msg)
+            raise RBACOperationBlocked(user_blocked_msg)
+        except AssertionError:
+            pass
+
         view = self.create_view(AllUserView)
         view.flash.assert_success_message(flash_message)
         assert view.is_displayed
@@ -236,18 +262,57 @@ class User(Updateable, Pretty, Navigatable):
         assert view.is_displayed
         return new_user
 
-    def delete(self, cancel=True):
-        """ Delete existing user
+    def _delete_using_all_selection(self):
+        """
+        Select the existing user by selecting it from the access control group list
+        """
+        name_column = "Full Name"
+        find_row_kwargs = {name_column: self.name}
 
+        view = navigate_to(User, 'All')
+        user_row = view.paginator.find_row_on_pages(view.table, **find_row_kwargs)
+        # Zero index is the unnamed column with the checkbox
+        user_row[0].check()
+
+    def delete(self, cancel=True, all_selection=False):
+        """
+        Delete existing user
         Args:
             cancel: Default value 'True', user will be deleted
                     'False' - deletion of user will be canceled
+        Throws:
+            RBACOperationBlocked: If operation is blocked due to current user
+                not having appropriate permissions OR delete is not allowed
+                for currently selected user
         """
-        view = navigate_to(self, 'Details')
-        view.configuration.item_select('Delete this User', handle_alert=cancel)
+        flash_success_msg = 'EVM User "{}": Delete successful'.format(self.name)
+        flash_blocked_msg = "Default EVM User \"{}\" cannot be deleted".format(self.name)
+        delete_user_txt = 'Delete this User'
+
+        if all_selection:
+            self._delete_using_all_selection()
+            delete_user_txt = 'Delete selected Users'
+            view = self.create_view(AllUserView)
+            assert view.is_displayed, "All Users view is not displayed after selecting users"
+        else:
+            view = navigate_to(self, 'Details')
+
+        if not view.configuration.item_enabled(delete_user_txt):
+            raise RBACOperationBlocked("Configuration action '{}' is not enabled".format(
+                delete_user_txt))
+
+        view.configuration.item_select(delete_user_txt, handle_alert=cancel)
+        try:
+            view.flash.assert_message(flash_blocked_msg)
+            raise RBACOperationBlocked(flash_blocked_msg)
+        except AssertionError:
+            pass
+
+        view.flash.assert_message(flash_success_msg)
+
         if cancel:
             view = self.create_view(AllUserView)
-            view.flash.assert_success_message('EVM User "{}": Delete successful'.format(self.name))
+            view.flash.assert_success_message(flash_success_msg)
         else:
             view = self.create_view(DetailsUserView)
         assert view.is_displayed
@@ -361,7 +426,14 @@ class UserTagsEdit(CFMENavigateStep):
     def step(self):
         self.prerequisite_view.policy.item_select("Edit 'My Company' Tags for this User")
 
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# RBAC USER METHODS
+####################################################################################################
 
+
+####################################################################################################
+# RBAC GROUP METHODS
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 class GroupForm(ConfigurationView):
     """ Group Form in CFME UI."""
     ldap_groups_for_user = BootstrapSelect(id='ldap_groups_user')
@@ -384,8 +456,7 @@ class GroupForm(ConfigurationView):
         TAB_NAME = "My Company Tags"
         tree_locator = VersionPick({
             Version.lowest(): 'tagsbox',
-            '5.8': 'tags_treebox'}
-        )
+            '5.8': 'tags_treebox'})
         tree = CheckableBootstrapTreeview(tree_locator)
 
     @View.nested
@@ -443,7 +514,6 @@ class AllGroupView(ConfigurationView):
     """ All Groups View in CFME UI """
     configuration = Dropdown('Configuration')
     policy = Dropdown('Policy')
-
     table = Table("//div[@id='main_div']//table")
     paginator = PaginationPane()
 
@@ -530,11 +600,20 @@ class Group(Updateable, Pretty, Navigatable):
 
     def create(self, cancel=False):
         """ Create group method
-
-        Args:
-            cancel: True - if you want to cancel group creation,
-                    by defaul group will be created
+            Args:
+                cancel: True - if you want to cancel group creation,
+                        by default group will be created
+            Throws:
+                RBACOperationBlocked: If operation is blocked due to current user
+                    not having appropriate permissions OR delete is not allowed
+                    for currently selected user
         """
+        if self.appliance.version < "5.8":
+            flash_blocked_msg = ("Description has already been taken")
+        else:
+            flash_blocked_msg = "Description is not unique within region {}".format(
+                self.appliance.server_region())
+
         view = navigate_to(self, 'Add')
         view.fill({
             'description_txt': self.description,
@@ -551,6 +630,13 @@ class Group(Updateable, Pretty, Navigatable):
             view.add_button.click()
             flash_message = 'Group "{}" was saved'.format(self.description)
         view = self.create_view(AllGroupView)
+
+        try:
+            view.flash.assert_message(flash_blocked_msg)
+            raise RBACOperationBlocked(flash_blocked_msg)
+        except AssertionError:
+            pass
+
         view.flash.assert_success_message(flash_message)
         assert view.is_displayed
 
@@ -600,7 +686,36 @@ class Group(Updateable, Pretty, Navigatable):
         view = self._retrieve_ext_auth_user_groups()
         self._fill_ldap_group_lookup(view)
 
-    def update(self, updates):
+    def _update_using_all_selection(self):
+        """
+        Update existing group by selecting it from the access control group list
+
+        Throws:
+            RBACOperationBlocked: If operation is blocked due to current user
+                not having appropriate permissions OR update is not allowed
+                for currently selected group
+        """
+        flash_blocked_msg = 'Read Only EVM Group "{}" can not be edited'.format(self.description)
+        name_column = "Name"
+        find_row_kwargs = {name_column: self.description}
+
+        view = navigate_to(Group, 'All')
+        try:
+            group_row = view.paginator.find_row_on_pages(view.table, **find_row_kwargs)
+            # Zero index is the unnamed column with the checkbox
+            group_row[0].check()
+        except NoSuchElementException:
+            raise Exception("Failed to find group row with name {}".format(self.description))
+
+        view.configuration.item_select('Edit the selected Group')
+
+        try:
+            view.flash.assert_message(flash_blocked_msg)
+            raise RBACOperationBlocked(flash_blocked_msg)
+        except AssertionError:
+            pass
+
+    def update(self, updates, all_selection=False):
         """ Update group method
 
         Args:
@@ -609,12 +724,26 @@ class Group(Updateable, Pretty, Navigatable):
         Note: In case updates is the same as original group data, update will be canceled,
         as 'Save' button will not be active
         """
-        view = navigate_to(self, 'Edit')
+        edit_group_txt = 'Edit this Group'
+
+        if all_selection:
+            self._update_using_all_selection()
+            view = self.create_view(EditGroupView)
+            assert view.is_displayed, (
+                "Edit Group Details page was not displayed after all selection")
+        else:
+            view = navigate_to(self, 'Details')
+            if not view.configuration.item_enabled(edit_group_txt):
+                raise RBACOperationBlocked("Configuration action '{}' is not enabled".format(
+                    edit_group_txt))
+            view = navigate_to(self, 'Edit')
+
         changed = view.fill({
             'description_txt': updates.get('description'),
             'role_select': updates.get('role'),
             'group_tenant': updates.get('tenant')
         })
+
         changed_tag = self._set_group_restriction(view.my_company_tags, updates.get('tag'), True)
         changed_host_cluster = self._set_group_restriction(
             view.hosts_and_clusters, updates.get('host_cluster'), True)
@@ -628,26 +757,81 @@ class Group(Updateable, Pretty, Navigatable):
         else:
             view.cancel_button.click()
             flash_message = 'Edit of Group was cancelled by the user'
-        view = self.create_view(DetailsGroupView, override=updates)
+        if all_selection:
+            view = self.create_view(AllGroupView, override=updates)
+        else:
+            view = self.create_view(DetailsGroupView, override=updates)
+
         view.flash.assert_message(flash_message)
         assert view.is_displayed
 
-    def delete(self, cancel=True):
-        """ Delete existing group
+    def _delete_using_all_selection(self):
+        """
+        Delete existing group by selecting it from the access control group list
+
+        Throws:
+            RBACOperationBlocked: If operation is blocked due to current user
+                not having appropriate permissions OR delete is not allowed
+                for currently selected group
+        """
+        name_column = "Name"
+        find_row_kwargs = {name_column: self.description}
+
+        view = navigate_to(Group, 'All')
+        try:
+            group_row = view.paginator.find_row_on_pages(view.table, **find_row_kwargs)
+            # Zero index is the unnamed column with the checkbox
+            group_row[0].check()
+        except NoSuchElementException:
+            raise Exception("Failed to find group row with name {}".format(self.description))
+
+    def delete(self, cancel=True, all_selection=False):
+        """
+        Delete existing group
 
         Args:
             cancel: Default value 'True', group will be deleted
                     'False' - deletion of group will be canceled
+        Throws:
+            RBACOperationBlocked: If operation is blocked due to current user
+                not having appropriate permissions OR delete is not allowed
+                for currently selected group
         """
-        view = navigate_to(self, 'Details')
-        view.configuration.item_select('Delete this Group', handle_alert=cancel)
+        flash_success_msg = 'EVM Group "{}": Delete successful'.format(self.description)
+        flash_blocked_msg = (
+            "EVM Group \"{}\": "
+            "Error during delete: A read only group cannot be deleted.".format(self.description))
+        delete_group_txt = 'Delete this Group'
+
+        if all_selection:
+            self._delete_using_all_selection()
+            delete_group_txt = 'Delete selected Groups'
+            view = self.create_view(AllGroupView)
+            assert view.is_displayed, "All Groups view is not displayed after selecting groups"
+        else:
+            view = navigate_to(self, 'Details')
+
+        if not view.configuration.item_enabled(delete_group_txt):
+            raise RBACOperationBlocked("Configuration action '{}' is not enabled".format(
+                delete_group_txt))
+
+        view.configuration.item_select(delete_group_txt, handle_alert=cancel)
+        try:
+            view.flash.assert_message(flash_blocked_msg)
+            raise RBACOperationBlocked(flash_blocked_msg)
+        except AssertionError:
+            pass
+
+        view.flash.assert_no_error()
+        view.flash.assert_message(flash_success_msg)
+
         if cancel:
             view = self.create_view(AllGroupView)
-            view.flash.assert_success_message(
-                'EVM Group "{}": Delete successful'.format(self.description))
+            view.flash.assert_success_message(flash_success_msg)
         else:
             view = self.create_view(DetailsGroupView)
-        assert view.is_displayed
+            assert view.is_displayed, (
+                "Access Control Group {} Detail View is not displayed".format(self.description))
 
     def edit_tags(self, tag, value):
         """ Edits tag for existing group
@@ -802,7 +986,14 @@ class GroupTagsEdit(CFMENavigateStep):
     def step(self):
         self.prerequisite_view.policy.item_select("Edit 'My Company' Tags for this Group")
 
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# END RBAC GROUP METHODS
+####################################################################################################
 
+
+####################################################################################################
+# RBAC ROLE METHODS
+####################################################################################################
 class RoleForm(ConfigurationView):
     """ Role Form for CFME UI """
     name_txt = Input(name='name')
@@ -854,6 +1045,8 @@ class AllRolesView(ConfigurationView):
     """ All Roles View """
     configuration = Dropdown('Configuration')
     policy = Dropdown('Policy')
+    table = Table("//div[@id='main_div']//table")
+    paginator = PaginationPane()
 
     @property
     def is_displayed(self):
@@ -883,11 +1076,16 @@ class Role(Updateable, Pretty, Navigatable):
 
     def create(self, cancel=False):
         """ Create role method
-
-        Args:
-            cancel: True - if you want to cancel role creation,
-                    by defaul, role will be created
+            Args:
+                cancel: True - if you want to cancel role creation,
+                        by default, role will be created
+        Throws:
+            RBACOperationBlocked: If operation is blocked due to current user
+                not having appropriate permissions OR update is not allowed
+                for currently selected role
         """
+        flash_blocked_msg = "Name has already been taken"
+
         view = navigate_to(self, 'Add')
         view.fill({'name_txt': self.name,
                    'vm_restriction_select': self.vm_restriction})
@@ -899,10 +1097,47 @@ class Role(Updateable, Pretty, Navigatable):
             view.add_button.click()
             flash_message = 'Role "{}" was saved'.format(self.name)
         view = self.create_view(AllRolesView)
+
+        try:
+            view.flash.assert_message(flash_blocked_msg)
+            raise RBACOperationBlocked(flash_blocked_msg)
+        except AssertionError:
+            pass
+
         view.flash.assert_success_message(flash_message)
+
         assert view.is_displayed
 
-    def update(self, updates):
+    def _update_using_all_selection(self):
+        """
+        Update existing role by selecting it from the access control role list
+
+        Throws:
+            RBACOperationBlocked: If operation is blocked due to current user
+                not having appropriate permissions OR update is not allowed
+                for currently selected role
+        """
+        flash_blocked_msg = 'Read Only Role "{}" can not be edited'.format(self.name)
+        name_column = "Name"
+        find_row_kwargs = {name_column: self.name}
+
+        view = navigate_to(Role, 'All')
+        try:
+            role_row = view.paginator.find_row_on_pages(view.table, **find_row_kwargs)
+            # Zero index is the unnamed column with the checkbox
+            role_row[0].check()
+        except NoSuchElementException:
+            raise Exception("Failed to find role row with name {}".format(self.name))
+
+        view.configuration.item_select('Edit the selected Role')
+
+        try:
+            view.flash.assert_message(flash_blocked_msg)
+            raise RBACOperationBlocked(flash_blocked_msg)
+        except AssertionError:
+            pass
+
+    def update(self, updates, all_selection=False):
         """ Update role method
 
         Args:
@@ -911,34 +1146,90 @@ class Role(Updateable, Pretty, Navigatable):
         Note: In case updates is the same as original role data, update will be canceled,
               as 'Save' button will not be active
         """
-        view = navigate_to(self, 'Edit')
-        changed = view.fill({
-            'name_txt': updates.get('name'),
-            'vm_restriction_select': updates.get('vm_restriction')
-        })
-        feature_changed = self.set_role_product_features(view, updates.get('product_features'))
-        if changed or feature_changed:
-            view.save_button.click()
-            flash_message = 'Role "{}" was saved'.format(updates.get('name', self.name))
+        flash_blocked_msg = "Read Only Role \"{}\" can not be edited".format(self.name)
+        edit_role_txt = 'Edit this Role'
+
+        if all_selection:
+            self._update_using_all_selection()
         else:
-            view.cancel_button.click()
-            flash_message = 'Edit of Role was cancelled by the user'
-        view = self.create_view(DetailsRoleView, override=updates)
-        view.flash.assert_message(flash_message)
-        assert view.is_displayed
+            view = navigate_to(self, 'Details')
+            if not view.configuration.item_enabled(edit_role_txt):
+                raise RBACOperationBlocked("Configuration action '{}' is not enabled".format(
+                    edit_role_txt))
 
-    def delete(self, cancel=True):
-        """ Delete existing role
+            view = navigate_to(self, 'Edit')
+            try:
+                view.flash.assert_message(flash_blocked_msg)
+                raise RBACOperationBlocked(flash_blocked_msg)
+            except AssertionError:
+                pass
 
-        Args:
-            cancel: Default value 'True', role will be deleted
-                    'False' - deletion of role will be canceled
+            changed = view.fill({
+                'name_txt': updates.get('name'),
+                'vm_restriction_select': updates.get('vm_restriction')
+            })
+            feature_changed = self.set_role_product_features(view, updates.get('product_features'))
+            if changed or feature_changed:
+                view.save_button.click()
+                flash_message = 'Role "{}" was saved'.format(updates.get('name', self.name))
+            else:
+                view.cancel_button.click()
+                flash_message = 'Edit of Role was cancelled by the user'
+            view = self.create_view(DetailsRoleView, override=updates)
+            view.flash.assert_message(flash_message)
+            assert view.is_displayed
+
+    def _delete_using_all_selection(self):
         """
-        view = navigate_to(self, 'Details')
-        view.configuration.item_select('Delete this Role', handle_alert=cancel)
+        Delete existing role by selecting it from the access control role list
+        """
+        name_column = "Name"
+        find_row_kwargs = {name_column: self.name}
+
+        view = navigate_to(Role, 'All')
+        role_row = view.paginator.find_row_on_pages(view.table, **find_row_kwargs)
+        # Zero index is the unnamed column with the checkbox
+        role_row[0].check()
+
+    def delete(self, cancel=True, all_selection=False):
+        """ Delete existing role
+            Args:
+                cancel: Default value 'True', role will be deleted
+                        'False' - deletion of role will be canceled
+            Throws:
+                RBACOperationBlocked: If operation is blocked due to current user
+                    not having appropriate permissions OR delete is not allowed
+                    for currently selected role
+        """
+        flash_blocked_msg = ("Role \"{}\": Error during delete: Cannot delete record "
+                "because of dependent entitlements".format(self.name))
+        flash_success_msg = 'Role "{}": Delete successful'.format(self.name)
+        delete_role_txt = 'Delete this Role'
+
+        if all_selection:
+            self._delete_using_all_selection()
+            delete_role_txt = 'Delete selected Roles'
+            view = self.create_view(AllRolesView)
+            assert view.is_displayed, "All Roles view is not displayed after selecting roles"
+        else:
+            view = navigate_to(self, 'Details')
+
+            if not view.configuration.item_enabled(delete_role_txt):
+                    raise RBACOperationBlocked("Configuration action '{}' is not enabled".format(
+                        delete_role_txt))
+
+        view.configuration.item_select(delete_role_txt, handle_alert=cancel)
+        try:
+            view.flash.assert_message(flash_blocked_msg)
+            raise RBACOperationBlocked(flash_blocked_msg)
+        except AssertionError:
+            pass
+
+        view.flash.assert_message(flash_success_msg)
+
         if cancel:
             view = self.create_view(AllRolesView)
-            view.flash.assert_success_message('Role "{}": Delete successful'.format(self.name))
+            view.flash.assert_success_message(flash_success_msg)
         else:
             view = self.create_view(DetailsRoleView)
         assert view.is_displayed
@@ -1017,6 +1308,9 @@ class RoleEdit(CFMENavigateStep):
         self.prerequisite_view.configuration.item_select('Edit this Role')
 
 
+####################################################################################################
+# RBAC TENANT METHODS
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 class TenantForm(ConfigurationView):
     """ Tenant Form """
     name = Input(name='name')
@@ -1323,7 +1617,14 @@ class TenantManageQuotas(CFMENavigateStep):
     def step(self):
         self.prerequisite_view.configuration.item_select('Manage Quotas')
 
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# END TENANT METHODS
+####################################################################################################
 
+
+####################################################################################################
+# RBAC PROJECT METHODS
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 class Project(Tenant):
     """ Class representing CFME projects in the UI.
 
@@ -1335,3 +1636,6 @@ class Project(Tenant):
         parent_tenant: Parent project, can be None, can be passed as string or object
     """
     pass
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# END PROJECT METHODS
+####################################################################################################

--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -508,15 +508,10 @@ class AllGroupView(ConfigurationView):
 class EditGroupSequenceView(ConfigurationView):
     """ Edit Groups Sequence View in CFME UI """
 
-    group_order_selector = VersionPick({
-        Version.lowest(): UpDownSelect(
-            '#seq_fields',
-            './/a[@title="Move selected fields up"]/img',
-            './/a[@title="Move selected fields down"]/img'),
-        '5.8': UpDownSelect(
-            '#seq_fields',
-            '//button[@title="Move selected fields up"]/i',
-            '//button[@title="Move selected fields down"]/i'), })
+    group_order_selector = UpDownSelect(
+        '#seq_fields',
+        '//button[@title="Move selected fields up"]/i',
+        '//button[@title="Move selected fields down"]/i')
 
     save_button = Button('Save')
     reset_button = Button('Reset')

--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -461,3 +461,11 @@ class ManyEntitiesFound(CFMEException):
 
 class RoleNotFound(CFMEException):
     """Raised when Deployment role not found"""
+
+
+class RBACOperationBlocked(CFMEException):
+    """
+    Raised when a Role Based Access Control operation is blocked from execution due to invalid
+    permissions. Also thrown when trying to perform actions CRUD operations on roles/groups/users
+    that are CFME defaults
+    """

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -41,9 +41,7 @@ def a_provider(request):
 
 
 def new_credential():
-    #return Credential(principal='uid' + fauxfactory.gen_alphanumeric(), secret='redhat')
-    #DELETE LINE BELOW
-    return Credential(principal='uid' + fauxfactory.gen_alphanumeric().lower(), secret='redhat')
+    return Credential(principal='uid' + fauxfactory.gen_alphanumeric(), secret='redhat')
 
 
 def new_user(group=usergrp):
@@ -770,9 +768,7 @@ def test_user_change_password(appliance, request):
     user = User(
         name="user {}".format(fauxfactory.gen_alphanumeric()),
         credential=Credential(
-            #principal="user_principal_{}".format(fauxfactory.gen_alphanumeric()),
-            #DELETE THE LINE BELOW
-            principal="user_principal_{}".format(fauxfactory.gen_alphanumeric().lower()),
+            principal="user_principal_{}".format(fauxfactory.gen_alphanumeric()),
             secret="very_secret",
             verify_secret="very_secret"
         ),
@@ -785,10 +781,6 @@ def test_user_change_password(appliance, request):
     request.addfinalizer(appliance.server.login_admin)
     with user:
         appliance.server.logout()
-        ##############################
-        # DELETE
-        pytest.set_trace()
-        ##############################
         appliance.server.login(user)
         assert appliance.server.current_full_name() == user.name
     appliance.server.login_admin()

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -41,7 +41,9 @@ def a_provider(request):
 
 
 def new_credential():
-    return Credential(principal='uid' + fauxfactory.gen_alphanumeric(), secret='redhat')
+    #return Credential(principal='uid' + fauxfactory.gen_alphanumeric(), secret='redhat')
+    #DELETE LINE BELOW
+    return Credential(principal='uid' + fauxfactory.gen_alphanumeric().lower(), secret='redhat')
 
 
 def new_user(group=usergrp):
@@ -222,19 +224,6 @@ def test_delete_default_user():
 
 
 @pytest.mark.tier(3)
-def test_delete_default_user_all_selection():
-    """Test for deleting default user Administrator.
-
-    Steps:
-        * Login as Administrator user
-        * Try deleting the user
-    """
-    user = User(name='Administrator')
-    with pytest.raises(RBACOperationBlocked):
-        user.delete(all_selection=True)
-
-
-@pytest.mark.tier(3)
 @pytest.mark.meta(automates=[BZ(1090877)])
 @pytest.mark.meta(blockers=[BZ(1408479)], forced_streams=["5.7", "upstream"])
 @pytest.mark.uncollectif(lambda: version.current_version() >= "5.7")
@@ -378,23 +367,6 @@ def test_delete_default_group():
 
 
 @pytest.mark.tier(3)
-@pytest.mark.meta(blockers=[BZ(1473828, forced_streams=['5.8'])])
-def test_delete_default_group_all_selection():
-    """Test for deleting default group EvmGroup-administrator using
-       the checklist displayed by selecting Configuration->Group
-
-    Steps:
-        * Login as Administrator user
-        * Navigate to Configuration -> Group
-        * Try deleting the group EvmGroup-adminstrator
-    """
-    group = Group(description='EvmGroup-administrator')
-
-    with pytest.raises(RBACOperationBlocked):
-        group.delete(all_selection=True)
-
-
-@pytest.mark.tier(3)
 def test_delete_group_with_assigned_user():
     """Test that CFME prevents deletion of a group that has users assigned
     """
@@ -423,25 +395,6 @@ def test_edit_default_group():
     group_updates = {}
     with pytest.raises(RBACOperationBlocked):
         group.update(group_updates)
-
-
-@pytest.mark.tier(3)
-@pytest.mark.uncollectif(lambda: version.current_version() >= "5.8")
-def test_edit_default_group_all_selection():
-    """Test that CFME prevents a user from editting a default group
-    when selecting it from the Access Control EVM Groups checklist
-
-    Steps:
-        * Login as Administrator user
-        * Navigate to Configuration -> Group
-        * Try editing the group EvmGroup-adminstrator
-    """
-    group = Group(description='EvmGroup-approver')
-    group_updates = {}
-    all_selection = True
-
-    with pytest.raises(RBACOperationBlocked):
-        group.update(group_updates, all_selection)
 
 
 @pytest.mark.tier(3)
@@ -525,21 +478,6 @@ def test_delete_default_roles():
 
 
 @pytest.mark.tier(3)
-def test_delete_default_roles_all_selection():
-    """Test that CFME prevents a user from deleting a default role
-    when selecting it from the Access Control EVM role checklist
-
-    Steps:
-        * Login as Administrator user
-        * Navigate to Configuration -> Role
-        * Try deleting the group EvmRole-approver
-    """
-    role = Role(name='EvmRole-approver')
-    with pytest.raises(RBACOperationBlocked):
-        role.delete(all_selection=True)
-
-
-@pytest.mark.tier(3)
 def test_edit_default_roles():
     """Test that CFME prevents a user from editing a default role
     when selecting it from the Access Control EVM Role checklist
@@ -555,24 +493,6 @@ def test_edit_default_roles():
 
     with pytest.raises(RBACOperationBlocked):
         role.update(role_updates)
-
-
-@pytest.mark.tier(3)
-def test_edit_default_roles_all_selection():
-    """Test that CFME prevents a user from editing a default role
-    when selecting it from the Access Control EVM Role checklist
-
-    Steps:
-        * Login as Administrator user
-        * Navigate to Configuration -> Role
-        * Try editing the group EvmRole-auditor
-    """
-    role = Role(name='EvmRole-auditor')
-    newrole_name = "{}-{}".format(role.name, fauxfactory.gen_alphanumeric())
-    role_updates = {'name': newrole_name}
-
-    with pytest.raises(RBACOperationBlocked):
-        role.update(role_updates, all_selection=True)
 
 
 @pytest.mark.tier(3)
@@ -621,7 +541,8 @@ def _test_vm_removal():
 @pytest.mark.parametrize(
     'product_features, action',
     [(
-        {version.LOWEST: [['Everything', 'Infrastructure', 'Virtual Machines', 'Accordions'],
+        {version.LOWEST: [
+            ['Everything', 'Compute', 'Infrastructure', 'Virtual Machines', 'Accordions'],
             ['Everything', 'Access Rules for all Virtual Machines', 'VM Access Rules', 'Modify',
              'Provision VMs']], },
         _test_vm_provision)])
@@ -849,7 +770,9 @@ def test_user_change_password(appliance, request):
     user = User(
         name="user {}".format(fauxfactory.gen_alphanumeric()),
         credential=Credential(
-            principal="user_principal_{}".format(fauxfactory.gen_alphanumeric()),
+            #principal="user_principal_{}".format(fauxfactory.gen_alphanumeric()),
+            #DELETE THE LINE BELOW
+            principal="user_principal_{}".format(fauxfactory.gen_alphanumeric().lower()),
             secret="very_secret",
             verify_secret="very_secret"
         ),
@@ -862,6 +785,10 @@ def test_user_change_password(appliance, request):
     request.addfinalizer(appliance.server.login_admin)
     with user:
         appliance.server.logout()
+        ##############################
+        # DELETE
+        pytest.set_trace()
+        ##############################
         appliance.server.login(user)
         assert appliance.server.current_full_name() == user.name
     appliance.server.login_admin()

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -16,7 +16,7 @@ from cfme.common.provider import base_types
 from cfme.infrastructure import virtual_machines as vms
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.services.myservice import MyService
-from cfme.web_ui import Table, InfoBlock, toolbar as tb
+from cfme.web_ui import InfoBlock, toolbar as tb
 from cfme.configure import tasks
 from fixtures.provider import setup_one_or_skip
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -27,7 +27,6 @@ from cfme.utils.update import update
 from cfme.utils import version
 
 
-records_table = Table("//div[@id='main_div']//table")
 usergrp = Group(description='EvmGroup-user')
 
 


### PR DESCRIPTION
This PR updates these tests so that they all call the widgetastic methods and adds a new exception (RBACOperationBlocked) that will be thrown when an action(create, delete, edit) is blocked due to operating on an object that is immutable (default user, group, role).  Tests can now catch RBACOperationBlocked without having to rely on checking for a specific flash message to see if RBAC allowed an operation.  The state of the page will not be modified so a test can check the page elements after the exception

{{pytest: -v -k 'test_delete_default_group or test_delete_default_roles or test_delete_default_user or test_delete_group_with_assigned_user or test_delete_roles_with_assigned_group or test_edit_default_group or test_edit_default_roles or test_edit_sequence_usergroups or test_group_duplicate_name or test_rolename_duplicate_validation or test_user_duplicate_name or test_current_user_login_delete' }}