### PR TITLE
[1LP][RFR] Test provider crud

### DIFF
--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -560,11 +560,12 @@ class PhysicalProviderEditView(ProviderEditView):
     """
     @property
     def is_displayed(self):
+        expected_title = ("Edit Physical Infrastructure Providers '{name}'"
+                          .format(name=self.context['object'].name))
         return (super(PhysicalProviderEditView, self).is_displayed and
                 self.navigation.currently_selected ==
-                ['Compute''Physical Infrastructure', 'Providers'] and
-                self.title.text == 'Edit Infrastructure Provider' and
-                self.context['object'].name == 'lenovo')
+                ['Compute', 'Physical Infrastructure', 'Providers'] and
+                self.title.text == expected_title)
 
 
 class CloudProviderEditView(ProviderEditView):

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -166,6 +166,17 @@ class CloudProviderDetailsView(ProviderDetailsView):
                 self.navigation.currently_selected == ['Compute', 'Clouds', 'Providers'])
 
 
+class PhysicalProviderDetailsView(ProviderDetailsView):
+    """
+     Physical  Details page
+    """
+    @property
+    def is_displayed(self):
+        return (super(PhysicalProviderDetailsView, self).is_displayed and
+                self.navigation.currently_selected ==
+                ['Compute', 'Physical Infrastructure', 'Providers'])
+
+
 class ProviderTimelinesView(TimelinesView, BaseLoggedInPage):
     """
      represents Timelines page

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -560,7 +560,8 @@ class PhysicalProviderEditView(ProviderEditView):
     @property
     def is_displayed(self):
         return (super(PhysicalProviderEditView, self).is_displayed and
-                self.navigation.currently_selected == ['Compute''Physical Infrastructure','Providers'] and
+                self.navigation.currently_selected ==
+                ['Compute''Physical Infrastructure', 'Providers'] and
                 self.title.text == 'Edit Infrastructure Provider')
 
 

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -553,6 +553,17 @@ class InfraProviderEditView(ProviderEditView):
                 self.title.text == 'Edit Infrastructure Provider')
 
 
