### PR TITLE
[1LP][RFR] fixing entity data for vms/instances in 5.7

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -304,7 +304,8 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable, SummaryMixin
         else:
             view = navigate_to(self, 'AllForProvider', use_resetter=False)
 
-        view.toolbar.view_selector.select('Grid View')
+        if 'Grid View' != view.toolbar.view_selector.selected:
+            view.toolbar.view_selector.select('Grid View')
 
         if use_search:
             search.normal_search(self.name)

--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -22,10 +22,17 @@ class InstanceQuadIconEntity(BaseQuadIconEntity):
     @property
     def data(self):
         br = self.browser
-        state = br.get_attribute('style', self.QUADRANT.format(pos='b'))
-        state = state.split('"')[1]
-        state = os.path.split(state)[1]
-        state = os.path.splitext(state)[0]
+        try:
+            if br.product_version > '5.8':
+                state = br.get_attribute('style', self.QUADRANT.format(pos='b'))
+                state = state.split('"')[1]
+            else:
+                state = br.get_attribute('src', self.QUADRANT.format(pos='b'))
+
+            state = os.path.split(state)[1]
+            state = os.path.splitext(state)[0]
+        except IndexError:
+            state = ''
 
         if br.is_displayed(self.QUADRANT.format(pos='g')):
             policy = br.get_attribute('src', self.QUADRANT.format(pos='g'))


### PR DESCRIPTION
vm's state is stored in style attr in 5.8 and img/src in 5.7.  This PR fixes this case.

{{ pytest: --long-running cfme/tests/infrastructure/test_vm_power_control.py }}

