### PR TITLE
[1LP][RFR] data property shouldn't raise exception  when quads are disabled

### DIFF
--- a/cfme/common/host_views.py
+++ b/cfme/common/host_views.py
@@ -59,12 +59,15 @@ class ComputeInfrastructureHostsView(BaseLoggedInPage):
 class HostQuadIconEntity(BaseQuadIconEntity):
     @property
     def data(self):
-        return {
-            'no_vm': int(self.browser.text(self.QUADRANT.format(pos="a"))),
-            'state': self.browser.get_attribute("style", self.QUADRANT.format(pos="b")),
-            'vendor': self.browser.get_attribute("alt", self.QUADRANT.format(pos="c")),
-            'creds': self.browser.get_attribute("alt", self.QUADRANT.format(pos="d"))
-        }
+        try:
+            return {
+                'no_vm': int(self.browser.text(self.QUADRANT.format(pos="a"))),
+                'state': self.browser.get_attribute("style", self.QUADRANT.format(pos="b")),
+                'vendor': self.browser.get_attribute("alt", self.QUADRANT.format(pos="c")),
+                'creds': self.browser.get_attribute("alt", self.QUADRANT.format(pos="d"))
+            }
+        except IndexError:
+            return {}
 
 
 class HostTileIconEntity(BaseTileIconEntity):
@@ -85,13 +88,16 @@ class JSHostEntity(JSBaseEntity):
     @property
     def data(self):
         data_dict = super(JSHostEntity, self).data
-        if 'quadicon' in data_dict and data_dict['quadicon']:
-            quad_data = document_fromstring(data_dict['quadicon'])
-            data_dict['no_vm'] = int(quad_data.xpath(self.QUADRANT.format(pos="a"))[0].text)
-            data_dict['state'] = quad_data.xpath(self.QUADRANT.format(pos="b"))[0].get('style')
-            data_dict['vendor'] = quad_data.xpath(self.QUADRANT.format(pos="c"))[0].get('alt')
-            data_dict['creds'] = quad_data.xpath(self.QUADRANT.format(pos="d"))[0].get('alt')
-        return data_dict
+        try:
+            if 'quadicon' in data_dict and data_dict['quadicon']:
+                quad_data = document_fromstring(data_dict['quadicon'])
+                data_dict['no_vm'] = int(quad_data.xpath(self.QUADRANT.format(pos="a"))[0].text)
+                data_dict['state'] = quad_data.xpath(self.QUADRANT.format(pos="b"))[0].get('style')
+                data_dict['vendor'] = quad_data.xpath(self.QUADRANT.format(pos="c"))[0].get('alt')
+                data_dict['creds'] = quad_data.xpath(self.QUADRANT.format(pos="d"))[0].get('alt')
+            return data_dict
+        except IndexError, TypeError:
+            return {}
 
 
 def HostEntity():  # noqa

--- a/cfme/common/host_views.py
+++ b/cfme/common/host_views.py
@@ -96,7 +96,7 @@ class JSHostEntity(JSBaseEntity):
                 data_dict['vendor'] = quad_data.xpath(self.QUADRANT.format(pos="c"))[0].get('alt')
                 data_dict['creds'] = quad_data.xpath(self.QUADRANT.format(pos="d"))[0].get('alt')
             return data_dict
-        except IndexError, TypeError:
+        except (IndexError, TypeError):
             return {}
 
 

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -67,7 +67,7 @@ class JSProviderEntity(JSBaseEntity):
                 data_dict['vendor'] = quad_data.xpath(self.QUADRANT.format(pos="c"))[0].get('src')
                 data_dict['creds'] = quad_data.xpath(self.QUADRANT.format(pos="d"))[0].get('src')
             return data_dict
-        except IndexError, TypeError:
+        except (IndexError, TypeError):
             return {}
 
 

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -30,11 +30,14 @@ class ProviderQuadIconEntity(BaseQuadIconEntity):
     @property
     def data(self):
         br = self.browser
-        return {
-            "no_host": br.text(self.QUADRANT.format(pos='a')),
-            "vendor": br.get_attribute('src', self.QUADRANT.format(pos='c')),
-            "creds": br.get_attribute('src', self.QUADRANT.format(pos='d')),
-        }
+        try:
+            return {
+                "no_host": int(br.text(self.QUADRANT.format(pos='a'))),
+                "vendor": br.get_attribute('src', self.QUADRANT.format(pos='c')),
+                "creds": br.get_attribute('src', self.QUADRANT.format(pos='d')),
+            }
+        except TypeError:
+            return {}
 
 
 class ProviderTileIconEntity(BaseTileIconEntity):
@@ -57,12 +60,15 @@ class JSProviderEntity(JSBaseEntity):
     @property
     def data(self):
         data_dict = super(JSProviderEntity, self).data
-        if 'quadicon' in data_dict and data_dict['quadicon']:
-            quad_data = document_fromstring(data_dict['quadicon'])
-            data_dict['no_host'] = int(quad_data.xpath(self.QUADRANT.format(pos="a"))[0].text)
-            data_dict['vendor'] = quad_data.xpath(self.QUADRANT.format(pos="c"))[0].get('src')
-            data_dict['creds'] = quad_data.xpath(self.QUADRANT.format(pos="d"))[0].get('src')
-        return data_dict
+        try:
+            if 'quadicon' in data_dict and data_dict['quadicon']:
+                quad_data = document_fromstring(data_dict['quadicon'])
+                data_dict['no_host'] = int(quad_data.xpath(self.QUADRANT.format(pos="a"))[0].text)
+                data_dict['vendor'] = quad_data.xpath(self.QUADRANT.format(pos="c"))[0].get('src')
+                data_dict['creds'] = quad_data.xpath(self.QUADRANT.format(pos="d"))[0].get('src')
+            return data_dict
+        except IndexError, TypeError:
+            return {}
 
 
 def ProviderEntity():  # noqa


### PR DESCRIPTION
It turned out that quads can be disabled for QuadIcons. Quadicon.data doesn't work in such case. This fix inhibits exceptions and return empty dict for such case 