### PR TITLE
[RFR] Fixing TypeErrors for appliance_date() and check_ntp_grep()

### DIFF
--- a/cfme/tests/configure/test_ntp_server.py
+++ b/cfme/tests/configure/test_ntp_server.py
@@ -85,12 +85,12 @@ def test_ntp_conf_file_update_check(request, appliance):
 @pytest.mark.tier(3)
 def test_ntp_server_check(request, appliance):
     request.addfinalizer(partial(clear_ntp_settings, appliance))
-    orig_date = appliance_date()
+    orig_date = appliance_date(appliance)
     past_date = orig_date - timedelta(days=10)
     logger.info("dates: orig_date - %s, past_date - %s", orig_date, past_date)
     status, result = appliance.ssh_client.run_command(
         "date +%Y%m%d -s \"{}\"".format(past_date.strftime('%Y%m%d')))
-    new_date = appliance_date()
+    new_date = appliance_date(appliance)
     if new_date != orig_date:
         logger.info("Successfully modified the date in the appliance")
         # Configuring the ntp server and restarting the appliance
@@ -110,7 +110,8 @@ def test_ntp_server_check(request, appliance):
         appliance.ssh_client.run_command("service chronyd restart")
         # Providing two hour runtime for the test run to avoid day changing problem
         # (in case if the is triggerred in the midnight)
-        wait_for(lambda: (orig_date - appliance_date()).total_seconds() <= 7200, num_sec=300)
+        wait_for(
+            lambda: (orig_date - appliance_date(appliance)).total_seconds() <= 7200, num_sec=300)
     else:
         raise Exception("Failed modifying the system date")
     # Calling the browser quit() method to compensate the session after the evm service restart

--- a/cfme/tests/configure/test_ntp_server.py
+++ b/cfme/tests/configure/test_ntp_server.py
@@ -66,7 +66,7 @@ def test_ntp_conf_file_update_check(request, appliance):
     wait_for(lambda: ntp_file_date_stamp != appliance.ssh_client.run_command(
         "stat --format '%y' /etc/chrony.conf")[1], num_sec=60, delay=10)
     for clock in cfme_data['clock_servers']:
-        status, wait_time = wait_for(lambda: check_ntp_grep(clock),
+        status, wait_time = wait_for(lambda: check_ntp_grep(appliance, clock),
             fail_condition=False, num_sec=60, delay=5)
         assert status is True, "Clock value {} not update in /etc/chrony.conf file".format(clock)
 
@@ -77,7 +77,7 @@ def test_ntp_conf_file_update_check(request, appliance):
     wait_for(lambda: ntp_file_date_stamp != appliance.ssh_client.run_command(
         "stat --format '%y' /etc/chrony.conf")[1], num_sec=60, delay=10)
     for clock in cfme_data['clock_servers']:
-        status, wait_time = wait_for(lambda: check_ntp_grep(clock),
+        status, wait_time = wait_for(lambda: check_ntp_grep(appliance, clock),
             fail_condition=True, num_sec=60, delay=5)
         assert status is False, "Found clock record '{}' in /etc/chrony.conf file".format(clock)
 


### PR DESCRIPTION
Fixing the ``appliance_date()`` and ``check_ntp_grep()`` calls.

Solving 
``TypeError: check_ntp_grep() takes exactly 2 arguments (1 given)``
and
``TypeError: appliance_date() takes exactly 1 argument (0 given)``
fails.

PRT results
---------------
The TypeErrors are fixed, the tests fails anyhow. The /etc/chrony.conf file is not updated when server addresses are cleared, it's probably a bug.