### PR TITLE
[1LP][RFR] Update IPAppliance, add start/stop_db_service

### DIFF
--- a/cfme/tests/distributed/test_appliance_replication.py
+++ b/cfme/tests/distributed/test_appliance_replication.py
@@ -49,7 +49,7 @@ def get_replication_appliances():
     appl2 = provision_appliance(ver_to_prov, 'long-test_repl_B')
     appl1.configure(region=1)
     appl1.ipapp.wait_for_web_ui()
-    appl2.update_uuid()
+    appl2.update_guid()
     appl2.configure(region=2, key_address=appl1.address)
     appl2.ipapp.wait_for_web_ui()
     return appl1, appl2

--- a/cfme/tests/distributed/test_appliance_replication.py
+++ b/cfme/tests/distributed/test_appliance_replication.py
@@ -98,10 +98,10 @@ def test_vm(virtualcenter_provider):
     vm = VM.factory(vm_name, virtualcenter_provider)
 
     if not virtualcenter_provider.mgmt.does_vm_exist(vm_name):
-        logger.info("deploying %s on provider %s", vm_name, virtualcenter_provider.key)
+        logger.info("deploying %r on provider %r", vm_name, virtualcenter_provider.key)
         vm.create_on_provider(allow_skip="default")
     else:
-        logger.info("recycling deployed vm %s on provider %s", vm_name, virtualcenter_provider.key)
+        logger.info("recycling deployed vm %r on provider %r", vm_name, virtualcenter_provider.key)
     vm.provider.refresh_provider_relationships()
     vm.wait_to_appear()
     yield vm
@@ -109,7 +109,7 @@ def test_vm(virtualcenter_provider):
     try:
         virtualcenter_provider.mgmt.delete_vm(vm_name=vm_name)
     except Exception:
-        logger.exception('Failed deleting VM "%s" on "%s"', vm_name, virtualcenter_provider.name)
+        logger.exception('Failed deleting VM "%r" on "%r"', vm_name, virtualcenter_provider.name)
 
 
 @pytest.mark.tier(2)

