### PR TITLE
[1LP][RFR] Fix flash message checking in Automate Domain model

### DIFF
--- a/cfme/automate/explorer/domain.py
+++ b/cfme/automate/explorer/domain.py
@@ -109,7 +109,12 @@ class DomainCollection(Navigatable):
         else:
             add_page.add_button.click()
             add_page.flash.assert_no_error()
-            add_page.flash.assert_message('Automate Domain "{}" was added'.format(name))
+            if self.appliance.version >= '5.8.2':
+                add_page.flash.assert_message(
+                    'Automate Domain "{}" was added'.format(description or name))
+            else:
+                add_page.flash.assert_message(
+                    'Automate Domain "{}" was added'.format(name))
             if enabled is None:
                 # Assume
                 enabled = False
@@ -413,8 +418,13 @@ class Domain(Navigatable, Fillable):
         assert view.is_displayed
         view.flash.assert_no_error()
         if changed:
-            view.flash.assert_message(
-                'Automate Domain "{}" was saved'.format(updates.get('name', self.name)))
+            if self.appliance.version >= '5.8.2':
+                text = (
+                    updates.get('description', self.description) or
+                    updates.get('name', self.name))
+            else:
+                text = updates.get('name', self.name)
+            view.flash.assert_message('Automate Domain "{}" was saved'.format(text))
         else:
             view.flash.assert_message(
                 'Edit of Automate Domain "{}" was cancelled by the user'.format(self.name))

--- a/cfme/automate/explorer/namespace.py
+++ b/cfme/automate/explorer/namespace.py
@@ -93,7 +93,11 @@ class NamespaceCollection(Navigatable):
         else:
             add_page.add_button.click()
             add_page.flash.assert_no_error()
-            add_page.flash.assert_message('Automate Namespace "{}" was added'.format(name))
+            if self.appliance.version >= '5.8.2':
+                add_page.flash.assert_message(
+                    'Automate Namespace "{}" was added'.format(description or name))
+            else:
+                add_page.flash.assert_message('Automate Namespace "{}" was added'.format(name))
             return self.instantiate(name=name, description=description)
 
     def delete(self, *namespaces):
@@ -130,7 +134,8 @@ class NamespaceCollection(Navigatable):
         all_page.flash.assert_no_error()
         for namespace in checked_namespaces:
             all_page.flash.assert_message(
-                'Automate Namespace "{}": Delete successful'.format(namespace.description))
+                'Automate Namespace "{}": Delete successful'.format(
+                    namespace.description or namespace.name))
 
 
 @navigator.register(NamespaceCollection)
@@ -225,8 +230,15 @@ class Namespace(Navigatable):
         assert view.is_displayed
         view.flash.assert_no_error()
         if changed:
-            view.flash.assert_message(
-                'Automate Namespace "{}" was saved'.format(updates.get('name', self.name)))
+            if self.appliance.version >= '5.8.2':
+                text = (
+                    updates.get('description', self.description) or
+                    updates.get('name', self.name))
+                view.flash.assert_message(
+                    'Automate Namespace "{}" was saved'.format(text))
+            else:
+                view.flash.assert_message(
+                    'Automate Namespace "{}" was saved'.format(updates.get('name', self.name)))
         else:
             view.flash.assert_message(
                 'Edit of Automate Namespace "{}" was cancelled by the user'.format(self.name))


### PR DESCRIPTION
{{pytest: cfme/tests/automate/ -v -k "(domain or namespace or lass or instance) and crud" --long-running }}