### PR TITLE
[RFR] Fix wait_for_host_state_change of Host class

### DIFF
--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -232,8 +232,8 @@ class Host(Updateable, Pretty, Navigatable, PolicyProfileAssignable):
         view = navigate_to(self, "All")
 
         def _looking_for_state_change():
-            entity = view.entities.get_entity(by_name=self.name)
-            return "currentstate-{}".format(desired_state) in entity.status
+            power_state = self.get_detail('Properties', 'Power State')
+            return power_state == desired_state
 
         return wait_for(
             _looking_for_state_change,


### PR DESCRIPTION
Fixing `wait_for_host_state_change` - `entity.status` returns `None`.

{{pytest: cfme/tests/openstack/infrastructure/test_host_power_control.py --use-provider rhos_uc}}

