### PR TITLE
[WIP] Added blockers BZ#1467639 and BZ#1469666

### DIFF
--- a/cfme/tests/containers/test_labels.py
+++ b/cfme/tests/containers/test_labels.py
@@ -86,7 +86,10 @@ def test_labels_create(provider, soft_assert, random_labels):
             )
 
 
-@pytest.mark.meta(blockers=[BZ(1451832, forced_streams=['5.7', '5.8', 'upstream'])])
+@pytest.mark.meta(blockers=[
+    BZ(1451832, forced_streams=['5.7', '5.8', 'upstream']),
+    BZ(1469666, forced_streams=['5.7', '5.8', 'upstream'])
+])
 @pytest.mark.polarion('CMP-10572')
 def test_labels_remove(provider, soft_assert, random_labels):
     # Removing the labels

--- a/cfme/tests/containers/test_relationships.py
+++ b/cfme/tests/containers/test_relationships.py
@@ -2,13 +2,8 @@ from random import shuffle
 
 import pytest
 
-from utils import testgen
-from utils.version import current_version
-from cfme.web_ui import paginator, summary_title
-
 from cfme.containers.pod import Pod
-from cfme.containers.provider import ContainersProvider,\
-    ContainersTestItem
+from cfme.containers.provider import ContainersProvider, ContainersTestItem
 from cfme.containers.service import Service
 from cfme.containers.node import Node
 from cfme.containers.replicator import Replicator
@@ -18,6 +13,11 @@ from cfme.containers.template import Template
 from cfme.containers.container import Container
 from cfme.containers.image_registry import ImageRegistry
 from cfme.containers.volume import Volume
+from cfme.web_ui import paginator, summary_title
+
+from utils import testgen
+from utils.version import current_version
+from utils.blockers import BZ
 
 
 pytestmark = [
@@ -69,8 +69,10 @@ def check_relationships(instance):
         assert '(Summary)' in summary_title()
 
 
+@pytest.mark.meta(blockers=[BZ(1467639, forced_streams=["5.8"],
+                               unblock=lambda test_item: test_item.obj != Container)])
 @pytest.mark.parametrize('test_item', TEST_ITEMS,
-                         ids=[ti.args[1].pretty_id() for ti in TEST_ITEMS])
+                         ids=[ContainersTestItem.get_pretty_id(ti) for ti in TEST_ITEMS])
 def test_relationships_tables(provider, test_item):
     """This test verifies the integrity of the Relationships table.
     clicking on each field in the Relationships table takes the user

--- a/cfme/tests/containers/test_search_bar.py
+++ b/cfme/tests/containers/test_search_bar.py
@@ -10,7 +10,6 @@ from cfme.containers.route import Route
 from cfme.containers.project import Project
 from cfme.containers.provider import ContainersProvider, navigate_and_get_rows
 from cfme.containers.replicator import Replicator
-from cfme.containers.container import Container
 from cfme.containers.service import Service
 from cfme.containers.pod import Pod
 
@@ -27,7 +26,10 @@ TEST_OBJECTS = [
     Service,
     ContainersProvider,
     Pod,
-    Container
+    # The next lines have been removed due to bug introduced in CFME 5.8.1 -
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1467639
+    # from cfme.containers.container import Container (add to imports when fixed)
+    # Container
 ]
 
 

--- a/cfme/tests/containers/test_table_views.py
+++ b/cfme/tests/containers/test_table_views.py
@@ -6,7 +6,6 @@ from utils.appliance.implementations.ui import navigate_to
 from cfme.web_ui import toolbar as tb
 from cfme.configure.settings import DefaultView
 
-from cfme.containers.container import Container
 from cfme.containers.image import Image
 from cfme.containers.image_registry import ImageRegistry
 from cfme.containers.node import NodeCollection
@@ -35,8 +34,11 @@ objects_mapping = OrderedDict({  # <object> : <ui name>
     NodeCollection: 'Nodes',
     Pod: 'Pods',
     Service: 'Services',
-    Container: 'Containers',
     Replicator: 'Replicators'
+    # The next lines have been removed due to bug introduced in CFME 5.8.1 -
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1467639
+    # from cfme.containers.container import Container (add to imports when fixed)
+    # Container: 'Containers',
 })
 
 

--- a/cfme/tests/containers/test_tables_fields.py
+++ b/cfme/tests/containers/test_tables_fields.py
@@ -8,7 +8,6 @@ from cfme.containers.node import Node
 from cfme.containers.replicator import Replicator
 from cfme.containers.image import Image
 from cfme.containers.project import Project
-from cfme.containers.container import Container
 from cfme.containers.image_registry import ImageRegistry
 from cfme.containers.route import Route
 
@@ -39,11 +38,14 @@ TEST_ITEMS = [
             Route, 'CMP-10651', fields_to_verify=['provider', 'project_name']
         )
     ),
-    pytest.mark.polarion('CMP-9943')(
-        ContainersTestItem(
-            Container, 'CMP-9943', fields_to_verify=['pod_name', 'image', 'state']
-        )
-    ),
+    # The next lines have been removed due to bug introduced in CFME 5.8.1 -
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1467639
+    # from cfme.containers.container import Container (add to imports when fixed)
+    # pytest.mark.polarion('CMP-9943')(
+    #     ContainersTestItem(
+    #         Container, 'CMP-9943', fields_to_verify=['pod_name', 'image', 'state']
+    #     )
+    # ),
     pytest.mark.polarion('CMP-9909')(
         ContainersTestItem(
             Pod, 'CMP-9909', fields_to_verify=[
@@ -96,7 +98,7 @@ TEST_ITEMS = [
 
 
 @pytest.mark.parametrize('test_item', TEST_ITEMS,
-                         ids=[ti.args[1].pretty_id() for ti in TEST_ITEMS])
+                         ids=[ContainersTestItem.get_pretty_id(ti) for ti in TEST_ITEMS])
 def test_tables_fields(provider, test_item, soft_assert):
 
     navigate_to(test_item.obj, 'All')


### PR DESCRIPTION
- Added blocker [BZ#1467639](https://bugzilla.redhat.com/show_bug.cgi?id=1467639) for tests that navigate to containers page.
- Added blocker [BZ#1469666](https://bugzilla.redhat.com/show_bug.cgi?id=1469666) to remove labels test.

{{ pytest: cfme/tests/containers/test_labels.py cfme/tests/containers/test_relationships.py cfme/tests/containers/test_search_bar.py cfme/tests/containers/test_table_views.py cfme/tests/containers/test_tables_fields.py --use-provider cm-env1 --long-running }}