### PR TITLE
[1LP][RFR] Zone Creation is broken in 5.9.0.5

### DIFF
--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -29,6 +29,8 @@ from . import Server, Region, Zone, ZoneCollection
 from cfme.utils import conf
 from cfme.utils.log import logger
 
+from cfme.exceptions import BugException
+from cfme.utils.blockers import BZ
 
 @Server.address.external_implementation_for(ViaUI)
 def address(self):
@@ -1283,6 +1285,10 @@ def delete(self, cancel=False):
 @ZoneCollection.create.external_implementation_for(ViaUI)
 def create(self, name=None, description=None, smartproxy_ip=None, ntp_servers=None,
            max_scans=None, user=None, cancel=False):
+
+    if BZ(1509452).blocks:
+        raise BugException(1509452, 'creating zones')
+
     add_page = navigate_to(self, 'Add')
     if not ntp_servers:
         ntp_servers = []

--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -13,6 +13,16 @@ class CFMEException(Exception):
     pass
 
 
+class BugException(CFMEException):
+    """Raised by methods inside the framework that are broken due to a bug"""
+    def __init__(self, bug_no, operation):
+        self.bug_no = bug_no
+        self.operation = operation
+
+    def __str__(self):
+        return "Bug {} blocks the operation [{}]".format(self.bug_no, self.operation)
+
+
 class ConsoleNotSupported(CFMEException):
     """Raised by functions in :py:mod:`cfme.configure.configuration` when an invalid
     console type is given"""


### PR DESCRIPTION
* This allows us to separate these NoSuchElementExceptions from real
  ones

{{pytest: cfme/tests/configure/test_zones.py -k test_zone_add_cancel_validation}}