### PR TITLE
[1LP][RFR] get_tag() multiple tags handling + vm, template classes update

### DIFF
--- a/cfme/cloud/instance/image.py
+++ b/cfme/cloud/instance/image.py
@@ -5,7 +5,7 @@ from widgetastic_manageiq import (
     ItemsToolBarViewSelector, SummaryTable, ItemNotFound, BaseEntitiesView)
 
 from cfme.exceptions import ImageNotFound
-from cfme.common import WidgetasticTaggable, TagPageView
+from cfme.common import TagPageView
 from cfme.common.vm import Template
 from cfme.common.vm_views import (
     EditView, SetOwnershipView, ManagePoliciesView, PolicySimulationView, BasicProvisionFormView)
@@ -126,7 +126,7 @@ class ImageProvisionView(CloudInstanceView):
             self.form.catalog.catalog_name.read_content()[0].get('Provider', None) == prov_name)
 
 
-class Image(Template, Navigatable, WidgetasticTaggable):
+class Image(Template, Navigatable):
     ALL_LIST_LOCATION = "clouds_images"
     TO_OPEN_EDIT = "Edit this Image"
     QUADICON_TYPE = "image"

--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -214,7 +214,8 @@ class WidgetasticTaggable(object):
             tag: tag(str) or Tag object
             cancel: set True to cancel tag assigment
             reset: set True to reset already set up tag
-            details:
+            details (bool): set False if tag should be added for list selection,
+                            default is details page
         """
         if details:
             view = navigate_to(self, 'EditTagsFromDetails')
@@ -261,7 +262,8 @@ class WidgetasticTaggable(object):
             tag: tag(str) or Tag object
             cancel: set True to cancel tag deletion
             reset: set True to reset tag changes
-            details:
+            details (bool): set False if tag should be added for list selection,
+                            default is details page
         """
         if details:
             view = navigate_to(self, 'EditTagsFromDetails')

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -16,6 +16,7 @@ from cfme.web_ui import (
     DriftGrid, BootstrapTreeview
 )
 import cfme.web_ui.toolbar as tb
+from cfme.common import WidgetasticTaggable
 from cfme.utils import version, ParamClassName
 from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -26,7 +27,7 @@ from cfme.utils.update import Updateable
 from cfme.utils.virtual_machines import deploy_template
 from cfme.utils.wait import wait_for, TimedOutError
 
-from . import PolicyProfileAssignable, Taggable, SummaryMixin
+from . import PolicyProfileAssignable, SummaryMixin
 
 access_btn = partial(toolbar.select, "Access")
 cfg_btn = partial(toolbar.select, "Configuration")
@@ -77,7 +78,8 @@ class _TemplateMixin(object):
     pass
 
 
-class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable, SummaryMixin, Navigatable):
+class BaseVM(Pretty, Updateable, PolicyProfileAssignable, WidgetasticTaggable,
+             SummaryMixin, Navigatable):
     """Base VM and Template class that holds the largest common functionality between VMs,
     instances, templates and images.
 

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -1189,10 +1189,9 @@ class VmAllWithTemplatesForProvider(CFMENavigateStep):
 @navigator.register(Vm, 'Details')
 class VmAllWithTemplatesDetails(CFMENavigateStep):
     VIEW = InfraVmDetailsView
-    prerequisite = NavigateToSibling('All')
+    prerequisite = NavigateToSibling('AllForProvider')
 
     def step(self):
-        self.prerequisite_view.sidebar.vmstemplates.tree.click_path('All VMs & Templates')
         try:
             entity_item = self.prerequisite_view.entities.get_entity(
                 by_name=self.obj.name, surf_pages=True)

--- a/cfme/tests/ansible/test_embedded_ansible_actions.py
+++ b/cfme/tests/ansible/test_embedded_ansible_actions.py
@@ -231,6 +231,6 @@ def test_action_run_ansible_playbook(request, ansible_catalog_item, ansible_acti
 def test_control_action_run_ansible_playbook_in_requests(request, vmware_vm, policy_for_testing,
         service_request):
     """Checks if execution of the Action result in a Task/Request being created."""
-    vmware_vm.add_tag(("Service Level", "Gold"), single_value=True)
-    request.addfinalizer(lambda: vmware_vm.remove_tag(("Service Level", "Gold")))
+    vmware_vm.add_tag("Service Level", "Gold")
+    request.addfinalizer(lambda: vmware_vm.remove_tag("Service Level", "Gold"))
     assert service_request.exists

--- a/cfme/tests/ansible/test_embedded_ansible_services.py
+++ b/cfme/tests/ansible/test_embedded_ansible_services.py
@@ -162,7 +162,7 @@ def test_service_ansible_playbook_crud(ansible_repository):
     assert not cat_item.exists
 
 
-def test_service_ansible_playbook_taging(request, ansible_catalog_item):
+def test_service_ansible_playbook_tagging(ansible_catalog_item):
     """ Tests ansible_playbook tag addition, check added tag and removal
 
     Steps:
