### PR TITLE
[1LP][RFR] expelling remaining quadicons from tests and classes

### DIFF
--- a/cfme/cloud/stack.py
+++ b/cfme/cloud/stack.py
@@ -3,8 +3,8 @@ from widgetastic.widget import View
 from widgetastic.exceptions import NoSuchElementException
 from widgetastic_patternfly import Button, Dropdown, FlashMessages, BootstrapNav
 from widgetastic_manageiq import (
-    Accordion, BreadCrumb, ItemsToolBarViewSelector, PaginationPane, Search,
-    SummaryTable, Table, Text)
+    Accordion, BreadCrumb, ItemsToolBarViewSelector, PaginationPane,
+    SummaryTable, Table, Text, BaseEntitiesView)
 
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import TagPageView, WidgetasticTaggable
@@ -53,14 +53,9 @@ class StackDetailsAccordion(View):
         nav = BootstrapNav('//div[@id="stack_rel"]//ul')
 
 
-class StackEntities(View):
-    """The entties on the main list page"""
-    title = Text('//div[@id="main-content"]//h1')
+class StackEntities(BaseEntitiesView):
+    """The entities on the main list page"""
     table = Table("//div[@id='gtl_div']//table")
-    search = View.nested(Search)
-    # element attributes changed from id to class in upstream-fine+, capture both with locator
-    flash = FlashMessages('.//div[@id="flash_msg_div"]'
-                          '/div[@id="flash_text_div" or contains(@class, "flash_text_div")]')
 
 
 class StackDetailsEntities(View):
@@ -131,7 +126,7 @@ class StackView(BaseLoggedInPage):
 class StackAllView(StackView):
     """The main list page"""
     toolbar = View.nested(StackToolbar)
-    entities = View.nested(StackEntities)
+    including_entities = View.include(StackEntities, use_parent=True)
     paginator = PaginationPane()
 
     @property

--- a/cfme/cloud/stack.py
+++ b/cfme/cloud/stack.py
@@ -56,6 +56,7 @@ class StackDetailsAccordion(View):
 class StackEntities(BaseEntitiesView):
     """The entities on the main list page"""
     table = Table("//div[@id='gtl_div']//table")
+    # todo: remove table and use entities instead
 
 
 class StackDetailsEntities(View):
@@ -233,7 +234,7 @@ class StackCollection(BaseCollection):
 
         for stack in stacks:
             try:
-                row = view.paginator.find_row_on_pages(view.entities.table, name=stack.name)
+                row = view.paginator.find_row_on_pages(view.table, name=stack.name)
                 row[0].check()
                 checked_stacks.append(stack)
             except NoSuchElementException:
@@ -270,7 +271,7 @@ class Stack(Pretty, BaseEntity, WidgetasticTaggable):
         view = navigate_to(self.collection, 'All')
         view.toolbar.view_selector.select('List View')
         try:
-            view.paginator.find_row_on_pages(view.entities.table, name=self.name)
+            view.paginator.find_row_on_pages(view.table, name=self.name)
             return True
         except NoSuchElementException:
             return False
@@ -308,7 +309,7 @@ class Stack(Pretty, BaseEntity, WidgetasticTaggable):
     def retire_stack(self, wait=True):
         view = navigate_to(self.collection, 'All')
         view.toolbar.view_selector.select('List View')
-        row = view.paginator.find_row_on_pages(view.entities.table, name=self.name)
+        row = view.paginator.find_row_on_pages(view.table, name=self.name)
         row[0].check()
         view.toolbar.lifecycle.item_select('Retire selected Orchestration Stacks',
                                            handle_alert=True)
@@ -351,7 +352,7 @@ class Details(CFMENavigateStep):
         """Go to the details page"""
         self.prerequisite_view.toolbar.view_selector.select('List View')
         row = self.prerequisite_view.paginator.find_row_on_pages(
-            self.prerequisite_view.entities.table, name=self.obj.name)
+            self.prerequisite_view.table, name=self.obj.name)
         row.click()
 
 

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -11,7 +11,7 @@ from cfme.exceptions import (
     VmOrInstanceNotFound, ItemNotFound, OptionNotAvailable, UnknownProviderType)
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import (
-    AngularCalendarInput, AngularSelect, Form, InfoBlock, Input, Quadicon, Select, fill, flash,
+    AngularCalendarInput, AngularSelect, Form, InfoBlock, Input, Select, fill, flash,
     form_buttons, toolbar, PagedTable, SplitPagedTable, search, CheckboxTable,
     DriftGrid, BootstrapTreeview
 )
