### PR TITLE
[1LP][RFR] pagination pane resetter

### DIFF
--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -129,12 +129,9 @@ class All(CFMENavigateStep):
 
     def resetter(self):
         tb = self.view.toolbar
-        paginator = self.view.entities.paginator
         if 'Grid View' not in tb.view_selector.selected:
             tb.view_selector.select('Grid View')
-        if paginator.exists:
-            paginator.check_all()
-            paginator.uncheck_all()
+        self.view.entities.paginator.reset_selection()
 
 
 @navigator.register(CloudProvider, 'Add')

--- a/cfme/cloud/stack.py
+++ b/cfme/cloud/stack.py
@@ -334,8 +334,7 @@ class All(CFMENavigateStep):
     def resetter(self):
         """Reset the view"""
         self.view.toolbar.view_selector.select('Grid View')
-        self.view.paginator.check_all()
-        self.view.paginator.uncheck_all()
+        self.view.paginator.reset_selection()
 
 
 @navigator.register(Stack, 'Details')

--- a/cfme/cloud/tenant.py
+++ b/cfme/cloud/tenant.py
@@ -324,9 +324,7 @@ class TenantAll(CFMENavigateStep):
     def resetter(self):
         """Reset the view"""
         self.view.toolbar.view_selector.select('List View')
-        if self.view.table.is_displayed:
-            self.view.paginator.check_all()
-            self.view.paginator.uncheck_all()
+        self.view.paginator.reset_selection()
 
 
 @navigator.register(Tenant, 'Details')

--- a/cfme/containers/container.py
+++ b/cfme/containers/container.py
@@ -86,9 +86,7 @@ class ContainerAll(CFMENavigateStep):
             self.view.Filters.Navigation.select('ALL (Default)')
         # Reset view and selection
         self.view.toolbar.view_selector.select("List View")
-        if self.view.paginator.is_displayed:
-            self.view.paginator.check_all()
-            self.view.paginator.uncheck_all()
+        self.view.paginator.reset_selection()
 
 
 @navigator.register(Container, 'Details')

--- a/cfme/containers/image.py
+++ b/cfme/containers/image.py
@@ -127,8 +127,7 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         self.view.toolbar.view_selector.select("List View")
-        self.view.paginator.check_all()
-        self.view.paginator.uncheck_all()
+        self.view.paginator.reset_selection()
 
 
 @navigator.register(Image, 'Details')

