### PR TITLE
[RFR] Fix delete from collection after partial fix to BZ 1511128

### DIFF
--- a/cfme/tests/cloud_infra_common/test_rest_providers.py
+++ b/cfme/tests/cloud_infra_common/test_rest_providers.py
@@ -6,7 +6,7 @@ from cfme.cloud.provider.azure import AzureProvider
 from cfme.common.provider import CloudInfraProvider
 from cfme.utils import error, testgen
 from cfme.utils.blockers import BZ
-from cfme.utils.rest import assert_response
+from cfme.utils.rest import assert_response, delete_resources_from_collection
 from cfme.utils.version import pick
 from cfme.utils.wait import wait_for
 
@@ -234,9 +234,5 @@ def test_provider_delete_from_collection(provider_rest, appliance):
     Metadata:
         test_flag: rest
     """
-    appliance.rest_api.collections.providers.action.delete(provider_rest)
-    assert_response(appliance)
-    provider_rest.wait_not_exists(num_sec=30)
-    with error.expected("ActiveRecord::RecordNotFound"):
-        appliance.rest_api.collections.providers.action.delete(provider_rest)
-    assert_response(appliance, http_status=404)
+    collection = appliance.rest_api.collections.providers
+    delete_resources_from_collection(collection, [provider_rest], num_sec=30)

--- a/cfme/tests/cloud_infra_common/test_snapshots_rest.py
+++ b/cfme/tests/cloud_infra_common/test_snapshots_rest.py
@@ -11,7 +11,7 @@ from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.utils import error, testgen
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
-from cfme.utils.rest import assert_response
+from cfme.utils.rest import assert_response, delete_resources_from_collection
 from cfme.utils.version import current_version
 from cfme.utils.wait import wait_for
 
@@ -119,22 +119,15 @@ class TestRESTSnapshots(object):
             del_action()
         assert_response(appliance, http_status=404)
 
-    def test_delete_snapshot_from_collection(self, appliance, vm_snapshot):
+    def test_delete_snapshot_from_collection(self, vm_snapshot):
         """Deletes VM/instance snapshot from collection using REST API
 
         Metadata:
             test_flag: rest
         """
         vm, snapshot = vm_snapshot
-
-        vm.snapshots.action.delete.POST(snapshot)
-        assert_response(appliance)
-        snapshot.wait_not_exists(num_sec=300, delay=5)
-
-        # testing BZ 1466225
-        with error.expected('ActiveRecord::RecordNotFound'):
-            vm.snapshots.action.delete.POST(snapshot)
-        assert_response(appliance, http_status=404)
+        delete_resources_from_collection(
+            vm.snapshots, [snapshot], not_found=True, num_sec=300, delay=5)
 
     @pytest.mark.uncollectif(lambda provider:
             not provider.one_of(InfraProvider) or current_version() < '5.8')

--- a/cfme/tests/configure/test_rest_access_control.py
+++ b/cfme/tests/configure/test_rest_access_control.py
@@ -13,7 +13,7 @@ from cfme.rest.gen_data import (
     users as _users,
 )
 from cfme.utils import error
-from cfme.utils.rest import assert_response
+from cfme.utils.rest import assert_response, delete_resources_from_collection
 from cfme.utils.wait import wait_for
 
 pytestmark = [
@@ -99,11 +99,8 @@ class TestTenantsViaREST(object):
         Metadata:
             test_flag: rest
         """
-        appliance.rest_api.collections.tenants.action.delete(*tenants)
-        assert appliance.rest_api.response.status_code == 200
-        with error.expected("ActiveRecord::RecordNotFound"):
-            appliance.rest_api.collections.tenants.action.delete(*tenants)
-        assert appliance.rest_api.response.status_code == 404
+        collection = appliance.rest_api.collections.tenants
+        delete_resources_from_collection(collection, tenants)
 
 
 class TestRolesViaREST(object):
@@ -184,11 +181,8 @@ class TestRolesViaREST(object):
         Metadata:
             test_flag: rest
         """
-        appliance.rest_api.collections.roles.action.delete(*roles)
-        assert appliance.rest_api.response.status_code == 200
-        with error.expected("ActiveRecord::RecordNotFound"):
-            appliance.rest_api.collections.roles.action.delete(*roles)
-        assert appliance.rest_api.response.status_code == 404
+        collection = appliance.rest_api.collections.roles
+        delete_resources_from_collection(collection, roles)
 
     @pytest.mark.tier(3)
     def test_add_delete_role(self, appliance):
@@ -321,11 +315,8 @@ class TestGroupsViaREST(object):
         Metadata:
             test_flag: rest
         """
