### PR TITLE
[1LP][RFR]Enable Container object testing

### DIFF
--- a/cfme/tests/containers/test_smart_management.py
+++ b/cfme/tests/containers/test_smart_management.py
@@ -13,6 +13,7 @@ from cfme.containers.node import Node
 from cfme.containers.image_registry import ImageRegistry
 from cfme.containers.pod import Pod
 from cfme.containers.template import Template
+from cfme.containers.container import Container
 from utils.wait import wait_for
 
 pytestmark = [
@@ -23,10 +24,7 @@ pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
 
 
 TEST_ITEMS = [
-    # The next lines have been removed due to bug introduced in CFME 5.8.1 -
-    # https://bugzilla.redhat.com/show_bug.cgi?id=1467639
-    # from cfme.containers.container import Container (add to imports)
-    # pytest.mark.polarion('CMP-9948')(ContainersTestItem(Container, 'CMP-9948')),
+    pytest.mark.polarion('CMP-9948')(ContainersTestItem(Container, 'CMP-9948')),
     pytest.mark.polarion('CMP-10320')(ContainersTestItem(Template, 'CMP-10320')),
     pytest.mark.polarion('CMP-9992')(ContainersTestItem(ImageRegistry, 'CMP-9992')),
     pytest.mark.polarion('CMP-9981')(ContainersTestItem(Image, 'CMP-9981')),

--- a/cfme/tests/containers/test_smart_management.py
+++ b/cfme/tests/containers/test_smart_management.py
@@ -3,6 +3,7 @@ import random
 import pytest
 from utils import testgen
 from utils.appliance.implementations.ui import navigate_to
+from utils.blockers import BZ
 from utils.version import current_version
 from cfme.web_ui import toolbar, AngularSelect, form_buttons
 from cfme.configure.configuration import Tag
@@ -24,6 +25,7 @@ pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
 
 
 TEST_ITEMS = [
+
     pytest.mark.polarion('CMP-9948')(ContainersTestItem(Container, 'CMP-9948')),
     pytest.mark.polarion('CMP-10320')(ContainersTestItem(Template, 'CMP-10320')),
     pytest.mark.polarion('CMP-9992')(ContainersTestItem(ImageRegistry, 'CMP-9992')),
@@ -68,6 +70,9 @@ def wait_for_tag(obj_inst):
 
 @pytest.mark.parametrize('test_item', TEST_ITEMS,
                          ids=[ContainersTestItem.get_pretty_id(ti) for ti in TEST_ITEMS])
+@pytest.mark.meta(blockers=[BZ(1479412,
+                               forced_streams=['5.7'],
+                               unblock=lambda test_item: test_item.obj != Container)])
 def test_smart_management_add_tag(provider, test_item):
 
     # validate no tag set to project


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_smart_management.py -v --use-provider cm-env2}}

Add Container object to smart management tests 