### PR TITLE
[1LP][RFR] Check for BZ1487199 to see if new creds need lowercasing when testing vm ownership

### DIFF
--- a/cfme/tests/cloud_infra_common/test_vm_ownership.py
+++ b/cfme/tests/cloud_infra_common/test_vm_ownership.py
@@ -64,7 +64,8 @@ def group_user_or_group_owned(appliance, role_user_or_group_owned):
 
 
 def new_credential():
-    if BZ.bugzilla.get_bug(1401912).is_opened:
+    # BZ1487199 - CFME allows usernames with uppercase chars which blocks logins
+    if BZ.bugzilla.get_bug(1487199).is_opened:
         return Credential(principal='uid' + fauxfactory.gen_alphanumeric().lower(), secret='redhat')
     else:
         return Credential(principal='uid' + fauxfactory.gen_alphanumeric(), secret='redhat')


### PR DESCRIPTION
test_vm_ownership creates new users for testing. These users are created with usernames that contain uppercase characters which fails when causes login to fail per BZ1487199. 

{{pytest: -v -k 'test_user_ownership_crud or test_group_ownership_on_user_only_role or test_group_ownership_on_user_or_group_role'}}