### PR TITLE
[1LP][RFR]Update classes to use WidgetasticTaggable

### DIFF
--- a/cfme/cloud/availability_zone.py
+++ b/cfme/cloud/availability_zone.py
@@ -6,13 +6,14 @@ from widgetastic.exceptions import NoSuchElementException
 from widgetastic_patternfly import Dropdown, Button
 
 from cfme.base.login import BaseLoggedInPage
+from cfme.common import TagPageView, WidgetasticTaggable
 from cfme.exceptions import AvailabilityZoneNotFound
 from cfme.web_ui import match_location
 from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator
 from widgetastic_manageiq import (
     TimelinesView, ItemsToolBarViewSelector, Text, Table, Search, PaginationPane, BreadCrumb,
-    SummaryTable, Accordion, ManageIQTree, BaseNonInteractiveEntitiesView)
+    SummaryTable, Accordion, ManageIQTree)
 
 
 class AvailabilityZoneToolBar(View):
@@ -97,25 +98,6 @@ class AvailabilityZoneDetailsView(AvailabilityZoneView):
     entities = View.nested(AvailabilityZoneDetailsEntities)
 
 
-class AvailabilityZoneEditTagsView(AvailabilityZoneView):
-    breadcrumb = BreadCrumb()
-    title = Text('//div[@id="main-content"]//h3')
-    # TODO Add tag table support when rowspan is supported in SummaryTable
-    entities = View.nested(BaseNonInteractiveEntitiesView)
-
-    save = Button('Save')
-    reset = Button('Reset')
-    cancel = Button('Cancel')
-
-    @property
-    def is_displayed(self):
-        return (
-            self.in_availability_zones and
-            self.title.text == 'Tag Assignment' and
-            '{} (Summary)'.format(self.context['object'].name) in self.breadcrumb.locations)
-        # TODO Add quadicon check to this return
-
-
 class CloudAvailabilityZoneTimelinesView(TimelinesView, AvailabilityZoneView):
     @property
     def is_displayed(self):
@@ -126,7 +108,7 @@ class CloudAvailabilityZoneTimelinesView(TimelinesView, AvailabilityZoneView):
             super(TimelinesView, self).is_displayed)
 
 
-class AvailabilityZone(Navigatable):
+class AvailabilityZone(WidgetasticTaggable, Navigatable):
     _param_name = "AvailabilityZone"
 
     def __init__(self, name, provider, appliance=None):
@@ -162,9 +144,9 @@ class AvailabilityZoneDetails(CFMENavigateStep):
         row.click()
 
 
-@navigator.register(AvailabilityZone, 'EditTags')
+@navigator.register(AvailabilityZone, 'EditTagsFromDetails')
 class AvailabilityZoneEditTags(CFMENavigateStep):
-    VIEW = AvailabilityZoneEditTagsView
+    VIEW = TagPageView
     prerequisite = NavigateToSibling('Details')
 
     def step(self, *args, **kwargs):

--- a/cfme/cloud/flavor.py
+++ b/cfme/cloud/flavor.py
@@ -5,6 +5,7 @@ from widgetastic.exceptions import NoSuchElementException
 from widgetastic_patternfly import Dropdown, Button, View
 
 from cfme.base.ui import BaseLoggedInPage
+from cfme.common import TagPageView, WidgetasticTaggable
 from cfme.exceptions import FlavorNotFound
 from cfme.web_ui import match_location
 from cfme.utils.appliance import Navigatable
@@ -86,24 +87,7 @@ class FlavorDetailsView(FlavorView):
     entities = FlavorDetailsEntities()
 
 
-class FlavorEditTagsView(FlavorView):
-    @property
-    def is_displayed(self):
-        return (
-            self.in_availability_zones and
-            self.title.text == 'Tag Assignment' and
-            '{} (Summary)'.format(self.context['object'].name) in self.breadcrumb.locations
-        )
-
-    breadcrumb = BreadCrumb()
-    title = Text('//div[@id="main-content"]//h3')
-    entities = View.nested(BaseNonInteractiveEntitiesView)
-    save = Button('Save')
-    reset = Button('Reset')
-    cancel = Button('Cancel')
-
-
-class Flavor(Navigatable):
+class Flavor(WidgetasticTaggable, Navigatable):
     """
     Flavor class to support navigation
     """
@@ -126,6 +110,7 @@ class FlavorAll(CFMENavigateStep):
 
 @navigator.register(Flavor, 'Details')
 class FlavorDetails(CFMENavigateStep):
+    VIEW = FlavorDetailsView
     prerequisite = NavigateToSibling('All')
 
     def step(self, *args, **kwargs):
@@ -141,8 +126,9 @@ class FlavorDetails(CFMENavigateStep):
         row.click()
 
 
-@navigator.register(Flavor, 'EditTags')
+@navigator.register(Flavor, 'EditTagsFromDetails')
 class FlavorEditTags(CFMENavigateStep):
+    VIEW = TagPageView
     prerequisite = NavigateToSibling('Details')
 
     def step(self, *args, **kwargs):

--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -5,10 +5,11 @@ from widgetastic_patternfly import Dropdown, Button
 from widgetastic_manageiq import ManageIQTree, TimelinesView, Accordion
 
 from cfme.base.login import BaseLoggedInPage
+from cfme.common import TagPageView
 from cfme.common.vm import VM
 from cfme.common.vm_views import (
     ProvisionView, VMToolbar, VMEntities, VMDetailsEntities, RetirementView, EditView,
-    EditTagsView, SetOwnershipView, ManagementEngineView, ManagePoliciesView,
+    SetOwnershipView, ManagementEngineView, ManagePoliciesView,
     PolicySimulationView)
 from cfme.exceptions import InstanceNotFound, ItemNotFound
 from cfme.web_ui import flash, match_location
@@ -445,9 +446,9 @@ class EditManagementEngineRelationship(CFMENavigateStep):
         configuration.item_select('Edit Management Engine Relationship')
 
 
-@navigator.register(Instance, 'EditTags')
+@navigator.register(Instance, 'EditTagsFromDetails')
 class EditTags(CFMENavigateStep):
-    VIEW = EditTagsView
+    VIEW = TagPageView
     prerequisite = NavigateToSibling('Details')
 
     def step(self, *args, **kwargs):

