### PR TITLE
[WIPTEST] Use test parameters to execute access control tests against all default groups and roles

### DIFF
--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -570,6 +570,15 @@ class Group(Updateable, Pretty, Navigatable):
             appliance: appliance under test
     """
     pretty_attrs = ['description', 'role']
+    DEFAULT_GROUP_NAMES = [
+        "EvmGroup-administrator", "EvmGroup-approver", "EvmGroup-auditor",
+        "EvmGroup-consumption_administrator", "EvmGroup-container_administrator",
+        "EvmGroup-desktop", "EvmGroup-operator", "EvmGroup-security",
+        "EvmGroup-super_administrator", "EvmGroup-support", "EvmGroup-tenant_administrator",
+        "EvmGroup-tenant_quota_administrator", "EvmGroup-user",
+        "EvmGroup-user_limited_self_service", "EvmGroup-user_self_service",
+        "EvmGroup-vm_user", ]
+
 
     def __init__(self, description=None, role=None, tenant="My Company", user_to_lookup=None,
                  ldap_credentials=None, tag=None, host_cluster=None, vm_template=None,

--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -846,23 +846,23 @@ class Group(Updateable, Pretty, Navigatable):
         assert view.is_displayed
 
     def get_default_group_names(self):
-        group_names = VersionPick({
-            '5.8': [
+        if self.appliance.version < '5.8':
+            group_names = [
+                "EvmGroup-administrator", "EvmGroup-approver", "EvmGroup-auditor",
+                "EvmGroup-consumption_administrator", "EvmGroup-desktop", "EvmGroup-operator",
+                "EvmGroup-security", "EvmGroup-super_administrator", "EvmGroup-support",
+                "EvmGroup-tenant_administrator", "EvmGroup-tenant_quota_administrator",
+                "EvmGroup-user", "EvmGroup-user_limited_self_service",
+                "EvmGroup-user_self_service", "EvmGroup-vm_user", ]
+        else:
+            group_names = [
                 "EvmGroup-administrator", "EvmGroup-approver", "EvmGroup-auditor",
                 "EvmGroup-consumption_administrator", "EvmGroup-container_administrator",
                 "EvmGroup-desktop", "EvmGroup-operator", "EvmGroup-security",
                 "EvmGroup-super_administrator", "EvmGroup-support", "EvmGroup-tenant_administrator",
                 "EvmGroup-tenant_quota_administrator", "EvmGroup-user",
                 "EvmGroup-user_limited_self_service", "EvmGroup-user_self_service",
-                "EvmGroup-vm_user", ],
-            '5.7': [
-                "EvmGroup-administrator", "EvmGroup-approver", "EvmGroup-auditor",
-                "EvmGroup-consumption_administrator", "EvmGroup-desktop", "EvmGroup-operator",
-                "EvmGroup-security", "EvmGroup-super_administrator", "EvmGroup-support",
-                "EvmGroup-tenant_administrator", "EvmGroup-tenant_quota_administrator",
-                "EvmGroup-user", "EvmGroup-user_limited_self_service",
-                "EvmGroup-user_self_service", "EvmGroup-vm_user", ], }).pick(
-                    self.appliance.version)
+                "EvmGroup-vm_user", ]
 
         return group_names
 
@@ -1250,23 +1250,23 @@ class Role(Updateable, Pretty, Navigatable):
         return feature_update
 
     def get_default_role_names(self):
-        role_names = VersionPick({
-            '5.8': [
+        if self.appliance.version < '5.8':
+            role_names = [
+                "EvmRole-administrator", "EvmRole-approver", "EvmRole-auditor",
+                "EvmRole-consumption_administrator", "EvmRole-desktop", "EvmRole-operator",
+                "EvmRole-security", "EvmRole-super_administrator", "EvmRole-support",
+                "EvmRole-tenant_administrator", "EvmRole-tenant_quota_administrator",
+                "EvmRole-user", "EvmRole-user_limited_self_service",
+                "EvmRole-user_self_service", "EvmRole-vm_user", ]
+        else:
+            role_names = [
                 "EvmRole-administrator", "EvmRole-approver", "EvmRole-auditor",
                 "EvmRole-consumption_administrator", "EvmRole-container_administrator",
                 "EvmRole-desktop", "EvmRole-operator", "EvmRole-security",
                 "EvmRole-super_administrator", "EvmRole-support", "EvmRole-tenant_administrator",
                 "EvmRole-tenant_quota_administrator", "EvmRole-user",
                 "EvmRole-user_limited_self_service", "EvmRole-user_self_service",
-                "EvmRole-vm_user", ],
-            '5.7': [
-                "EvmRole-administrator", "EvmRole-approver", "EvmRole-auditor",
-                "EvmRole-consumption_administrator", "EvmRole-desktop", "EvmRole-operator",
-                "EvmRole-security", "EvmRole-super_administrator", "EvmRole-support",
-                "EvmRole-tenant_administrator", "EvmRole-tenant_quota_administrator",
-                "EvmRole-user", "EvmRole-user_limited_self_service",
-                "EvmRole-user_self_service", "EvmRole-vm_user", ], }).pick(
-                    self.appliance.version)
+                "EvmRole-vm_user", ]
 
         return role_names
 

--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -1,14 +1,16 @@
 from navmazing import NavigateToSibling, NavigateToAttribute
-from widgetastic_manageiq import UpDownSelect, SummaryFormItem
+from widgetastic_manageiq import UpDownSelect, PaginationPane, SummaryFormItem, Table
 from widgetastic_patternfly import (
     BootstrapSelect, Button, Input, Tab, CheckableBootstrapTreeview,
     BootstrapSwitch, CandidateNotFound, Dropdown)
+from widgetastic.exceptions import NoSuchElementException
 from widgetastic.utils import VersionPick, Version
-from widgetastic.widget import Checkbox, View, Table, Text
+from widgetastic.widget import Checkbox, View, Text
 
 from cfme.base.credential import Credential
 from cfme.base.ui import ConfigurationView
-from cfme.exceptions import OptionNotAvailable
+from cfme.exceptions import OptionNotAvailable, RBACOperationBlocked
+
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
 from utils.log import logger
@@ -22,6 +24,9 @@ def simple_user(userid, password):
     return User(name=userid, credential=creds)
 
 
+####################################################################################################
+# RBAC USER METHODS
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 class UserForm(ConfigurationView):
     """ User Form View."""
     name_txt = Input(name='name')
@@ -43,6 +48,8 @@ class AllUserView(ConfigurationView):
     configuration = Dropdown('Configuration')
     policy = Dropdown('Policy')
     entities = View.nested(UsersEntities)
+    table = Table("//div[@id='main_div']//table")
+    paginator = PaginationPane()
 
     @property
     def is_displayed(self):
@@ -150,7 +157,17 @@ class User(Updateable, Pretty, Navigatable):
         Args:
             cancel: True - if you want to cancel user creation,
                     by defaul user will be created
+
+        Throws:
+            RBACOperationBlocked: If operation is blocked due to current user
+                not having appropriate permissions OR update is not allowed
+                for currently selected role
         """
+        user_blocked_msg = VersionPick({
+            '5.8': ("Userid is not unique within region {}".format(
+                self.appliance.server_region())),
+            '5.7': ("Userid has already been taken")}).pick(self.appliance.version)
+
         view = navigate_to(self, 'Add')
         view.fill({
             'name_txt': self.name,
@@ -160,12 +177,20 @@ class User(Updateable, Pretty, Navigatable):
             'email_txt': self.email,
             'user_group_select': getattr(self.group, 'description', None)
         })
+
         if cancel:
             view.cancel_button.click()
             flash_message = 'Add of new User was cancelled by the user'
         else:
             view.add_button.click()
             flash_message = 'User "{}" was saved'.format(self.name)
+
+        try:
+            view.flash.assert_message(user_blocked_msg)
+            raise RBACOperationBlocked(user_blocked_msg)
+        except AssertionError:
+            pass
+
         view = self.create_view(AllUserView)
         view.flash.assert_success_message(flash_message)
         assert view.is_displayed
@@ -232,17 +257,65 @@ class User(Updateable, Pretty, Navigatable):
         assert view.is_displayed
         return new_user
 
