### PR TITLE
[1LP][WIP] Non Interactive Quadicons support + BaseNonInteractiveEntitiesView

### DIFF
--- a/cfme/ansible/playbooks.py
+++ b/cfme/ansible/playbooks.py
@@ -151,4 +151,4 @@ class Details(CFMENavigateStep):
     prerequisite = NavigateToAttribute("appliance.server", "AnsiblePlaybooks")
 
     def step(self):
-        self.prerequisite_view.entities.get_first_entity(by_name=self.obj.name).click()
+        self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True).click()

--- a/cfme/cloud/availability_zone.py
+++ b/cfme/cloud/availability_zone.py
@@ -12,7 +12,7 @@ from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import CFMENavigateStep, navigator
 from widgetastic_manageiq import (
     TimelinesView, ItemsToolBarViewSelector, Text, Table, Search, PaginationPane, BreadCrumb,
-    SummaryTable, Accordion, ManageIQTree)
+    SummaryTable, Accordion, ManageIQTree, BaseNonInteractiveEntitiesView)
 
 
 class AvailabilityZoneToolBar(View):
@@ -101,7 +101,8 @@ class AvailabilityZoneEditTagsView(AvailabilityZoneView):
     breadcrumb = BreadCrumb()
     title = Text('//div[@id="main-content"]//h3')
     # TODO Add tag table support when rowspan is supported in SummaryTable
-    # TODO Add quadicon area
+    entities = View.nested(BaseNonInteractiveEntitiesView)
+
     save = Button('Save')
     reset = Button('Reset')
     cancel = Button('Cancel')

--- a/cfme/cloud/flavor.py
+++ b/cfme/cloud/flavor.py
@@ -11,7 +11,7 @@ from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import CFMENavigateStep, navigator
 from widgetastic_manageiq import (
     ItemsToolBarViewSelector, SummaryTable, Text, Table, PaginationPane, Accordion, ManageIQTree,
-    Search, BreadCrumb)
+    Search, BreadCrumb, BaseNonInteractiveEntitiesView)
 
 
 class FlavorView(BaseLoggedInPage):
@@ -91,12 +91,13 @@ class FlavorEditTagsView(FlavorView):
     def is_displayed(self):
         return (
             self.in_availability_zones and
-            self.entities.title.text == 'Tag Assignment' and
-            '{} (Summary)'.format(self.context['object'].name) in self.entities.breadcrumb.locations
+            self.title.text == 'Tag Assignment' and
+            '{} (Summary)'.format(self.context['object'].name) in self.breadcrumb.locations
         )
 
     breadcrumb = BreadCrumb()
     title = Text('//div[@id="main-content"]//h3')
+    entities = View.nested(BaseNonInteractiveEntitiesView)
     save = Button('Save')
     reset = Button('Reset')
     cancel = Button('Cancel')

--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -316,7 +316,7 @@ class Instance(VM, Navigatable):
             view = navigate_to(self, 'AllForProvider')
             view.toolbar.view_selector.select('List View')
             try:
-                row = view.entities.get_first_entity(by_name=self.name)
+                row = view.entities.get_entity(by_name=self.name)
             except ItemNotFound:
                 raise InstanceNotFound('Failed to find instance in table: {}'.format(self.name))
             row.check()
@@ -428,7 +428,7 @@ class Details(CFMENavigateStep):
     def step(self):
         self.prerequisite_view.toolbar.view_selector.select('List View')
         try:
-            row = self.prerequisite_view.entities.get_first_entity(by_name=self.obj.name)
+            row = self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True)
         except ItemNotFound:
             raise InstanceNotFound('Failed to locate instance with name "{}"'.format(self.obj.name))
         row.click()

--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -128,7 +128,7 @@ class Details(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name).click()
+        self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True).click()
 
 
 @navigator.register(CloudProvider, 'Edit')
@@ -137,7 +137,7 @@ class Edit(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name).check()
+        self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True).check()
         self.prerequisite_view.toolbar.configuration.item_select('Edit Selected Cloud Provider')
 
 
@@ -156,7 +156,7 @@ class ManagePolicies(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name).check()
+        self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True).check()
         self.prerequisite_view.toolbar.policy.item_select('Manage Policies')
 
 
@@ -175,7 +175,7 @@ class EditTags(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name).check()
+        self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True).check()
         self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
 
 

