### PR TITLE
[1LP][RFR] Adding ip_address property to BaseVM

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -263,6 +263,11 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable, SummaryMixin
             return False
 
     @property
+    def ip_address(self):
+        """Fetches IP Address of VM"""
+        return self.provider.mgmt.get_ip_address(self.name)
+
+    @property
     def is_retired(self):
         """"Check retirement status of vm"""
         self.summary.reload()


### PR DESCRIPTION
Purpose or Intent
=================

__Extending__ BaseVM Class to add ip_address property to it as per conversation with jkrocil on #cfme-qe-dev. Previously one would require using provider.mgmt.get_ip_address method, but now VM will have ip_address property. 