-    def delete(self, cancel=True):
-        """ Delete existing user
-            Args:
-                cancel: Default value 'True', user will be deleted
-                        'False' - deletion of user will be canceled
+    def _delete_using_all_selection(self):
         """
-        view = navigate_to(self, 'Details')
-        view.configuration.item_select('Delete this User', handle_alert=cancel)
+        Delete existing user by selecting it from the access control group list
+
+        Throws:
+            RBACOperationBlocked: If operation is blocked due to current user
+                not having appropriate permissions OR delete is not allowed
+                for currently selected user
+        """
+        name_column = "Full Name"
+        find_row_kwargs = {name_column: self.name}
+
+        view = navigate_to(User, 'All')
+        try:
+            user_row = view.paginator.find_row_on_pages(view.table, **find_row_kwargs)
+            # Zero index is the unnamed column with the checkbox
+            user_row[0].check()
+        except NoSuchElementException:
+            raise Exception("Failed to find user row with name {}".format(self.name))
+
+    def delete(self, cancel=True, all_selection=False):
+        """
+        Delete existing user
+        Args:
+            cancel: Default value 'True', user will be deleted
+                    'False' - deletion of user will be canceled
+        Throws:
+            RBACOperationBlocked: If operation is blocked due to current user
+                not having appropriate permissions OR delete is not allowed
+                for currently selected user
+        """
+        flash_success_msg = 'EVM User "{}": Delete successful'.format(self.name)
+        flash_blocked_msg = "Default EVM User \"{}\" cannot be deleted".format(self.name)
+        delete_user_txt = 'Delete this User'
+
+        if all_selection:
+            self._delete_using_all_selection()
+            delete_user_txt = 'Delete selected Users'
+            view = self.create_view(AllUserView)
+            assert view.is_displayed, "All Users view is not displayed after selecting users"
+        else:
+            view = navigate_to(self, 'Details')
+
+        if not view.configuration.item_enabled(delete_user_txt):
+            raise RBACOperationBlocked("Configuration action '{}' is not enabled".format(
+                delete_user_txt))
+
+        view.configuration.item_select(delete_user_txt, handle_alert=cancel)
+        try:
+            view.flash.assert_message(flash_blocked_msg)
+            raise RBACOperationBlocked(flash_blocked_msg)
+        except AssertionError:
+            pass
+
+        view.flash.assert_message(flash_success_msg)
+
         if cancel:
             view = self.create_view(AllUserView)
-            view.flash.assert_success_message('EVM User "{}": Delete successful'.format(self.name))
+            view.flash.assert_success_message(flash_success_msg)
         else:
             view = self.create_view(DetailsUserView)
         assert view.is_displayed
@@ -353,7 +426,14 @@ class UserTagsEdit(CFMENavigateStep):
     def step(self):
         self.prerequisite_view.policy.item_select("Edit 'My Company' Tags for this User")
 
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# RBAC USER METHODS
+####################################################################################################
 
+
+####################################################################################################
+# RBAC GROUP METHODS
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 class GroupForm(ConfigurationView):
     """ Group Form in CFME UI."""
     ldap_groups_for_user = BootstrapSelect(id='ldap_groups_user')
@@ -376,8 +456,7 @@ class GroupForm(ConfigurationView):
         TAB_NAME = "My Company Tags"
         tree_locator = VersionPick({
             Version.lowest(): 'tagsbox',
-            '5.8': 'tags_treebox'}
-        )
+            '5.8': 'tags_treebox'})
         tree = CheckableBootstrapTreeview(tree_locator)
 
     @View.nested
@@ -435,8 +514,8 @@ class AllGroupView(ConfigurationView):
     """ All Groups View in CFME UI """
     configuration = Dropdown('Configuration')
     policy = Dropdown('Policy')
-
     table = Table("//div[@id='main_div']//table")
+    paginator = PaginationPane()
 
     @property
     def is_displayed(self):
@@ -516,8 +595,18 @@ class Group(Updateable, Pretty, Navigatable):
         """ Create group method
             Args:
                 cancel: True - if you want to cancel group creation,
-                        by defaul group will be created
+                        by default group will be created
+            Throws:
+                RBACOperationBlocked: If operation is blocked due to current user
+                    not having appropriate permissions OR delete is not allowed
+                    for currently selected user
         """
+
+        flash_blocked_msg = VersionPick({
+            '5.8': ("Description is not unique within region {}".format(
+                self.appliance.server_region())),
+            '5.7': ("Description has already been taken")}).pick(self.appliance.version)
+
         view = navigate_to(self, 'Add')
         view.fill({
             'description_txt': self.description,
@@ -534,6 +623,13 @@ class Group(Updateable, Pretty, Navigatable):
             view.add_button.click()
             flash_message = 'Group "{}" was saved'.format(self.description)
         view = self.create_view(AllGroupView)
+
+        try:
+            view.flash.assert_message(flash_blocked_msg)
+            raise RBACOperationBlocked(flash_blocked_msg)
+        except AssertionError:
+            pass
+
         view.flash.assert_success_message(flash_message)
         assert view.is_displayed
 
@@ -582,19 +678,62 @@ class Group(Updateable, Pretty, Navigatable):
         view = self._retrieve_ext_auth_user_groups()
         self._fill_ldap_group_lookup(view)
 
-    def update(self, updates):
+    def _update_using_all_selection(self):
+        """
+        Update existing group by selecting it from the access control group list
+
+        Throws:
+            RBACOperationBlocked: If operation is blocked due to current user
+                not having appropriate permissions OR update is not allowed
+                for currently selected group
+        """
+        flash_blocked_msg = 'Read Only EVM Group "{}" can not be edited'.format(self.description)
+        name_column = "Name"
+        find_row_kwargs = {name_column: self.description}
+
+        view = navigate_to(Group, 'All')
+        try:
+            group_row = view.paginator.find_row_on_pages(view.table, **find_row_kwargs)
+            # Zero index is the unnamed column with the checkbox
+            group_row[0].check()
+        except NoSuchElementException:
+            raise Exception("Failed to find group row with name {}".format(self.description))
+
+        view.configuration.item_select('Edit the selected Group')
+
+        try:
+            view.flash.assert_message(flash_blocked_msg)
+            raise RBACOperationBlocked(flash_blocked_msg)
+        except AssertionError:
+            pass
+
+    def update(self, updates, all_selection=False):
         """ Update group method
             Args:
                 updates: group data that should be changed
         Note: In case updates is the same as original group data, update will be canceled,
         as 'Save' button will not be active
         """
-        view = navigate_to(self, 'Edit')
+        edit_group_txt = 'Edit this Group'
+
+        if all_selection:
+            self._update_using_all_selection()
+            view = self.create_view(EditGroupView)
+            assert view.is_displayed, (
+                "Edit Group Details page was not displayed after all selection")
+        else:
+            view = navigate_to(self, 'Details')
+            if not view.configuration.item_enabled(edit_group_txt):
+                raise RBACOperationBlocked("Configuration action '{}' is not enabled".format(
+                    edit_group_txt))
+            view = navigate_to(self, 'Edit')
+
         changed = view.fill({
             'description_txt': updates.get('description'),
             'role_select': updates.get('role'),
             'group_tenant': updates.get('tenant')
         })
+
         changed_tag = self._set_group_restriction(view.my_company_tags, updates.get('tag'), True)
         changed_host_cluster = self._set_group_restriction(
             view.hosts_and_clusters, updates.get('host_cluster'), True)
@@ -608,25 +747,82 @@ class Group(Updateable, Pretty, Navigatable):
         else:
             view.cancel_button.click()
             flash_message = 'Edit of Group was cancelled by the user'
-        view = self.create_view(DetailsGroupView, override=updates)
+        if all_selection:
+            view = self.create_view(AllGroupView, override=updates)
+        else:
+            view = self.create_view(DetailsGroupView, override=updates)
+
         view.flash.assert_message(flash_message)
         assert view.is_displayed
 
-    def delete(self, cancel=True):
-        """ Delete existing group
-            Args:
-                cancel: Default value 'True', group will be deleted
-                        'False' - deletion of group will be canceled
+    def _delete_using_all_selection(self):
         """
-        view = navigate_to(self, 'Details')
-        view.configuration.item_select('Delete this Group', handle_alert=cancel)
+        Delete existing group by selecting it from the access control group list
+
+        Throws:
+            RBACOperationBlocked: If operation is blocked due to current user
+                not having appropriate permissions OR delete is not allowed
+                for currently selected group
+        """
+        name_column = "Name"
+        find_row_kwargs = {name_column: self.description}
+
+        view = navigate_to(Group, 'All')
+        try:
+            group_row = view.paginator.find_row_on_pages(view.table, **find_row_kwargs)
+            # Zero index is the unnamed column with the checkbox
+            group_row[0].check()
+        except NoSuchElementException:
+            raise Exception("Failed to find group row with name {}".format(self.description))
+
+    def delete(self, cancel=True, all_selection=False):
+        """
+        Delete existing group
+
+        Args:
+            cancel: Default value 'True', group will be deleted
+                    'False' - deletion of group will be canceled
+        Throws:
+            RBACOperationBlocked: If operation is blocked due to current user
+                not having appropriate permissions OR delete is not allowed
+                for currently selected group
+        """
+        flash_success_msg = 'EVM Group "{}": Delete successful'.format(self.description)
+        flash_blocked_msg = (
+            "EVM Group \"{}\": "
+            "Error during delete: A read only group cannot be deleted.".format(self.description))
+
+        delete_group_txt = 'Delete this Group'
+
+        if all_selection:
+            self._delete_using_all_selection()
+            delete_group_txt = 'Delete selected Groups'
+            view = self.create_view(AllGroupView)
+            assert view.is_displayed, "All Groups view is not displayed after selecting groups"
+        else:
+            view = navigate_to(self, 'Details')
+
+        if not view.configuration.item_enabled(delete_group_txt):
+            raise RBACOperationBlocked("Configuration action '{}' is not enabled".format(
+                delete_group_txt))
+
+        view.configuration.item_select(delete_group_txt, handle_alert=cancel)
+        try:
+            view.flash.assert_message(flash_blocked_msg)
+            raise RBACOperationBlocked(flash_blocked_msg)
+        except AssertionError:
+            pass
+
+        view.flash.assert_no_error()
+        view.flash.assert_message(flash_success_msg)
+
         if cancel:
             view = self.create_view(AllGroupView)
