### PR TITLE
[1LP][RFR] Add return value to Snapshot.active

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -570,6 +570,7 @@ class Vm(VM):
                     return True
             except CandidateNotFound:
                 return False
+            return False
 
         def create(self, force_check_memory=False):
             snapshot_dict = {


### PR DESCRIPTION
This is a quick fix for `Snapshot.active` property. Originally, this returned False only if the `CandidateNotFound` exception occurred, meaning it did not return False if the snapshot was there, but was not active.
After this fix, it returns False correctly even in case the snapshot is there, but is not active, which is what we want.