### PR TITLE
Adding new server role for cockpit

### DIFF
--- a/cfme/configure/configuration/__init__.py
+++ b/cfme/configure/configuration/__init__.py
@@ -77,6 +77,7 @@ server_roles = Form(
         ('database_synchronization', CFMECheckbox("server_roles_database_synchronization")),
         ('git_owner', CFMECheckbox("server_roles_git_owner")),
         ('websocket', CFMECheckbox("server_roles_websocket")),
+        ('cockpit_ws', CFMECheckbox("server_roles_cockpit_ws")),
         # STORAGE OPTIONS
         ("storage_metrics_processor", CFMECheckbox("server_roles_storage_metrics_processor")),
         ("storage_metrics_collector", CFMECheckbox("server_roles_storage_metrics_collector")),


### PR DESCRIPTION

New server role cockpit is added in upstream and many test cases in upstream are failing due to this error "Exception: Unknown server role(s): cockpit_ws".
Adding this should fix all those  errors.
 