-            view.flash.assert_success_message(
-                'EVM Group "{}": Delete successful'.format(self.description))
+            view.flash.assert_success_message(flash_success_msg)
         else:
             view = self.create_view(DetailsGroupView)
-        assert view.is_displayed
+            assert view.is_displayed, (
+                "Access Control Group {} Detail View is not displayed".format(self.description))
 
     def edit_tags(self, tag, value):
         """ Edits tag for existing group
@@ -761,7 +957,13 @@ class GroupTagsEdit(CFMENavigateStep):
     def step(self):
         self.prerequisite_view.policy.item_select("Edit 'My Company' Tags for this Group")
 
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# END RBAC GROUP METHODS
+####################################################################################################
 
+####################################################################################################
+# RBAC ROLE METHODS
+####################################################################################################
 class RoleForm(ConfigurationView):
     """ Role Form for CFME UI """
     name_txt = Input(name='name')
@@ -813,6 +1015,8 @@ class AllRolesView(ConfigurationView):
     """ All Roles View """
     configuration = Dropdown('Configuration')
     policy = Dropdown('Policy')
+    table = Table("//div[@id='main_div']//table")
+    paginator = PaginationPane()
 
     @property
     def is_displayed(self):
@@ -843,8 +1047,14 @@ class Role(Updateable, Pretty, Navigatable):
         """ Create role method
             Args:
                 cancel: True - if you want to cancel role creation,
-                        by defaul, role will be created
+                        by default, role will be created
+        Throws:
+            RBACOperationBlocked: If operation is blocked due to current user
+                not having appropriate permissions OR update is not allowed
+                for currently selected role
         """
+        flash_blocked_msg = "Name has already been taken"
+
         view = navigate_to(self, 'Add')
         view.fill({'name_txt': self.name,
                    'vm_restriction_select': self.vm_restriction})
@@ -856,43 +1066,149 @@ class Role(Updateable, Pretty, Navigatable):
             view.add_button.click()
             flash_message = 'Role "{}" was saved'.format(self.name)
         view = self.create_view(AllRolesView)
+
+        try:
+            view.flash.assert_message(flash_blocked_msg)
+            raise RBACOperationBlocked(flash_blocked_msg)
+        except AssertionError:
+            pass
+
         view.flash.assert_success_message(flash_message)
+
         assert view.is_displayed
 
-    def update(self, updates):
+    def _update_using_all_selection(self):
+        """
+        Update existing role by selecting it from the access control role list
+
+        Throws:
+            RBACOperationBlocked: If operation is blocked due to current user
+                not having appropriate permissions OR update is not allowed
+                for currently selected role
+        """
+        flash_blocked_msg = 'Read Only Role "{}" can not be edited'.format(self.name)
+        name_column = "Name"
+        find_row_kwargs = {name_column: self.name}
+
+        view = navigate_to(Role, 'All')
+        try:
+            role_row = view.paginator.find_row_on_pages(view.table, **find_row_kwargs)
+            # Zero index is the unnamed column with the checkbox
+            role_row[0].check()
+        except NoSuchElementException:
+            raise Exception("Failed to find role row with name {}".format(self.name))
+
+        view.configuration.item_select('Edit the selected Role')
+
+        try:
+            view.flash.assert_message(flash_blocked_msg)
+            raise RBACOperationBlocked(flash_blocked_msg)
+        except AssertionError:
+            pass
+
+    def update(self, updates, all_selection=False):
         """ Update role method
             Args:
                 updates: role data that should be changed
         Note: In case updates is the same as original role data, update will be canceled,
         as 'Save' button will not be active
         """
-        view = navigate_to(self, 'Edit')
-        changed = view.fill({
-            'name_txt': updates.get('name'),
-            'vm_restriction_select': updates.get('vm_restriction')
-        })
-        feature_changed = self.set_role_product_features(view, updates.get('product_features'))
-        if changed or feature_changed:
-            view.save_button.click()
-            flash_message = 'Role "{}" was saved'.format(updates.get('name', self.name))
-        else:
-            view.cancel_button.click()
-            flash_message = 'Edit of Role was cancelled by the user'
-        view = self.create_view(DetailsRoleView, override=updates)
-        view.flash.assert_message(flash_message)
-        assert view.is_displayed
+        flash_blocked_msg = "Read Only Role \"{}\" can not be edited".format(self.name)
+        edit_role_txt = 'Edit this Role'
 
-    def delete(self, cancel=True):
+        if all_selection:
+            self._update_using_all_selection()
+        else:
+            view = navigate_to(self, 'Details')
+            if not view.configuration.item_enabled(edit_role_txt):
+                raise RBACOperationBlocked("Configuration action '{}' is not enabled".format(
+                    edit_role_txt))
+
+            view = navigate_to(self, 'Edit')
+            try:
+                view.flash.assert_message(flash_blocked_msg)
+                raise RBACOperationBlocked(flash_blocked_msg)
+            except AssertionError:
+                pass
+
+            changed = view.fill({
+                'name_txt': updates.get('name'),
+                'vm_restriction_select': updates.get('vm_restriction')
+            })
+            feature_changed = self.set_role_product_features(view, updates.get('product_features'))
+            if changed or feature_changed:
+                view.save_button.click()
+                flash_message = 'Role "{}" was saved'.format(updates.get('name', self.name))
+            else:
+                view.cancel_button.click()
+                flash_message = 'Edit of Role was cancelled by the user'
+            view = self.create_view(DetailsRoleView, override=updates)
+            view.flash.assert_message(flash_message)
+            assert view.is_displayed
+
+    def _delete_using_all_selection(self):
+        """
+        Delete existing role by selecting it from the access control role list
+
+        Throws:
+            RBACOperationBlocked: If operation is blocked due to current user
+                not having appropriate permissions OR delete is not allowed
+                for currently selected role
+        """
+        name_column = "Name"
+        find_row_kwargs = {name_column: self.name}
+
+        view = navigate_to(Role, 'All')
+        try:
+            role_row = view.paginator.find_row_on_pages(view.table, **find_row_kwargs)
+            # Zero index is the unnamed column with the checkbox
+            role_row[0].check()
+        except NoSuchElementException:
+            raise Exception("Failed to find role row with name {}".format(self.name))
+
+    def delete(self, cancel=True, all_selection=False):
         """ Delete existing role
             Args:
                 cancel: Default value 'True', role will be deleted
                         'False' - deletion of role will be canceled
