### PR TITLE
[1LP][RFR]PXE fixes for 5.9

### DIFF
--- a/cfme/infrastructure/pxe.py
+++ b/cfme/infrastructure/pxe.py
@@ -501,18 +501,10 @@ class CustomizationTemplate(Updateable, Pretty, BaseEntity):
         view = navigate_to(self, 'Edit')
         view.fill(updates)
         main_view = self.create_view(PXECustomizationTemplatesView, override=updates)
-        name = updates.get('name') or self.name
-        description = updates.get('description') or self.description
-
         if cancel:
             view.cancel.click()
-            # msg = 'Edit of Customization Template "{}" was cancelled by the user'.format(name)
         else:
             view.save.click()
-            # if self.appliance.version < 5.9:
-            #     msg = 'Customization Template "{}" was saved'.format(name)
-            # else:
-            #     msg = 'Customization Template "{}" was saved'.format(description)
         main_view.flash.assert_no_error()
 
 
@@ -547,13 +539,8 @@ class CustomizationTemplateCollection(BaseCollection):
         main_view = self.create_view(PXECustomizationTemplatesView)
         if cancel:
             view.cancel.click()
-            # msg = 'Add of new Customization Template was cancelled by the user'
         else:
             view.add.click()
-            # if self.appliance.version < 5.9:
-            #     msg = 'Customization Template "{}" was saved'.format(name)
-            # else:
-            #     msg = 'Customization Template "{}" was saved'.format(description)
         main_view.flash.assert_no_error()
         return customization_templates
 
@@ -572,8 +559,7 @@ class CustomizationTemplateCollection(BaseCollection):
                                                    handle_alert=not cancel)
             if not cancel:
                 main_view = ct_obj.create_view(PXECustomizationTemplatesView)
-                msg = 'Customization Template "{}": Delete successful'.format(ct_obj.description)
-                main_view.flash.assert_success_message(msg)
+                main_view.flash.assert_no_error()
             else:
                 navigate_to(ct_obj, 'Details')
 

--- a/cfme/infrastructure/pxe.py
+++ b/cfme/infrastructure/pxe.py
@@ -530,18 +530,19 @@ class CustomizationTemplateCollection(BaseCollection):
 
         customization_templates = self.instantiate(name, description, script_data,
                                                    image_type, script_type)
-        view = navigate_to(self, 'Add')
-        view.fill({'name': name,
-                   'description': description,
-                   'image_type': image_type,
-                   'type': script_type,
-                   'script': script_data})
-        main_view = self.create_view(PXECustomizationTemplatesView)
-        if cancel:
-            view.cancel.click()
-        else:
-            view.add.click()
-        main_view.flash.assert_no_error()
+        if not customization_templates.exists():
+            view = navigate_to(self, 'Add')
+            view.fill({'name': name,
+                       'description': description,
+                       'image_type': image_type,
+                       'type': script_type,
+                       'script': script_data})
+            main_view = self.create_view(PXECustomizationTemplatesView)
+            if cancel:
+                view.cancel.click()
+            else:
+                view.add.click()
+            main_view.flash.assert_no_error()
         return customization_templates
 
     def delete(self, cancel=False, *ct_objs):
@@ -964,7 +965,7 @@ class PXEMainPage(CFMENavigateStep):
 
 def get_template_from_config(template_config_name):
     """
-    Convenience function to grab the details for a template from the yamls.
+    Convenience function to grab the details for a template from the yamls and create template.
     """
 
     template_config = conf.cfme_data.get('customization_templates', {})[template_config_name]
@@ -975,11 +976,11 @@ def get_template_from_config(template_config_name):
     script_data = script_data.read()
     appliance = get_or_create_current_appliance()
     collection = appliance.collections.customization_templates
-    return collection.instantiate(name=template_config['name'],
-                                  description=template_config['description'],
-                                  image_type=template_config['image_type'],
-                                  script_type=template_config['script_type'],
-                                  script_data=script_data)
+    return collection.create(name=template_config['name'],
+                             description=template_config['description'],
+                             image_type=template_config['image_type'],
+                             script_type=template_config['script_type'],
+                             script_data=script_data)
 
 
 def get_pxe_server_from_config(pxe_config_name):

--- a/cfme/infrastructure/pxe.py
+++ b/cfme/infrastructure/pxe.py
@@ -506,14 +506,14 @@ class CustomizationTemplate(Updateable, Pretty, BaseEntity):
 
         if cancel:
             view.cancel.click()
