### PR TITLE
[1LP][RFR] replacing vm/instance find_quadicon with widgetastic implementation

### DIFF
--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -11,8 +11,7 @@ from cfme.common.vm_views import (
     EditTagsView, SetOwnershipView, ManagementEngineView, ManagePoliciesView,
     PolicySimulationView)
 from cfme.exceptions import InstanceNotFound, ItemNotFound
-from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import flash, Quadicon, match_location
+from cfme.web_ui import flash, match_location
 from utils.appliance import Navigatable
 from utils.appliance.implementations.ui import navigate_to, CFMENavigateStep, navigator
 from utils.log import logger
@@ -271,24 +270,14 @@ class Instance(VM, Navigatable):
         TODO: remove this method and refactor callers to use view entities instead
 
         Args:
-        Returns: :py:class:`cfme.web_ui.Quadicon` instance
+        Returns: entity of appropriate type
         """
-        if not kwargs.get('do_not_navigate', False):
-            navigate_to(self, 'All')
-
-        # Make sure we're looking at the quad grid
-        view = self.browser.create_view(InstanceAllView)
+        view = navigate_to(self, 'All')
         view.toolbar.view_selector.select('Grid View')
 
-        # Keeping paginator iteration here to create Quadicon object
-        # using entities.get_first_entity won't give the quadicon object we need for compatibility
-        for _ in view.entities.paginator.pages():
-            quadicon = Quadicon(self.name, "instance")
-            if quadicon.exists:
-                if kwargs.get('mark', False):
-                    sel.check(quadicon.checkbox())
-                return quadicon
-        else:
+        try:
+            return view.entities.get_entity(by_name=self.name, surf_pages=True)
+        except ItemNotFound:
             raise InstanceNotFound("Instance '{}' not found in UI!".format(self.name))
 
     @property

--- a/cfme/common/host_views.py
+++ b/cfme/common/host_views.py
@@ -56,23 +56,14 @@ class ComputeInfrastructureHostsView(BaseLoggedInPage):
 
 
 class HostQuadIconEntity(BaseQuadIconEntity):
-
-    # TODO Move these properties to one 'data' property
     @property
-    def no_vm(self):
-        return int(self.browser.text(self.QUADRANT.format(pos="a")))
-
-    @property
-    def status(self):
-        return self.browser.get_attribute("style", self.QUADRANT.format(pos="b"))
-
-    @property
-    def vendor(self):
-        return self.browser.get_attribute("alt", self.QUADRANT.format(pos="c"))
-
-    @property
-    def creds(self):
-        return self.browser.get_attribute("alt", self.QUADRANT.format(pos="d"))
+    def data(self):
+        return {
+            'no_vm': int(self.browser.text(self.QUADRANT.format(pos="a"))),
+            'state': self.browser.get_attribute("style", self.QUADRANT.format(pos="b")),
+            'vendor': self.browser.get_attribute("alt", self.QUADRANT.format(pos="c")),
+            'creds': self.browser.get_attribute("alt", self.QUADRANT.format(pos="d"))
+        }
 
 
 class HostTileIconEntity(BaseTileIconEntity):

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -403,6 +403,7 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable, SummaryMixin
         navigate_to(self, 'Details', use_resetter=False)
         if refresh:
             toolbar.refresh()
+            self.browser.ensure_page_safe()
 
     def open_edit(self):
         """Loads up the edit page of the object."""

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -403,7 +403,7 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable, SummaryMixin
         navigate_to(self, 'Details', use_resetter=False)
         if refresh:
             toolbar.refresh()
-            self.browser.ensure_page_safe()
+            self.browser.plugin.ensure_page_safe()
 
     def open_edit(self):
         """Loads up the edit page of the object."""

--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 from time import sleep
 
 from widgetastic.widget import View, Text, TextInput, Checkbox, ParametrizedView
@@ -21,13 +22,22 @@ class InstanceQuadIconEntity(BaseQuadIconEntity):
     @property
     def data(self):
         br = self.browser
+        state = br.get_attribute('style', self.QUADRANT.format(pos='b'))
+        state = state.split('"')[1]
+        state = os.path.split(state)[1]
+        state = os.path.splitext(state)[0]
+
+        if br.is_displayed(self.QUADRANT.format(pos='g')):
+            policy = br.get_attribute('src', self.QUADRANT.format(pos='g'))
+        else:
+            policy = None
 
         return {
             "os": br.get_attribute('src', self.QUADRANT.format(pos='a')),
-            "state": br.get_attribute('src', self.QUADRANT.format(pos='b')),
+            "state": state,
             "vendor": br.get_attribute('src', self.QUADRANT.format(pos='c')),
             "no_snapshot": br.text(self.QUADRANT.format(pos='d')),
-            "policy": br.get_attribute('src', self.QUADRANT.format(pos='g')),
+            "policy": policy,
         }
 
 

--- a/cfme/infrastructure/datastore.py
+++ b/cfme/infrastructure/datastore.py
@@ -118,8 +118,7 @@ class DatastoreCollection(Navigatable):
     """Collection class for `cfme.infrastructure.datastore.Datastore`"""
 
     def __init__(self, appliance=None):
-        self.appliance = appliance
-        Navigatable.__init__(self, appliance=self.appliance)
+        Navigatable.__init__(self, appliance=appliance)
 
     def instantiate(self, name, provider, type=None):
         return Datastore(name, provider, type=type, collection=self)
@@ -210,7 +209,7 @@ class Datastore(Pretty, Navigatable):
         view = navigate_to(self, 'Details')
         view.contents.relationships.click_at('Hosts')
         hosts_view = view.browser.create_view(RegisteredHostsView)
-        return [h.name for h in hosts_view.entities.get_all()]
+        return hosts_view.entities.get_all()
 
     def get_vms(self):
         """ Returns names of VMs (from quadicons) that use this datastore

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """A model of an Infrastructure Host in CFME."""
 
