### PR TITLE
[1LP][WIP] Fix test_snapshot_crud for RHV

### DIFF
--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -118,6 +118,11 @@ def test_snapshot_crud(small_test_vm, provider):
         snapshot = new_snapshot(small_test_vm)
     snapshot.create()
     snapshot.delete()
+    # The Snapshot.delete method does not wait for snapshot deletion, it just initializes
+    # the process. We however need to wait for the process to complete, otherwise there
+    # may be a failure when trying to delete small_test_vm from the provider. The VM can't be
+    # deleted, because there is a pending snapshot operation. Does occur on RHV provider.
+    wait_for(lambda: not snapshot.exists, num_sec=300, delay=20, fail_func=snapshot.refresh)
 
 
 @pytest.mark.uncollectif(lambda provider: not provider.one_of(VMwareProvider))


### PR DESCRIPTION
This is a quick fix for `test_snapshot_crud` mainly for RHV provider.
The `Snapshot.delete` method does not wait for the deletion process to complete. When the test is run against RHV provider, this causes error at the end of the test, when automation is trying to delete the test VM. The VM can't be deleted, because there is pending snapshot operation.
Proposed fix is to wait for the snapshot deletion inside the test.