### PR TITLE
[SHELVED] Some funky collections manangling

### DIFF
--- a/fixtures/parallelizer/remote.py
+++ b/fixtures/parallelizer/remote.py
@@ -1,4 +1,5 @@
 import signal
+import collections
 
 import zmq
 from py.path import local
@@ -56,7 +57,12 @@ class SlaveManager(object):
         self.session = session
         self.collection = {item.nodeid: item for item in session.items}
         terminalreporter.disable()
-        self.send_event("collectionfinish", node_ids=self.collection.keys())
+        to_remove = self.send_event("collectionfinish", node_ids=self.collection.keys())
+
+        # If we have tests that we shouldn't, we just log out and warn people
+        if isinstance(to_remove, collections.Iterable) and not isinstance(to_remove, str):
+            for item in to_remove:
+                self.log.warning("Test [{}] ignored, not on master collection".format(item))
 
     def pytest_runtest_logstart(self, nodeid, location):
         """pytest runtest logstart hook


### PR DESCRIPTION
Diff errors were plaguing us so now:
* If the slave detects a test that master doesn't have, it ignores it
* If master detects that it has a test that a slave doesn't it ignores
  it too.

Play fair!

This was tested with the following test file using --appliance twice, with a 58 and 59. Nothing broke, and nothing should break.

```python
import pytest
from cfme.utils.appliance import current_appliance
from cfme.utils import conf

def test_something():
    pass


@pytest.mark.uncollectif(current_appliance.version < '5.9')
def test_on_59():
    pass


@pytest.mark.uncollectif(current_appliance.version >= '5.9')
def test_on_58():
    pass


@pytest.mark.uncollectif(conf.runtime['env']['slaveid'] == None)
def test_on_slave():
    pass


@pytest.mark.uncollectif(conf.runtime['env']['slaveid'] is not None)
def test_on_master():
    pass
```