+            Throws:
+                RBACOperationBlocked: If operation is blocked due to current user
+                    not having appropriate permissions OR delete is not allowed
+                    for currently selected role
         """
-        view = navigate_to(self, 'Details')
-        view.configuration.item_select('Delete this Role', handle_alert=cancel)
+        flash_blocked_msg = VersionPick({
+            "5.7": ("Role \"{}\": Error during delete: Cannot delete record "
+                "because of dependent entitlements")}).pick(
+                    self.appliance.version).format(self.name)
+        flash_success_msg = VersionPick({
+            "5.7": ('Role "{}": Delete successful')}).pick(
+                self.appliance.version).format(self.name)
+        delete_role_txt = 'Delete this Role'
+
+        if all_selection:
+            self._delete_using_all_selection()
+            delete_role_txt = 'Delete selected Roles'
+            view = self.create_view(AllRolesView)
+            assert view.is_displayed, "All Roles view is not displayed after selecting roles"
+        else:
+            view = navigate_to(self, 'Details')
+
+            if not view.configuration.item_enabled(delete_role_txt):
+                    raise RBACOperationBlocked("Configuration action '{}' is not enabled".format(
+                        delete_role_txt))
+
+        view.configuration.item_select(delete_role_txt, handle_alert=cancel)
+        try:
+            view.flash.assert_message(flash_blocked_msg)
+            raise RBACOperationBlocked(flash_blocked_msg)
+        except AssertionError:
+            pass
+
+        view.flash.assert_message(flash_success_msg)
+
         if cancel:
             view = self.create_view(AllRolesView)
-            view.flash.assert_success_message('Role "{}": Delete successful'.format(self.name))
+            view.flash.assert_success_message(flash_success_msg)
         else:
             view = self.create_view(DetailsRoleView)
         assert view.is_displayed
@@ -969,6 +1285,9 @@ class RoleEdit(CFMENavigateStep):
         self.prerequisite_view.configuration.item_select('Edit this Role')
 
 
+####################################################################################################
+# RBAC TENANT METHODS
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 class TenantForm(ConfigurationView):
     """ Tenant Form """
     name = Input(name='name')
@@ -1271,7 +1590,13 @@ class TenantManageQuotas(CFMENavigateStep):
     def step(self):
         self.prerequisite_view.configuration.item_select('Manage Quotas')
 
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# END TENANT METHODS
+####################################################################################################
 
+####################################################################################################
+# RBAC PROJECT METHODS
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 class Project(Tenant):
     """ Class representing CFME projects in the UI.
 
@@ -1283,3 +1608,6 @@ class Project(Tenant):
         parent_tenant: Parent project, can be None, can be passed as string or object
     """
     pass
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# END PROJECT METHODS
+####################################################################################################

--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -848,7 +848,7 @@ class Group(Updateable, Pretty, Navigatable):
     def get_default_group_names(self):
         group_names = VersionPick({
             '5.8': [
-            "EvmGroup-Administrator", "EvmGroup-approver", "EvmGroup-auditor",
+            "EvmGroup-administrator", "EvmGroup-approver", "EvmGroup-auditor",
             "EvmGroup-consumption_administrator", "EvmGroup-container_administrator",
             "EvmGroup-desktop", "EvmGroup-operator", "EvmGroup-security",
             "EvmGroup-super_administrator", "EvmGroup-support", "EvmGroup-tenant_administrator",
@@ -1248,6 +1248,27 @@ class Role(Updateable, Pretty, Navigatable):
                     view.product_features_tree.uncheck_node(*path)
             feature_update = True
         return feature_update
+
+    def get_default_role_names(self):
+        role_names = VersionPick({
+            '5.8': [
+            "EvmRole-administrator", "EvmRole-approver", "EvmRole-auditor",
+            "EvmRole-consumption_administrator", "EvmRole-container_administrator",
+            "EvmRole-desktop", "EvmRole-operator", "EvmRole-security",
+            "EvmRole-super_administrator", "EvmRole-support", "EvmRole-tenant_administrator",
+            "EvmRole-tenant_quota_administrator", "EvmRole-user",
+            "EvmRole-user_limited_self_service", "EvmRole-user_self_service",
+            "EvmRole-vm_user", ],
+            '5.7': [
+            "EvmRole-administrator", "EvmRole-approver", "EvmRole-auditor",
+            "EvmRole-consumption_administrator", "EvmRole-desktop", "EvmRole-operator",
+            "EvmRole-security", "EvmRole-super_administrator", "EvmRole-support",
+            "EvmRole-tenant_administrator", "EvmRole-tenant_quota_administrator",
+            "EvmRole-user", "EvmRole-user_limited_self_service",
+            "EvmRole-user_self_service", "EvmRole-vm_user", ], }).pick(
+                    self.appliance.version)
+
+        return role_names
 
 
 @navigator.register(Role, 'All')

--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -570,15 +570,6 @@ class Group(Updateable, Pretty, Navigatable):
             appliance: appliance under test
     """
     pretty_attrs = ['description', 'role']
