### PR TITLE
[WIP] Add timeout as parameter for Sprout client, Add remote worker option for replicated env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ conf/README
 
 # virtual env
 .cfme/
+.env/
 
 # custom imports
 conf/miq_python_startup.py

--- a/cfme/scripting/setup_env.py
+++ b/cfme/scripting/setup_env.py
@@ -5,7 +5,6 @@ from collections import namedtuple
 from cfme.utils.conf import credentials, cfme_data
 from wait_for import wait_for
 
-
 TimedCommand = namedtuple('TimedCommand', ['command', 'timeout'])
 pwd = credentials['database']['password']
 
@@ -15,7 +14,7 @@ def tot_time(string):
     mtch = re.match('^((?P<days>\d+)+d)?\s?((?P<hours>\d+)+h)?\s?((?P<minutes>\d+)+m)?\s?', string)
     tot = int(mtch.group('days') or 0) * 24 * 60
     tot += int(mtch.group('hours') or 0) * 60
-    tot += int(mtch.group('minutes')or 0)
+    tot += int(mtch.group('minutes') or 0)
     return tot
 
 
@@ -55,8 +54,8 @@ def setup_distributed_env(cfme_version, provider, lease):
     vmdb_appliance.wait_for_evm_service()
     vmdb_appliance.wait_for_web_ui()
     print("VMDB appliance provisioned and configured {}".format(vmdb_appliance.address))
-    command_set1 = ('ap', '', opt, '2', vmdb_appliance.address, '', pwd, '', '3') + port + ('', '',
-        pwd, TimedCommand(pwd, 360), '')
+    command_set1 = ('ap', '', opt, '2', vmdb_appliance.address, '', pwd, '', '3') + port + \
+                   ('', '', pwd, TimedCommand(pwd, 360), '')
     node_appliance.appliance_console.run_commands(command_set1)
     node_appliance.wait_for_evm_service()
     node_appliance.wait_for_web_ui()
@@ -67,14 +66,15 @@ def setup_distributed_env(cfme_version, provider, lease):
 @main.command('ha', help='Sets up high availability environment')
 @click.option('--cfme-version', required=True)
 @click.option('--provider', default=cfme_data.get('basic_info', {}).get('ha_provider'),
-    help='Specify sprout provider, must not be RHOS')
+              help='Specify sprout provider, must not be RHOS')
 @click.option('--lease', default='3h', help='set pool lease time, example: 1d4h30m')
 def setup_ha_env(cfme_version, provider, lease):
     lease_time = tot_time(lease)
     """multi appliance setup consisting of dedicated primary and standy databases with a single
     UI appliance."""
     print("Provisioning and configuring HA environment")
-    apps = provision_appliances(count=3, cfme_version=cfme_version, provider=provider, lease_time=lease_time)
+    apps = provision_appliances(
+        count=3, cfme_version=cfme_version, provider=provider, lease_time=lease_time)
     ip0 = apps[0].address
     ip1 = apps[1].address
     ip2 = apps[2].address
@@ -96,7 +96,7 @@ def setup_ha_env(cfme_version, provider, lease):
     apps[0].appliance_console.run_commands(command_set2)
     print("Primary HA node configured {}".format(ip0))
     command_set3 = ('ap', '', rep, '2', '1', '2', '', '', pwd, pwd, ip0, ip2, 'y',
-        TimedCommand('y', 300), '')
+                    TimedCommand('y', 300), '')
     apps[2].appliance_console.run_commands(command_set3)
     print("Secondary HA node provision and configured {}".format(ip2))
     command_set4 = ('ap', '', mon, '1', '')
@@ -118,7 +118,8 @@ def setup_replication_env(cfme_version, provider, lease, remote_worker=False):
     if remote_worker:
         app_count = 3
 
-    apps = provision_appliances(count=app_count, cfme_version=cfme_version, provider=provider,lease_time=lease_time)
+    apps = provision_appliances(count=app_count, cfme_version=cfme_version,
+                                provider=provider, lease_time=lease_time)
 
     global_region_appliance = apps[0]
     remote_region_appliance = apps[1]
@@ -132,14 +133,16 @@ def setup_replication_env(cfme_version, provider, lease, remote_worker=False):
     global_region_appliance.appliance_console.run_commands(command_set0)
     global_region_appliance.wait_for_evm_service()
     global_region_appliance.wait_for_web_ui()
-    print("Global region appliance provisioned and configured {}".format(global_region_appliance.address))
+    print("Global region appliance provisioned and configured {}"
+          .format(global_region_appliance.address))
 
-    command_set1 = ('ap', '', opt, '2', global_region_appliance.address, '', pwd, '', '1', 'y', '1', 'n', '1', pwd,
-                    TimedCommand(pwd, 360), '')
+    command_set1 = ('ap', '', opt, '2', global_region_appliance.address,
+                    '', pwd, '', '1', 'y', '1', 'n', '1', pwd, TimedCommand(pwd, 360), '')
     remote_region_appliance.appliance_console.run_commands(command_set1)
     remote_region_appliance.wait_for_evm_service()
     remote_region_appliance.wait_for_web_ui()
