### PR TITLE
[1LP][RFR] Fix Snapshot.delete for RHV provider

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -533,9 +533,10 @@ class Vm(VM):
         @property
         def exists(self):
             self._nav_to_snapshot_mgmt()
+            title = self.description if self.vm.provider.one_of(RHEVMProvider) else self.name
             try:
                 self.snapshot_tree.find_path_to(
-                    re.compile(r"{}.*?".format(self.name or self.description)))
+                    re.compile(r"{}.*?".format(title)))
                 return True
             except CandidateNotFound:
                 return False
@@ -564,9 +565,10 @@ class Vm(VM):
                 bool: True if snapshot is active, False otherwise.
             """
             self._nav_to_snapshot_mgmt()
+            title = self.description if self.vm.provider.one_of(RHEVMProvider) else self.name
             try:
-                self._click_tree_path(self.name or self.description)
-                if sel.is_displayed_text("{} (Active)".format(self.name or self.description)):
+                self._click_tree_path(title)
+                if sel.is_displayed_text("{} (Active)".format(title)):
                     return True
             except CandidateNotFound:
                 return False
@@ -590,6 +592,10 @@ class Vm(VM):
 
         def delete(self, cancel=False):
             self._nav_to_snapshot_mgmt()
+
+            title = self.description if self.vm.provider.one_of(RHEVMProvider) else self.name
+            self._click_tree_path(title)
+
             toolbar.select('Delete Snapshots', 'Delete Selected Snapshot', invokes_alert=True)
             sel.handle_alert(cancel=cancel)
             if not cancel:
@@ -607,7 +613,8 @@ class Vm(VM):
         def revert_to(self, cancel=False):
             self._nav_to_snapshot_mgmt()
 
-            self._click_tree_path(self.name or self.description)
+            title = self.description if self.vm.provider.one_of(RHEVMProvider) else self.name
+            self._click_tree_path(title)
 
             toolbar.select('Revert to selected snapshot', invokes_alert=True)
             sel.handle_alert(cancel=cancel)


### PR DESCRIPTION
This is a quick fix for `Snapshot.delete`.
After creating a VM on a RHV provider, there already is one RHV-created snapshot, the default one. When we create another snapshot using automation, it does get created, but it is NOT active and it is NOT highlighted. This behaviour differs from what we can see when working with vmware providers, where most of snapshot testcases are runnning, and is causing failures.
The fix is simple, I make sure we are currently on the snapshot we created and not on the snapshot that gets created by RHV. This way, it works with RHV as well as vsphere providers.

PS: this is only a quick remedy for jenkins failures. For the future, more complex refactoring in snapshot area will be needed. I need to change the way we interact with snapshots so that these kind of problems won't appear anymore.

{{pytest: -v --long-running --use-provider vsphere65-nested --use-provider rhv41 -k test_snapshot_crud}}