### PR TITLE
[1LP][RFR] Fix orchestration templates creation using REST

### DIFF
--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -582,7 +582,9 @@ def orchestration_templates(request, rest_api, num=2):
         data.append({
             'name': 'test_{}'.format(uniq),
             'description': 'Test Template {}'.format(uniq),
-            'type': 'ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate',
+            'type': version.pick({
+                version.LOWEST: 'OrchestrationTemplateCfn',
+                '5.9': 'ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate'}),
             'orderable': False,
             'draft': False,
             'content': TEMPLATE_TORSO.replace('CloudFormation', uniq)})

--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -15,7 +15,7 @@ from cfme.utils.virtual_machines import deploy_template
 from cfme.utils.wait import wait_for
 
 
-_TEMPLATE_TORSO = """{
+TEMPLATE_TORSO = """{
   "AWSTemplateFormatVersion" : "2010-09-09",
   "Description" : "AWS CloudFormation Sample Template Rails_Single_Instance.",
 
@@ -582,10 +582,10 @@ def orchestration_templates(request, rest_api, num=2):
         data.append({
             'name': 'test_{}'.format(uniq),
             'description': 'Test Template {}'.format(uniq),
-            'type': 'OrchestrationTemplateCfn',
+            'type': 'ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate',
             'orderable': False,
             'draft': False,
-            'content': _TEMPLATE_TORSO.replace('CloudFormation', uniq)})
+            'content': TEMPLATE_TORSO.replace('CloudFormation', uniq)})
 
     return _creating_skeleton(request, rest_api, 'orchestration_templates', data)
 


### PR DESCRIPTION
* fixes orchestration templates creation using REST API
* adds new test testing https://bugzilla.redhat.com/show_bug.cgi?id=1510215

{{pytest: -v --long-running -k TestOrchestrationTemplatesRESTAPI cfme/tests/services/test_rest_services.py}}