### PR TITLE
[1LP][RFR] Script to upload images to Glance

### DIFF
--- a/scripts/image_upload_glance.py
+++ b/scripts/image_upload_glance.py
@@ -17,12 +17,18 @@ os.environ['OS_TENANT_NAME'] = 'admin'
 os.environ['OS_AUTH_URL'] = GLANCE_SERVER
 
 
-QCOW_IMAGE = os.path.basename(CFME_IMAGE_URL)
+CFME_QCOW_IMAGE = os.path.basename(CFME_IMAGE_URL)
 
-p = subprocess.Popen(['wget', '-N', CFME_IMAGE_URL, '-O', QCOW_IMAGE], stdout=subprocess.PIPE)
+# Fetch image from CFME_IMAGE_URL
+p = subprocess.Popen(['wget', '-N', CFME_IMAGE_URL, '-O', CFME_QCOW_IMAGE], stdout=subprocess.PIPE)
 err = p.communicate()
 
+# Upload fetched image to Glance server
 p = subprocess.Popen(['glance', 'image-create', '--name=IMAGE_NAME_IN_GLANCE',
    '--visibility public', '--container-format=bare', '--disk-format=qcow2', '--progress',
    '--file QCOW_IMAGE'])
 err = p.communicate
+
+# Delete local copy of CFME_QCOW_IMAGE
+p = subprocess.Popen(['rm', '-rf', CFME_QCOW_IMAGE], stdout=subprocess.PIPE)
+err = p.communicate()

--- a/scripts/image_upload_glance.py
+++ b/scripts/image_upload_glance.py
@@ -3,12 +3,17 @@
 import os
 import subprocess
 
+from keystoneauth1 import loading
+from keystoneauth1 import session
+from glanceclient import Client
+
 # TO DO : Fetch all variables from yamls
 #       : Add Glance server details and creds to the yamls
 CFME_IMAGE_URL = ('http://file.cloudforms.xx.yy.com/'
                   'builds/cfme/5.8/5.8.2.1/cfme-rhevm-5.8.2.1-1.x86_64.qcow2')
 GLANCE_SERVER = 'http://xx.yy.zz.aa:5000/v2.0/'
 IMAGE_NAME_IN_GLANCE = 'cfme-5821-qcow2'
+CFME_QCOW_IMAGE = os.path.basename(CFME_IMAGE_URL)
 
 # Set environment variables for Glance
 os.environ['OS_USERNAME'] = 'admin'
@@ -16,8 +21,17 @@ os.environ['OS_PASSWORD'] = ''
 os.environ['OS_TENANT_NAME'] = 'admin'
 os.environ['OS_AUTH_URL'] = GLANCE_SERVER
 
+loader = loading.get_plugin_loader('password')
+auth = loader.load_from_options(
+    auth_url="http://xx.yy.zz.aa:5000/v2.0/",
+    username='admin',
+    password='password',
+    tenant_name='admin')
+glance_session = session.Session(auth=auth)
+glance = Client('2', session=glance_session)
 
-CFME_QCOW_IMAGE = os.path.basename(CFME_IMAGE_URL)
+image = glance.images.create(name=IMAGE_NAME_IN_GLANCE)
+glance.images.upload(image.id, open('/tmp/abc.qcow2', 'rb'))
 
 # Fetch image from CFME_IMAGE_URL
 p = subprocess.Popen(['wget', '-N', CFME_IMAGE_URL, '-O', CFME_QCOW_IMAGE], stdout=subprocess.PIPE)

--- a/scripts/image_upload_glance.py
+++ b/scripts/image_upload_glance.py
@@ -1,16 +1,18 @@
 #!/usr/bin/env python2
 
 """
-Script to upload iso/ova/qcow images to Glance server.
-This script requires that python-glanceclient be installed.
-
-pip install python-glanceclient
+Script to upload iso/qcow2/ova images to Glance server
 
 Usage:
 1.scripts/image_upload_glance.py --image cfme-rhevm-5.8.2.1-1.x86_64.qcow2 \
                                  --image_name_in_glance cfme-5821.qcow2 \
-                                 --provider glance11
+                                 --provider glance11 \
+                                 --disk_format qcow2
+2.scripts/image_upload_glance.py --image cfme-rhevm-5.8.2.1-1.x86_64.qcow2 \
+                                 --image_name_in_glance cfme-rhevm-5.8.2.1-1.x86_64.qcow2 \
+                                 --provider glance11 \
 
+If disk_format is not passed, it defaults to qcow2.
 """
 import argparse
 import sys
