### PR TITLE
[1LP][RFR] Fix test_start_pages & test_search_bar

### DIFF
--- a/cfme/containers/container.py
+++ b/cfme/containers/container.py
@@ -11,8 +11,8 @@ from widgetastic.widget import Text
 from widgetastic.xpath import quote
 from widgetastic.utils import Version, VersionPick
 
-from cfme.base.login import BaseLoggedInPage
-from cfme.containers.provider import details_page, pol_btn, mon_btn
+from cfme.containers.provider import (details_page, pol_btn, mon_btn,
+    ContainerObjectAllBaseView)
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import CheckboxTable, toolbar as tb, match_location, PagedTable
@@ -67,17 +67,13 @@ class Container(Taggable, SummaryMixin, Navigatable):
                 for obj in itertools.islice(containers_list, count)]
 
 
-class ContainerAllView(BaseLoggedInPage):
+class ContainerAllView(ContainerObjectAllBaseView):
     """Containers All view"""
     summary = Text(VersionPick({
         Version.lowest(): '//h3[normalize-space(.) = {}]'.format(quote('All Containers')),
         '5.8': '//h1[normalize-space(.) = {}]'.format(quote('Containers'))
     }))
     containers = Table(locator="//div[@id='list_grid']//table")
-
-    @property
-    def table(self):
-        return self.containers
 
     @View.nested
     class Filters(Accordion):  # noqa

--- a/cfme/containers/image.py
+++ b/cfme/containers/image.py
@@ -6,6 +6,8 @@ from cached_property import cached_property
 
 from navmazing import NavigateToSibling, NavigateToAttribute
 from widgetastic_patternfly import Dropdown
+from wrapanapi.containers.image import Image as ApiImage
+
 from cfme.common import SummaryMixin, Taggable, PolicyProfileAssignable
 from cfme.containers.provider import Labelable, navigate_and_get_rows,\
     ContainerObjectAllBaseView
@@ -16,7 +18,6 @@ from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator,
 from cfme.utils.appliance import Navigatable
 from cfme.configure import tasks
 from cfme.utils.wait import wait_for, TimedOutError
-from wrapanapi.containers.image import Image as ApiImage
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
 paged_tbl = PagedTable(table_locator="//div[@id='list_grid']//table")