-        appliance.rest_api.collections.groups.action.delete(*groups)
-        assert appliance.rest_api.response.status_code == 200
-        with error.expected("ActiveRecord::RecordNotFound"):
-            appliance.rest_api.collections.groups.action.delete(*groups)
-        assert appliance.rest_api.response.status_code == 404
+        collection = appliance.rest_api.collections.groups
+        delete_resources_from_collection(collection, groups, not_found=True)
 
 
 class TestUsersViaREST(object):
@@ -475,8 +466,5 @@ class TestUsersViaREST(object):
         Metadata:
             test_flag: rest
         """
-        appliance.rest_api.collections.users.action.delete(*users)
-        assert appliance.rest_api.response.status_code == 200
-        with error.expected("ActiveRecord::RecordNotFound"):
-            appliance.rest_api.collections.users.action.delete(*users)
-        assert appliance.rest_api.response.status_code == 404
+        collection = appliance.rest_api.collections.users
+        delete_resources_from_collection(collection, users)

--- a/cfme/tests/configure/test_tag.py
+++ b/cfme/tests/configure/test_tag.py
@@ -13,7 +13,7 @@ from cfme.rest.gen_data import (
 )
 from cfme.utils.update import update
 from cfme.utils.wait import wait_for
-from cfme.utils.rest import assert_response
+from cfme.utils.rest import assert_response, delete_resources_from_collection
 from cfme.utils.version import current_version
 from cfme.utils.blockers import BZ
 from cfme.utils import error
@@ -180,11 +180,8 @@ class TestTagsViaREST(object):
         Metadata:
             test_flag: rest
         """
-        appliance.rest_api.collections.tags.action.delete(*tags)
-        assert_response(appliance)
-        with error.expected("ActiveRecord::RecordNotFound"):
-            appliance.rest_api.collections.tags.action.delete(*tags)
-        assert_response(appliance, http_status=404)
+        collection = appliance.rest_api.collections.tags
+        delete_resources_from_collection(collection, tags, not_found=True)
 
     @pytest.mark.tier(3)
     def test_create_tag_with_wrong_arguments(self, appliance):

--- a/cfme/tests/configure/test_tag_category.py
+++ b/cfme/tests/configure/test_tag_category.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 import fauxfactory
+import pytest
+
 from cfme.configure.configuration.region_settings import Category
 from cfme.rest.gen_data import categories as _categories
-import pytest
+from cfme.utils import error
+from cfme.utils.rest import delete_resources_from_collection
 from cfme.utils.update import update
 from cfme.utils.wait import wait_for
-from cfme.utils import error
 
 
 @pytest.mark.tier(2)
@@ -99,8 +101,5 @@ class TestCategoriesViaREST(object):
         Metadata:
             test_flag: rest
         """
-        appliance.rest_api.collections.categories.action.delete(*categories)
-        assert appliance.rest_api.response.status_code == 200
-        with error.expected("ActiveRecord::RecordNotFound"):
-            appliance.rest_api.collections.categories.action.delete(*categories)
-        assert appliance.rest_api.response.status_code == 404
+        collection = appliance.rest_api.collections.categories
+        delete_resources_from_collection(collection, categories, not_found=True)

--- a/cfme/tests/control/test_rest_control.py
+++ b/cfme/tests/control/test_rest_control.py
@@ -8,7 +8,7 @@ from cfme import test_requirements
 from cfme.rest.gen_data import conditions as _conditions
 from cfme.rest.gen_data import policies as _policies
 from cfme.utils.blockers import BZ
-from cfme.utils.rest import assert_response
+from cfme.utils.rest import assert_response, delete_resources_from_collection
 from cfme.utils.version import current_version
 from cfme.utils.wait import wait_for
 
@@ -73,20 +73,7 @@ class TestConditionsRESTAPI(object):
             test_flag: rest
         """
         collection = appliance.rest_api.collections.conditions
