### PR TITLE
[1LP][RFR] Use REST for catalog fixture

### DIFF
--- a/cfme/fixtures/service_fixtures.py
+++ b/cfme/fixtures/service_fixtures.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
-import fauxfactory
 import pytest
 
 from cfme.common.provider import cleanup_vm
 from cfme.rest.gen_data import dialog as _dialog
-from cfme.services.catalogs.catalog import Catalog
+from cfme.rest.gen_data import service_catalog_obj as _catalog
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils.log import logger
@@ -16,12 +15,8 @@ def dialog(request, appliance):
 
 
 @pytest.yield_fixture(scope="function")
-def catalog():
-    catalog = "cat_" + fauxfactory.gen_alphanumeric()
-    cat = Catalog(name=catalog,
-                  description="my catalog")
-    cat.create()
-    yield cat
+def catalog(request, appliance):
+    return _catalog(request, appliance.rest_api)
 
 
 @pytest.fixture(scope="function")

--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -34,10 +34,9 @@ def service_catalogs(request, rest_api, num=5):
     """Create service catalogs using REST API."""
     scls_data = []
     for _ in range(num):
-        uniq = fauxfactory.gen_alphanumeric()
         scls_data.append({
-            'name': 'name_{}'.format(uniq),
-            'description': 'description_{}'.format(uniq),
+            'name': 'cat_{}'.format(fauxfactory.gen_alphanumeric()),
+            'description': 'my catalog',
             'service_templates': []
         })
 


### PR DESCRIPTION
Use REST for catalog fixture to make it more robust (there are problem with the UI dialog).

{{pytest: '-v --long-running ''cfme/tests/services/test_service_catalogs.py::test_order_catalog_item[rhv41]'''}}