### PR TITLE
[1LP][RFR] Update Tests for Templates Change in Yaml

### DIFF
--- a/cfme/ansible/repositories.py
+++ b/cfme/ansible/repositories.py
@@ -232,6 +232,11 @@ class Repository(BaseEntity):
         return self.appliance.db.client.sessionmaker(autocommit=True).query(table).filter(
             table.name == self.name).first()
 
+    @property
+    def as_fill_value(self):
+        """For use when selecting this repo in the UI forms"""
+        return self.name
+
     def update(self, updates):
         """Update the repository in the UI.
 

--- a/cfme/tests/ansible/test_embedded_ansible_actions.py
+++ b/cfme/tests/ansible/test_embedded_ansible_actions.py
@@ -99,7 +99,8 @@ def ansible_catalog_item(ansible_repository):
 
 @pytest.yield_fixture(scope="module")
 def vmware_vm(full_template_modscope, provider):
-    vm_obj = VM.factory(random_vm_name("ansible"), provider, template_name=full_template_modscope)
+    vm_obj = VM.factory(random_vm_name("ansible"), provider,
+                        template_name=full_template_modscope.name)
     vm_obj.create_on_provider(allow_skip="default")
     provider.mgmt.start_vm(vm_obj.name)
     provider.mgmt.wait_vm_running(vm_obj.name)
@@ -163,8 +164,8 @@ def ansible_credential(appliance, full_template_modscope):
     credential = CredentialsCollection(appliance=appliance).create(
         fauxfactory.gen_alpha(),
         "Machine",
-        username=credentials[full_template_modscope]["username"],
-        password=credentials[full_template_modscope]["password"]
+        username=credentials[full_template_modscope.creds]["username"],
+        password=credentials[full_template_modscope.creds]["password"]
     )
     yield credential
 
@@ -194,9 +195,9 @@ def service(ansible_catalog_item):
 @pytest.mark.tier(3)
 @pytest.mark.parametrize("host_type,inventory", ANSIBLE_ACTION_VALUES, ids=[
     value[0] for value in ANSIBLE_ACTION_VALUES])
-def test_action_run_ansible_playbook(request, full_template, ansible_catalog_item, ansible_action,
-        policy_for_testing, vmware_vm, ansible_credential, service_request, service, host_type,
-        inventory):
+def test_action_run_ansible_playbook(request, ansible_catalog_item, ansible_action, vmware_vm,
+                                     ansible_credential, service_request, service, host_type,
+                                     inventory):
     """Tests a policy with ansible playbook action against localhost, manual address,
        target machine and unavailable address.
     """

--- a/cfme/tests/cloud_infra_common/test_events.py
+++ b/cfme/tests/cloud_infra_common/test_events.py
@@ -25,10 +25,11 @@ def pytest_generate_tests(metafunc):
 
 @pytest.yield_fixture(scope="function")
 def vm_crud(provider, setup_provider_modscope, small_template_modscope):
+    template = small_template_modscope
     vm = VM.factory(
         'test_events_{}'.format(fauxfactory.gen_alpha(length=8).lower()),
         provider,
-        template_name=small_template_modscope)
+        template_name=template.name)
     yield vm
     if vm.does_vm_exist_on_provider():
         vm.delete_from_provider()

--- a/cfme/tests/cloud_infra_common/test_genealogy.py
+++ b/cfme/tests/cloud_infra_common/test_genealogy.py
@@ -38,7 +38,7 @@ def pytest_generate_tests(metafunc):
 @pytest.fixture(scope="function")
 def vm_crud(provider, small_template):
     return VM.factory(random_vm_name(context='genealogy'), provider,
-                      template_name=small_template)
+                      template_name=small_template.name)
 
 
 # uncollected above in pytest_generate_tests
@@ -86,12 +86,12 @@ def test_vm_genealogy_detected(
         else:
             # Ordinary Select
             parent = pytest.sel.text(opt).strip()
-        assert parent.startswith(small_template), "The parent template not detected!"
+        assert parent.startswith(small_template.name), "The parent template not detected!"
     else:
         try:
             vm_crud_ancestors = vm_crud.genealogy.ancestors
         except NameError:
             logger.exception("The parent template not detected!")
             raise pytest.fail("The parent template not detected!")
-        assert small_template in vm_crud_ancestors, \
-            "{} is not in {}'s ancestors".format(small_template, vm_crud.name)
+        assert small_template.name in vm_crud_ancestors, \
+            "{} is not in {}'s ancestors".format(small_template.name, vm_crud.name)

--- a/cfme/tests/cloud_infra_common/test_power_control_rest.py
+++ b/cfme/tests/cloud_infra_common/test_power_control_rest.py
@@ -32,7 +32,7 @@ def vm_name():
 
 @pytest.fixture(scope="function")
 def vm_obj(request, provider, setup_provider, small_template, vm_name):
-    vm_obj = VM.factory(vm_name, provider, template_name=small_template)
+    vm_obj = VM.factory(vm_name, provider, template_name=small_template.name)
 
     @request.addfinalizer
     def _delete_vm():

--- a/cfme/tests/cloud_infra_common/test_retirement.py
+++ b/cfme/tests/cloud_infra_common/test_retirement.py
@@ -47,7 +47,7 @@ def retire_vm(small_template, provider):
         small_template: small template fixture, template on provider
         provider: provider crud object from fixture
     """