--- a/cfme/tests/distributed/test_appliance_replication.py
+++ b/cfme/tests/distributed/test_appliance_replication.py
@@ -260,9 +260,9 @@ def test_appliance_replicate_database_disconnection(request, virtualcenter_provi
     with appl1.ipapp:
         configure_db_replication(appl2.address)
         # Replication is up and running, now stop the DB on the replication parent
-        appl2.stop_db_service()
+        appl2.db.stop_db_service()
         sleep(60)
-        appl2.start_db_service()
+        appl2.db.start_db_service()
         navigate_to(appliance.server.zone.region, 'Replication')
         wait_for(conf.get_replication_status, func_kwargs={'navigate': False},
                  fail_condition=False, num_sec=360, delay=10,
@@ -297,9 +297,9 @@ def test_appliance_replicate_database_disconnection_with_backlog(request, virtua
         configure_db_replication(appl2.address)
         # Replication is up and running, now stop the DB on the replication parent
         virtualcenter_provider.create()
-        appl2.stop_db_service()
+        appl2.db.stop_db_service()
         sleep(60)
-        appl2.start_db_service()
+        appl2.db.start_db_service()
         navigate_to(appliance.server.zone.region, 'Replication')
         wait_for(conf.get_replication_status, func_kwargs={'navigate': False},
                  fail_condition=False, num_sec=360, delay=10,

--- a/cfme/tests/distributed/test_appliance_replication.py
+++ b/cfme/tests/distributed/test_appliance_replication.py
@@ -1,20 +1,19 @@
 # -*- coding: utf-8 -*-
-import fauxfactory
 import pytest
 
 from time import sleep
 from urlparse import urlparse
 
 import cfme.web_ui.flash as flash
+from cfme.base.ui import ServerView
 from cfme.common.vm import VM
 from cfme.configure import configuration as conf
 from cfme.infrastructure.provider import wait_for_a_provider
-import cfme.fixtures.pytest_selenium as sel
-
 from utils import version
 from utils.appliance import provision_appliance, current_appliance
 from utils.appliance.implementations.ui import navigate_to
 from utils.conf import credentials
+from utils.generators import random_vm_name
 from utils.log import logger
 from utils.ssh import SSHClient
 from utils.wait import wait_for
@@ -41,41 +40,19 @@ def get_ssh_client(hostname):
     return SSHClient(**connect_kwargs)
 
 
-# TODO: These calls here should not be separate functions, the functions should be on the appliance
-# and we should be using the with context manager, they are being used incorrectly below
-def stop_db_process(address):
-    with get_ssh_client(address) as ssh_client:
-        assert ssh_client.run_command('service {}-postgresql stop'.format(
-            current_appliance.db.client.postgres_version))[0] == 0,\
-            "Could not stop postgres process on {}".format(address)
-
-
-def start_db_process(address):
-    with get_ssh_client(address) as ssh_client:
-        assert ssh_client.run_command('systemctl start {}-postgresql'
-            .format(current_appliance.db.client.postgres_version))[0] == 0,\
-            "Could not start postgres process on {}".format(address)
-
-
-def update_appliance_uuid(address):
-    with get_ssh_client(address) as ssh_client:
-        assert ssh_client.run_command('uuidgen > /var/www/miq/vmdb/GUID')[0] == 0,\
-            "Could not update appliance's uuid on {}".format(address)
-
-
 def get_replication_appliances():
     """Returns two database-owning appliances configured
        with unique region numbers.
     """
-    ver_to_prov = str(version.current_version())
+    ver_to_prov = str(current_appliance.version)
     appl1 = provision_appliance(ver_to_prov, 'long-test_repl_A')
     appl2 = provision_appliance(ver_to_prov, 'long-test_repl_B')
     appl1.configure(region=1)
     appl1.ipapp.wait_for_web_ui()
-    update_appliance_uuid(appl2.address)
+    appl2.update_uuid()
     appl2.configure(region=2, key_address=appl1.address)
     appl2.ipapp.wait_for_web_ui()
-    return (appl1, appl2)
+    return appl1, appl2
 
 
 def get_distributed_appliances():
@@ -90,7 +67,7 @@ def get_distributed_appliances():
     appl2.configure(region=1, patch_ajax_wait=False, key_address=appl1.address,
                     db_address=appl1.address)
     appl2.ipapp.wait_for_web_ui()
-    return (appl1, appl2)
+    return appl1, appl2
 
 
 def configure_db_replication(db_address):
@@ -99,28 +76,26 @@ def configure_db_replication(db_address):
        as active and the backlog as empty.
     """
     conf.set_replication_worker_host(db_address)
-    flash.assert_message_contain("Configuration settings saved for CFME Server")
+    view = current_appliance.server.browser.create_view(ServerView)
+    view.flash.assert_message("Configuration settings saved for CFME Server")  # may be partial
     navigate_to(current_appliance.server, 'Server')
     conf.set_server_roles(database_synchronization=True)
     navigate_to(current_appliance.server.zone.region, 'Replication')
-    wait_for(lambda: conf.get_replication_status(navigate=False), fail_condition=False,
-             num_sec=360, delay=10, fail_func=sel.refresh, message="get_replication_status")
-    assert conf.get_replication_status()
+    rep_status, _ = wait_for(conf.get_replication_status, func_kwargs={'navigate': False},
+                             fail_condition=False, num_sec=360, delay=10,
+                             fail_func=current_appliance.server.browser.refresh,
+                             message="get_replication_status")
+    assert rep_status
     wait_for(lambda: conf.get_replication_backlog(navigate=False) == 0, fail_condition=False,
-             num_sec=120, delay=10, fail_func=sel.refresh, message="get_replication_backlog")
+             num_sec=120, delay=10, fail_func=current_appliance.server.browser.refresh,
+             message="get_replication_backlog")
 
 
-@pytest.fixture(scope="module")
-def vm_name():
-    return "test_repl_pwrctl_" + fauxfactory.gen_alphanumeric()
-
-
-@pytest.fixture(scope="module")
-def test_vm(request, virtualcenter_provider, vm_name):
+@pytest.yield_fixture(scope="module")
+def test_vm(virtualcenter_provider):
     """Fixture to provision appliance to the provider being tested if necessary"""
+    vm_name = random_vm_name('distpwr')
     vm = VM.factory(vm_name, virtualcenter_provider)
-
-    request.addfinalizer(vm.delete_from_provider)
 
     if not virtualcenter_provider.mgmt.does_vm_exist(vm_name):
         logger.info("deploying %s on provider %s", vm_name, virtualcenter_provider.key)
@@ -129,7 +104,12 @@ def test_vm(request, virtualcenter_provider, vm_name):
         logger.info("recycling deployed vm %s on provider %s", vm_name, virtualcenter_provider.key)
     vm.provider.refresh_provider_relationships()
     vm.wait_to_appear()
-    return vm
+    yield vm
+
+    try:
+        virtualcenter_provider.mgmt.delete_vm(vm_name=vm_name)
+    except Exception:
+        logger.exception('Failed deleting VM "%s" on "%s"', vm_name, virtualcenter_provider.name)
 
 
 @pytest.mark.tier(2)
@@ -205,12 +185,14 @@ def test_appliance_replicate_sync_role_change(request, virtualcenter_provider, a
         # Replication is up and running, now disable DB sync role
         conf.set_server_roles(database_synchronization=False)
         navigate_to(appliance.server.zone.region, 'Replication')
-        wait_for(lambda: conf.get_replication_status(navigate=False), fail_condition=True,
-                 num_sec=360, delay=10, fail_func=sel.refresh, message="get_replication_status")
+        wait_for(conf.get_replication_status, func_kwargs={'navigate': False}, fail_condition=True,
+                 num_sec=360, delay=10, fail_func=appl1.server.browser.refresh,
+                 message="get_replication_status")
         conf.set_server_roles(database_synchronization=True)
         navigate_to(appliance.server.zone.region, 'Replication')
-        wait_for(lambda: conf.get_replication_status(navigate=False), fail_condition=False,
-                 num_sec=360, delay=10, fail_func=sel.refresh, message="get_replication_status")
+        wait_for(conf.get_replication_status, func_kwargs={'navigate': False}, fail_condition=False,
+                 num_sec=360, delay=10, fail_func=appl1.server.browser.refresh,
+                 message="get_replication_status")
         assert conf.get_replication_status()
         virtualcenter_provider.create()
         wait_for_a_provider()
@@ -243,12 +225,14 @@ def test_appliance_replicate_sync_role_change_with_backlog(request, virtualcente
         virtualcenter_provider.create()
         conf.set_server_roles(database_synchronization=False)
         navigate_to(appliance.server.zone.region, 'Replication')
-        wait_for(lambda: conf.get_replication_status(navigate=False), fail_condition=True,
-                 num_sec=360, delay=10, fail_func=sel.refresh, message="get_replication_status")
+        wait_for(conf.get_replication_status, func_kwargs={'navigate': False}, fail_condition=True,
+                 num_sec=360, delay=10, fail_func=appl1.server.browser.refresh,
+                 message="get_replication_status")
         conf.set_server_roles(database_synchronization=True)
         navigate_to(appliance.server.zone.region, 'Replication')
-        wait_for(lambda: conf.get_replication_status(navigate=False), fail_condition=False,
-                 num_sec=360, delay=10, fail_func=sel.refresh, message="get_replication_status")
+        wait_for(conf.get_replication_status, func_kwargs={'navigate': False}, fail_condition=False,
+                 num_sec=360, delay=10, fail_func=appl1.server.browser.refresh,
+                 message="get_replication_status")
         assert conf.get_replication_status()
         wait_for_a_provider()
 
@@ -276,12 +260,13 @@ def test_appliance_replicate_database_disconnection(request, virtualcenter_provi
     with appl1.ipapp:
         configure_db_replication(appl2.address)
         # Replication is up and running, now stop the DB on the replication parent
-        stop_db_process(appl2.address)
+        appl2.stop_db_service()
         sleep(60)
-        start_db_process(appl2.address)
+        appl2.start_db_service()
         navigate_to(appliance.server.zone.region, 'Replication')
-        wait_for(lambda: conf.get_replication_status(navigate=False), fail_condition=False,
-                 num_sec=360, delay=10, fail_func=sel.refresh, message="get_replication_status")
+        wait_for(conf.get_replication_status, func_kwargs={'navigate': False},
+                 fail_condition=False, num_sec=360, delay=10,
+                 fail_func=appl1.server.browser.refresh, message="get_replication_status")
         assert conf.get_replication_status()
         virtualcenter_provider.create()
         wait_for_a_provider()
@@ -312,12 +297,13 @@ def test_appliance_replicate_database_disconnection_with_backlog(request, virtua
         configure_db_replication(appl2.address)
         # Replication is up and running, now stop the DB on the replication parent
         virtualcenter_provider.create()
-        stop_db_process(appl2.address)
+        appl2.stop_db_service()
         sleep(60)
-        start_db_process(appl2.address)
+        appl2.start_db_service()
         navigate_to(appliance.server.zone.region, 'Replication')
-        wait_for(lambda: conf.get_replication_status(navigate=False), fail_condition=False,
-                 num_sec=360, delay=10, fail_func=sel.refresh, message="get_replication_status")
+        wait_for(conf.get_replication_status, func_kwargs={'navigate': False},
+                 fail_condition=False, num_sec=360, delay=10,
+                 fail_func=appl1.server.browser.refresh, message="get_replication_status")
         assert conf.get_replication_status()
         wait_for_a_provider()
 

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -1535,26 +1535,6 @@ class IPAppliance(object):
                     'Appliance must be restarted before the netapp functionality can be used.')
         clear_property_cache(self, 'is_storage_enabled')
 
-    @logger_wrap('Starting postgresql service: {}')
-    def start_db_service(self, log_callback=None):
-        """Starts the postgresql service via systemctl"""
-        service = '{}-postgresql'.format(self.db.postgres_version)
-        log_callback('Starting {}'.format(service))
-        with self.ssh_client as ssh:
-            start_postgres = 'systemctl start {}'.format(service)
-            assert ssh.run_command(start_postgres).success, 'Failed to start {}'.format(service)
-        log_callback('Started service: {}'.format(service))
-
-    @logger_wrap('Stopping postgresql service: {}')
-    def stop_db_service(self, log_callback=None):
-        """Starts the postgresql service via systemctl"""
-        service = '{}-postgresql'.format(self.db.postgres_version)
-        log_callback('Stopping {}'.format(service))
-        with self.ssh_client as ssh:
-            stop_postgres = 'systemctl stop {}'.format(service)
-            assert ssh.run_command(stop_postgres).success, 'Failed to stop {}'.format(service)
-        log_callback('Stopped {}'.format(service))
-
     @logger_wrap('Updating appliance UUID: {}')
     def update_uuid(self, log_callback=None):
         uuid_gen = 'uuidgen |tee /var/www/miq/vmdb/GUID'
@@ -1563,7 +1543,7 @@ class IPAppliance(object):
             result = ssh.run_command(uuid_gen)
             assert result.success, 'Failed to generate UUID'
         log_callback('Updated UUID: {}'.format(str(result)))
-        return str(result)  # should return UUID from stdout
+        return str(result).rstrip('\n')  # should return UUID from stdout
 
     def wait_for_ssh(self, timeout=600):
         """Waits for appliance SSH connection to be ready

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -1535,6 +1535,36 @@ class IPAppliance(object):
                     'Appliance must be restarted before the netapp functionality can be used.')
         clear_property_cache(self, 'is_storage_enabled')
 
+    @logger_wrap('Starting postgresql service: {}')
+    def start_db_service(self, log_callback=None):
+        """Starts the postgresql service via systemctl"""
+        service = '{}-postgresql'.format(self.db.postgres_version)
+        log_callback('Starting {}'.format(service))
+        with self.ssh_client as ssh:
+            start_postgres = 'systemctl start {}'.format(service)
+            assert ssh.run_command(start_postgres).success, 'Failed to start {}'.format(service)
+        log_callback('Started service: {}'.format(service))
+
+    @logger_wrap('Stopping postgresql service: {}')
+    def stop_db_service(self, log_callback=None):
+        """Starts the postgresql service via systemctl"""
+        service = '{}-postgresql'.format(self.db.postgres_version)
+        log_callback('Stopping {}'.format(service))
+        with self.ssh_client as ssh:
+            stop_postgres = 'systemctl stop {}'.format(service)
+            assert ssh.run_command(stop_postgres).success, 'Failed to stop {}'.format(service)
+        log_callback('Stopped {}'.format(service))
+
+    @logger_wrap('Updating appliance UUID: {}')
+    def update_uuid(self, log_callback=None):
+        uuid_gen = 'uuidgen |tee /var/www/miq/vmdb/GUID'
+        log_callback('Running {} to generate UUID'.format(uuid_gen))
+        with self.ssh_client as ssh:
+            result = ssh.run_command(uuid_gen)
+            assert result.success, 'Failed to generate UUID'
+        log_callback('Updated UUID: {}'.format(str(result)))
+        return str(result)  # should return UUID from stdout
+
     def wait_for_ssh(self, timeout=600):
         """Waits for appliance SSH connection to be ready
 

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -1536,13 +1536,14 @@ class IPAppliance(object):
         clear_property_cache(self, 'is_storage_enabled')
 
     @logger_wrap('Updating appliance UUID: {}')
-    def update_uuid(self, log_callback=None):
-        uuid_gen = 'uuidgen |tee /var/www/miq/vmdb/GUID'
-        log_callback('Running {} to generate UUID'.format(uuid_gen))
+    def update_guid(self, log_callback=None):
+        guid_gen = 'uuidgen |tee /var/www/miq/vmdb/GUID'
+        log_callback('Running {} to generate UUID'.format(guid_gen))
         with self.ssh_client as ssh:
-            result = ssh.run_command(uuid_gen)
+            result = ssh.run_command(guid_gen)
             assert result.success, 'Failed to generate UUID'
         log_callback('Updated UUID: {}'.format(str(result)))
+        del self.__dict__['guid']  # invalidate cached_property
         return str(result).rstrip('\n')  # should return UUID from stdout
 
     def wait_for_ssh(self, timeout=600):

--- a/utils/appliance/__init__.py
+++ b/utils/appliance/__init__.py
@@ -1543,7 +1543,10 @@ class IPAppliance(object):
             result = ssh.run_command(guid_gen)
             assert result.success, 'Failed to generate UUID'
         log_callback('Updated UUID: {}'.format(str(result)))
-        del self.__dict__['guid']  # invalidate cached_property
+        try:
+            del self.__dict__['guid']  # invalidate cached_property
+        except KeyError:
+            logger.exception('Exception clearing cached_property "guid"')
         return str(result).rstrip('\n')  # should return UUID from stdout
 
     def wait_for_ssh(self, timeout=600):

--- a/utils/appliance/db.py
+++ b/utils/appliance/db.py
@@ -23,6 +23,7 @@ class ApplianceDB(AppliancePlugin):
 
     # Until this needs a version pick, make it an attr
     postgres_version = 'rh-postgresql95'
+    service_name = '{}-postgresql'.format(postgres_version)
 
     @cached_property
     def client(self):
@@ -385,3 +386,20 @@ class ApplianceDB(AppliancePlugin):
             'WHERE table_schema = \'public\';" vmdb_production | grep -q vmdb_production')
         result = self.ssh_client.run_command(db_check_command)
         return result.rc == 0
+
+    def start_db_service(self):
+        """Starts the postgresql service via systemctl"""
+        self.logger.info('Starting service: {}'.format(self.service_name))
+        with self.ssh_client as ssh:
+            result = ssh.run_command('systemctl start {}'.format(self.service_name))
+            assert result.success, 'Failed to start {}'.format(self.service_name)
+            self.logger.info('Started service: {}'.format(self.service_name))
+
+    def stop_db_service(self):
+        """Starts the postgresql service via systemctl"""
+        service = '{}-postgresql'.format(self.postgres_version)
+        self.logger.info('Stopping {}'.format(service))
+        with self.ssh_client as ssh:
+            result = ssh.run_command('systemctl stop {}'.format(self.service_name))
+            assert result.success, 'Failed to stop {}'.format(service)
+            self.logger.info('Stopped {}'.format(service))


### PR DESCRIPTION
Methods to start/stop postgresql service on the appliance using
systemctl.  Dynamically constructs the service name from
IPAppliance.db.postgres_version

**These tests are blocked by broken browser_steal, so we won't get PRT results here**

The new IPAppliance methods should be tested by hand, they were tested locally.

Also addresses open issue #3784 by using utils.generator.random_vm_name with a shorter prefix that's more compatible with a range of providers.

FIXES RHCFQE-3857