### PR TITLE
[1LP][RFR] Adding version pick ability to pagination

### DIFF
--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -353,7 +353,7 @@ class CustomSavedReport(Updateable, Pretty, Navigatable):
         Returns: :py:class:`SavedReportData`.
         """
         view = navigate_to(self, "Details")
-        view.paginator.set_items_per_page("1000 items")
+        view.paginator.set_items_per_page(1000)
         try:
             headers = tuple([hdr.encode("utf-8") for hdr in view.table.headers])
             body = []

--- a/cfme/tests/containers/test_tables_sort.py
+++ b/cfme/tests/containers/test_tables_sort.py
@@ -36,7 +36,7 @@ def test_tables_sort(test_item, soft_assert):
 
         if not header_text:
             continue
-        current_view.entities.paginator.set_items_per_page('1000 items')
+        current_view.entities.paginator.set_items_per_page(1000)
         # Checking both orders
         current_view.table.click_sort(header_text)
         rows_ascending = [r[col].text for r in current_view.table.rows()]

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -1316,13 +1316,17 @@ class NonJSPaginationPane(View):
         """Selects number of items to be displayed on page.
 
         Args:
-            value: Ideally a str of the format 'x items', x could be {10,20,50,..,1000}
-                   but if value is a number, 'items' is added to it as suffix
+            value: Ideally value is a positive int
         """
-        if not isinstance(value, (int, six.string_types)):
-            raise TypeError("Value should either be of format either e.g. 10 or a string"
-                " e.g. '10 items' not {}".format(value))
-        items_text = value if 'items' in str(value) else '{} items'.format(value)
+        try:
+            int(value)
+        except ValueError:
+            raise ValueError("Value should be integer and not {}".format(value))
+
+        items_text = VersionPick({
+            Version.lowest(): '{} items'.format(value),
+            '5.8.2': str(value),
+        }).pick(self.browser.product_version)
         self.items_on_page.select_by_visible_text(items_text)
 
     def _parse_pages(self):


### PR DESCRIPTION
Purpose or Intent
=================


__Extending__ set_items_per_page pagination function to accommodate different CFME versions. 



{{ pytest: cfme/tests/infrastructure/test_webmks_console.py --use-provider vsphere6-nested --use-provider vsphere65-nested}}