-            msg = 'Edit of Customization Template "{}" was cancelled by the user'.format(name)
+            # msg = 'Edit of Customization Template "{}" was cancelled by the user'.format(name)
         else:
             view.save.click()
-            if self.appliance.version < 5.9:
-                msg = 'Customization Template "{}" was saved'.format(name)
-            else:
-                msg = 'Customization Template "{}" was saved'.format(description)
-        main_view.flash.assert_success_message(msg)
+            # if self.appliance.version < 5.9:
+            #     msg = 'Customization Template "{}" was saved'.format(name)
+            # else:
+            #     msg = 'Customization Template "{}" was saved'.format(description)
+        main_view.flash.assert_no_error()
 
 
 @attr.s
@@ -547,14 +547,14 @@ class CustomizationTemplateCollection(BaseCollection):
         main_view = self.create_view(PXECustomizationTemplatesView)
         if cancel:
             view.cancel.click()
-            msg = 'Add of new Customization Template was cancelled by the user'
+            # msg = 'Add of new Customization Template was cancelled by the user'
         else:
             view.add.click()
-            if self.appliance.version < 5.9:
-                msg = 'Customization Template "{}" was saved'.format(name)
-            else:
-                msg = 'Customization Template "{}" was saved'.format(description)
-        main_view.flash.assert_success_message(msg)
+            # if self.appliance.version < 5.9:
+            #     msg = 'Customization Template "{}" was saved'.format(name)
+            # else:
+            #     msg = 'Customization Template "{}" was saved'.format(description)
+        main_view.flash.assert_no_error()
         return customization_templates
 
     def delete(self, cancel=False, *ct_objs):

--- a/cfme/infrastructure/pxe.py
+++ b/cfme/infrastructure/pxe.py
@@ -975,18 +975,18 @@ def get_template_from_config(template_config_name):
     script_data = script_data.read()
     appliance = get_or_create_current_appliance()
     collection = appliance.collections.customization_templates
-    custimization_template = collection.instantiate(name=template_config['name'],
+    customization_template = collection.instantiate(name=template_config['name'],
                                                     description=template_config['description'],
                                                     image_type=template_config['image_type'],
                                                     script_type=template_config['script_type'],
                                                     script_data=script_data)
-    if not custimization_template.exists():
+    if not customization_template.exists():
         return collection.create(name=template_config['name'],
                                  description=template_config['description'],
                                  image_type=template_config['image_type'],
                                  script_type=template_config['script_type'],
                                  script_data=script_data)
-    return custimization_template
+    return customization_template
 
 
 def get_pxe_server_from_config(pxe_config_name):

--- a/cfme/infrastructure/pxe.py
+++ b/cfme/infrastructure/pxe.py
@@ -530,19 +530,18 @@ class CustomizationTemplateCollection(BaseCollection):
 
         customization_templates = self.instantiate(name, description, script_data,
                                                    image_type, script_type)
-        if not customization_templates.exists():
-            view = navigate_to(self, 'Add')
-            view.fill({'name': name,
-                       'description': description,
-                       'image_type': image_type,
-                       'type': script_type,
-                       'script': script_data})
-            main_view = self.create_view(PXECustomizationTemplatesView)
-            if cancel:
-                view.cancel.click()
-            else:
-                view.add.click()
-            main_view.flash.assert_no_error()
+        view = navigate_to(self, 'Add')
+        view.fill({'name': name,
+                   'description': description,
+                   'image_type': image_type,
+                   'type': script_type,
+                   'script': script_data})
+        main_view = self.create_view(PXECustomizationTemplatesView)
+        if cancel:
+            view.cancel.click()
+        else:
+            view.add.click()
+        main_view.flash.assert_no_error()
         return customization_templates
 
     def delete(self, cancel=False, *ct_objs):
@@ -976,11 +975,18 @@ def get_template_from_config(template_config_name):
     script_data = script_data.read()
     appliance = get_or_create_current_appliance()
     collection = appliance.collections.customization_templates
-    return collection.create(name=template_config['name'],
-                             description=template_config['description'],
-                             image_type=template_config['image_type'],
-                             script_type=template_config['script_type'],
-                             script_data=script_data)
+    custimization_template = collection.instantiate(name=template_config['name'],
+                                                    description=template_config['description'],
+                                                    image_type=template_config['image_type'],
+                                                    script_type=template_config['script_type'],
+                                                    script_data=script_data)
+    if not custimization_template.exists():
+        return collection.create(name=template_config['name'],
+                                 description=template_config['description'],
+                                 image_type=template_config['image_type'],
+                                 script_type=template_config['script_type'],
+                                 script_data=script_data)
+    return custimization_template
 
 
 def get_pxe_server_from_config(pxe_config_name):

--- a/cfme/services/service_catalogs/ui.py
+++ b/cfme/services/service_catalogs/ui.py
@@ -10,6 +10,7 @@ from cfme.base.login import BaseLoggedInPage
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.services.requests import RequestsView
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to, ViaUI
+from cfme.utils.blockers import BZ
 from cfme.utils.version import Version
 from cfme.utils.wait import wait_for
 
@@ -134,6 +135,9 @@ def order(self):
     else:
         msg = "Dialog submitted successfully!"
         msg_type = "info"
+    # TODO Remove once repaired
+    if BZ(1513541, forced_streams=['5.9']).blocks:
+        raise NotImplementedError("Service Order is broken - check BZ 1513541")
     view.submit_button.click()
     view = self.create_view(RequestsView)
     view.flash.assert_no_error()

--- a/cfme/tests/infrastructure/test_customization_template.py
+++ b/cfme/tests/infrastructure/test_customization_template.py
@@ -104,9 +104,8 @@ def test_name_max_character_validation(collection):
         image_type='RHEL-6',
         script_type='Kickstart',
         script_data='Testing the script')
