### PR TITLE
[1LP][RFR]Fixing test case failure for quadicon

### DIFF
--- a/cfme/tests/configure/test_visual_cloud.py
+++ b/cfme/tests/configure/test_visual_cloud.py
@@ -158,5 +158,5 @@ def test_cloud_start_page(request, appliance, start_page):
 
 
 def test_cloudprovider_noquads(request, set_cloud_provider_quad):
-    navigate_to(CloudProvider, 'All')
-    assert visual.check_image_exists, "Image View Failed!"
+    view = navigate_to(CloudProvider, 'All')
+    assert view.entities.get_all()[0].data is None

--- a/cfme/tests/configure/test_visual_cloud.py
+++ b/cfme/tests/configure/test_visual_cloud.py
@@ -159,4 +159,5 @@ def test_cloud_start_page(request, appliance, start_page):
 
 def test_cloudprovider_noquads(request, set_cloud_provider_quad):
     view = navigate_to(CloudProvider, 'All')
-    assert view.entities.get_all()[0].data is None
+    view.toolbar.view_selector.select("Grid View")
+    assert view.entities.get_first_entity().data is None

--- a/cfme/tests/configure/test_visual_cloud.py
+++ b/cfme/tests/configure/test_visual_cloud.py
@@ -160,4 +160,5 @@ def test_cloud_start_page(request, appliance, start_page):
 def test_cloudprovider_noquads(request, set_cloud_provider_quad):
     view = navigate_to(CloudProvider, 'All')
     view.toolbar.view_selector.select("Grid View")
+    # Here get_first_entity() method will return None when the Quadrants option is deactivated.
     assert view.entities.get_first_entity().data is None

--- a/cfme/tests/configure/test_visual_infra.py
+++ b/cfme/tests/configure/test_visual_infra.py
@@ -214,12 +214,14 @@ def test_infra_start_page(request, appliance, start_page):
 
 def test_infraprovider_noquads(request, set_infra_provider_quad):
     view = navigate_to(InfraProvider, 'All')
-    assert view.entities.get_all()[0].data is None
+    view.toolbar.view_selector.select("Grid View")
+    assert view.entities.get_first_entity().data is None
 
 
 def test_host_noquads(request, set_host_quad):
     view = navigate_to(Host, 'All')
-    assert not bool(view.entities.get_all()[0].data)
+    view.toolbar.view_selector.select("Grid View")
+    assert view.entities.get_first_entity().data is None
 
 
 def test_datastore_noquads(request, set_datastore_quad, appliance):

--- a/cfme/tests/configure/test_visual_infra.py
+++ b/cfme/tests/configure/test_visual_infra.py
@@ -213,13 +213,13 @@ def test_infra_start_page(request, appliance, start_page):
 
 
 def test_infraprovider_noquads(request, set_infra_provider_quad):
-    navigate_to(InfraProvider, 'All')
-    assert visual.check_image_exists, "Image View Failed!"
+    view = navigate_to(InfraProvider, 'All')
+    assert view.entities.get_all()[0].data is None
 
 
 def test_host_noquads(request, set_host_quad):
-    navigate_to(Host, 'All')
-    assert visual.check_image_exists, "Image View Failed!"
+    view = navigate_to(Host, 'All')
+    assert not bool(view.entities.get_all()[0].data)
 
 
 def test_datastore_noquads(request, set_datastore_quad, appliance):

--- a/cfme/tests/configure/test_visual_infra.py
+++ b/cfme/tests/configure/test_visual_infra.py
@@ -215,12 +215,14 @@ def test_infra_start_page(request, appliance, start_page):
 def test_infraprovider_noquads(request, set_infra_provider_quad):
     view = navigate_to(InfraProvider, 'All')
     view.toolbar.view_selector.select("Grid View")
+    # Here get_first_entity() method will return None when the Quadrants option is deactivated.
     assert view.entities.get_first_entity().data is None
 
 
 def test_host_noquads(request, set_host_quad):
     view = navigate_to(Host, 'All')
     view.toolbar.view_selector.select("Grid View")
+    # Here get_first_entity() method will return None when the Quadrants option is deactivated.
     assert view.entities.get_first_entity().data is None
 
 


### PR DESCRIPTION

Purpose or Intent
=================
Fixed failure related to quadicon in test_visual_cloud.py and test_visual_cloud.py

{{pytest: -v -k 'test_cloudprovider_noquads or test_infraprovider_noquads or test_host_noquads' }}
