### PR TITLE
[1LP][RFR] Add support of keystone v3 to Openstack Cloud provider

### DIFF
--- a/cfme/cloud/provider/openstack.py
+++ b/cfme/cloud/provider/openstack.py
@@ -84,11 +84,16 @@ class OpenStackProvider(CloudProvider):
         from cfme.utils.providers import get_crud
         infra_prov_key = prov_config.get('infra_provider_key')
         infra_provider = get_crud(infra_prov_key, appliance=appliance) if infra_prov_key else None
+        api_version = prov_config.get('api_version', None)
+
+        if not api_version:
+            api_version = 'Keystone v2'
+
         return cls(name=prov_config['name'],
                    hostname=prov_config['hostname'],
                    ip_address=prov_config['ipaddress'],
                    api_port=prov_config['port'],
-                   api_version=prov_config.get('api_version', 'Keystone v2'),
+                   api_version=api_version,
                    endpoints=endpoints,
                    zone=prov_config['server_zone'],
                    key=prov_key,

--- a/cfme/cloud/provider/openstack.py
+++ b/cfme/cloud/provider/openstack.py
@@ -21,13 +21,16 @@ class OpenStackProvider(CloudProvider):
     _ctrl_alt_del_xpath = '//*[@id="sendCtrlAltDelButton"]'
 
     def __init__(self, name=None, endpoints=None, zone=None, key=None, hostname=None,
-                 ip_address=None, api_port=None, sec_protocol=None, amqp_sec_protocol=None,
-                 tenant_mapping=None, infra_provider=None, appliance=None):
+                 ip_address=None, api_port=None, api_version=None, sec_protocol=None,
+                 amqp_sec_protocol=None, keystone_v3_domain_id=None, tenant_mapping=None,
+                 infra_provider=None, appliance=None):
         super(OpenStackProvider, self).__init__(name=name, endpoints=endpoints,
                                                 zone=zone, key=key, appliance=appliance)
         self.hostname = hostname
         self.ip_address = ip_address
         self.api_port = api_port
+        self.api_version = api_version
+        self.keystone_v3_domain_id = keystone_v3_domain_id
         self.infra_provider = infra_provider
         self.sec_protocol = sec_protocol
         self.tenant_mapping = tenant_mapping
@@ -59,6 +62,8 @@ class OpenStackProvider(CloudProvider):
             'region': None,
             'infra_provider': infra_provider_name,
             'tenant_mapping': getattr(self, 'tenant_mapping', None),
+            'api_version': self.api_version,
+            'keystone_v3_domain_id': self.keystone_v3_domain_id
         }
 
     def deployment_helper(self, deploy_args):
@@ -83,9 +88,11 @@ class OpenStackProvider(CloudProvider):
                    hostname=prov_config['hostname'],
                    ip_address=prov_config['ipaddress'],
                    api_port=prov_config['port'],
+                   api_version=prov_config.get('api_version', 'Keystone v2'),
                    endpoints=endpoints,
                    zone=prov_config['server_zone'],
                    key=prov_key,
+                   keystone_v3_domain_id=prov_config.get('domain_id', None),
                    sec_protocol=prov_config.get('sec_protocol', "Non-SSL"),
                    tenant_mapping=prov_config.get('tenant_mapping', False),
                    infra_provider=infra_provider,

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -332,7 +332,6 @@ class ProviderAddView(BaseLoggedInPage):
     title = Text('//div[@id="main-content"]//h1')
     name = Input('name')
     prov_type = BootstrapSelect(id='emstype')
-    keystone_v3_domain_id = Input('keystone_v3_domain_id')  # OpenStack only
     zone = Input('zone')
     flash = FlashMessages('.//div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
                           'contains(@class, "flash_text_div")]')
@@ -374,6 +373,7 @@ class CloudProviderAddView(ProviderAddView):
     project_id = Input('project')  # only for Azure
     # bug in cfme this field has different ids for cloud and infra add views
     api_version = BootstrapSelect(id='ems_api_version')  # only for OpenStack
+    keystone_v3_domain_id = Input('keystone_v3_domain_id')  # OpenStack only
     infra_provider = BootstrapSelect(id='ems_infra_provider_id')  # OpenStack only
     tenant_mapping = Checkbox(name='tenant_mapping_enabled')  # OpenStack only
 


### PR DESCRIPTION
Provide a possibility of adding OSP cloud provider on keystone v3 api
PRT run is just to ensure that old configs still work
{{pytest: cfme/tests/openstack/cloud --use-provider rhos7-ga}}