### PR TITLE
[1LP][RFR] provider.contents -> provider.entities

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -548,7 +548,7 @@ class BaseProvider(Taggable, Updateable, SummaryMixin, Navigatable):
         """
         view = self.load_details()
         block, field = ident
-        return getattr(view.contents, block.lower()).get_text_of(field)
+        return getattr(view.entities, block.lower()).get_text_of(field)
 
     @classmethod
     def get_credentials(cls, credential_dict, cred_type=None):
@@ -910,10 +910,10 @@ class CloudInfraProvider(BaseProvider, PolicyProfileAssignable, WidgetasticTagga
 
         """
         view = navigate_to(self, 'Details')
-        if view.contents.relationships.get_text_of(self.vm_name) == "0":
+        if view.entities.relationships.get_text_of(self.vm_name) == "0":
             return False
         else:
-            view.contents.relationships.click_at(self.vm_name)
+            view.entities.relationships.click_at(self.vm_name)
             return True
 
     def load_all_provider_images(self):
@@ -925,10 +925,10 @@ class CloudInfraProvider(BaseProvider, PolicyProfileAssignable, WidgetasticTagga
         """
         # todo: replace these methods with new nav location
         view = navigate_to(self, 'Details')
-        if view.contents.relationships.get_text_of(self.template_name) == "0":
+        if view.entities.relationships.get_text_of(self.template_name) == "0":
             return False
         else:
-            view.contents.relationships.click_at(self.template_name)
+            view.entities.relationships.click_at(self.template_name)
             return True
 
 

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -45,10 +45,10 @@ class ProviderDetailsView(BaseLoggedInPage):
                           'contains(@class, "flash_text_div")]')
     toolbar = View.nested(ProviderDetailsToolBar)
 
-    contents = ConditionalSwitchableView(reference='toolbar.view_selector',
+    entities = ConditionalSwitchableView(reference='toolbar.view_selector',
                                          ignore_bad_reference=True)
 
-    @contents.register('Summary View', default=True)
+    @entities.register('Summary View', default=True)
     class ProviderDetailsSummaryView(View):
         """
         represents Details page when it is switched to Summary aka Tables view
@@ -59,7 +59,7 @@ class ProviderDetailsView(BaseLoggedInPage):
         overview = SummaryTable(title="Overview")
         smart_management = SummaryTable(title="Smart Management")
 
-    @contents.register('Dashboard View')
+    @entities.register('Dashboard View')
     class ProviderDetailsDashboardView(View):
         """
          represents Details page when it is switched to Dashboard aka Widgets view

--- a/cfme/infrastructure/deployment_roles.py
+++ b/cfme/infrastructure/deployment_roles.py
@@ -338,9 +338,9 @@ class AllForProvider(CFMENavigateStep):
 
     def step(self):
         try:
-            self.prerequisite_view.contents.relationships.click_at('Deployment Roles')
+            self.prerequisite_view.entities.relationships.click_at('Deployment Roles')
         except NameError:
-            self.prerequisite_view.contents.relationships.click_at('Clusters / Deployment Roles')
+            self.prerequisite_view.entities.relationships.click_at('Clusters / Deployment Roles')
 
 
 @navigator.register(DeploymentRoles, 'DetailsFromProvider')

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -314,7 +314,7 @@ class DetailsFromProvider(CFMENavigateStep):
 
     def step(self, *args, **kwargs):
         """Navigate to the correct view"""
-        self.prerequisite_view.contents.relationships.click_at('Clusters')
+        self.prerequisite_view.entities.relationships.click_at('Clusters')
 
 
 @navigator.register(InfraProvider, 'ProviderNodes')  # matching other infra class destinations
@@ -324,7 +324,7 @@ class ProviderNodes(CFMENavigateStep):
 
     def step(self):
         try:
-            self.prerequisite_view.contents.relationships.click_at(self.obj.hosts_menu_item)
+            self.prerequisite_view.entities.relationships.click_at(self.obj.hosts_menu_item)
         except NameError:
             raise DestinationNotFound(
                 "{} aren't present on details page of this provider"

--- a/cfme/infrastructure/provider/openstack_infra.py
+++ b/cfme/infrastructure/provider/openstack_infra.py
@@ -84,10 +84,10 @@ class OpenstackInfraProvider(InfraProvider):
     def has_nodes(self):
         details_view = navigate_to(self, 'Details')
         try:
-            details_view.contents.relationships.get_text_of('Hosts')
+            details_view.entities.relationships.get_text_of('Hosts')
             return False
         except NameError:
-            return int(details_view.contents.relationships.get_text_of('Hosts / Nodes')) > 0
+            return int(details_view.entities.relationships.get_text_of('Hosts / Nodes')) > 0
 
     @classmethod
     def from_config(cls, prov_config, prov_key, appliance=None):

--- a/cfme/middleware/provider/__init__.py
+++ b/cfme/middleware/provider/__init__.py
@@ -145,7 +145,7 @@ class ProviderServers(CFMENavigateStep):
     VIEW = ProviderServerAllView
 
     def step(self):
-        self.prerequisite_view.contents.relationships.click_at('Middleware Servers')
+        self.prerequisite_view.entities.relationships.click_at('Middleware Servers')
 
 
 @navigator.register(MiddlewareProvider, 'ProviderDatasources')
@@ -154,7 +154,7 @@ class ProviderDatasources(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        self.prerequisite_view.contents.relationships.click_at('Middleware Datasources')
+        self.prerequisite_view.entities.relationships.click_at('Middleware Datasources')
 
 
 @navigator.register(MiddlewareProvider, 'ProviderDeployments')
@@ -163,7 +163,7 @@ class ProviderDeployments(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        self.prerequisite_view.contents.relationships.click_at('Middleware Deployments')
+        self.prerequisite_view.entities.relationships.click_at('Middleware Deployments')
 
 
 @navigator.register(MiddlewareProvider, 'ProviderDomains')
@@ -172,7 +172,7 @@ class ProviderDomains(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        self.prerequisite_view.contents.relationships.click_at('Middleware Domains')
+        self.prerequisite_view.entities.relationships.click_at('Middleware Domains')
 
 
 @navigator.register(MiddlewareProvider, 'ProviderMessagings')
@@ -181,7 +181,7 @@ class ProviderMessagings(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        self.prerequisite_view.contents.relationships.click_at('Middleware Messagings')
+        self.prerequisite_view.entities.relationships.click_at('Middleware Messagings')
 
 
 @navigator.register(MiddlewareProvider, 'TopologyFromDetails')
@@ -190,7 +190,7 @@ class TopologyFromDetails(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        self.prerequisite_view.contents.overview.click_at('Topology')
+        self.prerequisite_view.entities.overview.click_at('Topology')
 
 
 class MiddlewareBase(Validatable):

--- a/cfme/tests/intelligence/reports/test_canned_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_canned_corresponds.py
@@ -26,7 +26,7 @@ def test_providers_summary(soft_assert):
         if any(ptype in provider["MS Type"] for ptype in {"ec2", "openstack"}):  # Skip cloud
             continue
         details_view = navigate_to(InfraProvider(name=provider["Name"]), 'Details')
-        props = details_view.contents.properties
+        props = details_view.entities.properties
 
         hostname = ("Host Name", "Hostname")
         soft_assert(props.get_text_of(hostname[0]) == provider[hostname[1]],

--- a/cfme/tests/networks/test_sdn_crud.py
+++ b/cfme/tests/networks/test_sdn_crud.py
@@ -20,7 +20,7 @@ def test_sdn_crud(provider, appliance):
     """
 
     view = navigate_to(provider, 'Details')
-    net_prov_name = view.contents.relationships.get_text_of("Network Manager")
+    net_prov_name = view.entities.relationships.get_text_of("Network Manager")
     collection = NetworkProviderCollection(appliance)
     network_provider = collection.instantiate(name=net_prov_name)
 

--- a/cfme/tests/networks/test_sdn_navigation.py
+++ b/cfme/tests/networks/test_sdn_navigation.py
@@ -16,7 +16,7 @@ pytestmark = pytest.mark.usefixtures('setup_provider')
                          "Security Groups", "Network Ports", "Load Balancers"])
 def test_provider_relationships_navigation(provider, tested_part, appliance):
     view = navigate_to(provider, 'Details')
-    net_prov_name = view.contents.relationships.get_text_of('Network Manager')
+    net_prov_name = view.entities.relationships.get_text_of('Network Manager')
 
     collection = NetworkProviderCollection(appliance)
     network_provider = collection.instantiate(name=net_prov_name)
@@ -29,7 +29,7 @@ def test_provider_relationships_navigation(provider, tested_part, appliance):
 
 def test_provider_topology_navigation(provider, appliance):
     view = navigate_to(provider, 'Details')
-    net_prov_name = view.contents.relationships.get_text_of('Network Manager')
+    net_prov_name = view.entities.relationships.get_text_of('Network Manager')
 
     collection = NetworkProviderCollection(appliance)
     network_provider = collection.instantiate(name=net_prov_name)


### PR DESCRIPTION
ProviderDetails page uses contents attribute instead of entities as everywhere.
This PR fixes this issue.

{{pytest: cfme/tests/cloud/test_providers.py cfme/tests/infrastructure/test_providers.py cfme/tests/middleware/test_middleware_provider.py cfme/tests/containers/test_ssl_providers.py }}

@gshefer, ^^