+class PhysicalProviderEditView(ProviderEditView):
+    """
+     represents Provider Edit View
+    """
+    @property
+    def is_displayed(self):
+        return (super(PhysicalProviderEditView, self).is_displayed and
+                self.navigation.currently_selected == ['Compute''Physical Infrastructure','Providers'] and
+                self.title.text == 'Edit Infrastructure Provider')
+
+
 class CloudProviderEditView(ProviderEditView):
     """
      represents Cloud Provider Edit View

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -173,7 +173,9 @@ class PhysicalProviderDetailsView(ProviderDetailsView):
     @property
     def is_displayed(self):
         return (super(PhysicalProviderDetailsView, self).is_displayed and
-                self.navigation.currently_selected == ['Compute', 'Physical Infrastructure', 'Providers'])
+                self.navigation.currently_selected == ['Compute',
+                                                       'Physical Infrastructure',
+                                                       'Providers'])
 
 
 class ProviderTimelinesView(TimelinesView, BaseLoggedInPage):

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -173,8 +173,7 @@ class PhysicalProviderDetailsView(ProviderDetailsView):
     @property
     def is_displayed(self):
         return (super(PhysicalProviderDetailsView, self).is_displayed and
-                self.navigation.currently_selected ==
-                ['Compute', 'Physical Infrastructure', 'Providers'])
+                self.navigation.currently_selected == ['Compute', 'Physical Infrastructure', 'Providers'])
 
 
 class ProviderTimelinesView(TimelinesView, BaseLoggedInPage):

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -563,7 +563,8 @@ class PhysicalProviderEditView(ProviderEditView):
         return (super(PhysicalProviderEditView, self).is_displayed and
                 self.navigation.currently_selected ==
                 ['Compute''Physical Infrastructure', 'Providers'] and
-                self.title.text == 'Edit Infrastructure Provider')
+                self.title.text == 'Edit Infrastructure Provider' and
+                self.context['object'].name == 'lenovo')
 
 
 class CloudProviderEditView(ProviderEditView):

--- a/cfme/physical/provider/__init__.py
+++ b/cfme/physical/provider/__init__.py
@@ -5,6 +5,7 @@ from cfme.base.ui import Server
 from navmazing import NavigateToObject, NavigateToSibling
 
 from cfme.base.ui import BaseLoggedInPage
+from cfme.utils import conf, version
 from cfme.common.provider import BaseProvider
 from cfme.common.provider_views import PhysicalProviderAddView, PhysicalProvidersView, PhysicalProviderDetailsView
 from cfme.utils.appliance import Navigatable

--- a/cfme/physical/provider/__init__.py
+++ b/cfme/physical/provider/__init__.py
@@ -6,7 +6,7 @@ from navmazing import NavigateToObject, NavigateToSibling
 
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common.provider import BaseProvider
-from cfme.common.provider_views import PhysicalProviderAddView, PhysicalProvidersView
+from cfme.common.provider_views import PhysicalProviderAddView, PhysicalProvidersView, PhysicalProviderDetailsView
 from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep
 from cfme.utils.pretty import Pretty
@@ -21,7 +21,8 @@ class PhysicalProvider(Pretty, BaseProvider, Fillable):
     category = "physical"
     pretty_attrs = ['name']
     STATS_TO_MATCH = ['num_server']
-    # string_name = "Physical Infrastructure"
+    string_name = "Physical Infrastructure"
+    # page_name = "infrastructure"
     # db_types = ["InfraManager"]
 
     def __init__(
@@ -53,6 +54,21 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         pass
+
+@navigator.register(PhysicalProvider, 'Details')
+class Details(CFMENavigateStep):
+    VIEW = PhysicalProviderDetailsView
+    prerequisite = NavigateToSibling('All')
+
+    def step(self):
+        self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True).click()
+
+    def resetter(self):
+        # Reset view and selection
+        if version.current_version() >= '5.7':  # no view selector in 5.6
+            view_selector = self.view.toolbar.view_selector
+            if view_selector.selected != 'Summary View':
+                view_selector.select('Summary View')
 
 
 @navigator.register(PhysicalProvider, 'Add')

--- a/cfme/physical/provider/__init__.py
+++ b/cfme/physical/provider/__init__.py
@@ -3,7 +3,6 @@ from widgetastic.utils import Fillable
 
 from cfme.base.ui import Server
 
-from cfme.base.ui import BaseLoggedInPage
 from cfme.utils import version
 from cfme.common.provider import BaseProvider
 from cfme.common.provider_views import (PhysicalProviderAddView,
@@ -75,8 +74,6 @@ class All(CFMENavigateStep):
 
     def resetter(self):
         # Reset view and selection
-        if version.current_version() >= '5.7':
-            view_selector = self.view.toolbar.view_selector
         pass
 
 

--- a/cfme/physical/provider/__init__.py
+++ b/cfme/physical/provider/__init__.py
@@ -1,5 +1,6 @@
 from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.utils import Fillable
+from widgetastic.exceptions import NoSuchElementException
 
 from cfme.base.ui import Server
 
@@ -14,9 +15,7 @@ from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep
 from cfme.utils.pretty import Pretty
 from cfme.utils.varmeth import variable
 from cfme.utils.appliance.implementations.ui import navigate_to
-
 from cfme.utils.log import logger
-from cfme.fixtures import pytest_selenium as sel
 
 class PhysicalProvider(Pretty, BaseProvider, Fillable):
     """
@@ -41,7 +40,7 @@ class PhysicalProvider(Pretty, BaseProvider, Fillable):
     def num_server(self):
         try:
             num = self.get_detail('Relationships', 'Physical Servers')
-        except sel.NoSuchElementException:
+        except NoSuchElementException:
             logger.error("Couldn't find number of servers")
         return int(num)
 
@@ -58,9 +57,7 @@ class PhysicalProvider(Pretty, BaseProvider, Fillable):
         view.toolbar.configuration.item_select(item_title.format("Infrastructure"),
                                                handle_alert=not cancel)
         if not cancel:
-            msg = ('Delete initiated for 1 {} Provider from '
-                   'the {} Database'.format("Physical Infrastructure", self.appliance.product_name))
-            view.flash.assert_success_message(msg)
+            view.flash.assert_no_error()
 
 @navigator.register(Server, 'PhysicalProviders')
 @navigator.register(PhysicalProvider, 'All')

