### PR TITLE
[1LP][RFR] Convert cloud.instance.image to Widgetastic

### DIFF
--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -9,7 +9,7 @@ from widgetastic_manageiq import BreadCrumb
 from cfme.base.login import BaseLoggedInPage
 from cfme.exceptions import TemplateNotFound
 from widgetastic_manageiq import (
-    Calendar, SummaryTable, Button, ItemsToolBarViewSelector, Table, MultiBoxSelect, CheckboxSelect,
+    Calendar, SummaryTable, Button, ItemsToolBarViewSelector, Table, MultiBoxSelect,
     CheckableManageIQTree, VersionPick, Version, BaseEntitiesView, NonJSBaseEntity, BaseListEntity,
     BaseQuadIconEntity, BaseTileIconEntity, JSBaseEntity, BaseNonInteractiveEntitiesView)
 
@@ -338,7 +338,7 @@ class EditView(BaseLoggedInPage):
         parent_vm = BootstrapSelect(id='chosen_parent')
         # MultiBoxSelect element only has table ID in CFME 5.8+
         # https://bugzilla.redhat.com/show_bug.cgi?id=1463265
-        chile_vms = MultiBoxSelect(id='child-vm-select')
+        child_vms = MultiBoxSelect(id='child-vm-select')
         save_button = Button('Save')
         reset_button = Button('Reset')
         cancel_button = Button('Cancel')
@@ -387,7 +387,7 @@ class SetOwnershipView(BaseLoggedInPage):
 
     @property
     def is_displayed(self):
-        # TODO match quadicon
+        # TODO match quadicon using entities, no provider match through icon asset yet
         return False
 
 
@@ -423,7 +423,7 @@ class ManagePoliciesView(BaseLoggedInPage):
 
     @property
     def is_displayed(self):
-        # TODO match quadicon
+        # TODO match quadicon using entities, no provider match through icon asset yet
         return False
 
 

--- a/cfme/fixtures/tag.py
+++ b/cfme/fixtures/tag.py
@@ -93,7 +93,7 @@ def new_credential():
         principal='uid{}'.format(fauxfactory.gen_alphanumeric().lower()), secret='redhat')
 
 
-# TODO should be updated(add_tag/remove_tag), after all used classes will support Taggable class
+# TODO Remove once widgetastic fixture replaces completely
 @pytest.fixture(scope='function')
 def check_item_visibility(tag, user_restricted):
     def _check_item_visibility(vis_object, visibility_result):
@@ -118,4 +118,28 @@ def check_item_visibility(tag, user_restricted):
             except Exception:
                 logger.debug('Tagged item is not visible')
         assert actual_visibility == visibility_result
+    return _check_item_visibility
+
+
+@pytest.fixture(scope='function')
+def widgetastic_check_tag_visibility(tag, user_restricted):
+    def _check_item_visibility(vis_object, vis_expect):
+        """
+        Args:
+            vis_object: the object with a tag to check
+            vis_expect: bool, True if tag should be visible
+
+        Returns: None
+        """
+        view = navigate_to(vis_object, 'Details')
+        if vis_expect:
+            vis_object.add_tag(tag)
+        elif tag.name in vis_object.get_tags(tenant=tag.category):
+            vis_object.remove_tag(tag)
+        with user_restricted:
+            view = navigate_to(vis_object, 'Details')
+            test_vis = tag.name in view.entities.smart_management.get_text_of(tag.category.name)
+
+        assert test_vis == vis_expect
+
     return _check_item_visibility


### PR DESCRIPTION
Testing, no specific Image tests

## PRT Results
Filtering pytest very specifically here to tests that actually import and use the Image navigation.

Well it looks like pretty much any test that is using Images is doing so with a collection of other cloud objects, and trying to do things like tagging or default view settings.

**In order for these tests to work on the collections of cloud objects, they need to be pretty heavily refactored, including the mixins that they're using, to work properly with the updated cloud objects.**

See PR #5296 for some initial work that goes in parallel with this PR to get things setup for consistent tag fixtures/testing across the framework.

This PR is a very good scope at the moment, and I'd really like to address the mixin (Taggable) refactoring to a GH issue, with another PR. We can uncollect tests with the issue in the meantime.

{{pytest:  --long-running -v --use-provider ec2west cfme/tests/cloud/test_cloud_object_tag_visibility.py cfme/tests/cloud/test_delete_cloud_object.py cfme/tests/configure/test_default_filters.py cfme/tests/configure/test_default_views_cloud.py -k 'Images or test_tagvis_cloud_object and images or test_delete_image_appear_after_refresh or test_cloudimage_defaultfilters'}}