### PR TITLE
[RFR][1LP] Fixes to tests + clean up

### DIFF
--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -53,7 +53,7 @@ def fqdn_appliance(appliance, preconfigured):
     else:
         logger.error("Couldn't provision an appliance at all")
         raise SproutException('No provision available')
-    yield apps[0]
+    return apps[0]
 
     apps[0].ssh_client.close()
     sp.destroy_pool(pool_id)
@@ -61,12 +61,12 @@ def fqdn_appliance(appliance, preconfigured):
 
 @pytest.yield_fixture(scope="function")
 def appliance_with_disk(appliance):
-    return fqdn_appliance(appliance, preconfigured=False)
+    yield fqdn_appliance(appliance, preconfigured=False)
 
 
 @pytest.yield_fixture(scope="function")
 def ipa_appliance(appliance):
-    return fqdn_appliance(appliance, preconfigured=True)
+    yield fqdn_appliance(appliance, preconfigured=True)
 
 
 @pytest.yield_fixture()

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -60,13 +60,13 @@ def fqdn_appliance(appliance, preconfigured):
 
 
 @pytest.yield_fixture(scope="function")
-def appliance_with_disk():
-    return fqdn_appliance(preconfigured=False)
+def appliance_with_disk(appliance):
+    return fqdn_appliance(appliance, preconfigured=False)
 
 
 @pytest.yield_fixture(scope="function")
-def ipa_appliance():
-    return fqdn_appliance(preconfigured=True)
+def ipa_appliance(appliance):
+    return fqdn_appliance(appliance, preconfigured=True)
 
 
 @pytest.yield_fixture()

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -60,7 +60,7 @@ def fqdn_appliance(appliance, preconfigured):
 
 
 @pytest.yield_fixture(scope="function")
-def extend_appliance():
+def appliance_with_disk():
     return fqdn_appliance(preconfigured=False)
 
 

--- a/cfme/tests/cli/test_appliance_cli.py
+++ b/cfme/tests/cli/test_appliance_cli.py
@@ -70,7 +70,7 @@ def test_external_auth(auth_type, ipa_crud, app_creds):
 
 
 @pytest.mark.skip('No IPA servers currently available')
