### PR TITLE
[1LP][RFR] Add Providers with SSL

### DIFF
--- a/cfme/tests/containers/test_manageiq_ansible_providers.py
+++ b/cfme/tests/containers/test_manageiq_ansible_providers.py
@@ -135,7 +135,7 @@ def test_manageiq_ansible_remove_provider(ansible_providers, provider, soft_asse
         wait_for(
             lambda: not get_yml_value(script_name, 'name') in view.entities.entity_names,
             num_sec=180, delay=10,
-            fail_func=view.browser.refresh(),
+            fail_func=view.browser.refresh,
             message='Provider was not deleted successfully',
             silent_failure=True)
     )

--- a/cfme/tests/containers/test_manageiq_ansible_providers.py
+++ b/cfme/tests/containers/test_manageiq_ansible_providers.py
@@ -73,8 +73,8 @@ def test_manageiq_ansible_update_provider(ansible_providers, provider):
                          values_to_update=providers_values_to_update, script=script_name)
     run_ansible(script_name)
     view = navigate_to(provider, 'Details')
-    assert get_yml_value(script_name, 'provider_api_hostname') in \
-           view.context['object'].summary.properties.host_name._el.text
+    assert get_yml_value(script_name, 'provider_api_hostname') in view.context['object'].\
+        summary.properties.host_name._el.text
 
 
 @pytest.mark.polarion('CMP-10292')

--- a/cfme/tests/containers/test_manageiq_ansible_providers.py
+++ b/cfme/tests/containers/test_manageiq_ansible_providers.py
@@ -1,19 +1,17 @@
 import pytest
 from cfme.containers.provider import ContainersProvider
-from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import CheckboxTable
 from utils import testgen
 from utils.ansible import setup_ansible_script, run_ansible, get_yml_value, \
     fetch_miq_ansible_module, create_tmp_directory, remove_tmp_files
 from utils.appliance.implementations.ui import navigate_to
 from utils.version import current_version
+from utils.wait import wait_for
 
 
 pytestmark = [
     pytest.mark.uncollectif(lambda provider: current_version() < "5.7")]
 pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
 
-list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
 
 providers_values_to_update = {
     'provider_api_hostname': 'something_different.redhat.com'
@@ -31,6 +29,22 @@ def ansible_providers():
     remove_tmp_files()
 
 
+@pytest.mark.polarion('CMP-xxx')
+@pytest.mark.usefixtures('has_no_containers_providers')
+def test_manageiq_ansible_add_provider_ssl(ansible_providers, provider):
+    """This test checks adding a Containers Provider using Ansible script
+    with SSL validation via Manage IQ module
+        Steps:
+        1. 'add_provider_ssl.yaml script runs against the appliance and adds a new provider
+        2. Test navigates to Containers Providers page and verifies the provider was added
+        """
+    script_name = 'add_provider_ssl'
+    setup_ansible_script(provider, script_type='providers', script=script_name)
+    run_ansible(script_name)
+    view = navigate_to(ContainersProvider, 'All', use_resetter=True)
+    assert get_yml_value(script_name, 'name') in view.entities.entity_names
+
+
 @pytest.mark.polarion('CMP-10290')
 @pytest.mark.usefixtures('has_no_containers_providers')
 def test_manageiq_ansible_add_provider(ansible_providers, provider):
@@ -39,9 +53,11 @@ def test_manageiq_ansible_add_provider(ansible_providers, provider):
         1. 'add_provider.yaml script runs against the appliance and adds a new provider
         2. Test navigates to Containers Providers page and verifies the provider was added
         """
-    setup_ansible_script(provider, script_type='providers', script='add_provider')
-    run_ansible('add_provider')
-    assert get_yml_value('add_provider', 'name') in provider.summary.properties.name.value
+    script_name = 'add_provider'
+    setup_ansible_script(provider, script_type='providers', script=script_name)
+    run_ansible(script_name)
+    view = navigate_to(ContainersProvider, 'All', use_resetter=True)
+    assert get_yml_value(script_name, 'name') in view.entities.entity_names
 
 
 @pytest.mark.polarion('CMP-10295')
@@ -52,11 +68,13 @@ def test_manageiq_ansible_update_provider(ansible_providers, provider):
             the previously added provider
         2. Test navigates to Containers Providers page and verifies the provider was updated
         """
+    script_name = 'update_provider'
     setup_ansible_script(provider, script_type='providers',
-                         values_to_update=providers_values_to_update, script='update_provider')
-    run_ansible('update_provider')
-    assert get_yml_value('update_provider', 'provider_api_hostname') in \
-        provider.summary.properties.host_name.value
+                         values_to_update=providers_values_to_update, script=script_name)
+    run_ansible(script_name)
+    view = navigate_to(provider, 'Details')
+    assert get_yml_value(script_name, 'provider_api_hostname') in \
+           view.context['object'].summary.properties.host_name._el.text
 
 
 @pytest.mark.polarion('CMP-10292')
