### PR TITLE
[1LP][RFR] update appliance.db.enable_internal, umount dbdisk

### DIFF
--- a/cfme/utils/appliance/db.py
+++ b/cfme/utils/appliance/db.py
@@ -223,6 +223,9 @@ class ApplianceDB(AppliancePlugin):
                 self.logger.warning(
                     'Failed to set --dbdisk from the appliance. On 5.9.0.3+ it will fail.')
 
+        # make sure the dbdisk is unmounted, RHOS ephemeral disks come up mounted
+        client.run_command('umount {}'.format(db_disk))
+
         if self.appliance.has_cli:
             base_command = 'appliance_console_cli --region {}'.format(region)
             # use the cli

--- a/cfme/utils/appliance/db.py
+++ b/cfme/utils/appliance/db.py
@@ -224,7 +224,9 @@ class ApplianceDB(AppliancePlugin):
                     'Failed to set --dbdisk from the appliance. On 5.9.0.3+ it will fail.')
 
         # make sure the dbdisk is unmounted, RHOS ephemeral disks come up mounted
-        client.run_command('umount {}'.format(db_disk))
+        result = client.run_command('umount {}'.format(db_disk))
+        if not result.success:
+            self.logger.warning('umount non-zero return, output was: '.format(result))
 
         if self.appliance.has_cli:
             base_command = 'appliance_console_cli --region {}'.format(region)


### PR DESCRIPTION
This impacts appliance configuration and the sprout appliances that PRT gets won't have this applied to their configuration.

I've been testing this locally against the RHOS and non-RHOS providers.

In the case where dbdisk isn't mounted, calling umount shouldn't be a problem. It will have non-zero return code, but that's fine and we can basically ignore. Log the output anyway.

This option is required for g-release MIQ builds or CFME 5.9+ configuration.