@@ -172,7 +172,9 @@ def test_service_ansible_playbook_taging(request, ansible_catalog_item):
         4. Remove the given tag
     """
     ansible_catalog_item.add_tag('Department', 'Support')
-    assert ansible_catalog_item.get_tags() == ['Department', 'Support']
+    assert any(tag.category.display_name == "Department" and tag.display_name == "Support"
+               for tag in ansible_catalog_item.get_tags()), (
+        'Assigned tag was not found on the details page')
     ansible_catalog_item.remove_tag('Department', 'Support')
     assert ansible_catalog_item.get_tags() == []
 

--- a/cfme/tests/cloud/test_keypairs.py
+++ b/cfme/tests/cloud/test_keypairs.py
@@ -105,7 +105,10 @@ def test_keypair_add_and_remove_tag(openstack_provider, keypairs):
 
     keypair.add_tag('Department', 'Accounting')
     tagged_value = keypair.get_tags()
-    assert tagged_value[1] == 'Accounting', "Add tag failed."
+    assert (
+        tag.category.display_name == 'Department' and tag.display_name == 'Accounting'
+        for tag in keypair.get_tags()), (
+        'Assigned tag was not found on the details page')
 
     keypair.remove_tag('Department', 'Accounting')
     tagged_value1 = keypair.get_tags()

--- a/cfme/tests/cloud_infra_common/test_tag_visibility.py
+++ b/cfme/tests/cloud_infra_common/test_tag_visibility.py
@@ -17,10 +17,10 @@ pytestmark = [test_requirements.tag]
 def tagged_vm(tag, setup_provider_modscope, provider):
     ownership_vm = provider.data.cap_and_util.capandu_vm
     tag_vm = VM.factory(ownership_vm, provider)
-    tag_vm.add_tag(tag)
+    tag_vm.add_tag(tag=tag)
     yield tag_vm
     tag_vm.appliance.server.login_admin()
-    tag_vm.remove_tag(tag)
+    tag_vm.remove_tag(tag=tag)
 
 
 @pytest.mark.tier(3)

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -692,7 +692,7 @@ def test_action_tag(request, vm, vm_off, policy_for_testing, action_collection):
     """
     if any(tag.category.display_name == "Service Level" and tag.display_name == "Gold"
            for tag in vm.crud.get_tags()):
