### PR TITLE
[RFR] Convert navigate_and_get_rows to widgetastic

### DIFF
--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -23,8 +23,7 @@ from cfme.common.provider_views import BeforeFillMixin,\
     ContainersProviderEditView, ProvidersView
 from cfme.base.credential import TokenCredential
 from cfme.web_ui import (
-    Quadicon, toolbar as tb,
-    InfoBlock, Region, match_location, PagedTable, CheckboxTable)
+    Quadicon, toolbar as tb, InfoBlock, Region, match_location, PagedTable)
 from utils import version
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
@@ -551,8 +550,7 @@ class Labelable(object):
             raise exceptions.LabelNotFoundException(failure_signature)
 
 
-def navigate_and_get_rows(provider, obj, count, table_class=CheckboxTable,
-                          silent_failure=False):
+def navigate_and_get_rows(provider, obj, count, silent_failure=False):
     """Get <count> random rows from the obj list table,
     if <count> is greater that the number of rows, return number of rows.
 
@@ -566,14 +564,12 @@ def navigate_and_get_rows(provider, obj, count, table_class=CheckboxTable,
 
     return: list of rows"""
 
-    navigate_to(obj, 'All')
-    tb.select('List View')
+    view = navigate_to(obj, 'All')
+    view.toolbar.view_selector.list_button.click()
     if sel.is_displayed_text("No Records Found.") and silent_failure:
         return []
-    from cfme.web_ui import paginator
-    paginator.results_per_page('1000 items')
-    table = table_class(table_locator="//div[@id='list_grid']//table")
-    rows = table.rows_as_list()
+    view.entities.paginator.set_items_per_page(1000)
+    rows = list(view.table.rows())
     if not rows:
         return []
 

--- a/cfme/containers/template.py
+++ b/cfme/containers/template.py
@@ -6,11 +6,9 @@ from functools import partial
 from cached_property import cached_property
 
 from navmazing import NavigateToAttribute, NavigateToSibling
-from widgetastic_manageiq import Table
 
-from cfme.base.ui import BaseLoggedInPage
 from cfme.common import SummaryMixin, Taggable
-from cfme.containers.provider import Labelable
+from cfme.containers.provider import Labelable, ContainerObjectAllBaseView
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import toolbar as tb, match_location,\
     PagedTable, CheckboxTable
@@ -69,13 +67,8 @@ class Template(Taggable, Labelable, SummaryMixin, Navigatable):
                 for obj in itertools.islice(template_list, count)]
 
 
-class TemplateAllView(BaseLoggedInPage):
-
-    table = Table(locator="//div[@id='list_grid']//table")
-
-    @property
-    def is_displayed(self):
-        return match_page(summary='Container Templates')
+class TemplateAllView(ContainerObjectAllBaseView):
+    TITLE_TEXT = 'Container Templates'
 
 
 @navigator.register(Template, 'All')

--- a/cfme/containers/volume.py
+++ b/cfme/containers/volume.py
@@ -6,11 +6,10 @@ import itertools
 from cached_property import cached_property
 
 from navmazing import NavigateToSibling, NavigateToAttribute
-from widgetastic_manageiq import Table
 
-from cfme.base.ui import BaseLoggedInPage
 from cfme.common import SummaryMixin, Taggable
-from cfme.containers.provider import navigate_and_get_rows
+from cfme.containers.provider import navigate_and_get_rows,\
+    ContainerObjectAllBaseView
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import toolbar as tb, match_location, InfoBlock,\
     PagedTable, CheckboxTable
@@ -65,13 +64,8 @@ class Volume(Taggable, SummaryMixin, Navigatable):
                 for row in itertools.islice(rows, count)]
 
 
-class VolumeAllView(BaseLoggedInPage):
-
-    table = Table(locator="//div[@id='list_grid']//table")
-
-    @property
-    def is_displayed(self):
-        return match_page(summary='Persistent Volumes')
+class VolumeAllView(ContainerObjectAllBaseView):
+    TITLE_TEXT = 'Persistent Volumes'
 
 
 @navigator.register(Volume, 'All')

--- a/cfme/tests/containers/test_breadcrumbs.py
+++ b/cfme/tests/containers/test_breadcrumbs.py
@@ -60,7 +60,7 @@ def test_breadcrumbs(provider, soft_assert):
                         .format(dataset.obj.__name__))
         row = rows[-1]
         instance_name = row[2].text
-        sel.click(row)
+        row.click()
 
         breadcrumb_elements = breadcrumbs()
         soft_assert(breadcrumb_elements,


### PR DESCRIPTION
{{ pytest: cfme/tests/containers/test_breadcrumbs.py --use-provider cm-env2 }}
- Convert navigate_and_get_rows to widgetastic.
- TemplateAllView to inherit ContainerObjectAllBaseView.
