### PR TITLE
[RFR][1LP] quadicons: support complex keys

### DIFF
--- a/cfme/ansible/playbooks.py
+++ b/cfme/ansible/playbooks.py
@@ -146,4 +146,4 @@ class Details(CFMENavigateStep):
     prerequisite = NavigateToAttribute("appliance.server", "AnsiblePlaybooks")
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True).click()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True).click()

--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -279,7 +279,7 @@ class Instance(VM, Navigatable):
         view.toolbar.view_selector.select('Grid View')
 
         try:
-            return view.entities.get_entity(by_name=self.name, surf_pages=True)
+            return view.entities.get_entity(name=self.name, surf_pages=True)
         except ItemNotFound:
             raise InstanceNotFound("Instance '{}' not found in UI!".format(self.name))
 
@@ -308,7 +308,7 @@ class Instance(VM, Navigatable):
             view = navigate_to(self, 'AllForProvider')
             view.toolbar.view_selector.select('List View')
             try:
-                row = view.entities.get_entity(by_name=self.name)
+                row = view.entities.get_entity(name=self.name)
             except ItemNotFound:
                 raise InstanceNotFound('Failed to find instance in table: {}'.format(self.name))
             row.check()
@@ -420,7 +420,7 @@ class Details(CFMENavigateStep):
     def step(self):
         self.prerequisite_view.toolbar.view_selector.select('List View')
         try:
-            row = self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True)
+            row = self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True)
         except ItemNotFound:
             raise InstanceNotFound('Failed to locate instance with name "{}"'.format(self.obj.name))
         row.click()

--- a/cfme/cloud/instance/image.py
+++ b/cfme/cloud/instance/image.py
@@ -173,7 +173,7 @@ class ImageDetails(CFMENavigateStep):
     def step(self):
         self.prerequisite_view.toolbar.view_selector.select('List View')
         try:
-            row = self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True)
+            row = self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True)
         except ItemNotFound:
             raise ImageNotFound('Failed to locate image with name "{}"'.format(self.obj.name))
         row.click()

--- a/cfme/cloud/keypairs.py
+++ b/cfme/cloud/keypairs.py
@@ -225,7 +225,7 @@ class Details(CFMENavigateStep):
 
     def step(self, *args, **kwargs):
         try:
-            item = self.prerequisite_view.entities.get_entity(by_name=self.obj.name,
+            item = self.prerequisite_view.entities.get_entity(name=self.obj.name,
                                                               surf_pages=True)
         except ItemNotFound:
             raise KeyPairNotFound

--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -123,7 +123,7 @@ class Details(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True).click()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True).click()
 
 
 @navigator.register(CloudProvider, 'Edit')
@@ -132,7 +132,7 @@ class Edit(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True).check()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True).check()
         self.prerequisite_view.toolbar.configuration.item_select('Edit Selected Cloud Provider')
 
 
@@ -151,7 +151,7 @@ class ManagePolicies(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True).check()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True).check()
         self.prerequisite_view.toolbar.policy.item_select('Manage Policies')
 
 
@@ -170,7 +170,7 @@ class EditTags(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True).check()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True).check()
         self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
 
 

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -422,7 +422,7 @@ class BaseProvider(WidgetasticTaggable, Updateable, SummaryMixin, Navigatable):
         """Clicks on Refresh relationships button in provider"""
         if from_list_view:
             view = navigate_to(self, 'All')
-            entity = view.entities.get_entity(self.name, surf_pages=True)
+            entity = view.entities.get_entity(name=self.name, surf_pages=True)
             entity.check()
 
         else:
@@ -511,7 +511,7 @@ class BaseProvider(WidgetasticTaggable, Updateable, SummaryMixin, Navigatable):
 
         def is_entity_present():
             try:
-                view.entities.get_entity(self.name, surf_pages=True)
+                view.entities.get_entity(name=self.name, surf_pages=True)
                 return True
             except ItemNotFound:
                 return False

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -328,7 +328,7 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, WidgetasticTaggable,
             search.normal_search(self.name)
 
         try:
-            return view.entities.get_entity(by_name=self.name, surf_pages=True)
+            return view.entities.get_entity(name=self.name, surf_pages=True)
         except ItemNotFound:
             raise VmOrInstanceNotFound("VM '{}' not found in UI!".format(self.name))
 

--- a/cfme/containers/container.py
+++ b/cfme/containers/container.py
@@ -10,8 +10,7 @@ from widgetastic.widget import Text
 from widgetastic.xpath import quote
 from widgetastic.utils import Version, VersionPick
 
-from cfme.containers.provider import (ContainerObjectAllBaseView, ContainerObjectDetailsBaseView,
-                                      click_row)
+from cfme.containers.provider import (ContainerObjectAllBaseView, ContainerObjectDetailsBaseView)
 from cfme.common import WidgetasticTaggable, TagPageView
 from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator
