### PR TITLE
[1LP][RFR] RHV5 fixes and lingering PR review fixes

### DIFF
--- a/cfme/tests/cloud_infra_common/test_html5_vm_console.py
+++ b/cfme/tests/cloud_infra_common/test_html5_vm_console.py
@@ -6,6 +6,7 @@ import time
 import re
 
 from cfme.cloud.provider.openstack import OpenStackProvider
+from cfme.common.provider import CloudInfraProvider
 from cfme.configure.configuration import VMwareConsoleSupport
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.configure import configuration
@@ -14,12 +15,14 @@ from utils import testgen, version, ssh
 from utils.appliance.implementations.ui import navigate_to
 from utils.log import logger
 from utils.conf import credentials
+from utils.providers import ProviderFilter
 from wait_for import wait_for
 
 pytestmark = pytest.mark.usefixtures('setup_provider')
 
 pytest_generate_tests = testgen.generate(
-    [OpenStackProvider, VMwareProvider],
+    gen_func=testgen.providers,
+    filters=[ProviderFilter(classes=[CloudInfraProvider], required_flags=['html5_console'])],
     scope='module'
 )
 


### PR DESCRIPTION
- searching for canvas element is now using a wait_for loop and
  a try-catch to avoid having an initial miss in finding the
  canvas element not cause the test to fail.
- Fixed the exceptions that were being caught from the provider
  in vm_console.py.  Previously we had been catching the selenium
  exception, but now the provider code throws its own exception, so
  now vm_console.py catches that.
- Make running of HTML5 Console test be based on a test_flag,
  html5_console, in the cfme_data.yaml file rather than provider                                                           
  type.

The problem with failing on the first time you access a VM console on a provider failing because we never see the status element (really its having a problem connecting to the websocket) still exists, so PRT may very well fail.