### PR TITLE
[1LP][RFR] Add ansible.repository.as_fill_value method

### DIFF
--- a/cfme/ansible/repositories.py
+++ b/cfme/ansible/repositories.py
@@ -293,6 +293,9 @@ class Repository(BaseEntity):
     def playbooks(self):
         return PlaybooksCollection(self)
 
+    def as_fill_value(self):
+        return self.name
+
 
 @navigator.register(RepositoryCollection, 'All')
 class AnsibleRepositories(CFMENavigateStep):

--- a/cfme/ansible/repositories.py
+++ b/cfme/ansible/repositories.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Page model for Automation/Ansible/Repositories"""
 from navmazing import NavigateToAttribute, NavigateToSibling
-from widgetastic.widget import Text, Checkbox
+from widgetastic.widget import Text, Checkbox, Fillable
 from widgetastic.exceptions import NoSuchElementException
 from widgetastic_patternfly import Dropdown, Button, Input, FlashMessages
 from widgetastic_manageiq import Table, PaginationPane
@@ -210,7 +210,7 @@ class RepositoryCollection(BaseCollection):
                 'Delete of Repository "{}" was successfully initiated.'.format(repository.name))
 
 
-class Repository(BaseEntity):
+class Repository(BaseEntity, Fillable):
     """A class representing one Embedded Ansible repository in the UI."""
 
     def __init__(self, collection, name, url, description=None, scm_credentials=None,

--- a/cfme/tests/ansible/test_embedded_ansible_basic.py
+++ b/cfme/tests/ansible/test_embedded_ansible_basic.py
@@ -89,7 +89,7 @@ def catalog_item(ansible_repository):
         fauxfactory.gen_alphanumeric(),
         fauxfactory.gen_alphanumeric(),
         provisioning={
-            "repository": ansible_repository.as_fill_value(),
+            "repository": ansible_repository,
             "playbook": "dump_all_variables.yml",
             "machine_credential": "CFME Default Credential",
             "create_new": True,

--- a/cfme/tests/ansible/test_embedded_ansible_basic.py
+++ b/cfme/tests/ansible/test_embedded_ansible_basic.py
@@ -89,7 +89,7 @@ def catalog_item(ansible_repository):
         fauxfactory.gen_alphanumeric(),
         fauxfactory.gen_alphanumeric(),
         provisioning={
-            "repository": ansible_repository.as_fill_value,
+            "repository": ansible_repository.as_fill_value(),
             "playbook": "dump_all_variables.yml",
             "machine_credential": "CFME Default Credential",
             "create_new": True,


### PR DESCRIPTION
Add method that's used in a test in catalog_item creation.

Works fine locally

## PRT Results
Run 16506: Dropdown was disabled in UI for adding ansible repository. I saw this locally, and it cleared when I re-ran the test. There may be a UI bug here.  Continuing to fail on re-runs of the test.

{{pytest: -v --use-provider complete --long-running cfme/tests/ansible/test_embedded_ansible_basic.py::test_control_add_ansible_playbook_action_invalid_address}}