### PR TITLE
[1LP][RFR] HTML5 Remote Console Test - Initial Prototype

### DIFF
--- a/cfme/cloud/provider/openstack.py
+++ b/cfme/cloud/provider/openstack.py
@@ -3,6 +3,7 @@ from wrapanapi.openstack import OpenstackSystem
 from . import CloudProvider
 from cfme.common.provider import EventsEndpoint
 from cfme.infrastructure.provider.openstack_infra import RHOSEndpoint, OpenStackInfraEndpointForm
+from cfme.exceptions import ItemNotFound
 
 
 class OpenStackProvider(CloudProvider):
@@ -14,6 +15,10 @@ class OpenStackProvider(CloudProvider):
     mgmt_class = OpenstackSystem
     db_types = ["Openstack::CloudManager"]
     endpoints_form = OpenStackInfraEndpointForm
+    # xpath locators for elements, to be used by selenium
+    _console_connection_status_element = '//*[@id="noVNC_status"]'
+    _canvas_element = '//*[@id="noVNC_canvas"]'
+    _ctrl_alt_del_xpath = '//*[@id="sendCtrlAltDelButton"]'
 
     def __init__(self, name=None, endpoints=None, zone=None, key=None, hostname=None,
                  ip_address=None, api_port=None, sec_protocol=None, amqp_sec_protocol=None,
@@ -85,3 +90,27 @@ class OpenStackProvider(CloudProvider):
                    tenant_mapping=prov_config.get('tenant_mapping', False),
                    infra_provider=infra_provider,
                    appliance=appliance)
+
+    # Following methods will only work if the remote console window is open
+    # and if selenium focused on it. These will not work if the selenium is
+    # focused on Appliance window.
+    def get_console_connection_status(self):
+        try:
+            return self.appliance.browser.widgetastic.selenium.find_element_by_xpath(
+                self._console_connection_status_element).text
+        except:
+            raise ItemNotFound("Element not found on screen, is current focus on console window?")
+
+    def get_remote_console_canvas(self):
+        try:
+            return self.appliance.browser.widgetastic.selenium.find_element_by_xpath(
+                self._canvas_element)
+        except:
+            raise ItemNotFound("Element not found on screen, is current focus on console window?")
+
+    def get_console_ctrl_alt_del_btn(self):
+        try:
+            return self.appliance.browser.widgetastic.selenium.find_element_by_xpath(
+                self._ctrl_alt_del_xpath)
+        except:
+            raise ItemNotFound("Element not found on screen, is current focus on console window?")

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -718,6 +718,16 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
         else:
             raise ValueError("Endpoints should be either dict or endpoint class")
 
+    # These methods need to be overridden in the provider specific classes
+    def get_console_connection_status(self):
+        raise NotImplementedError("This method is not implemented for given provider")
+
+    def get_remote_console_canvas(self):
+        raise NotImplementedError("This method is not implemented for given provider")
+
+    def get_console_ctrl_alt_del_btn(self):
+        raise NotImplementedError("This method is not implemented for given provider")
+
 
 def get_paginator_value():
     return paginator.rec_total()

--- a/cfme/common/vm_console.py
+++ b/cfme/common/vm_console.py
@@ -39,13 +39,13 @@ class VMConsole(Pretty):
         # due to an exception being thrown.
         try:
             text = self.provider.get_console_connection_status()
-            logger.info('Read following text from console banner: {}'.format(text))
-        except NoSuchElementException as e:
-            logger.info('Could not find banner element.')
-            logger.info('Exception: {}'.format(e))
+        except NoSuchElementException:
+            logger.exception('Could not find banner element.')
             return None
+        finally:
+            self.switch_to_appliance()
 
-        self.switch_to_appliance()
+        logger.info('Read following text from console banner: %s', text)
         return text
 
     def get_screen(self):

