### PR TITLE
[1LP][RFR]Fix logging and sprout shutdown

### DIFF
--- a/cfme/test_framework/sprout/plugin.py
+++ b/cfme/test_framework/sprout/plugin.py
@@ -268,12 +268,15 @@ def pytest_miq_node_shutdown(config, nodeinfo):
         netloc = urlparse(nodeinfo).netloc
         ip_address = netloc.split(":")[0]
         log.debug("Trying to end appliance {}".format(ip_address))
-        try:
-            log.debug(config._sprout_mgr.client.call_method('appliance_data', ip_address))
-            log.debug(config._sprout_mgr.client.call_method('destroy_appliance', ip_address))
-        except Exception as e:
-            log.debug('Error trying to end sprout appliance %s', ip_address)
-            log.debug(e)
+        if config.getoption('use_sprout'):
+            try:
+                log.debug(config._sprout_mgr.client.call_method('appliance_data', ip_address))
+                log.debug(config._sprout_mgr.client.call_method('destroy_appliance', ip_address))
+            except Exception as e:
+                log.debug('Error trying to end sprout appliance %s', ip_address)
+                log.debug(e)
+        else:
+            log.debug('Not a sprout run so not doing anything')
     else:
         log.debug('The IP address was not present - not terminating any appliance')
 

--- a/fixtures/artifactor_plugin.py
+++ b/fixtures/artifactor_plugin.py
@@ -135,6 +135,8 @@ def pytest_configure(config):
         config._art_proc = None
     from utils.log import artifactor_handler
     artifactor_handler.artifactor = art_client
+    if store.slave_manager:
+        artifactor_handler.slaveid = store.slaveid
     config._art_client = art_client
     art_client.fire_hook('setup_merkyl', ip=get_or_create_current_appliance().address)
 

--- a/fixtures/parallelizer/__init__.py
+++ b/fixtures/parallelizer/__init__.py
@@ -473,7 +473,7 @@ class ParallelSession(object):
                     self.kill(slave)
                 elif event_name == 'shutdown':
                     self.config.hook.pytest_miq_node_shutdown(
-                        config=self.config, nodeinfo=slave.url)
+                        config=self.config, nodeinfo=slave.appliance.url)
                     self.ack(slave, event_name)
                     del self.slaves[slave.id]
                     self.monitor_shutdown(slave)


### PR DESCRIPTION
* Sprout shutdown would be attempted even if sprout hadn't been used
  for deployment of appliance
* No slaveid was being set on the handlers, so no per test logging was
  occuring as the slaveid was always None (which didn't exist in
  artifactor)