### PR TITLE
[1LP][RFR] Implement Collections in RBAC Groups

### DIFF
--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -754,7 +754,6 @@ class Group(BaseEntity):
         """
         name_column = "Name"
         find_row_kwargs = {name_column: self.description}
-        #TODO: cfme/fixtures/tag.py - Update to use collection
         view = navigate_to(self.parent, 'All')
         row = view.paginator.find_row_on_pages(view.table, **find_row_kwargs)
         original_sequence = row.sequence.text
@@ -898,7 +897,6 @@ class GroupAdd(CFMENavigateStep):
 @navigator.register(Group, 'EditGroupSequence')
 class EditGroupSequence(CFMENavigateStep):
     VIEW = EditGroupSequenceView
-    #prerequisite = NavigateToSibling('All')
     prerequisite = NavigateToAttribute('parent', 'All')
 
     def step(self):

--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -560,7 +560,7 @@ class GroupEditTagsView(ConfigurationView):
 class Group(BaseEntity):
     """Represents a group in CFME UI
 
-    Args:
+    Properties:
         description: group description
         role: group role
         tenant: group tenant
@@ -823,6 +823,15 @@ class GroupCollection(BaseCollection):
         """ Create group method
 
         Args:
+            description: group description
+            role: group role
+            tenant: group tenant
+            user_to_lookup: ldap user to lookup
+            ldap_credentials: ldap user credentials
+            tag: tag for group restriction
+            host_cluster: host/cluster for group restriction
+            vm_template: vm/template for group restriction
+            appliance: appliance under test
             cancel: True - if you want to cancel group creation,
                     by default group will be created
         Throws:

--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -11,7 +11,7 @@ from widgetastic.widget import Checkbox, View, Text
 
 from cfme.base.credential import Credential
 from cfme.base.ui import ConfigurationView
-from cfme.exceptions import OptionNotAvailable, RBACOperationBlocked
+from cfme.exceptions import RBACOperationBlocked
 from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
@@ -173,7 +173,7 @@ class User(Updateable, Pretty, Navigatable):
                 for currently selected role
         """
         if self.appliance.version < "5.8":
-            user_blocked_msg = ("Userid has already been taken")
+            user_blocked_msg = "Userid has already been taken"
         else:
             user_blocked_msg = ("Userid is not unique within region {}".format(
                 self.appliance.server_region()))

--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -908,7 +908,7 @@ class EditGroupSequence(CFMENavigateStep):
 @navigator.register(Group, 'Details')
 class GroupDetails(CFMENavigateStep):
     VIEW = DetailsGroupView
