### PR TITLE
[1LP][RFR] Implementing changes in the test case to use the new setting page

### DIFF
--- a/cfme/configure/settings.py
+++ b/cfme/configure/settings.py
@@ -13,14 +13,21 @@ from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
 
 
+# Todo: Will remove this widget from here once it is available in widgetastic_patternly.
+class SaveButton(Button):
+    @property
+    def disabled(self):
+        return 'disabled' in self.browser.classes(self)
+
+
 class TimeProfileAddForm(View):
     description = Input(id='description')
     scope = BootstrapSelect('profile_type')
     timezone = BootstrapSelect('profile_tz')
     days = BootstrapSwitch(name='all_days')
     hours = BootstrapSwitch(name='all_hours')
-    save_button = Button(VersionPick({Version.lowest(): 'Add',
-                                      '5.8': 'Save'}))
+    save_button = SaveButton(VersionPick({Version.lowest(): 'Add',
+                                          '5.8': 'Save'}))
     configuration = Dropdown('Configuration')
     table = Table("//div[@id='main_div']//table")
     save_edit_button = Button('Save')

--- a/cfme/configure/settings.py
+++ b/cfme/configure/settings.py
@@ -32,6 +32,7 @@ class TimeProfileAddForm(View):
     table = Table("//div[@id='main_div']//table")
     save_edit_button = Button('Save')
     cancel_button = Button('Cancel')
+    help_block = Text("//span[contains(@class, 'help-block')]")
 
 
 class TimeprofileAddEntities(View):

--- a/cfme/tests/configure/test_timeprofile.py
+++ b/cfme/tests/configure/test_timeprofile.py
@@ -54,7 +54,7 @@ def test_timeprofile_name_max_character_validation():
 
 
 @pytest.mark.sauce
-def test_days_required_error_validation():
+def test_days_required_error_validation(soft_assert):
     tp = st.Timeprofile(
         description='time_profile' + fauxfactory.gen_alphanumeric(),
         scope='Current User',
@@ -63,15 +63,13 @@ def test_days_required_error_validation():
         hours=True)
     view = navigate_to(st.Timeprofile, 'All')
     tp.create(cancel=True)
-    if view.timeprofile_form.help_block.text == "At least one day needs to be selected":
-        assert view.timeprofile_form.save_button.disabled
-        view.timeprofile_form.cancel_button.click()
-    else:
-        assert view.timeprofile_form.help_block.text == "At least one day needs to be selected"
+    soft_assert(view.timeprofile_form.help_block.text == "At least one day needs to be selected")
+    soft_assert(view.timeprofile_form.save_button.disabled)
+    view.timeprofile_form.cancel_button.click()
 
 
 @pytest.mark.sauce
-def test_hours_required_error_validation():
+def test_hours_required_error_validation(soft_assert):
     tp = st.Timeprofile(
         description='time_profile' + fauxfactory.gen_alphanumeric(),
         scope='Current User',
@@ -80,23 +78,19 @@ def test_hours_required_error_validation():
         hours=False)
     view = navigate_to(st.Timeprofile, 'All')
     tp.create(cancel=True)
-    if view.timeprofile_form.help_block.text == "At least one hour needs to be selected":
-        assert view.timeprofile_form.save_button.disabled
-        view.timeprofile_form.cancel_button.click()
-    else:
-        assert view.timeprofile_form.help_block.text == "At least one hour needs to be selected"
+    soft_assert(view.timeprofile_form.help_block.text == "At least one hour needs to be selected")
+    soft_assert(view.timeprofile_form.save_button.disabled)
+    view.timeprofile_form.cancel_button.click()
 
 
 @pytest.mark.sauce
-def test_timeprofile_description_required_error_validation():
+def test_timeprofile_description_required_error_validation(soft_assert):
     tp = st.Timeprofile(
         description=None,
         scope='Current User',
         timezone="(GMT-10:00) Hawaii")
     view = navigate_to(st.Timeprofile, 'All')
     tp.create(cancel=True)
