### PR TITLE
[1LP][RFR] Update configure.tasks, tab names for 59z

### DIFF
--- a/cfme/configure/tasks.py
+++ b/cfme/configure/tasks.py
@@ -200,12 +200,14 @@ class TasksView(BaseLoggedInPage):
 
         @View.nested
         class myothertasks(Tab):  # noqa
-            TAB_NAME = VersionPick({'5.9': 'My Tasks', Version.lowest(): 'My Other UI Tasks'})
+            TAB_NAME = VersionPick({'5.9': 'My Tasks',
+                                    Version.lowest(): 'My Other UI Tasks'})
             table = Table(table_loc)
 
         @View.nested
         class alltasks(Tab):  # noqa
-            TAB_NAME = "All VM and Container Analysis Tasks"
+            TAB_NAME = VersionPick({'5.9': 'All Tasks',
+                                    Version.lowest(): "All VM and Container Analysis Tasks"})
             table = Table(table_loc)
 
         @View.nested


### PR DESCRIPTION
Does not create new view for only 2 tabs in 59z vs 4 tabs in 58z

WORKAROUND: I'd consider this a bit of a workaround, as ultimately the views/tests should be reworked to use a separate view for versions before the change from 4 tabs to 2 tabs.  The scope of refactoring view/tests is much larger than an rc-regression-fix

 I 50% expect it to get closed unmerged and we'll wait for a more complete fix

{{ pytest: cfme/tests/infrastructure/test_instance_analysis.py --long-running --use-provider rhos7-ga }}