### PR TITLE
[RFR] MultiBoxSelect refactored

### DIFF
--- a/cfme/control/explorer/actions.py
+++ b/cfme/control/explorer/actions.py
@@ -1,16 +1,17 @@
 # -*- coding: utf-8 -*-
 """Page model for Control / Explorer"""
 from cached_property import cached_property
-from utils.pretty import Pretty
-from utils.appliance.implementations.ui import navigator, navigate_to, CFMENavigateStep
 from navmazing import NavigateToAttribute
 
-from widgetastic.widget import Text
-from widgetastic_manageiq import SummaryFormItem, MultiBoxSelect, ManageIQTree, CheckboxSelect
+from widgetastic_manageiq import CheckboxSelect, ManageIQTree, MultiBoxSelect, SummaryFormItem
 from widgetastic_patternfly import BootstrapSelect, Button, Input
+
+from widgetastic.widget import Text
 
 from . import ControlExplorerView
 from utils.appliance import Navigatable
+from utils.appliance.implementations.ui import navigator, navigate_to, CFMENavigateStep
+from utils.pretty import Pretty
 from utils.update import Updateable
 
 
@@ -32,11 +33,7 @@ class ActionFormCommon(ControlExplorerView):
     action_type = BootstrapSelect("miq_action_type")
     snapshot_name = Input("snapshot_name")
     analysis_profile = BootstrapSelect("analysis_profile")
-    alerts_to_evaluate = MultiBoxSelect(
-        "formtest",
-        move_into=".//a[@data-submit='choices_chosen_div']/img",
-        move_from=".//a[@data-submit='members_chosen_div']/img"
-    )
+    alerts_to_evaluate = MultiBoxSelect()
     snapshot_age = BootstrapSelect("snapshot_age")
     parent_type = BootstrapSelect("parent_type")
     cpu_number = BootstrapSelect("cpu_value")

--- a/cfme/control/explorer/alert_profiles.py
+++ b/cfme/control/explorer/alert_profiles.py
@@ -1,16 +1,15 @@
 # -*- coding: utf-8 -*-
-from utils.pretty import Pretty
-from utils.appliance.implementations.ui import navigator, navigate_to, CFMENavigateStep
 from navmazing import NavigateToAttribute
-
 from widgetastic.widget import Text, TextInput
-from widgetastic_manageiq import MultiBoxSelect, CheckableManageIQTree
-from widgetastic_patternfly import Button, Input, BootstrapSelect
+from widgetastic_manageiq import CheckableManageIQTree, MultiBoxSelect
+from widgetastic_patternfly import BootstrapSelect, Button, Input
 
 from . import ControlExplorerView
-from utils.appliance import Navigatable
-from utils.update import Updateable
 from utils import version, ParamClassName
+from utils.appliance import Navigatable
+from utils.appliance.implementations.ui import navigator, navigate_to, CFMENavigateStep
+from utils.pretty import Pretty
+from utils.update import Updateable
 
 
 class AlertProfileFormCommon(ControlExplorerView):
@@ -18,11 +17,7 @@ class AlertProfileFormCommon(ControlExplorerView):
 
     description = Input(name="description")
     notes = TextInput(name="notes")
-    alerts = MultiBoxSelect(
-        "formtest",
-        move_into=".//a[@data-submit='choices_chosen_div']/img",
-        move_from=".//a[@data-submit='members_chosen_div']/img"
-    )
+    alerts = MultiBoxSelect()
 
     cancel_button = Button("Cancel")
 

--- a/cfme/control/explorer/alerts.py
+++ b/cfme/control/explorer/alerts.py
@@ -1,18 +1,17 @@
 # -*- coding: utf-8 -*-
 """Page model for Control / Explorer"""
-from utils.pretty import Pretty
-from utils.appliance.implementations.ui import navigator, navigate_to, CFMENavigateStep
+from copy import copy
 from navmazing import NavigateToAttribute
 
