### PR TITLE
[1LP][RFR] Fix failure in access_control::test_user_edit_tag due to incorrect test fixture

### DIFF
--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -213,7 +213,7 @@ def test_user_email_error_validation(group_collection):
 
 
 @pytest.mark.tier(2)
-def test_user_edit_tag(appliance):
+def test_user_edit_tag(group_collection):
     group_name = 'EvmGroup-user'
     group = group_collection.instantiate(description=group_name)
 


### PR DESCRIPTION
During a PR 5664 update, I failed to update this test to use group_collection fixture instead of appliance. The test will still fail on 5.9.0.8 [BZ 1512645](https://bugzilla.redhat.com/show_bug.cgi?id=1512645)  but not due to group_collection not being passed as a fixture :)

[BZ 1512645](https://bugzilla.redhat.com/show_bug.cgi?id=1512645) was closed as a duplicate of [BZ 1503076](https://bugzilla.redhat.com/show_bug.cgi?id=1503076)

{{pytest: -v -k 'test_user_edit_tag'}}