### PR TITLE
[WIP] entities shouldn't use id to store hold entity id

### DIFF
--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -2850,8 +2850,13 @@ class JSBaseEntity(View, ReportDataControllerMixin):
         """
         data = self._invoke_cmd('get_item', self.id)['item']
         cells = data.pop('cells')
+        cells = {str(key).replace(' ', '_').lower(): value for key, value in cells.items()}
+        data = {str(key).replace(' ', '_').lower(): value for key, value in data.items()}
+        # some entities have id column in List View mode.
+        if 'id' in cells:
+            cells['another_id'] = cells.pop('id')
         data.update(cells)
-        return {str(key).replace(' ', '_').lower(): value for key, value in data.items()}
+        return data
 
     def read(self):
         return self.is_checked


### PR DESCRIPTION
It turned out that some entities like containers.Image use id to hold some their internal ids. Whereas current implementation of entities use id to hold entity_id. 
So, this PR will make entities use entity_id property instead of id.