### PR TITLE
[1LP][RFR] Refactoring to repo collection

### DIFF
--- a/cfme/tests/test_db_migrate.py
+++ b/cfme/tests/test_db_migrate.py
@@ -138,7 +138,6 @@ def test_db_migrate(app_creds, temp_appliance_extended_db, db_url, db_version, d
     app.server.login(app.user)
 
 
-@pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
 def test_upgrade_single_inplace(appliance_preupdate, appliance):
     '''Tests appliance upgrade between streams'''
     appliance_preupdate.evmserverd.stop()

--- a/cfme/tests/test_db_migrate.py
+++ b/cfme/tests/test_db_migrate.py
@@ -35,7 +35,7 @@ def temp_appliance_extended_db(temp_appliance_preconfig):
 
 @pytest.yield_fixture(scope="function")
 def appliance_preupdate(temp_appliance_preconfig_funcscope_upgrade, appliance):
-    '''Reconfigures appliance partitions and adds repo file for upgrade'''
+    '''Reconfigure appliance partitions and adds repo file for upgrade'''
     update_url = ('update_url_' + ''.join([i for i in get_stream(appliance.version)
         if i.isdigit()]))
     temp_appliance_preconfig_funcscope_upgrade.db.extend_partition()

--- a/cfme/tests/test_db_migrate.py
+++ b/cfme/tests/test_db_migrate.py
@@ -6,6 +6,7 @@ from utils.appliance import ApplianceException
 from utils.blockers import BZ
 from utils.conf import cfme_data
 from utils.log import logger
+from utils.version import get_stream
 from scripts.repo_gen import process_url, build_file
 import tempfile
 
@@ -33,10 +34,12 @@ def temp_appliance_extended_db(temp_appliance_preconfig):
 
 
 @pytest.yield_fixture(scope="function")
-def appliance_preupdate(temp_appliance_preconfig_funcscope_upgrade):
+def appliance_preupdate(temp_appliance_preconfig_funcscope_upgrade, appliance):
     '''Reconfigures appliance partitions and adds repo file for upgrade'''
+    update_url = ('update_url_' + ''.join([i for i in get_stream(appliance.version)
+        if i.isdigit()]))
     temp_appliance_preconfig_funcscope_upgrade.db.extend_partition()
-    urls = process_url(cfme_data['basic_info']['update_url'])
+    urls = process_url(cfme_data['basic_info'][update_url])
     output = build_file(urls)
     with tempfile.NamedTemporaryFile('w') as f:
         f.write(output)

--- a/fixtures/appliance.py
+++ b/fixtures/appliance.py
@@ -14,6 +14,7 @@ from contextlib import contextmanager
 
 import pytest
 
+from utils.version import get_stream
 from cfme.test_framework.sprout.client import SproutClient
 
 
@@ -66,7 +67,8 @@ def temp_appliance_preconfig_funcscope():
 
 @pytest.yield_fixture(scope="function")
 def temp_appliance_preconfig_funcscope_upgrade(appliance):
-    stream = 5.8 if appliance.version >= "5.9" else 5.7
+    stream = (int(''.join([i for i in get_stream(appliance.version)
+        if i.isdigit()])) - 1)
     with temp_appliances(preconfigured=True, stream=stream) as appliances:
         yield appliances[0]
 


### PR DESCRIPTION
Changes to test_db_migrate to collect the new repo files for upgrades.
Also fix to version picking to save manual intervention.
{{ pytest: -k test_upgrade_single_inplace}}