### PR TITLE
[1LP][RFR]fix logging test 

### DIFF
--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -28,7 +28,7 @@ from cfme.web_ui import (
 from utils import version
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
-from utils.browser import ensure_browser_open
+from utils.browser import ensure_browser_open, browser
 from utils.pretty import Pretty
 from utils.varmeth import variable
 from utils.log import logger
@@ -294,6 +294,27 @@ class ProviderDetailsView(BaseLoggedInPage):
     @property
     def is_displayed(self):
         return match_page(summary="{} (Summary)".format(self.obj.name))
+
+    def get_logging_url(self):
+        self.monitor.item_select('External Logging')
+        browser_instance = browser()
+        all_windows = browser_instance.window_handles
+        current_window = browser_instance.current_window_handle
+
+        new_window = set(all_windows) - set([current_window])
+
+        if len(new_window) == 0:
+            raise RuntimeError("No logging window was open!")
+        new_window = new_window.pop()
+        old_window = set(all_windows) - set([new_window])
+        browser_instance.switch_to_window(new_window)
+
+        logging_url = browser_instance.current_url
+        old_window = old_window.pop()
+
+        browser_instance.switch_to_window(old_window)
+
+        return logging_url
 
 
 @navigator.register(ContainersProvider, 'Details')

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -296,23 +296,26 @@ class ProviderDetailsView(BaseLoggedInPage):
         return match_page(summary="{} (Summary)".format(self.obj.name))
 
     def get_logging_url(self):
-        self.monitor.item_select('External Logging')
         browser_instance = browser()
-        all_windows = browser_instance.window_handles
-        current_window = browser_instance.current_window_handle
 
-        new_window = set(all_windows) - set([current_window])
+        all_windows_before = browser_instance.window_handles
+        appliance_window = browser_instance.current_window_handle
 
-        if len(new_window) == 0:
+        self.monitor.item_select('External Logging')
+
+        all_windows_after = browser_instance.window_handles
+
+        new_windows = set(all_windows_after) - set(all_windows_before)
+
+        if not new_windows:
             raise RuntimeError("No logging window was open!")
-        new_window = new_window.pop()
-        old_window = set(all_windows) - set([new_window])
-        browser_instance.switch_to_window(new_window)
+
+        logging_window = new_windows.pop()
+        browser_instance.switch_to_window(logging_window)
 
         logging_url = browser_instance.current_url
-        old_window = old_window.pop()
 
-        browser_instance.switch_to_window(old_window)
+        browser_instance.switch_to_window(appliance_window)
 
         return logging_url
 

--- a/cfme/tests/containers/test_logging.py
+++ b/cfme/tests/containers/test_logging.py
@@ -15,7 +15,7 @@ pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
 
 
 @pytest.fixture(scope="function")
-def validate_logging_up_and_running(provider):
+def logging_routes(provider):
     routers = [router for router in provider.mgmt.o_api.get('route')[1]['items']
                if "logging" in router["metadata"]["name"]]
     all_routers_up = all([router["status"]["ingress"][0]["conditions"][0]["status"]
@@ -24,12 +24,21 @@ def validate_logging_up_and_running(provider):
     assert len(routers) <= NUM_OF_DEFAULT_LOG_ROUTES, "some logging route is missing"
     assert all_routers_up, "some logging route is off"
 
+    return routers
 
-@pytest.mark.polarion('CMP-10643')
-def test_external_logging_activated(provider, validate_logging_up_and_running):
+
+def get_ose_logging_url(logging_routes):
+    ops_router = [router for router in logging_routes
+                  if "logging-kibana-ops" in router["metadata"]["name"]].pop()
+    return ops_router['status']['ingress'][0]['host']
+
+
+@pytest.mark.polarion('CMP-10634')
+def test_external_logging_activated(provider):
     view = navigate_to(provider, 'Details')
-
     assert view.monitor.item_enabled('External Logging'), (
         "Monitoring --> External Logging not activated")
 
-    view.monitor.item_select('External Logging')
+    cfme_logging_url = "https://{url}".format(url=view.get_logging_url())
+    ose_logging_url = get_ose_logging_url(logging_routes(provider))
+    assert ose_logging_url in cfme_logging_url, "CFME loggging address is invalid"


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_logging.py -v --use-provider cm-env2}}

I had some issues with this test so i was asked to fix some code.

The fixes i made are:

1. The polarion id of the test was inexact
2. I was asked to add validation to the popup window which come up after the external logging button is pushed, so i had to get the correct URL from OSE and assert it with the actual URL of the popup window.
