### PR TITLE
[WIP] Fix splitter usage

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -128,6 +128,17 @@ class VmsTemplatesAccordion(View):
         ACCORDION_NAME = 'Templates'
         tree = ManageIQTree()
 
+    def child_widget_accessed(self, _):
+        from cfme.web_ui.splitter import pull_splitter_right, pull_splitter_left
+        # <div class="col-md-10 col-md-push-2 max-height resizable" id="right_div" style="min-height: 0px;">
+        # use for splitter reset
+        if not _.is_displayed:
+            pull_splitter_right()
+            pull_splitter_right()
+        if not _.is_displayed:
+            pull_splitter_left()
+            pull_splitter_left()
+
 
 class InfraVmView(BaseLoggedInPage):
     """Base view for header/nav check, inherit for navigatable views"""


### PR DESCRIPTION
This will probably become a new WT type if one isn't already there
that tries to reset the splitter in the case that it isn't already in
the right place

Splitter tests and usage, do not fail correctly, we should actually take the burden off the tests and instead make the widget intelligent so that if the trees are not visible, we at least TRY to open the pslitter back to reasonable levels and THEN FAIL