### PR TITLE
[1LP][RFR] add Openstack networks tests

### DIFF
--- a/cfme/networks/cloud_network.py
+++ b/cfme/networks/cloud_network.py
@@ -64,8 +64,8 @@ class CloudNetworkCollection(BaseCollection):
     def create(self, name, tenant, provider, network_manager, network_type, is_external=False,
                admin_state='up', is_shared=False):
         view = navigate_to(self, 'Add')
-        view.network_manager.fill(network_manager)
-        view.cloud_tenant.fill(tenant)
+        view.network_manager.item_select(network_manager)
+        view.cloud_tenant.item_select(tenant)
         view.network_type.fill(network_type)
         view.network_name.fill(name)
         if is_external:
@@ -106,7 +106,7 @@ class Details(CFMENavigateStep):
 
 
 @navigator.register(CloudNetworkCollection, 'Add')
-class Details(CFMENavigateStep):
+class Add(CFMENavigateStep):
     prerequisite = NavigateToAttribute('parent', 'All')
     VIEW = CloudNetworkAddView
 

--- a/cfme/networks/cloud_network.py
+++ b/cfme/networks/cloud_network.py
@@ -60,12 +60,13 @@ class CloudNetwork(WidgetasticTaggable, BaseEntity):
         return view.entities.relationships.get_text_of('Cloud tenant')
 
     def edit(self, name, change_external=None, change_admin_state=None, change_shared=None):
-        """
-        Edit cloud network
-        :param name: (str) new network name
-        :param change_external: (bool) is network external
-        :param change_admin_state: (bool) network's administrative state, 'Up' or 'Down'
-        :param change_shared: (bool) is network shared, 'Yes' or 'No'
+        """Edit cloud network
+
+        Args:
+            name: (str) new network name
+            change_external: (bool) is network external
+            change_admin_state: (bool) network's administrative state, 'Up' or 'Down'
+            change_shared: (bool) is network shared, 'Yes' or 'No'
         """
         view = navigate_to(self, 'Edit')
         view.fill({'network_name': name,
@@ -105,18 +106,20 @@ class CloudNetworkCollection(BaseCollection):
 
     def create(self, name, tenant, provider, network_manager, network_type, is_external=False,
                admin_state=True, is_shared=False):
-        """
-        Create cloud network
-        :param name: (str) name of the network
-        :param tenant: (str) name of cloud tenant to place network to
-        :param provider: crud object of Openstack Cloud provider
-        :param network_manager: (str) name of network manager
-        :param network_type: (str) type of network, such as 'VXLAN', 'VLAN', 'GRE' etc.
-        :param is_external: (bool) is network external
-        :param admin_state: (bool) network's initial administrative state, True stands for 'Up',
+        """Create cloud network
+
+        Args:
+            name: (str) name of the network
+            tenant: (str) name of cloud tenant to place network to
+            provider: crud object of Openstack Cloud provider
+            network_manager: (str) name of network manager
+            network_type: (str) type of network, such as 'VXLAN', 'VLAN', 'GRE' etc.
+            is_external: (bool) is network external
+            admin_state: (bool) network's initial administrative state, True stands for 'Up',
                             False - 'Down'
-        :param is_shared: (bool) is network shared
-        :return: instance of cfme.networks.cloud_network.CloudNetwork
+            is_shared: (bool) is network shared
+        Returns:
+            instance of cfme.networks.cloud_network.CloudNetwork
         """
         view = navigate_to(self, 'Add')
         view.fill({'network_manager': network_manager,

--- a/cfme/networks/cloud_network.py
+++ b/cfme/networks/cloud_network.py
@@ -76,8 +76,8 @@ class CloudNetworkCollection(BaseCollection):
     def create(self, name, tenant, provider, network_manager, network_type, is_external=False,
                admin_state='up', is_shared=False):
         view = navigate_to(self, 'Add')
-        view.network_manager.item_select(network_manager)
-        view.cloud_tenant.item_select(tenant)
+        view.network_manager.fill(network_manager)
+        view.cloud_tenant.fill(tenant)
         view.network_type.fill(network_type)
         view.network_name.fill(name)
         if is_external:

--- a/cfme/networks/cloud_network.py
+++ b/cfme/networks/cloud_network.py
@@ -68,15 +68,14 @@ class CloudNetwork(WidgetasticTaggable, BaseEntity):
             view.administrative_state.click()
         if change_shared:
             view.shared.click()
-        view.add.click()
+        view.save.click()
         view.flash.assert_success_message('Cloud Network "{}" updated'.format(name))
         self.name = name
 
     def delete(self):
         view = navigate_to(self, 'Details')
         view.toolbar.configuration.item_select('Delete this Cloud Network', handle_alert=True)
-        # TODO: add particular message verification once BZ#1502736 is resolved
-        view.flash.assert_no_error()
+        view.flash.assert_success_message('The selected Cloud Network was deleted')
 
     @property
     def network_provider(self):
@@ -158,7 +157,7 @@ class Add(CFMENavigateStep):
 
 @navigator.register(CloudNetwork, 'Edit')
 class Edit(CFMENavigateStep):
-    prerequisite = NavigateToAttribute('parent', 'Details')
+    prerequisite = NavigateToSibling('Details')
     VIEW = CloudNetworkEditView
 
     def step(self):

--- a/cfme/networks/cloud_network.py
+++ b/cfme/networks/cloud_network.py
@@ -22,6 +22,8 @@ class CloudNetwork(WidgetasticTaggable, BaseEntity):
     db_types = ['CloudNetwork']
 
     name = attr.ib()
+    provider = attr.ib()
+    tenant = attr.ib()
 
     @property
     def provider(self):
@@ -88,7 +90,7 @@ class CloudNetworkCollection(BaseCollection):
             view.shared.click()
         view.add.click()
         view.flash.assert_success_message('Cloud Network "{}" created'.format(name))
-        network = self.instantiate(name, provider)
+        network = self.instantiate(name, provider, tenant)
         # Refresh provider's relationships to have new network displayed
         wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600)
         return network

--- a/cfme/networks/cloud_network.py
+++ b/cfme/networks/cloud_network.py
@@ -23,7 +23,6 @@ class CloudNetwork(WidgetasticTaggable, BaseEntity):
 
     name = attr.ib()
     provider = attr.ib()
-    tenant = attr.ib()
 
     @property
     def provider(self):
@@ -90,9 +89,10 @@ class CloudNetworkCollection(BaseCollection):
             view.shared.click()
         view.add.click()
         view.flash.assert_success_message('Cloud Network "{}" created'.format(name))
-        network = self.instantiate(name, provider, tenant)
+        network = self.instantiate(name, provider)
         # Refresh provider's relationships to have new network displayed
         wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600)
+        network.browser.refresh()
         return network
 
     def all(self):

--- a/cfme/networks/cloud_network.py
+++ b/cfme/networks/cloud_network.py
@@ -46,6 +46,10 @@ class CloudNetwork(WidgetasticTaggable, BaseEntity):
         view.save.click()
         view.flash.assert_success_message('Cloud Network "{}" created'.format(self.name))
 
+    def delete(self):
+        view = navigate_to(self, 'Details')
+        view.configuration.item_select('Delete this Cloud Network', handle_alert=True)
+
     @property
     def provider(self):
         from cfme.networks.provider import NetworkProvider
@@ -118,4 +122,4 @@ class Details(CFMENavigateStep):
     VIEW = CloudNetworkAddView
 
     def step(self):
-        self.prerequisite_view.configuration.select('Add a new Cloud Network')
+        self.prerequisite_view.configuration.item_select('Add a new Cloud Network')

--- a/cfme/networks/cloud_network.py
+++ b/cfme/networks/cloud_network.py
@@ -59,13 +59,13 @@ class CloudNetwork(WidgetasticTaggable, BaseEntity):
         view = navigate_to(self, 'Details')
         return view.entities.relationships.get_text_of('Cloud tenant')
 
