### PR TITLE
[1LP][RFR] Fix for report does not getting selected

### DIFF
--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -465,7 +465,7 @@ class CannedSavedReport(CustomSavedReport, Navigatable):
         self.datetime_in_tree = parsetime.from_american_with_utc(self.datetime).to_iso_with_utc()
 
     def navigate(self):
-        navigate_to(self, "Info")
+        navigate_to(self, "Details")
 
     @classmethod
     def new(cls, path):


### PR DESCRIPTION
Fixing `navigate` method as now `"Info"` does not gives desired page of report's information.

Changing `"Info"` to `"Details"` fixes it and `cfme/tests/intelligence/reports/test_views.py` `test_report_view` passes.

Signed-off-by: Aleksei Slaikovskii <aslaikov@redhat.com>


{{pytest:  -v --long-running cfme/tests/intelligence/reports/test_views.py }}