### PR TITLE
[RFR] Test cases: Tier and Requirement check

### DIFF
--- a/cfme/fixtures/tccheck.py
+++ b/cfme/fixtures/tccheck.py
@@ -5,7 +5,8 @@ Use ``--validate-test-cases`` to enable it.
 
 Currently does not work on ``--collect-only`` due to pytest's implementation bug.
 
-All output lines are prefixed by ``[TCVE]``.
+Error output lines are prefixed by ``[TCV-E]``.
+If no error nappens, a line prefixed with ``[TCV-OK]`` appears at the end of collection.
 """
 
 
@@ -16,29 +17,65 @@ def pytest_addoption(parser):
         help="Enable test case validation")
 
 
+def load_available_requirements():
+    """Slightly hacky, run through all objects in the module and only pick the correct ones."""
+    from _pytest.mark import MarkDecorator
+    from cfme import test_requirements
+    names = set()
+    for requirement_name in dir(test_requirements):
+        if requirement_name.startswith('_') or requirement_name == 'pytest':
+            continue
+        requirement_marker = getattr(test_requirements, requirement_name)
+        if not isinstance(requirement_marker, MarkDecorator):
+            continue
+        if requirement_marker.name == 'requirement':
+            names.add(requirement_marker.args[0])
+    return names
+
+
+def check_tier(item):
+    strings = []
+    tier = item.get_marker('tier')
+    if tier is None:
+        strings.append('[TCV-E] MISSING TIER: {}'.format(item.nodeid))
+    else:
+        try:
+            tier = tier.args[0]
+        except IndexError:
+            strings.append('[TCV-E] BAD TIER SPECIFICATION: {}'.format(item.nodeid))
+        else:
+            if not 1 <= tier <= 3:
+                strings.append('[TCV-E] BAD TIER NUMBER ({}): {}'.format(tier, item.nodeid))
+    return strings
+
+
+def check_requirement(item, available_requirements):
+    strings = []
+    requirement = item.get_marker('requirement')
+    if requirement is None:
+        strings.append('[TCV-E] MISSING REQUIREMENT: {}'.format(item.nodeid))
+    else:
+        try:
+            requirement = requirement.args[0]
+        except IndexError:
+            strings.append('[TCV-E] BAD REQUIREMENT SPECIFICATION: {}'.format(item.nodeid))
+        else:
+            if requirement not in available_requirements:
+                strings.append(
+                    '[TCV-E] BAD REQUIREMENT STRING ({}): {}'.format(requirement, item.nodeid))
+    return strings
+
+
 def pytest_report_collectionfinish(config, startdir, items):
     if not config.option.validate_tcs:
         return
     strings = []
+    available_requirements = load_available_requirements()
     for item in items:
-        tier = item.get_marker('tier')
-        if tier is None:
-            strings.append('[TCVE] MISSING TIER: {}'.format(item.nodeid))
-        else:
-            try:
-                tier = tier.args[0]
-            except IndexError:
-                strings.append('[TCVE] BAD TIER SPECIFICATION: {}'.format(item.nodeid))
-            else:
-                if not 1 <= tier <= 3:
-                    strings.append('[TCVE] BAD TIER NUMBER: {}'.format(item.nodeid))
-
-        requirement = item.get_marker('requirement')
-        if requirement is None:
-            strings.append('[TCVE] MISSING REQUIREMENT: {}'.format(item.nodeid))
-        else:
-            try:
-                requirement = requirement.args[0]
-            except IndexError:
-                strings.append('[TCVE] BAD REQUIREMENT SPECIFICATION: {}'.format(item.nodeid))
+        strings.extend(check_tier(item))
+        strings.extend(check_requirement(item, available_requirements))
+    if not strings:
+        strings.append('[TCV-OK] TEST CASES VALIDATED OK!')
+    else:
+        strings.append('[TCV-E] SOME TEST CASES NEED REVIEWING!')
     return strings

--- a/cfme/fixtures/tccheck.py
+++ b/cfme/fixtures/tccheck.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""Plugin that does basic test case validation.
+
+Use ``--validate-test-cases`` to enable it.
+
+Currently does not work on ``--collect-only`` due to pytest's implementation bug.
+
+All output lines are prefixed by ``[TCVE]``.
+"""
+
+
+def pytest_addoption(parser):
+    group = parser.getgroup('cfme')
+    group.addoption(
+        '--validate-test-cases', dest='validate_tcs', action='store_true', default=False,
+        help="Enable test case validation")
+
+
+def pytest_report_collectionfinish(config, startdir, items):
+    if not config.option.validate_tcs:
+        return
+    strings = []
+    for item in items:
+        tier = item.get_marker('tier')
+        if tier is None:
+            strings.append('[TCVE] MISSING TIER: {}'.format(item.nodeid))
+        else:
+            try:
+                tier = tier.args[0]
+            except IndexError:
+                strings.append('[TCVE] BAD TIER SPECIFICATION: {}'.format(item.nodeid))
+            else:
+                if not 1 <= tier <= 3:
+                    strings.append('[TCVE] BAD TIER NUMBER: {}'.format(item.nodeid))
+
+        requirement = item.get_marker('requirement')
+        if requirement is None:
+            strings.append('[TCVE] MISSING REQUIREMENT: {}'.format(item.nodeid))
+        else:
+            try:
+                requirement = requirement.args[0]
+            except IndexError:
+                strings.append('[TCVE] BAD REQUIREMENT SPECIFICATION: {}'.format(item.nodeid))
+    return strings

