### PR TITLE
[1LP][RFR] Update cloud.keypairs, use BaseEntitiesView

### DIFF
--- a/cfme/cloud/keypairs.py
+++ b/cfme/cloud/keypairs.py
@@ -5,10 +5,9 @@ from widgetastic.utils import VersionPick, Version
 from widgetastic_patternfly import Dropdown, Button, FlashMessages
 from widgetastic_manageiq import (
     ItemsToolBarViewSelector, Text, TextInput, Accordion, ManageIQTree, BreadCrumb,
-    SummaryTable, BootstrapSelect, ItemNotFound)
+    SummaryTable, BootstrapSelect, ItemNotFound, BaseEntitiesView)
 
 from cfme.base.ui import BaseLoggedInPage
-from cfme.common.vm_views import VMEntities
 from cfme.exceptions import KeyPairNotFound
 
 from cfme.web_ui import match_location, mixins
@@ -82,7 +81,7 @@ class KeyPairAllView(KeyPairView):
             self.entities.title.text == 'Key Pairs')
 
     toolbar = View.nested(KeyPairToolbar)
-    including_entities = View.include(VMEntities, use_parent=True)
+    including_entities = View.include(BaseEntitiesView, use_parent=True)
 
 
 class KeyPairDetailsView(KeyPairView):

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -2337,6 +2337,12 @@ class EntitiesConditionalView(View, ReportDataControllerMixin):
             entities = self._invoke_cmd('get_all_items')
             return [entity['item']['cells']['Name'] for entity in entities]
 
+    @property
+    def all_entity_names(self):
+        """Gets all entity names from all pages by default"""
+        # get_all uses self.entity_names, which handles versioned name query
+        return [e.name for e in self.get_all(surf_pages=True)]
+
     def get_all(self, surf_pages=False):
         """ obtains all entities like QuadIcon displayed by view
         Args:


### PR DESCRIPTION
Original conversion done before BaseEntitiesView was written, convert it over. So pretty.

Use BaseEntitiesView via common.vm_views.VMEntities, since it handles the version picking already.  Maybe those entities views are a bit more common than vm's.

Tests are fine on RHOS running locally. The CFME QE RHOS provider that was available for PRT has been unstable and removed, so we won't get PRT results.

## PRT Results
Run 15737:
* 57z pass
* 58z failures from slow UI updates.

{{ pytest: -v --long-running --use-provider rhos7-ga cfme/tests/cloud/test_keypairs.py }}