-    DEFAULT_GROUP_NAMES = [
-        "EvmGroup-administrator", "EvmGroup-approver", "EvmGroup-auditor",
-        "EvmGroup-consumption_administrator", "EvmGroup-container_administrator",
-        "EvmGroup-desktop", "EvmGroup-operator", "EvmGroup-security",
-        "EvmGroup-super_administrator", "EvmGroup-support", "EvmGroup-tenant_administrator",
-        "EvmGroup-tenant_quota_administrator", "EvmGroup-user",
-        "EvmGroup-user_limited_self_service", "EvmGroup-user_self_service",
-        "EvmGroup-vm_user", ]
-
 
     def __init__(self, description=None, role=None, tenant="My Company", user_to_lookup=None,
                  ldap_credentials=None, tag=None, host_cluster=None, vm_template=None,
@@ -853,6 +844,27 @@ class Group(Updateable, Pretty, Navigatable):
         view = self.create_view(DetailsGroupView)
         view.flash.assert_success_message('Tag edits were successfully saved')
         assert view.is_displayed
+    
+    def get_default_group_names(self):
+        group_names = VersionPick({
+            '5.8': [
+            "EvmGroup-Administrator", "EvmGroup-approver", "EvmGroup-auditor",
+            "EvmGroup-consumption_administrator", "EvmGroup-container_administrator",
+            "EvmGroup-desktop", "EvmGroup-operator", "EvmGroup-security",
+            "EvmGroup-super_administrator", "EvmGroup-support", "EvmGroup-tenant_administrator",
+            "EvmGroup-tenant_quota_administrator", "EvmGroup-user",
+            "EvmGroup-user_limited_self_service", "EvmGroup-user_self_service",
+            "EvmGroup-vm_user", ],
+            '5.7': [
+            "EvmGroup-administrator", "EvmGroup-approver", "EvmGroup-auditor",
+            "EvmGroup-consumption_administrator", "EvmGroup-desktop", "EvmGroup-operator",
+            "EvmGroup-security", "EvmGroup-super_administrator", "EvmGroup-support",
+            "EvmGroup-tenant_administrator", "EvmGroup-tenant_quota_administrator",
+            "EvmGroup-user", "EvmGroup-user_limited_self_service",
+            "EvmGroup-user_self_service", "EvmGroup-vm_user", ], }).pick(
+                    self.appliance.version)
+
+        return group_names
 
     def set_group_order(self, updated_order):
         """ Sets group order for group lookup

--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -1176,13 +1176,9 @@ class Role(Updateable, Pretty, Navigatable):
                     not having appropriate permissions OR delete is not allowed
                     for currently selected role
         """
-        flash_blocked_msg = VersionPick({
-            "5.7": ("Role \"{}\": Error during delete: Cannot delete record "
-                "because of dependent entitlements")}).pick(
-                    self.appliance.version).format(self.name)
-        flash_success_msg = VersionPick({
-            "5.7": ('Role "{}": Delete successful')}).pick(
-                self.appliance.version).format(self.name)
+        flash_blocked_msg = ("Role \"{}\": Error during delete: Cannot delete record "
+                "because of dependent entitlements".format(self.name))
+        flash_success_msg = 'Role "{}": Delete successful'.format(self.name)
         delete_role_txt = 'Delete this Role'
 
         if all_selection:

--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -844,24 +844,24 @@ class Group(Updateable, Pretty, Navigatable):
         view = self.create_view(DetailsGroupView)
         view.flash.assert_success_message('Tag edits were successfully saved')
         assert view.is_displayed
-    
+
     def get_default_group_names(self):
         group_names = VersionPick({
             '5.8': [
-            "EvmGroup-administrator", "EvmGroup-approver", "EvmGroup-auditor",
-            "EvmGroup-consumption_administrator", "EvmGroup-container_administrator",
-            "EvmGroup-desktop", "EvmGroup-operator", "EvmGroup-security",
-            "EvmGroup-super_administrator", "EvmGroup-support", "EvmGroup-tenant_administrator",
-            "EvmGroup-tenant_quota_administrator", "EvmGroup-user",
-            "EvmGroup-user_limited_self_service", "EvmGroup-user_self_service",
-            "EvmGroup-vm_user", ],
+                "EvmGroup-administrator", "EvmGroup-approver", "EvmGroup-auditor",
+                "EvmGroup-consumption_administrator", "EvmGroup-container_administrator",
+                "EvmGroup-desktop", "EvmGroup-operator", "EvmGroup-security",
+                "EvmGroup-super_administrator", "EvmGroup-support", "EvmGroup-tenant_administrator",
+                "EvmGroup-tenant_quota_administrator", "EvmGroup-user",
+                "EvmGroup-user_limited_self_service", "EvmGroup-user_self_service",
+                "EvmGroup-vm_user", ],
             '5.7': [
-            "EvmGroup-administrator", "EvmGroup-approver", "EvmGroup-auditor",
-            "EvmGroup-consumption_administrator", "EvmGroup-desktop", "EvmGroup-operator",
-            "EvmGroup-security", "EvmGroup-super_administrator", "EvmGroup-support",
-            "EvmGroup-tenant_administrator", "EvmGroup-tenant_quota_administrator",
-            "EvmGroup-user", "EvmGroup-user_limited_self_service",
-            "EvmGroup-user_self_service", "EvmGroup-vm_user", ], }).pick(
+                "EvmGroup-administrator", "EvmGroup-approver", "EvmGroup-auditor",
+                "EvmGroup-consumption_administrator", "EvmGroup-desktop", "EvmGroup-operator",
+                "EvmGroup-security", "EvmGroup-super_administrator", "EvmGroup-support",
+                "EvmGroup-tenant_administrator", "EvmGroup-tenant_quota_administrator",
+                "EvmGroup-user", "EvmGroup-user_limited_self_service",
+                "EvmGroup-user_self_service", "EvmGroup-vm_user", ], }).pick(
                     self.appliance.version)
 
         return group_names
@@ -1252,20 +1252,20 @@ class Role(Updateable, Pretty, Navigatable):
     def get_default_role_names(self):
         role_names = VersionPick({
             '5.8': [
-            "EvmRole-administrator", "EvmRole-approver", "EvmRole-auditor",
-            "EvmRole-consumption_administrator", "EvmRole-container_administrator",
-            "EvmRole-desktop", "EvmRole-operator", "EvmRole-security",
-            "EvmRole-super_administrator", "EvmRole-support", "EvmRole-tenant_administrator",
-            "EvmRole-tenant_quota_administrator", "EvmRole-user",
-            "EvmRole-user_limited_self_service", "EvmRole-user_self_service",
-            "EvmRole-vm_user", ],
+                "EvmRole-administrator", "EvmRole-approver", "EvmRole-auditor",
+                "EvmRole-consumption_administrator", "EvmRole-container_administrator",
+                "EvmRole-desktop", "EvmRole-operator", "EvmRole-security",
+                "EvmRole-super_administrator", "EvmRole-support", "EvmRole-tenant_administrator",
+                "EvmRole-tenant_quota_administrator", "EvmRole-user",
+                "EvmRole-user_limited_self_service", "EvmRole-user_self_service",
+                "EvmRole-vm_user", ],
             '5.7': [
-            "EvmRole-administrator", "EvmRole-approver", "EvmRole-auditor",
-            "EvmRole-consumption_administrator", "EvmRole-desktop", "EvmRole-operator",
-            "EvmRole-security", "EvmRole-super_administrator", "EvmRole-support",
-            "EvmRole-tenant_administrator", "EvmRole-tenant_quota_administrator",
-            "EvmRole-user", "EvmRole-user_limited_self_service",
-            "EvmRole-user_self_service", "EvmRole-vm_user", ], }).pick(
+                "EvmRole-administrator", "EvmRole-approver", "EvmRole-auditor",
+                "EvmRole-consumption_administrator", "EvmRole-desktop", "EvmRole-operator",
+                "EvmRole-security", "EvmRole-super_administrator", "EvmRole-support",
+                "EvmRole-tenant_administrator", "EvmRole-tenant_quota_administrator",
+                "EvmRole-user", "EvmRole-user_limited_self_service",
+                "EvmRole-user_self_service", "EvmRole-vm_user", ], }).pick(
                     self.appliance.version)
 
         return role_names

--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -163,10 +163,11 @@ class User(Updateable, Pretty, Navigatable):
                 not having appropriate permissions OR update is not allowed
                 for currently selected role
         """
-        user_blocked_msg = VersionPick({
-            '5.8': ("Userid is not unique within region {}".format(
-                self.appliance.server_region())),
-            '5.7': ("Userid has already been taken")}).pick(self.appliance.version)
+        if self.appliance.version < "5.8":
+            user_blocked_msg = ("Userid has already been taken")
+        else:
+            user_blocked_msg = ("Userid is not unique within region {}".format(
+                self.appliance.server_region()))
 
         view = navigate_to(self, 'Add')
         view.fill({
@@ -259,23 +260,15 @@ class User(Updateable, Pretty, Navigatable):
 
     def _delete_using_all_selection(self):
         """
-        Delete existing user by selecting it from the access control group list
-
-        Throws:
-            RBACOperationBlocked: If operation is blocked due to current user
-                not having appropriate permissions OR delete is not allowed
-                for currently selected user
+        Select the existing user by selecting it from the access control group list
         """
         name_column = "Full Name"
         find_row_kwargs = {name_column: self.name}
 
         view = navigate_to(User, 'All')
-        try:
-            user_row = view.paginator.find_row_on_pages(view.table, **find_row_kwargs)
-            # Zero index is the unnamed column with the checkbox
-            user_row[0].check()
-        except NoSuchElementException:
-            raise Exception("Failed to find user row with name {}".format(self.name))
+        user_row = view.paginator.find_row_on_pages(view.table, **find_row_kwargs)
+        # Zero index is the unnamed column with the checkbox
+        user_row[0].check()
 
     def delete(self, cancel=True, all_selection=False):
         """
@@ -601,11 +594,11 @@ class Group(Updateable, Pretty, Navigatable):
                     not having appropriate permissions OR delete is not allowed
                     for currently selected user
         """
-
-        flash_blocked_msg = VersionPick({
-            '5.8': ("Description is not unique within region {}".format(
-                self.appliance.server_region())),
-            '5.7': ("Description has already been taken")}).pick(self.appliance.version)
+        if self.appliance.version < "5.8":
+            flash_blocked_msg = ("Description has already been taken")
+        else:
+            flash_blocked_msg = "Description is not unique within region {}".format(
+                self.appliance.server_region())
 
         view = navigate_to(self, 'Add')
         view.fill({
@@ -961,6 +954,7 @@ class GroupTagsEdit(CFMENavigateStep):
 # END RBAC GROUP METHODS
 ####################################################################################################
 
+
 ####################################################################################################
 # RBAC ROLE METHODS
 ####################################################################################################
@@ -1149,22 +1143,14 @@ class Role(Updateable, Pretty, Navigatable):
     def _delete_using_all_selection(self):
         """
         Delete existing role by selecting it from the access control role list