-    created_template = collection.create(name=template_name.name[:255],
+    created_template = collection.instantiate(name=template_name.name[:255],
                                          image_type=template_name.image_type)
     view = navigate_to(created_template, 'Details')
     assert len(view.entities.basic_information.get_text_of('Name')) < 256
-    created_template.delete(cancel=False)
     collection.delete(False, created_template)

--- a/cfme/tests/infrastructure/test_customization_template.py
+++ b/cfme/tests/infrastructure/test_customization_template.py
@@ -2,7 +2,9 @@
 import fauxfactory
 import pytest
 
-from cfme.utils import error, version
+from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils import error
+from cfme.utils.blockers import BZ
 from cfme.utils.update import update
 
 pytestmark = [pytest.mark.tier(3)]
@@ -63,7 +65,12 @@ def test_pxe_image_type_required_error_validation(collection):
             script_data='Testing the script')
 
 
-@pytest.mark.uncollectif(lambda: version.current_version() < '5.9')
+@pytest.mark.meta(
+    blockers=[
+        BZ(1092951, ignore_bugs=[1083198]),
+        BZ(1450927, forced_streams=['5.8']),
+    ]
+)
 def test_duplicate_name_error_validation(collection):
     """Test to validate duplication in customization templates."""
 
@@ -86,16 +93,20 @@ def test_duplicate_name_error_validation(collection):
     collection.delete(False, template_name)
 
 
-@pytest.mark.xfail(message='http://cfme-tests.readthedocs.org/guides/gotchas.html#'
-                           'selenium-is-not-clicking-on-the-element-it-says-it-is')
 def test_name_max_character_validation(collection):
-    """Test to validate name with maximum characters in customization templates."""
-
-    with error.expected('Name is required'):
-        template_name = collection.create(
-            name=fauxfactory.gen_alphanumeric(256),
-            description=fauxfactory.gen_alphanumeric(16),
-            image_type='RHEL-6',
-            script_type='Kickstart',
-            script_data='Testing the script')
-    collection.delete(False, template_name)
+    """Test to validate name with maximum characters in customization templates.
+       Max length is controlled by UI elements - we are not allowed to input more than we should
+       Opens template details to verify that extra symbols were cut
+    """
+    template_name = collection.create(
+        name=fauxfactory.gen_alphanumeric(256),
+        description=fauxfactory.gen_alphanumeric(16),
+        image_type='RHEL-6',
+        script_type='Kickstart',
+        script_data='Testing the script')
+    created_template = collection.create(name=template_name.name[:255],
+                                         image_type=template_name.image_type)
+    view = navigate_to(created_template, 'Details')
+    assert len(view.entities.basic_information.get_text_of('Name')) < 256
+    created_template.delete(cancel=False)
+    collection.delete(False, created_template)

