### PR TITLE
[RFR] Fix infra.test_host import error, credentials_form

### DIFF
--- a/cfme/common/host_views.py
+++ b/cfme/common/host_views.py
@@ -299,6 +299,7 @@ class HostAddView(HostFormView):
 
 
 class HostEditView(HostFormView):
+    """View for editing a single host"""
     save_button = Button("Save")
     reset_button = Button("Reset")
     change_stored_password = Text(".//a[contains(@ng-hide, 'bChangeStoredPassword')]")
@@ -306,3 +307,16 @@ class HostEditView(HostFormView):
     @property
     def is_displayed(self):
         return self.in_compute_infrastructure_hosts and self.title.text == "Info/Settings"
+
+
+class HostsEditView(HostEditView):
+    """View when editing multiple hosts
+        Restricted to endpoints section of the form
+        Title changes
+        Must select host before validation
+    """
+    validation_host = BootstrapSelect('validate_id')  # only shown when editing multiple hosts
+
+    @property
+    def is_displayed(self):
+        return self.in_compute_infrastructure_hosts and self.title.text == 'Credentials/Settings'

--- a/cfme/infrastructure/provider/virtualcenter.py
+++ b/cfme/infrastructure/provider/virtualcenter.py
@@ -1,6 +1,11 @@
-from cfme.common.provider import DefaultEndpoint, DefaultEndpointForm
-from . import InfraProvider
+from navmazing import NavigateToSibling
 from wrapanapi.virtualcenter import VMWareSystem
+
+from cfme.common.provider import DefaultEndpoint, DefaultEndpointForm
+from cfme.common.provider_views import ProviderNodesView
+from cfme.exceptions import DestinationNotFound
+from utils.appliance.implementations.ui import CFMENavigateStep, navigator
+from . import InfraProvider
 
 
 class VirtualCenterEndpoint(DefaultEndpoint):
@@ -62,3 +67,15 @@ class VMwareProvider(InfraProvider):
         return {'name': self.name,
                 'prov_type': 'VMware vCenter'
                 }
+
+
+@navigator.register(VMwareProvider, 'ProviderNodes')  # matching other infra class destinations
+class ProviderNodes(CFMENavigateStep):
+    VIEW = ProviderNodesView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        try:
+            self.prerequisite_view.contents.relationships.click_at('Hosts')
+        except NameError:
+            raise DestinationNotFound("Hosts aren't present on details page of this provider")


### PR DESCRIPTION
The credentials_form was removed during widgetastic configuration, and is causing an ImportError for `infrastructure/test_host.py`.

Refactor tests to use widgetastic views/forms.

FIXES #5098