--- a/cfme/common/vm_console.py
+++ b/cfme/common/vm_console.py
@@ -1,0 +1,203 @@
+# -*- coding: utf-8 -*-
+"""
+Module containing classes with common behaviour for consoles of both VMs and Instances of all types.
+"""
+
+import base64
+import re
+import tempfile
+
+from PIL import Image, ImageFilter
+from pytesseract import image_to_string
+from utils.log import logger
+from utils.pretty import Pretty
+from wait_for import wait_for, TimedOutError
+from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.common.keys import Keys
+
+
+class VMConsole(Pretty):
+    """Class to manage the VM Console.   Presently, only support HTML5 Console."""
+
+    pretty_attrs = ['appliance_handle', 'browser', 'console_handle', 'name']
+
+    def __init__(self, vm, console_handle, appliance_handle):
+        self.name = vm.name
+        self.selenium = vm.appliance.browser.widgetastic.selenium
+        self.console_handle = console_handle
+        self.appliance_handle = appliance_handle
+        self.provider = vm.provider
+
+    ###
+    # Methods
+    #
+    def get_banner(self):
+        """Get the text of the banner above the console screen."""
+        self.switch_to_console()
+        # We know the widget may or may not be available right away
+        # so we do this in a try-catch to ensure the code is not stopped
+        # due to an exception being thrown.
+        try:
+            text = self.provider.get_console_connection_status()
+            logger.info('Read following text from console banner: {}'.format(text))
+        except NoSuchElementException as e:
+            logger.info('Could not find banner element.')
+            logger.info('Exception: {}'.format(e))
+            return None
+
+        self.switch_to_appliance()
+        return text
+
+    def get_screen(self):
+        """
+        Retrieve the bit map from the canvas widget that represents the console screen.
+
+        Returns it as a binary string.
+
+        Implementation:
+        The canvas tag has a method toDataURL() which one can use in javascript to
+        obtain the canvas image  base64 encoded.   Examples of how to do this can be
+        seen here:
+
+            https://qxf2.com/blog/selenium-html5-canvas-verify-what-was-drawn/
+            https://stackoverflow.com/questions/38316402/how-to-save-a-canvas-as-png-in-selenium
+        """
+        self.switch_to_console()
+
+        # Get the canvas element
+        canvas = self.provider.get_remote_console_canvas()
+
+        # Now run some java script to get the contents of the canvas element
+        # base 64 encoded.
+        image_base64_url = self.selenium.execute_script(
+            "return arguments[0].toDataURL('image/jpeg',1);",
+            canvas
+        )
+
+        # The results will look like:
+        #
+        #   data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAAfQAAABkCAYAAABwx8J9AA...
+        #
+        # So parse out the data from the non image data from the URL:
+        image_base64 = image_base64_url.split(",")[1]
+
+        # Now convert to binary:
+        image_jpeg = base64.b64decode(image_base64)
+
+        self.switch_to_appliance()
+        return image_jpeg
+
+    def get_screen_text(self):
+        """
+        Return the text from a text console.
+
+        Uses OCR to scrape the text from the console image taken at the time of the call.
+        """
+        image_str = self.get_screen()
+
+        # Write the image string to a file as pytesseract requires
+        # a file, and doesn't take a string.
+        tmp_file = tempfile.NamedTemporaryFile(suffix='.jpeg')
+        tmp_file.write(image_str)
+        tmp_file.flush()
+        tmp_file_name = tmp_file.name
+        # Open Image file, resize it to high resolution, sharpen it for clearer text
+        # and then run image_to_string operation which returns unicode that needs to
+        # be converted to utf-8 which gives us text [typr(text) == 'str']
+        # higher resolution allows tesseract to recognize text correctly
+        text = (image_to_string(((Image.open(tmp_file_name)).resize((7680, 4320),
+         Image.ANTIALIAS)).filter(ImageFilter.SHARPEN), lang='eng',
+         config='--user-words eng.user-words')).encode('utf-8')
+        tmp_file.close()
+
+        logger.info('screen text:{}'.format(text))
+        return text
+
+    def is_connected(self):
+        """Wait for the banner on the console to say the console is connected."""
+        banner = self.get_banner()
+        if banner is None:
+            return False
+        return re.match('Connected', banner) is not None
+
+    def send_keys(self, text):
+        """Send text to the console."""
+        self.switch_to_console()
+        canvas = self.provider.get_remote_console_canvas()
+        canvas.send_keys(text)
+        canvas.send_keys(Keys.ENTER)
+        logger.info("Sending following Keys to Console {}".format(text))
+        self.switch_to_appliance()
+
+    def send_ctrl_alt_delete(self):
+        """Press the ctrl-alt-delete button in the console tab."""
+        self.switch_to_console()
+        ctrl_alt_del_btn = self.provider.get_console_ctrl_alt_del_btn()
+        logger.info("Sending following Keys to Console CTRL+ALT+DEL")
+        ctrl_alt_del_btn.click()
+        self.switch_to_appliance()
+
+    def switch_to_appliance(self):
+        """Switch focus to appliance tab/window."""
+        logger.info("Switching to appliance: window handle = {}".format(self.appliance_handle))
+        self.selenium.switch_to_window(self.appliance_handle)
+
+    def switch_to_console(self):
+        """Switch focus to console tab/window."""
+        logger.info("Switching to console: window handle = {}".format(self.console_handle))
+        self.selenium.switch_to_window(self.console_handle)
+
+    def wait_for_connect(self, timeout=15):
+        """Wait for as long as the specified/default timeout for the console to be connected."""
+        try:
+            logger.info('Waiting for console connection (timeout={})'.format(timeout))
+            wait_for(func=lambda: self.is_connected(),
+                     delay=1, handle_exceptions=True,
+                     num_sec=timeout)
+            return True
+        except TimedOutError:
+            return False
+
+    def close_console_window(self):
+        """Attempt to close Console window at the end of test."""
+        if self.console_handle is not None:
+            self.switch_to_console()
+            self.selenium.close()
+            logger.info("Browser window/tab containing Console was closed.")
+            self.switch_to_appliance()
+
+    def find_text_on_screen(self, text_to_find, current_line=False):
+        """Find particular text is present on Screen.
+
+        This function uses get_screen_text function to get string containing
+        the text on the screen and then tries to match it against the 'text_to_find'.
+
+        Args:
+            text_to_find   - This is what re.search will try to search for on screen.
+        Returns:
+            If the match is found returns True else False.
+        """
+        if current_line:
+            return re.search(text_to_find, self.get_screen_text().split('\n')[-1]) is not None
+        return re.search(text_to_find, self.get_screen_text()) is not None
+
+    def wait_for_text(self, timeout=45, text_to_find="", to_disappear=False):
+        """Wait for as long as the specified/default timeout for the 'text' to show up on screen.
+
+        Args:
+            timeout         - Wait Time before wait_for function times out.
+            text_to_find    - value passed to find_text_on_screen function
+            to_disappear    - if set to True, function will wait for text_to_find to disappear
+                          from screen.
+        """
+        if not text_to_find:
+            return None
+        try:
+            if to_disappear:
+                logger.info("Waiting for {} to disappear from screen".format(text_to_find))
+            result = wait_for(func=lambda: to_disappear != self.find_text_on_screen(text_to_find),
+                     delay=5,
+                     num_sec=timeout)
+            return result.out
+        except TimedOutError:
+            return None

