### PR TITLE
[WIPTEST]Fix teardown for test_alerts.py

### DIFF
--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -157,6 +157,8 @@ def setup_candu(appliance):
         'ems_metrics_coordinator', 'ems_metrics_collector', 'ems_metrics_processor')
     yield
     candu.disable_all()
+    appliance.server.settings.disable_server_roles(
+        'ems_metrics_coordinator', 'ems_metrics_collector', 'ems_metrics_processor')
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Purpose or Intent
=================
Add teardown for server roles for test_alerts.py

{{pytest: -v cfme/tests/control/test_alerts.py}}