### PR TITLE
[1LP][RFR] Verify RBAC User/Group/Role is highlighted in accordion when Details view is displayed

### DIFF
--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -77,7 +77,9 @@ class DetailsUserView(ConfigurationView):
     def is_displayed(self):
         return (
             self.title.text == 'EVM User "{}"'.format(self.context['object'].name) and
-            self.accordions.accesscontrol.is_opened
+            self.accordions.accesscontrol.is_opened and
+            (self.accordions.accesscontrol.tree.selected_item.text ==
+                self.context['object'].name)
         )
 
 
@@ -475,7 +477,9 @@ class DetailsGroupView(ConfigurationView):
     def is_displayed(self):
         return (
             self.accordions.accesscontrol.is_opened and
-            self.title.text == 'EVM Group "{}"'.format(self.context['object'].description)
+            self.title.text == 'EVM Group "{}"'.format(self.context['object'].description) and
+            (self.accordions.accesscontrol.tree.selected_item.text ==
+                self.context['object'].description)
         )
 
 
@@ -955,7 +959,9 @@ class DetailsRoleView(RoleForm):
     def is_displayed(self):
         return (
             self.accordions.accesscontrol.is_opened and
-            self.title.text == 'Role "{}"'.format(self.context['object'].name)
+            self.title.text == 'Role "{}"'.format(self.context['object'].name) and
+            (self.accordions.accesscontrol.tree.selected_item.text ==
+                self.context['object'].name)
         )
 
 

--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -78,8 +78,9 @@ class DetailsUserView(ConfigurationView):
         return (
             self.title.text == 'EVM User "{}"'.format(self.context['object'].name) and
             self.accordions.accesscontrol.is_opened and
-            (self.accordions.accesscontrol.tree.selected_item.text ==
-                self.context['object'].name)
+            # tree.currently_selected returns a list of strings with each item being the text of
+            # each level of the accordion. Last element should be the User's name
+            self.accordions.accesscontrol.tree.currently_selected[-1] == self.context['object'].name
         )
 
 
@@ -478,7 +479,9 @@ class DetailsGroupView(ConfigurationView):
         return (
             self.accordions.accesscontrol.is_opened and
             self.title.text == 'EVM Group "{}"'.format(self.context['object'].description) and
-            (self.accordions.accesscontrol.tree.selected_item.text ==
+            # tree.currently_selected returns a list of strings with each item being the text of
+            # each level of the accordion. Last element should be the Group's name
+            (self.accordions.accesscontrol.tree.currently_selected[-1] ==
                 self.context['object'].description)
         )
 
@@ -960,8 +963,9 @@ class DetailsRoleView(RoleForm):
         return (
             self.accordions.accesscontrol.is_opened and
             self.title.text == 'Role "{}"'.format(self.context['object'].name) and
-            (self.accordions.accesscontrol.tree.selected_item.text ==
-                self.context['object'].name)
+            # tree.currently_selected returns a list of strings with each item being the text of
+            # each level of the accordion. Last element should be the Role's name
+            self.accordions.accesscontrol.tree.currently_selected[-1] == self.context['object'].name
         )
 
 


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1498075

{{pytest: -v -k 'test_group_crud or test_user_crud or test_role_crud or test_delete_default_group or test_delete_default_roles or test_edit_default_group or test_edit_default_roles'}}