-    if view.timeprofile_form.description.help_block == "Required":
-        assert view.timeprofile_form.save_button.disabled
-        view.timeprofile_form.cancel_button.click()
-    else:
-        assert view.timeprofile_form.description.help_block == "Required"
+    soft_assert(view.timeprofile_form.description.help_block == "Required")
+    soft_assert(view.timeprofile_form.save_button.disabled)
+    view.timeprofile_form.cancel_button.click()

--- a/cfme/tests/configure/test_timeprofile.py
+++ b/cfme/tests/configure/test_timeprofile.py
@@ -63,9 +63,11 @@ def test_days_required_error_validation():
         hours=True)
     view = navigate_to(st.Timeprofile, 'All')
     tp.create(cancel=True)
-    if view.timeprofile_form.help_block.read() == "At least one day needs to be selected":
+    if view.timeprofile_form.help_block.text == "At least one day needs to be selected":
         assert view.timeprofile_form.save_button.disabled
-    view.timeprofile_form.cancel_button.click()
+        view.timeprofile_form.cancel_button.click()
+    else:
+        assert view.timeprofile_form.help_block.text == "At least one day needs to be selected"
 
 
 @pytest.mark.sauce
@@ -78,9 +80,11 @@ def test_hours_required_error_validation():
         hours=False)
     view = navigate_to(st.Timeprofile, 'All')
     tp.create(cancel=True)
-    if view.timeprofile_form.help_block.read() == "At least one hour needs to be selecte":
+    if view.timeprofile_form.help_block.text == "At least one hour needs to be selected":
         assert view.timeprofile_form.save_button.disabled
-    view.timeprofile_form.cancel_button.click()
+        view.timeprofile_form.cancel_button.click()
+    else:
+        assert view.timeprofile_form.help_block.text == "At least one hour needs to be selected"
 
 
 @pytest.mark.sauce
@@ -93,4 +97,6 @@ def test_timeprofile_description_required_error_validation():
     tp.create(cancel=True)
     if view.timeprofile_form.description.help_block == "Required":
         assert view.timeprofile_form.save_button.disabled
-    view.timeprofile_form.cancel_button.click()
+        view.timeprofile_form.cancel_button.click()
+    else:
+        assert view.timeprofile_form.description.help_block == "Required"

--- a/cfme/tests/configure/test_timeprofile.py
+++ b/cfme/tests/configure/test_timeprofile.py
@@ -6,7 +6,8 @@ from cfme.utils import error
 from cfme.utils.update import update
 from cfme.utils import version
 from cfme import test_requirements
-from cfme.web_ui import form_buttons
+from cfme.utils.appliance.implementations.ui import navigate_to
+
 
 pytestmark = [pytest.mark.tier(3),
               test_requirements.settings]
@@ -53,45 +54,39 @@ def test_timeprofile_name_max_character_validation():
 
 
 @pytest.mark.sauce
-def test_days_required_error_validation():
+def test_days_required_error_validation(appliance):
     tp = st.Timeprofile(
         description='time_profile' + fauxfactory.gen_alphanumeric(),
         scope='Current User',
         timezone="(GMT-10:00) Hawaii",
         days=False,
         hours=True)
-    if version.current_version() > "5.7":
-        tp.create(cancel=True)
-        assert "At least one day needs to be selected" == \
-               tp.timeprofile_form.days.angular_help_block
-        if version.current_version() > "5.8":
-            assert form_buttons.save.is_dimmed
-        else:
-            assert form_buttons.add.is_dimmed
-    else:
-        with error.expected("At least one Day must be selected"):
-            tp.create()
+    view = navigate_to(st.Timeprofile, 'All')
+    tp.create(cancel=True)
+    help_blocks = appliance.browser.widgetastic.elements("//span[contains(@class,"
+                                                         " 'help-block')]", check_visibility=True)
+    for help_block in help_blocks:
+        if help_block == "At least one day needs to be selected":
+            assert view.timeprofile_form.save_button.disabled
+    view.timeprofile_form.cancel_button.click()
 
 
 @pytest.mark.sauce
-def test_hours_required_error_validation():
+def test_hours_required_error_validation(appliance):
     tp = st.Timeprofile(
         description='time_profile' + fauxfactory.gen_alphanumeric(),
         scope='Current User',
         timezone="(GMT-10:00) Hawaii",
         days=True,
         hours=False)
