### PR TITLE
[1LP][RFR] Adding new test cases for testing of Vm visibility in explorer treeview

### DIFF
--- a/cfme/configure/settings.py
+++ b/cfme/configure/settings.py
@@ -1,4 +1,5 @@
 import re
+
 from navmazing import NavigateToAttribute
 from widgetastic_manageiq import Table, BootstrapSelect, BreadCrumb, Text, ViewButtonGroup
 from widgetastic_patternfly import (BootstrapSwitch,
@@ -382,7 +383,7 @@ class DefaultViewForm(MySettingsView):
     container_builds = ViewButtonGroup("Containers", "Builds")
     container_volumes = ViewButtonGroup("Containers", "Volumes")
     container_templates = ViewButtonGroup("Containers", "Templates")
-
+    vm_visibility = BootstrapSwitch("display_vms")
     save = Button("Save")
 
 
@@ -452,6 +453,20 @@ class DefaultView(Updateable, Navigatable):
         view = navigate_to(cls, 'All')
         value = getattr(view, cls.look_up[button_group_name])
         return value.active_button
+
+    @classmethod
+    def set_default_view_switch_on(cls):
+        view = navigate_to(cls, 'All')
+        if view.vm_visibility.fill(True):
+            view.save.click()
+        return True
+
+    @classmethod
+    def set_default_view_switch_off(cls):
+        view = navigate_to(cls, 'All')
+        if view.vm_visibility.fill(False):
+            view.save.click()
+        return True
 
 
 @navigator.register(DefaultView, 'All')

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -1337,12 +1337,3 @@ class EditTagsFromDetails(CFMENavigateStep):
 
     def step(self):
         self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
-
-
-@navigator.register(Vm, 'Explore')
-class VmExplore(CFMENavigateStep):
-    prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
-    VIEW = InfraVmDetailsView
-
-    def step(self, *args, **kwargs):
-        self.prerequisite_view.navigation.select('Compute', 'Infrastructure', 'Virtual Machines')

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -155,7 +155,7 @@ class VmsTemplatesAllView(InfraVmView):
     def is_displayed(self):
         return (
             self.in_infra_vms and
-            self.sidebar.vmstemplates.tree.currently_selected[0] == 'All VMs & Templates' and
+            self.sidebar.vmstemplates.tree.currently_selected == 'All VMs & Templates' and
             self.entities.title.text == 'All VMs & Templates')
 
     def reset_page(self):
@@ -231,7 +231,7 @@ class InfraVmDetailsView(InfraVmView):
     @property
     def is_displayed(self):
         expected_name = self.context['object'].name
-        expected_provider = self.context['object'].provider
+        expected_provider = self.context['object'].provider.name
         try:
             relationship_provider_name = self.entities.relationships.get_text_of('Infrastructure '
                                                                                  'Provider')
@@ -241,8 +241,8 @@ class InfraVmDetailsView(InfraVmView):
                 return (
                     self.in_infra_vms and
                     self.entities.title.text == 'VM and Instance "{}"'.format(expected_name))
-            self.logger.warning('No "Infrastructure Provider" Relationship, VM details view not '
-                           'displayed')
+            self.logger.warning('No "Infrastructure Provider" Relationship, VM details view not'
+                                ' displayed')
             return False
         return (
             self.in_infra_vms and

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -155,7 +155,7 @@ class VmsTemplatesAllView(InfraVmView):
     def is_displayed(self):
         return (
             self.in_infra_vms and
-            self.sidebar.vmstemplates.tree.currently_selected == 'All VMs & Templates' and
+            self.sidebar.vmstemplates.tree.currently_selected[0] == 'All VMs & Templates' and
             self.entities.title.text == 'All VMs & Templates')
 
     def reset_page(self):
@@ -231,7 +231,7 @@ class InfraVmDetailsView(InfraVmView):
     @property
     def is_displayed(self):
         expected_name = self.context['object'].name
-        expected_provider = self.context['object'].provider.name
+        expected_provider = self.context['object'].provider
         try:
             relationship_provider_name = self.entities.relationships.get_text_of('Infrastructure '
                                                                                  'Provider')

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -1337,3 +1337,12 @@ class EditTagsFromDetails(CFMENavigateStep):
 
     def step(self):
         self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
+
+
+@navigator.register(Vm, 'Explore')
+class VmExplore(CFMENavigateStep):
+    prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
+    VIEW = InfraVmDetailsView
+
+    def step(self, *args, **kwargs):
+        self.prerequisite_view.navigation.select('Compute', 'Infrastructure', 'Virtual Machines')

--- a/cfme/tests/configure/test_default_views_infra.py
+++ b/cfme/tests/configure/test_default_views_infra.py
@@ -41,6 +41,20 @@ def set_and_test_default_view(group_name, view, page):
     assert tb.is_active(view), "{} view setting failed".format(view)
     DefaultView.set_default_view(group_name, old_default)
 
+
+def check_vm_visibility():
+    view = navigate_to(Vm, 'Explore')
+    value = view.sidebar.vmstemplates.tree.read_contents()
+    # Selecting the path and last Vm in the accordion to perform click
+    tree_root = value[0]
+    tree_provider = value[1][0][0]
+    tree_datacenter = value[1][0][1][0][0]
+    length = len(value[1][0][1][0][1])
+    tree_vm = value[1][0][1][0][1][length - 1]
+    view.sidebar.vmstemplates.tree.click_path(tree_root,
+                                              tree_provider, tree_datacenter, tree_vm)
+    return "Instance" in view.title.text
+
 # BZ 1283118 written against 5.5 has a mix of what default views do and don't work on different
 # pages in different releases
 
@@ -84,3 +98,13 @@ def test_infra_details_view():
 
 def test_infra_exists_view():
     set_and_test_view('Compare Mode', 'Exists Mode')
+
+
+def test_vm_visibility_off():
+    DefaultView.set_default_view_switch_off()
+    assert not(check_vm_visibility())
+
+
+def test_vm_visibility_on():
+    DefaultView.set_default_view_switch_on()
+    assert check_vm_visibility()

--- a/cfme/tests/configure/test_default_views_infra.py
+++ b/cfme/tests/configure/test_default_views_infra.py
@@ -4,7 +4,7 @@ import pytest
 from cfme import test_requirements
 from cfme.configure.settings import DefaultView
 from cfme.infrastructure.provider import InfraProvider
-from cfme.infrastructure.virtual_machines import Vm
+from cfme.infrastructure.virtual_machines import Vm, InfraVmDetailsView
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.myservice import MyService
 from cfme.services.workloads import VmsInstances, TemplatesImages
@@ -43,7 +43,7 @@ def set_and_test_default_view(group_name, view, page):
 
 
 def check_vm_visibility():
-    view = navigate_to(Vm, 'Explore')
+    view = navigate_to(Vm, 'All')
     value = view.sidebar.vmstemplates.tree.read_contents()
     # Selecting the path and last Vm in the accordion to perform click
     tree_root = value[0]
@@ -53,6 +53,7 @@ def check_vm_visibility():
     tree_vm = value[1][0][1][0][1][length - 1]
     view.sidebar.vmstemplates.tree.click_path(tree_root,
                                               tree_provider, tree_datacenter, tree_vm)
+    view = view.browser.create_view(InfraVmDetailsView)
     return "Instance" in view.title.text
 
 # BZ 1283118 written against 5.5 has a mix of what default views do and don't work on different

--- a/cfme/tests/configure/test_default_views_infra.py
+++ b/cfme/tests/configure/test_default_views_infra.py
@@ -108,7 +108,7 @@ def test_infra_exists_view():
 
 def test_vm_visibility_off():
     DefaultView.set_default_view_switch_off()
-    assert not(check_vm_visibility())
+    assert not check_vm_visibility()
 
 
 def test_vm_visibility_on():

--- a/cfme/tests/configure/test_default_views_infra.py
+++ b/cfme/tests/configure/test_default_views_infra.py
@@ -10,6 +10,7 @@ from cfme.services.myservice import MyService
 from cfme.services.workloads import VmsInstances, TemplatesImages
 from cfme.web_ui import toolbar as tb
 from cfme.utils.appliance.implementations.ui import navigate_to
+from selenium.common.exceptions import NoSuchElementException
 
 
 pytestmark = [pytest.mark.tier(3),
@@ -53,8 +54,12 @@ def check_vm_visibility():
     tree_vm = value[1][0][1][0][1][length - 1]
     view.sidebar.vmstemplates.tree.click_path(tree_root,
                                               tree_provider, tree_datacenter, tree_vm)
-    view = view.browser.create_view(InfraVmDetailsView)
-    return "Instance" in view.title.text
+    vm = Vm(name=tree_vm, provider=tree_provider)
+    view = vm.create_view(InfraVmDetailsView)
+    try:
+        return view.is_displayed
+    except NoSuchElementException:
+        return False
 
 # BZ 1283118 written against 5.5 has a mix of what default views do and don't work on different
 # pages in different releases

--- a/cfme/tests/configure/test_default_views_infra.py
+++ b/cfme/tests/configure/test_default_views_infra.py
@@ -54,7 +54,7 @@ def check_vm_visibility(check=False):
     if vm_name == "<Orphaned>" and check:
         view.sidebar.vmstemplates.tree.click_path("All VMs & Templates", vm_name)
         try:
-            view.entities.get_entities()
+            view.entities.get_first_entity()
         except ItemNotFound:
             pass
     return True

--- a/cfme/tests/configure/test_default_views_infra.py
+++ b/cfme/tests/configure/test_default_views_infra.py
@@ -4,14 +4,12 @@ import pytest
 from cfme import test_requirements
 from cfme.configure.settings import DefaultView
 from cfme.infrastructure.provider import InfraProvider
-from cfme.infrastructure.virtual_machines import Vm, InfraVmDetailsView
+from cfme.infrastructure.virtual_machines import Vm
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.myservice import MyService
 from cfme.services.workloads import VmsInstances, TemplatesImages
 from cfme.web_ui import toolbar as tb
 from cfme.utils.appliance.implementations.ui import navigate_to
-from selenium.common.exceptions import NoSuchElementException
-
 
 pytestmark = [pytest.mark.tier(3),
               test_requirements.settings,
@@ -46,20 +44,14 @@ def set_and_test_default_view(group_name, view, page):
 def check_vm_visibility():
     view = navigate_to(Vm, 'All')
     value = view.sidebar.vmstemplates.tree.read_contents()
-    # Selecting the path and last Vm in the accordion to perform click
-    tree_root = value[0]
-    tree_provider = value[1][0][0]
-    tree_datacenter = value[1][0][1][0][0]
-    length = len(value[1][0][1][0][1])
-    tree_vm = value[1][0][1][0][1][length - 1]
-    view.sidebar.vmstemplates.tree.click_path(tree_root,
-                                              tree_provider, tree_datacenter, tree_vm)
-    vm = Vm(name=tree_vm, provider=tree_provider)
-    view = vm.create_view(InfraVmDetailsView)
-    try:
-        return view.is_displayed
-    except NoSuchElementException:
+    # Below steps assigns last name of the last list to vm_name variable.
+    vm_name = value[-1]
+    while isinstance(vm_name, list):
+        vm_name = vm_name[-1]
+    if vm_name == "<Orphaned>":
         return False
+    return True
+
 
 # BZ 1283118 written against 5.5 has a mix of what default views do and don't work on different
 # pages in different releases


### PR DESCRIPTION
Adding new test case for checking the working of vm visibility in explorer tree option on the setting page.

{{pytest: -v -k 'test_vm_visibility_off or test_vm_visibility_on' }}