-    def edit(self, name, change_external=False, change_admin_state=False, change_shared=False):
+    def edit(self, name, change_external=None, change_admin_state=None, change_shared=None):
         """
         Edit cloud network
         :param name: (str) new network name
-        :param change_external: (bool) if True swithes 'external gateway' checkbox
-        :param change_admin_state: (bool) if True swithes 'administrative state' checkbox
-        :param change_shared: (bool) if True swithes 'shared' checkbox
+        :param change_external: (bool) is network external
+        :param change_admin_state: (bool) network's administrative state, 'Up' or 'Down'
+        :param change_shared: (bool) is network shared, 'Yes' or 'No'
         """
         view = navigate_to(self, 'Edit')
         view.fill({'network_name': name,
@@ -104,7 +104,7 @@ class CloudNetworkCollection(BaseCollection):
     ENTITY = CloudNetwork
 
     def create(self, name, tenant, provider, network_manager, network_type, is_external=False,
-               admin_state='up', is_shared=False):
+               admin_state=True, is_shared=False):
         """
         Create cloud network
         :param name: (str) name of the network
@@ -112,14 +112,13 @@ class CloudNetworkCollection(BaseCollection):
         :param provider: crud object of Openstack Cloud provider
         :param network_manager: (str) name of network manager
         :param network_type: (str) type of network, such as 'VXLAN', 'VLAN', 'GRE' etc.
-        :param is_external: (bool) if True creates network as an external one
-        :param admin_state: (bool) if True create network with administrative state 'Down'.
-                            Default to 'Up'
-        :param is_shared: (bool) if True makes network to be shared
+        :param is_external: (bool) is network external
+        :param admin_state: (bool) network's initial administrative state, True stands for 'Up',
+                            False - 'Down'
+        :param is_shared: (bool) is network shared
         :return: instance of cfme.networks.cloud_network.CloudNetwork
         """
         view = navigate_to(self, 'Add')
-        admin_state = True if admin_state.lower() == 'down' else False
         view.fill({'network_manager': network_manager,
                    'cloud_tenant': tenant,
                    'network_type': network_type,
@@ -141,7 +140,7 @@ class CloudNetworkCollection(BaseCollection):
         else:
             view = navigate_to(self, 'All')
         list_networks_obj = view.entities.get_all(surf_pages=True)
-        return [self.instantiate(name=n.name) for n in list_networks_obj]
+        return [self.instantiate(name=n.name, provider_obj=None) for n in list_networks_obj]
 
 
 @navigator.register(CloudNetworkCollection, 'All')

--- a/cfme/networks/network_router.py
+++ b/cfme/networks/network_router.py
@@ -28,9 +28,10 @@ class NetworkRouter(WidgetasticTaggable, BaseEntity):
     ext_network = attr.ib()
 
     def add_interface(self, subnet_name):
-        """
-        Adds subnet as an interface to current router
-        :param subnet_name: (str) name of the subnet to be added
+        """Adds subnet as an interface to current router
+
+        Args:
+            subnet_name: (str) name of the subnet to be added
         """
         view = navigate_to(self, 'AddInterface')
         view.subnet_name.fill(subnet_name)
@@ -46,14 +47,15 @@ class NetworkRouter(WidgetasticTaggable, BaseEntity):
         view.flash.assert_success_message('Delete initiated for 1 Network Router.')
 
     def edit(self, name=None, change_external_gw=None, ext_network=None, ext_network_subnet=None):
-        """
-        Edit this router
-        :param name: (str) new name of router
-        :param change_external_gw: (bool) external gateway, True stands for 'Yes', False - 'No'
-        :param ext_network: (str) name of external network to be connected as gateway to router.
-                            applicable if 'external gateway' is enabled
-        :param ext_network_subnet: (str) name of subnet of ext_network.
-                            applicable if 'external gateway' is enabled
+        """Edit this router
+
+        Args:
+            name: (str) new name of router
+            change_external_gw: (bool) external gateway, True stands for 'Yes', False - 'No'
+            ext_network: (str) name of external network to be connected as gateway to router.
+                applicable if 'external gateway' is enabled
+            ext_network_subnet: (str) name of subnet of ext_network.
+                applicable if 'external gateway' is enabled
         """
         view = navigate_to(self, 'Edit')
         view.fill({'router_name': name,
@@ -121,19 +123,20 @@ class NetworkRouterCollection(BaseCollection):
 
     def create(self, name, provider, tenant, network_manager, has_external_gw=False,
                ext_network=None, ext_network_subnet=None):
-        """
-        Create network router
-        :param name: (str) name of router
-        :param provider: crud object of OpenStack cloud provider
-        :param tenant: (str) name of tenant to place router to
-        :param network_manager: (str) name of network manager
-        :param has_external_gw: (bool) represents if router has external gateway
-        :param ext_network: (str) name of the external cloud network
-                            to be connected as a gateway to the router.
-                            Is used if has_external_gw == 'Yes'
-        :param ext_network_subnet: (str) name of the subnet of ext_network.
-                            Is used if has_external_gw == 'Yes'
-        :return: instance of cfme.networks.network_router.NetworkRouter
+        """Create network router
+
+        Args:
+            name: (str) name of router
+            provider: crud object of OpenStack cloud provider
+            tenant: (str) name of tenant to place router to
+            network_manager: (str) name of network manager
+            has_external_gw: (bool) represents if router has external gateway
+            ext_network: (str) name of the external cloud network
+                to be connected as a gateway to the router.
+                Is used if has_external_gw == 'Yes'
+            ext_network_subnet: (str) name of the subnet of ext_network.
+                Is used if has_external_gw == 'Yes'
+        Returns: instance of cfme.networks.network_router.NetworkRouter
         """
         view = navigate_to(self, 'Add')
         form_params = {'network_manager': network_manager,

--- a/cfme/networks/network_router.py
+++ b/cfme/networks/network_router.py
@@ -29,7 +29,7 @@ class NetworkRouter(WidgetasticTaggable, BaseEntity):
 
     def delete(self):
         view = navigate_to(self, 'Details')
-        view.toolbar.configuration.item_select('Delete this Router')
+        view.toolbar.configuration.item_select('Delete this Router', handle_alert=True)
         view.flash.assert_success_message('Delete initiated for 1 Network Router.')
 
     def edit(self, name=None, change_external_gw=False, ext_network=None, ext_network_subnet=None):

--- a/cfme/networks/network_router.py
+++ b/cfme/networks/network_router.py
@@ -52,7 +52,8 @@ class NetworkRouter(WidgetasticTaggable, BaseEntity):
         view.save.click()
         success_msg = 'Network Router "{}" updated'.format(name if name else self.name)
         view.flash.assert_success_message(success_msg)
-        self.name = name
+        if name:
+            self.name = name
         if change_external_gw and not self.ext_network:
             self.ext_network = ext_network
         elif change_external_gw and self.ext_network:

--- a/cfme/networks/subnet.py
+++ b/cfme/networks/subnet.py
@@ -36,28 +36,33 @@ class Subnet(WidgetasticTaggable, BaseEntity):
             return True
 
     def edit(self, new_name, gateway=None):
+        """
+        Edit cloud subnet
+        :param new_name: (str) new name of subnet
+        :param gateway: (str) IP of new gateway, for example: 11.11.11.1
+        """
         view = navigate_to(self, 'Edit')
-        view.subnet_name.fill(new_name)
-        if gateway:
-            view.gateway.fill(gateway)
+        view.fill({'subnet_name': new_name,
+                   'gateway': gateway})
         view.save.click()
         view.flash.assert_success_message('Network Subnet "{}" updated'.format(new_name))
         self.name = new_name
 
     def delete(self):
+        """Deletes this subnet"""
         view = navigate_to(self, 'Details')
         view.toolbar.configuration.item_select('Delete this Cloud Subnet', handle_alert=True)
         view.flash.assert_success_message('The selected Cloud Subnet was deleted')
 
     @property
     def cloud_tenant(self):
-        """ Return tenant that subnet belongs to"""
+        """ Return name of tenant that subnet belongs to"""
         view = navigate_to(self, 'Details')
         return view.entities.relationships.get_text_of('Cloud tenant')
 
     @property
     def cloud_network(self):
-        """ Return network that subnet belongs to"""
+        """ Return name of network that subnet belongs to"""
         view = navigate_to(self, 'Details')
         return view.entities.relationships.get_text_of('Cloud network')
 
@@ -115,14 +120,24 @@ class SubnetCollection(BaseCollection):
     ENTITY = Subnet
 
     def create(self, name, tenant, provider, network_manager, network_name, cidr, gateway=None):
+        """
+        Create subnet
+        :param name: (str) name of the subnet
+        :param tenant: (str) name of the tenant to place subnet to
+        :param provider: crud object of Openstack cloud provider
+        :param network_manager: (str) name of network manager
+        :param network_name: (str) name of the network to create subnet under
+        :param cidr: (str) CIDR of subnet, for example: 192.168.12.2/24
+        :param gateway: (str) gateway of subnet, if None - appliance will set it automatically
+        :return: instance of cfme.newtorks.subnet.Subnet
+        """
         view = navigate_to(self, 'Add')
-        view.network_manager.fill(network_manager)
-        view.network.fill(network_name)
-        view.subnet_name.fill(name)
-        view.subnet_cidr.fill(cidr)
-        if gateway:
-            view.gateway.fill(gateway)
-        view.cloud_tenant.fill(tenant)
+        view.fill({'network_manager': network_manager,
+                   'network': network_name,
+                   'subnet_name': name,
+                   'subnet_cidr': cidr,
+                   'gateway': gateway,
+                   'cloud_tenant': tenant})
         view.add.click()
         view.flash.assert_success_message('Cloud Subnet "{}" created'.format(name))
         subnet = self.instantiate(name, provider, network_name)

--- a/cfme/networks/subnet.py
+++ b/cfme/networks/subnet.py
@@ -126,7 +126,7 @@ class SubnetCollection(BaseCollection):
         view.add.click()
         view.flash.assert_success_message('Cloud Subnet "{}" created'.format(name))
         subnet = self.instantiate(name, provider, network_name)
-        # Refresh provider's relationships to have new network displayed
+        # Refresh provider's relationships to have new subnet displayed
         wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600)
         wait_for(lambda: subnet.exists, timeout=100, fail_func=subnet.browser.refresh)
         return subnet

--- a/cfme/networks/subnet.py
+++ b/cfme/networks/subnet.py
@@ -36,10 +36,11 @@ class Subnet(WidgetasticTaggable, BaseEntity):
             return True
 
     def edit(self, new_name, gateway=None):
-        """
-        Edit cloud subnet
-        :param new_name: (str) new name of subnet
-        :param gateway: (str) IP of new gateway, for example: 11.11.11.1
+        """Edit cloud subnet
+
+        Args:
+            new_name: (str) new name of subnet
+            gateway: (str) IP of new gateway, for example: 11.11.11.1
         """
         view = navigate_to(self, 'Edit')
         view.fill({'subnet_name': new_name,
@@ -120,16 +121,18 @@ class SubnetCollection(BaseCollection):
     ENTITY = Subnet
 
     def create(self, name, tenant, provider, network_manager, network_name, cidr, gateway=None):
-        """
-        Create subnet
-        :param name: (str) name of the subnet
-        :param tenant: (str) name of the tenant to place subnet to
-        :param provider: crud object of Openstack cloud provider
-        :param network_manager: (str) name of network manager
-        :param network_name: (str) name of the network to create subnet under
-        :param cidr: (str) CIDR of subnet, for example: 192.168.12.2/24
-        :param gateway: (str) gateway of subnet, if None - appliance will set it automatically
-        :return: instance of cfme.newtorks.subnet.Subnet
+        """Create subnet
+
+        Args:
+            name: (str) name of the subnet
+            tenant: (str) name of the tenant to place subnet to
+            provider: crud object of Openstack cloud provider
+            network_manager: (str) name of network manager
+            network_name: (str) name of the network to create subnet under
+            cidr: (str) CIDR of subnet, for example: 192.168.12.2/24
+            gateway: (str) gateway of subnet, if None - appliance will set it automatically
+
+        Returns: instance of cfme.newtorks.subnet.Subnet
         """
         view = navigate_to(self, 'Add')
         view.fill({'network_manager': network_manager,

--- a/cfme/networks/views.py
+++ b/cfme/networks/views.py
@@ -1,6 +1,6 @@
 from widgetastic_manageiq import (ManageIQTree, SummaryTable, ItemsToolBarViewSelector,
                                  BaseEntitiesView)
-from widgetastic_patternfly import Dropdown, Accordion, FlashMessages, Button
+from widgetastic_patternfly import Dropdown, Accordion, FlashMessages, Button, TextInput
 from widgetastic.widget import View, Text
 
 from cfme.base.login import BaseLoggedInPage
@@ -226,6 +226,21 @@ class CloudNetworkDetailsView(BaseLoggedInPage):
         return (super(BaseLoggedInPage, self).is_displayed and
                 self.navigation.currently_selected == ['Networks', 'Networks'] and
                 self.title.text == '{name} (Summary)'.format(name=self.context['object'].name))
+
+
+class CloudNetworkAddView(BaseLoggedInPage):
+    """ Represents detail view of cloud network """
+    title = Text('//div[@id="main-content"]//h1')
+    flash = FlashMessages('.//div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
+                          'contains(@class, "flash_text_div")]')
+    network_manager = Dropdown(text='Network Manager')
+    cloud_tenant = Dropdown(text='Cloud Tenant')
+    network_type = Dropdown(text='Provider Network Type')
+    network_name = TextInput(name='name')
+    ext_router = Button(id='cloud_network_external_facing')
+    administrative_state = Button(id='cloud_network_enabled')
+    shared = Button(text='Shared')
+    save = Button(text='Add')
 
 
 class NetworkPortToolBar(View):

--- a/cfme/networks/views.py
+++ b/cfme/networks/views.py
@@ -419,8 +419,6 @@ class NetworkRouterDetailsView(BaseLoggedInPage):
 
 class NetworkRouterAddView(BaseLoggedInPage):
     """ Represents Add NetworkRouters page """
-    # flash = FlashMessages('.//div[@div="flash_msg_div"]/div[@id="flash_text_div" or '
-    #                       'contains(@class, "flash_text_div")]')
     flash = FlashMessages('.//div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
                           'contains(@class, "flash_text_div")]')
     network_manager = Select(id='ems_id')
@@ -432,6 +430,23 @@ class NetworkRouterAddView(BaseLoggedInPage):
     subnet_name = Select(name='cloud_subnet_id')
     cloud_tenant = Select(name='cloud_tenant_id')
     add = Button('Add')
+
+    @property
+    def is_displayed(self):
+        return False
+
+
+class NetworkRouterEditView(BaseLoggedInPage):
+    """ Represents Edit NetworkRouters page """
+    flash = FlashMessages('.//div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
+                          'contains(@class, "flash_text_div")]')
+    router_name = TextInput(name='name')
+    ext_gateway = Checkbox(
+        locator='//div[contains(@class, "network_router_external_gateway")]//'
+                'span[contains(@class, "switch-label")]')
+    network_name = Select(name='cloud_network_id')
+    subnet_name = Select(name='cloud_subnet_id')
+    save = Button('Save')
 
     @property
     def is_displayed(self):

--- a/cfme/networks/views.py
+++ b/cfme/networks/views.py
@@ -259,9 +259,15 @@ class CloudNetworkEditView(BaseLoggedInPage):
     flash = FlashMessages('.//div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
                           'contains(@class, "flash_text_div")]')
     network_name = TextInput(name='name')
-    ext_router = Button(id='cloud_network_external_facing')
-    administrative_state = Button(id='cloud_network_enabled')
-    shared = Button(id='cloud_network_shared')
+    ext_router = Checkbox(
+        locator='//div[contains(@class, "cloud_network_external_facing")]//'
+                'span[contains(@class, "switch-label")]')
+    administrative_state = Checkbox(
+        locator='//div[contains(@class, "cloud_network_enabled")]//'
+                'span[contains(@class, "switch-label")]')
+    shared = Checkbox(
+        locator='//div[contains(@class, "cloud_network_shared")]//'
+                'span[contains(@class, "switch-label")]')
     save = Button('Save')
 
     @property

--- a/cfme/networks/views.py
+++ b/cfme/networks/views.py
@@ -1,7 +1,7 @@
 from widgetastic_manageiq import (ManageIQTree, SummaryTable, ItemsToolBarViewSelector,
                                  BaseEntitiesView)
 from widgetastic_patternfly import Dropdown, Accordion, FlashMessages, Button, TextInput
-from widgetastic.widget import View, Text
+from widgetastic.widget import View, Text, Select
 
 from cfme.base.login import BaseLoggedInPage
 
@@ -233,14 +233,14 @@ class CloudNetworkAddView(BaseLoggedInPage):
     title = Text('//div[@id="main-content"]//h1')
     flash = FlashMessages('.//div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
                           'contains(@class, "flash_text_div")]')
-    network_manager = Dropdown(text='Network Manager')
-    cloud_tenant = Dropdown(text='Cloud Tenant')
-    network_type = Dropdown(text='Provider Network Type')
+    network_manager = Select(id='ems_id')
+    cloud_tenant = Select(name='cloud_tenant_id')
+    network_type = Select(name='provider_network_type')
     network_name = TextInput(name='name')
     ext_router = Button(id='cloud_network_external_facing')
     administrative_state = Button(id='cloud_network_enabled')
-    shared = Button(text='Shared')
-    save = Button(text='Add')
+    shared = Button(id='cloud_network_shared')
+    add = Button('Add')
 
 
 class NetworkPortToolBar(View):

--- a/cfme/networks/views.py
+++ b/cfme/networks/views.py
@@ -453,6 +453,18 @@ class NetworkRouterEditView(BaseLoggedInPage):
         return False
 
 
+class NetworkRouterAddInterfaceView(BaseLoggedInPage):
+    """ Represents Add Interface to Network Router page """
+    flash = FlashMessages('.//div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
+                          'contains(@class, "flash_text_div")]')
+    subnet_name = Select(id='cloud_subnet_id')
+    add = Button('Add')
+
+    @property
+    def is_displayed(self):
+        return False
+
+
 class SecurityGroupToolBar(View):
     """ Represents provider toolbar and its controls """
     configuration = Dropdown(text='Configuration')

--- a/cfme/networks/views.py
+++ b/cfme/networks/views.py
@@ -1,7 +1,7 @@
 from widgetastic_manageiq import (ManageIQTree, SummaryTable, ItemsToolBarViewSelector,
                                  BaseEntitiesView)
 from widgetastic_patternfly import Dropdown, Accordion, FlashMessages, Button, TextInput
-from widgetastic.widget import View, Text, Select
+from widgetastic.widget import View, Text, Select, Checkbox
 
 from cfme.base.login import BaseLoggedInPage
 
@@ -237,9 +237,9 @@ class CloudNetworkAddView(BaseLoggedInPage):
     cloud_tenant = Select(name='cloud_tenant_id')
     network_type = Select(name='provider_network_type')
     network_name = TextInput(name='name')
-    ext_router = Button(id='cloud_network_external_facing')
-    administrative_state = Button(id='cloud_network_enabled')
-    shared = Button(id='cloud_network_shared')
+    ext_router = Checkbox(id='cloud_network_external_facing')
+    administrative_state = Checkbox(id='cloud_network_enabled')
+    shared = Checkbox(id='cloud_network_shared')
     add = Button('Add')
 
     @property
@@ -346,6 +346,7 @@ class NetworkRouterToolBar(View):
 
 class NetworkRouterDetailsToolBar(View):
     """ Represents provider toolbar and its controls """
+    configuration = Dropdown(text='Configuration')
     policy = Dropdown(text='Policy')
     download = Button(title='Download')
 
@@ -408,6 +409,23 @@ class NetworkRouterDetailsView(BaseLoggedInPage):
         return (super(BaseLoggedInPage, self).is_displayed and
                 self.navigation.currently_selected == ['Networks', 'Providers'] and
                 self.title.text == '{name} (Summary)'.format(name=self.context['object'].name))
+
+
+class NetworkRouterAddView(BaseLoggedInPage):
+    """ Represents Add NetworkRouters page """
+    flash = FlashMessages('.//div[@div="flash_msg_div"]/div[@id="flash_text_div" or '
+                          'contains(@class, "flash_text_div")]')
+    network_manager = Select(id='ems_id')
+    router_name = TextInput(name='name')
+    ext_gateway = Checkbox(id='network_router_external_gateway')
+    network_name = Select(name='cloud_network_id')
+    subnet_name = Select(name='cloud_subnet_id')
+    cloud_tenant = Select(name='cloud_tenant_id')
+    add = Button('Add')
+
+    @property
+    def is_displayed(self):
+        return False
 
 
 class SecurityGroupToolBar(View):

--- a/cfme/networks/views.py
+++ b/cfme/networks/views.py
@@ -243,6 +243,18 @@ class CloudNetworkAddView(BaseLoggedInPage):
     add = Button('Add')
 
 
+class CloudNetworkEditView(BaseLoggedInPage):
+    """ Represents detail view of cloud network """
+    title = Text('//div[@id="main-content"]//h1')
+    flash = FlashMessages('.//div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
+                          'contains(@class, "flash_text_div")]')
+    network_name = TextInput(name='name')
+    ext_router = Button(id='cloud_network_external_facing')
+    administrative_state = Button(id='cloud_network_enabled')
+    shared = Button(id='cloud_network_shared')
+    save = Button('save')
+
+
 class NetworkPortToolBar(View):
     """ Represents provider toolbar and its controls """
     policy = Dropdown(text='Policy')

--- a/cfme/networks/views.py
+++ b/cfme/networks/views.py
@@ -1,7 +1,8 @@
 from widgetastic_manageiq import (ManageIQTree, SummaryTable, ItemsToolBarViewSelector,
-                                 BaseEntitiesView)
-from widgetastic_patternfly import Dropdown, Accordion, FlashMessages, Button, TextInput
-from widgetastic.widget import View, Text, Select, Checkbox
+                                  BaseEntitiesView)
+from widgetastic_patternfly import (Dropdown, Accordion, FlashMessages, Button, TextInput,
+                                    BootstrapSwitch)
+from widgetastic.widget import View, Text, Select
 
 from cfme.base.login import BaseLoggedInPage
 
@@ -237,15 +238,9 @@ class CloudNetworkAddView(BaseLoggedInPage):
     cloud_tenant = Select(name='cloud_tenant_id')
     network_type = Select(name='provider_network_type')
     network_name = TextInput(name='name')
-    ext_router = Checkbox(
-        locator='//div[contains(@class, "cloud_network_external_facing")]//'
-                'span[contains(@class, "switch-label")]')
-    administrative_state = Checkbox(
-        locator='//div[contains(@class, "cloud_network_enabled")]//'
-                'span[contains(@class, "switch-label")]')
-    shared = Checkbox(
-        locator='//div[contains(@class, "cloud_network_shared")]//'
-                'span[contains(@class, "switch-label")]')
+    ext_router = BootstrapSwitch(id='cloud_network_external_facing')
+    administrative_state = BootstrapSwitch(id='cloud_network_enabled')
+    shared = BootstrapSwitch(id='cloud_network_shared')
     add = Button('Add')
 
     @property
@@ -259,15 +254,9 @@ class CloudNetworkEditView(BaseLoggedInPage):
     flash = FlashMessages('.//div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
                           'contains(@class, "flash_text_div")]')
     network_name = TextInput(name='name')
-    ext_router = Checkbox(
-        locator='//div[contains(@class, "cloud_network_external_facing")]//'
-                'span[contains(@class, "switch-label")]')
-    administrative_state = Checkbox(
-        locator='//div[contains(@class, "cloud_network_enabled")]//'
-                'span[contains(@class, "switch-label")]')
-    shared = Checkbox(
-        locator='//div[contains(@class, "cloud_network_shared")]//'
-                'span[contains(@class, "switch-label")]')
+    ext_router = BootstrapSwitch(id='cloud_network_external_facing')
+    administrative_state = BootstrapSwitch(id='cloud_network_enabled')
+    shared = BootstrapSwitch(id='cloud_network_shared')
     save = Button('Save')
 
     @property
@@ -429,9 +418,7 @@ class NetworkRouterAddView(BaseLoggedInPage):
                           'contains(@class, "flash_text_div")]')
     network_manager = Select(id='ems_id')
     router_name = TextInput(name='name')
-    ext_gateway = Checkbox(
-        locator='//div[contains(@class, "network_router_external_gateway")]//'
-                'span[contains(@class, "switch-label")]')
+    ext_gateway = BootstrapSwitch(id='network_router_external_gateway')
     network_name = Select(name='cloud_network_id')
     subnet_name = Select(name='cloud_subnet_id')
     cloud_tenant = Select(name='cloud_tenant_id')
@@ -447,9 +434,7 @@ class NetworkRouterEditView(BaseLoggedInPage):
     flash = FlashMessages('.//div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
                           'contains(@class, "flash_text_div")]')
     router_name = TextInput(name='name')
-    ext_gateway = Checkbox(
-        locator='//div[contains(@class, "network_router_external_gateway")]//'
-                'span[contains(@class, "switch-label")]')
+    ext_gateway = BootstrapSwitch(id='network_router_external_gateway')
     network_name = Select(name='cloud_network_id')
     subnet_name = Select(name='cloud_subnet_id')
     save = Button('Save')

--- a/cfme/networks/views.py
+++ b/cfme/networks/views.py
@@ -242,6 +242,10 @@ class CloudNetworkAddView(BaseLoggedInPage):
     shared = Button(id='cloud_network_shared')
     add = Button('Add')
 
+    @property
+    def is_displayed(self):
+        return False
+
 
 class CloudNetworkEditView(BaseLoggedInPage):
     """ Represents detail view of cloud network """
@@ -252,7 +256,11 @@ class CloudNetworkEditView(BaseLoggedInPage):
     ext_router = Button(id='cloud_network_external_facing')
     administrative_state = Button(id='cloud_network_enabled')
     shared = Button(id='cloud_network_shared')
-    save = Button('save')
+    save = Button('Save')
+
+    @property
+    def is_displayed(self):
+        return False
 
 
 class NetworkPortToolBar(View):
@@ -487,8 +495,27 @@ class SubnetToolBar(View):
 
 class SubnetDetailsToolBar(View):
     """ Represents provider details toolbar """
+    configuration = Dropdown(text='Configuration')
     policy = Dropdown(text='Policy')
     download = Button(title='Download summary in PDF format')
+
+
+class SubnetAddView(BaseLoggedInPage):
+    """ Represents detail view of cloud network """
+    title = Text('//div[@id="main-content"]//h1')
+    flash = FlashMessages('.//div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
+                          'contains(@class, "flash_text_div")]')
+    network_manager = Select(id='ems_id')
+    cloud_tenant = Select(name='cloud_tenant_id')
+    network = Select(name='cloud_network_id')
+    subnet_name = TextInput(name='name')
+    subnet_cidr = TextInput(name='cidr')
+    gateway = TextInput(name='gateway_ip')
+    add = Button('Add')
+
+    @property
+    def is_displayed(self):
+        return False
 
 
 class SubnetSideBar(View):

--- a/cfme/networks/views.py
+++ b/cfme/networks/views.py
@@ -229,7 +229,7 @@ class CloudNetworkDetailsView(BaseLoggedInPage):
 
 
 class CloudNetworkAddView(BaseLoggedInPage):
-    """ Represents detail view of cloud network """
+    """ Represents Add view of cloud network """
     title = Text('//div[@id="main-content"]//h1')
     flash = FlashMessages('.//div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
                           'contains(@class, "flash_text_div")]')
@@ -248,7 +248,7 @@ class CloudNetworkAddView(BaseLoggedInPage):
 
 
 class CloudNetworkEditView(BaseLoggedInPage):
-    """ Represents detail view of cloud network """
+    """ Represents Edit view of cloud network """
     title = Text('//div[@id="main-content"]//h1')
     flash = FlashMessages('.//div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
                           'contains(@class, "flash_text_div")]')
@@ -501,7 +501,7 @@ class SubnetDetailsToolBar(View):
 
 
 class SubnetAddView(BaseLoggedInPage):
-    """ Represents detail view of cloud network """
+    """ Represents Add view of subnet """
     title = Text('//div[@id="main-content"]//h1')
     flash = FlashMessages('.//div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
                           'contains(@class, "flash_text_div")]')
@@ -512,6 +512,20 @@ class SubnetAddView(BaseLoggedInPage):
     subnet_cidr = TextInput(name='cidr')
     gateway = TextInput(name='gateway_ip')
     add = Button('Add')
+
+    @property
+    def is_displayed(self):
+        return False
+
+
+class SubnetEditView(BaseLoggedInPage):
+    """ Represents Edit view of subnet """
+    title = Text('//div[@id="main-content"]//h1')
+    flash = FlashMessages('.//div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
+                          'contains(@class, "flash_text_div")]')
+    subnet_name = TextInput(name='name')
+    gateway = TextInput(name='gateway_ip')
+    save = Button('Save')
 
     @property
     def is_displayed(self):

--- a/cfme/networks/views.py
+++ b/cfme/networks/views.py
@@ -237,9 +237,15 @@ class CloudNetworkAddView(BaseLoggedInPage):
     cloud_tenant = Select(name='cloud_tenant_id')
     network_type = Select(name='provider_network_type')
     network_name = TextInput(name='name')
-    ext_router = Checkbox(id='cloud_network_external_facing')
-    administrative_state = Checkbox(id='cloud_network_enabled')
-    shared = Checkbox(id='cloud_network_shared')
+    ext_router = Checkbox(
+        locator='//div[contains(@class, "cloud_network_external_facing")]//'
+                'span[contains(@class, "switch-label")]')
+    administrative_state = Checkbox(
+        locator='//div[contains(@class, "cloud_network_enabled")]//'
+                'span[contains(@class, "switch-label")]')
+    shared = Checkbox(
+        locator='//div[contains(@class, "cloud_network_shared")]//'
+                'span[contains(@class, "switch-label")]')
     add = Button('Add')
 
     @property
@@ -413,11 +419,15 @@ class NetworkRouterDetailsView(BaseLoggedInPage):
 
 class NetworkRouterAddView(BaseLoggedInPage):
     """ Represents Add NetworkRouters page """
-    flash = FlashMessages('.//div[@div="flash_msg_div"]/div[@id="flash_text_div" or '
+    # flash = FlashMessages('.//div[@div="flash_msg_div"]/div[@id="flash_text_div" or '
+    #                       'contains(@class, "flash_text_div")]')
+    flash = FlashMessages('.//div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
                           'contains(@class, "flash_text_div")]')
     network_manager = Select(id='ems_id')
     router_name = TextInput(name='name')
-    ext_gateway = Checkbox(id='network_router_external_gateway')
+    ext_gateway = Checkbox(
+        locator='//div[contains(@class, "network_router_external_gateway")]//'
+                'span[contains(@class, "switch-label")]')
     network_name = Select(name='cloud_network_id')
     subnet_name = Select(name='cloud_subnet_id')
     cloud_tenant = Select(name='cloud_tenant_id')

--- a/cfme/tests/openstack/cloud/test_networks.py
+++ b/cfme/tests/openstack/cloud/test_networks.py
@@ -92,19 +92,28 @@ def test_create_subnet(subnet, subnet_cidr, provider):
     assert subnet.cloud_network == subnet.network
     assert subnet.net_protocol == 'ipv4'
 
+
+def test_edit_subnet(subnet):
+    subnet.edit(new_name=fauxfactory.gen_alpha())
+    wait_for(subnet.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
+             delay=15)
+    subnet.browser.refresh()
+    assert subnet.exists
+
+
+def test_delete_subnet(subnet):
+    subnet.delete()
+    wait_for(subnet.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
+             delay=15)
+    subnet.browser.refresh()
+    assert not subnet.exists
+
 # def test_create_router():
 #
 # def test_connect_inteface_to_router():
 #
 # def test_edit_router()
 #
-#
-#
-# def test_edit_subnet()
-#
-#
-#
-# def test_delete_subnet()
 #
 # def test_delete_router()
 #

--- a/cfme/tests/openstack/cloud/test_networks.py
+++ b/cfme/tests/openstack/cloud/test_networks.py
@@ -34,5 +34,6 @@ def network(provider, appliance):
     network.delete()
 
 
-def test_create_network(network):
-    assert network.network_type == 'VXLAN'
+def test_create_network(network, provider):
+    assert network.parent_provider.name == provider.name
+    assert network.cloud_tenant == provider.get_yaml_data()['tenant']

--- a/cfme/tests/openstack/cloud/test_networks.py
+++ b/cfme/tests/openstack/cloud/test_networks.py
@@ -21,23 +21,18 @@ pytest_generate_tests = testgen.generate([OpenStackProvider],
 pytestmark = [pytest.mark.usefixtures("setup_provider_modscope")]
 
 
-@pytest.mark.yield_fixture(scope='function')
-def network(provider):
-    network = CloudNetwork(name=fauxfactory.gen_alpha(),
-                           tenant=provider.get_yaml_data()['tenant'],
-                           network_type='VXLAN')
-    network.create()
+@pytest.yield_fixture(scope='function')
+def network(provider, appliance):
+    collection = CloudNetworkCollection(appliance)
+    network = collection.create(name=fauxfactory.gen_alpha(),
+                                tenant=provider.get_yaml_data()['tenant'],
+                                provider=provider,
+                                network_type='VXLAN',
+                                network_manager='{} Network Manager'.format(provider.name))
     yield network
     # TODO: replace this with neutron client request
     network.delete()
 
 
-def test_list_networks(provider, appliance):
-    networks = provider.mgmt.list_network()
-    displayed_networks = CloudNetworkCollection(appliance).all()
-    for n in networks:
-        assert n in displayed_networks
-
-
 def test_create_network(network):
-    assert network.network_type == network.type
+    assert network.network_type == 'VXLAN'

--- a/cfme/tests/openstack/cloud/test_networks.py
+++ b/cfme/tests/openstack/cloud/test_networks.py
@@ -31,7 +31,7 @@ def delete_entity(entity):
 def create_network(appliance, provider, is_external):
     collection = appliance.collections.cloud_networks
     network = collection.create(name=fauxfactory.gen_alpha(),
-                                tenant=provider.get_yaml_data()['tenant'],
+                                tenant=provider.data['provisioning']['cloud_tenant'],
                                 provider=provider,
                                 network_type='VXLAN',
                                 network_manager='{} Network Manager'.format(provider.name),
@@ -42,7 +42,7 @@ def create_network(appliance, provider, is_external):
 def create_subnet(appliance, provider, network):
     collection = appliance.collections.network_subnets
     subnet = collection.create(name=fauxfactory.gen_alpha(),
-                               tenant=provider.get_yaml_data()['tenant'],
+                               tenant=provider.data['provisioning']['cloud_tenant'],
                                provider=provider,
                                network_manager='{} Network Manager'.format(provider.name),
                                network_name=network.name,

--- a/cfme/tests/openstack/cloud/test_networks.py
+++ b/cfme/tests/openstack/cloud/test_networks.py
@@ -133,11 +133,19 @@ def test_create_router(router, provider):
     assert router.exists
     assert router.cloud_tenant == provider.get_yaml_data()['tenant']
     assert router.cloud_network == router.ext_network
-#
-# def test_connect_inteface_to_router():
-#
-# def test_edit_router()
-#
-#
-# def test_delete_router()
-#
+
+
+def test_edit_router(router):
+    router.edit(name=fauxfactory.gen_alpha())
+    wait_for(router.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=1), timeout=600,
+             delay=15)
+    router.browser.refresh()
+    assert router.exists
+
+
+def test_delete_router(router, appliance):
+    router.delete()
+    wait_for(router.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=1), timeout=600,
+             delay=15)
+    navigate_to(appliance.collections.network_routers, 'All')
+    assert not router.exists

--- a/cfme/tests/openstack/cloud/test_networks.py
+++ b/cfme/tests/openstack/cloud/test_networks.py
@@ -36,4 +36,4 @@ def network(provider, appliance):
 
 def test_create_network(network, provider):
     assert network.parent_provider.name == provider.name
-    assert network.cloud_tenant == provider.get_yaml_data()['tenant']
+    assert network.cloud_tenant == network.tenant

--- a/cfme/tests/openstack/cloud/test_networks.py
+++ b/cfme/tests/openstack/cloud/test_networks.py
@@ -36,4 +36,4 @@ def network(provider, appliance):
 
 def test_create_network(network, provider):
     assert network.parent_provider.name == provider.name
-    assert network.cloud_tenant == network.tenant
+    assert network.cloud_tenant == provider.get_yaml_data()['tenant']

--- a/cfme/tests/openstack/cloud/test_networks.py
+++ b/cfme/tests/openstack/cloud/test_networks.py
@@ -24,7 +24,7 @@ pytestmark = [pytest.mark.usefixtures("setup_provider_modscope")]
 
 @pytest.yield_fixture(scope='function')
 def network(provider, appliance):
-    collection = CloudNetworkCollection(appliance)
+    collection = appliance.collections.cloud_networks
     network = collection.create(name=fauxfactory.gen_alpha(),
                                 tenant=provider.get_yaml_data()['tenant'],
                                 provider=provider,
@@ -40,22 +40,24 @@ def network(provider, appliance):
 
 
 def test_create_network(network, provider):
+    assert network.exists
     assert network.parent_provider.name == provider.name
     assert network.cloud_tenant == provider.get_yaml_data()['tenant']
 
 
 def test_edit_network(network):
     network.edit(name=fauxfactory.gen_alpha())
-    wait_for(network.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600)
+    wait_for(network.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
+             delay=10)
     network.browser.refresh()
-    view = navigate_to(network, 'Details')
-    name = view.entities.properties.get_text_of('Name')
-    assert network.name == name
+    assert network.exists
 
 
-def test_delete_network():
+def test_delete_network(network):
     network.delete()
-    wait_for(network.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600)
+    wait_for(network.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
+             delay=10)
+    network.browser.refresh()
     assert not network.exists
 
 # def test_create_subnet():

--- a/cfme/tests/openstack/cloud/test_networks.py
+++ b/cfme/tests/openstack/cloud/test_networks.py
@@ -13,6 +13,7 @@ from cfme.utils import testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.log import logger
 from cfme.utils.version import current_version
+from cfme.utils.wait import wait_for
 
 
 pytest_generate_tests = testgen.generate([OpenStackProvider],
@@ -31,9 +32,48 @@ def network(provider, appliance):
                                 network_manager='{} Network Manager'.format(provider.name))
     yield network
     # TODO: replace this with neutron client request
-    network.delete()
+    try:
+        if network.exists:
+            network.delete()
+    except Exception:
+        logger.warning('Exception during network deletion - skipping..')
 
 
 def test_create_network(network, provider):
     assert network.parent_provider.name == provider.name
     assert network.cloud_tenant == provider.get_yaml_data()['tenant']
+
+
+def test_edit_network(network):
+    network.edit(name=fauxfactory.gen_alpha())
+    wait_for(network.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600)
+    network.browser.refresh()
+    view = navigate_to(network, 'Details')
+    name = view.entities.properties.get_text_of('Name')
+    assert network.name == name
+
+
+def test_delete_network():
+    network.delete()
+    wait_for(network.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600)
+    assert not network.exists
+
+# def test_create_subnet():
+#
+#
+# def test_create_router():
+#
+# def test_connect_inteface_to_router():
+#
+# def test_edit_router()
+#
+#
+#
+# def test_edit_subnet()
+#
+#
+#
+# def test_delete_subnet()
+#
+# def test_delete_router()
+#

--- a/cfme/tests/openstack/cloud/test_networks.py
+++ b/cfme/tests/openstack/cloud/test_networks.py
@@ -114,12 +114,14 @@ def router_with_gw(provider, appliance, ext_subnet):
 
 
 def test_create_network(network, provider):
+    """Creates private cloud network and verifies it's relationships"""
     assert network.exists
     assert network.parent_provider.name == provider.name
     assert network.cloud_tenant == provider.get_yaml_data()['tenant']
 
 
 def test_edit_network(network):
+    """Edits private cloud network's name"""
     network.edit(name=fauxfactory.gen_alpha())
     wait_for(network.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
              delay=10)
@@ -128,6 +130,7 @@ def test_edit_network(network):
 
 
 def test_delete_network(network, appliance):
+    """Deletes private cloud network"""
     network.delete()
     wait_for(network.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
              delay=10)
@@ -136,6 +139,7 @@ def test_delete_network(network, appliance):
 
 
 def test_create_subnet(subnet, subnet_cidr, provider):
+    """Creates private subnet and verifies it's relationships"""
     assert subnet.exists
     assert subnet.parent_provider.name == provider.name
     assert subnet.cloud_tenant == provider.get_yaml_data()['tenant']
@@ -145,6 +149,7 @@ def test_create_subnet(subnet, subnet_cidr, provider):
 
 
 def test_edit_subnet(subnet):
+    """Edits private subnet's name"""
     subnet.edit(new_name=fauxfactory.gen_alpha())
     wait_for(subnet.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
              delay=10)
@@ -153,6 +158,7 @@ def test_edit_subnet(subnet):
 
 
 def test_delete_subnet(subnet):
+    """Deletes private subnet"""
     subnet.delete()
     wait_for(subnet.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
              delay=10)
@@ -161,17 +167,20 @@ def test_delete_subnet(subnet):
 
 
 def test_create_router(router, provider):
+    """Create router without gateway"""
     assert router.exists
     assert router.cloud_tenant == provider.get_yaml_data()['tenant']
 
 
 def test_create_router_with_gateway(router_with_gw, provider):
+    """Creates router with gateway (external network)"""
     assert router_with_gw.exists
     assert router_with_gw.cloud_tenant == provider.get_yaml_data()['tenant']
     assert router_with_gw.cloud_network == router_with_gw.ext_network
 
 
 def test_edit_router(router):
+    """Edits router's name"""
     router.edit(name=fauxfactory.gen_alpha())
     wait_for(router.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
              delay=10)
@@ -180,6 +189,7 @@ def test_edit_router(router):
 
 
 def test_delete_router(router, appliance):
+    """Deletes router"""
     router.delete()
     wait_for(router.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
              delay=10)
@@ -188,6 +198,7 @@ def test_delete_router(router, appliance):
 
 
 def test_clear_router_gateway(router_with_gw):
+    """Deletes a gateway from the router"""
     router_with_gw.edit(change_external_gw=True)
     wait_for(router_with_gw.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10),
              timeout=600, delay=10)
@@ -197,6 +208,7 @@ def test_clear_router_gateway(router_with_gw):
 
 
 def test_add_gateway_to_router(router, ext_subnet):
+    """Adds gateway to the router"""
     router.edit(change_external_gw=True, ext_network=ext_subnet.network,
                 ext_network_subnet=ext_subnet.name)
     wait_for(router.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
@@ -206,6 +218,7 @@ def test_add_gateway_to_router(router, ext_subnet):
 
 
 def test_add_interface_to_router(router, subnet):
+    """Adds interface (subnet) to router"""
     router.add_interface(subnet.name)
     wait_for(router.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
              delay=10)

--- a/cfme/tests/openstack/cloud/test_networks.py
+++ b/cfme/tests/openstack/cloud/test_networks.py
@@ -129,12 +129,11 @@ def test_edit_network(network):
     assert network.exists
 
 
-def test_delete_network(network, appliance):
+def test_delete_network(network):
     """Deletes private cloud network"""
     network.delete()
     wait_for(network.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
              delay=10)
-    navigate_to(appliance.collections.cloud_networks, 'All')
     assert not network.exists
 
 
@@ -153,7 +152,6 @@ def test_edit_subnet(subnet):
     subnet.edit(new_name=fauxfactory.gen_alpha())
     wait_for(subnet.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
              delay=10)
-    subnet.browser.refresh()
     assert subnet.exists
 
 

--- a/cfme/tests/openstack/cloud/test_networks.py
+++ b/cfme/tests/openstack/cloud/test_networks.py
@@ -1,0 +1,43 @@
+"""Tests for Openstack cloud networks and subnets"""
+
+import fauxfactory
+import pytest
+from selenium.common.exceptions import TimeoutException
+from wait_for import TimedOutError
+
+from cfme.cloud.instance.openstack import OpenStackInstance
+from cfme.cloud.provider.openstack import OpenStackProvider
+from cfme.exceptions import ItemNotFound
+from cfme.networks.cloud_network import CloudNetwork, CloudNetworkCollection
+from cfme.utils import testgen
+from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.log import logger
+from cfme.utils.version import current_version
+
+
+pytest_generate_tests = testgen.generate([OpenStackProvider],
+                                         scope='module')
+
+pytestmark = [pytest.mark.usefixtures("setup_provider_modscope")]
+
+
+@pytest.mark.yield_fixture(scope='function')
+def network(provider):
+    network = CloudNetwork(name=fauxfactory.gen_alpha(),
+                           tenant=provider.get_yaml_data()['tenant'],
+                           network_type='VXLAN')
+    network.create()
+    yield network
+    # TODO: replace this with neutron client request
+    network.delete()
+
+
+def test_list_networks(provider, appliance):
+    networks = provider.mgmt.list_network()
+    displayed_networks = CloudNetworkCollection(appliance).all()
+    for n in networks:
+        assert n in displayed_networks
+
+
+def test_create_network(network):
+    assert network.network_type == network.type

--- a/cfme/tests/openstack/cloud/test_networks.py
+++ b/cfme/tests/openstack/cloud/test_networks.py
@@ -122,7 +122,7 @@ def test_create_network(network, provider):
 def test_edit_network(network):
     network.edit(name=fauxfactory.gen_alpha())
     wait_for(network.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
-             delay=15)
+             delay=10)
     network.browser.refresh()
     assert network.exists
 
@@ -130,7 +130,7 @@ def test_edit_network(network):
 def test_delete_network(network, appliance):
     network.delete()
     wait_for(network.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
-             delay=15)
+             delay=10)
     navigate_to(appliance.collections.cloud_networks, 'All')
     assert not network.exists
 
@@ -147,7 +147,7 @@ def test_create_subnet(subnet, subnet_cidr, provider):
 def test_edit_subnet(subnet):
     subnet.edit(new_name=fauxfactory.gen_alpha())
     wait_for(subnet.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
-             delay=15)
+             delay=10)
     subnet.browser.refresh()
     assert subnet.exists
 
@@ -155,7 +155,7 @@ def test_edit_subnet(subnet):
 def test_delete_subnet(subnet):
     subnet.delete()
     wait_for(subnet.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
-             delay=15)
+             delay=10)
     subnet.browser.refresh()
     assert not subnet.exists
 
@@ -174,7 +174,7 @@ def test_create_router_with_gateway(router_with_gw, provider):
 def test_edit_router(router):
     router.edit(name=fauxfactory.gen_alpha())
     wait_for(router.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
-             delay=15)
+             delay=10)
     router.browser.refresh()
     assert router.exists
 
@@ -182,7 +182,7 @@ def test_edit_router(router):
 def test_delete_router(router, appliance):
     router.delete()
     wait_for(router.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
-             delay=15)
+             delay=10)
     navigate_to(appliance.collections.network_routers, 'All')
     assert not router.exists
 
@@ -190,7 +190,7 @@ def test_delete_router(router, appliance):
 def test_clear_router_gateway(router_with_gw):
     router_with_gw.edit(change_external_gw=True)
     wait_for(router_with_gw.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10),
-             timeout=600, delay=15)
+             timeout=600, delay=10)
     router_with_gw.browser.refresh()
     view = navigate_to(router_with_gw, 'Details')
     assert 'Cloud Network' not in view.entities.relationships.items
