### PR TITLE
[1LP][RFR] Nodes Logging test

### DIFF
--- a/cfme/containers/node.py
+++ b/cfme/containers/node.py
@@ -8,7 +8,6 @@ from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.widget import View
 from widgetastic_manageiq import (
     BootstrapSelect, Button, Table, Accordion, ManageIQTree, PaginationPane)
-from widgetastic_patternfly import Dropdown
 
 from cfme.common import Taggable, SummaryMixin
 from cfme.containers.provider import ContainersProvider, Labelable,\
@@ -130,7 +129,6 @@ class All(CFMENavigateStep):
 
 class NodeDetailsView(NodeView):
     download = Button(name='download_view')
-    monitor = Dropdown('Monitoring')
 
     @property
     def is_displayed(self):

--- a/cfme/containers/node.py
+++ b/cfme/containers/node.py
@@ -12,7 +12,7 @@ from widgetastic_patternfly import Dropdown
 
 from cfme.common import Taggable, SummaryMixin
 from cfme.containers.provider import ContainersProvider, Labelable,\
-    ContainerObjectAllBaseView
+    ContainerObjectAllBaseView, LoggingableView
 from cfme.exceptions import NodeNotFound
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import CheckboxTable, toolbar as tb, InfoBlock, match_location
@@ -27,10 +27,9 @@ match_page = partial(match_location, controller='container_node', title='Nodes')
 resource_locator = "//div[@id='records_div']/table//span[@title='{}']"
 
 
-class NodeView(ContainerObjectAllBaseView):
+class NodeView(ContainerObjectAllBaseView, LoggingableView):
     TITLE_TEXT = 'Nodes'
 
-    monitor = Dropdown('Monitoring')
     nodes = Table(locator="//div[@id='list_grid']//table")
 
     @property
@@ -131,6 +130,7 @@ class All(CFMENavigateStep):
 
 class NodeDetailsView(NodeView):
     download = Button(name='download_view')
+    monitor = Dropdown('Monitoring')
 
     @property
     def is_displayed(self):

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -293,6 +293,10 @@ class LoggingableView(View):
     monitor = Dropdown('Monitoring')
 
     def get_logging_url(self):
+
+        def report_kibana_failure():
+            raise RuntimeError("Kibana not found in the window title or content")
+
         browser_instance = browser()
 
         all_windows_before = browser_instance.window_handles
@@ -311,6 +315,11 @@ class LoggingableView(View):
         browser_instance.switch_to_window(logging_window)
 
         logging_url = browser_instance.current_url
+
+        wait_for(lambda: "kibana" in
+                         browser_instance.title.lower() + " " +
+                         browser_instance.page_source.lower(),
+                 fail_func=report_kibana_failure, num_sec=60, delay=5)
 
         browser_instance.close()
         browser_instance.switch_to_window(appliance_window)

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -288,12 +288,9 @@ class Add(CFMENavigateStep):
         }))
 
 
-class ProviderDetailsView(BaseLoggedInPage):
-    monitor = Dropdown('Monitoring')
+class LoggingableView(View):
 
-    @property
-    def is_displayed(self):
-        return match_page(summary="{} (Summary)".format(self.obj.name))
+    monitor = Dropdown('Monitoring')
 
     def get_logging_url(self):
         browser_instance = browser()
@@ -315,9 +312,17 @@ class ProviderDetailsView(BaseLoggedInPage):
 
         logging_url = browser_instance.current_url
 
+        browser_instance.close()
         browser_instance.switch_to_window(appliance_window)
 
         return logging_url
+
+
+class ProviderDetailsView(BaseLoggedInPage, LoggingableView):
+
+    @property
+    def is_displayed(self):
+        return match_page(summary="{} (Summary)".format(self.obj.name))
 
 
 @navigator.register(ContainersProvider, 'Details')

--- a/cfme/tests/containers/test_logging.py
+++ b/cfme/tests/containers/test_logging.py
@@ -3,10 +3,13 @@ import pytest
 from utils import testgen
 from utils.version import current_version
 from utils.appliance.implementations.ui import navigate_to
+from cfme.containers.node import Node
 
