### PR TITLE
[1LP][WIP] Add wait to Snapshot.delete

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -602,6 +602,7 @@ class Vm(VM):
             if not cancel:
                 flash.assert_message_match('Remove Snapshot initiated for 1 '
                                            'VM and Instance from the CFME Database')
+            wait_for(lambda: not self.exists, num_sec=300, delay=20, fail_func=sel.refresh)
 
         def delete_all(self, cancel=False):
             self._nav_to_snapshot_mgmt()

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -132,6 +132,9 @@ def test_delete_all_snapshots(small_test_vm, provider):
     snapshot2 = new_snapshot(small_test_vm)
     snapshot2.create()
     snapshot2.delete_all()
+    # Make sure the snapshots are indeed deleted
+    wait_for(lambda: not snapshot1.exists, num_sec=300, delay=20, fail_func=snapshot1.refresh)
+    wait_for(lambda: not snapshot2.exists, num_sec=300, delay=20, fail_func=snapshot1.refresh)
 
 
 @pytest.mark.uncollectif(lambda provider:
@@ -274,12 +277,9 @@ def test_operations_suspended_vm(small_test_vm, provider, soft_assert):
                 "Quadicon state is {}".format(current_state))
     assert small_test_vm.provider.mgmt.is_vm_suspended(small_test_vm.name)
     # Try to delete both snapshots while the VM is suspended
-    snapshot2.delete_all()
-    # Wait for both snapshots to disappear
-    wait_for(lambda: not snapshot1.exists, num_sec=300, delay=20, fail_func=snapshot1.refresh)
-    logger.info("First snapshot successfully deleted")
-    wait_for(lambda: not snapshot2.exists, num_sec=300, delay=20, fail_func=snapshot2.refresh)
-    logger.info("Second snapshot successfully deleted")
+    # The delete method will make sure the snapshots are indeed deleted
+    snapshot1.delete()
+    snapshot2.delete()
 
 
 @pytest.mark.uncollectif(lambda provider: not provider.one_of(VMwareProvider))
@@ -299,11 +299,9 @@ def test_operations_powered_off_vm(small_test_vm, provider, soft_assert):
     snapshot1.revert_to()
     wait_for(lambda: snapshot1.active is True, num_sec=300, delay=20, fail_func=snapshot1.refresh)
     # Try to delete both snapshots while the VM is off
-    snapshot2.delete_all()
-    wait_for(lambda: not snapshot1.exists, num_sec=300, delay=20, fail_func=snapshot1.refresh)
-    logger.info("First snapshot successfully deleted")
-    wait_for(lambda: not snapshot2.exists, num_sec=300, delay=20, fail_func=snapshot2.refresh)
-    logger.info("Second snapshot successfully deleted")
+    # The delete method will make sure the snapshots are indeed deleted
+    snapshot1.delete()
+    snapshot2.delete()
 
 
 @pytest.mark.uncollectif(lambda provider: not provider.one_of(VMwareProvider))


### PR DESCRIPTION
This adds waiting for completion of delete action for snapshots. The `Snapshot.delete` method did not wait for the snapshot to be actually deleted, it just initiated the action. This required changes in some of the snapshot tests that were checking for successful deletion.

I've decided not to add waiting to `Snapshot.delete_all`, since this method can not wait for deletion of all the snapshots that are currently on a test VM. It could wait for the snapshot that it has been called on, but this would not ensure the deletion of all snapshots. I modified the tests accordingly.

This solves the problem that PR #5422 has been originally created for.

PRT results of changed tests:
 - test_snapshot_crud: PASS for both vsphere and RHV providers
 - test_delete_all_snapshots: PASS
 - test_operations_suspended_vm: PASS
 - test_operations_powered_off_vm: 5.8 PASS, 5.7 FAIL at creating first snapshot (unrelated)
   - PASS after rerun

{{pytest: -v --long-running --use-provider vsphere65-nested -k test_operations_powered_off_vm}}