### PR TITLE
[1LP][RFR] Adding ToggleFullScreen Button Test for HTML5 Remote Console

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -751,6 +751,9 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
     def get_console_ctrl_alt_del_btn(self):
         raise NotImplementedError("This method is not implemented for given provider")
 
+    def get_console_fullscreen_btn(self):
+        raise NotImplementedError("This method is not implemented for given provider")
+
     def get_all_provider_ids(self):
         """
         Returns an integer list of provider ID's via the REST API

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -379,13 +379,16 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable, SummaryMixin
         # Get the consoles window handle, and then create a VMConsole object, and store
         # the VMConsole object aside.
         console_handle = self.console_handle
+
         if console_handle is None:
             raise TypeError("Console handle should not be None")
+
         appliance_handle = self.appliance.browser.widgetastic.window_handle
         logger.info("Creating VMConsole:")
         logger.info("   appliance_handle: {}".format(appliance_handle))
         logger.info("     console_handle: {}".format(console_handle))
         logger.info("               name: {}".format(self.name))
+
         self.vm_console = VMConsole(
             appliance_handle=appliance_handle,
             console_handle=console_handle,

--- a/cfme/common/vm_console.py
+++ b/cfme/common/vm_console.py
@@ -153,6 +153,20 @@ class VMConsole(Pretty):
         ctrl_alt_del_btn.click()
         self.switch_to_appliance()
 
+    def send_fullscreen(self):
+        """Press the fullscreen button in the console tab."""
+        self.switch_to_console()
+        fullscreen_btn = self.provider.get_console_fullscreen_btn()
+        logger.info("Sending following Keys to Console Toggle Fullscreen")
+        before_height = self.selenium.get_window_size()['height']
+        fullscreen_btn.click()
+        after_height = self.selenium.get_window_size()['height']
+        fullscreen_btn.click()
+        self.switch_to_console()
+        if after_height > before_height:
+            return True
+        return False
+
     def switch_to_appliance(self):
         """Switch focus to appliance tab/window."""
         logger.info("Switching to appliance: window handle = {}".format(self.appliance_handle))

--- a/cfme/infrastructure/provider/rhevm.py
+++ b/cfme/infrastructure/provider/rhevm.py
@@ -53,6 +53,7 @@ class RHEVMProvider(InfraProvider):
     _console_connection_status_element = '//*[@id="connection-status"]'
     _canvas_element = '//*[@id="remote-console"]/canvas'
     _ctrl_alt_del_xpath = '//*[@id="ctrlaltdel"]'
+    _fullscreen_xpath = '//*[@id="fullscreen"]'
 
     def __init__(self, name=None, endpoints=None, zone=None, key=None, hostname=None,
                  ip_address=None, start_ip=None, end_ip=None, provider_data=None, appliance=None):
@@ -124,5 +125,12 @@ class RHEVMProvider(InfraProvider):
         try:
             return self.appliance.browser.widgetastic.selenium.find_element_by_xpath(
                 self._ctrl_alt_del_xpath)
+        except:
+            raise ItemNotFound("Element not found on screen, is current focus on console window?")
+
+    def get_console_fullscreen_btn(self):
+        try:
+            return self.appliance.browser.widgetastic.selenium.find_element_by_xpath(
+                self._fullscreen_xpath)
         except:
             raise ItemNotFound("Element not found on screen, is current focus on console window?")

--- a/cfme/infrastructure/provider/virtualcenter.py
+++ b/cfme/infrastructure/provider/virtualcenter.py
@@ -27,6 +27,7 @@ class VMwareProvider(InfraProvider):
     _console_connection_status_element = '//*[@id="connection-status"]'
     _canvas_element = '//*[@id="remote-console"]/canvas'
     _ctrl_alt_del_xpath = '//*[@id="ctrlaltdel"]'
+    _fullscreen_xpath = '//*[@id="fullscreen"]'
 
     def __init__(self, name=None, endpoints=None, key=None, zone=None, hostname=None,
                  ip_address=None, start_ip=None, end_ip=None, provider_data=None, appliance=None):
@@ -94,6 +95,13 @@ class VMwareProvider(InfraProvider):
         try:
             return self.appliance.browser.widgetastic.selenium.find_element_by_xpath(
                 self._ctrl_alt_del_xpath)
+        except:
+            raise ItemNotFound("Element not found on screen, is current focus on console window?")
+
+    def get_console_fullscreen_btn(self):
+        try:
+            return self.appliance.browser.widgetastic.selenium.find_element_by_xpath(
+                self._fullscreen_xpath)
         except:
             raise ItemNotFound("Element not found on screen, is current focus on console window?")
 

--- a/cfme/tests/cloud_infra_common/test_html5_vm_console.py
+++ b/cfme/tests/cloud_infra_common/test_html5_vm_console.py
@@ -115,20 +115,20 @@ def test_html5_vm_console(appliance, provider, vm_obj, configure_websocket,
     try:
         # If the banner/connection-status element exists we can get
         # the connection status text and if the console is healthy, it should connect.
-        assert vm_console.wait_for_connect(), "VM Console did not reach 'connected' state"
+        assert vm_console.wait_for_connect(180), "VM Console did not reach 'connected' state"
 
         # Get the login screen image, and make sure it is a jpeg file:
         screen = vm_console.get_screen()
         assert imghdr.what('', screen) == 'jpeg'
 
-        assert vm_console.wait_for_text(text_to_find="login:", timeout=200),\
-            "VM Console didn't prompt for Login"
+        assert vm_console.wait_for_text(text_to_find="login:", timeout=200), ("VM Console"
+            " didn't prompt for Login")
 
         # Enter Username:
         vm_console.send_keys(console_vm_username)
 
-        assert vm_console.wait_for_text(text_to_find="Password", timeout=200),\
-            "VM Console didn't prompt for Password"
+        assert vm_console.wait_for_text(text_to_find="Password", timeout=200), ("VM Console"
+            " didn't prompt for Password")
         # Enter Password:
         vm_console.send_keys("{}\n".format(console_vm_password))
 
@@ -178,8 +178,12 @@ def test_html5_vm_console(appliance, provider, vm_obj, configure_websocket,
         # Test pressing ctrl-alt-delete...we should be able to get a new login prompt:
         vm_console.send_ctrl_alt_delete()
         vm_console.wait_for_text(text_to_find="login:", timeout=200, to_disappear=True)
-        assert vm_console.wait_for_text(text_to_find="login:", timeout=200),\
-            "VM Console didn't prompt for Login"
+        assert vm_console.wait_for_text(text_to_find="login:", timeout=200), ("VM Console"
+            " didn't prompt for Login")
+
+        if not provider.one_of(OpenStackProvider):
+            assert vm_console.send_fullscreen(), ("VM Console Toggle Full Screen button does"
+            " not work")
 
         with ssh.SSHClient(hostname=vm_obj.ip_address, username=console_vm_username,
                 password=console_vm_password) as ssh_client:
@@ -191,3 +195,4 @@ def test_html5_vm_console(appliance, provider, vm_obj, configure_websocket,
             assert command_result
     finally:
         vm_console.close_console_window()
+        appliance.server.logout()


### PR DESCRIPTION
Purpose or Intent
=================


__Adding tests__ for feature ToggleFullScreen Button on HTML5 Remote Console. 

**Expected Result:**Tests are supposed to fail against the vsphere6-nested and RHV41 because it is a known Bug (https://bugzilla.redhat.com/1479935) and RHOS7-GA would be skipped for ToggleFullScreen button test since it does not support this functionality.  

{{ pytest: cfme/tests/cloud_infra_common/test_html5_vm_console.py --use-provider vsphere6-nested --use-provider default }}