@@ -129,7 +130,7 @@ class Image(Taggable, Labelable, SummaryMixin, Navigatable, PolicyProfileAssigna
 
 
 class ImageAllView(ContainerObjectAllBaseView):
-    TITLE_TEXT = 'Container Images'
+    TITLE_TEXT = "Container Images"
     configuration = Dropdown('Configuration')
 
 

--- a/cfme/containers/image_registry.py
+++ b/cfme/containers/image_registry.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 from functools import partial
 import random
-
 from cached_property import cached_property
+
 from navmazing import NavigateToSibling, NavigateToAttribute
+from wrapanapi.containers.image_registry import ImageRegistry as ApiImageRegistry
 
 from cfme.common import SummaryMixin, Taggable
 from cfme.containers.provider import pol_btn, navigate_and_get_rows,\
@@ -13,7 +14,6 @@ from cfme.web_ui import CheckboxTable, toolbar as tb, match_location,\
     PagedTable
 from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
-from wrapanapi.containers.image_registry import ImageRegistry as ApiImageRegistry
 
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
@@ -56,7 +56,7 @@ class ImageRegistry(Taggable, SummaryMixin, Navigatable):
 
 
 class ImageRegistryAllView(ContainerObjectAllBaseView):
-    TITLE_TEXT = 'Image Registries'
+    TITLE_TEXT = "Image Registries"
 
 
 @navigator.register(ImageRegistry, 'All')

--- a/cfme/containers/node.py
+++ b/cfme/containers/node.py
@@ -3,8 +3,9 @@
 from functools import partial
 import random
 import itertools
-
 from cached_property import cached_property
+
+from wrapanapi.containers.node import Node as ApiNode
 
 from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.widget import View
@@ -19,7 +20,6 @@ from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import CheckboxTable, toolbar as tb, InfoBlock, match_location
 from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
-from wrapanapi.containers.node import Node as ApiNode
 
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
@@ -31,7 +31,7 @@ resource_locator = "//div[@id='records_div']/table//span[@title='{}']"
 
 
 class NodeView(ContainerObjectAllBaseView, LoggingableView):
-    TITLE_TEXT = 'Nodes'
+    TITLE_TEXT = "Nodes"
 
     nodes = Table(locator="//div[@id='list_grid']//table")
 

--- a/cfme/containers/pod.py
+++ b/cfme/containers/pod.py
@@ -2,8 +2,9 @@
 from functools import partial
 import random
 import itertools
-
 from cached_property import cached_property
+
+from wrapanapi.containers.pod import Pod as ApiPod
 
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
@@ -15,7 +16,6 @@ from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep,\
     navigate_to
 from navmazing import NavigateToAttribute, NavigateToSibling
-from wrapanapi.containers.pod import Pod as ApiPod
 
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
@@ -68,7 +68,7 @@ class Pod(Taggable, Labelable, SummaryMixin, Navigatable):
 
 
 class PodAllView(ContainerObjectAllBaseView):
-    TITLE_TEXT = 'Pods'
+    TITLE_TEXT = "Pods"
 
 
 @navigator.register(Pod, 'All')

--- a/cfme/containers/project.py
+++ b/cfme/containers/project.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 import random
 import itertools
-
 from cached_property import cached_property
+
+from wrapanapi.containers.project import Project as ApiProject
 
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
@@ -15,7 +16,6 @@ from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator,
     navigate_to
 from navmazing import NavigateToAttribute, NavigateToSibling
 from functools import partial
-from wrapanapi.containers.project import Project as ApiProject
 
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
@@ -65,7 +65,7 @@ class Project(Taggable, Labelable, SummaryMixin, Navigatable):
 
 
 class ProjectAllView(ContainerObjectAllBaseView):
-    TITLE_TEXT = 'Projects'
+    TITLE_TEXT = "Projects"
 
 
 @navigator.register(Project, 'All')

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -10,7 +10,6 @@ from widgetastic_patternfly import (SelectorDropdown, Dropdown, BootstrapSelect,
                                     Input, Button, Tab)
 from widgetastic.widget import Text, View, TextInput
 from wrapanapi.utils import eval_strings
-from widgetastic.xpath import quote
 
 
 from cfme.base.login import BaseLoggedInPage
@@ -440,8 +439,9 @@ class AdHocMain(CFMENavigateStep):
 
 class ContainerObjectAllBaseView(ProvidersView):
     """Base class for container object All view.
-    TITLE_TEXT should be defined in child."""
-
+    TITLE_TEXT should be defined in child.
+    """
+    summary = Text('//div[@id="main-content"]//h1')
     policy = Dropdown('Policy')
     download = Dropdown('Download')
 
@@ -449,15 +449,9 @@ class ContainerObjectAllBaseView(ProvidersView):
     def table(self):
         return self.entities.elements
 
-    def title(self):
-        if not hasattr(self, 'TITLE_TEXT'):
-            raise Exception('TITLE_TEXT is not defined for destination {} ("All").'
-                            .format(self.__class__.__name__))
-        return Text('//h1[normalize-space(.) = {}]'.format(quote(self.TITLE_TEXT)))
-
     @property
     def is_displayed(self):
-        return self.title.is_displayed
+        return self.summary.text == self.TITLE_TEXT
 
 
 # Common methods:

--- a/cfme/containers/replicator.py
+++ b/cfme/containers/replicator.py
@@ -2,8 +2,9 @@
 import random
 import itertools
 from functools import partial
-
 from cached_property import cached_property
+
+from wrapanapi.containers.replicator import Replicator as ApiReplicator
 
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
@@ -15,7 +16,6 @@ from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep,\
     navigate_to
 from navmazing import NavigateToAttribute, NavigateToSibling
-from wrapanapi.containers.replicator import Replicator as ApiReplicator
 
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
@@ -67,7 +67,7 @@ class Replicator(Taggable, Labelable, SummaryMixin, Navigatable):
 
 
 class ReplicatorAllView(ContainerObjectAllBaseView):
-    TITLE_TEXT = 'Replicators'
+    TITLE_TEXT = "Replicators"
 
 
 @navigator.register(Replicator, 'All')

--- a/cfme/containers/route.py
+++ b/cfme/containers/route.py
@@ -2,8 +2,9 @@
 import random
 import itertools
 from functools import partial
-
 from cached_property import cached_property
+
+from wrapanapi.containers.route import Route as ApiRoute
 
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
@@ -15,7 +16,6 @@ from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep,
     navigate_to
 from navmazing import NavigateToAttribute, NavigateToSibling
 from cfme.utils.appliance import Navigatable
-from wrapanapi.containers.route import Route as ApiRoute
 
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
@@ -66,7 +66,7 @@ class Route(Taggable, Labelable, SummaryMixin, Navigatable):
 
 
 class RouteAllView(ContainerObjectAllBaseView):
-    TITLE_TEXT = 'Routes'
+    TITLE_TEXT = "Routes"
 
 
 @navigator.register(Route, 'All')

--- a/cfme/containers/service.py
+++ b/cfme/containers/service.py
@@ -2,8 +2,9 @@
 import random
 import itertools
 from functools import partial
-
 from cached_property import cached_property
+
+from wrapanapi.containers.service import Service as ApiService
 
 from cfme.common import SummaryMixin, Taggable
 from cfme.fixtures import pytest_selenium as sel
@@ -15,7 +16,6 @@ from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep,\
     navigate_to
 from navmazing import NavigateToAttribute, NavigateToSibling
-from wrapanapi.containers.service import Service as ApiService
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
 paged_tbl = PagedTable(table_locator="//div[@id='list_grid']//table")
@@ -65,7 +65,7 @@ class Service(Taggable, Labelable, SummaryMixin, Navigatable):
 
 
 class ServiceAllView(ContainerObjectAllBaseView):
-    TITLE_TEXT = 'Container Services'
+    TITLE_TEXT = "Container Services"
 
 
 @navigator.register(Service, 'All')

--- a/cfme/containers/template.py
+++ b/cfme/containers/template.py
@@ -2,10 +2,10 @@
 import random
 import itertools
 from functools import partial
-
 from cached_property import cached_property
 
 from navmazing import NavigateToAttribute, NavigateToSibling
+from wrapanapi.containers.template import Template as ApiTemplate
 
 from cfme.common import SummaryMixin, Taggable
 from cfme.containers.provider import Labelable, ContainerObjectAllBaseView
@@ -16,7 +16,6 @@ from .provider import details_page
 from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep,\
     navigate_to
-from wrapanapi.containers.template import Template as ApiTemplate
 
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
@@ -68,7 +67,7 @@ class Template(Taggable, Labelable, SummaryMixin, Navigatable):
 
 
 class TemplateAllView(ContainerObjectAllBaseView):
-    TITLE_TEXT = 'Container Templates'
+    TITLE_TEXT = "Container Templates"
 
 
 @navigator.register(Template, 'All')

--- a/cfme/containers/volume.py
+++ b/cfme/containers/volume.py
@@ -2,10 +2,10 @@
 from functools import partial
 import random
 import itertools
-
 from cached_property import cached_property
 
 from navmazing import NavigateToSibling, NavigateToAttribute
+from wrapanapi.containers.volume import Volume as ApiVolume
 
 from cfme.common import SummaryMixin, Taggable
 from cfme.containers.provider import navigate_and_get_rows,\
@@ -15,7 +15,6 @@ from cfme.web_ui import toolbar as tb, match_location, InfoBlock,\
     PagedTable, CheckboxTable
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
 from cfme.utils.appliance import Navigatable
-from wrapanapi.containers.volume import Volume as ApiVolume
 
 
 list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
@@ -65,7 +64,7 @@ class Volume(Taggable, SummaryMixin, Navigatable):
 
 
 class VolumeAllView(ContainerObjectAllBaseView):
-    TITLE_TEXT = 'Persistent Volumes'
+    TITLE_TEXT = "Persistent Volumes"
 
 
 @navigator.register(Volume, 'All')


### PR DESCRIPTION
{{ pytest: cfme/tests/containers/test_search_bar.py cfme/tests/containers/test_start_page.py --use-provider cm-env2 }}
ContainerObjectAllBaseView implementation was wrong and is_displayed didn't work properly in the container objects.