### PR TITLE
[1LP][READY-TO-MERGE] replacement of web_ui paginator with widgetastic one

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -729,10 +729,6 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
         raise NotImplementedError("This method is not implemented for given provider")
 
 
-def get_paginator_value():
-    return paginator.rec_total()
-
-
 class CloudInfraProvider(BaseProvider, PolicyProfileAssignable):
     vm_name = ""
     template_name = ""

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -19,7 +19,7 @@ from cfme.exceptions import (
     ProviderHasNoKey, HostStatsNotContains, ProviderHasNoProperty, FlashMessageException)
 from cfme.web_ui import (
     breadcrumbs_names, summary_title, flash, Quadicon, Region, fill, Form, toolbar as tb,
-    form_buttons, paginator)
+    form_buttons)
 from utils import ParamClassName, version, conf
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigate_to

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -13,7 +13,7 @@ from cfme.exceptions import (
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import (
     AngularCalendarInput, AngularSelect, Form, InfoBlock, Input, Quadicon, Select, fill, flash,
-    form_buttons, paginator, toolbar, PagedTable, SplitPagedTable, search, CheckboxTable,
+    form_buttons, toolbar, PagedTable, SplitPagedTable, search, CheckboxTable,
     DriftGrid, BootstrapTreeview
 )
 import cfme.web_ui.toolbar as tb
@@ -296,6 +296,7 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable, SummaryMixin
         Returns: :py:class:`cfme.web_ui.Quadicon` instance
         Raises: VmOrInstanceNotFound
         """
+        from cfme.web_ui import paginator
         quadicon = Quadicon(self.name, self.quadicon_type)
         if not do_not_navigate:
             if from_any_provider:

--- a/cfme/containers/container.py
+++ b/cfme/containers/container.py
@@ -15,7 +15,7 @@ from cfme.base.login import BaseLoggedInPage
 from cfme.containers.provider import details_page, pol_btn, mon_btn
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import CheckboxTable, toolbar as tb, paginator, match_location, PagedTable
+from cfme.web_ui import CheckboxTable, toolbar as tb, match_location, PagedTable
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
 from utils import version
@@ -111,6 +111,7 @@ class ContainerAll(CFMENavigateStep):
         else:
             self.view.Filters.Navigation.select('ALL (Default)')
         tb.select('List View')
+        from cfme.web_ui import paginator
         if paginator.page_controls_exist():
             paginator.check_all()
             paginator.uncheck_all()

--- a/cfme/containers/container.py
+++ b/cfme/containers/container.py
@@ -112,8 +112,8 @@ class ContainerAll(CFMENavigateStep):
             self.view.Filters.Navigation.select('ALL (Default)')
         tb.select('List View')
         if paginator.page_controls_exist():
-            sel.check(paginator.check_all())
-            sel.uncheck(paginator.check_all())
+            paginator.check_all()
+            paginator.uncheck_all()
 
 
 @navigator.register(Container, 'Details')

--- a/cfme/containers/image.py
+++ b/cfme/containers/image.py
@@ -10,7 +10,7 @@ from cfme.common import SummaryMixin, Taggable, PolicyProfileAssignable
 from cfme.containers.provider import Labelable, navigate_and_get_rows,\
     ContainerObjectAllBaseView
 from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import toolbar as tb, CheckboxTable, paginator, match_location, InfoBlock,\
+from cfme.web_ui import toolbar as tb, CheckboxTable, match_location, InfoBlock,\
     flash, PagedTable
 from utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
 from utils.appliance import Navigatable
@@ -138,6 +138,7 @@ class All(CFMENavigateStep):
         self.prerequisite_view.navigation.select('Compute', 'Containers', 'Container Images')
 
     def resetter(self):
+        from cfme.web_ui import paginator
         tb.select('Grid View')
         paginator.check_all()
         paginator.uncheck_all()

--- a/cfme/containers/image.py
+++ b/cfme/containers/image.py
@@ -139,8 +139,8 @@ class All(CFMENavigateStep):
 
     def resetter(self):
         tb.select('Grid View')
-        sel.check(paginator.check_all())
-        sel.uncheck(paginator.check_all())
+        paginator.check_all()
+        paginator.uncheck_all()
 
 
 @navigator.register(Image, 'Details')

--- a/cfme/containers/image_registry.py
+++ b/cfme/containers/image_registry.py
@@ -8,7 +8,7 @@ from cfme.common import SummaryMixin, Taggable
 from cfme.containers.provider import pol_btn, navigate_and_get_rows,\
     ContainerObjectAllBaseView
 from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import CheckboxTable, toolbar as tb, paginator, match_location,\
+from cfme.web_ui import CheckboxTable, toolbar as tb, match_location,\
     PagedTable
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
@@ -61,6 +61,7 @@ class ImageRegistryAll(CFMENavigateStep):
         self.prerequisite_view.navigation.select('Compute', 'Containers', 'Image Registries')
 
     def resetter(self):
+        from cfme.web_ui import paginator
         tb.select('List View')
         if paginator.page_controls_exist():
             paginator.check_all()

--- a/cfme/containers/image_registry.py
+++ b/cfme/containers/image_registry.py
@@ -63,8 +63,8 @@ class ImageRegistryAll(CFMENavigateStep):
     def resetter(self):
         tb.select('List View')
         if paginator.page_controls_exist():
-            sel.check(paginator.check_all())
-            sel.uncheck(paginator.check_all())
+            paginator.check_all()
+            paginator.uncheck_all()
 
 
 @navigator.register(ImageRegistry, 'Details')

--- a/cfme/containers/pod.py
+++ b/cfme/containers/pod.py
@@ -74,8 +74,8 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         tb.select("List View")
-        sel.check(paginator.check_all())
-        sel.uncheck(paginator.check_all())
+        paginator.check_all()
+        paginator.uncheck_all()
 
 
 @navigator.register(Pod, 'Details')

--- a/cfme/containers/pod.py
+++ b/cfme/containers/pod.py
@@ -5,7 +5,7 @@ import itertools
 
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import toolbar as tb, paginator, match_location,\
+from cfme.web_ui import toolbar as tb, match_location,\
     PagedTable, CheckboxTable
 from cfme.containers.provider import details_page, Labelable,\
     ContainerObjectAllBaseView
@@ -72,6 +72,7 @@ class All(CFMENavigateStep):
         self.prerequisite_view.navigation.select('Compute', 'Containers', 'Pods')
 
     def resetter(self):
+        from cfme.web_ui import paginator
         # Reset view and selection
         tb.select("List View")
         paginator.check_all()

--- a/cfme/containers/project.py
+++ b/cfme/containers/project.py
@@ -4,7 +4,7 @@ import itertools
 
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import toolbar as tb, paginator, match_location,\
+from cfme.web_ui import toolbar as tb, match_location,\
     PagedTable, CheckboxTable
 from cfme.containers.provider import details_page, Labelable,\
     ContainerObjectAllBaseView
@@ -71,6 +71,7 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         tb.select("List View")
+        from cfme.web_ui import paginator
         paginator.check_all()
         paginator.uncheck_all()
 

--- a/cfme/containers/project.py
+++ b/cfme/containers/project.py
@@ -71,8 +71,8 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         tb.select("List View")
-        sel.check(paginator.check_all())
-        sel.uncheck(paginator.check_all())
+        paginator.check_all()
+        paginator.uncheck_all()
 
 
 @navigator.register(Project, 'Details')

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -24,7 +24,7 @@ from cfme.common.provider_views import BeforeFillMixin,\
 from cfme.base.credential import TokenCredential
 from cfme.web_ui import (
     Quadicon, toolbar as tb,
-    InfoBlock, Region, paginator, match_location, PagedTable, CheckboxTable)
+    InfoBlock, Region, match_location, PagedTable, CheckboxTable)
 from utils import version
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
@@ -272,6 +272,7 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         tb.select("Grid View")
+        from cfme.web_ui import paginator
         paginator.check_all()
         paginator.uncheck_all()
 
@@ -639,6 +640,7 @@ def navigate_and_get_rows(provider, obj, count, table_class=CheckboxTable,
     tb.select('List View')
     if sel.is_displayed_text("No Records Found.") and silent_failure:
         return []
+    from cfme.web_ui import paginator
     paginator.results_per_page(1000)
     table = table_class(table_locator="//div[@id='list_grid']//table")
     rows = table.rows_as_list()

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -272,8 +272,8 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         tb.select("Grid View")
-        sel.check(paginator.check_all())
-        sel.uncheck(paginator.check_all())
+        paginator.check_all()
+        paginator.uncheck_all()
 
 
 @navigator.register(ContainersProvider, 'Add')

--- a/cfme/containers/replicator.py
+++ b/cfme/containers/replicator.py
@@ -73,8 +73,8 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         tb.select("List View")
-        sel.check(paginator.check_all())
-        sel.uncheck(paginator.check_all())
+        paginator.check_all()
+        paginator.uncheck_all()
 
 
 @navigator.register(Replicator, 'Details')

--- a/cfme/containers/replicator.py
+++ b/cfme/containers/replicator.py
@@ -5,7 +5,7 @@ from functools import partial
 
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import toolbar as tb, paginator, match_location,\
+from cfme.web_ui import toolbar as tb, match_location,\
     PagedTable, CheckboxTable
 from cfme.containers.provider import details_page, Labelable,\
     ContainerObjectAllBaseView
@@ -73,6 +73,7 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         tb.select("List View")
+        from cfme.web_ui import paginator
         paginator.check_all()
         paginator.uncheck_all()
 

--- a/cfme/containers/route.py
+++ b/cfme/containers/route.py
@@ -5,7 +5,7 @@ from functools import partial
 
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import toolbar as tb, paginator, match_location,\
+from cfme.web_ui import toolbar as tb, match_location,\
     PagedTable, CheckboxTable
 from cfme.containers.provider import details_page, Labelable,\
     ContainerObjectAllBaseView
@@ -72,6 +72,7 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         tb.select("List View")
+        from cfme.web_ui import paginator
         paginator.check_all()
         paginator.uncheck_all()
 

--- a/cfme/containers/route.py
+++ b/cfme/containers/route.py
@@ -72,8 +72,8 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         tb.select("List View")
-        sel.check(paginator.check_all())
-        sel.uncheck(paginator.check_all())
+        paginator.check_all()
+        paginator.uncheck_all()
 
 
 @navigator.register(Route, 'Details')

--- a/cfme/containers/service.py
+++ b/cfme/containers/service.py
@@ -72,8 +72,8 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         tb.select("List View")
-        sel.check(paginator.check_all())
-        sel.uncheck(paginator.check_all())
+        paginator.check_all()
+        paginator.uncheck_all()
 
 
 @navigator.register(Service, 'Details')

--- a/cfme/containers/service.py
+++ b/cfme/containers/service.py
@@ -4,7 +4,7 @@ import itertools
 
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import toolbar as tb, paginator, match_location,\
+from cfme.web_ui import toolbar as tb, match_location,\
     PagedTable, CheckboxTable
 from cfme.containers.provider import details_page, Labelable,\
     ContainerObjectAllBaseView
@@ -72,6 +72,7 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         tb.select("List View")
+        from cfme.web_ui import paginator
         paginator.check_all()
         paginator.uncheck_all()
 

--- a/cfme/containers/template.py
+++ b/cfme/containers/template.py
@@ -10,7 +10,7 @@ from cfme.base.ui import BaseLoggedInPage
 from cfme.common import SummaryMixin, Taggable
 from cfme.containers.provider import Labelable
 from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import toolbar as tb, paginator, match_location,\
+from cfme.web_ui import toolbar as tb, match_location,\
     PagedTable, CheckboxTable
 from .provider import details_page
 from utils.appliance import Navigatable
@@ -82,6 +82,7 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         tb.select("List View")
+        from cfme.web_ui import paginator
         paginator.check_all()
         paginator.uncheck_all()
 

--- a/cfme/containers/template.py
+++ b/cfme/containers/template.py
@@ -82,8 +82,8 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         tb.select("List View")
-        sel.check(paginator.check_all())
-        sel.uncheck(paginator.check_all())
+        paginator.check_all()
+        paginator.uncheck_all()
 
 
 @navigator.register(Template, 'Details')

--- a/cfme/containers/volume.py
+++ b/cfme/containers/volume.py
@@ -77,8 +77,8 @@ class All(CFMENavigateStep):
 
     def resetter(self):
         tb.select('Grid View')
-        sel.check(paginator.check_all())
-        sel.uncheck(paginator.check_all())
+        paginator.check_all()
+        paginator.uncheck_all()
 
 
 @navigator.register(Volume, 'Details')

--- a/cfme/containers/volume.py
+++ b/cfme/containers/volume.py
@@ -10,7 +10,7 @@ from cfme.base.ui import BaseLoggedInPage
 from cfme.common import SummaryMixin, Taggable
 from cfme.containers.provider import navigate_and_get_rows
 from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import toolbar as tb, paginator, match_location, InfoBlock,\
+from cfme.web_ui import toolbar as tb, match_location, InfoBlock,\
     PagedTable, CheckboxTable
 from utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
 from utils.appliance import Navigatable
@@ -76,6 +76,7 @@ class All(CFMENavigateStep):
         self.prerequisite_view.navigation.select('Compute', 'Containers', 'Volumes')
 
     def resetter(self):
+        from cfme.web_ui import paginator
         tb.select('Grid View')
         paginator.check_all()
         paginator.uncheck_all()

--- a/cfme/infrastructure/pxe.py
+++ b/cfme/infrastructure/pxe.py
@@ -753,6 +753,6 @@ def remove_all_pxe_servers():
     navigate_to(PXEServer, 'All')
     navigate_to(PXEServer, 'All')  # Yes we really do this twice.
     if sel.is_displayed(pxe_server_table_exist):
-        sel.click(pg.check_all())
+        pg.check_all()
         cfg_btn('Remove PXE Servers from the VMDB', invokes_alert=True)
         sel.handle_alert(cancel=False)

--- a/cfme/infrastructure/pxe.py
+++ b/cfme/infrastructure/pxe.py
@@ -10,7 +10,6 @@ import cfme.web_ui.accordion as acc
 import cfme.web_ui.flash as flash
 import cfme.web_ui.toolbar as tb
 from cfme.web_ui import fill, InfoBlock, Region, Form, ScriptBox, Select, Table, form_buttons, Input
-from cfme.web_ui import paginator as pg
 from navmazing import NavigateToSibling, NavigateToAttribute
 from selenium.common.exceptions import NoSuchElementException
 from utils.appliance import Navigatable
@@ -753,6 +752,7 @@ def remove_all_pxe_servers():
     navigate_to(PXEServer, 'All')
     navigate_to(PXEServer, 'All')  # Yes we really do this twice.
     if sel.is_displayed(pxe_server_table_exist):
+        from cfme.web_ui import paginator as pg
         pg.check_all()
         cfg_btn('Remove PXE Servers from the VMDB', invokes_alert=True)
         sel.handle_alert(cancel=False)

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -97,8 +97,8 @@ def reset_page():
         search.ensure_normal_search_empty()
     if paginator.page_controls_exist():
         # paginator.results_per_page(1000)
-        sel.check(paginator.check_all())
-        sel.uncheck(paginator.check_all())
+        paginator.check_all()
+        paginator.uncheck_all()
 
 
 drift_table = CheckboxTable("//th[normalize-space(.)='Timestamp']/ancestor::table[1]")

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -22,7 +22,7 @@ from cfme.services import requests
 import cfme.web_ui.toolbar as tb
 from cfme.web_ui import (
     CheckboxTree, Form, InfoBlock, Region, Quadicon, Tree, accordion, fill, flash, form_buttons,
-    match_location, Table, search, paginator, toolbar, Calendar, Select, Input, CheckboxTable,
+    match_location, Table, search, toolbar, Calendar, Select, Input, CheckboxTable,
     summary_title, BootstrapTreeview, AngularSelect
 )
 from cfme.web_ui.search import search_box
@@ -93,6 +93,7 @@ templates_tree = partial(accordion.tree, "Templates")
 
 def reset_page():
     tb.select("Grid View")
+    from cfme.web_ui import paginator
     if sel.is_displayed(search_box.search_field):
         search.ensure_normal_search_empty()
     if paginator.page_controls_exist():
@@ -804,6 +805,7 @@ def _method_setup(vm_names, provider_crud=None):
         provider_crud.load_all_provider_vms()
     else:
         navigate_to(Vm, 'VMsOnly')
+    from cfme.web_ui import paginator
     if paginator.page_controls_exist():
         paginator.results_per_page(1000)
     for vm_name in vm_names:
@@ -819,6 +821,7 @@ def find_quadicon(vm_name, do_not_navigate=False):
     """
     if not do_not_navigate:
         navigate_to(Vm, 'VMsOnly')
+    from cfme.web_ui import paginator
     if not paginator.page_controls_exist():
         raise VmNotFound("VM '{}' not found in UI!".format(vm_name))
 
@@ -945,6 +948,7 @@ def get_number_of_vms(do_not_navigate=False):
     logger.info("Getting number of vms")
     if not do_not_navigate:
         navigate_to(Vm, 'VMsOnly')
+    from cfme.web_ui import paginator
     if not paginator.page_controls_exist():
         logger.debug("No page controls")
         return 0

--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -12,7 +12,7 @@ from cfme.fixtures import pytest_selenium as sel
 from cfme.intelligence.reports.ui_elements import (ColumnHeaderFormatTable, ColumnStyleTable,
     RecordGrouper)
 from cfme.web_ui import (CAndUGroupTable, Form, Table, Select, ShowingInputs, accordion, fill,
-    flash, form_buttons, paginator, table_in_object, tabstrip, toolbar, CheckboxTable)
+    flash, form_buttons, table_in_object, tabstrip, toolbar, CheckboxTable)
 from cfme.web_ui.expression_editor import Expression
 from cfme.web_ui.tabstrip import TabStripForm
 from cfme.web_ui.multibox import MultiBoxSelect
