### PR TITLE
[1LP][READTOMERGE] utils/providers.py Fix for test flags.

### DIFF
--- a/utils/providers.py
+++ b/utils/providers.py
@@ -128,12 +128,12 @@ class ProviderFilter(object):
             test_flags = [flag.strip() for flag in self.required_flags]
 
             defined_flags = conf.cfme_data.get('test_flags', '')
-            if isinstance(defined_flags, str):
+            if isinstance(defined_flags, six.string_types):
                 defined_flags = defined_flags.split(',')
             defined_flags = [flag.strip() for flag in defined_flags]
 
             excluded_flags = provider.data.get('excluded_test_flags', '')
-            if isinstance(excluded_flags, str):
+            if isinstance(excluded_flags, six.string_types):
                 excluded_flags = excluded_flags.split(',')
             excluded_flags = [flag.strip() for flag in excluded_flags]
 

--- a/utils/providers.py
+++ b/utils/providers.py
@@ -127,10 +127,14 @@ class ProviderFilter(object):
         if self.required_flags:
             test_flags = [flag.strip() for flag in self.required_flags]
 
-            defined_flags = conf.cfme_data.get('test_flags', '').split(',')
+            defined_flags = conf.cfme_data.get('test_flags', '')
+            if isinstance(defined_flags, str):
+                defined_flags = defined_flags.split(',')
             defined_flags = [flag.strip() for flag in defined_flags]
 
-            excluded_flags = provider.data.get('excluded_test_flags', '').split(',')
+            excluded_flags = provider.data.get('excluded_test_flags', '')
+            if isinstance(excluded_flags, str):
+                excluded_flags = excluded_flags.split(',')
             excluded_flags = [flag.strip() for flag in excluded_flags]
 
             allowed_flags = set(defined_flags) - set(excluded_flags)


### PR DESCRIPTION
Now test flags are expecting string type in CFME yaml, but unfortunately it could be list in some environments. 

In this patch I've just added a check for a type so tests will not fail at string splitting and will proceed successfully in environments where test flags are defined as list.

Thanks.

Signed-off-by: Aleksei Slaikovskii <aslaikov@redhat.com>