--- a/cfme/cloud/instance/image.py
+++ b/cfme/cloud/instance/image.py
@@ -5,11 +5,10 @@ from widgetastic_manageiq import (
     ItemsToolBarViewSelector, SummaryTable, ItemNotFound, BaseEntitiesView)
 
 from cfme.exceptions import ImageNotFound
-from cfme.common import WidgetasticTaggable
+from cfme.common import WidgetasticTaggable, TagPageView
 from cfme.common.vm import Template
 from cfme.common.vm_views import (
-    EditView, SetOwnershipView, ManagePoliciesView, PolicySimulationView, EditTagsView,
-    BasicProvisionFormView)
+    EditView, SetOwnershipView, ManagePoliciesView, PolicySimulationView, BasicProvisionFormView)
 from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import navigate_to, CFMENavigateStep, navigator
 from . import CloudInstanceView, InstanceAccordion
@@ -226,9 +225,9 @@ class ImagePolicySimulation(CFMENavigateStep):
         self.prerequisite_view.toolbar.policy.item_select('Policy Simulation')
 
 
-@navigator.register(Image, 'EditTags')
+@navigator.register(Image, 'EditTagsFromDetails')
 class ImageEditTags(CFMENavigateStep):
-    VIEW = EditTagsView
+    VIEW = TagPageView
     prerequisite = NavigateToSibling('Details')
 
     def step(self, *args, **kwargs):

--- a/cfme/cloud/keypairs.py
+++ b/cfme/cloud/keypairs.py
@@ -7,10 +7,11 @@ from widgetastic_manageiq import (
     ItemsToolBarViewSelector, Text, TextInput, Accordion, ManageIQTree, BreadCrumb,
     SummaryTable, BootstrapSelect, ItemNotFound, BaseEntitiesView)
 
+from cfme.common import TagPageView, WidgetasticTaggable
 from cfme.base.ui import BaseLoggedInPage
 from cfme.exceptions import KeyPairNotFound
 
-from cfme.web_ui import match_location, mixins
+from cfme.web_ui import match_location
 from cfme.utils.appliance.implementations.ui import navigate_to, navigator, CFMENavigateStep
 from cfme.utils.appliance import NavigatableMixin
 from cfme.utils.wait import wait_for
@@ -152,7 +153,7 @@ class KeyPairCollection(NavigatableMixin):
         return self.instantiate(name, provider, public_key=public_key)
 
 
-class KeyPair(NavigatableMixin):
+class KeyPair(NavigatableMixin, WidgetasticTaggable):
     """ Automate Model page of KeyPairs
 
     Args:
@@ -201,16 +202,6 @@ class KeyPair(NavigatableMixin):
                 fail_func=refresh
             )
 
-    def add_tag(self, tag, **kwargs):
-        """Tags the Keypair by given tag"""
-        navigate_to(self, 'Details')
-        mixins.add_tag(tag, **kwargs)
-
-    def remove_tag(self, tag, **kwargs):
-        """Untag the Keypair by given tag"""
-        navigate_to(self, 'Details')
-        mixins.remove_tag(tag)
-
     @property
     def exists(self):
         try:
@@ -253,3 +244,12 @@ class Add(CFMENavigateStep):
     def step(self, *args, **kwargs):
         """Raises DropdownItemDisabled from widgetastic_patternfly if no RHOS provider present"""
         self.prerequisite_view.toolbar.configuration.item_select('Add a new Key Pair')
+
+
+@navigator.register(KeyPair, 'EditTagsFromDetails')
+class EditTagsFromDetails(CFMENavigateStep):
+    VIEW = TagPageView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')

--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -7,13 +7,14 @@ from navmazing import NavigateToSibling, NavigateToAttribute
 from widgetastic_manageiq import TimelinesView
 
 from cfme.base.login import BaseLoggedInPage
+from cfme.common import TagPageView
 from cfme.common.provider_views import (CloudProviderAddView,
                                         CloudProviderEditView,
                                         CloudProviderDetailsView,
                                         CloudProvidersView,
                                         CloudProvidersDiscoverView,
-                                        ProvidersManagePoliciesView,
-                                        ProvidersEditTagsView)
+                                        ProvidersManagePoliciesView
+                                        )
 import cfme.fixtures.pytest_selenium as sel
 from cfme.common.provider import CloudInfraProvider
 from cfme.web_ui import InfoBlock, match_location
@@ -171,7 +172,7 @@ class ManagePoliciesFromDetails(CFMENavigateStep):
 
 @navigator.register(CloudProvider, 'EditTags')
 class EditTags(CFMENavigateStep):
-    VIEW = ProvidersEditTagsView
+    VIEW = TagPageView
     prerequisite = NavigateToSibling('All')
 
     def step(self):
@@ -181,7 +182,7 @@ class EditTags(CFMENavigateStep):
 
 @navigator.register(CloudProvider, 'EditTagsFromDetails')
 class EditTagsFromDetails(CFMENavigateStep):
-    VIEW = ProvidersEditTagsView
+    VIEW = TagPageView
     prerequisite = NavigateToSibling('Details')
 
     def step(self):

--- a/cfme/cloud/tenant.py
+++ b/cfme/cloud/tenant.py
@@ -14,6 +14,7 @@ from widgetastic_manageiq import (
     SummaryTable, Table, Text, BaseNonInteractiveEntitiesView)
 
 from cfme.base.ui import BaseLoggedInPage
+from cfme.common import TagPageView, WidgetasticTaggable
 from cfme.exceptions import TenantNotFound, DestinationNotFound
 from cfme.web_ui import match_location
 from cfme.utils.appliance import NavigatableMixin
@@ -175,26 +176,6 @@ class TenantEditView(TenantView):
             self.entities.breadcrumb.active_location == expected_title)
 
 
-class TenantEditTagsView(TenantView):
-    """The edit tags page"""
-    entities = View.nested(TenantEditTagEntities)
-    select_tag = BootstrapSelect('tag_cat')
-    select_value = BootstrapSelect('tag_add')
-    save_button = Button('Save')
-    reset_button = Button('Reset')
-    cancel = Button('Cancel')
-
-    @property
-    def is_displayed(self):
-        """Is this page currently being displayed"""
-        return (
-            self.in_tenants and
-            self.entities.breadcrumb.locations == [
-                'Cloud Tenants', '{} (Summary)'.format(self.context['object'].name),
-                'Tag Assignment'] and
-            self.entities.breadcrumb.active_location == 'Tag Assignment')
-
-
 class TenantCollection(NavigatableMixin):
     """Collection object for the :py:class:`cfme.cloud.tenant.Tenant`."""
 
@@ -278,7 +259,7 @@ class TenantCollection(NavigatableMixin):
         # it is not shown in current UI, so not asserting
 
 
-class Tenant(NavigatableMixin):
+class Tenant(NavigatableMixin, WidgetasticTaggable):
     '''Tenant Class'''
     _param_name = 'Tenant'
 
@@ -404,9 +385,9 @@ class TenantEdit(CFMENavigateStep):
             raise DestinationNotFound('Cannot edit Cloud Tenants in CFME < 5.7')
 
 
-@navigator.register(Tenant, 'EditTags')
+@navigator.register(Tenant, 'EditTagsFromDetails')
 class TenantEditTags(CFMENavigateStep):
-    VIEW = TenantEditTagsView
+    VIEW = TagPageView
     prerequisite = NavigateToSibling('Details')
 
     def step(self, *args, **kwargs):

--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -215,7 +215,7 @@ class WidgetasticTaggable(object):
             cancel: set True to cancel tag assigment
             reset: set True to reset already set up tag
         """