@@ -98,8 +97,8 @@ class ContainerDetails(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        click_row(self.prerequisite_view,
-                  name=self.obj.name, pod_name=self.obj.pod)
+        self.prerequisite_view.entities.get_entity(name=self.obj.name,
+                                                   pod_name=self.obj.pod).click()
 
 
 @navigator.register(Container, 'EditTags')

--- a/cfme/containers/image.py
+++ b/cfme/containers/image.py
@@ -8,9 +8,9 @@ from wrapanapi.containers.image import Image as ApiImage
 
 from cfme.common import (WidgetasticTaggable, PolicyProfileAssignable,
                          TagPageView)
-from cfme.containers.provider import (Labelable, navigate_and_get_rows,
-    ContainerObjectAllBaseView, ContainerObjectDetailsBaseView, click_row,
-    LoadDetailsMixin, refresh_and_navigate, ContainerObjectDetailsEntities)
+from cfme.containers.provider import (Labelable, navigate_and_get_rows, ContainerObjectAllBaseView,
+                                      ContainerObjectDetailsBaseView, LoadDetailsMixin,
+                                      refresh_and_navigate, ContainerObjectDetailsEntities)
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
 from cfme.utils.appliance import Navigatable
 from cfme.configure import tasks
@@ -137,8 +137,8 @@ class Details(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        click_row(self.prerequisite_view,
-            provider=self.obj.provider.name, id=self.obj.id)
+        self.prerequisite_view.entities.get_entity(provider=self.obj.provider.name,
+                                                   id=self.obj.id).click()
 
 
 @navigator.register(Image, 'EditTags')

--- a/cfme/containers/image_registry.py
+++ b/cfme/containers/image_registry.py
@@ -7,7 +7,7 @@ from wrapanapi.containers.image_registry import ImageRegistry as ApiImageRegistr
 
 from cfme.common import WidgetasticTaggable, TagPageView
 from cfme.containers.provider import (navigate_and_get_rows, ContainerObjectAllBaseView,
-                                      ContainerObjectDetailsBaseView, click_row)
+                                      ContainerObjectDetailsBaseView)
 from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator
 
@@ -70,7 +70,7 @@ class ImageRegistryDetails(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        click_row(self.prerequisite_view, host=self.obj.host)
+        self.prerequisite_view.entities.get_entity(host=self.obj.host).click()
 
 
 @navigator.register(ImageRegistry, 'EditTags')

--- a/cfme/containers/node.py
+++ b/cfme/containers/node.py
@@ -14,8 +14,7 @@ from widgetastic_manageiq import Button, Text, TimelinesView
 
 from cfme.common import WidgetasticTaggable, TagPageView
 from cfme.containers.provider import (ContainersProvider, Labelable,
-    ContainerObjectAllBaseView, LoggingableView, ContainerObjectDetailsBaseView,
-    click_row)
+    ContainerObjectAllBaseView, LoggingableView, ContainerObjectDetailsBaseView)
 from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.utils.appliance.implementations.ui import (CFMENavigateStep, navigator,
                                                      navigate_to)
@@ -136,8 +135,8 @@ class Details(CFMENavigateStep):
     prerequisite = NavigateToAttribute('parent', 'All')
 
     def step(self, *args, **kwargs):
-        click_row(self.prerequisite_view,
-                  name=self.obj.name, provider=self.obj.provider.name)
+        self.prerequisite_view.entities.get_entity(name=self.obj.name,
+                                                   provider=self.obj.provider.name).click()
 
 
 @navigator.register(Node, 'EditTags')

--- a/cfme/containers/pod.py
+++ b/cfme/containers/pod.py
@@ -10,7 +10,7 @@ from widgetastic.widget import View
 
 from cfme.common import WidgetasticTaggable, TagPageView
 from cfme.containers.provider import (Labelable, ContainerObjectAllBaseView,
-    ContainerObjectDetailsBaseView, click_row, ContainerObjectDetailsEntities)
+    ContainerObjectDetailsBaseView, ContainerObjectDetailsEntities)
 from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep
 
@@ -73,8 +73,8 @@ class Details(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        click_row(self.prerequisite_view,
-                  name=self.obj.name, project_name=self.obj.project_name)
+        self.prerequisite_view.entities.get_entity(name=self.obj.name,
+                                                   project_name=self.obj.project_name).click()
 
 
 @navigator.register(Pod, 'EditTags')

--- a/cfme/containers/project.py
+++ b/cfme/containers/project.py
@@ -7,7 +7,7 @@ from wrapanapi.containers.project import Project as ApiProject
 
 from cfme.common import WidgetasticTaggable, TagPageView
 from cfme.containers.provider import (Labelable, ContainerObjectAllBaseView,
-                                      ContainerObjectDetailsBaseView, click_row)
+                                      ContainerObjectDetailsBaseView)
 from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator
 from navmazing import NavigateToAttribute, NavigateToSibling
@@ -67,7 +67,7 @@ class Details(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        click_row(self.prerequisite_view, Name=self.obj.name)
+        self.prerequisite_view.entities.get_entity(name=self.obj.name).click()
 
 
 @navigator.register(Project, 'EditTags')

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -13,7 +13,6 @@ from widgetastic.widget import Text, View, TextInput
 from widgetastic_manageiq import (
     SummaryTable, BreadCrumb, Accordion, ManageIQTree
 )
-from widgetastic.exceptions import RowNotFound
 
 from wrapanapi.utils import eval_strings
 
@@ -336,7 +335,7 @@ class Details(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(self.obj.name,
+        self.prerequisite_view.entities.get_entity(name=self.obj.name,
                                                    surf_pages=True).click()
 
     def resetter(self):
@@ -358,7 +357,8 @@ class Edit(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True).check()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name,
+                                                   surf_pages=True).check()
         self.prerequisite_view.toolbar.configuration.item_select(
             'Edit Selected Containers Provider')
 
@@ -377,7 +377,7 @@ class EditTags(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(self.obj.name,
+        self.prerequisite_view.entities.get_entity(name=self.obj.name,
                                                    surf_pages=True).click()
         self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
 
@@ -640,23 +640,6 @@ def navigate_and_get_rows(provider, obj, count, silent_failure=False):
         return []
 
     return sample(rows, min(count, len(rows)))
-
-
-def click_row(view, **filters):
-    """Since we still unable to get entity by multiple elements (not only by name),
-    We have this workaround for the navigation to details page.
-    Args:
-        view (ContainerObjectAllBaseView): the prerequisite view of the details view.
-        filters: the filters, the elements of this object.
-    """
-    view.toolbar.view_selector.select('List View')
-    for _ in view.paginator.pages():
-        try:
-            row = view.table.row(**filters)
-            row.click()
-            break
-        except RowNotFound:
-            pass
 
 
 def refresh_and_navigate(*args, **kwargs):

--- a/cfme/containers/replicator.py
+++ b/cfme/containers/replicator.py
@@ -7,7 +7,7 @@ from wrapanapi.containers.replicator import Replicator as ApiReplicator
 
 from cfme.common import WidgetasticTaggable, TagPageView
 from cfme.containers.provider import (Labelable, ContainerObjectAllBaseView,
-    ContainerObjectDetailsBaseView, click_row)
+    ContainerObjectDetailsBaseView)
 from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep
 from navmazing import NavigateToAttribute, NavigateToSibling
@@ -68,8 +68,8 @@ class Details(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        click_row(self.prerequisite_view,
-                  name=self.obj.name, project_name=self.obj.project_name)
+        self.prerequisite_view.entities.get_entity(name=self.obj.name,
+                                                   project_name=self.obj.project_name).click()
 
 
 @navigator.register(Replicator, 'EditTags')

--- a/cfme/containers/route.py
+++ b/cfme/containers/route.py
@@ -7,7 +7,7 @@ from wrapanapi.containers.route import Route as ApiRoute
 
 from cfme.common import WidgetasticTaggable, TagPageView
 from cfme.containers.provider import (Labelable, ContainerObjectAllBaseView,
-    ContainerObjectDetailsBaseView, click_row)
+    ContainerObjectDetailsBaseView)
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep
 from navmazing import NavigateToAttribute, NavigateToSibling
 from cfme.utils.appliance import Navigatable
@@ -68,8 +68,8 @@ class Details(CFMENavigateStep):
     VIEW = RouteDetailsView
 
     def step(self):
-        click_row(self.prerequisite_view,
-                  name=self.obj.name, project_name=self.obj.project_name)
+        self.prerequisite_view.entities.get_entity(name=self.obj.name,
+                                                   project_name=self.obj.project_name).click()
 
 
 @navigator.register(Route, 'EditTags')

--- a/cfme/containers/service.py
+++ b/cfme/containers/service.py
@@ -7,7 +7,7 @@ from wrapanapi.containers.service import Service as ApiService
 
 from cfme.common import WidgetasticTaggable, TagPageView
 from cfme.containers.provider import (Labelable, ContainerObjectAllBaseView,
-    ContainerObjectDetailsBaseView, click_row)
+    ContainerObjectDetailsBaseView)
 from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep
 from navmazing import NavigateToAttribute, NavigateToSibling
@@ -68,8 +68,8 @@ class Details(CFMENavigateStep):
     VIEW = ServiceDetailsView
 
     def step(self):
-        click_row(self.prerequisite_view,
-                  name=self.obj.name, project_name=self.obj.project_name)
+        self.prerequisite_view.entities.get_entity(name=self.obj.name,
+                                                   project_name=self.obj.project_name).click()
 
 
 @navigator.register(Service, 'EditTags')

--- a/cfme/containers/template.py
+++ b/cfme/containers/template.py
@@ -8,7 +8,7 @@ from wrapanapi.containers.template import Template as ApiTemplate
 
 from cfme.common import WidgetasticTaggable, TagPageView
 from cfme.containers.provider import (Labelable, ContainerObjectAllBaseView,
-    ContainerObjectDetailsBaseView, click_row)
+    ContainerObjectDetailsBaseView)
 from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep
 
@@ -68,8 +68,8 @@ class Details(CFMENavigateStep):
     VIEW = TemplateDetailsView
 
     def step(self):
-        click_row(self.prerequisite_view,
-                  name=self.obj.name, project_name=self.obj.project_name)
+        self.prerequisite_view.entities.get_entity(name=self.obj.name,
+                                                   project_name=self.obj.project_name).click()
 
 
 @navigator.register(Template, 'EditTags')

--- a/cfme/containers/volume.py
+++ b/cfme/containers/volume.py
@@ -8,7 +8,7 @@ from wrapanapi.containers.volume import Volume as ApiVolume
 
 from cfme.common import WidgetasticTaggable, TagPageView
 from cfme.containers.provider import (ContainerObjectAllBaseView,
-                                      ContainerObjectDetailsBaseView, click_row)
+                                      ContainerObjectDetailsBaseView)
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator
 from cfme.utils.appliance import Navigatable
 
