### PR TITLE
[1LP][RFR] Adding BZ wrapper for test_vm_migrate and test_no_template_power_control

### DIFF
--- a/cfme/tests/infrastructure/test_vm_migrate.py
+++ b/cfme/tests/infrastructure/test_vm_migrate.py
@@ -6,6 +6,7 @@ from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme import test_requirements
 
+from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
 from cfme.utils import testgen
 
@@ -34,6 +35,7 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.mark.tier(2)
+@pytest.mark.meta(blockers=[BZ(1478518, forced_streams=['5.7', '5.8', '5.9', 'upstream'])])
 def test_vm_migrate(appliance, new_vm, provider):
     """Tests migration of a vm
 

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -12,6 +12,7 @@ from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.virtual_machines import get_all_vms
 from cfme.web_ui import toolbar
 from cfme.utils import testgen
+from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for, TimedOutError
@@ -312,6 +313,7 @@ class TestVmDetailsPowerControlPerProvider(object):
             testing_vm.provider.mgmt.is_vm_running(testing_vm.name), "vm not running")
 
 
+@pytest.mark.meta(blockers=[BZ(1496383, forced_streams=['5.7', '5.8', '5.9', 'upstream'])])
 def test_no_template_power_control(provider, soft_assert):
     """ Ensures that no power button is displayed for templates.
 


### PR DESCRIPTION
__Skipping__ two test blocked by reported BZs.

{{pytest: cfme/tests/infrastructure/test_vm_migrate.py::test_vm_migrate cfme/tests/infrastructure/test_vm_power_control.py::test_no_template_power_control --use-provider rhv41 -v}}