### PR TITLE
[1LP][RFR] wrapanapi.azure method will be renamed to wrapanapi.msazure

### DIFF
--- a/cfme/cloud/provider/azure.py
+++ b/cfme/cloud/provider/azure.py
@@ -1,4 +1,4 @@
-from wrapanapi.azure import AzureSystem
+from wrapanapi.msazure import AzureSystem
 
 from . import CloudProvider
 from cfme.common.provider import DefaultEndpoint, DefaultEndpointForm

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -283,7 +283,7 @@ MOCK_MODULES = ['pycurl', 'wrapanapi', 'ovirt-engine-sdk-python', 'wrapanapi.uti
                 'wrapanapi.ec2', 'wrapanapi.openstack', 'wrapanapi.rhevm',
                 'wrapanapi.scvmm', 'wrapanapi.virtualcenter', 'wrapanapi.kubernetes',
                 'wrapanapi.openshift', 'wrapanapi.rest_client', 'wrapanapi.openstack_infra',
-                'wrapanapi.hawkular', 'wrapanapi.azure', 'wrapanapi.google', 'ovirtsdk',
+                'wrapanapi.hawkular', 'wrapanapi.msazure', 'wrapanapi.google', 'ovirtsdk',
                 'wrapanapi.containers.providers.openshift', 'wrapanapi.containers',
                 'wrapanapi.containers.providers', 'wrapanapi.containers.providers.kubernetes',
                 'wrapanapi.containers.volume', 'wrapanapi.containers.template',

--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -195,7 +195,7 @@ Werkzeug==0.12.2
 widgetastic.core==0.11.0
 widgetastic.patternfly==0.0.12
 widgetsnbextension==2.0.0
-wrapanapi==2.3.1
+wrapanapi==2.4.0
 wrapt==1.10.10
 xmltodict==0.11.0
 yaycl==0.2.0


### PR DESCRIPTION
wrapanapi.azure is moved to rest. now it uses "azure" package. In order to resolve name resolution confict it was decided to rename wrapanapi.azure to msazure.
This PR should be merged when https://github.com/ManageIQ/wrapanapi/pull/169 gets merged.

{{pytest: cfme/tests/cloud cfme/tests/cloud_infra_common --use-provider=azure --long-running}}