### PR TITLE
[1LP][RFR] Add Openstack Node lifecycle tests

### DIFF
--- a/cfme/common/host_views.py
+++ b/cfme/common/host_views.py
@@ -39,9 +39,12 @@ class ComputeInfrastructureHostsView(BaseLoggedInPage):
 
     @property
     def in_compute_infrastructure_hosts(self):
+        def _host_page(title):
+            return self.navigation.currently_selected == ["Compute", "Infrastructure", title]
+
         return (
-            self.logged_in_as_current_user and
-            self.navigation.currently_selected == ["Compute", "Infrastructure", "Hosts"]
+            self.logged_in_as_current_user and (_host_page("Hosts") or _host_page("Nodes") or
+                                                _host_page("Hosts / Nodes"))
         )
 
 

--- a/cfme/common/host_views.py
+++ b/cfme/common/host_views.py
@@ -95,6 +95,7 @@ class HostDetailsEntities(View):
     configuration = SummaryTable(title="Configuration")
     smart_management = SummaryTable(title="Smart Management")
     authentication_status = SummaryTable(title="Authentication Status")
+    openstack_hardware = SummaryTable(title="Openstack Hardware")
 
 
 class HostDetailsView(ComputeInfrastructureHostsView):

--- a/cfme/common/host_views.py
+++ b/cfme/common/host_views.py
@@ -240,7 +240,7 @@ class HostsView(ComputeInfrastructureHostsView):
 
     @property
     def is_displayed(self):
-        return self.in_compute_infrastructure_hosts and self.title.text == "Hosts"
+        return self.in_compute_infrastructure_hosts and self.title.text in "Hosts / Nodes"
 
 
 class HostFormView(ComputeInfrastructureHostsView):

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -412,7 +412,7 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
         return False
 
     @variable(alias='rest')
-    def is_refreshed(self, refresh_timer=None):
+    def is_refreshed(self, refresh_timer=None, refresh_delta=600):
         if refresh_timer:
             if refresh_timer.is_it_time():
                 logger.info(' Time for a refresh!')
@@ -422,7 +422,7 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
         if not rdate:
             return False
         td = self.appliance.utc_time() - rdate