-    vm = VM.factory(random_vm_name('retire'), provider, template_name=small_template)
+    vm = VM.factory(random_vm_name('retire'), provider, template_name=small_template.name)
     vm.create_on_provider(find_in_cfme=True, allow_skip="default")
     yield vm
 

--- a/cfme/tests/cloud_infra_common/test_snapshots_rest.py
+++ b/cfme/tests/cloud_infra_common/test_snapshots_rest.py
@@ -36,7 +36,7 @@ def pytest_generate_tests(metafunc):
 def vm_obj(provider, setup_provider_modscope, small_template_modscope):
     """Creates new VM or instance"""
     vm_name = random_vm_name('snpsht')
-    new_vm = VM.factory(vm_name, provider, template_name=small_template_modscope)
+    new_vm = VM.factory(vm_name, provider, template_name=small_template_modscope.name)
 
     if not provider.mgmt.does_vm_exist(vm_name):
         new_vm.create_on_provider(find_in_cfme=True, allow_skip='default')

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -127,8 +127,8 @@ def _get_vm(request, provider, template_name, vm_name):
         kwargs = {"cluster": provider.data["default_cluster"]}
     elif provider.one_of(OpenStackProvider):
         kwargs = {}
-        if 'small_template' in provider.data:
-            kwargs = {"flavour_name": provider.data.get('small_template')}
+        if 'small_template' in provider.data.templates:
+            kwargs = {"flavour_name": provider.data.templates.get('small_template').name}
     elif provider.one_of(SCVMMProvider):
         kwargs = {
             "host_group": provider.data.get("provisioning", {}).get("host_group", "All Hosts")}
@@ -188,12 +188,12 @@ def _get_vm(request, provider, template_name, vm_name):
 
 @pytest.fixture(scope="module")
 def vm(request, provider, setup_provider_modscope, small_template_modscope, vm_name):
-    return _get_vm(request, provider, small_template_modscope, vm_name)
+    return _get_vm(request, provider, small_template_modscope.name, vm_name)
 
 
 @pytest.fixture(scope="module")
 def vm_big(request, provider, setup_provider_modscope, big_template_modscope, vm_name_big):
-    return _get_vm(request, provider, big_template_modscope, vm_name_big)
+    return _get_vm(request, provider, big_template_modscope.name, vm_name_big)
 
 
 @pytest.fixture(scope="module")

--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -144,7 +144,7 @@ def vm_name():
 
 @pytest.yield_fixture(scope="function")
 def vm(vm_name, full_template, provider, setup_provider):
-    vm_obj = VM.factory(vm_name, provider, template_name=full_template)
+    vm_obj = VM.factory(vm_name, provider, template_name=full_template.name)
     vm_obj.create_on_provider(allow_skip="default")
     provider.mgmt.start_vm(vm_obj.name)
     provider.mgmt.wait_vm_running(vm_obj.name)
@@ -170,8 +170,8 @@ def vm(vm_name, full_template, provider, setup_provider):
 @pytest.yield_fixture(scope="function")
 def ssh(provider, full_template, vm_name):
     with SSHClient(
-            username=credentials[full_template]['username'],
-            password=credentials[full_template]['password'],
+            username=credentials[full_template.creds]['username'],
+            password=credentials[full_template.creds]['password'],
             hostname=provider.mgmt.get_ip_address(vm_name)) as ssh_client:
         yield ssh_client
 

