### PR TITLE
[1LP][RFR] Update services.requests, add RequestCollection

### DIFF
--- a/cfme/fixtures/service_fixtures.py
+++ b/cfme/fixtures/service_fixtures.py
@@ -7,7 +7,7 @@ from cfme.common.provider import cleanup_vm
 from cfme.services.catalogs.catalog import Catalog
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
-from cfme.services.requests import Request
+from cfme.services.requests import RequestCollection
 from cfme.utils.log import logger
 
 
@@ -66,7 +66,7 @@ def catalog_item(provider, provisioning, vm_name, dialog, catalog):
 
 
 @pytest.fixture(scope="function")
-def order_catalog_item_in_ops_ui(provider, catalog_item, request):
+def order_catalog_item_in_ops_ui(appliance, provider, catalog_item, request):
     """
         Fixture for SSUI tests.
         Orders catalog item in OPS UI.
@@ -78,7 +78,8 @@ def order_catalog_item_in_ops_ui(provider, catalog_item, request):
     service_catalogs.order()
     logger.info("Waiting for cfme provision request for service {}".format(catalog_item.name))
     request_description = catalog_item.name
-    provision_request = Request(request_description, partial_check=True)
+    provision_request = RequestCollection(appliance).instantiate(request_description,
+                                                                 partial_check=True)
     provision_request.wait_for_request()
     assert provision_request.is_finished()
     return catalog_item.name

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -29,7 +29,7 @@ from cfme.exceptions import (
     VmOrInstanceNotFound)
 from cfme.fixtures import pytest_selenium as sel
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
-from cfme.services.requests import Request
+from cfme.services.requests import RequestCollection
 from cfme.web_ui import (
     CheckboxTree, Form, InfoBlock, Region, Quadicon, Tree, fill, flash, form_buttons,
     match_location, Table, toolbar, Calendar, Select, Input, CheckboxTable,
@@ -730,7 +730,7 @@ class Vm(VM):
         from cfme.provisioning import provisioning_form
         fill(provisioning_form, provisioning_data, action=provisioning_form.submit_button)
         cells = {'Description': 'Publish from [{}] to [{}]'.format(self.name, template_name)}
-        provision_request = Request(cells=cells)
+        provision_request = RequestCollection(self.appliance).instantiate(cells=cells)
         provision_request.wait_for_request()
         return Template(template_name, self.provider)
 

--- a/cfme/provisioning.py
+++ b/cfme/provisioning.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from cfme import web_ui as ui
 from cfme.fixtures import pytest_selenium as sel
 from cfme.infrastructure.virtual_machines import Vm
-from cfme.services.requests import Request
+from cfme.services.requests import RequestCollection
 from cfme.web_ui import AngularSelect, flash, form_buttons, tabstrip
 from cfme.utils import version
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -165,7 +165,7 @@ provisioning_form = tabstrip.TabStripForm(
 )
 
 
-def do_vm_provisioning(template_name, provider, vm_name, provisioning_data, request,
+def do_vm_provisioning(appliance, template_name, provider, vm_name, provisioning_data, request,
                        smtp_test, num_sec=1500, wait=True):
     # generate_tests makes sure these have values
     vm = Vm(name=vm_name, provider=provider, template_name=template_name)
@@ -185,7 +185,7 @@ def do_vm_provisioning(template_name, provider, vm_name, provisioning_data, requ
     # Provision Re important in this test
     logger.info('Waiting for cfme provision request for vm %s', vm_name)
     request_description = 'Provision from [{}] to [{}]'.format(template_name, vm_name)
-    provision_request = Request(request_description)
+    provision_request = RequestCollection(appliance).instantiate(request_description)
     provision_request.wait_for_request(method='ui')
     assert provision_request.is_succeeded(method='ui'), \
         "Provisioning failed with the message {}".format(provision_request.row.last_message.text)

--- a/cfme/services/requests.py
+++ b/cfme/services/requests.py
@@ -85,7 +85,7 @@ class Request(BaseEntity):
 
     def get_request_row_from_ui(self):
         """Opens CFME UI and return table_row object"""
-        view = navigate_to(self, 'All')
+        view = navigate_to(self.collection, 'All')
         self.row = view.find_request(self.rest.description, partial_check=False)
         return self.row
 
@@ -117,7 +117,7 @@ class Request(BaseEntity):
         Request might be removed from CFME UI but present in DB
 
         """
-        view = navigate_to(self, 'All')
+        view = navigate_to(self.collection, 'All')
         return bool(view.find_request(self.cells, self.partial_check))
 
     @variable(alias='rest')
@@ -130,7 +130,7 @@ class Request(BaseEntity):
 
     @update.variant('ui')
     def update_ui(self):
-        view = navigate_to(self, 'All')
+        view = navigate_to(self.collection, 'All')
         view.toolbar.reload.click()
         self.row = view.find_request(cells=self.cells, partial_check=self.partial_check)
 
@@ -487,7 +487,7 @@ class RequestAll(CFMENavigateStep):
 @navigator.register(Request, 'Details')
 class RequestDetails(CFMENavigateStep):
     VIEW = RequestDetailsView
-    prerequisite = NavigateToSibling('All')
+    prerequisite = NavigateToAttribute('collection', 'All')
 
     def step(self, *args, **kwargs):
         try:

--- a/cfme/services/requests.py
+++ b/cfme/services/requests.py
@@ -2,33 +2,44 @@
 from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.widget import Text, Table, Checkbox, View
 from widgetastic_manageiq import BreadCrumb, SummaryForm, SummaryFormItem, PaginationPane, Button
-from widgetastic_patternfly import Input, Tab, BootstrapTreeview, FlashMessages
+from widgetastic_patternfly import Input, Tab, BootstrapTreeview
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.common.vm_views import ProvisionView, BasicProvisionFormView
 from cfme.exceptions import RequestException, ItemNotFound
 from cfme.utils.log import logger
-from cfme.utils.appliance import Navigatable
+from cfme.utils.appliance import BaseCollection, BaseEntity
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
 from cfme.utils.varmeth import variable
 from cfme.utils.wait import wait_for
 
 
-class Request(Navigatable):
+class RequestCollection(BaseCollection):
+    """The appliance collection of requests"""
+    def __init__(self, appliance):
+        self.appliance = appliance
+
+    def instantiate(self, description=None, cells=None, partial_check=False):
+        """Create a request object"""
+        return Request(self, description=None, cells=None, partial_check=False)
+
+
+class Request(BaseEntity):
     """
     Class describes request row from Services - Requests page
     """
 
     REQUEST_FINISHED_STATES = {'Migrated', 'Finished'}
 
