### PR TITLE
[1LP][WIPTEST] Integrate wrapanapi containers

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -127,19 +127,11 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
         """
         # gotta stash this in here to prevent circular imports
         from utils.providers import get_mgmt
-        from cfme.containers.provider.openshift import OpenshiftProvider
-
-        if isinstance(self, OpenshiftProvider):
-            credentials = conf.cfme_data['management_systems'][self.key]['endpoints']['default']['credentials']
-            credentials = conf.credentials[credentials]
-            credentials['token'] = self.cli.run_command('oc whoami -t').output
-        else:
-            credentials = None
 
         if self.key:
-            return get_mgmt(self.key, credentials=credentials)
+            return get_mgmt(self.key)
         elif getattr(self, 'provider_data', None):
-            return get_mgmt(self.provider_data, credentials=credentials)
+            return get_mgmt(self.provider_data)
         else:
             raise ProviderHasNoKey(
                 'Provider {} has no key, so cannot get mgmt system'.format(self.name))

--- a/cfme/containers/image.py
+++ b/cfme/containers/image.py
@@ -38,7 +38,7 @@ class Image(Taggable, Labelable, SummaryMixin, Navigatable, PolicyProfileAssigna
 
     @cached_property
     def mgmt(self):
-        return ApiImage(self.provider.mgmt, self.name, self.id)
+        return ApiImage(self.provider.mgmt, self.name, self.sha256)
 
     # TODO: remove load_details and dynamic usage from cfme.common.Summary when nav is more complete
     def load_details(self, refresh=False):
@@ -57,7 +57,7 @@ class Image(Taggable, Labelable, SummaryMixin, Navigatable, PolicyProfileAssigna
 
     @cached_property
     def sha256(self):
-        return self.id.split('sha256:')[-1]
+        return self.id.split('@')[-1]
 
     def perform_smartstate_analysis(self, wait_for_finish=False, timeout='7M'):
         """Performing SmartState Analysis on this Image
@@ -75,14 +75,13 @@ class Image(Taggable, Labelable, SummaryMixin, Navigatable, PolicyProfileAssigna
                                     .format(timeout))
 
     @classmethod
-    def get_random_instances(cls, provider, count=1, appliance=None, ocp_only=False):
-        """Generating random instances. (ocp_only: means for images available in OCP only)"""
+    def get_random_instances(cls, provider, count=1, appliance=None, docker_only=False):
+        """Generating random instances. (docker_only: means for docker images only)"""
         # Grab the images from the UI since we have no way to calculate the name by API attributes
         rows = navigate_and_get_rows(provider, cls, count=1000)
