### PR TITLE
[RFR] Fix get random instances

### DIFF
--- a/cfme/containers/node.py
+++ b/cfme/containers/node.py
@@ -116,7 +116,8 @@ class Node(Taggable, Labelable, SummaryMixin, BaseEntity):
         """Generating random instances."""
         node_list = provider.mgmt.list_node()
         random.shuffle(node_list)
-        return [cls(obj.name, provider, appliance=appliance)
+        collection = NodeCollection(appliance)
+        return [collection.instantiate(obj.name, provider)
                 for obj in itertools.islice(node_list, count)]
 
 


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_relationships.py}}
Fix node instantiation in get_random_instances().
Complete this PR: https://github.com/ManageIQ/integration_tests/pull/5479
