### PR TITLE
[1LP][RFR] Filter collections attrs

### DIFF
--- a/cfme/modeling/base.py
+++ b/cfme/modeling/base.py
@@ -1,0 +1,143 @@
+import attr
+from collections import Callable
+
+from cached_property import cached_property
+
+from cfme.utils.appliance import NavigatableMixin
+
+
+class ApplianceCollections(object):
+    """Caches instances of collection objects for use by the collections accessor
+
+    The appliance object has a ``collections`` attribute. This attribute is an instance
+    of this class. It is initialized with an appliance object and locally stores a cache
+    of all known good collections.
+    """
+    _collection_classes = None
+
+    def __init__(self, appliance):
+        self._collection_cache = {}
+        self.appliance = appliance
+        if not self._collection_classes:
+            self.load_collections()
+        for collection, cls in self._collection_classes.items():
+            self._collection_cache[collection] = cls(self.appliance)
+
+    def load_collections(self):
+        """Loads the collection definitions from the entrypoints system"""
+        from pkg_resources import iter_entry_points
+        ApplianceCollections._collection_classes = {
+            ep.name: ep.resolve() for ep in iter_entry_points('manageiq.appliance_collections')
+        }
+
+    def __getattr__(self, name):
+        try:
+            return self._collection_cache[name]
+        except KeyError:
+            raise AttributeError('Collection [{}] not known to applinace'.format(name))
+
+
+class ObjectCollections(ApplianceCollections):
+    def __init__(self, parent):
+        self._collection_cache = {}
+        self.parent = parent
+        self.appliance = self.parent.appliance
+        self.collections = self.parent._collections
+        self.load_collections()
+
+    def load_collections(self):
+        for collection, cls_and_or_filter in self.collections.items():
+            filter = {'parent': self.parent}
+            if isinstance(cls_and_or_filter, tuple):
+                filter.update(cls_and_or_filter[1])
+                cls = cls_and_or_filter[0]
+            else:
+                cls = cls_and_or_filter
+            collection_instance = cls(self.appliance, filters=filter)
+            self._collection_cache[collection] = collection_instance
+
+
+@attr.s
+class BaseCollection(NavigatableMixin):
+    """Class for helping create consistent Collections
+
+    The BaseCollection class is responsible for ensuring two things:
+
+    1) That the API consistently has the first argument passed to it
+    2) That that first argument is an appliance instance
+
+    This class works in tandem with the entrypoint loader which ensures that the correct
+    argument names have been used.
+    """
+
+    ENTITY = None
+
+    parent = attr.ib()
+    filters = attr.ib(default=attr.Factory(dict))
+
+    @property
+    def appliance(self):
+        if isinstance(self.parent, BaseEntity):
+            return self.parent.appliance
+        else:
+            return self.parent
+
+    @classmethod
+    def for_appliance(cls, appliance, *k, **kw):
+        return cls(appliance)
+
+    @classmethod
+    def for_entity(cls, obj, *k, **kw):
+        return cls(obj, *k, **kw)
+
+    @classmethod
+    def for_entity_with_filter(cls, obj, filt, *k, **kw):
+        return cls.for_entity(obj, *k, **kw).filter(filt)
+
+    def instantiate(self, *args, **kwargs):
+        return self.ENTITY.from_collection(self, *args, **kwargs)
+
+    def filter(self, filter):
+        filters = self.filters.copy()
+        filters.update(filter)
+        return attr.evolve(self, filters=filters)
+
+
+@attr.s
+class BaseEntity(NavigatableMixin):
+    """Class for helping create consistent entitys
+
+    The BaseEntity class is responsible for ensuring two things:
+
+    1) That the API consistently has the first argument passed to it
+    2) That that first argument is a collection instance
+
+    This class works in tandem with the entrypoint loader which ensures that the correct
+    argument names have been used.
+    """
+
+    parent = attr.ib(repr=False)  # This is the collection
+
+    @property
+    def appliance(self):
+        return self.parent.appliance
+
+    @classmethod
+    def from_collection(cls, collection, *k, **kw):
+        return cls(collection, *k, **kw)
+
+    @cached_property
+    def collections(self):
+        return ObjectCollections(self)
+
+
+@attr.s
+class CollectionProperty(object):
+    type_or_get_type = attr.ib(validator=attr.validators.instance_of((Callable, type)))
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+        if not isinstance(self.type_or_get_type, type):
+            self.type_or_get_type = self.type_or_get_type()
+        return self.type_or_get_type.for_entity_with_filter(instance, {'parent': instance})


