### PR TITLE
[1LP][RFR] Replace NavigateToObject with NavigateToAttribute; minor lint

### DIFF
--- a/cfme/base/__init__.py
+++ b/cfme/base/__init__.py
@@ -4,7 +4,6 @@ import importscan
 import sentaku
 
 from cfme.modeling.base import BaseCollection, BaseEntity
-from cfme.utils.appliance import Navigatable
 from cfme.utils.pretty import Pretty
 
 
@@ -49,6 +48,7 @@ class ServerCollection(BaseCollection, sentaku.modeling.ElementMixin):
 
     all = sentaku.ContextualMethod()
     get_master = sentaku.ContextualMethod()
+
 
 @attr.s
 class Zone(Pretty, BaseEntity, sentaku.modeling.ElementMixin):

--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -5,8 +5,7 @@ from selenium.webdriver.common.keys import Keys
 import re
 from navmazing import NavigateToSibling, NavigateToAttribute
 
-from widgetastic_manageiq import (ManageIQTree, Checkbox, AttributeValueForm, SummaryFormItem,
-                                  TimelinesView)
+from widgetastic_manageiq import (ManageIQTree, Checkbox, AttributeValueForm, TimelinesView)
 from widgetastic_patternfly import (Accordion, Input, Button, Dropdown,
     FlashMessages, BootstrapSelect, Tab)
 from widgetastic.utils import Version, VersionPick
@@ -31,6 +30,7 @@ from cfme.utils.log import logger
 
 from cfme.exceptions import BugException
 from cfme.utils.blockers import BZ
+
 
 @Server.address.external_implementation_for(ViaUI)
 def address(self):

--- a/cfme/configure/configuration/analysis_profile.py
+++ b/cfme/configure/configuration/analysis_profile.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from copy import deepcopy
 
-from navmazing import NavigateToSibling, NavigateToObject, NavigationDestinationNotFound
+from navmazing import NavigateToSibling, NavigateToAttribute, NavigationDestinationNotFound
 from widgetastic.widget import View, Text, ConditionalSwitchableView
 from widgetastic.utils import Fillable
 from widgetastic_patternfly import Dropdown, Button, CandidateNotFound, TextInput, Tab
@@ -388,7 +388,7 @@ class AnalysisProfile(Pretty, Updateable, Fillable, Navigatable):
 @navigator.register(AnalysisProfile, 'All')
 class AnalysisProfileAll(CFMENavigateStep):
     VIEW = AnalysisProfileAllView
-    prerequisite = NavigateToObject(Server, 'Configuration')
+    prerequisite = NavigateToAttribute('appliance.server', 'Configuration')
 
     def step(self):
         server_region = self.obj.appliance.server_region_string()

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -4,7 +4,7 @@ from widgetastic.utils import Fillable
 
 from cached_property import cached_property
 from cfme.exceptions import DestinationNotFound
-from navmazing import NavigateToSibling, NavigateToObject
+from navmazing import NavigateToSibling, NavigateToAttribute
 from widgetastic_manageiq import BreadCrumb, BaseEntitiesView, View
 
 from cfme.base.ui import Server
@@ -205,7 +205,7 @@ class InfraProvider(Pretty, CloudInfraProvider, Fillable):
 @navigator.register(InfraProvider, 'All')
 class All(CFMENavigateStep):
     VIEW = InfraProvidersView
-    prerequisite = NavigateToObject(Server, 'LoggedIn')
+    prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
 
     def step(self):
         self.prerequisite_view.navigation.select('Compute', 'Infrastructure', 'Providers')

--- a/cfme/physical/provider/__init__.py
+++ b/cfme/physical/provider/__init__.py
@@ -1,6 +1,6 @@
 from widgetastic.utils import Fillable
 
-from navmazing import NavigateToObject
+from navmazing import NavigateToAttribute
 
 from cfme.base.ui import BaseLoggedInPage
 from cfme.utils.pretty import Pretty
@@ -43,7 +43,7 @@ class PhysicalProvider(Pretty, BaseProvider, Fillable):
 class All(CFMENavigateStep):
     # This view will need to be created
     VIEW = BaseLoggedInPage
-    prerequisite = NavigateToObject(Server, 'LoggedIn')
+    prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
 
     def step(self):
         self.prerequisite_view.navigation.select('Compute', 'Physical Infrastructure', 'Providers')


### PR DESCRIPTION
This issue is currently blocking master ^

As long as there is no `AttributeError: 'property' object has no attribute 'server'` on PRT, we are good.

{{pytest: cfme/tests/infrastructure/test_providers.py -k test_provider_add_with_bad_credentials --use-provider vsphere6-nested}}