### PR TITLE
[RFR][1LP][NOTEST] Remove all references to psphere

### DIFF
--- a/cfme/utils/log.py
+++ b/cfme/utils/log.py
@@ -499,6 +499,3 @@ _configure_warnings()
 
 # Register a custom excepthook to log unhandled exceptions
 sys.excepthook = _custom_excepthook
-
-# Suppress psphere's really annoying "No handler found" messages.
-logging.getLogger('psphere').addHandler(logging.NullHandler())

--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -115,7 +115,6 @@ positional==1.1.1
 prettytable==0.7.2
 progress==1.3
 prompt-toolkit==1.0.14
-psphere==0.5.2
 psycopg2==2.7.3.2
 ptyprocess==0.5.1
 py==1.4.34

--- a/requirements/frozen_docs.txt
+++ b/requirements/frozen_docs.txt
@@ -90,7 +90,6 @@ positional==1.1.1
 prettytable==0.7.2
 progress==1.3
 prompt-toolkit==1.0.14
-psphere==0.5.2
 psycopg2==2.7.1
 ptyprocess==0.5.1
 py==1.4.34

--- a/requirements/template_docs.txt
+++ b/requirements/template_docs.txt
@@ -36,7 +36,6 @@ paramiko
 parsedatetime
 pdfminer
 progress
-psphere
 py
 pycrypto
 pygal


### PR DESCRIPTION
We no longer use psphere, wrapanapi moved to pyVmomi. Remove psphere from the requirements, and use the methods in wrapanapi to delete the VirtualCentre vms and templates.