### PR TITLE
[1LP][RFR] Dialog fixture using REST API

### DIFF
--- a/cfme/fixtures/service_fixtures.py
+++ b/cfme/fixtures/service_fixtures.py
@@ -2,8 +2,8 @@
 import fauxfactory
 import pytest
 
-from cfme.automate.service_dialogs import DialogCollection
 from cfme.common.provider import cleanup_vm
+from cfme.rest.gen_data import dialog as _dialog
 from cfme.services.catalogs.catalog import Catalog
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.catalogs.service_catalogs import ServiceCatalogs
@@ -11,26 +11,9 @@ from cfme.services.requests import RequestCollection
 from cfme.utils.log import logger
 
 
-@pytest.yield_fixture(scope="function")
-def dialog(appliance):
-    service_dialogs = DialogCollection(appliance)
-    dialog = fauxfactory.gen_alphanumeric()
-    element_data = dict(
-        ele_label="ele_" + fauxfactory.gen_alphanumeric(),
-        ele_name="service_name",
-        ele_desc="my ele desc",
-        choose_type="Text Box",
-        default_text_box=dialog
-    )
-
-    sd = service_dialogs.create(label=dialog,
-        description="my dialog", submit=True, cancel=True,)
-    tab = sd.tabs.create(tab_label='tab_' + fauxfactory.gen_alphanumeric(),
-        tab_desc="my tab desc")
-    box = tab.boxes.create(box_label='box_' + fauxfactory.gen_alphanumeric(),
-        box_desc="my box desc")
-    box.elements.create(element_data=[element_data])
-    yield sd
+@pytest.fixture(scope="function")
+def dialog(request, appliance):
+    return _dialog(request, appliance)
 
 
 @pytest.yield_fixture(scope="function")

--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -80,23 +80,70 @@ def tags(request, rest_api, categories):
     return _creating_skeleton(request, rest_api, 'tags', tags, substr_search=True)
 
 
-def dialog(appliance):
+def dialog_rest(request, rest_api, label=None, description=None, submit=False, cancel=False):
+    """Creates service dialog using REST API."""
+    uid = fauxfactory.gen_alphanumeric()
+    data = {
+        "description": description or "my dialog {}".format(uid),
+        "label": label or "dialog_{}".format(uid),
+        "dialog_tabs": [{
+            "description": "my tab desc {}".format(uid),
+            "position": 0,
+            "label": "tab_{}".format(uid),
+            "display": "edit",
+            "dialog_groups": [{
+                "description": "my box desc {}".format(uid),
+                "label": "box_{}".format(uid),
+                "display": "edit",
+                "position": 0,
+                "dialog_fields": [{
+                    "name": "ele{}".format(uid),
+                    "description": "my ele desc {}".format(uid),
+                    "label": "ele_{}".format(uid),
+                    "data_type": "string",
+                    "display": "edit",
+                    "required": False,
+                    "default_value": "default value",
+                    "options": {
+                        "protected": False
+                    },
+                    "position": 0,
+                    "dynamic": False,
+                    "read_only": False,
+                    "visible": True,
+                    "type": "DialogFieldTextBox",
+                    "resource_action": {
+                        "resource_type": "DialogField",
+                        "ae_attributes": {}
+                    }
+                }]
+            }]
+        }]
+    }
+
+    buttons = []
+    if submit:
+        buttons.append("submit")
+    if cancel:
+        buttons.append("cancel")
+    buttons = ",".join(buttons)
+    if buttons:
+        data["buttons"] = buttons
+
+    service_dialog = _creating_skeleton(request, rest_api, "service_dialogs", [data])
+    return service_dialog[0]
+
+
+def dialog(request, appliance):
+    """Returns service dialog object."""
+    rest_resource = dialog_rest(request, appliance.rest_api, submit=True, cancel=True)
     service_dialogs = appliance.get(DialogCollection)