--- a/cfme/infrastructure/provider/rhevm.py
+++ b/cfme/infrastructure/provider/rhevm.py
@@ -6,7 +6,7 @@ from utils import version
 from . import InfraProvider
 from cfme.common.provider import CANDUEndpoint, DefaultEndpoint, DefaultEndpointForm
 from wrapanapi.rhevm import RHEVMSystem
-
+from cfme.exceptions import ItemNotFound
 
 class RHEVMEndpoint(DefaultEndpoint):
     @property
@@ -48,6 +48,10 @@ class RHEVMProvider(InfraProvider):
     db_types = ["Redhat::InfraManager"]
     endpoints_form = RHEVMEndpointForm
     discover_dict = {"rhevm": True}
+    # xpath locators for elements, to be used by selenium
+    _console_connection_status_element = '//*[@id="connection-status"]'
+    _canvas_element = '//*[@id="remote-console"]/canvas'
+    _ctrl_alt_del_xpath = '//*[@id="ctrlaltdel"]'
 
     def __init__(self, name=None, endpoints=None, zone=None, key=None, hostname=None,
                  ip_address=None, start_ip=None, end_ip=None, provider_data=None, appliance=None):
@@ -97,3 +101,27 @@ class RHEVMProvider(InfraProvider):
                    start_ip=start_ip,
                    end_ip=end_ip,
                    appliance=appliance)
+
+    # Following methods will only work if the remote console window is open
+    # and if selenium focused on it. These will not work if the selenium is
+    # focused on Appliance window.
+    def get_console_connection_status(self):
+        try:
+            return self.appliance.browser.widgetastic.selenium.find_element_by_xpath(
+                self._console_connection_status_element).text
+        except:
+            raise ItemNotFound("Element not found on screen, is current focus on console window?")
+
+    def get_remote_console_canvas(self):
+        try:
+            return self.appliance.browser.widgetastic.selenium.find_element_by_xpath(
+                self._canvas_element)
+        except:
+            raise ItemNotFound("Element not found on screen, is current focus on console window?")
+
+    def get_console_ctrl_alt_del_btn(self):
+        try:
+            return self.appliance.browser.widgetastic.selenium.find_element_by_xpath(
+                self._ctrl_alt_del_xpath)
+        except:
+            raise ItemNotFound("Element not found on screen, is current focus on console window?")