@@ -67,7 +67,7 @@ class Details(CFMENavigateStep):
     VIEW = VolumeDetailsView
 
     def step(self):
-        click_row(self.prerequisite_view, name=self.obj.name)
+        self.prerequisite_view.entities.get_entity(name=self.obj.name).click()
 
 
 @navigator.register(Volume, 'EditTags')

--- a/cfme/infrastructure/cluster.py
+++ b/cfme/infrastructure/cluster.py
@@ -216,7 +216,7 @@ class Cluster(Pretty, BaseEntity, WidgetasticTaggable):
     def exists(self):
         view = navigate_to(self.parent, 'All')
         try:
-            view.entities.get_entity(by_name=self.name, surf_pages=True)
+            view.entities.get_entity(name=self.name, surf_pages=True)
             return True
         except ItemNotFound:
             return False
@@ -299,10 +299,10 @@ class Details(CFMENavigateStep):
         """Navigate to the correct view"""
         # todo: figure out why the same cfme version shows clusters with short and long name
         try:
-            entity = self.prerequisite_view.entities.get_entity(by_name=self.obj.short_name,
+            entity = self.prerequisite_view.entities.get_entity(name=self.obj.short_name,
                                                                 surf_pages=True)
         except ItemNotFound:
-            entity = self.prerequisite_view.entities.get_entity(by_name=self.obj.name,
+            entity = self.prerequisite_view.entities.get_entity(name=self.obj.name,
                                                                 surf_pages=True)
         entity.click()
 

--- a/cfme/infrastructure/datastore.py
+++ b/cfme/infrastructure/datastore.py
@@ -278,7 +278,7 @@ class DatastoreCollection(BaseCollection):
 
         for datastore in datastores:
             try:
-                view.entities.get_entity(by_name=datastore.name, surf_pages=True).check()
+                view.entities.get_entity(name=datastore.name, surf_pages=True).check()
                 checked_datastores.append(datastore)
             except ItemNotFound:
                 raise ValueError('Could not find datastore {} in the UI'.format(datastore.name))
@@ -301,7 +301,7 @@ class DatastoreCollection(BaseCollection):
 
         for datastore in datastores:
             try:
-                view.entities.get_entity(by_name=datastore.name, surf_pages=True).check()
+                view.entities.get_entity(name=datastore.name, surf_pages=True).check()
                 checked_datastores.append(datastore)
             except ItemNotFound:
                 raise ValueError('Could not find datastore {} in the UI'.format(datastore.name))
@@ -341,7 +341,7 @@ class Details(CFMENavigateStep):
     prerequisite = NavigateToAttribute('parent', 'All')
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True).click()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True).click()
 
 
 @navigator.register(Datastore, 'DetailsFromProvider')

--- a/cfme/infrastructure/deployment_roles.py
+++ b/cfme/infrastructure/deployment_roles.py
@@ -289,7 +289,7 @@ class DeploymentRoleCollection(BaseCollection):
         if view.entities.get_all(surf_pages=True) and roles:
             for role in roles:
                 try:
-                    view.entities.get_entity(role.name).check()
+                    view.entities.get_entity(name=role.name).check()
                 except ItemNotFound:
                     raise RoleNotFound("Deployment role {} not found".format(role.name))
 
@@ -325,7 +325,7 @@ class Details(CFMENavigateStep):
     def step(self, *args, **kwargs):
         """Navigate to the details page of Role"""
         try:
