### PR TITLE
[1LP][RFR]Adding ability to get canvas/sendCtrlAltDel element for RHV and VMware for SSUI VM Console

### DIFF
--- a/cfme/infrastructure/provider/rhevm.py
+++ b/cfme/infrastructure/provider/rhevm.py
@@ -51,7 +51,7 @@ class RHEVMProvider(InfraProvider):
     discover_dict = {"rhevm": True}
     # xpath locators for elements, to be used by selenium
     _console_connection_status_element = '//*[@id="connection-status"]'
-    _canvas_element = '//*[@id="remote-console"]/canvas'
+    _canvas_element = '(//*[@id="remote-console"]/canvas|//*[@id="spice-screen"]/canvas)'
     _ctrl_alt_del_xpath = '//*[@id="ctrlaltdel"]'
     _fullscreen_xpath = '//*[@id="fullscreen"]'
     bad_credentials_error_msg = 'Cannot complete login due to an incorrect user name or password.'

--- a/cfme/infrastructure/provider/virtualcenter.py
+++ b/cfme/infrastructure/provider/virtualcenter.py
@@ -21,8 +21,9 @@ class VMwareProvider(InfraProvider):
     discover_dict = {"vmware": True}
     # xpath locators for elements, to be used by selenium
     _console_connection_status_element = '//*[@id="connection-status"]'
-    _canvas_element = '//*[@id="remote-console" or @id="wmksContainer"]/canvas'
-    _ctrl_alt_del_xpath = '//*[@id="ctrlaltdel"]'
+    _canvas_element = ('(//*[@id="remote-console" or @id="wmksContainer"]/canvas|'
+        '//*[@id="noVNC_canvas"])')
+    _ctrl_alt_del_xpath = '(//*[@id="ctrlaltdel"]|//*[@id="sendCtrlAltDelButton"])'
     _fullscreen_xpath = '//*[@id="fullscreen"]'
     bad_credentials_error_msg = 'Cannot complete login due to an incorrect user name or password.'
 


### PR DESCRIPTION
Purpose or Intent
=================

__Extending__ rhevm.py and virtualcenter.py to find correct elements from screen of SSUI Console. This code previously helped to find correct elements for HTML5 console and webMKS consoles. By using piped(|) OR in the xpath selector I am trying to reuse same code for SSUI VM Console as well. 

{{pytest: -v --long-running cfme/tests/ssui/test_ssui_myservice.py -k 'test_vm_console' }}