### PR TITLE
[1LP][RFR] Converting settings page to widgetastic

### DIFF
--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -6,7 +6,7 @@ import re
 from navmazing import NavigateToSibling, NavigateToAttribute
 
 from widgetastic_manageiq import (ManageIQTree, Checkbox, AttributeValueForm, SummaryFormItem,
-                                  TimelinesView)
+                                  TimelinesView, Table as table)
 from widgetastic_patternfly import (Accordion, Input, Button, Dropdown,
     FlashMessages, BootstrapSelect, Tab)
 from widgetastic.utils import Version, VersionPick
@@ -321,6 +321,36 @@ class Configuration(CFMENavigateStep):
             self.prerequisite_view.browser.handle_alert(wait=2, cancel=False, squash=True)
         else:
             self.prerequisite_view.navigation.select('Settings', 'Configuration')
+
+
+class MySettingsView(BaseLoggedInPage):
+
+    @View.nested
+    class tabs(View):  # noqa
+
+        @View.nested
+        class visual_all(Tab):  # noqa
+            TAB_NAME = "Visual"
+
+        @View.nested
+        class default_views(Tab):  # noqa
+            TAB_NAME = "Default Views"
+
+        @View.nested
+        class default_filter(Tab):  # noqa
+            TAB_NAME = "Default Filters"
+
+        @View.nested
+        class time_profile(Tab):  # noqa
+            TAB_NAME = "Time Profiles"
+
+    @property
+    def is_displayed(self):
+        return (
+            self.tabs.visual_all.is_displayed and
+            self.tabs.default_views.is_displayed and
+            self.tabs.default_filter.is_displayed and
+            self.time_profile.is_displayed)
 
 
 @navigator.register(Server)


### PR DESCRIPTION
Purpose or Intent
=================
cfme/configure/settings.py page was in web_ui, in this PR I have converted it to widgetastic.

{{pytest: -v -k 'test_cloud_grid_page_per_item or test_cloud_tile_page_per_item or test_cloud_list_page_per_item or test_infra_grid_page_per_item or test_infra_tile_page_per_item or test_infra_list_page_per_item or test_infra_report_page_per_item or test_infra_start_page or test_timezone_setting or test_timeprofile_crud or test_timeprofile_duplicate_name or test_timeprofile_name_max_character_validation or test_cloudimage_defaultfilters or test_cloudinstance_defaultfilters or test_infrastructurehost_defaultfilters or test_infrastructurevms_defaultfilters or test_infrastructuretemplates_defaultfilters or test_servicetemplateandimages_defaultfilters or test_servicevmsandinstances_defaultfilters or test_infra_tile_defaultview or test_infra_list_defaultview or test_infra_grid_defaultview or test_infra_expanded_view or test_infra_compressed_view or test_infra_details_view or test_infra_exists_view or test_cloud_tile_defaultview or test_cloud_list_defaultview or test_cloud_grid_defaultview or test_cloud_expanded_view or test_cloud_compressed_view or test_cloud_details_view or test_cloud_exists_view' }}









