### PR TITLE
[1LP][RFR] Correct recognition of entities in list view 

### DIFF
--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -2155,6 +2155,14 @@ class BaseEntitiesView(View):
     class ListView(EntitiesConditionalView):
         elements = Table(locator='//div[@id="list_grid"]/table')
 
+        @property
+        def entity_names(self):
+            """ looks for entities and extracts their names
+
+            Returns: all current page entities
+            """
+            return [row.name.text for row in self.elements.rows()]
+
     @entities.register('Tile View')
     class TileView(EntitiesConditionalView):
         pass


### PR DESCRIPTION
When BaseEntitiesView is switched to list view, it cannot correctly recognize entities in it due to missing entity_names method.
This PR fixes that issue.