### PR TITLE
[1LP][RFR]EditTags navigation steps cleanup/move

### DIFF
--- a/cfme/cloud/availability_zone.py
+++ b/cfme/cloud/availability_zone.py
@@ -6,7 +6,7 @@ from widgetastic.exceptions import NoSuchElementException
 from widgetastic_patternfly import Dropdown, Button
 
 from cfme.base.login import BaseLoggedInPage
-from cfme.common import TagPageView, WidgetasticTaggable
+from cfme.common import WidgetasticTaggable
 from cfme.exceptions import AvailabilityZoneNotFound
 from cfme.web_ui import match_location
 from cfme.utils.appliance import Navigatable
@@ -142,15 +142,6 @@ class AvailabilityZoneDetails(CFMENavigateStep):
             raise AvailabilityZoneNotFound('Could not locate Availability Zone "{}" on provider {}'
                                            .format(self.obj.name, self.obj.provider.name))
         row.click()
-
-
-@navigator.register(AvailabilityZone, 'EditTagsFromDetails')
-class AvailabilityZoneEditTags(CFMENavigateStep):
-    VIEW = TagPageView
-    prerequisite = NavigateToSibling('Details')
-
-    def step(self, *args, **kwargs):
-        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
 
 
 @navigator.register(AvailabilityZone, 'Timelines')

--- a/cfme/cloud/flavor.py
+++ b/cfme/cloud/flavor.py
@@ -5,7 +5,7 @@ from widgetastic.exceptions import NoSuchElementException
 from widgetastic_patternfly import Dropdown, Button, View
 
 from cfme.base.ui import BaseLoggedInPage
-from cfme.common import TagPageView, WidgetasticTaggable
+from cfme.common import WidgetasticTaggable
 from cfme.exceptions import FlavorNotFound
 from cfme.web_ui import match_location
 from cfme.utils.appliance import Navigatable
@@ -124,12 +124,3 @@ class FlavorDetails(CFMENavigateStep):
             raise FlavorNotFound('Could not locate flavor "{}" on provider {}'
                                  .format(self.obj.name, self.obj.provider.name))
         row.click()
-
-
-@navigator.register(Flavor, 'EditTagsFromDetails')
-class FlavorEditTags(CFMENavigateStep):
-    VIEW = TagPageView
-    prerequisite = NavigateToSibling('Details')
-
-    def step(self, *args, **kwargs):
-        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')

--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -6,7 +6,6 @@ from widgetastic_patternfly import Dropdown, Button
 from widgetastic_manageiq import ManageIQTree, TimelinesView, Accordion
 
 from cfme.base.login import BaseLoggedInPage
