### PR TITLE
[RFR][1LP] Fixed BaseQuadIconEntity

### DIFF
--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -2033,7 +2033,7 @@ class BaseQuadIconEntity(ParametrizedView, ClickableMixin):
     LIST = '//dl[contains(@class, "tile")]/*[self::dt or self::dd]'
     label = Text(locator=ParametrizedLocator('./tbody/tr/td/a[contains(@title, {name|quote})]'))
     checkbox = Checkbox(locator='./tbody/tr/td/input[@type="checkbox"]')
-    QUADRANT = './/div[@class="flobj {pos}72"]/*[self::p or self::img]'
+    QUADRANT = './/div[@class="flobj {pos}72"]/*[self::p or self::img or self::div]'
 
     @property
     def is_checked(self):
@@ -2044,7 +2044,6 @@ class BaseQuadIconEntity(ParametrizedView, ClickableMixin):
 
     def uncheck(self):
         return self.checkbox.fill(False)
-
 
     @property
     def data(self):


### PR DESCRIPTION
Purpose
=================

status property in `HostQuadIconEntity`, which inherits `BaseQuadIconEntity`, always returns `None` due incorrect locator.
```html
<div class="flobj b72">
    <div class="stretch" style="background-image: url('/assets/svg/currentstate-on-d9d3fbe67ad09da2fb76e7674b093c3843b03b9a392b32d7e7d13e7bb35883cf.svg')"/>
</div>
```
