### PR TITLE
[1LP][RFR] Fix chargeback rate assignment

### DIFF
--- a/cfme/tests/containers/test_chargeback_for_images.py
+++ b/cfme/tests/containers/test_chargeback_for_images.py
@@ -68,7 +68,7 @@ def assign_compute_custom_rate(new_chargeback_fixed_rate, provider):
         assign_to="Labeled Container Images",
         docker_labels="Architecture",
         selections={
-            'x86_64': new_chargeback_fixed_rate.description
+            'x86_64': {'Rate': new_chargeback_fixed_rate.description}
         })
     asignment.computeassign()
     logger.info('ASSIGNING COMPUTE RATE FOR LABELED CONTAINER IMAGES')
@@ -78,7 +78,7 @@ def assign_compute_custom_rate(new_chargeback_fixed_rate, provider):
     asignment = assignments.Assign(
         assign_to="Selected Containers Providers",
         selections={
-            provider.name: "Default"
+            provider.name: {'Rate': 'Default'}
         })
     asignment.computeassign()
 

--- a/cfme/tests/containers/test_chargeback_for_projects.py
+++ b/cfme/tests/containers/test_chargeback_for_projects.py
@@ -85,7 +85,7 @@ def assign_compute_custom_rate(new_chargeback_fixed_rate, provider):
     asignment = assignments.Assign(
         assign_to="Selected Containers Providers",
         selections={
-            provider.name: new_chargeback_fixed_rate.description
+            provider.name: {'Rate': new_chargeback_fixed_rate.description}
         })
     asignment.computeassign()
     logger.info('ASSIGNING CUSTOM COMPUTE RATE')
@@ -95,7 +95,7 @@ def assign_compute_custom_rate(new_chargeback_fixed_rate, provider):
     asignment = assignments.Assign(
         assign_to="Selected Containers Providers",
         selections={
-            provider.name: "Default"
+            provider.name: {'Rate': 'Default'}
         })
     asignment.computeassign()
 


### PR DESCRIPTION
{{ pytest: cfme/tests/containers/test_chargeback_for_projects.py -m 'not long_running_env' --use-provider cm-env2 }}
Fix rate assignment in chargeback tests