### PR TITLE
[RFR] Marked blocked alert tests

### DIFF
--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -33,6 +33,7 @@ pytestmark = [
     pytest.mark.long_running,
     pytest.mark.meta(server_roles=["+automate", "+smartproxy", "+notifier"]),
     pytest.mark.uncollectif(BZ(1491576, forced_streams=['5.7']).blocks, 'BZ 1491576'),
+    pytest.mark.uncollectif(BZ(1501895, forced_streams=['5.9']).blocks, 'BZ 1501895'),
     pytest.mark.tier(3),
     test_requirements.alert
 ]


### PR DESCRIPTION
Purpose
=================

Control alert tests marked as blocked due the BZ https://bugzilla.redhat.com/show_bug.cgi?id=1501895