-        view = navigate_to(self, 'EditTags')
+        view = navigate_to(self, 'EditTagsFromDetails')
         if isinstance(tag, Tag):
             category = tag.category.display_name
             tag = tag.display_name
@@ -258,7 +258,7 @@ class WidgetasticTaggable(object):
             cancel: set True to cancel tag deletion
             reset: set True to reset tag changes
         """
-        view = navigate_to(self, 'EditTags')
+        view = navigate_to(self, 'EditTagsFromDetails')
         if isinstance(tag, Tag):
             category = tag.category.display_name
             tag = tag.display_name
@@ -293,8 +293,9 @@ class WidgetasticTaggable(object):
             List of tags in format "Tag_category: Tag_name"
         """
         view = navigate_to(self, 'Details')
-        # look for simple 'tag' widget first, then standard entities.smart_management
-        tag_table = getattr(view, 'tag', view.entities.smart_management)
+        # look for simple 'smart_management' widget first, then standard entities.smart_management
+# TODO remove this double check after classes updates to entities.smart_management implementation
+        tag_table = getattr(view, 'smart_management', view.entities.smart_management)
         tags = tag_table.read()
         if isinstance(tags, dict):
             tags = tags[tenant]

--- a/cfme/common/host_views.py
+++ b/cfme/common/host_views.py
@@ -217,21 +217,6 @@ class HostManagePoliciesView(BaseLoggedInPage):
         return False
 
 
-class HostEditTagsView(BaseLoggedInPage):
-    """Host's Edit Tags view."""
-    tag_category = BootstrapSelect("tag_cat")
-    tag = BootstrapSelect("tag_add")
-    chosen_tags = Table(locator='.//div[@id="assignments_div"]/table')
-    entities = View.nested(BaseNonInteractiveEntitiesView)
-    save_button = Button("Save")
-    reset_button = Button("Reset")
-    cancel_button = Button("Cancel")
-
-    @property
-    def is_displayed(self):
-        return False
-
-
 class HostsToolbar(View):
     """Represents hosts toolbar and its controls."""
     configuration = Dropdown(text="Configuration")

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -10,6 +10,7 @@ import cfme.fixtures.pytest_selenium as sel
 from cfme.base.credential import (
     Credential, EventsCredential, TokenCredential, SSHCredential, CANDUCredential, AzureCredential,
     ServiceAccountCredential)
