### PR TITLE
[1LP][RFR] Handling vm console opening in SSUI and returning console handle to the test

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -243,6 +243,26 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, WidgetasticTaggable,
                 #      for a console tab.
                 return handle
 
+    @property
+    def vm_console(self):
+        """Get the consoles window handle, and then create a VMConsole object, and store
+        the VMConsole object aside.
+        """
+        console_handle = self.console_handle
+
+        if console_handle is None:
+            raise TypeError("Console handle should not be None")
+
+        appliance_handle = self.appliance.browser.widgetastic.window_handle
+        logger.info("Creating VMConsole:")
+        logger.info("   appliance_handle: {}".format(appliance_handle))
+        logger.info("     console_handle: {}".format(console_handle))
+        logger.info("               name: {}".format(self.name))
+
+        return VMConsole(appliance_handle=appliance_handle,
+                console_handle=console_handle,
+                vm=self)
+
     def delete(self, cancel=False, from_details=False):
         """Deletes the VM/Instance from the VMDB.
 
@@ -353,25 +373,8 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, WidgetasticTaggable,
         # Click console button given by type
         view.toolbar.access.item_select(console, handle_alert=None
             if invokes_alert is False else True)
+        self.vm_console
 
-        # Get the consoles window handle, and then create a VMConsole object, and store
-        # the VMConsole object aside.
-        console_handle = self.console_handle
-
-        if console_handle is None:
-            raise TypeError("Console handle should not be None")
-
-        appliance_handle = self.appliance.browser.widgetastic.window_handle
-        logger.info("Creating VMConsole:")
-        logger.info("   appliance_handle: {}".format(appliance_handle))
-        logger.info("     console_handle: {}".format(console_handle))
-        logger.info("               name: {}".format(self.name))
-
-        self.vm_console = VMConsole(
-            appliance_handle=appliance_handle,
-            console_handle=console_handle,
-            vm=self
-        )
 
     def open_details(self, properties=None):
         """Clicks on details infoblock"""

--- a/cfme/common/vm_console.py
+++ b/cfme/common/vm_console.py
@@ -18,7 +18,7 @@ from wait_for import wait_for, TimedOutError
 
 
 class VMConsole(Pretty):
-    """Class to manage the VM Console.   Presently, only support HTML5 Console."""
+    """Class to manage the VM Console. Presently, only support HTML5/WebMKS Console."""
 
     pretty_attrs = ['appliance_handle', 'browser', 'console_handle', 'name']
 

--- a/cfme/fixtures/service_fixtures.py
+++ b/cfme/fixtures/service_fixtures.py
@@ -79,4 +79,4 @@ def order_catalog_item_in_ops_ui(appliance, provider, provisioning, vm_name, dia
                                                                    partial_check=True)
     provision_request.wait_for_request()
     assert provision_request.is_finished()
-    return catalog_item.name
+    return catalog_item

--- a/cfme/services/myservice/ssui.py
+++ b/cfme/services/myservice/ssui.py
@@ -4,6 +4,7 @@ from widgetastic_manageiq import SSUIlist, SSUIDropdown, SSUIAppendToBodyDropdow
 from widgetastic_patternfly import Input, Button
 
 from cfme.base.ssui import SSUIBaseLoggedInPage
+from cfme.common.vm import VM
 from cfme.utils.appliance.implementations.ssui import (
     navigator,
     SSUINavigateStep,
@@ -80,8 +81,16 @@ def update(self, updates):
 
 
 @MyService.launch_vm_console.external_implementation_for(ViaSSUI)
-def launch_vm_console(self):
+def launch_vm_console(self, catalog_item):
     navigate_to(self, 'VM Console')
+    # TODO need to remove 001 from the line below and find correct place/way to put it in code
+    vm_obj = VM.factory(catalog_item.provisioning_data.get('vm_name') + '001',
+                catalog_item.provider, template_name=catalog_item.catalog_name)
+    wait_for(
+        func=lambda: vm_obj.vm_console, num_sec=30, delay=2, handle_exception=True,
+        message="waiting for VM Console window to open"
+    )
+    return vm_obj.vm_console
 
 
 @navigator.register(MyService, 'All')

--- a/cfme/tests/ssui/test_ssui_myservice.py
+++ b/cfme/tests/ssui/test_ssui_myservice.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""Test Service Details page functionality."""
 import pytest
 
 from cfme.infrastructure.provider import InfraProvider
@@ -25,8 +26,8 @@ pytest_generate_tests = testgen.generate([InfraProvider], required_fields=[
 
 @pytest.fixture(scope="module")
 def configure_websocket(appliance):
-    """
-    Enable websocket role if it is disabled.
+    """Enable websocket role if it is disabled.
+
     Currently the fixture cfme/fixtures/base.py:27,
     disables the websocket role to avoid intrusive popups.
     """
@@ -40,8 +41,8 @@ def configure_websocket(appliance):
 @pytest.mark.uncollectif(lambda: current_version() < '5.8')
 @pytest.mark.parametrize('context', [ViaSSUI])
 def test_myservice_crud(appliance, setup_provider, context, order_catalog_item_in_ops_ui):
-    """Tests Myservice crud in SSUI."""
-    service_name = order_catalog_item_in_ops_ui
+    """Test Myservice crud in SSUI."""
+    service_name = order_catalog_item_in_ops_ui.name
     with appliance.context.use(context):
         appliance.server.login()
         myservice = MyService(appliance, service_name)
@@ -54,9 +55,10 @@ def test_myservice_crud(appliance, setup_provider, context, order_catalog_item_i
 @pytest.mark.parametrize('order_catalog_item_in_ops_ui', [['console_test']], indirect=True)
 def test_vm_console(appliance, setup_provider, context, configure_websocket,
         order_catalog_item_in_ops_ui):
-    """Tests Myservice VM Console in SSUI."""
-    service_name = order_catalog_item_in_ops_ui
+    """Test Myservice VM Console in SSUI."""
+    catalog_item = order_catalog_item_in_ops_ui
+    service_name = catalog_item.name
     with appliance.context.use(context):
         appliance.server.login()
         myservice = MyService(appliance, service_name)
-        myservice.launch_vm_console()
+        myservice.launch_vm_console(catalog_item)


### PR DESCRIPTION

Purpose or Intent
=================


__Updating test and other files__ to be able to handle the VM Console opening for SSUI. I have tried to use existing HTML5 console code by slight modification to achieve DRY.

{{pytest: -v --long-running cfme/tests/ssui/test_ssui_myservice.py -k 'test_vm_console' }}