-def test_ipa_crud(ipa_creds, ipa_appliance):
-    ipa_appliance.appliance_console_cli.configure_ipa(ipa_creds['ipaserver'],
+def test_ipa_crud(ipa_creds, configured_appliance):
+    configured_appliance.appliance_console_cli.configure_ipa(ipa_creds['ipaserver'],
         ipa_creds['username'], ipa_creds['password'], ipa_creds['domain'], ipa_creds['realm'])
-    ipa_appliance.appliance_console_cli.uninstall_ipa_client()
+    configured_appliance.appliance_console_cli.uninstall_ipa_client()

--- a/cfme/tests/cli/test_appliance_cli.py
+++ b/cfme/tests/cli/test_appliance_cli.py
@@ -3,7 +3,7 @@ from cfme.utils import version
 import pytest
 
 
-def test_set_hostname(request, appliance):
+def test_set_hostname(appliance):
     hostname = 'test.example.com'
     appliance.appliance_console_cli.set_hostname(hostname)
     return_code, output = appliance.ssh_client.run_command("hostname -f")
@@ -12,7 +12,7 @@ def test_set_hostname(request, appliance):
 
 
 def test_configure_appliance_internal_fetch_key(
-        request, app_creds, temp_appliance_unconfig_funcscope, appliance):
+        app_creds, temp_appliance_unconfig_funcscope, appliance):
     fetch_key_ip = appliance.address
     temp_appliance_unconfig_funcscope.appliance_console_cli.configure_appliance_internal_fetch_key(
         0, 'localhost', app_creds['username'], app_creds['password'], 'vmdb_production',
@@ -22,7 +22,7 @@ def test_configure_appliance_internal_fetch_key(
     temp_appliance_unconfig_funcscope.wait_for_web_ui()
 
 
-def test_configure_appliance_external_join(request, app_creds, appliance,
+def test_configure_appliance_external_join(app_creds, appliance,
         temp_appliance_unconfig_funcscope):
     appliance_ip = appliance.address
     temp_appliance_unconfig_funcscope.appliance_console_cli.configure_appliance_external_join(
@@ -34,7 +34,7 @@ def test_configure_appliance_external_join(request, app_creds, appliance,
 
 @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
 def test_configure_appliance_external_create(
-        request, app_creds, dedicated_db_appliance, temp_appliance_unconfig_funcscope):
+        app_creds, dedicated_db_appliance, temp_appliance_unconfig_funcscope):
     hostname = dedicated_db_appliance.address
     temp_appliance_unconfig_funcscope.appliance_console_cli.configure_appliance_external_create(5,
         hostname, app_creds['username'], app_creds['password'], 'vmdb_production', hostname,
@@ -46,7 +46,7 @@ def test_configure_appliance_external_create(
 @pytest.mark.skip('No IPA servers currently available')
 @pytest.mark.parametrize('auth_type', ['sso_enabled', 'saml_enabled', 'local_login_disabled'],
     ids=['sso', 'saml', 'local_login'])
-def test_external_auth(request, auth_type, ipa_crud, app_creds):
+def test_external_auth(auth_type, ipa_crud, app_creds):
     evm_tail = LogValidator('/var/www/miq/vmdb/log/evm.log',
                             matched_patterns=['.*{} to true.*'.format(auth_type)],
                             hostname=ipa_crud.address,
@@ -70,7 +70,7 @@ def test_external_auth(request, auth_type, ipa_crud, app_creds):
 
 
 @pytest.mark.skip('No IPA servers currently available')
-def test_ipa_crud(request, ipa_creds, fqdn_appliance):
-    fqdn_appliance.appliance_console_cli.configure_ipa(ipa_creds['ipaserver'],
+def test_ipa_crud(ipa_creds, ipa_appliance):
+    ipa_appliance.appliance_console_cli.configure_ipa(ipa_creds['ipaserver'],
         ipa_creds['username'], ipa_creds['password'], ipa_creds['domain'], ipa_creds['realm'])
-    fqdn_appliance.appliance_console_cli.uninstall_ipa_client()
+    ipa_appliance.appliance_console_cli.uninstall_ipa_client()

--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -143,17 +143,17 @@ def test_black_console_external_db_create(app_creds, dedicated_db_appliance,
     temp_appliance_unconfig_funcscope.wait_for_web_ui()
 
 
-def test_black_console_extend_storage(extend_appliance):
+def test_black_console_extend_storage(appliance_with_disk):
     """'ap' launches appliance_console, '' clears info screen, '10/13' extend storage, '1' select
     disk, 'y' confirm configuration and '' complete."""
 
-    opt = '10' if extend_appliance.version >= "5.8" else '13'
+    opt = '10' if appliance_with_disk.version >= "5.8" else '13'
     command_set = ('ap', '', opt, '1', 'y', '')
-    extend_appliance.appliance_console.run_commands(command_set)
+    appliance_with_disk.appliance_console.run_commands(command_set)
 
-    def is_storage_extended(extend_appliance):
-        assert extend_appliance.ssh_client.run_command("df -h | grep /var/www/miq_tmp")
-    wait_for(is_storage_extended, func_args=[extend_appliance])
+    def is_storage_extended(appliance_with_disk):
+        assert appliance_with_disk.ssh_client.run_command("df -h | grep /var/www/miq_tmp")
+    wait_for(is_storage_extended, func_args=[appliance_with_disk])
 
 
 @pytest.mark.skip('No IPA servers currently available')

--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -60,7 +60,7 @@ def test_black_console_set_hostname(appliance):
 
 
 @pytest.mark.parametrize('timezone', tzs, ids=[tz.name for tz in tzs])
-def test_black_console_set_timezone(request, timezone, temp_appliance_preconfig_modscope):
+def test_black_console_set_timezone(timezone, temp_appliance_preconfig_modscope):
     """'ap' launch appliance_console, '' clear info screen, '2/5' set timezone, 'opt' select
     region, 'timezone' selects zone, 'y' confirm slection, '' finish."""
     opt = '2' if temp_appliance_preconfig_modscope.version >= "5.8" else '5'
@@ -83,7 +83,7 @@ def test_black_console_internal_db(app_creds, temp_appliance_unconfig_funcscope)
     temp_appliance_unconfig_funcscope.wait_for_web_ui()
 
 
-def test_black_console_internal_db_reset(app_creds, temp_appliance_preconfig_funcscope):
+def test_black_console_internal_db_reset(temp_appliance_preconfig_funcscope):
     """'ap' launch appliance_console, '' clear info screen, '5/8' setup db, '4' reset db, 'y'
     confirm db reset, '1' db region number + wait 360 secs, '' continue"""
 
@@ -143,33 +143,33 @@ def test_black_console_external_db_create(app_creds, dedicated_db_appliance,
     temp_appliance_unconfig_funcscope.wait_for_web_ui()
 
 
-def test_black_console_extend_storage(fqdn_appliance):
+def test_black_console_extend_storage(extend_appliance):
     """'ap' launches appliance_console, '' clears info screen, '10/13' extend storage, '1' select
     disk, 'y' confirm configuration and '' complete."""
 
-    opt = '10' if fqdn_appliance.version >= "5.8" else '13'
+    opt = '10' if extend_appliance.version >= "5.8" else '13'
     command_set = ('ap', '', opt, '1', 'y', '')
-    fqdn_appliance.appliance_console.run_commands(command_set)
+    extend_appliance.appliance_console.run_commands(command_set)
 
-    def is_storage_extended(fqdn_appliance):
-        assert fqdn_appliance.ssh_client.run_command("df -h | grep /var/www/miq_tmp")
-    wait_for(is_storage_extended, func_args=[fqdn_appliance])
+    def is_storage_extended(extend_appliance):
+        assert extend_appliance.ssh_client.run_command("df -h | grep /var/www/miq_tmp")
+    wait_for(is_storage_extended, func_args=[extend_appliance])
 
 
 @pytest.mark.skip('No IPA servers currently available')
-def test_black_console_ipa(ipa_creds, fqdn_appliance):
+def test_black_console_ipa(ipa_creds, ipa_appliance):
     """'ap' launches appliance_console, '' clears info screen, '11/14' setup IPA, 'y' confirm setup
     + wait 40 secs and '' finish."""
 
-    opt = '11' if fqdn_appliance.version >= "5.8" else '14'
+    opt = '11' if ipa_appliance.version >= "5.8" else '14'
     command_set = ('ap', '', opt, ipa_creds['hostname'], ipa_creds['domain'], '',
         ipa_creds['username'], ipa_creds['password'], TimedCommand('y', 40), '')
-    fqdn_appliance.appliance_console.run_commands(command_set)
+    ipa_appliance.appliance_console.run_commands(command_set)
 
-    def is_sssd_running(fqdn_appliance):
-        assert fqdn_appliance.ssh_client.run_command("systemctl status sssd | grep running")
-    wait_for(is_sssd_running, func_args=[fqdn_appliance])
-    return_code, output = fqdn_appliance.ssh_client.run_command(
+    def is_sssd_running(ipa_appliance):
+        assert ipa_appliance.ssh_client.run_command("systemctl status sssd | grep running")
+    wait_for(is_sssd_running, func_args=[ipa_appliance])
+    return_code, output = ipa_appliance.ssh_client.run_command(
         "cat /etc/ipa/default.conf | grep 'enable_ra = True'")
     assert return_code == 0
 

--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -143,33 +143,33 @@ def test_black_console_external_db_create(app_creds, dedicated_db_appliance,
     temp_appliance_unconfig_funcscope.wait_for_web_ui()
 
 
-def test_black_console_extend_storage(appliance_with_disk):
+def test_black_console_extend_storage(unconfigured_appliance):
     """'ap' launches appliance_console, '' clears info screen, '10/13' extend storage, '1' select
     disk, 'y' confirm configuration and '' complete."""
 
-    opt = '10' if appliance_with_disk.version >= "5.8" else '13'
+    opt = '10' if unconfigured_appliance.version >= "5.8" else '13'
     command_set = ('ap', '', opt, '1', 'y', '')
-    appliance_with_disk.appliance_console.run_commands(command_set)
+    unconfigured_appliance.appliance_console.run_commands(command_set)
 
-    def is_storage_extended(appliance_with_disk):
-        assert appliance_with_disk.ssh_client.run_command("df -h | grep /var/www/miq_tmp")
-    wait_for(is_storage_extended, func_args=[appliance_with_disk])
+    def is_storage_extended(unconfigured_appliance):
+        assert unconfigured_appliance.ssh_client.run_command("df -h | grep /var/www/miq_tmp")
+    wait_for(is_storage_extended, func_args=[unconfigured_appliance])
 
 
 @pytest.mark.skip('No IPA servers currently available')
-def test_black_console_ipa(ipa_creds, ipa_appliance):
+def test_black_console_ipa(ipa_creds, configured_appliance):
     """'ap' launches appliance_console, '' clears info screen, '11/14' setup IPA, 'y' confirm setup
     + wait 40 secs and '' finish."""
 
-    opt = '11' if ipa_appliance.version >= "5.8" else '14'
+    opt = '11' if configured_appliance.version >= "5.8" else '14'
     command_set = ('ap', '', opt, ipa_creds['hostname'], ipa_creds['domain'], '',
         ipa_creds['username'], ipa_creds['password'], TimedCommand('y', 40), '')
-    ipa_appliance.appliance_console.run_commands(command_set)
+    configured_appliance.appliance_console.run_commands(command_set)
 
-    def is_sssd_running(ipa_appliance):
-        assert ipa_appliance.ssh_client.run_command("systemctl status sssd | grep running")
-    wait_for(is_sssd_running, func_args=[ipa_appliance])
-    return_code, output = ipa_appliance.ssh_client.run_command(
+    def is_sssd_running(configured_appliance):
+        assert configured_appliance.ssh_client.run_command("systemctl status sssd | grep running")
+    wait_for(is_sssd_running, func_args=[configured_appliance])
+    return_code, output = configured_appliance.ssh_client.run_command(
         "cat /etc/ipa/default.conf | grep 'enable_ra = True'")
     assert return_code == 0
 

--- a/cfme/tests/configure/test_register_appliance.py
+++ b/cfme/tests/configure/test_register_appliance.py
@@ -113,6 +113,7 @@ def test_rh_creds_validation(request, reg_method, reg_data, proxy_url, proxy_cre
     red_hat_updates.update_registration(cancel=True)
 
 
+@pytest.mark.meta(blockers=[BZ(1513493, forced_streams=['5.9', 'upstream'])])
 @pytest.mark.ignore_stream("upstream")
 def test_rh_registration(appliance, request, reg_method, reg_data, proxy_url, proxy_creds):
     """ Tests whether an appliance can be registered againt RHSM and SAT6 """

--- a/cfme/tests/configure/test_register_appliance.py
+++ b/cfme/tests/configure/test_register_appliance.py
@@ -2,10 +2,11 @@ import pytest
 
 from cfme.configure.configuration.region_settings import RedHatUpdates
 from cfme.utils import conf, version
+from cfme.utils.conf import cfme_data
+from cfme.utils.blockers import BZ
+from cfme.utils.log import logger
 from cfme.utils.testgen import parametrize
 from cfme.utils.wait import wait_for
-from cfme.utils.log import logger
-from cfme.utils.conf import cfme_data
 
 REG_METHODS = ('rhsm', 'sat6')
 
@@ -188,6 +189,7 @@ def test_rh_registration(appliance, request, reg_method, reg_data, proxy_url, pr
     )
 
 
+@pytest.mark.meta(blockers=[BZ(1500878, forced_streams=['5.9', 'upstream'])])
 def test_rh_updates(appliance_preupdate, appliance):
     """ Tests whether the update button in the webui functions correctly """
 


### PR DESCRIPTION
Fixes to extend storage test for 5.9, added bug skip to test_rh_updates. Also removed some unused args. We see the odd test failures on some database configurations due to current rhos template issues, this issue is because there is no additional disk to configure the database with.