### PR TITLE
[1LP][RFR] workaround for catalogs view which causes some tests fail

### DIFF
--- a/cfme/services/catalogs/__init__.py
+++ b/cfme/services/catalogs/__init__.py
@@ -44,7 +44,7 @@ class ServicesCatalogView(BaseLoggedInPage):
         tree = ManageIQTree()
 
     @View.nested
-    class toolbar(View):
+    class toolbar(View):  # noqa
         configuration = Dropdown('Configuration')
         policy = Dropdown('Policy')
 

--- a/cfme/services/catalogs/__init__.py
+++ b/cfme/services/catalogs/__init__.py
@@ -50,8 +50,13 @@ class ServicesCatalogView(BaseLoggedInPage):
 
     # for backward compatibility. it is difficult to figure out where those are used
     # TODO: this should be fixed by this code owner
-    configuration = toolbar.configuration
-    policy = toolbar.policy
+    @property
+    def configuration(self):
+        return self.toolbar.configuration
+
+    @property
+    def policy(self):
+        return self.toolbar.policy
 
     flash = FlashMessages(".//div[@id='flash_msg_div']/div")
 

--- a/cfme/services/catalogs/__init__.py
+++ b/cfme/services/catalogs/__init__.py
@@ -18,7 +18,8 @@ class ServicesCatalogView(BaseLoggedInPage):
 
     @property
     def is_displayed(self):
-        return self.in_explorer and self.configuration.is_displayed and not self.catalogs.is_dimmed
+        return (self.in_explorer and self.toolbar.configuration.is_displayed and
+                not self.catalogs.is_dimmed)
 
     @View.nested
     class service_catalogs(Accordion):  # noqa
@@ -42,8 +43,16 @@ class ServicesCatalogView(BaseLoggedInPage):
     class catalogs(Accordion):  # noqa
         tree = ManageIQTree()
 
-    configuration = Dropdown('Configuration')
-    policy = Dropdown('Policy')
+    @View.nested
+    class toolbar(View):
+        configuration = Dropdown('Configuration')
+        policy = Dropdown('Policy')
+
+    # for backward compatibility. it is difficult to figure out where those are used
+    # TODO: this should be fixed by this code owner
+    configuration = toolbar.configuration
+    policy = toolbar.policy
+
     flash = FlashMessages(".//div[@id='flash_msg_div']/div")
 
 

--- a/cfme/services/catalogs/orchestration_template.py
+++ b/cfme/services/catalogs/orchestration_template.py
@@ -244,7 +244,8 @@ class AddDialog(CFMENavigateStep):
     VIEW = AddDialogView
 
     def step(self):
-        self.view.toolbar.configuration.item_select('Create Service Dialog from Orchestration Template')
+        item_name = 'Create Service Dialog from Orchestration Template'
+        self.view.toolbar.configuration.item_select(item_name)
 
 
 @navigator.register(OrchestrationTemplate, 'Edit')

--- a/cfme/services/catalogs/orchestration_template.py
+++ b/cfme/services/catalogs/orchestration_template.py
@@ -169,7 +169,7 @@ class OrchestrationTemplate(Updateable, Pretty, Navigatable, WidgetasticTaggable
         msg = "Remove this Orchestration Template"
         if self.appliance.version >= '5.9':
             msg = '{} from Inventory'.format(msg)
-        view.configuration.item_select(msg, handle_alert=True)
+        view.toolbar.configuration.item_select(msg, handle_alert=True)
         view.flash.assert_success_message('Orchestration Template "{}" was deleted.'.format(
             self.template_name))
 
@@ -244,7 +244,7 @@ class AddDialog(CFMENavigateStep):
     VIEW = AddDialogView
 
     def step(self):
-        self.view.configuration.item_select('Create Service Dialog from Orchestration Template')
+        self.view.toolbar.configuration.item_select('Create Service Dialog from Orchestration Template')
 
 
 @navigator.register(OrchestrationTemplate, 'Edit')
@@ -254,7 +254,7 @@ class EditTemplate(CFMENavigateStep):
     VIEW = EditTemplateView
 
     def step(self):
-        self.view.configuration.item_select("Edit this Orchestration Template")
+        self.view.toolbar.configuration.item_select("Edit this Orchestration Template")
 
 
 @navigator.register(OrchestrationTemplate, 'AddTemplate')
@@ -264,7 +264,7 @@ class AddTemplate(CFMENavigateStep):
     VIEW = AddTemplateView
 
     def step(self):
-        self.view.configuration.item_select("Create new Orchestration Template")
+        self.view.toolbar.configuration.item_select("Create new Orchestration Template")
 
 
 @navigator.register(OrchestrationTemplate, 'CopyTemplate')
@@ -274,4 +274,4 @@ class CopyTemplate(CFMENavigateStep):
     VIEW = CopyTemplateView
 
     def step(self):
-        self.view.configuration.item_select("Copy this Orchestration Template")
+        self.view.toolbar.configuration.item_select("Copy this Orchestration Template")


### PR DESCRIPTION
Fix for test errors like:
```
    def step(self):
>       self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
E       AttributeError: 'DetailsTemplateView' object has no attribute 'toolbar'
```
{{pytest: --long-running cfme/tests/services/test_orchestration_template.py}}