### PR TITLE
[RFR] Skipping blueprints tests on 5.9

### DIFF
--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -1223,6 +1223,9 @@ class TestServiceRequests(object):
         request.addfinalizer(new_service.action.delete)
 
 
+@pytest.mark.skipif(
+    store.current_appliance.version >= '5.9',
+    reason='blueprints were removed in versions >= 5.9')
 class TestBlueprintsRESTAPI(object):
     @pytest.fixture(scope="function")
     def blueprints(self, request, appliance):

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -1223,9 +1223,8 @@ class TestServiceRequests(object):
         request.addfinalizer(new_service.action.delete)
 
 
-@pytest.mark.skipif(
-    store.current_appliance.version >= '5.9',
-    reason='blueprints were removed in versions >= 5.9')
+# blueprints were removed in versions >= 5.9'
+@pytest.mark.uncollectif(lambda: store.current_appliance.version >= '5.9')
 class TestBlueprintsRESTAPI(object):
     @pytest.fixture(scope="function")
     def blueprints(self, request, appliance):


### PR DESCRIPTION
... as this collection was removed in 5.9

{{pytest: -v --long-running -k TestBlueprintsRESTAPI cfme/tests/services/test_rest_services.py}}