-        collection.action.delete.POST(*conditions)
-        assert_response(appliance)
-
-        for condition in conditions:
-            wait_for(
-                lambda: not appliance.rest_api.collections.conditions.find_by(
-                    name=condition.name),
-                num_sec=100,
-                delay=5
-            )
-
-        with error.expected('ActiveRecord::RecordNotFound'):
-            collection.action.delete.POST(*conditions)
-        assert_response(appliance, http_status=404)
+        delete_resources_from_collection(collection, conditions, num_sec=100, delay=5)
 
     @pytest.mark.uncollectif(lambda: current_version() < '5.8')
     @pytest.mark.parametrize(
@@ -196,20 +183,7 @@ class TestPoliciesRESTAPI(object):
             test_flag: rest
         """
         collection = appliance.rest_api.collections.policies
-        collection.action.delete.POST(*policies)
-        assert_response(appliance)
-
-        for policy in policies:
-            wait_for(
-                lambda: not appliance.rest_api.collections.policies.find_by(
-                    name=policy.name),
-                num_sec=100,
-                delay=5
-            )
-
-        with error.expected('ActiveRecord::RecordNotFound'):
-            collection.action.delete.POST(*policies)
-        assert_response(appliance, http_status=404)
+        delete_resources_from_collection(collection, policies, num_sec=100, delay=5)
 
     @pytest.mark.uncollectif(lambda: current_version() < '5.8')
     @pytest.mark.meta(blockers=[BZ(1435777, forced_streams=['5.8', 'upstream'])])

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -6,7 +6,7 @@ import pytest
 
 from copy import copy, deepcopy
 
-from cfme.utils import error
+from cfme import test_requirements
 from cfme.base.credential import Credential
 from cfme.common.provider_views import (InfraProviderAddView,
                                         InfraProvidersView,
@@ -14,10 +14,11 @@ from cfme.common.provider_views import (InfraProviderAddView,
 from cfme.infrastructure.provider import discover, wait_for_a_provider, InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider, RHEVMEndpoint
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider, VirtualCenterEndpoint
+from cfme.utils import error
 from cfme.utils import testgen, version
-from cfme.utils.update import update
 from cfme.utils.blockers import BZ
-from cfme import test_requirements
+from cfme.utils.rest import delete_resources_from_collection
+from cfme.utils.update import update
 
 pytest_generate_tests = testgen.generate([InfraProvider], scope="function")
 
@@ -311,26 +312,20 @@ class TestProvidersRESTAPI(object):
                 entity.action.delete.DELETE()
             assert appliance.rest_api.response.status_code == 404
 
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     @pytest.mark.tier(3)
     @test_requirements.rest
-    def test_delete_custom_attributes_from_collection(self, appliance, custom_attributes):
+    def test_delete_custom_attributes_from_collection(self, custom_attributes):
         """Test deleting custom attributes from collection using REST API.
 
         Metadata:
             test_flag: rest
         """
         attributes, provider = custom_attributes
-        provider.custom_attributes.action.delete(*attributes)
-        assert appliance.rest_api.response.status_code == 200
-        with error.expected('ActiveRecord::RecordNotFound'):
-            provider.custom_attributes.action.delete(*attributes)
-        assert appliance.rest_api.response.status_code == 404
+        delete_resources_from_collection(provider.custom_attributes, attributes, not_found=True)
 
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     @pytest.mark.tier(3)
     @test_requirements.rest
-    def test_delete_single_custom_attribute_from_collection(self, appliance, custom_attributes):
+    def test_delete_single_custom_attribute_from_collection(self, custom_attributes):
         """Test deleting single custom attribute from collection using REST API.
 
         Metadata:
@@ -338,11 +333,7 @@ class TestProvidersRESTAPI(object):
         """
         attributes, provider = custom_attributes
         attribute = attributes[0]
-        provider.custom_attributes.action.delete(attribute)
-        assert appliance.rest_api.response.status_code == 200
-        with error.expected('ActiveRecord::RecordNotFound'):
-            provider.custom_attributes.action.delete(attribute)
-        assert appliance.rest_api.response.status_code == 404
+        delete_resources_from_collection(provider.custom_attributes, [attribute], not_found=True)
 
     @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     @pytest.mark.tier(3)

--- a/cfme/tests/infrastructure/test_rest_templates.py
+++ b/cfme/tests/infrastructure/test_rest_templates.py
@@ -6,6 +6,7 @@ from cfme.rest.gen_data import a_provider as _a_provider
 from cfme.rest.gen_data import mark_vm_as_template
 from cfme.rest.gen_data import vm as _vm
 from cfme.utils import error
+from cfme.utils.rest import delete_resources_from_collection
 from cfme.utils.version import current_version
 
 pytestmark = [test_requirements.rest]
@@ -99,8 +100,5 @@ def test_delete_template_from_collection(appliance, template):
     Metadata:
         test_flag: rest
     """
-    appliance.rest_api.collections.templates.action.delete(template)
-    assert appliance.rest_api.response.status_code == 200
-    with error.expected("ActiveRecord::RecordNotFound"):
-        appliance.rest_api.collections.templates.action.delete(template)
-    assert appliance.rest_api.response.status_code == 404
+    collection = appliance.rest_api.collections.templates
+    delete_resources_from_collection(collection, [template])

--- a/cfme/tests/infrastructure/test_vm_rest.py
+++ b/cfme/tests/infrastructure/test_vm_rest.py
@@ -6,7 +6,7 @@ from cfme import test_requirements
 from cfme.rest.gen_data import a_provider as _a_provider
 from cfme.rest.gen_data import vm as _vm
 from cfme.utils import error
-from cfme.utils.rest import assert_response
+from cfme.utils.rest import assert_response, delete_resources_from_collection
 from cfme.utils.wait import wait_for
 
 
@@ -75,9 +75,4 @@ def test_delete_vm_from_detail(vm_name, appliance, method):
 def test_delete_vm_from_collection(vm_name, appliance):
     vm = appliance.rest_api.collections.vms.get(name=vm_name)
     collection = appliance.rest_api.collections.vms
-    collection.action.delete(vm)
-    assert_response(appliance)
-    wait_for(lambda: not collection.find_by(name=vm_name), num_sec=300, delay=10)
-    with error.expected('ActiveRecord::RecordNotFound'):
-        collection.action.delete(vm)
-    assert_response(appliance, http_status=404)
+    delete_resources_from_collection(collection, [vm], not_found=True, num_sec=300, delay=10)

--- a/cfme/tests/intelligence/test_chargeback.py
+++ b/cfme/tests/intelligence/test_chargeback.py
@@ -9,6 +9,7 @@ from cfme import test_requirements
 from cfme.rest.gen_data import rates as _rates
 from cfme.utils import error
 from cfme.utils.blockers import BZ
+from cfme.utils.rest import delete_resources_from_collection
 from cfme.utils.update import update
 from cfme.utils.wait import wait_for
 
@@ -185,8 +186,5 @@ class TestRatesViaREST(object):
         Metadata:
             test_flag: rest
         """
-        appliance.rest_api.collections.rates.action.delete(*rates)
-        assert appliance.rest_api.response.status_code == 200
-        with error.expected("ActiveRecord::RecordNotFound"):
-            appliance.rest_api.collections.rates.action.delete(*rates)
-        assert appliance.rest_api.response.status_code == 404
+        collection = appliance.rest_api.collections.rates
+        delete_resources_from_collection(collection, rates)

--- a/cfme/tests/services/test_generic_service_catalogs.py
+++ b/cfme/tests/services/test_generic_service_catalogs.py
@@ -2,15 +2,16 @@
 import fauxfactory
 import pytest
 
+from cfme import test_requirements
 from cfme.automate.service_dialogs import DialogCollection
 from cfme.rest.gen_data import service_catalogs as _service_catalogs
+from cfme.services.catalogs.catalog_item import CatalogBundle
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.service_catalogs import ServiceCatalogs
-from cfme.services.catalogs.catalog_item import CatalogBundle
-from cfme import test_requirements
-from selenium.common.exceptions import NoSuchElementException
 from cfme.utils import error
 from cfme.utils.log import logger
+from cfme.utils.rest import delete_resources_from_collection
+from selenium.common.exceptions import NoSuchElementException
 
 
 pytestmark = [
@@ -143,11 +144,8 @@ class TestServiceCatalogViaREST(object):
         Metadata:
             test_flag: rest
         """
-        appliance.rest_api.collections.service_catalogs.action.delete(*service_catalogs)
-        assert appliance.rest_api.response.status_code == 200
-        with error.expected("ActiveRecord::RecordNotFound"):
-            appliance.rest_api.collections.service_catalogs.action.delete(*service_catalogs)
-        assert appliance.rest_api.response.status_code == 404
+        collection = appliance.rest_api.collections.service_catalogs
+        delete_resources_from_collection(collection, service_catalogs)
 
     def test_edit_service_catalog(self, appliance, service_catalogs):
         """Tests editing a service catalog via rest.

--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -16,7 +16,7 @@ from cfme.rest.gen_data import vm as _vm
 from cfme.utils import error
 from cfme.utils.blockers import BZ
 from cfme.utils.providers import ProviderFilter
-from cfme.utils.rest import assert_response
+from cfme.utils.rest import assert_response, delete_resources_from_collection
 from cfme.utils.version import current_version
 from cfme.utils.wait import wait_for, wait_for_decorator
 from fixtures.provider import setup_one_or_skip
@@ -905,9 +905,4 @@ class TestNotificationsRESTAPI(object):
         collection = appliance.rest_api.collections.notifications
         collection.reload()
         notifications = [collection[-i] for i in range(1, 3)]
-
-        collection.action.delete(*notifications)
-        assert_response(appliance)
-        with error.expected("ActiveRecord::RecordNotFound"):
-            collection.action.delete(*notifications)
-        assert_response(appliance, http_status=404)
+        delete_resources_from_collection(collection, notifications)


### PR DESCRIPTION
{{pytest: -v --long-running -k '_delete_ and _from_collection and not TestReposRESTAPI and not TestAuthenticationsRESTAPI' --use-provider vsphere65-nested}}