### PR TITLE
[RFR] Updated name for cloud tenants

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
             'domains = cfme.automate.explorer.domain:DomainCollection',
             'keypairs = cfme.cloud.keypairs:KeyPairCollection',
             'stacks = cfme.cloud.stack:StackCollection',
-            'tenants = cfme.cloud.tenant:TenantCollection',
+            'cloud_tenants = cfme.cloud.tenant:TenantCollection',
             'candus = cfme.configure.configuration.region_settings:CANDUCollection',
             'nodes = cfme.containers.node:NodeCollection',
             'dashboards = cfme.dashboard:DashboardCollection',


### PR DESCRIPTION
Updated name for cloud_tenants, because just `tenants` would be for cfme tenants collection