### PR TITLE
[1LP][RFR] Fixed virt_env problem for the ansible-playbook command

### DIFF
--- a/cfme/tests/containers/test_manageiq_ansible_users.py
+++ b/cfme/tests/containers/test_manageiq_ansible_users.py
@@ -9,7 +9,7 @@ from utils.version import current_version
 
 
 pytestmark = [
-    pytest.mark.uncollectif(lambda: current_version() < "5.8"),
+    pytest.mark.uncollectif(lambda: current_version() < "5.7"),
     pytest.mark.usefixtures('setup_provider')]
 pytest_generate_tests = testgen.generate([ContainersProvider], scope='module')
 

--- a/utils/ansible.py
+++ b/utils/ansible.py
@@ -1,9 +1,8 @@
-
 import tempfile
 from os import listdir, mkdir, makedirs, path
 from shutil import copy, copyfile, rmtree
 from subprocess import check_output, CalledProcessError, STDOUT
-
+import sys
 from fauxfactory import gen_alphanumeric
 from utils import conf
 from utils.providers import providers_data
@@ -267,7 +266,14 @@ def setup_ansible_script(provider, script, script_type=None, values_to_update=No
 
 
 def run_ansible(script):
-    cmd = "ansible-playbook " + path.join(basic_yml_path, script + yml)
+    ansible_playbook_cmd = "ansible-playbook -e ansible_python_interpreter="
+    interpreter_path = sys.executable
+    script_path = path.join(basic_yml_path, script + ".yml")
+    cmd = '{}{} {}'.format(ansible_playbook_cmd, interpreter_path, script_path)
+    return run_cmd(cmd)
+
+
+def run_cmd(cmd):
     try:
         response = check_output(cmd, shell=True, stderr=STDOUT)
     except CalledProcessError as exc:


### PR DESCRIPTION
Purpose or Intent
=================
{{pytest: cfme/tests/containers/test_manageiq_ansible_users.py -v --use-provider cm-env2 }}

This fix allows running successfully the ansible-playbook command by creating a separated virt_env within the test run.
Sorry for somewhat an unorthodox solution, lots of bricks were lifted to find it.
https://stackoverflow.com/questions/45795480/import-error-when-running-an-ansible-playbook-with-a-python-module.