-    prerequisite = NavigateToSibling('All')
+    prerequisite = NavigateToAttribute('parent', 'All')
 
     def step(self):
         self.prerequisite_view.accordions.accesscontrol.tree.click_path(

--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -818,9 +818,9 @@ class GroupCollection(BaseCollection):
     """ Collection object for the :py:class: `cfme.configure.access_control.Group`. """
     ENTITY = Group
 
-    def create(self, description=None, role=None, tenant="My Company", 
-                 tag=None, host_cluster=None, vm_template=None,
-                 cancel=False):
+    def create(self, description=None, role=None, tenant="My Company",
+               tag=None, host_cluster=None, vm_template=None,
+               cancel=False):
         """ Create group method
 
         Args:
@@ -844,7 +844,7 @@ class GroupCollection(BaseCollection):
         group = self.instantiate(
             description=description, role=role, tenant=tenant,
             tag=tag, host_cluster=host_cluster, vm_template=vm_template,
-            )
+        )
 
         view.fill({
             'description_txt': group.description,

--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -571,7 +571,6 @@ class Group(BaseEntity):
         vm_template: vm/template for group restriction
         appliance: appliance under test
     """
-    #DELETE pretty_attrs???
     pretty_attrs = ['description', 'role']
 
     description = attr.ib(default=None)
@@ -755,7 +754,8 @@ class Group(BaseEntity):
         """
         name_column = "Name"
         find_row_kwargs = {name_column: self.description}
-        view = navigate_to(self, 'All')
+        #TODO: cfme/fixtures/tag.py - Update to use collection
+        view = navigate_to(self.parent, 'All')
         row = view.paginator.find_row_on_pages(view.table, **find_row_kwargs)
         original_sequence = row.sequence.text
 

--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -801,7 +801,7 @@ class Group(BaseEntity):
 
     @property
     def group_order(self):
-        view = navigate_to(Group, 'EditGroupSequence')
+        view = navigate_to(self, 'EditGroupSequence')
         return view.group_order_selector.items
 
     @property
@@ -898,7 +898,8 @@ class GroupAdd(CFMENavigateStep):
 @navigator.register(Group, 'EditGroupSequence')
 class EditGroupSequence(CFMENavigateStep):
     VIEW = EditGroupSequenceView
-    prerequisite = NavigateToSibling('All')
+    #prerequisite = NavigateToSibling('All')
+    prerequisite = NavigateToAttribute('parent', 'All')
 
     def step(self):
         self.prerequisite_view.toolbar.configuration.item_select(

--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -817,9 +817,8 @@ class GroupCollection(BaseCollection):
     """ Collection object for the :py:class: `cfme.configure.access_control.Group`. """
     ENTITY = Group
 
-    def create(self, description=None, role=None, tenant="My Company",
-               tag=None, host_cluster=None, vm_template=None,
-               cancel=False):
+    def create(self, description=None, role=None, tenant="My Company", ldap_credentials=None,
+            user_to_lookup=None, tag=None, host_cluster=None, vm_template=None, cancel=False):
         """ Create group method
 
         Args:
@@ -850,9 +849,9 @@ class GroupCollection(BaseCollection):
         view = navigate_to(self, 'Add')
 
         group = self.instantiate(
-            description=description, role=role, tenant=tenant,
-            tag=tag, host_cluster=host_cluster, vm_template=vm_template,
-        )
+            description=description, role=role, tenant=tenant, ldap_credentials=ldap_credentials,
+            user_to_lookup=user_to_lookup, tag=tag, host_cluster=host_cluster,
+            vm_template=vm_template)
 
         view.fill({
             'description_txt': group.description,

--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -838,8 +838,6 @@ class GroupCollection(BaseCollection):
                 not having appropriate permissions OR delete is not allowed
                 for currently selected user
         """
-        group = None
-
         if self.appliance.version < "5.8":
             flash_blocked_msg = ("Description has already been taken")
         else:

--- a/cfme/fixtures/tag.py
+++ b/cfme/fixtures/tag.py
@@ -2,7 +2,7 @@ import fauxfactory
 import pytest
 
 from cfme.base.credential import Credential
-from cfme.configure.access_control import Group, Role, User
+from cfme.configure.access_control import Role, User
 from cfme.configure.configuration.region_settings import Category, Tag
 from cfme.web_ui import mixins
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -51,16 +51,15 @@ def role():
 
 
 @pytest.yield_fixture(scope="module")
-def group_with_tag(role, category, tag):
+def group_with_tag(appliance, role, category, tag):
     """
         Returns group object with set up tag filter used in test module
     """
-    group = Group(
+    group = appliance.collections.groups.create(
         description='grp{}'.format(fauxfactory.gen_alphanumeric()),
         role=role.name,
         tag=[category.display_name, tag.display_name]
     )
-    group.create()
     yield group
     group.delete()
 

--- a/cfme/fixtures/tag.py
+++ b/cfme/fixtures/tag.py
@@ -55,7 +55,7 @@ def group_with_tag(appliance, role, category, tag):
     """
         Returns group object with set up tag filter used in test module
     """
-    group = appliance.collections.groups.create(
+    group = appliance.collections.rbac_groups.create(
         description='grp{}'.format(fauxfactory.gen_alphanumeric()),
         role=role.name,
         tag=[category.display_name, tag.display_name]

--- a/cfme/tests/cloud_infra_common/test_vm_ownership.py
+++ b/cfme/tests/cloud_infra_common/test_vm_ownership.py
@@ -34,9 +34,9 @@ def role_only_user_owned(appliance):
 
 @pytest.yield_fixture(scope="module")
 def group_only_user_owned(appliance, role_only_user_owned):
-    group_collection = appliance.collections.groups
+    group_collection = appliance.collections.rbac_groups
     group = group_collection.create(
-        description='group_only_user_owned_' + fauxfactory.gen_alphanumeric(),
+        description='group_only_user_owned_{}'.format(fauxfactory.gen_alphanumeric()),
         role=role_only_user_owned.name)
     yield group
     appliance.server.login_admin()
@@ -56,7 +56,7 @@ def role_user_or_group_owned(appliance):
 
 @pytest.yield_fixture(scope="module")
 def group_user_or_group_owned(appliance, role_user_or_group_owned):
-    group_collection = appliance.collections.groups
+    group_collection = appliance.collections.rbac_groups
     group = group_collection.create(
         description='group_user_or_group_owned_' + fauxfactory.gen_alphanumeric(),
         role=role_user_or_group_owned.name)

--- a/cfme/tests/cloud_infra_common/test_vm_ownership.py
+++ b/cfme/tests/cloud_infra_common/test_vm_ownership.py
@@ -58,7 +58,7 @@ def role_user_or_group_owned(appliance):
 def group_user_or_group_owned(appliance, role_user_or_group_owned):
     group_collection = appliance.collections.rbac_groups
     group = group_collection.create(
-        description='group_user_or_group_owned_' + fauxfactory.gen_alphanumeric(),
+        description='group_user_or_group_owned_{}'.format(fauxfactory.gen_alphanumeric()),
         role=role_user_or_group_owned.name)
     yield group
     appliance.server.login_admin()

--- a/cfme/tests/cloud_infra_common/test_vm_ownership.py
+++ b/cfme/tests/cloud_infra_common/test_vm_ownership.py
@@ -35,8 +35,9 @@ def role_only_user_owned(appliance):
 @pytest.yield_fixture(scope="module")
 def group_only_user_owned(appliance, role_only_user_owned):
     group_collection = appliance.collections.groups
-    group = group_collection.create(description='group_only_user_owned_' + fauxfactory.gen_alphanumeric(),
-                     role=role_only_user_owned.name)
+    group = group_collection.create(
+        description='group_only_user_owned_' + fauxfactory.gen_alphanumeric(),
+        role=role_only_user_owned.name)
     yield group
     appliance.server.login_admin()
     group.delete()
@@ -56,8 +57,9 @@ def role_user_or_group_owned(appliance):
 @pytest.yield_fixture(scope="module")
 def group_user_or_group_owned(appliance, role_user_or_group_owned):
     group_collection = appliance.collections.groups
-    group = group_collection.create(description='group_user_or_group_owned_' + fauxfactory.gen_alphanumeric(),
-                     role=role_user_or_group_owned.name)
+    group = group_collection.create(
+        description='group_user_or_group_owned_' + fauxfactory.gen_alphanumeric(),
+        role=role_user_or_group_owned.name)
     yield group
     appliance.server.login_admin()
     group.delete()

--- a/cfme/tests/cloud_infra_common/test_vm_ownership.py
+++ b/cfme/tests/cloud_infra_common/test_vm_ownership.py
@@ -34,9 +34,9 @@ def role_only_user_owned(appliance):
 
 @pytest.yield_fixture(scope="module")
 def group_only_user_owned(appliance, role_only_user_owned):
-    group = ac.Group(description='group_only_user_owned_' + fauxfactory.gen_alphanumeric(),
+    group_collection = appliance.collections.groups
+    group = group_collection.create(description='group_only_user_owned_' + fauxfactory.gen_alphanumeric(),
                      role=role_only_user_owned.name)
-    group.create()
     yield group
     appliance.server.login_admin()
     group.delete()
@@ -55,9 +55,9 @@ def role_user_or_group_owned(appliance):
 
 @pytest.yield_fixture(scope="module")
 def group_user_or_group_owned(appliance, role_user_or_group_owned):
-    group = ac.Group(description='group_user_or_group_owned_' + fauxfactory.gen_alphanumeric(),
+    group_collection = appliance.collections.groups
+    group = group_collection.create(description='group_user_or_group_owned_' + fauxfactory.gen_alphanumeric(),
                      role=role_user_or_group_owned.name)
-    group.create()
     yield group
     appliance.server.login_admin()
     group.delete()

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -45,7 +45,7 @@ def new_credential():
     return Credential(principal='uid' + fauxfactory.gen_alphanumeric(), secret='redhat')
 
 
-def new_user(group=usergrp):
+def new_user(group):
     from fixtures.blockers import bug
 
     uppercase_username_bug = bug(1487199)
@@ -68,11 +68,6 @@ def new_user(group=usergrp):
 @pytest.fixture(scope='function')
 def group_collection(appliance):
     return appliance.collections.groups
-
-def new_group(role='EvmRole-approver'):
-    return Group(
-        description='grp' + fauxfactory.gen_alphanumeric(),
-        role=role)
 
 def new_role():
     return Role(
@@ -99,8 +94,11 @@ def check_item_visibility(tag):
 
 # User test cases
 @pytest.mark.tier(2)
-def test_user_crud():
-    user = new_user()
+def test_user_crud(appliance):
+    group_name = 'EvmGroup-user'
+    group = appliance.collections.groups.instantiate(description=group_name)
+
+    user = new_user(group)
     user.create()
     with update(user):
         user.name = user.name + "edited"
@@ -111,8 +109,11 @@ def test_user_crud():
 
 # @pytest.mark.meta(blockers=[1035399]) # work around instead of skip
 @pytest.mark.tier(2)
-def test_user_login():
-    user = new_user()
+def test_user_login(appliance):
+    group_name = 'EvmGroup-user'
+    group = appliance.collections.groups.instantiate(description=group_name)
+
+    user = new_user(group)
     user.create()
     try:
         with user:
@@ -122,8 +123,11 @@ def test_user_login():
 
 
 @pytest.mark.tier(3)
-def test_user_duplicate_name():
-    nu = new_user()
+def test_user_duplicate_name(appliance):
+    group_name = 'EvmGroup-user'
+    group = appliance.collections.groups.instantiate(description=group_name)
+
+    nu = new_user(group)
     nu.create()
     with pytest.raises(RBACOperationBlocked):
         nu.create()
@@ -133,27 +137,30 @@ def test_user_duplicate_name():
     navigate_to(nu.appliance.server, 'Dashboard')
 
 
-group_user = Group("EvmGroup-user")
-
-
 @pytest.mark.tier(3)
 def test_username_required_error_validation():
+    group_name = 'EvmGroup-user'
+    group = appliance.collections.groups.instantiate(description=group_name)
+
     user = User(
         name="",
         credential=new_credential(),
         email='xyz@redhat.com',
-        group=group_user)
+        group=group)
     with error.expected("Name can't be blank"):
         user.create()
 
 
 @pytest.mark.tier(3)
-def test_userid_required_error_validation():
+def test_userid_required_error_validation(appliance):
+    group_name = 'EvmGroup-user'
+    group = appliance.collections.groups.instantiate(description=group_name)
+
     user = User(
         name='user' + fauxfactory.gen_alphanumeric(),
         credential=Credential(principal='', secret='redhat'),
         email='xyz@redhat.com',
-        group=group_user)
+        group=group)
     with error.expected("Userid can't be blank"):
         user.create()
 
@@ -163,12 +170,15 @@ def test_userid_required_error_validation():
 
 
 @pytest.mark.tier(3)
-def test_user_password_required_error_validation():
+def test_user_password_required_error_validation(appliance):
+    group_name = 'EvmGroup-user'
+    group = appliance.collections.groups.instantiate(description=group_name)
+
     user = User(
         name='user' + fauxfactory.gen_alphanumeric(),
         credential=Credential(principal='uid' + fauxfactory.gen_alphanumeric(), secret=None),
         email='xyz@redhat.com',
-        group=group_user)
+        group=group)
 
     check = "Password can't be blank"
 
@@ -192,19 +202,25 @@ def test_user_group_error_validation():
 
 
 @pytest.mark.tier(3)
-def test_user_email_error_validation():
+def test_user_email_error_validation(appliance):
+    group_name = 'EvmGroup-user'
+    group = appliance.collections.groups.instantiate(description=group_name)
+
     user = User(
         name='user' + fauxfactory.gen_alphanumeric(),
         credential=new_credential(),
         email='xyzdhat.com',
-        group=group_user)
+        group=group)
     with error.expected("Email must be a valid email address"):
         user.create()
 
 
 @pytest.mark.tier(2)
-def test_user_edit_tag():
-    user = new_user()
+def test_user_edit_tag(appliance):
+    group_name = 'EvmGroup-user'
+    group = appliance.collections.groups.instantiate(description=group_name)
+
+    user = new_user(group)
     user.create()
     user.edit_tags("Cost Center *", "Cost Center 001")
     assert get_tag() == "Cost Center: Cost Center 001", "User edit tag failed"
@@ -212,8 +228,11 @@ def test_user_edit_tag():
 
 
 @pytest.mark.tier(3)
-def test_user_remove_tag():
-    user = new_user()
+def test_user_remove_tag(appliance):
+    group_name = 'EvmGroup-user'
+    group = appliance.collections.groups.instantiate(description=group_name)
+
+    user = new_user(group)
     user.create()
     user.edit_tags("Department", "Engineering")
     user.remove_tag("Department", "Engineering")
@@ -238,7 +257,7 @@ def test_delete_default_user():
 @pytest.mark.tier(3)
 @pytest.mark.meta(automates=[BZ(1090877)])
 @pytest.mark.meta(blockers=[BZ(1408479)], forced_streams=["5.7", "upstream"])
-def test_current_user_login_delete(request):
+def test_current_user_login_delete(request, appliance):
     """Test for deleting current user login.
 
     Steps:
@@ -247,8 +266,10 @@ def test_current_user_login_delete(request):
         * Login with the new user
         * Try deleting the user
     """
-    group_user = Group("EvmGroup-super_administrator")
-    user = new_user(group=group_user)
+    group_name = "EvmGroup-super_administrator"
+    group = appliance.collections.groups.instantiate(description=group_name)
+
+    user = new_user(group)
     user.create()
     request.addfinalizer(user.delete)
     request.addfinalizer(user.appliance.server.login_admin)
@@ -274,9 +295,9 @@ def test_tagvis_user(user_restricted, check_item_visibility):
 
 @pytest.mark.tier(2)
 # Group test cases
-def test_group_crud(group_collection):
+def test_group_crud(appliance):
     role = 'EvmRole-administrator'
-    group = group_collection.create(
+    group = appliance.collections.groups.create(
             description='grp' + fauxfactory.gen_alphanumeric(), role=role)
     with update(group):
         group.description = group.description + "edited"
@@ -284,7 +305,7 @@ def test_group_crud(group_collection):
 
 
 @pytest.mark.tier(2)
-def test_group_crud_with_tag(a_provider, category, tag):
+def test_group_crud_with_tag(a_provider, category, tag, appliance):
     """Test for verifying group create with tag defined
 
     Steps:
@@ -294,7 +315,7 @@ def test_group_crud_with_tag(a_provider, category, tag):
         * Set tag
         * Save group
     """
-    group = Group(
+    group = appliance.collections.groups.create(
         description='grp{}'.format(fauxfactory.gen_alphanumeric()),
         role='EvmRole-approver',
         tag=[category.display_name, tag.display_name],
@@ -302,7 +323,6 @@ def test_group_crud_with_tag(a_provider, category, tag):
         vm_template=[a_provider.data['name'], a_provider.data['datacenters'][0],
                      'Discovered virtual machine']
     )
-    group.create()
     with update(group):
         group.tag = [tag.category.display_name, tag.display_name]
         group.host_cluster = [a_provider.data['name']]
@@ -312,11 +332,17 @@ def test_group_crud_with_tag(a_provider, category, tag):
 
 
 @pytest.mark.tier(3)
-def test_group_duplicate_name():
-    group = new_group()
-    group.create()
+def test_group_duplicate_name(appliance):
+
+    group_collection = appliance.collections.groups
+    role='EvmRole-approver'
+    group_name = 'EvmGroup-user'
+    group_description = description='grp' + fauxfactory.gen_alphanumeric()
+    group = group_collection.create(description=group_description, role=role)
+
     with pytest.raises(RBACOperationBlocked):
-        group.create()
+        group = group_collection.create(
+            description=group_description, role=role)
 
     # Navigating away from this page will create an "Abandon Changes" alert
     # Since group creation failed we need to reset the state of the page
@@ -324,18 +350,24 @@ def test_group_duplicate_name():
 
 
 @pytest.mark.tier(2)
-def test_group_edit_tag():
-    group = new_group()
-    group.create()
+def test_group_edit_tag(appliance):
+    group_collection = appliance.collections.groups
+    role='EvmRole-approver'
+    group_description = description='grp' + fauxfactory.gen_alphanumeric()
+    group = group_collection.create(description=group_description, role=role)
+
     group.edit_tags("Cost Center *", "Cost Center 001")
     assert get_tag() == "Cost Center: Cost Center 001", "Group edit tag failed"
     group.delete()
 
 
 @pytest.mark.tier(2)
-def test_group_remove_tag():
-    group = new_group()
-    group.create()
+def test_group_remove_tag(appliance):
+    group_collection = appliance.collections.groups
+    role='EvmRole-approver'
+    group_description = description='grp' + fauxfactory.gen_alphanumeric()
+    group = group_collection.create(description=group_description, role=role)
+
     navigate_to(group, 'Edit')
     group.edit_tags("Department", "Engineering")
     group.remove_tag("Department", "Engineering")
@@ -344,37 +376,42 @@ def test_group_remove_tag():
 
 
 @pytest.mark.tier(3)
-def test_group_description_required_error_validation():
+def test_group_description_required_error_validation(appliance):
     error_text = "Description can't be blank"
-    group = Group(description=None, role='EvmRole-approver')
+    group_collection = appliance.collections.groups
+    group = None
+
     with error.expected(error_text):
-        group.create()
+        group = group_collection.create(description=None, role='EvmRole-approver')
 
     # Navigating away from this page will create an "Abandon Changes" alert
     # Since group creation failed we need to reset the state of the page
-    navigate_to(group.appliance.server, 'Dashboard')
+    navigate_to(appliance.server, 'Dashboard')
 
 
 @pytest.mark.tier(3)
-def test_delete_default_group():
+def test_delete_default_group(appliance):
     """Test for deleting default group EvmGroup-administrator.
 
     Steps:
         * Login as Administrator user
         * Try deleting the group EvmGroup-adminstrator
     """
-    group = Group(description='EvmGroup-administrator')
+    group_collection = appliance.collections.groups
+    group = group_collection.instantiate(description='EvmGroup-administrator')
 
     with pytest.raises(RBACOperationBlocked):
         group.delete()
 
 
 @pytest.mark.tier(3)
-def test_delete_group_with_assigned_user():
+def test_delete_group_with_assigned_user(appliance):
     """Test that CFME prevents deletion of a group that has users assigned
     """
-    group = new_group()
-    group.create()
+    group_collection = appliance.collections.groups
+    role = 'EvmRole-approver'
+    group_description = description='grp' + fauxfactory.gen_alphanumeric()
+    group = group_collection.create(description=group_description, role=role)
     user = new_user(group=group)
     user.create()
     with pytest.raises(RBACOperationBlocked):
@@ -382,14 +419,15 @@ def test_delete_group_with_assigned_user():
 
 
 @pytest.mark.tier(3)
-def test_edit_default_group():
+def test_edit_default_group(appliance):
     """Test that CFME prevents a user from editing a default group
 
     Steps:
         * Login as Administrator user
         * Try editing the group EvmGroup-adminstrator
     """
-    group = Group(description='EvmGroup-approver')
+    group_collection = appliance.collections.groups
+    group = group_collection.instantiate(description='EvmGroup-approver')
 
     group_updates = {}
     with pytest.raises(RBACOperationBlocked):
@@ -397,7 +435,7 @@ def test_edit_default_group():
 
 
 @pytest.mark.tier(3)
-def test_edit_sequence_usergroups(request):
+def test_edit_sequence_usergroups(request, appliance):
     """Test for editing the sequence of user groups for LDAP lookup.
 
     Steps:
@@ -406,8 +444,10 @@ def test_edit_sequence_usergroups(request):
         * Edit the sequence of the new group
         * Verify the changed sequence
     """
-    group = new_group()
-    group.create()
+    group_collection = appliance.collections.groups
+    role_name = 'EvmRole-approver'
+    group_description = description='grp' + fauxfactory.gen_alphanumeric()
+    group = group_collection.create(description=group_description, role=role_name)
     request.addfinalizer(group.delete)
 
     group.set_group_order(group.description)
@@ -495,11 +535,14 @@ def test_edit_default_roles():
 
 
 @pytest.mark.tier(3)
-def test_delete_roles_with_assigned_group():
+def test_delete_roles_with_assigned_group(appliance):
     role = new_role()
     role.create()
-    group = new_group(role=role.name)
-    group.create()
+
+    group_collection = appliance.collections.groups 
+    group_description = description='grp' + fauxfactory.gen_alphanumeric()
+    group = group_collection.create(description=group_description, role=role.name)
+
     with pytest.raises(RBACOperationBlocked):
         role.delete()
 
@@ -508,8 +551,11 @@ def test_delete_roles_with_assigned_group():
 def test_assign_user_to_new_group():
     role = new_role()  # call function to get role
     role.create()
-    group = new_group(role=role.name)
-    group.create()
+
+    group_collection = appliance.collections.groups 
+    group_description = description='grp' + fauxfactory.gen_alphanumeric()
+    group = group_collection.create(description=group_description, role=role.name)
+
     user = new_user(group=group)
     user.create()
 
@@ -563,8 +609,9 @@ def test_permission_edit(appliance, request, product_features, action):
                 product_features=[(['Everything'], False)] +  # role_features
                                  [(k, True) for k in product_features])
     role.create()
-    group = new_group(role=role.name)
-    group.create()
+    group_collection = appliance.collections.groups
+    group_description = description='grp' + fauxfactory.gen_alphanumeric()
+    group = group_collection.create(description=group_description, role=role.name)
     user = new_user(group=group)
     user.create()
     with user:
@@ -641,8 +688,9 @@ def test_permissions(appliance, role, allowed_actions, disallowed_actions):
     # create a user and role
     role = role()  # call function to get role
     role.create()
-    group = new_group(role=role.name)
-    group.create()
+    group_collection = appliance.collections.groups
+    group_description = description='grp' + fauxfactory.gen_alphanumeric()
+    group = group_collection.create(description=group_description, role=role.name)
     user = new_user(group=group)
     user.create()
     fails = {}
@@ -769,7 +817,11 @@ def test_permissions_vm_provisioning(appliance):
 
 @pytest.mark.tier(2)
 def test_user_change_password(appliance, request):
-    user = new_user(group=usergrp)
+    group_collection = appliance.collections.groups
+    group_name = 'EvmGroup-user'
+    group = group_collection.instantiate(description=group_name)
+
+    user = new_user(group=group)
 
     user.create()
     request.addfinalizer(user.delete)

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -30,9 +30,9 @@ from cfme.utils import version
 pytestmark = test_requirements.rbac
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='module')
 def group_collection(appliance):
-    return appliance.collections.groups
+    return appliance.collections.rbac_groups
 
 
 @pytest.fixture(scope='module')
@@ -90,9 +90,8 @@ def check_item_visibility(tag):
 
 # User test cases
 @pytest.mark.tier(2)
-def test_user_crud(appliance):
+def test_user_crud(group_collection):
     group_name = 'EvmGroup-user'
-    group_collection = appliance.collections.groups
     group = group_collection.instantiate(description=group_name)
 
     user = new_user(group)
@@ -106,9 +105,8 @@ def test_user_crud(appliance):
 
 # @pytest.mark.meta(blockers=[1035399]) # work around instead of skip
 @pytest.mark.tier(2)
-def test_user_login(appliance):
+def test_user_login(group_collection):
     group_name = 'EvmGroup-user'
-    group_collection = appliance.collections.groups
     group = group_collection.instantiate(description=group_name)
 
     user = new_user(group)
@@ -121,9 +119,8 @@ def test_user_login(appliance):
 
 
 @pytest.mark.tier(3)
-def test_user_duplicate_name(appliance):
+def test_user_duplicate_name(group_collection):
     group_name = 'EvmGroup-user'
-    group_collection = appliance.collections.groups
     group = group_collection.instantiate(description=group_name)
 
     nu = new_user(group)
@@ -137,9 +134,8 @@ def test_user_duplicate_name(appliance):
 
 
 @pytest.mark.tier(3)
-def test_username_required_error_validation(appliance):
+def test_username_required_error_validation(group_collection):
     group_name = 'EvmGroup-user'
-    group_collection = appliance.collections.groups
     group = group_collection.instantiate(description=group_name)
 
     user = User(
@@ -152,9 +148,8 @@ def test_username_required_error_validation(appliance):
 
 
 @pytest.mark.tier(3)
-def test_userid_required_error_validation(appliance):
+def test_userid_required_error_validation(group_collection):
     group_name = 'EvmGroup-user'
-    group_collection = appliance.collections.groups
     group = group_collection.instantiate(description=group_name)
 
     user = User(
@@ -171,9 +166,8 @@ def test_userid_required_error_validation(appliance):
 
 
 @pytest.mark.tier(3)
-def test_user_password_required_error_validation(appliance):
+def test_user_password_required_error_validation(group_collection):
     group_name = 'EvmGroup-user'
-    group_collection = appliance.collections.groups
     group = group_collection.instantiate(description=group_name)
 
     user = User(
@@ -204,9 +198,8 @@ def test_user_group_error_validation():
 
 
 @pytest.mark.tier(3)
-def test_user_email_error_validation(appliance):
+def test_user_email_error_validation(group_collection):
     group_name = 'EvmGroup-user'
-    group_collection = appliance.collections.groups
     group = group_collection.instantiate(description=group_name)
 
     user = User(
@@ -221,7 +214,6 @@ def test_user_email_error_validation(appliance):
 @pytest.mark.tier(2)
 def test_user_edit_tag(appliance):
     group_name = 'EvmGroup-user'
-    group_collection = appliance.collections.groups
     group = group_collection.instantiate(description=group_name)
 
     user = new_user(group)
@@ -232,9 +224,8 @@ def test_user_edit_tag(appliance):
 
 
 @pytest.mark.tier(3)
-def test_user_remove_tag(appliance):
+def test_user_remove_tag(group_collection):
     group_name = 'EvmGroup-user'
-    group_collection = appliance.collections.groups
     group = group_collection.instantiate(description=group_name)
 
     user = new_user(group)
@@ -272,8 +263,7 @@ def test_current_user_login_delete(appliance, request):
         * Try deleting the user
     """
     group_name = "EvmGroup-super_administrator"
-    group_collection = appliance.collections.groups
-    group = group_collection.instantiate(description=group_name)
+    group = group_collection(appliance).instantiate(description=group_name)
 
     user = new_user(group)
     user.create()
@@ -301,9 +291,8 @@ def test_tagvis_user(user_restricted, check_item_visibility):
 
 @pytest.mark.tier(2)
 # Group test cases
-def test_group_crud(appliance):
+def test_group_crud(group_collection):
     role = 'EvmRole-administrator'
-    group_collection = appliance.collections.groups
     group = group_collection.create(description='grp' + fauxfactory.gen_alphanumeric(), role=role)
     with update(group):
         group.description = group.description + "edited"
@@ -311,7 +300,7 @@ def test_group_crud(appliance):
 
 
 @pytest.mark.tier(2)
-def test_group_crud_with_tag(a_provider, category, tag, appliance):
+def test_group_crud_with_tag(a_provider, category, tag, group_collection):
     """Test for verifying group create with tag defined
 
     Steps:
@@ -321,7 +310,6 @@ def test_group_crud_with_tag(a_provider, category, tag, appliance):
         * Set tag
         * Save group
     """
-    group_collection = appliance.collections.groups
     group = group_collection.create(
         description='grp{}'.format(fauxfactory.gen_alphanumeric()),
         role='EvmRole-approver',
@@ -339,11 +327,10 @@ def test_group_crud_with_tag(a_provider, category, tag, appliance):
 
 
 @pytest.mark.tier(3)
-def test_group_duplicate_name(appliance):
+def test_group_duplicate_name(group_collection):
     """ Verify that two groups can't have the same name """
     role = 'EvmRole-approver'
     group_description = 'grp' + fauxfactory.gen_alphanumeric()
-    group_collection = appliance.collections.groups
     group = group_collection.create(description=group_description, role=role)
 
     with pytest.raises(RBACOperationBlocked):
@@ -356,10 +343,9 @@ def test_group_duplicate_name(appliance):
 
 
 @pytest.mark.tier(2)
-def test_group_edit_tag(appliance):
+def test_group_edit_tag(group_collection):
     role = 'EvmRole-approver'
     group_description = 'grp' + fauxfactory.gen_alphanumeric()
-    group_collection = appliance.collections.groups
     group = group_collection.create(description=group_description, role=role)
 
     group.edit_tags("Cost Center *", "Cost Center 001")
@@ -368,10 +354,9 @@ def test_group_edit_tag(appliance):
 
 
 @pytest.mark.tier(2)
-def test_group_remove_tag(appliance):
+def test_group_remove_tag(group_collection):
     role = 'EvmRole-approver'
     group_description = 'grp' + fauxfactory.gen_alphanumeric()
-    group_collection = appliance.collections.groups
     group = group_collection.create(description=group_description, role=role)
 
     navigate_to(group, 'Edit')
@@ -382,9 +367,8 @@ def test_group_remove_tag(appliance):
 
 
 @pytest.mark.tier(3)
-def test_group_description_required_error_validation(appliance):
+def test_group_description_required_error_validation(group_collection):
     error_text = "Description can't be blank"
-    group_collection = appliance.collections.groups
 
     with error.expected(error_text):
         group_collection.create(description=None, role='EvmRole-approver')
@@ -395,14 +379,13 @@ def test_group_description_required_error_validation(appliance):
 
 
 @pytest.mark.tier(3)
-def test_delete_default_group(appliance):
+def test_delete_default_group(group_collection):
     """Test for deleting default group EvmGroup-administrator.
 
     Steps:
         * Login as Administrator user
         * Try deleting the group EvmGroup-adminstrator
     """
-    group_collection = appliance.collections.groups
     group = group_collection.instantiate(description='EvmGroup-administrator')
 
     with pytest.raises(RBACOperationBlocked):
@@ -410,12 +393,11 @@ def test_delete_default_group(appliance):
 
 
 @pytest.mark.tier(3)
-def test_delete_group_with_assigned_user(appliance):
+def test_delete_group_with_assigned_user(group_collection):
     """Test that CFME prevents deletion of a group that has users assigned
     """
     role = 'EvmRole-approver'
     group_description = 'grp' + fauxfactory.gen_alphanumeric()
-    group_collection = appliance.collections.groups
     group = group_collection.create(description=group_description, role=role)
     user = new_user(group=group)
     user.create()
@@ -424,14 +406,13 @@ def test_delete_group_with_assigned_user(appliance):
 
 
 @pytest.mark.tier(3)
-def test_edit_default_group(appliance):
+def test_edit_default_group(group_collection):
     """Test that CFME prevents a user from editing a default group
 
     Steps:
         * Login as Administrator user
         * Try editing the group EvmGroup-adminstrator
     """
-    group_collection = appliance.collections.groups
     group = group_collection.instantiate(description='EvmGroup-approver')
 
     group_updates = {}
@@ -440,7 +421,7 @@ def test_edit_default_group(appliance):
 
 
 @pytest.mark.tier(3)
-def test_edit_sequence_usergroups(appliance, request):
+def test_edit_sequence_usergroups(request, group_collection):
     """Test for editing the sequence of user groups for LDAP lookup.
 
     Steps:
@@ -451,7 +432,6 @@ def test_edit_sequence_usergroups(appliance, request):
     """
     role_name = 'EvmRole-approver'
     group_description = 'grp' + fauxfactory.gen_alphanumeric()
-    group_collection = appliance.collections.groups
     group = group_collection.create(description=group_description, role=role_name)
     request.addfinalizer(group.delete)
 
@@ -540,11 +520,10 @@ def test_edit_default_roles():
 
 
 @pytest.mark.tier(3)
-def test_delete_roles_with_assigned_group(appliance):
+def test_delete_roles_with_assigned_group(group_collection):
     role = new_role()
     role.create()
     group_description = 'grp' + fauxfactory.gen_alphanumeric()
-    group_collection = appliance.collections.groups
     group_collection.create(description=group_description, role=role.name)
 
     with pytest.raises(RBACOperationBlocked):
@@ -552,12 +531,11 @@ def test_delete_roles_with_assigned_group(appliance):
 
 
 @pytest.mark.tier(3)
-def test_assign_user_to_new_group(appliance):
+def test_assign_user_to_new_group(group_collection):
     role = new_role()  # call function to get role
     role.create()
 
     group_description = 'grp' + fauxfactory.gen_alphanumeric()
-    group_collection = appliance.collections.groups
     group = group_collection.create(description=group_description, role=role.name)
 
     user = new_user(group=group)
@@ -613,9 +591,8 @@ def test_permission_edit(appliance, request, product_features, action):
                 product_features=[(['Everything'], False)] +  # role_features
                                  [(k, True) for k in product_features])
     role.create()
-    group_collection = appliance.collections.groups
     group_description = 'grp' + fauxfactory.gen_alphanumeric()
-    group = group_collection.create(description=group_description, role=role.name)
+    group = group_collection(appliance).create(description=group_description, role=role.name)
     user = new_user(group=group)
     user.create()
     with user:
@@ -692,9 +669,8 @@ def test_permissions(appliance, role, allowed_actions, disallowed_actions):
     # create a user and role
     role = role()  # call function to get role
     role.create()
-    group_collection = appliance.collections.groups
     group_description = 'grp' + fauxfactory.gen_alphanumeric()
-    group = group_collection.create(description=group_description, role=role.name)
+    group = group_collection(appliance).create(description=group_description, role=role.name)
     user = new_user(group=group)
     user.create()
     fails = {}
@@ -822,8 +798,7 @@ def test_permissions_vm_provisioning(appliance):
 @pytest.mark.tier(2)
 def test_user_change_password(appliance, request):
     group_name = 'EvmGroup-user'
-    group_collection = appliance.collections.groups
-    group = group_collection.instantiate(description=group_name)
+    group = group_collection(appliance).instantiate(description=group_name)
 
     user = new_user(group=group)
 

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -27,7 +27,9 @@ from cfme.utils.update import update
 from cfme.utils import version
 
 
-usergrp = Group(description='EvmGroup-user')
+#DELETE
+#usergrp = Group(description='EvmGroup-user')
+usergrp = None
 
 
 pytestmark = test_requirements.rbac
@@ -63,11 +65,14 @@ def new_user(group=usergrp):
     return user
 
 
+@pytest.fixture(scope='function')
+def group_collection(appliance):
+    return appliance.collections.groups
+
 def new_group(role='EvmRole-approver'):
     return Group(
         description='grp' + fauxfactory.gen_alphanumeric(),
         role=role)
-
 
 def new_role():
     return Role(
@@ -269,9 +274,10 @@ def test_tagvis_user(user_restricted, check_item_visibility):
 
 @pytest.mark.tier(2)
 # Group test cases
-def test_group_crud():
-    group = new_group()
-    group.create()
+def test_group_crud(group_collection):
+    role = 'EvmRole-administrator'
+    group = group_collection.create(
+            description='grp' + fauxfactory.gen_alphanumeric(), role=role)
     with update(group):
         group.description = group.description + "edited"
     group.delete()

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -90,8 +90,9 @@ def check_item_visibility(tag):
 
 # User test cases
 @pytest.mark.tier(2)
-def test_user_crud(group_collection):
+def test_user_crud(appliance):
     group_name = 'EvmGroup-user'
+    group_collection = appliance.collections.groups
     group = group_collection.instantiate(description=group_name)
 
     user = new_user(group)
@@ -105,8 +106,9 @@ def test_user_crud(group_collection):
 
 # @pytest.mark.meta(blockers=[1035399]) # work around instead of skip
 @pytest.mark.tier(2)
-def test_user_login(group_collection):
+def test_user_login(appliance):
     group_name = 'EvmGroup-user'
+    group_collection = appliance.collections.groups
     group = group_collection.instantiate(description=group_name)
 
     user = new_user(group)
@@ -119,8 +121,9 @@ def test_user_login(group_collection):
 
 
 @pytest.mark.tier(3)
-def test_user_duplicate_name(group_collection):
+def test_user_duplicate_name(appliance):
     group_name = 'EvmGroup-user'
+    group_collection = appliance.collections.groups
     group = group_collection.instantiate(description=group_name)
 
     nu = new_user(group)
@@ -134,8 +137,9 @@ def test_user_duplicate_name(group_collection):
 
 
 @pytest.mark.tier(3)
-def test_username_required_error_validation(group_collection):
+def test_username_required_error_validation(appliance):
     group_name = 'EvmGroup-user'
+    group_collection = appliance.collections.groups
     group = group_collection.instantiate(description=group_name)
 
     user = User(
@@ -148,8 +152,9 @@ def test_username_required_error_validation(group_collection):
 
 
 @pytest.mark.tier(3)
-def test_userid_required_error_validation(group_collection):
+def test_userid_required_error_validation(appliance):
     group_name = 'EvmGroup-user'
+    group_collection = appliance.collections.groups
     group = group_collection.instantiate(description=group_name)
 
     user = User(
@@ -166,8 +171,9 @@ def test_userid_required_error_validation(group_collection):
 
 
 @pytest.mark.tier(3)
-def test_user_password_required_error_validation(group_collection):
+def test_user_password_required_error_validation(appliance):
     group_name = 'EvmGroup-user'
+    group_collection = appliance.collections.groups
     group = group_collection.instantiate(description=group_name)
 
     user = User(
@@ -198,8 +204,9 @@ def test_user_group_error_validation():
 
 
 @pytest.mark.tier(3)
-def test_user_email_error_validation(group_collection):
+def test_user_email_error_validation(appliance):
     group_name = 'EvmGroup-user'
+    group_collection = appliance.collections.groups
     group = group_collection.instantiate(description=group_name)
 
     user = User(
@@ -212,8 +219,9 @@ def test_user_email_error_validation(group_collection):
 
 
 @pytest.mark.tier(2)
-def test_user_edit_tag(group_collection):
+def test_user_edit_tag(appliance):
     group_name = 'EvmGroup-user'
+    group_collection = appliance.collections.groups
     group = group_collection.instantiate(description=group_name)
 
     user = new_user(group)
@@ -224,8 +232,9 @@ def test_user_edit_tag(group_collection):
 
 
 @pytest.mark.tier(3)
-def test_user_remove_tag(group_collection):
+def test_user_remove_tag(appliance):
     group_name = 'EvmGroup-user'
+    group_collection = appliance.collections.groups
     group = group_collection.instantiate(description=group_name)
 
     user = new_user(group)
@@ -253,7 +262,7 @@ def test_delete_default_user():
 @pytest.mark.tier(3)
 @pytest.mark.meta(automates=[BZ(1090877)])
 @pytest.mark.meta(blockers=[BZ(1408479)], forced_streams=["5.7", "upstream"])
-def test_current_user_login_delete(request, group_collection):
+def test_current_user_login_delete(appliance, request):
     """Test for deleting current user login.
 
     Steps:
@@ -263,6 +272,7 @@ def test_current_user_login_delete(request, group_collection):
         * Try deleting the user
     """
     group_name = "EvmGroup-super_administrator"
+    group_collection = appliance.collections.groups
     group = group_collection.instantiate(description=group_name)
 
     user = new_user(group)
@@ -291,8 +301,9 @@ def test_tagvis_user(user_restricted, check_item_visibility):
 
 @pytest.mark.tier(2)
 # Group test cases
-def test_group_crud(appliance, group_collection):
+def test_group_crud(appliance):
     role = 'EvmRole-administrator'
+    group_collection = appliance.collections.groups
     group = group_collection.create(description='grp' + fauxfactory.gen_alphanumeric(), role=role)
     with update(group):
         group.description = group.description + "edited"
@@ -300,7 +311,7 @@ def test_group_crud(appliance, group_collection):
 
 
 @pytest.mark.tier(2)
-def test_group_crud_with_tag(a_provider, category, tag, appliance, group_collection):
+def test_group_crud_with_tag(a_provider, category, tag, appliance):
     """Test for verifying group create with tag defined
 
     Steps:
@@ -310,6 +321,7 @@ def test_group_crud_with_tag(a_provider, category, tag, appliance, group_collect
         * Set tag
         * Save group
     """
+    group_collection = appliance.collections.groups
     group = group_collection.create(
         description='grp{}'.format(fauxfactory.gen_alphanumeric()),
         role='EvmRole-approver',
@@ -327,10 +339,11 @@ def test_group_crud_with_tag(a_provider, category, tag, appliance, group_collect
 
 
 @pytest.mark.tier(3)
-def test_group_duplicate_name(group_collection):
+def test_group_duplicate_name(appliance):
     """ Verify that two groups can't have the same name """
     role = 'EvmRole-approver'
     group_description = 'grp' + fauxfactory.gen_alphanumeric()
+    group_collection = appliance.collections.groups
     group = group_collection.create(description=group_description, role=role)
 
     with pytest.raises(RBACOperationBlocked):
@@ -343,9 +356,10 @@ def test_group_duplicate_name(group_collection):
 
 
 @pytest.mark.tier(2)
-def test_group_edit_tag(group_collection):
+def test_group_edit_tag(appliance):
     role = 'EvmRole-approver'
     group_description = 'grp' + fauxfactory.gen_alphanumeric()
+    group_collection = appliance.collections.groups
     group = group_collection.create(description=group_description, role=role)
 
     group.edit_tags("Cost Center *", "Cost Center 001")
@@ -354,9 +368,10 @@ def test_group_edit_tag(group_collection):
 
 
 @pytest.mark.tier(2)
-def test_group_remove_tag(group_collection):
+def test_group_remove_tag(appliance):
     role = 'EvmRole-approver'
     group_description = 'grp' + fauxfactory.gen_alphanumeric()
+    group_collection = appliance.collections.groups
     group = group_collection.create(description=group_description, role=role)
 
     navigate_to(group, 'Edit')
@@ -367,8 +382,9 @@ def test_group_remove_tag(group_collection):
 
 
 @pytest.mark.tier(3)
-def test_group_description_required_error_validation(group_collection):
+def test_group_description_required_error_validation(appliance):
     error_text = "Description can't be blank"
+    group_collection = appliance.collections.groups
 
     with error.expected(error_text):
         group_collection.create(description=None, role='EvmRole-approver')
@@ -379,13 +395,14 @@ def test_group_description_required_error_validation(group_collection):
 
 
 @pytest.mark.tier(3)
-def test_delete_default_group(group_collection):
+def test_delete_default_group(appliance):
     """Test for deleting default group EvmGroup-administrator.
 
     Steps:
         * Login as Administrator user
         * Try deleting the group EvmGroup-adminstrator
     """
+    group_collection = appliance.collections.groups
     group = group_collection.instantiate(description='EvmGroup-administrator')
 
     with pytest.raises(RBACOperationBlocked):
@@ -393,11 +410,12 @@ def test_delete_default_group(group_collection):
 
 
 @pytest.mark.tier(3)
-def test_delete_group_with_assigned_user(group_collection):
+def test_delete_group_with_assigned_user(appliance):
     """Test that CFME prevents deletion of a group that has users assigned
     """
     role = 'EvmRole-approver'
     group_description = 'grp' + fauxfactory.gen_alphanumeric()
+    group_collection = appliance.collections.groups
     group = group_collection.create(description=group_description, role=role)
     user = new_user(group=group)
     user.create()
@@ -406,13 +424,14 @@ def test_delete_group_with_assigned_user(group_collection):
 
 
 @pytest.mark.tier(3)
-def test_edit_default_group(group_collection):
+def test_edit_default_group(appliance):
     """Test that CFME prevents a user from editing a default group
 
     Steps:
         * Login as Administrator user
         * Try editing the group EvmGroup-adminstrator
     """
+    group_collection = appliance.collections.groups
     group = group_collection.instantiate(description='EvmGroup-approver')
 
     group_updates = {}
@@ -421,7 +440,7 @@ def test_edit_default_group(group_collection):
 
 
 @pytest.mark.tier(3)
-def test_edit_sequence_usergroups(request, group_collection):
+def test_edit_sequence_usergroups(appliance, request):
     """Test for editing the sequence of user groups for LDAP lookup.
 
     Steps:
@@ -432,6 +451,7 @@ def test_edit_sequence_usergroups(request, group_collection):
     """
     role_name = 'EvmRole-approver'
     group_description = 'grp' + fauxfactory.gen_alphanumeric()
+    group_collection = appliance.collections.groups
     group = group_collection.create(description=group_description, role=role_name)
     request.addfinalizer(group.delete)
 
@@ -520,10 +540,11 @@ def test_edit_default_roles():
 
 
 @pytest.mark.tier(3)
-def test_delete_roles_with_assigned_group(group_collection):
+def test_delete_roles_with_assigned_group(appliance):
     role = new_role()
     role.create()
     group_description = 'grp' + fauxfactory.gen_alphanumeric()
+    group_collection = appliance.collections.groups
     group = group_collection.create(description=group_description, role=role.name)
 
     with pytest.raises(RBACOperationBlocked):
@@ -531,11 +552,12 @@ def test_delete_roles_with_assigned_group(group_collection):
 
 
 @pytest.mark.tier(3)
-def test_assign_user_to_new_group(group_collection):
+def test_assign_user_to_new_group(appliance):
     role = new_role()  # call function to get role
     role.create()
 
     group_description = 'grp' + fauxfactory.gen_alphanumeric()
+    group_collection = appliance.collections.groups
     group = group_collection.create(description=group_description, role=role.name)
 
     user = new_user(group=group)
@@ -574,7 +596,7 @@ def _test_vm_removal():
             ['Everything', 'Access Rules for all Virtual Machines', 'VM Access Rules', 'Modify',
              'Provision VMs']], },
         _test_vm_provision)])
-def test_permission_edit(appliance, request, product_features, action, group_collection):
+def test_permission_edit(appliance, request, product_features, action):
     """
     Ensures that changes in permissions are enforced on next login
     Args:
@@ -591,6 +613,7 @@ def test_permission_edit(appliance, request, product_features, action, group_col
                 product_features=[(['Everything'], False)] +  # role_features
                                  [(k, True) for k in product_features])
     role.create()
+    group_collection = appliance.collections.groups
     group_description = 'grp' + fauxfactory.gen_alphanumeric()
     group = group_collection.create(description=group_description, role=role.name)
     user = new_user(group=group)
@@ -651,7 +674,7 @@ def _go_to(cls, dest='All'):
           'automate explorer': _go_to(Server, 'AutomateExplorer')},
       {}]])
 @pytest.mark.meta(blockers=[1262759])
-def test_permissions(appliance, role, allowed_actions, disallowed_actions, group_collection):
+def test_permissions(appliance, role, allowed_actions, disallowed_actions):
     """ Test that that under the specified role the allowed acctions succeed
         and the disallowed actions fail
 
@@ -669,6 +692,7 @@ def test_permissions(appliance, role, allowed_actions, disallowed_actions, group
     # create a user and role
     role = role()  # call function to get role
     role.create()
+    group_collection = appliance.collections.groups
     group_description = 'grp' + fauxfactory.gen_alphanumeric()
     group = group_collection.create(description=group_description, role=role.name)
     user = new_user(group=group)
@@ -700,13 +724,14 @@ def test_permissions(appliance, role, allowed_actions, disallowed_actions, group
         appliance.server.login_admin()
 
 
-def single_task_permission_test(appliance, product_features, actions, group_collection):
+def single_task_permission_test(appliance, product_features, actions):
     """Tests that action succeeds when product_features are enabled, and
        fail when everything but product_features are enabled"""
     # Enable only specified product features
+    group_collection = appliance.collections.groups
     test_prod_features = [(['Everything'], False)] + [(f, True) for f in product_features]
     test_permissions(appliance, _mk_role(name=fauxfactory.gen_alphanumeric(),
-                              product_features=test_prod_features), actions, {}, group_collection)
+                              product_features=test_prod_features), actions, {})
 
     # Enable everything but specified product features
     test_prod_features = [(['Everything'], True)]
@@ -718,20 +743,20 @@ def single_task_permission_test(appliance, product_features, actions, group_coll
 
     test_prod_features += [(f, False) for f in product_features]
     test_permissions(appliance, _mk_role(name=fauxfactory.gen_alphanumeric(),
-                              product_features=test_prod_features), {}, actions, group_collection)
+                              product_features=test_prod_features), {}, actions)
 
 
 @pytest.mark.tier(3)
 @pytest.mark.meta(blockers=[1262764])
-def test_permissions_role_crud(appliance, group_collection):
+def test_permissions_role_crud(appliance):
     single_task_permission_test(appliance,
                                 [['Everything', 'Settings', 'Configuration'],
                                  ['Everything', 'Services', 'Catalogs Explorer']],
-                                {'Role CRUD': test_role_crud}, group_collection)
+                                {'Role CRUD': test_role_crud})
 
 
 @pytest.mark.tier(3)
-def test_permissions_vm_provisioning(appliance, group_collection):
+def test_permissions_vm_provisioning(appliance):
     features = [
         ['Everything', 'Compute', 'Infrastructure', 'Virtual Machines', 'Accordions'],
         ['Everything', 'Access Rules for all Virtual Machines', 'VM Access Rules', 'Modify',
@@ -741,8 +766,7 @@ def test_permissions_vm_provisioning(appliance, group_collection):
     single_task_permission_test(
         appliance,
         features,
-        {'Provision VM': _test_vm_provision},
-        group_collection
+        {'Provision VM': _test_vm_provision}
     )
 
 
@@ -797,8 +821,9 @@ def test_permissions_vm_provisioning(appliance, group_collection):
 
 
 @pytest.mark.tier(2)
-def test_user_change_password(appliance, request, group_collection):
+def test_user_change_password(appliance, request):
     group_name = 'EvmGroup-user'
+    group_collection = appliance.collections.groups
     group = group_collection.instantiate(description=group_name)
 
     user = new_user(group=group)

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -330,7 +330,7 @@ def test_group_crud_with_tag(a_provider, category, tag, group_collection):
 def test_group_duplicate_name(group_collection):
     """ Verify that two groups can't have the same name """
     role = 'EvmRole-approver'
-    group_description = 'grp' + fauxfactory.gen_alphanumeric()
+    group_description = 'grp{}'.format(fauxfactory.gen_alphanumeric())
     group = group_collection.create(description=group_description, role=role)
 
     with pytest.raises(RBACOperationBlocked):

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -545,7 +545,7 @@ def test_delete_roles_with_assigned_group(appliance):
     role.create()
     group_description = 'grp' + fauxfactory.gen_alphanumeric()
     group_collection = appliance.collections.groups
-    group = group_collection.create(description=group_description, role=role.name)
+    group_collection.create(description=group_description, role=role.name)
 
     with pytest.raises(RBACOperationBlocked):
         role.delete()
@@ -728,7 +728,6 @@ def single_task_permission_test(appliance, product_features, actions):
     """Tests that action succeeds when product_features are enabled, and
        fail when everything but product_features are enabled"""
     # Enable only specified product features
-    group_collection = appliance.collections.groups
     test_prod_features = [(['Everything'], False)] + [(f, True) for f in product_features]
     test_permissions(appliance, _mk_role(name=fauxfactory.gen_alphanumeric(),
                               product_features=test_prod_features), actions, {})

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -42,7 +42,7 @@ def a_provider(request):
 
 
 def new_credential():
-    return Credential(principal='uid' + fauxfactory.gen_alphanumeric(), secret='redhat')
+    return Credential(principal='uid{}'.format(fauxfactory.gen_alphanumeric()), secret='redhat')
 
 
 def new_user(group):
@@ -51,7 +51,7 @@ def new_user(group):
     uppercase_username_bug = bug(1487199)
 
     user = User(
-        name='user' + fauxfactory.gen_alphanumeric(),
+        name='user{}'.format(fauxfactory.gen_alphanumeric()),
         credential=new_credential(),
         email='xyz@redhat.com',
         group=group,
@@ -67,7 +67,7 @@ def new_user(group):
 
 def new_role():
     return Role(
-        name='rol' + fauxfactory.gen_alphanumeric(),
+        name='rol{}'.format(fauxfactory.gen_alphanumeric()),
         vm_restriction='None')
 
 
@@ -97,7 +97,7 @@ def test_user_crud(group_collection):
     user = new_user(group)
     user.create()
     with update(user):
-        user.name = user.name + "edited"
+        user.name = "{}edited".format(user.name)
     copied_user = user.copy()
     copied_user.delete()
     user.delete()
@@ -153,7 +153,7 @@ def test_userid_required_error_validation(group_collection):
     group = group_collection.instantiate(description=group_name)
 
     user = User(
-        name='user' + fauxfactory.gen_alphanumeric(),
+        name='user{}'.format(fauxfactory.gen_alphanumeric()),
         credential=Credential(principal='', secret='redhat'),
         email='xyz@redhat.com',
         group=group)
@@ -171,8 +171,9 @@ def test_user_password_required_error_validation(group_collection):
     group = group_collection.instantiate(description=group_name)
 
     user = User(
-        name='user' + fauxfactory.gen_alphanumeric(),
-        credential=Credential(principal='uid' + fauxfactory.gen_alphanumeric(), secret=None),
+        name='user{}'.format(fauxfactory.gen_alphanumeric()),
+        credential=Credential(
+            principal='uid{}'.format(fauxfactory.gen_alphanumeric()), secret=None),
         email='xyz@redhat.com',
         group=group)
 
@@ -189,7 +190,7 @@ def test_user_password_required_error_validation(group_collection):
 @pytest.mark.tier(3)
 def test_user_group_error_validation():
     user = User(
-        name='user' + fauxfactory.gen_alphanumeric(),
+        name='user{}'.format(fauxfactory.gen_alphanumeric()),
         credential=new_credential(),
         email='xyz@redhat.com',
         group='')
@@ -203,7 +204,7 @@ def test_user_email_error_validation(group_collection):
     group = group_collection.instantiate(description=group_name)
 
     user = User(
-        name='user' + fauxfactory.gen_alphanumeric(),
+        name='user{}'.format(fauxfactory.gen_alphanumeric()),
         credential=new_credential(),
         email='xyzdhat.com',
         group=group)
@@ -293,9 +294,10 @@ def test_tagvis_user(user_restricted, check_item_visibility):
 # Group test cases
 def test_group_crud(group_collection):
     role = 'EvmRole-administrator'
-    group = group_collection.create(description='grp' + fauxfactory.gen_alphanumeric(), role=role)
+    group = group_collection.create(
+        description='grp{}'.format(fauxfactory.gen_alphanumeric()), role=role)
     with update(group):
-        group.description = group.description + "edited"
+        group.description = "{}edited".format(group.description)
     group.delete()
 
 
@@ -345,7 +347,7 @@ def test_group_duplicate_name(group_collection):
 @pytest.mark.tier(2)
 def test_group_edit_tag(group_collection):
     role = 'EvmRole-approver'
-    group_description = 'grp' + fauxfactory.gen_alphanumeric()
+    group_description = 'grp{}'.format(fauxfactory.gen_alphanumeric())
     group = group_collection.create(description=group_description, role=role)
 
     group.edit_tags("Cost Center *", "Cost Center 001")
@@ -356,7 +358,7 @@ def test_group_edit_tag(group_collection):
 @pytest.mark.tier(2)
 def test_group_remove_tag(group_collection):
     role = 'EvmRole-approver'
-    group_description = 'grp' + fauxfactory.gen_alphanumeric()
+    group_description = 'grp{}'.format(fauxfactory.gen_alphanumeric())
     group = group_collection.create(description=group_description, role=role)
 
     navigate_to(group, 'Edit')
@@ -397,7 +399,7 @@ def test_delete_group_with_assigned_user(group_collection):
     """Test that CFME prevents deletion of a group that has users assigned
     """
     role = 'EvmRole-approver'
-    group_description = 'grp' + fauxfactory.gen_alphanumeric()
+    group_description = 'grp{}'.format(fauxfactory.gen_alphanumeric())
     group = group_collection.create(description=group_description, role=role)
     user = new_user(group=group)
     user.create()
@@ -431,7 +433,7 @@ def test_edit_sequence_usergroups(request, group_collection):
         * Verify the changed sequence
     """
     role_name = 'EvmRole-approver'
-    group_description = 'grp' + fauxfactory.gen_alphanumeric()
+    group_description = 'grp{}'.format(fauxfactory.gen_alphanumeric())
     group = group_collection.create(description=group_description, role=role_name)
     request.addfinalizer(group.delete)
 
@@ -459,7 +461,7 @@ def test_role_crud():
     role = new_role()
     role.create()
     with update(role):
-        role.name = role.name + "edited"
+        role.name = "{}edited".format(role.name)
     copied_role = role.copy()
     copied_role.delete()
     role.delete()
@@ -523,7 +525,7 @@ def test_edit_default_roles():
 def test_delete_roles_with_assigned_group(group_collection):
     role = new_role()
     role.create()
-    group_description = 'grp' + fauxfactory.gen_alphanumeric()
+    group_description = 'grp{}'.format(fauxfactory.gen_alphanumeric())
     group_collection.create(description=group_description, role=role.name)
 
     with pytest.raises(RBACOperationBlocked):
@@ -535,7 +537,7 @@ def test_assign_user_to_new_group(group_collection):
     role = new_role()  # call function to get role
     role.create()
 
-    group_description = 'grp' + fauxfactory.gen_alphanumeric()
+    group_description = 'grp{}'.format(fauxfactory.gen_alphanumeric())
     group = group_collection.create(description=group_description, role=role.name)
 
     user = new_user(group=group)
@@ -561,7 +563,7 @@ def _test_vm_provision():
 def _test_vm_removal():
     logger.info("Testing for VM removal permission")
     vm_name = vms.get_first_vm()
-    logger.debug("VM " + vm_name + " selected")
+    logger.debug("VM {} selected".format(vm_name))
     vms.remove(vm_name, cancel=True)
 
 
@@ -591,7 +593,7 @@ def test_permission_edit(appliance, request, product_features, action):
                 product_features=[(['Everything'], False)] +  # role_features
                                  [(k, True) for k in product_features])
     role.create()
-    group_description = 'grp' + fauxfactory.gen_alphanumeric()
+    group_description = 'grp{}'.format(fauxfactory.gen_alphanumeric())
     group = group_collection(appliance).create(description=group_description, role=role.name)
     user = new_user(group=group)
     user.create()
@@ -669,7 +671,7 @@ def test_permissions(appliance, role, allowed_actions, disallowed_actions):
     # create a user and role
     role = role()  # call function to get role
     role.create()
-    group_description = 'grp' + fauxfactory.gen_alphanumeric()
+    group_description = 'grp{}'.format(fauxfactory.gen_alphanumeric())
     group = group_collection(appliance).create(description=group_description, role=role.name)
     user = new_user(group=group)
     user.create()
@@ -839,7 +841,7 @@ def test_superadmin_tenant_crud(request, appliance):
     """
     tenant_collection = appliance.collections.tenants
     tenant = tenant_collection.create(
-        name='tenant1' + fauxfactory.gen_alphanumeric(),
+        name='tenant1{}'.format(fauxfactory.gen_alphanumeric()),
         description='tenant1 description',
         parent=tenant_collection.get_root_tenant()
     )
@@ -850,9 +852,9 @@ def test_superadmin_tenant_crud(request, appliance):
             tenant.delete()
 
     with update(tenant):
-        tenant.description = tenant.description + "edited"
+        tenant.description = "{}edited".format(tenant.description)
     with update(tenant):
-        tenant.name = tenant.name + "edited"
+        tenant.name = "{}edited".format(tenant.name)
     tenant.delete()
 
 
@@ -875,12 +877,12 @@ def test_superadmin_tenant_project_crud(request, appliance):
     tenant_collection = appliance.collections.tenants
     project_collection = appliance.collections.projects
     tenant = tenant_collection.create(
-        name='tenant1' + fauxfactory.gen_alphanumeric(),
+        name='tenant1{}'.format(fauxfactory.gen_alphanumeric()),
         description='tenant1 description',
         parent=tenant_collection.get_root_tenant())
 
     project = project_collection.create(
-        name='project1' + fauxfactory.gen_alphanumeric(),
+        name='project1{}'.format(fauxfactory.gen_alphanumeric()),
         description='project1 description',
         parent=project_collection.get_root_tenant())
 
@@ -891,9 +893,9 @@ def test_superadmin_tenant_project_crud(request, appliance):
                 item.delete()
 
     with update(project):
-        project.description = project.description + "edited"
+        project.description = "{}edited".format(project.description)
     with update(project):
-        project.name = project.name + "edited"
+        project.name = "{}edited".format(project.name)
     project.delete()
     tenant.delete()
 
@@ -933,9 +935,9 @@ def test_superadmin_child_tenant_crud(request, appliance, number_of_childrens):
 
     tenant_update = tenant.parent_tenant
     with update(tenant_update):
-        tenant_update.description = tenant_update.description + "edited"
+        tenant_update.description = "{}edited".format(tenant_update.description)
     with update(tenant_update):
-        tenant_update.name = tenant_update.name + "edited"
+        tenant_update.name = "{}edited".format(tenant_update.name)
 
 
 def tenant_unique_tenant_project_name_on_parent_level(request, object_type):

--- a/cfme/tests/infrastructure/test_infra_quota.py
+++ b/cfme/tests/infrastructure/test_infra_quota.py
@@ -28,7 +28,7 @@ def vm_name():
 
 @pytest.yield_fixture(scope="module")
 def set_group_memory(appliance):
-    group_collection = appliance.collections.groups
+    group_collection = appliance.collections.rbac_groups
     group = group_collection.instantiate(description='EvmGroup-super_administrator')
     group.edit_tags("Quota - Max Memory *", '2GB')
     yield
@@ -37,7 +37,7 @@ def set_group_memory(appliance):
 
 @pytest.yield_fixture(scope="module")
 def set_group_cpu(appliance):
-    group_collection = appliance.collections.groups
+    group_collection = appliance.collections.rbac_groups
     group = group_collection.instantiate(description='EvmGroup-super_administrator')
     group.edit_tags("Quota - Max CPUs *", '2')
     yield

--- a/cfme/tests/infrastructure/test_infra_quota.py
+++ b/cfme/tests/infrastructure/test_infra_quota.py
@@ -2,7 +2,6 @@
 import fauxfactory
 import pytest
 
-import cfme.configure.access_control as ac
 from cfme import test_requirements
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.provisioning import do_vm_provisioning
@@ -37,7 +36,7 @@ def set_group_memory(appliance):
 
 
 @pytest.yield_fixture(scope="module")
-def set_group_cpu():
+def set_group_cpu(appliance):
     group_collection = appliance.collections.groups
     group = group_collection.instantiate(description='EvmGroup-super_administrator')
     group.edit_tags("Quota - Max CPUs *", '2')

--- a/cfme/tests/infrastructure/test_infra_quota.py
+++ b/cfme/tests/infrastructure/test_infra_quota.py
@@ -28,8 +28,9 @@ def vm_name():
 
 
 @pytest.yield_fixture(scope="module")
-def set_group_memory():
-    group = ac.Group(description='EvmGroup-super_administrator')
+def set_group_memory(appliance):
+    group_collection = appliance.collections.groups
+    group = group_collection.instantiate(description='EvmGroup-super_administrator')
     group.edit_tags("Quota - Max Memory *", '2GB')
     yield
     group.remove_tag("Quota - Max Memory *", "2GB")
@@ -37,7 +38,8 @@ def set_group_memory():
 
 @pytest.yield_fixture(scope="module")
 def set_group_cpu():
-    group = ac.Group(description='EvmGroup-super_administrator')
+    group_collection = appliance.collections.groups
+    group = group_collection.instantiate(description='EvmGroup-super_administrator')
     group.edit_tags("Quota - Max CPUs *", '2')
     yield
     group.remove_tag("Quota - Max CPUs *", "2")

--- a/cfme/tests/integration/test_cfme_auth.py
+++ b/cfme/tests/integration/test_cfme_auth.py
@@ -35,7 +35,7 @@ def group(request, data, auth_mode, add_group, appliance):
         principal=data["username"],
         secret=data["password"],
     )
-    group_collection = appliance.collections.groups
+    group_collection = appliance.collections.rbac_groups
     user_group = None
     if add_group == RETRIEVE_GROUP:
         user_group = group_collection.instantiate(

--- a/cfme/tests/integration/test_cfme_auth.py
+++ b/cfme/tests/integration/test_cfme_auth.py
@@ -36,16 +36,20 @@ def group(request, data, auth_mode, add_group, appliance):
         secret=data["password"],
     )
     group_collection = appliance.collections.groups
-    user_group = group_collection.instantiate(description=data['group_name'], role="EvmRole-user",
-                       user_to_lookup=data["username"], ldap_credentials=credentials)
+    user_group = None
     if add_group == RETRIEVE_GROUP:
+        user_group = group_collection.instantiate(
+            description=data['group_name'], role="EvmRole-user",
+            user_to_lookup=data["username"], ldap_credentials=credentials)
         if 'ext' in auth_mode:
             user_group.add_group_from_ext_auth_lookup()
         elif 'miq' in auth_mode:
             user_group.add_group_from_ldap_lookup()
         request.addfinalizer(user_group.delete)
     elif add_group == CREATE_GROUP:
-        user_group.create()
+        user_group = group_collection.create(
+            description=data['group_name'], role="EvmRole-user",
+            user_to_lookup=data["username"], ldap_credentials=credentials)
         request.addfinalizer(user_group.delete)
 
 

--- a/cfme/tests/integration/test_cfme_auth.py
+++ b/cfme/tests/integration/test_cfme_auth.py
@@ -2,7 +2,7 @@
 import pytest
 
 from cfme.base.credential import Credential
-from cfme.configure.access_control import Group, User
+from cfme.configure.access_control import User
 from cfme.utils.conf import cfme_data
 
 
@@ -28,14 +28,15 @@ def data(request, auth_mode, add_group):
 
 
 @pytest.fixture()
-def group(request, data, auth_mode, add_group):
+def group(request, data, auth_mode, add_group, appliance):
     if not data:
         pytest.skip("No data spcified for user group")
     credentials = Credential(
         principal=data["username"],
         secret=data["password"],
     )
-    user_group = Group(description=data['group_name'], role="EvmRole-user",
+    group_collection = appliance.collections.groups
+    user_group = group_collection.instantiate(description=data['group_name'], role="EvmRole-user",
                        user_to_lookup=data["username"], ldap_credentials=credentials)
     if add_group == RETRIEVE_GROUP:
         if 'ext' in auth_mode:

--- a/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
+++ b/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
@@ -66,7 +66,7 @@ def new_credential():
 
 
 @pytest.yield_fixture(scope="module")
-def vm_ownership(enable_candu, clean_setup_provider, provider):
+def vm_ownership(enable_candu, clean_setup_provider, provider, appliance):
     # In these tests, chargeback reports are filtered on VM owner.So,VMs have to be
     # assigned ownership.
     vm_name = provider.data['cap_and_util']['chargeback_vm']
@@ -77,7 +77,8 @@ def vm_ownership(enable_candu, clean_setup_provider, provider):
         provider.mgmt.start_vm(vm_name)
         provider.mgmt.wait_vm_running(vm_name)
 
-    cb_group = ac.Group(description='EvmGroup-user')
+    group_collection = appliance.collections.groups
+    cb_group = group_collection.instantiate(description='EvmGroup-user')
     user = ac.User(name=provider.name + fauxfactory.gen_alphanumeric(),
         credential=new_credential(),
         email='abc@example.com',

--- a/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
+++ b/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
@@ -76,7 +76,7 @@ def vm_ownership(enable_candu, clean_setup_provider, provider, appliance):
         provider.mgmt.start_vm(vm_name)
         provider.mgmt.wait_vm_running(vm_name)
 
-    group_collection = appliance.collections.groups
+    group_collection = appliance.collections.rbac_groups
     cb_group = group_collection.instantiate(description='EvmGroup-user')
     user = ac.User(name=provider.name + fauxfactory.gen_alphanumeric(),
         credential=new_credential(),

--- a/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
+++ b/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
@@ -14,7 +14,6 @@ from cfme import test_requirements
 from cfme.base.credential import Credential
 from cfme.common.vm import VM
 from cfme.common.provider import BaseProvider
-from cfme.configure.configuration.region_settings import CANDUCollection
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.intelligence.reports.reports import CustomReport

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ setup(
             'tenants = cfme.configure.access_control:TenantCollection',
             'projects = cfme.configure.access_control:ProjectCollection',
             'candus = cfme.configure.configuration.region_settings:CANDUCollection',
+            'groups = cfme.configure.access_control:GroupCollection',
             'nodes = cfme.containers.node:NodeCollection',
             'dashboards = cfme.dashboard:DashboardCollection',
             'clusters = cfme.infrastructure.cluster:ClusterCollection',

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
             'tenants = cfme.configure.access_control:TenantCollection',
             'projects = cfme.configure.access_control:ProjectCollection',
             'candus = cfme.configure.configuration.region_settings:CANDUCollection',
-            'groups = cfme.configure.access_control:GroupCollection',
+            'rbac_groups = cfme.configure.access_control:GroupCollection',
             'nodes = cfme.containers.node:NodeCollection',
             'dashboards = cfme.dashboard:DashboardCollection',
             'clusters = cfme.infrastructure.cluster:ClusterCollection',


### PR DESCRIPTION
Implementing Collections in the RBAC Group object.  This PR just updates tests that rely on RBAC groups

{{ pytest: -v -k 'test_validate_default_rate or test_group_quota_max or test_form_button_validation or test_user_ownership_crud or test_group_ownership_on_user_only_role or test_group_ownership_on_user_or_group_role or test_user_crud or test_user_login or test_user_duplicate_name or test_username_required_error_validation or test_current_user_login_delete or test_group_crud_with_tag or test_group_duplicate_name or test_group_remove_tag or test_group_description_required_error_validation or test_delete_default_group or test_delete_group_with_assigned_user or test_edit_default_group or test_edit_sequence_usergroups or test_tagvis_group or test_delete_default_roles_with_assigned_group or test_assign_user_to_new_group or test_permission_edit or single_task_permission_test'}}