@@ -200,7 +200,7 @@ def test_add_gateway_to_router(router, ext_subnet):
     router.edit(change_external_gw=True, ext_network=ext_subnet.network,
                 ext_network_subnet=ext_subnet.name)
     wait_for(router.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
-             delay=15)
+             delay=10)
     router.browser.refresh()
     assert router.cloud_network == ext_subnet.network
 
@@ -208,7 +208,7 @@ def test_add_gateway_to_router(router, ext_subnet):
 def test_add_interface_to_router(router, subnet):
     router.add_interface(subnet.name)
     wait_for(router.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
-             delay=15)
+             delay=10)
     router.browser.refresh()
     # TODO: verify the exact entities' names and relationships, not only count
     view = navigate_to(router, 'Details')

--- a/cfme/tests/openstack/cloud/test_networks.py
+++ b/cfme/tests/openstack/cloud/test_networks.py
@@ -154,7 +154,7 @@ def test_edit_subnet(subnet):
 
 def test_delete_subnet(subnet):
     subnet.delete()
-    wait_for(subnet.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=1), timeout=600,
+    wait_for(subnet.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
              delay=15)
     subnet.browser.refresh()
     assert not subnet.exists
@@ -173,7 +173,7 @@ def test_create_router_with_gateway(router_with_gw, provider):
 
 def test_edit_router(router):
     router.edit(name=fauxfactory.gen_alpha())