@@ -69,10 +87,12 @@ def test_manageiq_ansible_add_provider_same_name(ansible_providers, provider):
         2. Test navigates to Containers Providers page and verifies the provider was not added
 
         """
-    setup_ansible_script(provider, script_type='providers', script='add_provider')
-    run_ansible('add_provider')
-    run_ansible('add_provider')
-    assert get_yml_value('add_provider', 'name') in provider.summary.properties.name.value
+    script_name = 'add_provider'
+    setup_ansible_script(provider, script_type='providers', script=script_name)
+    run_ansible(script_name)
+    run_ansible(script_name)
+    view = navigate_to(ContainersProvider, 'All', use_resetter=True)
+    assert get_yml_value(script_name, 'name') in view.entities.entity_names
 
 
 @pytest.mark.polarion('CMP-10298')
@@ -87,27 +107,38 @@ def test_manageiq_ansible_update_provider_incorrect_user(ansible_providers, prov
 
         """
     # Add provider script is added to verify against it in the end
+    script_name = 'update_provider_bad_user'
     setup_ansible_script(provider, script_type='providers', script='add_provider')
     setup_ansible_script(provider, script_type='providers',
                          values_to_update=providers_values_to_update,
-                         script='update_provider_bad_user')
-    run_status = run_ansible('update_provider_bad_user')
+                         script=script_name)
+    run_status = run_ansible(script_name)
     assert 'Authentication failed' in run_status
-    assert get_yml_value('add_provider', 'name') in provider.summary.properties.name.value
+    view = navigate_to(ContainersProvider, 'All', use_resetter=True)
+    assert get_yml_value(script_name, 'name') in view.entities.entity_names
 
 
 @pytest.mark.polarion('CMP-10298')
-def test_manageiq_ansible_remove_provider(ansible_providers, provider):
+@pytest.mark.usefixtures('setup_provider')
+def test_manageiq_ansible_remove_provider(ansible_providers, provider, soft_assert):
     """This test checks removing a Containers Provider using Ansible script via Manage IQ module
         Steps:
         1. 'remove_provider.yaml script runs against the appliance and removes
             the provider
         2. Test navigates to Containers Providers page and verifies the provider was removed
         """
-    setup_ansible_script(provider, script_type='providers', script='remove_provider')
-    run_ansible('remove_provider')
-    navigate_to(ContainersProvider, 'All', use_resetter=True)
-    assert sel.is_displayed_text('No Records Found.')
+    script_name = 'remove_provider'
+    setup_ansible_script(provider, script_type='providers', script=script_name)
+    run_ansible(script_name)
+    view = navigate_to(ContainersProvider, 'All', use_resetter=True)
+    soft_assert(
+        wait_for(
+            lambda: not get_yml_value(script_name, 'name') in view.entities.entity_names,
+            num_sec=180, delay=10,
+            fail_func=view.browser.refresh(),
+            message='Provider was not deleted successfully',
+            silent_failure=True)
+    )
 
 
 @pytest.mark.polarion('CMP-10300')