-from functools import partial
 from navmazing import NavigateToSibling, NavigateToAttribute
 from manageiq_client.api import APIException
 from selenium.common.exceptions import NoSuchElementException
@@ -19,7 +18,7 @@ from cfme.common.host_views import (
     HostsView,
     HostTimelinesView
 )
-from cfme.exceptions import HostNotFound, ItemNotFound
+from cfme.exceptions import ItemNotFound
 from cfme.infrastructure.datastore import HostAllDatastoresView
 from cfme.web_ui import mixins
 from utils import conf
@@ -275,7 +274,7 @@ class Host(Updateable, Pretty, Navigatable, PolicyProfileAssignable):
         """
         view = navigate_to(self, "All")
         entity = view.entities.get_entity(by_name=self.name, surf_pages=True)
-        return entity.creds.strip().lower() == "checkmark"
+        return entity.data['creds'].strip().lower() == "checkmark"
 
     def update_credentials_rest(self, credentials):
         """ Updates host's credentials via rest api
@@ -575,21 +574,3 @@ def get_all_hosts():
     view = navigate_to(Host, "All")
     return [entity.name for entity in view.entities.get_all(surf_pages=True)]
 
-
-def find_quadicon(host_name):
-    """Find and return a quadicon belonging to a specific host.
-
-    Args:
-        host_name (str): A host name as displayed at the quadicon
-
-    Returns: :py:class:`cfme.common.host_views.HostQuadIconItem` instance
-    """
-    view = navigate_to(Host, "All")
-    if view.toolbar.view_selector.selected != "Grid View":
-        view.toolbar.view_selector.select("Grid View")
-    try:
-        quad_icon = view.entities.get_entity(by_name=host_name, surf_pages=True)
-    except ItemNotFound:
-        raise HostNotFound("Host '{}' not found in UI!".format(host_name))
-    else:
-        return quad_icon

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -28,7 +28,6 @@ from cfme.exceptions import (
 from cfme.fixtures import pytest_selenium as sel
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.services.requests import Request
-import cfme.web_ui.toolbar as tb
 from cfme.web_ui import (
     CheckboxTree, Form, InfoBlock, Region, Quadicon, Tree, fill, flash, form_buttons,
     match_location, Table, toolbar, Calendar, Select, Input, CheckboxTable,
@@ -992,25 +991,18 @@ def _method_setup(vm_names, provider_crud=None):
         sel.check(Quadicon(vm_name, 'vm').checkbox())
 
 
-def find_quadicon(vm_name, do_not_navigate=False):
+def find_quadicon(vm_name):
     """Find and return a quadicon belonging to a specific vm
 
     Args:
         vm: vm name as displayed at the quadicon
-    Returns: :py:class:`cfme.web_ui.Quadicon` instance
+    Returns: entity of appropriate class
     """
-    if not do_not_navigate:
-        navigate_to(Vm, 'VMsOnly')
-    from cfme.web_ui import paginator
-    if not paginator.page_controls_exist():
-        raise VmNotFound("VM '{}' not found in UI!".format(vm_name))
-
-    paginator.results_per_page(1000)
-    for page in paginator.pages():
-        quadicon = Quadicon(vm_name, "vm")
-        if sel.is_displayed(quadicon):
-            return quadicon
-    else:
+    # todo: VMs have such method, so, this function is good candidate for removal
+    view = navigate_to(Vm, 'VMsOnly')
+    try:
+        return view.entites.get_entity(vm_name, surf_pages=True)
+    except ItemNotFound:
         raise VmNotFound("VM '{}' not found in UI!".format(vm_name))
 
 
@@ -1038,13 +1030,13 @@ def wait_for_vm_state_change(vm_name, desired_state, timeout=300, provider_crud=
         timeout: Specify amount of time (in seconds) to wait until TimedOutError is raised
         provider_crud: provider object where vm resides on (optional)
     """
-    def _looking_for_state_change():
-        toolbar.refresh()
-        return 'currentstate-' + desired_state in find_quadicon(
-            vm_name, do_not_navigate=False).state
+    def _looking_for_state_change(view, entity):
+        view.toolbar.reload()
+        return 'currentstate-' + desired_state in entity.data['state']
 
-    _method_setup(vm_name, provider_crud)
-    return wait_for(_looking_for_state_change, num_sec=timeout)
+    view = navigate_to(Vm, 'VMsOnly')
+    entity = view.entites.get_entity(vm_name, surf_pages=True)
+    return wait_for(_looking_for_state_change, func_args=[view, entity], num_sec=timeout)
 
 
 def is_pwr_option_visible(vm_names, option, provider_crud=None):

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -1207,7 +1207,8 @@ class VmDetails(CFMENavigateStep):
 
     def step(self, *args, **kwargs):
         try:
-            row = self.prerequisite_view.entities.get_entity(by_name=self.obj.name)
+            row = self.prerequisite_view.entities.get_entity(by_name=self.obj.name,
+                                                             surf_pages=True)
         except ItemNotFound:
             raise VmOrInstanceNotFound('Failed to locate VM/Template with name "{}"'.
                                        format(self.obj.name))

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -137,7 +137,7 @@ def test_quadicon_terminate_cancel(provider, testing_instance, verify_vm_running
     testing_instance.power_control_from_cfme(option=testing_instance.TERMINATE,
                                              cancel=True,
                                              from_details=False)
-    soft_assert('currentstate-on' in testing_instance.find_quadicon().state)
+    soft_assert('currentstate-on' in testing_instance.find_quadicon().data['state'])
 
 
 def test_quadicon_terminate(provider, testing_instance, verify_vm_running, soft_assert):

--- a/cfme/tests/cloud_infra_common/test_discovery.py
+++ b/cfme/tests/cloud_infra_common/test_discovery.py
@@ -38,11 +38,11 @@ def wait_for_vm_state_changes(vm, timeout=600):
     count = 0
     while count < timeout:
         try:
-            quadicon = vm.find_quadicon(refresh=True, from_any_provider=True)
-            logger.info("Quadicon state for %s is %s", vm.name, repr(quadicon.state))
-            if "archived" in quadicon.state.lower():
+            vm_state = vm.find_quadicon(from_any_provider=True).data['state'].lower()
+            logger.info("Quadicon state for %s is %s", vm.name, repr(vm_state))
+            if "archived" in vm_state:
                 return True
-            elif "orphaned" in quadicon.state.lower():
+            elif "orphaned" in vm_state:
                 raise CFMEException("VM should be Archived but it is Orphaned now.")
         except Exception as e:
             logger.exception(e)

--- a/cfme/tests/distributed/test_appliance_replication.py
+++ b/cfme/tests/distributed/test_appliance_replication.py
@@ -347,7 +347,7 @@ def test_distributed_vm_power_control(request, test_vm, virtualcenter_provider, 
         flash.assert_message_contain("Stop initiated")
         navigate_to(test_vm.provider, 'Details')
         test_vm.wait_for_vm_state_change(desired_state=test_vm.STATE_OFF, timeout=900)
-        soft_assert(test_vm.find_quadicon().state == 'currentstate-off')
+        soft_assert(test_vm.find_quadicon().data['state'] == 'currentstate-off')
         soft_assert(
             not test_vm.provider.mgmt.is_vm_running(test_vm.name),
             "vm running")

--- a/cfme/tests/infrastructure/test_advanced_search_host.py
+++ b/cfme/tests/infrastructure/test_advanced_search_host.py
@@ -23,8 +23,11 @@ def hosts(infra_provider):
 def hosts_with_vm_count(hosts):
     """Returns a list of tuples (hostname, vm_count)"""
     hosts_with_vm_count = []
-    for host_name in hosts:
-        hosts_with_vm_count.append((host_name, int(host.find_quadicon(host_name).no_vm)))
+    view = navigate_to(Host, 'All')
+    view.toolbar.view_selector.select("Grid View")
+    for hostname in hosts:
+        entity = view.entities.get_entity(by_name=hostname)
+        hosts_with_vm_count.append((hostname, entity.data['no_vm']))
     return sorted(hosts_with_vm_count, key=lambda tup: tup[1])
 
 

--- a/cfme/tests/infrastructure/test_datastore_analysis.py
+++ b/cfme/tests/infrastructure/test_datastore_analysis.py
@@ -82,22 +82,21 @@ def test_run_datastore_analysis(request, setup_provider, provider, datastore, so
     """
 
     # Check if there is a host with valid credentials
-    host_names = datastore.get_hosts()
-    assert len(host_names) != 0, "No hosts attached to this datastore found"
-    for host_name in host_names:
-        host_qi = Quadicon(host_name, 'host')
-        if 'checkmark' in host_qi.creds:
+    host_entities = datastore.get_hosts()
+    assert len(host_entities) != 0, "No hosts attached to this datastore found"
+    for host_entity in host_entities:
+        if 'checkmark' in host_entity.data['creds']:
             break
     else:
         # If not, get credentials for one of the present hosts
         found_host = False
-        for host_name in host_names:
-            host_data = get_host_data_by_name(provider.key, host_name)
+        for host_entity in host_entities:
+            host_data = get_host_data_by_name(provider.key, host_entity.name)
             if host_data is None:
                 continue
 
             found_host = True
-            test_host = host.Host(name=host_name, provider=provider)
+            test_host = host.Host(name=host_entity.name, provider=provider)
 
             # Add them to the host
             wait_for(lambda: test_host.exists, delay=10, num_sec=120, fail_func=sel.refresh)

--- a/cfme/tests/infrastructure/test_instance_analysis.py
+++ b/cfme/tests/infrastructure/test_instance_analysis.py
@@ -372,7 +372,7 @@ def test_ssa_template(request, local_setup_provider, provider, soft_assert, vm_a
              delay=15, timeout="35m", fail_func=lambda: toolbar.select('Reload'))
 
     # Check release and quadricon
-    quadicon_os_icon = template.find_quadicon().os
+    quadicon_os_icon = template.find_quadicon().data['os']
     details_os_icon = template.get_detail(
         properties=('Properties', 'Operating System'), icon_href=True)
     logger.info("Icons: {}, {}".format(details_os_icon, quadicon_os_icon))
@@ -441,7 +441,7 @@ def test_ssa_vm(provider, instance, soft_assert):
              delay=15, timeout="35m", fail_func=lambda: toolbar.select('Reload'))
 
     # Check release and quadricon
-    quadicon_os_icon = instance.find_quadicon().os
+    quadicon_os_icon = instance.find_quadicon().data['os']
     details_os_icon = instance.get_detail(
         properties=('Properties', 'Operating System'), icon_href=True)
     logger.info("Icons: %s, %s", details_os_icon, quadicon_os_icon)

--- a/cfme/tests/infrastructure/test_instance_analysis.py
+++ b/cfme/tests/infrastructure/test_instance_analysis.py
@@ -353,7 +353,7 @@ def test_ssa_template(request, local_setup_provider, provider, soft_assert, vm_a
         datastore_collection = datastore.DatastoreCollection()
         test_datastore = datastore_collection.instantiate(name=datastore_name, provider=provider)
         host_list = cfme_data.get('management_systems', {})[provider.key].get('hosts', [])
-        host_names = test_datastore.get_hosts()
+        host_names = [h.name for h in test_datastore.get_hosts()]
         for host_name in host_names:
             test_host = host.Host(name=host_name, provider=provider)
             hosts_data = [x for x in host_list if x.name == host_name]

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -156,7 +156,7 @@ def test_verify_revert_snapshot(full_test_vm, provider, soft_assert, register_ev
     full_test_vm.wait_for_vm_state_change(desired_state=full_test_vm.STATE_OFF, timeout=720)
     full_test_vm.power_control_from_cfme(option=full_test_vm.POWER_ON, cancel=False)
     full_test_vm.wait_for_vm_state_change(desired_state=full_test_vm.STATE_ON, timeout=900)
-    current_state = full_test_vm.find_quadicon().state
+    current_state = full_test_vm.find_quadicon().data['state']
     soft_assert(current_state.startswith('currentstate-on'),
                 "Quadicon state is {}".format(current_state))
     soft_assert(full_test_vm.provider.mgmt.is_vm_running(full_test_vm.name), "vm not running")
@@ -221,7 +221,7 @@ def test_operations_suspended_vm(small_test_vm, provider, soft_assert):
     # Suspend the VM
     small_test_vm.power_control_from_cfme(option=small_test_vm.SUSPEND, cancel=False)
     small_test_vm.wait_for_vm_state_change(desired_state=small_test_vm.STATE_SUSPENDED)
-    current_state = small_test_vm.find_quadicon().state
+    current_state = small_test_vm.find_quadicon().data['state']
     soft_assert(current_state.startswith('currentstate-suspended'),
                 "Quadicon state is {}".format(current_state))
     # Create second snapshot when VM is suspended
@@ -232,7 +232,7 @@ def test_operations_suspended_vm(small_test_vm, provider, soft_assert):
     snapshot1.revert_to()
     wait_for(lambda: snapshot1.active, num_sec=300, delay=20, fail_func=snapshot1.refresh)
     # Check VM state, VM should be off
-    current_state = small_test_vm.find_quadicon().state
+    current_state = small_test_vm.find_quadicon().data['state']
     soft_assert(current_state.startswith('currentstate-off'),
                 "Quadicon state is {}".format(current_state))
     assert small_test_vm.provider.mgmt.is_vm_stopped(small_test_vm.name)
@@ -240,7 +240,7 @@ def test_operations_suspended_vm(small_test_vm, provider, soft_assert):
     snapshot2.revert_to()
     wait_for(lambda: snapshot2.active, num_sec=300, delay=20, fail_func=snapshot2.refresh)
     # Check VM state, VM should be suspended
-    current_state = small_test_vm.find_quadicon().state
+    current_state = small_test_vm.find_quadicon().data['state']
     soft_assert(current_state.startswith('currentstate-suspended'),
                 "Quadicon state is {}".format(current_state))
     assert small_test_vm.provider.mgmt.is_vm_suspended(small_test_vm.name)

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -149,7 +149,8 @@ class TestControlOnQuadicons(object):
         if_scvmm_refresh_provider(testing_vm.provider)
         # TODO: assert no event.
         time.sleep(60)
-        soft_assert('currentstate-on' in testing_vm.find_quadicon().state)
+        vm_state = testing_vm.find_quadicon().data['state']
+        soft_assert('currentstate-on' in vm_state)
         soft_assert(
             testing_vm.provider.mgmt.is_vm_running(testing_vm.name), "vm not running")
 
@@ -164,7 +165,8 @@ class TestControlOnQuadicons(object):
         flash.assert_message_contain("Stop initiated")
         if_scvmm_refresh_provider(testing_vm.provider)
         testing_vm.wait_for_vm_state_change(desired_state=testing_vm.STATE_OFF, timeout=900)
-        soft_assert('currentstate-off' in testing_vm.find_quadicon().state)
+        vm_state = testing_vm.find_quadicon().data['state']
+        soft_assert('currentstate-off' in vm_state)
         soft_assert(
             not testing_vm.provider.mgmt.is_vm_running(testing_vm.name), "vm running")
 
@@ -178,7 +180,8 @@ class TestControlOnQuadicons(object):
         testing_vm.power_control_from_cfme(option=testing_vm.POWER_ON, cancel=True)
         if_scvmm_refresh_provider(testing_vm.provider)
         time.sleep(60)
-        soft_assert('currentstate-off' in testing_vm.find_quadicon().state)
+        vm_state = testing_vm.find_quadicon().data['state']
+        soft_assert('currentstate-off' in vm_state)
         soft_assert(
             not testing_vm.provider.mgmt.is_vm_running(testing_vm.name), "vm running")
 
@@ -194,7 +197,8 @@ class TestControlOnQuadicons(object):
         flash.assert_message_contain("Start initiated")
         if_scvmm_refresh_provider(testing_vm.provider)
         testing_vm.wait_for_vm_state_change(desired_state=testing_vm.STATE_ON, timeout=900)
-        soft_assert('currentstate-on' in testing_vm.find_quadicon().state)
+        vm_state = testing_vm.find_quadicon().data['state']
+        soft_assert('currentstate-on' in vm_state)
         soft_assert(
             testing_vm.provider.mgmt.is_vm_running(testing_vm.name), "vm not running")
 
@@ -325,11 +329,12 @@ def test_no_template_power_control(provider, soft_assert):
     selected_template = VM.factory(template_name, provider, template=True)
 
     # Check the power button with checking the quadicon
-    quadicon = selected_template.find_quadicon(do_not_navigate=True, mark=True, refresh=False)
+    entity = selected_template.find_quadicon()
+    entity.check()
     soft_assert(not toolbar.exists("Power"), "Power displayed when template quadicon checked!")
 
     # Ensure there isn't a power button on the details page
-    pytest.sel.click(quadicon)
+    entity.click()
     soft_assert(not toolbar.exists("Power"), "Power displayed in template details!")
 
 
@@ -347,11 +352,13 @@ def test_no_power_controls_on_archived_vm(testing_vm, archived_vm, soft_assert):
 
 
 def test_archived_vm_status(testing_vm, archived_vm):
-    assert ('currentstate-archived' in testing_vm.find_quadicon(from_any_provider=True).state)
+    vm_state = testing_vm.find_quadicon(from_any_provider=True).data['state']
+    assert ('currentstate-archived' in vm_state)
 
 
 def test_orphaned_vm_status(testing_vm, orphaned_vm):
-    assert ('currentstate-orphaned' in testing_vm.find_quadicon(from_any_provider=True).state)
+    vm_state = testing_vm.find_quadicon(from_any_provider=True).data['state']
+    assert ('currentstate-orphaned' in vm_state)
 
 
 @pytest.mark.uncollectif(lambda provider: provider.one_of(RHEVMProvider))

--- a/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
+++ b/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
@@ -21,7 +21,7 @@ def host(provider):
     hosts = view.entities.get_all()
     # Find a compute host with no instances on it
     for h in hosts:
-        if 'Compute' in h.name and h.quad_entity(h.name).no_vm == 0:
+        if 'Compute' in h.name and h.data['no_vm'] == 0:
             return OpenstackNode(h.name, provider=provider)
     raise HostNotFound('There is no proper host for tests')
 

--- a/cfme/tests/test_db_restore.py
+++ b/cfme/tests/test_db_restore.py
@@ -118,9 +118,8 @@ def test_db_restore(request, soft_assert, virtualcenter_provider_crud, ec2_provi
 
         # Verify that existing provider can detect new VMs on the second appliance
         vm = provision_vm(request, virtualcenter_provider_crud)
-        soft_assert(vm.find_quadicon().state == 'currentstate-on')
-        soft_assert(vm.provider.mgmt.is_vm_running(vm.name),
-            "vm running")
+        soft_assert(vm.find_quadicon().data['state'] == 'currentstate-on')
+        soft_assert(vm.provider.mgmt.is_vm_running(vm.name), "vm running")
 
         # Assert server roles on the second appliance
         for role, is_enabled in config.get_server_roles(db=False).iteritems():

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -2433,7 +2433,10 @@ class BaseEntitiesView(View):
 
             Returns: all current page entities
             """
-            return [row.name.text for row in self.elements.rows()]
+            try:
+                return [row.name.text for row in self.elements.rows()]
+            except NoSuchElementException:
+                return []
 
     @entities.register('Tile View')
     class TileView(EntitiesConditionalView):


### PR DESCRIPTION
vm/instance.find_quadicon method is widely used and doesn't allow to get rid of web_ui.QuadIcon. 
This PR intends to replace find_quadicon with widgetastic calls and updates all tests to use widgetastic Entity instead