### PR TITLE
[1LP][RFR] Update request, get description from cells

### DIFF
--- a/cfme/services/requests.py
+++ b/cfme/services/requests.py
@@ -42,7 +42,7 @@ class Request(BaseEntity):
         """
         self.collection = collection
         self.appliance = self.collection.appliance
-        self.description = description
+        self.description = description or cells.get('Description')
         self.partial_check = partial_check
         self.cells = cells or {'Description': self.description}
         self.row = None
@@ -225,6 +225,10 @@ class Request(BaseEntity):
         if view.form.fill(values):
             if not cancel:
                 view.form.submit_button.click()
+                # TODO remove this hack for description update that anchors the request
+                if values.get('Description'):
+                    self.description = values['Description']
+                    self.cells.update({'Description': self.description})
                 self.update()
             else:
                 view.cancel_button.click()

--- a/cfme/tests/infrastructure/test_provisioning.py
+++ b/cfme/tests/infrastructure/test_provisioning.py
@@ -147,7 +147,9 @@ def test_provision_approval(appliance, setup_provider, provider, vm_name, smtp_t
     if edit:
         # Automatic approval after editing the request to conform
         new_vm_name = vm_name + "-xx"
-        modifications = {'catalog': {'num_vms': "1", 'vm_name': new_vm_name}}
+        modifications = {
+            'catalog': {'num_vms': "1", 'vm_name': new_vm_name},
+            'Description': 'Provision from [{}] to [{}]'.format(template, new_vm_name)}
         provision_request.edit_request(values=modifications)
         vm_names = [new_vm_name]  # Will be just one now
         request.addfinalizer(


### PR DESCRIPTION
This is kinda hackish, but @mfalesni identified a failure where after editing a request navigation failed.

I believe the core failure is not in updating the description as the request is edited to change some values (number of vms), but because the description was never set because only `cells` was passed to the Request constructor.

RHCFQE-4868

## PRT Results

* 57z: webdriver exceptions during smtp setup, not related to these change, test_operations passed
* 58z: success
* upstream: Requests table isn't recognized/found in xpath, larger bug at play.

{{pytest: cfme/tests/infrastructure/test_provisioning.py cfme/tests/services/test_operations.py --use-provider vsphere6-nested --use-provider ec2west --long-running -v }}