### PR TITLE
[1LP][RFR] Update post_jenkins_result, remove RUNNER_RETURN

### DIFF
--- a/scripts/post_jenkins_result.py
+++ b/scripts/post_jenkins_result.py
@@ -1,62 +1,58 @@
 #!/usr/bin/env python2
 import json
-import os
 import os.path
 from datetime import datetime
 
+import requests
+
 from artifactor.plugins.post_result import test_report
-from cfme.utils import read_env
-from cfme.utils.path import project_path
+from cfme.utils.conf import cfme_data, credentials
 from cfme.utils.trackerbot import post_jenkins_result
 
 job_name = os.environ['JOB_NAME']
 number = int(os.environ['BUILD_NUMBER'])
 date = str(datetime.now())
 
-# reduce returns to bools for easy logic
-runner_src = read_env(project_path.join('.jenkins_runner_result'))
-runner_return = runner_src.get('RUNNER_RETURN', '1') == '0'
-test_return = runner_src.get('TEST_RETURN', '1') == '0'
-
-
-# 'stream' environ is set by jenkins for all stream test jobs
-# but not in the template tester
-if job_name not in ('template-tester', 'template-tester-openstack',
-                    'template-tester-rhevm', 'template-tester-virtualcenter'):
-    # try to pull out the appliance template name
-    template_src = read_env(project_path.join('.appliance_template'))
-    template = template_src.get('appliance_template', 'Unknown')
-    stream = os.environ['stream']
+# no env var for build status, have to query Jenkins API directly and parse json
+jenkins_url = cfme_data.jenkins.url
+jenkins_user = credentials.get(cfme_data.jenkins.credentials).msgbus_username
+jenkins_token = credentials.get(cfme_data.jenkins.credentials).msgbus_token
+build_data_url = '/'.join([jenkins_url, 'job', job_name, 'lastBuild', 'api', 'json'])
+build_data = requests.get(build_data_url,
+                          verify=False,
+                          auth=(jenkins_user, jenkins_token))
+if build_data.status_code != 200:
+    raise ValueError('Bad return status ({}) from jenkins lastBuild API url: {}'
+                     .format(build_data.status_code, build_data_url))
 else:
-    tester_src = read_env(project_path.join('.template_tester'))
-    stream = tester_src['stream']
-    template = tester_src['appliance_template']
+    build_data_json = build_data.json()
+
+build_status = build_data_json.get('result')
+
+stream = os.environ['stream']
+template = os.environ['appliance_template']
 
 if test_report.check():
     with test_report.open() as f:
         artifact_report = json.load(f)
 else:
-    raise RuntimeError('Unable to post to jenkins without test report: '
-        '{} does not exist!'.format(test_report.strpath))
+    raise RuntimeError('Unable to post to jenkins without test report: {} does not exist!'
+                       .format(test_report.strpath))
 
-if runner_return and test_return:
-    build_status = 'success'
-elif runner_return:
-    build_status = 'unstable'
-else:
-    build_status = 'failed'
 
-result_attrs = ('job_name', 'number', 'stream', 'date', 'template',
-    'build_status', 'artifact_report')
+post_vars = {'job_name': job_name,
+             'number': number,
+             'stream': stream,
+             'date': date,
+             'template': template,
+             'build_status': build_status,
+             'artifact_report': artifact_report}
+
+
+print('calling trackerbot.post_jenkins_result with attributes: ')
+for name, attr in post_vars.items():
+    if name != 'artifact_report':
+        print('    {}: {}'.format(name, attr))
 
 # pack the result attr values into the jenkins post
-post_jenkins_result(*[eval(attr) for attr in result_attrs])
-
-# vain output padding calculation
-# get len of longest string, pad with an extra space to make the output pretty
-max_len = len(max(result_attrs, key=len)) + 1
-
-# now print all the attrs so we can see what we posted (and *that* we
-# posted) in the jenkins log
-for attr in result_attrs[:-1]:
-    print('{:>{width}}: {}'.format(attr, eval(attr), width=max_len))
+post_jenkins_result(**post_vars)


### PR DESCRIPTION
The template-test jobs were updated and no longer use jenkins-runner, so
there are no longer RUNNER_RETURN/TEST_RETURN variables, or a file with
these values.

New creds have been pushed to cfme_data/credentials.eyaml.

Tested in CI on one-off, running full template_tester build now to confirm.