### PR TITLE
[1LP][RFR] Fix to test_appliance_console smoke test

### DIFF
--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -29,8 +29,8 @@ tzs = [
 
 @pytest.mark.smoke
 def test_black_console(appliance):
-    """'exec > >(tee /tmp/opt.txt)' saves stdout to file, 'ap' launch appliance_console."""
-    command_set = ('exec > >(tee /tmp/opt.txt)', 'ap')
+    """'ap | tee /tmp/opt.txt)' saves stdout to file, 'ap' launch appliance_console."""
+    command_set = ('ap | tee -a /tmp/opt.txt', 'ap')
     appliance.appliance_console.run_commands(command_set)
     assert appliance.ssh_client.run_command("cat /tmp/opt.txt | grep '{} Virtual Appliance'"
                                             .format(appliance.product_name))


### PR DESCRIPTION
Smoke test was randomly failing, changed the collection method of command output to fix the issue.
{{pytest: -v test_appliance_console.py::test_black_console}}