### PR TITLE
[RFR][NOTEST] Make 1 provider the default limit

### DIFF
--- a/fixtures/provider.py
+++ b/fixtures/provider.py
@@ -61,7 +61,7 @@ SETUP_FAIL_LIMIT = 3
 def pytest_addoption(parser):
     # Create the cfme option group for use in other plugins
     parser.getgroup('cfme')
-    parser.addoption("--provider-limit", action="store", default=0, type=int,
+    parser.addoption("--provider-limit", action="store", default=1, type=int,
         help=(
             "Number of providers allowed to coexist on appliance. 0 means no limit. "
             "Use 1 or 2 when running on a single appliance, depending on HW configuration."))


### PR DESCRIPTION
Parallelizer is not enough to take care of this; jenkins simply has to run limited to 1 provider and since there is really no reason not to have this as a default for non-parallelized (local) runs either, let's set it to 1.