### PR TITLE
[1LP][RFR] Fix to enable embedded ansible script

### DIFF
--- a/cfme/scripting/setup_ansible.py
+++ b/cfme/scripting/setup_ansible.py
@@ -77,7 +77,6 @@ def get_ansible_password(app):
 
 def open_port(app):
     run_command(app, "firewall-cmd --zone manageiq --add-port {}/tcp".format(ports.TOWER))
-    run_command(app, "firewall-cmd --reload")
     print("Waiting until port {} will be opened".format(ports.TOWER))
     wait_for(
         net_check,


### PR DESCRIPTION
Removed line firewall-cmd reload, this was reloading firewalld and clearing the added ports from iptables, preventing ports opening.