### PR TITLE
[WIPTEST] Adding different path to Details view for archived VM

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -305,6 +305,24 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, WidgetasticTaggable,
         else:
             return False
 
+    def get_state_from_quadicon(self):
+        """Extracts current state from quadicon"""
+        return self.find_quadicon(from_any_provider=True).data['state']
+
+    @property
+    def is_archived(self):
+        """Check from quadicon if VM is archived"""
+        if self.get_state_from_quadicon().startswith(u'currentstate-archived'):
+            return True
+        return False
+
+    @property
+    def is_orphaned(self):
+        """Check from quadicon if VM is orphaned"""
+        if self.get_state_from_quadicon().startswith(u'currentstate-orphaned'):
+            return True
+        return False
+
     def find_quadicon(self, from_any_provider=False, use_search=True):
         """Find and return a quadicon belonging to a specific vm
 
@@ -403,7 +421,10 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, WidgetasticTaggable,
             VmOrInstanceNotFound:
                 When unable to find the VM passed
         """
-        navigate_to(self, 'Details', use_resetter=False)
+        if self.is_archived or self.is_orphaned:
+            navigate_to(self, 'ArchivedDetails', use_resetter=False)
+        else:
+            navigate_to(self, 'Details', use_resetter=False)
         if refresh:
             toolbar.refresh()
             self.browser.plugin.ensure_page_safe()
@@ -615,7 +636,7 @@ class VM(BaseVM):
 
     def wait_for_vm_state_change(self, desired_state=None, timeout=300, from_details=False,
                                  with_relationship_refresh=True, from_any_provider=False):
-        """Wait for M to come to desired state.
+        """Wait for VM to come to desired state.
 
         This function waits just the needed amount of time thanks to wait_for.
 

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -1219,6 +1219,12 @@ class VmAllWithTemplatesDetails(CFMENavigateStep):
         self.view.toolbar.reload.click()
 
 
+@navigator.register(Template, 'ArchivedDetails')
+@navigator.register(Vm, 'ArchivedDetails')
+class VmAllWithTemplatesDetailsArchived(VmAllWithTemplatesDetails):
+    prerequisite = NavigateToSibling('All')
+
+
 @navigator.register(Vm, 'VMsOnly')
 class VmAll(CFMENavigateStep):
     VIEW = VmsOnlyAllView

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -359,13 +359,11 @@ def test_no_power_controls_on_archived_vm(testing_vm, archived_vm, soft_assert):
 
 
 def test_archived_vm_status(testing_vm, archived_vm):
-    vm_state = testing_vm.find_quadicon(from_any_provider=True).data['state']
-    assert ('currentstate-archived' in vm_state)
+    assert testing_vm.is_archived
 
 
 def test_orphaned_vm_status(testing_vm, orphaned_vm):
-    vm_state = testing_vm.find_quadicon(from_any_provider=True).data['state']
-    assert ('currentstate-orphaned' in vm_state)
+    assert testing_vm.is_orphaned
 
 
 @pytest.mark.uncollectif(lambda provider: provider.one_of(RHEVMProvider))


### PR DESCRIPTION
__Extending__ VM model. The reason is that if you want to access VM's details, navmazing path to it contains view with VM of provider. However, archived VM is no longer visible under provider. That's why VM model now first determines whether the VM is archived or not and chooses navmazing path according to that.

{{pytest: cfme/tests/infrastructure/test_vm_power_control.py -k "not test_no_template_power_control" --use-provider rhv41 -v}}