### PR TITLE
[RFR] Add toolbar to explorer/policies/EventDetailsView

### DIFF
--- a/cfme/control/explorer/policies.py
+++ b/cfme/control/explorer/policies.py
@@ -3,7 +3,7 @@
 from navmazing import NavigateToAttribute
 from widgetastic_patternfly import Button, Input
 from widgetastic.utils import Version, VersionPick
-from widgetastic.widget import Text, Checkbox, TextInput
+from widgetastic.widget import Text, Checkbox, TextInput, View
 
 from . import ControlExplorerView
 from actions import Action
@@ -13,8 +13,8 @@ from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import navigator, navigate_to, CFMENavigateStep
 from cfme.utils.pretty import Pretty
 from cfme.utils.update import Updateable
-from widgetastic_manageiq import (BootstrapSwitchSelect, CheckboxSelect, MultiBoxSelect,
-    SummaryFormItem)
+from widgetastic_manageiq import (
+    BootstrapSwitchSelect, CheckboxSelect, MultiBoxSelect, SummaryFormItem, Dropdown)
 
 
 class PoliciesAllView(ControlExplorerView):
@@ -169,8 +169,14 @@ class ConditionDetailsView(ControlExplorerView):
         )
 
 
+class EventDetailsToolbar(View):
+    """Toolbar widets on the event details page"""
+    configuration = Dropdown('Configuration')
+
+
 class EventDetailsView(ControlExplorerView):
     title = Text("#explorer_title_text")
+    toolbar = View.nested(EventDetailsToolbar)
 
     @property
     def is_displayed(self):
@@ -406,7 +412,7 @@ class BasePolicy(Updateable, Navigatable, Pretty):
         self.testing_event = event
         view = navigate_to(self, "Event Details")
         assert view.is_displayed