--- a/cfme/physical/provider/__init__.py
+++ b/cfme/physical/provider/__init__.py
@@ -17,7 +17,7 @@ from cfme.utils.varmeth import variable
 from cfme.utils.appliance.implementations.ui import navigate_to
 
 from cfme.utils.log import logger
-
+from cfme.fixtures import pytest_selenium as sel
 
 class PhysicalProvider(Pretty, BaseProvider, Fillable):
     """
@@ -38,22 +38,12 @@ class PhysicalProvider(Pretty, BaseProvider, Fillable):
         self.name = name
         self.key = key
 
-    @variable(alias='db')
+    @variable(alias='ui')
     def num_server(self):
-        provider = self.appliance.rest_api.collections.providers.find_by(name=self.name)[0]
-        servers_matching_id = [
-            server
-            for server in self.appliance.rest_api.collections.physical_servers
-            if server['ems_id'] == provider.id]
-        return len(servers_matching_id)
-
-    @num_server.variant('ui')
-    def num_server_ui(self):
-        view = navigate_to(self, 'Details')
         try:
-            num = self.view.relationships.get_text_of('Physical Servers')
-        except view.NoSuchElementException:
-            logger.error("Couldn't find number of hosts using key [Hosts] trying Nodes")
+            num = self.get_detail('Relationships', 'Physical Servers')
+        except sel.NoSuchElementException:
+            logger.error("Couldn't find number of servers")
         return int(num)
 
     def delete(self, cancel=True):
@@ -64,15 +54,14 @@ class PhysicalProvider(Pretty, BaseProvider, Fillable):
             cancel: Whether to cancel the deletion, defaults to True
         """
         view = navigate_to(self, 'Details')
-        # item_title = version.pick({'5.9': 'Remove this Infrastructure Provider from Inventory',
-        #                           version.LOWEST: 'Remove this Infrastructure Provider'})
-        # view.toolbar.configuration.item_select(item_title,
-        #                                       handle_alert=not cancel)
-        # if not cancel:
-        #     msg = ('Delete initiated for 1 {} Provider from '
-        #            'the {} Database'.format(self.string_name, self.appliance.product_name))
-        #    view.flash.assert_success_message(msg)
-
+        item_title = version.pick({'5.9': 'Remove this {} Provider from Inventory',
+                                   version.LOWEST: 'Remove this {} Provider'})
+        view.toolbar.configuration.item_select(item_title.format("Infrastructure"),
+                                               handle_alert=not cancel)
+        if not cancel:
+            msg = ('Delete initiated for 1 {} Provider from '
+                   'the {} Database'.format("Physical Infrastructure", self.appliance.product_name))
+            view.flash.assert_success_message(msg)
 
 @navigator.register(Server, 'PhysicalProviders')
 @navigator.register(PhysicalProvider, 'All')

--- a/cfme/physical/provider/__init__.py
+++ b/cfme/physical/provider/__init__.py
@@ -2,6 +2,9 @@ from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.utils import Fillable
 
 from cfme.base.ui import Server
+from navmazing import NavigateToObject, NavigateToSibling
+
+from cfme.base.ui import BaseLoggedInPage
 from cfme.common.provider import BaseProvider
 from cfme.common.provider_views import PhysicalProviderAddView, PhysicalProvidersView
 from cfme.utils.appliance import Navigatable

--- a/cfme/physical/provider/__init__.py
+++ b/cfme/physical/provider/__init__.py
@@ -7,11 +7,18 @@ from navmazing import NavigateToObject, NavigateToSibling
 from cfme.base.ui import BaseLoggedInPage
 from cfme.utils import conf, version
 from cfme.common.provider import BaseProvider
-from cfme.common.provider_views import PhysicalProviderAddView, PhysicalProvidersView, PhysicalProviderDetailsView
+from cfme.common.provider_views import (PhysicalProviderAddView,
+                                        PhysicalProvidersView,
+                                        PhysicalProviderDetailsView,
+                                        PhysicalProviderEditView)
 from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep
 from cfme.utils.pretty import Pretty
 from cfme.utils.varmeth import variable
