### PR TITLE
[RFR] workaround for policy profiles view in 5.9

### DIFF
--- a/cfme/control/explorer/policy_profiles.py
+++ b/cfme/control/explorer/policy_profiles.py
@@ -66,9 +66,11 @@ class PolicyProfilesAllView(ControlExplorerView):
 
     @property
     def is_displayed(self):
+
         return (
             self.in_control_explorer and
-            self.title.text == "All Policy Profiles"
+            # BZ(1516302)
+            'All Policy Profile' in self.title.text
         )
 
 


### PR DESCRIPTION
{{pytest: --use-provider=scvmm --long-running cfme/tests/cloud_infra_common/test_events.py}}