### PR TITLE
[RFR]adding BZ blocker and workaround for Requests page

### DIFF
--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -14,6 +14,7 @@ from cached_property import cached_property
 from jsmin import jsmin
 from lxml.html import document_fromstring
 from selenium.common.exceptions import WebDriverException
+from utils.blockers import BZ
 from widgetastic.exceptions import NoSuchElementException
 from widgetastic.log import logged
 from widgetastic.utils import ParametrizedLocator, Parameter, ParametrizedString, attributize_string
@@ -1386,7 +1387,8 @@ class NonJSPaginationPane(View):
                 else:
                     self.logger.debug('Paginator advancing to next page')
                     self.next_page()
-
+        elif BZ.bugzilla.get_bug('1460377').is_opened:
+            yield
         else:
             return
 


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__  GH issue #5180. When we are using paginator, we expect some page result. such workaround would give us a try to go thru items at page we currently have. as that happened with Requests page - no pagination controls at all if we open them manually
