### PR TITLE
[RFR] replacing provider views with navigation.get_class

### DIFF
--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -65,8 +65,6 @@ class CloudProvider(Pretty, CloudInfraProvider):
     vm_name = "Instances"
     template_name = "Images"
     db_types = ["CloudManager"]
-    main_view = CloudProvidersView
-    details_view = CloudProviderDetailsView
 
     def __init__(self, name=None, endpoints=None, zone=None, key=None, appliance=None):
         Navigatable.__init__(self, appliance=appliance)

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -12,7 +12,7 @@ from cfme.exceptions import (
     ProviderHasNoKey, HostStatsNotContains, ProviderHasNoProperty, ItemNotFound)
 from cfme.utils import ParamClassName, version, conf
 from cfme.utils.appliance import Navigatable
-from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.appliance.implementations.ui import navigate_to, navigator
 from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 from cfme.utils.net import resolve_hostname
@@ -167,7 +167,7 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
                         add_view.flash.assert_success_message(
                             'Credential validation was successful')
 
-            main_view = self.create_view(self.main_view)
+            main_view = self.create_view(navigator.get_class(self, 'All').VIEW)
             if cancel:
                 created = False
                 add_view.cancel.click()
@@ -273,8 +273,8 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
                 if hasattr(endp_view, 'validate') and endp_view.validate.is_displayed:
                     endp_view.validate.click()
 
-        details_view = self.create_view(self.details_view)
-        main_view = self.create_view(self.main_view)
+        details_view = self.create_view(navigator.get_class(self, 'Details').VIEW)
+        main_view = self.create_view(navigator.get_class(self, 'All').VIEW)
 
         if cancel:
             edit_view.cancel.click()

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -111,8 +111,6 @@ class ContainersProvider(BaseProvider, Pretty):
     quad_name = None
     db_types = ["ContainerManager"]
     endpoints_form = ContainersProviderEndpointsForm
-    main_view = ContainersProvidersView
-    details_view = ProviderDetailsView
 
     def __init__(
             self,

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -60,8 +60,6 @@ class InfraProvider(Pretty, CloudInfraProvider, Fillable):
     page_name = "infrastructure"
     templates_destination_name = "Templates"
     db_types = ["InfraManager"]
-    main_view = InfraProvidersView
-    details_view = InfraProviderDetailsView
 
     def __init__(
             self, name=None, endpoints=None, key=None, zone=None, provider_data=None,

--- a/cfme/middleware/provider/__init__.py
+++ b/cfme/middleware/provider/__init__.py
@@ -52,8 +52,6 @@ class MiddlewareProvider(BaseProvider):
     refresh_text = "Refresh items and relationships"
     taggable_type = 'ExtManagementSystem'
     db_types = ["MiddlewareManager"]
-    details_view = MiddlewareProviderDetailsView
-    main_view = MiddlewareProvidersView
 
 
 @navigator.register(MiddlewareProvider, 'All')

--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -79,7 +79,7 @@ mock==2.0.0
 monotonic==1.3
 msgpack-python==0.4.8
 multimethods.py==0.5.3
-navmazing==1.1.2
+navmazing==1.1.4
 nbconvert==5.2.1
 nbformat==4.3.0
 netaddr==0.7.19

--- a/requirements/frozen_docs.txt
+++ b/requirements/frozen_docs.txt
@@ -63,7 +63,7 @@ mock==2.0.0
 monotonic==1.3
 msgpack-python==0.4.8
 multimethods.py==0.5.3
-navmazing==1.1.2
+navmazing==1.1.4
 nbconvert==5.2.1
 nbformat==4.3.0
 netaddr==0.7.19


### PR DESCRIPTION
Tying views with each provider class isn't good idea. Especially when those views are already defined in navmazing destinations. 
This PR intends to replace such predefined views with new navmazing feature Navigate->get_class() method.

{{pytest: cfme/tests/cloud/test_providers.py cfme/tests/infrastructure/test_providers.py cfme/tests/middleware/test_middleware_provider.py cfme/tests/containers/test_ssl_providers.py }}