### PR TITLE
[WIP] ContainerAllView inherit ContainerObjectAllBaseView

### DIFF
--- a/cfme/containers/container.py
+++ b/cfme/containers/container.py
@@ -11,8 +11,8 @@ from widgetastic.widget import Text
 from widgetastic.xpath import quote
 from widgetastic.utils import Version, VersionPick
 
-from cfme.base.login import BaseLoggedInPage
-from cfme.containers.provider import details_page, pol_btn, mon_btn
+from cfme.containers.provider import details_page, pol_btn, mon_btn,\
+    ContainerObjectAllBaseView
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import CheckboxTable, toolbar as tb, match_location, PagedTable
@@ -67,17 +67,21 @@ class Container(Taggable, SummaryMixin, Navigatable):
                 for obj in itertools.islice(containers_list, count)]
 
 
-class ContainerAllView(BaseLoggedInPage):
+class ContainerAllView(ContainerObjectAllBaseView):
     """Containers All view"""
-    summary = Text(VersionPick({
+    TITLE_TEXT = VersionPick({
         Version.lowest(): '//h3[normalize-space(.) = {}]'.format(quote('All Containers')),
         '5.8': '//h1[normalize-space(.) = {}]'.format(quote('Containers'))
-    }))
+    })
+    summary = Text(TITLE_TEXT)
     containers = Table(locator="//div[@id='list_grid']//table")
 
     @property
     def table(self):
         return self.containers
+
+    def title(self):
+        return self.summary
 
     @View.nested
     class Filters(Accordion):  # noqa


### PR DESCRIPTION
{{ pytest: cfme/tests/containers/test_search_bar.py --use-provider cm-env2 }}
- ContainerAllView inherit ContainerObjectAllBaseView - that fixing search bar tests which assumed ContainerAllView has toolbar. also increase consistency.