-from cfme.common import TagPageView
 from cfme.common.vm import VM
 from cfme.common.vm_views import (
     ProvisionView, VMToolbar, VMEntities, VMDetailsEntities, RetirementView, EditView,
@@ -445,15 +444,6 @@ class EditManagementEngineRelationship(CFMENavigateStep):
     def step(self, *args, **kwargs):
         configuration = self.prerequisite_view.toolbar.configuration
         configuration.item_select('Edit Management Engine Relationship')
-
-
-@navigator.register(Instance, 'EditTagsFromDetails')
-class EditTags(CFMENavigateStep):
-    VIEW = TagPageView
-    prerequisite = NavigateToSibling('Details')
-
-    def step(self, *args, **kwargs):
-        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
 
 
 @navigator.register(Instance, 'ManagePolicies')

--- a/cfme/cloud/instance/image.py
+++ b/cfme/cloud/instance/image.py
@@ -5,7 +5,6 @@ from widgetastic_manageiq import (
     ItemsToolBarViewSelector, SummaryTable, ItemNotFound, BaseEntitiesView)
 
 from cfme.exceptions import ImageNotFound
-from cfme.common import TagPageView
 from cfme.common.vm import Template
 from cfme.common.vm_views import (
     EditView, SetOwnershipView, ManagePoliciesView, PolicySimulationView, BasicProvisionFormView)
@@ -223,12 +222,3 @@ class ImagePolicySimulation(CFMENavigateStep):
 
     def step(self, *args, **kwargs):
         self.prerequisite_view.toolbar.policy.item_select('Policy Simulation')
-
-
-@navigator.register(Image, 'EditTagsFromDetails')
-class ImageEditTags(CFMENavigateStep):
-    VIEW = TagPageView
-    prerequisite = NavigateToSibling('Details')
-
-    def step(self, *args, **kwargs):
-        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')

--- a/cfme/cloud/keypairs.py
+++ b/cfme/cloud/keypairs.py
@@ -7,7 +7,7 @@ from widgetastic_manageiq import (
     ItemsToolBarViewSelector, Text, TextInput, Accordion, ManageIQTree, BreadCrumb,
     SummaryTable, BootstrapSelect, ItemNotFound, BaseEntitiesView)
 
-from cfme.common import TagPageView, WidgetasticTaggable
+from cfme.common import WidgetasticTaggable
 from cfme.base.ui import BaseLoggedInPage
 from cfme.exceptions import KeyPairNotFound
 
@@ -245,12 +245,3 @@ class Add(CFMENavigateStep):
     def step(self, *args, **kwargs):
         """Raises DropdownItemDisabled from widgetastic_patternfly if no RHOS provider present"""
         self.prerequisite_view.toolbar.configuration.item_select('Add a new Key Pair')
-
-
-@navigator.register(KeyPair, 'EditTagsFromDetails')
-class EditTagsFromDetails(CFMENavigateStep):
-    VIEW = TagPageView
-    prerequisite = NavigateToSibling('Details')
-
-    def step(self):
-        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')

--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -180,15 +180,6 @@ class EditTags(CFMENavigateStep):
         self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
 
 
-@navigator.register(CloudProvider, 'EditTagsFromDetails')
-class EditTagsFromDetails(CFMENavigateStep):
-    VIEW = TagPageView
-    prerequisite = NavigateToSibling('Details')
-
-    def step(self):
-        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
-
-
 @navigator.register(CloudProvider, 'Timelines')
 class Timelines(CFMENavigateStep):
     VIEW = CloudProviderTimelinesView

--- a/cfme/cloud/stack.py
+++ b/cfme/cloud/stack.py
@@ -7,7 +7,7 @@ from widgetastic_manageiq import (
     SummaryTable, Table, Text, BaseEntitiesView)
 
 from cfme.base.ui import BaseLoggedInPage
-from cfme.common import TagPageView, WidgetasticTaggable
+from cfme.common import WidgetasticTaggable
 from cfme.exceptions import CandidateNotFound
 from cfme.web_ui import match_location
 from cfme.utils.appliance import BaseCollection, BaseEntity
@@ -354,16 +354,6 @@ class Details(CFMENavigateStep):
         row = self.prerequisite_view.paginator.find_row_on_pages(
             self.prerequisite_view.table, name=self.obj.name)
         row.click()
-
-
-@navigator.register(Stack, 'EditTagsFromDetails')
-class EditTags(CFMENavigateStep):
-    VIEW = TagPageView
-    prerequisite = NavigateToSibling('Details')
-
-    def step(self, *args, **kwargs):
-        """Go to the edit tags screen"""
-        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
 
 
 @navigator.register(Stack, 'RelationshipSecurityGroups')

--- a/cfme/cloud/tenant.py
+++ b/cfme/cloud/tenant.py
@@ -10,7 +10,7 @@ from widgetastic_manageiq import (
     SummaryTable, Table, Text, BaseNonInteractiveEntitiesView, BaseEntitiesView)
 
 from cfme.base.ui import BaseLoggedInPage
-from cfme.common import TagPageView, WidgetasticTaggable
+from cfme.common import WidgetasticTaggable
 from cfme.exceptions import TenantNotFound, DestinationNotFound
 from cfme.web_ui import match_location
 from cfme.utils.appliance import BaseCollection, BaseEntity
@@ -377,13 +377,3 @@ class TenantEdit(CFMENavigateStep):
             self.prerequisite_view.toolbar.configuration.item_select('Edit Cloud Tenant')
         else:
             raise DestinationNotFound('Cannot edit Cloud Tenants in CFME < 5.7')
-
-
-@navigator.register(Tenant, 'EditTagsFromDetails')
-class TenantEditTags(CFMENavigateStep):
-    VIEW = TagPageView
-    prerequisite = NavigateToSibling('Details')
-
-    def step(self, *args, **kwargs):
-        """Navigate to the edit tags page"""
-        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')

--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from functools import partial
+from navmazing import NavigateToSibling
 from urlparse import urlparse
 from widgetastic.exceptions import NoSuchElementException, RowNotFound
 from widgetastic_patternfly import BootstrapSelect, Button
@@ -15,7 +16,7 @@ from cfme.web_ui.timelines import Timelines
 from cfme.web_ui.topology import Topology
 from cfme.web_ui.utilization import Utilization
 from sqlalchemy.orm import aliased
-from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.appliance.implementations.ui import navigate_to, navigator, CFMENavigateStep
 from cfme.utils import attributize_string, version, deferred_verpick
 from cfme.utils.units import Unit
 from cfme.utils.varmeth import variable
@@ -332,6 +333,15 @@ class WidgetasticTaggable(object):
         if not reset and not cancel:
             view.form.save.click()
             view.flash.assert_success_message('Tag edits were successfully saved')
+
+
+@navigator.register(WidgetasticTaggable, 'EditTagsFromDetails')
+class EditTagsFromDetails(CFMENavigateStep):
+    VIEW = TagPageView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
 
 
 class SummaryMixin(object):

--- a/cfme/infrastructure/cluster.py
+++ b/cfme/infrastructure/cluster.py
@@ -8,7 +8,7 @@ from widgetastic_manageiq import (Accordion, BreadCrumb, ItemsToolBarViewSelecto
 from widgetastic_patternfly import Button, Dropdown, FlashMessages
 
 from cfme.base.login import BaseLoggedInPage
-from cfme.common import TagPageView, WidgetasticTaggable
+from cfme.common import WidgetasticTaggable
 from cfme.exceptions import ItemNotFound
 from cfme.utils.appliance import BaseCollection, BaseEntity
 from cfme.utils.appliance.implementations.ui import navigate_to, navigator, CFMENavigateStep
@@ -319,12 +319,3 @@ class Timelines(CFMENavigateStep):
     def step(self, *args, **kwargs):
         """Navigate to the correct view"""
         self.prerequisite_view.toolbar.monitoring.item_select('Timelines')
-
-
-@navigator.register(Cluster, 'EditTagsFromDetails')
-class EditTagsFromDetails(CFMENavigateStep):
-    VIEW = TagPageView
-    prerequisite = NavigateToSibling('Details')
-
-    def step(self):
-        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')

--- a/cfme/infrastructure/datastore.py
+++ b/cfme/infrastructure/datastore.py
@@ -1,6 +1,6 @@
 """ A model of an Infrastructure Datastore in CFME
 """
-from navmazing import NavigateToAttribute, NavigateToSibling
+from navmazing import NavigateToAttribute
 from widgetastic.widget import View, Text
 from cfme.exceptions import ItemNotFound
 from widgetastic_manageiq import (ManageIQTree,
@@ -16,7 +16,7 @@ from widgetastic.widget import ParametrizedView
 from widgetastic_patternfly import Dropdown, Accordion, FlashMessages
 from widgetastic.utils import Version, VersionPick
 from cfme.base.login import BaseLoggedInPage
-from cfme.common import TagPageView, WidgetasticTaggable
+from cfme.common import WidgetasticTaggable
 from cfme.common.host_views import HostsView
 from cfme.utils.appliance import BaseCollection, BaseEntity
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
@@ -356,15 +356,6 @@ class DetailsFromProvider(CFMENavigateStep):
     def step(self):
         prov_view = navigate_to(self.obj.provider, 'Details')
         prov_view.contents.relationships.click_at('Datastores')
-
-
-@navigator.register(Datastore, 'EditTagsFromDetails')
-class EditTagsFromDetails(CFMENavigateStep):
-    VIEW = TagPageView
-    prerequisite = NavigateToSibling('Details')
-
-    def step(self):
-        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
 
 
 def get_all_datastores():

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -6,7 +6,7 @@ from manageiq_client.api import APIException
 from selenium.common.exceptions import NoSuchElementException
 
 from cfme.base.credential import Credential as BaseCredential
-from cfme.common import PolicyProfileAssignable, WidgetasticTaggable, TagPageView
+from cfme.common import PolicyProfileAssignable, WidgetasticTaggable
 from cfme.common.host_views import (
     HostAddView,
     HostDetailsView,
@@ -476,15 +476,6 @@ class Timelines(CFMENavigateStep):
 
     def step(self):
         self.prerequisite_view.toolbar.monitoring.item_select("Timelines")
-
-
-@navigator.register(Host)
-class EditTagsFromDetails(CFMENavigateStep):
-    VIEW = TagPageView
-    prerequisite = NavigateToSibling("Details")
-
-    def step(self):
-        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
 
 
 def get_credentials_from_config(credential_config_name):

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -285,15 +285,6 @@ class EditTags(CFMENavigateStep):
         self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
 
 
-@navigator.register(InfraProvider, 'EditTagsFromDetails')
-class EditTagsFromDetails(CFMENavigateStep):
-    VIEW = TagPageView
-    prerequisite = NavigateToSibling('Details')
-
-    def step(self):
-        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
-
-
 @navigator.register(InfraProvider, 'Edit')
 class Edit(CFMENavigateStep):
     VIEW = InfraProviderEditView

--- a/cfme/infrastructure/resource_pool.py
+++ b/cfme/infrastructure/resource_pool.py
@@ -10,7 +10,7 @@ from widgetastic.exceptions import NoSuchElementException
 from widgetastic_patternfly import Button, Dropdown, FlashMessages
 
 from cfme.base.ui import BaseLoggedInPage
-from cfme.common import TagPageView, WidgetasticTaggable
+from cfme.common import WidgetasticTaggable
 from cfme.exceptions import ResourcePoolNotFound
 from cfme.web_ui import match_location
 from cfme.utils.pretty import Pretty
@@ -250,12 +250,3 @@ class Details(CFMENavigateStep):
         except NoSuchElementException:
             raise ResourcePoolNotFound('Resource pool {} not found'.format(self.obj.name))
         row.click()
-
-
-@navigator.register(ResourcePool, 'EditTagsFromDetails')
-class EditTagsFromDetails(CFMENavigateStep):
-    VIEW = TagPageView
-    prerequisite = NavigateToSibling('Details')
-
-    def step(self):
-        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -19,7 +19,6 @@ from widgetastic_manageiq import (
 from widgetastic_manageiq.vm_reconfigure import DisksTable
 
 from cfme.base.login import BaseLoggedInPage
-from cfme.common import TagPageView
 from cfme.common.vm import VM, Template as BaseTemplate
 from cfme.common.vm_views import (
     ManagementEngineView, ProvisionView, EditView, RetirementView, VMDetailsEntities, VMToolbar,
@@ -1326,13 +1325,3 @@ class VmEngineRelationship(CFMENavigateStep):
     def step(self):
         self.prerequisite_view.toolbar.configuration.item_select(
             'Edit Management Engine Relationship')
-
-
-@navigator.register(Template, 'EditTagsFromDetails')
-@navigator.register(Vm, 'EditTagsFromDetails')
-class EditTagsFromDetails(CFMENavigateStep):
-    VIEW = TagPageView
-    prerequisite = NavigateToSibling('Details')
-
-    def step(self):
-        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')

--- a/cfme/networks/balancer.py
+++ b/cfme/networks/balancer.py
@@ -1,6 +1,6 @@
-from navmazing import NavigateToSibling, NavigateToAttribute
+from navmazing import NavigateToAttribute
 
-from cfme.common import WidgetasticTaggable, TagPageView
+from cfme.common import WidgetasticTaggable
 from cfme.exceptions import ItemNotFound
 from cfme.networks.views import BalancerDetailsView, BalancerView
 from cfme.utils import version
@@ -88,12 +88,3 @@ class Details(CFMENavigateStep):
 
     def step(self):
         self.prerequisite_view.entities.get_entity(by_name=self.obj.name).click()
-
-
-@navigator.register(Balancer, 'EditTagsFromDetails')
-class EditTags(CFMENavigateStep):
-    VIEW = TagPageView
-    prerequisite = NavigateToSibling('Details')
-
-    def step(self):
-        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')

--- a/cfme/networks/cloud_network.py
+++ b/cfme/networks/cloud_network.py
@@ -1,6 +1,6 @@
-from navmazing import NavigateToSibling, NavigateToAttribute
+from navmazing import NavigateToAttribute
 
-from cfme.common import WidgetasticTaggable, TagPageView
+from cfme.common import WidgetasticTaggable
 from cfme.exceptions import ItemNotFound
 from cfme.networks.views import CloudNetworkDetailsView, CloudNetworkView
 from cfme.utils import providers, version
@@ -87,12 +87,3 @@ class Details(CFMENavigateStep):
 
     def step(self):
         self.prerequisite_view.entities.get_entity(by_name=self.obj.name).click()
-
-
-@navigator.register(CloudNetwork, 'EditTagsFromDetails')
-class EditTags(CFMENavigateStep):
-    VIEW = TagPageView
-    prerequisite = NavigateToSibling('Details')
-
-    def step(self):
-        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')

--- a/cfme/networks/network_port.py
+++ b/cfme/networks/network_port.py
@@ -1,6 +1,6 @@
-from navmazing import NavigateToSibling, NavigateToAttribute
+from navmazing import NavigateToAttribute
 
-from cfme.common import WidgetasticTaggable, TagPageView
+from cfme.common import WidgetasticTaggable
 from cfme.exceptions import ItemNotFound
 from cfme.networks.views import NetworkPortDetailsView, NetworkPortView
 from cfme.utils import version
@@ -99,12 +99,3 @@ class Details(CFMENavigateStep):
 
     def step(self):
         self.prerequisite_view.entities.get_entity(by_name=self.obj.name).click()
-
-
-@navigator.register(NetworkPort, 'EditTagsFromDetails')
-class EditTags(CFMENavigateStep):
-    VIEW = TagPageView
-    prerequisite = NavigateToSibling('Details')
-
-    def step(self):
-        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')

--- a/cfme/networks/network_router.py
+++ b/cfme/networks/network_router.py
@@ -1,6 +1,6 @@
-from navmazing import NavigateToSibling, NavigateToAttribute
+from navmazing import NavigateToAttribute
 
-from cfme.common import WidgetasticTaggable, TagPageView
+from cfme.common import WidgetasticTaggable
 from cfme.exceptions import ItemNotFound
 from cfme.networks.views import NetworkRouterDetailsView, NetworkRouterView
 from cfme.utils import version
@@ -76,12 +76,3 @@ class Details(CFMENavigateStep):
 
     def step(self):
         self.prerequisite_view.entities.get_entity(by_name=self.obj.name).click()
-
-
-@navigator.register(NetworkRouter, 'EditTagsFromDetails')
-class EditTags(CFMENavigateStep):
-    VIEW = TagPageView
-    prerequisite = NavigateToSibling('Details')
-
-    def step(self):
-        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')

--- a/cfme/networks/provider/__init__.py
+++ b/cfme/networks/provider/__init__.py
@@ -1,7 +1,7 @@
 from navmazing import NavigateToSibling, NavigateToAttribute
 from cached_property import cached_property
 
-from cfme.common import WidgetasticTaggable, TagPageView
+from cfme.common import WidgetasticTaggable
 from cfme.common.provider import BaseProvider
 from cfme.exceptions import ItemNotFound
 from cfme.networks.balancer import BalancerCollection
@@ -209,12 +209,3 @@ class OpenTopologyFromDetails(CFMENavigateStep):
 
     def step(self):
         self.prerequisite_view.entities.overview.click_at('Topology')
-
-
-@navigator.register(NetworkProvider, 'EditTagsFromDetails')
-class EditTags(CFMENavigateStep):
-    VIEW = TagPageView
-    prerequisite = NavigateToSibling('Details')
-
-    def step(self):
-        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')

--- a/cfme/networks/security_group.py
+++ b/cfme/networks/security_group.py
@@ -1,6 +1,6 @@
-from navmazing import NavigateToSibling, NavigateToAttribute
+from navmazing import NavigateToAttribute
 
-from cfme.common import WidgetasticTaggable, TagPageView
+from cfme.common import WidgetasticTaggable
 from cfme.exceptions import ItemNotFound
 from cfme.networks.views import SecurityGroupDetailsView, SecurityGroupView
 from cfme.utils import version
@@ -76,12 +76,3 @@ class Details(CFMENavigateStep):
 
     def step(self):
         self.prerequisite_view.entities.get_entity(by_name=self.obj.name).click()
-
-
-@navigator.register(SecurityGroup, 'EditTagsFromDetails')
-class EditTags(CFMENavigateStep):
-    VIEW = TagPageView
-    prerequisite = NavigateToSibling('Details')
-
-    def step(self):
-        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')

--- a/cfme/networks/subnet.py
+++ b/cfme/networks/subnet.py
@@ -1,6 +1,6 @@
-from navmazing import NavigateToSibling, NavigateToAttribute
+from navmazing import NavigateToAttribute
 
-from cfme.common import WidgetasticTaggable, TagPageView
+from cfme.common import WidgetasticTaggable
 from cfme.exceptions import ItemNotFound
 from cfme.networks.views import SubnetDetailsView, SubnetView
 from cfme.utils import providers, version
@@ -88,12 +88,3 @@ class OpenCloudNetworks(CFMENavigateStep):
 
     def step(self):
         self.prerequisite_view.entities.get_entity(by_name=self.obj.name).click()
-
-
-@navigator.register(Subnet, 'EditTagsFromDetails')
-class EditTags(CFMENavigateStep):
-    prerequisite = NavigateToSibling('Details')
-    VIEW = TagPageView
-
-    def step(self):
-        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')

--- a/cfme/services/catalogs/catalog.py
+++ b/cfme/services/catalogs/catalog.py
@@ -4,7 +4,7 @@ from widgetastic_manageiq import MultiBoxSelect
 from widgetastic_patternfly import Button, Input
 from navmazing import NavigateToAttribute, NavigateToSibling
 
-from cfme.common import TagPageView, WidgetasticTaggable
+from cfme.common import WidgetasticTaggable
 from cfme.utils.update import Updateable
 from cfme.utils.pretty import Pretty
 from cfme.utils.appliance import Navigatable
@@ -183,12 +183,3 @@ class Edit(CFMENavigateStep):
 
     def step(self):
         self.prerequisite_view.configuration.item_select('Edit this Item')
-
-
-@navigator.register(Catalog, 'EditTagsFromDetails')
-class EditTagsFromDetails(CFMENavigateStep):
-    VIEW = TagPageView
-    prerequisite = NavigateToSibling('Details')
-
-    def step(self):
-        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')

--- a/cfme/services/catalogs/orchestration_template.py
+++ b/cfme/services/catalogs/orchestration_template.py
@@ -3,7 +3,7 @@ from widgetastic.widget import Text, Checkbox
 from widgetastic_patternfly import BootstrapSelect, Button, Input
 from widgetastic_manageiq import ScriptBox, Table
 from navmazing import NavigateToAttribute, NavigateToSibling
-from cfme.common import TagPageView, WidgetasticTaggable
+from cfme.common import WidgetasticTaggable
 from cfme.utils.update import Updateable
 from cfme.utils.pretty import Pretty
 from cfme.utils.appliance import Navigatable
@@ -272,12 +272,3 @@ class CopyTemplate(CFMENavigateStep):
 
     def step(self):
         self.view.configuration.item_select("Copy this Orchestration Template")
-
-
-@navigator.register(OrchestrationTemplate, 'EditTagsFromDetails')
-class EditTagsFromDetails(CFMENavigateStep):
-    VIEW = TagPageView
-    prerequisite = NavigateToSibling('Details')
-
-    def step(self):
-        self.prerequisite_view.policy.item_select('Edit Tags')

--- a/cfme/storage/manager.py
+++ b/cfme/storage/manager.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from navmazing import NavigateToAttribute, NavigateToSibling
+from navmazing import NavigateToAttribute
 from widgetastic.utils import Version, VersionPick
 from widgetastic.widget import View, NoSuchElementException, Text
 from widgetastic_manageiq import (
@@ -19,7 +19,7 @@ from widgetastic_patternfly import (
 )
 
 from cfme.base.ui import BaseLoggedInPage
-from cfme.common import TagPageView, WidgetasticTaggable
+from cfme.common import WidgetasticTaggable
 from cfme.exceptions import ItemNotFound
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
 from cfme.utils.appliance import BaseCollection, BaseEntity
@@ -216,13 +216,3 @@ class StorageManagerDetails(CFMENavigateStep):
             row.click()
         except NoSuchElementException:
             raise ItemNotFound('Could not locate {}'.format(self.obj.name))
-
-
-@navigator.register(StorageManager, 'EditTagsFromDetails')
-class StorageObjectDetailEditTag(CFMENavigateStep):
-    """ This navigation destination help to WidgetasticTaggable"""
-    VIEW = TagPageView
-    prerequisite = NavigateToSibling('Details')
-
-    def step(self, *args, **kwargs):
-        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')


### PR DESCRIPTION
Purpose or Intent
=================
Move common "EditTagsFromDetails" navigation step to WidgetasticTaggable class
Should be merged after https://github.com/ManageIQ/integration_tests/pull/5425

{{pytest: -v -k 'test_tagvis_cloud_object or test_tagvis_infra_object'}}