-    print("Remote region appliance provisioned and configured {}".format(remote_region_appliance.address))
+    print("Remote region appliance provisioned and configured {}"
+          .format(remote_region_appliance.address))
     print("Setup - Replication on remote appliance")
     remote_region_appliance.set_pglogical_replication(replication_type=':remote')
     print("Setup - Replication on global appliance")
@@ -147,9 +150,10 @@ def setup_replication_env(cfme_version, provider, lease, remote_worker=False):
     global_region_appliance.add_pglogical_replication_subscription(remote_region_appliance.address)
 
     if remote_worker:
-        port = (remote_region_appliance.address, '') if cfme_version >= "5.8" else (remote_region_appliance.address,)
+        port = (remote_region_appliance.address, '') \
+            if cfme_version >= "5.8" else (remote_region_appliance.address,)
         command_set2 = ('ap', '', opt, '2', remote_region_appliance.address, '',
-                        pwd, '', '3') + port + ('', '',pwd, TimedCommand(pwd, 360), '')
+                        pwd, '', '3') + port + ('', '', pwd, TimedCommand(pwd, 360), '')
         remote_worker_appliance.appliance_console.run_commands(command_set2)
         remote_worker_appliance.wait_for_evm_service()
         remote_worker_appliance.wait_for_web_ui()

--- a/cfme/scripting/setup_env.py
+++ b/cfme/scripting/setup_env.py
@@ -39,7 +39,8 @@ def main():
 @click.option('--cfme-version', required=True)
 @click.option('--provider', default=None, help='Specify sprout provider')
 @click.option('--lease', default='3h', help='Set pool lease time, example: 1d4h30m')
-@click.option('--sprout-timeout', default=None, help='Set Sprout client timeout in seconds: example 300')
+@click.option('--sprout-timeout', default=None,
+              help='Set Sprout client timeout in seconds: example 300')
 def setup_distributed_env(cfme_version, provider, lease, sprout_timeout):
     lease_time = tot_time(lease)
     """multi appliance single region configuration (distributed setup, 1st appliance has
@@ -88,7 +89,8 @@ def setup_ha_env(cfme_version, provider, lease):
     apps[0].appliance_console.run_commands(command_set0)
     wait_for(lambda: apps[0].db.is_dedicated_active)
     print("Dedicated database provisioned and configured {}".format(ip0))
-    command_set1 = ('ap', '', opt, '1', '2', '1', 'y') + port + ('', '', pwd, TimedCommand(pwd, 360), '')
+    command_set1 = \
+        ('ap', '', opt, '1', '2', '1', 'y') + port + ('', '', pwd, TimedCommand(pwd, 360), '')
     apps[1].appliance_console.run_commands(command_set1)
     apps[1].wait_for_evm_service()
     apps[1].wait_for_web_ui()
@@ -110,7 +112,8 @@ def setup_ha_env(cfme_version, provider, lease):
 @click.option('--cfme-version', required=True)
 @click.option('--provider', default=None, help='Specify sprout provider')
 @click.option('--lease', default='3h', help='set pool lease time, example: 1d4h30m')
-@click.option('--sprout-timeout', default='600', help='Set Sprout client timeout in seconds: example 300')
+@click.option('--sprout-timeout', default='600',
+              help='Set Sprout client timeout in seconds: example 300')
 def setup_replication_env(cfme_version, provider, lease, sprout_timeout):
     lease_time = tot_time(lease)
     """Multi appliance setup with multi region and replication from remote to global"""

--- a/cfme/scripting/setup_env.py
+++ b/cfme/scripting/setup_env.py
@@ -43,7 +43,7 @@ def setup_distributed_env(cfme_version, provider, lease):
     a local database and workers, 2nd appliance has workers pointing at 1st appliance)"""
     print("Provisioning and configuring distributed environment")
     apps = provision_appliances(
-        count=2, cfme_version=cfme_version, provider=provider,lease_time=lease_time
+        count=2, cfme_version=cfme_version, provider=provider, lease_time=lease_time
     )
 
     vmdb_appliance = apps[0]

--- a/cfme/test_framework/sprout/client.py
+++ b/cfme/test_framework/sprout/client.py
@@ -95,7 +95,7 @@ class SproutClient(object):
 
     def provision_appliances(
             self, count=1, preconfigured=False, version=None, stream=None, provider=None,
-            lease_time=120, ram=None, cpu=None):
+            lease_time=120, ram=None, cpu=None, timeout=300):
         # If we specify version, stream is ignored because we will get that specific version
         if version:
             stream = get_stream(version)
@@ -111,7 +111,7 @@ class SproutClient(object):
             group=stream, provider=provider, lease_time=lease_time, ram=ram, cpu=cpu, count=count
         )
         wait_for(
-            lambda: self.call_method('request_check', str(request_id))['finished'], num_sec=300,
+            lambda: self.call_method('request_check', str(request_id))['finished'], num_sec=timeout,
             message='provision {} appliance(s) from sprout'.format(count))
         data = self.call_method('request_check', str(request_id))
         logger.debug(data)


### PR DESCRIPTION
Fixing because the Sprout client can timeout when provisioning non-configured appliances under high load.