-from widgetastic.widget import Text, Checkbox, View
+from widgetastic.widget import Checkbox, Text, View
+from widgetastic_manageiq import AlertEmail, SNMPForm
 from widgetastic_patternfly import BootstrapSelect, Button, Input
-from widgetastic_manageiq import SNMPForm, AlertEmail
 
 from . import ControlExplorerView
 from utils.appliance import Navigatable
+from utils.appliance.implementations.ui import navigator, navigate_to, CFMENavigateStep
+from utils.pretty import Pretty
 from utils.update import Updateable
-
-from copy import copy
 
 
 class AlertsAllView(ControlExplorerView):

--- a/cfme/control/explorer/policies.py
+++ b/cfme/control/explorer/policies.py
@@ -56,16 +56,7 @@ class EditPolicyEventAssignments(ControlExplorerView):
 
 class EditPolicyConditionAssignments(ControlExplorerView):
     title = Text("#explorer_title_text")
-
-    move_into_button = Button(title="Move selected Conditions into this Policy")
-    move_from_button = Button(title="Remove selected Conditions from this Policy")
-
-    conditions = MultiBoxSelect(
-        "formtest",
-        move_into=move_into_button,
-        move_from=move_from_button
-    )
-
+    conditions = MultiBoxSelect()
     cancel_button = Button("Cancel")
     save_button = Button("Save")
 
@@ -193,19 +184,15 @@ class EditEventView(ControlExplorerView):
     title = Text("#explorer_title_text")
 
     true_actions = MultiBoxSelect(
-        "formtest",
-        number=1,
-        move_into=".//a[@data-submit='choices_chosen_true_div']/img",
-        move_from=".//a[@data-submit='members_chosen_true_div']/img",
+        move_into="choices_chosen_true_div",
+        move_from="members_chosen_true_div",
         available_items="choices_chosen_true",
         chosen_items="members_chosen_true"
     )
 
     false_actions = MultiBoxSelect(
-        "formtest",
-        number=2,
-        move_into=".//a[@data-submit='choices_chosen_false_div']/img",
-        move_from=".//a[@data-submit='members_chosen_false_div']/img",
+        move_into="choices_chosen_false_div",
+        move_from="members_chosen_false_div",
         available_items="choices_chosen_false",
         chosen_items="members_chosen_false"
     )

--- a/cfme/control/explorer/policy_profiles.py
+++ b/cfme/control/explorer/policy_profiles.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
-from utils.pretty import Pretty
-from utils.appliance.implementations.ui import navigator, navigate_to, CFMENavigateStep
 from navmazing import NavigateToAttribute
-
 from widgetastic.widget import Text, TextInput
 from widgetastic_manageiq import MultiBoxSelect
 from widgetastic_patternfly import Button, Input
 
 from . import ControlExplorerView
 from utils.appliance import Navigatable
+from utils.appliance.implementations.ui import navigator, navigate_to, CFMENavigateStep
+from utils.pretty import Pretty
 from utils.update import Updateable
 
 
@@ -17,12 +16,7 @@ class PolicyProfileFormCommon(ControlExplorerView):
 
     description = Input(name="description")
     notes = TextInput(name="notes")
-    policies = MultiBoxSelect(
-        "formtest",
-        move_into=".//a[@data-submit='choices_chosen_div']/img",
-        move_from=".//a[@data-submit='members_chosen_div']/img"
-    )
-
+    policies = MultiBoxSelect()
     cancel_button = Button("Cancel")
 
 


### PR DESCRIPTION
Purpose
=================

In 5.8.1 all image buttons in MultiBoxSelect are replaced by usual `<button>` elements. This PR adds temporary NewMultiBoxSelect view which uses `Button` widget from widgetastic_patternfly.
 

{{pytest: -v -k 'test_assign_condition_to_control_policy or test_policy_profile_crud or test_alert_profile_crud' --long-running}}
