### PR TITLE
[1LP][RFR] Fix test_host_drift_analysis, versioned task tabs

### DIFF
--- a/cfme/configure/tasks.py
+++ b/cfme/configure/tasks.py
@@ -14,7 +14,7 @@ from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep,
 from cfme.utils.log import logger
 from cfme.utils.wait import TimedOutError
 
-table_loc = '//div[@id="records_div" or @id="main_div"]//table'
+table_loc = '//div[@id="gtl_div"]//table'
 
 
 def is_vm_analysis_finished(name, **kwargs):


### PR DESCRIPTION
version pick the task tab name for 5.9 change

Versioned picked the tab name in the tasks view class during sprint 16, but this was insufficient to fully fix the test.

Tasks is in need of a pretty full refactor to move to collection and to move all the module methods into a proper entity class.

So far working like I want locally. though there are test failures.  They're not related to the tasks views/widgets.

Can't explain the 5909 failure selecting 'Department' tag category.

{{ pytest: cfme/tests/infrastructure/test_host_drift_analysis.py --long-running --use-provider vsphere65-nested --use-provider scvmm --use-provider rhv41 }}