### PR TITLE
[RFR] Fixing creation of provider via REST for CFME < 5.8

### DIFF
--- a/cfme/tests/cloud_infra_common/test_rest_providers.py
+++ b/cfme/tests/cloud_infra_common/test_rest_providers.py
@@ -92,7 +92,7 @@ def provider_rest(request, appliance, provider):
         pytest.skip("No credentials info found for provider {}.".format(provider.name))
 
     cert = getattr(endpoint_default, "ca_certs", None)
-    if cert:
+    if cert and appliance.version >= '5.8':
         default_connection["endpoint"]["certificate_authority"] = cert
         con_config_to_include.append(default_connection)
 


### PR DESCRIPTION
__Fixing__ provider creating via REST. I found out that REST API in 5.7 does not accept certificate_authority.

`APIException: Api::BadRequestError: Could not create the new provider - unknown attribute 'certificate_authority' for Endpoint`

{{pytest: cfme/tests/cloud_infra_common/test_rest_providers.py -v --use-provider rhv41}}