### PR TITLE
[1LP][RFR] Widgetastic conversions

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -20,7 +20,7 @@ from cfme.utils.stats import tol_check
 from cfme.utils.update import Updateable
 from cfme.utils.varmeth import variable
 from cfme.utils.wait import wait_for, RefreshTimer
-from . import PolicyProfileAssignable, Taggable, SummaryMixin
+from . import PolicyProfileAssignable, SummaryMixin
 
 
 def base_types():
@@ -43,7 +43,7 @@ def all_types():
     return all_types
 
 
-class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
+class BaseProvider(WidgetasticTaggable, Updateable, SummaryMixin, Navigatable):
     # List of constants that every non-abstract subclass must have defined
     _param_name = ParamClassName('name')
     STATS_TO_MATCH = []

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -31,6 +31,7 @@ class ProviderDetailsToolBar(View):
     reload = Button(title='Reload Current Display')
     policy = Dropdown(text='Policy')
     authentication = Dropdown(text='Authentication')
+    download = Button(title='Download summary in PDF format')
 
     view_selector = View.nested(DetailsToolBarViewSelector)
 
@@ -58,6 +59,7 @@ class ProviderDetailsView(BaseLoggedInPage):
         relationships = SummaryTable(title="Relationships")
         overview = SummaryTable(title="Overview")
         smart_management = SummaryTable(title="Smart Management")
+        custom_attributes = SummaryTable(title='Custom Attributes')
 
     @entities.register('Dashboard View')
     class ProviderDetailsDashboardView(View):
@@ -276,13 +278,18 @@ class ContainersProvidersView(ProvidersView):
     """
      represents Main view displaying all Containers providers
     """
+    SUMMARY_TEXT = 'Containers Providers'
     table = Table(locator="//div[@id='list_grid']//table")
+
+    @property
+    def paginator(self):
+        return self.entities.paginator
 
     @property
     def is_displayed(self):
         return (super(ContainersProvidersView, self).is_displayed and
                 self.navigation.currently_selected == ['Compute', 'Containers', 'Providers'] and
-                self.entities.title.text == 'Containers Providers')
+                self.entities.title.text == self.SUMMARY_TEXT)
 
 
 class InfraProvidersView(ProvidersView):
@@ -462,7 +469,7 @@ class ContainersProviderEditView(ProviderEditView):
     def is_displayed(self):
         return (super(ProviderEditView, self).is_displayed and
                 self.navigation.currently_selected == ['Compute', 'Containers', 'Providers'] and
-                self.title.text == 'Edit Containers Provider')
+                'Edit Containers Provider' in self.title.text)
 
 
 class MiddlewareProviderEditView(ProviderEditView):

--- a/cfme/containers/container.py
+++ b/cfme/containers/container.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from functools import partial
 import random
 import itertools
 
@@ -11,60 +10,12 @@ from widgetastic.widget import Text
 from widgetastic.xpath import quote
 from widgetastic.utils import Version, VersionPick
 
-from cfme.containers.provider import (details_page, pol_btn, mon_btn,
-    ContainerObjectAllBaseView)
-from cfme.common import SummaryMixin, Taggable
-from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import CheckboxTable, toolbar as tb, match_location, PagedTable
+from cfme.containers.provider import (ContainerObjectAllBaseView, ContainerObjectDetailsBaseView,
+                                      click_row)
+from cfme.common import WidgetasticTaggable, TagPageView
 from cfme.utils.appliance import Navigatable
-from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
+from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator
 from cfme.utils import version
-
-
-list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
-paged_tbl = PagedTable(table_locator="//div[@id='list_grid']//table")
-
-match_page = partial(match_location, controller='container', title='Containers')
-
-
-class Container(Taggable, SummaryMixin, Navigatable):
-
-    PLURAL = 'Containers'
-
-    def __init__(self, name, pod, appliance=None):
-        self.name = name
-        self.pod = pod
-        Navigatable.__init__(self, appliance=appliance)
-
-    def load_details(self, refresh=False):
-        navigate_to(self, 'Details')
-        if refresh:
-            tb.refresh()
-
-    def click_element(self, *ident):
-        self.load_details(refresh=True)
-        return sel.click(details_page.infoblock.element(*ident))
-
-    def get_detail(self, *ident):
-        """ Gets details from the details infoblock
-        Args:
-            *ident: An InfoBlock title, followed by the Key name, e.g. "Relationships", "Images"
-        Returns: A string representing the contents of the InfoBlock's value.
-        """
-        self.load_details(refresh=True)
-        return details_page.infoblock.text(*ident)
-
-    @property
-    def project_name(self):
-        return self.pod.project_name
-
-    @classmethod
-    def get_random_instances(cls, provider, count=1, appliance=None):
-        """Generating random instances."""
-        containers_list = provider.mgmt.list_container()
-        random.shuffle(containers_list)
-        return [cls(obj.name, obj.cg_name, appliance=appliance)
-                for obj in itertools.islice(containers_list, count)]
 
 
 class ContainerAllView(ContainerObjectAllBaseView):
@@ -93,6 +44,34 @@ class ContainerAllView(ContainerObjectAllBaseView):
         return self.summary.is_displayed
 
 
+class ContainerDetailsView(ContainerObjectDetailsBaseView):
+    pass
+
+
+class Container(WidgetasticTaggable, Navigatable):
+
+    PLURAL = 'Containers'
+    all_view = ContainerAllView
+    details_view = ContainerDetailsView
+
+    def __init__(self, name, pod, appliance=None):
+        self.name = name
+        self.pod = pod
+        Navigatable.__init__(self, appliance=appliance)
+
+    @property
+    def project_name(self):
+        return self.pod.project_name
+
+    @classmethod
+    def get_random_instances(cls, provider, count=1, appliance=None):
+        """Generating random instances."""
+        containers_list = provider.mgmt.list_container()
+        random.shuffle(containers_list)
+        return [cls(obj.name, obj.cg_name, appliance=appliance)
+                for obj in itertools.islice(containers_list, count)]
+
+
 @navigator.register(Container, 'All')
 class ContainerAll(CFMENavigateStep):
     VIEW = ContainerAllView
@@ -106,29 +85,30 @@ class ContainerAll(CFMENavigateStep):
             self.view.Filters.tree.click_path('All Containers')
         else:
             self.view.Filters.Navigation.select('ALL (Default)')
-        tb.select('List View')
-        from cfme.web_ui import paginator
-        if paginator.page_controls_exist():
-            paginator.check_all()
-            paginator.uncheck_all()
+        # Reset view and selection
+        self.view.toolbar.view_selector.select("List View")
+        if self.view.paginator.is_displayed:
+            self.view.paginator.check_all()
+            self.view.paginator.uncheck_all()
 
 
 @navigator.register(Container, 'Details')
 class ContainerDetails(CFMENavigateStep):
+    VIEW = ContainerDetailsView
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        tb.select('List View')
-        sel.click(paged_tbl.find_row_by_cell_on_all_pages(
-            {'Name': self.obj.name, 'Pod Name': self.obj.pod}))
+        click_row(self.prerequisite_view,
+                  name=self.obj.name, pod_name=self.obj.pod)
 
 
 @navigator.register(Container, 'EditTags')
 class ContainerEditTags(CFMENavigateStep):