@@ -382,14 +382,11 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, Taggable, SummaryMixin
         sel.click(InfoBlock(*properties))
 
     @classmethod
-    def get_first_vm_title(cls, do_not_navigate=False, provider=None):
-        """Get the title of first VM/Instance."""
-        if not do_not_navigate:
-            if provider is None:
-                navigate_to(cls, 'All')
-            else:
-                provider.load_all_provider_vms()
-        return Quadicon.get_first_quad_title()
+    def get_first_vm(cls, provider):
+        """Get first VM/Instance."""
+        # todo: move this to base provider ?
+        view = navigate_to(cls, 'AllForProvider', provider=provider)
+        return view.entities.get_first_entity()
 
     @property
     def last_analysed(self):

--- a/cfme/services/myservice/ui.py
+++ b/cfme/services/myservice/ui.py
@@ -1,17 +1,16 @@
 from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.widget import Text, View
-from widgetastic_manageiq import Accordion, ManageIQTree, Calendar, SummaryTable
+from widgetastic_manageiq import (Accordion, ManageIQTree, Calendar, SummaryTable,
+                                  BaseNonInteractiveEntitiesView)
 from widgetastic_patternfly import Input, BootstrapSelect, Dropdown, Button, CandidateNotFound, Tab
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.common import TagPageView
-from cfme.fixtures import pytest_selenium as sel
 from cfme.services.myservice import MyService
 from cfme.services.requests import RequestsView
 from cfme.utils.appliance import current_appliance
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to, ViaUI
 from cfme.utils.wait import wait_for
-from cfme.web_ui import Quadicon
 
 
 class MyServicesView(BaseLoggedInPage):
@@ -70,6 +69,7 @@ class MyServiceDetailsToolbar(View):
 class MyServiceDetailView(MyServicesView):
     title = Text("#explorer_title_text")
     toolbar = View.nested(MyServiceDetailsToolbar)
+    entities = View.nested(BaseNonInteractiveEntitiesView)
 
     @View.nested
     class details(Tab):  # noqa
@@ -253,9 +253,7 @@ def edit_tags(self, tag, value):
 @MyService.check_vm_add.external_implementation_for(ViaUI)
 def check_vm_add(self, add_vm_name):
     view = navigate_to(self, 'Details')
-    # TODO - replace Quadicon later
-    quadicon = Quadicon(add_vm_name, "vm")
-    sel.click(quadicon)
+    view.entities.get_entity(add_vm_name).click()
     view.flash.assert_no_error()
 
 

--- a/cfme/storage/object_store.py
+++ b/cfme/storage/object_store.py
@@ -1,17 +1,57 @@
 # -*- coding: utf-8 -*-
-from functools import partial
 from navmazing import NavigateToSibling, NavigateToAttribute
+from widgetastic.widget import View, Text
+from widgetastic_patternfly import Dropdown, FlashMessages
+from widgetastic_manageiq import (DetailsToolBarViewSelector, BaseEntitiesView)
 
+from cfme.base.login import BaseLoggedInPage
 from cfme.common import SummaryMixin, Taggable
-from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import toolbar as tb
-from cfme.web_ui import Quadicon, match_location, mixins
+from cfme.web_ui import mixins
 from cfme.utils.appliance.implementations.ui import navigate_to, navigator, CFMENavigateStep
 from cfme.utils.appliance import Navigatable
 
 
-match_page = partial(match_location, controller='cloud_object_store_container',
-                     title='Object Stores')
+class ObjectStoreContainersToolBar(View):
+    configuration = Dropdown(text='Configuration')
+    policy = Dropdown(text='Policy')
+    view_selector = View.nested(DetailsToolBarViewSelector)
+
+
+class ObjectStoreContainersSideBar(View):
+    """
+    represents left side bar. it usually contains navigation, filters, etc
+    """
+    pass
+
+
+class ObjectStoreContainersView(BaseLoggedInPage):
+    """
+     represents Main view displaying all Cloud Object Store Containers
+    """
+    toolbar = View.nested(ObjectStoreContainersToolBar)
+    sidebar = View.nested(ObjectStoreContainersSideBar)
+    including_entities = View.include(BaseEntitiesView, use_parent=True)
+
+    @property
+    def is_displayed(self):
+        return (self.logged_in_as_current_user and
+                self.entities.title.text == 'Cloud Object Store Containers')
+
+
+class ObjectStoreContainersDetailsView(BaseLoggedInPage):
+    """
+     main Details page
+    """
+    title = Text('//div[@id="main-content"]//h1')
+    flash = FlashMessages('.//div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
+                          'contains(@class, "flash_text_div")]')
+    # todo: the rest of widgets should be defined by FA owner
+    toolbar = View.nested(View)
+
+    @property
+    def is_displayed(self):
+        title = '{name} (Summary)'.format(name=self.context['object'].name)
+        return self.logged_in_as_current_user and self.title.text == title
 
 
 class ObjectStore(Taggable, SummaryMixin, Navigatable):
