### PR TITLE
[1LP][RFR] Adding @pytest.mark.rhv marker for purposes of RHV-CFME integration

### DIFF
--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -78,7 +78,6 @@ def new_snapshot(test_vm, has_name=True, memory=False):
 @pytest.mark.uncollectif(lambda provider:
                          (provider.one_of(RHEVMProvider) and provider.version < 4) or
                          current_version() < '5.8', 'Must be RHEVM provider version >= 4')
-@pytest.mark.rhv3
 def test_memory_checkbox(small_test_vm, provider, soft_assert):
     # Make sure the VM is powered on
     small_test_vm.power_control_from_cfme(option=small_test_vm.POWER_ON, cancel=False)
@@ -104,7 +103,6 @@ def test_memory_checkbox(small_test_vm, provider, soft_assert):
 
 @pytest.mark.uncollectif(lambda provider: (provider.one_of(RHEVMProvider) and provider.version < 4),
                          'Must be RHEVM provider version >= 4')
-@pytest.mark.rhv1
 def test_snapshot_crud(small_test_vm, provider):
     """Tests snapshot crud
 

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -78,6 +78,7 @@ def new_snapshot(test_vm, has_name=True, memory=False):
 @pytest.mark.uncollectif(lambda provider:
                          (provider.one_of(RHEVMProvider) and provider.version < 4) or
                          current_version() < '5.8', 'Must be RHEVM provider version >= 4')
+@pytest.mark.rhv3
 def test_memory_checkbox(small_test_vm, provider, soft_assert):
     # Make sure the VM is powered on
     small_test_vm.power_control_from_cfme(option=small_test_vm.POWER_ON, cancel=False)
@@ -103,6 +104,7 @@ def test_memory_checkbox(small_test_vm, provider, soft_assert):
 
 @pytest.mark.uncollectif(lambda provider: (provider.one_of(RHEVMProvider) and provider.version < 4),
                          'Must be RHEVM provider version >= 4')
+@pytest.mark.rhv1
 def test_snapshot_crud(small_test_vm, provider):
     """Tests snapshot crud
 

--- a/markers/__init__.py
+++ b/markers/__init__.py
@@ -16,6 +16,7 @@ pytest_plugins = [
     "markers.meta",
     "markers.stream_excluder",
     "markers.requires",
+    "markers.rhv",
     "markers.sauce",
     "markers.skipper",
     "markers.uses",

--- a/markers/rhv.py
+++ b/markers/rhv.py
@@ -1,5 +1,4 @@
-"""rhv(tier_number): Run only tests marked with RHV tier, e.g. rhv2.
-
+"""
 This marker is used for purposes of RHV - CFME integration.
 
 Tests can be marked like this:
@@ -16,8 +15,41 @@ Usage on CLI::
     pytest -m 'rhv1 or rhv2 or rhv3'  # Run all the tiers
     pytest -m 'not rhv3'  # Run all test methods except for RHV tier 3
     pytest -m 'not rhv1 and not rhv2 and not rhv3'  # Run everything that is not marked with rhv1-3
+
+To test this module::
+
+    pytest -p pytester markers/rhv.py
 """
+RHV_CFME_TIERS = (1, 2, 3)
 
 
 def pytest_configure(config):
-    config.addinivalue_line("markers", __doc__.splitlines()[0])
+    for tier in RHV_CFME_TIERS:
+        config.addinivalue_line("markers", "rhv{t}: Run tier {t} of RHV-CFME tests.".format(t=tier))
+
+
+def test_rhv_markers(testdir):
+
+    testdir.makepyfile("""
+        import pytest
+
+        @pytest.mark.rhv1
+        def test_rhv_marker_tier_1():
+            assert True
+
+        @pytest.mark.rhv2
+        def test_rhv_marker_tier_2():
+            assert True
+
+        @pytest.mark.rhv3
+        def test_rhv_marker_tier_3():
+            assert True
+
+        def test_without_marker():
+            assert False
+    """)
+
+    testdir.runpytest("-m rhv1", "--strict").assert_outcomes(passed=1)
+    testdir.runpytest("-m rhv1 or rhv2 or rhv3", "--strict").assert_outcomes(passed=3)
+    testdir.runpytest("-m not rhv3", "--strict").assert_outcomes(passed=2, failed=1)
+    testdir.runpytest("-m not rhv1 and not rhv2 and not rhv3", "--strict").assert_outcomes(failed=1)

--- a/markers/rhv.py
+++ b/markers/rhv.py
@@ -1,0 +1,22 @@
+"""rhv(tier_number): Run only tests marked with RHV tier, e.g. rhv2.
+
+This marker is used for purposes of RHV - CFME integration.
+
+Tests can be marked like this:
+
+.. code-block:: python
+
+    @pytest.mark.rhv2
+    def test_something():
+        assert True
+
+Usage on CLI::
+
+    pytest -m 'rhv1'  # Run only tier 1
+    pytest -m 'rhv1 or rhv2 or rhv3'  # Run all the tiers
+    pytest -m 'not rhv3'  # Run all test methods except for RHV tier 3
+"""
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", __doc__.splitlines()[0])

--- a/markers/rhv.py
+++ b/markers/rhv.py
@@ -15,6 +15,7 @@ Usage on CLI::
     pytest -m 'rhv1'  # Run only tier 1
     pytest -m 'rhv1 or rhv2 or rhv3'  # Run all the tiers
     pytest -m 'not rhv3'  # Run all test methods except for RHV tier 3
+    pytest -m 'not rhv1 and not rhv2 and not rhv3'  # Run everything that is not marked with rhv1-3
 """
 
 


### PR DESCRIPTION
__Extending__ framework with @pytest.mark.rhv marker because we at the RHV-CFME integration want to categorize tests into three tiers according to their importance specifically to integration work.
Note: Once this is in downstream-stable, we will mark all tests relevant for RHV-CFME integration with one of those.

{{pytest: markers/rhv.py -p pytester}}