### PR TITLE
[1LP][RFR] Fixing test_edit_catalog_after_deleting_provider with WA

### DIFF
--- a/cfme/services/catalogs/catalog_item.py
+++ b/cfme/services/catalogs/catalog_item.py
@@ -14,6 +14,7 @@ from cfme.utils.pretty import Pretty
 from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
 from cfme.utils import version
+from cfme.utils.wait import wait_for
 from . import ServicesCatalogView
 
 
@@ -111,6 +112,11 @@ class EditCatalogItemView(BasicInfoForm):
             self.title.text == 'Editing Service Catalog Item "{}"'
                 .format(self.context['object'].name)
         )
+
+    def after_fill(self, was_change):
+        # TODO: This is a workaround (Jira RHCFQE-5429)
+        if was_change:
+            wait_for(lambda: not self.save_button.disabled, timeout='10s', delay=0.2)
 
 
 class AddButtonGroupView(ButtonGroupForm):


### PR DESCRIPTION
__Fixing__ test_edit_catalog_after_deleting_provider with this workaround after consulting with @mfalesni. The reason is that framework sometimes attempted to click "Save" button on Catalog Item edit sceen before it was actually clickable.

{{pytest: cfme/tests/services/test_service_catalogs.py::test_edit_catalog_after_deleting_provider --use-provider rhv41 --long-running -vv}}

