### PR TITLE
[RFR] Updating version of psycopg2 in requirements

### DIFF
--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -116,7 +116,7 @@ prettytable==0.7.2
 progress==1.3
 prompt-toolkit==1.0.14
 psphere==0.5.2
-psycopg2==2.7.1
+psycopg2==2.7.3
 ptyprocess==0.5.1
 py==1.4.34
 pyasn1==0.2.3


### PR DESCRIPTION

__Updating__ required version of psycopg2 package because of this [issue](https://github.com/psycopg/psycopg2-wheels/issues/2) (problem with new version of glibc)