### PR TITLE
[1LP][RFR] Open vm console ssui

### DIFF
--- a/cfme/services/myservice/__init__.py
+++ b/cfme/services/myservice/__init__.py
@@ -22,6 +22,7 @@ class MyService(Updateable, Navigatable, WidgetasticTaggable, sentaku.modeling.E
     check_vm_add = sentaku.ContextualMethod()
     download_file = sentaku.ContextualMethod()
     reconfigure_service = sentaku.ContextualMethod()
+    launch_vm_console = sentaku.ContextualMethod()
 
     def __init__(self, appliance, name=None, description=None, vm_name=None):
         self.appliance = appliance

--- a/cfme/services/myservice/ssui.py
+++ b/cfme/services/myservice/ssui.py
@@ -1,6 +1,6 @@
 from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.widget import Text
-from widgetastic_manageiq import SSUIlist, SSUIDropdown
+from widgetastic_manageiq import SSUIlist, SSUIDropdown, SSUIAppendToBodyDropdown
 from widgetastic_patternfly import Input, Button
 
 from cfme.base.ssui import SSUIBaseLoggedInPage
@@ -40,7 +40,8 @@ class DetailsMyServiceView(MyServicesView):
     configuration = SSUIDropdown('Configuration')
     policy_btn = SSUIDropdown('Policy')
     lifecycle_btn = SSUIDropdown('Lifecycle')
-    power_operations = SSUIDropdown('Download')
+    power_operations = SSUIDropdown('Power Operations')
+    access_dropdown = SSUIAppendToBodyDropdown('Access')
 
 
 class ServiceEditForm(MyServicesView):
@@ -78,6 +79,11 @@ def update(self, updates):
     # TODO - implement notifications and then assert.
 
 
+@MyService.launch_vm_console.external_implementation_for(ViaSSUI)
+def launch_vm_console(self):
+    navigate_to(self, 'VM Console')
+
+
 @navigator.register(MyService, 'All')
 class MyServiceAll(SSUINavigateStep):
     VIEW = MyServicesView
@@ -106,3 +112,13 @@ class MyServiceEdit(SSUINavigateStep):
 
     def step(self):
         self.prerequisite_view.configuration.item_select('Edit')
+
+
+@navigator.register(MyService, 'VM Console')
+class LaunchVMConsole(SSUINavigateStep):
+    VIEW = EditMyServiceView
+
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        self.prerequisite_view.access_dropdown.item_select('VM Console')

--- a/cfme/tests/ssui/test_ssui_myservice.py
+++ b/cfme/tests/ssui/test_ssui_myservice.py
@@ -5,7 +5,7 @@ from cfme.infrastructure.provider import InfraProvider
 from cfme.services.myservice import MyService
 from cfme import test_requirements
 from cfme.utils import testgen
-from cfme.utils.appliance import get_or_create_current_appliance, ViaSSUI
+from cfme.utils.appliance import ViaSSUI
 from cfme.utils.log import logger
 from cfme.utils.version import current_version
 
@@ -27,7 +27,6 @@ pytest_generate_tests = testgen.generate([InfraProvider], required_fields=[
 def configure_websocket(appliance):
     """
     Enable websocket role if it is disabled.
-
     Currently the fixture cfme/fixtures/base.py:27,
     disables the websocket role to avoid intrusive popups.
     """
@@ -40,9 +39,8 @@ def configure_websocket(appliance):
 
 @pytest.mark.uncollectif(lambda: current_version() < '5.8')
 @pytest.mark.parametrize('context', [ViaSSUI])
-def test_myservice_crud(setup_provider, context, order_catalog_item_in_ops_ui):
+def test_myservice_crud(appliance, setup_provider, context, order_catalog_item_in_ops_ui):
     """Tests Myservice crud in SSUI."""
-    appliance = get_or_create_current_appliance()
     service_name = order_catalog_item_in_ops_ui
     with appliance.context.use(context):
         appliance.server.login()
@@ -54,5 +52,11 @@ def test_myservice_crud(setup_provider, context, order_catalog_item_in_ops_ui):
 @pytest.mark.uncollectif(lambda: current_version() < '5.8')
 @pytest.mark.parametrize('context', [ViaSSUI])
 @pytest.mark.parametrize('order_catalog_item_in_ops_ui', [['console_test']], indirect=True)
-def test_vm_console(setup_provider, context, configure_websocket, order_catalog_item_in_ops_ui):
-    pass
+def test_vm_console(appliance, setup_provider, context, configure_websocket,
+        order_catalog_item_in_ops_ui):
+    """Tests Myservice VM Console in SSUI."""
+    service_name = order_catalog_item_in_ops_ui
+    with appliance.context.use(context):
+        appliance.server.login()
+        myservice = MyService(appliance, service_name)
+        myservice.launch_vm_console()

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -1204,6 +1204,18 @@ class SSUIDropdown(Dropdown):
         self.text = text
 
 
+class SSUIAppendToBodyDropdown(Dropdown):
+    """This is a special dropdown where the dropdown options
+       are appended to the body and not to the dropdown."""
+
+    ITEMS_LOCATOR = '//ul[contains(@class, "dropdown-menu")]/li/a'
+    ITEM_LOCATOR = '//ul[contains(@class, "dropdown-menu")]/li/a[normalize-space(.)={}]'
+
+    def __init__(self, parent, text, logger=None):
+        Widget.__init__(self, parent, logger=logger)
+        self.text = text
+
+
 class SSUIPrimarycard(Widget, ClickableMixin):
     """Represents a primary card on dashboard like Total Service or Total Requests."""
 


### PR DESCRIPTION
Purpose or Intent
=================

__Adding tests__ for feature VM Console in SSUI. In this PR, actual test is not added, but the groundwork for being able to navigate to the "Access" Dropdown of a service and clicking "VM Console" from the dropdown is done. 

{{pytest: -v --long-running cfme/tests/ssui/test_ssui_myservice.py -k 'test_vm_console' }}