--- a/cfme/tests/infrastructure/test_customization_template.py
+++ b/cfme/tests/infrastructure/test_customization_template.py
@@ -65,12 +65,7 @@ def test_pxe_image_type_required_error_validation(collection):
             script_data='Testing the script')
 
 
-@pytest.mark.meta(
-    blockers=[
-        BZ(1092951, ignore_bugs=[1083198]),
-        BZ(1450927, forced_streams=['5.8']),
-    ]
-)
+@pytest.mark.uncollectif(BZ(1449116, forced_streams=['5.7', '5.8']).blocks, reason='BZ 1449116')
 def test_duplicate_name_error_validation(collection):
     """Test to validate duplication in customization templates."""
 

--- a/cfme/tests/infrastructure/test_customization_template.py
+++ b/cfme/tests/infrastructure/test_customization_template.py
@@ -65,7 +65,7 @@ def test_pxe_image_type_required_error_validation(collection):
             script_data='Testing the script')
 
 
-@pytest.mark.uncollectif(BZ(1449116, forced_streams=['5.7', '5.8']).blocks, reason='BZ 1449116')
+@pytest.mark.meta(blockers=[BZ(1449116, forced_streams=['5.7', '5.8'])])
 def test_duplicate_name_error_validation(collection):
     """Test to validate duplication in customization templates."""
 
@@ -99,8 +99,7 @@ def test_name_max_character_validation(collection):
         image_type='RHEL-6',
         script_type='Kickstart',
         script_data='Testing the script')
-    created_template = collection.instantiate(name=template_name.name[:255],
-                                         image_type=template_name.image_type)
-    view = navigate_to(created_template, 'Details')
+    template_name.name = template_name.name[:255]
+    view = navigate_to(template_name, 'Details')
     assert len(view.entities.basic_information.get_text_of('Name')) < 256
-    collection.delete(False, created_template)
+    collection.delete(False, template_name)

--- a/cfme/tests/infrastructure/test_pxe_provisioning.py
+++ b/cfme/tests/infrastructure/test_pxe_provisioning.py
@@ -122,4 +122,4 @@ def test_pxe_provision_from_template(appliance, provider, vm_name, smtp_test, se
             'vlan': pxe_vlan}}
 
     do_vm_provisioning(appliance, pxe_template, provider, vm_name, provisioning_data, request,
-                       smtp_test, num_sec=2100)
+                       smtp_test, num_sec=2400)

--- a/cfme/tests/infrastructure/test_pxe_provisioning.py
+++ b/cfme/tests/infrastructure/test_pxe_provisioning.py
@@ -122,4 +122,4 @@ def test_pxe_provision_from_template(appliance, provider, vm_name, smtp_test, se
             'vlan': pxe_vlan}}
 
     do_vm_provisioning(appliance, pxe_template, provider, vm_name, provisioning_data, request,
-                       smtp_test, num_sec=2400)
+                       smtp_test, num_sec=3600)

--- a/cfme/tests/services/test_pxe_service_catalogs.py
+++ b/cfme/tests/services/test_pxe_service_catalogs.py
@@ -69,8 +69,6 @@ def setup_pxe_servers_vm_prov(pxe_server, pxe_cust_template, provisioning):
     if not pxe_server.exists():
         pxe_server.create()
     pxe_server.set_pxe_image_type(provisioning['pxe_image'], provisioning['pxe_image_type'])
-    if not pxe_cust_template.exists():
-        pxe_cust_template.create()
 
 
 @pytest.yield_fixture(scope="function")

--- a/cfme/tests/services/test_pxe_service_catalogs.py
+++ b/cfme/tests/services/test_pxe_service_catalogs.py
@@ -125,5 +125,5 @@ def test_pxe_servicecatalog(appliance, setup_provider, provider, catalog_item, r
     request_description = catalog_item.name
     provision_request = appliance.collections.requests.instantiate(request_description,
                                                                    partial_check=True)
-    provision_request.wait_for_request()
+    provision_request.wait_for_request(num_sec=3600)
     assert provision_request.is_succeeded()


### PR DESCRIPTION
fixes for PXE tests in 5.9.
{{pytest: cfme/tests/infrastructure/test_customization_template.py cfme/tests/infrastructure/test_pxe.py cfme/tests/infrastructure/test_pxe_provisioning.py  cfme/tests/services/test_pxe_service_catalogs.py  --long-running --use-provider vsphere65-nested}}