--- a/cfme/infrastructure/provider/virtualcenter.py
+++ b/cfme/infrastructure/provider/virtualcenter.py
@@ -6,6 +6,7 @@ from cfme.common.provider_views import ProviderNodesView
 from cfme.exceptions import DestinationNotFound
 from utils.appliance.implementations.ui import CFMENavigateStep, navigator
 from . import InfraProvider
+from cfme.exceptions import ItemNotFound
 
 
 class VirtualCenterEndpoint(DefaultEndpoint):
@@ -22,6 +23,10 @@ class VMwareProvider(InfraProvider):
     db_types = ["Vmware::InfraManager"]
     endpoints_form = VirtualCenterEndpointForm
     discover_dict = {"vmware": True}
+    # xpath locators for elements, to be used by selenium
+    _console_connection_status_element = '//*[@id="connection-status"]'
+    _canvas_element = '//*[@id="remote-console"]/canvas'
+    _ctrl_alt_del_xpath = '//*[@id="ctrlaltdel"]'
 
     def __init__(self, name=None, endpoints=None, key=None, zone=None, hostname=None,
                  ip_address=None, start_ip=None, end_ip=None, provider_data=None, appliance=None):
@@ -67,6 +72,30 @@ class VMwareProvider(InfraProvider):
         return {'name': self.name,
                 'prov_type': 'VMware vCenter'
                 }
+
+    # Following methods will only work if the remote console window is open
+    # and if selenium focused on it. These will not work if the selenium is
+    # focused on Appliance window.
+    def get_console_connection_status(self):
+        try:
+            return self.appliance.browser.widgetastic.selenium.find_element_by_xpath(
+                self._console_connection_status_element).text
+        except:
+            raise ItemNotFound("Element not found on screen, is current focus on console window?")
+
+    def get_remote_console_canvas(self):
+        try:
+            return self.appliance.browser.widgetastic.selenium.find_element_by_xpath(
+                self._canvas_element)
+        except:
+            raise ItemNotFound("Element not found on screen, is current focus on console window?")
+
+    def get_console_ctrl_alt_del_btn(self):
+        try:
+            return self.appliance.browser.widgetastic.selenium.find_element_by_xpath(
+                self._ctrl_alt_del_xpath)
+        except:
+            raise ItemNotFound("Element not found on screen, is current focus on console window?")
 
 
 @navigator.register(VMwareProvider, 'ProviderNodes')  # matching other infra class destinations

