### PR TITLE
[1LP][RFR] Update test_delete_group_with_assigned_user to catch RBACOperationBlocked exception

### DIFF
--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -717,9 +717,13 @@ class Group(Updateable, Pretty, Navigatable):
                 for currently selected group
         """
         flash_success_msg = 'EVM Group "{}": Delete successful'.format(self.description)
-        flash_blocked_msg = (
-            "EVM Group \"{}\": "
-            "Error during delete: A read only group cannot be deleted.".format(self.description))
+        flash_blocked_msg_list = [
+            ('EVM Group "{}": '
+                'Error during delete: A read only group cannot be deleted.'.format(
+                    self.description)),
+            ('EVM Group "{}": Error during delete: '
+                'The group has users assigned that do not '
+                'belong to any other group'.format(self.description))]
         delete_group_txt = 'Delete this Group'
 
         view = navigate_to(self, 'Details')
@@ -729,11 +733,12 @@ class Group(Updateable, Pretty, Navigatable):
                 delete_group_txt))
 
         view.toolbar.configuration.item_select(delete_group_txt, handle_alert=cancel)
-        try:
-            view.flash.assert_message(flash_blocked_msg)
-            raise RBACOperationBlocked(flash_blocked_msg)
-        except AssertionError:
-            pass
+        for flash_blocked_msg in flash_blocked_msg_list:
+            try:
+                view.flash.assert_message(flash_blocked_msg)
+                raise RBACOperationBlocked(flash_blocked_msg)
+            except AssertionError:
+                pass
 
         view.flash.assert_no_error()
         view.flash.assert_message(flash_success_msg)

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -367,15 +367,11 @@ def test_delete_default_group():
 def test_delete_group_with_assigned_user():
     """Test that CFME prevents deletion of a group that has users assigned
     """
-    flash_msg = ("EVM Group \"{}\": Error during delete: "
-                "The group has users assigned that do not "
-                "belong to any other group")
-
     group = new_group()
     group.create()
     user = new_user(group=group)
     user.create()
-    with error.expected(flash_msg.format(group.description)):
+    with pytest.raises(RBACOperationBlocked):
         group.delete()
 
 


### PR DESCRIPTION
PR #4974 added an RBACOperationBlocked exception that will be thrown whenever an operation is performed but blocked due to permissions. This test was mistakenly left out of that update. This moves the flash message check out of the test and adds Group.delete() where it will be checked against a list of messages that specify that the delete operation was blocked

{{pytest: -v -k 'test_delete_group_with_assigned_user or test_delete_default_group or test_group_crud'}}