### PR TITLE
[1LP][RFR] Fix test_memory_checkbox

### DIFF
--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -71,7 +71,8 @@ def full_test_vm(setup_provider_modscope, provider, full_template_modscope, requ
 def new_snapshot(test_vm, has_name=True, memory=False):
     return Vm.Snapshot(
         name="snpshot_{}".format(fauxfactory.gen_alphanumeric(8)) if has_name else None,
-        description="snapshot", memory=memory, parent_vm=test_vm)
+        description="snapshot_{}".format(fauxfactory.gen_alphanumeric(8)),
+        memory=memory, parent_vm=test_vm)
 
 
 @pytest.mark.uncollectif(lambda provider:
@@ -81,7 +82,7 @@ def test_memory_checkbox(small_test_vm, provider, soft_assert):
     # Make sure the VM is powered on
     small_test_vm.power_control_from_cfme(option=small_test_vm.POWER_ON, cancel=False)
     # Try to create snapshot with memory on powered on VM
-    has_name = provider.one_of(RHEVMProvider)
+    has_name = not provider.one_of(RHEVMProvider)
     snapshot1 = new_snapshot(small_test_vm, has_name=has_name, memory=True)
     snapshot1.create()
     assert snapshot1.exists


### PR DESCRIPTION
This is a fix for a snapshot test `test_memory_checkbox`. Two things have been changed:
 - line 74: added random alphanumeric part to snapshot description. Reason: when using RHV provider, we can't create snapshot with name, only with description. This is RHV-provider-specific and I can't do anything about it. The name of the created snapshot, that is displayed in CFME UI, is then created from the description. Without the fix, when creating two snapshots, they would have the same name and cause errors when checking for existence. With the fix, every snapshot has different name, as it is with snapshots created on different provider than RHV.
 - line 85: added `not`. This is my mistake that I didn't notice first time around. The snapshot needs to have a name when it is created on a provider that is _NOT_ RHV.

{{pytest: -v --long-running -k test_memory_checkbox}}