### PR TITLE
[1LP][RFR] Update TimelinesView is_diplayed calls

### DIFF
--- a/cfme/cloud/availability_zone.py
+++ b/cfme/cloud/availability_zone.py
@@ -104,7 +104,7 @@ class CloudAvailabilityZoneTimelinesView(TimelinesView, AvailabilityZoneView):
             self.in_availability_zones and
             self.breadcrumb.active_location == 'Timelines' and
             "{} (Summary)".format(self.context['object'].name) in self.breadcrumb.locations and
-            super(TimelinesView, self).is_displayed)
+            self.is_timelines)
 
 
 class AvailabilityZone(WidgetasticTaggable, Navigatable):

--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -124,12 +124,13 @@ class InstanceDetailsView(CloudInstanceView):
     entities = View.nested(VMDetailsEntities)
 
 
-class InstanceTimelinesView(CloudInstanceView, TimelinesView):
+class InstanceTimelinesView(TimelinesView, CloudInstanceView):
     @property
     def is_displayed(self):
+        expected_name = self.context['object'].name
         return (
             self.in_cloud_instance and
-            super(TimelinesView, self).is_displayed)
+            self.title.text == 'Timelines for Instance "{}"'.format(expected_name))
 
 
 class Instance(VM, Navigatable):

--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -20,11 +20,15 @@ from cfme.utils.pretty import Pretty
 
 
 class CloudProviderTimelinesView(TimelinesView, BaseLoggedInPage):
+    breadcrumb = BreadCrumb()
+
     @property
     def is_displayed(self):
-        return self.logged_in_as_current_user and \
-            self.navigation.currently_selected == ['Compute', 'Clouds', 'Providers'] and \
-            super(TimelinesView, self).is_displayed
+        return (
+            self.logged_in_as_current_user and
+            self.navigation.currently_selected == ['Compute', 'Clouds', 'Providers'] and
+            '{} (Summary)'.format(self.context['object'].name) in self.breadcrumb.locations and
+            self.is_timelines)
 
 
 class CloudProviderInstancesView(BaseLoggedInPage):

--- a/cfme/common/host_views.py
+++ b/cfme/common/host_views.py
@@ -193,10 +193,14 @@ class HostDriftAnalysis(ComputeInfrastructureHostsView):
 
 class HostTimelinesView(TimelinesView, ComputeInfrastructureHostsView):
     """Represents a Host Timelines page."""
+    breadcrumb = BreadCrumb()
 
     @property
     def is_displayed(self):
-        return self.in_compute_infrastructure_hosts and super(TimelinesView, self).is_displayed
+        return (
+            self.in_compute_infrastructure_hosts and
+            '{} (Summary)'.format(self.context['object'].name) in self.breadcrumb.locations and
+            self.is_timelines)
 
 
 class HostDiscoverView(ComputeInfrastructureHostsView):

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -181,11 +181,17 @@ class ProviderTimelinesView(TimelinesView, BaseLoggedInPage):
     """
      represents Timelines page
     """
+    breadcrumb = BreadCrumb()
+
     @property
     def is_displayed(self):
-        return (self.logged_in_as_current_user and
-                self.navigation.currently_selected == ['Compute', 'Infrastructure', 'Providers'] and
-                TimelinesView.is_displayed)
+        expected_name = self.context['object'].name
+        return (
+            self.logged_in_as_current_user and
+            self.navigation.currently_selected == ['Compute', 'Infrastructure', 'Providers'] and
+            ('{} (Summary)'.format(expected_name) in self.breadcrumb.locations or
+                '{} (Dashboard)'.format(expected_name) in self.breadcrumb.locations) and
+            self.is_timelines)
 
 
 class InfraProvidersDiscoverView(BaseLoggedInPage):

--- a/cfme/containers/node.py
+++ b/cfme/containers/node.py
@@ -10,7 +10,7 @@ from wrapanapi.containers.node import Node as ApiNode
 from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.exceptions import NoSuchElementException
 from widgetastic.widget import View
