### PR TITLE
[1LP][RFR][NOTEST] Adding templates section under the provider on example cfme_data template

### DIFF
--- a/conf/cfme_data.yaml.template
+++ b/conf/cfme_data.yaml.template
@@ -56,6 +56,13 @@ management_systems:
             template: provisioning_template_name
             host: target provisioning host name (from hosts above)
             datastore: target provisioning datastore name (from datastores above)
+        templates:
+            console_template:
+                name: template1
+                creds: template1Creds
+            small_template:
+                name: template2
+                creds: template2Creds
     rhevm31:
         name: RHEV 3.1
         default_name: RHEV-M (10.0.0.3)


### PR DESCRIPTION

Purpose or Intent
=================


__Extending__ cfme_data.yaml.template to reflect extended Provider Data that includes a templates section to track those templates that are required for testing and any additional info about each of them may require such as credentials. 