### PR DESCRIPTION
So we got talking about how just instantiating a collection wasn't always enough and indeed there were some collection objects that already take some secondary arguments which they use for filtering. This would allow you to have a collection object for VirtualMachines, that only listed virtual machines for a particular provider.

The issue is the in order to get the BaseCollection, we had to make all of the constructors the same and since we wanted to get it via the appliance,  we had introduced this kind of methodology

```python
appliance.collections.virtualmachines.all
```

Which would return for you a list/iterator of all VirtualMachine objects that the appliance has access to. However, even though the Collection may look like this:

```python
class VirtualMachineCollection(BaseCollection):
    def __init__(self, provider=None):
        self.provider = provider

    def all(self):
        # pseudocode
        list = []
        for virt_machine in list_of_all_virt_machines:
            if virt_machine.provider == self.provider
                list.append(virt_machine)
        return
```

It would mean that everytime you used ```all```, or any other function that needed to be filtered, we'd somehow need to convert all the functions to take all the filter parameters. This seemed clunky, and counter to the good practice that people seemed to already have, which was to create "filtered" collection objects.

So we did some thinking and came up with this

```python
appliance.collections.virtualmachines.filter(provider=ProviderObject).all()
```

In here, the collection has a filter method which returns a new collection which would set the filtering on it. Note that now though, each constructor for the Collection would need to be different, ie, which args do they take. We didn't like this, so we changed it slightly.

```python
appliance.collections.virtualmachines.filter({'provider': ProviderObject}).all()
```

So now, we are only passing a single argument which is a dict called ```filter``` internally. This is nice, and leads us to now have identical constructors for all collection objects, but with the benefit of being able to pass in some filter dict which can be used inside the collection for filtering ```all``` and any other methods we require.

Now we have this though, a single homogenous way of creating collections with and without filtering. It also means we can link ```Entity``` objects to other collections. As an example a provider can now have a collection object on it, which details all of the virtualmachines which are associated with it. This could be created like so.

```python
class Provider(BaseEntity):
    def __init__(self, collection, **kwargs):
        self.collection = collection
        self.appliance = self.collection.appliance

    def vms(self):
        return self.appliance.collections.virtualmachines.filter({'provider': self})
```

Now we can access the virtualmachines on a provider like so

```python
for vm in provider.vms.all()
```

Swanky eh? But we decided to try to take it one further. Since a Provider could have multiple collections associated with it, we implemented a helper scheme

```python
class Provider(BaseEntity):

    _collections = {'vms': VirtualMachineCollection}
    _collections_obj = None
```

This will, thanks to ```BaseEntity```, create a collections attribute which points to a special ```ObjectCollections``` object, which automatically loads all collections in the _collections dict, and instantiates them with a ```parent``` filter. This looks like this ```{'parent': self}```. We don't think there is actually too many other objects needed for filtering but the collections can also be specified like this.


```python
class Provider(BaseEntity):

    _collections = {'vms': (VirtualMachineCollection, {'on': True})}
    _collections_obj = None
```

Which passes an additional filter. This allows you now to access ```provider.collections.vms.all()``` without writing any special ```vms``` property on the provider object. Nifty eh?

~~Once last point that isn't handled yet. When you filter, we don't yet chain the filters, it is a replacement. I expect chainable filtering to land in about 45mins.~~
OK it took a little longer, but you can now do

```python
    col = appliance.collections.virtualmachines.filter({'provider': provider})
    col.filter(({'on': True})
```

This would apply both filters to the new collection.

As an additional benefit, we have now, since we introduced the ```ENTITY``` attribute on the collections class, can do away with the normal ```instantiate``` method and delegate it to the base class. This means no one has to write one of these, unless there is something special. The method is basically a wrapper around having to pass the collection to the entity.