--- a/cfme/cloud/stack.py
+++ b/cfme/cloud/stack.py
@@ -4,7 +4,7 @@ from widgetastic.exceptions import NoSuchElementException
 from widgetastic_patternfly import Button, Dropdown, FlashMessages, BootstrapNav
 from widgetastic_manageiq import (
     Accordion, BootstrapSelect, BreadCrumb, ItemsToolBarViewSelector, PaginationPane, Search,
-    SummaryTable, Table, Text)
+    SummaryTable, Table, Text, BaseNonInteractiveEntitiesView)
 
 from cfme.base.ui import BaseLoggedInPage
 from cfme.exceptions import DestinationNotFound, StackNotFound, CandidateNotFound
@@ -80,6 +80,7 @@ class StackEditTagEntities(View):
     """The entities on the edit tags page"""
     breadcrumb = BreadCrumb()
     title = Text('#explorer_title_text')
+    included_widgets = View.include(BaseNonInteractiveEntitiesView, use_parent=True)
 
 
 class StackSecurityGroupsEntities(View):

--- a/cfme/cloud/tenant.py
+++ b/cfme/cloud/tenant.py
@@ -11,7 +11,7 @@ from widgetastic.widget import View
 from widgetastic_patternfly import BootstrapNav, Button, Dropdown, FlashMessages, Input
 from widgetastic_manageiq import (
     Accordion, BootstrapSelect, BreadCrumb, ItemsToolBarViewSelector, PaginationPane, Search,
-    SummaryTable, Table, Text)
+    SummaryTable, Table, Text, BaseNonInteractiveEntitiesView)
 
 from cfme.base.ui import BaseLoggedInPage
 from cfme.exceptions import TenantNotFound, DestinationNotFound, OptionNotAvailable
@@ -82,6 +82,7 @@ class TenantEditTagEntities(View):
     """The entities on the edit tags page"""
     breadcrumb = BreadCrumb()
     title = Text('#explorer_title_text')
+    included_widgets = View.include(BaseNonInteractiveEntitiesView, use_parent=True)
 
 
 class TenantView(BaseLoggedInPage):

--- a/cfme/common/host_views.py
+++ b/cfme/common/host_views.py
@@ -17,7 +17,8 @@ from widgetastic_manageiq import (
     PaginationPane,
     SummaryTable,
     Table,
-    TimelinesView
+    TimelinesView,
+    BaseNonInteractiveEntitiesView
 )
 from widgetastic_patternfly import (
     BootstrapSelect,
@@ -197,6 +198,7 @@ class HostDiscoverView(ComputeInfrastructureHostsView):
 class HostManagePoliciesView(BaseLoggedInPage):
     """Host's Manage Policies view."""
     policies = BootstrapTreeview("protectbox")
+    entities = View.nested(BaseNonInteractiveEntitiesView)
     save_button = Button("Save")
     reset_button = Button("Reset")
     cancel_button = Button("Cancel")
@@ -211,7 +213,7 @@ class HostEditTagsView(BaseLoggedInPage):
     tag_category = BootstrapSelect("tag_cat")
     tag = BootstrapSelect("tag_add")
     chosen_tags = Table(locator='.//div[@id="assignments_div"]/table')
-
+    entities = View.nested(BaseNonInteractiveEntitiesView)
     save_button = Button("Save")
     reset_button = Button("Reset")
     cancel_button = Button("Cancel")

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -17,7 +17,8 @@ from widgetastic_manageiq import (BreadCrumb,
                                   BaseEntitiesView,
                                   DynaTree,
                                   BootstrapTreeview,
-                                  ProviderEntity)
+                                  ProviderEntity,
+                                  BaseNonInteractiveEntitiesView)
 
 
 class ProviderDetailsToolBar(View):
