### PR TITLE
[WIP] Removed keyword arguments from class instantiations in test_vm_create.

### DIFF
--- a/cfme/tests/cloud_infra_common/test_events.py
+++ b/cfme/tests/cloud_infra_common/test_events.py
@@ -53,13 +53,13 @@ def test_vm_create(request, appliance, vm_crud, provider, register_event):
     Metadata:
         test_flag: provision
     """
-    action = ActionCollection(appliance=appliance).create(
+    action = ActionCollection(appliance).create(
         fauxfactory.gen_alpha(),
         "Tag",
         dict(tag=("My Company Tags", "Environment", "Development")))
     request.addfinalizer(action.delete)
 
-    policy = PolicyCollection(appliance=appliance).create(
+    policy = PolicyCollection(appliance).create(
         VMControlPolicy,
         fauxfactory.gen_alpha()
     )
@@ -69,7 +69,7 @@ def test_vm_create(request, appliance, vm_crud, provider, register_event):
     request.addfinalizer(policy.assign_events)
     policy.assign_actions_to_event("VM Create Complete", action)
 
-    profile = PolicyProfileCollection(appliance=appliance).create(
+    profile = PolicyProfileCollection(appliance).create(
         fauxfactory.gen_alpha(), policies=[policy])
     request.addfinalizer(profile.delete)
 


### PR DESCRIPTION
{{pytest: -v cfme/tests/cloud_infra_common/test_events.py -k test_vm_create --use-provider rhv41}}

__Fixing__ X because it is currently fails on unexpected keyword argument.