-        vm.crud.remove_tag(("Service Level", "Gold"))
+        vm.crud.remove_tag("Service Level", "Gold")
 
     tag_assign_action = action_collection.create(
         fauxfactory.gen_alphanumeric(),
@@ -730,13 +730,13 @@ def test_action_untag(request, vm, vm_off, policy_for_testing, action_collection
     """
     if not any(tag.category.display_name == "Service Level" and tag.display_name == "Gold"
            for tag in vm.crud.get_tags()):
-        vm.crud.add_tag(("Service Level", "Gold"), single_value=True)
+        vm.crud.add_tag("Service Level", "Gold")
 
     @request.addfinalizer
     def _remove_tag():
         if any(tag.category.display_name == "Service Level" and tag.display_name == "Gold"
                for tag in vm.crud.get_tags()):
-            vm.crud.remove_tag(("Service Level", "Gold"))
+            vm.crud.remove_tag("Service Level", "Gold")
 
     tag_unassign_action = action_collection.create(
         fauxfactory.gen_alphanumeric(),
@@ -805,17 +805,17 @@ def test_action_check_compliance(request, provider, vm, vm_name, policy_for_test
     """
     if any(tag.category.display_name == "Service Level" and tag.display_name == "Gold"
            for tag in vm.crud.get_tags()):
-        vm.crud.remove_tag(("Service Level", "Gold"))
+        vm.crud.remove_tag("Service Level", "Gold")
 
     @request.addfinalizer
     def _remove_tag():
         if any(tag.category.display_name == "Service Level" and tag.display_name == "Gold"
                for tag in vm.crud.get_tags()):
-            vm.crud.remove_tag(("Service Level", "Gold"))
+            vm.crud.remove_tag("Service Level", "Gold")
 
     policy_for_testing.assign_actions_to_event("Tag Complete", ["Check Host or VM Compliance"])
     request.addfinalizer(policy_for_testing.assign_events)
-    vm.crud.add_tag(("Service Level", "Gold"), single_value=True)
+    vm.crud.add_tag("Service Level", "Gold")
     view = navigate_to(vm.crud, "Details")
     view.toolbar.reload.click()
     assert vm.crud.compliant

--- a/cfme/tests/infrastructure/test_infra_object_tag_visibility.py
+++ b/cfme/tests/infrastructure/test_infra_object_tag_visibility.py
@@ -1,7 +1,7 @@
 import pytest
 
 from cfme import test_requirements
-from cfme.infrastructure.cluster import Cluster
+from cfme.infrastructure.cluster import ClusterCollection
 from cfme.infrastructure.host import Host
 from cfme.infrastructure.datastore import DatastoreCollection
 from cfme.infrastructure.provider import InfraProvider
@@ -21,7 +21,7 @@ def a_provider(request):
 
 test_items = [
     ('providers', InfraProvider),
-    ('clusters', Cluster),
+    ('clusters', ClusterCollection),
     ('hosts', Host),
     ('data_stores', DatastoreCollection),
     ('vms', Vm),
@@ -47,12 +47,13 @@ def testing_vis_object(request, a_provider, appliance):
             if test_item_value.vendor == item_type:
                 return param_class(name=test_item_value.name, provider=a_provider)
     elif collection_name != 'providers':
+        entity_name = test_items[0].name
+        if collection_name == 'clusters':
+            entity_name = '{} in Datacenter'.format(test_items[0].name)
         try:
-            return param_class(name=test_items[0].name, provider=a_provider)
+            return param_class(name=entity_name, provider=a_provider)
         except TypeError:
-            return param_class(appliance).instantiate(
-                name=test_items[0].name, provider=a_provider)
-
+            return param_class(appliance).instantiate(name=entity_name, provider=a_provider)
     else:
         return a_provider
 

--- a/cfme/tests/infrastructure/test_instance_analysis.py
+++ b/cfme/tests/infrastructure/test_instance_analysis.py
@@ -653,9 +653,8 @@ def test_drift_analysis(request, provider, instance, soft_assert):
     drift_new = int(InfoBlock("Relationships", "Drift History").text)
 
     # add a tag and a finalizer to remove it
-    tag = ('Department', 'Accounting')
-    instance.add_tag(tag, single_value=False)
-    request.addfinalizer(lambda: instance.remove_tag(tag))
+    instance.add_tag('Department', 'Accounting')
+    request.addfinalizer(lambda: instance.remove_tag('Department', 'Accounting'))
 
     instance.smartstate_scan()
     wait_for(lambda: is_vm_analysis_finished(instance.name),

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -916,7 +916,9 @@ class SummaryTable(VanillaTable):
         else:
             rowspan_image_element = self.browser.element('{}/*[self::i or self::img]'.format(
                 rowspan_path), self)
-            rowspan_child_class = rowspan_image_element.get_attribute(rowspan_attribute)
+            rowspan_child_class = rowspan_image_element.get_attribute('class')
+            if not rowspan_child_class:
+                rowspan_child_class = rowspan_image_element.get_attribute('alt')
             multiple_fields = self.browser.elements(
                 './tbody//*[self::i or self::img][contains(@class|@alt, {})]/parent::td'.format(
                     quote(rowspan_child_class), self))


### PR DESCRIPTION
Purpose or Intent
=================
Update SummaruTable  and SummaryForm widgets to handle multiple tags on details page.
Update VM, Template classes to use WidgetasticTaggable

{{pytest: -v -k 'test_control_action_run_ansible_playbook_in_requests or test_service_ansible_playbook_tagging or test_keypair_add_and_remove_tag or test_tag_vis_vm or test_tagvis_infra_object' --long-running}}
PRT: some of test_tagvis_infra_object tests can fail but those will be refactored this sprint to be more stable