### PR TITLE
[RFR] disable_bytecode: switch to sitecustomize

### DIFF
--- a/cfme/scripting/disable_bytecode.py
+++ b/cfme/scripting/disable_bytecode.py
@@ -4,7 +4,7 @@ from os import path
 import distutils
 
 
-DISABLE_BYTECODE_USERCUSTOMIZE = "import sys\nsys.dont_write_bytecode = True\n"
+DISABLE_BYTECODE = "import sys\nsys.dont_write_bytecode = True\n"
 
 
 def ensure_file_contains(target, content):
@@ -22,5 +22,5 @@ def ensure_file_contains(target, content):
 
 if __name__ == '__main__':
     site_packages = distutils.sysconfig_get_python_lib()
-    target = path.join(site_packages, 'usercustomize.py')
-    ensure_file_contains(target, content=DISABLE_BYTECODE_USERCUSTOMIZE)
+    target = path.join(site_packages, 'sitecustomize.py')
+    ensure_file_contains(target, content=DISABLE_BYTECODE)


### PR DESCRIPTION
this is necessary since based on virutalenv setup usercustomize may be disabled

after my last system upgrade and venv remake i started to see bytecode,
applying this change fixed it

ref #4936 @vatsalparekh this should match what you see
due to a minor system difference the issue was hidden