-    if version.current_version() > "5.7":
-        tp.create(cancel=True)
-        assert "At least one hour needs to be selected" == \
-               tp.timeprofile_form.days.angular_help_block
-        if version.current_version() > "5.8":
-            assert form_buttons.save.is_dimmed
-        else:
-            assert form_buttons.add.is_dimmed
-    else:
-        with error.expected("At least one Hour must be selected"):
-            tp.create()
+    view = navigate_to(st.Timeprofile, 'All')
+    tp.create(cancel=True)
+    help_blocks = appliance.browser.widgetastic.elements("//span[contains(@class,"
+                                                         " 'help-block')]", check_visibility=True)
+    for help_block in help_blocks:
+        if help_block == "At least one hour needs to be selecte":
+            assert view.timeprofile_form.save_button.disabled
+    view.timeprofile_form.cancel_button.click()
 
 
 @pytest.mark.sauce
@@ -100,13 +95,8 @@ def test_timeprofile_description_required_error_validation():
         description=None,
         scope='Current User',
         timezone="(GMT-10:00) Hawaii")
-    if version.current_version() > "5.7":
-        tp.create(cancel=True)
-        assert tp.timeprofile_form.description.angular_help_block == "Required"
-        if version.current_version() > "5.8":
-            assert form_buttons.save.is_dimmed
-        else:
-            assert form_buttons.add.is_dimmed
-    else:
-        with error.expected("Description is required"):
-            tp.create()
+    view = navigate_to(st.Timeprofile, 'All')
+    tp.create(cancel=True)
+    if view.timeprofile_form.description.help_block == "Required":
+        assert view.timeprofile_form.save_button.disabled
+    view.timeprofile_form.cancel_button.click()

--- a/cfme/tests/configure/test_timeprofile.py
+++ b/cfme/tests/configure/test_timeprofile.py
@@ -54,7 +54,7 @@ def test_timeprofile_name_max_character_validation():
 
 
 @pytest.mark.sauce
-def test_days_required_error_validation(appliance):
+def test_days_required_error_validation():
     tp = st.Timeprofile(
         description='time_profile' + fauxfactory.gen_alphanumeric(),
         scope='Current User',
@@ -63,16 +63,13 @@ def test_days_required_error_validation(appliance):
         hours=True)
     view = navigate_to(st.Timeprofile, 'All')
     tp.create(cancel=True)
-    help_blocks = appliance.browser.widgetastic.elements("//span[contains(@class,"
-                                                         " 'help-block')]", check_visibility=True)
-    for help_block in help_blocks:
-        if help_block == "At least one day needs to be selected":
-            assert view.timeprofile_form.save_button.disabled
+    if view.timeprofile_form.help_block.read() == "At least one day needs to be selected":
+        assert view.timeprofile_form.save_button.disabled
     view.timeprofile_form.cancel_button.click()
 
 
 @pytest.mark.sauce
-def test_hours_required_error_validation(appliance):
+def test_hours_required_error_validation():
     tp = st.Timeprofile(
         description='time_profile' + fauxfactory.gen_alphanumeric(),
         scope='Current User',
@@ -81,11 +78,8 @@ def test_hours_required_error_validation(appliance):
         hours=False)
     view = navigate_to(st.Timeprofile, 'All')
     tp.create(cancel=True)
-    help_blocks = appliance.browser.widgetastic.elements("//span[contains(@class,"
-                                                         " 'help-block')]", check_visibility=True)
-    for help_block in help_blocks:
-        if help_block == "At least one hour needs to be selecte":
-            assert view.timeprofile_form.save_button.disabled
+    if view.timeprofile_form.help_block.read() == "At least one hour needs to be selecte":
+        assert view.timeprofile_form.save_button.disabled
     view.timeprofile_form.cancel_button.click()
 
 


### PR DESCRIPTION

Purpose or Intent
=================
Implementing changes in test case related to cfme/tests/configure/timeprofile.py to work with new cfme/configurewidgetastic/settings.py page.

{{pytest: -v -k 'test_timeprofile_description_required_error_validation or test_hours_required_error_validation or test_days_required_error_validation' }}



