### PR TITLE
[RFR] Updated name for cloud tenants

### DIFF
--- a/cfme/tests/cloud/test_tenant.py
+++ b/cfme/tests/cloud/test_tenant.py
@@ -12,7 +12,7 @@ pytestmark = [pytest.mark.provider([OpenStackProvider], scope='module')]
 
 @pytest.yield_fixture(scope='function')
 def tenant(provider, setup_provider, appliance):
-    collection = appliance.collections.tenants
+    collection = appliance.collections.cloud_tenants
     tenant = collection.create(name=fauxfactory.gen_alphanumeric(8), provider=provider)
 
     yield tenant

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
             'domains = cfme.automate.explorer.domain:DomainCollection',
             'keypairs = cfme.cloud.keypairs:KeyPairCollection',
             'stacks = cfme.cloud.stack:StackCollection',
-            'tenants = cfme.cloud.tenant:TenantCollection',
+            'cloud_tenants = cfme.cloud.tenant:TenantCollection',
             'candus = cfme.configure.configuration.region_settings:CANDUCollection',
             'nodes = cfme.containers.node:NodeCollection',
             'dashboards = cfme.dashboard:DashboardCollection',


### PR DESCRIPTION
Updated name to `cloud_tenants`, because just `tenants` would be for cfme tenants collection
{{ pytest: -v cfme/tests/cloud/test_tenant.py }}