### PR TITLE
[1LP][RFR] Convert automate.provisioning_dialogs to widgetastic

### DIFF
--- a/cfme/automate/__init__.py
+++ b/cfme/automate/__init__.py
@@ -11,6 +11,7 @@ from utils.appliance.implementations.ui import navigator, CFMENavigateStep
 
 
 class AutomateCustomizationView(BaseLoggedInPage):
+    # TODO re-model this so it can be nested as a sidebar instead of inherited
     @property
     def in_customization(self):
         return (

--- a/cfme/tests/automate/test_provisioning_dialogs.py
+++ b/cfme/tests/automate/test_provisioning_dialogs.py
@@ -3,20 +3,19 @@ import fauxfactory
 import pytest
 
 from cfme import test_requirements
-from cfme.automate import provisioning_dialogs
-from cfme.web_ui import accordion
+from cfme.automate.provisioning_dialogs import ProvisioningDialog
 from utils.update import update
 from utils.appliance.implementations.ui import navigate_to
 
 
 @pytest.yield_fixture(scope="function")
 def dialog():
-    dlg = provisioning_dialogs.ProvisioningDialog(
-        provisioning_dialogs.ProvisioningDialog.VM_PROVISION,
+    dlg = ProvisioningDialog(
         name=fauxfactory.gen_alphanumeric(),
-        description=fauxfactory.gen_alphanumeric()
-    )
+        description=fauxfactory.gen_alphanumeric(),
+        diag_type=ProvisioningDialog.VM_PROVISION)
     yield dlg
+
     if dlg.exists:
         dlg.delete()
 
@@ -30,14 +29,15 @@ def test_provisioning_dialog_crud(dialog):
         dialog.name = fauxfactory.gen_alphanumeric()
         dialog.description = fauxfactory.gen_alphanumeric()
     assert dialog.exists
-    dialog.change_type(provisioning_dialogs.ProvisioningDialog.HOST_PROVISION)
+    with update(dialog):
+        dialog.diag_type = ProvisioningDialog.HOST_PROVISION
     assert dialog.exists
     dialog.delete()
     assert not dialog.exists
 
 
 sort_by_params = []
-for nav_loc, name in provisioning_dialogs.ProvisioningDialog.ALLOWED_TYPES:
+for name in ProvisioningDialog.ALLOWED_TYPES:
     sort_by_params.append((name, "Name", "ascending"))
     sort_by_params.append((name, "Name", "descending"))
     sort_by_params.append((name, "Description", "ascending"))
@@ -46,10 +46,9 @@ for nav_loc, name in provisioning_dialogs.ProvisioningDialog.ALLOWED_TYPES:
 
 @test_requirements.general_ui
 @pytest.mark.tier(3)
-@pytest.mark.meta(blockers=[1096388])
 @pytest.mark.parametrize(("name", "by", "order"), sort_by_params)
 def test_provisioning_dialogs_sorting(name, by, order):
-    navigate_to(provisioning_dialogs.ProvisioningDialog, 'All')
-    accordion.tree("Provisioning Dialogs", "All Dialogs", name)
-    provisioning_dialogs.dialog_table.sort_by(by, order)
+    view = navigate_to(ProvisioningDialog, 'All')
+    view.sidebar.provisioning_dialogs.tree.click_path("All Dialogs", name)
+    view.entities.table.sort_by(by, order)
     # When we can get the same comparing function as the PGSQL DB has, we can check

--- a/cfme/tests/automate/test_provisioning_dialogs.py
+++ b/cfme/tests/automate/test_provisioning_dialogs.py
@@ -11,8 +11,8 @@ from utils.appliance.implementations.ui import navigate_to
 @pytest.yield_fixture(scope="function")
 def dialog():
     dlg = ProvisioningDialog(
-        name=fauxfactory.gen_alphanumeric(),
-        description=fauxfactory.gen_alphanumeric(),
+        name='test-{}'.format(fauxfactory.gen_alphanumeric(length=5)),
+        description='test-{}'.format(fauxfactory.gen_alphanumeric(length=5)),
         diag_type=ProvisioningDialog.VM_PROVISION)
     yield dlg
 
@@ -23,14 +23,26 @@ def dialog():
 @test_requirements.automate
 @pytest.mark.tier(3)
 def test_provisioning_dialog_crud(dialog):
+    # CREATE
     dialog.create()
     assert dialog.exists
+
+    # UPDATE
     with update(dialog):
         dialog.name = fauxfactory.gen_alphanumeric()
         dialog.description = fauxfactory.gen_alphanumeric()
     assert dialog.exists
+
     with update(dialog):
         dialog.diag_type = ProvisioningDialog.HOST_PROVISION
+    assert dialog.exists
+    # Update with cancel
+    dialog.update(updates={'description': 'not saved'}, cancel=True)
+    view = navigate_to(dialog, 'Details')
+    assert view.entities
+
+    # DELETE
+    dialog.delete(cancel=True)
     assert dialog.exists
     dialog.delete()
     assert not dialog.exists


### PR DESCRIPTION
Conversion of automate.provisioning_dialog to widgetastic.

CRUD methods implemented, old 'change_type' method removed, this can be done through update method.

Modification of the 'type' attribute from tuples to a string of the UI value.

FIXES RHCFQE-2971

## PRT Results

Run 15314 passed 57z and 58z provisioning dialog tests.

{{ pytest: cfme/tests/automate/test_provisioning_dialogs.py -v --long-running }}