### PR TITLE
[1LP][RFR] xunit_tools blacklist update

### DIFF
--- a/fixtures/xunit_tools.py
+++ b/fixtures/xunit_tools.py
@@ -35,9 +35,10 @@ blacklist = [
     'cfme/tests/containers/',
     'cfme/tests/middleware/',
     'cfme/tests/openstack/',
-    'rhos',
-    'rhev',
     'hawkular',
+    r'\[.*rhos',
+    r'\[.*rhev',
+    r'\[.*rhv',
 ]
 compiled_blacklist = re.compile('(' + ')|('.join(blacklist) + ')')
 


### PR DESCRIPTION
* updates blacklist so it matches also the new rhv41
* is more specific about what's supposed to be matched only in test parameters

No PRT necessary.