--- a/cfme/tests/cloud_infra_common/test_html5_vm_console.py
+++ b/cfme/tests/cloud_infra_common/test_html5_vm_console.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+"""Test for HTML5 Remote Consoles of VMware/RHEV/RHOSP Providers."""
+import pytest
+import imghdr
+import time
+import re
+
+from cfme.cloud.provider.openstack import OpenStackProvider
+from cfme.configure.configuration import VMwareConsoleSupport
+from cfme.infrastructure.provider.virtualcenter import VMwareProvider
+from cfme.configure import configuration
+from cfme.common.vm import VM
+from utils import testgen, version, ssh
+from utils.appliance.implementations.ui import navigate_to
+from utils.log import logger
+from utils.conf import credentials
+from wait_for import wait_for
+
+pytestmark = pytest.mark.usefixtures('setup_provider')
+
+pytest_generate_tests = testgen.generate(
+    [OpenStackProvider, VMwareProvider],
+    scope='module'
+)
+
+
+@pytest.fixture(scope="function")
+def vm_obj(request, provider, setup_provider, console_template, vm_name):
+    """
+    Create a VM on the provider with the given template, and return the vm_obj.
+
+    Also, it will remove VM from provider using nested function _delete_vm
+    after the test is completed.
+
+    """
+    vm_obj = VM.factory(vm_name, provider, template_name=console_template)
+
+    @request.addfinalizer
+    def _delete_vm():
+        try:
+            vm_obj.delete_from_provider()
+        except Exception:
+            logger.warning("Failed to delete vm `{}`.".format(vm_obj.name))
+
+    vm_obj.create_on_provider(timeout=2400, find_in_cfme=True, allow_skip="default")
+    if provider.one_of(OpenStackProvider):
+        # Assign FloatingIP to Openstack Instance from pool 'public'
+        # so that we can SSH to it
+        provider.mgmt.assign_floating_ip(vm_obj.name, 'public')
+    return vm_obj
+
+
+@pytest.fixture(scope="module")
+def configure_vmware_console_for_test(appliance, provider):
+    """Configure VMware Console to use VNC which is what is required for the HTML5 console."""
+    if provider.one_of(VMwareProvider):
+        navigate_to(appliance.server, 'Server')
+
+        settings_pg = VMwareConsoleSupport(
+            appliance=appliance,
+            console_type='VNC',
+        )
+        settings_pg.update()
+
+
+@pytest.fixture(scope="session")
+def configure_websocket():
+    """
+    Enable websocket role if it is disabled.
+
+    Currently the fixture cfme/fixtures/base.py,
+    disables the websocket role to avoid intrusive popups.
+    """
+    roles = configuration.get_server_roles()
+    if 'websocket' in roles and not roles['websocket']:
+        logger.info('Enabling the websocket role to allow console connections')
+        roles['websocket'] = True
+        configuration.set_server_roles(**roles)
+        yield
+    roles['websocket'] = False
+    logger.info('Disabling the websocket role to avoid intrusive popups')
+    configuration.set_server_roles(**roles)
+
+
+@pytest.mark.uncollectif(lambda: version.current_version() < '5.8', reason='Only valid for >= 5.8')
+def test_html5_vm_console(appliance, provider, vm_obj, configure_websocket,
+        configure_vmware_console_for_test):
+    """
+    Test the HTML5 console support for a particular provider.
+
+    The supported providers are:
+
+        VMware
+        Openstack
+        RHV
+
+    For a given provider, and a given VM, the console will be opened, and then:
+
+        - The console's status will be checked.
+        - A command that creates a file will be sent through the console.
+        - Using ssh we will check that the command worked (i.e. that the file
+          was created.
+    """
+    console_vm_username = credentials[provider.data.templates.get('console_template')
+                            ['creds']].get('username')
+    console_vm_password = credentials[provider.data.templates.get('console_template')
+                            ['creds']].get('password')
+
+    vm_obj.open_console(console='VM Console')
+    assert vm_obj.vm_console, 'VMConsole object should be created'
+    vm_console = vm_obj.vm_console
+    try:
+        # If the banner/connection-status element exists we can get
+        # the connection status text and if the console is healthy, it should connect.
+        assert vm_console.wait_for_connect(), "VM Console did not reach 'connected' state"
+
+        # Get the login screen image, and make sure it is a jpeg file:
+        screen = vm_console.get_screen()
+        assert imghdr.what('', screen) == 'jpeg'
+
+        assert vm_console.wait_for_text(text_to_find="login:", timeout=200),\
+            "VM Console didn't prompt for Login"
+
+        # Enter Username:
+        vm_console.send_keys(console_vm_username)
+
+        assert vm_console.wait_for_text(text_to_find="Password", timeout=200),\
+            "VM Console didn't prompt for Password"
+        # Enter Password:
+        vm_console.send_keys("{}\n".format(console_vm_password))
+
+        time.sleep(5)  # wait for login to complete
+
+        # This regex can find if there is a word 'login','password','incorrect' present in
+        # text, irrespective of its case
+        regex_for_login_password = re.compile(r'\blogin\b | \bpassword\b| \bincorrect\b',
+         flags=re.I | re.X)
+
+        def _validate_login():
+            """
+            Try to read what is on present on the last line in console.
+
+            If it is word 'login', enter username, if 'password' enter password, in order
+            to make the login successful
+            """
+            if vm_console.find_text_on_screen(text_to_find='login', current_line=True):
+                vm_console.send_keys(console_vm_username)
+
+            if vm_console.find_text_on_screen(text_to_find='Password', current_line=True):
+                vm_console.send_keys("{}\n".format(console_vm_password))
+            # if the login attempt failed for some reason (happens with RHOS-cirros),
+            # last line of the console will contain one of the following words:
+            # [login, password, incorrect]
+            # if so, regex_for_login_password will find it and result will not be []
+            # .split('\n')[-1] splits the console text on '\n' & picks last item of resulting list
+            result = regex_for_login_password.findall(vm_console.get_screen_text().split('\n')[-1])
+            return result == []
+
+        # if _validate_login() returns True, it means we did not find any of words
+        # [login, password, incorrect] on last line of console text, which implies login success
+        wait_for(func=_validate_login, timeout=300, delay=5)
+
+        logger.info("Wait to get the '$' prompt")
+        if provider.one_of(VMwareProvider):
+            vm_console.wait_for_text(text_to_find=provider.data.templates.get('console_template')
+                            ['prompt_text'], timeout=200)
+        else:
+            time.sleep(15)
+
+        # create file on system
+        vm_console.send_keys("touch blather\n")
+        logger.info("Wait 5 sec for file creation")
+        time.sleep(5)  # Wait for file creation
+
+        # Test pressing ctrl-alt-delete...we should be able to get a new login prompt:
+        vm_console.send_ctrl_alt_delete()
+        vm_console.wait_for_text(text_to_find="login:", timeout=200, to_disappear=True)
+        assert vm_console.wait_for_text(text_to_find="login:", timeout=200),\
+            "VM Console didn't prompt for Login"
+
+        with ssh.SSHClient(hostname=vm_obj.ip_address, username=console_vm_username,
+                password=console_vm_password) as ssh_client:
+            # if file was created in previous steps it will be removed here
+            # we will get instance of SSHResult
+            # Sometimes Openstack drops characters from word 'blather' hence try to remove
+            # file using partial file name. Known issue, being worked on.
+            command_result = ssh_client.run_command("rm bla*", ensure_user=True)
+            assert command_result
+    finally:
+        vm_console.close_console_window()

