### PR TITLE
[1LP][RFR] Sometimes page takes time to load and ends up with NoSuchElement, handling that with wait_for

### DIFF
--- a/cfme/services/myservice/ssui.py
+++ b/cfme/services/myservice/ssui.py
@@ -258,7 +258,9 @@ class MyServiceEdit(SSUINavigateStep):
 @navigator.register(MyService, 'VM Console')
 class LaunchVMConsole(SSUINavigateStep):
     VIEW = EditMyServiceView
-    prerequisite = NavigateToSibling('Details')
+
+    def prerequisite(self):
+        return navigate_to(self.obj, 'Details', wait_for_view=True)
 
     def step(self):
         if self.appliance.version < "5.8":


### PR DESCRIPTION

Purpose or Intent
=================

__Fixing__ SSUI VM Console view to wait_for page to load before throwing NoSuchElement.


{{pytest: -v --long-running cfme/tests/ssui/test_ssui_myservice.py -k 'test_vm_console' --use-provider vsphere6-nested --use-provider rhv41}}