### PR TITLE
[RFR] Fix TypeError: discover() takes at most 4 arguments (6 given)

### DIFF
--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -359,9 +359,7 @@ def discover(discover_cls, cancel=False, start_ip=None, end_ip=None):
     wait for it to finish.
 
     Args:
-        rhevm: Whether to scan for RHEVM providers
-        vmware: Whether to scan for VMware providers
-        scvmm: Whether to scan for SCVMM providers
+        discover_cls: Instance of provider class
         cancel:  Whether to cancel out of the discover UI.
         start_ip: String start of the IP range for discovery
         end_ip: String end of the IP range for discovery

--- a/cfme/tests/infrastructure/test_provider_discovery.py
+++ b/cfme/tests/infrastructure/test_provider_discovery.py
@@ -89,19 +89,8 @@ def delete_providers_after_test():
 @pytest.mark.tier(2)
 @pytest.mark.usefixtures('has_no_infra_providers', 'delete_providers_after_test')
 def test_discover_infra(providers_for_discover, start_ip, max_range):
-    rhevm = False
-    scvmm = False
-    virtualcenter = False
-
-    for i in providers_for_discover:
-        if type(i) == RHEVMProvider:
-                rhevm = True
-        if type(i) == SCVMMProvider:
-                scvmm = True
-        if type(i) == VMwareProvider:
-                virtualcenter = True
-
-    discover(rhevm, virtualcenter, scvmm, False, start_ip, max_range)
+    for provider in providers_for_discover:
+        discover(provider, False, start_ip, max_range)
 
     @wait_for_decorator(num_sec=count_timeout(start_ip, max_range), delay=5)
     def _wait_for_all_providers():


### PR DESCRIPTION
Fixing ``discover()`` calls
See e.g. https://cfmeqe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/Downstream-58z/job/downstream-58z-tests-master/87/Artifactor_Report/cfme/tests/infrastructure/test_provider_discovery.py/test_discover_infra[virtualcenter]/filedump-traceback.log

{{pytest: -v -k 'test_discover_infra and virtualcenter'}}