### PR TITLE
[1LP][RFR] Expand BZ1487199 check to versions between 5.8.2 < 5.9

### DIFF
--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -57,7 +57,7 @@ def new_user(group=usergrp):
         value_assign='Database')
 
     # Version 5.8.2 has a regression blocking logins for usernames w/ uppercase chars
-    if user.appliance.version == '5.8.2.0' and uppercase_username_bug:
+    if '5.8.2' <= user.appliance.version < '5.9' and uppercase_username_bug:
         user.credential.principal = user.credential.principal.lower()
 
     return user


### PR DESCRIPTION
BZ 1487199 Logins fail in version >= 5.8.2 when they have an uppercase character in the username. This fix is planned for 5.9 so we need to expand the BZ check to versions from 5.8.2 to < 5.9

{{pytest: -v -k 'test_user_login or test_current_user_login_delete or test_user_change_password'}}