### PR TITLE
[WIPTEST] Add pytest params to access controls tests when testing edit/delete operations on default groups and roles

### DIFF
--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -840,6 +840,27 @@ class Group(Updateable, Pretty, Navigatable):
         except CandidateNotFound:
             return False
 
+    def get_default_group_names(self):
+        if self.appliance.version < '5.8':
+            group_names = [
+                "EvmGroup-administrator", "EvmGroup-approver", "EvmGroup-auditor",
+                "EvmGroup-consumption_administrator", "EvmGroup-desktop", "EvmGroup-operator",
+                "EvmGroup-security", "EvmGroup-super_administrator", "EvmGroup-support",
+                "EvmGroup-tenant_administrator", "EvmGroup-tenant_quota_administrator",
+                "EvmGroup-user", "EvmGroup-user_limited_self_service",
+                "EvmGroup-user_self_service", "EvmGroup-vm_user", ]
+        else:
+            group_names = [
+                "EvmGroup-administrator", "EvmGroup-approver", "EvmGroup-auditor",
+                "EvmGroup-consumption_administrator", "EvmGroup-container_administrator",
+                "EvmGroup-desktop", "EvmGroup-operator", "EvmGroup-security",
+                "EvmGroup-super_administrator", "EvmGroup-support", "EvmGroup-tenant_administrator",
+                "EvmGroup-tenant_quota_administrator", "EvmGroup-user",
+                "EvmGroup-user_limited_self_service", "EvmGroup-user_self_service",
+                "EvmGroup-vm_user", ]
+
+        return group_names
+
 
 @navigator.register(Group, 'All')
 class GroupAll(CFMENavigateStep):
@@ -1128,6 +1149,27 @@ class Role(Updateable, Pretty, Navigatable):
                     view.product_features_tree.uncheck_node(*path)
             feature_update = True
         return feature_update
+
+    def get_default_role_names(self):
+        if self.appliance.version < '5.8':
+            role_names = [
+                "EvmRole-administrator", "EvmRole-approver", "EvmRole-auditor",
+                "EvmRole-consumption_administrator", "EvmRole-desktop", "EvmRole-operator",
+                "EvmRole-security", "EvmRole-super_administrator", "EvmRole-support",
+                "EvmRole-tenant_administrator", "EvmRole-tenant_quota_administrator",
+                "EvmRole-user", "EvmRole-user_limited_self_service",
+                "EvmRole-user_self_service", "EvmRole-vm_user", ]
+        else:
+            role_names = [
+                "EvmRole-administrator", "EvmRole-approver", "EvmRole-auditor",
+                "EvmRole-consumption_administrator", "EvmRole-container_administrator",
+                "EvmRole-desktop", "EvmRole-operator", "EvmRole-security",
+                "EvmRole-super_administrator", "EvmRole-support", "EvmRole-tenant_administrator",
+                "EvmRole-tenant_quota_administrator", "EvmRole-user",
+                "EvmRole-user_limited_self_service", "EvmRole-user_self_service",
+                "EvmRole-vm_user", ]
+
+        return role_names
 
 
 @navigator.register(Role, 'All')

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -350,14 +350,15 @@ def test_group_description_required_error_validation():
 
 
 @pytest.mark.tier(3)
-def test_delete_default_group():
+@pytest.mark.parametrize('test_group_name', Group().get_default_group_names())
+def test_delete_default_group(test_group_name):
     """Test for deleting default group EvmGroup-administrator.
 
     Steps:
         * Login as Administrator user
         * Try deleting the group EvmGroup-adminstrator
     """
-    group = Group(description='EvmGroup-administrator')
+    group = Group(description=test_group_name)
 
     with pytest.raises(RBACOperationBlocked):
         group.delete()
@@ -380,14 +381,15 @@ def test_delete_group_with_assigned_user():
 
 
 @pytest.mark.tier(3)
-def test_edit_default_group():
+@pytest.mark.parametrize('test_group_name', Group().get_default_group_names())
+def test_edit_default_group(test_group_name):
     """Test that CFME prevents a user from editing a default group
 
     Steps:
         * Login as Administrator user
         * Try editing the group EvmGroup-adminstrator
     """
-    group = Group(description='EvmGroup-approver')
+    group = Group(description=test_group_name)
 
     group_updates = {}
     with pytest.raises(RBACOperationBlocked):
@@ -460,7 +462,8 @@ def test_rolename_duplicate_validation():
 
 
 @pytest.mark.tier(3)
-def test_delete_default_roles():
+@pytest.mark.parametrize('test_role_name', Role().get_default_role_names())
+def test_delete_default_roles(test_role_name):
     """Test that CFME prevents a user from deleting a default role
     when selecting it from the Access Control EVM Role checklist
 
@@ -469,13 +472,14 @@ def test_delete_default_roles():
         * Navigate to Configuration -> Role
         * Try editing the group EvmRole-approver
     """
-    role = Role(name='EvmRole-approver')
+    role = Role(name=test_role_name)
     with pytest.raises(RBACOperationBlocked):
         role.delete()
 
 
 @pytest.mark.tier(3)
-def test_edit_default_roles():
+@pytest.mark.parametrize('test_role_name', Role().get_default_role_names())
+def test_edit_default_roles(test_role_name):
     """Test that CFME prevents a user from editing a default role
     when selecting it from the Access Control EVM Role checklist
 
@@ -484,7 +488,7 @@ def test_edit_default_roles():
         * Navigate to Configuration -> Role
         * Try editing the group EvmRole-auditor
     """
-    role = Role(name='EvmRole-auditor')
+    role = Role(name=test_role_name)
     newrole_name = "{}-{}".format(role.name, fauxfactory.gen_alphanumeric())
     role_updates = {'name': newrole_name}
 


### PR DESCRIPTION
Add pytest parameters to validate against all default RBAC groups and roles any test that attempts to delete OR edit default groups and roles

{{pytest: -v -k 'test_delete_default_group or test_edit_default_group or test_delete_default_roles or test_edit_default_roles'}}