### PR TITLE
[1LP][RFR] storage volume backups model page[ WT and collection]

### DIFF
--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -473,6 +473,10 @@ class RoleNotFound(CFMEException):
     """Raised when Deployment role not found"""
 
 
+class BackupNotFound(CFMEException):
+    """Raised when volume backup not found"""
+
+
 class RBACOperationBlocked(CFMEException):
     """
     Raised when a Role Based Access Control operation is blocked from execution due to invalid

--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -324,7 +324,7 @@ class AvailabilityZoneNotFound(CFMEException):
     pass
 
 
-class VolumeNotFound(CFMEException):
+class VolumeNotFoundError(CFMEException):
     """
     Raised if a specific cloud volume cannot be found in the UI
     """
@@ -473,7 +473,7 @@ class RoleNotFound(CFMEException):
     """Raised when Deployment role not found"""
 
 
-class BackupNotFound(CFMEException):
+class BackupNotFoundError(CFMEException):
     """Raised when volume backup not found"""
 
 

--- a/cfme/storage/volume.py
+++ b/cfme/storage/volume.py
@@ -268,7 +268,7 @@ class Volume(BaseEntity):
         """ size of storage cloud volume.
 
         Returns:
-            :py:class:`int' size of volume.
+            :py:class:`str' size of volume.
         """
         view = navigate_to(self, 'Details')
         return view.entities.properties.get_text_of('Size')

--- a/cfme/storage/volume_backup.py
+++ b/cfme/storage/volume_backup.py
@@ -70,6 +70,10 @@ class VolumeBackupView(BaseLoggedInPage):
             self.navigation.currently_selected == ['Storage', 'Block Storage', 'Volume Backups']
         )
 
+    @property
+    def is_displayed(self):
+        return self.in_volume_backup
+
 
 class VolumeBackupAllView(VolumeBackupView):
     """The all Volume Backup page"""

--- a/cfme/storage/volume_backup.py
+++ b/cfme/storage/volume_backup.py
@@ -157,7 +157,7 @@ class VolumeBackup(BaseEntity, WidgetasticTaggable):
             :py:class:`int' size of volume backup in GB.
         """
         view = navigate_to(self, 'Details')
-        return int(view.entities.properties.get_text_of('Size')[:-2])
+        return int(view.entities.properties.get_text_of('Size').split()[0])
 
     @property
     def status(self):

