### PR TITLE
[RFR]ManageIQ Ansible Module Tests - Tags

### DIFF
--- a/cfme/tests/containers/test_manageiq_ansible_tags.py
+++ b/cfme/tests/containers/test_manageiq_ansible_tags.py
@@ -1,0 +1,86 @@
+import pytest
+from cfme.containers.provider import ContainersProvider
+from utils import testgen
+from utils.ansible import setup_ansible_script, run_ansible, \
+    fetch_miq_ansible_module, create_tmp_directory, remove_tmp_files
+from utils.version import current_version
+
+
+pytestmark = [
+    pytest.mark.uncollectif(lambda provider: current_version() < "5.7")]
+pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
+
+tags_to_add = {
+    'category': 'environment',
+    'name': 'qa'
+}, {
+    'category': 'department',
+    'name': 'accounting'
+}
+
+tags_to_test = {
+    'category': 'environment',
+    'name': 'quality assurance'
+}, {
+    'category': 'department',
+    'name': 'accounting'
+}
+
+tags_after_deletion = 'No My Company Tags have been assigned'
+
+
+@pytest.yield_fixture(scope='function')
+def ansible_tags():
+    create_tmp_directory()
+    fetch_miq_ansible_module()
+    yield
+    remove_tmp_files()
+
+
+def get_smart_management(provider):
+    index = 0
+    smart_management_tags = []
+    if isinstance(provider.summary.smart_management.my_company_tags, list):
+        for tag in provider.summary.smart_management.my_company_tags:
+            smart_management_tags.append(tag.value)
+            index += 1
+    else:
+        smart_management_tags.append(provider.summary.smart_management.my_company_tags)
+    return smart_management_tags
+
+
+def clean_tags(provider):
+    setup_ansible_script(provider, script='remove_tags',
+                         values_to_update=tags_to_add,
+                         script_type='tags')
+    run_ansible('remove_tags')
+
+
+@pytest.mark.polarion('CMP-11111')
+@pytest.mark.usefixtures('setup_provider')
+def test_add_tags(ansible_tags, provider):
+    """This test adds tags to the Containers Provider
+    and verifies in GUI they were added successfully
+        """
+    setup_ansible_script(provider, script='add_tags',
+                         values_to_update=tags_to_add,
+                         script_type='tags')
+    run_ansible('add_tags')
+    gui_tags = [x.lower() for x in(get_smart_management(provider))]
+    for tag_to_test in tags_to_test:
+        full_string = '{}{} {}'.format(tag_to_test.values()[0], ":", tag_to_test.values()[1])
+        assert full_string in gui_tags
+
+
+@pytest.mark.polarion('CMP-11112')
+@pytest.mark.usefixtures('setup_provider')
+def test_remove_tags(ansible_tags, provider):
+    """This test removes tags from the Containers Provider
+    and verifies in GUI they were removed successfully
+        """
+    setup_ansible_script(provider, script='remove_tags',
+                         values_to_update=tags_to_add,
+                         script_type='tags')
+    run_ansible('remove_tags')
+    gui_tags = str(get_smart_management(provider))
+    assert tags_after_deletion in gui_tags

--- a/utils/ansible.py
+++ b/utils/ansible.py
@@ -1,3 +1,4 @@
+
 import tempfile
 from os import listdir, mkdir, makedirs, path
 from shutil import copy, copyfile, rmtree
@@ -5,7 +6,6 @@ from subprocess import check_output, CalledProcessError, STDOUT
 
 from fauxfactory import gen_alphanumeric
 from utils import conf
-from utils.providers import get_crud
 from utils.providers import providers_data
 
 
@@ -60,7 +60,7 @@ def get_values_for_providers_test(provider):
         'miq_password': conf.credentials['default'].password,
         'provider_api_hostname': providers_data[provider.name]['endpoints']['default'].hostname,
         'provider_api_port': providers_data[provider.name]['endpoints']['default'].api_port,
