### PR TITLE
[1LP][RFR] Debugging of overwritten ifcfg-eth0

### DIFF
--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -423,6 +423,12 @@ class IPAppliance(object):
         key_address = kwargs.pop('key_address', None)
         with self as ipapp:
             ipapp.wait_for_ssh()
+
+            # Debuuging - ifcfg-eth0 overwritten by unknown process
+            self.ssh_client.run_command(
+                "cp -pr /etc/sysconfig/network-scripts/ifcfg-eth0 /var/tmp", ensure_host=True)
+            self.ssh_client.run_command(
+                "auditctl -w /etc/sysconfig/network-scripts/ifcfg-eth0 -p wa", ensure_host=True)
             self.deploy_merkyl(start=True, log_callback=log_callback)
             if fix_ntp_clock:
                 self.fix_ntp_clock(log_callback=log_callback)


### PR DESCRIPTION
Purpose or Intent
=================
Upstream Sprout appliances won't get IP addresses because of erased ifcfg-eth0 configuration file. We try to use auditd here and set monitoring of the network config file.
