### PR TITLE
[RFR] Update flavour_name for openstack in test_actions

### DIFF
--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -17,7 +17,7 @@ from functools import partial
 
 from cfme.common.provider import cleanup_vm
 from cfme.common.vm import VM
-from cfme.control.explorer import actions, conditions, policies, policy_profiles
+from cfme.control.explorer import conditions, policies
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
@@ -127,7 +127,7 @@ def _get_vm(request, provider, template_name, vm_name):
     elif provider.one_of(OpenStackProvider):
         kwargs = {}
         if 'small_template' in provider.data.templates:
-            kwargs = {"flavour_name": provider.data.templates.get('small_template').name}
+            kwargs = {"flavour_name": provider.data.provisioning.get('instance_type')}
     elif provider.one_of(SCVMMProvider):
         kwargs = {
             "host_group": provider.data.get("provisioning", {}).get("host_group", "All Hosts")}


### PR DESCRIPTION
Grab flavour_name from the provisioning AttrDict, don't use template
name

{{pytest: --use-provider rhos7-ga --long-running -k test_action_start_virtual_machine_after_stopping cfme/tests/control/test_actions.py}}