### PR TITLE
[RFR][1LP] Fix IPAppliance._encrypt_string

### DIFF
--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -514,8 +514,8 @@ class IPAppliance(object):
             # Let's not log passwords
             logging.disable(logging.CRITICAL)
             rc, out = self.ssh_client.run_rails_command(
-                "puts MiqPassword.encrypt('{}')".format(string))
-            return out
+                "\"puts MiqPassword.encrypt('{}')\"".format(string))
+            return out.strip()
         finally:
             logging.disable(logging.NOTSET)
 


### PR DESCRIPTION
SSIA

Tested manually.
```
current_appliance._encrypt_string('smartvm')
```