### PR TITLE
[1LP][RFR] Refactored test_service_ansible_playbook_order_pass_extra_vars

### DIFF
--- a/cfme/services/catalogs/__init__.py
+++ b/cfme/services/catalogs/__init__.py
@@ -9,6 +9,8 @@ from utils.appliance.implementations.ui import navigator, CFMENavigateStep
 
 
 class ServicesCatalogView(BaseLoggedInPage):
+
+    @property
     def in_explorer(self):
         return (
             self.logged_in_as_current_user and

--- a/cfme/services/catalogs/ansible_catalog_item.py
+++ b/cfme/services/catalogs/ansible_catalog_item.py
@@ -152,7 +152,7 @@ class SelectCatalogItemTypeView(ServicesCatalogView):
     @property
     def is_displayed(self):
         return (
-            self.in_explorer() and
+            self.in_explorer and
             self.title.text == "Adding a new Service Catalog Item" and
             self.catalog_item_type.is_displayed
         )
@@ -200,7 +200,7 @@ class DetailsAnsibleCatalogItemView(ServicesCatalogView):
     @property
     def is_displayed(self):
         return (
-            self.in_explorer() and
+            self.in_explorer and
             self.entities.title.text == 'Service Catalog Item "{}"'.format(
                 self.context["object"].name
             )


### PR DESCRIPTION
Intent
=================

`test_service_ansible_playbook_order_pass_extra_vars` renamed to `test_service_ansible_playbook_pass_extra_vars`. Also from now it has two parameters: provisioning and retirement.

{{pytest: -v -k "test_service_ansible_playbook_pass_extra_vars or test_service_ansible_playbook_plays_table" --long-running}}