### PR TITLE
[RFR] BootstrapSelectByLocator doesn't respect parent

### DIFF
--- a/widgetastic_manageiq/hacks.py
+++ b/widgetastic_manageiq/hacks.py
@@ -5,8 +5,9 @@ from widgetastic_patternfly import BootstrapSelect
 
 class BootstrapSelectByLocator(BootstrapSelect):
     """Modified :py:class:`widgetastic_patternfly.BootstrapSelect` that uses the div locator."""
-    ROOT = ParametrizedLocator('{@locator}')
-
     def __init__(self, parent, locator, can_hide_on_select=False, logger=None):
         BootstrapSelect.__init__(self, parent, locator, can_hide_on_select, logger)
         self.locator = locator
+
+    def __locator__(self):
+        return self.browser.element(self.locator, parent=self.parent)


### PR DESCRIPTION
BootstrapSelectByLocator ignores parent. So, when locator is relative, it finds first boostrap_select control matching to locator.
This doesn't fit for cases when there are a lot of widgets on page matching this locator and difference is only in parent.

example of code:

```
from utils.providers import get_crud
from widgetastic.widget import View, Text
from widgetastic_patternfly import BootstrapSelect
from widgetastic_manageiq import Table
from widgetastic_manageiq.hacks import BootstrapSelectByLocator
from utils.appliance.implementations.ui import navigate_to
from utils.appliance import get_or_create_current_appliance
from random import choice

app = get_or_create_current_appliance()
view = navigate_to(app.server, 'Chargeback')
# now manually go for example to Cloud Intel -> Chargeback ->Assignments->Compute->(Tagged VMs and Instances, Auto Approve - Max Memory)

class RateAssignments(View):
    title = Text(locator='<define later>')
    assign_to = BootstrapSelect(id="cbshow_typ")
    tag_category = BootstrapSelect(id='cbtag_cat')
    _table_locator= '//h3[contains(text(),"Selections")]/following-sibling::table'
    _table_widget_locator = './/div[contains(@class, "bootstrap-select")]'
    
    selections = Table(locator=_table_locator, 
                       column_widgets={'Rate': BootstrapSelectByLocator(locator=_table_widget_locator)})

assignment_view = view.browser.create_view(RateAssignments)

for row in assignment_view.selections.rows():
    print row.name.text
    option = choice(row.rate.widget.all_options)
    row.rate.widget.select_by_visible_text(option.text)
```