-    def __init__(self, description=None, cells=None, partial_check=False, appliance=None):
+    def __init__(self, collection, description=None, cells=None, partial_check=False):
         """
         Args:
             description: by default we'll be checking Description column to find required row
             cells: cells used to find required row in table
             partial_check: greedy search or not?
         """
-        Navigatable.__init__(self, appliance=appliance)
+        self.collection = collection
+        self.appliance = self.collection.appliance
         self.description = description
         self.partial_check = partial_check
         self.cells = cells or {'Description': self.description}
@@ -240,7 +251,6 @@ class RequestBasicView(BaseLoggedInPage):
 class RequestsView(RequestBasicView):
     table = Table(locator='//*[@id="list_grid"]/table')
     paginator = PaginationPane()
-    flash = FlashMessages('.//div[@id="flash_msg_div"]')
 
     def find_request(self, cells, partial_check=False):
         """Finds the request and returns the row element
@@ -465,7 +475,7 @@ class RequestCopyView(RequestProvisionView):
             return False
 
 
-@navigator.register(Request, 'All')
+@navigator.register(RequestCollection, 'All')
 class RequestAll(CFMENavigateStep):
     VIEW = RequestsView
     prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')

--- a/cfme/tests/ansible/test_embedded_ansible_actions.py
+++ b/cfme/tests/ansible/test_embedded_ansible_actions.py
@@ -11,7 +11,7 @@ from cfme.control.explorer.policy_profiles import PolicyProfile
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.services.catalogs.ansible_catalog_item import AnsiblePlaybookCatalogItem
 from cfme.services.myservice import MyService
-from cfme.services.requests import Request
+from cfme.services.requests import RequestCollection
 from cfme.utils import ports
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.conf import credentials
@@ -171,9 +171,9 @@ def ansible_credential(appliance, full_template_modscope):
 
 
 @pytest.yield_fixture
-def service_request(ansible_catalog_item):
+def service_request(appliance, ansible_catalog_item):
     request_desc = "Provisioning Service [{0}] from [{0}]".format(ansible_catalog_item.name)
-    service_request_ = Request(request_desc)
+    service_request_ = RequestCollection(appliance).instantiate(request_desc)
     yield service_request_
 
     if service_request_.exists:

--- a/cfme/tests/cloud/test_provisioning.py
+++ b/cfme/tests/cloud/test_provisioning.py
@@ -15,7 +15,7 @@ from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.openstack import OpenStackProvider
-from cfme.services.requests import Request
+from cfme.services.requests import RequestCollection
 from cfme.utils import testgen
 from cfme.utils.rest import assert_response
 from cfme.utils.generators import random_vm_name
@@ -126,7 +126,7 @@ def vm_name(request):
 
 
 @pytest.mark.parametrize('testing_instance', [True, False], ids=["Auto", "Manual"], indirect=True)
-def test_provision_from_template(provider, testing_instance, soft_assert):
+def test_provision_from_template(appliance, provider, testing_instance, soft_assert):
     """ Tests instance provision from template
 
     Metadata:
@@ -136,7 +136,7 @@ def test_provision_from_template(provider, testing_instance, soft_assert):
     instance.create(**inst_args)
     logger.info('Waiting for cfme provision request for vm %s', instance.name)
     request_description = 'Provision from [{}] to [{}]'.format(image, instance.name)
-    provision_request = Request(request_description)
+    provision_request = RequestCollection(appliance).instantiate(request_description)
     try:
         provision_request.wait_for_request(method='ui')
     except Exception as e:

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -18,7 +18,7 @@ from functools import partial
 from cfme.common.provider import cleanup_vm
 from cfme.common.vm import VM
 from cfme.control.explorer import actions, conditions, policies, policy_profiles
-from cfme.services.requests import Request
+from cfme.services.requests import RequestCollection
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
@@ -759,7 +759,7 @@ def test_action_untag(request, vm, vm_off, policy_for_testing):
 
 @pytest.mark.meta(blockers=[1381255])
 @pytest.mark.provider([VMwareProvider], scope="module")
-def test_action_cancel_clone(request, provider, vm_name, vm_big, policy_for_testing):
+def test_action_cancel_clone(appliance, request, provider, vm_name, vm_big, policy_for_testing):
     """This test checks if 'Cancel vCenter task' action works.
     For this test we need big template otherwise CFME won't have enough time
     to cancel the task https://bugzilla.redhat.com/show_bug.cgi?id=1383372#c9
@@ -782,7 +782,8 @@ def test_action_cancel_clone(request, provider, vm_name, vm_big, policy_for_test
 
     vm_big.crud.clone_vm(fauxfactory.gen_email(), "first", "last", clone_vm_name, "VMware")
     request_description = clone_vm_name
-    clone_request = Request(description=request_description, partial_check=True)
+    clone_request = RequestCollection(appliance).instantiate(description=request_description,
+                                                             partial_check=True)
     clone_request.wait_for_request(method='ui')
     assert clone_request.status == "Error"
 

--- a/cfme/tests/infrastructure/test_cloud_init_provisioning.py
+++ b/cfme/tests/infrastructure/test_cloud_init_provisioning.py
@@ -43,7 +43,7 @@ def vm_name():
     return vm_name
 
 
-def test_provision_cloud_init(setup_provider, provider, setup_ci_template,
+def test_provision_cloud_init(appliance, setup_provider, provider, setup_ci_template,
                               vm_name, smtp_test, request, provisioning):
     """Tests cloud init provisioning
 
@@ -72,8 +72,8 @@ def test_provision_cloud_init(setup_provider, provider, setup_ci_template,
             'custom_template': {'name': [provisioning['ci-template']]}}
     }
 
-    do_vm_provisioning(template, provider, vm_name, provisioning_data, request, smtp_test,
-                       num_sec=900)
+    do_vm_provisioning(appliance, template, provider, vm_name, provisioning_data, request,
+                       smtp_test, num_sec=900)
 
     connect_ip, tc = wait_for(mgmt_system.get_ip_address, [vm_name], num_sec=300,
                               handle_exception=True)

--- a/cfme/tests/infrastructure/test_host_provisioning.py
+++ b/cfme/tests/infrastructure/test_host_provisioning.py
@@ -4,7 +4,7 @@ from cfme.infrastructure import host
 from cfme.infrastructure.pxe import get_pxe_server_from_config, get_template_from_config
 from cfme.infrastructure.provider import InfraProvider
 from cfme.provisioning import provisioning_form
-from cfme.services.requests import Request
+from cfme.services.requests import RequestCollection
 from cfme.web_ui import flash, fill
 from cfme.utils.conf import cfme_data
 from cfme.utils.log import logger
