### PR TITLE
[1LP][RFR] Adding new console button for cfme5.7 and mechanism to select correct widget for 5.7 and 5.8

### DIFF
--- a/cfme/services/myservice/ssui.py
+++ b/cfme/services/myservice/ssui.py
@@ -59,6 +59,7 @@ class DetailsMyServiceView(MyServicesView):
     configuration = VersionPick({
         Version.lowest(): SSUIConfigDropdown("dropdownKebabRight"),
         '5.8': SSUIDropdown('Configuration')})
+    console_button = Button(tooltip="HTML5 console", classes=['open-console-button'])
 
 
 class ServiceEditForm(MyServicesView):
@@ -260,7 +261,10 @@ class LaunchVMConsole(SSUINavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        self.prerequisite_view.access_dropdown.item_select('VM Console')
+        if self.appliance.version < "5.8":
+            self.prerequisite_view.console_button.click()
+        else:
+            self.prerequisite_view.access_dropdown.item_select('VM Console')
 
 
 @navigator.register(MyService, 'SetOwnership')

--- a/cfme/tests/ssui/test_ssui_myservice.py
+++ b/cfme/tests/ssui/test_ssui_myservice.py
@@ -56,7 +56,7 @@ def test_myservice_crud(appliance, setup_provider, context, order_catalog_item_i
         my_service.delete()
 
 
-@pytest.mark.uncollectif(lambda: current_version() < '5.8' or current_version() >= '5.9')
+@pytest.mark.uncollectif(lambda: current_version() >= '5.9')
 @pytest.mark.parametrize('context', [ViaSSUI])
 @pytest.mark.parametrize('order_catalog_item_in_ops_ui', [['console_test']], indirect=True)
 def test_vm_console(request, appliance, setup_provider, context, configure_websocket,


### PR DESCRIPTION

Purpose or Intent
=================

__Extending__ SSUI Console test to appropriately select HTML5 console button for CFME 5.7 while choosing Access Dropdown for CFME 5.8



{{pytest: -v --long-running cfme/tests/ssui/test_ssui_myservice.py -k 'test_vm_console' --use-provider vsphere6-nested --use-provider rhv41}}