### PR TITLE
[RFR] api_port can be absent in yamls for rhemv providers

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -965,7 +965,7 @@ class CANDUEndpoint(DefaultEndpoint):
     @property
     def view_value_mapping(self):
         return {'hostname': self.hostname,
-                'api_port': self.api_port,
+                'api_port': getattr(self, 'api_port', None),
                 'database_name': self.database}
 
 

--- a/cfme/infrastructure/provider/rhevm.py
+++ b/cfme/infrastructure/provider/rhevm.py
@@ -12,7 +12,7 @@ class RHEVMEndpoint(DefaultEndpoint):
     @property
     def view_value_mapping(self):
         return {'hostname': self.hostname,
-                'api_port': self.api_port,
+                'api_port': getattr(self, 'api_port', None),
                 'verify_tls': version.pick({version.LOWEST: None,
                                             '5.8': self.verify_tls}),
                 'ca_certs': version.pick({version.LOWEST: None,


### PR DESCRIPTION
It turned out that sprout yamls don't have api_port in their yaml. This didn't allow sprout to add rhevm providers.
Since this field isn't mandatory, provider object should handle this properly