-from widgetastic_manageiq import Button, Text, TimelinesView
+from widgetastic_manageiq import Button, Text, TimelinesView, BreadCrumb
 
 from cfme.common import WidgetasticTaggable, TagPageView
 from cfme.containers.provider import (ContainersProvider, Labelable,
@@ -183,14 +183,15 @@ class Utilization(CFMENavigateStep):
 
 class NodeTimelinesView(TimelinesView, NodeView):
     """Timeline page for Nodes"""
+    breadcrumb = BreadCrumb()
 
     @property
     def is_displayed(self):
         """Is this page currently being displayed"""
         return (
             self.in_node and
-            super(NodeTimelinesView, self).is_displayed
-        )
+            '{} (Summary)'.format(self.context['object'].name) in self.breadcrumb.locations and
+            self.is_timelines)
 
 
 @navigator.register(Node, 'Timelines')

--- a/cfme/infrastructure/cluster.py
+++ b/cfme/infrastructure/cluster.py
@@ -110,12 +110,15 @@ class ClusterDetailsView(ClusterView):
 
 class ClusterTimelinesView(TimelinesView, ClusterView):
     """The timelines page of a cluster"""
+    breadcrumb = BreadCrumb()
+
     @property
     def is_displayed(self):
         """Determine if this page is currently being displayed"""
         return (
             self.in_cluster and
-            super(TimelinesView, self).is_displayed)
+            '{} (Summary)'.format(self.context['object'].name) in self.breadcrumb.locations and
+            self.is_timelines)
 
 
 @attr.s

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -248,14 +248,14 @@ class InfraVmDetailsView(InfraVmView):
             relationship_provider_name == expected_provider)
 
 
-class InfraVmTimelinesView(TimelinesView, BaseLoggedInPage):
+class InfraVmTimelinesView(TimelinesView, InfraVmView):
     @property
     def is_displayed(self):
+        expected_name = self.context['object'].name
         return (
-            self.logged_in_as_current_user and
-            self.navigation.currently_selected == ['Compute', 'Infrastructure',
-                                                   '/vm_infra/explorer'] and
-            super(TimelinesView, self).is_displayed)
+            self.in_infra_vms and
+            self.title.text == 'Timelines for Virtual Machine "{}"'.format(expected_name))
+    # Timelines for Virtual Machine "landon-test"
 
 
 class InfraVmReconfigureView(BaseLoggedInPage):

--- a/cfme/middleware/provider/middleware_views.py
+++ b/cfme/middleware/provider/middleware_views.py
@@ -824,6 +824,9 @@ class DomainServerGroupAllView(DomainView):
 class MiddlewareProviderTimelinesView(TimelinesView, BaseLoggedInPage):
     @property
     def is_displayed(self):
-        return (self.logged_in_as_current_user and
-            self.navigation.currently_selected == ['Middleware', 'Providers'] and
-            TimelinesView.is_displayed)
+        return False
+        #     (
+        # self.logged_in_as_current_user and
+        # self.navigation.currently_selected == ['Middleware', 'Providers'] and
+        # # TODO unique identifier for middleware timelines
+        # self.is_timelines)

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -2481,6 +2481,11 @@ class TimelinesView(View):
     def is_displayed(self):
         return self.title.text == 'Timelines'
 
+    @property
+    def is_timelines(self):
+        """method to check title text for base Timelines without overriding is_displayed"""
+        return self.title.text == 'Timelines'
+
 
 class AttributeValueForm(View):
     @View.nested


### PR DESCRIPTION
remove use of super() for timelines view checking

Add property to base TimelinesView to check title without overriding
is_displayed.

add some breadcrumb widgets for reliable is_displayed returns unique to
the resource they're on.

NOTE:
There is a TODO for middleware_providers, because I don't have a provider to test this on and find a unique identifier. Should be trivial to add breadcrumb or title validation.

{{ pytest: --long-running -v --use-provider rhos7-ga --use-provider rhv41  cfme/tests/infrastructure/test_timelines.py cfme/tests/cloud/test_cloud_timelines.py }}

Removed azure from providers to run against, producing URLError failures that are completely unrelated.

## PRT Results
The 59z/upstream failures are a StopIteration in the test because its not finding a cluster of the expected name.  

92% passing on these streams in 17951

Outside the scope of this change, would rather not address in this PR.
