### PR TITLE
[RFR] PoC for filtered collections

### DIFF
--- a/cfme/ansible/playbooks.py
+++ b/cfme/ansible/playbooks.py
@@ -103,9 +103,6 @@ class PlaybooksCollection(BaseCollection):
     def init(self):
         self.parent = self.filters.get('parent', None) if self.filters else None
 
-    def instantiate(self, name, repository):
-        return Playbook(self, name, repository)
-
     def all(self):
         view = navigate_to(Server, "AnsiblePlaybooks")
         playbooks = []

--- a/cfme/ansible/playbooks.py
+++ b/cfme/ansible/playbooks.py
@@ -100,9 +100,8 @@ class PlaybooksView(PlaybookBaseView):
 class PlaybooksCollection(BaseCollection):
     """Collection object for the :py:class:`Playbook`."""
 
-    def __init__(self, appliance, filter=None):
-        self.appliance = appliance
-        self.parent = filter.get('parent', None) if filter else None
+    def init(self):
+        self.parent = self.filters.get('parent', None) if self.filters else None
 
     def instantiate(self, name, repository):
         return Playbook(self, name, repository)
@@ -119,9 +118,7 @@ class PlaybooksCollection(BaseCollection):
 class Playbook(BaseEntity):
     """A class representing one Embedded Ansible playbook in the UI."""
 
-    def __init__(self, collection, name, repository):
-        self.collection = collection
-        self.appliance = self.collection.appliance
+    def init(self, name, repository):
         self.name = name
         self.repository = repository
 

--- a/cfme/ansible/playbooks.py
+++ b/cfme/ansible/playbooks.py
@@ -102,7 +102,7 @@ class PlaybooksCollection(BaseCollection):
 
     def __init__(self, appliance, filter=None):
         self.appliance = appliance
-        self.parent = filter.get('parent_repository', None) if filter else None
+        self.parent = filter.get('parent', None) if filter else None
 
     def instantiate(self, name, repository):
         return Playbook(self, name, repository)

--- a/cfme/ansible/playbooks.py
+++ b/cfme/ansible/playbooks.py
@@ -100,9 +100,9 @@ class PlaybooksView(PlaybookBaseView):
 class PlaybooksCollection(BaseCollection):
     """Collection object for the :py:class:`Playbook`."""
 
-    def __init__(self, appliance, parent_repository):
+    def __init__(self, appliance, filter=None):
         self.appliance = appliance
-        self.parent = parent_repository
+        self.parent = filter.get('parent_repository', None) if filter else None
 
     def instantiate(self, name, repository):
         return Playbook(self, name, repository)
@@ -111,10 +111,8 @@ class PlaybooksCollection(BaseCollection):
         view = navigate_to(Server, "AnsiblePlaybooks")
         playbooks = []
         for entity in view.entities.get_all(surf_pages=True):
-            if entity.data["Repository"] == self.parent.name:
-                playbooks.append(
-                    self.instantiate(entity.data["Name"], entity.data["Repository"])
-                )
+            if (self.parent and entity.data["Repository"] == self.parent.name) or not self.parent:
+                playbooks.append(self.instantiate(entity.data["Name"], entity.data["Repository"]))
         return playbooks
 
 

--- a/cfme/ansible/repositories.py
+++ b/cfme/ansible/repositories.py
@@ -213,6 +213,9 @@ class RepositoryCollection(BaseCollection):
 class Repository(BaseEntity, Fillable):
     """A class representing one Embedded Ansible repository in the UI."""
 
+    _collections = {'playbook': (PlaybooksCollection, {})}
+    _collections_obj = None
+
     def __init__(self, collection, name, url, description=None, scm_credentials=None,
                  scm_branch=None, clean=None, delete_on_update=None, update_on_launch=None):
         self.name = name

--- a/cfme/ansible/repositories.py
+++ b/cfme/ansible/repositories.py
@@ -88,10 +88,6 @@ class RepositoryEditView(RepositoryFormView):
 
 class RepositoryCollection(BaseCollection):
     """Collection object for the :py:class:`cfme.ansible.repositories.Repository`."""