-            self.prerequisite_view.entities.get_entity(by_name=self.obj.name,
+            self.prerequisite_view.entities.get_entity(name=self.obj.name,
                                                        surf_pages=True).click()
         except ItemNotFound:
             raise RoleNotFound("Deployment Role {} not found".format(self.obj.name))
@@ -350,6 +350,6 @@ class DetailsFromProvider(CFMENavigateStep):
 
     def step(self):
         try:
-            self.prerequisite_view.entities.get_entity(by_name=self.obj.name).click()
+            self.prerequisite_view.entities.get_entity(name=self.obj.name).click()
         except ItemNotFound:
             raise RoleNotFound("Deployment Role {} not found".format(self.obj.name))

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -184,7 +184,7 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, WidgetasticT
         view = navigate_to(self.parent, "All")
 
         def _looking_for_state_change():
-            entity = view.entities.get_entity(by_name=self.name)
+            entity = view.entities.get_entity(name=self.name)
             return "currentstate-{}".format(desired_state) in entity.data['state']
 
         return wait_for(
@@ -221,7 +221,7 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, WidgetasticT
         """
         view = navigate_to(self.parent, "All")
         try:
-            view.entities.get_entity(by_name=self.name, surf_pages=True)
+            view.entities.get_entity(name=self.name, surf_pages=True)
         except ItemNotFound:
             return False
         else:
@@ -234,7 +234,7 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, WidgetasticT
         Returns: :py:class:`bool`
         """
         view = navigate_to(self.parent, "All")
-        entity = view.entities.get_entity(by_name=self.name, surf_pages=True)
+        entity = view.entities.get_entity(name=self.name, surf_pages=True)
         return entity.data['creds'].strip().lower() == "checkmark"
 
     def update_credentials_rest(self, credentials):
@@ -400,7 +400,7 @@ class HostCollection(BaseCollection):
 
         for host in hosts:
             try:
-                view.entities.get_entity(by_name=host.name, surf_pages=True).check()
+                view.entities.get_entity(name=host.name, surf_pages=True).check()
                 checked_hosts.append(host)
             except ItemNotFound:
                 raise ItemNotFound('Could not find host {} in the UI'.format(host.name))
@@ -500,7 +500,7 @@ class Details(CFMENavigateStep):
     prerequisite = NavigateToAttribute("parent", "All")
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True).click()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True).click()
 
 
 @navigator.register(Host)

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -247,7 +247,7 @@ class Details(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True).click()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True).click()
 
     def resetter(self):
         # Reset view and selection
@@ -263,7 +263,7 @@ class ManagePolicies(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True).check()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True).check()
         self.prerequisite_view.toolbar.policy.item_select('Manage Policies')
 
 
@@ -282,7 +282,7 @@ class EditTags(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True).check()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True).check()
         self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
 
 
@@ -292,7 +292,7 @@ class Edit(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True).check()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True).check()
         self.prerequisite_view.toolbar.configuration.item_select('Edit Selected '
                                                                  'Infrastructure Providers')
 

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -1025,7 +1025,7 @@ def _method_setup(vm_names, provider_crud=None):
     if view.entities.paginator.exists:
         view.entities.paginator.set_items_per_page(1000)
     for vm_name in vm_names:
-        view.entities.get_entity(vm_name).check()
+        view.entities.get_entity(name=vm_name).check()
 
 
 def find_quadicon(vm_name):
@@ -1038,7 +1038,7 @@ def find_quadicon(vm_name):
     # todo: VMs have such method, so, this function is good candidate for removal
     view = navigate_to(Vm, 'VMsOnly')
     try:
-        return view.entites.get_entity(vm_name, surf_pages=True)
+        return view.entites.get_entity(name=vm_name, surf_pages=True)
     except ItemNotFound:
         raise VmNotFound("VM '{}' not found in UI!".format(vm_name))
 
@@ -1072,7 +1072,7 @@ def wait_for_vm_state_change(vm_name, desired_state, timeout=300, provider_crud=
         return 'currentstate-' + desired_state in entity.data['state']
 
     view = navigate_to(Vm, 'VMsOnly')
-    entity = view.entites.get_entity(vm_name, surf_pages=True)
+    entity = view.entites.get_entity(name=vm_name, surf_pages=True)
     return wait_for(_looking_for_state_change, func_args=[view, entity], num_sec=timeout)
 
 
@@ -1215,7 +1215,7 @@ class VmAllWithTemplatesDetails(CFMENavigateStep):
     def step(self):
         try:
             entity_item = self.prerequisite_view.entities.get_entity(
-                by_name=self.obj.name, surf_pages=True)
+                name=self.obj.name, surf_pages=True)
         except ItemNotFound:
             raise VmOrInstanceNotFound('Failed to locate VM/Template with name "{}"'.
                                        format(self.obj.name))
@@ -1262,7 +1262,7 @@ class VmDetails(CFMENavigateStep):
 
     def step(self, *args, **kwargs):
         try:
-            row = self.prerequisite_view.entities.get_entity(by_name=self.obj.name,
+            row = self.prerequisite_view.entities.get_entity(name=self.obj.name,
                                                              surf_pages=True)
         except ItemNotFound:
             raise VmOrInstanceNotFound('Failed to locate VM/Template with name "{}"'.

--- a/cfme/middleware/datasource.py
+++ b/cfme/middleware/datasource.py
@@ -172,7 +172,7 @@ class MiddlewareDatasource(MiddlewareBase, WidgetasticTaggable, Navigatable, Uti
     @classmethod
     def remove_from_list(cls, datasource):
         view = _get_datasources_page(server=datasource.server)
-        view.entities.get_item(by_name=datasource.name).check()
+        view.entities.get_entity(name=datasource.name).check()
         view.toolbar.configuration.item_select('Remove', handle_alert=True)
         view.flash.assert_success_message('The selected datasources were removed')
 

--- a/cfme/middleware/provider/__init__.py
+++ b/cfme/middleware/provider/__init__.py
@@ -84,7 +84,7 @@ class Details(CFMENavigateStep):
     def step(self):
         self.prerequisite_view.toolbar.view_selector.select('List View')
         try:
-            entity = self.prerequisite_view.entities.get_entity(by_name=self.obj.name)
+            entity = self.prerequisite_view.entities.get_entity(name=self.obj.name)
         except NoSuchElementException:
             raise MiddlewareProviderNotFound(
                 "Middleware Provider '{}' not found in table".format(self.obj.name))
@@ -97,7 +97,7 @@ class Edit(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name).check()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name).check()
         self.prerequisite_view.toolbar.configuration \
             .item_select('Edit Selected Middleware Providers')
 
@@ -117,7 +117,7 @@ class EditTags(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name).check()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name).check()
         self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
 
 

--- a/cfme/networks/balancer.py
+++ b/cfme/networks/balancer.py
@@ -87,4 +87,4 @@ class Details(CFMENavigateStep):
     VIEW = BalancerDetailsView
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name).click()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name).click()

--- a/cfme/networks/cloud_network.py
+++ b/cfme/networks/cloud_network.py
@@ -161,7 +161,7 @@ class Details(CFMENavigateStep):
     VIEW = CloudNetworkDetailsView
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name).click()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name).click()
 
 
 @navigator.register(CloudNetworkCollection, 'Add')

--- a/cfme/networks/network_port.py
+++ b/cfme/networks/network_port.py
@@ -98,4 +98,4 @@ class Details(CFMENavigateStep):
     VIEW = NetworkPortDetailsView
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name).click()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name).click()

