### PR TITLE
[1LP][RFR] fix cluster id type

### DIFF
--- a/cfme/infrastructure/cluster.py
+++ b/cfme/infrastructure/cluster.py
@@ -142,7 +142,7 @@ class Cluster(Pretty, BaseEntity, WidgetasticTaggable):
     def __attrs_post_init__(self):
         col = self.appliance.rest_api.collections
         self._id = [
-            cl.id
+            int(cl.id)
             for cl in col.clusters
             if cl.name in (self.short_name, self.name) and cl.ems_id == self.provider.id
         ][-1]


### PR DESCRIPTION
cluster_id obtained thru rest has unicode type since 5.9. It had int before.

{{pytest: --use-provider=vsphere6-nested cfme/tests/infrastructure/test_timelines.py}}