### PR TITLE
[1LP][RFR] Added a simple plugin for artifactor that gives traceback info

### DIFF
--- a/artifactor/plugins/reporter.py
+++ b/artifactor/plugins/reporter.py
@@ -348,6 +348,7 @@ class Reporter(ArtifactorBasePlugin, ReporterBase):
         self.register_plugin_hook('finish_test', self.finish_test)
         self.register_plugin_hook('session_info', self.session_info)
         self.register_plugin_hook('composite_pump', self.composite_pump)
+        self.register_plugin_hook('tb_info', self.tb_info)
 
     def configure(self):
         self.only_failed = self.data.get('only_failed', False)
@@ -396,6 +397,14 @@ class Reporter(ArtifactorBasePlugin, ReporterBase):
         return None, {
             'build': build, 'stream': stream, 'version': version, 'fw_version': fw_version
         }
+
+    @ArtifactorBasePlugin.check_configured
+    def tb_info(self, test_location, test_name, exception, file_line, short_tb):
+        test_ident = "{}/{}".format(test_location, test_name)
+        return None, {'artifacts': {test_ident: {
+            'exception':
+                {'file_line': file_line, 'exception': exception, 'short_tb': short_tb}
+        }}}
 
     @ArtifactorBasePlugin.check_configured
     def run_report(self, old_artifacts, artifact_dir, version=None, fw_version=None):

--- a/fixtures/browser.py
+++ b/fixtures/browser.py
@@ -5,7 +5,7 @@ import cfme.utils.browser
 from cfme.fixtures.pytest_selenium import ensure_browser_open, take_screenshot
 from fixtures.artifactor_plugin import fire_art_test_hook
 from cfme.utils.datafile import template_env
-from cfme.utils.path import log_path
+from cfme.utils.path import log_path, project_path
 from cfme.utils import browser as browser_module, safe_string
 from cfme.utils.log import logger
 browser_fixtures = {'browser'}
@@ -61,6 +61,17 @@ def pytest_exception_interact(node, call, report):
         description="Short traceback", contents=short_tb, file_type="short_tb",
         display_type="danger", display_glyph="align-justify", group_id="pytest-exception",
         slaveid=store.slaveid)
+    exception_name = call.excinfo.type.__name__
+    exception_lineno = call.excinfo.traceback[-1].lineno
+    exception_filename = call.excinfo.traceback[-1].path.strpath.replace(
+        project_path.strpath + "/", ''
+    )
+    exception_location = "{}:{}".format(exception_filename, exception_lineno)
+    fire_art_test_hook(
+        node, 'tb_info',
+        exception=exception_name, file_line=exception_location,
+        short_tb=short_tb, slave_id=store.slaveid
+    )
 
     # base64 encoded to go into a data uri, same for screenshots
     full_tb = report.longreprtext.encode('base64').strip()


### PR DESCRIPTION
* tb_info hook is now registered with the tb_info() method
* browser.py now fires more information into the test information to
  give a better view into test failures and classification