-        if ocp_only:
-            list_by_cli = str(provider.cli.run_command(
-                'oc get images --all-namespaces'))
-            rows = filter(lambda r: r.id.text.split('@sha256:')[-1] in list_by_cli,
+        if docker_only:
+            docker_image_ids = [img.id for img in provider.mgmt.list_docker_image()]
+            rows = filter(lambda r: r.id.text.split('@')[-1] in docker_image_ids,
                           rows)
         random.shuffle(rows)
         return [cls(row.name.text, row.id.text, provider, appliance=appliance)

--- a/cfme/containers/image.py
+++ b/cfme/containers/image.py
@@ -16,6 +16,7 @@ from utils.appliance.implementations.ui import CFMENavigateStep, navigator, navi
 from utils.appliance import Navigatable
 from cfme.configure import tasks
 from utils.wait import wait_for, TimedOutError
+from wrapanapi.containers.image import Image as ApiImage
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
 paged_tbl = PagedTable(table_locator="//div[@id='list_grid']//table")
@@ -34,6 +35,10 @@ class Image(Taggable, Labelable, SummaryMixin, Navigatable, PolicyProfileAssigna
         self.id = image_id
         self.provider = provider
         Navigatable.__init__(self, appliance=appliance)
+
+    @cached_property
+    def mgmt(self):
+        return ApiImage(self.provider.mgmt, self.name, self.id)
 
     # TODO: remove load_details and dynamic usage from cfme.common.Summary when nav is more complete
     def load_details(self, refresh=False):

--- a/cfme/containers/image_registry.py
+++ b/cfme/containers/image_registry.py
@@ -2,6 +2,7 @@
 from functools import partial
 import random
 
+from cached_property import cached_property
 from navmazing import NavigateToSibling, NavigateToAttribute
 
 from cfme.common import SummaryMixin, Taggable
@@ -12,6 +13,8 @@ from cfme.web_ui import CheckboxTable, toolbar as tb, match_location,\
     PagedTable
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
+from wrapanapi.containers.image_registry import ImageRegistry as ApiImageRegistry
+
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
 paged_tbl = PagedTable(table_locator="//div[@id='list_grid']//table")
@@ -29,6 +32,10 @@ class ImageRegistry(Taggable, SummaryMixin, Navigatable):
         self.host = host
         self.provider = provider
         Navigatable.__init__(self, appliance=appliance)
+
+    @cached_property
+    def mgmt(self):
+        return ApiImageRegistry(self.provider.mgmt, self.name, self.host, None)
 
     def load_details(self, refresh=False):
         navigate_to(self, 'Details')

--- a/cfme/containers/node.py
+++ b/cfme/containers/node.py
@@ -4,6 +4,8 @@ from functools import partial
 import random
 import itertools
 
+from cached_property import cached_property
+
 from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.widget import View
 from widgetastic_manageiq import (
@@ -17,6 +19,8 @@ from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import CheckboxTable, toolbar as tb, InfoBlock, match_location
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
+from wrapanapi.containers.node import Node as ApiNode
+
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
 
@@ -88,6 +92,10 @@ class Node(Taggable, Labelable, SummaryMixin, Navigatable):
             collection = NodeCollection(appliance=appliance)
         self.collection = collection
         Navigatable.__init__(self, appliance=appliance)
+
+    @cached_property
+    def mgmt(self):
+        return ApiNode(self.provider.mgmt, self.name)
 
     def load_details(self, refresh=False):
         navigate_to(self, 'Details')

--- a/cfme/containers/pod.py
+++ b/cfme/containers/pod.py
@@ -3,6 +3,8 @@ from functools import partial
 import random
 import itertools
 
+from cached_property import cached_property
+
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import toolbar as tb, match_location,\
@@ -13,6 +15,8 @@ from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep,\
     navigate_to
 from navmazing import NavigateToAttribute, NavigateToSibling
+from wrapanapi.containers.pod import Pod as ApiPod
+
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
 paged_tbl = PagedTable(table_locator="//div[@id='list_grid']//table")
@@ -30,6 +34,10 @@ class Pod(Taggable, Labelable, SummaryMixin, Navigatable):
         self.provider = provider
         self.project_name = project_name
         Navigatable.__init__(self, appliance=appliance)
+
+    @cached_property
+    def mgmt(self):
+        return ApiPod(self.provider.mgmt, self.name, self.project_name)
 
     def load_details(self, refresh=False):
         navigate_to(self, 'Details')

--- a/cfme/containers/project.py
+++ b/cfme/containers/project.py
@@ -2,6 +2,8 @@
 import random
 import itertools
 
+from cached_property import cached_property
+
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import toolbar as tb, match_location,\
@@ -13,6 +15,8 @@ from utils.appliance.implementations.ui import CFMENavigateStep, navigator,\
     navigate_to
 from navmazing import NavigateToAttribute, NavigateToSibling
 from functools import partial
+from wrapanapi.containers.project import Project as ApiProject
+
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
 paged_tbl = PagedTable(table_locator="//div[@id='list_grid']//table")
@@ -28,6 +32,10 @@ class Project(Taggable, Labelable, SummaryMixin, Navigatable):
         self.name = name
         self.provider = provider
         Navigatable.__init__(self, appliance=appliance)
+
+    @cached_property
+    def mgmt(self):
+        return ApiProject(self.provider.mgmt, self.name)
 
     def load_details(self, refresh=False):
         navigate_to(self, 'Details')

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -10,6 +10,7 @@ from cfme.containers.provider import ContainersProviderDefaultEndpoint,\
     ContainersProviderEndpointsForm
 from cfme.common.provider import DefaultEndpoint
 from utils.version import current_version
+from cfme.exceptions import ProviderHasNoKey
 
 
 class CustomAttribute(object):
@@ -69,6 +70,34 @@ class OpenshiftProvider(ContainersProvider):
     @cached_property
     def cli(self):
         return OcpCli(self)
+
+    def get_bearer_token(self):
+
+        username = self.endpoints['default'].credentials.principal
+        res = self.cli.run_command('oc login -u={} -p={}'.format(
+            username, self.endpoints['default'].credentials.secret))
+        if not res.success:
+            raise Exception('Failed to login user "{}": "{}"'.format(username, res.output))
+        res = self.cli.run_command('oc whoami -t')
+        if res.success:
+            return res.output.strip()
+        raise Exception('Failed to get Bearer token: "{}"'.format(res.output))
+
+    def get_mgmt_system(self):
+        """ Returns the mgmt_system using the :py:func:`utils.providers.get_mgmt` method.
+        """
+        # gotta stash this in here to prevent circular imports
+        from utils.providers import get_mgmt
+
+        credentials = {'token': self.get_bearer_token()}
+
+        if self.key:
+            return get_mgmt(self.key, credentials=credentials)
+        elif hasattr(self, 'provider_data'):
+            return get_mgmt(self.provider_data, credentials=credentials)
+        else:
+            raise ProviderHasNoKey(
+                'Provider {} has no key, so cannot get mgmt system'.format(self.name))
 
     def href(self):
         return self.appliance.rest_api.collections.providers\

--- a/cfme/containers/replicator.py
+++ b/cfme/containers/replicator.py
@@ -3,6 +3,8 @@ import random
 import itertools
 from functools import partial
 
+from cached_property import cached_property
+
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import toolbar as tb, match_location,\
@@ -13,6 +15,8 @@ from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep,\
     navigate_to
 from navmazing import NavigateToAttribute, NavigateToSibling
+from wrapanapi.containers.replicator import Replicator as ApiReplicator
+
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
 paged_tbl = PagedTable(table_locator="//div[@id='list_grid']//table")
@@ -29,6 +33,10 @@ class Replicator(Taggable, Labelable, SummaryMixin, Navigatable):
         self.project_name = project_name
         self.provider = provider
         Navigatable.__init__(self, appliance=appliance)
+
+    @cached_property
+    def mgmt(self):
+        return ApiReplicator(self.provider.mgmt, self.name, self.project_name)
 
     def load_details(self, refresh=False):
         navigate_to(self, 'Details')

--- a/cfme/containers/route.py
+++ b/cfme/containers/route.py
@@ -3,6 +3,8 @@ import random
 import itertools
 from functools import partial
 
+from cached_property import cached_property
+
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import toolbar as tb, match_location,\
@@ -13,6 +15,8 @@ from utils.appliance.implementations.ui import navigator, CFMENavigateStep,\
     navigate_to
 from navmazing import NavigateToAttribute, NavigateToSibling
 from utils.appliance import Navigatable
+from wrapanapi.containers.route import Route as ApiRoute
+
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
 paged_tbl = PagedTable(table_locator="//div[@id='list_grid']//table")
@@ -29,6 +33,10 @@ class Route(Taggable, Labelable, SummaryMixin, Navigatable):
         self.project_name = project_name
         self.provider = provider
         Navigatable.__init__(self, appliance=appliance)
+
+    @cached_property
+    def mgmt(self):
+        return ApiRoute(self.provider.mgmt, self.name, self.project_name)
 
     def load_details(self, refresh=False):
         navigate_to(self, 'Details')

--- a/cfme/containers/service.py
+++ b/cfme/containers/service.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 import random
 import itertools
+from functools import partial
+
+from cached_property import cached_property
 
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
@@ -12,7 +15,7 @@ from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep,\
     navigate_to
 from navmazing import NavigateToAttribute, NavigateToSibling
-from functools import partial
+from wrapanapi.containers.service import Service as ApiService
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
 paged_tbl = PagedTable(table_locator="//div[@id='list_grid']//table")
@@ -29,6 +32,10 @@ class Service(Taggable, Labelable, SummaryMixin, Navigatable):
         self.provider = provider
         self.project_name = project_name
         Navigatable.__init__(self, appliance=appliance)
+
+    @cached_property
+    def mgmt(self):
+        return ApiService(self.provider.mgmt, self.name, self.project_name)
 
     def load_details(self, refresh=False):
         navigate_to(self, 'Details')

--- a/cfme/containers/template.py
+++ b/cfme/containers/template.py
@@ -3,6 +3,8 @@ import random
 import itertools
 from functools import partial
 
+from cached_property import cached_property
+
 from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic_manageiq import Table
 
@@ -16,6 +18,7 @@ from .provider import details_page
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep,\
     navigate_to
+from wrapanapi.containers.template import Template as ApiTemplate
 
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
@@ -33,6 +36,10 @@ class Template(Taggable, Labelable, SummaryMixin, Navigatable):
         self.project_name = project_name
         self.provider = provider
         Navigatable.__init__(self, appliance=appliance)
+
+    @cached_property
+    def mgmt(self):
+        return ApiTemplate(self.provider.mgmt, self.name, self.project_name)
 
     def load_details(self, refresh=False):
         navigate_to(self, 'Details')

--- a/cfme/containers/volume.py
+++ b/cfme/containers/volume.py
@@ -3,6 +3,8 @@ from functools import partial
 import random
 import itertools
 
+from cached_property import cached_property
+
 from navmazing import NavigateToSibling, NavigateToAttribute
 from widgetastic_manageiq import Table
 
@@ -14,6 +16,7 @@ from cfme.web_ui import toolbar as tb, match_location, InfoBlock,\
     PagedTable, CheckboxTable
 from utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
 from utils.appliance import Navigatable
+from wrapanapi.containers.volume import Volume as ApiVolume
 
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
@@ -32,6 +35,10 @@ class Volume(Taggable, SummaryMixin, Navigatable):
         self.name = name
         self.provider = provider
         Navigatable.__init__(self, appliance=appliance)
+
+    @cached_property
+    def mgmt(self):
+        return ApiVolume(self.provider.mgmt, self.name)
 
     # TODO: remove load_details and dynamic usage from cfme.common.Summary when nav is more complete
     def load_details(self, refresh=False):

--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -406,11 +406,6 @@ class DbAllocatorConfigNotFound(CFMEException):
     """Raised when cdme_data.yaml file does not contain configuration of 'db_allocator'."""
 
 
-class SetLabelException(Exception):
-    "Raised when failed to set label to an object via cli"
-    pass
-
-
 class LabelNotFoundException(Exception):
     "Raises when failed to remove label from object via cli"
     pass


### PR DESCRIPTION
{{ pytest: cfme/tests/containers/test_labels.py --use-provider cm-env2 }}

- Added mgmt property to containers objects for API access.
- Getting bearer token and use it for the mgmt system.
- + get_bearer_token function  …
- Match Labalable class to use mgmt
- Removed redundant exceptions