### PR TITLE
[1LP][RFR] Chargeback support for cloud -2

### DIFF
--- a/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
+++ b/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
@@ -247,7 +247,11 @@ def resource_usage(vm_ownership, appliance, provider):
 
         for record in appliance.db.client.session.query(metrics).filter(
                 metrics.id.in_(result.subquery())):
-            if record.cpu_usagemhz_rate_average:
+            if (record.cpu_usagemhz_rate_average or
+               record.cpu_usage_rate_average or
+               record.derived_memory_used or
+               record.net_usage_rate_average or
+               record.disk_usage_rate_average):
                 return True
         return False
 


### PR DESCRIPTION
{{pytest: cfme/tests/intelligence/reports/test_validate_chargeback_report.py --use-provider complete}}

This is a follow up to https://github.com/ManageIQ/integration_tests/pull/4891 .
I'm adding an additional check for cloud providers through this PR.

PRT results
----------------------------
1)57.z: 
Tests skipped because of a BZ

2)58.z 
The tests passed for Azure on PRT.The tests will be skipped for GCE until BZ 1486529 is resolved.

The tests for also skipped for vsphere6, vsphere65, rhv41 because the cu-24x7 VM is not running on these providers.