### PR TITLE
[1LP][RFR] added cloud-init script for ec2 appliance and increased timeout for image import

### DIFF
--- a/scripts/template_upload_ec2.py
+++ b/scripts/template_upload_ec2.py
@@ -144,7 +144,7 @@ def create_image(ec2, ami_name, bucket_name):
              func_args=[import_task_id],
              fail_condition=False,
              delay=5,
-             timeout='30m',
+             timeout='90m',
              message='Importing image to EC2')
 
     ami_id = ec2.get_image_id_if_import_completed(import_task_id)


### PR DESCRIPTION
Cloud-init had to be overridden to allow root login with password.
Now ec2 appliance will behave as any other provider appliance and can be configured and used for template_testing.