### PR TITLE
[1LP][RFR] fixed azure search template

### DIFF
--- a/scripts/azure_cleanup.py
+++ b/scripts/azure_cleanup.py
@@ -10,9 +10,9 @@ from utils.providers import list_provider_keys, get_mgmt
 def parse_cmd_line():
     parser = argparse.ArgumentParser(argument_default=None)
     parser.add_argument('--nic-template',
-                        help='NIC Name template to be removed', default="test*", type=str)
+                        help='NIC Name template to be removed', default="test-", type=str)
     parser.add_argument('--pip-template',
-                        help='PIP Name template to be removed', default="test*", type=str)
+                        help='PIP Name template to be removed', default="test-", type=str)
     parser.add_argument('--days-old',
                         help='--days-old argument to find stack items older than X days ',
                         default="7", type=int)


### PR DESCRIPTION
Template format has been slightly changed after moving wrapanapi.azure to rest.
Comparison is done using "in" operation now instead of regexp.
So, asterisk shouldn't be present in templates now.

I'd use "test-" but there are cases when nics/pips are calles testblabla and test_blabla