### PR TITLE
[1LP][RFR] refactoring ProviderDetailsView

### DIFF
--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -1422,6 +1422,9 @@ class DetailsToolBarViewSelector(View):
         # so, default is_displayed works wrong in such case
         return self.summary_button.is_displayed
 
+    def read(self):
+        return self.selected
+
 
 class Search(View):
     """ Represents search_text control


### PR DESCRIPTION
1. According to hhovsepy, this view didn't work well with Middleware providers
2. this view had to be refactored since CondtionalView widget was developed

{{pytest: cfme/tests/infrastructure/test_providers.py cfme/tests/cloud/test_providers.py}}