### PR TITLE
[RFR] Skipping tests on arbitration_* collections

### DIFF
--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -331,9 +331,8 @@ class TestProvidersRESTAPI(object):
             assert 'SecurityGroup' in security_groups[0]['type']
 
     @pytest.mark.tier(3)
-    @pytest.mark.skipif(
-        store.current_appliance.version >= '5.9',
-        reason='arbitration_profiles were removed in versions >= 5.9')
+    # arbitration_profiles were removed in versions >= 5.9'
+    @pytest.mark.uncollectif(lambda: store.current_appliance.version >= '5.9')
     def test_create_arbitration_profiles(self, appliance, arbitration_profiles):
         """Tests creation of arbitration profiles.
 
@@ -347,9 +346,8 @@ class TestProvidersRESTAPI(object):
             assert 'ArbitrationProfile' in profile.type
 
     @pytest.mark.tier(3)
-    @pytest.mark.skipif(
-        store.current_appliance.version >= '5.9',
-        reason='arbitration_profiles were removed in versions >= 5.9')
+    # arbitration_profiles were removed in versions >= 5.9'
+    @pytest.mark.uncollectif(lambda: store.current_appliance.version >= '5.9')
     @pytest.mark.parametrize('method', ['post', 'delete'])
     def test_delete_arbitration_profiles_from_detail(self, appliance, arbitration_profiles, method):
         """Tests delete arbitration profiles from detail.
@@ -366,9 +364,8 @@ class TestProvidersRESTAPI(object):
             assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
-    @pytest.mark.skipif(
-        store.current_appliance.version >= '5.9',
-        reason='arbitration_profiles were removed in versions >= 5.9')
+    # arbitration_profiles were removed in versions >= 5.9'
+    @pytest.mark.uncollectif(lambda: store.current_appliance.version >= '5.9')
     def test_delete_arbitration_profiles_from_collection(self, appliance, arbitration_profiles):
         """Tests delete arbitration profiles from collection.
 
@@ -383,9 +380,8 @@ class TestProvidersRESTAPI(object):
         assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
-    @pytest.mark.skipif(
-        store.current_appliance.version >= '5.9',
-        reason='arbitration_profiles were removed in versions >= 5.9')
+    # arbitration_profiles were removed in versions >= 5.9'
+    @pytest.mark.uncollectif(lambda: store.current_appliance.version >= '5.9')
     @pytest.mark.parametrize('from_detail', [True, False], ids=['from_detail', 'from_collection'])
     def test_edit_arbitration_profiles(self, appliance, arbitration_profiles, from_detail):
         """Tests editing of arbitration profiles.
@@ -412,10 +408,10 @@ class TestProvidersRESTAPI(object):
             assert edited[i].availability_zone_id == zone.id
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: store.current_appliance.version < '5.8')
-    @pytest.mark.skipif(
-        store.current_appliance.version >= '5.9',
-        reason='arbitration_rules were removed in versions >= 5.9')
+    # arbitration_rules were removed in versions >= 5.9'
+    @pytest.mark.uncollectif(lambda:
+        store.current_appliance.version >= '5.9' or
+        store.current_appliance.version < '5.8')
     def test_create_arbitration_rules_with_profile(self, request, appliance, arbitration_profiles):
         """Tests creation of arbitration rules referencing arbitration profiles.
 
@@ -442,10 +438,10 @@ class TestProvidersRESTAPI(object):
             assert record.arbitration_profile_id == rule.arbitration_profile_id == profile.id
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: store.current_appliance.version < '5.8')
-    @pytest.mark.skipif(
-        store.current_appliance.version >= '5.9',
-        reason='arbitration_rules were removed in versions >= 5.9')
+    # arbitration_rules were removed in versions >= 5.9'
+    @pytest.mark.uncollectif(lambda:
+        store.current_appliance.version >= '5.9' or
+        store.current_appliance.version < '5.8')
     def test_create_arbitration_rule_with_invalid_profile(self, request, appliance):
         """Tests creation of arbitration rule referencing invalid arbitration profile.
 

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -23,6 +23,7 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.update import update
 from cfme.rest.gen_data import arbitration_profiles as _arbitration_profiles
 from cfme.rest.gen_data import _creating_skeleton as creating_skeleton
+from fixtures.pytest_store import store
 
 pytestmark = [pytest.mark.provider([CloudProvider], scope="function")]
 
@@ -330,7 +331,9 @@ class TestProvidersRESTAPI(object):
             assert 'SecurityGroup' in security_groups[0]['type']
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
+    @pytest.mark.skipif(
+        store.current_appliance.version >= '5.9',
+        reason='arbitration_profiles were removed in versions >= 5.9')
     def test_create_arbitration_profiles(self, appliance, arbitration_profiles):
         """Tests creation of arbitration profiles.
 
@@ -344,7 +347,9 @@ class TestProvidersRESTAPI(object):
             assert 'ArbitrationProfile' in profile.type
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
+    @pytest.mark.skipif(
+        store.current_appliance.version >= '5.9',
+        reason='arbitration_profiles were removed in versions >= 5.9')
     @pytest.mark.parametrize('method', ['post', 'delete'])
     def test_delete_arbitration_profiles_from_detail(self, appliance, arbitration_profiles, method):
         """Tests delete arbitration profiles from detail.