-    dialog = "dialog_{}".format(fauxfactory.gen_alphanumeric())
-    element_data = dict(
-        ele_label="ele_{}".format(fauxfactory.gen_alphanumeric()),
-        ele_name=fauxfactory.gen_alphanumeric(),
-        ele_desc="my ele desc",
-        choose_type="Text Box",
-        default_text_box="default value"
+    service_dialog = service_dialogs.instantiate(
+        label=rest_resource.label,
+        description=rest_resource.description,
+        submit=True,
+        cancel=True
     )
-    service_dialog = service_dialogs.create(label=dialog,
-        description="my dialog", submit=True, cancel=True,)
-    tab = service_dialog.tabs.create(tab_label='tab_' + fauxfactory.gen_alphanumeric(),
-        tab_desc="my tab desc")
-    box = tab.boxes.create(box_label='box_' + fauxfactory.gen_alphanumeric(),
-        box_desc="my box desc")
-    box.elements.create(element_data=[element_data])
     return service_dialog
 
 
@@ -203,7 +250,7 @@ def vm(request, a_provider, rest_api):
 def service_templates_ui(request, appliance, service_dialog=None, service_catalog=None,
         a_provider=None, num=4):
     if not service_dialog:
-        service_dialog = dialog(appliance)
+        service_dialog = dialog(request, appliance)
     if not service_catalog:
         service_catalog = service_catalog_obj(request, appliance.rest_api)
 
@@ -275,7 +322,7 @@ def service_templates_ui(request, appliance, service_dialog=None, service_catalo
 
 def service_templates_rest(request, appliance, service_dialog=None, service_catalog=None, num=4):
     if not service_dialog:
-        service_dialog = dialog(appliance)
+        service_dialog = dialog(request, appliance)
     if not service_catalog:
         service_catalog = service_catalog_obj(request, appliance.rest_api)
 

--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -80,7 +80,7 @@ def tags(request, rest_api, categories):
     return _creating_skeleton(request, rest_api, 'tags', tags, substr_search=True)
 
 
-def dialog_ui(appliance, label=None, description=None, submit=False, cancel=False):
+def dialog_ui(appliance):
     """Creates service dialog using UI."""
     service_dialogs = appliance.get(DialogCollection)
     uid = fauxfactory.gen_alphanumeric()
@@ -92,10 +92,10 @@ def dialog_ui(appliance, label=None, description=None, submit=False, cancel=Fals
         default_text_box="default value"
     )
     service_dialog = service_dialogs.create(
-        label=label or "dialog_{}".format(uid),
-        description=description or "my dialog {}".format(uid),
-        submit=submit,
-        cancel=cancel
+        label="dialog_{}".format(uid),
+        description="my dialog {}".format(uid),
+        submit=True,
+        cancel=True
     )
     tab = service_dialog.tabs.create(
         tab_label="tab_{}".format(uid),
@@ -109,12 +109,13 @@ def dialog_ui(appliance, label=None, description=None, submit=False, cancel=Fals
     return service_dialog
 
 
-def dialog_rest(request, rest_api, label=None, description=None, submit=False, cancel=False):
+def dialog_rest(request, rest_api):
     """Creates service dialog using REST API."""
     uid = fauxfactory.gen_alphanumeric()
     data = {
-        "description": description or "my dialog {}".format(uid),
-        "label": label or "dialog_{}".format(uid),
+        "description": "my dialog {}".format(uid),
+        "label": "dialog_{}".format(uid),
+        "buttons": "submit,cancel",
         "dialog_tabs": [{
             "description": "my tab desc {}".format(uid),
             "position": 0,
@@ -150,15 +151,6 @@ def dialog_rest(request, rest_api, label=None, description=None, submit=False, c
         }]
     }
 
-    buttons = []
-    if submit:
-        buttons.append("submit")
-    if cancel:
-        buttons.append("cancel")
-    buttons = ",".join(buttons)
-    if buttons:
-        data["buttons"] = buttons
-
     service_dialog = _creating_skeleton(request, rest_api, "service_dialogs", [data])
     return service_dialog[0]
 
@@ -167,10 +159,10 @@ def dialog(request, appliance):
     """Returns service dialog object."""
     # action "create" is not supported in version < 5.8, use UI
     if version.current_version() < '5.8':
-        return dialog_ui(appliance, submit=True, cancel=True)
+        return dialog_ui(appliance)
 
     # setup dialog using REST API
-    rest_resource = dialog_rest(request, appliance.rest_api, submit=True, cancel=True)
+    rest_resource = dialog_rest(request, appliance.rest_api)
     service_dialogs = appliance.get(DialogCollection)
     service_dialog = service_dialogs.instantiate(
         label=rest_resource.label,

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -15,7 +15,6 @@ from cfme.rest.gen_data import (
     blueprints as _blueprints,
     copy_role,
     dialog as _dialog,
-    dialog_rest as _dialog_rest,
     groups,
     orchestration_templates as _orchestration_templates,
     service_catalog_obj as _service_catalog_obj,
@@ -91,11 +90,6 @@ def service_body(**kwargs):
 @pytest.fixture(scope="function")
 def dialog(request, appliance):
     return _dialog(request, appliance)
-
-
-@pytest.fixture(scope="function")
-def dialog_rest(request, appliance):
-    return _dialog_rest(request, appliance.rest_api, submit=True, cancel=True)
 
 
 @pytest.fixture(scope="function")
@@ -572,16 +566,18 @@ class TestServiceRESTAPI(object):
 
 class TestServiceDialogsRESTAPI(object):
     @pytest.mark.parametrize("method", ["post", "delete"])
-    def test_delete_service_dialog(self, appliance, dialog_rest, method):
+    def test_delete_service_dialog(self, appliance, dialog, method):
         """Tests deleting service dialogs from detail.
 
         Metadata:
             test_flag: rest
         """
+        service_dialog = appliance.rest_api.collections.service_dialogs.get(label=dialog.label)
+
         if method == "delete":
-            del_action = dialog_rest.action.delete.DELETE
+            del_action = service_dialog.action.delete.DELETE
         else:
-            del_action = dialog_rest.action.delete.POST
+            del_action = service_dialog.action.delete.POST
 
         del_action()
         assert_response(appliance)
@@ -589,16 +585,17 @@ class TestServiceDialogsRESTAPI(object):
             del_action()
         assert_response(appliance, http_status=404)
 
-    def test_delete_service_dialogs(self, appliance, dialog_rest):
+    def test_delete_service_dialogs(self, appliance, dialog):
         """Tests deleting service dialogs from collection.
 
         Metadata:
             test_flag: rest
         """
-        appliance.rest_api.collections.service_dialogs.action.delete(dialog_rest)
+        service_dialog = appliance.rest_api.collections.service_dialogs.get(label=dialog.label)
+        appliance.rest_api.collections.service_dialogs.action.delete(service_dialog)
         assert_response(appliance)
         with error.expected("ActiveRecord::RecordNotFound"):
-            appliance.rest_api.collections.service_dialogs.action.delete(dialog_rest)
+            appliance.rest_api.collections.service_dialogs.action.delete(service_dialog)
         assert_response(appliance, http_status=404)
 
 


### PR DESCRIPTION
As discussed with @psav and @sshveta, this makes the ``dialog`` fixture use REST API as it's more reliable than the UI.

{{pytest: -v --long-running cfme/tests/services/test_service_catalogs.py}}

**PRT**
Some timeout errors and failed soft asserts due to timeout errors, nothing related to dialog creation.