--- a/cfme/networks/network_router.py
+++ b/cfme/networks/network_router.py
@@ -179,7 +179,7 @@ class Details(CFMENavigateStep):
     VIEW = NetworkRouterDetailsView
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name).click()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name).click()
 
 
 @navigator.register(NetworkRouterCollection, 'Add')

--- a/cfme/networks/provider/__init__.py
+++ b/cfme/networks/provider/__init__.py
@@ -145,7 +145,7 @@ class Details(CFMENavigateStep):
     VIEW = NetworkProviderDetailsView
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name).click()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name).click()
 
 
 @navigator.register(NetworkProvider, 'CloudSubnets')

--- a/cfme/networks/security_group.py
+++ b/cfme/networks/security_group.py
@@ -74,4 +74,4 @@ class Details(CFMENavigateStep):
     VIEW = SecurityGroupDetailsView
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name).click()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name).click()

--- a/cfme/networks/subnet.py
+++ b/cfme/networks/subnet.py
@@ -173,7 +173,7 @@ class OpenCloudNetworks(CFMENavigateStep):
     prerequisite = NavigateToAttribute('parent', 'All')
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name).click()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name).click()
 
 
 @navigator.register(SubnetCollection, 'Add')

--- a/cfme/services/myservice/ui.py
+++ b/cfme/services/myservice/ui.py
@@ -263,7 +263,7 @@ def edit_tags(self, tag, value):
 @MyService.check_vm_add.external_implementation_for(ViaUI)
 def check_vm_add(self, add_vm_name):
     view = navigate_to(self, 'Details')
-    view.entities.get_entity(add_vm_name).click()
+    view.entities.get_entity(name=add_vm_name).click()
     view.flash.assert_no_error()
 
 
