### PR TITLE
[RFR] Fixed full_template name

### DIFF
--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -144,7 +144,7 @@ def vm_name():
 
 @pytest.yield_fixture(scope="function")
 def vm(vm_name, full_template, provider, setup_provider):
-    vm_obj = VM.factory(vm_name, provider, template_name=full_template["name"])
+    vm_obj = VM.factory(vm_name, provider, template_name=full_template)
     vm_obj.create_on_provider(allow_skip="default")
     provider.mgmt.start_vm(vm_obj.name)
     provider.mgmt.wait_vm_running(vm_obj.name)
@@ -170,8 +170,8 @@ def vm(vm_name, full_template, provider, setup_provider):
 @pytest.yield_fixture(scope="function")
 def ssh(provider, full_template, vm_name):
     with SSHClient(
-            username=credentials[full_template['creds']]['username'],
-            password=credentials[full_template['creds']]['password'],
+            username=credentials[full_template]['username'],
+            password=credentials[full_template]['password'],
             hostname=provider.mgmt.get_ip_address(vm_name)) as ssh_client:
         yield ssh_client
 

--- a/cfme/tests/control/test_compliance.py
+++ b/cfme/tests/control/test_compliance.py
@@ -86,7 +86,7 @@ def configure_fleecing(appliance, has_no_providers_modscope, provider, setup_pro
 @pytest.yield_fixture(scope="module")
 def compliance_vm(configure_fleecing, provider, full_template_modscope):
     name = "{}-{}".format("test-compliance", fauxfactory.gen_alpha(4))
-    vm = VM.factory(name, provider, template_name=full_template_modscope["name"])
+    vm = VM.factory(name, provider, template_name=full_template_modscope)
     vm.create_on_provider(allow_skip="default")
     provider.mgmt.start_vm(vm.name)
     provider.mgmt.wait_vm_running(vm.name)

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -67,7 +67,7 @@ def orphaned_vm(provider, testing_vm):
 @pytest.fixture(scope="function")
 def testing_vm_tools(request, provider, vm_name, full_template):
     """Fixture to provision vm with preinstalled tools to the provider being tested"""
-    vm = VM.factory(vm_name, provider, template_name=full_template["name"])
+    vm = VM.factory(vm_name, provider, template_name=full_template)
     logger.info("provider_key: %s", provider.key)
 
     @request.addfinalizer


### PR DESCRIPTION
Purpose
=================

After merging #5044 some tests failed. `full_template` fixture now always returns a string and respectful tests should be fixed.
{{pytest: -v -k "test_alert_snmp or test_check_package_presence or testing_vm_tools" --long-running --use-provider vsphere6-nested}}