### PR TITLE
[1LP][RFR] Changes to test_delete_authentications tests

### DIFF
--- a/cfme/infrastructure/config_management.py
+++ b/cfme/infrastructure/config_management.py
@@ -352,7 +352,11 @@ class ConfigManager(Updateable, Pretty, Navigatable):
         row = view.entities.paginator.find_row_on_pages(view.entities.elements,
                                                         provider_name=self.ui_name)
         row[0].check()
-        view.toolbar.configuration.item_select('Remove selected items', handle_alert=not cancel)
+        remove_item = VersionPick({
+            '5.8': 'Remove selected items',
+            '5.9': 'Remove selected items from Inventory'
+        }).pick(self.appliance.version)
+        view.toolbar.configuration.item_select(remove_item, handle_alert=not cancel)
         if not cancel:
             view.entities.flash.assert_success_message('Delete initiated for 1 Provider')
             if wait_deleted:

--- a/cfme/tests/infrastructure/test_config_management_rest.py
+++ b/cfme/tests/infrastructure/test_config_management_rest.py
@@ -4,7 +4,7 @@ import pytest
 import fauxfactory
 
 from cfme import test_requirements
-from cfme.configure.settings import DefaultView
+from cfme.utils import error
 from cfme.utils.rest import assert_response
 from cfme.utils.testgen import config_managers, generate
 from cfme.utils.wait import wait_for
@@ -17,7 +17,6 @@ pytestmark = [test_requirements.config_management]
 @pytest.yield_fixture(scope='module')
 def config_manager(config_manager_obj):
     """Fixture that provides a random config manager and sets it up."""
-    DefaultView.set_default_view('Configuration Management Providers', 'Grid View')
     if config_manager_obj.type == 'Ansible Tower':
         config_manager_obj.create(validate=True)
     else:
@@ -31,7 +30,6 @@ def authentications(appliance, config_manager):
     """Creates and returns authentication resources under /api/authentications."""
     auth_num = 2
     collection = appliance.rest_api.collections.authentications
-    user_id = appliance.rest_api.collections.users[0].id
     prov = appliance.rest_api.collections.providers.get(name='{} %'.format(config_manager.name))
     data = []
     cred_names = []
@@ -43,8 +41,8 @@ def authentications(appliance, config_manager):
             'description': 'Test Description {}'.format(uniq),
             'name': cred_name,
             'related': {},
-            'user': user_id,
-            'username': 'foo',
+            'user': 1,
+            'userid': 'foo',
             'password': 'bar',
             'host': 'baz',
             'type': 'ManageIQ::Providers::AnsibleTower::AutomationManager::VmwareCredential',
@@ -131,9 +129,11 @@ class TestAuthenticationsRESTAPI(object):
             assert_response(appliance)
             auth.wait_not_exists(num_sec=180, delay=5)
 
-            # this will fail once BZ1476869 is fixed
-            auth.action.delete.POST()
-            assert_response(appliance, success=False)
+            # the BZ1476869 is fixed for versions >= 5.9
+            if appliance.version >= '5.9':
+                with error.expected('ActiveRecord::RecordNotFound'):
+                    auth.action.delete.POST()
+                assert_response(appliance, http_status=404)
 
     def test_delete_authentications_from_detail_delete(self, appliance, authentications):
         """Tests deleting authentications from detail using DELETE method.
@@ -146,9 +146,11 @@ class TestAuthenticationsRESTAPI(object):
             assert_response(appliance)
             auth.wait_not_exists(num_sec=180, delay=5)
 
-            # this will fail once BZ1476869 is fixed
-            auth.action.delete.DELETE()
-            assert_response(appliance, success=False)
+            # the BZ1476869 is fixed for versions >= 5.9
+            if appliance.version >= '5.9':
+                with error.expected('ActiveRecord::RecordNotFound'):
+                    auth.action.delete.DELETE()
+                assert_response(appliance, http_status=404)
 
     def test_delete_authentications_from_collection(self, appliance, authentications):
         """Tests deleting authentications from collection.
@@ -162,12 +164,11 @@ class TestAuthenticationsRESTAPI(object):
         for auth in authentications:
             auth.wait_not_exists(num_sec=180, delay=5)
 
-        # this will fail once BZ1476869 is fixed
         appliance.rest_api.collections.authentications.action.delete.POST(*authentications)
         assert_response(appliance, success=False)
 
     def test_authentications_options(self, appliance, config_manager):
-        """Tests that credential types can be listed through OPTIONS HTTP method..
+        """Tests that credential types can be listed through OPTIONS HTTP method.
 
         Metadata:
             test_flag: rest


### PR DESCRIPTION
* BZ 1476869 fixed
* fixed data for authentication creation where wrong user id was used ("user" is not CFME user)

{{pytest: -v -k test_delete_authentications cfme/tests/infrastructure/test_config_management_rest.py}}

Error in ``config_manager_obj.delete()`` is known bug https://bugzilla.redhat.com/show_bug.cgi?id=1491704
Otherwise PRT was successful.