-    wait_for(router.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=1), timeout=600,
+    wait_for(router.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
              delay=15)
     router.browser.refresh()
     assert router.exists
@@ -181,7 +181,7 @@ def test_edit_router(router):
 
 def test_delete_router(router, appliance):
     router.delete()
-    wait_for(router.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=1), timeout=600,
+    wait_for(router.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
              delay=15)
     navigate_to(appliance.collections.network_routers, 'All')
     assert not router.exists
@@ -189,16 +189,17 @@ def test_delete_router(router, appliance):
 
 def test_clear_router_gateway(router_with_gw):
     router_with_gw.edit(change_external_gw=True)
-    wait_for(router.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=1), timeout=600,
-             delay=15)
+    wait_for(router_with_gw.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10),
+             timeout=600, delay=15)
     router_with_gw.browser.refresh()
     view = navigate_to(router_with_gw, 'Details')
     assert 'Cloud Network' not in view.entities.relationships.items
 
 
 def test_add_gateway_to_router(router, ext_subnet):
-    router.edit(change_external_gw=True, ext_network=ext_subnet.network, ext_subnet=ext_subnet.name)
-    wait_for(router.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=1), timeout=600,
+    router.edit(change_external_gw=True, ext_network=ext_subnet.network,
+                ext_network_subnet=ext_subnet.name)
+    wait_for(router.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
              delay=15)
     router.browser.refresh()
     assert router.cloud_network == ext_subnet.network
