### PR TITLE
[1LP][RFR] test_service_manual_approval fix

### DIFF
--- a/cfme/tests/services/test_service_manual_approval.py
+++ b/cfme/tests/services/test_service_manual_approval.py
@@ -54,7 +54,7 @@ def modify_instance(create_domain):
         .classes.instantiate(name='ServiceProvisionRequestApproval')\
         .instances.instantiate(name='Default')
     with update(instance):
-        instance.fields = {"approval_type ": {"value": "manual"}}
+        instance.fields = {"approval_type": {"value": "manual"}}
 
 
 @pytest.mark.ignore_stream("upstream")


### PR DESCRIPTION
{{pytest: --long-running --use-provider=rhv41 cfme/tests/services/test_service_manual_approval.py}}