--- a/cfme/tests/control/test_compliance.py
+++ b/cfme/tests/control/test_compliance.py
@@ -86,7 +86,7 @@ def configure_fleecing(appliance, provider, setup_provider_modscope, vddk_url):
 @pytest.yield_fixture(scope="module")
 def compliance_vm(configure_fleecing, provider, full_template_modscope):
     name = "{}-{}".format("test-compliance", fauxfactory.gen_alpha(4))
-    vm = VM.factory(name, provider, template_name=full_template_modscope)
+    vm = VM.factory(name, provider, template_name=full_template_modscope.name)
     vm.create_on_provider(allow_skip="default")
     provider.mgmt.start_vm(vm.name)
     provider.mgmt.wait_vm_running(vm.name)

--- a/cfme/tests/infrastructure/test_provisioning_rest.py
+++ b/cfme/tests/infrastructure/test_provisioning_rest.py
@@ -14,8 +14,8 @@ pytestmark = [test_requirements.provision]
 pytest_generate_tests = testgen.generate([VMwareProvider, RHEVMProvider], scope="module")
 
 
-def get_provision_data(rest_api, provider, small_template, auto_approve=True):
-    templates = rest_api.collections.templates.find_by(name=small_template)
+def get_provision_data(rest_api, provider, template_name, auto_approve=True):
+    templates = rest_api.collections.templates.find_by(name=template_name)
     for template in templates:
         try:
             ems_id = template.ems_id
@@ -25,7 +25,7 @@ def get_provision_data(rest_api, provider, small_template, auto_approve=True):
             guid = template.guid
             break
     else:
-        raise Exception("No such template {} on provider!".format(small_template))
+        raise Exception("No such template {} on provider!".format(template_name))
 
     result = {
         "version": "1.1",
@@ -63,7 +63,7 @@ def get_provision_data(rest_api, provider, small_template, auto_approve=True):
 
 @pytest.fixture(scope="module")
 def provision_data(appliance, provider, small_template_modscope):
-    return get_provision_data(appliance.rest_api, provider, small_template_modscope)
+    return get_provision_data(appliance.rest_api, provider, small_template_modscope.name)
 
 
 # Here also available the ability to create multiple provision request, but used the save
@@ -111,7 +111,7 @@ def test_create_pending_provision_requests(appliance, provider, small_template):
         test_flag: rest, provision
     """
     provision_data = get_provision_data(
-        appliance.rest_api, provider, small_template, auto_approve=False)
+        appliance.rest_api, provider, small_template.name, auto_approve=False)
     response = appliance.rest_api.collections.provision_requests.action.create(**provision_data)
     assert appliance.rest_api.response.status_code == 200
     # check that the `approval_state` is pending_approval
@@ -140,7 +140,7 @@ def test_provision_attributes(appliance, provider, small_template):
         test_flag: rest, provision
     """
     provision_data = get_provision_data(
-        appliance.rest_api, provider, small_template, auto_approve=False)
+        appliance.rest_api, provider, small_template.name, auto_approve=False)
     response = appliance.rest_api.collections.provision_requests.action.create(**provision_data)
     assert appliance.rest_api.response.status_code == 200
     provision_request = response[0]

--- a/cfme/tests/infrastructure/test_scvmm_specific.py
+++ b/cfme/tests/infrastructure/test_scvmm_specific.py
@@ -17,7 +17,8 @@ pytest_generate_tests = testgen.generate([SCVMMProvider], scope="module")
 def test_no_dvd_ruins_refresh(provider, small_template):
     host_group = provider.data["provisioning"]["host_group"]
     with provider.mgmt.with_vm(
-            small_template, vm_name="test_no_dvd_{}".format(fauxfactory.gen_alpha()),
+            small_template.name,
+            vm_name="test_no_dvd_{}".format(fauxfactory.gen_alpha()),
             host_group=host_group) as vm_name:
         provider.mgmt.disconnect_dvd_drives(vm_name)
         vm = VM.factory(vm_name, provider)

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -67,7 +67,7 @@ def orphaned_vm(provider, testing_vm):
 @pytest.fixture(scope="function")
 def testing_vm_tools(request, provider, vm_name, full_template):
     """Fixture to provision vm with preinstalled tools to the provider being tested"""