-
-    def __init__(self, appliance):
-        self.appliance = appliance
-
     def instantiate(self, name, url, description=None, scm_credentials=None,
                     scm_branch=None, clean=None, delete_on_update=None, update_on_launch=None):
         return Repository(
@@ -216,12 +212,10 @@ class Repository(BaseEntity, Fillable):
     _collections = {'playbook': PlaybooksCollection}
     _collections_obj = None
 
-    def __init__(self, collection, name, url, description=None, scm_credentials=None,
-                 scm_branch=None, clean=None, delete_on_update=None, update_on_launch=None):
+    def init(self, name, url, description=None, scm_credentials=None,
+             scm_branch=None, clean=None, delete_on_update=None, update_on_launch=None):
         self.name = name
         self.url = url
-        self.collection = collection
-        self.appliance = self.collection.appliance
         self.description = description or ""
         self.scm_credentials = scm_credentials
         self.scm_branch = scm_branch or ""

--- a/cfme/ansible/repositories.py
+++ b/cfme/ansible/repositories.py
@@ -213,7 +213,7 @@ class RepositoryCollection(BaseCollection):
 class Repository(BaseEntity, Fillable):
     """A class representing one Embedded Ansible repository in the UI."""
 
-    _collections = {'playbook': (PlaybooksCollection, {})}
+    _collections = {'playbook': PlaybooksCollection}
     _collections_obj = None
 
     def __init__(self, collection, name, url, description=None, scm_credentials=None,

--- a/cfme/ansible/repositories.py
+++ b/cfme/ansible/repositories.py
@@ -86,20 +86,100 @@ class RepositoryEditView(RepositoryFormView):
         )
 
 
+class Repository(BaseEntity, Fillable):
+    """A class representing one Embedded Ansible repository in the UI."""
+
+    _collections = {'playbook': PlaybooksCollection}
+    _collections_obj = None
+
+    def init(self, name, url, description=None, scm_credentials=None,
+             scm_branch=None, clean=None, delete_on_update=None, update_on_launch=None):
+        self.name = name
+        self.url = url
+        self.description = description or ""
+        self.scm_credentials = scm_credentials
+        self.scm_branch = scm_branch or ""
+        self.clean = clean or False
+        self.delete_on_update = delete_on_update or False
+        self.update_on_launch = update_on_launch or False
+
+    @property
+    def db_object(self):
+        table = self.appliance.db.client["configuration_script_sources"]
+        return self.appliance.db.client.sessionmaker(autocommit=True).query(table).filter(
+            table.name == self.name).first()
+
+    @property
+    def as_fill_value(self):
+        """For use when selecting this repo in the UI forms"""
+        return self.name
+
+    def update(self, updates):
+        """Update the repository in the UI.
+
+        Args:
+            updates (dict): :py:class:`dict` of the updates.
+        """
+        original_updated_at = self.db_object.updated_at
+        view = navigate_to(self, "Edit")
+        changed = view.fill(updates)
+        if changed:
+            view.save_button.click()
+        else:
+            view.cancel_button.click()
+        view = self.create_view(RepositoryAllView)
+        assert view.is_displayed
+        view.flash.assert_no_error()
+        if changed:
+            view.flash.assert_message(
+                'Edit of Repository "{}" was successfully initialized.'.format(
+                    updates.get("name", self.name)))
+
+            def _wait_until_changes_applied():
+                changed_updated_at = self.db_object.updated_at
+                return not original_updated_at == changed_updated_at
+
+            wait_for(_wait_until_changes_applied, delay=10, timeout="5m")
+        else:
+            view.flash.assert_message(
+                'Edit of Repository "{}" cancelled by the user.'.format(self.name))
+
+    @property
+    def exists(self):
+        try:
+            navigate_to(self, "Details")
+            return True
+        except ItemNotFound:
+            return False
+
+    def delete(self):
+        """Delete the repository in the UI."""
+        view = navigate_to(self, "Details")
+        view.configuration.item_select("Remove this Repository", handle_alert=True)
+        repo_list_page = self.create_view(RepositoryAllView)
+        assert repo_list_page.is_displayed
+        repo_list_page.flash.assert_no_error()
+        repo_list_page.flash.assert_message(
+            'Delete of Repository "{}" was successfully initiated.'.format(self.name))
+        wait_for(lambda: not self.exists, delay=10,
+            fail_func=repo_list_page.browser.selenium.refresh)
+
+    def refresh(self):
+        """Perform a refresh to update the repository."""
+        view = navigate_to(self, "Details")
+        view.configuration.item_select("Refresh this Repository", handle_alert=True)
+        view.flash.assert_no_error()
+        view.flash.assert_message("Embedded Ansible refresh has been successfully initiated")
+
+    @property
+    def playbooks(self):
+        return PlaybooksCollection(self.appliance, self)
+
+
 class RepositoryCollection(BaseCollection):
     """Collection object for the :py:class:`cfme.ansible.repositories.Repository`."""
-    def instantiate(self, name, url, description=None, scm_credentials=None,
-                    scm_branch=None, clean=None, delete_on_update=None, update_on_launch=None):
-        return Repository(
-            self,
-            name,
-            url,
-            description=description,
-            scm_credentials=scm_credentials,
-            scm_branch=scm_branch,
-            clean=clean,
-            delete_on_update=delete_on_update,
-            update_on_launch=update_on_launch)
+
+    ENTITY = Repository
 
     def create(self, name, url, description=None, scm_credentials=None, scm_branch=None,
                clean=None, delete_on_update=None, update_on_launch=None):
@@ -204,99 +284,6 @@ class RepositoryCollection(BaseCollection):
         for repository in checked_repositories:
             view.flash.assert_message(
                 'Delete of Repository "{}" was successfully initiated.'.format(repository.name))
-
-
-class Repository(BaseEntity, Fillable):
-    """A class representing one Embedded Ansible repository in the UI."""
-
-    _collections = {'playbook': PlaybooksCollection}
-    _collections_obj = None
-
-    def init(self, name, url, description=None, scm_credentials=None,
-             scm_branch=None, clean=None, delete_on_update=None, update_on_launch=None):
-        self.name = name
-        self.url = url
-        self.description = description or ""
-        self.scm_credentials = scm_credentials
-        self.scm_branch = scm_branch or ""
-        self.clean = clean or False
-        self.delete_on_update = delete_on_update or False
-        self.update_on_launch = update_on_launch or False
-
-    @property
-    def db_object(self):
-        table = self.appliance.db.client["configuration_script_sources"]
-        return self.appliance.db.client.sessionmaker(autocommit=True).query(table).filter(
-            table.name == self.name).first()
-
-    @property
-    def as_fill_value(self):
-        """For use when selecting this repo in the UI forms"""
-        return self.name
-
-    def update(self, updates):
-        """Update the repository in the UI.
-
-        Args:
-            updates (dict): :py:class:`dict` of the updates.
-        """
-        original_updated_at = self.db_object.updated_at
-        view = navigate_to(self, "Edit")
-        changed = view.fill(updates)
-        if changed:
-            view.save_button.click()
-        else:
-            view.cancel_button.click()
-        view = self.create_view(RepositoryAllView)
-        assert view.is_displayed
-        view.flash.assert_no_error()
-        if changed:
-            view.flash.assert_message(
-                'Edit of Repository "{}" was successfully initialized.'.format(
-                    updates.get("name", self.name)))
-
-            def _wait_until_changes_applied():
-                changed_updated_at = self.db_object.updated_at
-                return not original_updated_at == changed_updated_at
-
-            wait_for(_wait_until_changes_applied, delay=10, timeout="5m")
-        else:
-            view.flash.assert_message(
-                'Edit of Repository "{}" cancelled by the user.'.format(self.name))
-
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, "Details")
-            return True
-        except ItemNotFound:
-            return False
-
-    def delete(self):
-        """Delete the repository in the UI."""
-        view = navigate_to(self, "Details")
-        view.configuration.item_select("Remove this Repository", handle_alert=True)
-        repo_list_page = self.create_view(RepositoryAllView)
-        assert repo_list_page.is_displayed
-        repo_list_page.flash.assert_no_error()
-        repo_list_page.flash.assert_message(
-            'Delete of Repository "{}" was successfully initiated.'.format(self.name))
-        wait_for(lambda: not self.exists, delay=10,
-            fail_func=repo_list_page.browser.selenium.refresh)
-
-    def refresh(self):
-        """Perform a refresh to update the repository."""
-        view = navigate_to(self, "Details")
-        view.configuration.item_select("Refresh this Repository", handle_alert=True)
-        view.flash.assert_no_error()
-        view.flash.assert_message("Embedded Ansible refresh has been successfully initiated")
-
-    @property
-    def playbooks(self):
-        return PlaybooksCollection(self.appliance, self)
-
-    def as_fill_value(self):
-        return self.name
 
 
 @navigator.register(RepositoryCollection, 'All')

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -245,7 +245,10 @@ class ObjectCollections(ApplianceCollections):
             filter = {'parent': self.parent}
             if isinstance(cls_and_or_filter, tuple):
                 filter.update(cls_and_or_filter[1])
