### PR TITLE
[RFR] Fixing code broken by PR #5629

### DIFF
--- a/cfme/services/myservice/ssui.py
+++ b/cfme/services/myservice/ssui.py
@@ -83,8 +83,8 @@ def update(self, updates):
 @MyService.launch_vm_console.external_implementation_for(ViaSSUI)
 def launch_vm_console(self, catalog_item):
     navigate_to(self, 'VM Console')
-    # TODO need to remove 001 from the line below and find correct place/way to put it in code
-    vm_obj = VM.factory(catalog_item.provisioning_data.get('vm_name') + '001',
+    # TODO need to remove 0001 from the line below and find correct place/way to put it in code
+    vm_obj = VM.factory(catalog_item.provisioning_data['catalog']['vm_name'] + '0001',
                 catalog_item.provider, template_name=catalog_item.catalog_name)
     wait_for(
         func=lambda: vm_obj.vm_console, num_sec=30, delay=2, handle_exception=True,


### PR DESCRIPTION

Purpose or Intent
=================

__Fixing__ access to dict provisioning_data since PR #5629 broke it. Also changing 001 to 0001 since that will give correct name of VM, previously missed a 0.

{{pytest: -v --long-running cfme/tests/ssui/test_ssui_myservice.py -k 'test_vm_console' }}
