### PR TITLE
[RFR] Mark both test_provider_crud methods as tier(1)

### DIFF
--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -118,7 +118,8 @@ def test_provider_add_with_bad_credentials(provider):
         provider.create(validate_credentials=True)
 
 
-@pytest.mark.tier(2)
+@pytest.mark.tier(1)
+@pytest.mark.smoke
 @pytest.mark.usefixtures('has_no_cloud_providers')
 @test_requirements.discovery
 def test_provider_crud(provider):

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -182,6 +182,7 @@ def test_provider_add_with_bad_credentials(provider):
 
 @pytest.mark.usefixtures('has_no_infra_providers')
 @pytest.mark.tier(1)
+@pytest.mark.smoke
 @test_requirements.discovery
 @pytest.mark.meta(blockers=[BZ(1450527, unblock=lambda provider: provider.type != 'scvmm')])
 def test_provider_crud(provider):


### PR DESCRIPTION
These tests should be the same tier, infra was already set to 1

CFME QE wants to include these in smoke testing as well, so add smoke mark.