### PR TITLE
[1LP][RFR] RHV Provider create/delete test with & without tls.

### DIFF
--- a/cfme/infrastructure/provider/rhevm.py
+++ b/cfme/infrastructure/provider/rhevm.py
@@ -64,14 +64,11 @@ class RHEVMProvider(InfraProvider):
     def view_value_mapping(self):
         return {
             'name': self.name,
-            'prov_type': version.pick({
-                version.LOWEST: 'Red Hat Enterprise Virtualization Manager',
-                '5.7.1': 'Red Hat Virtualization Manager',
-                '5.7.3': 'Red Hat Virtualization',
-                '5.8': 'Red Hat Virtualization Manager',
-                '5.8.0.10': 'Red Hat Virtualization',
-                '5.8.1': 'Red Hat Virtualization',
-            }),
+            'prov_type': version.pick({version.LOWEST: 'Red Hat Enterprise Virtualization Manager',
+                                       '5.7.1': 'Red Hat Virtualization Manager',
+                                       '5.7.3': 'Red Hat Virtualization',
+                                       '5.8': 'Red Hat Virtualization Manager',
+                                       '5.8.0.10': 'Red Hat Virtualization'}),
         }
 
     def deployment_helper(self, deploy_args):

--- a/cfme/infrastructure/provider/rhevm.py
+++ b/cfme/infrastructure/provider/rhevm.py
@@ -64,11 +64,14 @@ class RHEVMProvider(InfraProvider):
     def view_value_mapping(self):
         return {
             'name': self.name,
-            'prov_type': version.pick({version.LOWEST: 'Red Hat Enterprise Virtualization Manager',
-                                       '5.7.1': 'Red Hat Virtualization Manager',
-                                       '5.7.3': 'Red Hat Virtualization',
-                                       '5.8': 'Red Hat Virtualization Manager',
-                                       '5.8.0.10': 'Red Hat Virtualization'}),
+            'prov_type': version.pick({
+                version.LOWEST: 'Red Hat Enterprise Virtualization Manager',
+                '5.7.1': 'Red Hat Virtualization Manager',
+                '5.7.3': 'Red Hat Virtualization',
+                '5.8': 'Red Hat Virtualization Manager',
+                '5.8.0.10': 'Red Hat Virtualization',
+                '5.8.1': 'Red Hat Virtualization',
+            }),
         }
 
     def deployment_helper(self, deploy_args):

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -4,6 +4,7 @@ import fauxfactory
 
 import pytest
 
+from copy import copy, deepcopy
 
 from utils import error
 from cfme.base.credential import Credential
@@ -220,6 +221,35 @@ def test_provider_crud(provider):
 
     provider.delete(cancel=False)
     provider.wait_for_delete()
+
+
+@pytest.mark.usefixtures('has_no_infra_providers')
+@pytest.mark.tier(1)
+@test_requirements.provider_discovery
+@pytest.mark.parametrize('verify_tls', [False, True])
+@pytest.mark.uncollectif(lambda provider:
+    not provider.one_of(RHEVMProvider) and not provider.data['verify_tls'])
+def test_provider_rhv_create_delete_tls(provider, verify_tls):
+    """Tests RHV provider creation with and without TLS encryption
+
+    Metadata:
+       test_flag: crud
+    """
+    p = copy(provider)
+
+    if not verify_tls:
+        endpoints = deepcopy(p.endpoints)
+        endpoints['default'].verify_tls = False
+        endpoints['default'].ca_certs = None
+
+        p.endpoints = endpoints
+        p.name = "{}-no-tls".format(provider.name)
+
+    p.create()
+    p.validate_stats(ui=True)
+
+    p.delete(cancel=False)
+    p.wait_for_delete()
 
 
 class TestProvidersRESTAPI(object):


### PR DESCRIPTION
Adding test for RHV provider to cover it's creation with and without tls.

Signed-off-by: Aleksei Slaikovskii <aslaikov@redhat.com>

{{pytest: -v --long-running cfme/tests/infrastructure/test_providers.py -k test_provider_rhv_create_delete_tls --use-provider rhv41}}
