### PR TITLE
[RFR] fixing paginator for cfme versions 5.8 > version < 5.8.2

### DIFF
--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -1337,11 +1337,11 @@ class NonJSPaginationPane(View):
             int(value)
         except ValueError:
             raise ValueError("Value should be integer and not {}".format(value))
-
-        items_text = VersionPick({
-            Version.lowest(): '{} items'.format(value),
-            '5.7.4': str(value),
-        }).pick(self.browser.product_version)
+        version = self.browser.product_version
+        if (version >= '5.7.4' and version < '5.8') or version >= '5.8.2':
+            items_text = str(value)
+        else:
+            items_text = '{} items'.format(value)
         self.items_on_page.select_by_visible_text(items_text)
 
     def _parse_pages(self):


### PR DESCRIPTION
It turned out that some external teams still use old cfme 5.8 > version < 5.8.2.
So, paginator should support such versions.