### PR TITLE
[1LP][RFR] Fix test generation in test_appliance_update

### DIFF
--- a/cfme/tests/cli/test_appliance_update.py
+++ b/cfme/tests/cli/test_appliance_update.py
@@ -19,7 +19,11 @@ def pytest_generate_tests(metafunc):
 
     version = current_appliance.version
     split_ver = str(version).split(".")
-    minor_build = split_ver[2]
+    try:
+        minor_build = split_ver[2]
+    except IndexError:
+        logger.exception('Caught IndexError generating for test_appliance_update, skipping')
+        pytest.skip('Could not parse minor_build version from: {}'.format(version))
 
     for i in range(int(minor_build) - 1, -1, -1):
         versions.append("{}.{}.{}".format(split_ver[0], split_ver[1], i))
@@ -63,6 +67,7 @@ def appliance_preupdate(old_version, appliance):
 
 
 @pytest.mark.parametrize('old_version', versions)
+@pytest.mark.uncollectif(lambda appliance: not appliance.is_downstream)
 def test_update_yum(appliance_preupdate, appliance):
 
     """Tests appliance update between versions"""


### PR DESCRIPTION
skip if an IndexError occurs because we can't parse minor version

In testing I'm seeing the following, showing that the test is skipped during generation where 2141 tests are initially collected.
```
=============================================================================================== test session starts ===============================================================================================
platform linux2 -- Python 2.7.13, pytest-3.2.0, py-1.4.34, pluggy-0.4.0
rootdir: /home/mshriver/repos/integration_tests, inifile:
plugins: wait-for-1.0.9, manageiq-integration-tests-0.0.0
collected 2141 items / 1 skipped 

Appliance's streams: [upstream]
=============================================================================================== Running smoke tests ===============================================================================================
Uncollection Stats:
 manual: 15
 uncollectif: 607
 30 tests left after all uncollections
```