### PR TITLE
[1LP][RFR] Bump wt-pf to 0.0.14 everywhere

### DIFF
--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -193,7 +193,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.12.2
 widgetastic.core==0.11.0
-widgetastic.patternfly==0.0.12
+widgetastic.patternfly==0.0.14
 widgetsnbextension==2.0.0
 wrapanapi==2.3.1
 wrapt==1.10.10

--- a/requirements/frozen_docs.txt
+++ b/requirements/frozen_docs.txt
@@ -148,7 +148,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.12.2
 widgetastic.core==0.11.0
-widgetastic.patternfly==0.0.12
+widgetastic.patternfly==0.0.14
 widgetsnbextension==2.0.0
 wrapt==1.10.10
 xmltodict==0.11.0

--- a/requirements/template_docs.txt
+++ b/requirements/template_docs.txt
@@ -64,7 +64,7 @@ tornado
 tzlocal
 wait_for
 widgetastic.core>=0.3.2
-widgetastic.patternfly>=0.0.1
+widgetastic.patternfly>=0.0.14
 yaycl
 yaycl-crypt
 


### PR DESCRIPTION
Fixes bootstrap switch when used as a widget in a table, among other things. That's why the vm reconfigure test below.

{{pytest: cfme/tests/infrastructure/test_vm_reconfigure.py -v --use-provider vsphere65-nested --long-running}}