### PR TITLE
[1LP][RFR] Ability to choose template for console tests by parametarizing the order_catalog_items_in_ops_ui

### DIFF
--- a/cfme/tests/ssui/test_ssui_myservice.py
+++ b/cfme/tests/ssui/test_ssui_myservice.py
@@ -49,3 +49,10 @@ def test_myservice_crud(setup_provider, context, order_catalog_item_in_ops_ui):
         myservice = MyService(appliance, service_name)
         myservice.update({'name': '{}_edited'.format(service_name)})
         # TODO - add rest of myservice crud like delete in next phase.
+
+
+@pytest.mark.uncollectif(lambda: current_version() < '5.8')
+@pytest.mark.parametrize('context', [ViaSSUI])
+@pytest.mark.parametrize('order_catalog_item_in_ops_ui', [['console_test']], indirect=True)
+def test_vm_console(setup_provider, context, configure_websocket, order_catalog_item_in_ops_ui):
+    pass


### PR DESCRIPTION
Purpose or Intent
=================

__Extending__ order_catalog_item_in_ops_ui fixture to accept 'console_test' parameter so that I can use the same fixture for Console tests in SSUI and any other test in SSUI. The difference that this fixture will make when passed 'console_test' parameter is that, it will choose the console_template from templates section of yaml rather than template sub-section of Provisioning section of yamls.

{{pytest: -v --long-running cfme/tests/ssui/test_ssui_myservice.py -k 'test_vm_console'  }}