+from cfme.common import WidgetasticTaggable
 from cfme.common.provider_views import (InfraProvidersView,
                                         CloudProvidersView,
                                         InfraProviderDetailsView,
@@ -951,7 +952,7 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
         return result_list
 
 
-class CloudInfraProvider(BaseProvider, PolicyProfileAssignable):
+class CloudInfraProvider(BaseProvider, PolicyProfileAssignable, WidgetasticTaggable):
     vm_name = ""
     template_name = ""
     detail_page_suffix = 'provider'

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -203,29 +203,6 @@ class ProvidersManagePoliciesView(BaseLoggedInPage):
         return False
 
 
-class ProvidersEditTagsView(BaseLoggedInPage):
-    """
-     Provider's Edit Tags view
-    """
-    tag_category = BootstrapSelect('tag_cat')
-    tag = BootstrapSelect('tag_add')
-    chosen_tags = Table(locator='//div[@id="assignments_div"]/table')
-
-    @View.nested
-    class entities(BaseNonInteractiveEntitiesView):  # noqa
-        @property
-        def entity_class(self):
-            return ProviderEntity().pick(self.browser.product_version)
-
-    save = Button('Save')
-    reset = Button('Reset')
-    cancel = Button('Cancel')
-
-    @property
-    def is_displayed(self):
-        return False
-
-
 class NodesToolBar(View):
     """
      represents nodes toolbar and its controls (exists for Infra OpenStack provider)

--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -359,28 +359,6 @@ class EditView(BaseLoggedInPage):
         return False
 
 
-class EditTagsView(BaseLoggedInPage):
-    """
-    Edit vms/instance tags page
-    The title actually as Instance|VM.VM_TYPE string in it, otherwise the same
-    """
-    @View.nested
-    class form(View):  # noqa
-        tag_category = BootstrapSelect('tag_cat')
-        tag = BootstrapSelect('tag_add')
-        # TODO implement table element with ability to remove selected tags
-        # https://github.com/RedHatQE/widgetastic.core/issues/26
-        entities = View.nested(BaseNonInteractiveEntitiesView)
-        save_button = Button('Save')
-        reset_button = Button('Reset')
-        cancel_button = Button('Cancel')
-
-    @property
-    def is_displayed(self):
-        # TODO match quadicon
-        return False
-
-
 class SetOwnershipView(BaseLoggedInPage):
     """
     Set vms/instance ownership page

--- a/cfme/fixtures/tag.py
+++ b/cfme/fixtures/tag.py
@@ -102,18 +102,18 @@ def check_item_visibility(tag, user_restricted):
             visibility_result: pass 'True' is item should be visible,
                                'False' if not
         """
-        navigate_to(vis_object, 'Details')
+        navigate_to(vis_object, 'EditTagsFromDetails')
         if visibility_result:
-            mixins.add_tag(tag)
+            mixins.add_tag(tag=tag)
         else:
             try:
-                mixins.remove_tag(tag)
+                mixins.remove_tag(tag=tag)
             except TypeError:
                 logger.debug('Tag is already removed')
         actual_visibility = False
         with user_restricted:
             try:
-                navigate_to(vis_object, 'Details')
+                navigate_to(vis_object, 'EditTagsFromDetails')
                 actual_visibility = True
             except Exception:
                 logger.debug('Tagged item is not visible')

--- a/cfme/infrastructure/cluster.py
+++ b/cfme/infrastructure/cluster.py
@@ -12,6 +12,7 @@ from widgetastic_manageiq import (Accordion, BreadCrumb, ItemsToolBarViewSelecto
 from widgetastic_patternfly import Button, Dropdown, FlashMessages
 
 from cfme.base.login import BaseLoggedInPage
+from cfme.common import TagPageView, WidgetasticTaggable
 from cfme.exceptions import ClusterNotFound
 from cfme.web_ui import match_location
 from cfme.utils.appliance import Navigatable
@@ -172,7 +173,7 @@ class ClusterCollection(Navigatable):
             cluster.wait_for_disappear()
 
 
-class Cluster(Pretty, Navigatable):
+class Cluster(Pretty, Navigatable, WidgetasticTaggable):
     """ Model of an infrastructure cluster in cfme
 
     Args:
@@ -339,6 +340,14 @@ class Timelines(CFMENavigateStep):
         """Navigate to the correct view"""
         self.prerequisite_view.toolbar.monitoring.item_select('Timelines')
 
+
+@navigator.register(Cluster, 'EditTagsFromDetails')
+class EditTagsFromDetails(CFMENavigateStep):
+    VIEW = TagPageView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
 
 # TODO: This doesn't seem to be used, and needs to be migrated to Widgetastic
 # @navigator.register(Cluster, 'DetailsFromProvider')

--- a/cfme/infrastructure/datastore.py
+++ b/cfme/infrastructure/datastore.py
@@ -1,6 +1,6 @@
 """ A model of an Infrastructure Datastore in CFME
 """
-from navmazing import NavigateToAttribute
+from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.widget import View, Text
 from cfme.exceptions import ItemNotFound
 from widgetastic_manageiq import (ManageIQTree, SummaryTable, ItemsToolBarViewSelector,
@@ -8,6 +8,7 @@ from widgetastic_manageiq import (ManageIQTree, SummaryTable, ItemsToolBarViewSe
 from widgetastic_patternfly import Dropdown, Accordion, FlashMessages
 
 from cfme.base.login import BaseLoggedInPage
+from cfme.common import TagPageView, WidgetasticTaggable
 from cfme.common.host_views import HostsView
 from cfme.utils.appliance import NavigatableMixin
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
@@ -169,7 +170,7 @@ class DatastoreCollection(NavigatableMixin):
                 '"{}": scan successfully initiated'.format(datastore.name))
 
 
-class Datastore(Pretty, NavigatableMixin):
+class Datastore(Pretty, NavigatableMixin, WidgetasticTaggable):
     """ Model of an infrastructure datastore in cfme
 
     Args:
@@ -310,6 +311,15 @@ class DetailsFromProvider(CFMENavigateStep):
     def step(self):
         prov_view = navigate_to(self.obj.provider, 'Details')
         prov_view.contents.relationships.click_at('Datastores')
+
+
+@navigator.register(Datastore, 'EditTagsFromDetails')
+class EditTagsFromDetails(CFMENavigateStep):
+    VIEW = TagPageView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
 
 
 def get_all_datastores():

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -6,7 +6,7 @@ from manageiq_client.api import APIException
 from selenium.common.exceptions import NoSuchElementException
 
 from cfme.base.credential import Credential as BaseCredential
-from cfme.common import PolicyProfileAssignable
+from cfme.common import PolicyProfileAssignable, WidgetasticTaggable, TagPageView
 from cfme.common.host_views import (
     HostAddView,
     HostDetailsView,
@@ -31,7 +31,7 @@ from cfme.utils.update import Updateable
 from cfme.utils.wait import wait_for
 
 
-class Host(Updateable, Pretty, Navigatable, PolicyProfileAssignable):
+class Host(Updateable, Pretty, Navigatable, PolicyProfileAssignable, WidgetasticTaggable):
     """Model of an infrastructure host in cfme.
 
     Args:
@@ -403,16 +403,6 @@ class Host(Updateable, Pretty, Navigatable, PolicyProfileAssignable):
             drift_analysis_view.toolbar.all_attributes.click()
         return drift_analysis_view.drift_analysis(drift_section).is_changed
 
-    def tag(self, tag, **kwargs):
-        """Tags the system by given tag"""
-        navigate_to(self, 'Details')
-        mixins.add_tag(tag, **kwargs)
-
-    def untag(self, tag):
-        """Removes the selected tag off the system"""
-        navigate_to(self, 'Details')
-        mixins.remove_tag(tag)
-
 
 @navigator.register(Host)
 class All(CFMENavigateStep):
@@ -486,6 +476,15 @@ class Timelines(CFMENavigateStep):
 
     def step(self):
         self.prerequisite_view.toolbar.monitoring.item_select("Timelines")
+
+
+@navigator.register(Host)
+class EditTagsFromDetails(CFMENavigateStep):
+    VIEW = TagPageView
+    prerequisite = NavigateToSibling("Details")
+
+    def step(self):
+        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
 
 
 def get_credentials_from_config(credential_config_name):

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -7,6 +7,7 @@ from cached_property import cached_property
 from navmazing import NavigateToSibling, NavigateToObject
 
 from cfme.base.ui import Server
+from cfme.common import TagPageView
 from cfme.common.provider import CloudInfraProvider
 from cfme.common.provider_views import (InfraProviderAddView,
                                         InfraProviderEditView,
@@ -14,7 +15,6 @@ from cfme.common.provider_views import (InfraProviderAddView,
                                         ProviderTimelinesView,
                                         InfraProvidersDiscoverView,
                                         ProvidersManagePoliciesView,
-                                        ProvidersEditTagsView,
                                         InfraProvidersView)
 from cfme.fixtures import pytest_selenium as sel
 from cfme.infrastructure.cluster import Cluster
@@ -285,7 +285,7 @@ class ManagePoliciesFromDetails(CFMENavigateStep):
 
 @navigator.register(InfraProvider, 'EditTags')
 class EditTags(CFMENavigateStep):
-    VIEW = ProvidersEditTagsView
+    VIEW = TagPageView
     prerequisite = NavigateToSibling('All')
 
     def step(self):
@@ -295,7 +295,7 @@ class EditTags(CFMENavigateStep):
 
 @navigator.register(InfraProvider, 'EditTagsFromDetails')
 class EditTagsFromDetails(CFMENavigateStep):
-    VIEW = ProvidersEditTagsView
+    VIEW = TagPageView
     prerequisite = NavigateToSibling('Details')
 
     def step(self):

--- a/cfme/infrastructure/resource_pool.py
+++ b/cfme/infrastructure/resource_pool.py
@@ -10,6 +10,7 @@ from widgetastic.exceptions import NoSuchElementException
 from widgetastic_patternfly import Button, Dropdown, FlashMessages
 
 from cfme.base.ui import BaseLoggedInPage
+from cfme.common import TagPageView, WidgetasticTaggable
 from cfme.exceptions import ResourcePoolNotFound
 from cfme.web_ui import match_location
 from cfme.utils.pretty import Pretty
@@ -109,7 +110,7 @@ class ResourcePoolDetailsView(ResourcePoolView):
     entities = View.nested(ResourcePoolDetailsEntities)
 
 
-class ResourcePool(Pretty, Navigatable):
+class ResourcePool(Pretty, Navigatable, WidgetasticTaggable):
     """ Model of an infrastructure Resource pool in cfme
 
     Args:
@@ -249,3 +250,12 @@ class Details(CFMENavigateStep):
         except NoSuchElementException:
             raise ResourcePoolNotFound('Resource pool {} not found'.format(self.obj.name))
         row.click()
+
+
+@navigator.register(ResourcePool, 'EditTagsFromDetails')
+class EditTagsFromDetails(CFMENavigateStep):
+    VIEW = TagPageView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -19,6 +19,7 @@ from widgetastic_manageiq import (
 from widgetastic_manageiq.vm_reconfigure import DisksTable
 
 from cfme.base.login import BaseLoggedInPage
+from cfme.common import TagPageView
 from cfme.common.vm import VM, Template as BaseTemplate
 from cfme.common.vm_views import (
     ManagementEngineView, ProvisionView, EditView, RetirementView, VMDetailsEntities, VMToolbar,
@@ -1308,3 +1309,13 @@ class VmEngineRelationship(CFMENavigateStep):
     def step(self):
         self.prerequisite_view.toolbar.configuration.item_select(
             'Edit Management Engine Relationship')
+
+
+@navigator.register(Template, 'EditTagsFromDetails')
+@navigator.register(Vm, 'EditTagsFromDetails')
+class EditTagsFromDetails(CFMENavigateStep):
+    VIEW = TagPageView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')

--- a/cfme/middleware/provider/__init__.py
+++ b/cfme/middleware/provider/__init__.py
@@ -6,13 +6,12 @@ from random import sample
 from navmazing import NavigateToSibling, NavigateToAttribute
 from selenium.common.exceptions import NoSuchElementException
 
-from cfme.common import Validatable, SummaryMixin
+from cfme.common import Validatable, SummaryMixin, TagPageView
 from cfme.common.provider import BaseProvider
 from cfme.common.provider_views import (
     MiddlewareProviderAddView,
     MiddlewareProviderEditView,
     MiddlewareProvidersView,
-    ProvidersEditTagsView,
     MiddlewareProviderDetailsView)
 from cfme.exceptions import MiddlewareProviderNotFound
 from cfme.middleware.provider.middleware_views import (ProviderMessagingAllView,
@@ -120,7 +119,7 @@ class EditFromDetails(CFMENavigateStep):
 
 @navigator.register(MiddlewareProvider, 'EditTags')
 class EditTags(CFMENavigateStep):
-    VIEW = ProvidersEditTagsView
+    VIEW = TagPageView
     prerequisite = NavigateToSibling('All')
 
     def step(self):
@@ -130,7 +129,7 @@ class EditTags(CFMENavigateStep):
 
 @navigator.register(MiddlewareProvider, 'EditTagsFromDetails')
 class EditTagsFromDetails(CFMENavigateStep):
-    VIEW = ProvidersEditTagsView
+    VIEW = TagPageView
     prerequisite = NavigateToSibling('Details')
 
     def step(self):

--- a/cfme/networks/balancer.py
+++ b/cfme/networks/balancer.py
@@ -1,6 +1,6 @@
 from navmazing import NavigateToSibling, NavigateToAttribute
 
-from cfme.common import WidgetasticTaggable
+from cfme.common import WidgetasticTaggable, TagPageView
 from cfme.exceptions import ItemNotFound
 from cfme.networks.views import BalancerDetailsView, BalancerView
 from cfme.utils import version
@@ -90,8 +90,9 @@ class Details(CFMENavigateStep):
         self.prerequisite_view.entities.get_entity(by_name=self.obj.name).click()
 
 
-@navigator.register(Balancer, 'EditTags')
+@navigator.register(Balancer, 'EditTagsFromDetails')
 class EditTags(CFMENavigateStep):
+    VIEW = TagPageView
     prerequisite = NavigateToSibling('Details')
 
     def step(self):

--- a/cfme/networks/cloud_network.py
+++ b/cfme/networks/cloud_network.py
@@ -1,6 +1,6 @@
 from navmazing import NavigateToSibling, NavigateToAttribute
 
-from cfme.common import WidgetasticTaggable
+from cfme.common import WidgetasticTaggable, TagPageView
 from cfme.exceptions import ItemNotFound
 from cfme.networks.views import CloudNetworkDetailsView, CloudNetworkView
 from cfme.utils import providers, version
@@ -89,8 +89,9 @@ class Details(CFMENavigateStep):
         self.prerequisite_view.entities.get_entity(by_name=self.obj.name).click()
 
 
-@navigator.register(CloudNetwork, 'EditTags')
+@navigator.register(CloudNetwork, 'EditTagsFromDetails')
 class EditTags(CFMENavigateStep):
+    VIEW = TagPageView
     prerequisite = NavigateToSibling('Details')
 
     def step(self):

--- a/cfme/networks/network_port.py
+++ b/cfme/networks/network_port.py
@@ -1,6 +1,6 @@
 from navmazing import NavigateToSibling, NavigateToAttribute
 
-from cfme.common import WidgetasticTaggable
+from cfme.common import WidgetasticTaggable, TagPageView
 from cfme.exceptions import ItemNotFound
 from cfme.networks.views import NetworkPortDetailsView, NetworkPortView
 from cfme.utils import version
@@ -101,8 +101,9 @@ class Details(CFMENavigateStep):
         self.prerequisite_view.entities.get_entity(by_name=self.obj.name).click()
 
 
-@navigator.register(NetworkPort, 'EditTags')
+@navigator.register(NetworkPort, 'EditTagsFromDetails')
 class EditTags(CFMENavigateStep):
+    VIEW = TagPageView
     prerequisite = NavigateToSibling('Details')
 
     def step(self):

--- a/cfme/networks/network_router.py
+++ b/cfme/networks/network_router.py
@@ -1,6 +1,6 @@
 from navmazing import NavigateToSibling, NavigateToAttribute
 
-from cfme.common import WidgetasticTaggable
+from cfme.common import WidgetasticTaggable, TagPageView
 from cfme.exceptions import ItemNotFound
 from cfme.networks.views import NetworkRouterDetailsView, NetworkRouterView
 from cfme.utils import version
@@ -78,8 +78,9 @@ class Details(CFMENavigateStep):
         self.prerequisite_view.entities.get_entity(by_name=self.obj.name).click()
 
 
-@navigator.register(NetworkRouter, 'EditTags')
+@navigator.register(NetworkRouter, 'EditTagsFromDetails')
 class EditTags(CFMENavigateStep):
+    VIEW = TagPageView
     prerequisite = NavigateToSibling('Details')
 
     def step(self):

--- a/cfme/networks/provider/__init__.py
+++ b/cfme/networks/provider/__init__.py
@@ -1,6 +1,7 @@
 from navmazing import NavigateToSibling, NavigateToAttribute
 from cached_property import cached_property
 
+from cfme.common import WidgetasticTaggable, TagPageView
 from cfme.common.provider import BaseProvider
 from cfme.exceptions import ItemNotFound
 from cfme.networks.balancer import BalancerCollection
@@ -41,7 +42,7 @@ class NetworkProviderCollection(Navigatable):
         return [self.instantiate(name=p.name) for p in list_networks]
 
 
-class NetworkProvider(BaseProvider):
+class NetworkProvider(BaseProvider, WidgetasticTaggable):
     """ Class representing network provider in sdn
         Note: Network provider can be added to cfme database
               only automaticaly with cloud provider
@@ -209,8 +210,9 @@ class OpenTopologyFromDetails(CFMENavigateStep):
         self.prerequisite_view.entities.overview.click_at('Topology')
 
 
-@navigator.register(NetworkProvider, 'EditTags')
+@navigator.register(NetworkProvider, 'EditTagsFromDetails')
 class EditTags(CFMENavigateStep):
+    VIEW = TagPageView
     prerequisite = NavigateToSibling('Details')
 
     def step(self):

--- a/cfme/networks/security_group.py
+++ b/cfme/networks/security_group.py
@@ -1,6 +1,6 @@
 from navmazing import NavigateToSibling, NavigateToAttribute
 
-from cfme.common import WidgetasticTaggable
+from cfme.common import WidgetasticTaggable, TagPageView
 from cfme.exceptions import ItemNotFound
 from cfme.networks.views import SecurityGroupDetailsView, SecurityGroupView
 from cfme.utils import version
@@ -78,8 +78,9 @@ class Details(CFMENavigateStep):
         self.prerequisite_view.entities.get_entity(by_name=self.obj.name).click()
 
 
-@navigator.register(SecurityGroup, 'EditTags')
+@navigator.register(SecurityGroup, 'EditTagsFromDetails')
 class EditTags(CFMENavigateStep):
+    VIEW = TagPageView
     prerequisite = NavigateToSibling('Details')
 
     def step(self):

--- a/cfme/networks/subnet.py
+++ b/cfme/networks/subnet.py
@@ -1,6 +1,6 @@
 from navmazing import NavigateToSibling, NavigateToAttribute
 
-from cfme.common import WidgetasticTaggable
+from cfme.common import WidgetasticTaggable, TagPageView
 from cfme.exceptions import ItemNotFound
 from cfme.networks.views import SubnetDetailsView, SubnetView
 from cfme.utils import providers, version
@@ -90,10 +90,10 @@ class OpenCloudNetworks(CFMENavigateStep):
         self.prerequisite_view.entities.get_entity(by_name=self.obj.name).click()
 
 
-@navigator.register(Subnet, 'EditTags')
+@navigator.register(Subnet, 'EditTagsFromDetails')
 class EditTags(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
-    VIEW = SubnetDetailsView
+    VIEW = TagPageView
 
     def step(self):
         self.prerequisite_view.toolbar.policy.item_select('Edit Tags')

--- a/cfme/services/catalogs/ansible_catalog_item.py
+++ b/cfme/services/catalogs/ansible_catalog_item.py
@@ -399,7 +399,7 @@ class Edit(CFMENavigateStep):
         self.prerequisite_view.configuration.item_select("Edit this Item")
 
 
-@navigator.register(AnsiblePlaybookCatalogItem, 'EditTags')
+@navigator.register(AnsiblePlaybookCatalogItem, 'EditTagsFromDetails')
 class EditTags(CFMENavigateStep):
     VIEW = TagPageView
     prerequisite = NavigateToSibling('Details')

--- a/cfme/services/catalogs/catalog.py
+++ b/cfme/services/catalogs/catalog.py
@@ -3,6 +3,8 @@ from widgetastic.widget import Text
 from widgetastic_manageiq import MultiBoxSelect
 from widgetastic_patternfly import Button, Input
 from navmazing import NavigateToAttribute, NavigateToSibling
+
+from cfme.common import TagPageView, WidgetasticTaggable
 from cfme.utils.update import Updateable
 from cfme.utils.pretty import Pretty
 from cfme.utils.appliance import Navigatable
@@ -81,7 +83,7 @@ class EditCatalogView(CatalogForm):
         )
 
 
-class Catalog(Updateable, Pretty, Navigatable):
+class Catalog(Updateable, Pretty, Navigatable, WidgetasticTaggable):
 
     def __init__(self, name=None, description=None, items=None, appliance=None):
         Navigatable.__init__(self, appliance=appliance)
@@ -181,3 +183,12 @@ class Edit(CFMENavigateStep):
 
     def step(self):
         self.prerequisite_view.configuration.item_select('Edit this Item')
+
+
+@navigator.register(Catalog, 'EditTagsFromDetails')
+class EditTagsFromDetails(CFMENavigateStep):
+    VIEW = TagPageView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')

--- a/cfme/services/catalogs/catalog_item.py
+++ b/cfme/services/catalogs/catalog_item.py
@@ -415,7 +415,7 @@ class AddButton(CFMENavigateStep):
         self.prerequisite_view.configuration.item_select('Add a new Button')
 
 
-@navigator.register(CatalogItem, 'EditTags')
+@navigator.register(CatalogItem, 'EditTagsFromDetails')
 class EditTags(CFMENavigateStep):
     VIEW = TagPageView
     prerequisite = NavigateToSibling('Details')

--- a/cfme/services/catalogs/orchestration_template.py
+++ b/cfme/services/catalogs/orchestration_template.py
@@ -3,6 +3,7 @@ from widgetastic.widget import Text, Checkbox
 from widgetastic_patternfly import BootstrapSelect, Button, Input
 from widgetastic_manageiq import ScriptBox, Table
 from navmazing import NavigateToAttribute, NavigateToSibling
+from cfme.common import TagPageView, WidgetasticTaggable
 from cfme.utils.update import Updateable
 from cfme.utils.pretty import Pretty
 from cfme.utils.appliance import Navigatable
@@ -123,7 +124,7 @@ class AddDialogView(DialogForm):
         )
 
 
-class OrchestrationTemplate(Updateable, Pretty, Navigatable):
+class OrchestrationTemplate(Updateable, Pretty, Navigatable, WidgetasticTaggable):
 
     def __init__(self, template_type=None, template_name=None, description=None,
                  draft=None, content=None, appliance=None):
@@ -271,3 +272,12 @@ class CopyTemplate(CFMENavigateStep):
 
     def step(self):
         self.view.configuration.item_select("Copy this Orchestration Template")
+
+
+@navigator.register(OrchestrationTemplate, 'EditTagsFromDetails')
+class EditTagsFromDetails(CFMENavigateStep):
+    VIEW = TagPageView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        self.prerequisite_view.policy.item_select('Edit Tags')

--- a/cfme/tests/ansible/test_embedded_ansible_actions.py
+++ b/cfme/tests/ansible/test_embedded_ansible_actions.py
@@ -192,8 +192,8 @@ def test_action_run_ansible_playbook(request, full_template, ansible_catalog_ite
             ansible_catalog_item.provisioning = {"machine_credential": ansible_credential.name}
     with update(ansible_action):
         ansible_action.run_ansible_playbook = inventory
-    vmware_vm.add_tag(("Service Level", "Gold"), single_value=True)
-    request.addfinalizer(lambda: vmware_vm.remove_tag(("Service Level", "Gold")))
+    vmware_vm.add_tag("Service Level", "Gold")
+    request.addfinalizer(lambda: vmware_vm.remove_tag("Service Level", "Gold"))
     wait_for(service_request.exists, num_sec=600)
     service_request.wait_for_request()
     view = navigate_to(service, "Details")

--- a/cfme/tests/cloud/test_cloud_object_tag_visibility.py
+++ b/cfme/tests/cloud/test_cloud_object_tag_visibility.py
@@ -6,8 +6,8 @@ from cfme.cloud.availability_zone import AvailabilityZone
 from cfme.cloud.flavor import Flavor
 from cfme.cloud.instance import Instance
 from cfme.cloud.instance.image import Image
-from cfme.cloud.keypairs import KeyPair
-from cfme.cloud.stack import Stack
+from cfme.cloud.keypairs import KeyPairCollection
+from cfme.cloud.stack import StackCollection
 from cfme.cloud.provider import CloudProvider
 from cfme.utils import version
 from cfme.utils.blockers import BZ
@@ -30,7 +30,7 @@ test_items = [
     ('flavors', Flavor),
     ('instances', Instance),
     ('templates', Image),
-    ('stacks', Stack)
+    ('stacks', StackCollection)
 ]
 
 
@@ -40,29 +40,36 @@ def testing_vis_object(request, a_provider, appliance):
     """ Fixture creates class object for tag visibility test
     Returns: class object of certain type
     """
+    # TODO refactor, when all classes supports collections
     collection_name, param_class = request.param
     if collection_name == 'stacks':
-        return param_class(name=a_provider.data['provisioning']['stacks'][0], provider=a_provider)
-    test_items = getattr(appliance.rest_api.collections, collection_name)
-    if not test_items:
-        pytest.skip('No content found for test!')
-    if collection_name == 'templates':
-        item_type = a_provider.data['type']
-        for test_item_value in test_items:
-            if test_item_value.vendor == item_type:
-                return param_class(name=test_item_value.name, provider=a_provider)
-    elif collection_name in ['availability_zones', 'flavors', 'instances']:
-        return param_class(name=test_items[0].name, provider=a_provider)
-    return a_provider
+        return param_class(appliance).instantiate(
+            name=a_provider.data.provisioning.stacks[0], provider=a_provider)
+    elif collection_name in ['instances', 'flavors', 'availability_zones']:
+        test_items = getattr(appliance.rest_api.collections, collection_name)
+        if not test_items:
+            pytest.skip('No content found for test!')
+        try:
+            item_type = a_provider.data.provisioning.item_type.lower()
+            for test_item_value in test_items:
+                if test_item_value.vendor == item_type:
+                    return param_class(name=test_item_value.name, provider=a_provider)
+        except AttributeError:
+            return param_class(name=test_items[0].name, provider=a_provider)
+    elif collection_name == 'templates':
+        return param_class(name=a_provider.data.small_template,
+                           provider=a_provider)
+    else:
+        return a_provider
 
 
 @pytest.yield_fixture(scope="function")
-def key_pair(openstack_provider):
+def key_pair(openstack_provider, appliance):
     """
     Returns key pair object needed for the test
     """
-    keypair = KeyPair(name=fauxfactory.gen_alphanumeric(), provider=openstack_provider)
-    keypair.create()
+    keypairs = KeyPairCollection(appliance)
+    keypair = keypairs.create(name=fauxfactory.gen_alphanumeric(), provider=openstack_provider)
     yield keypair
     keypair.delete(wait=True)
 

--- a/cfme/tests/cloud/test_keypairs.py
+++ b/cfme/tests/cloud/test_keypairs.py
@@ -4,7 +4,6 @@ from Crypto.PublicKey import RSA
 
 from cfme.cloud.keypairs import KeyPairCollection
 from cfme.cloud.provider.openstack import OpenStackProvider
-from cfme.web_ui import mixins
 from cfme.utils import testgen
 from cfme.utils.blockers import BZ
 from cfme.utils.wait import TimedOutError
@@ -95,9 +94,8 @@ def test_keypair_add_and_remove_tag(openstack_provider, keypairs):
         * Remove tag from Keypair
         * Also delete it.
     """
-    tag = ('Department', 'Accounting')
     try:
-        keypair = keypairs.create(fauxfactory.gen_alphanumeric(), openstack_provider)
+        keypair = keypairs.create(name=fauxfactory.gen_alphanumeric(), provider=openstack_provider)
     except TimedOutError:
         if BZ(1444520, forced_streams=['5.6', '5.7', 'upstream']).blocks:
             pytest.skip('Timed out creating keypair, BZ1444520')
@@ -105,12 +103,12 @@ def test_keypair_add_and_remove_tag(openstack_provider, keypairs):
             pytest.fail('Timed out creating keypair')
     assert keypair.exists
 
-    keypair.add_tag(tag)
-    tagged_value = mixins.get_tags(tag="My Company Tags")
-    assert tuple(tagged_value[0].split(": ", 1)) == tag, "Add tag failed."
+    keypair.add_tag('Department', 'Accounting')
+    tagged_value = keypair.get_tags()
+    assert tagged_value[1] == 'Accounting', "Add tag failed."
 
-    keypair.remove_tag(tag)
-    tagged_value1 = mixins.get_tags(tag="My Company Tags")
+    keypair.remove_tag('Department', 'Accounting')
+    tagged_value1 = keypair.get_tags()
     assert tagged_value1 != tagged_value, "Remove tag failed."
     # Above small conversion in assert statement convert 'tagged_value' in tuple("a","b") and then
     # compare with tag which is tuple. As get_tags will return assigned tag in list format["a: b"].

--- a/cfme/tests/cloud/test_stack.py
+++ b/cfme/tests/cloud/test_stack.py
@@ -109,7 +109,7 @@ def test_resources_link(stack):
 @pytest.mark.tier(3)
 @test_requirements.tag
 def test_edit_tags(stack):
-    stack.edit_tags("Cost Center *", "Cost Center 001")
+    stack.add_tag("Cost Center *", "Cost Center 001")
 
 
 @pytest.mark.tier(3)

--- a/cfme/tests/cloud_infra_common/test_retirement.py
+++ b/cfme/tests/cloud_infra_common/test_retirement.py
@@ -167,8 +167,7 @@ def test_retirement_now_ec2_instance_backed(retire_ec2_s3_vm, tagged):
     """
     # Tag the VM with lifecycle for full retirement based on parameter
     if tagged:
-        retire_ec2_s3_vm.add_tag(('LifeCycle', 'Fully retire VM and remove from Provider'),
-                               single_value=True)
+        retire_ec2_s3_vm.add_tag('LifeCycle', 'Fully retire VM and remove from Provider')
         expected_power_state = ['terminated']
     else:
         # no tagging

--- a/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
+++ b/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
@@ -38,7 +38,7 @@ def testing_vis_object(request, a_provider, appliance):
     if not test_items:
         pytest.skip('No content found for test!')
 
-    if collection_name == 'templates':
+    if collection_name in ['templates', 'vms']:
         item_type = a_provider.data['provisioning']['catalog_item_type'].lower()
         for resource in collection_rest:
             if resource.vendor == item_type:

--- a/cfme/tests/services/test_myservice.py
+++ b/cfme/tests/services/test_myservice.py
@@ -88,7 +88,7 @@ def test_crud_set_ownership_and_edit_tags(myservice):
         test_flag: provision
     """
     myservice.set_ownership("Administrator", "EvmGroup-administrator")
-    myservice.edit_tags("Cost Center *", "Cost Center 001")
+    myservice.add_tag("Cost Center *", "Cost Center 001")
     with update(myservice):
         myservice.description = "my edited description"
     myservice.delete()

--- a/cfme/tests/services/test_orchestration_template.py
+++ b/cfme/tests/services/test_orchestration_template.py
@@ -119,6 +119,6 @@ def test_tag_orchestration_template(provisioning, tag, create_template):
                                     description="my template")
     template.create(create_template)
     navigate_to(template, "Details")
-    mixins.add_tag(tag)
-    mixins.remove_tag(tag)
+    template.add_tag(tag=tag)
+    template.remove_tag(tag=tag)
     template.delete()


### PR DESCRIPTION
Purpose or Intent
=================
Update classes(that are already converted to widgetastic) to use WidgetasticTaggable class:
1. Replace EditTags views for common TagPageView
2. Update EditTags step to EditTagsFromDetails(as also tag can be added via collections)
3. Update/Fix WidgetasticTaggable

Vm and Template will be updated in another PR after SummaryTable widget update, as get_tags() doesn't work properly if multiple tags assigned

{{pytest: -v -k 'test_keypair_add_and_remove_tag or test_tagvis_cloud_object' --long-running}}