### PR TITLE
[WIP] Provider Abstraction

### DIFF
--- a/cfme/cloud/provider/azure.py
+++ b/cfme/cloud/provider/azure.py
@@ -2,6 +2,8 @@ from wrapanapi.azure import AzureSystem
 
 from . import CloudProvider
 from cfme.common.provider import DefaultEndpoint, DefaultEndpointForm
+from cfme.cloud.instance.azure import AzureInstance
+
 from utils.version import pick
 
 
@@ -28,6 +30,7 @@ class AzureProvider(CloudProvider):
     """
     type_name = "azure"
     mgmt_class = AzureSystem
+    vm_type = AzureInstance
     db_types = ["Azure::CloudManager"]
     endpoints_form = AzureEndpointForm
     discover_name = "Azure"

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -59,6 +59,7 @@ def all_types():
 
 class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
     # List of constants that every non-abstract subclass must have defined
+    vm_type = None
     _param_name = ParamClassName('name')
     STATS_TO_MATCH = []
     string_name = ""

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -19,6 +19,7 @@ from cfme.common.provider_views import (InfraProviderAddView,
 from cfme.fixtures import pytest_selenium as sel
 from cfme.infrastructure.cluster import Cluster
 from cfme.infrastructure.host import Host
+from cfme.infrastructure.virtual_machines import Vm
 from cfme.web_ui import Quadicon, match_location
 from utils import conf, version
 from utils.appliance import Navigatable
@@ -52,6 +53,7 @@ class InfraProvider(Pretty, CloudInfraProvider, Fillable):
         myprov.create()
 
     """
+    vm_class = Vm
     provider_types = {}
     category = "infra"
     pretty_attrs = ['name', 'key', 'zone']

--- a/cfme/tests/infrastructure/test_infra_quota.py
+++ b/cfme/tests/infrastructure/test_infra_quota.py
@@ -7,7 +7,6 @@ from cfme import test_requirements
 from cfme.configure.access_control import Tenant
 from cfme.fixtures import pytest_selenium as sel
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
-from cfme.infrastructure.virtual_machines import Vm
 from cfme.provisioning import provisioning_form
 from cfme.services import requests
 from cfme.web_ui import fill, flash
@@ -114,7 +113,7 @@ def template_name(provisioning):
 @pytest.fixture(scope="function")
 def provisioner(request, setup_provider, provider):
     def _provisioner(template, provisioning_data, delayed=None):
-        vm = Vm(name=vm_name, provider=provider, template_name=template)
+        vm = provider.vm_type(name=vm_name, provider=provider, template_name=template)
         navigate_to(vm, 'ProvisionVM')
 
         fill(provisioning_form, provisioning_data, action=provisioning_form.submit_button)


### PR DESCRIPTION
Purpose or Intent
=================
For the scenarios where we need to provision a VM, where we need work with multiple providers of different types(Cloud, Infra of containers maybe), we would have to check the type of the provider that is coming to the function pytest parameterized, and provision by its according class, like for Cloud provider, we would use cfme.cloud.instance.Instance, and similarly for infra; 
A better design, suggested by @psav would solve this where we define the instance/VM class inside the provider class itself, so we can easily use it

