### PR TITLE
[RFR] Fixed BaseListEntity parent_table locator

### DIFF
--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -1989,9 +1989,8 @@ class BaseListEntity(ParametrizedView, ClickableMixin):
 
     """
     PARAMETERS = ('name',)
-    TABLE_LOCATOR = ParametrizedLocator('.//table[.//td[normalize-space(.)={name|quote}]]')
     ROOT = ParametrizedLocator('.//tr[./td[normalize-space(.)={name|quote}]]')
-    parent_table = Table(locator=TABLE_LOCATOR)
+    parent_table = Table(locator='./ancestor::table[1]')
     checkbox = Checkbox(locator='.//input[@type="checkbox"]')
 
     @property


### PR DESCRIPTION
Purpose
=================

Current `parent_table` in `BaseListEntity` is always not displayed. `ParametrizedLocator('.//table[.//td[normalize-space(.)={name|quote}]]')` searches **descendant** table of the `ROOT`, but we need the parent one. Therefore such xpath `./ancestor::table[1]` can be used here. It searches the first **ancestor** table of the `ROOT`.