@@ -363,4 +363,4 @@ class MyServiceVMDetails(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(self.obj.vm_name).click()
+        self.prerequisite_view.entities.get_entity(name=self.obj.vm_name).click()

--- a/cfme/storage/object_store_container.py
+++ b/cfme/storage/object_store_container.py
@@ -145,7 +145,7 @@ class Details(CFMENavigateStep):
 
     def step(self, *args, **kwargs):
         try:
-            self.prerequisite_view.entities.get_entity(self.obj.key,
+            self.prerequisite_view.entities.get_entity(name=self.obj.key,
                                                        surf_pages=True).click()
         except ItemNotFound:
             raise ItemNotFound('Could not locate container {}'.format(self.obj.key))

--- a/cfme/storage/volume.py
+++ b/cfme/storage/volume.py
@@ -293,7 +293,7 @@ class VolumeCollection(BaseCollection):
         if view.entities.get_all():
             for volume in volumes:
                 try:
-                    view.entities.get_entity(volume.name).check()
+                    view.entities.get_entity(name=volume.name).check()
                 except ItemNotFound:
                     raise VolumeNotFound("Volume {} not found".format(volume.name))
 
@@ -324,7 +324,7 @@ class VolumeDetails(CFMENavigateStep):
     def step(self, *args, **kwargs):
 
         try:
-            self.prerequisite_view.entities.get_entity(by_name=self.obj.name,
+            self.prerequisite_view.entities.get_entity(name=self.obj.name,
                                                        surf_pages=True).click()
 
         except ItemNotFound:

--- a/cfme/tests/infrastructure/test_advanced_search_host.py
+++ b/cfme/tests/infrastructure/test_advanced_search_host.py
@@ -28,9 +28,9 @@ def hosts_with_vm_count(hosts, host_collection):
     hosts_with_vm_count = []
     view = navigate_to(host_collection, 'All')
     view.toolbar.view_selector.select("Grid View")
-    for hostname in hosts:
-        entity = view.entities.get_entity(by_name=hostname)
-        hosts_with_vm_count.append((hostname, entity.data['no_vm']))
+    for host in hosts:
+        entity = view.entities.get_entity(name=host.name)
+        hosts_with_vm_count.append((host.name, entity.data['no_vm']))
     return sorted(hosts_with_vm_count, key=lambda tup: tup[1])
 
 

--- a/cfme/tests/openstack/cloud/test_instances.py
+++ b/cfme/tests/openstack/cloud/test_instances.py
@@ -165,7 +165,7 @@ def test_delete_instance(new_instance):
     assert new_instance.name not in new_instance.provider.mgmt.list_vm()
     view = navigate_to(new_instance, 'AllForProvider')
     try:
-        view.entities.get_entity(new_instance.name, surf_pages=True)
+        view.entities.get_entity(name=new_instance.name, surf_pages=True)
         assert False, "entity still exists"
     except ItemNotFound:
         pass

--- a/cfme/tests/openstack/cloud/test_volumes.py
+++ b/cfme/tests/openstack/cloud/test_volumes.py
@@ -49,7 +49,7 @@ def test_edit_volume(volume, appliance):
     new_name = fauxfactory.gen_alpha()
     volume.edit(new_name)
     view = navigate_to(appliance.collections.volumes, 'All')
-    assert view.entities.get_entity(by_name=new_name, surf_pages=True)
+    assert view.entities.get_entity(name=new_name, surf_pages=True)
 
 
 @pytest.mark.meta(blockers=[BZ(1502609, forced_streams=["5.9"])])

--- a/cfme/tests/openstack/infrastructure/test_provider.py
+++ b/cfme/tests/openstack/infrastructure/test_provider.py
@@ -19,7 +19,7 @@ def test_api_port(provider):
 
 def test_credentials_quads(provider):
     view = navigate_to(provider, 'All')
-    prov_item = view.entities.get_entity(by_name=provider.name, surf_pages=True)
+    prov_item = view.entities.get_entity(name=provider.name, surf_pages=True)
     assert prov_item.data.get('creds') and 'checkmark' in prov_item.data['creds']
 
 

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -1507,7 +1507,7 @@ class ReportDataControllerMixin(object):
     def _call_item_method(self, method):
         raw_data = {'controller': 'reportDataController',
                     'action': 'get_item',
-                    'data': [self.name]}
+                    'data': [self.id]}
         js_data = json.dumps(raw_data)
         js_cmd = ('sendDataWithRx({data}); '
                   'return ManageIQ.qe.gtl.result.{method}()').format(data=js_data, method=method)
@@ -1516,6 +1516,26 @@ class ReportDataControllerMixin(object):
         result = self.browser.execute_script(js_cmd)
         self.browser.plugin.ensure_page_safe()
         return result
+
+    def get_id_by_keys(self, **keys):
+        updated_keys = keys.copy()
+        for key in updated_keys:
+            # js api compares values in lower case but don't replace space with underscore
+            updated_keys[key.replace('_', ' ')] = str(updated_keys.pop(key))
+
+        raw_data = {'controller': 'reportDataController',
+                    'action': 'query',
+                    'data': [updated_keys]}
+        js_cmd = ('sendDataWithRx({data}); '
+                  'return ManageIQ.qe.gtl.result').format(data=json.dumps(raw_data))
+        self.logger.info("executed command: {cmd}".format(cmd=js_cmd))
+        self.browser.plugin.ensure_page_safe()
+        result = self.browser.execute_script(js_cmd)
+        self.browser.plugin.ensure_page_safe()
+        try:
+            return int(result[0]['id'])
+        except (TypeError, IndexError):
+            return None
 
 
 class JSPaginationPane(View, ReportDataControllerMixin):
@@ -2555,12 +2575,14 @@ class BaseQuadIconEntity(ParametrizedView, ClickableMixin):
     It is expected that some properties like "data" will be overridden in its children
 
     """
-    PARAMETERS = ('name',)
+    PARAMETERS = ('id',)
     ROOT = ParametrizedLocator('.//table[./tbody/tr/td/*[(self::a or self::span) and '
-                               'contains(@title, {name|quote})]]')
+                               'substring(@href, '
+                               'string-length(@href)-string-length("/{id}")+1)="/{id}"]]')
     LIST = '//dl[contains(@class, "tile")]/*[self::dt or self::dd]'
     label = Text(locator=ParametrizedLocator('./tbody/tr/td/*[(self::a or self::span) and '
-                                             'contains(@title, {name|quote})]'))
+                                             'substring(@href, string-length(@href)-'
+                                             'string-length("/{id}")+1)="/{id}"]'))
     checkbox = Checkbox(locator='./tbody/tr/td/input[@type="checkbox"]')
     QUADRANT = './/div[@class="flobj {pos}72"]/*[self::p or self::img or self::div]'
 
@@ -2602,21 +2624,22 @@ class BaseTileIconEntity(ParametrizedView):
     """ represents Tile Icon entity. one of states entity can be in
 
     """
-    PARAMETERS = ('name',)
+    PARAMETERS = ('id',)
     ROOT = ParametrizedLocator('.//table[.//table[./tbody/tr/td/*[(self::a or self::span) and '
-                               'contains(@title, {name|quote})]]]')
+                               'substring(@href, string-length(@href)-'
+                               'string-length("/{id}")+1)="/{id}"]]]')
     LIST = '//dl[contains(@class, "tile")]/*[self::dt or self::dd]'
     quad_icon = ParametrizedView.nested(BaseQuadIconEntity)
 
     @property
     def is_checked(self):
-        return self.quad_icon(self.context['name']).is_checked
+        return self.quad_icon(self.context['id']).is_checked
 
     def check(self):
-        return self.quad_icon(self.context['name']).check()
+        return self.quad_icon(self.context['id']).check()
 
     def uncheck(self):
-        return self.quad_icon(self.context['name']).uncheck()
+        return self.quad_icon(self.context['id']).uncheck()
 
     @property
     def data(self):
@@ -2624,7 +2647,7 @@ class BaseTileIconEntity(ParametrizedView):
         which is different for each entity type.
         This is property which should hold such data.
         """
-        quad_data = self.quad_icon(self.context['name']).data
+        quad_data = self.quad_icon(self.context['id']).data
         br = self.browser
         # it seems we don't have list widget in other places.
         # so, this code just parses it, creates dict and adds it to quad icon dict
@@ -2634,10 +2657,10 @@ class BaseTileIconEntity(ParametrizedView):
         return quad_data
 
     def read(self):
-        return self.quad_icon(self.context['name']).read()
+        return self.quad_icon(self.context['id']).read()
 
     def fill(self, values):
-        return self.quad_icon(self.context['name']).fill()
+        return self.quad_icon(self.context['id']).fill()
 
     @property
     def is_displayed(self):
@@ -2652,8 +2675,8 @@ class BaseListEntity(ParametrizedView, ClickableMixin):
     """ represents List entity. one of states entity can be in
 
     """
-    PARAMETERS = ('name',)
-    ROOT = ParametrizedLocator('.//tr[./td[normalize-space(.)={name|quote}]]')
+    PARAMETERS = ('id',)
+    ROOT = ParametrizedLocator('.//tr[contains(@onclick, "miqRowClick(\'{id}\'")]')
     parent_table = Table(locator='./ancestor::table[1]')
     checkbox = Checkbox(locator='.//input[@type="checkbox"]')
 
@@ -2673,11 +2696,11 @@ class BaseListEntity(ParametrizedView, ClickableMixin):
         which is different for each entity type.
         This is property which should hold such data.
         """
-        row = next(row for row in self.parent_table.rows() if row.name.text == self.context['name'])
-        item_data = {}
-        for col_name in (h for h in self.parent_table.headers if h is not None):
-            item_data[col_name] = row[col_name].text
-        return item_data
+        br = self.browser
+        col_names = [col_name for col_name in self.parent_table.headers]
+        col_names = map(lambda c: c.replace(' ', '_').lower() if c else c, col_names)
+        col_values = [br.text(val) for val in br.elements('./td', parent=self)]
+        return dict(col for col in zip(col_names, col_values) if col[0] is not None)
 
     def read(self):
         return self.is_checked
@@ -2694,30 +2717,37 @@ class NonJSBaseEntity(View):
     list_entity = BaseListEntity
     tile_entity = BaseTileIconEntity
 
-    def __init__(self, parent, name, logger=None):
+    def __init__(self, parent, id, logger=None):
         View.__init__(self, parent, logger=logger)
-        self.name = name
+        self.id = id
 
     def _get_existing_entity(self):
         for item in (self.quad_entity, self.tile_entity, self.list_entity):
-            if item(name=self.name).is_displayed:
-                return item(name=self.name)
+            if item(id=self.id).is_displayed:
+                return item(id=self.id)
         else:
-            raise NoSuchElementException("Item {name} isn't found on page".format(name=self.name))
+            raise NoSuchElementException("Item {id} isn't found on page".format(id=self.id))
 
     def __getattr__(self, name):
         if name.startswith('__'):
             return self.__dict__[name]
 
         item = self._get_existing_entity()
-        if hasattr(item, name):  # needed for is displayed
-            return getattr(item, name)
+        return getattr(item, name)
 
     def __str__(self):
         return str(self._get_existing_entity())
 
     def __repr__(self):
         return repr(self._get_existing_entity())
+
+    @property
+    def is_displayed(self):
+        try:
+            self._get_existing_entity()
+            return True
+        except NoSuchElementException:
+            return False
 
 
 class JSBaseEntity(View, ReportDataControllerMixin):
@@ -2726,13 +2756,17 @@ class JSBaseEntity(View, ReportDataControllerMixin):
     """
     QUADRANT = './/div[@class="flobj {pos}72"]/*[self::p or self::img or self::div]'
 
-    def __init__(self, parent, name, logger=None):
+    def __init__(self, parent, id, logger=None):
         View.__init__(self, parent, logger=logger)
-        self.name = name
+        self.id = id
 
     @property
     def is_checked(self):
-        return self._call_item_method('is_selected')
+        checked = self._call_item_method('is_selected')
+        if checked is None:
+            return False
+        else:
+            return checked
 
     def check(self):
         self._call_item_method('select')
@@ -2749,7 +2783,7 @@ class JSBaseEntity(View, ReportDataControllerMixin):
         which is different for each entity type.
         This is property which should hold such data.
         """
-        data = self._invoke_cmd('get_item', self.name)['item']
+        data = self._invoke_cmd('get_item', self.id)['item']
         cells = data.pop('cells')
         data.update(cells)
         return {str(key).replace(' ', '_').lower(): value for key, value in data.items()}
@@ -2765,7 +2799,7 @@ class JSBaseEntity(View, ReportDataControllerMixin):
 
     @property
     def is_displayed(self):
-        return self._invoke_cmd('is_displayed', self.name)
+        return self._invoke_cmd('is_displayed', self.id)
 
 
 class EntitiesConditionalView(View, ReportDataControllerMixin):
@@ -2780,17 +2814,71 @@ class EntitiesConditionalView(View, ReportDataControllerMixin):
                           'contains(@class, "flash_text_div")]')
 
     @property
+    def _current_page_elements(self):
+        elements = []
+        if self.browser.product_version < '5.9':
+            br = self.browser
+            for el in br.elements(self.elements):
+                el_id = int(br.get_attribute('href', el).split('/')[-1])
+                el_name = br.get_attribute('title', el)
+                elements.append({'name': el_name, 'id': el_id})
+        else:
+            entities = self._invoke_cmd('get_all_items')
+            for entity in entities:
+                elements.append({'name': entity['item']['cells']['Name'],
+                                 'id': entity['item']['id']})
+        return elements
+
+    @property
+    def entity_ids(self):
+        return [el['id'] for el in self._current_page_elements]
+
+    @property
     def entity_names(self):
         """ looks for entities and extracts their names
 
         Returns: all current page entities
         """
+        return [el['name'] for el in self._current_page_elements]
+
+    def get_id_by_name(self, name):
+        for el in self._current_page_elements:
+            if el['name'] == name:
+                return el['id']
+        return None
+
+    def get_entity_by_keys(self, **keys):
+        # some fields aren't available in Tile or Grid View.
+        # So, we decided to switch to List View mode if several keys are passed
+        # btw, it isn't necessary in 5.9+
         if self.browser.product_version < '5.9':
-            br = self.browser
-            return [br.get_attribute('title', el) for el in br.elements(self.elements)]
+            # todo: fix this ugly hack somehow else
+            view_selector = getattr(self.parent.parent.toolbar, 'view_selector', None)
+            if view_selector and view_selector.selected != 'List View':
+                view_selector.select('List View')
+
+            if type(self).__name__ in ('GridView', 'TileView'):
+                elements = self.parent.entities._current_page_elements
+            else:
+                elements = self._current_page_elements
+
+            for el in elements:
+                entity = self.parent.entity_class(parent=self, id=el['id'])
+                for key, value in keys.items():
+                    try:
+                        if entity.data[key] != str(value):
+                            break
+                    except KeyError:
+                        break
+                else:
+                    return entity
         else:
-            entities = self._invoke_cmd('get_all_items')
-            return [entity['item']['cells']['Name'] for entity in entities]
+            entity_id = keys.pop('id', None)
+            if entity_id:
+                return self.parent.entity_class(parent=self, id=entity_id)
+            else:
+                return self.parent.entity_class(parent=self, id=self.get_id_by_keys(**keys))
+        return None
 
     @property
     def all_entity_names(self):
@@ -2806,53 +2894,40 @@ class EntitiesConditionalView(View, ReportDataControllerMixin):
         Returns: all entities (QuadIcon/etc.) displayed by view
         """
         if not surf_pages:
-            return [self.parent.entity_class(parent=self, name=name) for name in self.entity_names]
+            return [self.parent.entity_class(parent=self, id=id) for id in self.entity_ids]
         else:
             entities = []
             for _ in self.paginator.pages():
-                entities.extend([self.parent.entity_class(parent=self, name=name)
-                                for name in self.entity_names])
+                entities.extend([self.parent.entity_class(parent=self, id=id)
+                                for id in self.entity_ids])
             return entities
 
-    def get_entities(self, by_partial_name, surf_pages=False):
-        """ obtains all matched entities like QuadIcon displayed by view
-        Args:
-            by_partial_name (str): only entities which match to by_name will be returned
-            surf_pages (bool): current page entities if False, all entities otherwise
-
-        Returns: all matched entities (QuadIcon/etc.) displayed by view
-        """
-        entities = self.get_all(surf_pages)
-        remaining_entities = []
-        for entity in entities:
-            if by_partial_name in entity.name:
-                remaining_entities.append(entity)
-            # todo: by_type and by_regexp will be implemented later if needed
-        if not remaining_entities:
-            raise ItemNotFound("Entities matching to {name} "
-                               "aren't found on this page".format(name=by_partial_name))
-        return remaining_entities
-
-    def get_entity(self, by_name, surf_pages=False):
+    def get_entity(self, surf_pages=False, **keys):
         """ obtains one entity matched to by_name and stops on that page
         Args:
-            by_name (str): only entity which match to by_name will be returned
+            keys: only entity which matches to keys will be returned
             surf_pages (bool): current page entity if False, all entities otherwise
 
         Returns: matched entity (QuadIcon/etc.)
         """
         for _ in self.paginator.pages():
-            found_entities = [self.parent.entity_class(parent=self, name=name)
-                              for name in self.entity_names if by_name == name]
-            if len(found_entities) == 1:
-                return found_entities[0]
-            elif len(found_entities) > 1:
-                raise ManyEntitiesFound("Several entities with "
-                                        "{name} were found".format(name=by_name))
+            if len(keys) == 1 and 'name' in keys:
+                entity_id = self.get_id_by_name(name=keys['name'])
+            elif len(keys) == 1 and 'id' in keys:
+                entity_id = keys['id']
+            else:
+                entity_id = None
+                entity = self.get_entity_by_keys(**keys)
+                if entity:
+                    return entity
+
+            if entity_id:
+                return self.parent.entity_class(parent=self, id=entity_id)
+
             if not surf_pages:
-                raise ItemNotFound("Entity {name} isn't found on this page".format(name=by_name))
+                raise ItemNotFound("Entity {keys} isn't found on this page".format(keys=keys))
         else:
-            raise ItemNotFound("Entity {name} isn't found on this page".format(name=by_name))
+            raise ItemNotFound("Entity {keys} isn't found on this page".format(keys=keys))
 
     def get_first_entity(self):
         """ obtains first entity on page and returns it
@@ -2860,8 +2935,8 @@ class EntitiesConditionalView(View, ReportDataControllerMixin):
 
         Returns: matched entity (QuadIcon/etc.)
         """
-        for entity_name in self.entity_names:
-            return self.parent.entity_class(parent=self, name=entity_name)
+        for entity_id in self.entity_ids:
+            return self.parent.entity_class(parent=self, id=entity_id)
 
         raise ItemNotFound("No Entities found on this page")
 
@@ -2898,6 +2973,24 @@ class BaseEntitiesView(View):
                 return [row.name.text for row in self.elements.rows()]
             except NoSuchElementException:
                 return []
+
+        @property
+        def _current_page_elements(self):
+            elements = []
+            if self.browser.product_version < '5.9':
+                br = self.browser
+                for row in self.elements.rows():
+                    # ex: miqRowClick('2', '/ems_infra/', false); return false;
+                    attr = br.get_attribute('onclick', row)
+                    el_id = int(re.search("miqRowClick\('(\d+)", attr).group(1))
+                    el_name = row.name.text if getattr(row, 'name', None) else ''
+                    elements.append({'name': el_name, 'id': el_id})
+            else:
+                entities = self._invoke_cmd('get_all_items')
+                for entity in entities:
+                    elements.append({'name': entity['item']['cells']['Name'],
+                                     'id': entity['item']['id']})
+            return elements
 
     @entities.register('Tile View')
     class TileView(EntitiesConditionalView):
@@ -3306,6 +3399,60 @@ class BaseNonInteractiveEntitiesView(View, ReportDataControllerMixin):
                 'self::span]')
 
     @property
+    def _current_page_elements(self):
+        elements = []
+        if self.browser.product_version < '5.9':
+            br = self.browser
+            for el in br.elements(self.elements):
+                el_id = int(br.get_attribute('href', el).split('/')[-1])
+                el_name = br.get_attribute('title', el)
+                elements.append({'name': el_name, 'id': el_id})
+        else:
+            entities = self._invoke_cmd('get_all_items')
+            for entity in entities:
+                elements.append({'name': entity['item']['cells']['Name'],
+                                 'id': entity['item']['id']})
+        return elements
+
+    @property
+    def entity_ids(self):
+        return [el['id'] for el in self._current_page_elements]
+
+    @property
+    def entity_names(self):
+        """ looks for entities and extracts their names
+
+        Returns: all current page entities
+        """
+        return [el['name'] for el in self._current_page_elements]
+
+    def get_id_by_name(self, name):
+        for el in self._current_page_elements:
+            if el['name'] == name:
+                return el['id']
+        return None
+
+    def get_entity_by_keys(self, **keys):
+        if self.browser.product_version < '5.9':
+            for el in self._current_page_elements:
+                entity = self.entity_class(parent=self, id=el['id'])
+                for key, value in keys.items():
+                    try:
+                        if entity.data[key] != str(value):
+                            break
+                    except KeyError:
+                        break
+                else:
+                    return entity
+        else:
+            entity_id = keys.pop('id', None)
+            if entity_id:
+                return self.entity_class(parent=self, id=entity_id)
+            else:
+                return self.entity_class(parent=self, id=self.get_id_by_keys(**keys))
+        return None
+
+    @property
     def entity_class(self):
         if self.browser.product_version < '5.9':
             return NonJSBaseEntity
@@ -3330,47 +3477,38 @@ class BaseNonInteractiveEntitiesView(View, ReportDataControllerMixin):
 
         Returns: all entities (QuadIcon/etc.) displayed by view
         """
-        return [self.entity_class(parent=self, name=name) for name in self.entity_names]
+        return [self.entity_class(parent=self, id=id) for id in self.entity_ids]
 
-    def get_entities(self, by_partial_name):
-        """ obtains all matched entities like QuadIcon displayed by view
-        raises exception if no entities found
-        Args:
-            by_partial_name (str): only entities which match to by_name will be returned
-
-        Returns: all matched entities (QuadIcon/etc.) displayed by view
-        """
-        remaining_entities = []
-        for entity in self.get_all():
-            if by_partial_name in entity.name:
-                remaining_entities.append(entity)
-                # todo: by_type and by_regexp will be implemented later if needed
-        if not remaining_entities:
-            raise ItemNotFound("Entities matching to {name} "
-                               "aren't found on this page".format(name=by_partial_name))
-        return remaining_entities
-
-    def get_entity(self, by_partial_name):
-        """ obtains one entity matched to by_name
+    def get_entity(self, **keys):
+        """ obtains one entity matched to some of keys
         raises exception several entities were found
         Args:
-            by_partial_name (str): only entity which match to by_name will be returned
+            keys: only entity which match to keys will be returned
 
         Returns: matched entities (QuadIcon/etc.)
         """
-        entities = self.get_entities(by_partial_name=by_partial_name)
-        if len(entities) > 1:
-            raise ManyEntitiesFound("Several entities with "
-                                    "{name} were found".format(name=by_partial_name))
-        return entities[0]
+        if len(keys) == 1 and 'name' in keys:
+            entity_id = self.get_id_by_name(name=keys['name'])
+        elif len(keys) == 1 and 'id' in keys:
+            entity_id = keys['id']
+        else:
+            entity_id = None
+            entity = self.get_entity_by_keys(**keys)
+            if entity:
+                return entity
+
+        if entity_id:
+            return self.entity_class(parent=self, id=entity_id)
+
+        raise ItemNotFound("Entity {keys} isn't found on this page".format(keys=keys))
 
     def get_first_entity(self):
         """ obtains first entity
 
         Returns: matched entity (QuadIcon/etc.)
         """
-        for name in self.entity_names:
-            return self.entity_class(parent=self, name=name)
+        for entity_id in self.entity_ids:
+            return self.entity_class(parent=self, id=entity_id)
 
         raise ItemNotFound("No Entities found on this page")
 


### PR DESCRIPTION
It should be possible to look for quad icons using several keys not only name. 
In 5.8,  the view is automatically switched to List View since all possible keys are available only in List View.
In 5.9, JS Api provides all neccessary keys, so, it isn't neccessary to change view mode.