### PR TITLE
[1LP][RFR] Update MyService.ui, services.Request, and settings.DefaultView, small fixes

### DIFF
--- a/cfme/configure/settings.py
+++ b/cfme/configure/settings.py
@@ -371,6 +371,7 @@ class DefaultViewForm(MySettingsView):
     templates = ViewButtonGroup("Services", "Templates & Images")
     vms = ViewButtonGroup("Infrastructure", "VMs")
     vms_instances = ViewButtonGroup("Services", "VMs & Instances")
+    cloud_stacks = ViewButtonGroup('Clouds', 'Stacks')
 
     containers_providers = ViewButtonGroup("Containers", "Containers Providers")
     container_nodes = ViewButtonGroup("Containers", "Nodes")
@@ -417,7 +418,8 @@ class DefaultView(Updateable, Navigatable):
                'Builds': 'container_builds',
                'Volumes': 'container_volumes',
                'Templates': 'container_templates',
-               'Configuration Management Providers': 'configuration_management_providers'
+               'Configuration Management Providers': 'configuration_management_providers',
+               'Stacks': 'cloud_stacks'
                }
 
     def __init__(self, appliance=None):

--- a/cfme/services/myservice/__init__.py
+++ b/cfme/services/myservice/__init__.py
@@ -2,9 +2,10 @@ import sentaku
 
 from cfme.utils.appliance import Navigatable
 from cfme.common import WidgetasticTaggable
+from cfme.utils.update import Updateable
 
 
-class MyService(Navigatable, WidgetasticTaggable, sentaku.modeling.ElementMixin):
+class MyService(Updateable, Navigatable, WidgetasticTaggable, sentaku.modeling.ElementMixin):
     """
         My Service main class to context switch between ui
         and ssui. All the below methods are implemented in both ui

--- a/cfme/services/requests.py
+++ b/cfme/services/requests.py
@@ -49,7 +49,7 @@ class Request(Navigatable):
             self.update(method='ui')
             return self.row.request_state.text in self.REQUEST_FINISHED_STATES
 
-        wait_for(_finished, num_sec=800, delay=20, message="Request finished")
+        wait_for(_finished, num_sec=1200, delay=10, message="Request finished")
 
     @property
     def rest(self):
@@ -120,7 +120,7 @@ class Request(Navigatable):
     @update.variant('ui')
     def update_ui(self):
         view = navigate_to(self, 'All')
-        view.reload.click()
+        view.toolbar.reload.click()
         self.row = view.find_request(cells=self.cells, partial_check=self.partial_check)
 
     @variable(alias='rest')
@@ -221,9 +221,14 @@ class Request(Navigatable):
         view.flash.assert_no_error()
 
 
+class RequestsToolbar(View):
+    """Toolbar on the requests view"""
+    reload = Button(title='Reload the current display')
+
+
 class RequestBasicView(BaseLoggedInPage):
     title = Text('//div[@id="main-content"]//h1')
-    reload = Button(title='Reload the current display')
+    toolbar = View.nested(RequestsToolbar)
 
     @property
     def in_requests(self):

--- a/cfme/tests/services/test_provision_stack.py
+++ b/cfme/tests/services/test_provision_stack.py
@@ -11,7 +11,7 @@ from cfme.services.myservice import MyService
 from cfme.services.requests import Request
 from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider.azure import AzureProvider
-from cfme.cloud.stack import Stack
+from cfme.cloud.stack import StackCollection
 from cfme import test_requirements
 from cfme.utils import testgen
 from cfme.utils.conf import credentials
@@ -229,7 +229,7 @@ def test_remove_template_provisioning(provider, provisioning, catalog, catalog_i
             provision_request.row.status.text == "Error")
 
 
-def test_retire_stack(provider, provisioning, catalog, catalog_item, request):
+def test_retire_stack(appliance, provider, provisioning, catalog, catalog_item, request):
     """Tests stack provisioning
 
     Metadata:
@@ -246,7 +246,7 @@ def test_retire_stack(provider, provisioning, catalog, catalog_item, request):
     provision_request = Request(request_description, partial_check=True)
     provision_request.wait_for_request()
     assert provision_request.is_succeeded()
-    stack = Stack(stack_data['stack_name'], provider=provider)
+    stack = StackCollection(appliance).instantiate(stack_data['stack_name'], provider=provider)
     stack.wait_for_exists()
     stack.retire_stack()
 


### PR DESCRIPTION
Removed some originally committed code to add a web_ui.Quadicon.click() method, screw that.

Small tweaks to services/myservice, biggest being the use of RequestsView for redirect validation.

## PRT Results
* 57z: 75% passing, test_remove_template_provisioning is failing when requests succeed, working with @sshveta on finding/writing BZ, not really related 
* 58z: 88% passing, same test failure, but only on one provider here
* upstream: uncollected, stream ignored.