### PR TITLE
[RFR] AutomateExplorer loaded server base

### DIFF
--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -5,14 +5,13 @@ from selenium.webdriver.common.keys import Keys
 import re
 from navmazing import NavigateToSibling, NavigateToAttribute
 
-from widgetastic_manageiq import (ManageIQTree, Checkbox, AttributeValueForm, SummaryFormItem,
-                                  TimelinesView)
+from widgetastic_manageiq import (ManageIQTree, Checkbox, AttributeValueForm, TimelinesView)
 from widgetastic_patternfly import (Accordion, Input, Button, Dropdown,
     FlashMessages, BootstrapSelect, Tab)
 from widgetastic.utils import Version, VersionPick
 from widgetastic.widget import View, Table, Text, Image, FileInput
 
-
+from cfme.automate.explorer import AutomateExplorer  # noqa
 from cfme.base.login import BaseLoggedInPage
 from cfme.base.credential import Credential
 from cfme.configure.about import AboutView


### PR DESCRIPTION
* This is NOT what we want to do, but is happening because the
  registration is in a different file Not seeing much of a way around
  this, but it is most definitely not ideal

{{pytest: -k test_pull_splitter_persistence[Server-AutomateExplorer]}}