### PR TITLE
[RFR] miq-runtest restart the python process to avoid global state

### DIFF
--- a/cfme/scripting/runtest.py
+++ b/cfme/scripting/runtest.py
@@ -1,9 +1,15 @@
 import sys
+import os
 from . import quickstart
+QUICKSTART_DONE = 'MIQ_RUNTEST_QUICKSTART_DONE'
 
 
 def main():
-    quickstart.main(quickstart.parser.parse_args(
-        ['--mk-virtualenv', sys.prefix]))
-    import pytest
-    pytest.main()
+    if QUICKSTART_DONE not in os.environ:
+        quickstart.main(quickstart.parser.parse_args(
+            ['--mk-virtualenv', sys.prefix]))
+        os.environ[QUICKSTART_DONE] = QUICKSTART_DONE
+        os.execl(sys.executable, sys.executable, *sys.argv)
+    else:
+        import pytest
+        pytest.main()


### PR DESCRIPTION
pkg_ressources would be initialized with stale data the time pytest gets to it after the updates
