### PR TITLE
[1LP][RFR] made some parameters not mandatory for cloud/infra providers

### DIFF
--- a/cfme/cloud/provider/azure.py
+++ b/cfme/cloud/provider/azure.py
@@ -49,7 +49,7 @@ class AzureProvider(CloudProvider):
             'prov_type': 'Azure',
             'region': region,
             'tenant_id': self.tenant_id,
-            'subscription': self.subscription_id
+            'subscription': getattr(self, 'subscription_id', None)
         }
 
     def deployment_helper(self, deploy_args):

--- a/cfme/cloud/provider/openstack.py
+++ b/cfme/cloud/provider/openstack.py
@@ -53,7 +53,7 @@ class OpenStackProvider(CloudProvider):
             'prov_type': 'OpenStack',
             'region': None,
             'infra_provider': infra_provider_name,
-            'tenant_mapping': self.tenant_mapping,
+            'tenant_mapping': getattr(self, 'tenant_mapping', None),
         }
 
     def deployment_helper(self, deploy_args):

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -976,9 +976,9 @@ class EventsEndpoint(DefaultEndpoint):
     @property
     def view_value_mapping(self):
         return {'event_stream': self.event_stream,
-                'security_protocol': self.security_protocol,
+                'security_protocol': getattr(self, 'security_protocol', None),
                 'hostname': self.hostname,
-                'api_port': self.api_port,
+                'api_port': getattr(self, 'api_port', None),
                 }
 
 

--- a/cfme/infrastructure/provider/openstack_infra.py
+++ b/cfme/infrastructure/provider/openstack_infra.py
@@ -16,7 +16,7 @@ class RHOSEndpoint(DefaultEndpoint):
     def view_value_mapping(self):
         return {'security_protocol': self.security_protocol,
                 'hostname': self.hostname,
-                'api_port': self.api_port,
+                'api_port': getattr(self, 'api_port', None)
                 }
 
 

--- a/cfme/infrastructure/provider/rhevm.py
+++ b/cfme/infrastructure/provider/rhevm.py
@@ -14,9 +14,9 @@ class RHEVMEndpoint(DefaultEndpoint):
         return {'hostname': self.hostname,
                 'api_port': getattr(self, 'api_port', None),
                 'verify_tls': version.pick({version.LOWEST: None,
-                                            '5.8': self.verify_tls}),
+                                            '5.8': getattr(self, 'verify_tls', None)}),
                 'ca_certs': version.pick({version.LOWEST: None,
-                                          '5.8': self.ca_certs})
+                                          '5.8': getattr(self, 'ca_certs', None)})
                 }
 
 

--- a/cfme/infrastructure/provider/scvmm.py
+++ b/cfme/infrastructure/provider/scvmm.py
@@ -9,8 +9,8 @@ class SCVMMEndpoint(DefaultEndpoint):
     @property
     def view_value_mapping(self):
         return {'hostname': self.hostname,
-                'security_protocol': self.security_protocol,
-                'realm': self.security_realm
+                'security_protocol': getattr(self,'security_protocol', None),
+                'realm': getattr(self, 'security_realm', None)
                 }
 
 


### PR DESCRIPTION
It turned out that some yamls don't contain full endpoints. So, sometimes providers cannot be added just because some not mandatory parameters are absent in provider endpoints in yaml.
This PR fixes this issue for Cloud and Infra providers

{{pytest: cfme/tests/cloud/test_providers.py cfme/tests/infrastructure/test_providers.py}}