### PR TITLE
[1LP][RFR] Add a Polarion marker to integration test

### DIFF
--- a/markers/polarion.py
+++ b/markers/polarion.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """polarion(\*tcid): Marker for marking tests as automation for polarion test cases."""
+import pytest
 
 
 def pytest_configure(config):
@@ -13,3 +14,13 @@ def extract_polarion_ids(item):
         return None
 
     return map(str, polarion.args)
+
+
+@pytest.fixture(autouse=True)
+def _update_polarion_in_junit(request, record_xml_property):
+    """Adds the supplied test case id to the xunit file as a property"""
+    from functools import partial
+    record_id_to_xml = partial(record_xml_property, ("test_id",))
+    ids = extract_polarion_ids(request.node)
+    if ids is not None:
+        map(record_id_to_xml, ids)

--- a/markers/polarion.py
+++ b/markers/polarion.py
@@ -24,4 +24,5 @@ def _update_polarion_in_junit(request, record_xml_property):
     record_id_to_xml = partial(record_xml_property, "test_id")
     ids = extract_polarion_ids(request.node)
     if ids is not None:
-        map(record_id_to_xml, ids)
+        for id in ids:
+            record_id_to_xml(id)

--- a/markers/polarion.py
+++ b/markers/polarion.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """polarion(\*tcid): Marker for marking tests as automation for polarion test cases."""
 import pytest
+from functools import partial
 
 
 def pytest_configure(config):
@@ -19,8 +20,8 @@ def extract_polarion_ids(item):
 @pytest.fixture(autouse=True)
 def _update_polarion_in_junit(request, record_xml_property):
     """Adds the supplied test case id to the xunit file as a property"""
-    from functools import partial
-    record_id_to_xml = partial(record_xml_property, ("test_id",))
+
+    record_id_to_xml = partial(record_xml_property, "test_id")
     ids = extract_polarion_ids(request.node)
     if ids is not None:
         map(record_id_to_xml, ids)


### PR DESCRIPTION
In this PR I created a new polarion marker for our test so each test that decorated with pytest.mark.polarion("some-id"), will be translated into the xunit.xml file

**For example:**
```xml
<testcase classname="cfme.tests.containers.fake_test" file="cfme/tests/containers/fake_test.py" line="14" name="test_nothing2[1]" time="0.00894999504089">
    <skipped message="skipping..." type="pytest.skip">cfme/tests/containers/fake_test.py:14: &lt;py._xmlgen.raw object at 0x7f84c032fd90&gt;</skipped>
	</testcase>
	<testcase classname="cfme.tests.containers.fake_test" file="cfme/tests/containers/fake_test.py" line="14" name="test_nothing2[2]" time="0.0127758979797">
		<properties>
			<property name="test_id" value="CMP-002"/>
		</properties>
		<system-out>
                       This is just an empty test
                </system-out>
	</testcase>

```