### PR TITLE
[1LP][RFR]Correcting configuration for VMware Console

### DIFF
--- a/cfme/configure/configuration/server_settings.py
+++ b/cfme/configure/configuration/server_settings.py
@@ -222,7 +222,7 @@ class ServerInformation(Updateable, Pretty, NavigatableMixin):
 # ============================= VMware Console Form =================================
 
     def update_vmware_console(self, updates, reset=False):
-        """ Navigate to a Server Tab. Updates Vmware comsole
+        """ Navigate to a Server Tab. Updates Vmware console
 
         Args:
              updates: dict, widgets will be updated regarding updates.
@@ -232,7 +232,7 @@ class ServerInformation(Updateable, Pretty, NavigatableMixin):
         view = navigate_to(self, 'Details')
         for name, value in updates.items():
             if name == 'console_type':
-                if name not in self.CONSOLE_TYPES:
+                if value not in self.CONSOLE_TYPES:
                     raise ConsoleTypeNotSupported(value)
                 if self.appliance.version < '5.8':
                     raise ConsoleNotSupported(


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ Configuration because it is currently doing looking for name in CONSOLE_TYPES which is incorrect and causing Console Test Failures. It should be looking for Value in CONSOLE_TYPES. 

{{ pytest: cfme/tests/cloud_infra_common/test_html5_vm_console.py --use-provider vsphere6-nested }}