### PR TITLE
[1LP][RFR] Initial fixes for ContainerProvider form for 5.9

### DIFF
--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -114,6 +114,16 @@ class MiddlewareProviderDetailsView(ProviderDetailsView):
                 self.navigation.currently_selected == ['Middleware', 'Providers'])
 
 
+class ContainerProviderDetailsView(ProviderDetailsView):
+    """
+     Container Details page
+    """
+    @property
+    def is_displayed(self):
+        return (super(ContainerProviderDetailsView, self).is_displayed and
+                self.navigation.currently_selected == ['Compute', 'Containers', 'Providers'])
+
+
 class ProviderTimelinesView(TimelinesView, BaseLoggedInPage):
     """
      represents Timelines page
@@ -274,7 +284,7 @@ class ProvidersView(BaseLoggedInPage):
     including_entities = View.include(ProviderEntitiesView, use_parent=True)
 
 
-class ContainersProvidersView(ProvidersView):
+class ContainerProvidersView(ProvidersView):
     """
      represents Main view displaying all Containers providers
     """
@@ -287,7 +297,7 @@ class ContainersProvidersView(ProvidersView):
 
     @property
     def is_displayed(self):
-        return (super(ContainersProvidersView, self).is_displayed and
+        return (super(ContainerProvidersView, self).is_displayed and
                 self.navigation.currently_selected == ['Compute', 'Containers', 'Providers'] and
                 self.entities.title.text == self.SUMMARY_TEXT)
 
@@ -393,9 +403,9 @@ class CloudProviderAddView(ProviderAddView):
                 self.title.text == 'Add New Cloud Provider')
 
 
-class ContainersProviderAddView(ProviderAddView):
+class ContainerProviderAddView(ProviderAddView):
     """
-     represents Containers Provider Add View
+     represents Container Provider Add View
     """
     prov_type = BootstrapSelect(id='ems_type')
 
@@ -404,6 +414,15 @@ class ContainersProviderAddView(ProviderAddView):
         return (super(ProviderAddView, self).is_displayed and
                 self.navigation.currently_selected == ['Compute', 'Containers', 'Providers'] and
                 self.title.text == 'Add New Containers Provider')
+
+
+class ContainerProviderAddViewUpdated(ContainerProviderAddView):
+    """
+     Additional widgets for builds 5.9 and up
+    """
+
+    metrics_type = BootstrapSelect(id='metrics_selection')
+    alerts_type = BootstrapSelect(id='alerts_selection')
 
 
 class MiddlewareProviderAddView(ProviderAddView):
@@ -461,15 +480,24 @@ class CloudProviderEditView(ProviderEditView):
                 self.title.text == 'Edit Cloud Provider')
 
 
-class ContainersProviderEditView(ProviderEditView):
+class ContainerProviderEditView(ProviderEditView):
     """
-     represents Containers Provider Edit View
+     represents Container Provider Edit View
     """
     @property
     def is_displayed(self):
         return (super(ProviderEditView, self).is_displayed and
                 self.navigation.currently_selected == ['Compute', 'Containers', 'Providers'] and
                 'Edit Containers Provider' in self.title.text)
+
+
+class ContainerProviderEditViewUpdated(ContainerProviderEditView):
+    """
+     Additional widgets for builds 5.9 and up
+    """
+
+    metrics_type = BootstrapSelect(id='metrics_selection')
+    alerts_type = BootstrapSelect(id='alerts_selection')
 
 
 class MiddlewareProviderEditView(ProviderEditView):

--- a/cfme/tests/containers/test_ssl_providers.py
+++ b/cfme/tests/containers/test_ssl_providers.py
@@ -7,7 +7,7 @@ import pytest
 from cfme.containers.provider import ContainersProvider
 from cfme.exceptions import FlashMessageException
 from cfme.utils.version import current_version
-from cfme.common.provider_views import ContainersProvidersView
+from cfme.common.provider_views import ContainerProvidersView
 
 
 pytestmark = [
@@ -68,7 +68,7 @@ def test_add_provider_naming_conventions(provider, appliance, soft_assert):
         new_provider.endpoints['default'].sec_protocol = 'SSL'
         try:
             new_provider.setup()
-            view = appliance.browser.create_view(ContainersProvidersView)
+            view = appliance.browser.create_view(ContainerProvidersView)
             view.flash.assert_success_message(
                 'Containers Providers "' + provider_name + '" was saved')
         except FlashMessageException:
@@ -120,7 +120,7 @@ def test_add_hawkular_provider_ssl(provider, appliance, test_item, soft_assert):
     new_provider.endpoints['hawkular'].sec_protocol = test_item.hawkular_sec_protocol
     try:
         new_provider.setup()
-        view = appliance.browser.create_view(ContainersProvidersView)
+        view = appliance.browser.create_view(ContainerProvidersView)
         view.flash.assert_success_message(
             'Containers Providers "' + provider.name + '" was saved')
     except FlashMessageException:

--- a/cfme/tests/containers/test_start_page.py
+++ b/cfme/tests/containers/test_start_page.py
@@ -8,7 +8,7 @@ from cfme.containers.overview import ContainersOverviewView
 from cfme.containers.node import NodeAllView
 from cfme.containers.pod import PodAllView
 from cfme.containers.service import ServiceAllView
-from cfme.containers.provider import ContainersProvider, ContainersProvidersView
+from cfme.containers.provider import ContainersProvider, ContainerProvidersView
 from cfme.containers.project import ProjectAllView
 from cfme.containers.image_registry import ImageRegistryAllView
 from cfme.containers.template import TemplateAllView
@@ -29,7 +29,7 @@ pytestmark = [
 DataSet = namedtuple('DataSet', ['obj_view', 'page_name'])
 data_sets = (
     DataSet(ContainersOverviewView, 'Compute / Containers / Overview'),
-    DataSet(ContainersProvidersView, 'Compute / Containers / Providers'),
+    DataSet(ContainerProvidersView, 'Compute / Containers / Providers'),
     DataSet(NodeAllView, 'Compute / Containers / Container Nodes'),
     DataSet(PodAllView, 'Compute / Containers / Pods'),
     DataSet(ServiceAllView, 'Compute / Containers / Container Services'),


### PR DESCRIPTION
In 5.9, there were recent changes that renamed the 'Hawkular' endpoint from "Hawkular" to "Metrics" and added a new drop down widget called Metrics. The changes in this PR address these updates and allow the creation of a ContainerProvider in 5.9 

{{ pytest: --use-provider cm-env2 --long-running cfme/tests/containers/test_start_page.py cfme/tests/containers/test_ssl_providers.py}}