--- a/cfme/containers/image_registry.py
+++ b/cfme/containers/image_registry.py
@@ -59,9 +59,7 @@ class ImageRegistryAll(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         self.view.toolbar.view_selector.select("List View")
-        if self.view.paginator.is_displayed:
-            self.view.paginator.check_all()
-            self.view.paginator.uncheck_all()
+        self.view.paginator.reset_selection()
 
 
 @navigator.register(ImageRegistry, 'Details')

--- a/cfme/containers/node.py
+++ b/cfme/containers/node.py
@@ -124,9 +124,7 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         self.view.toolbar.view_selector.select("List View")
-        if self.view.paginator.is_displayed:
-            self.view.paginator.check_all()
-            self.view.paginator.uncheck_all()
+        self.view.paginator.reset_selection()
 
 
 @navigator.register(Node, 'Details')

--- a/cfme/containers/pod.py
+++ b/cfme/containers/pod.py
@@ -63,8 +63,7 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         self.view.toolbar.view_selector.select("List View")
-        self.view.paginator.check_all()
-        self.view.paginator.uncheck_all()
+        self.view.paginator.reset_selection()
 
 
 @navigator.register(Pod, 'Details')

--- a/cfme/containers/project.py
+++ b/cfme/containers/project.py
@@ -57,8 +57,7 @@ class All(CFMENavigateStep):
         # Reset view and selection
         self.view.toolbar.view_selector.select("List View")
         if self.view.paginator.is_displayed:
-            self.view.paginator.check_all()
-            self.view.paginator.uncheck_all()
+            self.view.paginator.reset_selection()
 
 
 @navigator.register(Project, 'Details')

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -303,8 +303,7 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         self.view.toolbar.view_selector.select("Grid View")
-        self.view.paginator.check_all()
-        self.view.paginator.uncheck_all()
+        self.view.paginator.reset_selection()
 
 
 @navigator.register(ContainersProvider, 'Add')

--- a/cfme/containers/replicator.py
+++ b/cfme/containers/replicator.py
@@ -57,9 +57,7 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         self.view.toolbar.view_selector.select("List View")
-        if self.view.paginator.is_displayed:
-            self.view.paginator.check_all()
-            self.view.paginator.uncheck_all()
+        self.view.paginator.reset_selection()
 
 
 @navigator.register(Replicator, 'Details')

--- a/cfme/containers/route.py
+++ b/cfme/containers/route.py
@@ -57,9 +57,7 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         self.view.toolbar.view_selector.select("List View")
-        if self.view.paginator.is_displayed:
-            self.view.paginator.check_all()
-            self.view.paginator.uncheck_all()
+        self.view.paginator.reset_selection()
 
 
 @navigator.register(Route, 'Details')

--- a/cfme/containers/service.py
+++ b/cfme/containers/service.py
@@ -57,9 +57,7 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         self.view.toolbar.view_selector.select("List View")
-        if self.view.paginator.is_displayed:
-            self.view.paginator.check_all()
-            self.view.paginator.uncheck_all()
+        self.view.paginator.reset_selection()
 
 
 @navigator.register(Service, 'Details')

--- a/cfme/containers/template.py
+++ b/cfme/containers/template.py
@@ -57,9 +57,7 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         self.view.toolbar.view_selector.select("List View")
-        if self.view.paginator.is_displayed:
-            self.view.paginator.check_all()
-            self.view.paginator.uncheck_all()
+        self.view.paginator.reset_selection()
 
 
 @navigator.register(Template, 'Details')

--- a/cfme/containers/volume.py
+++ b/cfme/containers/volume.py
@@ -56,9 +56,7 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         self.view.toolbar.view_selector.select("List View")
-        if self.view.paginator.is_displayed:
-            self.view.paginator.check_all()
-            self.view.paginator.uncheck_all()
+        self.view.paginator.reset_selection()
 
 
 @navigator.register(Volume, 'Details')

--- a/cfme/infrastructure/cluster.py
+++ b/cfme/infrastructure/cluster.py
@@ -285,9 +285,7 @@ class All(CFMENavigateStep):
 
     def resetter(self):
         """Reset the view"""
-        if self.view.entities.paginator.exists:
-            self.view.entities.paginator.check_all()
-            self.view.entities.paginator.uncheck_all()
+        self.view.paginator.reset_selection()
 
 
 @navigator.register(Cluster, 'Details')

--- a/cfme/infrastructure/datastore.py
+++ b/cfme/infrastructure/datastore.py
@@ -329,10 +329,7 @@ class All(CFMENavigateStep):
         tb = self.view.toolbar
         if tb.view_selector.is_displayed and 'Grid View' not in tb.view_selector.selected:
             tb.view_selector.select("Grid View")
-        paginator = self.view.entities.paginator
-        if paginator.exists:
-            paginator.check_all()
-            paginator.uncheck_all()
+        self.view.entities.paginator.reset_selection()
 
 
 @navigator.register(Datastore, 'Details')

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -213,12 +213,9 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         tb = self.view.toolbar
-        paginator = self.view.entities.paginator
         if 'Grid View' not in tb.view_selector.selected:
             tb.view_selector.select('Grid View')
-        if paginator.exists:
-            paginator.check_all()
-            paginator.uncheck_all()
+        self.view.entities.paginator.reset_selection()
 
 
 @navigator.register(InfraProvider, 'Add')

--- a/cfme/infrastructure/resource_pool.py
+++ b/cfme/infrastructure/resource_pool.py
@@ -229,8 +229,7 @@ class All(CFMENavigateStep):
     def resetter(self):
         """Reset view and selection"""
         self.view.toolbar.view_selector.select('Grid View')
-        self.view.paginator.check_all()
-        self.view.paginator.uncheck_all()
+        self.view.paginator.reset_selection()
 
 
 @navigator.register(ResourcePool, 'Details')

--- a/cfme/middleware/datasource.py
+++ b/cfme/middleware/datasource.py
@@ -263,8 +263,7 @@ class All(CFMENavigateStep):
 
     def resetter(self):
         """Reset view and selection"""
-        self.view.entities.paginator.check_all()
-        self.view.entities.paginator.uncheck_all()
+        self.view.entities.paginator.reset_selection()
 
 
 @navigator.register(MiddlewareDatasource, 'Details')

--- a/cfme/middleware/deployment.py
+++ b/cfme/middleware/deployment.py
@@ -229,8 +229,7 @@ class All(CFMENavigateStep):
 
     def resetter(self):
         # Reset view and selection
-        self.view.entities.paginator.check_all()
-        self.view.entities.paginator.uncheck_all()
+        self.view.entities.paginator.reset_selection()
 
 
 @navigator.register(MiddlewareDeployment, 'Details')

--- a/cfme/middleware/domain.py
+++ b/cfme/middleware/domain.py
@@ -241,8 +241,7 @@ class All(CFMENavigateStep):
 
     def resetter(self):
         # Reset view and selection
-        self.view.entities.paginator.check_all()
-        self.view.entities.paginator.uncheck_all()
+        self.view.entities.paginator.reset_selection()
 
 
 @navigator.register(MiddlewareDomain, 'Details')

--- a/cfme/middleware/messaging.py
+++ b/cfme/middleware/messaging.py
@@ -235,9 +235,7 @@ class All(CFMENavigateStep):
         self.prerequisite_view.navigation.select('Middleware', 'Messagings')
 
     def resetter(self):
-        # Reset view and selection
-        self.view.entities.paginator.check_all()
-        self.view.entities.paginator.uncheck_all()
+        self.view.entities.paginator.reset_selection()
 
 
 @navigator.register(MiddlewareMessaging, 'Details')

--- a/cfme/web_ui/paginator.py
+++ b/cfme/web_ui/paginator.py
@@ -72,3 +72,7 @@ def pages():
         :py:class:`ValueError`: When the paginator "breaks" (does not change)
     """
     return new_paginator().pages()
+
+
+def reset_selection():
+    new_paginator().reset_selection()

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -1654,6 +1654,13 @@ class JSPaginationPane(View, ReportDataControllerMixin):
             raise NoSuchElementException('Row matching filter {} not found on table {}'
                                          .format(kwargs, table))
 
+    def reset_selection(self):
+        if self.is_displayed:
+            self.check_all()
+            self.uncheck_all()
+            return True
+        return False
+
 
 class NonJSPaginationPane(View):
     """ Represents Paginator Pane with the following controls.
@@ -1815,6 +1822,13 @@ class NonJSPaginationPane(View):
         else:
             raise NoSuchElementException('Row matching filter {} not found on table {}'
                                          .format(kwargs, table))
+
+    def reset_selection(self):
+        if self.is_displayed:
+            self.check_all()
+            self.uncheck_all()
+            return True
+        return False
 
 
 def PaginationPane(*args, **kwargs):  # noqa
@@ -3508,19 +3522,6 @@ class BaseNonInteractiveEntitiesView(View, ReportDataControllerMixin):
             return NonJSBaseEntity
         else:
             return JSBaseEntity
-
-    @property
-    def entity_names(self):
-        """ looks for entities and extracts their names
-
-        Returns: all current page entities
-        """
-        if self.browser.product_version < '5.9':
-            br = self.browser
-            return [br.get_attribute('title', el) for el in br.elements(self.elements)]
-        else:
-            entities = self._invoke_cmd('get_all_items')
-            return [entity['item']['cells']['Name'] for entity in entities]
 
     def get_all(self):
         """ obtains all entities like QuadIcon displayed by view


### PR DESCRIPTION
redundant paginator's check_all/uncheck_all calls are moved from navmazing resetter to appropriate paginator method

{{pytest: --long-running cfme/tests/cloud/test_providers.py cfme/tests/infrastructure/test_providers.py cfme/tests/infrastructure/test_datastore_analysis.py}}