-        view.configuration.item_select("Edit Actions for this Policy Event")
+        view.toolbar.configuration.item_select("Edit Actions for this Policy Event")
         view = self.create_view(EditEventView)
         assert view.is_displayed
         changed = view.fill({

--- a/cfme/tests/ansible/test_embedded_ansible_actions.py
+++ b/cfme/tests/ansible/test_embedded_ansible_actions.py
@@ -13,6 +13,7 @@ from cfme.services.catalogs.ansible_catalog_item import AnsiblePlaybookCatalogIt
 from cfme.services.myservice import MyService
 from cfme.services.requests import RequestCollection
 from cfme.utils import ports
+from cfme.utils.blockers import BZ
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.conf import credentials
 from cfme.utils.generators import random_vm_name
@@ -136,6 +137,7 @@ def ansible_action(ansible_catalog_item):
         action.delete()
 
 
+@pytest.mark.uncollectif(BZ(1491576, forced_streams=['5.7']).blocks, 'BZ 1491576')
 @pytest.yield_fixture(scope="module")
 def policy_for_testing(vmware_vm, provider, ansible_action):
     policy = VMControlPolicy(

--- a/cfme/tests/cloud_infra_common/test_events.py
+++ b/cfme/tests/cloud_infra_common/test_events.py
@@ -8,6 +8,7 @@ from cfme.control.explorer.policy_profiles import PolicyProfile
 from cfme.control.explorer.policies import VMControlPolicy
 from cfme.control.explorer.actions import Action
 from cfme.utils import testgen
+from cfme.utils.blockers import BZ
 from cfme.utils.wait import wait_for
 
 
@@ -33,6 +34,7 @@ def vm_crud(provider, setup_provider_modscope, small_template_modscope):
         vm.delete_from_provider()
 
 
+@pytest.mark.uncollectif(BZ(1491576, forced_streams=['5.7']).blocks, 'BZ 1491576')
 @pytest.mark.meta(blockers=[1238371], automates=[1238371])
 def test_vm_create(request, vm_crud, provider, register_event):
     """ Test whether vm_create_complete event is emitted.

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -41,12 +41,8 @@ from . import do_scan, wait_for_ssa_enabled
 
 pytestmark = [
     pytest.mark.long_running,
-    pytest.mark.meta(blockers=[
-        BZ(
-            1149128,
-            unblock=lambda provider: not provider.one_of(SCVMMProvider))
-    ]),
     pytest.mark.meta(server_roles="+automate +smartproxy +smartstate"),
+    pytest.mark.uncollectif(BZ(1491576, forced_streams=['5.7']).blocks, 'BZ 1491576'),
     pytest.mark.tier(2),
     test_requirements.control
 ]
@@ -364,7 +360,6 @@ def test_action_suspend_virtual_machine_after_starting(request, vm, vm_off,
         pytest.fail("CFME did not suspend the VM {}".format(vm.name))
 
 
-@pytest.mark.meta(blockers=[1142875])
 @pytest.mark.provider(
     [VMwareProvider, RHEVMProvider, OpenStackProvider, AzureProvider],
     scope="module"
@@ -711,7 +706,6 @@ def test_action_tag(request, vm, vm_off, policy_for_testing):
         pytest.fail("Tags were not assigned!")
 
 
-@pytest.mark.meta(blockers=[1205496])
 @pytest.mark.provider(
     [VMwareProvider, RHEVMProvider, OpenStackProvider, AzureProvider],
     scope="module"
@@ -757,8 +751,8 @@ def test_action_untag(request, vm, vm_off, policy_for_testing):
         pytest.fail("Tags were not unassigned!")
 
 
-@pytest.mark.meta(blockers=[1381255])
 @pytest.mark.provider([VMwareProvider], scope="module")
+@pytest.mark.meta(blockers=[1381255])
 def test_action_cancel_clone(appliance, request, provider, vm_name, vm_big, policy_for_testing):
     """This test checks if 'Cancel vCenter task' action works.
     For this test we need big template otherwise CFME won't have enough time

--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -13,6 +13,7 @@ from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from markers.env_markers.provider import providers
 from cfme.utils import ports
+from cfme.utils.blockers import BZ
 from cfme.utils.conf import credentials
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
@@ -31,6 +32,7 @@ CANDU_PROVIDER_TYPES = [VMwareProvider]  # TODO: rhevm
 pytestmark = [
     pytest.mark.long_running,
     pytest.mark.meta(server_roles=["+automate", "+notifier"]),
+    pytest.mark.uncollectif(BZ(1491576, forced_streams=['5.7']).blocks, 'BZ 1491576'),
     pytest.mark.tier(3),
     test_requirements.alert
 ]

--- a/cfme/tests/control/test_bugs.py
+++ b/cfme/tests/control/test_bugs.py
@@ -215,7 +215,8 @@ def test_check_compliance_history(request, virtualcenter_provider, vmware_vm):
         vmware_vm.name)
 
 
-@pytest.mark.meta(blockers=[BZ(1395965, forced_streams=["5.6", "5.7"])])
+@pytest.mark.meta(blockers=[BZ(1395965, forced_streams=["5.6", "5.7"]),
+                            BZ(1491576)])
 def test_delete_all_actions_from_compliance_policy(request):
     """We should not allow a compliance policy to be saved
     if there are no actions on the compliance event.

--- a/cfme/tests/control/test_compliance.py
+++ b/cfme/tests/control/test_compliance.py
@@ -10,6 +10,7 @@ from cfme.control.explorer.policy_profiles import PolicyProfile
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.configure.configuration.analysis_profile import AnalysisProfile
 from cfme.utils import testgen, conf
+from cfme.utils.blockers import BZ
 from cfme.utils.hosts import setup_providers_hosts_credentials
 from cfme.utils.update import update
 from cfme import test_requirements
@@ -172,6 +173,7 @@ def test_check_files(request, compliance_vm, analysis_profile):
     assert compliance_vm.check_compliance()
 
 
+@pytest.mark.uncollectif(BZ(1491576, forced_streams=['5.7']).blocks, 'BZ 1491576')
 def test_compliance_with_unconditional_policy(host, assign_policy_for_testing):
     assign_policy_for_testing.assign_actions_to_event(
         "Host Compliance Check",

--- a/cfme/tests/infrastructure/test_instance_analysis.py
+++ b/cfme/tests/infrastructure/test_instance_analysis.py
@@ -19,6 +19,7 @@ from cfme.infrastructure import host, datastore
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.web_ui import InfoBlock, DriftGrid, toolbar
 from cfme.utils import testgen, ssh, safe_string, error
+from cfme.utils.blockers import BZ
 from cfme.utils.conf import cfme_data
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for, wait_for_decorator
@@ -608,6 +609,7 @@ def test_ssa_packages(provider, instance, soft_assert):
 
 
 @pytest.mark.long_running
+@pytest.mark.uncollectif(BZ(1491576, forced_streams=['5.7']).blocks, 'BZ 1491576')
 def test_ssa_files(provider, instance, policy_profile, soft_assert):
     """Tests that instances can be scanned for specific file."""
 


### PR DESCRIPTION
Nested view of toolbar with configuration dropdown

{{pytest: -v --long-running --use-provider complete  --collect-only cfme/tests/ansible/test_embedded_ansible_actions.py
cfme/tests/ansible/test_embedded_ansible_services.py
cfme/tests/cloud/test_cloud_object_tag_visibility.py
cfme/tests/cloud_infra_common/test_events.py
cfme/tests/configure/test_access_control.py
cfme/tests/configure/test_visual_cloud.py
cfme/tests/control/test_actions.py
cfme/tests/control/test_alerts.py
cfme/tests/control/test_bugs.py
cfme/tests/control/test_compliance.py
cfme/tests/infrastructure/test_instance_analysis.py}}