@@ -24,7 +64,6 @@ class ObjectStore(Taggable, SummaryMixin, Navigatable):
     def __init__(self, name=None, appliance=None):
         Navigatable.__init__(self, appliance=appliance)
         self.name = name
-        self.quad_name = 'object_store'
 
     def add_tag(self, tag, **kwargs):
         """Tags the system by given tag"""
@@ -39,6 +78,7 @@ class ObjectStore(Taggable, SummaryMixin, Navigatable):
 
 @navigator.register(ObjectStore, 'All')
 class All(CFMENavigateStep):
+    VIEW = ObjectStoreContainersView
     prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
 
     def step(self):
@@ -49,15 +89,13 @@ class All(CFMENavigateStep):
                 'Storage', 'Object Storage', 'Object Store Containers')
 
     def resetter(self):
-        tb.select("Grid View")
+        self.view.toolbar.select("Grid View")
 
 
 @navigator.register(ObjectStore, 'Details')
 class Details(CFMENavigateStep):
+    VIEW = ObjectStoreContainersDetailsView
     prerequisite = NavigateToSibling('All')
 
-    def am_i_here(self):
-        return match_page(summary="{} (Summary)".format(self.obj.name))
-
     def step(self):
-        sel.click(Quadicon(self.obj.name, self.obj.quad_name))
+        self.prerequisite_view.entities.get_entity(self.obj.name).click()

--- a/cfme/storage/object_store.py
+++ b/cfme/storage/object_store.py
@@ -89,7 +89,7 @@ class All(CFMENavigateStep):
                 'Storage', 'Object Storage', 'Object Store Containers')
 
     def resetter(self):
-        self.view.toolbar.select("Grid View")
+        self.view.toolbar.view_selector.select("Grid View")
 
 
 @navigator.register(ObjectStore, 'Details')

--- a/cfme/tests/cloud/test_delete_cloud_object.py
+++ b/cfme/tests/cloud/test_delete_cloud_object.py
@@ -4,7 +4,7 @@ import pytest
 from cfme import test_requirements
 from cfme.cloud.instance.image import Image
 from cfme.cloud.provider import CloudProvider
