### PR TITLE
[1LP][RFR] fix creating snapshot for powered off VMs

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -393,14 +393,16 @@ class Vm(BaseVM):
 
         def create(self):
             snapshot_dict = {
-                'description': self.description,
-                'snapshot_memory': self.memory
+                'description': self.description
             }
             self._nav_to_snapshot_mgmt()
             toolbar.select('Create a new snapshot for this VM')
 
             if self.name is not None:
                 snapshot_dict['name'] = self.name
+
+            if self.vm.provider.mgmt.is_vm_running(self.vm.name):
+                snapshot_dict["snapshot_memory"] = self.memory
 
             fill(snapshot_form, snapshot_dict, action=snapshot_form.create_button)
             wait_for(lambda: self.exists, num_sec=300, delay=20, fail_func=sel.refresh,


### PR DESCRIPTION
This is a quick fix for snapshot creating when VM is in state other than POWERED_ON.

When a VM is suspended or powered off, we cannot create a snapshot that would contain VM's memory. There is also no checkbox displayed on the page. This was causing errors in the original code, which expected the checkbox to be there at all times.