### PR TITLE
[1LP][RFR] Update ViewDefault, add Configuration Management

### DIFF
--- a/cfme/configure/settings.py
+++ b/cfme/configure/settings.py
@@ -364,6 +364,8 @@ class DefaultViewForm(MySettingsView):
     compare = ViewButtonGroup("General", "Compare")
     compare_mode = ViewButtonGroup("General", "Compare Mode")
     infrastructure_providers = ViewButtonGroup("Infrastructure", "Infrastructure Providers")
+    configuration_management_providers = ViewButtonGroup('Infrastructure',
+                                                         'Configuration Management Providers')
     my_services = ViewButtonGroup("Services", "My Services")
     catalog_items = ViewButtonGroup("Services", "Catalog Items")
     templates = ViewButtonGroup("Services", "Templates & Images")
@@ -386,7 +388,8 @@ class DefaultView(Updateable, Navigatable):
                'Catalog Items': "catalog_items",
                'Templates & Images': "templates",
                'VMs': "vms",
-               'VMs & Instances': "vms_instances"
+               'VMs & Instances': "vms_instances",
+               'Configuration Management Providers': 'configuration_management_providers'
                }
 
     def __init__(self, appliance=None):


### PR DESCRIPTION
Add a widget for Configuration Management Providers.

This could be modeled much better with a wrapper widget for the ViewButtonGroups, so I wrote issue #5335.

For now we'll have to write widgets and maps for whatever tests use default view settings.

Testing passes locally, this is only called at the very end of test_order_tower_catalog_item, which may fail for other reasons.

## PRT Results
Tests failing before the DefaultView call for unrelated reasons.

Reviewers can easily test this by running `miq shell`, and then:
```python
from cfme.configure.settings import DefaultView
DefaultView.set_default_view('Configuration Management Providers', 'List View')
# Tile View, Grid view are other valid options to set_default_view()
```

{{pytest: -v --long-running --use-provider complete cfme/tests/services/test_config_provider_servicecatalogs.py::test_order_tower_catalog_item}}