### PR TITLE
[1LP][RFR] Wrapping retirements tests with BZ

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -567,12 +567,11 @@ def date_retire_element(fill_data):
 class VM(BaseVM):
     TO_RETIRE = None
 
+    retire_form_click_away = "//label[contains(normalize-space(.), 'Retirement Date')]"
     retire_form = Form(fields=[
         ('date_retire',
-            AngularCalendarInput(version.pick(
-                {"5.9": "retirement_date_datepicker",
-                version.LOWEST: "retirement_date"}),
-                "//label[contains(normalize-space(.), 'Retirement Date')]")),
+            {version.LOWEST: AngularCalendarInput("retirement_date", retire_form_click_away),
+             '5.9': AngularCalendarInput("retirement_date_datepicker", retire_form_click_away)}),
         ('warn', AngularSelect('retirementWarning'))
     ])
 

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -143,7 +143,8 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, WidgetasticTaggable,
                      '5.6.2.2': 'Remove from the VMDB',
                      '5.7': 'Remove Virtual Machine'}
     RETIRE_DATE_FMT = {version.LOWEST: parsetime.american_date_only_format,
-                       '5.7': parsetime.american_minutes_with_utc}
+                       '5.7': parsetime.american_minutes_with_utc,
+                       '5.9': parsetime.saved_report_title_format}
     _param_name = ParamClassName('name')
 
     ###

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -568,8 +568,10 @@ class VM(BaseVM):
 
     retire_form = Form(fields=[
         ('date_retire',
-            AngularCalendarInput("retirement_date_datepicker",
-                                 "//label[contains(normalize-space(.), 'Retirement Date')]")),
+            AngularCalendarInput(version.pick(
+                {"5.9": "retirement_date_datepicker",
+                version.LOWEST: "retirement_date"}),
+                "//label[contains(normalize-space(.), 'Retirement Date')]")),
         ('warn', AngularSelect('retirementWarning'))
     ])
 

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -568,7 +568,7 @@ class VM(BaseVM):
 
     retire_form = Form(fields=[
         ('date_retire',
-            AngularCalendarInput("retirement_date",
+            AngularCalendarInput("retirement_date_datepicker",
                                  "//label[contains(normalize-space(.), 'Retirement Date')]")),
         ('warn', AngularSelect('retirementWarning'))
     ])

--- a/cfme/tests/cloud_infra_common/test_retirement.py
+++ b/cfme/tests/cloud_infra_common/test_retirement.py
@@ -191,7 +191,7 @@ def test_retirement_now_ec2_instance_backed(retire_ec2_s3_vm, tagged):
 
 @test_requirements.retirement
 @pytest.mark.tier(1)
-@pytest.mark.meta(blockers=[BZ(1516953, forced_streams='5.9')])
+@pytest.mark.meta(blockers=[BZ(1516953, forced_streams=['5.9'])])
 @pytest.mark.parametrize('warn', warnings, ids=[warning.id for warning in warnings])
 def test_set_retirement_date(retire_vm, warn):
     """Tests setting retirement date and verifies configured date is reflected in UI
@@ -206,7 +206,7 @@ def test_set_retirement_date(retire_vm, warn):
 
 @test_requirements.retirement
 @pytest.mark.tier(1)
-@pytest.mark.meta(blockers=[BZ(1516953, forced_streams='5.9')])
+@pytest.mark.meta(blockers=[BZ(1516953, forced_streams=['5.9'])])
 def test_unset_retirement_date(retire_vm):
     """Tests cancelling a scheduled retirement by removing the set date
     """
@@ -225,7 +225,7 @@ def test_unset_retirement_date(retire_vm):
 
 @test_requirements.retirement
 @pytest.mark.tier(2)
-@pytest.mark.meta(blockers=[BZ(1516953, forced_streams='5.9'),
+@pytest.mark.meta(blockers=[BZ(1516953, forced_streams=['5.9']),
                             BZ(1430373, forced_streams=['5.6'],
                                unblock=lambda provider: provider.one_of(InfraProvider))])
 @pytest.mark.parametrize('remove_date', [True, False], ids=['remove_date', 'set_future_date'])

--- a/cfme/tests/cloud_infra_common/test_retirement.py
+++ b/cfme/tests/cloud_infra_common/test_retirement.py
@@ -16,7 +16,7 @@ from cfme.utils.log import logger
 from cfme.utils.providers import ProviderFilter
 from cfme.utils.timeutil import parsetime
 from cfme.utils.wait import wait_for
-from cfme.utils.version import pick, current_version
+from cfme.utils.version import pick
 
 
 pytest_generate_tests = testgen.generate(
@@ -104,6 +104,8 @@ def verify_retirement_date(retire_vm, expected_date='Never'):
         # convert to a parsetime object for comparsion, function depends on version
         if 'UTC' in pick(VM.RETIRE_DATE_FMT):
             convert_func = parsetime.from_american_minutes_with_utc
+        elif pick(VM.RETIRE_DATE_FMT).endswith('+0000'):
+            convert_func = parsetime.from_saved_report_title_format
         else:
             convert_func = parsetime.from_american_date_only
         expected_date.update({'retire': convert_func(retire_vm.retirement_date)})

--- a/cfme/tests/cloud_infra_common/test_retirement.py
+++ b/cfme/tests/cloud_infra_common/test_retirement.py
@@ -223,7 +223,7 @@ def test_unset_retirement_date(retire_vm):
 
 @test_requirements.retirement
 @pytest.mark.tier(2)
-@pytest.mark.meta(blockers=[BZ(1306471, unblock=lambda provider: provider.one_of(InfraProvider)),
+@pytest.mark.meta(blockers=[BZ(1516953, forced_streams='5.9'),
                             BZ(1430373, forced_streams=['5.6'],
                                unblock=lambda provider: provider.one_of(InfraProvider))])
 @pytest.mark.parametrize('remove_date', [True, False], ids=['remove_date', 'set_future_date'])

--- a/cfme/tests/cloud_infra_common/test_retirement.py
+++ b/cfme/tests/cloud_infra_common/test_retirement.py
@@ -189,8 +189,7 @@ def test_retirement_now_ec2_instance_backed(retire_ec2_s3_vm, tagged):
 
 @test_requirements.retirement
 @pytest.mark.tier(1)
-@pytest.mark.meta(blockers=[BZ(1419150, forced_streams='5.6',
-                               unblock=lambda: current_version() >= '5.7')])
+@pytest.mark.meta(blockers=[BZ(1516953, forced_streams='5.9')])
 @pytest.mark.parametrize('warn', warnings, ids=[warning.id for warning in warnings])
 def test_set_retirement_date(retire_vm, warn):
     """Tests setting retirement date and verifies configured date is reflected in UI
@@ -205,6 +204,7 @@ def test_set_retirement_date(retire_vm, warn):
 
 @test_requirements.retirement
 @pytest.mark.tier(1)
+@pytest.mark.meta(blockers=[BZ(1516953, forced_streams='5.9')])
 def test_unset_retirement_date(retire_vm):
     """Tests cancelling a scheduled retirement by removing the set date
     """


### PR DESCRIPTION
__Wrapping__ tests that set retirement date with BZ, since remove retirement date button (used to be red X) is missing in the page. Also input_name was changed for retirement date field.

{{pytest: cfme/tests/cloud_infra_common/test_retirement.py -vv --use-provider rhv41}}
