### PR TITLE
[1LP][RFR] Fix pagination widgetastic

### DIFF
--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -1261,7 +1261,17 @@ class NonJSPaginationPane(View):
         return int(re.sub(r'\s+items', '', selected))
 
     def set_items_per_page(self, value):
-        self.items_on_page.select_by_visible_text(str(value))
+        """Selects number of items to be displayed on page.
+
+        Args:
+            value: Ideally a str of the format 'x items', x could be {10,20,50,..,1000}
+                   but if value is a number, 'items' is added to it as suffix
+        """
+        if not isinstance(value, (int, six.string_types)):
+            raise TypeError("Value should either be of format either e.g. 10 or a string"
+                " e.g. '10 items' not {}".format(value))
+        items_text = value if 'items' in str(value) else '{} items'.format(value)
+        self.items_on_page.select_by_visible_text(items_text)
 
     def _parse_pages(self):
         min_item, max_item, item_amt = self.paginator.page_info()


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ set_items_per_page because I was getting following error during execution of my tests:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    def select_by_visible_text(self, *items):
        """Selects items in the select.

            Args:
                *items: Items to be selected. If the select does not support multiple selections and you
                    pass more than one item, it will raise an exception.
            """
        if len(items) > 1 and not self.is_multiple:
            raise ValueError(
                'The BootstrapSelect {} does not allow multiple selections'.format(self.id))
        self.open()
        for text in items:
            self.logger.info('selecting by visible text: %r', text)
            try:
                self.browser.click(self.BY_VISIBLE_TEXT.format(quote(text)), parent=self)
            except NoSuchElementException:
              raise NoSuchElementException('Could not find {!r} in {!r}'.format(text, self))
E               NoSuchElementException: Message: Could not find '1000' in BootstrapSelect('ppsetting')../cfme_venv/lib/python2.7/site-packages/widgetastic_patternfly/__init__.py:778: NoSuchElementException (fixtures/log.py:70)



PR #5168 might fail until this fix is merged.

{{ pytest: cfme/tests/cloud_infra_common/test_html5_vm_console.py --use-provider vsphere6-nested }}