### PR TITLE
[1LP][RFR] Adding different path to Details view for archived/orphaned VM

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -393,17 +393,21 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, WidgetasticTaggable,
         """Returns the contents of the ``Last Analysed`` field in summary"""
         return self.get_detail(properties=('Lifecycle', 'Last Analyzed')).strip()
 
-    def load_details(self, refresh=False):
+    def load_details(self, refresh=False, from_any_provider=False):
         """Navigates to an VM's details page.
 
         Args:
             refresh: Refreshes the VM page if already there
+            from_any_provider: Archived/Orphaned VMs need this
 
         Raises:
             VmOrInstanceNotFound:
                 When unable to find the VM passed
         """
-        navigate_to(self, 'Details', use_resetter=False)
+        if from_any_provider:
+            navigate_to(self, 'AnyProviderDetails', use_resetter=False)
+        else:
+            navigate_to(self, 'Details', use_resetter=False)
         if refresh:
             toolbar.refresh()
             self.browser.plugin.ensure_page_safe()
@@ -615,7 +619,7 @@ class VM(BaseVM):
 
     def wait_for_vm_state_change(self, desired_state=None, timeout=300, from_details=False,
                                  with_relationship_refresh=True, from_any_provider=False):
-        """Wait for M to come to desired state.
+        """Wait for VM to come to desired state.
 
         This function waits just the needed amount of time thanks to wait_for.
 

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -1222,6 +1222,12 @@ class VmAllWithTemplatesDetails(CFMENavigateStep):
 @navigator.register(Template, 'AnyProviderDetails')
 @navigator.register(Vm, 'AnyProviderDetails')
 class VmAllWithTemplatesDetailsAnyProvider(VmAllWithTemplatesDetails):
+    """
+    Page with details for VM or template.
+    This is required in case you want to get details about archived/orphaned VM/template.
+    In such case, you cannot get to the detail page by navigating from list of VMs for a provider
+    since archived/orphaned VMs has lost its relationship with the original provider.
+    """
     prerequisite = NavigateToSibling('All')
 
 

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -1219,6 +1219,12 @@ class VmAllWithTemplatesDetails(CFMENavigateStep):
         self.view.toolbar.reload.click()
 
 
+@navigator.register(Template, 'AnyProviderDetails')
+@navigator.register(Vm, 'AnyProviderDetails')
+class VmAllWithTemplatesDetailsAnyProvider(VmAllWithTemplatesDetails):
+    prerequisite = NavigateToSibling('All')
+
+
 @navigator.register(Vm, 'VMsOnly')
 class VmAll(CFMENavigateStep):
     VIEW = VmsOnlyAllView

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -354,7 +354,7 @@ def test_no_power_controls_on_archived_vm(testing_vm, archived_vm, soft_assert):
         * Open the view of VM Details
         * Verify the Power toolbar button is not visible
     """
-    testing_vm.load_details()
+    testing_vm.load_details(from_any_provider=True)
     soft_assert(not toolbar.exists("Power"), "Power displayed in template details!")
 
 


### PR DESCRIPTION
__Extending__ VM model. The reason is that if you want to access VM's details, navmazing path to it contains view with VMs of a provider. However, archived VM is no longer visible under provider. That's why you can now specify that you want to load details independently of provider.

{{pytest: cfme/tests/infrastructure/test_vm_power_control.py::test_no_power_controls_on_archived_vm --use-provider rhv41 -v --long-running}}