### PR TITLE
[WIPTEST] Remove match_location from some files

### DIFF
--- a/cfme/cloud/availability_zone.py
+++ b/cfme/cloud/availability_zone.py
@@ -8,7 +8,6 @@ from widgetastic_patternfly import Dropdown, Button
 from cfme.base.login import BaseLoggedInPage
 from cfme.common import WidgetasticTaggable
 from cfme.exceptions import AvailabilityZoneNotFound
-from cfme.web_ui import match_location
 from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator
 from widgetastic_manageiq import (
@@ -65,8 +64,7 @@ class AvailabilityZoneView(BaseLoggedInPage):
     def in_availability_zones(self):
         return (
             self.logged_in_as_current_user and
-            self.navigation.currently_selected == ['Compute', 'Clouds', 'Availability Zones'] and
-            match_location(controller='availability_zone', title='Availability Zones'))
+            self.navigation.currently_selected == ['Compute', 'Clouds', 'Availability Zones'])
 
 
 class AvailabilityZoneAllView(AvailabilityZoneView):

--- a/cfme/cloud/flavor.py
+++ b/cfme/cloud/flavor.py
@@ -7,7 +7,6 @@ from widgetastic_patternfly import Dropdown, Button, View
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import WidgetasticTaggable
 from cfme.exceptions import FlavorNotFound
-from cfme.web_ui import match_location
 from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator
 from widgetastic_manageiq import (
@@ -20,8 +19,7 @@ class FlavorView(BaseLoggedInPage):
     def in_availability_zones(self):
         return (
             self.logged_in_as_current_user and
-            self.navigation.currently_selected == ['Compute', 'Clouds', 'Flavors'] and
-            match_location(controller='flavor', title='Flavors'))
+            self.navigation.currently_selected == ['Compute', 'Clouds', 'Flavors'])
 
 
 class FlavorToolBar(View):

--- a/cfme/cloud/keypairs.py
+++ b/cfme/cloud/keypairs.py
@@ -13,7 +13,6 @@ from cfme.common import WidgetasticTaggable
 from cfme.base.ui import BaseLoggedInPage
 from cfme.exceptions import KeyPairNotFound
 
-from cfme.web_ui import match_location
 from cfme.utils.appliance.implementations.ui import navigate_to, navigator, CFMENavigateStep
 from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.utils.wait import wait_for
@@ -72,8 +71,7 @@ class KeyPairView(BaseLoggedInPage):
     def in_keypair(self):
         return(
             self.logged_in_as_current_user and
-            self.navigation.currently_selected == ['Compute', 'Clouds', 'Key Pairs'] and
-            match_location(controller='auth_key_pair_cloud', title='Key Pairs'))
+            self.navigation.currently_selected == ['Compute', 'Clouds', 'Key Pairs'])
 
 
 class KeyPairAllView(KeyPairView):

--- a/cfme/cloud/stack.py
+++ b/cfme/cloud/stack.py
@@ -11,7 +11,6 @@ from widgetastic_manageiq import (
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import WidgetasticTaggable
 from cfme.exceptions import CandidateNotFound
-from cfme.web_ui import match_location
 from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.utils.appliance.implementations.ui import navigator, navigate_to, CFMENavigateStep
 from cfme.utils.pretty import Pretty
@@ -121,9 +120,7 @@ class StackView(BaseLoggedInPage):
         """Determine if the Stacks page is currently open"""
         return (
             self.logged_in_as_current_user and
-            self.navigation.currently_selected == ['Compute', 'Clouds', 'Stacks'] and
-            # TODO: Needs to be converted once there's a Widgetastic alternative
-            match_location(controller='orchestration_stack', title='Stacks'))
+            self.navigation.currently_selected == ['Compute', 'Clouds', 'Stacks'])
 
 
 class StackAllView(StackView):

--- a/cfme/cloud/tenant.py
+++ b/cfme/cloud/tenant.py
@@ -13,7 +13,6 @@ from widgetastic_manageiq import (
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import WidgetasticTaggable
 from cfme.exceptions import TenantNotFound, DestinationNotFound
-from cfme.web_ui import match_location
 from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
 from cfme.utils.log import logger
@@ -86,9 +85,7 @@ class TenantView(BaseLoggedInPage):
         """Determine if the Tenants page is currently open"""
         return (
             self.logged_in_as_current_user and
-            self.navigation.currently_selected == ['Compute', 'Clouds', 'Tenants'] and
-            # TODO: Needs to be converted once there's a Widgetastic alternative
-            match_location(controller='cloud_tenant', title='Cloud Tenants'))
+            self.navigation.currently_selected == ['Compute', 'Clouds', 'Tenants'])
 
 
 class TenantAllView(TenantView):

--- a/cfme/infrastructure/resource_pool.py
+++ b/cfme/infrastructure/resource_pool.py
@@ -12,7 +12,6 @@ from widgetastic_patternfly import Button, Dropdown, FlashMessages
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import WidgetasticTaggable
 from cfme.exceptions import ResourcePoolNotFound
-from cfme.web_ui import match_location
 from cfme.utils.pretty import Pretty
 from cfme.utils.providers import get_crud
 from cfme.utils.wait import wait_for
@@ -76,9 +75,7 @@ class ResourcePoolView(BaseLoggedInPage):
         nav_chain = ['Compute', 'Infrastructure', 'Resource Pools']
         return (
             self.logged_in_as_current_user and
-            self.navigation.currently_selected == nav_chain and
-            # TODO: Also needs to be converted to Widgetastic
-            match_location(controller='resource_pool', title='Resource Pools'))
+            self.navigation.currently_selected == nav_chain)
 
 
 class ResourcePoolAllView(ResourcePoolView):

--- a/cfme/storage/volume.py
+++ b/cfme/storage/volume.py
@@ -24,7 +24,6 @@ from widgetastic.widget import View, Text, ParametrizedView
 
 from cfme.base.ui import BaseLoggedInPage
 from cfme.exceptions import VolumeNotFound, ItemNotFound
-from cfme.web_ui import match_location
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
 from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.utils.log import logger
@@ -105,8 +104,7 @@ class VolumeView(BaseLoggedInPage):
         nav = Volume.nav.pick(self.context['object'].appliance.version)
         return (
             self.logged_in_as_current_user and
-            self.navigation.currently_selected == nav and
-            match_location(controller='cloud_volume', title='Cloud Volumes'))
+            self.navigation.currently_selected == nav)
 
 
 class VolumeAllView(VolumeView):


### PR DESCRIPTION
Start removing the `match_location()` function. In these cases, we probably don't need to replace it with anything, as these are from base views which are then inherited by child views.