### PR TITLE
[1LP][RFR] Test snapshot memory checkbox for powered off VM

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -396,7 +396,7 @@ class Vm(VM):
             except CandidateNotFound:
                 return False
 
-        def create(self):
+        def create(self, force_check_memory=False):
             snapshot_dict = {
                 'description': self.description
             }
@@ -406,7 +406,7 @@ class Vm(VM):
             if self.name is not None:
                 snapshot_dict['name'] = self.name
 
-            if self.vm.provider.mgmt.is_vm_running(self.vm.name):
+            if force_check_memory or self.vm.provider.mgmt.is_vm_running(self.vm.name):
                 snapshot_dict["snapshot_memory"] = self.memory
 
             fill(snapshot_form, snapshot_dict, action=snapshot_form.create_button)


### PR DESCRIPTION
New test for the snapshot area.

In this one, I'm checking that we can't create snapshot with memory on powered off VM. First, I check if I can create snapshot with memory on powered on VM, which should succeed. Then I power down the VM and again try to create snapshot with memory. This should throw a NoSuchElementException, which I catch as an expected behaviour. The wait_for at the end is to double check that the snapshot on powered off VM was indeed not created.

All this will run only if current_version() >= 5.8. In 5.7, there is an unfixed bug that allows users to create snapshot with memory even on a powered off VM.

Included in this are changes in some of snapshot methods:
 - ~~Snapshot.exists now catches also NameError~~ This was merged in another PR
 - Snapshot.create now contains a test_memory flag. When the flag is set we don't check if the VM is on for the purposes of testing the memory checkbox