### PR TITLE
[1LP][RFR] Update services/test_rest_services, service names and collection fixtures

### DIFF
--- a/cfme/automate/explorer/instance.py
+++ b/cfme/automate/explorer/instance.py
@@ -105,7 +105,9 @@ class InstanceEditView(AutomateExplorerView):
     @ParametrizedView.nested
     class fields(ParametrizedView):  # noqa
         PARAMETERS = ('name', )
-        ROOT = ParametrizedLocator('.//tr[./td[1][contains(normalize-space(.), "({name})")]]')
+        ROOT = ParametrizedLocator('//h3[normalize-space(.)="Fields"]'
+                                   '/following-sibling::table'
+                                   '//tr[./td[1][contains(normalize-space(.), "({name})")]]')
         ALL_FIELDS = './/table//tr/td[1]'
 
         @cached_property

--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import re
-
 import fauxfactory
 
 from cfme.exceptions import OptionNotAvailable
@@ -209,8 +207,8 @@ def services(request, appliance, a_provider, service_dialog=None, service_catalo
     assert 'error' not in service_request.message.lower(), \
         'Provisioning failed with the message `{}`'.format(service_request.message)
 
-    service_name = re.search(
-        r'\[({}[0-9-]*)\] '.format(template_subcollection.name), service_request.message).group(1)
+    service_name = str(service_request.options['dialog']['dialog_service_name'])
+    assert '[{}]'.format(service_name) in service_request.message
     provisioned_service = appliance.rest_api.collections.services.get(name=service_name)
 
     @request.addfinalizer


### PR DESCRIPTION
test is trying to get ordered service name from request message, but was
adding in the template name, which isn't present in 58z

As @mkoura suggested, get the dialog name from the request options, this is the service name.


RHCFQE-4905

## PRT Results
* **58z 75% passing**
There are 2 failures in 58z that I'd like to leave to @mkoura if he's alright with that. This PR fixes ~10 failures in the rest test in the latest builds because of UI changes and framework collections changes.

Limiting PRT to test cases that were modified
{{pytest: cfme/tests/services/test_rest_services.py --long-running -v -k "test_order_single_catalog_item or test_order_multiple_catalog_items or test_order_catalog_bundle or test_order_manual_approval or test_user_item_order or test_order_cart or test_power_service" }}