-from cfme.containers.provider import ContainersProvider
+from cfme.containers.provider import ContainersProvider, ContainersTestItem
 
 NUM_OF_DEFAULT_LOG_ROUTES = 2
+
+
 pytestmark = [
     pytest.mark.uncollectif(lambda provider: current_version() < "5.8"),
     pytest.mark.usefixtures('setup_provider'),
@@ -14,10 +17,17 @@ pytestmark = [
 pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
 
 
+TEST_ITEMS = [
+    pytest.mark.polarion('CMP-10634')(ContainersTestItem(ContainersProvider, 'CMP-10634')),
+    pytest.mark.polarion('CMP-10635')(ContainersTestItem(Node, 'CMP-10635'))
+]
+
+
 @pytest.fixture(scope="function")
 def logging_routes(provider):
     routers = [router for router in provider.mgmt.o_api.get('route')[1]['items']
                if "logging" in router["metadata"]["name"]]
+
     all_routers_up = all([router["status"]["ingress"][0]["conditions"][0]["status"]
                           for router in routers])
 
@@ -33,9 +43,16 @@ def get_ose_logging_url(logging_routes):
     return ops_router['status']['ingress'][0]['host']
 
 
-@pytest.mark.polarion('CMP-10634')
-def test_external_logging_activated(provider):
-    view = navigate_to(provider, 'Details')
+@pytest.mark.parametrize('test_item', TEST_ITEMS,
+                         ids=[ContainersTestItem.get_pretty_id(ti) for ti in TEST_ITEMS])
+def test_external_logging_activated(provider, test_item):
+
+    if test_item.obj is ContainersProvider:
+        obj_inst = provider
+    else:
+        obj_inst = test_item.obj.get_random_instances(provider, count=1).pop()
+
+    view = navigate_to(obj_inst, 'Details')
     assert view.monitor.item_enabled('External Logging'), (
         "Monitoring --> External Logging not activated")
 

--- a/cfme/tests/containers/test_logging.py
+++ b/cfme/tests/containers/test_logging.py
@@ -30,9 +30,7 @@ def logging_routes(provider):
                           for router in routers])
 
     all_pods = {pod: status["Ready"]
-                for pod, status in provider.pods_per_ready_status().iteritems()}
-
-    all_pods = {pod: status for pod, status in all_pods.iteritems() if "logging" in pod}
+                for pod, status in provider.pods_per_ready_status().iteritems() if "logging" in pod}
 
     assert all_pods, "no logging pods found"
     assert all(all_pods), "some pods not ready"

--- a/cfme/tests/containers/test_logging.py
+++ b/cfme/tests/containers/test_logging.py
@@ -8,8 +8,6 @@ from cfme.containers.node import Node
 from cfme.containers.provider import ContainersProvider, ContainersTestItem
 
 NUM_OF_DEFAULT_LOG_ROUTES = 2
-
-
 pytestmark = [
     pytest.mark.uncollectif(lambda provider: current_version() < "5.8"),
     pytest.mark.usefixtures('setup_provider'),
@@ -31,6 +29,13 @@ def logging_routes(provider):
     all_routers_up = all([router["status"]["ingress"][0]["conditions"][0]["status"]
                           for router in routers])
 
+    all_pods = {pod: status["Ready"]
+                for pod, status in provider.pods_per_ready_status().iteritems()}
+
+    all_pods = {pod: status for pod, status in all_pods.iteritems() if "logging" in pod}
+
+    assert all_pods, "no logging pods found"
+    assert all(all_pods), "some pods not ready"
     assert len(routers) <= NUM_OF_DEFAULT_LOG_ROUTES, "some logging route is missing"
     assert all_routers_up, "some logging route is off"
 


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_logging.py -v --use-provider cm-env2}}

### Summery:

In this PR I automated test case CMP-10635, 

**Short explanation about logging:**

The feature logging allow to save system logs to second location for backup goals, this option allowed for provider and for node. 

I had to create new view for logging-able object to avoid code duplication.
I also moved "Monitoring" dropdown to  logging-able view because each object that support logging have to navigate through "Monitoring --> External logging"