--- a/cfme/storage/volume_backup.py
+++ b/cfme/storage/volume_backup.py
@@ -1,0 +1,249 @@
+# -*- coding: utf-8 -*-
+import attr
+
+from navmazing import NavigateToSibling, NavigateToAttribute
+from widgetastic_manageiq import (
+    Accordion,
+    BaseEntitiesView,
+    BreadCrumb,
+    ItemsToolBarViewSelector,
+    ManageIQTree,
+    SummaryTable
+)
+from widgetastic_patternfly import BootstrapSelect, Button, Dropdown, FlashMessages
+from widgetastic.widget import View, Text
+
+from cfme.base.ui import BaseLoggedInPage
+from cfme.common import TagPageView, WidgetasticTaggable
+from cfme.exceptions import BackupNotFound, ItemNotFound
+from cfme.modeling.base import BaseCollection, BaseEntity
+from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
+from cfme.utils.wait import wait_for
+
+
+class VolumeBackupToolbar(View):
+    """The toolbar on the Volume Backup page"""
+    configuration = Dropdown('Configuration')
+    policy = Dropdown('Policy')
+    download = Dropdown('Download')
+    view_selector = View.nested(ItemsToolBarViewSelector)
+
+
+class VolumeBackupDetailsToolbar(View):
+    """The toolbar on the Volume Backup detail page"""
+    configuration = Dropdown('Configuration')
+    policy = Dropdown('Policy')
+    download = Button('Download summary in PDF format')
+
+
+class VolumeBackupDetailsEntities(View):
+    """The entities on the Volume Backup detail page"""
+    breadcrumb = BreadCrumb()
+    properties = SummaryTable('Properties')
+    relationships = SummaryTable('Relationships')
+    smart_management = SummaryTable('Smart Management')
+
+
+class VolumeBackupDetailSidebar(View):
+    """The accordion on the Volume Backup details page"""
+    @View.nested
+    class properties(Accordion):  # noqa
+        tree = ManageIQTree()
+
+    @View.nested
+    class relationships(Accordion):  # noqa
+        tree = ManageIQTree()
+
+
+class VolumeBackupView(BaseLoggedInPage):
+    """A base view for all the Volume Backup pages"""
+    title = Text('.//div[@id="center_div" or @id="main-content"]//h1')
+    flash = FlashMessages(
+        './/div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
+        'contains(@class, "flash_text_div")]')
+
+    @property
+    def in_volume_backup(self):
+        return (
+            self.logged_in_as_current_user and
+            self.navigation.currently_selected == ['Storage', 'Block Storage', 'Volume Backups']
+        )
+
+
+class VolumeBackupAllView(VolumeBackupView):
+    """The all Volume Backup page"""
+    toolbar = View.nested(VolumeBackupToolbar)
+    including_entities = View.include(BaseEntitiesView, use_parent=True)
+
+    @property
+    def is_displayed(self):
+        return (
+            self.in_volume_backup and
+            self.title.text == 'Cloud Volume Backups')
+
+
+class VolumeBackupDetailsView(VolumeBackupView):
+    """The detail Volume Backup page"""
+    @property
+    def is_displayed(self):
+        expected_title = '{} (Summary)'.format(self.context['object'].name)
+
+        return (
+            self.title.text == expected_title and
+            self.entities.breadcrumb.active_location == expected_title)
+
+    toolbar = View.nested(VolumeBackupDetailsToolbar)
+    sidebar = View.nested(VolumeBackupDetailSidebar)
+    entities = View.nested(VolumeBackupDetailsEntities)
+
+
+class VolumeRestoreView(VolumeBackupView):
+    """The restore Volume backup view"""
+    @property
+    def is_displayed(self):
+        return False
+
+    volume_name = BootstrapSelect(name='volume_id')
+    save = Button('Save')
+    reset = Button('Reset')
+    cancel = Button('cancel')
+
+
+@attr.s
+class VolumeBackup(BaseEntity, WidgetasticTaggable):
+    """ Model of an Storage Volume Backups in cfme
+
+    Args:
+        name: name of the backup
+        provider: provider
+    """
+    name = attr.ib()
+    provider = attr.ib()
+
+    def restore(self, name):
+        """Restore the volume backup. this feature included in 5.9 and above.
+
+        Args:
+            name: volume name
+        """
+        view = navigate_to(self, 'restore')
+        view.volume_name.fill(name)
+        view.save.click()
+        view.flash.assert_success_message('Restoring Cloud Volume "{}"'.format(self.name))
+
+    def refresh(self):
+        self.provider.refresh_provider_relationships()
+        self.browser.refresh()
+
+    @property
+    def size(self):
+        """ size of cloud volume backup.
+
+        Returns:
+            :py:class:`int' size of volume backup.
+        """
+        view = navigate_to(self, 'Details')
+        return view.entities.properties.get_text_of('Size')
+
+    @property
+    def status(self):
+        """ Present status of cloud volume backup.
+
+        Returns:
+            :py:class:`str' status [available/restoring] of volume backup.
+        """
+        view = navigate_to(self, 'Details')
+        return view.entities.properties.get_text_of('Status')
+
+    @property
+    def volume(self):
+        """ volume name of backup.
+
+        Returns:
+            :py:class:`str' respective volume name.
+        """
+        view = navigate_to(self, 'Details')
+        return view.entities.relationships.get_text_of('Cloud Volume')
+
+
+@attr.s
+class VolumeBackupCollection(BaseCollection):
+    """Collection object for :py:class:'cfme.storage.volume_backups.VolumeBackup' """
+    ENTITY = VolumeBackup
+
+    def all(self):
+        """returning all backup objects"""
+        view = navigate_to(self, 'All')
+        backups = [self.instantiate(name=item, provider=self.filters.get('provider'))
+                   for item in view.entities.all_entity_names]
+        return backups
+
+    def delete(self, *backups):
+        """Delete one or more backups
+
+        Args:
+            One or Multiple 'cfme.storage.volume_backup.VolumeBackup' objects
+        """
+
+        view = navigate_to(self, 'All')
+
+        if view.entities.get_all():
+            for backup in backups:
+                try:
+                    view.entities.get_entity(backup.name).check()
+                except ItemNotFound:
+                    raise BackupNotFound("Volume backup {} not found".format(backup.name))
+
+            view.toolbar.configuration.item_select('Delete selected Backups', handle_alert=True)
+
+            for backup in backups:
+                wait_for(
+                    lambda: backup.name not in view.entities.all_entity_names,
+                    message="Wait backups to disappear",
+                    delay=20,
+                    fail_func=backup.refresh
+                )
+        else:
+            raise BackupNotFound('No Volume Backups for Deletion')
+
+
+@navigator.register(VolumeBackupCollection, 'All')
+class All(CFMENavigateStep):
+    VIEW = VolumeBackupAllView
+    prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
+
+    def step(self):
+            self.prerequisite_view.navigation.select(
+                'Storage', 'Block Storage', 'Volume Backups')
+
+
+@navigator.register(VolumeBackup, 'Details')
+class Details(CFMENavigateStep):
+    VIEW = VolumeBackupDetailsView
+    prerequisite = NavigateToAttribute('parent', 'All')
+
+    def step(self, *args, **kwargs):
+        try:
+            self.prerequisite_view.entities.get_entity(self.obj.name,
+                                                       surf_pages=True).click()
+        except ItemNotFound:
+            raise ItemNotFound('Could not locate volume backup {}'.format(self.obj.name))
+
+
+@navigator.register(VolumeBackup, 'EditTagsFromDetails')
+class BackupDetailEditTag(CFMENavigateStep):
+    """ This navigation destination help to WidgetasticTaggable"""
+    VIEW = TagPageView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self, *args, **kwargs):
+        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
+
+
+@navigator.register(VolumeBackup, 'restore')
+class VolumeRestore(CFMENavigateStep):
+    VIEW = VolumeRestoreView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self, *args, **kwargs):
+        self.prerequisite_view.toolbar.configuration.item_select('Restore backup to Cloud Volume')