-from cfme.cloud.stack import Stack
+from cfme.cloud.stack import StackCollection
 from cfme.common.vm import VM
 from cfme.utils import testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -58,13 +58,16 @@ def test_delete_image_appear_after_refresh(setup_provider, provider, set_grid, r
     request.addfinalizer(reset)
 
 
-def test_delete_stack_appear_after_refresh(setup_provider, provider, provisioning, request):
+def test_delete_stack_appear_after_refresh(setup_provider, provider, provisioning, request,
+                                           appliance):
     """ Tests delete stack
 
     Metadata:
         test_flag: delete_object
     """
-    stack = Stack(provisioning['stacks'][0], provider=provider)
+
+    stack = StackCollection(appliance).instantiate(name=provisioning['stacks'][0],
+                                                   provider=provider)
     # wait for delete implemented in delete()
     stack.delete()
     # refresh relationships is implemented in wait_for_exists()

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -518,13 +518,14 @@ def _test_vm_provision():
     vms.lcl_btn("Provision VMs")
 
 
-def _test_vm_power_on():
-    """Ensures power button is shown for a VM"""
-    logger.info("Checking for power button")
-    vm_name = vms.Vm.get_first_vm_title()
-    logger.debug("VM " + vm_name + " selected")
-    if not vms.is_pwr_option_visible(vm_name, option=vms.Vm.POWER_ON):
-        raise OptionNotAvailable("Power button does not exist")
+# this fixture is used in disabled tests. it should be updated along with tests
+# def _test_vm_power_on():
+#     """Ensures power button is shown for a VM"""
+#     logger.info("Checking for power button")
+#     vm_name = vms.Vm.get_first_vm()
+#     logger.debug("VM " + vm_name + " selected")
+#     if not vms.is_pwr_option_visible(vm_name, option=vms.Vm.POWER_ON):
+#         raise OptionNotAvailable("Power button does not exist")
 
 
 def _test_vm_removal():

--- a/cfme/tests/configure/test_default_views_cloud.py
+++ b/cfme/tests/configure/test_default_views_cloud.py
@@ -8,7 +8,7 @@ from cfme.cloud.flavor import Flavor
 from cfme.cloud.instance import Instance
 from cfme.cloud.instance.image import Image
 from cfme.configure.settings import DefaultView
-from cfme.web_ui import Quadicon, fill, toolbar as tb
+from cfme.web_ui import toolbar as tb
 from cfme.utils.appliance.implementations.ui import navigate_to
 
 pytestmark = [pytest.mark.tier(3),
@@ -25,15 +25,6 @@ gtl_params = {
 
 
 # TODO refactor for setup_provider parametrization with new 'latest' tag
-
-
-def select_two_quads():
-    count = 0
-    for quad in Quadicon.all("cloud_prov", this_page=True):
-        count += 1
-        if count > 2:
-            break
-        fill(quad.checkbox(), True)
 
 
 def set_and_test_default_view(group_name, view, page):
@@ -66,9 +57,9 @@ def test_cloud_grid_defaultview(request, key):
 def set_and_test_view(group_name, view):
     old_default = DefaultView.get_default_view(group_name)
     DefaultView.set_default_view(group_name, view)
-    navigate_to(Instance, 'All')
-    select_two_quads()
-    tb.select('Configuration', 'Compare Selected items')
+    inst_view = navigate_to(Instance, 'All')
+    [e.check() for e in inst_view.entities.get_all()[:2]]
+    inst_view.toolbar.configuration.item_select('Compare Selected items')
     assert tb.is_active(view), "{} setting failed".format(view)
     DefaultView.set_default_view(group_name, old_default)
 

--- a/cfme/tests/configure/test_default_views_infra.py
+++ b/cfme/tests/configure/test_default_views_infra.py
@@ -8,7 +8,7 @@ from cfme.infrastructure.virtual_machines import Vm
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.myservice import MyService
 from cfme.services.workloads import VmsInstances, TemplatesImages
-from cfme.web_ui import Quadicon, fill, toolbar as tb
+from cfme.web_ui import toolbar as tb
 from cfme.utils.appliance.implementations.ui import navigate_to
 
 
@@ -30,15 +30,6 @@ gtl_params = {
     'Templates & Images': TemplatesImages}
 
 
-def select_two_quads():
-    count = 0
-    for quad in Quadicon.all("infra_prov", this_page=True):
-        count += 1
-        if count > 2:
-            break
-        fill(quad.checkbox(), True)
-
-
 def set_and_test_default_view(group_name, view, page):
     old_default = DefaultView.get_default_view(group_name)
     DefaultView.set_default_view(group_name, view)
@@ -55,41 +46,41 @@ def set_and_test_default_view(group_name, view, page):
 
 
 @pytest.mark.parametrize('key', gtl_params, scope="module")
-def test_infra_tile_defaultview(request, key):
+def test_infra_tile_defaultview(key):
     set_and_test_default_view(key, 'Tile View', gtl_params[key])
 
 
 @pytest.mark.parametrize('key', gtl_params, scope="module")
-def test_infra_list_defaultview(request, key):
+def test_infra_list_defaultview(key):
     set_and_test_default_view(key, 'List View', gtl_params[key])
 
 
 @pytest.mark.parametrize('key', gtl_params, scope="module")
-def test_infra_grid_defaultview(request, key):
+def test_infra_grid_defaultview(key):
     set_and_test_default_view(key, 'Grid View', gtl_params[key])
 
 
 def set_and_test_view(group_name, view):
     old_default = DefaultView.get_default_view(group_name)
     DefaultView.set_default_view(group_name, view)
-    navigate_to(Vm, 'All')
-    select_two_quads()
-    tb.select('Configuration', 'Compare Selected items')
+    vm_view = navigate_to(Vm, 'All')
+    [e.check() for e in vm_view.entities.get_all()[:2]]
+    vm_view.toolbar.configuration.item_select('Compare Selected items')
     assert tb.is_active(view), "{} setting failed".format(view)
     DefaultView.set_default_view(group_name, old_default)
 
 
-def test_infra_expanded_view(request):
+def test_infra_expanded_view():
     set_and_test_view('Compare', 'Expanded View')
 
 
-def test_infra_compressed_view(request):
+def test_infra_compressed_view():
     set_and_test_view('Compare', 'Compressed View')
 
 
-def test_infra_details_view(request):
+def test_infra_details_view():
     set_and_test_view('Compare Mode', 'Details Mode')
 
 
-def test_infra_exists_view(request):
+def test_infra_exists_view():
     set_and_test_view('Compare Mode', 'Exists Mode')

--- a/cfme/tests/control/test_bugs.py
+++ b/cfme/tests/control/test_bugs.py
@@ -132,7 +132,7 @@ def test_scope_windows_registry_stuck(request, infra_provider):
     request.addfinalizer(lambda: profile.delete() if profile.exists else None)
     profile.create()
     # Now assign this malformed profile to a VM
-    vm = VM.factory(Vm.get_first_vm_title(provider=infra_provider), infra_provider)
+    vm = VM.factory(Vm.get_first_vm(provider=infra_provider).name, infra_provider)
     vm.assign_policy_profiles(profile.description)
     # It should be screwed here, but do additional check
     navigate_to(Server, 'Dashboard')

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -2,12 +2,10 @@
 import pytest
 import random
 
-import cfme.fixtures.pytest_selenium as sel
 from cfme.base.credential import Credential
 from cfme.common.host_views import HostsEditView
 from cfme.common.provider_views import ProviderNodesView
 from cfme.infrastructure.provider import InfraProvider
-from cfme.web_ui import Quadicon
 from cfme.utils import testgen
 from cfme.utils.conf import credentials
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -43,15 +41,11 @@ def navigate_and_select_quads(provider):
         view: the provider nodes view, quadicons already selected"""
     hosts_view = navigate_to(provider, 'ProviderNodes')
     assert hosts_view.is_displayed
-
-    quads = Quadicon.all("host", this_page=True)
-    for quad in quads:
-        sel.check(quad.checkbox())
+    [h.check() for h in hosts_view.entities.get_all()]
 
     hosts_view.toolbar.configuration.item_select('Edit Selected items')
     edit_view = provider.create_view(HostsEditView)
     assert edit_view.is_displayed
-
     return edit_view
 
 

--- a/cfme/tests/openstack/cloud/test_instances.py
+++ b/cfme/tests/openstack/cloud/test_instances.py
@@ -173,6 +173,9 @@ def test_delete_instance(new_instance):
 
 
 def test_list_vms_infra_node(provider, soft_assert):
+    if getattr(provider, 'infra_provider', None):
+        pytest.skip("Provider {prov} doesn't have infra provider set".format(prov=provider.name))
+
     view = navigate_to(provider.infra_provider, 'ProviderNodes')
     # Match hypervisors by IP with count of running VMs
     hvisors = {hv.host_ip: hv.running_vms for hv in provider.mgmt.api.hypervisors.list()}

--- a/cfme/tests/openstack/infrastructure/test_host_power_control.py
+++ b/cfme/tests/openstack/infrastructure/test_host_power_control.py
@@ -3,7 +3,6 @@ from navmazing import NavigationDestinationNotFound
 
 from cfme.infrastructure.host import Host
 from cfme.infrastructure.provider.openstack_infra import OpenstackInfraProvider
-from cfme.web_ui import Quadicon
 from cfme.utils import testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.version import current_version
@@ -18,13 +17,12 @@ pytestmark = [pytest.mark.uncollectif(lambda: current_version() < '5.7'),
 @pytest.fixture(scope='module')
 def host_on(provider):
     try:
-        navigate_to(provider, 'ProviderNodes')
+        view = navigate_to(provider, 'ProviderNodes')
     except NavigationDestinationNotFound:
-        assert "Missing nodes in provider's details"
+        assert False, "Missing nodes in provider's details"
 
-    my_quads = list(Quadicon.all())
-    quad = my_quads[0]
-    my_host_on = Host(name=quad.name, provider=provider)
+    first_host = view.entities.get_first_entity()
+    my_host_on = Host(name=first_host.name, provider=provider)
 
     if my_host_on.get_power_state() == 'off':
         my_host_on.power_on()
@@ -35,13 +33,12 @@ def host_on(provider):
 @pytest.fixture(scope='module')
 def host_off(provider):
     try:
-        navigate_to(provider, 'ProviderNodes')
+        view = navigate_to(provider, 'ProviderNodes')
     except NavigationDestinationNotFound:
-        assert "Missing nodes in provider's details"
+        assert False, "Missing nodes in provider's details"
 
-    my_quads = list(Quadicon.all())
-    quad = my_quads[0]
-    my_host_off = Host(name=quad.name, provider=provider)
+    first_host = view.entities.get_first_entity()
+    my_host_off = Host(name=first_host.name, provider=provider)
 
     if my_host_off.get_power_state() == 'on':
         my_host_off.power_off()

--- a/cfme/tests/openstack/infrastructure/test_hosts.py
+++ b/cfme/tests/openstack/infrastructure/test_hosts.py
@@ -1,10 +1,9 @@
 import pytest
 
 from cfme.configure.tasks import is_host_analysis_finished
-from cfme.fixtures import pytest_selenium as sel
 from cfme.infrastructure.host import Host
 from cfme.infrastructure.provider.openstack_infra import OpenstackInfraProvider
-from cfme.web_ui import InfoBlock, Quadicon, toolbar
+from cfme.web_ui import toolbar
 from cfme.utils import testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.wait import wait_for
@@ -16,12 +15,11 @@ pytestmark = [pytest.mark.usefixtures("setup_provider_modscope")]
 
 
 def test_host_configuration(provider, soft_assert):
-    navigate_to(provider, 'Details')
-    sel.click(InfoBlock.element("Relationships", "Nodes"))
-    my_quads = list(Quadicon.all())
-    assert len(my_quads) > 0
-    for quad in my_quads:
-        host = Host(name=quad.name, provider=provider)
+    view = navigate_to(provider, 'ProviderNodes')
+    entity_names = view.entities.all_entity_names
+    assert len(entity_names) > 0
+    for entity_name in entity_names:
+        host = Host(name=entity_name, provider=provider)
         host.run_smartstate_analysis()
         wait_for(is_host_analysis_finished, [host.name], delay=15,
                  timeout="10m", fail_func=toolbar.refresh)
@@ -32,12 +30,11 @@ def test_host_configuration(provider, soft_assert):
 
 
 def test_host_cpu_resources(provider, soft_assert):
-    navigate_to(provider, 'Details')
-    sel.click(InfoBlock.element("Relationships", "Nodes"))
-    my_quads = list(Quadicon.all())
-    assert len(my_quads) > 0
-    for quad in my_quads:
-        host = Host(name=quad.name, provider=provider)
+    view = navigate_to(provider, 'ProviderNodes')
+    entity_names = view.entities.all_entity_names
+    assert len(entity_names) > 0
+    for entity_name in entity_names:
+        host = Host(name=entity_name, provider=provider)
         fields = ['Number of CPUs', 'Number of CPU Cores',
                   'CPU Cores Per Socket']
         for field in fields:
@@ -46,10 +43,11 @@ def test_host_cpu_resources(provider, soft_assert):
 
 
 def test_host_auth(provider, soft_assert):
-    navigate_to(provider, 'ProviderNodes')
-    quads = list(Quadicon.all())
-    for quad in quads:
-        host = Host(name=quad.name, provider=provider)
+    view = navigate_to(provider, 'ProviderNodes')
+    entity_names = view.entities.all_entity_names
+    assert len(entity_names) > 0
+    for entity_name in entity_names:
+        host = Host(name=entity_name, provider=provider)
         navigate_to(host, 'Details')
         auth_status = host.get_detail('Authentication Status', 'SSH Key Pair Credentials')
         soft_assert(auth_status == 'Valid',
@@ -57,43 +55,40 @@ def test_host_auth(provider, soft_assert):
 
 
 def test_host_devices(provider):
-    navigate_to(provider, 'Details')
-    sel.click(InfoBlock.element("Relationships", "Nodes"))
-    my_quads = list(Quadicon.all())
-    assert len(my_quads) > 0
-    for quad in my_quads:
-        host = Host(name=quad.name, provider=provider)
+    view = navigate_to(provider, 'ProviderNodes')
+    entity_names = view.entities.all_entity_names
+    assert len(entity_names) > 0
+    for entity_name in entity_names:
+        host = Host(name=entity_name, provider=provider)
         assert int(host.get_detail("Properties", "Devices")) > 0
 
 
 def test_host_hostname(provider, soft_assert):
-    provider.summary.relationships.nodes.click()
-    my_quads = list(Quadicon.all())
-    assert len(my_quads) > 0
-    for quad in my_quads:
-        host = Host(name=quad.name, provider=provider)
+    view = navigate_to(provider, 'ProviderNodes')
+    entity_names = view.entities.all_entity_names
+    assert len(entity_names) > 0
+    for entity_name in entity_names:
+        host = Host(name=entity_name, provider=provider)
         result = host.get_detail("Properties", "Hostname")
         soft_assert(result, "Missing hostname in: " + str(result))
 
 
 def test_host_memory(provider):
-    navigate_to(provider, 'Details')
-    sel.click(InfoBlock.element("Relationships", "Nodes"))
-    my_quads = list(Quadicon.all())
-    assert len(my_quads) > 0
-    for quad in my_quads:
-        host = Host(name=quad.name, provider=provider)
+    view = navigate_to(provider, 'ProviderNodes')
+    entity_names = view.entities.all_entity_names
+    assert len(entity_names) > 0
+    for entity_name in entity_names:
+        host = Host(name=entity_name, provider=provider)
         result = int(host.get_detail("Properties", "Memory").split()[0])
         assert result > 0
 
 
 def test_host_security(provider, soft_assert):
-    navigate_to(provider, 'Details')
-    sel.click(InfoBlock.element("Relationships", "Nodes"))
-    my_quads = list(Quadicon.all())
-    assert len(my_quads) > 0
-    for quad in my_quads:
-        host = Host(name=quad.name, provider=provider)
+    view = navigate_to(provider, 'ProviderNodes')
+    entity_names = view.entities.all_entity_names
+    assert len(entity_names) > 0
+    for entity_name in entity_names:
+        host = Host(name=entity_name, provider=provider)
         soft_assert(
             int(host.get_detail("Security", "Users")) > 0,
             'Nodes number of Users is 0')
@@ -105,10 +100,11 @@ def test_host_security(provider, soft_assert):
 
 def test_host_smbios_data(provider, soft_assert):
     """Checks that Manufacturer/Model values are shown for each infra node"""
-    navigate_to(provider, 'ProviderNodes')
-    names = [q.name for q in list(Quadicon.all())]
-    for node in names:
-        host = Host(node, provider=provider)
+    view = navigate_to(provider, 'ProviderNodes')
+    entity_names = view.entities.all_entity_names
+    assert len(entity_names) > 0
+    for entity_name in entity_names:
+        host = Host(entity_name, provider=provider)
         navigate_to(host, 'Details')
         res = host.get_detail('Properties', 'Manufacturer / Model')
         soft_assert(res, 'Manufacturer / Model value are empty')
@@ -116,13 +112,10 @@ def test_host_smbios_data(provider, soft_assert):
 
 
 def test_host_zones_assigned(provider):
-    navigate_to(provider, 'Details')
-    sel.click(InfoBlock.element("Relationships", "Nodes"))
-    my_quads = list(Quadicon.all())
-    assert len(my_quads) > 0
-    my_quads = filter(lambda q: True if 'Compute' in q.name else False,
-                      my_quads)
-    for quad in my_quads:
-        host = Host(name=quad.name, provider=provider)
+    view = navigate_to(provider, 'ProviderNodes')
+    entity_names = [en for en in view.entities.all_entity_names if 'Compute' in en]
+    assert len(entity_names) > 0
+    for entity_name in entity_names:
+        host = Host(name=entity_name, provider=provider)
         result = host.get_detail('Relationships', 'Availability Zone')
         assert result, "Availability zone doesn't specified"


### PR DESCRIPTION
{{pytest: cfme/tests/cloud/test_stack.py cfme/tests/control/test_bugs.py cfme/tests/infrastructure/test_advanced_search_vms.py cfme/tests/storage/test_object_store.py cfme/tests/cloud/test_delete_cloud_object.py cfme/tests/cloud_infra_common/test_tag_objects.py cfme/tests/configure/test_access_control.py cfme/tests/configure/test_default_views_cloud.py cfme/tests/configure/test_default_views_infra.py cfme/tests/infrastructure/test_host.py cfme/tests/openstack/cloud/test_instances.py cfme/tests/openstack/infrastructure/test_host_power_control.py cfme/tests/openstack/infrastructure/test_hosts.py}}