@@ -21,33 +23,34 @@ from keystoneauth1 import session
 from glanceclient import Client
 
 
-def upload_to_glance(image, image_name_in_glance, provider):
+def upload_to_glance(image, image_name_in_glance, provider, disk_format):
     """
-    Upload iso/qcow images to Glance.
+    Upload iso/qcow2/ova images to Glance.
     """
     api_version = '2'  # python-glanceclient API version
     provider_dict = cfme_data['management_systems'][provider]
+    creds_key = provider_dict['credentials']
 
     loader = loading.get_plugin_loader('password')
     auth = loader.load_from_options(
         auth_url=provider_dict['auth_url'],
-        username=credentials['cloudqe_rhos_default']['username'],
-        password=credentials['cloudqe_rhos_default']['password'],
-        tenant_name=credentials['cloudqe_rhos_default']['tenant'])
+        username=credentials[creds_key]['username'],
+        password=credentials[creds_key]['password'],
+        tenant_name=credentials[creds_key]['tenant'])
     glance_session = session.Session(auth=auth)
     glance = Client(api_version, session=glance_session)
 
     # Two images on Glance could have the same name since Glance assigns them different IDS.
     # So, we are running a check to make sure an image with the same name doesn't already exist.
-    for image in glance.images.list():
-        if image.name == image_name_in_glance:
+    for img in glance.images.list():
+        if img.name == image_name_in_glance:
             print("Image already exists on Glance server")
             sys.exit(127)
 
     glance_img = glance.images.create(name=image_name_in_glance)
     # Update image properties before uploading the image.
     glance.images.update(glance_img.id, container_format="bare")
-    glance.images.update(glance_img.id, disk_format="qcow2")
+    glance.images.update(glance_img.id, disk_format=disk_format)
     glance.images.update(glance_img.id, visibility="public")
     glance.images.upload(glance_img.id, open(image, 'rb'))
 
@@ -56,13 +59,14 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter)
 
-    parser.add_argument('--image', help='Image to be uploaded to Glance')
-    parser.add_argument('--image_name_in_glance', help='Image name in Glance')
-    parser.add_argument('--provider', help='Glance provider key in cfme_data')
+    parser.add_argument('--image', help='Image to be uploaded to Glance', required=True)
+    parser.add_argument('--image_name_in_glance', help='Image name in Glance', required=True)
+    parser.add_argument('--provider', help='Glance provider key in cfme_data', required=True)
+    parser.add_argument('--disk_format', help='Disk format of image', default='qcow2')
 
     args = parser.parse_args()
 
-    upload_to_glance(args.image, args.image_name_in_glance, args.provider)
+    upload_to_glance(args.image, args.image_name_in_glance, args.provider, args.disk_format)
 
 
 if __name__ == "__main__":

--- a/scripts/image_upload_glance.py
+++ b/scripts/image_upload_glance.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python2
+
+import os
+import subprocess
+
+# TO DO : Fetch all variables from yamls
+#       : Add Glance server details and creds to the yamls
+CFME_IMAGE_URL = ('http://file.cloudforms.xx.yy.com/'
+                  'builds/cfme/5.8/5.8.2.1/cfme-rhevm-5.8.2.1-1.x86_64.qcow2')
+GLANCE_SERVER = 'http://xx.yy.zz.aa:5000/v2.0/'
+IMAGE_NAME_IN_GLANCE = 'cfme-5821-qcow2'
+
+# Set environment variables for Glance
+os.environ['OS_USERNAME'] = 'admin'
+os.environ['OS_PASSWORD'] = ''
+os.environ['OS_TENANT_NAME'] = 'admin'
+os.environ['OS_AUTH_URL'] = GLANCE_SERVER
+
+
+QCOW_IMAGE = os.path.basename(CFME_IMAGE_URL)
+
+p = subprocess.Popen(['wget', '-N', CFME_IMAGE_URL, '-O', QCOW_IMAGE], stdout=subprocess.PIPE)
+err = p.communicate()
+
+p = subprocess.Popen(['glance', 'image-create', '--name=IMAGE_NAME_IN_GLANCE',
+   '--visibility public', '--container-format=bare', '--disk-format=qcow2', '--progress',
+   '--file QCOW_IMAGE'])
+err = p.communicate


### PR DESCRIPTION
Script to upload iso/ova/qcow images to Glance server.
I have tested the script locally.

Usage:
scripts/image_upload_glance.py --image cfme-rhevm-5.8.2.1-1.x86_64.qcow2 \
                                 --image_name_in_glance cfme-5821.qcow2 \
                                 --provider glance11

