### PR TITLE
[1LP][RFR] Update BaseProvider.create, validate creds flash

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -203,6 +203,13 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
                             # there are some endpoints which don't demand validation like
                             #  RSA key pair
                             endp_view.validate.click()
+                            # Flash message widget is in add_view, not in endpoints tab
+                            logger.info(
+                                'Validating credentials flash message for endpoint %s',
+                                endpoint_name)
+                            add_view.flash.assert_no_error()
+                            add_view.flash.assert_success_message(
+                                'Credential validation was successful')
                 if self.one_of(InfraProvider):
                     main_view_obj = InfraProvidersView
                 elif self.one_of(CloudProvider):
@@ -760,18 +767,6 @@ class CloudInfraProvider(BaseProvider, PolicyProfileAssignable):
                 self.default_endpoint.ipaddress = value
         else:
             logger.warn("can't set ipaddress because default endpoint is absent")
-
-    def wait_for_creds_ok(self):
-        """Waits for provider's credentials to become O.K. (circumvents the summary rails exc.)"""
-        self.refresh_provider_relationships(from_list_view=True)
-
-        def _wait_f():
-            navigate_to(self, 'All')
-            q = Quadicon(self.name, self.quad_name)
-            creds = q.creds
-            return "checkmark" in creds
-
-        wait_for(_wait_f, num_sec=300, delay=5, message="credentials of {} ok!".format(self.name))
 
     @property
     def _assigned_policy_profiles(self):


### PR DESCRIPTION
The flash message during endpoint credentials validation was not being
asserted against.

Add calls to WT.patternfly.FlashMessages assert_no_errors() and
assert_success_message for the credentials validation against each
endpoint

Remove CloudInfraProvider.wait_for_creds_ok(), it was using
web_ui.Quadicon.creds and generating an exception due to bad Quadicon
attr resolution.  The method was unused in the framework, and if needed
should be rewritten using Widgetastic quadicon implementation.

FIXES RHCFQE-3858
FIXES #3792

## PRT
{{ pytest: -v --long-running --use-provider complete -k 'test_provider_crud' }}

80% / 70% passing on CFME
Seeing some stats_match `TimedOutError` failures and a 401 on rhos7-ga *after* the provider is created and this new creds validation code is called, and is happening in master at the moment. I think its RFR, and these failures aren't related to this change.