-        if td > datetime.timedelta(0, 600):
+        if td > datetime.timedelta(0, refresh_delta):
             self.refresh_provider_relationships()
             return False
         else:

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -13,7 +13,6 @@ from widgetastic_manageiq import (BreadCrumb,
                                   Checkbox,
                                   Input,
                                   Table,
-                                  FileInput,
                                   BaseEntitiesView,
                                   DynaTree,
                                   BootstrapTreeview,
@@ -211,47 +210,6 @@ class NodesToolBar(View):
     power = Dropdown(text='Power')
     download = Dropdown(text='Download')
     view_selector = View.nested(ItemsToolBarViewSelector)
-
-
-class ProviderRegisterNodesView(View):
-    """
-     represents Register Nodes view (exists for Infra OpenStack provider)
-    """
-    file = FileInput(locator='//input[@id="nodes_json_file"]')
-    register = Button(value='Register')
-    cancel = Button(value='Cancel')
-
-    @property
-    def is_displayed(self):
-        return False
-
-
-class ProviderScaleDownView(View):
-    """
-     represents Scale down view (exists for Infra OpenStack provider)
-    """
-    table = Table(locator='//div[contains(@class, "form-horizontal")]//table')
-    checkbox = Checkbox(name='host_ids[]')
-    scale_down = Button('Scale Down')
-    cancel = Button('Cancel')
-
-    @property
-    def is_displayed(self):
-        return False
-
-
-class ProviderScaleOutView(View):
-    """
-     represents Scale view (exists for Infra OpenStack provider)
-    """
-
-    compute_count = Input(name='ComputeCount')
-    scale = Button('Scale')
-    cancel = Button('Cancel')
-
-    @property
-    def is_displayed(self):
-        return False
 
 
 class ProviderNodesView(BaseLoggedInPage):

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -240,6 +240,20 @@ class ProviderScaleDownView(View):
         return False
 
 
+class ProviderScaleOutView(View):
+    """
+     represents Scale view (exists for Infra OpenStack provider)
+    """
+
+    compute_count = Input(name='ComputeCount')
+    scale = Button('Scale')
+    cancel = Button('Cancel')
+
+    @property
+    def is_displayed(self):
+        return False
+
+
 class ProviderNodesView(BaseLoggedInPage):
     """
      represents main Nodes view (exists for Infra OpenStack provider)

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -218,8 +218,8 @@ class ProviderRegisterNodesView(View):
      represents Register Nodes view (exists for Infra OpenStack provider)
     """
     file = FileInput(locator='//input[@id="nodes_json_file"]')
-    register = Button('Register')
-    cancel = Button('Cancel')
+    register = Button(value='Register')
+    cancel = Button(value='Cancel')
 
     @property
     def is_displayed(self):

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -231,6 +231,7 @@ class ProviderScaleDownView(View):
      represents Scale down view (exists for Infra OpenStack provider)
     """
     table = Table(locator='//div[contains(@class, "form-horizontal")]//table')
+    checkbox = Checkbox(name='host_ids[]')
     scale_down = Button('Scale Down')
     cancel = Button('Cancel')
 

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -226,6 +226,19 @@ class ProviderRegisterNodesView(View):
         return False
 
 
+class ProviderScaleDownView(View):
+    """
+     represents Scale down view (exists for Infra OpenStack provider)
+    """
+    table = Table(locator='//div[contains(@class, "form-horizontal")]//table')
+    scale_down = Button('Scale Down')
+    cancel = Button('Cancel')
+
+    @property
+    def is_displayed(self):
+        return False
+
+
 class ProviderNodesView(BaseLoggedInPage):
     """
      represents main Nodes view (exists for Infra OpenStack provider)

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -166,6 +166,10 @@ class Host(Updateable, Pretty, Navigatable, PolicyProfileAssignable):
         """
         view = navigate_to(self, "Details")
         view.toolbar.configuration.item_select("Remove item", handle_alert=not cancel)
+        if not cancel:
+            view = self.create_view(HostsView)
+            assert view.is_displayed
+            view.flash.assert_success_message("The selected Hosts / Nodes was deleted")
 
     def load_details(self, refresh=False):
         """To be compatible with the Taggable and PolicyProfileAssignable mixins.

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -166,10 +166,6 @@ class Host(Updateable, Pretty, Navigatable, PolicyProfileAssignable):
         """
         view = navigate_to(self, "Details")
         view.toolbar.configuration.item_select("Remove item", handle_alert=not cancel)
-        if not cancel:
-            view = self.create_view(HostsView)
-            assert view.is_displayed
-            view.flash.assert_success_message("The selected Hosts / Nodes was deleted")
 
     def load_details(self, refresh=False):
         """To be compatible with the Taggable and PolicyProfileAssignable mixins.
@@ -414,6 +410,16 @@ class Host(Updateable, Pretty, Navigatable, PolicyProfileAssignable):
         """Initiate maintenance mode"""
         view = navigate_to(self, 'Details')
         view.toolbar.configuration.item_select('Toggle Maintenance Mode', handle_alert=True)
+
+    def provide_node(self):
+        """Provide node - make it available"""
+        view = navigate_to(self, 'Details')
+        view.toolbar.configuration.item_select('Provide Node', handle_alert=True)
+
+    def run_introspection(self):
+        """Run introspection"""
+        view = navigate_to(self, 'Details')
+        view.toolbar.configuration.item_select('Introspect Node', handle_alert=True)
 
 
 @navigator.register(Host)

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -165,9 +165,8 @@ class Host(Updateable, Pretty, Navigatable, PolicyProfileAssignable):
         Args:
             cancel (bool): Whether to cancel the deletion, defaults to True
         """
-
         view = navigate_to(self, "Details")
-        view.toolbar.configuration.item_select("Remove item", handle_alert=cancel)
+        view.toolbar.configuration.item_select("Remove item", handle_alert=not cancel)
         if not cancel:
             view = self.create_view(HostsView)
             assert view.is_displayed

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -19,6 +19,7 @@ from cfme.common.host_views import (
     HostTimelinesView
 )
 from cfme.exceptions import HostNotFound, ItemNotFound
+from cfme.fixtures import pytest_selenium as sel
 from cfme.infrastructure.datastore import HostAllDatastoresView
 from cfme.web_ui import mixins
 from utils import conf
@@ -405,6 +406,12 @@ class Host(Updateable, Pretty, Navigatable, PolicyProfileAssignable):
         """Removes the selected tag off the system"""
         navigate_to(self, 'Details')
         mixins.remove_tag(tag)
+
+    def toggle_maintenance_mode(self):
+        """Initiate maintenance mode"""
+        view = navigate_to(self, 'Details')
+        view.toolbar.configuration.item_select('Toggle Maintenance Mode')
+        sel.handle_alert()
 
 
 @navigator.register(Host)

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -210,11 +210,6 @@ class Host(Updateable, Pretty, Navigatable, PolicyProfileAssignable):
     def get_power_state(self):
         return self.get_detail("Properties", "Power State")
 
-    def provide(self):
-        """Provide Openstack infra node"""
-        view = navigate_to(self, 'Details')
-        view.toolbar.configuration.item_select('Provide Node', handle_alert=True)
-
     def refresh(self, cancel=False):
         """Perform 'Refresh Relationships and Power States' for the host.
 
@@ -409,21 +404,6 @@ class Host(Updateable, Pretty, Navigatable, PolicyProfileAssignable):
         """Removes the selected tag off the system"""
         navigate_to(self, 'Details')
         mixins.remove_tag(tag)
-
-    def toggle_maintenance_mode(self):
-        """Initiate maintenance mode"""
-        view = navigate_to(self, 'Details')
-        view.toolbar.configuration.item_select('Toggle Maintenance Mode', handle_alert=True)
-
-    def provide_node(self):
-        """Provide node - make it available"""
-        view = navigate_to(self, 'Details')
-        view.toolbar.configuration.item_select('Provide Node', handle_alert=True)
-
-    def run_introspection(self):
-        """Run introspection"""
-        view = navigate_to(self, 'Details')
-        view.toolbar.configuration.item_select('Introspect Node', handle_alert=True)
 
 
 @navigator.register(Host)

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -210,6 +210,11 @@ class Host(Updateable, Pretty, Navigatable, PolicyProfileAssignable):
     def get_power_state(self):
         return self.get_detail("Properties", "Power State")
 
+    def provide(self):
+        """Provide Openstack infra node"""
+        view = navigate_to(self, 'Details')
+        view.toolbar.configuration.item_select('Provide Node', handle_alert=True)
+
     def refresh(self, cancel=False):
         """Perform 'Refresh Relationships and Power States' for the host.
 

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -19,7 +19,6 @@ from cfme.common.host_views import (
     HostTimelinesView
 )
 from cfme.exceptions import HostNotFound, ItemNotFound
-from cfme.fixtures import pytest_selenium as sel
 from cfme.infrastructure.datastore import HostAllDatastoresView
 from cfme.web_ui import mixins
 from utils import conf
@@ -409,8 +408,7 @@ class Host(Updateable, Pretty, Navigatable, PolicyProfileAssignable):
     def toggle_maintenance_mode(self):
         """Initiate maintenance mode"""
         view = navigate_to(self, 'Details')
-        view.toolbar.configuration.item_select('Toggle Maintenance Mode')
-        sel.handle_alert()
+        view.toolbar.configuration.item_select('Toggle Maintenance Mode', handle_alert=True)
 
 
 @navigator.register(Host)

--- a/cfme/infrastructure/openstack_node.py
+++ b/cfme/infrastructure/openstack_node.py
@@ -16,6 +16,8 @@ class OpenstackNode(Host):
         """Initiate maintenance mode"""
         view = navigate_to(self, 'Details')
         view.toolbar.configuration.item_select('Toggle Maintenance Mode', handle_alert=True)
+        exp_msg = '"{}": Toggle Maintenance successfully initiated'.format(self.name)
+        view.flash.assert_success_message(exp_msg)
 
     def provide_node(self):
         """Provide node - make it available"""
@@ -26,3 +28,5 @@ class OpenstackNode(Host):
         """Run introspection"""
         view = navigate_to(self, 'Details')
         view.toolbar.configuration.item_select('Introspect Node', handle_alert=True)
+        # exp_msg = '"{}": Toggle Maintenance successfully initiated'.format(self.name)
+        view.flash.assert_success_message(exp_msg)

--- a/cfme/infrastructure/openstack_node.py
+++ b/cfme/infrastructure/openstack_node.py
@@ -23,10 +23,12 @@ class OpenstackNode(Host):
         """Provide node - make it available"""
         view = navigate_to(self, 'Details')
         view.toolbar.configuration.item_select('Provide Node', handle_alert=True)
+        exp_msg = '"{}": Provide successfully initiated'.format(self.name)
+        view.flash.assert_success_message(exp_msg)
 
     def run_introspection(self):
         """Run introspection"""
         view = navigate_to(self, 'Details')
         view.toolbar.configuration.item_select('Introspect Node', handle_alert=True)
-        # exp_msg = '"{}": Toggle Maintenance successfully initiated'.format(self.name)
+        exp_msg = '"{}": Introspect successfully initiated'.format(self.name)
         view.flash.assert_success_message(exp_msg)

--- a/cfme/infrastructure/openstack_node.py
+++ b/cfme/infrastructure/openstack_node.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""A model of an Openstack Infrastructure Node in CFME."""
+
+from cfme.infrastructure.host import Host
+from utils.appliance.implementations.ui import navigate_to
+
+
+class OpenstackNode(Host):
+    """
+    Model of Openstack Infrastructure node.
+    Extends the behavior of Infrastructure Host with Openstack-only functions.
+    For usage and __init__ args check the doc to Host class
+    """
+
+    def toggle_maintenance_mode(self):
+        """Initiate maintenance mode"""
+        view = navigate_to(self, 'Details')
+        view.toolbar.configuration.item_select('Toggle Maintenance Mode', handle_alert=True)
+
+    def provide_node(self):
+        """Provide node - make it available"""
+        view = navigate_to(self, 'Details')
+        view.toolbar.configuration.item_select('Provide Node', handle_alert=True)
+
+    def run_introspection(self):
+        """Run introspection"""
+        view = navigate_to(self, 'Details')
+        view.toolbar.configuration.item_select('Introspect Node', handle_alert=True)

--- a/cfme/infrastructure/provider/openstack_infra.py
+++ b/cfme/infrastructure/provider/openstack_infra.py
@@ -1,14 +1,12 @@
 from navmazing import NavigateToSibling
 from widgetastic.widget import View, Text
 from widgetastic_patternfly import Tab, Input, BootstrapSelect, Button
-from widgetastic_manageiq import RadioGroup, FileInput
+from widgetastic_manageiq import Checkbox, RadioGroup, FileInput, Table
 from wrapanapi.openstack_infra import OpenstackInfraSystem
 
 from cfme.infrastructure.provider import InfraProvider
 from cfme.common.provider import EventsEndpoint, SSHEndpoint, DefaultEndpoint, DefaultEndpointForm
-from cfme.common.provider_views import (BeforeFillMixin, ProviderNodesView,
-                                        ProviderRegisterNodesView, ProviderScaleDownView,
-                                        ProviderScaleOutView)
+from cfme.common.provider_views import BeforeFillMixin, ProviderNodesView
 from cfme.exceptions import DestinationNotFound
 from utils.appliance.implementations.ui import navigate_to, CFMENavigateStep, navigator
 
@@ -165,6 +163,47 @@ class ProviderNodes(CFMENavigateStep):
             view.contents.relationships.click_at('Nodes')
         except NameError:
             raise DestinationNotFound("Nodes aren't present on details page of this provider")
+
+
+class ProviderRegisterNodesView(View):
+    """
+     represents Register Nodes view
+    """
+    file = FileInput(locator='//input[@id="nodes_json_file"]')
+    register = Button(value='Register')
+    cancel = Button(value='Cancel')
+
+    @property
+    def is_displayed(self):
+        return False
+
+
+class ProviderScaleDownView(View):
+    """
+     represents Scale down view
+    """
+    table = Table(locator='//div[contains(@class, "form-horizontal")]//table')
+    checkbox = Checkbox(name='host_ids[]')
+    scale_down = Button('Scale Down')
+    cancel = Button('Cancel')
+
+    @property
+    def is_displayed(self):
+        return False
+
+
+class ProviderScaleOutView(View):
+    """
+     represents Scale view
+    """
+
+    compute_count = Input(name='ComputeCount')
+    scale = Button('Scale')
+    cancel = Button('Cancel')
+
+    @property
+    def is_displayed(self):
+        return False
 
 
 @navigator.register(OpenstackInfraProvider, 'RegisterNodes')

--- a/cfme/infrastructure/provider/openstack_infra.py
+++ b/cfme/infrastructure/provider/openstack_infra.py
@@ -132,7 +132,7 @@ class OpenstackInfraProvider(InfraProvider):
             increase_by - count of nodes to be added to infra provider
         """
         view = navigate_to(self, 'ScaleOut')
-        curr_compute_count = view.compute_count.read()
+        curr_compute_count = int(view.compute_count.value)
         view.compute_count.fill(curr_compute_count + increase_by)
         view.scale.click()
 

--- a/cfme/infrastructure/provider/openstack_infra.py
+++ b/cfme/infrastructure/provider/openstack_infra.py
@@ -6,7 +6,8 @@ from wrapanapi.openstack_infra import OpenstackInfraSystem
 
 from cfme.infrastructure.provider import InfraProvider
 from cfme.common.provider import EventsEndpoint, SSHEndpoint, DefaultEndpoint, DefaultEndpointForm
-from cfme.common.provider_views import ProviderNodesView, ProviderRegisterNodesView, BeforeFillMixin
+from cfme.common.provider_views import (BeforeFillMixin, ProviderNodesView,
+                                        ProviderRegisterNodesView, ProviderScaleDownView)
 from cfme.exceptions import DestinationNotFound
 from utils.appliance.implementations.ui import navigate_to, CFMENavigateStep, navigator
 
@@ -156,3 +157,13 @@ class ProviderRegisterNodes(CFMENavigateStep):
 
     def step(self):
         self.prerequisite_view.toolbar.configuration.item_select('Register Nodes')
+
+
+@navigator.register(OpenstackInfraProvider, 'ScaleDown')
+class ProviderScaleDown(CFMENavigateStep):
+    VIEW = ProviderScaleDownView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        item_title = 'Scale this Infrastructure Provider down'
+        self.prerequisite_view.toolbar.configuration.item_select(item_title)

--- a/cfme/infrastructure/provider/openstack_infra.py
+++ b/cfme/infrastructure/provider/openstack_infra.py
@@ -118,7 +118,7 @@ class OpenstackInfraProvider(InfraProvider):
         view.fill({'file': file_path})
         view.register.click()
         exp_msg = 'Nodes were added successfully. Refresh queued.'
-        self.create_view(ProviderNodesView).flash.assert_succes_messages(exp_msg)
+        self.create_view(ProviderNodesView).flash.assert_success_message(exp_msg)
 
     def scale_down(self):
         """Scales down provider"""

--- a/cfme/infrastructure/provider/openstack_infra.py
+++ b/cfme/infrastructure/provider/openstack_infra.py
@@ -7,7 +7,8 @@ from wrapanapi.openstack_infra import OpenstackInfraSystem
 from cfme.infrastructure.provider import InfraProvider
 from cfme.common.provider import EventsEndpoint, SSHEndpoint, DefaultEndpoint, DefaultEndpointForm
 from cfme.common.provider_views import (BeforeFillMixin, ProviderNodesView,
-                                        ProviderRegisterNodesView, ProviderScaleDownView)
+                                        ProviderRegisterNodesView, ProviderScaleDownView,
+                                        ProviderScaleOutView)
 from cfme.exceptions import DestinationNotFound
 from utils.appliance.implementations.ui import navigate_to, CFMENavigateStep, navigator
 
@@ -125,6 +126,16 @@ class OpenstackInfraProvider(InfraProvider):
         view.checkbox.click()
         view.scale_down.click()
 
+    def scale_out(self, increase_by=1):
+        """Scale out Openstack Infra provider
+        Args:
+            increase_by - count of nodes to be added to infra provider
+        """
+        view = navigate_to(self, 'ScaleOut')
+        curr_compute_count = view.compute_count.read()
+        view.compute_count.fill(curr_compute_count + increase_by)
+        view.scale.click()
+
     def node_exist(self, name='my_node'):
         """" registered imported host exist
         This function is valid only for RHOS10 and above
@@ -172,4 +183,14 @@ class ProviderScaleDown(CFMENavigateStep):
 
     def step(self):
         item_title = 'Scale this Infrastructure Provider down'
+        self.prerequisite_view.toolbar.configuration.item_select(item_title)
+
+
+@navigator.register(OpenstackInfraProvider, 'ScaleOut')
+class ProviderScaleOut(CFMENavigateStep):
+    VIEW = ProviderScaleOutView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        item_title = 'Scale this Infrastructure Provider'
         self.prerequisite_view.toolbar.configuration.item_select(item_title)

--- a/cfme/infrastructure/provider/openstack_infra.py
+++ b/cfme/infrastructure/provider/openstack_infra.py
@@ -119,6 +119,12 @@ class OpenstackInfraProvider(InfraProvider):
         view.fill({'file': file_path})
         view.register.click()
 
+    def scale_down(self):
+        """Scales down provider"""
+        view = navigate_to(self, 'ScaleDown')
+        view.checkbox.click()
+        view.scale_down.click()
+
     def node_exist(self, name='my_node'):
         """" registered imported host exist
         This function is valid only for RHOS10 and above

--- a/cfme/infrastructure/provider/openstack_infra.py
+++ b/cfme/infrastructure/provider/openstack_infra.py
@@ -136,6 +136,7 @@ class OpenstackInfraProvider(InfraProvider):
         curr_compute_count = int(view.compute_count.value)
         view.compute_count.fill(curr_compute_count + increase_by)
         view.scale.click()
+        self.create_view(ProviderNodesView).flash.assert_no_error()
 
     def node_exist(self, name='my_node'):
         """" registered imported host exist

--- a/cfme/infrastructure/provider/openstack_infra.py
+++ b/cfme/infrastructure/provider/openstack_infra.py
@@ -117,12 +117,15 @@ class OpenstackInfraProvider(InfraProvider):
         view = navigate_to(self, 'RegisterNodes')
         view.fill({'file': file_path})
         view.register.click()
+        exp_msg = 'Nodes were added successfully. Refresh queued.'
+        self.create_view(ProviderNodesView).flash.assert_succes_messages(exp_msg)
 
     def scale_down(self):
         """Scales down provider"""
         view = navigate_to(self, 'ScaleDown')
         view.checkbox.click()
         view.scale_down.click()
+        self.create_view(ProviderNodesView).flash.assert_no_error()
 
     def scale_out(self, increase_by=1):
         """Scale out Openstack Infra provider

--- a/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
+++ b/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
@@ -37,7 +37,7 @@ def test_scale_provider_down(provider, host):
     wait_for(lambda: provider.mgmt.iapi.node.get(host_uuid).maintenance, timeout=600, delay=5)
     wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
     assert host.get_detail('Properties', 'Maintenance Mode') == 'Enabled'
-    provider.scale_down(host_uuid)
+    provider.scale_down()
     flash.assert_success()
     provider.mgmt.iapi.node.wait_for_provision_state(host_uuid, 'available', timeout=1200)
     wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)

--- a/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
+++ b/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
@@ -90,3 +90,21 @@ def test_provide_host(host, provider):
     provider.mgmt.iapi.node.wait_for_provision_state(host.name, 'available', timeout=300)
     wait_for(provider.is_refreshed, [RefreshTimer(400)], timeout=600)
     assert host.get_detail('Openstack Hardware', 'Provisioning State') == 'available'
+
+
+@pytest.mark.requires_test('test_provide_host')
+def test_scale_provider_out(host, provider):
+    """Scale out Infra provider"""
+    # Host has to be given a profile role before the scale out
+    params = [{'path': '/properties/capabilities', 'value': 'profile:compute,boot_device:local',
+               'op': 'replace'}]
+    provider.mgmt.iapi.node.update(host.name, params)
+    provider.scale_out(1)
+    flash.assert_success()
+    # This action takes usually a lot of time, so big delay and timeout are set
+    wait_for(lambda: provider.mgmt.iapi.node.get(host.name).provision_state == 'active', delay=120,
+             timeout=1200)
+    wait_for(provider.is_refreshed, [RefreshTimer(400)], timeout=600)
+    host.name += ' (NovaCompute)'  # Host will change it's name after successful scale out
+    assert host.exists()
+    assert host.get_detail('Openstack Hardware', 'Provisioning State') == 'active'

--- a/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
+++ b/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
@@ -1,0 +1,61 @@
+import pytest
+
+
+from cfme.configure.tasks import is_host_analysis_finished
+from cfme.exceptions import HostNotFound
+from cfme.fixtures import pytest_selenium as sel
+from cfme.infrastructure.host import get_all_hosts, Host, wait_for_host_delete
+from cfme.infrastructure.provider.openstack_infra import OpenstackInfraProvider
+from cfme.web_ui import InfoBlock, Quadicon, toolbar, flash
+from utils import testgen
+from utils.appliance.implementations.ui import navigate_to
+from utils.wait import RefreshTimer, wait_for
+
+
+pytest_generate_tests = testgen.generate([OpenstackInfraProvider],
+                                         scope='module')
+pytestmark = [pytest.mark.usefixtures("setup_provider_modscope")]
+
+
+@pytest.fixture(scope='module')
+def host(provider):
+    """Find a host for test scenario"""
+    view = navigate_to(Host, 'All')
+    hosts = view.entities.get_all()
+    # Find a compute host with no instances on it
+    for h in hosts:
+        if 'Compute' in h.name and h.quad_entity(h.name).no_vm == 0:
+            return Host(h.name, provider=provider)
+    raise HostNotFound('There is no proper host for tests')
+
+
+def test_scale_provider_down(provider, host):
+    """Scale down Openstack Infrastructure provider"""
+    host.toggle_maintenance_mode()
+    flash.assert_success()
+    host_uuid = host.name.split()[0]  # cut off deployment role part from host's name
+    wait_for(lambda: provider.mgmt.iapi.node.get(host_uuid).maintenance, timeout=600, delay=5)
+    wait_for(provider.is_refreshed, [RefreshTimer(400)], timeout=600)
+    assert host.get_detail('Properties', 'Maintenance Mode') == 'Enabled'
+    provider.scale_down(host_uuid)
+    flash.assert_success()
+    provider.mgmt.iapi.node.wait_for_provision_state(host_uuid, 'available', timeout=1200)
+    wait_for(provider.is_refreshed, [RefreshTimer(400)], timeout=600)  # Refresh again
+    host.name = host_uuid  # host's name is changed after scale down
+    assert host.get_detail('Openstack Hardware', 'Provisioning State') == 'available'
+
+
+@pytest.mark.requires_test('test_scale_provider_down')
+def test_delete_host(host):
+    """Remove host from appliance and Ironic service"""
+    host.delete(cancel=False)
+    wait_for_host_delete(host)
+    assert host.name not in get_all_hosts()
+
+
+# @pytest.mark.requires_test('test_delete_host')
+# def test_register_host(provider):
+#     """Register new host by uploading instackenv.json file"""
+#     provider.register(provider.get_yaml_data()['instackenv_file_path'])
+#     flash.assert_success()
+#     wait_for(lambda: provider.mgmt.iapi.node.)

--- a/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
+++ b/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
@@ -39,7 +39,8 @@ def test_scale_provider_down(provider, host):
     assert host.get_detail('Properties', 'Maintenance Mode') == 'Enabled'
     provider.scale_down()
     flash.assert_success()
-    provider.mgmt.iapi.node.wait_for_provision_state(host_uuid, 'available', timeout=1200)
+    wait_for(lambda: provider.mgmt.iapi.node.get(host_uuid).provision_state == 'available', delay=5,
+             timeout=1200)
     wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
     host.name = host_uuid  # host's name is changed after scale down
     assert host.get_detail('Openstack Hardware', 'Provisioning State') == 'available'
@@ -89,7 +90,8 @@ def test_introspect_host(host, provider):
 def test_provide_host(host, provider):
     """Provide host"""
     host.provide_node()
-    provider.mgmt.iapi.node.wait_for_provision_state(host.name, 'available', timeout=300)
+    wait_for(lambda: provider.mgmt.iapi.node.get(host.name).provision_state == 'available', delay=5,
+             timeout=300)
     wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
     assert host.get_detail('Openstack Hardware', 'Provisioning State') == 'available'
 

--- a/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
+++ b/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
@@ -46,7 +46,7 @@ def test_scale_provider_down(provider, host):
     assert host.get_detail('Openstack Hardware', 'Provisioning State') == 'available'
 
 
-@pytest.mark.requires_test('test_scale_provider_down')
+@pytest.mark.requires_test(test_scale_provider_down)
 def test_delete_host(host, provider):
     """Remove host from appliance and Ironic service"""
     def is_host_disappeared():
@@ -58,7 +58,7 @@ def test_delete_host(host, provider):
     assert host.name not in get_all_hosts()
 
 
-@pytest.mark.requires_test('test_delete_host')
+@pytest.mark.requires_test(test_delete_host)
 def test_register_host(provider, host):
     """Register new host by uploading instackenv.json file"""
     hosts_before = [h.uuid for h in provider.mgmt.iapi.node.list()]
@@ -76,27 +76,29 @@ def test_register_host(provider, host):
     assert host.exists()
 
 
-@pytest.mark.requires_test('test_register_host')
+@pytest.mark.requires_test(test_register_host)
 def test_introspect_host(host, provider):
     """Introspect host"""
     host.run_introspection()
+    flash.assert_success()
     wait_for(lambda: provider.mgmt.iapi.node.get(host.name).inspection_finished_at, delay=15,
              func_kwargs=dict(refresh_delta=20), timeout=600)
     wait_for(provider.is_refreshed, timeout=600)
     assert host.get_detail('Openstack Hardware', 'Introspected') == 'true'
 
 
-@pytest.mark.requires_test('test_register_host')
+@pytest.mark.requires_test(test_register_host)
 def test_provide_host(host, provider):
     """Provide host"""
     host.provide_node()
+    flash.assert_success()
     wait_for(lambda: provider.mgmt.iapi.node.get(host.name).provision_state == 'available', delay=5,
              timeout=300)
     wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
     assert host.get_detail('Openstack Hardware', 'Provisioning State') == 'available'
 
 
-@pytest.mark.requires_test('test_provide_host')
+@pytest.mark.requires_test(test_provide_host)
 def test_scale_provider_out(host, provider):
     """Scale out Infra provider"""
     # Host has to be given a profile role before the scale out

--- a/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
+++ b/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
@@ -47,7 +47,9 @@ def test_scale_provider_down(provider, host):
 
 
 def test_delete_host(host, provider):
-    """Remove host from appliance and Ironic service"""
+    """Remove host from appliance and Ironic service
+    Metadata:
+        test_flag: openstack_scale"""
     def is_host_disappeared():
         return host.name not in [h.uuid for h in provider.mgmt.iapi.node.list()]
 
@@ -58,7 +60,9 @@ def test_delete_host(host, provider):
 
 
 def test_register_host(provider, host):
-    """Register new host by uploading instackenv.json file"""
+    """Register new host by uploading instackenv.json file
+    Metadata:
+        test_flag: openstack_scale"""
     hosts_before = [h.uuid for h in provider.mgmt.iapi.node.list()]
     provider.register(provider.get_yaml_data()['instackenv_file_path'])
     flash.assert_success()
@@ -75,7 +79,9 @@ def test_register_host(provider, host):
 
 
 def test_introspect_host(host, provider):
-    """Introspect host"""
+    """Introspect host
+    Metadata:
+        test_flag: openstack_scale"""
     host.run_introspection()
     flash.assert_success()
     wait_for(lambda: provider.mgmt.iapi.node.get(host.name).inspection_finished_at, delay=15,
@@ -85,7 +91,9 @@ def test_introspect_host(host, provider):
 
 
 def test_provide_host(host, provider):
-    """Provide host"""
+    """Provide host
+    Metadata:
+        test_flag: openstack_scale"""
     host.provide_node()
     flash.assert_success()
     wait_for(lambda: provider.mgmt.iapi.node.get(host.name).provision_state == 'available', delay=5,
@@ -95,7 +103,9 @@ def test_provide_host(host, provider):
 
 
 def test_scale_provider_out(host, provider):
-    """Scale out Infra provider"""
+    """Scale out Infra provider
+    Metadata:
+        test_flag: openstack_scale"""
     # Host has to be given a profile role before the scale out
     params = [{'path': '/properties/capabilities', 'value': 'profile:compute,boot_option:local',
                'op': 'replace'}]
@@ -104,7 +114,7 @@ def test_scale_provider_out(host, provider):
     flash.assert_success()
     # This action takes usually a lot of time, so big delay and timeout are set
     wait_for(lambda: provider.mgmt.iapi.node.get(host.name).provision_state == 'active', delay=120,
-             timeout=1200)
+             timeout=1800)
     wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
     host.name += ' (NovaCompute)'  # Host will change it's name after successful scale out
     assert host.exists

--- a/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
+++ b/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
@@ -7,7 +7,7 @@ from cfme.infrastructure.provider.openstack_infra import OpenstackInfraProvider
 from cfme.web_ui import flash
 from utils import testgen
 from utils.appliance.implementations.ui import navigate_to
-from utils.wait import RefreshTimer, wait_for
+from utils.wait import wait_for
 
 
 pytest_generate_tests = testgen.generate([OpenstackInfraProvider],
@@ -35,12 +35,12 @@ def test_scale_provider_down(provider, host):
     flash.assert_success()
     host_uuid = host.name.split()[0]  # cut off deployment role part from host's name
     wait_for(lambda: provider.mgmt.iapi.node.get(host_uuid).maintenance, timeout=600, delay=5)
-    wait_for(provider.is_refreshed, [RefreshTimer(400)], timeout=600)
+    wait_for(provider.is_refreshed, timeout=600)
     assert host.get_detail('Properties', 'Maintenance Mode') == 'Enabled'
     provider.scale_down(host_uuid)
     flash.assert_success()
     provider.mgmt.iapi.node.wait_for_provision_state(host_uuid, 'available', timeout=1200)
-    wait_for(provider.is_refreshed, [RefreshTimer(400)], timeout=600)  # Refresh again
+    wait_for(provider.is_refreshed, timeout=600)  # Refresh again
     host.name = host_uuid  # host's name is changed after scale down
     assert host.get_detail('Openstack Hardware', 'Provisioning State') == 'available'
 
@@ -53,7 +53,7 @@ def test_delete_host(host, provider):
 
     host.delete(cancel=False)
     wait_for(is_host_disappeared, timeout=300, delay=5)
-    wait_for(provider.is_refreshed, [RefreshTimer(400)], timeout=600)
+    wait_for(provider.is_refreshed, timeout=600)
     assert host.name not in get_all_hosts()
 
 
@@ -71,7 +71,7 @@ def test_register_host(provider, host):
     for h in hosts_after:
         if h not in hosts_before:
             host.name = h
-    wait_for(provider.is_refreshed, [RefreshTimer(400)], timeout=600)
+    wait_for(provider.is_refreshed, timeout=600)
     assert host.exists()
 
 
@@ -81,7 +81,7 @@ def test_introspect_host(host, provider):
     host.run_introspection()
     wait_for(lambda: provider.mgmt.iapi.node.get(host.name).inspection_finished_at, delay=15,
              timeout=600)
-    wait_for(provider.is_refreshed, [RefreshTimer(400)], timeout=600)
+    wait_for(provider.is_refreshed, timeout=600)
     assert host.get_detail('Openstack Hardware', 'Introspected') == 'true'
 
 
@@ -90,7 +90,7 @@ def test_provide_host(host, provider):
     """Provide host"""
     host.provide_node()
     provider.mgmt.iapi.node.wait_for_provision_state(host.name, 'available', timeout=300)
-    wait_for(provider.is_refreshed, [RefreshTimer(400)], timeout=600)
+    wait_for(provider.is_refreshed, timeout=600)
     assert host.get_detail('Openstack Hardware', 'Provisioning State') == 'available'
 
 
@@ -106,7 +106,7 @@ def test_scale_provider_out(host, provider):
     # This action takes usually a lot of time, so big delay and timeout are set
     wait_for(lambda: provider.mgmt.iapi.node.get(host.name).provision_state == 'active', delay=120,
              timeout=1200)
-    wait_for(provider.is_refreshed, [RefreshTimer(400)], timeout=600)
+    wait_for(provider.is_refreshed, timeout=600)
     host.name += ' (NovaCompute)'  # Host will change it's name after successful scale out
     assert host.exists()
     assert host.get_detail('Openstack Hardware', 'Provisioning State') == 'active'

--- a/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
+++ b/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
@@ -28,7 +28,9 @@ def host(provider):
 
 
 def test_scale_provider_down(provider, host):
-    """Scale down Openstack Infrastructure provider"""
+    """Scale down Openstack Infrastructure provider
+    Metadata:
+        test_flag: openstack_scale"""
     host.toggle_maintenance_mode()
     flash.assert_success()
     host_uuid = host.name.split()[0]  # cut off deployment role part from host's name

--- a/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
+++ b/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
@@ -1,6 +1,5 @@
 import pytest
 
-from cfme.common.host_views import HostDetailsView
 from cfme.exceptions import HostNotFound
 from cfme.infrastructure.host import get_all_hosts
 from cfme.infrastructure.openstack_node import OpenstackNode
@@ -83,7 +82,6 @@ def test_introspect_host(host, provider):
     Metadata:
         test_flag: openstack_scale"""
     host.run_introspection()
-    flash.assert_success()
     wait_for(lambda: provider.mgmt.iapi.node.get(host.name).inspection_finished_at, delay=15,
              timeout=600)
     wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
@@ -96,7 +94,6 @@ def test_provide_host(host, provider):
     Metadata:
         test_flag: openstack_scale"""
     host.provide_node()
-    flash.assert_success()
     wait_for(lambda: provider.mgmt.iapi.node.get(host.name).provision_state == 'available', delay=5,
              timeout=300)
     wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
@@ -113,7 +110,6 @@ def test_scale_provider_out(host, provider):
                'op': 'replace'}]
     provider.mgmt.iapi.node.update(host.name, params)
     provider.scale_out(1)
-    flash.assert_success()
     # This action takes usually a lot of time, so big delay and timeout are set
     wait_for(lambda: provider.mgmt.iapi.node.get(host.name).provision_state == 'active', delay=120,
              timeout=1800)

--- a/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
+++ b/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
@@ -5,7 +5,7 @@ from cfme.exceptions import HostNotFound
 from cfme.infrastructure.host import get_all_hosts
 from cfme.infrastructure.openstack_node import OpenstackNode
 from cfme.infrastructure.provider.openstack_infra import OpenstackInfraProvider
-from cfme.web_ui import flash
+from cfme.web_ui import flash, toolbar
 from utils import testgen
 from utils.appliance.implementations.ui import navigate_to
 from utils.wait import wait_for
@@ -37,6 +37,7 @@ def test_scale_provider_down(provider, host):
     host_uuid = host.name.split()[0]  # cut off deployment role part from host's name
     wait_for(lambda: provider.mgmt.iapi.node.get(host_uuid).maintenance, timeout=600, delay=5)
     wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
+    toolbar.refresh()
     assert host.get_detail('Properties', 'Maintenance Mode') == 'Enabled'
     provider.scale_down()
     flash.assert_success()
@@ -44,6 +45,7 @@ def test_scale_provider_down(provider, host):
              timeout=1200)
     wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
     host.name = host_uuid  # host's name is changed after scale down
+    toolbar.refresh()
     assert host.get_detail('Openstack Hardware', 'Provisioning State') == 'available'
 
 
@@ -57,6 +59,7 @@ def test_delete_host(host, provider):
     host.delete(cancel=False)
     wait_for(is_host_disappeared, timeout=300, delay=5)
     wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
+    toolbar.refresh()
     assert host.name not in get_all_hosts()
 
 
@@ -88,6 +91,7 @@ def test_introspect_host(host, provider):
     wait_for(lambda: provider.mgmt.iapi.node.get(host.name).inspection_finished_at, delay=15,
              timeout=600)
     wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
+    toolbar.refresh()
     assert host.get_detail('Openstack Hardware', 'Introspected') == 'true'
 
 
@@ -100,6 +104,7 @@ def test_provide_host(host, provider):
     wait_for(lambda: provider.mgmt.iapi.node.get(host.name).provision_state == 'available', delay=5,
              timeout=300)
     wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
+    toolbar.refresh()
     assert host.get_detail('Openstack Hardware', 'Provisioning State') == 'available'
 
 
@@ -118,5 +123,6 @@ def test_scale_provider_out(host, provider):
              timeout=1800)
     wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
     host.name += ' (NovaCompute)'  # Host will change it's name after successful scale out
+    toolbar.refresh()
     assert host.exists
     assert host.get_detail('Openstack Hardware', 'Provisioning State') == 'active'

--- a/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
+++ b/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
@@ -46,7 +46,6 @@ def test_scale_provider_down(provider, host):
     assert host.get_detail('Openstack Hardware', 'Provisioning State') == 'available'
 
 
-@pytest.mark.requires_test(test_scale_provider_down)
 def test_delete_host(host, provider):
     """Remove host from appliance and Ironic service"""
     def is_host_disappeared():
@@ -58,7 +57,6 @@ def test_delete_host(host, provider):
     assert host.name not in get_all_hosts()
 
 
-@pytest.mark.requires_test(test_delete_host)
 def test_register_host(provider, host):
     """Register new host by uploading instackenv.json file"""
     hosts_before = [h.uuid for h in provider.mgmt.iapi.node.list()]
@@ -73,21 +71,19 @@ def test_register_host(provider, host):
         if h not in hosts_before:
             host.name = h
     wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
-    assert host.exists()
+    assert host.exists
 
 
-@pytest.mark.requires_test(test_register_host)
 def test_introspect_host(host, provider):
     """Introspect host"""
     host.run_introspection()
     flash.assert_success()
     wait_for(lambda: provider.mgmt.iapi.node.get(host.name).inspection_finished_at, delay=15,
-             func_kwargs=dict(refresh_delta=20), timeout=600)
-    wait_for(provider.is_refreshed, timeout=600)
+             timeout=600)
+    wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
     assert host.get_detail('Openstack Hardware', 'Introspected') == 'true'
 
 
-@pytest.mark.requires_test(test_register_host)
 def test_provide_host(host, provider):
     """Provide host"""
     host.provide_node()
@@ -98,7 +94,6 @@ def test_provide_host(host, provider):
     assert host.get_detail('Openstack Hardware', 'Provisioning State') == 'available'
 
 
-@pytest.mark.requires_test(test_provide_host)
 def test_scale_provider_out(host, provider):
     """Scale out Infra provider"""
     # Host has to be given a profile role before the scale out

--- a/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
+++ b/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
@@ -2,7 +2,8 @@ import pytest
 
 
 from cfme.exceptions import HostNotFound
-from cfme.infrastructure.host import get_all_hosts, Host
+from cfme.infrastructure.host import get_all_hosts
+from cfme.infrastructure.openstack_node import OpenstackNode
 from cfme.infrastructure.provider.openstack_infra import OpenstackInfraProvider
 from cfme.web_ui import flash
 from utils import testgen
@@ -18,12 +19,12 @@ pytestmark = [pytest.mark.usefixtures("setup_provider_modscope")]
 @pytest.fixture(scope='module')
 def host(provider):
     """Find a host for test scenario"""
-    view = navigate_to(Host, 'All')
+    view = navigate_to(OpenstackNode, 'All')
     hosts = view.entities.get_all()
     # Find a compute host with no instances on it
     for h in hosts:
         if 'Compute' in h.name and h.quad_entity(h.name).no_vm == 0:
-            return Host(h.name, provider=provider)
+            return OpenstackNode(h.name, provider=provider)
     raise HostNotFound('There is no proper host for tests')
 
 

--- a/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
+++ b/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
@@ -107,5 +107,5 @@ def test_scale_provider_out(host, provider):
              timeout=1200)
     wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
     host.name += ' (NovaCompute)'  # Host will change it's name after successful scale out
-    assert host.exists()
+    assert host.exists
     assert host.get_detail('Openstack Hardware', 'Provisioning State') == 'active'

--- a/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
+++ b/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
@@ -98,7 +98,7 @@ def test_provide_host(host, provider):
 def test_scale_provider_out(host, provider):
     """Scale out Infra provider"""
     # Host has to be given a profile role before the scale out
-    params = [{'path': '/properties/capabilities', 'value': 'profile:compute,boot_device:local',
+    params = [{'path': '/properties/capabilities', 'value': 'profile:compute,boot_option:local',
                'op': 'replace'}]
     provider.mgmt.iapi.node.update(host.name, params)
     provider.scale_out(1)

--- a/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
+++ b/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
@@ -33,13 +33,13 @@ def test_scale_provider_down(provider, host):
     host.toggle_maintenance_mode()
     host_uuid = host.name.split()[0]  # cut off deployment role part from host's name
     wait_for(lambda: provider.mgmt.iapi.node.get(host_uuid).maintenance, timeout=600, delay=5)
-    wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
+    wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600)
     host.browser.refresh()
     assert host.get_detail('Properties', 'Maintenance Mode') == 'Enabled'
     provider.scale_down()
     wait_for(lambda: provider.mgmt.iapi.node.get(host_uuid).provision_state == 'available', delay=5,
              timeout=1200)
-    wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
+    wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600)
     host.name = host_uuid  # host's name is changed after scale down
     host.browser.refresh()
     assert host.get_detail('Openstack Hardware', 'Provisioning State') == 'available'
@@ -54,7 +54,7 @@ def test_delete_host(host, provider):
 
     host.delete(cancel=False)
     wait_for(is_host_disappeared, timeout=300, delay=5)
-    wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
+    wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600)
     host.browser.refresh()
     assert host.name not in get_all_hosts()
 
@@ -73,7 +73,7 @@ def test_register_host(provider, host):
     for h in hosts_after:
         if h not in hosts_before:
             host.name = h
-    wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
+    wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600)
     assert host.exists
 
 
@@ -84,7 +84,7 @@ def test_introspect_host(host, provider):
     host.run_introspection()
     wait_for(lambda: provider.mgmt.iapi.node.get(host.name).inspection_finished_at, delay=15,
              timeout=600)
-    wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
+    wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600)
     host.browser.refresh()
     assert host.get_detail('Openstack Hardware', 'Introspected') == 'true'
 
@@ -96,7 +96,7 @@ def test_provide_host(host, provider):
     host.provide_node()
     wait_for(lambda: provider.mgmt.iapi.node.get(host.name).provision_state == 'available', delay=5,
              timeout=300)
-    wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
+    wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600)
     host.browser.refresh()
     assert host.get_detail('Openstack Hardware', 'Provisioning State') == 'available'
 
@@ -113,7 +113,7 @@ def test_scale_provider_out(host, provider):
     # This action takes usually a lot of time, so big delay and timeout are set
     wait_for(lambda: provider.mgmt.iapi.node.get(host.name).provision_state == 'active', delay=120,
              timeout=1800)
-    wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
+    wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600)
     host.name += ' (NovaCompute)'  # Host will change it's name after successful scale out
     host.browser.refresh()
     assert host.exists

--- a/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
+++ b/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
@@ -71,3 +71,22 @@ def test_register_host(provider, host):
             host.name = h
     wait_for(provider.is_refreshed, [RefreshTimer(400)], timeout=600)
     assert host.exists()
+
+
+@pytest.mark.requires_test('test_register_host')
+def test_introspect_host(host, provider):
+    """Introspect host"""
+    host.run_introspection()
+    wait_for(lambda: provider.mgmt.iapi.node.get(host.name).inspection_finished_at, delay=15,
+             timeout=600)
+    wait_for(provider.is_refreshed, [RefreshTimer(400)], timeout=600)
+    assert host.get_detail('Openstack Hardware', 'Introspected') == 'true'
+
+
+@pytest.mark.requires_test('test_register_host')
+def test_provide_host(host, provider):
+    """Provide host"""
+    host.provide_node()
+    provider.mgmt.iapi.node.wait_for_provision_state(host.name, 'available', timeout=300)
+    wait_for(provider.is_refreshed, [RefreshTimer(400)], timeout=600)
+    assert host.get_detail('Openstack Hardware', 'Provisioning State') == 'available'

--- a/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
+++ b/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
@@ -35,12 +35,12 @@ def test_scale_provider_down(provider, host):
     flash.assert_success()
     host_uuid = host.name.split()[0]  # cut off deployment role part from host's name
     wait_for(lambda: provider.mgmt.iapi.node.get(host_uuid).maintenance, timeout=600, delay=5)
-    wait_for(provider.is_refreshed, timeout=600)
+    wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
     assert host.get_detail('Properties', 'Maintenance Mode') == 'Enabled'
     provider.scale_down(host_uuid)
     flash.assert_success()
     provider.mgmt.iapi.node.wait_for_provision_state(host_uuid, 'available', timeout=1200)
-    wait_for(provider.is_refreshed, timeout=600)  # Refresh again
+    wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
     host.name = host_uuid  # host's name is changed after scale down
     assert host.get_detail('Openstack Hardware', 'Provisioning State') == 'available'
 
@@ -53,7 +53,7 @@ def test_delete_host(host, provider):
 
     host.delete(cancel=False)
     wait_for(is_host_disappeared, timeout=300, delay=5)
-    wait_for(provider.is_refreshed, timeout=600)
+    wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
     assert host.name not in get_all_hosts()
 
 
@@ -71,7 +71,7 @@ def test_register_host(provider, host):
     for h in hosts_after:
         if h not in hosts_before:
             host.name = h
-    wait_for(provider.is_refreshed, timeout=600)
+    wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
     assert host.exists()
 
 
@@ -80,7 +80,7 @@ def test_introspect_host(host, provider):
     """Introspect host"""
     host.run_introspection()
     wait_for(lambda: provider.mgmt.iapi.node.get(host.name).inspection_finished_at, delay=15,
-             timeout=600)
+             func_kwargs=dict(refresh_delta=20), timeout=600)
     wait_for(provider.is_refreshed, timeout=600)
     assert host.get_detail('Openstack Hardware', 'Introspected') == 'true'
 
@@ -90,7 +90,7 @@ def test_provide_host(host, provider):
     """Provide host"""
     host.provide_node()
     provider.mgmt.iapi.node.wait_for_provision_state(host.name, 'available', timeout=300)
-    wait_for(provider.is_refreshed, timeout=600)
+    wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
     assert host.get_detail('Openstack Hardware', 'Provisioning State') == 'available'
 
 
@@ -106,7 +106,7 @@ def test_scale_provider_out(host, provider):
     # This action takes usually a lot of time, so big delay and timeout are set
     wait_for(lambda: provider.mgmt.iapi.node.get(host.name).provision_state == 'active', delay=120,
              timeout=1200)
-    wait_for(provider.is_refreshed, timeout=600)
+    wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=600)
     host.name += ' (NovaCompute)'  # Host will change it's name after successful scale out
     assert host.exists()
     assert host.get_detail('Openstack Hardware', 'Provisioning State') == 'active'

--- a/cfme/tests/openstack/infrastructure/test_hosts.py
+++ b/cfme/tests/openstack/infrastructure/test_hosts.py
@@ -1,11 +1,10 @@
 import pytest
-import random
 
 from cfme.configure.tasks import is_host_analysis_finished
 from cfme.fixtures import pytest_selenium as sel
-from cfme.infrastructure.host import Host, wait_for_host_delete
+from cfme.infrastructure.host import Host
 from cfme.infrastructure.provider.openstack_infra import OpenstackInfraProvider
-from cfme.web_ui import flash, InfoBlock, Quadicon, toolbar
+from cfme.web_ui import InfoBlock, Quadicon, toolbar
 from utils import testgen
 from utils.appliance.implementations.ui import navigate_to
 from utils.wait import wait_for
@@ -127,15 +126,3 @@ def test_host_zones_assigned(provider):
         host = Host(name=quad.name, provider=provider)
         result = host.get_detail('Relationships', 'Availability Zone')
         assert result, "Availability zone doesn't specified"
-
-
-def test_host_delete(provider):
-    navigate_to(provider, 'ProviderNodes')
-    quad_names = [q.name for q in Quadicon.all() if 'Compute' in q.name]
-    host_name = random.choice(quad_names)
-    host = Host(host_name, provider=provider)
-    host.delete(cancel=False)
-    flash.assert_no_errors()
-    wait_for_host_delete(host)
-    navigate_to(provider, 'ProviderNodes')
-    assert host_name not in [q.name for q in Quadicon.all()]


### PR DESCRIPTION
Adding tests for Openstack nodes' lifecycle operations: scale down, delete, register, introspect, provide, scale out.
Please no PRT run, any wrong thing might wreck your OSP environment. Added test_flag for avoid you of running this on your environments.