+    VIEW = TagPageView
     prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        pol_btn('Edit Tags')
+        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
 
 
 @navigator.register(Container, 'Timelines')
@@ -136,7 +116,7 @@ class ContainerTimeLines(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        mon_btn('Timelines')
+        self.prerequisite_view.toolbar.monitoring.item_select('Timelines')
 
 
 @navigator.register(Container, 'Utilization')
@@ -144,4 +124,4 @@ class ContainerUtilization(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        mon_btn('Utilization')
+        self.prerequisite_view.toolbar.monitoring.item_select('Utilization')

--- a/cfme/containers/overview.py
+++ b/cfme/containers/overview.py
@@ -1,33 +1,43 @@
 # -*- coding: utf-8 -*-
-from functools import partial
-
 from navmazing import NavigateToAttribute
+from widgetastic_manageiq import StatusBox
 
-from cfme.containers.provider import ContainersProvider
-from cfme.web_ui import match_location, StatusBox
+from cfme.base.login import BaseLoggedInPage
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator
 from cfme.utils.appliance import Navigatable
 from cfme.utils.wait import wait_for
-
-
-match_page = partial(match_location, controller='container_dashboard', title='Container Dashboards')
 
 
 class ContainersOverview(Navigatable):
     pass
 
 
+class ContainersOverviewView(BaseLoggedInPage):
+    providers = StatusBox('Providers')
+    nodes = StatusBox('Nodes')
+    containers = StatusBox('Containers')
+    registries = StatusBox('Registries')
+    projects = StatusBox('Projects')
+    pods = StatusBox('Pods')
+    services = StatusBox('Services')
+    images = StatusBox('Images')
+    routes = StatusBox('Routes')
+    # TODO: Add widgets for utilization trends
+
+    @property
+    def is_displayed(self):
+        return self.navigation.currently_selected == ['Compute', 'Containers', 'Overview']
+
+
 @navigator.register(ContainersOverview, 'All')
 class All(CFMENavigateStep):
+    VIEW = ContainersOverviewView
     prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
-
-    def am_i_here(self):
-        return match_page()
 
     def step(self):
         self.prerequisite_view.navigation.select('Compute', 'Containers', 'Overview')
 
     def resetter(self):
         # We should wait ~2 seconds for the StatusBox population
-        wait_for(lambda: StatusBox(ContainersProvider.PLURAL.split(' ')[-1]).value(),
-                 num_sec=10, delay=1)
+        wait_for(lambda: self.view.providers.value,
+                 num_sec=10, delay=1, silent_failure=True)

--- a/cfme/containers/pod.py
+++ b/cfme/containers/pod.py
@@ -1,33 +1,37 @@
 # -*- coding: utf-8 -*-
-from functools import partial
 import random
 import itertools
 from cached_property import cached_property
 
-from wrapanapi.containers.pod import Pod as ApiPod
-
-from cfme.common import SummaryMixin, Taggable
-from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import toolbar as tb, match_location,\
-    PagedTable, CheckboxTable
-from cfme.containers.provider import details_page, Labelable,\
-    ContainerObjectAllBaseView
-from cfme.utils.appliance import Navigatable
-from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep,\
-    navigate_to
 from navmazing import NavigateToAttribute, NavigateToSibling
+from wrapanapi.containers.pod import Pod as ApiPod
+from widgetastic_manageiq import NestedSummaryTable, SummaryTable
+from widgetastic.widget import View
+
+from cfme.common import WidgetasticTaggable, TagPageView
+from cfme.containers.provider import (Labelable, ContainerObjectAllBaseView,
+    ContainerObjectDetailsBaseView, click_row, ContainerObjectDetailsEntities)
+from cfme.utils.appliance import Navigatable
+from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep
 
 
-list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
-paged_tbl = PagedTable(table_locator="//div[@id='list_grid']//table")
+class PodAllView(ContainerObjectAllBaseView):
+    SUMMARY_TEXT = "Pods"
 
 
-match_page = partial(match_location, controller='container_group', title='Pods')
+class PodDetailsView(ContainerObjectDetailsBaseView):
+    @View.nested
+    class entities(ContainerObjectDetailsEntities):  # noqa
+        volumes = NestedSummaryTable(title='Volumes')
+        conditions = NestedSummaryTable(title='Conditions')
+        container_statuses_summary = SummaryTable(title='Container Statuses Summary')
 
 
-class Pod(Taggable, Labelable, SummaryMixin, Navigatable):
+class Pod(WidgetasticTaggable, Labelable, Navigatable):
 
     PLURAL = 'Pods'
+    all_view = PodAllView
+    details_view = PodDetailsView
 
     def __init__(self, name, project_name, provider, appliance=None):
         self.name = name
@@ -39,25 +43,6 @@ class Pod(Taggable, Labelable, SummaryMixin, Navigatable):
     def mgmt(self):
         return ApiPod(self.provider.mgmt, self.name, self.project_name)
 
-    def load_details(self, refresh=False):
-        navigate_to(self, 'Details')
-        if refresh:
-            tb.refresh()
-
-    def click_element(self, *ident):
-        self.load_details(refresh=True)
-        return sel.click(details_page.infoblock.element(*ident))
-
-    def get_detail(self, *ident):
-        """ Gets details from the details infoblock
-
-        Args:
-            *ident: An InfoBlock title, followed by the Key name, e.g. "Relationships", "Images"
-        Returns: A string representing the contents of the InfoBlock's value.
-        """
-        self.load_details(refresh=True)
-        return details_page.infoblock.text(*ident)
-
     @classmethod
     def get_random_instances(cls, provider, count=1, appliance=None):
         """Generating random instances."""
@@ -65,10 +50,6 @@ class Pod(Taggable, Labelable, SummaryMixin, Navigatable):
         random.shuffle(pod_list)
         return [cls(obj.name, obj.project_name, provider, appliance=appliance)
                 for obj in itertools.islice(pod_list, count)]
-
-
-class PodAllView(ContainerObjectAllBaseView):
-    TITLE_TEXT = "Pods"
 
 
 @navigator.register(Pod, 'All')
@@ -80,21 +61,26 @@ class All(CFMENavigateStep):
         self.prerequisite_view.navigation.select('Compute', 'Containers', 'Pods')
 
     def resetter(self):
-        from cfme.web_ui import paginator
         # Reset view and selection
-        tb.select("List View")
-        paginator.check_all()
-        paginator.uncheck_all()
+        self.view.toolbar.view_selector.select("List View")
+        self.view.paginator.check_all()
+        self.view.paginator.uncheck_all()
 
 
 @navigator.register(Pod, 'Details')
 class Details(CFMENavigateStep):
+    VIEW = PodDetailsView
     prerequisite = NavigateToSibling('All')
 
-    def am_i_here(self):
-        return match_page(summary='{} (Summary)'.format(self.obj.name))
+    def step(self):
+        click_row(self.prerequisite_view,
+                  name=self.obj.name, project_name=self.obj.project_name)
+
+
+@navigator.register(Pod, 'EditTags')
+class ImageRegistryEditTags(CFMENavigateStep):
+    VIEW = TagPageView
+    prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        tb.select('List View')
-        sel.click(paged_tbl.find_row_by_cell_on_all_pages({'Name': self.obj.name,
-                                                           'Project Name': self.obj.project_name}))
+        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')

--- a/cfme/containers/replicator.py
+++ b/cfme/containers/replicator.py
@@ -1,32 +1,31 @@
 # -*- coding: utf-8 -*-
 import random
 import itertools
-from functools import partial
 from cached_property import cached_property
 
 from wrapanapi.containers.replicator import Replicator as ApiReplicator
 
-from cfme.common import SummaryMixin, Taggable
-from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import toolbar as tb, match_location,\
-    PagedTable, CheckboxTable
-from cfme.containers.provider import details_page, Labelable,\
-    ContainerObjectAllBaseView
+from cfme.common import WidgetasticTaggable, TagPageView
+from cfme.containers.provider import (Labelable, ContainerObjectAllBaseView,
+    ContainerObjectDetailsBaseView, click_row)
 from cfme.utils.appliance import Navigatable
-from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep,\
-    navigate_to
+from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep
 from navmazing import NavigateToAttribute, NavigateToSibling
 
 
-list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
-paged_tbl = PagedTable(table_locator="//div[@id='list_grid']//table")
-
-match_page = partial(match_location, controller='container_replicators', title='Replicators')
+class ReplicatorAllView(ContainerObjectAllBaseView):
+    SUMMARY_TEXT = "Replicators"
 
 
-class Replicator(Taggable, Labelable, SummaryMixin, Navigatable):
+class ReplicatorDetailsView(ContainerObjectDetailsBaseView):
+    pass
+
+
+class Replicator(WidgetasticTaggable, Labelable, Navigatable):
 
     PLURAL = 'Replicators'
+    all_view = ReplicatorAllView
+    details_view = ReplicatorDetailsView
 
     def __init__(self, name, project_name, provider, appliance=None):
         self.name = name
@@ -38,25 +37,6 @@ class Replicator(Taggable, Labelable, SummaryMixin, Navigatable):
     def mgmt(self):
         return ApiReplicator(self.provider.mgmt, self.name, self.project_name)
 
-    def load_details(self, refresh=False):
-        navigate_to(self, 'Details')
-        if refresh:
-            tb.refresh()
-
-    def click_element(self, *ident):
-        self.load_details(refresh=True)
-        return sel.click(details_page.infoblock.element(*ident))
-
-    def get_detail(self, *ident):
-        """ Gets details from the details infoblock
-
-        Args:
-            *ident: An InfoBlock title, followed by the Key name, e.g. "Relationships", "Images"
-        Returns: A string representing the contents of the InfoBlock's value.
-        """
-        self.load_details(refresh=True)
-        return details_page.infoblock.text(*ident)
-
     @classmethod
     def get_random_instances(cls, provider, count=1, appliance=None):
         """Generating random instances."""
@@ -64,10 +44,6 @@ class Replicator(Taggable, Labelable, SummaryMixin, Navigatable):
         random.shuffle(rc_list)
         return [cls(obj.name, obj.project_name, provider, appliance=appliance)
                 for obj in itertools.islice(rc_list, count)]
-
-
-class ReplicatorAllView(ContainerObjectAllBaseView):
-    TITLE_TEXT = "Replicators"
 
 
 @navigator.register(Replicator, 'All')
@@ -80,20 +56,26 @@ class All(CFMENavigateStep):
 
     def resetter(self):
         # Reset view and selection
-        tb.select("List View")
-        from cfme.web_ui import paginator
-        paginator.check_all()
-        paginator.uncheck_all()
+        self.view.toolbar.view_selector.select("List View")
+        if self.view.paginator.is_displayed:
+            self.view.paginator.check_all()
+            self.view.paginator.uncheck_all()
 
 
 @navigator.register(Replicator, 'Details')
 class Details(CFMENavigateStep):
+    VIEW = ReplicatorDetailsView
     prerequisite = NavigateToSibling('All')
 
-    def am_i_here(self):
-        return match_page(summary='{} (Summary)'.format(self.obj.name))
+    def step(self):
+        click_row(self.prerequisite_view,
+                  name=self.obj.name, project_name=self.obj.project_name)
+
+
+@navigator.register(Replicator, 'EditTags')
+class ImageRegistryEditTags(CFMENavigateStep):
+    VIEW = TagPageView
+    prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        tb.select('List View')
-        sel.click(paged_tbl.find_row_by_cell_on_all_pages({'Name': self.obj.name,
-                                                           'Project Name': self.obj.project_name}))
+        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')

--- a/cfme/containers/route.py
+++ b/cfme/containers/route.py
@@ -1,32 +1,31 @@
 # -*- coding: utf-8 -*-
 import random
 import itertools
-from functools import partial
 from cached_property import cached_property
 
 from wrapanapi.containers.route import Route as ApiRoute
 
-from cfme.common import SummaryMixin, Taggable
-from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import toolbar as tb, match_location,\
-    PagedTable, CheckboxTable
-from cfme.containers.provider import details_page, Labelable,\
-    ContainerObjectAllBaseView
-from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep,\
-    navigate_to
+from cfme.common import WidgetasticTaggable, TagPageView
+from cfme.containers.provider import (Labelable, ContainerObjectAllBaseView,
+    ContainerObjectDetailsBaseView, click_row)
+from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep
 from navmazing import NavigateToAttribute, NavigateToSibling
 from cfme.utils.appliance import Navigatable
 
 
-list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
-paged_tbl = PagedTable(table_locator="//div[@id='list_grid']//table")
-
-match_page = partial(match_location, controller='container_routes', title='Routes')
+class RouteAllView(ContainerObjectAllBaseView):
+    SUMMARY_TEXT = "Routes"
 
 
-class Route(Taggable, Labelable, SummaryMixin, Navigatable):
+class RouteDetailsView(ContainerObjectDetailsBaseView):
+    pass
+
+
+class Route(WidgetasticTaggable, Labelable, Navigatable):
 
     PLURAL = 'Routes'
+    all_view = RouteAllView
+    details_view = RouteDetailsView
 
     def __init__(self, name, project_name, provider, appliance=None):
         self.name = name
@@ -38,24 +37,6 @@ class Route(Taggable, Labelable, SummaryMixin, Navigatable):
     def mgmt(self):
         return ApiRoute(self.provider.mgmt, self.name, self.project_name)
 
-    def load_details(self, refresh=False):
-        navigate_to(self, 'Details')
-        if refresh:
-            tb.refresh()
-
-    def click_element(self, *ident):
-        self.load_details(refresh=True)
-        return sel.click(details_page.infoblock.element(*ident))
-
-    def get_detail(self, *ident):
-        """ Gets details from the details infoblock
-        Args:
-            *ident: An InfoBlock title, followed by the Key name, e.g. "Relationships", "Images"
-        Returns: A string representing the contents of the InfoBlock's value.
-        """
-        self.load_details(refresh=True)
-        return details_page.infoblock.text(*ident)
-
     @classmethod
     def get_random_instances(cls, provider, count=1, appliance=None):
         """Generating random instances."""
@@ -63,10 +44,6 @@ class Route(Taggable, Labelable, SummaryMixin, Navigatable):
         random.shuffle(route_list)
         return [cls(obj.name, obj.project_name, provider, appliance=appliance)
                 for obj in itertools.islice(route_list, count)]
-
-
-class RouteAllView(ContainerObjectAllBaseView):
-    TITLE_TEXT = "Routes"
 
 
 @navigator.register(Route, 'All')
@@ -79,20 +56,26 @@ class All(CFMENavigateStep):
 
     def resetter(self):
         # Reset view and selection
-        tb.select("List View")
-        from cfme.web_ui import paginator
-        paginator.check_all()
-        paginator.uncheck_all()
+        self.view.toolbar.view_selector.select("List View")
+        if self.view.paginator.is_displayed:
+            self.view.paginator.check_all()
+            self.view.paginator.uncheck_all()
 
 
 @navigator.register(Route, 'Details')
 class Details(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
-
-    def am_i_here(self):
-        return match_page(summary='{} (Summary)'.format(self.obj.name))
+    VIEW = RouteDetailsView
 
     def step(self):
-        tb.select('List View')
-        sel.click(paged_tbl.find_row_by_cell_on_all_pages({'Name': self.obj.name,
-                                                           'Project Name': self.obj.project_name}))
+        click_row(self.prerequisite_view,
+                  name=self.obj.name, project_name=self.obj.project_name)
+
+
+@navigator.register(Route, 'EditTags')
+class ImageRegistryEditTags(CFMENavigateStep):
+    VIEW = TagPageView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')

--- a/cfme/containers/template.py
+++ b/cfme/containers/template.py
@@ -1,32 +1,31 @@
 # -*- coding: utf-8 -*-
 import random
 import itertools
-from functools import partial
 from cached_property import cached_property
 
 from navmazing import NavigateToAttribute, NavigateToSibling
 from wrapanapi.containers.template import Template as ApiTemplate
 
-from cfme.common import SummaryMixin, Taggable
-from cfme.containers.provider import Labelable, ContainerObjectAllBaseView
-from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import toolbar as tb, match_location,\
-    PagedTable, CheckboxTable
-from .provider import details_page
+from cfme.common import WidgetasticTaggable, TagPageView
+from cfme.containers.provider import (Labelable, ContainerObjectAllBaseView,
+    ContainerObjectDetailsBaseView, click_row)
 from cfme.utils.appliance import Navigatable
-from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep,\
-    navigate_to
+from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep
 
 
-list_tbl = CheckboxTable(table_locator="//div[@id='list_grid']//table")
-paged_tbl = PagedTable(table_locator="//div[@id='list_grid']//table")
-
-match_page = partial(match_location, controller='container_templates', title='Container Templates')
+class TemplateAllView(ContainerObjectAllBaseView):
+    SUMMARY_TEXT = "Container Templates"
 
 
-class Template(Taggable, Labelable, SummaryMixin, Navigatable):
+class TemplateDetailsView(ContainerObjectDetailsBaseView):
+    pass
+
+
+class Template(WidgetasticTaggable, Labelable, Navigatable):
 
     PLURAL = 'Templates'
+    all_view = TemplateAllView
+    details_view = TemplateDetailsView
 
     def __init__(self, name, project_name, provider, appliance=None):
         self.name = name
@@ -38,25 +37,6 @@ class Template(Taggable, Labelable, SummaryMixin, Navigatable):
     def mgmt(self):
         return ApiTemplate(self.provider.mgmt, self.name, self.project_name)
 
-    def load_details(self, refresh=False):
-        navigate_to(self, 'Details')
-        if refresh:
-            tb.refresh()
-
-    def click_element(self, *ident):
-        self.load_details(refresh=True)
-        return sel.click(details_page.infoblock.element(*ident))
-
-    def get_detail(self, *ident):
-        """ Gets details from the details infoblock
-
-        Args:
-            *ident: An InfoBlock title, followed by the Key name, e.g. "Relationships", "Images"
-        Returns: A string representing the contents of the InfoBlock's value.
-        """
-        self.load_details(refresh=True)
-        return details_page.infoblock.text(*ident)
-
     @classmethod
     def get_random_instances(cls, provider, count=1, appliance=None):
         """Generating random instances."""
@@ -64,10 +44,6 @@ class Template(Taggable, Labelable, SummaryMixin, Navigatable):
         random.shuffle(template_list)
         return [cls(obj.name, obj.project_name, provider, appliance=appliance)
                 for obj in itertools.islice(template_list, count)]
-
-
-class TemplateAllView(ContainerObjectAllBaseView):
-    TITLE_TEXT = "Container Templates"
 
 
 @navigator.register(Template, 'All')
@@ -80,20 +56,26 @@ class All(CFMENavigateStep):
 
     def resetter(self):
         # Reset view and selection
-        tb.select("List View")
-        from cfme.web_ui import paginator
-        paginator.check_all()
-        paginator.uncheck_all()
+        self.view.toolbar.view_selector.select("List View")
+        if self.view.paginator.is_displayed:
+            self.view.paginator.check_all()
+            self.view.paginator.uncheck_all()
 
 
 @navigator.register(Template, 'Details')
 class Details(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
-
-    def am_i_here(self):
-        return match_page(summary='{} (Summary)'.format(self.obj.name))
+    VIEW = TemplateDetailsView
 
     def step(self):
-        tb.select('List View')
-        sel.click(paged_tbl.find_row_by_cell_on_all_pages({'Name': self.obj.name,
-                                                           'Project Name': self.obj.project_name}))
+        click_row(self.prerequisite_view,
+                  name=self.obj.name, project_name=self.obj.project_name)
+
+
+@navigator.register(Template, 'EditTags')
+class ImageRegistryEditTags(CFMENavigateStep):
+    VIEW = TagPageView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')

--- a/cfme/fixtures/has_persistent_volume.py
+++ b/cfme/fixtures/has_persistent_volume.py
@@ -1,0 +1,27 @@
+import pytest
+
+from cfme.containers.volume import Volume
+
+
+@pytest.yield_fixture(scope='module')
+def has_persistent_volume(provider, appliance):
+    """Verifying that some persistent volume exists"""
+    name = 'pv-{}'.format(len(provider.mgmt.list_volume()) + 1)
+    payload = {
+        'metadata': {'name': name},
+        'spec': {
+            'accessModes': ['ReadWriteOnce'],
+            'capacity': {'storage': '1Gi'},
+            'nfs': {
+                'path': '/tmp',
+                'server': '12.34.56.78'
+            }
+        },
+        'persistentVolumeReclaimPolicy': 'Retain'
+    }
+    assert provider.mgmt.api.post('persistentvolume', payload)[0] in [200, 201]
+    # TODO: switch to below once wrapanapi version > 2.4.4:
+    #     from wrapanapi.containers.volume import Volume as VolumeApi
+    #     volume = VolumeApi.create(provider, payload)
+    yield Volume(name, provider, appliance)
+    provider.mgmt.api.delete('persistentvolume', name)

--- a/cfme/test_framework/pytest_plugin.py
+++ b/cfme/test_framework/pytest_plugin.py
@@ -96,6 +96,7 @@ pytest_plugins = (
     'cfme.fixtures.vm_name',
     'cfme.fixtures.vporizer',
     'cfme.fixtures.model_collections',
+    'cfme.fixtures.has_persistent_volume',
 
     'cfme.metaplugins',
 )

--- a/cfme/tests/containers/test_ad_hoc_metrics.py
+++ b/cfme/tests/containers/test_ad_hoc_metrics.py
@@ -1,6 +1,5 @@
 import pytest
 import requests
-from cfme.utils import testgen
 from cfme.utils.log import logger
 from cfme.containers.provider import ContainersProvider
 from cfme.utils.version import current_version
@@ -10,8 +9,8 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 pytestmark = [
     pytest.mark.uncollectif(lambda provider: current_version() < "5.8"),
     pytest.mark.usefixtures('setup_provider'),
-    pytest.mark.tier(1)]
-pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
+    pytest.mark.tier(1),
+    pytest.mark.provider([ContainersProvider], scope='function')]
 
 
 @pytest.fixture(scope="function")

--- a/cfme/tests/containers/test_basic_metrics.py
+++ b/cfme/tests/containers/test_basic_metrics.py
@@ -1,15 +1,14 @@
 import pytest
 import re
 from cfme.containers.provider import ContainersProvider
-from cfme.utils import testgen
 from cfme.utils.version import current_version
 
 
 pytestmark = [
     pytest.mark.uncollectif(lambda provider: current_version() < "5.6"),
     pytest.mark.usefixtures('setup_provider'),
-    pytest.mark.tier(1)]
-pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
+    pytest.mark.tier(1),
+    pytest.mark.provider([ContainersProvider], scope='function')]
 
 
 @pytest.mark.polarion('CMP-10205')

--- a/cfme/tests/containers/test_breadcrumbs.py
+++ b/cfme/tests/containers/test_breadcrumbs.py
@@ -1,10 +1,6 @@
-import pytest
+from collections import namedtuple
 
-from cfme.utils import testgen
-from cfme.utils.soft_get import soft_get
-from cfme.web_ui import breadcrumbs, summary_title
-from cfme.fixtures import pytest_selenium as sel
-from cfme.utils.version import current_version
+import pytest
 
 from cfme.containers.service import Service
 from cfme.containers.route import Route
@@ -12,78 +8,53 @@ from cfme.containers.project import Project
 from cfme.containers.pod import Pod
 from cfme.containers.image_registry import ImageRegistry
 from cfme.containers.image import Image
+from cfme.containers.node import Node
 from cfme.containers.replicator import Replicator
 from cfme.containers.template import Template
 from cfme.containers.volume import Volume
-from cfme.containers.provider import ContainersProvider, navigate_and_get_rows
+from cfme.containers.provider import ContainersProvider
+from cfme.utils.appliance.implementations.ui import navigate_to
 
 
 pytestmark = [
-    pytest.mark.usefixtures('setup_provider'),
-    pytest.mark.tier(1)]
-pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
+    pytest.mark.usefixtures('setup_provider_modscope'),
+    pytest.mark.usefixtures('has_persistent_volume'),
+    pytest.mark.tier(1),
+    pytest.mark.provider([ContainersProvider], scope='module')]
 
 
-class DataSet(object):
-    def __init__(self, obj, obj_base_name):
-        self.obj = obj
-        self.obj_base_name = obj_base_name
+DataSet = namedtuple('DataSet', ['obj', 'allView'])
 
 
-DATA_SETS = [
-    DataSet(Service, 'service'),
-    DataSet(Route, 'route'),
-    DataSet(Project, 'project'),
-    DataSet(Pod, 'pod'),
-    DataSet(Image, 'image'),
-    DataSet(ContainersProvider, 'provider'),
-    DataSet(ImageRegistry, 'image regist'),
-    # TODO Add Node back into the list when other classes are updated to use WT views and widgets.
-    # DataSet(Node, 'node'),
-    DataSet(Replicator, 'replicator'),
-    DataSet(Template, 'template'),
-    DataSet(Volume, 'volume')
+TESTED_OBJECTS = [
+    Service, Route, Project, Pod, Image, ContainersProvider, ImageRegistry,
+    Node, Replicator, Template, Volume
 ]
 
 
 @pytest.mark.polarion('CMP-10576')
-def test_breadcrumbs(provider, soft_assert):
+def test_breadcrumbs(provider, appliance, soft_assert):
 
-    for dataset in DATA_SETS:
+    for obj in TESTED_OBJECTS:
 
-        if current_version() < '5.7' and dataset.obj == Template:
-            continue
+        inst = (provider if obj is ContainersProvider
+                else obj.get_random_instances(provider, 1, appliance).pop())
+        view = navigate_to(inst, 'Details')
 
-        rows = navigate_and_get_rows(provider, dataset.obj, 1)
-        if not rows:
-            pytest.skip('Could not test breadcrums: No records found in {}\'s table'
-                        .format(dataset.obj.__name__))
-        row = rows[-1]
-        instance_name = row[2].text
-        row.click()
-
-        breadcrumb_elements = breadcrumbs()
-        soft_assert(breadcrumb_elements,
+        soft_assert(view.breadcrumb.is_displayed,
                     'Breadcrumbs not found in {} {} summary page'
-                    .format(dataset.obj.__name__, instance_name))
-        bread_names_2_element = {sel.text_sane(b): b for b in breadcrumb_elements}
+                    .format(obj.__name__, inst.name))
 
-        try:
-            breadcrumb_element = soft_get(bread_names_2_element,
-                                          dataset.obj_base_name, dict_=True)
-        except:
-            soft_assert(False,
-                'Could not find breadcrumb "{}" in {} {} summary page. breadcrumbs: {}'
-                .format(dataset.obj_base_name, bread_names_2_element.keys(),
-                        dataset.obj.__name__, instance_name))
+        soft_assert(obj.all_view.SUMMARY_TEXT in view.breadcrumb.locations,
+            'Could not find breadcrumb "{}" in {} {} summary page. breadcrumbs: {}'
+            .format(obj.all_view.SUMMARY_TEXT, view.breadcrumb.locations,
+                    obj.__name__, inst.name))
 
-        breadcrumb_name = sel.text_sane(breadcrumb_element)
-        sel.click(breadcrumb_element)
+        view.breadcrumb.click_location(obj.all_view.SUMMARY_TEXT)
+        view = appliance.browser.create_view(obj.all_view)
 
-        # We verify the location as following since we want to prevent from name convention errors
-        soft_assert(dataset.obj_base_name in summary_title().lower(),
-            'Breadcrumb link "{}" in {} {} page should navigate to '
-            '{}s main page. navigated instead to: {}'
-            .format(breadcrumb_name, dataset.obj.__name__,
-                    instance_name, dataset.obj.__name__,
-                    sel.current_url()))
+        soft_assert(view.is_displayed,
+            'Breadcrumb link "{summary}" in {obj} {name} page should navigate to '
+            '{name}s main page. navigated instead to: {url}'
+            .format(summary=obj.all_view.SUMMARY_TEXT, obj=obj.__name__,
+                    name=inst.name, url=view.browser.url))

--- a/cfme/tests/containers/test_chargeback.py
+++ b/cfme/tests/containers/test_chargeback.py
@@ -11,9 +11,7 @@ import pytest
 from cfme.containers.provider import ContainersProvider
 from cfme.intelligence.chargeback import assignments, rates
 from cfme.intelligence.reports.reports import CustomReport
-from cfme.fixtures import pytest_selenium as sel
 
-from cfme.utils import testgen
 from cfme.utils.log import logger
 from cfme.utils.units import CHARGEBACK_HEADER_NAMES, parse_number
 
@@ -33,9 +31,9 @@ pytestmark = [
     pytest.mark.parametrize('obj_type', obj_types, scope='module'),
     pytest.mark.parametrize('rate_type', rate_types, scope='module'),
     pytest.mark.parametrize('interval', intervals, scope='module'),
-    pytest.mark.long_running_env
+    pytest.mark.long_running_env,
+    pytest.mark.provider([ContainersProvider], scope='module')
 ]
-pytest_generate_tests = testgen.generate([ContainersProvider], scope='module')
 
 # We cannot calculate the accurate value because the prices in the reports
 # appears in a lower precision (floored). Hence we're using this accuracy coefficient:
@@ -213,12 +211,6 @@ def abstract_test_chargeback_cost(
         :py:class:`ComputeRate` compute_rate: The compute rate object.
         :var soft_assert: soft_assert fixture.
     """
-    if sel.is_displayed_text("No records found for this report"):
-        pytest.skip('No records found in the report. probably the setup didn\'t '
-                    'manage to collect enough metrics for the current rate. '
-                    'rate={}; interval={}'
-                    .format(compute_rate.description, interval))
-
     report_headers = CHARGEBACK_HEADER_NAMES[rate_key]
 
     found_something_to_test = False

--- a/cfme/tests/containers/test_cockpit.py
+++ b/cfme/tests/containers/test_cockpit.py
@@ -1,20 +1,14 @@
 import pytest
 
 from cfme.containers.provider import ContainersProvider
-from cfme.fixtures import pytest_selenium as sel
-from cfme.web_ui import toolbar as tb
-from cfme.utils import testgen, version
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 
 
 pytestmark = [
-    pytest.mark.uncollectif(
-        lambda provider: version.current_version() < "5.7"),
     pytest.mark.usefixtures('setup_provider'),
-    pytest.mark.tier(1)]
-pytest_generate_tests = testgen.generate(
-    [ContainersProvider], scope='function')
+    pytest.mark.tier(1),
+    pytest.mark.provider([ContainersProvider], scope='function')]
 
 
 @pytest.mark.polarion('CMP-10255')
@@ -24,25 +18,20 @@ def test_cockpit_button_access(provider, appliance, soft_assert):
         button on master node, then presses on the button and
         opens up the cockpit main page in a new window. Then
         we verify the title of the main cockpit page. The test
-        will not work until the single sign-on bug is fixed
-
+        will not work until the single sign-on bug is fixed.
     """
 
     collection = appliance.collections.nodes
     nodes = collection.all()
     node = [node for node in nodes if 'master' in node.name][0]
-    navigate_to(node, 'Details')
+    view = navigate_to(node, 'Details')
 
-    soft_assert(
-        tb.exists(
-            'Open a new browser window with Cockpit for this '
-            'VM.  This requires that Cockpit is pre-configured on the VM.'),
-        'No "Web Console" button found')
-    tb.select('Open a new browser window with Cockpit for this '
-              'VM.  This requires that Cockpit is pre-configured on the VM.')
+    assert view.toolbar.web_console.is_displayed, 'No "Web Console" button found'
+    assert view.toolbar.web_console.active
+    view.toolbar.web_console.click()
 
     port_num = ':9090/system'
     url_cockpit = provider.hostname + port_num
-    sel.get(url_cockpit)
-    title_pg = sel.title()
-    soft_assert(title_pg == 'Cockpit', 'Cockpit main page failed to open')
+    view.browser.url = url_cockpit
+    title_pg = view.browser.selenium.title()
+    assert title_pg == 'Cockpit', 'Cockpit main page failed to open'

--- a/cfme/tests/containers/test_configurable_menus.py
+++ b/cfme/tests/containers/test_configurable_menus.py
@@ -3,13 +3,14 @@ import pytest
 
 from cfme.containers.provider import ContainersProvider
 from cfme.base.login import BaseLoggedInPage
-from cfme.utils import testgen
 from cfme.utils.version import current_version
 from cfme.utils.appliance.implementations.ui import navigate_to
 
 
-pytestmark = [pytest.mark.uncollectif(lambda: current_version() < "5.8")]
-pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
+pytestmark = [
+    pytest.mark.uncollectif(lambda: current_version() < "5.8"),
+    pytest.mark.provider([ContainersProvider], scope='function')
+]
 
 
 def config_menus_visibility(appliance, is_visible):

--- a/cfme/tests/containers/test_logging.py
+++ b/cfme/tests/containers/test_logging.py
@@ -1,6 +1,5 @@
 import pytest
 
-from cfme.utils import testgen
 from cfme.utils.version import current_version
 from cfme.utils.appliance.implementations.ui import navigate_to
 
@@ -10,8 +9,8 @@ NUM_OF_DEFAULT_LOG_ROUTES = 2
 pytestmark = [
     pytest.mark.uncollectif(lambda provider: current_version() < "5.8"),
     pytest.mark.usefixtures('setup_provider'),
-    pytest.mark.tier(1)]
-pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
+    pytest.mark.tier(1),
+    pytest.mark.provider([ContainersProvider], scope='function')]
 
 
 TEST_ITEMS = [
@@ -48,12 +47,12 @@ def get_ose_logging_url(logging_routes):
 
 @pytest.mark.parametrize('test_item', TEST_ITEMS,
                          ids=[ContainersTestItem.get_pretty_id(ti) for ti in TEST_ITEMS])
-def test_external_logging_activated(provider, test_item):
+def test_external_logging_activated(provider, appliance, test_item):
 
     if test_item.obj is ContainersProvider:
         obj_inst = provider
     else:
-        obj_inst = test_item.obj.get_random_instances(provider, count=1).pop()
+        obj_inst = test_item.obj.get_random_instances(provider, 1, appliance).pop()
 
     view = navigate_to(obj_inst, 'Details')
     assert view.monitor.item_enabled('External Logging'), (

--- a/cfme/tests/containers/test_manageiq_ansible_tags.py
+++ b/cfme/tests/containers/test_manageiq_ansible_tags.py
@@ -1,14 +1,12 @@
 import pytest
+
 from cfme.containers.provider import ContainersProvider
-from cfme.utils import testgen
-from cfme.utils.ansible import setup_ansible_script, run_ansible, \
-    fetch_miq_ansible_module, create_tmp_directory, remove_tmp_files
-from cfme.utils.version import current_version
+from cfme.utils.ansible import (setup_ansible_script, run_ansible,
+    fetch_miq_ansible_module, create_tmp_directory, remove_tmp_files)
+from cfme.utils.appliance.implementations.ui import navigate_to
 
 
-pytestmark = [
-    pytest.mark.uncollectif(lambda provider: current_version() < "5.7")]
-pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
+pytestmark = [pytest.mark.provider([ContainersProvider], scope='function')]
 
 tags_to_add = {
     'category': 'environment',
@@ -38,15 +36,10 @@ def ansible_tags():
 
 
 def get_smart_management(provider):
-    index = 0
-    smart_management_tags = []
-    if isinstance(provider.summary.smart_management.my_company_tags, list):
-        for tag in provider.summary.smart_management.my_company_tags:
-            smart_management_tags.append(tag.value)
-            index += 1
-    else:
-        smart_management_tags.append(provider.summary.smart_management.my_company_tags)
-    return smart_management_tags
+    view = navigate_to(provider, 'Details')
+    my_company_tags = view.entities.smart_management.read().get('My Company Tags')
+    return (my_company_tags if isinstance(my_company_tags, list)
+            else [my_company_tags])
 
 
 def clean_tags(provider):

--- a/cfme/tests/containers/test_manageiq_ansible_users.py
+++ b/cfme/tests/containers/test_manageiq_ansible_users.py
@@ -1,17 +1,16 @@
 import pytest
+
 from cfme.containers.provider import ContainersProvider
 from cfme.configure.access_control import User
-from cfme.utils import testgen
-from cfme.utils.ansible import setup_ansible_script, run_ansible, \
-    fetch_miq_ansible_module, create_tmp_directory, remove_tmp_files
+from cfme.utils.ansible import (setup_ansible_script, run_ansible,
+    fetch_miq_ansible_module, create_tmp_directory, remove_tmp_files)
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.version import current_version
 
 
 pytestmark = [
-    pytest.mark.uncollectif(lambda: current_version() < "5.7"),
-    pytest.mark.usefixtures('setup_provider')]
-pytest_generate_tests = testgen.generate([ContainersProvider], scope='module')
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.provider([ContainersProvider], scope='module')
+]
 
 
 users_values_to_create = {

--- a/cfme/tests/containers/test_overview_data_integrity.py
+++ b/cfme/tests/containers/test_overview_data_integrity.py
@@ -7,17 +7,15 @@ from cfme.containers.service import Service
 from cfme.containers.project import Project
 from cfme.containers.route import Route
 from cfme.containers.overview import ContainersOverview
-from cfme.web_ui import StatusBox
 
-from cfme.utils import testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
 
 
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
-    pytest.mark.tier(1)]
-pytest_generate_tests = testgen.generate(
-    [ContainersProvider], scope='function')
+    pytest.mark.tier(1),
+    pytest.mark.provider([ContainersProvider], scope='function')
+]
 
 
 DataSet = namedtuple('DataSet', ['object', 'name'])
@@ -60,11 +58,11 @@ def test_containers_overview_data_integrity(appliance, soft_assert):
             # of providers
             # ...
     """
-    navigate_to(ContainersOverview, 'All')
+    view = navigate_to(ContainersOverview, 'All')
     api_values = get_api_object_counts(appliance)
 
     for cls in tested_objects:
-        statusbox_value = StatusBox(cls.PLURAL.split(' ')[-1]).value()
+        statusbox_value = getattr(view, cls.PLURAL.split(' ')[-1].lower()).value
         soft_assert(
             api_values[cls] == statusbox_value,
             'There is a mismatch between API and UI values: {}: {} (API) != {} (UI)'.format(

--- a/cfme/tests/containers/test_reload_button_provider.py
+++ b/cfme/tests/containers/test_reload_button_provider.py
@@ -1,15 +1,13 @@
 import pytest
 
 from cfme.containers.provider import ContainersProvider
-from cfme.utils import testgen, version
 
 
 pytestmark = [
-    pytest.mark.uncollectif(
-        lambda: version.current_version() < "5.6"),
     pytest.mark.usefixtures('setup_provider'),
-    pytest.mark.tier(2)]
-pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
+    pytest.mark.tier(2),
+    pytest.mark.provider([ContainersProvider], scope='function')
+]
 
 
 @pytest.mark.polarion('CMP-9878')

--- a/cfme/tests/containers/test_reports.py
+++ b/cfme/tests/containers/test_reports.py
@@ -8,7 +8,6 @@ from wrapanapi.utils import eval_strings
 
 from cfme.containers.provider import ContainersProvider
 from cfme.intelligence.reports.reports import CannedSavedReport, CustomReport
-from cfme.utils import testgen
 from cfme.utils.blockers import BZ
 from cfme.utils.appliance.implementations.ui import navigate_to
 
@@ -18,8 +17,9 @@ pytestmark = [
     pytest.mark.meta(blockers=[BZ(1467059, forced_streams=["5.8"])]),
     pytest.mark.meta(
         server_roles='+ems_metrics_coordinator +ems_metrics_collector +ems_metrics_processor'),
-    pytest.mark.tier(1)]
-pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
+    pytest.mark.tier(1),
+    pytest.mark.provider([ContainersProvider], scope='function')
+]
 
 
 @pytest.fixture(scope='module')

--- a/cfme/tests/containers/test_start_page.py
+++ b/cfme/tests/containers/test_start_page.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 import pytest
 
 from cfme.configure import settings
-# from cfme.containers.overview import OverviewView
+from cfme.containers.overview import ContainersOverviewView
 from cfme.containers.node import NodeAllView
 from cfme.containers.pod import PodAllView
 from cfme.containers.service import ServiceAllView
@@ -15,22 +15,20 @@ from cfme.containers.template import TemplateAllView
 from cfme.containers.replicator import ReplicatorAllView
 from cfme.containers.route import RouteAllView
 from cfme.containers.volume import VolumeAllView
-from cfme.web_ui import browser_title
-from cfme.utils import testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.version import current_version
 
 
 pytestmark = [
     pytest.mark.uncollectif(lambda: current_version() < "5.8"),
-    pytest.mark.usefixtures("setup_provider")]
-pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
+    pytest.mark.usefixtures("setup_provider"),
+    pytest.mark.provider([ContainersProvider], scope='function')
+]
 
 
 DataSet = namedtuple('DataSet', ['obj_view', 'page_name'])
 data_sets = (
-    # TODO: Uncomment once OverviewView is implemented
-    # DataSet(OverviewView, 'Compute / Containers / Overview'),
+    DataSet(ContainersOverviewView, 'Compute / Containers / Overview'),
     DataSet(ContainersProvidersView, 'Compute / Containers / Providers'),
     DataSet(NodeAllView, 'Compute / Containers / Container Nodes'),
     DataSet(PodAllView, 'Compute / Containers / Pods'),
@@ -57,8 +55,6 @@ def test_start_page(appliance, soft_assert):
         view = appliance.browser.create_view(data_set.obj_view)
         soft_assert(
             view.is_displayed,
-            'Configured start page is "{page_name}", but the start page now'
-            ' is "{title}" instead of "{page_name}"'.format(
-                page_name=data_set.page_name, title=browser_title()
-            )
+            'Configured start page is "{page_name}", but the start page now is "{cur_page}".'
+            .format(page_name=data_set.page_name, cur_page=view.navigation.currently_selected)
         )

--- a/cfme/tests/containers/test_table_views.py
+++ b/cfme/tests/containers/test_table_views.py
@@ -1,12 +1,11 @@
 from random import choice
+from collections import OrderedDict
+
 import pytest
 
-from cfme.utils import testgen
 from cfme.modeling.base import BaseCollection
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.web_ui import toolbar as tb
 from cfme.configure.settings import DefaultView
-
 from cfme.containers.container import Container
 from cfme.containers.image import Image
 from cfme.containers.image_registry import ImageRegistry
@@ -16,11 +15,13 @@ from cfme.containers.replicator import Replicator
 from cfme.containers.pod import Pod
 from cfme.containers.route import Route
 from cfme.containers.project import Project
-from collections import OrderedDict
 
 
-pytestmark = [pytest.mark.tier(2), pytest.mark.usefixtures('setup_provider')]
-pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
+pytestmark = [
+    pytest.mark.tier(2),
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.provider([ContainersProvider], scope='function')
+]
 
 
 VIEWS = ('Grid View', 'Tile View', 'List View')
@@ -59,11 +60,10 @@ def random_default_views():
 @pytest.mark.polarion('CMP-10568')
 def test_default_views(random_default_views):
     for obj in objects_mapping.keys():
-        navigate_to(obj, 'All', use_resetter=False)
-        view = random_default_views[obj]
-    if not tb.is_active(view):
-        raise Exception("Failed to setup default view \"{}\" for {}"
-                        .format(view, objects_mapping[obj]))
+        view = navigate_to(obj, 'All', use_resetter=False)
+        assert random_default_views[obj].lower() == view.toolbar.view_selector.selected.lower(), (
+            "Failed to setup default view \"{}\" for {}".format(view, objects_mapping[obj])
+        )
 
 
 @pytest.mark.polarion('CMP-10570')
@@ -71,8 +71,9 @@ def test_table_views(appliance):
     for obj in objects_mapping.keys():
         if isinstance(obj, BaseCollection):
             obj = appliance.get(obj)
-        navigate_to(obj, 'All')
-        view = choice(VIEWS)
-        tb.select(view)
-        if not tb.is_active(view):
-            raise Exception("Failed to set view \"{}\" For {}".format(view, obj.__name__))
+        view = navigate_to(obj, 'All')
+        view_to_select = choice(VIEWS)
+        view.toolbar.view_selector.select(view_to_select)
+        assert view_to_select.lower() == view.toolbar.view_selector.selected.lower(), (
+            "Failed to set view \"{}\" For {}".format(view, obj.__name__)
+        )

--- a/cfme/tests/containers/test_tables_sort.py
+++ b/cfme/tests/containers/test_tables_sort.py
@@ -1,6 +1,5 @@
 import pytest
-from cfme.utils import testgen
-from cfme.web_ui import toolbar
+
 from cfme.containers.replicator import Replicator
 from cfme.containers.route import Route
 from cfme.containers.provider import ContainersProvider, ContainersTestItem
@@ -9,8 +8,9 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
-    pytest.mark.tier(1)]
-pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
+    pytest.mark.tier(1),
+    pytest.mark.provider([ContainersProvider], scope='function')
+]
 
 
 # The polarion markers below are used to mark the test item
@@ -30,7 +30,7 @@ TEST_ITEMS = [
 def test_tables_sort(test_item, soft_assert):
 
     current_view = navigate_to(test_item.obj, 'All')
-    toolbar.select('List View')
+    current_view.toolbar.view_selector.select('List View')
 
     for col, header_text in enumerate(current_view.table.headers):
 

--- a/cfme/tests/containers/test_topology.py
+++ b/cfme/tests/containers/test_topology.py
@@ -4,7 +4,6 @@ from random import choice
 
 import pytest
 
-from cfme.utils import testgen
 from cfme.utils.blockers import BZ
 from cfme.utils.wait import wait_for
 from cfme.utils.browser import WithZoom
@@ -17,8 +16,9 @@ from cfme.fixtures.pytest_selenium import is_displayed_text
 
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
-    pytest.mark.tier(1)]
-pytest_generate_tests = testgen.generate([ContainersProvider], scope='function')
+    pytest.mark.tier(1),
+    pytest.mark.provider([ContainersProvider], scope='function')
+]
 
 
 @pytest.mark.polarion('CMP-9996')

--- a/cfme/utils/ansible.py
+++ b/cfme/utils/ansible.py
@@ -4,8 +4,10 @@ from shutil import copy, copyfile, rmtree
 from subprocess import check_output, CalledProcessError, STDOUT
 import sys
 from fauxfactory import gen_alphanumeric
+
 from cfme.utils import conf
 from cfme.utils.providers import providers_data
+from cfme.utils.appliance import current_appliance
 
 
 from git import Repo
@@ -308,11 +310,9 @@ def reply_status(reply):
         return 'No Change', message_status, ok_status
 
 
-def config_formatter():
-    if "https://" in conf.env.get("base_url", None):
-        return conf.env.get("base_url", None)
-    else:
-        return "https://" + conf.env.get("base_url", None)
+def config_formatter(appliance=None):
+    appliance = appliance or current_appliance()
+    return appliance.url
 
 
 def remove_tmp_files():

--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -2669,27 +2669,3 @@ def match_location(controller=None, title=None, summary=None):
                       (sel.is_displayed('//h3[normalize-space(.) = {}]'.format(quote(summary)))))
 
     return all(result)
-
-
-class StatusBox(object):
-    """ Status box as seen in containers overview page
-
-    Status box modelling.
-
-    Args:
-        name: The name of the status box as it appears in CFME, e.g. 'Nodes'
-
-    Returns: A StatusBox instance.
-
-    """
-    def __init__(self, name):
-        self.name = name
-
-    def value(self):
-        if "_" in self.name:
-            self.name = self.name.split('_', 1)[-1]
-        elem_text = sel.text(
-            "//span[contains(@class,'card-pf-aggregate-status-count')]"
-            "/../../../../../div[contains(@status, 'objectStatus.{}')]".format(self.name.lower()))
-        match = re.search(r'\d+', elem_text)
-        return int(match.group())


### PR DESCRIPTION
{{ pytest: cfme/tests/containers --use-provider cm-env2 -m "not long_running_env"}}

Widgetastic conversions of containers. most of the objects/tests has been converted.
Remaining work:
- [Topology view](https://github.com/ManageIQ/integration_tests/blob/master/cfme/containers/topology.py) (still using the web_ui)
- smartstate analysis - [cfme.common.PolicyProfileAssignable](https://github.com/ManageIQ/integration_tests/blob/master/cfme/common/__init__.py#L28) object should be converted as well.