### PR TITLE
[RFR][1LP] Adding tesseract dependency in quickstart

### DIFF
--- a/cfme/scripting/quickstart.py
+++ b/cfme/scripting/quickstart.py
@@ -38,20 +38,20 @@ REDHAT_PACKAGES_OLD = (
     " python-virtualenv gcc postgresql-devel libxml2-devel"
     " libxslt-devel zeromq3-devel libcurl-devel"
     " redhat-rpm-config gcc-c++ openssl-devel"
-    " libffi-devel python-devel")
+    " libffi-devel python-devel tesseract")
 
 
 REDHAT_PACKAGES_F25 = (
     " python2-virtualenv gcc postgresql-devel libxml2-devel"
     " libxslt-devel zeromq3-devel libcurl-devel"
     " redhat-rpm-config gcc-c++ openssl-devel"
-    " libffi-devel python2-devel")
+    " libffi-devel python2-devel tesseract")
 
 REDHAT_PACKAGES_F26 = (
     " python2-virtualenv gcc postgresql-devel libxml2-devel"
     " libxslt-devel zeromq-devel libcurl-devel"
     " redhat-rpm-config gcc-c++ openssl-devel"
-    " libffi-devel python2-devel")
+    " libffi-devel python2-devel tesseract")
 
 
 if REDHAT_BASED:


### PR DESCRIPTION


Purpose or Intent
=================

__Extending__ quickstart to include the "tesseract" package. As  @RonnyPfannschmidt pointed it out that PRT may start using quickstart to build containers for testing, I would need those to contain the package mentioned above in order to get PR #4998 tested on PRT before it is merged.