### PR TITLE
[1LP][RFR] Service Dialogs now use new UI which is not modeled in FW

### DIFF
--- a/cfme/automate/service_dialogs.py
+++ b/cfme/automate/service_dialogs.py
@@ -143,6 +143,10 @@ class Add(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
+        if self.obj.appliance.version > '5.9':
+            raise NotImplementedError(
+                'Service Catalogs have moved to a new UI in UI 5.9 which is not modeled'
+            )
         self.prerequisite_view.configuration.item_select('Add a new Dialog')
 
 


### PR DESCRIPTION
Service Dialogs now use new UI which is not modeled in FW

{{pytest: cfme/tests/services/test_service_catalogs.py}}