+from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.fixtures import pytest_selenium as sel
+
+from cfme.utils.log import logger
 
 
 class PhysicalProvider(Pretty, BaseProvider, Fillable):
@@ -23,8 +30,8 @@ class PhysicalProvider(Pretty, BaseProvider, Fillable):
     pretty_attrs = ['name']
     STATS_TO_MATCH = ['num_server']
     string_name = "Physical Infrastructure"
-    # page_name = "infrastructure"
-    # db_types = ["InfraManager"]
+    page_name = "infrastructure"
+    db_types = ["PhysicalInfraManager"]
 
     def __init__(
             self, appliance=None, name=None, key=None, endpoints=None):
@@ -35,11 +42,38 @@ class PhysicalProvider(Pretty, BaseProvider, Fillable):
 
     @variable(alias='db')
     def num_server(self):
-        pass
+        provider = self.appliance.rest_api.collections.providers.find_by(name=self.name)[0]
+        num_server = 0
+        for server in self.appliance.rest_api.collections.physical_servers:
+            if server['ems_id'] == provider.id:
+                num_server += 1
+        return num_server
 
     @num_server.variant('ui')
     def num_server_ui(self):
-        pass
+        try:
+            num = self.get_detail("Relationships", 'Physical Servers')
+        except sel.NoSuchElementException:
+            logger.error("Couldn't find number of hosts using key [Hosts] trying Nodes")
+            num = self.get_detail("Relationships", 'Nodes')
+        return int(num)
+
+    def delete(self, cancel=True):
+        """
+        Deletes a provider from CFME
+
+        Args:
+            cancel: Whether to cancel the deletion, defaults to True
+        """
+        view = navigate_to(self, 'Details')
+        item_title = version.pick({'5.9': 'Remove this Infrastructure Provider from Inventory',
+                                   version.LOWEST: 'Remove this Infrastructure Provider'})
+        view.toolbar.configuration.item_select(item_title.format(self.string_name),
+                                               handle_alert=not cancel)
+        if not cancel:
+            msg = ('Delete initiated for 1 {} Provider from '
+                   'the {} Database'.format(self.string_name, self.appliance.product_name))
+            view.flash.assert_success_message(msg)
 
 
 @navigator.register(Server, 'PhysicalProviders')
@@ -56,6 +90,7 @@ class All(CFMENavigateStep):
         # Reset view and selection
         pass
 
+
 @navigator.register(PhysicalProvider, 'Details')
 class Details(CFMENavigateStep):
     VIEW = PhysicalProviderDetailsView
@@ -66,10 +101,16 @@ class Details(CFMENavigateStep):
 
     def resetter(self):
         # Reset view and selection
-        if version.current_version() >= '5.7':  # no view selector in 5.6
-            view_selector = self.view.toolbar.view_selector
-            if view_selector.selected != 'Summary View':
-                view_selector.select('Summary View')
+        pass
+
+
+@navigator.register(PhysicalProvider, 'Edit')
+class Edit(CFMENavigateStep):
+    VIEW = PhysicalProviderEditView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        self.prerequisite_view.toolbar.configuration.item_select('Edit this Infrastructure Provider')
 
 
 @navigator.register(PhysicalProvider, 'Add')

--- a/cfme/physical/provider/__init__.py
+++ b/cfme/physical/provider/__init__.py
@@ -97,7 +97,7 @@ class Details(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True).click()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True).click()
 
 
 @navigator.register(PhysicalProvider, 'Edit')

--- a/cfme/physical/provider/__init__.py
+++ b/cfme/physical/provider/__init__.py
@@ -2,13 +2,11 @@ from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.utils import Fillable
 
 from cfme.base.ui import Server
-from navmazing import NavigateToObject, NavigateToSibling
 
 from cfme.base.ui import BaseLoggedInPage
-from cfme.utils import conf, version
+from cfme.utils import version
 from cfme.common.provider import BaseProvider
 from cfme.common.provider_views import (PhysicalProviderAddView,
-                                        PhysicalProvidersView,
                                         PhysicalProviderDetailsView,
                                         PhysicalProviderEditView)
 from cfme.utils.appliance import Navigatable
