### PR TITLE
[1LP][RFR] test snapshot operations on suspended vm

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -366,6 +366,8 @@ class Vm(VM):
                 return False
             except NoSuchElementException:
                 return False
+            except NameError:
+                return False
 
         def _click_tree_path(self, prop):
             """Find and click the given property in a snapshot tree path.
@@ -436,6 +438,10 @@ class Vm(VM):
             sel.handle_alert(cancel=cancel)
             flash.assert_message_match('Revert To Snapshot initiated for 1 VM and Instance from '
                                        'the CFME Database')
+
+        def refresh(self):
+            self._nav_to_snapshot_mgmt()
+            toolbar.select('Reload current display')
 
     # POWER CONTROL OPTIONS
     SUSPEND = "Suspend"

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -174,6 +174,52 @@ def test_verify_revert_snapshot(full_test_vm, provider, soft_assert, register_ev
 
 
 @pytest.mark.uncollectif(lambda provider: not provider.one_of(VMwareProvider))
+def test_operations_suspended_vm(small_test_vm, provider, soft_assert):
+    """Tests snapshot operations on suspended vm
+
+    Metadata:
+        test_flag: snapshot, provision
+    """
+    # Create first snapshot when VM is running
+    snapshot1 = new_snapshot(small_test_vm)
+    snapshot1.create()
+    wait_for(lambda: snapshot1.active, num_sec=300, delay=20, fail_func=snapshot1.refresh)
+    # Suspend the VM
+    small_test_vm.power_control_from_cfme(option=small_test_vm.SUSPEND, cancel=False)
+    small_test_vm.wait_for_vm_state_change(desired_state=small_test_vm.STATE_SUSPENDED)
+    current_state = small_test_vm.find_quadicon().state
+    soft_assert(current_state.startswith('currentstate-suspended'),
+                "Quadicon state is {}".format(current_state))
+    # Create second snapshot when VM is suspended
+    snapshot2 = new_snapshot(small_test_vm)
+    snapshot2.create()
+    wait_for(lambda: snapshot2.active, num_sec=300, delay=20, fail_func=snapshot2.refresh)
+    # Try to revert to first snapshot while the VM is suspended
+    snapshot1.revert_to()
+    wait_for(lambda: snapshot1.active, num_sec=300, delay=20, fail_func=snapshot1.refresh)
+    # Check VM state, VM should be off
+    current_state = small_test_vm.find_quadicon().state
+    soft_assert(current_state.startswith('currentstate-off'),
+                "Quadicon state is {}".format(current_state))
+    assert small_test_vm.provider.mgmt.is_vm_stopped(small_test_vm.name)
+    # Revert back to second snapshot
+    snapshot2.revert_to()
+    wait_for(lambda: snapshot2.active, num_sec=300, delay=20, fail_func=snapshot2.refresh)
+    # Check VM state, VM should be suspended
+    current_state = small_test_vm.find_quadicon().state
+    soft_assert(current_state.startswith('currentstate-suspended'),
+                "Quadicon state is {}".format(current_state))
+    assert small_test_vm.provider.mgmt.is_vm_suspended(small_test_vm.name)
+    # Try to delete both snapshots while the VM is suspended
+    snapshot2.delete_all()
+    # Wait for both snapshots to disappear
+    wait_for(lambda: not snapshot1.exists, num_sec=300, delay=20, fail_func=snapshot1.refresh)
+    logger.info("First snapshot successfully deleted")
+    wait_for(lambda: not snapshot2.exists, num_sec=300, delay=20, fail_func=snapshot2.refresh)
+    logger.info("Second snapshot successfully deleted")
+
+
+@pytest.mark.uncollectif(lambda provider: not provider.one_of(VMwareProvider))
 def test_create_snapshot_via_ae(request, domain, small_test_vm):
     """This test checks whether the vm.create_snapshot works in AE.
 


### PR DESCRIPTION
This is a new test for testing basic snapshot operations on a suspended vm.

First, I create a snapshot when the vm is running, then I suspend it and create a second snapshot [1]. While the vm is suspended, I try to revert to first snapshot and check the status of the vm (off). I then revert back to the second snapshot, check the status of the vm (suspended) and try to delete all the snapshots. ~~This is a bit tricky since I can't mask the NameError with wait_for, so I used try/except blocks.~~ Update: The NameError is now caught within Snapshot.exists.

[1] we can't create two snapshots when the vm is suspended: https://bugzilla.redhat.com/show_bug.cgi?id=1419872