@@ -121,15 +152,17 @@ def test_manageiq_ansible_remove_non_existing_provider(ansible_providers, provid
         2. Test navigates to Containers Providers page and verifies no provider was removed
         """
     # Add provider script is added to verify against it in the end
+    script_name = 'remove_non_existing_provider'
     setup_ansible_script(provider, script_type='providers', script='add_provider')
-    setup_ansible_script(provider, script_type='providers', script='remove_non_existing_provider')
-    run_ansible('remove_non_existing_provider')
-    assert get_yml_value('add_provider', 'name') in provider.summary.properties.name.value
+    setup_ansible_script(provider, script_type='providers', script=script_name)
+    run_ansible(script_name)
+    view = navigate_to(ContainersProvider, 'All', use_resetter=True)
+    assert get_yml_value('add_provider', 'name') in view.entities.entity_names
 
 
 @pytest.mark.polarion('CMP-10294')
 @pytest.mark.usefixtures('has_no_containers_providers')
-def test_manageiq_ansible_add_provider_incorrect_user(ansible_providers, provider):
+def test_manageiq_ansible_add_provider_incorrect_user(ansible_providers, provider, soft_assert):
     """This test checks adding a Containers Provider with a wrong user using
         Ansible script via Manage IQ module
         Steps:
@@ -139,11 +172,12 @@ def test_manageiq_ansible_add_provider_incorrect_user(ansible_providers, provide
         2. Test navigates to Containers Providers page and verifies the provider was not added.
 
         """
-    setup_ansible_script(provider, script_type='providers', script='add_provider_bad_user')
-    run_status = run_ansible('add_provider_bad_user')
+    script_name = 'add_provider_bad_user'
+    setup_ansible_script(provider, script_type='providers', script=script_name)
+    run_status = run_ansible(script_name)
     assert 'Authentication failed' in run_status
-    navigate_to(ContainersProvider, 'All', use_resetter=True)
-    assert sel.is_displayed_text('No Records Found.')
+    view = navigate_to(ContainersProvider, 'All', use_resetter=True)
+    assert not get_yml_value(script_name, 'name') in view.entities.entity_names
 
 
 @pytest.mark.polarion('CMP-10302')
@@ -159,10 +193,12 @@ def test_manageiq_ansible_remove_provider_incorrect_user(ansible_providers, prov
 
         """
     # Add provider script is added to verify against it in the end
+    script_name = 'remove_provider_bad_user'
     setup_ansible_script(provider, script_type='providers', script='add_provider')
     setup_ansible_script(provider, script_type='providers',
                          values_to_update=providers_values_to_update,
-                         script='remove_provider_bad_user')
-    run_status = run_ansible('remove_provider_bad_user')
+                         script=script_name)
+    run_status = run_ansible(script_name)
     assert 'Authentication failed' in run_status
-    assert get_yml_value('add_provider', 'name') in provider.summary.properties.name.value
+    view = navigate_to(ContainersProvider, 'All', use_resetter=True)
+    assert get_yml_value(script_name, 'name') in view.entities.entity_names

--- a/utils/ansible.py
+++ b/utils/ansible.py
@@ -65,7 +65,7 @@ def get_values_for_providers_test(provider):
     }
 
 
-def get_values_for_users_test(provider):
+def get_values_for_users_test():
     return {
         'fullname': 'MIQUser',
         'name': 'MIQU',
@@ -160,6 +160,10 @@ def setup_ansible_script(provider, script, script_type=None, values_to_update=No
     setup_basic_script(provider, script_type)
     doc = open_yml(script, script_type)
     if script == 'add_provider':
+        write_yml(script, doc)
+
+    if script == 'add_provider_ssl':
+        doc[0]['tasks'][0]['manageiq_provider']['provider_verify_ssl'] = 'True'
         write_yml(script, doc)
 
     elif script == 'update_provider':


### PR DESCRIPTION
This adds SSL verification test to Add Providers and also fixes refresh timeout for one of the tests.
The test currently fails on PRT due to cfme_data.yml discrepancy but passes on our Jenkins

Purpose or Intent
=================
{{pytest: cfme/tests/containers/test_manageiq_ansible_providers.py -v --use-provider cm-env2 }}