@@ -194,6 +194,7 @@ class CustomReport(Updateable, Navigatable):
         navigate_to(self, 'Saved')
         results = []
         try:
+            from cfme.web_ui import paginator
             for page in paginator.pages():
                 sel.wait_for_element(records_table)
                 for row in records_table.rows():
@@ -313,6 +314,7 @@ class CustomSavedReport(Updateable, Pretty, Navigatable):
         try:
             headers = tuple([sel.text(hdr).encode("utf-8") for hdr in self._table.headers])
             body = []
+            from cfme.web_ui import paginator
             for page in paginator.pages():
                 for row in self._table.rows():
                     row_data = tuple([sel.text(row[header]).encode("utf-8") for header in headers])
@@ -411,6 +413,7 @@ class CannedSavedReport(CustomSavedReport, Navigatable):
         navigate_to(self, "Saved")
         results = []
         try:
+            from cfme.web_ui import paginator
             for page in paginator.pages():
                 for row in records_table.rows():
                     results.append(

--- a/cfme/middleware/datasource.py
+++ b/cfme/middleware/datasource.py
@@ -3,7 +3,7 @@ from cfme.fixtures import pytest_selenium as sel
 from cfme.middleware.provider import parse_properties
 from cfme.middleware.provider.hawkular import HawkularProvider
 from cfme.middleware.server import MiddlewareServer
-from cfme.web_ui import CheckboxTable, paginator, flash, toolbar as tb
+from cfme.web_ui import CheckboxTable, flash, toolbar as tb
 from wrapanapi.hawkular import CanonicalPath
 from navmazing import NavigateToSibling, NavigateToAttribute
 from utils import attributize_string
@@ -106,6 +106,7 @@ class MiddlewareDatasource(MiddlewareBase, Taggable, Navigatable, UtilizationMix
         datasources = []
         _get_datasources_page(provider=provider, server=server)
         if sel.is_displayed(list_tbl):
+            from cfme.web_ui import paginator
             for _ in paginator.pages():
                 for row in list_tbl.rows():
                     _server = MiddlewareServer(provider=provider,
@@ -174,6 +175,7 @@ class MiddlewareDatasource(MiddlewareBase, Taggable, Navigatable, UtilizationMix
     @classmethod
     def remove_from_list(cls, datasource):
         _get_datasources_page(server=datasource.server)
+        from cfme.web_ui import paginator
         if paginator.page_controls_exist():
             paginator.results_per_page(1000)
         list_tbl.select_row_by_cells({
@@ -273,6 +275,7 @@ class Details(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
+        from cfme.web_ui import paginator
         if paginator.page_controls_exist():
             paginator.results_per_page(1000)
         list_tbl.click_row_by_cells({

--- a/cfme/middleware/deployment.py
+++ b/cfme/middleware/deployment.py
@@ -6,7 +6,7 @@ from cfme.fixtures import pytest_selenium as sel
 from cfme.middleware.provider import Deployable
 from cfme.middleware.provider.hawkular import HawkularProvider
 from cfme.middleware.server import MiddlewareServer
-from cfme.web_ui import CheckboxTable, paginator, toolbar as tb
+from cfme.web_ui import CheckboxTable, toolbar as tb
 from utils.appliance import Navigatable, current_appliance
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
 from utils.providers import get_crud_by_name, list_providers_by_class
@@ -97,6 +97,7 @@ class MiddlewareDeployment(MiddlewareBase, Taggable, Navigatable, Deployable):
         deployments = []
         _get_deployments_page(provider=provider, server=server)
         if sel.is_displayed(list_tbl):
+            from cfme.web_ui import paginator
             _provider = provider  # In deployment UI, we cannot get provider name on list all page
             for _ in paginator.pages():
                 for row in list_tbl.rows():
@@ -233,6 +234,7 @@ class Details(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
+        from cfme.web_ui import paginator
         if paginator.page_controls_exist():
             paginator.results_per_page(1000)
         list_tbl.click_row_by_cells({'Deployment Name': self.obj.name,

--- a/cfme/middleware/domain.py
+++ b/cfme/middleware/domain.py
@@ -5,7 +5,7 @@ from cfme.exceptions import MiddlewareDomainNotFound
 from cfme.fixtures import pytest_selenium as sel
 from cfme.middleware.provider import parse_properties
 from cfme.middleware.provider.hawkular import HawkularProvider
-from cfme.web_ui import CheckboxTable, paginator, InfoBlock, toolbar as tb
+from cfme.web_ui import CheckboxTable, InfoBlock, toolbar as tb
 from wrapanapi.hawkular import CanonicalPath
 from utils import attributize_string
 from utils.appliance import Navigatable, current_appliance
@@ -85,6 +85,7 @@ class MiddlewareDomain(MiddlewareBase, Navigatable, Taggable):
         _get_domains_page(provider=provider)
         if sel.is_displayed(list_tbl):
             _provider = provider
+            from cfme.web_ui import paginator
             for _ in paginator.pages():
                 for row in list_tbl.rows():
                     if strict:

--- a/cfme/middleware/messaging.py
+++ b/cfme/middleware/messaging.py
@@ -4,7 +4,7 @@ from cfme.fixtures import pytest_selenium as sel
 from cfme.middleware.provider import parse_properties
 from cfme.middleware.provider.hawkular import HawkularProvider
 from cfme.middleware.server import MiddlewareServer
-from cfme.web_ui import CheckboxTable, paginator, toolbar as tb
+from cfme.web_ui import CheckboxTable, toolbar as tb
 from navmazing import NavigateToSibling, NavigateToAttribute
 from utils import attributize_string
 from utils.appliance import Navigatable, current_appliance
@@ -105,6 +105,7 @@ class MiddlewareMessaging(MiddlewareBase, Navigatable, Taggable, UtilizationMixi
         messagings = []
         _get_messagings_page(provider=provider, server=server)
         if sel.is_displayed(list_tbl):
+            from cfme.web_ui import paginator
             for _ in paginator.pages():
                 for row in list_tbl.rows():
                     _server = MiddlewareServer(provider=provider, name=row.server.text)

--- a/cfme/middleware/provider/__init__.py
+++ b/cfme/middleware/provider/__init__.py
@@ -11,7 +11,7 @@ from cfme.common.provider import BaseProvider
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import (
     Region, Form, AngularSelect, InfoBlock, Input, Quadicon,
-    form_buttons, toolbar as tb, paginator, fill, FileInput,
+    form_buttons, toolbar as tb, fill, FileInput,
     CFMECheckbox, Select, flash, tabstrip
 )
 from utils import version
@@ -119,6 +119,7 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         tb.select("Grid View")
+        from cfme.web_ui import paginator
         if paginator.page_controls_exist():
             paginator.check_all()
             paginator.uncheck_all()

--- a/cfme/middleware/provider/__init__.py
+++ b/cfme/middleware/provider/__init__.py
@@ -120,8 +120,8 @@ class All(CFMENavigateStep):
         # Reset view and selection
         tb.select("Grid View")
         if paginator.page_controls_exist():
-            sel.check(paginator.check_all())
-            sel.uncheck(paginator.check_all())
+            paginator.check_all()
+            paginator.uncheck_all()
 
 
 @navigator.register(MiddlewareProvider, 'Add')

--- a/cfme/middleware/server.py
+++ b/cfme/middleware/server.py
@@ -6,7 +6,7 @@ from cfme.fixtures import pytest_selenium as sel
 from cfme.middleware.provider import parse_properties, Container
 from cfme.middleware.provider.hawkular import HawkularProvider
 from cfme.web_ui import (
-    CheckboxTable, paginator, Form, Input, fill, InfoBlock
+    CheckboxTable, Form, Input, fill, InfoBlock
 )
 from cfme.web_ui.form_buttons import FormButton
 from cfme.web_ui import toolbar as tb
@@ -121,6 +121,7 @@ class MiddlewareServer(MiddlewareBase, Taggable, Container, Navigatable, Utiliza
         _get_servers_page(provider=provider, server_group=server_group)
         if sel.is_displayed(list_tbl):
             _provider = provider
+            from cfme.web_ui import paginator
             for _ in paginator.pages():
                 for row in list_tbl.rows():
                     if strict:

--- a/cfme/middleware/server_group.py
+++ b/cfme/middleware/server_group.py
@@ -5,7 +5,7 @@ from cfme.common import Taggable
 from cfme.fixtures import pytest_selenium as sel
 from cfme.middleware.provider import parse_properties, Container
 from cfme.web_ui import (
-    CheckboxTable, paginator, InfoBlock, toolbar as tb, Form, Input, fill
+    CheckboxTable, InfoBlock, toolbar as tb, Form, Input, fill
 )
 from cfme.web_ui.form_buttons import FormButton
 from wrapanapi.hawkular import CanonicalPath
@@ -96,6 +96,7 @@ class MiddlewareServerGroup(MiddlewareBase, Taggable, Container, Navigatable):
         _get_server_groups_page(domain=domain)
         if sel.is_displayed(list_tbl):
             _domain = domain
+            from cfme.web_ui import paginator
             for _ in paginator.pages():
                 for row in list_tbl.rows():
                     if strict:

--- a/cfme/services/catalogs/orchestration_template.py
+++ b/cfme/services/catalogs/orchestration_template.py
@@ -172,7 +172,7 @@ class OrchestrationTemplate(Updateable, Pretty, Navigatable):
 
     def delete_all_templates(self):
         view = navigate_to(self, "TemplateType")
-        sel.click(pg.check_all())
+        pg.check_all()
         view.configuration.item_select("Remove selected Orchestration Templates", handle_alert=True)
 
     def copy_template(self, template_name, content, draft=None, description=None):

--- a/cfme/services/catalogs/orchestration_template.py
+++ b/cfme/services/catalogs/orchestration_template.py
@@ -2,8 +2,6 @@
 from widgetastic.widget import Text, Checkbox
 from widgetastic_patternfly import BootstrapSelect, Button, Input
 from widgetastic_manageiq import ScriptBox, Table
-from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import paginator as pg
 from navmazing import NavigateToAttribute, NavigateToSibling
 from utils.update import Updateable
 from utils.pretty import Pretty
@@ -172,7 +170,8 @@ class OrchestrationTemplate(Updateable, Pretty, Navigatable):
 
     def delete_all_templates(self):
         view = navigate_to(self, "TemplateType")
-        pg.check_all()
+        from cfme.web_ui import paginator
+        paginator.check_all()
         view.configuration.item_select("Remove selected Orchestration Templates", handle_alert=True)
 
     def copy_template(self, template_name, content, draft=None, description=None):

--- a/cfme/services/requests.py
+++ b/cfme/services/requests.py
@@ -6,7 +6,7 @@ from navmazing import NavigateToAttribute
 from cfme.exceptions import RequestException
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import (
-    Input, Region, Table, fill, flash, paginator, toolbar, match_location)
+    Input, Region, Table, fill, flash, toolbar, match_location)
 from utils.log import logger
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
@@ -188,6 +188,7 @@ def wait_for_request(cells, partial_check=False):
 
 def debug_requests():
     logger.debug('Outputting current requests')
+    from cfme.web_ui import paginator
     for page in paginator.pages():
         for row in fields.request_list.rows():
             logger.debug(' %s', row)
@@ -202,6 +203,7 @@ def find_request(cells, partial_check=False):
     Returns: row
     """
     navigate_to(Request, 'All')
+    from cfme.web_ui import paginator
     for page in paginator.pages():
         results = fields.request_list.find_rows_by_cells(cells, partial_check)
         if len(results) == 0:

--- a/cfme/tests/automate/test_customization_paginator.py
+++ b/cfme/tests/automate/test_customization_paginator.py
@@ -4,7 +4,7 @@ import pytest
 
 from cfme import test_requirements
 from cfme.automate.service_dialogs import DialogCollection
-from cfme.web_ui import paginator, Table
+from cfme.web_ui import Table
 from utils.appliance.implementations.ui import navigate_to
 
 
@@ -62,6 +62,7 @@ def test_paginator(some_dialogs, soft_assert):
         * During the cycling, assert the paginator does not get stuck.
     """
     navigate_to(DialogCollection, 'All')
+    from cfme.web_ui import paginator
     paginator.results_per_page(50)
     paginator.results_per_page(5)
     # Now we must have only 5

--- a/cfme/tests/configure/test_visual_cloud.py
+++ b/cfme/tests/configure/test_visual_cloud.py
@@ -11,7 +11,7 @@ from cfme.cloud.instance import Instance
 from cfme.cloud.keypairs import KeyPair
 from cfme.cloud.stack import Stack
 from cfme.cloud.tenant import Tenant
-from cfme.web_ui import paginator, toolbar as tb, match_location
+from cfme.web_ui import toolbar as tb, match_location
 from utils.appliance.implementations.ui import navigate_to
 
 
@@ -99,6 +99,7 @@ def test_cloud_grid_page_per_item(request, page, set_grid):
     limit = visual.grid_view_limit
     navigate_to(page, 'All')
     tb.select('Grid View')
+    from cfme.web_ui import paginator
     if paginator.rec_total() is not None:
         if int(paginator.rec_total()) >= int(limit):
             assert int(paginator.rec_end()) == int(limit), \
@@ -116,6 +117,7 @@ def test_cloud_tile_page_per_item(request, page, set_tile):
     limit = visual.tile_view_limit
     navigate_to(page, 'All')
     tb.select('Tile View')
+    from cfme.web_ui import paginator
     if paginator.rec_total() is not None:
         if int(paginator.rec_total()) >= int(limit):
             assert int(paginator.rec_end()) == int(limit), \
@@ -133,6 +135,7 @@ def test_cloud_list_page_per_item(request, page, set_list):
     limit = visual.list_view_limit
     navigate_to(page, 'All')
     tb.select('List View')
+    from cfme.web_ui import paginator
     if paginator.rec_total() is not None:
         if int(paginator.rec_total()) >= int(limit):
             assert int(paginator.rec_end()) == int(limit), \

--- a/cfme/tests/configure/test_visual_infra.py
+++ b/cfme/tests/configure/test_visual_infra.py
@@ -6,7 +6,7 @@ import pytest
 from cfme import test_requirements
 from cfme.configure.settings import visual
 from cfme.intelligence.reports.reports import CannedSavedReport
-from cfme.web_ui import paginator, toolbar as tb
+from cfme.web_ui import toolbar as tb
 from cfme.infrastructure import virtual_machines as vms  # NOQA
 from cfme.infrastructure.provider import InfraProvider
 from utils.appliance.implementations.ui import navigate_to
@@ -134,6 +134,7 @@ def test_infra_grid_page_per_item(request, page, set_grid):
     limit = visual.grid_view_limit
     navigate_to(page, 'All')
     tb.select('Grid View')
+    from cfme.web_ui import paginator
     if int(paginator.rec_total()) >= int(limit):
         assert int(paginator.rec_end()) == int(limit), "Gridview Failed for page {}!".format(page)
 
@@ -150,6 +151,7 @@ def test_infra_tile_page_per_item(request, page, set_tile):
     limit = visual.tile_view_limit
     navigate_to(page, 'All')
     tb.select('Tile View')
+    from cfme.web_ui import paginator
     if int(paginator.rec_total()) >= int(limit):
         assert int(paginator.rec_end()) == int(limit), "Tileview Failed for page {}!".format(page)
 
@@ -166,6 +168,7 @@ def test_infra_list_page_per_item(request, page, set_list):
     limit = visual.list_view_limit
     navigate_to(page, 'All')
     tb.select('List View')
+    from cfme.web_ui import paginator
     if int(paginator.rec_total()) >= int(limit):
         assert int(paginator.rec_end()) == int(limit), "Listview Failed for page {}!".format(page)
 
@@ -181,6 +184,7 @@ def test_infra_report_page_per_item(set_report):
     limit = visual.report_view_limit
     report = CannedSavedReport.new(path)
     report.navigate()
+    from cfme.web_ui import paginator
     if int(paginator.rec_total()) >= int(limit):
         assert int(paginator.rec_end()) == int(limit), "Reportview Failed!"
 

--- a/cfme/tests/containers/test_relationships.py
+++ b/cfme/tests/containers/test_relationships.py
@@ -4,7 +4,7 @@ import pytest
 
 from utils import testgen
 from utils.version import current_version
-from cfme.web_ui import paginator, summary_title
+from cfme.web_ui import summary_title
 
 from cfme.containers.pod import Pod
 from cfme.containers.provider import ContainersProvider,\
@@ -60,6 +60,7 @@ def check_relationships(instance):
     link_value = attr.value
     attr.click()
     if type(link_value) is int:
+        from cfme.web_ui import paginator
         rec_total = paginator.rec_total()
         if rec_total != link_value:
             raise Exception('Difference between the value({}) in the relationships table in {}'

--- a/cfme/web_ui/paginator.py
+++ b/cfme/web_ui/paginator.py
@@ -6,6 +6,11 @@ from selenium.common.exceptions import NoSuchElementException
 from functools import partial
 from utils import version
 from cfme.exceptions import PaginatorException
+from widgetastic_manageiq import PaginationPane
+from utils.appliance import get_or_create_current_appliance
+
+appliance = get_or_create_current_appliance()
+new_paginator = PaginationPane(parent=appliance.browser.widgetastic)
 
 
 def _locator():
@@ -28,16 +33,21 @@ _regexp = r"{}(?P<first>\d+)-?(?P<last>\d+)? of (?P<total>\d+)\s*(?:items?)?".fo
 
 def page_controls_exist():
     """ Simple check to see if page controls exist. """
-    return sel.is_displayed(_locator() + _page_cell)
+    return new_paginator.is_displayed
 
 
 def _page_nums():
-    return sel.text(_locator() + _page_cell)
+    return new_paginator.pages_amount
 
 
 def check_all():
-    """ Returns the Check All locator."""
-    return sel.element(_locator() + _check_all)
+    """ selects all items """
+    new_paginator.check_all()
+
+
+def uncheck_all():
+    """ unselects all items """
+    new_paginator.uncheck_all()
 
 
 def is_dimmed(btn):

--- a/cfme/web_ui/paginator.py
+++ b/cfme/web_ui/paginator.py
@@ -1,34 +1,10 @@
 """A set of functions for dealing with the paginator controls."""
-from cfme.web_ui import Select, Input, AngularSelect
-import cfme.fixtures.pytest_selenium as sel
-import re
-from selenium.common.exceptions import NoSuchElementException
-from functools import partial
-from utils import version
 from cfme.exceptions import PaginatorException
 from widgetastic_manageiq import PaginationPane
 from utils.appliance import get_or_create_current_appliance
 
 appliance = get_or_create_current_appliance()
 new_paginator = PaginationPane(parent=appliance.browser.widgetastic)
-
-
-def _locator():
-    return version.pick({version.LOWEST: '(//div[@id="paging_div"]//div[@id="pc_div_1"])',
-        '5.5': '(//div[@id="paging_div"]//div[@id="rpb_div_1" or @id="pc_div_1"])'})
-
-
-_next = '//img[@alt="Next"]|//li[contains(@class, "next")]/span'
-_previous = '//img[@alt="Previous"]|//li[contains(@class, "prev")]/span'
-_first = '//img[@alt="First"]|//li[contains(@class, "first")]/span'
-_last = '//img[@alt="Last"]|//li[contains(@class, "last")]/span'
-_num_results = '//select[@id="ppsetting" or @id="perpage_setting1"]'
-_sort_by = '//select[@id="sort_choice"]'
-_page_cell = '//td//td[contains(., " of ")]|//li//span[contains(., " of ")]'
-_check_all = Input("masterToggle")
-
-_prefix = r"(?:Items?|Rows?|Showing)?\s*"
-_regexp = r"{}(?P<first>\d+)-?(?P<last>\d+)? of (?P<total>\d+)\s*(?:items?)?".format(_prefix)
 
 
 def page_controls_exist():
@@ -50,41 +26,24 @@ def uncheck_all():
     new_paginator.uncheck_all()
 
 
-def is_dimmed(btn):
-    tag = sel.tag(btn)
-    if tag in {"li", "img"}:
-        class_attr = sel.get_attribute(btn, "class")
-    elif tag == "span":
-        class_attr = sel.get_attribute(sel.element("..", root=btn), "class")
-    else:
-        raise TypeError("Wrong tag name {}".format(tag))
-    class_att = set(re.split(r"\s+", class_attr))
-    if {"dimmed", "disabled"}.intersection(class_att):
-        return True
-
-
 def next():
     """ Returns the Next button locator."""
-    btn = sel.element(_locator() + _next)
-    return btn
+    new_paginator.next_page()
 
 
 def previous():
     """ Returns the Previous button locator."""
-    btn = sel.element(_locator() + _previous)
-    return btn
+    new_paginator.prev_page()
 
 
 def first():
     """ Returns the First button locator."""
-    btn = sel.element(_locator() + _first)
-    return btn
+    new_paginator.first_page()
 
 
 def last():
     """ Returns the Last button locator."""
-    btn = sel.element(_locator() + _last)
-    return btn
+    new_paginator.last_page()
 
 
 def results_per_page(num):
@@ -93,10 +52,7 @@ def results_per_page(num):
     Args:
         num: Number of results per page
     """
-    _select = version.pick({
-        version.LOWEST: Select(_locator() + _num_results),
-        "5.5": AngularSelect('ppsetting')})
-    sel.select(_select, sel.ByText(str(num)))
+    new_paginator.set_items_per_page(num)
 
 
 def sort_by(sort):
@@ -105,56 +61,30 @@ def sort_by(sort):
     Args:
         sort: Value to sort by (visible text in select box)
     """
-    _select = version.pick({
-        version.LOWEST: Select(_locator() + _sort_by),
-        "5.5": AngularSelect('sort_choice')})
-    sel.select(_select, sel.ByText(str(sort)))
-
-
-def _get_rec(partial):
-    offset = re.search(_regexp, _page_nums())
-    if offset:
-        return offset.groupdict()[partial]
-    else:
-        return None
+    new_paginator.sort(sort)
 
 
 def rec_offset():
     """ Returns the first record offset."""
     try:
-        return int(_get_rec('first'))
+        return int(new_paginator.paginator.page_info()[0])
     except TypeError:
             raise PaginatorException()
 
 
 def rec_end():
     """ Returns the record set index."""
-    rec = _get_rec('last')
-    if rec is not None:
-        try:
-            return int(rec)
-        except TypeError:
-            raise PaginatorException()
-    else:
-        # Items might be displayed as 'Item 1 of 1'
-        try:
-            return int(_get_rec('first'))
-        except TypeError:
-            raise PaginatorException()
+    return new_paginator.paginator.page_info()[1]
 
 
 def rec_total():
     """ Returns the total number of records."""
-    try:
-        return int(_get_rec('total'))
-    except TypeError:
-        raise PaginatorException()
+    return new_paginator.items_amount
 
 
 def reset():
     """Reset the paginator to the first page or do nothing if no pages"""
-    if not is_dimmed(first()):
-        sel.click(first())
+    new_paginator.first_page()
 
 
 def pages():
@@ -168,38 +98,4 @@ def pages():
     Raises:
         :py:class:`ValueError`: When the paginator "breaks" (does not change)
     """
-    # Reset the paginator, then yield the first page
-    if page_controls_exist():
-        reset()
-        yield
-        # Yield while there are more pages
-        current_page_nums = _page_nums()
-        while not is_dimmed(next()):
-            sel.click(next())
-            new_page_nums = _page_nums()
-            if new_page_nums == current_page_nums:
-                raise ValueError('The paginator did not change: {}'.format(new_page_nums))
-            current_page_nums = new_page_nums
-            yield
-    else:
-        yield
-
-
-def find(pred):
-    """Advance the pages until pred (a no-arg function) is true."""
-    for page in pages():
-        if pred():
-            break
-    else:
-        raise NoSuchElementException
-
-
-def find_element(el):
-    """Advance the pages until the given element is displayed"""
-    find(partial(sel.is_displayed, el))
-
-
-def click_element(el):
-    """Advance the page until the given element is displayed, and click it"""
-    find_element(el)
-    sel.click(el)
+    return new_paginator.pages()

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -1083,7 +1083,7 @@ class Paginator(Widget):
     def page_info(self):
         cur_page = self.browser.element(self.CUR_PAGE_CTL, parent=self._paginator)
         text = cur_page.text
-        return re.search('(\d+)\s+of\s+(\d+)', text).groups()
+        return re.search('(\d+)?-?(\d+)\s+of\s+(\d+)', text).groups()
 
 
 class PaginationPane(View):
@@ -1130,7 +1130,7 @@ class PaginationPane(View):
         self.items_on_page.select_by_visible_text(str(value))
 
     def _parse_pages(self):
-        max_item, item_amt = self.paginator.page_info()
+        min_item, max_item, item_amt = self.paginator.page_info()
 
         item_amt = int(item_amt)
         max_item = int(max_item)
@@ -1197,7 +1197,7 @@ class PaginationPane(View):
 
     @property
     def items_amount(self):
-        return self.paginator.page_info()[1]
+        return self.paginator.page_info()[2]
 
     def find_row_on_pages(self, table, *args, **kwargs):
         """Find first row matching filters provided by kwargs on the given table widget


### PR DESCRIPTION
This PR does all necessary changes to web_ui paginator in order to replace it with widgetastic paginator.
This is necessary for moving to JS API Paginator appeared in 5.9/upstream.

{{pytest: -k default }}