@@ -206,7 +207,7 @@ def test_add_gateway_to_router(router, ext_subnet):
 
 def test_add_interface_to_router(router, subnet):
     router.add_interface(subnet.name)
-    wait_for(router.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=1), timeout=600,
+    wait_for(router.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
              delay=15)
     router.browser.refresh()
     # TODO: verify the exact entities' names and relationships, not only count

--- a/cfme/tests/openstack/infrastructure/test_networks.py
+++ b/cfme/tests/openstack/infrastructure/test_networks.py
@@ -3,11 +3,12 @@
 import pytest
 
 from cfme.cloud.provider.openstack import OpenStackProvider
+from cfme.infrastructure.provider.openstack_infra import OpenstackInfraProvider
 from cfme.networks.cloud_network import CloudNetworkCollection
 from cfme.utils import testgen
 
 
-pytest_generate_tests = testgen.generate([OpenStackProvider],
+pytest_generate_tests = testgen.generate([OpenStackProvider, OpenstackInfraProvider],
                                          scope='module')
 
 pytestmark = [pytest.mark.usefixtures("setup_provider_modscope")]
@@ -15,6 +16,6 @@ pytestmark = [pytest.mark.usefixtures("setup_provider_modscope")]
 
 def test_list_networks(provider, appliance):
     networks = [n.label for n in provider.mgmt.api.networks.list()]
-    displayed_networks = CloudNetworkCollection(appliance).all()
+    displayed_networks = [n.name for n in CloudNetworkCollection(appliance).all()]
     for n in networks:
         assert n in displayed_networks

--- a/cfme/tests/openstack/infrastructure/test_networks.py
+++ b/cfme/tests/openstack/infrastructure/test_networks.py
@@ -1,0 +1,20 @@
+"""Tests for Openstack cloud networks and subnets"""
+
+import pytest
+
+from cfme.cloud.provider.openstack import OpenStackProvider
+from cfme.networks.cloud_network import CloudNetworkCollection
+from cfme.utils import testgen
+
+
+pytest_generate_tests = testgen.generate([OpenStackProvider],
+                                         scope='module')
+
+pytestmark = [pytest.mark.usefixtures("setup_provider_modscope")]
+
+
+def test_list_networks(provider, appliance):
+    networks = [n.label for n in provider.mgmt.api.networks.list()]
+    displayed_networks = CloudNetworkCollection(appliance).all()
+    for n in networks:
+        assert n in displayed_networks

--- a/cfme/tests/openstack/infrastructure/test_networks.py
+++ b/cfme/tests/openstack/infrastructure/test_networks.py
@@ -4,7 +4,6 @@ import pytest
 
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.infrastructure.provider.openstack_infra import OpenstackInfraProvider
-from cfme.networks.cloud_network import CloudNetworkCollection
 from cfme.utils import testgen
 
 
@@ -16,6 +15,6 @@ pytestmark = [pytest.mark.usefixtures("setup_provider_modscope")]
 
 def test_list_networks(provider, appliance):
     networks = [n.label for n in provider.mgmt.api.networks.list()]
-    displayed_networks = [n.name for n in CloudNetworkCollection(appliance).all()]
+    displayed_networks = [n.name for n in appliance.collections.cloud_networks.all()]
     for n in networks:
         assert n in displayed_networks


### PR DESCRIPTION
Added tests for Openstack Cloud provider networks, subnets and routers with corresponding naviagtions and views.

Edit subnet fails by [BZ#1467725](https://bugzilla.redhat.com/show_bug.cgi?id=1467725)
Delete network fails by [BZ#1502736](https://bugzilla.redhat.com/show_bug.cgi?id=1502736)

{{pytest: cfme/tests/openstack/cloud/test_networks.py cfme/tests/openstack/infrastructure/test_networks.py --use-provider rhos7-ga}}