--- a/cfme/test_framework/pytest_plugin.py
+++ b/cfme/test_framework/pytest_plugin.py
@@ -97,6 +97,7 @@ pytest_plugins = (
     'cfme.fixtures.vporizer',
     'cfme.fixtures.model_collections',
     'cfme.fixtures.has_persistent_volume',
+    'cfme.fixtures.tccheck',
 
     'cfme.metaplugins',
 )


### PR DESCRIPTION
Use ``--validate-test-cases``

Does not work with ``--collect-only`` currently.

```
================================================ test session starts =================================================
platform linux2 -- Python 2.7.11, pytest-3.2.0, py-1.4.34, pluggy-0.4.0
rootdir: /home/mfalesni/git/cfme_tests, inifile:
plugins: wait-for-1.0.9, cov-2.5.1, polarion-cfme-0.1.1, manageiq-integration-tests-0.0.0
collected 6 items 

Appliance's streams: [5.9, downstream]
[TCV-E] MISSING REQUIREMENT: cfme/tests/automate/test_namespace.py::test_namespace_crud[plain]
[TCV-E] MISSING REQUIREMENT: cfme/tests/automate/test_namespace.py::test_namespace_delete_from_table[plain]
[TCV-E] MISSING REQUIREMENT: cfme/tests/automate/test_namespace.py::test_duplicate_namespace_disallowed[plain]
[TCV-E] MISSING REQUIREMENT: cfme/tests/automate/test_namespace.py::test_namespace_crud[nested_existing]
[TCV-E] MISSING REQUIREMENT: cfme/tests/automate/test_namespace.py::test_namespace_delete_from_table[nested_existing]
[TCV-E] MISSING REQUIREMENT: cfme/tests/automate/test_namespace.py::test_duplicate_namespace_disallowed[nested_existing]
[TCV-E] SOME TEST CASES NEED REVIEWING!
Uncollection Stats:
 manual: 0
 uncollectif: 0
 6 tests left after all uncollections

cfme/tests/automate/test_namespace.py
```

```
================================================ test session starts =================================================
platform linux2 -- Python 2.7.11, pytest-3.2.0, py-1.4.34, pluggy-0.4.0
rootdir: /home/mfalesni/git/cfme_tests, inifile:
plugins: wait-for-1.0.9, cov-2.5.1, polarion-cfme-0.1.1, manageiq-integration-tests-0.0.0
collected 10 items 

Appliance's streams: [5.9, downstream]
[TCV-OK] TEST CASES VALIDATED OK!
Uncollection Stats:
 manual: 0
 uncollectif: 0
 10 tests left after all uncollections

cfme/tests/automate/test_class.py
```