### PR TITLE
[1LP][RFR] Dialog widgetastic impact on ansible test

### DIFF
--- a/cfme/fixtures/service_fixtures.py
+++ b/cfme/fixtures/service_fixtures.py
@@ -42,7 +42,6 @@ def catalog():
 def catalog_item(provider, provisioning, vm_name, dialog, catalog):
     template, host, datastore, iso_file, catalog_item_type, vlan = map(provisioning.get,
         ('template', 'host', 'datastore', 'iso_file', 'catalog_item_type', 'vlan'))
-    # dialog, element = dialog
     item_name = dialog.label
     provisioning_data = dict(
         vm_name=vm_name,

--- a/cfme/infrastructure/config_management.py
+++ b/cfme/infrastructure/config_management.py
@@ -230,12 +230,11 @@ class ConfigManager(Updateable, Pretty, Navigatable):
         """Returns 'ConfigProfile' configuration profiles (hostgroups) available on this manager"""
         navigate_to(self, 'Details')
         # TODO - remove it later.Workaround for BZ 1452425
-        sel.click(RELOAD_LOC)
         tb.select('List View')
         wait_for(self._does_profile_exist, num_sec=300, delay=20, fail_func=sel.refresh)
         config_profiles = []
         for row in page.list_table_config_profiles.rows():
-            if self.type == 'Ansible Tower' and version.current_version() >= '5.8':
+            if self.type == 'Ansible Tower':
                 name = row['name'].text
             else:
                 name = row['Description'].text

--- a/cfme/tests/services/test_config_provider_servicecatalogs.py
+++ b/cfme/tests/services/test_config_provider_servicecatalogs.py
@@ -36,7 +36,6 @@ def pytest_generate_tests(metafunc):
 @pytest.yield_fixture
 def config_manager(config_manager_obj):
     """ Fixture that provides a random config manager and sets it up"""
-    DefaultView.set_default_view("Configuration Management Providers", "Grid View")
     if config_manager_obj.type == "Ansible Tower":
         config_manager_obj.create(validate=True)
     else:
@@ -52,9 +51,8 @@ def catalog_item(request, config_manager, dialog, catalog):
     provisioning_data = config_manager_obj.yaml_data['provisioning_data']
     item_type, provider_type, template = map(provisioning_data.get,
                                             ('item_type', 'provider_type', 'template'))
-    item_name = dialog.element_data.get("default_text_box")
     catalog_item = CatalogItem(item_type=item_type,
-                               name=item_name,
+                               name=dialog.label,
                                description="my catalog",
                                display_in=True,
                                catalog=catalog,


### PR DESCRIPTION
{{pytest: -v --long-running --use-provider ansible_tower_310 cfme/tests/services/test_config_provider_servicecatalogs.py }}

Due to recent widgetastic changes in dialog One field needs to be modified here .
Note : The ansible tower provider are having issues so the test will fail .
Pavol is checking the issues .