@@ -361,7 +366,9 @@ class TestProvidersRESTAPI(object):
             assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
+    @pytest.mark.skipif(
+        store.current_appliance.version >= '5.9',
+        reason='arbitration_profiles were removed in versions >= 5.9')
     def test_delete_arbitration_profiles_from_collection(self, appliance, arbitration_profiles):
         """Tests delete arbitration profiles from collection.
 
@@ -376,7 +383,9 @@ class TestProvidersRESTAPI(object):
         assert appliance.rest_api.response.status_code == 404
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
+    @pytest.mark.skipif(
+        store.current_appliance.version >= '5.9',
+        reason='arbitration_profiles were removed in versions >= 5.9')
     @pytest.mark.parametrize('from_detail', [True, False], ids=['from_detail', 'from_collection'])
     def test_edit_arbitration_profiles(self, appliance, arbitration_profiles, from_detail):
         """Tests editing of arbitration profiles.
@@ -403,7 +412,10 @@ class TestProvidersRESTAPI(object):
             assert edited[i].availability_zone_id == zone.id
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
+    @pytest.mark.uncollectif(lambda: store.current_appliance.version < '5.8')
+    @pytest.mark.skipif(
+        store.current_appliance.version >= '5.9',
+        reason='arbitration_rules were removed in versions >= 5.9')
     def test_create_arbitration_rules_with_profile(self, request, appliance, arbitration_profiles):
         """Tests creation of arbitration rules referencing arbitration profiles.
 
@@ -430,7 +442,10 @@ class TestProvidersRESTAPI(object):
             assert record.arbitration_profile_id == rule.arbitration_profile_id == profile.id
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
+    @pytest.mark.uncollectif(lambda: store.current_appliance.version < '5.8')
+    @pytest.mark.skipif(
+        store.current_appliance.version >= '5.9',
+        reason='arbitration_rules were removed in versions >= 5.9')
     def test_create_arbitration_rule_with_invalid_profile(self, request, appliance):
         """Tests creation of arbitration rule referencing invalid arbitration profile.
 

--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -676,9 +676,8 @@ class TestBulkQueryRESTAPI(object):
         assert data0 == response[0]._data and data1 == response[1]._data
 
 
-@pytest.mark.skipif(
-    store.current_appliance.version >= '5.9',
-    reason='arbitration_settings were removed in versions >= 5.9')
+# arbitration_settings were removed in versions >= 5.9'
+@pytest.mark.uncollectif(lambda: store.current_appliance.version >= '5.9')
 class TestArbitrationSettingsRESTAPI(object):
     @pytest.fixture(scope='function')
     def arbitration_settings(self, request, appliance):
@@ -754,9 +753,8 @@ class TestArbitrationSettingsRESTAPI(object):
                     edited[i].display_name == new[i]['display_name'])
 
 
-@pytest.mark.skipif(
-    store.current_appliance.version >= '5.9',
-    reason='arbitration_rules were removed in versions >= 5.9')
+# arbitration_rules were removed in versions >= 5.9'
+@pytest.mark.uncollectif(lambda: store.current_appliance.version >= '5.9')
 class TestArbitrationRulesRESTAPI(object):
     @pytest.fixture(scope='function')
     def arbitration_rules(self, request, appliance):

--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -20,6 +20,7 @@ from cfme.utils.rest import assert_response
 from cfme.utils.version import current_version
 from cfme.utils.wait import wait_for, wait_for_decorator
 from fixtures.provider import setup_one_or_skip
+from fixtures.pytest_store import store
 
 
 pytestmark = [test_requirements.rest]
@@ -675,6 +676,9 @@ class TestBulkQueryRESTAPI(object):
         assert data0 == response[0]._data and data1 == response[1]._data
 
 
+@pytest.mark.skipif(
+    store.current_appliance.version >= '5.9',
+    reason='arbitration_settings were removed in versions >= 5.9')
 class TestArbitrationSettingsRESTAPI(object):
     @pytest.fixture(scope='function')
     def arbitration_settings(self, request, appliance):
@@ -750,6 +754,9 @@ class TestArbitrationSettingsRESTAPI(object):
                     edited[i].display_name == new[i]['display_name'])
 
 
+@pytest.mark.skipif(
+    store.current_appliance.version >= '5.9',
+    reason='arbitration_rules were removed in versions >= 5.9')
 class TestArbitrationRulesRESTAPI(object):
     @pytest.fixture(scope='function')
     def arbitration_rules(self, request, appliance):


### PR DESCRIPTION
... as these were removed in 5.9

{{pytest: -v -k 'TestArbitrationRulesRESTAPI or TestArbitrationSettingsRESTAPI or _arbitration_' cfme/tests/cloud/test_providers.py cfme/tests/test_rest.py}}