### PR TITLE
[RFR] test_snapshot.py test_snapshot_crud RHV Workaround

### DIFF
--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -117,6 +117,9 @@ def test_snapshot_crud(small_test_vm, provider):
     else:
         snapshot = new_snapshot(small_test_vm)
     snapshot.create()
+    if provider.one_of(RHEVMProvider):
+        # Workaround to select the snapshot
+        snapshot.active
     snapshot.delete()
 
 


### PR DESCRIPTION
Hi!
When there's RHV as a provider the newly created snapshot is not getting selected after creation.
So this changes are only to select this snapshot to delete it then.

Signed-off-by: Aleksei Slaikovskii <aslaikov@redhat.com>