### PR TITLE
[RFR] Snapshot: remove soft asserts

### DIFF
--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -184,9 +184,6 @@ def test_verify_revert_snapshot(full_test_vm, provider, soft_assert, register_ev
     full_test_vm.wait_for_vm_state_change(desired_state=full_test_vm.STATE_OFF, timeout=720)
     full_test_vm.power_control_from_cfme(option=full_test_vm.POWER_ON, cancel=False)
     full_test_vm.wait_for_vm_state_change(desired_state=full_test_vm.STATE_ON, timeout=900)
-    current_state = full_test_vm.find_quadicon().data['state']
-    soft_assert(current_state.startswith('currentstate-on'),
-                "Quadicon state is {}".format(current_state))
     soft_assert(full_test_vm.provider.mgmt.is_vm_running(full_test_vm.name), "vm not running")
     wait_for(lambda: ssh_client.run_command('test -e snapshot1.txt').rc == 0,
              num_sec=400, delay=20, handle_exception=True, fail_func=ssh_client.close())
@@ -251,9 +248,6 @@ def test_operations_suspended_vm(small_test_vm, soft_assert):
     # Suspend the VM
     small_test_vm.power_control_from_cfme(option=small_test_vm.SUSPEND, cancel=False)
     small_test_vm.wait_for_vm_state_change(desired_state=small_test_vm.STATE_SUSPENDED)
-    current_state = small_test_vm.find_quadicon().data['state']
-    soft_assert(current_state.startswith('currentstate-suspended'),
-                "Quadicon state is {}".format(current_state))
     # Create second snapshot when VM is suspended
     snapshot2 = new_snapshot(small_test_vm)
     snapshot2.create()
@@ -262,17 +256,11 @@ def test_operations_suspended_vm(small_test_vm, soft_assert):
     snapshot1.revert_to()
     wait_for(lambda: snapshot1.active, num_sec=300, delay=20, fail_func=snapshot1.refresh)
     # Check VM state, VM should be off
-    current_state = small_test_vm.find_quadicon().data['state']
-    soft_assert(current_state.startswith('currentstate-off'),
-                "Quadicon state is {}".format(current_state))
     assert small_test_vm.provider.mgmt.is_vm_stopped(small_test_vm.name)
     # Revert back to second snapshot
     snapshot2.revert_to()
     wait_for(lambda: snapshot2.active, num_sec=300, delay=20, fail_func=snapshot2.refresh)
     # Check VM state, VM should be suspended
-    current_state = small_test_vm.find_quadicon().data['state']
-    soft_assert(current_state.startswith('currentstate-suspended'),
-                "Quadicon state is {}".format(current_state))
     assert small_test_vm.provider.mgmt.is_vm_suspended(small_test_vm.name)
     # Try to delete both snapshots while the VM is suspended
     # The delete method will make sure the snapshots are indeed deleted


### PR DESCRIPTION
**WAS**: Fix wait_for_vm_state_change for 5.9

~~This is a quick fix to enable `wait_for_vm_state_change` usage for 5.9. There was a change in dictionary that is returned from `find_quadicon().data`, in 5.9 we must be looking for key 'quadicon' instead of 'state' which is not there any more.~~

~~`find_quadicon().data['quadicon']` returns a rather nasty and long line of html code, which thankfully contains also 'currentstate-*', so there is no need to change anything else but the item key.~~

Also removed all occurrences of `find_quadicon` from snapshot tests, since it is exactly what `wait_for_vm_state_change` does, so `find_quadicon` doesn't bring any added value to the test.

{{pytest: -v --long-running --use-provider vsphere65-nested -k "test_operations_suspended_vm"}}