### PR TITLE
[1LP][RFR] Adding extended timeout to avoid RHV Console failure due to TimedOutError

### DIFF
--- a/cfme/tests/cloud_infra_common/test_html5_vm_console.py
+++ b/cfme/tests/cloud_infra_common/test_html5_vm_console.py
@@ -86,7 +86,7 @@ def configure_websocket():
 
 
 @pytest.mark.uncollectif(lambda: version.current_version() < '5.8', reason='Only valid for >= 5.8')
-def test_html5_vm_console(appliance, provider, vm_obj, configure_websocket,
+def test_html5_vm_console(appliance, provider, configure_websocket, vm_obj,
         configure_vmware_console_for_test):
     """
     Test the HTML5 console support for a particular provider.
@@ -195,4 +195,12 @@ def test_html5_vm_console(appliance, provider, vm_obj, configure_websocket,
             assert command_result
     finally:
         vm_console.close_console_window()
+        # Logout is required because when running the Test back 2 back against RHV and VMware
+        # Providers, following issue would arise:
+        # If test for RHV is just finished, code would proceed to adding VMware Provider and once it
+        # is added, then it will navigate to Infrastructure -> Virtual Machines Page, it will see
+        # "Page Does not Exists" Error, because the browser will try to go to the
+        # VM details page of RHV VM which is already deleted
+        # at the End of test for RHV Provider Console and test would fail.
+        # Logging out would get rid of this issue.
         appliance.server.logout()


### PR DESCRIPTION
Purpose or Intent
=================
__Extending__ Timeout for the wait_for_connect() function call because RHV HTML5 console takes longer time to open on first launch. OSP does not require that much time and it was working with default (30 sec) timeout with the function as well. This PR is connected to **RHCFQE-3577** on our sprint board. See comments on that card for additional details. Also moved the fixture configure_websocket before vm_obj, so that there is more time between Enabling Websocket Role and Opening of Remote Console.

{{ pytest: cfme/tests/cloud_infra_common/test_html5_vm_console.py --use-provider vsphere6-nested --use-provider default }}

