### PR TITLE
[1LP][RFR] Update utils.ext_auth set_auth_mode call

### DIFF
--- a/cfme/configure/configuration/server_settings.py
+++ b/cfme/configure/configuration/server_settings.py
@@ -626,7 +626,7 @@ class AuthenticationSetting(NavigatableMixin, Updateable, Pretty):
             ex. auth_settings.update_form({"hours_timeout": hours, "mode": "Amazon"}, reset=True)
         """
         view = navigate_to(self, self.auth_mode)
-        view.fill(updates)
+        changed = view.fill(updates)
         try:
             view.validate.click()
             view.flash.assert_message(
@@ -637,7 +637,8 @@ class AuthenticationSetting(NavigatableMixin, Updateable, Pretty):
         if reset:
             view.reset_button.click()
             view.flash.assert_message('All changes have been reset')
-        else:
+        # Can't save the form if nothing was changed
+        elif changed:
             view.save_button.click()
             flash_message = (
                 'Authentication settings saved for {} Server "{} [{}]" in Zone "{}"'.format(
@@ -646,6 +647,8 @@ class AuthenticationSetting(NavigatableMixin, Updateable, Pretty):
                     self.appliance.server_id(),
                     self.appliance.server.zone.name))
             view.flash.assert_message(flash_message)
+        else:
+            logger.info('No authentication settings changed, not saving form.')
 
     @property
     def auth_settings(self):

--- a/cfme/utils/ext_auth.py
+++ b/cfme/utils/ext_auth.py
@@ -57,7 +57,7 @@ def setup_external_auth_ipa(**data):
         current_appliance.server.login_admin()
 
         if data["ipaserver"] not in (
-                current_appliance.server.settings.ntp_servers_form.values()):
+                current_appliance.server.settings.ntp_servers_values):
             current_appliance.server.settings.update_ntp_servers(
                 {'ntp_server_1': data["ipaserver"]})
             sleep(120)

--- a/cfme/utils/ext_auth.py
+++ b/cfme/utils/ext_auth.py
@@ -2,12 +2,13 @@
 import fauxfactory
 from time import sleep
 
-from cfme.utils import appliance
 from cfme.utils.browser import ensure_browser_open
 from cfme.utils.conf import credentials
 from cfme.utils.ssh import SSHClient
 from cfme.utils.appliance import get_or_create_current_appliance
 from cfme.utils.path import conf_path
+
+# TODO move these into appliance
 
 
 def disable_external_auth(auth_mode):
@@ -60,7 +61,7 @@ def setup_external_auth_ipa(**data):
             current_appliance.server.settings.update_ntp_servers(
                 {'ntp_server_1': data["ipaserver"]})
             sleep(120)
-        appliance.server.authentication.set_auth_mode(
+        current_appliance.server.authentication.set_auth_mode(
             mode='external', get_groups=data.pop("get_groups", False)
         )
         creds = credentials.get(data.pop("credentials"), {})
@@ -98,12 +99,12 @@ def setup_external_auth_openldap(**data):
         ldapserver_ssh.get_file(remote_file=data['cert_filepath'],
                                 local_path=conf_path.strpath)
     ensure_browser_open()
-    appliance.current_appliance.server.login_admin()
-    appliance.server.authentication.set_auth_mode(
+    current_appliance.server.login_admin()
+    current_appliance.server.authentication.set_auth_mode(
         mode='external', get_groups=data.pop("get_groups", True)
     )
     current_appliance.configure_appliance_for_openldap_ext_auth(appliance_fqdn)
-    appliance.current_appliance.server.logout()
+    current_appliance.server.logout()
 
 
 def disable_external_auth_ipa():
@@ -111,24 +112,24 @@ def disable_external_auth_ipa():
     current_appliance = get_or_create_current_appliance()
     with current_appliance.ssh_client as ssh:
         ensure_browser_open()
-        appliance.current_appliance.server.login_admin()
-        appliance.server.authentication.set_auth_mode()
+        current_appliance.server.login_admin()
+        current_appliance.server.authentication.set_auth_mode()
         assert ssh.run_command("appliance_console_cli --uninstall-ipa")
         current_appliance.wait_for_web_ui()
-    appliance.current_appliance.server.logout()
+    current_appliance.server.logout()
 
 
 def disable_external_auth_openldap():
-    appliance.server.authentication.set_auth_mode()
+    current_appliance = get_or_create_current_appliance()
+    current_appliance.server.authentication.set_auth_mode()
     sssd_conf = '/etc/sssd/sssd.conf'
     httpd_auth = '/etc/pam.d/httpd-auth'
     manageiq_remoteuser = '/etc/httpd/conf.d/manageiq-remote-user.conf'
     manageiq_ext_auth = '/etc/httpd/conf.d/manageiq-external-auth.conf'
     command = 'rm -rf {} && rm -rf {} && rm -rf {} && rm -rf {}'.format(
         sssd_conf, httpd_auth, manageiq_ext_auth, manageiq_remoteuser)
-    current_appliance = get_or_create_current_appliance()
     with current_appliance.ssh_client as ssh:
         assert ssh.run_command(command)
         ssh.run_command('systemctl restart evmserverd')
         get_or_create_current_appliance().wait_for_web_ui()
-    appliance.current_appliance.server.logout()
+    current_appliance.server.logout()


### PR DESCRIPTION
Need an appliance object, not the module, in order to access
appliance.server property.

Tried to update utils.ext_auth to use appliance.current_appliance consistently and always use the appliance object, not the module to call functions.

FIXES RHCFQE-5227

## PRT Results
Its going to be a mess, because the ext-auth servers aren't available.  But reviewers can directly import and call the methods to modify their auth settings to verify.  Some of the tests get past or call the methods in their teardown after failing, so the results are still useful - but won't be green.

All failures in PRT are because ext-auth servers aren't up, no more AttributeErrors or TypeErrors

{{pytest: cfme/tests/integration/test_cfme_auth.py --long-running -v}}