-        'provider_api_auth_token': get_crud(provider.name).credentials['token'].token,
+        'provider_api_auth_token': providers_data[provider.name]['endpoints']['default'].token,
         'monitoring_hostname': providers_data[provider.name]['endpoints']['hawkular'].hostname,
         'monitoring_port': providers_data[provider.name]['endpoints']['hawkular'].api_port
     }
@@ -89,6 +89,15 @@ def get_values_for_custom_attributes_test(provider):
     }
 
 
+def get_values_for_tags_test(provider):
+    return {
+        'resource': 'provider',
+        'resource_name': provider.name,
+        'miq_url': config_formatter(),
+        'miq_username': conf.credentials['default'].username,
+        'miq_password': conf.credentials['default'].password,
+    }
+
 def get_values_from_conf(provider, script_type):
     if script_type == 'providers':
         return get_values_for_providers_test(provider)
@@ -96,6 +105,8 @@ def get_values_from_conf(provider, script_type):
         return get_values_for_users_test(provider)
     if script_type == 'custom_attributes':
         return get_values_for_custom_attributes_test(provider)
+    if script_type == 'tags':
+        return get_values_for_tags_test(provider)
 
 
 # TODO Avoid reading files every time
@@ -125,6 +136,8 @@ def setup_basic_script(provider, script_type):
             doc[0]['tasks'][0]['manageiq_user'][key] = values_dict[key]
         elif script_type == 'custom_attributes':
             doc[0]['tasks'][0]['manageiq_custom_attributes'][key] = values_dict[key]
+        elif script_type == 'tags':
+            doc[0]['tasks'][0]['manageiq_tag_assignment'][key] = values_dict[key]
         with open(script_path, 'w') as f:
             f.write(dump(doc))
 
@@ -226,6 +239,30 @@ def setup_ansible_script(provider, script, script_type=None, values_to_update=No
                 doc[0]['tasks'][0]['manageiq_custom_attributes']['custom_attributes'][count] = key
                 count += 1
         write_yml(script, doc)
+
+    elif script == 'add_tags':
+        count = 0
+        while count < len(values_to_update):
+            for key in values_to_update:
+                doc[0]['tasks'][0]['manageiq_tag_assignment']['tags'][count]['category'] = \
+                    values_to_update[count]['category']
+                doc[0]['tasks'][0]['manageiq_tag_assignment']['tags'][count]['name'] = \
+                    values_to_update[count]['name']
+                count += 1
+            doc[0]['tasks'][0]['manageiq_tag_assignment']['state'] = 'present'
+            write_yml(script, doc)
+
+    elif script == 'remove_tags':
+        count = 0
+        while count < len(values_to_update):
+            for key in values_to_update:
+                doc[0]['tasks'][0]['manageiq_tag_assignment']['tags'][count]['category'] = \
+                    values_to_update[count]['category']
+                doc[0]['tasks'][0]['manageiq_tag_assignment']['tags'][count]['name'] = \
+                    values_to_update[count]['name']
+                count += 1
+            doc[0]['tasks'][0]['manageiq_tag_assignment']['state'] = 'absent'
+            write_yml(script, doc)
 
 
 def run_ansible(script):

--- a/utils/ansible_conf/tags_basic_script.yml
+++ b/utils/ansible_conf/tags_basic_script.yml
@@ -1,0 +1,16 @@
+- hosts: localhost
+  tasks:
+  - manageiq_tag_assignment:
+      tags:
+      - {category: ca1, name: value 1}
+      - {category: ca2, name: value 2}
+      resource: provider
+      resource_name:
+      miq_password:
+      miq_url:
+      miq_username:
+      miq_verify_ssl: false
+      state:
+    name: Create a tag in ManageIQ
+    register: result
+  - {debug: var=result}


### PR DESCRIPTION
**Purpose or Intent**

{{pytest: cfme/tests/containers/test_manageiq_ansible_tags.py -v --use-provider cm-env2 }}

This test is testing the Tags function of MIQ Ansible Module which adds adds to objects inside ManageIQ.
For this test to run successfully it needs the git library added to requirements