### PR TITLE
[RFR] Removed the grabbing of bearer token

### DIFF
--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -71,34 +71,6 @@ class OpenshiftProvider(ContainersProvider):
     def cli(self):
         return OcpCli(self)
 
-    def get_bearer_token(self):
-
-        username = self.endpoints['default'].credentials.principal
-        res = self.cli.run_command('oc login -u={} -p={}'.format(
-            username, self.endpoints['default'].credentials.secret))
-        if not res.success:
-            raise Exception('Failed to login user "{}": "{}"'.format(username, res.output))
-        res = self.cli.run_command('oc whoami -t')
-        if res.success:
-            return res.output.strip()
-        raise Exception('Failed to get Bearer token: "{}"'.format(res.output))
-
-    def get_mgmt_system(self):
-        """ Returns the mgmt_system using the :py:func:`utils.providers.get_mgmt` method.
-        """
-        # gotta stash this in here to prevent circular imports
-        from utils.providers import get_mgmt
-
-        credentials = {'token': self.get_bearer_token()}
-
-        if self.key:
-            return get_mgmt(self.key, credentials=credentials)
-        elif hasattr(self, 'provider_data'):
-            return get_mgmt(self.provider_data, credentials=credentials)
-        else:
-            raise ProviderHasNoKey(
-                'Provider {} has no key, so cannot get mgmt system'.format(self.name))
-
     def href(self):
         return self.appliance.rest_api.collections.providers\
             .find_by(name=self.name).resources[0].href


### PR DESCRIPTION
{{ pytest: cfme/tests/containers/test_labels.py --use-provider cm-env2 }}
We don't have to use the session token and we can just use the token from the config.