### PR TITLE
[1LP][RFR] Move OpenStackInstance nav destinations

### DIFF
--- a/cfme/cloud/instance/openstack.py
+++ b/cfme/cloud/instance/openstack.py
@@ -1,7 +1,14 @@
 # -*- coding: utf-8 -*-
-from cfme.exceptions import OptionNotAvailable
+from navmazing import NavigateToSibling
+from widgetastic.widget import View, NoSuchElementException
+from widgetastic_patternfly import Button, BootstrapSelect
+from widgetastic_manageiq import CheckboxSelect, Select, Input
+
+from cfme.exceptions import OptionNotAvailable, DestinationNotFound
+from cfme.common.vm_views import RightSizeView
 from utils import version, deferred_verpick
-from . import Instance
+from utils.appliance.implementations.ui import CFMENavigateStep, navigator
+from . import Instance, CloudInstanceView
 
 
 class OpenStackInstance(Instance):
@@ -91,3 +98,202 @@ class OpenStackInstance(Instance):
             self.provider.mgmt.delete_vm(self.name)
         else:
             raise OptionNotAvailable(option + " is not a supported action")
+
+
+class AddFloatingIPView(CloudInstanceView):
+    @View.nested
+    class form(View):  # noqa
+        ip = Select(name='floating_ip')
+        submit_button = Button('Submit')
+        cancel_button = Button('Cancel')
+
+    @property
+    def is_displayed(self):
+        # Only the instance name is displayed, cannot confirm provider
+        return False
+
+
+class RemoveFloatingIPView(CloudInstanceView):
+    @View.nested
+    class form(View):  # noqa
+        ip = Select('floating_ip')
+        submit_button = Button('Submit')
+        cancel_button = Button('Cancel')
+
+    @property
+    def is_displayed(self):
+        # Only the instance name is displayed, cannot confirm provider
+        return False
+
+
+class AttachVolumeView(CloudInstanceView):
+    @View.nested
+    class form(View):  # noqa
+        volume = BootstrapSelect('volume_id')
+        mountpoint = Input(name='device_path')
+        submit_button = Button('Submit')
+        cancel_button = Button('Cancel')
+
+    @property
+    def is_displayed(self):
+        # Only the instance name is displayed, cannot confirm provider
+        return False
+
+
+class DetachVolumeView(CloudInstanceView):
+    @View.nested
+    class form(View):  # noqa
+        volume = BootstrapSelect('volume_id')
+        submit_button = Button('Submit')
+        cancel_button = Button('Cancel')
+
+    @property
+    def is_displayed(self):
+        # Only the instance name is displayed, cannot confirm provider
+        return False
+
+
+class EvacuateView(CloudInstanceView):
+    @View.nested
+    class form(View):  # noqa
+        auto_select = CheckboxSelect('auto_select_host')
+        shared_storage = CheckboxSelect('on_shared_storage')
+        submit_button = Button('Submit')
+        cancel_button = Button('Cancel')
+
+    @property
+    def is_displayed(self):
+        # Only the instance name is displayed, cannot confirm provider
+        return False
+
+
+class MigrateView(CloudInstanceView):
+    @View.nested
+    class form(View):  # noqa
+        auto_select = CheckboxSelect('auto_select_host')
+        block_migration = CheckboxSelect('block_migration')
+        disk_overcommit = CheckboxSelect('disk_over_commit')
+        submit_button = Button('Submit')
+        cancel_button = Button('Cancel')
+
+    @property
+    def is_displayed(self):
+        # Only the instance name is displayed, cannot confirm provider
+        return False
+
+
+class ReconfigureView(CloudInstanceView):
+    @View.nested
+    class form(View):  # noqa
+        flavor = BootstrapSelect('flavor')
+        submit_button = Button('Submit')
+        cancel_button = Button('Cancel')
+
+    @property
+    def is_displayed(self):
+        # Only the instance name is displayed, cannot confirm provider
+        return False
+
+
+@navigator.register(OpenStackInstance, 'AddFloatingIP')
+class AddFloatingIP(CFMENavigateStep):
+    VIEW = AddFloatingIPView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        configuration = self.prerequisite_view.toolbar.configuration
+        try:
+            configuration.item_select('Associate a Floating IP with this Instance')
+        except NoSuchElementException:
+            raise DestinationNotFound('Add Floating IP option not available for instance')
+
+
+@navigator.register(Instance, 'RemoveFloatingIP')
+class RemoveFloatingIP(CFMENavigateStep):
+    VIEW = RemoveFloatingIPView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        configuration = self.prerequisite_view.toolbar.configuration
+        try:
+            configuration.item_select('Disassociate a Floating IP from this Instance')
+        except NoSuchElementException:
+            raise DestinationNotFound('Remove Floating IP option not available for instance')
+
+
+@navigator.register(OpenStackInstance, 'AttachVolume')
+class AttachVolume(CFMENavigateStep):
+    VIEW = AttachVolumeView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        configuration = self.prerequisite_view.toolbar.configuration
+        try:
+            configuration.item_select('Attach a Cloud Volume to this Instance')
+        except NoSuchElementException:
+            raise DestinationNotFound('Attach Cloud Volume option not available for instance')
+
+
+@navigator.register(OpenStackInstance, 'DetachVolume')
+class DetachVolume(CFMENavigateStep):
+    VIEW = DetachVolumeView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        configuration = self.prerequisite_view.toolbar.configuration
+        try:
+            configuration.item_select('Detach a Cloud Volume from this Instance')
+        except NoSuchElementException:
+            raise DestinationNotFound('Detach Cloud Volume option not available for instance')
+
+
+@navigator.register(OpenStackInstance, 'Evacuate')
+class Evacuate(CFMENavigateStep):
+    VIEW = EvacuateView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        lifecycle = self.prerequisite_view.toolbar.lifecycle
+        try:
+            lifecycle.item_select('Evacuate Instance')
+        except NoSuchElementException:
+            raise DestinationNotFound('Evacuate option not available for instance')
+
+
+@navigator.register(OpenStackInstance, 'Migrate')
+class Migrate(CFMENavigateStep):
+    VIEW = MigrateView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        lifecycle = self.prerequisite_view.toolbar.lifecycle
+        try:
+            lifecycle.item_select('Migrate Instance')
+        except NoSuchElementException:
+            raise DestinationNotFound('Migrate option not available for instance')
+
+
+@navigator.register(Instance, 'Reconfigure')
+class Reconfigure(CFMENavigateStep):
+    VIEW = ReconfigureView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        configuration = self.prerequisite_view.toolbar.configuration
+        try:
+            configuration.item_select('Reconfigure this Instance')
+        except NoSuchElementException:
+            raise DestinationNotFound('Reconfigure option not available for instance')
+
+
+@navigator.register(OpenStackInstance, 'RightSize')
+class RightSize(CFMENavigateStep):
+    VIEW = RightSizeView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        configuration = self.prerequisite_view.toolbar.configuration
+        try:
+            configuration.item_select('Right-Size Recommendations')
+        except NoSuchElementException:
+            raise DestinationNotFound('Right Size option not available for instance')


### PR DESCRIPTION
There were several navigation destinations that were only available for
openstack type instances. Instead of checking for correct class type in
the navigation destination, move the classes and register them against
OpenStackInstance only.

There don't appear to be any tests that directly use these navigation destinations? It's an enhancement, just moving existing nav+views to the only module/class where they're relevant.