### PR TITLE
[RFR] Fix DisksTable locator

### DIFF
--- a/widgetastic_manageiq/vm_reconfigure.py
+++ b/widgetastic_manageiq/vm_reconfigure.py
@@ -13,7 +13,7 @@ class DisksButton(Button):
     def __locator__(self):
         # Don't EVER do this, unless you are 100% sure that you have to! This is an exception!
         btn_loc = super(DisksButton, self).__locator__()
-        loc = '{}/{}//{}'.format(self.parent.__locator__(), self.BTN_CONTAINER_LOC, btn_loc)
+        loc = '{}/{}//{}'.format(self.parent.locator, self.BTN_CONTAINER_LOC, btn_loc)
         return loc
 
 


### PR DESCRIPTION
`Table.__locator__()` used to return `str` but now it returns `Locator` obj, which doesn't work with `.format`. This fixes the issue because `Table.locator` is a `str`.

{{pytest: -k test_vm_reconfig_add_remove_disk_cold --use-provider vsphere6-nested --long-running}}