--- a/eng.user-words
+++ b/eng.user-words
@@ -1,0 +1,14 @@
+root@photon-machine
+touch
+blather
+Welcome
+to
+Photon
+1.0
+(x86_64)
+-
+Kernel
+4.4.71-1.ph1-esx
+tty1
+$ touch blather
+cubswin:)

--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -99,6 +99,7 @@ pandocfilters==1.4.1
 paramiko==2.1.2
 parsedatetime==2.4
 pathlib2==2.2.1
+pillow==4.2.0
 pbr==3.0.1
 pdfminer==20140328
 pexpect==4.2.1
@@ -125,6 +126,7 @@ Pygments==2.2.0
 PyJWT==1.5.0
 pyparsing==2.2.0
 pytest==3.0.7
+pytesseract==0.1.7
 python-bugzilla==2.1.0
 python-cinderclient==2.2.0
 python-dateutil==2.6.0

--- a/utils/appliance/implementations/ui.py
+++ b/utils/appliance/implementations/ui.py
@@ -136,6 +136,7 @@ class MiqBrowser(Browser):
             plugin_class=MiqBrowserPlugin,
             logger=create_sublogger('MiqBrowser'),
             extra_objects=extra_objects)
+        self.window_handle = selenium.current_window_handle
 
     @property
     def appliance(self):


### PR DESCRIPTION
Purpose or Intent
=================
Adding HTML5 Remote Console tests.  It does following:
- For VMware: 
Configures VMware Console Support option on  Appliance Config to use VNC

- For VMware and RHOSP: 
Deploys a VM small_template and opens HTML5 Console to it, login using credentials, and touch a file. 

-For VMware: 
It can SSH to VM and try to remove the file which was created through HTML5 console, which if succeeds indicates that file was created and removes it, and if fails, indicates there was some issue with console and could not create file. 

- For VMware and RHOSP:
Tests Ctrl+Alt+Del Button functionality as well
Note:

-  Requires tesseract to be installed via dnf/yum.
- It might work well with RHEV, but not tested. 
- Tests do not run back to back, please run them against a single provider at a time using "--use-provider", back to back execution will be supported soon. 
- Need to run VMware tests against PhotonOS Template(currently yamls take 'damnSmallLinux' as value for small_template) and OpenStack Tests against Cirros.

**UPDATE**: The code should now support testing on multiple providers back to back.


**PRT Expected Result** 
- Against RHV the test is expected to fail
- Against OSP(rhos7-ga) it is expected to Pass - not 100% since sometimes console drops some characters while file creation and then SSH can not fine it to delete it. 
- Against VMware(vsphere6-nested) the test is expected to Pass - unless websocket hangs in "Connected" state for console with the "Blank screen"


**mshriver** Limiting execution for PRT to currently supported providers in CFME QE.
{{ pytest: --long-running --use-provider=vsphere6-nested --use-provider=rhos7-ga cfme/tests/cloud_infra_common/test_html5_vm_console.py }}