### PR TITLE
[RFR] fixed test alerts -> it passed provider key instead of object

### DIFF
--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -117,11 +117,11 @@ def vddk_url(provider):
 @pytest.yield_fixture(scope="function")
 def configure_fleecing(appliance, provider, vm, vddk_url):
     host = vm.get_detail(properties=("Relationships", "Host"))
-    setup_host_creds(provider.key, host)
+    setup_host_creds(provider, host)
     appliance.install_vddk(vddk_url=vddk_url)
     yield
     appliance.uninstall_vddk()
-    setup_host_creds(provider.key, host, remove_creds=True)
+    setup_host_creds(provider, host, remove_creds=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
Fix for test_alerts
```
>       setup_host_creds(provider.key, host)

cfme/tests/control/test_alerts.py:120: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

provider = 'vsphere65-nested'
host_name = 'env-nvc65-h03.cfme2.lab.eng.rdu2.******.com', remove_creds = False
ignore_errors = False

    def setup_host_creds(provider, host_name, remove_creds=False, ignore_errors=False):
        try:
>           appliance = provider.appliance
E           AttributeError: 'str' object has no attribute 'appliance'

cfme/utils/hosts.py:23: AttributeError
```

{{pytest: --long-running cfme/tests/control/test_alerts.py}}