### PR TITLE
[1LP][RFR] DB setup reacts to the output of appliance_console_cli

### DIFF
--- a/cfme/utils/appliance/db.py
+++ b/cfme/utils/appliance/db.py
@@ -238,6 +238,8 @@ class ApplianceDB(AppliancePlugin):
                 command_options = ' '.join([command_options, '--dbdisk {}'.format(db_disk)])
 
             status, out = client.run_command(' '.join([base_command, command_options]))
+            if status != 0 or 'failed' in out.lower():
+                raise Exception('Could not set up the database:\n{}'.format(out))
         else:
             # no cli, use the enable internal db script
             rbt_repl = {


### PR DESCRIPTION
Appliance DB setup happily ignores the error messages coming out of appliance_console_cli. This recitfies the issue by looking at the RC and the output of the CLI script. Unfortunately, with the current issue it does not change the RC so I also added a check for "failed" in the output.