### PR TITLE
[WIP] Fix test failure in access_control test_permissions_role_crud

### DIFF
--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -576,14 +576,11 @@ def _go_to(cls, dest='All'):
     return lambda: navigate_to(cls, dest)
 
 
-cat_name = "Settings"
-
-
 @pytest.mark.tier(3)
 @pytest.mark.parametrize(
     'role,allowed_actions,disallowed_actions',
     [[_mk_role(product_features=[[['Everything'], False],  # minimal permission
-                                 [['Everything', cat_name, 'Tasks'], True]]),
+                                 [['Everything', 'Settings', 'Tasks'], True]]),
       {'tasks': lambda: sel.click(tasks.buttons.default)},  # can only access one thing
       {
           'my services': _go_to(MyService),
@@ -606,9 +603,6 @@ def test_permissions(appliance, role, allowed_actions, disallowed_actions):
     """ Test that that under the specified role the allowed acctions succeed
         and the disallowed actions fail
 
-        actions are a list of actions with each item consisting of a dictionary object:
-               [ { "Action Name": function_reference_action }, ...]
-
         Args:
             appliance - cfme_test appliance fixture
             role - reference to a function that will create a role object
@@ -616,6 +610,9 @@ def test_permissions(appliance, role, allowed_actions, disallowed_actions):
                 permission
             disallowed_actions - Action(s) that should fail under given roles
                 permission
+
+        *_actions are a list of actions with each item consisting of a dictionary
+            object: [ { "Action Name": function_reference_action }, ...]
     """
     # create a user and role
     role = role()  # call function to get role
@@ -674,7 +671,7 @@ def single_task_permission_test(appliance, product_features, actions):
 @pytest.mark.meta(blockers=[1262764])
 def test_permissions_role_crud(appliance):
     single_task_permission_test(appliance,
-                                [['Everything', cat_name, 'Configuration'],
+                                [['Everything', 'Settings', 'Configuration'],
                                  ['Everything', 'Services', 'Catalogs Explorer']],
                                 {'Role CRUD': test_role_crud})
 


### PR DESCRIPTION
Resolves the failing access_control test test_permissions_role_crud
Resolves 2 issues in the test:
- Test was incorrectly logging in as admin instead of the test user when verifying role permissions
- When creating appropriate role permissions in 5.7, the default permissions don't have all child permissions selected.