-
-        Throws:
-            RBACOperationBlocked: If operation is blocked due to current user
-                not having appropriate permissions OR delete is not allowed
-                for currently selected role
         """
         name_column = "Name"
         find_row_kwargs = {name_column: self.name}
 
         view = navigate_to(Role, 'All')
-        try:
-            role_row = view.paginator.find_row_on_pages(view.table, **find_row_kwargs)
-            # Zero index is the unnamed column with the checkbox
-            role_row[0].check()
-        except NoSuchElementException:
-            raise Exception("Failed to find role row with name {}".format(self.name))
+        role_row = view.paginator.find_row_on_pages(view.table, **find_row_kwargs)
+        # Zero index is the unnamed column with the checkbox
+        role_row[0].check()
 
     def delete(self, cancel=True, all_selection=False):
         """ Delete existing role
@@ -1589,6 +1575,7 @@ class TenantManageQuotas(CFMENavigateStep):
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 # END TENANT METHODS
 ####################################################################################################
+
 
 ####################################################################################################
 # RBAC PROJECT METHODS

--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -434,3 +434,11 @@ class ItemNotFound(CFMEException):
 
 class ManyEntitiesFound(CFMEException):
     """Raised when one or no items were expected but several/many items were obtained instead."""
+
+
+class RBACOperationBlocked(CFMEException):
+    """
+    Raised when a Role Based Access Control operation is blocked from execution due to invalid
+    permissions. Also thrown when trying to perform actions CRUD operations on roles/groups/users
+    that are CFME defaults
+    """

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -512,7 +512,8 @@ def test_rolename_duplicate_validation():
 
 
 @pytest.mark.tier(3)
-def test_delete_default_roles():
+@pytest.mark.parametrize("default_role_name", Role().get_default_role_names())
+def test_delete_default_roles(default_role_name):
     """Test that CFME prevents a user from deleting a default role
     when selecting it from the Access Control EVM Role checklist
 
@@ -521,13 +522,14 @@ def test_delete_default_roles():
         * Navigate to Configuration -> Role
         * Try editing the group EvmRole-approver
     """
-    role = Role(name='EvmRole-approver')
+    role = Role(name=default_role_name)
     with pytest.raises(RBACOperationBlocked):
         role.delete()
 
 
 @pytest.mark.tier(3)
-def test_delete_default_roles_all_selection():
+@pytest.mark.parametrize("default_role_name", Role().get_default_role_names())
+def test_delete_default_roles_all_selection(default_role_name):
     """Test that CFME prevents a user from deleting a default role
     when selecting it from the Access Control EVM role checklist
 
@@ -536,13 +538,14 @@ def test_delete_default_roles_all_selection():
         * Navigate to Configuration -> Role
         * Try deleting the group EvmRole-approver
     """
-    role = Role(name='EvmRole-approver')
+    role = Role(name=default_role_name)
     with pytest.raises(RBACOperationBlocked):
         role.delete(all_selection=True)
 
 
 @pytest.mark.tier(3)
-def test_edit_default_roles():
+@pytest.mark.parametrize("default_role_name", Role().get_default_role_names())
+def test_edit_default_roles(default_role_name):
     """Test that CFME prevents a user from editing a default role
     when selecting it from the Access Control EVM Role checklist
 
@@ -551,7 +554,7 @@ def test_edit_default_roles():
         * Navigate to Configuration -> Role
         * Try editing the group EvmRole-auditor
     """
-    role = Role(name='EvmRole-auditor')
+    role = Role(name=default_role_name)
     newrole_name = "{}-{}".format(role.name, fauxfactory.gen_alphanumeric())
     role_updates = {'name': newrole_name}
 
@@ -560,7 +563,8 @@ def test_edit_default_roles():
 
 
 @pytest.mark.tier(3)
-def test_edit_default_roles_all_selection():
+@pytest.mark.parametrize("default_role_name", Role().get_default_role_names())
+def test_edit_default_roles_all_selection(default_role_name):
     """Test that CFME prevents a user from editing a default role
     when selecting it from the Access Control EVM Role checklist
 
@@ -569,7 +573,7 @@ def test_edit_default_roles_all_selection():
         * Navigate to Configuration -> Role
         * Try editing the group EvmRole-auditor
     """
-    role = Role(name='EvmRole-auditor')
+    role = Role(name=default_role_name)
     newrole_name = "{}-{}".format(role.name, fauxfactory.gen_alphanumeric())
     role_updates = {'name': newrole_name}
 

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -39,11 +39,6 @@ def a_provider(request):
     prov_filter = ProviderFilter(classes=[VMwareProvider])
     return setup_one_or_skip(request, filters=[prov_filter])
 
-@pytest.fixture(scope="module", params=Group.DEFAULT_GROUP_NAMES)
-def default_group_name(request):
-    return request.param
-
-
 
 def new_credential():
     return Credential(principal='uid' + fauxfactory.gen_alphanumeric(), secret='redhat')
@@ -361,8 +356,9 @@ def test_group_description_required_error_validation():
 
 
 @pytest.mark.tier(3)
+@pytest.mark.parametrize("default_group_name", Group().get_default_group_names())
 def test_delete_default_group(default_group_name):
-    """Test for deleting default group EvmGroup-administrator.
+    """Test for deleting a default group.
 
     Steps:
         * Login as Administrator user
@@ -376,16 +372,17 @@ def test_delete_default_group(default_group_name):
 
 @pytest.mark.tier(3)
 @pytest.mark.meta(blockers=[BZ(1473828, forced_streams=['5.8'])])
-def test_delete_default_group_all_selection():
-    """Test for deleting default group EvmGroup-administrator using
-       the checklist displayed by selecting Configuration->Group
+@pytest.mark.parametrize("default_group_name", Group().get_default_group_names())
+def test_delete_default_group_all_selection(default_group_name):
+    """Test for deleting a default group using the checklist displayed
+    by selecting Configuration->Group
 
     Steps:
         * Login as Administrator user
         * Navigate to Configuration -> Group
-        * Try deleting the group EvmGroup-adminstrator
+        * Try deleting the group 
     """
-    group = Group(description='EvmGroup-administrator')
+    group = Group(description=default_group_name)
 
     with pytest.raises(RBACOperationBlocked):
         group.delete(all_selection=True)

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -16,7 +16,7 @@ from cfme.common.provider import base_types
 from cfme.infrastructure import virtual_machines as vms
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.services.myservice import MyService
-from cfme.web_ui import flash, Table, InfoBlock, toolbar as tb
+from cfme.web_ui import Table, InfoBlock, toolbar as tb
 from cfme.configure import tasks
 from fixtures.provider import setup_one_or_skip
 from utils.appliance.implementations.ui import navigate_to
@@ -317,7 +317,6 @@ def test_group_crud_with_tag(a_provider, category, tag):
 
 @pytest.mark.tier(3)
 def test_group_duplicate_name(appliance):
-    region = appliance.server_region
     group = new_group()
     group.create()
     with pytest.raises(RBACOperationBlocked):
@@ -389,9 +388,12 @@ def test_delete_default_group_all_selection():
 
 @pytest.mark.tier(3)
 def test_delete_group_with_assigned_user():
-    flash_msg = version.pick({
-        '5.7': ("EVM Group \"{}\": Error during delete: "
-                "The group has users assigned that do not belong to any other group"), })
+    """Test that CFME prevents deletion of a group that has users assigned
+    """
+    flash_msg = ("EVM Group \"{}\": Error during delete: "
+                "The group has users assigned that do not "
+                "belong to any other group")
+
     group = new_group()
     group.create()
     user = new_user(group=group)
@@ -504,6 +506,7 @@ def test_rolename_duplicate_validation():
     # Navigating away from this page will create an "Abandon Changes" alert
     # Since group creation failed we need to reset the state of the page
     navigate_to(role.appliance.server, 'Dashboard')
+
 
 @pytest.mark.tier(3)
 def test_delete_default_roles():
@@ -754,12 +757,11 @@ def test_permissions_role_crud(appliance):
 
 @pytest.mark.tier(3)
 def test_permissions_vm_provisioning(appliance):
-    features = version.pick({
-        version.LOWEST: [
-            ['Everything', 'Compute', 'Infrastructure', 'Virtual Machines', 'Accordions'],
-            ['Everything', 'Access Rules for all Virtual Machines', 'VM Access Rules', 'Modify',
-                'Provision VMs']
-        ], })
+    features = [
+        ['Everything', 'Compute', 'Infrastructure', 'Virtual Machines', 'Accordions'],
+        ['Everything', 'Access Rules for all Virtual Machines', 'VM Access Rules', 'Modify',
+            'Provision VMs']
+    ]
 
     single_task_permission_test(
         appliance,

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -39,6 +39,11 @@ def a_provider(request):
     prov_filter = ProviderFilter(classes=[VMwareProvider])
     return setup_one_or_skip(request, filters=[prov_filter])
 
+@pytest.fixture(scope="module", params=Group.DEFAULT_GROUP_NAMES)
+def default_group_name(request):
+    return request.param
+
+
 
 def new_credential():
     return Credential(principal='uid' + fauxfactory.gen_alphanumeric(), secret='redhat')
@@ -356,14 +361,14 @@ def test_group_description_required_error_validation():
 
 
 @pytest.mark.tier(3)
-def test_delete_default_group():
+def test_delete_default_group(default_group_name):
     """Test for deleting default group EvmGroup-administrator.
 
     Steps:
         * Login as Administrator user
