### PR TITLE
[1LP][RFR] Fixing TypeError: 'NoneType' object is not iterable

### DIFF
--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -2056,6 +2056,8 @@ class BootstrapTreeview(object):
                 target = re.compile(r".*?{}.*?".format(re.escape(str(target))))
 
         def _find_in_tree(t, p=None):
+            if t is None:
+                return
             if p is None:
                 p = []
             for item in t:
@@ -2070,7 +2072,7 @@ class BootstrapTreeview(object):
                     if target.match(item) is not None:
                         return p + [item]
             else:
-                return None
+                return
 
         result = _find_in_tree(self.read_contents())
         if result is None:


### PR DESCRIPTION
The ``self.read_contents()`` can (and does) return ``None`` which leads to the
mentioned error.

See https://cfmeqe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/Downstream-58z/job/downstream-58z-tests-master/87/Artifactor_Report/cfme/tests/infrastructure/test_snapshot.py/test_create_snapshot_via_ae[vsphere6-nested]/filedump-traceback.log

{{pytest: -v --long-running --use-provider vsphere6-nested -k test_create_snapshot_via_ae}}