### PR TITLE
[1LP][RFR] Bump dump2polarion version

### DIFF
--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -32,7 +32,7 @@ docker-py==1.10.6
 docker-pycreds==0.2.1
 docutils==0.13.1
 dogpile.cache==0.6.3
-dump2polarion==0.8
+dump2polarion==0.9
 entrypoints==0.2.2
 enum34==1.1.6
 fauxfactory==2.1.0

--- a/requirements/frozen_docs.txt
+++ b/requirements/frozen_docs.txt
@@ -23,7 +23,7 @@ diaper==1.3
 docker-py==1.10.6
 docker-pycreds==0.2.1
 docutils==0.13.1
-dump2polarion==0.8
+dump2polarion==0.9
 entrypoints==0.2.2
 enum34==1.1.6
 fauxfactory==2.1.0


### PR DESCRIPTION
Mainly workaround for problem of ``stomp.py`` that can get stuck terminating
the subscription to the Polarion message bus.
Useful for our jenkins jobs that are submitting results to Polarion.

No PRT necessary.