### PR TITLE
[1LP][WIPTEST] Include certificate when creating provider via REST

### DIFF
--- a/cfme/tests/cloud_infra_common/test_rest_providers.py
+++ b/cfme/tests/cloud_infra_common/test_rest_providers.py
@@ -91,8 +91,13 @@ def provider_rest(request, appliance, provider):
     else:
         pytest.skip("No credentials info found for provider {}.".format(provider.name))
 
-    if hasattr(endpoint_default, "verify_tls") and not endpoint_default.verify_tls:
-        default_connection["endpoint"]["verify_ssl"] = 0
+    cert = getattr(endpoint_default, "ca_certs", None)
+    if cert:
+        default_connection["endpoint"]["certificate_authority"] = cert
+        con_config_to_include.append(default_connection)
+
+    if hasattr(endpoint_default, "verify_tls"):
+        default_connection["endpoint"]["verify_ssl"] = 1 if endpoint_default.verify_tls else 0
         con_config_to_include.append(default_connection)
     if hasattr(endpoint_default, "api_port") and endpoint_default.api_port:
         default_connection["endpoint"]["port"] = endpoint_default.api_port


### PR DESCRIPTION
__Extending__ cfme/tests/cloud_infra_common/test_rest_providers.py because it was not possible to set up provider via REST with SSL certificate.

{{pytest: cfme/tests/cloud_infra_common/test_rest_providers.py --use-provider rhv41 -v}}