--- a/cfme/storage/volume_backup.py
+++ b/cfme/storage/volume_backup.py
@@ -126,7 +126,7 @@ class VolumeBackup(BaseEntity, WidgetasticTaggable):
         Args:
             name: volume name
         """
-        view = navigate_to(self, 'restore')
+        view = navigate_to(self, 'Restore')
         view.volume_name.fill(name)
         view.save.click()
         view.flash.assert_success_message('Restoring Cloud Volume "{}"'.format(self.name))
@@ -240,7 +240,7 @@ class BackupDetailEditTag(CFMENavigateStep):
         self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
 
 
-@navigator.register(VolumeBackup, 'restore')
+@navigator.register(VolumeBackup, 'Restore')
 class VolumeRestore(CFMENavigateStep):
     VIEW = VolumeRestoreView
     prerequisite = NavigateToSibling('Details')

--- a/cfme/storage/volume_backup.py
+++ b/cfme/storage/volume_backup.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import attr
+import random
 
 from navmazing import NavigateToSibling, NavigateToAttribute
 from widgetastic_manageiq import (
@@ -196,13 +197,15 @@ class VolumeBackupCollection(BaseCollection):
 
             view.toolbar.configuration.item_select('Delete selected Backups', handle_alert=True)
 
-            for backup in backups:
-                wait_for(
-                    lambda: backup.name not in view.entities.all_entity_names,
-                    message="Wait backups to disappear",
-                    delay=20,
-                    fail_func=backup.refresh
-                )
+            wait_for(
+                lambda: not bool({backup.name for backup in backups} &
+                             set(view.entities.all_entity_names)),
+                message="Wait backups to disappear",
+                delay=20,
+                timeout=800,
+                fail_func=random.choice(backups).refresh
+            )
+
         else:
             raise BackupNotFound('No Volume Backups for Deletion')
 

--- a/cfme/tests/storage/test_volume_backup.py
+++ b/cfme/tests/storage/test_volume_backup.py
@@ -67,7 +67,12 @@ def test_storage_volume_backup_edit_tag_from_detail(backup):
 
 
 @pytest.mark.tier(3)
-@pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
+@pytest.mark.uncollectif(lambda: version.current_version() < '5.9')
 def test_storage_volume_backup_delete(backup):
-    backup.parent.delete(backup)
+    """ Volume backup deletion method not support by 5.8;
+        Implementing collective delete
+    """
+
+    backups = backup.parent.all()
+    backup.parent.delete(*backups)
     assert not backup.exists

--- a/cfme/tests/storage/test_volume_backup.py
+++ b/cfme/tests/storage/test_volume_backup.py
@@ -3,13 +3,12 @@ import pytest
 import random
 
 from cfme.cloud.provider.openstack import OpenStackProvider
-from cfme.utils import testgen, version
+from cfme.utils import version
 
 
-pytestmark = pytest.mark.usefixtures("setup_provider")
-
-
-pytest_generate_tests = testgen.generate([OpenStackProvider], scope="module")
+pytestmark = [pytest.mark.ignore_stream("upstream"),
+              pytest.mark.usefixtures('setup_provider'),
+              pytest.mark.provider([OpenStackProvider], scope='module')]
 
 
 @pytest.mark.tier(3)
@@ -28,4 +27,4 @@ def test_storage_volume_backup_edit_tag_from_detail(appliance, provider):
     # remove assigned tag
     backup.remove_tag('Department', 'Communication')
     tag_available = backup.get_tags()
-    assert tag_available == []
+    assert not tag_available

--- a/cfme/tests/storage/test_volume_backup.py
+++ b/cfme/tests/storage/test_volume_backup.py
@@ -48,7 +48,7 @@ def backup(appliance, provider):
 @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
 def test_storage_volume_backup_create(backup):
     assert backup.exists
-    assert backup.size == '{} GB'.format(STORAGE_SIZE)
+    assert backup.size == STORAGE_SIZE
 
 
 @pytest.mark.tier(3)

--- a/cfme/tests/storage/test_volume_backup.py
+++ b/cfme/tests/storage/test_volume_backup.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+import pytest
+import random
+
+from cfme.cloud.provider.openstack import OpenStackProvider
+from cfme.utils import testgen, version
+
+
+pytestmark = pytest.mark.usefixtures("setup_provider")
+
+
+pytest_generate_tests = testgen.generate([OpenStackProvider], scope="module")
+
+
+@pytest.mark.tier(3)
+@pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
+def test_storage_volume_backup_edit_tag_from_detail(appliance, provider):
+    collection = appliance.collections.volume_backups.filter({'provider': provider})
+    backups = collection.all()
+    backup = random.choice(backups)
+
+    # add tag with category Department and tag communication
+    backup.add_tag('Department', 'Communication')
+    tag_available = backup.get_tags()
+    assert tag_available[0].display_name == 'Communication'
+    assert tag_available[0].category.display_name == 'Department'
+
+    # remove assigned tag
+    backup.remove_tag('Department', 'Communication')
+    tag_available = backup.get_tags()
+    assert tag_available == []

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ setup(
             'network_subnets = cfme.networks.subnet:SubnetCollection',
             'requests = cfme.services.requests:RequestCollection',
             'volumes = cfme.storage.volume:VolumeCollection',
+            'volume_backups = cfme.storage.volume_backup:VolumeBackupCollection',
             'block_managers = cfme.storage.manager:BlockManagerCollection',
             'object_managers = cfme.storage.manager:ObjectManagerCollection',
             'object_store_objects = cfme.storage.object_store_object:ObjectStoreObjectCollection',


### PR DESCRIPTION
- Its supporting model page for cfme.storage.volume.py for volume backup operations.
- from version >5.7 separations of backups and snapshot page came.
- backup creation going to be add using volume.py.
- added a simple tag test using available backups only. as create method add in volume.py its possible to add and remove a tag on newly created backup.  [RHCFQE-5459](https://projects.engineering.redhat.com/browse/RHCFQE-5459)

{{pytest: cfme/tests/storage/test_volume_backup.py --use-provider rhos7-ga  -v}}