-    vm = VM.factory(vm_name, provider, template_name=full_template)
+    vm = VM.factory(vm_name, provider, template_name=full_template.name)
     logger.info("provider_key: %s", provider.key)
 
     @request.addfinalizer

--- a/cfme/tests/infrastructure/test_vm_reconfigure.py
+++ b/cfme/tests/infrastructure/test_vm_reconfigure.py
@@ -9,16 +9,18 @@ from cfme.utils.generators import random_vm_name
 
 pytest_generate_tests = testgen.generate(
     [VMwareProvider, RHEVMProvider],
-    required_fields=['small_template'],
+    required_fields=['templates'],
     scope="module")
 
 pytestmark = [
-    pytest.mark.usefixtures('setup_provider'), pytest.mark.long_running, pytest.mark.tier(2)]
+    pytest.mark.usefixtures('setup_provider_modscope'),
+    pytest.mark.long_running,
+    pytest.mark.tier(2)]
 
 
 @pytest.yield_fixture(scope='module')
 def small_vm(provider, small_template_modscope):
-    vm = VM.factory(random_vm_name(context='reconfig'), provider, small_template_modscope)
+    vm = VM.factory(random_vm_name(context='reconfig'), provider, small_template_modscope.name)
     vm.create_on_provider(find_in_cfme=True, allow_skip="default")
     vm.refresh_relationships()
 

--- a/cfme/tests/perf/workloads/test_provisioning.py
+++ b/cfme/tests/perf/workloads/test_provisioning.py
@@ -21,8 +21,8 @@ roles_provisioning_cleanup = ['database_operations', 'ems_inventory', 'ems_opera
     'event', 'notifier', 'reporting', 'scheduler', 'user_interface', 'web_services']
 
 
-def get_provision_data(rest_api, provider, small_template, auto_approve=True):
-    templates = rest_api.collections.templates.find_by(name=small_template)
+def get_provision_data(rest_api, provider, template_name, auto_approve=True):
+    templates = rest_api.collections.templates.find_by(name=template_name)
     for template in templates:
         try:
             ems_id = template.ems_id
@@ -32,7 +32,7 @@ def get_provision_data(rest_api, provider, small_template, auto_approve=True):
             guid = template.guid
             break
     else:
-        raise Exception("No such template {} on provider!".format(small_template))
+        raise Exception("No such template {} on provider!".format(template_name))
 
     result = {
         "version": "1.1",
@@ -149,8 +149,8 @@ def test_provisioning(appliance, request, scenario):
             provision_list.append((vm_to_provision, guid_to_provision,
                 prov.data['provisioning']['vlan']))
 
-        template = prov.data.get('small_template')
-        provision_data = get_provision_data(appliance.rest_api, prov, template)
+        template = prov.data.templates.get('small_template')
+        provision_data = get_provision_data(appliance.rest_api, prov, template.name)
         vm_name = provision_data["vm_fields"]["vm_name"]
         response = appliance.rest_api.collections.provision_requests.action.create(**provision_data)
         assert appliance.rest_api.response.status_code == 200
@@ -201,5 +201,5 @@ def test_provisioning(appliance, request, scenario):
     quantifiers['Queued_VM_Provisionings'] = total_provisioned_vms
     quantifiers['Deleted_VMs'] = total_deleted_vms
     logger.info('Provisioned {} VMs and deleted {} VMs during the scenario.'
-        .format(total_provisioned_vms, total_deleted_vms))
+                .format(total_provisioned_vms, total_deleted_vms))
     logger.info('Test Ending...')


### PR DESCRIPTION
This goes with a CFME QE YAML merge request (# 297) that implements a 'templates' section for all providers, with 'small_template', 'big_template', etc, as relevant for the different providers.

The pairing to that is updating the `_get_template` method that supplies all of of the `small_template`, `big_template`, etc fixtures, and updating all of the tests to handle these fixtures providing a template AttrDict instead of just the template name.

## PRT Results
I am not addressing test failures directly here. I've created PRs #5400, #5401, #5429, #5413, #5384 to fix tests/modules that I found had bugs during testing of this PR.

{{pytest: --long-running --use-provider complete}}