### PR TITLE
[1LP][RFR] Revert snapshot tests redone

### DIFF
--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -133,19 +133,15 @@ def test_delete_all_snapshots(small_test_vm, provider):
     wait_for(lambda: not snapshot2.exists, num_sec=300, delay=20, fail_func=snapshot1.refresh)
 
 
-@pytest.mark.uncollectif(lambda provider: (provider.one_of(RHEVMProvider) and provider.version < 4),
-                         'Must be RHEVM provider version >= 4')
-def test_verify_revert_snapshot(full_test_vm, provider, soft_assert, register_event):
-    """Tests revert snapshot
-
-    Metadata:
-        test_flag: snapshot, provision
-    """
+def verify_revert_snapshot(full_test_vm, provider, soft_assert, register_event, request,
+                           active_snapshot=False):
     if provider.one_of(RHEVMProvider):
+        # RHV snapshots have only description, no name
         snapshot1 = new_snapshot(full_test_vm, has_name=False)
     else:
         snapshot1 = new_snapshot(full_test_vm)
     full_template = getattr(provider.data.templates, 'full_template')
+    # Define parameters of the ssh connection
     ssh_kwargs = {
         'hostname': snapshot1.vm.provider.mgmt.get_ip_address(snapshot1.vm.name),
         'username': credentials[full_template.creds]['username'],
@@ -158,20 +154,21 @@ def test_verify_revert_snapshot(full_test_vm, provider, soft_assert, register_ev
     # and wait for successful completition of the ssh command.
     # The 'fail_func' ensures we close the connection that failed with exception.
     # Without this, the connection would hang there and wait_for would fail with timeout.
-    wait_for(lambda: ssh_client.run_command('touch snapshot1.txt').rc == 0, num_sec=300,
+    wait_for(lambda: ssh_client.run_command('touch snapshot1.txt').rc == 0, num_sec=400,
              delay=20, handle_exception=True, fail_func=ssh_client.close())
+    # Create first snapshot
     snapshot1.create()
-    register_event(target_type='VmOrTemplate', target_name=full_test_vm.name,
-                   event_type='vm_snapshot_complete')
-    register_event(target_type='VmOrTemplate', target_name=full_test_vm.name,
-                   event_type='vm_snapshot')
     ssh_client.run_command('touch snapshot2.txt')
-    if provider.one_of(RHEVMProvider):
-        snapshot2 = new_snapshot(full_test_vm, has_name=False)
-    else:
-        snapshot2 = new_snapshot(full_test_vm)
-    snapshot2.create()
 
+    # If we are not testing 'revert to active snapshot' situation, we create another snapshot
+    if not active_snapshot:
+        if provider.one_of(RHEVMProvider):
+            snapshot2 = new_snapshot(full_test_vm, has_name=False)
+        else:
+            snapshot2 = new_snapshot(full_test_vm)
+        snapshot2.create()
+
+    # VM on RHV provider must be powered off before snapshot revert
     if provider.one_of(RHEVMProvider):
         full_test_vm.power_control_from_cfme(option=full_test_vm.POWER_OFF, cancel=False)
         full_test_vm.wait_for_vm_state_change(
@@ -181,13 +178,16 @@ def test_verify_revert_snapshot(full_test_vm, provider, soft_assert, register_ev
     # Wait for the snapshot to become active
     logger.info('Waiting for vm %s to become active', snapshot1.name)
     wait_for(lambda: snapshot1.active, num_sec=300, delay=20, fail_func=provider.browser.refresh)
+    # VM state after revert should be OFF
     full_test_vm.wait_for_vm_state_change(desired_state=full_test_vm.STATE_OFF, timeout=720)
+    # Let's power it ON again
     full_test_vm.power_control_from_cfme(option=full_test_vm.POWER_ON, cancel=False)
     full_test_vm.wait_for_vm_state_change(desired_state=full_test_vm.STATE_ON, timeout=900)
     current_state = full_test_vm.find_quadicon().data['state']
     soft_assert(current_state.startswith('currentstate-on'),
                 "Quadicon state is {}".format(current_state))
     soft_assert(full_test_vm.provider.mgmt.is_vm_running(full_test_vm.name), "vm not running")
+    # Wait for successful ssh connection
     wait_for(lambda: ssh_client.run_command('test -e snapshot1.txt').rc == 0,
              num_sec=400, delay=20, handle_exception=True, fail_func=ssh_client.close())
     try:
@@ -199,6 +199,29 @@ def test_verify_revert_snapshot(full_test_vm, provider, soft_assert, register_ev
     except:
         logger.exception('Revert to snapshot %s Failed', snapshot1.name)
     ssh_client.close()
+
+
+@pytest.mark.uncollectif(lambda provider: (provider.one_of(RHEVMProvider) and provider.version < 4),
+                         'Must be RHEVM provider version >= 4')
+def test_verify_revert_snapshot(full_test_vm, provider, soft_assert, register_event, request):
+    """Tests revert snapshot
+
+    Metadata:
+        test_flag: snapshot, provision
+    """
+    verify_revert_snapshot(full_test_vm, provider, soft_assert, register_event, request)
+
+
+@pytest.mark.uncollectif(lambda provider: provider.one_of(RHEVMProvider),
+                         'Must NOT be RHEVM provider')
+def test_revert_active_snapshot(full_test_vm, provider, soft_assert, register_event, request):
+    """Tests revert active snapshot
+
+    Metadata:
+        test_flag: snapshot, provision
+    """
+    verify_revert_snapshot(full_test_vm, provider, soft_assert, register_event, request,
+                           active_snapshot=True)
 
 
 def setup_snapshot_env(test_vm, memory):


### PR DESCRIPTION
This changes the way how `test_verify_revert_snapshot` is run and adds additional very similar test `test_revert_active_snapshot`.
Because the two tests are so similar, I extracted the code to a standalone function `verify_revert_snapshot` that gets called in each test with different `active_snapshot` parameter. The body of the function is basically the original `test_verify_revert_snapshot` test, with exception of:
 - added `active_snapshot` parameter
 - line 169: determine if we need second snapshot OR we are reverting to active snapshot
 - added comments

I had to comment out the events after some testing. They work fine with `test_verify_revert_snapshot` but not when `test_revert_active_snapshot` is run. According to evm.log, events are appearing fine in both cases. I have no idea where the catch is. Reviewers please, have any idea?

{{pytest: -v --long-running --use-provider vsphere65-nested -k "test_revert_active_snapshot"}}