-            self._collection_cache[collection] = cls_and_or_filter[0](self.appliance, filter)
+                cls = cls_and_or_filter[0]
+            else:
+                cls = cls_and_or_filter
+            self._collection_cache[collection] = cls(self.appliance, filter)
 
 
 class IPAppliance(object):

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2747,6 +2747,9 @@ class BaseCollection(NavigatableMixin):
         #     raise Exception('First argument must be an appliance')
         return super(BaseCollection, cls).__new__(cls)
 
+    def filter(self, filter):
+        return self.__class__(self.appliance, filter)
+
 
 class BaseEntity(NavigatableMixin):
     """Class for helping create consistent entitys

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2773,6 +2773,9 @@ class BaseCollection(NavigatableMixin):
         self.filters = kwargs.pop('filters', None)
         self.init(*args, **kwargs)
 
+    def instantiate(self, *args, **kwargs):
+        return self.ENTITY(self, *args, **kwargs)
+
     def init(self, *args, **kwargs):
         pass
 


### PR DESCRIPTION
PoC for filtered collections
---------------------------------

So we got talking about how just instantiating a collection wasn't always enough and indeed there were some collection objects that already take some secondary arguments which they use for filtering. This would allow you to have a collection object for VirtualMachines, that only listed virtual machines for a particular provider.

The issue is the in order to get the BaseCollection, we had to make all of the constructors the same and since we wanted to get it via the appliance,  we had introduced this kind of methodology

```python
appliance.collections.virtualmachines.all
```

Which would return for you a list/iterator of all VirtualMachine objects that the appliance has access to. However, even though the Collection may look like this:

```python
class VirtualMachineCollection(BaseCollection):
    def __init__(self, provider=None):
        self.provider = provider

    def all(self):
        # pseudocode
        list = []
        for virt_machine in list_of_all_virt_machines:
            if virt_machine.provider == self.provider
                list.append(virt_machine)
        return
```

It would mean that everytime you used ```all```, or any other function that needed to be filtered, we'd somehow need to convert all the functions to take all the filter parameters. This seemed clunky, and counter to the good practice that people seemed to already have, which was to create "filtered" collection objects.

So we did some thinking and came up with this

```python
appliance.collections.virtualmachines.filter(provider=ProviderObject).all()
```

In here, the collection has a filter method which returns a new collection which would set the filtering on it. Note that now though, each constructor for the Collection would need to be different, ie, which args do they take. We didn't like this, so we changed it slightly.

```python
appliance.collections.virtualmachines.filter({'provider': ProviderObject}).all()
```

So now, we are only passing a single argument which is a dict called ```filter``` internally. This is nice, and leads us to now have identical constructors for all collection objects, but with the benefit of being able to pass in some filter dict which can be used inside the collection for filtering ```all``` and any other methods we require.

Now we have this though, a single homogenous way of creating collections with and without filtering. It also means we can link ```Entity``` objects to other collections. As an example a provider can now have a collection object on it, which details all of the virtualmachines which are associated with it. This could be created like so.

```python
class Provider(BaseEntity):
    def __init__(self, collection, **kwargs):
        self.collection = collection
        self.appliance = self.collection.appliance

    def vms(self):
        return self.appliance.collections.virtualmachines.filter({'provider': self})
```

Now we can access the virtualmachines on a provider like so

```python
for vm in provider.vms.all()
```

Swanky eh? But we decided to try to take it one further. Since a Provider could have multiple collections associated with it, we implemented a helper scheme

```python
class Provider(BaseEntity):

    _collections = {'vms': VirtualMachineCollection}
    _collections_obj = None
```

This will, thanks to ```BaseEntity```, create a collections attribute which points to a special ```ObjectCollections``` object, which automatically loads all collections in the _collections dict, and instantiates them with a ```parent``` filter. This looks like this ```{'parent': self}```. We don't think there is actually too many other objects needed for filtering but the collections can also be specified like this.


```python
class Provider(BaseEntity):

    _collections = {'vms': (VirtualMachineCollection, {'on': True})}
    _collections_obj = None
```

Which passes an additional filter. This allows you now to access ```provider.collections.vms.all()``` without writing any special ```vms``` property on the provider object. Nifty eh?

~~Once last point that isn't handled yet. When you filter, we don't yet chain the filters, it is a replacement. I expect chainable filtering to land in about 45mins.~~
OK it took a little longer, but you can now do

```python
    col = appliance.collections.virtualmachines.filter({'provider': provider})
    col.filter(({'on': True})
```

This would apply both filters to the new collection.

As an additional benefit, we have now, since we introduced the ```ENTITY``` attribute on the collections class, can do away with the normal ```instantiate``` method and delegate it to the base class. This means no one has to write one of these, unless there is something special. The method is basically a wrapper around having to pass the collection to the entity.

This rework also introduces a new ```init``` method. Why? well it means that we can delegate the handling of ```appliance``` and ```collection``` to the base class ```__init__``` meaning no one needs to handle them anymore, unless they are doing something fancy. Just remember to use ```init``` and not ```__init__``` when writing constructors for Collection and Entity objects. As a side not ```__init__``` calls ```init```.