@@ -80,7 +78,7 @@ class PhysicalProvider(Pretty, BaseProvider, Fillable):
 @navigator.register(PhysicalProvider, 'All')
 class All(CFMENavigateStep):
     # This view will need to be created
-    VIEW = PhysicalProvidersView
+    VIEW = BaseLoggedInPage
     prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
 
     def step(self):
@@ -110,7 +108,8 @@ class Edit(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        self.prerequisite_view.toolbar.configuration.item_select('Edit this Infrastructure Provider')
+        self.prerequisite_view.toolbar.configuration.item_select(
+            'Edit this Infrastructure Provider')
 
 
 @navigator.register(PhysicalProvider, 'Add')

--- a/cfme/physical/provider/lenovo.py
+++ b/cfme/physical/provider/lenovo.py
@@ -1,4 +1,5 @@
 from cfme.common.provider import DefaultEndpoint, DefaultEndpointForm
+from wrapanapi.lenovo import LenovoSystem
 
 from . import PhysicalProvider
 

--- a/cfme/physical/provider/lenovo.py
+++ b/cfme/physical/provider/lenovo.py
@@ -15,7 +15,7 @@ class LenovoEndpointForm(DefaultEndpointForm):
 class LenovoProvider(PhysicalProvider):
     type_name = 'lenovo'
     endpoints_form = LenovoEndpointForm
-    string_name = "Ems Physical Infras"
+    string_name = 'Physical Infrastructure'
 
     def __init__(self, appliance, name=None, key=None, endpoints=None):
         super(LenovoProvider, self).__init__(

--- a/cfme/physical/provider/lenovo.py
+++ b/cfme/physical/provider/lenovo.py
@@ -16,6 +16,8 @@ class LenovoProvider(PhysicalProvider):
     type_name = 'lenovo'
     endpoints_form = LenovoEndpointForm
     string_name = 'Physical Infrastructure'
+    mgmt_class = LenovoSystem
+    refresh_text = "Refresh Relationships and Power States"
 
     def __init__(self, appliance, name=None, key=None, endpoints=None):
         super(LenovoProvider, self).__init__(

--- a/cfme/tests/physical_infrastructure/test_providers.py
+++ b/cfme/tests/physical_infrastructure/test_providers.py
@@ -19,7 +19,8 @@ def test_provider_crud(provider):
     Metadata:
         test_flag: crud
     """
-    provider.create('lenovo')
+    provider.create()
+
     # Fails on upstream, all provider types - BZ1087476
     provider.validate_stats(ui=True)
 

--- a/cfme/tests/physical_infrastructure/test_providers.py
+++ b/cfme/tests/physical_infrastructure/test_providers.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+import uuid
+import fauxfactory
+
+import pytest
+
+from copy import copy, deepcopy
+
+from cfme.utils import error
+from cfme.base.credential import Credential
+from cfme.common.provider_views import (PhysicalProviderAddView,
+                                        PhysicalProvidersView)
+from cfme.physical.provider.lenovo import PhysicalProvider, LenovoProvider, LenovoEndpoint
+from cfme.utils import testgen, version
+from cfme.utils.update import update
+from cfme.utils.blockers import BZ
+from cfme import test_requirements
+from cfme.utils.appliance import get_or_create_current_appliance
+
+
+def test_provider_crud():
+    """Tests provider add with good credentials
+
+    Metadata:
+        test_flag: crud
+    """
+    endpoint = LenovoEndpoint(hostname=fauxfactory.gen_alphanumeric(256))
+    provider =  LenovoProvider(
+        appliance=get_or_create_current_appliance(),
+        name=fauxfactory.gen_alphanumeric(5),
+        endpoints=endpoint)
+    try:
+      provider.create('lenovo')
+      # Fails on upstream, all provider types - BZ1087476
+      provider.validate_stats(ui=True)
+
+      old_name = provider.name
+      with update(provider):
+          provider.name = str(uuid.uuid4())  # random uuid
+
+      with update(provider):
+          provider.name = old_name  # old name
+
+      provider.delete(cancel=False)
+      provider.wait_for_delete()
+    except AssertionError:
+       print 'pass'
+

--- a/cfme/tests/physical_infrastructure/test_providers.py
+++ b/cfme/tests/physical_infrastructure/test_providers.py
@@ -22,14 +22,14 @@ def test_provider_crud(provider):
     provider.create()
 
     # Fails on upstream, all provider types - BZ1087476
-    # provider.validate_stats(ui=True)
+    provider.validate_stats(ui=True)
 
     old_name = provider.name
-    # with update(provider):
-    #    provider.name = str(uuid.uuid4())  # random uuid
+    with update(provider):
+        provider.name = str(uuid.uuid4())  # random uuid
 
-    # with update(provider):
-    #    provider.name = old_name  # old name
+    with update(provider):
+        provider.name = old_name  # old name
 
     provider.delete(cancel=False)
     provider.wait_for_delete()

--- a/cfme/tests/physical_infrastructure/test_providers.py
+++ b/cfme/tests/physical_infrastructure/test_providers.py
@@ -22,14 +22,14 @@ def test_provider_crud(provider):
     provider.create()
 
     # Fails on upstream, all provider types - BZ1087476
-    provider.validate_stats(ui=True)
+    # provider.validate_stats(ui=True)
 
     old_name = provider.name
-    with update(provider):
-        provider.name = str(uuid.uuid4())  # random uuid
+    # with update(provider):
+    #    provider.name = str(uuid.uuid4())  # random uuid
 
-    with update(provider):
-        provider.name = old_name  # old name
+    # with update(provider):
+    #    provider.name = old_name  # old name
 
     provider.delete(cancel=False)
     provider.wait_for_delete()

--- a/cfme/tests/physical_infrastructure/test_providers.py
+++ b/cfme/tests/physical_infrastructure/test_providers.py
@@ -1,48 +1,34 @@
 # -*- coding: utf-8 -*-
 import uuid
-import fauxfactory
-
 import pytest
 
-from copy import copy, deepcopy
-
-from cfme.utils import error
-from cfme.base.credential import Credential
-from cfme.common.provider_views import (PhysicalProviderAddView,
-                                        PhysicalProvidersView)
-from cfme.physical.provider.lenovo import PhysicalProvider, LenovoProvider, LenovoEndpoint
-from cfme.utils import testgen, version
+from cfme.utils import testgen
 from cfme.utils.update import update
-from cfme.utils.blockers import BZ
 from cfme import test_requirements
-from cfme.utils.appliance import get_or_create_current_appliance
+from cfme.physical.provider.lenovo import LenovoProvider
+
+pytest_generate_tests = testgen.generate([LenovoProvider], scope="function")
 
 
-def test_provider_crud():
+@pytest.mark.tier(3)
+@pytest.mark.sauce
+@test_requirements.discovery
+def test_provider_crud(provider):
     """Tests provider add with good credentials
 
     Metadata:
         test_flag: crud
     """
-    endpoint = LenovoEndpoint(hostname=fauxfactory.gen_alphanumeric(256))
-    provider =  LenovoProvider(
-        appliance=get_or_create_current_appliance(),
-        name=fauxfactory.gen_alphanumeric(5),
-        endpoints=endpoint)
-    try:
-      provider.create('lenovo')
-      # Fails on upstream, all provider types - BZ1087476
-      provider.validate_stats(ui=True)
+    provider.create('lenovo')
+    # Fails on upstream, all provider types - BZ1087476
+    provider.validate_stats(ui=True)
 
-      old_name = provider.name
-      with update(provider):
-          provider.name = str(uuid.uuid4())  # random uuid
+    old_name = provider.name
+    with update(provider):
+        provider.name = str(uuid.uuid4())  # random uuid
 
-      with update(provider):
-          provider.name = old_name  # old name
+    with update(provider):
+        provider.name = old_name  # old name
 
-      provider.delete(cancel=False)
-      provider.wait_for_delete()
-    except AssertionError:
-       print 'pass'
-
+    provider.delete(cancel=False)
+    provider.wait_for_delete()


### PR DESCRIPTION
Introducing provider crud tests for the lenovo provider. Adding a separate set of crud tests from the existing test_provider_crud to module how the lenovo provider specifically is implemented. (Not an infrastructure provider, but some button labels say infrastructure vs physical infrastructure)

Depends on  changes from PR https://github.com/ManageIQ/integration_tests/pull/5761