### PR TITLE
[1LP][RFR] Get rid of web_ui in infra provider

### DIFF
--- a/cfme/infrastructure/cluster.py
+++ b/cfme/infrastructure/cluster.py
@@ -196,7 +196,7 @@ class Cluster(Pretty, NavigatableMixin, WidgetasticTaggable):
         col = self.appliance.rest_api.collections
         self._id = [
             cl.id
-            for cl in col.clusters.all
+            for cl in col.clusters
             if cl.name in (self._short_name, self.name) and cl.ems_id == self.provider.id
         ][-1]
 

--- a/cfme/infrastructure/cluster.py
+++ b/cfme/infrastructure/cluster.py
@@ -90,20 +90,6 @@ class ClusterAllView(ClusterView):
     including_entities = View.include(BaseEntitiesView, use_parent=True)
 
 
-class ClusterAllFromProviderView(ClusterView):
-    """The all view page for clusters open from provider detail page"""
-    @property
-    def is_displayed(self):
-        """Determine if this page is currently being displayed"""
-        return (
-            self.logged_in_as_current_user and
-            self.entities.title.text == '{p}(All Clusters)'.format(p=self.context['object'].name))
-
-    toolbar = View.nested(ClusterToolbar)
-    breadcrumb = BreadCrumb()
-    including_entities = View.include(BaseEntitiesView, use_parent=True)
-
-
 class ClusterDetailsView(ClusterView):
     """The details page of a cluster"""
     @property
@@ -340,13 +326,3 @@ class EditTagsFromDetails(CFMENavigateStep):
 
     def step(self):
         self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
-
-# TODO: This doesn't seem to be used, and needs to be migrated to Widgetastic
-# @navigator.register(Cluster, 'DetailsFromProvider')
-# class DetailsFromProvider(CFMENavigateStep):
-    # def step(self, *args, **kwargs):
-        # """Navigate to the correct view"""
-        # navigate_to(self.obj.provider, 'Details')
-        # list_acc.select('Relationships', 'Show all managed Clusters', by_title=True,
-        #                 partial=False)
-        # sel.click(Quadicon(self.obj.name, self.obj.quad_name))

--- a/cfme/infrastructure/cluster.py
+++ b/cfme/infrastructure/cluster.py
@@ -288,8 +288,9 @@ class All(CFMENavigateStep):
 
     def resetter(self):
         """Reset the view"""
-        self.view.entities.paginator.check_all()
-        self.view.entities.paginator.uncheck_all()
+        if self.view.entities.paginator.exists:
+            self.view.entities.paginator.check_all()
+            self.view.entities.paginator.uncheck_all()
 
 
 @navigator.register(Cluster, 'Details')

--- a/cfme/infrastructure/cluster.py
+++ b/cfme/infrastructure/cluster.py
@@ -54,12 +54,6 @@ class ClusterDetailsAccordion(View):
         tree = ManageIQTree()
 
 
-class ClusterEntities(BaseEntitiesView):
-    """A list of clusters"""
-    breadcrumb = BreadCrumb()  # exists on ClusterAllFromProviderView
-    # element attributes changed from id to class in upstream-fine+, capture both with locator
-
-
 class ClusterDetailsEntities(View):
     """A cluster properties on the details page"""
     breadcrumb = BreadCrumb()
@@ -94,7 +88,7 @@ class ClusterAllView(ClusterView):
             self.entities.title.text == 'Clusters')
 
     toolbar = View.nested(ClusterToolbar)
-    entities = View.nested(ClusterEntities)
+    including_entities = View.include(BaseEntitiesView, use_parent=True)
 
 
 class ClusterAllFromProviderView(ClusterView):
@@ -107,7 +101,8 @@ class ClusterAllFromProviderView(ClusterView):
             self.entities.title.text == '{p}(All Clusters)'.format(p=self.context['object'].name))
 
     toolbar = View.nested(ClusterToolbar)
-    entities = View.nested(ClusterEntities)
+    breadcrumb = BreadCrumb()
+    including_entities = View.include(BaseEntitiesView, use_parent=True)
 
 
 class ClusterDetailsView(ClusterView):
@@ -274,7 +269,7 @@ class Cluster(Pretty, NavigatableMixin, WidgetasticTaggable):
     def exists(self):
         view = navigate_to(self.collection, 'All')
         try:
-            self.prerequisite_view.entities.get_entity(name=self.name, surf_pages=True)
+            view.entities.get_entity(by_name=self.name, surf_pages=True)
             return True
         except ItemNotFound:
             return False
@@ -325,7 +320,8 @@ class Details(CFMENavigateStep):
         else:
             cluster_name = self.obj.name
         try:
-            entity = self.prerequisite_view.entities.get_entity(name=cluster_name, surf_pages=True)
+            entity = self.prerequisite_view.entities.get_entity(by_name=cluster_name,
+                                                                surf_pages=True)
             entity.click()
         except NoSuchElementException:
             raise ClusterNotFound('Cluster {} not found'.format(cluster_name))

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -195,9 +195,8 @@ class InfraProvider(Pretty, CloudInfraProvider, Fillable):
     def get_clusters(self):
         """returns the list of clusters belonging to the provider"""
         view = navigate_to(self, 'Clusters')
-        cluster_col = self.appliance.get(ClusterCollection)
-        # todo: to handle clusters on multiple pages
-        return [cluster_col.instantiate(e.name, self) for e in view.entities.get_all()]
+        col = self.appliance.get(ClusterCollection)
+        return [col.instantiate(e.name, self) for e in view.entities.get_all(surf_pages=True)]
 
     def as_fill_value(self):
         return self.name


### PR DESCRIPTION
{{ pytest: cfme/tests/infrastructure/test_providers.py  cfme/tests/infrastructure/test_timelines.py cfme/tests/infrastructure/test_cluster_analysis.py }}

1. This PR intends to remove web_ui traces from infra provider. This is necessary for successful testing 5.9/upstream.
2. It refactors clusters in order to use BaseEntitiesView instead of table.