-        * Try deleting the group EvmGroup-adminstrator
+        * Try deleting the group specified by group name
     """
-    group = Group(description='EvmGroup-administrator')
+    group = Group(description=default_group_name)
 
     with pytest.raises(RBACOperationBlocked):
         group.delete()

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -380,7 +380,7 @@ def test_delete_default_group_all_selection(default_group_name):
     Steps:
         * Login as Administrator user
         * Navigate to Configuration -> Group
-        * Try deleting the group 
+        * Try deleting the group
     """
     group = Group(description=default_group_name)
 
@@ -579,6 +579,10 @@ def test_edit_default_roles_all_selection(default_role_name):
 
     with pytest.raises(RBACOperationBlocked):
         role.update(role_updates, all_selection=True)
+
+    # When the role update is blocked the screen will leave the current role checked
+    # which causes the next edit role test to have all previous role messages selected
+    navigate_to(role.appliance.server, 'Dashboard')
 
 
 @pytest.mark.tier(3)

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -405,14 +405,15 @@ def test_delete_group_with_assigned_user():
 
 
 @pytest.mark.tier(3)
-def test_edit_default_group():
+@pytest.mark.parametrize("default_group_name", Group().get_default_group_names())
+def test_edit_default_group(default_group_name):
     """Test that CFME prevents a user from editing a default group
 
     Steps:
         * Login as Administrator user
         * Try editing the group EvmGroup-adminstrator
     """
-    group = Group(description='EvmGroup-approver')
+    group = Group(default_group_name)
 
     group_updates = {}
     with pytest.raises(RBACOperationBlocked):

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -10,8 +10,8 @@ from cfme import test_requirements
 from cfme.base.credential import Credential
 from cfme.automate.explorer import AutomateExplorer  # NOQA
 from cfme.base import Server
-from cfme.control.explorer import ControlExplorer  # NOQA
-from cfme.exceptions import OptionNotAvailable
+from cfme.control.explorer import ControlExplorer # NOQA
+from cfme.exceptions import OptionNotAvailable, RBACOperationBlocked
 from cfme.common.provider import base_types
 from cfme.infrastructure import virtual_machines as vms
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
@@ -29,7 +29,6 @@ from utils import version
 
 records_table = Table("//div[@id='main_div']//table")
 usergrp = Group(description='EvmGroup-user')
-group_table = Table("//div[@id='main_div']//table")
 
 
 pytestmark = test_requirements.rbac
@@ -110,14 +109,9 @@ def test_user_login():
 
 @pytest.mark.tier(3)
 def test_user_duplicate_name(appliance):
-    region = appliance.server_region
     nu = new_user()
     nu.create()
-    msg = version.pick({
-        version.LOWEST: "Userid has already been taken",
-        '5.8': "Userid is not unique within region {}".format(region)
-    })
-    with error.expected(msg):
+    with pytest.raises(RBACOperationBlocked):
         nu.create()
 
 
@@ -145,6 +139,10 @@ def test_userid_required_error_validation():
     with error.expected("Userid can't be blank"):
         user.create()
 
+    # Navigating away from this page will create an "Abandon Changes" alert
+    # Since group creation failed we need to reset the state of the page
+    navigate_to(user.appliance.server, 'Dashboard')
+
 
 @pytest.mark.tier(3)
 def test_user_password_required_error_validation():
@@ -153,12 +151,15 @@ def test_user_password_required_error_validation():
         credential=Credential(principal='uid' + fauxfactory.gen_alphanumeric(), secret=None),
         email='xyz@redhat.com',
         group=group_user)
-    if version.current_version() < "5.5":
-        check = "Password_digest can't be blank"
-    else:
-        check = "Password can't be blank"
+
+    check = "Password can't be blank"
+
     with error.expected(check):
         user.create()
+
+    # Navigating away from this page will create an "Abandon Changes" alert
+    # Since group creation failed we need to reset the state of the page
+    navigate_to(user.appliance.server, 'Dashboard')
 
 
 @pytest.mark.tier(3)
