### PR TITLE
[RFR] version bump riggerlib on order to get rid of locks

### DIFF
--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -148,7 +148,7 @@ requests==2.17.3
 requests-ntlm==1.0.0
 requestsexceptions==1.2.0
 rfc3986==1.0.0
-riggerlib==3.0.4
+riggerlib==3.1.2
 rsa==3.4.2
 ruamel.ordereddict==0.4.9
 ruamel.yaml==0.15.3

--- a/requirements/frozen_docs.txt
+++ b/requirements/frozen_docs.txt
@@ -115,7 +115,7 @@ reg==0.11
 repoze.lru==0.6
 requests==2.17.3
 requests-ntlm==1.0.0
-riggerlib==3.0.2
+riggerlib==3.1.2
 scandir==1.5
 scp==0.10.2
 selenium==2.53.6

--- a/requirements/template_docs.txt
+++ b/requirements/template_docs.txt
@@ -49,7 +49,7 @@ python-jenkins
 pywinrm
 PyYAML
 requests
-riggerlib>=2.0
+riggerlib>=3.1.2
 scp
 # since 3.0 uses marionette by default
 selenium<3.0.0


### PR DESCRIPTION
with this pr we update riggerlib to a version that correct uses per thread socket patterns as well as the lazy pirate pattern for signal and artifactor shutdown aware message handling

this should remove the occasional deadlocks we see in the larger jenkins builds