@@ -176,6 +177,13 @@ class ProvidersManagePoliciesView(BaseLoggedInPage):
     """
     policies = VersionPick({Version.lowest(): DynaTree('protect_treebox'),
                             '5.7': BootstrapTreeview('protectbox')})
+
+    @View.nested
+    class entities(BaseNonInteractiveEntitiesView):  # noqa
+        @property
+        def entity_class(self):
+            return ProviderEntity().pick(self.browser.product_version)
+
     save = Button('Save')
     reset = Button('Reset')
     cancel = Button('Cancel')
@@ -192,6 +200,12 @@ class ProvidersEditTagsView(BaseLoggedInPage):
     tag_category = BootstrapSelect('tag_cat')
     tag = BootstrapSelect('tag_add')
     chosen_tags = Table(locator='//div[@id="assignments_div"]/table')
+
+    @View.nested
+    class entities(BaseNonInteractiveEntitiesView):  # noqa
+        @property
+        def entity_class(self):
+            return ProviderEntity().pick(self.browser.product_version)
 
     save = Button('Save')
     reset = Button('Reset')

--- a/cfme/containers/node.py
+++ b/cfme/containers/node.py
@@ -6,8 +6,8 @@ import itertools
 
 from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.widget import View
-from widgetastic_manageiq import (
-    BootstrapSelect, Button, Table, Accordion, ManageIQTree, PaginationPane)
+from widgetastic_manageiq import (BootstrapSelect, Button, Table, Accordion, ManageIQTree,
+                                  PaginationPane, BaseNonInteractiveEntitiesView)
 
 from cfme.common import Taggable, SummaryMixin
 from cfme.containers.provider import ContainersProvider, Labelable,\
@@ -167,6 +167,7 @@ class NodeEditTagsForm(NodeView):
     tag = BootstrapSelect('tag_add')
     # TODO: table for added tags with removal support
     # less than ideal button duplication between classes
+    entities = View.nested(BaseNonInteractiveEntitiesView)
     save_button = Button('Save')
     reset_button = Button('Reset')
     cancel_button = Button('Cancel')
@@ -192,6 +193,7 @@ class EditTags(CFMENavigateStep):
 class NodeManagePoliciesForm(NodeView):
     policy_profiles = BootstrapSelect('protectbox')
     # less than ideal button duplication between classes
+    entities = View.nested(BaseNonInteractiveEntitiesView)
     save_button = Button('Save')
     reset_button = Button('Reset')
     cancel_button = Button('Cancel')

--- a/cfme/infrastructure/datastore.py
+++ b/cfme/infrastructure/datastore.py
@@ -241,7 +241,7 @@ class Details(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.entities.get_first_entity(by_name=self.obj.name).click()
+        self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True).click()
 
 
 @navigator.register(Datastore, 'DetailsFromProvider')

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -275,7 +275,7 @@ class Host(Updateable, Pretty, Navigatable, PolicyProfileAssignable):
         """
         view = navigate_to(self, "All")
         try:
-            view.entities.get_first_entity(by_name=self.name)
+            view.entities.get_entity(by_name=self.name, surf_pages=True)
         except ItemNotFound:
             return False
         else:
@@ -288,7 +288,7 @@ class Host(Updateable, Pretty, Navigatable, PolicyProfileAssignable):
         Returns: :py:class:`bool`
         """
         view = navigate_to(self, "All")
-        entity = view.entities.get_first_entity(by_name=self.name)
+        entity = view.entities.get_entity(by_name=self.name, surf_pages=True)
         return entity.creds.strip().lower() == "checkmark"
 
     def update_credentials_rest(self, credentials):
@@ -447,7 +447,7 @@ class Details(CFMENavigateStep):
     prerequisite = NavigateToSibling("All")
 
     def step(self):
-        self.prerequisite_view.entities.get_first_entity(by_name=self.obj.name).click()
+        self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True).click()
 
 
 @navigator.register(Host)
@@ -602,7 +602,7 @@ def find_quadicon(host_name):
     if view.toolbar.view_selector.selected != "Grid View":
         view.toolbar.view_selector.select("Grid View")
     try:
-        quad_icon = view.entities.get_first_entity(by_name=host_name)
+        quad_icon = view.entities.get_entity(by_name=host_name, surf_pages=True)
     except ItemNotFound:
         raise HostNotFound("Host '{}' not found in UI!".format(host_name))
     else:

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -254,7 +254,7 @@ class Details(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name).click()
+        self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True).click()
 
     def resetter(self):
         # Reset view and selection
@@ -270,7 +270,7 @@ class ManagePolicies(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name).check()
+        self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True).check()
         self.prerequisite_view.toolbar.policy.item_select('Manage Policies')
 
 
@@ -289,7 +289,7 @@ class EditTags(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name).check()
+        self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True).check()
         self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
 
 
@@ -308,7 +308,7 @@ class Edit(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name).check()
+        self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True).check()
         self.prerequisite_view.toolbar.configuration.item_select('Edit Selected '
                                                                  'Infrastructure Providers')
 

--- a/cfme/tests/openstack/infrastructure/test_provider.py
+++ b/cfme/tests/openstack/infrastructure/test_provider.py
@@ -19,7 +19,7 @@ def test_api_port(provider):
 
 def test_credentials_quads(provider):
     view = navigate_to(provider, 'All')
-    prov_item = view.entities.get_entity(by_name=provider.name)
+    prov_item = view.entities.get_entity(by_name=provider.name, surf_pages=True)
     assert prov_item.data.get('creds') and 'checkmark' in prov_item.data['creds']
 
 


### PR DESCRIPTION
We have a bunch of views which contain quadicons like Edit Tags/Manage Policies/etc. Those quadicons provide some info and can be clicked. 
This PR allows to use BaseEntity widget for interaction with such QuadIcons. Besides that, it has a BaseNonInteractiveEntitiesView which is added to mentioned above views and allows to get all quadicons there and play with them.