@@ -212,12 +213,21 @@ def test_delete_default_user():
         * Try deleting the user
     """
     user = User(name='Administrator')
-    navigate_to(User, 'All')
-    row = records_table.find_row_by_cells({'Full Name': user.name})
-    sel.check(sel.element(".//input[@type='checkbox']", root=row[0]))
-    tb.select('Configuration', 'Delete selected Users', invokes_alert=True)
-    sel.handle_alert()
-    flash.assert_message_match('Default EVM User "{}" cannot be deleted' .format(user.name))
+    with pytest.raises(RBACOperationBlocked):
+        user.delete()
+
+
+@pytest.mark.tier(3)
+def test_delete_default_user_all_selection():
+    """Test for deleting default user Administrator.
+
+    Steps:
+        * Login as Administrator user
+        * Try deleting the user
+    """
+    user = User(name='Administrator')
+    with pytest.raises(RBACOperationBlocked):
+        user.delete(all_selection=True)
 
 
 @pytest.mark.tier(3)
@@ -310,11 +320,7 @@ def test_group_duplicate_name(appliance):
     region = appliance.server_region
     group = new_group()
     group.create()
-    msg = version.pick({
-        version.LOWEST: "Description has already been taken",
-        '5.8': "Description is not unique within region {}".format(region)
-    })
-    with error.expected(msg):
+    with pytest.raises(RBACOperationBlocked):
         group.create()
 
 
@@ -344,25 +350,48 @@ def test_group_description_required_error_validation():
     group = Group(description=None, role='EvmRole-approver')
     with error.expected(error_text):
         group.create()
-    flash.dismiss()
+
+    # Navigating away from this page will create an "Abandon Changes" alert
+    # Since group creation failed we need to reset the state of the page
+    navigate_to(group.appliance.server, 'Dashboard')
 
 
 @pytest.mark.tier(3)
 def test_delete_default_group():
-    flash_msg = "EVM Group \"{}\": Error during delete: A read only group cannot be deleted."
+    """Test for deleting default group EvmGroup-administrator.
+
+    Steps:
+        * Login as Administrator user
+        * Try deleting the group EvmGroup-adminstrator
+    """
     group = Group(description='EvmGroup-administrator')
-    view = navigate_to(Group, 'All')
-    row = group_table.find_row_by_cells({'Name': group.description})
-    sel.check(sel.element(".//input[@type='checkbox']", root=row[0]))
-    view.configuration.item_select('Delete selected Groups', handle_alert=True)
-    view.flash.assert_message(flash_msg.format(group.description))
+
+    with pytest.raises(RBACOperationBlocked):
+        group.delete()
+
+
+@pytest.mark.tier(3)
+@pytest.mark.meta(blockers=[BZ(1473828, forced_streams=['5.8'])])
+def test_delete_default_group_all_selection():
+    """Test for deleting default group EvmGroup-administrator using
+       the checklist displayed by selecting Configuration->Group
+
+    Steps:
+        * Login as Administrator user
+        * Navigate to Configuration -> Group
+        * Try deleting the group EvmGroup-adminstrator
+    """
+    group = Group(description='EvmGroup-administrator')
+
+    with pytest.raises(RBACOperationBlocked):
+        group.delete(all_selection=True)
 
 
 @pytest.mark.tier(3)
 def test_delete_group_with_assigned_user():
     flash_msg = version.pick({
-        '5.6': ("EVM Group \"{}\": Error during delete: Still has users assigned"),
-        '5.5': ("EVM Group \"{}\": Error during \'destroy\': Still has users assigned")})
+        '5.7': ("EVM Group \"{}\": Error during delete: "
+                "The group has users assigned that do not belong to any other group"), })
     group = new_group()
     group.create()
     user = new_user(group=group)
@@ -373,13 +402,38 @@ def test_delete_group_with_assigned_user():
 
 @pytest.mark.tier(3)
 def test_edit_default_group():
-    flash_msg = 'Read Only EVM Group "{}" can not be edited'
+    """Test that CFME prevents a user from editing a default group
+
+    Steps:
+        * Login as Administrator user
+        * Try editing the group EvmGroup-adminstrator
+    """
     group = Group(description='EvmGroup-approver')
-    navigate_to(Group, 'All')
-    row = group_table.find_row_by_cells({'Name': group.description})
-    sel.check(sel.element(".//input[@type='checkbox']", root=row[0]))
-    tb.select('Configuration', 'Edit the selected Group')
-    flash.assert_message_match(flash_msg.format(group.description))
+
+    group_updates = {}
+    with pytest.raises(RBACOperationBlocked):
+        group.update(group_updates)
+
+
+@pytest.mark.tier(3)
+@pytest.mark.uncollectif(lambda: version.current_version() >= "5.8")
+def test_edit_default_group_all_selection():
+    """Test that CFME prevents a user from editting a default group
+    when selecting it from the Access Control EVM Groups checklist
+
+    Steps:
+        * Login as Administrator user
+        * Navigate to Configuration -> Group
+        * Try editing the group EvmGroup-adminstrator
+    """
+    group = Group(description='EvmGroup-approver')
+
+    group_updates = {}
+
+    all_selection = True
+
+    with pytest.raises(RBACOperationBlocked):
+        group.update(group_updates, all_selection)
 
 
 @pytest.mark.tier(3)
@@ -444,41 +498,86 @@ def test_rolename_required_error_validation():
 def test_rolename_duplicate_validation():
     role = new_role()
     role.create()
-    with error.expected("Name has already been taken"):
+    with pytest.raises(RBACOperationBlocked):
         role.create()
 
+    # Navigating away from this page will create an "Abandon Changes" alert
+    # Since group creation failed we need to reset the state of the page
+    navigate_to(role.appliance.server, 'Dashboard')
 
 @pytest.mark.tier(3)
 def test_delete_default_roles():
-    flash_msg = version.pick({
-        '5.6': ("Role \"{}\": Error during delete: Cannot delete record "
-                "because of dependent entitlements"),
-        '5.5': ("Role \"{}\": Error during \'destroy\': Cannot delete record "
-                "because of dependent miq_groups")})
+    """Test that CFME prevents a user from deleting a default role
+    when selecting it from the Access Control EVM Role checklist
+
+    Steps:
+        * Login as Administrator user
+        * Navigate to Configuration -> Role
+        * Try editing the group EvmRole-approver
+    """
     role = Role(name='EvmRole-approver')
-    with error.expected(flash_msg.format(role.name)):
+    with pytest.raises(RBACOperationBlocked):
         role.delete()
 
 
 @pytest.mark.tier(3)
+def test_delete_default_roles_all_selection():
+    """Test that CFME prevents a user from deleting a default role
+    when selecting it from the Access Control EVM role checklist
+
+    Steps:
+        * Login as Administrator user
+        * Navigate to Configuration -> Role
+        * Try deleting the group EvmRole-approver
+    """
+    role = Role(name='EvmRole-approver')
+    with pytest.raises(RBACOperationBlocked):
+        role.delete(all_selection=True)
+
+
+@pytest.mark.tier(3)
 def test_edit_default_roles():
+    """Test that CFME prevents a user from editing a default role
+    when selecting it from the Access Control EVM Role checklist
+
+    Steps:
+        * Login as Administrator user
+        * Navigate to Configuration -> Role
+        * Try editing the group EvmRole-auditor
+    """
     role = Role(name='EvmRole-auditor')
-    navigate_to(role, 'Edit')
-    flash.assert_message_match("Read Only Role \"{}\" can not be edited" .format(role.name))
+    newrole_name = "{}-{}".format(role.name, fauxfactory.gen_alphanumeric())
+    role_updates = {'name': newrole_name}
+
+    with pytest.raises(RBACOperationBlocked):
+        role.update(role_updates)
+
+
+@pytest.mark.tier(3)
+def test_edit_default_roles_all_selection():
+    """Test that CFME prevents a user from editing a default role
+    when selecting it from the Access Control EVM Role checklist
+
+    Steps:
+        * Login as Administrator user
+        * Navigate to Configuration -> Role
+        * Try editing the group EvmRole-auditor
+    """
+    role = Role(name='EvmRole-auditor')
+    newrole_name = "{}-{}".format(role.name, fauxfactory.gen_alphanumeric())
+    role_updates = {'name': newrole_name}
+
+    with pytest.raises(RBACOperationBlocked):
+        role.update(role_updates, all_selection=True)
 
 
 @pytest.mark.tier(3)
 def test_delete_roles_with_assigned_group():
-    flash_msg = version.pick({
-        '5.6': ("Role \"{}\": Error during delete: Cannot delete record "
-                "because of dependent entitlements"),
-        '5.5': ("Role \"{}\": Error during \'destroy\': Cannot delete record "
-                "because of dependent miq_groups")})
     role = new_role()
     role.create()
     group = new_group(role=role.name)
     group.create()
-    with error.expected(flash_msg.format(role.name)):
+    with pytest.raises(RBACOperationBlocked):
         role.delete()
 
 
@@ -520,10 +619,7 @@ def _test_vm_removal():
     [(
         {version.LOWEST: [['Everything', 'Infrastructure', 'Virtual Machines', 'Accordions'],
             ['Everything', 'Access Rules for all Virtual Machines', 'VM Access Rules', 'Modify',
-             'Provision VMs']],
-         '5.6': [['Everything', 'Compute', 'Infrastructure', 'Virtual Machines', 'Accordions'],
-            ['Everything', 'Access Rules for all Virtual Machines', 'VM Access Rules', 'Modify',
-             'Provision VMs']]},
+             'Provision VMs']], },
         _test_vm_provision)])
 def test_permission_edit(appliance, request, product_features, action):
     """
@@ -660,15 +756,11 @@ def test_permissions_role_crud(appliance):
 def test_permissions_vm_provisioning(appliance):
     features = version.pick({
         version.LOWEST: [
-            ['Everything', 'Infrastructure', 'Virtual Machines', 'Accordions'],
-            ['Everything', 'Access Rules for all Virtual Machines', 'VM Access Rules', 'Modify',
-                'Provision VMs']
-        ],
-        '5.6': [
             ['Everything', 'Compute', 'Infrastructure', 'Virtual Machines', 'Accordions'],
             ['Everything', 'Access Rules for all Virtual Machines', 'VM Access Rules', 'Modify',
                 'Provision VMs']
-        ]})
+        ], })
+
     single_task_permission_test(
         appliance,
         features,
@@ -738,9 +830,10 @@ def test_user_change_password(appliance, request):
         email="test@test.test",
         group=usergrp,
     )
+
     user.create()
     request.addfinalizer(user.delete)
-    request.addfinalizer(appliance.server.login_admin())
+    request.addfinalizer(appliance.server.login_admin)
     with user:
         appliance.server.logout()
         appliance.server.login(user)


### PR DESCRIPTION
Add pytest parameters to execute access control tests against all default groups(EvmGroup-*) and roles (EvmRole-*).  This PR is rebased on top of #4974 

test_delete_default_group*
test_edit_default_group*
test_delete_default_role*
test_edit_default_role*