### PR TITLE
[RFR] Update CFMENavigateStep.appliance, collections

### DIFF
--- a/cfme/utils/appliance/implementations/ui.py
+++ b/cfme/utils/appliance/implementations/ui.py
@@ -167,7 +167,7 @@ class CFMENavigateStep(NavigateStep):
 
     @property
     def appliance(self):
-        return self.obj.appliance
+        return getattr(self.obj, 'appliance', self.obj.collection.appliance)
 
     def create_view(self, *args, **kwargs):
         return self.appliance.browser.create_view(*args, **kwargs)


### PR DESCRIPTION
use appliance attribute, fallback to collection.appliance
handles appliance definition at instance and collection level.
eventually all appliance references will be in the collection


In using storage.volume as an example for use of the new NavigatableMixin, I found that nested NavigateToAttribute calls from an instance registered destination to a collection registered destination would fail, because the NavigateToAttribute against the collection would try to resolve the attribute against the instance.

For example, a 'Details' destination registered against the singular class that has 'All'  as prereq. The 'All' destination has a prereq of `NavigateToAttribute` that assumes its going to be resolving against the Collection class its registered against. When I eventually call `navigate_to(singular_instance, 'Details')`, it tries to resolve the attribute against the singular_instance.