### PR TITLE
[1LP][RFR] Cloud provision with tag test

### DIFF
--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -4,7 +4,7 @@ from time import sleep
 
 from widgetastic.widget import View, Text, TextInput, Checkbox, ParametrizedView
 from widgetastic_patternfly import (
-    Dropdown, BootstrapSelect, FlashMessages, Tab, Input, BootstrapTreeview)
+    Dropdown, BootstrapSelect, FlashMessages, Tab, Input, CheckableBootstrapTreeview)
 from widgetastic_manageiq import BreadCrumb
 
 from cfme.base.login import BaseLoggedInPage
@@ -173,7 +173,7 @@ class BasicProvisionFormView(View):
     @View.nested
     class purpose(Tab):  # noqa
         TAB_NAME = 'Purpose'
-        apply_tags = BootstrapTreeview('all_tags_treebox')
+        apply_tags = CheckableBootstrapTreeview('all_tags_treebox')
 
     @View.nested
     class catalog(Tab):  # noqa

--- a/cfme/tests/cloud/test_provisioning.py
+++ b/cfme/tests/cloud/test_provisioning.py
@@ -158,7 +158,7 @@ def provision_check(request, provider):
 
 
 @pytest.mark.parametrize('testing_instance', [True, False], ids=["Auto", "Manual"], indirect=True)
-def test_provision_from_template(appliance, provider, testing_instance, soft_assert):
+def test_provision_from_template(provider, testing_instance, soft_assert, provision_check):
     """ Tests instance provision from template
 
     Metadata:
@@ -647,4 +647,3 @@ def test_cloud_provision_with_tag(testing_instance, provision_check, soft_assert
     tags = instance.get_tags()
     assert any(tag.category.display_name == "Service Level" and tag.display_name == "Gold"
                for tag in tags), "Service Level: Gold not in tags ({})".format(str(tags))
-

--- a/cfme/tests/cloud/test_provisioning.py
+++ b/cfme/tests/cloud/test_provisioning.py
@@ -163,13 +163,13 @@ def provisioned_instance(provider, testing_instance, appliance):
 
 
 @pytest.mark.parametrize('testing_instance', [True, False], ids=["Auto", "Manual"], indirect=True)
-def test_provision_from_template(provider, provisioned_instance, soft_assert):
+def test_provision_from_template(provider, provisioned_instance):
     """ Tests instance provision from template
 
     Metadata:
         test_flag: provision
     """
-    soft_assert(provisioned_instance.does_vm_exist_on_provider(), "Instance wasn't provisioned")
+    assert provisioned_instance.does_vm_exist_on_provider(), "Instance wasn't provisioned"
 
 
 @pytest.mark.uncollectif(lambda provider: not provider.one_of(GCEProvider) or
@@ -633,7 +633,7 @@ def test_provision_with_additional_volume(request, testing_instance, provider, s
 
 
 @pytest.mark.parametrize('testing_instance', ['tag'], indirect=True)
-def test_cloud_provision_with_tag(provisioned_instance, soft_assert, tag):
+def test_cloud_provision_with_tag(provisioned_instance, tag):
     """ Tests tagging instance using provisioning dialogs.
 
     Steps:
@@ -644,7 +644,7 @@ def test_cloud_provision_with_tag(provisioned_instance, soft_assert, tag):
     Metadata:
         test_flag: provision
     """
-    soft_assert(provisioned_instance.does_vm_exist_on_provider(), "Instance wasn't provisioned")
+    assert provisioned_instance.does_vm_exist_on_provider(), "Instance wasn't provisioned"
     tags = provisioned_instance.get_tags()
     assert any(
         instance_tag.category.display_name == tag.category.display_name and


### PR DESCRIPTION
Purpose or Intent
=================
Cloud provivioning tests with selected tag

{{pytest: cfme/tests/cloud/test_provisioning.py -v -k 'test_provision_from_template or test_cloud_provision_with_tag' --long-running }}