@@ -82,8 +82,8 @@ def setup_pxe_servers_host_prov(pxe_server, pxe_cust_template, host_provisioning
 
 @pytest.mark.meta(blockers=[1203775, 1232427])
 @pytest.mark.usefixtures('setup_pxe_servers_host_prov')
-def test_host_provisioning(setup_provider, cfme_data, host_provisioning, provider, smtp_test,
-                           request):
+def test_host_provisioning(appliance, setup_provider, cfme_data, host_provisioning, provider,
+                           smtp_test, request):
     """Tests host provisioning
 
     Metadata:
@@ -165,7 +165,7 @@ def test_host_provisioning(setup_provider, cfme_data, host_provisioning, provide
         "Host Request was Submitted, you will be notified when your Hosts are ready")
 
     request_description = 'PXE install on [{}] from image [{}]'.format(prov_host_name, pxe_image)
-    host_request = Request(request_description)
+    host_request = RequestCollection(appliance).instantiate(request_description)
     host_request.wait_for_request(method='ui')
     assert host_request.row.last_message.text == 'Host Provisioned Successfully'
     assert host_request.row.status.text != 'Error'

--- a/cfme/tests/infrastructure/test_infra_quota.py
+++ b/cfme/tests/infrastructure/test_infra_quota.py
@@ -8,7 +8,7 @@ from cfme.configure.access_control import Tenant
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.infrastructure.virtual_machines import Vm
 from cfme.provisioning import provisioning_form
-from cfme.services.requests import Request
+from cfme.services.requests import RequestCollection
 from cfme.web_ui import fill, flash
 from cfme.utils import testgen, version
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -122,8 +122,8 @@ def provisioner(request, setup_provider, provider):
 
 
 @pytest.mark.uncollectif(lambda: version.current_version() >= '5.5')
-def test_group_quota_max_memory_check_by_tagging(
-        provisioner, prov_data, template_name, provider, request, vm_name, set_group_memory, bug):
+def test_group_quota_max_memory_check_by_tagging(appliance, provisioner, prov_data, template_name,
+                                                 provider, request, vm_name, set_group_memory, bug):
 
     """ Test group Quota-Max Memory by tagging.
 
@@ -149,7 +149,7 @@ def test_group_quota_max_memory_check_by_tagging(
 
     # nav to requests page to check quota validation
     request_description = 'Provision from [{}] to [{}]'.format(template_name, vm_name)
-    provision_request = Request(request_description)
+    provision_request = RequestCollection(appliance).instantiate(request_description)
     provision_request.wait_for_request(method='ui')
     assert provision_request.row.last_message.text == \
         'Request denied due to the following quota limits:(Group Allocated Memory 0.00GB + ' \
@@ -157,8 +157,8 @@ def test_group_quota_max_memory_check_by_tagging(
 
 
 @pytest.mark.uncollectif(lambda: version.current_version() >= '5.5')
-def test_group_quota_max_cpu_check_by_tagging(
-        provisioner, prov_data, template_name, provider, request, vm_name, set_group_cpu, bug):
+def test_group_quota_max_cpu_check_by_tagging(appliance, provisioner, prov_data, template_name,
+                                              provider, request, vm_name, set_group_cpu, bug):
 
     """ Test group Quota-Max CPU by tagging.
 
@@ -184,7 +184,7 @@ def test_group_quota_max_cpu_check_by_tagging(
 
     # nav to requests page to check quota validation
     request_description = 'Provision from [{}] to [{}]'.format(template_name, vm_name)
-    provision_request = Request(request_description)
+    provision_request = RequestCollection(appliance).instantiate(request_description)
     provision_request.wait_for_request(method='ui')
     assert provision_request.row.last_message.text == \
         'Request denied due to the following quota limits:' \
@@ -192,8 +192,8 @@ def test_group_quota_max_cpu_check_by_tagging(
 
 
 @pytest.mark.tier(2)
-def test_tenant_quota_max_cpu_check(
-        provisioner, prov_data, template_name, provider, request, vm_name, set_tenant_cpu, bug):
+def test_tenant_quota_max_cpu_check(appliance, provisioner, prov_data, template_name, provider,
+                                    request, vm_name, set_tenant_cpu, bug):
     """Test Tenant Quota-Max CPU by UI.
 
     Prerequisities:
@@ -218,7 +218,7 @@ def test_tenant_quota_max_cpu_check(
 
     # nav to requests page to check quota validation
     request_description = 'Provision from [{}] to [{}]'.format(template_name, vm_name)
-    provision_request = Request(request_description)
+    provision_request = RequestCollection(appliance).instantiate(request_description)
     provision_request.wait_for_request(method='ui')
     # BUG - https://bugzilla.redhat.com/show_bug.cgi?id=1364381
     # TODO: update assert message once the above bug is fixed.
@@ -228,8 +228,8 @@ def test_tenant_quota_max_cpu_check(
 
 
 @pytest.mark.tier(2)
-def test_tenant_quota_max_memory_check(
-        provisioner, prov_data, template_name, provider, request, vm_name, set_tenant_memory, bug):
+def test_tenant_quota_max_memory_check(appliance, provisioner, prov_data, template_name,
+                                       provider, request, vm_name, set_tenant_memory, bug):
     """Test Tenant Quota-Max Memory by UI.
 
     Prerequisities:
@@ -254,14 +254,14 @@ def test_tenant_quota_max_memory_check(
 
     # nav to requests page to check quota validation
     request_description = 'Provision from [{}] to [{}]'.format(template_name, vm_name)
-    provision_request = Request(request_description)
+    provision_request = RequestCollection(appliance).instantiate(request_description)
     provision_request.wait_for_request(method='ui')
     assert provision_request.row.reason.text == "Quota Exceeded"
 
 
 @pytest.mark.tier(2)
-def test_tenant_quota_max_storage_check(
-        provisioner, prov_data, template_name, provider, request, vm_name, set_tenant_storage, bug):
+def test_tenant_quota_max_storage_check(appliance, provisioner, prov_data, template_name,
+                                        provider, request, vm_name, set_tenant_storage, bug):
     """Test Tenant Quota-Max Storage by UI.
 
     Prerequisities:
@@ -285,14 +285,14 @@ def test_tenant_quota_max_storage_check(
 
     # nav to requests page to check quota validation
     request_description = 'Provision from [{}] to [{}]'.format(template_name, vm_name)
-    provision_request = Request(request_description)
+    provision_request = RequestCollection(appliance).instantiate(request_description)
     provision_request.wait_for_request(method='ui')
     assert provision_request.row.reason.text == "Quota Exceeded"
 
 
 @pytest.mark.tier(2)
-def test_tenant_quota_max_num_vms_check(
-        provisioner, prov_data, template_name, provider, request, vm_name, set_tenant_vm, bug):
+def test_tenant_quota_max_num_vms_check(appliance, provisioner, prov_data, template_name, provider,
+                                        request, vm_name, set_tenant_vm, bug):
     """Test Tenant Quota-Max number of vms by UI.
 
     Prerequisities:
@@ -318,7 +318,7 @@ def test_tenant_quota_max_num_vms_check(
 
     # nav to requests page to check quota validation
     request_description = 'Provision from [{}] to [{}###]'.format(template_name, vm_name)
-    provision_request = Request(request_description)
+    provision_request = RequestCollection(appliance).instantiate(request_description)
     provision_request.approve_request(method='ui', reason="Approved")
     provision_request.wait_for_request(method='ui')
     assert provision_request.row.reason.text == "Quota Exceeded"

--- a/cfme/tests/infrastructure/test_iso_provisioning.py
+++ b/cfme/tests/infrastructure/test_iso_provisioning.py
@@ -68,8 +68,7 @@ def vm_name():
 
 
 @pytest.mark.tier(2)
-@pytest.mark.meta(blockers=[1200783, 1207209])
-def test_iso_provision_from_template(provider, vm_name, smtp_test, datastore_init,
+def test_iso_provision_from_template(appliance, provider, vm_name, smtp_test, datastore_init,
                                      request, setup_provider):
     """Tests ISO provisioning
 
@@ -99,5 +98,5 @@ def test_iso_provision_from_template(provider, vm_name, smtp_test, datastore_ini
         'network': {
             'vlan': vlan}}
 
-    do_vm_provisioning(iso_template, provider, vm_name, provisioning_data, request, smtp_test,
-                       num_sec=1500)
+    do_vm_provisioning(appliance, iso_template, provider, vm_name, provisioning_data, request,
+                       smtp_test, num_sec=1500)

--- a/cfme/tests/infrastructure/test_provisioning.py
+++ b/cfme/tests/infrastructure/test_provisioning.py
@@ -6,7 +6,7 @@ from cfme.common.provider import cleanup_vm
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.provisioning import do_vm_provisioning
-from cfme.services.requests import Request
+from cfme.services.requests import RequestCollection
 from cfme.utils import normalize_text, testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
@@ -43,7 +43,7 @@ def vm_name():
 
 @pytest.mark.tier(1)
 @pytest.mark.parametrize('auto', [True, False], ids=["Auto", "Manual"])
-def test_provision_from_template(setup_provider, provider, vm_name, smtp_test,
+def test_provision_from_template(appliance, setup_provider, provider, vm_name, smtp_test,
                                  request, provisioning, auto):
     """ Tests provisioning from a template
 
@@ -74,13 +74,13 @@ def test_provision_from_template(setup_provider, provider, vm_name, smtp_test,
             'automatic_placement': True if auto else None},
         'network':
             {'vlan': provisioning['vlan']}}
-    do_vm_provisioning(template, provider, vm_name, provisioning_data, request, smtp_test,
-                       num_sec=900)
+    do_vm_provisioning(appliance, template, provider, vm_name, provisioning_data, request,
+                       smtp_test, num_sec=900)
 
 
 @pytest.mark.parametrize("edit", [True, False], ids=["edit", "approve"])
-def test_provision_approval(
-        setup_provider, provider, vm_name, smtp_test, request, edit, provisioning):
+def test_provision_approval(appliance, setup_provider, provider, vm_name, smtp_test, request,
+                            edit, provisioning):
     """ Tests provisioning approval. Tests couple of things.
 
     * Approve manually
@@ -124,8 +124,8 @@ def test_provision_approval(
         'network':
             {'vlan': provisioning['vlan']}}
 
-    do_vm_provisioning(template, provider, vm_name, provisioning_data, request, smtp_test,
-                       wait=False)
+    do_vm_provisioning(appliance, template, provider, vm_name, provisioning_data, request,
+                       smtp_test, wait=False)
     wait_for(
         lambda:
         len(filter(
@@ -142,7 +142,7 @@ def test_provision_approval(
         num_sec=90, delay=5)
 
     cells = {'Description': 'Provision from [{}] to [{}###]'.format(template, vm_name)}
-    provision_request = Request(cells=cells)
+    provision_request = RequestCollection(appliance).instantiate(cells=cells)
     navigate_to(provision_request, 'Details')
     if edit:
         # Automatic approval after editing the request to conform

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -13,7 +13,7 @@ from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.provisioning import provisioning_form
-from cfme.services.requests import Request
+from cfme.services.requests import RequestCollection
 from cfme.web_ui import InfoBlock, fill, flash
 from cfme.utils import testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -76,7 +76,7 @@ def prov_data(provisioning, provider):
 
 
 @pytest.fixture(scope="function")
-def provisioner(request, setup_provider, provider, vm_name):
+def provisioner(appliance, request, setup_provider, provider, vm_name):
 
     def _provisioner(template, provisioning_data, delayed=None):
         vm = Vm(name=vm_name, provider=provider, template_name=template)
@@ -88,7 +88,8 @@ def provisioner(request, setup_provider, provider, vm_name):
 
         request.addfinalizer(lambda: cleanup_vm(vm_name, provider))
         request_description = 'Provision from [{}] to [{}]'.format(template, vm_name)
-        provision_request = Request(description=request_description)
+        provision_request = RequestCollection(appliance).instantiate(
+            description=request_description)
         if delayed is not None:
             total_seconds = (delayed - datetime.utcnow()).total_seconds()
             try:

--- a/cfme/tests/infrastructure/test_pxe_provisioning.py
+++ b/cfme/tests/infrastructure/test_pxe_provisioning.py
@@ -81,10 +81,8 @@ def vm_name():
     return vm_name
 
 
-def test_pxe_provision_from_template(
-        provider, vm_name, smtp_test, setup_provider,
-        request, setup_pxe_servers_vm_prov
-):
+def test_pxe_provision_from_template(appliance, provider, vm_name, smtp_test, setup_provider,
+                                     request, setup_pxe_servers_vm_prov):
     """Tests provisioning via PXE
 
     Metadata:
@@ -123,7 +121,5 @@ def test_pxe_provision_from_template(
         'network': {
             'vlan': pxe_vlan}}
 
-    do_vm_provisioning(
-        pxe_template, provider, vm_name, provisioning_data,
-        request, smtp_test, num_sec=2100
-    )
+    do_vm_provisioning(appliance, pxe_template, provider, vm_name, provisioning_data, request,
+                       smtp_test, num_sec=2100)

--- a/cfme/tests/infrastructure/test_vm_clone.py
+++ b/cfme/tests/infrastructure/test_vm_clone.py
@@ -9,7 +9,7 @@ from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
-from cfme.services.requests import Request
+from cfme.services.requests import RequestCollection
 from cfme.web_ui import flash
 from cfme.utils import testgen
 from cfme.utils.log import logger
@@ -59,7 +59,7 @@ def clone_vm_name():
 
 
 @pytest.fixture
-def create_vm(provider, setup_provider, catalog_item, request):
+def create_vm(appliance, provider, setup_provider, catalog_item, request):
     vm_name = catalog_item.provisioning_data["vm_name"]
     catalog_item.create()
     service_catalogs = ServiceCatalogs(catalog_item.name)
@@ -67,7 +67,7 @@ def create_vm(provider, setup_provider, catalog_item, request):
     flash.assert_no_errors()
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     request_description = catalog_item.name
-    request_row = Request(request_description, partial_check=True)
+    request_row = RequestCollection(appliance).instantiate(request_description, partial_check=True)
     request_row.wait_for_request()
     assert request_row.is_succeeded()
     return vm_name
@@ -76,7 +76,7 @@ def create_vm(provider, setup_provider, catalog_item, request):
 @pytest.mark.usefixtures("setup_provider")
 @pytest.mark.uncollectif(lambda: version.appliance_is_downstream())
 @pytest.mark.long_running
-def test_vm_clone(provider, clone_vm_name, request, create_vm):
+def test_vm_clone(appliance, provider, clone_vm_name, request, create_vm):
     vm_name = create_vm + "_0001"
     request.addfinalizer(lambda: cleanup_vm(vm_name, provider))
     request.addfinalizer(lambda: cleanup_vm(clone_vm_name, provider))
@@ -87,6 +87,6 @@ def test_vm_clone(provider, clone_vm_name, request, create_vm):
         provision_type = 'VMware'
     vm.clone_vm("email@xyz.com", "first", "last", clone_vm_name, provision_type)
     request_description = clone_vm_name
-    request_row = Request(request_description, partial_check=True)
+    request_row = RequestCollection(appliance).instantiate(request_description, partial_check=True)
     request_row.wait_for_request(method='ui')
     assert request_row.is_succeeded(method='ui')

--- a/cfme/tests/infrastructure/test_vm_migrate.py
+++ b/cfme/tests/infrastructure/test_vm_migrate.py
@@ -4,7 +4,7 @@ import pytest
 from cfme.common.vm import VM
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
-from cfme.services.requests import Request
+from cfme.services.requests import RequestCollection
 from cfme.web_ui import flash
 from cfme import test_requirements
 
@@ -36,8 +36,7 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.mark.tier(2)
-@pytest.mark.meta(blockers=[1256903])
-def test_vm_migrate(new_vm, provider):
+def test_vm_migrate(appliance, new_vm, provider):
     """Tests migration of a vm
 
     Metadata:
@@ -50,6 +49,7 @@ def test_vm_migrate(new_vm, provider):
     flash.assert_no_errors()
     request_description = new_vm.name
     cells = {'Description': request_description, 'Request Type': 'Migrate'}
-    migrate_request = Request(request_description, cells=cells, partial_check=True)
+    migrate_request = RequestCollection(appliance).instantiate(request_description,
+                                                               cells=cells, partial_check=True)
     migrate_request.wait_for_request(method='ui')
     assert migrate_request.is_succeeded(method='ui')

--- a/cfme/tests/services/test_add_remove_vm_to_service.py
+++ b/cfme/tests/services/test_add_remove_vm_to_service.py
@@ -6,7 +6,7 @@ from cfme.automate.explorer.domain import DomainCollection
 from cfme.automate.simulation import simulate
 from cfme.common.provider import cleanup_vm
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
-from cfme.services.requests import Request
+from cfme.services.requests import RequestCollection
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
 from cfme.services.myservice import MyService
 
@@ -49,7 +49,8 @@ def myservice(appliance, setup_provider, provider, catalog_item, request):
     service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     request_description = catalog_item.name
-    provision_request = Request(request_description, partial_check=True)
+    provision_request = RequestCollection(appliance).instantiate(request_description,
+                                                                 partial_check=True)
     provision_request.wait_for_request()
     assert provision_request.is_finished()
     service = MyService(appliance, catalog_item.name, vm_name)

--- a/cfme/tests/services/test_cloud_service_catalogs.py
+++ b/cfme/tests/services/test_cloud_service_catalogs.py
@@ -6,7 +6,7 @@ from cfme.common.provider import cleanup_vm
 from cfme.cloud.provider import CloudProvider
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
-from cfme.services.requests import Request
+from cfme.services.requests import RequestCollection
 from cfme.web_ui import flash
 from cfme import test_requirements
 from cfme.utils import testgen
@@ -24,7 +24,8 @@ pytest_generate_tests = testgen.generate(
     [CloudProvider], required_fields=[['provisioning', 'image']], scope="module")
 
 
-def test_cloud_catalog_item(setup_provider, provider, dialog, catalog, request, provisioning):
+def test_cloud_catalog_item(appliance, setup_provider, provider, dialog, catalog, request,
+                            provisioning):
     """Tests cloud catalog item
 
     Metadata:
@@ -71,6 +72,7 @@ def test_cloud_catalog_item(setup_provider, provider, dialog, catalog, request, 
     flash.assert_no_errors()
     logger.info('Waiting for cfme provision request for service %s', item_name)
     request_description = item_name
-    provision_request = Request(request_description, partial_check=True)
+    provision_request = RequestCollection(appliance).instantiate(request_description,
+                                                                 partial_check=True)
     provision_request.wait_for_request()
     assert provision_request.if_succeeded()

--- a/cfme/tests/services/test_config_provider_servicecatalogs.py
+++ b/cfme/tests/services/test_config_provider_servicecatalogs.py
@@ -2,7 +2,7 @@ import pytest
 
 from cfme import test_requirements
 from cfme.configure.settings import DefaultView
-from cfme.services.requests import Request
+from cfme.services.requests import RequestCollection
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
 from cfme.services.myservice import MyService
 from cfme.services.catalogs.catalog_item import CatalogItem
@@ -68,7 +68,7 @@ def catalog_item(request, config_manager, dialog, catalog):
 
 @pytest.mark.tier(2)
 @pytest.mark.ignore_stream("upstream")
-def test_order_tower_catalog_item(catalog_item, request):
+def test_order_tower_catalog_item(appliance, catalog_item, request):
     """Tests order catalog item
     Metadata:
         test_flag: provision
@@ -78,7 +78,7 @@ def test_order_tower_catalog_item(catalog_item, request):
     service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     cells = {'Description': catalog_item.name}
-    order_request = Request(cells=cells, partial_check=True)
+    order_request = RequestCollection(appliance).instantiate(cells=cells, partial_check=True)
     order_request.wait_for_request(method='ui')
     assert order_request.is_succeeded(method='ui')
     DefaultView.set_default_view("Configuration Management Providers", "List View")
@@ -96,7 +96,7 @@ def test_retire_ansible_service(appliance, catalog_item, request):
     service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     cells = {'Description': catalog_item.name}
-    order_request = Request(cells=cells, partial_check=True)
+    order_request = RequestCollection(appliance).instantiate(cells=cells, partial_check=True)
     order_request.wait_for_request(method='ui')
     assert order_request.is_succeeded(method='ui')
     myservice = MyService(appliance, catalog_item.name)

--- a/cfme/tests/services/test_different_dialogs_in_catalogs.py
+++ b/cfme/tests/services/test_different_dialogs_in_catalogs.py
@@ -9,7 +9,7 @@ from cfme.services.catalogs.catalog import Catalog
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.infrastructure.provider import InfraProvider
 from cfme.common.provider import cleanup_vm
-from cfme.services.requests import Request
+from cfme.services.requests import RequestCollection
 from cfme.utils import testgen
 from cfme.utils.log import logger
 from cfme.utils.blockers import BZ
@@ -89,7 +89,7 @@ def catalog_item(provider, provisioning, vm_name, tagcontrol_dialog, catalog):
 @pytest.mark.tier(2)
 @pytest.mark.ignore_stream("upstream")
 @pytest.mark.meta(blockers=[BZ(1434990, forced_streams=["5.7", "upstream"])])
-def test_tagdialog_catalog_item(provider, setup_provider, catalog_item, request):
+def test_tagdialog_catalog_item(appliance, provider, setup_provider, catalog_item, request):
     """Tests tag dialog catalog item
     Metadata:
         test_flag: provision
@@ -105,6 +105,7 @@ def test_tagdialog_catalog_item(provider, setup_provider, catalog_item, request)
     service_catalogs.order()
     logger.info('Waiting for cfme provision request for service {}'.format(catalog_item.name))
     request_description = catalog_item.name
-    provision_request = Request(request_description, partial_check=True)
+    provision_request = RequestCollection(appliance).instantiate(request_description,
+                                                                 partial_check=True)
     provision_request.wait_for_request()
     assert provision_request.is_succeeded()

--- a/cfme/tests/services/test_generic_service_catalogs.py
+++ b/cfme/tests/services/test_generic_service_catalogs.py
@@ -7,7 +7,7 @@ from cfme.rest.gen_data import service_catalogs as _service_catalogs
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
 from cfme.services.catalogs.catalog_item import CatalogBundle
-from cfme.services.requests import Request
+from cfme.services.requests import RequestCollection
 from cfme.web_ui import flash
 from cfme import test_requirements
 from selenium.common.exceptions import NoSuchElementException
@@ -68,7 +68,7 @@ def test_service_circular_reference(catalog_item):
         catalog_bundle.update({'catalog_items': sec_catalog_bundle.name})
 
 
-def test_service_generic_catalog_bundle(catalog_item):
+def test_service_generic_catalog_bundle(appliance, catalog_item):
     bundle_name = "generic_" + fauxfactory.gen_alphanumeric()
     catalog_bundle = CatalogBundle(name=bundle_name, description="catalog_bundle",
                    display_in=True, catalog=catalog_item.catalog, dialog=catalog_item.dialog,
@@ -79,12 +79,13 @@ def test_service_generic_catalog_bundle(catalog_item):
     flash.assert_no_errors()
     logger.info('Waiting for cfme provision request for service %s', bundle_name)
     request_description = bundle_name
-    provision_request = Request(request_description, partial_check=True)
+    provision_request = RequestCollection(appliance).instantiate(request_description,
+                                                                 partial_check=True)
     provision_request.wait_for_request()
     assert provision_request.is_succeeded()
 
 
-def test_bundles_in_bundle(catalog_item):
+def test_bundles_in_bundle(appliance, catalog_item):
     bundle_name = "first_" + fauxfactory.gen_alphanumeric()
     catalog_bundle = CatalogBundle(name=bundle_name, description="catalog_bundle",
                    display_in=True, catalog=catalog_item.catalog, dialog=catalog_item.dialog,
@@ -105,7 +106,8 @@ def test_bundles_in_bundle(catalog_item):
     flash.assert_no_errors()
     logger.info('Waiting for cfme provision request for service %s', bundle_name)
     request_description = third_bundle_name
-    provision_request = Request(request_description, partial_check=True)
+    provision_request = RequestCollection(appliance).instantiate(request_description,
+                                                                 partial_check=True)
     provision_request.wait_for_request()
     assert provision_request.is_succeeded()
 

--- a/cfme/tests/services/test_iso_service_catalogs.py
+++ b/cfme/tests/services/test_iso_service_catalogs.py
@@ -7,7 +7,7 @@ from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.pxe import get_template_from_config, ISODatastore
-from cfme.services.requests import Request
+from cfme.services.requests import RequestCollection
 from cfme import test_requirements
 from cfme.utils import testgen
 from cfme.utils.log import logger
@@ -92,7 +92,7 @@ def catalog_item(setup_provider, provider, vm_name, dialog, catalog, provisionin
 
 @pytest.mark.usefixtures('setup_iso_datastore')
 @pytest.mark.meta(blockers=[BZ(1358069, forced_streams=["5.6", "5.7", "upstream"])])
-def test_rhev_iso_servicecatalog(setup_provider, provider, catalog_item, request):
+def test_rhev_iso_servicecatalog(appliance, setup_provider, provider, catalog_item, request):
     """Tests RHEV ISO service catalog
 
     Metadata:
@@ -106,6 +106,7 @@ def test_rhev_iso_servicecatalog(setup_provider, provider, catalog_item, request
     # nav to requests page happens on successful provision
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     request_description = catalog_item.name
-    provision_request = Request(request_description, partial_check=True)
+    provision_request = RequestCollection(appliance).instantiate(request_description,
+                                                                 partial_check=True)
     provision_request.wait_for_request()
     assert provision_request.is_succeeded()

--- a/cfme/tests/services/test_myservice.py
+++ b/cfme/tests/services/test_myservice.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from cfme import test_requirements
 from cfme.common.provider import cleanup_vm
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
-from cfme.services.requests import Request
+from cfme.services.requests import RequestCollection
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
 from cfme.services.myservice import MyService
 
@@ -55,7 +55,8 @@ def myservice(appliance, setup_provider, provider, catalog_item, request):
     service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     request_description = catalog_item.name
-    service_request = Request(request_description, partial_check=True)
+    service_request = RequestCollection(appliance).instantiate(request_description,
+                                                               partial_check=True)
     service_request.wait_for_request()
     assert service_request.is_succeeded()
 

--- a/cfme/tests/services/test_operations.py
+++ b/cfme/tests/services/test_operations.py
@@ -7,7 +7,7 @@ from cfme import test_requirements
 from cfme.infrastructure.virtual_machines import Vm
 from cfme.fixtures import pytest_selenium as sel
 from cfme.provisioning import provisioning_form
-from cfme.services.requests import Request
+from cfme.services.requests import RequestCollection
 from cfme.web_ui import flash, fill
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.browser import browser
@@ -87,7 +87,7 @@ def generated_request(appliance,
     request_cells = {
         "Description": "Provision from [{}] to [{}###]".format(template_name, vm_name),
     }
-    provision_request = Request(cells=request_cells)
+    provision_request = RequestCollection(appliance).instantiate(cells=request_cells)
     yield provision_request
 
     browser().get(store.base_url)

--- a/cfme/tests/services/test_provision_stack.py
+++ b/cfme/tests/services/test_provision_stack.py
@@ -8,7 +8,7 @@ from cfme.services.catalogs.catalog import Catalog
 from cfme.services.catalogs.orchestration_template import OrchestrationTemplate
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
 from cfme.services.myservice import MyService
-from cfme.services.requests import Request
+from cfme.services.requests import RequestCollection
 from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.stack import StackCollection
@@ -162,7 +162,8 @@ def prepare_stack_data(provider, provisioning):
     return stack_data
 
 
-def test_provision_stack(setup_provider, provider, provisioning, catalog, catalog_item, request):
+def test_provision_stack(appliance, setup_provider, provider, provisioning, catalog, catalog_item,
+                         request):
     """Tests stack provisioning
 
     Metadata:
@@ -179,7 +180,8 @@ def test_provision_stack(setup_provider, provider, provisioning, catalog, catalo
     service_catalogs.order()
     logger.info('Waiting for cfme provision request for service {}'.format(catalog_item.name))
     request_description = catalog_item.name
-    provision_request = Request(request_description, partial_check=True)
+    provision_request = RequestCollection(appliance).instantiate(request_description,
+                                                                 partial_check=True)
     provision_request.wait_for_request()
     assert provision_request.is_succeeded()
 
@@ -201,7 +203,8 @@ def test_reconfigure_service(appliance, provider, provisioning, catalog, catalog
     service_catalogs.order()
     logger.info('Waiting for cfme provision request for service {}'.format(catalog_item.name))
     request_description = catalog_item.name
-    provision_request = Request(request_description, partial_check=True)
+    provision_request = RequestCollection(appliance).instantiate(request_description,
+                                                                 partial_check=True)
     provision_request.wait_for_request()
     assert provision_request.is_succeeded()
 
@@ -209,7 +212,7 @@ def test_reconfigure_service(appliance, provider, provisioning, catalog, catalog
     myservice.reconfigure_service()
 
 
-def test_remove_template_provisioning(provider, provisioning, catalog, catalog_item):
+def test_remove_template_provisioning(appliance, provider, provisioning, catalog, catalog_item):
     """Tests stack provisioning
 
     Metadata:
@@ -223,7 +226,7 @@ def test_remove_template_provisioning(provider, provisioning, catalog, catalog_i
     template.delete()
     request_description = 'Provisioning Service [{}] from [{}]'.format(catalog_item.name,
                                                                        catalog_item.name)
-    provision_request = Request(request_description)
+    provision_request = RequestCollection(appliance).instantiate(request_description)
     provision_request.wait_for_request(method='ui')
     assert (provision_request.row.last_message.text == 'Service_Template_Provisioning failed' or
             provision_request.row.status.text == "Error")
@@ -243,7 +246,8 @@ def test_retire_stack(appliance, provider, provisioning, catalog, catalog_item, 
     service_catalogs.order()
     logger.info('Waiting for cfme provision request for service {}'.format(catalog_item.name))
     request_description = catalog_item.name
-    provision_request = Request(request_description, partial_check=True)
+    provision_request = RequestCollection(appliance).instantiate(request_description,
+                                                                 partial_check=True)
     provision_request.wait_for_request()
     assert provision_request.is_succeeded()
     stack = StackCollection(appliance).instantiate(stack_data['stack_name'], provider=provider)

--- a/cfme/tests/services/test_pxe_service_catalogs.py
+++ b/cfme/tests/services/test_pxe_service_catalogs.py
@@ -7,7 +7,7 @@ from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.pxe import get_pxe_server_from_config, get_template_from_config
-from cfme.services.requests import Request
+from cfme.services.requests import RequestCollection
 from cfme import test_requirements
 from cfme.utils import testgen
 from cfme.utils.log import logger
@@ -104,7 +104,7 @@ def catalog_item(provider, vm_name, dialog, catalog, provisioning, setup_pxe_ser
 
 
 @pytest.mark.usefixtures('setup_pxe_servers_vm_prov')
-def test_pxe_servicecatalog(setup_provider, provider, catalog_item, request):
+def test_pxe_servicecatalog(appliance, setup_provider, provider, catalog_item, request):
     """Tests RHEV PXE service catalog
 
     Metadata:
@@ -118,6 +118,7 @@ def test_pxe_servicecatalog(setup_provider, provider, catalog_item, request):
     # nav to requests page happens on successful provision
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     request_description = catalog_item.name
-    provision_request = Request(request_description, partial_check=True)
+    provision_request = RequestCollection(appliance).instantiate(request_description,
+                                                                 partial_check=True)
     provision_request.wait_for_request()
     assert provision_request.is_succeeded()

--- a/cfme/tests/services/test_request.py
+++ b/cfme/tests/services/test_request.py
@@ -4,7 +4,7 @@ import pytest
 from cfme.common.provider import cleanup_vm
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
-from cfme.services.requests import Request
+from cfme.services.requests import RequestCollection
 from cfme import test_requirements
 from cfme.utils import testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -21,7 +21,7 @@ pytestmark = [
 pytest_generate_tests = testgen.generate([VMwareProvider], scope="module")
 
 
-def test_copy_request(setup_provider, provider, catalog_item, request):
+def test_copy_request(appliance, setup_provider, provider, catalog_item, request):
     """Automate BZ 1194479"""
     vm_name = catalog_item.provisioning_data["vm_name"]
     request.addfinalizer(lambda: cleanup_vm(vm_name + "_0001", provider))
@@ -29,6 +29,7 @@ def test_copy_request(setup_provider, provider, catalog_item, request):
     service_catalogs = ServiceCatalogs(catalog_item.catalog, catalog_item.name)
     service_catalogs.order()
     request_description = catalog_item.name
-    service_request = Request(request_description, partial_check=True)
+    service_request = RequestCollection(appliance).instantiate(request_description,
+                                                               partial_check=True)
     service_request.wait_for_request()
     assert navigate_to(service_request, 'Details')

--- a/cfme/tests/services/test_service_catalogs.py
+++ b/cfme/tests/services/test_service_catalogs.py
@@ -7,7 +7,7 @@ from cfme.infrastructure.provider import InfraProvider
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.catalogs.catalog_item import CatalogBundle
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
-from cfme.services.requests import Request
+from cfme.services.requests import RequestCollection
 from cfme.web_ui import flash
 from cfme import test_requirements
 from cfme.utils.log import logger
@@ -31,7 +31,8 @@ pytest_generate_tests = testgen.generate([InfraProvider], required_fields=[
 
 
 @pytest.mark.tier(2)
-def test_order_catalog_item(provider, setup_provider, catalog_item, request, register_event):
+def test_order_catalog_item(appliance, provider, setup_provider, catalog_item, request,
+                            register_event):
     """Tests order catalog item
     Metadata:
         test_flag: provision
@@ -47,7 +48,8 @@ def test_order_catalog_item(provider, setup_provider, catalog_item, request, reg
     service_catalogs.order()
     logger.info("Waiting for cfme provision request for service {}".format(catalog_item.name))
     request_description = catalog_item.name
-    provision_request = Request(request_description, partial_check=True)
+    provision_request = RequestCollection(appliance).instantiate(request_description,
+                                                                 partial_check=True)
     provision_request.wait_for_request()
     assert provision_request.is_succeeded()
 
@@ -81,7 +83,7 @@ def test_order_catalog_item_via_rest(
 
 
 @pytest.mark.tier(2)
-def test_order_catalog_bundle(provider, setup_provider, catalog_item, request):
+def test_order_catalog_bundle(appliance, provider, setup_provider, catalog_item, request):
     """Tests ordering a catalog bundle
     Metadata:
         test_flag: provision
@@ -99,7 +101,8 @@ def test_order_catalog_bundle(provider, setup_provider, catalog_item, request):
     service_catalogs.order()
     logger.info("Waiting for cfme provision request for service {}".format(bundle_name))
     request_description = bundle_name
-    provision_request = Request(request_description, partial_check=True)
+    provision_request = RequestCollection(appliance).instantiate(request_description,
+                                                                 partial_check=True)
     provision_request.wait_for_request()
     assert provision_request.is_succeeded()
 
@@ -138,7 +141,7 @@ def test_edit_catalog_after_deleting_provider(provider, setup_provider, catalog_
 
 @pytest.mark.tier(3)
 @pytest.mark.usefixtures('setup_provider')
-def test_request_with_orphaned_template(provider, setup_provider, catalog_item):
+def test_request_with_orphaned_template(appliance, provider, setup_provider, catalog_item):
     """Tests edit catalog item after deleting provider
     Metadata:
         test_flag: provision
@@ -148,7 +151,8 @@ def test_request_with_orphaned_template(provider, setup_provider, catalog_item):
     service_catalogs.order()
     logger.info("Waiting for cfme provision request for service {}".format(catalog_item.name))
     request_description = catalog_item.name
-    provision_request = Request(request_description, partial_check=True)
+    provision_request = RequestCollection(appliance).instantiate(request_description,
+                                                                 partial_check=True)
     provider.delete(cancel=False)
     provider.wait_for_delete()
     provision_request.wait_for_request(method='ui')

--- a/cfme/tests/services/test_service_manual_approval.py
+++ b/cfme/tests/services/test_service_manual_approval.py
@@ -6,7 +6,7 @@ from cfme.common.provider import cleanup_vm
 from cfme.infrastructure.provider import InfraProvider
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
 from cfme.automate.explorer.domain import DomainCollection
-from cfme.services.requests import Request
+from cfme.services.requests import RequestCollection
 from cfme import test_requirements
 from cfme.utils.log import logger
 from cfme.utils.update import update
@@ -60,7 +60,8 @@ def modify_instance(create_domain):
 
 @pytest.mark.ignore_stream("upstream")
 @pytest.mark.tier(2)
-def test_service_manual_approval(provider, setup_provider, modify_instance, catalog_item, request):
+def test_service_manual_approval(appliance, provider, setup_provider, modify_instance,
+                                 catalog_item, request):
     """Tests order catalog item
     Metadata:
         test_flag: provision
@@ -73,6 +74,7 @@ def test_service_manual_approval(provider, setup_provider, modify_instance, cata
     service_catalogs.order()
     logger.info("Waiting for cfme provision request for service {}".format(catalog_item.name))
     request_description = catalog_item.name
-    service_request = Request(description=request_description, partial_check=True)
+    service_request = RequestCollection(appliance).instantiate(description=request_description,
+                                                               partial_check=True)
     service_request.update(method='ui')
     assert service_request.row.approval_state.text == 'Pending Approval'


### PR DESCRIPTION
Using BaseCollection and BaseEntity for Request itself

{{pytest: -v --long-running --use-provider complete cfme/tests/ansible/test_embedded_ansible_actions.py
cfme/tests/ansible/test_embedded_ansible_services.py
cfme/tests/cloud/test_provisioning.py
cfme/tests/control/test_actions.py
cfme/tests/infrastructure/test_host_provisioning.py
cfme/tests/infrastructure/test_infra_quota.py
cfme/tests/infrastructure/test_provisioning.py
cfme/tests/infrastructure/test_provisioning_dialog.py
cfme/tests/infrastructure/test_vm_clone.py
cfme/tests/infrastructure/test_vm_migrate.py
cfme/tests/services/test_add_remove_vm_to_service.py
cfme/tests/services/test_cloud_service_catalogs.py
cfme/tests/services/test_config_provider_servicecatalogs.py
cfme/tests/services/test_different_dialogs_in_catalogs.py
cfme/tests/services/test_generic_service_catalogs.py
cfme/tests/services/test_iso_service_catalogs.py
cfme/tests/services/test_myservice.py
cfme/tests/services/test_operations.py
cfme/tests/services/test_provision_stack.py
cfme/tests/services/test_pxe_service_catalogs.py
cfme/tests/services/test_request.py
cfme/tests/services/test_service_catalogs.py
cfme/tests/services/test_service_manual_approval.py
}}

Not trying to fix all test failures here, there are plenty that aren't because of the change to Request object instantiation.