### PR TITLE
[RFR] fix for case when OpenStack provider uses Oscilomenter instead of AMPQ

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -198,7 +198,8 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
                             endp_view.fill(endpoint.credentials.view_value_mapping)
                         # sometimes we have cases that we need to validate even though
                         # there is no credentials, such as Hawkular endpoint
-                        if validate_credentials and hasattr(endp_view, 'validate'):
+                        if (validate_credentials and hasattr(endp_view, 'validate') and
+                                endp_view.validate.is_displayed):
                             # there are some endpoints which don't demand validation like
                             #  RSA key pair
                             endp_view.validate.click()
@@ -309,7 +310,8 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
                             endp_view.fill(endpoint.credentials.view_value_mapping)
                     # sometimes we have cases that we need to validate even though
                     # there is no credentials, such as Hawkular endpoint
-                    if validate_credentials and hasattr(endp_view, 'validate'):
+                    if (validate_credentials and hasattr(endp_view, 'validate') and
+                            endp_view.validate.is_displayed):
                         endp_view.validate.click()
 
             # cloud rhos provider always requires validation of all endpoints
@@ -318,7 +320,8 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
             if self.one_of(OpenStackProvider):
                 for endp in self.endpoints.values():
                     endp_view = getattr(self.endpoints_form(parent=edit_view), endp.name)
-                    endp_view.validate.click()
+                    if hasattr(endp_view, 'validate') and endp_view.validate.is_displayed:
+                        endp_view.validate.click()
 
             if self.one_of(InfraProvider):
                 details_view_obj = InfraProviderDetailsView


### PR DESCRIPTION
Quick fix of Events endpoint for OpenStack provider.
Honestly, the best fix would be to turn this view into ConditionalView but I'm not sure that ConditionalView can be used along with View.include. Otherwise,  fill scheme has to be changed.

Closes #5028

{{pytest: cfme/tests/cloud/test_providers.py cfme/tests/infrastructure/test_providers.py}}