### PR TITLE
[1LP][RFR] Fixing TypeError in test_access_control tests

### DIFF
--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -634,15 +634,15 @@ def test_permissions(appliance, role, allowed_actions, disallowed_actions):
         appliance.server.login_admin()
 
 
-def single_task_permission_test(product_features, actions):
+def single_task_permission_test(appliance, product_features, actions):
     """Tests that action succeeds when product_features are enabled, and
        fail when everything but product_features are enabled"""
-    test_permissions(_mk_role(name=fauxfactory.gen_alphanumeric(),
+    test_permissions(appliance, _mk_role(name=fauxfactory.gen_alphanumeric(),
                               product_features=[(['Everything'], False)] +
                               [(f, True) for f in product_features]),
                      actions,
                      {})
-    test_permissions(_mk_role(name=fauxfactory.gen_alphanumeric(),
+    test_permissions(appliance, _mk_role(name=fauxfactory.gen_alphanumeric(),
                               product_features=[(['Everything'], True)] +
                               [(f, False) for f in product_features]),
                      {},
@@ -651,14 +651,15 @@ def single_task_permission_test(product_features, actions):
 
 @pytest.mark.tier(3)
 @pytest.mark.meta(blockers=[1262764])
-def test_permissions_role_crud():
-    single_task_permission_test([['Everything', cat_name, 'Configuration'],
+def test_permissions_role_crud(appliance):
+    single_task_permission_test(appliance,
+                                [['Everything', cat_name, 'Configuration'],
                                  ['Everything', 'Services', 'Catalogs Explorer']],
                                 {'Role CRUD': test_role_crud})
 
 
 @pytest.mark.tier(3)
-def test_permissions_vm_provisioning():
+def test_permissions_vm_provisioning(appliance):
     features = version.pick({
         version.LOWEST: [
             ['Everything', 'Infrastructure', 'Virtual Machines', 'Accordions'],
@@ -671,19 +672,21 @@ def test_permissions_vm_provisioning():
                 'Provision VMs']
         ]})
     single_task_permission_test(
+        appliance,
         features,
         {'Provision VM': _test_vm_provision}
     )
 
 
 # This test is disabled until it has been rewritten
-# def test_permissions_vm_power_on_access():
+# def test_permissions_vm_power_on_access(appliance):
 #    # Ensure VMs exist
 #    if not vms.get_number_of_vms():
 #        logger.debug("Setting up providers")
 #        infra_provider
 #        logger.debug("Providers setup")
 #    single_task_permission_test(
+#        appliance,
 #        [
 #            ['Infrastructure', 'Virtual Machines', 'Accordions'],
 #            ['Infrastructure', 'Virtual Machines', 'VM Access Rules', 'Operate', 'Power On']
@@ -693,13 +696,14 @@ def test_permissions_vm_provisioning():
 
 
 # This test is disabled until it has been rewritten
-# def test_permissions_vm_remove():
+# def test_permissions_vm_remove(appliance):
 #    # Ensure VMs exist
 #    if not vms.get_number_of_vms():
 #        logger.debug("Setting up providers")
 #        setup_infrastructure_providers()
 #        logger.debug("Providers setup")
 #    single_task_permission_test(
+#        appliance,
 #        [
 #            ['Infrastructure', 'Virtual Machines', 'Accordions'],
 #            ['Infrastructure', 'Virtual Machines', 'VM Access Rules', 'Modify', 'Remove']

--- a/cfme/tests/services/test_catalog.py
+++ b/cfme/tests/services/test_catalog.py
@@ -32,10 +32,11 @@ def test_catalog_duplicate_name():
 
 
 @pytest.mark.sauce
-def test_permissions_catalog_add():
+def test_permissions_catalog_add(appliance):
     """ Tests that a catalog can be added only with the right permissions"""
     cat = Catalog(name=fauxfactory.gen_alphanumeric(),
                   description="my catalog")
 
-    tac.single_task_permission_test([['Everything', 'Services', 'Catalogs Explorer', 'Catalogs']],
+    tac.single_task_permission_test(appliance,
+                                    [['Everything', 'Services', 'Catalogs Explorer', 'Catalogs']],
                                     {'Add Catalog': cat.create})


### PR DESCRIPTION
Fixing ``TypeError: test_permissions() takes exactly 4 arguments (3 given)``
by adding the ``appliance`` parameter to function definitions where it's
missing.

See e.g. https://cfmeqe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/Downstream-58z/job/downstream-58z-tests-master/87/Artifactor_Report/cfme/tests/services/test_catalog.py/test_permissions_catalog_add/filedump-traceback.log

{{pytest: -v -k test_permissions_ cfme/tests/configure/test_access_control.py cfme/tests/services/test_catalog.py}}

PRT results
---------------
The tests fails anyhow (assert errors), but the TypeErrors are fixed. It's up to the test owners to decide if it's bug in test logic or in the product, I'm not knowledgeable enough.