### PR TITLE
[RFR][NOTEST] Logging refactor for CI scripts

### DIFF
--- a/scripts/template_upload_rhevm.py
+++ b/scripts/template_upload_rhevm.py
@@ -19,13 +19,15 @@ from threading import Lock, Thread
 from ovirtsdk.xml import params
 
 from utils import net, trackerbot
-from utils.conf import cfme_data
-from utils.conf import credentials
+from utils.conf import cfme_data, credentials
+from utils.log import logger, add_stdout_handler
 from utils.providers import get_mgmt, list_provider_keys
 from utils.ssh import SSHClient
 from utils.wait import wait_for
 
 lock = Lock()
+
+add_stdout_handler(logger)
 
 
 def parse_cmd_line():
@@ -67,16 +69,14 @@ def make_ssh_client(rhevip, sshname, sshpass):
 
 def is_ovirt_engine_running(rhevm_ip, sshname, sshpass):
     try:
-        ssh_client = make_ssh_client(rhevm_ip, sshname, sshpass)
-        stdout = ssh_client.run_command('systemctl status ovirt-engine')[1]
-        # fallback to sysV commands if necessary
-        if 'command not found' in stdout:
-            stdout = ssh_client.run_command('service ovirt-engine status')[1]
-        ssh_client.close()
+        with make_ssh_client(rhevm_ip, sshname, sshpass) as ssh_client:
+            stdout = ssh_client.run_command('systemctl status ovirt-engine')[1]
+            # fallback to sysV commands if necessary
+            if 'command not found' in stdout:
+                stdout = ssh_client.run_command('service ovirt-engine status')[1]
         return 'running' in stdout
     except Exception:
-        print('RHEVM: While checking status of ovirt engine, an exception happened')
-        tb.print_exc()
+        logger.exception('RHEVM: While checking status of ovirt engine, an exception happened')
         return False
 
 
@@ -88,24 +88,24 @@ def change_edomain_state(api, state, edomain, provider):
             if export_domain:
                 if state == 'maintenance' and export_domain.get_status().state == 'active':
                     # may be tasks on the storage, try multiple times
-                    print('RHEVM:{} {} in active, waiting for deactivate...').format(
-                        provider, edomain)
+                    logger.info('RHEVM:{} {} in active, waiting for deactivate...',
+                                provider, edomain)
                     wait_for(lambda: dc.storagedomains.get(edomain).deactivate(), delay=5,
                              num_sec=600, handle_exception=True)
                 elif state == 'active' and export_domain.get_status().state != 'active':
-                    print('RHEVM:{} {} not active, waiting for active...').format(provider,
-                        edomain)
+                    logger.info('RHEVM:{} {} not active, waiting for active...',
+                                provider, edomain)
                     wait_for(lambda: dc.storagedomains.get(edomain).activate(), delay=5,
                              num_sec=600, handle_exception=True)
 
-                wait_for(is_edomain_in_state,
-                        [api, state, edomain], fail_condition=False, delay=5, num_sec=240)
-                print('RHEVM:{} {} successfully set to {} state'.format(provider, edomain, state))
+                wait_for(is_edomain_in_state, [api, state, edomain],
+                         fail_condition=False, delay=5, num_sec=240)
+                logger.info('RHEVM:{} {} successfully set to {} state', provider, edomain, state)
                 return True
         return False
     except Exception:
-        print("RHEVM:{} Exception occurred while changing {} state to {}".format(
-            provider, edomain, state))
+        logger.exception("RHEVM:{} Exception occurred while changing {} state to {}",
+                         provider, edomain, state)
         tb.print_exc()
         return False
 
@@ -132,10 +132,9 @@ def download_ova(ssh_client, ovaurl):
         ovaurl: URL of ova file
     """
     command = 'curl -O {}'.format(ovaurl)
-    exit_status, output = ssh_client.run_command(command, timeout=1800)
-    if exit_status != 0:
-        print("RHEVM: There was an error while downloading ova file:")
-        print(output)
+    result = ssh_client.run_command(command, timeout=1800)
+    if result.failed:
+        logger.error("There was an error while downloading ova file: \n %r", str(result))
         sys.exit(127)
 
 
@@ -156,16 +155,17 @@ def template_from_ova(api, username, password, rhevip, edomain, ovaname, ssh_cli
     """
     try:
         if api.storagedomains.get(edomain).templates.get(temp_template_name) is not None:
-            print("RHEVM:{} Warning: found another template with this name.".format(provider))
-            print("RHEVM:{} Skipping this step. Attempting to continue...".format(provider))
+            logger.info("RHEVM:%r Warning: found another template with this name.", provider)
+            logger.info("RHEVM:%r Skipping this step. Attempting to continue...", provider)
             return
         version_cmd = 'rpm -qa| grep image-uploader'
-        command = ['rhevm-image-uploader']
-        status, out = ssh_client.run_command(version_cmd)
-        if status == 0:
-            version = re.findall(r'(\d.\d)', out)[0]
+        version_result = ssh_client.run_command(version_cmd)
+        if version_result.success:
+            version = re.findall(r'(\d.\d)', str(version_result))[0]
             if float(version) >= 3.6:
                 command = ['engine-image-uploader']
+        else:
+            command = ['rhevm-image-uploader']
         command.append("-u {}".format(username))
         command.append("-p {}".format(password))
         command.append("-v -m --insecure")
@@ -174,19 +174,17 @@ def template_from_ova(api, username, password, rhevip, edomain, ovaname, ssh_cli
         command.append("-e {}".format(edomain))
         command.append("upload {}".format(ovaname))
         command = ' '.join(command)
-        print(
-            'RHEVM:{} Executing command: {}'.format(
-                provider, re.sub(re.escape(password), '*' * len(password), command)))
-        exit_status, output = ssh_client.run_command(command)
-        if exit_status != 0:
-            print("RHEVM:{} There was an error while making template from ova file:".format(
-                provider))
-            print(output)
+        logger.info('RHEVM:%r Executing command: %r',
+                    provider, re.sub(re.escape(password), '*' * len(password), command))
+
+        result = ssh_client.run_command(command)
+        if result.failed:
+            logger.info("RHEVM:%r There was an error while making template from ova file: \n %r",
+                        provider, str(result))
             sys.exit(127)
-        print("RHEVM:{} successfully created template from ova file:".format(provider))
+        logger.info("RHEVM:%r successfully created template from ova file:", provider)
     except Exception:
-        print("RHEVM:{} template_from_ova failed:".format(provider))
-        tb.print_exc()
+        logger.exception("RHEVM:%r template_from_ova failed:", provider)
 
 
 def import_template(api, edomain, sdomain, cluster, temp_template_name, provider):
@@ -200,8 +198,8 @@ def import_template(api, edomain, sdomain, cluster, temp_template_name, provider
     """
     try:
         if api.templates.get(temp_template_name) is not None:
-            print("RHEVM:{} Warning: found another template with this name.".format(provider))
-            print("RHEVM:{} Skipping this step, attempting to continue...".format(provider))
+            logger.info("RHEVM:%r Warning: found another template with this name.", provider)
+            logger.info("RHEVM:%r Skipping this step, attempting to continue...", provider)
             return
         actual_template = api.storagedomains.get(edomain).templates.get(temp_template_name)
         actual_storage_domain = api.storagedomains.get(sdomain)
@@ -211,12 +209,11 @@ def import_template(api, edomain, sdomain, cluster, temp_template_name, provider
         actual_template.import_template(action=import_action)
         # Check if the template is really there
         if not api.templates.get(temp_template_name):
-            print("RHEVM:{} The template failed to import on data domain".format(provider))
+            logger.info("RHEVM:%r The template failed to import on data domain", provider)
             sys.exit(127)
-        print("RHEVM:{} successfully imported template on data domain".format(provider))
+        logger.info("RHEVM:%r successfully imported template on data domain", provider)
     except Exception:
-        print("RHEVM:{} import_template to data domain failed:".format(provider))
-        tb.print_exc()
+        logger.exception("RHEVM:%r import_template to data domain failed:", provider)
 
 
 def make_vm_from_template(api, cluster, temp_template_name, temp_vm_name, provider,
@@ -235,10 +232,9 @@ def make_vm_from_template(api, cluster, temp_template_name, temp_vm_name, provid
     """
     try:
         if api.vms.get(temp_vm_name) is not None:
-            print(
-                "RHEVM:{} Warning: found another VM with this name ({}).".format(
-                    provider, temp_vm_name))
-            print("RHEVM:{} Skipping this step, attempting to continue...".format(provider))
+            logger.info("RHEVM:%r Warning: found another VM with this name (%r).",
+                        provider, temp_vm_name)
+            logger.info("RHEVM:%r Skipping this step, attempting to continue...", provider)
             return
         actual_template = api.templates.get(temp_template_name)
         actual_cluster = api.clusters.get(cluster)
@@ -259,12 +255,11 @@ def make_vm_from_template(api, cluster, temp_template_name, temp_vm_name, provid
             nic.update()
         # check, if the vm is really there
         if not api.vms.get(temp_vm_name):
-            print("RHEVM:{} temp VM could not be provisioned".format(provider))
+            logger.error("RHEVM:%r temp VM could not be provisioned", provider)
             sys.exit(127)
-        print("RHEVM:{} successfully provisioned temp vm".format(provider))
+        logger.info("RHEVM:%r successfully provisioned temp vm", provider)
     except Exception:
-        print("RHEVM:{} Make_temp_vm_from_template failed:".format(provider))
-        tb.print_exc()
+        logger.exception("RHEVM:%r Make_temp_vm_from_template failed:", provider)
 
 
 def check_disks(api, temp_vm_name):
@@ -313,10 +308,9 @@ def add_disk_to_vm(api, sdomain, disk_size, disk_format, disk_interface, temp_vm
     """
     try:
         if len(api.vms.get(temp_vm_name).disks.list()) > 1:
-            print(
-                "RHEVM:{} Warning: found more than one disk in existing VM ({}).".format(
-                    provider, temp_vm_name))
-            print("RHEVM:{} Skipping this step, attempting to continue...".format(provider))
+            logger.info("RHEVM:%r Warning: found more than one disk in existing VM (%r).",
+                    provider, temp_vm_name)
+            logger.info("RHEVM:%r Skipping this step, attempting to continue...", provider)
             return
         actual_sdomain = api.storagedomains.get(sdomain)
         temp_vm = api.vms.get(temp_vm_name)
@@ -328,12 +322,11 @@ def add_disk_to_vm(api, sdomain, disk_size, disk_format, disk_interface, temp_vm
 
         # check, if there are two disks
         if len(api.vms.get(temp_vm_name).disks.list()) < 2:
-            print("RHEVM:{} Disk failed to add".format(provider))
+            logger.error("RHEVM:%r Disk failed to add", provider)
             sys.exit(127)
-        print("RHEVM:{} Successfully added disk".format(provider))
+        logger.info("RHEVM:%r Successfully added disk", provider)
     except Exception:
-        print("RHEVM:{} add_disk_to_temp_vm failed:".format(provider))
-        tb.print_exc()
+        logger.exception("RHEVM:%r add_disk_to_temp_vm failed:", provider)
 
 
 def templatize_vm(api, template_name, cluster, temp_vm_name, provider):
@@ -346,10 +339,9 @@ def templatize_vm(api, template_name, cluster, temp_vm_name, provider):
     """
     try:
         if api.templates.get(template_name) is not None:
-            print(
-                "RHEVM:{} Warning: found finished template with this name ({}).".format(
-                    provider, template_name))
-            print("RHEVM:{} Skipping this step, attempting to continue...".format(provider))
+            logger.info("RHEVM:%r Warning: found finished template with this name (%r).",
+                    provider, template_name)
+            logger.info("RHEVM:%r Skipping this step, attempting to continue", provider)
             return
         temporary_vm = api.vms.get(temp_vm_name)
         actual_cluster = api.clusters.get(cluster)
@@ -360,12 +352,11 @@ def templatize_vm(api, template_name, cluster, temp_vm_name, provider):
 
         # check, if template is really there
         if not api.templates.get(template_name):
-            print("RHEVM:{} templatizing temporary VM failed".format(provider))
+            logger.error("RHEVM:%r templatizing temporary VM failed", provider)
             sys.exit(127)
-        print("RHEVM:{} successfully templatized the temporary VM".format(provider))
+        logger.info("RHEVM:%r successfully templatized the temporary VM", provider)
     except Exception:
-        print("RHEVM:{} templatizing temporary VM failed".format(provider))
-        tb.print_exc()
+        logger.exception("RHEVM:%r templatizing temporary VM failed", provider)
 
 
 # get the domain edomain path on the rhevm
@@ -389,7 +380,6 @@ def cleanup_empty_dir_on_edomain(path, edomainip, sshname, sshpass, provider_ip,
         provider_ip: provider ip address
     """
     try:
-        ssh_client = make_ssh_client(provider_ip, sshname, sshpass)
         edomain_path = edomainip + ':' + path
         temp_path = '~/tmp_filemount'
         command = 'mkdir -p {} &&'.format(temp_path)
@@ -398,16 +388,17 @@ def cleanup_empty_dir_on_edomain(path, edomainip, sshname, sshpass, provider_ip,
         command += 'find . -maxdepth 1 -type d -empty -delete &&'
         command += 'cd ~ && umount {} &&'.format(temp_path)
         command += 'rmdir {}'.format(temp_path)
-        print("RHEVM:{} Deleting the empty directories on edomain/vms file...".format(provider))
-        exit_status, output = ssh_client.run_command(command)
-        ssh_client.close()
-        if exit_status != 0:
-            print("RHEVM:{} Error while deleting the empty directories on path..".format(
-                provider))
-            print(output)
-        print("RHEVM:{} successfully deleted the empty directories on path..".format(provider))
+        logger.info("RHEVM:%r Deleting the empty directories on edomain/vms file...", provider)
+
+        with make_ssh_client(provider_ip, sshname, sshpass) as ssh_client:
+            result = ssh_client.run_command(command)
+        if result.failed:
+            logger.error("RHEVM:%r Error while deleting the empty directories on path: \n %r",
+                provider, str(result))
+        else:
+            logger.info("RHEVM:%r successfully deleted the empty directories on path..", provider)
     except Exception:
-        tb.print_exc()
+        logger.exception('RHEVM:%r Exception cleaning up empty dir on edomain', provider)
         return False
 
 
@@ -419,16 +410,18 @@ def cleanup(api, edomain, ssh_client, ovaname, provider, temp_template_name, tem
         edomain: Export domain of chosen RHEVM provider.
     """
     try:
-        print("RHEVM:{} Deleting the  .ova file...".format(provider))
+        logger.info("RHEVM:%r Deleting the  .ova file...", provider)
         command = 'rm {}'.format(ovaname)
-        exit_status, output = ssh_client.run_command(command)
+        result = ssh_client.run_command(command)
+        if result.failed:
+            logger.error('Failure deleting ova file: %r', str(result))
 
-        print("RHEVM:{} Deleting the temp_vm on sdomain...".format(provider))
+        logger.info("RHEVM:%r Deleting the temp_vm on sdomain...", provider)
         temporary_vm = api.vms.get(temp_vm_name)
         if temporary_vm:
             temporary_vm.delete()
 
-        print("RHEVM:{} Deleting the temp_template on sdomain...".format(provider))
+        logger.info("RHEVM:%r Deleting the temp_template on sdomain...", provider)
         temporary_template = api.templates.get(temp_template_name)
         if temporary_template:
             temporary_template.delete()
@@ -436,22 +429,21 @@ def cleanup(api, edomain, ssh_client, ovaname, provider, temp_template_name, tem
         # waiting for template on export domain
         unimported_template = api.storagedomains.get(edomain).templates.get(
             temp_template_name)
-        print("RHEVM:{} waiting for template on export domain...".format(provider))
+        logger.info("RHEVM:%r waiting for template on export domain...", provider)
         wait_for(check_edomain_template, [api, edomain, temp_template_name],
                  fail_condition=False, delay=5, num_sec=600)
 
         if unimported_template:
-            print("RHEVM:{} deleting the template on export domain...".format(provider))
+            logger.info("RHEVM:%r deleting the template on export domain...", provider)
             wait_for(unimported_template.delete, delay=10, num_sec=600, handle_exception=True)
 
-        print("RHEVM:{} waiting for template delete on export domain...".format(provider))
+        logger.info("RHEVM:%r waiting for template delete on export domain...", provider)
         wait_for(is_edomain_template_deleted, [api, temp_template_name, edomain],
                  fail_condition=False, delay=5, num_sec=600)
-        print("RHEVM:{} successfully deleted template on export domain...".format(provider))
+        logger.info("RHEVM:%r successfully deleted template on export domain...", provider)
 
     except Exception:
-        print("RHEVM:{} Exception occurred in cleanup method:".format(provider))
-        tb.print_exc()
+        logger.exception("RHEVM:%r Exception occurred in cleanup method:", provider)
         return False
 
 
@@ -464,14 +456,13 @@ def api_params_resolution(item_list, item_name, item_param):
         item_param: Name of parameter representing data in the script.
     """
     if len(item_list) == 0:
-        print("RHEVM: Cannot find {} ({}) automatically.".format(item_name, item_param))
-        print("Please specify it by cmd-line parameter '--{}' or in cfme_data.".format(item_param))
+        logger.info("RHEVM: Cannot find %r (%r) automatically.", item_name, item_param)
+        logger.info("Please specify it by cmd-line parameter '--%r' or in cfme_data.", item_param)
         return None
     elif len(item_list) > 1:
-        print("RHEVM: Found multiple instances of {}. Picking '{}'.".format(
-            item_name, item_list[0]))
+        logger.info("RHEVM: Found multiple instances of %r. Picking '%r'.", item_name, item_list[0])
     else:
-        print("RHEVM: Found {} '{}'.".format(item_name, item_list[0]))
+        logger.info("RHEVM: Found %r '%r'.", item_name, item_list[0])
 
     return item_list[0]
 
@@ -525,7 +516,7 @@ def get_cluster(api):
 def check_kwargs(**kwargs):
     for key, val in kwargs.iteritems():
         if val is None:
-            print("RHEVM: please supply required parameter '{}'.".format(key))
+            logger.error("RHEVM: please supply required parameter '%r'.", key)
             sys.exit(127)
 
 
@@ -614,7 +605,7 @@ def make_kwargs_rhevm(cfmeqe_data, provider):
 def upload_template(rhevip, sshname, sshpass, username, password,
                     provider, image_url, template_name, provider_data, stream):
     try:
-        print("RHEVM:{} Template {} upload started".format(provider, template_name))
+        logger.info("RHEVM:%r Template %r upload started", provider, template_name)
         if provider_data:
             kwargs = make_kwargs_rhevm(provider_data, provider)
             providers = provider_data['management_systems']
@@ -625,7 +616,6 @@ def upload_template(rhevip, sshname, sshpass, username, password,
         kwargs['image_url'] = image_url
         kwargs['template_name'] = template_name
         ovaname = get_ova_name(image_url)
-        ssh_client = make_ssh_client(rhevip, sshname, sshpass)
         temp_template_name = ('auto-tmp-{}-'.format(
             fauxfactory.gen_alphanumeric(8))) + template_name
         temp_vm_name = ('auto-vm-{}-'.format(
@@ -636,35 +626,38 @@ def upload_template(rhevip, sshname, sshpass, username, password,
         path, edomain_ip = get_edomain_path(api, kwargs.get('edomain'))
 
         kwargs = update_params_api(api, **kwargs)
-
         check_kwargs(**kwargs)
 
         if api.templates.get(template_name) is not None:
-            print("RHEVM:{} Found finished template with name {}.".format(provider, template_name))
-            print("RHEVM:{} The script will now end.".format(provider))
-            ssh_client.close()
-        else:
-            print("RHEVM:{} Downloading .ova file...".format(provider))
+            logger.info("RHEVM:%r Found finished template with name %r.", provider, template_name)
+            logger.info("RHEVM:%r The script will now end.", provider)
+            return True
+        logger.info("RHEVM:%r Downloading .ova file...", provider)
+        with make_ssh_client(rhevip, sshname, sshpass) as ssh_client:
             download_ova(ssh_client, kwargs.get('image_url'))
             try:
-                print("RHEVM:{} Templatizing .ova file...".format(provider))
+                logger.info("RHEVM:%r Templatizing .ova file", provider)
                 template_from_ova(api, username, password, rhevip, kwargs.get('edomain'),
                                   ovaname, ssh_client, temp_template_name, provider)
-                print("RHEVM:{} Importing new template to data domain...".format(provider))
+
+                logger.info("RHEVM:%r Importing new template to data domain", provider)
                 import_template(api, kwargs.get('edomain'), kwargs.get('sdomain'),
                                 kwargs.get('cluster'), temp_template_name, provider)
-                print("RHEVM:{} Making a temporary VM from new template...".format(provider))
+
+                logger.info("RHEVM:%r Making a temporary VM from new template", provider)
                 make_vm_from_template(api, kwargs.get('cluster'), temp_template_name, temp_vm_name,
                                       provider, mgmt_network=kwargs.get('mgmt_network'))
-                print("RHEVM:{} Adding disk to created VM...".format(provider))
+
+                logger.info("RHEVM:%r Adding disk to created VM", provider)
                 add_disk_to_vm(api, kwargs.get('sdomain'), kwargs.get('disk_size'),
                                kwargs.get('disk_format'), kwargs.get('disk_interface'),
                                temp_vm_name, provider)
-                print("RHEVM:{} Templatizing VM...".format(provider))
+
+                logger.info("RHEVM:%r Templatizing VM", provider)
                 templatize_vm(api, template_name, kwargs.get('cluster'), temp_vm_name, provider)
+
                 if not provider_data:
-                    print("RHEVM:{} Adding template {} to trackerbot..".format(
-                        provider, template_name))
+                    logger.info("RHEVM:%r Add template %r to trackerbot", provider, template_name)
                     trackerbot.trackerbot_add_provider_template(stream, provider, template_name)
             finally:
                 cleanup(api, kwargs.get('edomain'), ssh_client, ovaname, provider,
@@ -673,18 +666,17 @@ def upload_template(rhevip, sshname, sshpass, username, password,
                 cleanup_empty_dir_on_edomain(path, edomain_ip,
                                              sshname, sshpass, rhevip, provider)
                 change_edomain_state(api, 'active', kwargs.get('edomain'), provider)
-                ssh_client.close()
                 api.disconnect()
-                print("RHEVM:{} Template {} upload Ended".format(provider, template_name))
+                logger.info("RHEVM:%r Template %r upload Ended", provider, template_name)
         if provider_data and api.templates.get(template_name):
-            print("RHEVM:{} Deploying Template {}....".format(provider, template_name))
+            logger.info("RHEVM:%r Deploying Template %r", provider, template_name)
             vm_name = 'test_{}_{}'.format(template_name, fauxfactory.gen_alphanumeric(8))
             deploy_args = {'provider': provider, 'vm_name': vm_name,
                            'template': template_name, 'deploy': True}
             getattr(__import__('clone_template'), "main")(**deploy_args)
-        print("RHEVM:{} Template {} upload Ended".format(provider, template_name))
-    except Exception as e:
-        print("RHEVM:{} Template {} upload exception: {}".format(provider, template_name, e))
+        logger.info("RHEVM:%r Template %r upload Ended", provider, template_name)
+    except Exception:
+        logger.exception("RHEVM:%r Template %r upload exception", provider, template_name)
         return False
 
 
@@ -720,11 +712,11 @@ def run(**kwargs):
             # Providers template_upload section indicates upload should not happen on this provider
             continue
 
-        print("RHEVM:{} verifying provider's state before template upload".format(provider))
+        logger.info("RHEVM:%r verifying provider's state before template upload", provider)
         if not net.is_pingable(rhevip):
             continue
         elif not is_ovirt_engine_running(rhevip, sshname, sshpass):
-            print('RHEVM:{} ovirt-engine service not running..'.format(provider))
+            logger.info('RHEVM:%r ovirt-engine service not running..', provider)
             continue
         valid_providers.append(provider)
 

--- a/utils/log.py
+++ b/utils/log.py
@@ -477,6 +477,16 @@ def setup_for_worker(workername, loggers=('cfme', 'py.warnings')):
         log.debug("worker log started")  # directly reopens the file
 
 
+def add_stdout_handler(logger):
+    """Look for a stdout handler in the logger, add one if not present"""
+    for handle in logger.handlers:
+        if isinstance(handle, logging.StreamHandler) and 'stdout' in handle.stream.name:
+            break
+    else:
+        # Never found a stdout StreamHandler
+        logger.addHandler(logging.StreamHandler(sys.stdout))
+
+
 _configure_warnings()
 
 # Register a custom excepthook to log unhandled exceptions


### PR DESCRIPTION
Use logger to print all messages to stdout and to the log.

Within the scope of the `scripts` directory, and especially with those scripts run by CI infrastructure, we want to simultaneously write all info/debug/warning/error/exception messages both to stdout and to the logger provided by `utils.log.logger`.

These scripts can't/won't be tested by PRT for now, so I'm testing all of them locally before committing changes.

Adding basic logging import and console args where appropriate for the scripts that are scoped for this PR. 

Ignore the damn lint tool.

FIXES #4472 