### PR TITLE
[WIPTEST] Update appliance.db enable_internal for dbdata

### DIFF
--- a/cfme/utils/appliance/db.py
+++ b/cfme/utils/appliance/db.py
@@ -139,16 +139,17 @@ class ApplianceDB(AppliancePlugin):
 
         """
         self.logger.info('Starting DB setup')
-        if self.appliance.is_downstream:
+        # TODO is this check even needed?
+        # if self.appliance.is_downstream:
             # We only execute this on downstream appliances.
             # TODO: Handle external DB setup. Probably pop the db_address and decide on that one.
-            self.enable_internal(**kwargs)
-        else:
+        self.enable_internal(**kwargs)
+        # else:
             # Ensure the evmserverd is on on the upstream appliance
-            if not self.appliance.evmserverd.running:
-                self.appliance.evmserverd.start()
-                self.appliance.evmserverd.enable()  # just to be sure here.
-                self.appliance.wait_for_web_ui()
+        if not self.appliance.evmserverd.running:
+            self.appliance.evmserverd.start()
+            self.appliance.evmserverd.enable()  # just to be sure here.
+            self.appliance.wait_for_web_ui()
 
         # Make sure the database is ready
         wait_for(func=lambda: self.is_ready,
@@ -208,7 +209,7 @@ class ApplianceDB(AppliancePlugin):
         Note:
             If key_address is None, a new encryption key is generated for the appliance.
         """
-        self.logger.info('Enabling internal DB (region {}) on {}.'.format(region, self.address))
+        # self.logger.info('Enabling internal DB (region {}) on {}.'.format(region, self.address))
         self.address = self.appliance.address
         clear_property_cache(self, 'client')
 

--- a/cfme/utils/appliance/db.py
+++ b/cfme/utils/appliance/db.py
@@ -231,16 +231,16 @@ class ApplianceDB(AppliancePlugin):
             # use the cli
             if key_address:
                 command_options = ('--internal --fetch-key {key} -p {db_pass} -a {ssh_pass}'
-                                .format(key=key_address, db_pass=db_password,
-                                        ssh_pass=ssh_password))
+                                   .format(key=key_address, db_pass=db_password,
+                                           ssh_pass=ssh_password))
 
             else:
                 command_options = '--internal --force-key -p {db_pass}'.format(db_pass=db_password)
 
             if db_disk:
-                ' '.join(command_options, '--dbdisk {}'.format(db_disk))
+                command_options = ' '.join([command_options, '--dbdisk {}'.format(db_disk)])
 
-            status, out = client.run_command(' '.join(base_command, command_options))
+            status, out = client.run_command(' '.join([base_command, command_options]))
         else:
             # no cli, use the enable internal db script
             rbt_repl = {

--- a/cfme/utils/appliance/db.py
+++ b/cfme/utils/appliance/db.py
@@ -5,7 +5,6 @@ from textwrap import dedent
 
 from cfme.utils import db, conf, clear_property_cache, datafile
 from cfme.utils.path import scripts_path
-from cfme.utils.version import LATEST
 from cfme.utils.wait import wait_for
 
 from .plugin import AppliancePlugin, AppliancePluginException
@@ -140,7 +139,7 @@ class ApplianceDB(AppliancePlugin):
 
         """
         self.logger.info('Starting DB setup')
-        if self.appliance.version != LATEST:
+        if self.appliance.is_downstream:
             # We only execute this on downstream appliances.
             # TODO: Handle external DB setup. Probably pop the db_address and decide on that one.
             self.enable_internal(**kwargs)
@@ -197,12 +196,14 @@ class ApplianceDB(AppliancePlugin):
         status, out = client.run_command("systemctl restart {scl}-postgresql".format(scl=scl))
         return status
 
-    def enable_internal(self, region=0, key_address=None, db_password=None, ssh_password=None):
+    def enable_internal(self, region=0, key_address=None, db_password=None, ssh_password=None,
+                        db_disk=None):
         """Enables internal database
 
         Args:
             region: Region number of the CFME appliance.
             key_address: Address of CFME appliance where key can be fetched.
+            db_disk: Path of the db disk for --dbdisk appliance_console_cli
 
         Note:
             If key_address is None, a new encryption key is generated for the appliance.
@@ -216,19 +217,29 @@ class ApplianceDB(AppliancePlugin):
         # Defaults
         db_password = db_password or conf.credentials['database']['password']
         ssh_password = ssh_password or conf.credentials['ssh']['password']
+        if not db_disk:
+            try:
+                app_provider = conf.cfme_data.management_systems.get(self.appliance._provider_key)
+                db_disk = app_provider.get('template_upload').get('db_disk')
+            except AttributeError:
+                db_disk = None
+                self.logger.warning('Failed to set a default dbdisk from yaml config')
 
         if self.appliance.has_cli:
+            base_command = 'appliance_console_cli --region {}'.format(region)
             # use the cli
             if key_address:
-                status, out = client.run_command(
-                    'appliance_console_cli --region {0} --internal --fetch-key {1} -p {2} -a {3}'
-                    .format(region, key_address, db_password, ssh_password)
-                )
+                command_options = ('--internal --fetch-key {key} -p {db_pass} -a {ssh_pass}'
+                                .format(key=key_address, db_pass=db_password,
+                                        ssh_pass=ssh_password))
+
             else:
-                status, out = client.run_command(
-                    'appliance_console_cli --region {} --internal --force-key -p {}'
-                    .format(region, db_password)
-                )
+                command_options = '--internal --force-key -p {db_pass}'.format(db_pass=db_password)
+
+            if db_disk:
+                ' '.join(command_options, '--dbdisk {}'.format(db_disk))
+
+            status, out = client.run_command(' '.join(base_command, command_options))
         else:
             # no cli, use the enable internal db script
             rbt_repl = {


### PR DESCRIPTION
CFME 5.9 requires a separate disk for setup, which we can pass via
--dbdata to appliance_console_cli

Following is copied from JIRA card notes:
```
Note my PR has several lines commented out that were accessing appliance properties that triggered running ssh or rails commands that would fail without the database setup.
Got to the point where the appliance_console_cli command is running with dbdisk, and I'm seeing the following output, with a 0 exit code!
So if you run appliance.configure or scripts/clone_template.py on my branch, it will fail starting evmserverd, because the db setup call returns 0 after failing.


u'create encryption key
configuring internal database
Initialize postgresql disk starting
Initialize postgresql disk failed with error - /sbin/parted exit code: 1.
MiqSignalError
Failed to configure internal database
TERM environment variable not set.
'
```