### PR TITLE
[1LP][RFR] Making sure 'touch blather' command is sent to console correctly for RHOS and RHV

### DIFF
--- a/cfme/common/vm_console.py
+++ b/cfme/common/vm_console.py
@@ -6,6 +6,7 @@ Module containing classes with common behaviour for consoles of both VMs and Ins
 import base64
 import re
 import tempfile
+import time
 
 from cfme.exceptions import ItemNotFound
 from PIL import Image, ImageFilter
@@ -140,9 +141,13 @@ class VMConsole(Pretty):
         """Send text to the console."""
         self.switch_to_console()
         canvas = self.provider.get_remote_console_canvas()
-        canvas.send_keys(text)
-        canvas.send_keys(Keys.ENTER)
         logger.info("Sending following Keys to Console {}".format(text))
+        for character in text:
+            canvas.send_keys(character)
+            # time.sleep() is used as a short delay between two keystrokes.
+            # If keys are sent to canvas any faster, canvas fails to receive them.
+            time.sleep(0.3)
+        canvas.send_keys(Keys.ENTER)
         self.switch_to_appliance()
 
     def send_ctrl_alt_delete(self):

--- a/cfme/tests/cloud_infra_common/test_html5_vm_console.py
+++ b/cfme/tests/cloud_infra_common/test_html5_vm_console.py
@@ -171,9 +171,7 @@ def test_html5_vm_console(appliance, provider, configure_websocket, vm_obj,
             time.sleep(15)
 
         # create file on system
-        vm_console.send_keys("touch blather\n")
-        logger.info("Wait 5 sec for file creation")
-        time.sleep(5)  # Wait for file creation
+        vm_console.send_keys("touch blather")
 
         # Test pressing ctrl-alt-delete...we should be able to get a new login prompt:
         vm_console.send_ctrl_alt_delete()
@@ -191,7 +189,7 @@ def test_html5_vm_console(appliance, provider, configure_websocket, vm_obj,
             # we will get instance of SSHResult
             # Sometimes Openstack drops characters from word 'blather' hence try to remove
             # file using partial file name. Known issue, being worked on.
-            command_result = ssh_client.run_command("rm bla*", ensure_user=True)
+            command_result = ssh_client.run_command("rm blather", ensure_user=True)
             assert command_result
     finally:
         vm_console.close_console_window()


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ File creation command 'touch blather' to make sure that RHV and RHOS HTML5 Remote consoles are receiving all characters correctly, otherwise sometimes RHOS and RHV Providers drop some characters resulting in the file not being created.


{{ pytest: cfme/tests/cloud_infra_common/test_html5_vm_console.py --use-provider vsphere6-nested --use-provider default }}