### PR TITLE
[1LP][WIP]adding wait_for_elements into paginator pages - fix for 5.9

### DIFF
--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -15,6 +15,7 @@ from cached_property import cached_property
 from jsmin import jsmin
 from lxml.html import document_fromstring
 from selenium.common.exceptions import WebDriverException
+import cfme.fixtures.pytest_selenium as sel
 from cfme.utils.blockers import BZ
 from widgetastic.exceptions import NoSuchElementException
 from widgetastic.log import logged
@@ -1522,6 +1523,12 @@ class JSPaginationPane(View, ReportDataControllerMixin):
 
             # Adding 1 to pages_amount to include the last page in loop
             for page in range(1, self.pages_amount + 1):
+                # JSPaginatinoPane will wait for elements to load after changing page
+                # miq-tile-selection covers both - Grid and Tile view
+                if sel.is_displayed('//*[@class="miq-data-table"]'):
+                    sel.wait_for_element('//*[@class="miq-data-table"]/table')
+                elif sel.is_displayed('//*[@class="miq-tile-section"]'):
+                    sel.wait_for_element('//*[@class="card-view-pf"]/div')
                 yield self.cur_page
                 if self.cur_page == self.pages_amount:
                     # last or only page, stop looping

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -15,7 +15,6 @@ from cached_property import cached_property
 from jsmin import jsmin
 from lxml.html import document_fromstring
 from selenium.common.exceptions import WebDriverException
-import cfme.fixtures.pytest_selenium as sel
 from cfme.utils.blockers import BZ
 from widgetastic.exceptions import NoSuchElementException
 from widgetastic.log import logged
@@ -42,7 +41,7 @@ from widgetastic_patternfly import (
     Accordion as PFAccordion, BootstrapSwitch, BootstrapTreeview,
     BootstrapSelect, Button, CheckableBootstrapTreeview,
     CandidateNotFound, Dropdown, Input, FlashMessages,
-    NavDropdown, VerticalNavigation, Tab)
+    VerticalNavigation, Tab)
 
 from cfme.exceptions import ItemNotFound, ManyEntitiesFound
 
@@ -1525,10 +1524,12 @@ class JSPaginationPane(View, ReportDataControllerMixin):
             for page in range(1, self.pages_amount + 1):
                 # JSPaginatinoPane will wait for elements to load after changing page
                 # miq-tile-selection covers both - Grid and Tile view
-                if sel.is_displayed('//*[@class="miq-data-table"]'):
-                    sel.wait_for_element('//*[@class="miq-data-table"]/table')
-                elif sel.is_displayed('//*[@class="miq-tile-section"]'):
-                    sel.wait_for_element('//*[@class="card-view-pf"]/div')
+                if self.browser.is_displayed('//*[@class="miq-data-table"]'):
+                    wait_for(lambda: self.browser.is_displayed(
+                        '//*[@class="miq-data-table"]/table'), num_sec=10, delay=1)
+                elif self.browser.is_displayed('//*[@class="miq-tile-section"]'):
+                    wait_for(lambda: self.browser.is_displayed('//*[@class="card-view-pf"]/div'),
+                             num_sec=10, delay=1)
                 yield self.cur_page
                 if self.cur_page == self.pages_amount:
                     # last or only page, stop looping


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ page surfing with paginator because it is runs too fast - we get empty entities_names because UI elements haven't been loaded
This affects 5.9 only
no testing at the moment except :

```
view = navigate_to(Vm, 'All')
view.toolbar.view_selector.selected
Out[10]: u'Tile View'
view.entities.paginator.items_amount (at the moment this shows - how many items are shown on page, not the whole amount)
Out[11]: 20
view.entities.paginator.pages_amount
Out[12]: 56
view.entities.paginator.set_items_per_page(100)
view.entities.paginator.items_amount <<<<<<<<<< this is the issue. this line was called while UI was loading page with 100 items on it
Out[14]: 0
view.entities.paginator.items_amount
Out[15]: 100
view.entities.get_entity(by_name='webmks-photonos-kkulkarn',surf_pages=True)
Out[16]: <widgetastic_manageiq.JSBaseEntity at 0x7f92069ecb10>
view.toolbar.view_selector.select('Tile View')
view.entities.paginator.pages_amount
Out[19]: 12
view.entities.get_entity(by_name='webmks-photonos-kkulkarn',surf_pages=True)
Out[20]: <widgetastic_manageiq.JSBaseEntity at 0x7f91ebcd65d0>
view.toolbar.view_selector.select('List View')
view.entities.paginator.items_per_page
Out[22]: 100
view.entities.get_entity(by_name='webmks-photonos-kkulkarn',surf_pages=True)
Out[23]: <widgetastic_manageiq.JSBaseEntity at 0x7f91ebccd410>
```



