### PR TITLE
[WIP] adding Physical Server API tests

### DIFF
--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -422,6 +422,18 @@ class PhysicalProvidersView(ProvidersView):
                 self.entities.title.text == 'Physical Infrastructure Providers')
 
 
+class PhysicalProvidersView(ProvidersView):
+    """
+     represents Main view displaying all Infra providers
+    """
+    @property
+    def is_displayed(self):
+        return (super(PhysicalProvidersView, self).is_displayed and
+                self.navigation.currently_selected == [
+                    'Compute', 'Physical Infrastructure', 'Providers'] and
+                self.entities.title.text == 'Physical Infrastructure Providers')
+
+
 class BeforeFillMixin(object):
     """
      this mixin is used to activate appropriate tab before filling this tab
@@ -541,6 +553,19 @@ class ContainerProviderAddViewUpdated(ContainerProviderAddView, ContainerProvide
 class PhysicalProviderAddView(ProviderAddView):
     """
      represents Provider Add View
+    """
+
+    @property
+    def is_displayed(self):
+        return (super(PhysicalProviderAddView, self).is_displayed and
+                self.navigation.currently_selected == [
+                    'Compute', 'Physical Infrastructure', 'Providers'] and
+                self.title.text == 'Add New Ems Physical Infra')
+
+
+class PhysicalProviderAddView(ProviderAddView):
+    """
+     represents Middleware Provider Add View
     """
 
     @property

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -178,6 +178,25 @@ class PhysicalProviderDetailsView(ProviderDetailsView):
                                                        'Providers'])
 
 
+class ContainerProviderDetailsView(ProviderDetailsView):
+    """
+     Container Details page
+    """
+    @property
+    def is_displayed(self):
+        return (super(ContainerProviderDetailsView, self).is_displayed and
+                self.navigation.currently_selected == ['Compute', 'Containers', 'Providers'])
+
+class PhysicalProviderDetailsView(ProviderDetailsView):
+    """
+     Physical  Details page
+    """
+    @property
+    def is_displayed(self):
+        return (super(PhysicalProviderDetailsView, self).is_displayed and
+                self.navigation.currently_selected ==
+                ['Compute', 'Physical Infrastructure', 'Providers'])
+
 class ProviderTimelinesView(TimelinesView, BaseLoggedInPage):
     """
      represents Timelines page

--- a/cfme/physical/physical_server.py
+++ b/cfme/physical/physical_server.py
@@ -277,8 +277,7 @@ class PhysicalServerCollection(BaseCollection):
         view = self.select_entity_rows(physical_servers)
         view.toolbar.power.item_select("Power Off", handle_alert=True)
 
-
-@navigator.register(PhysicalServerCollection, 'All')
+@navigator.register(PhysicalServerCollection)
 class All(CFMENavigateStep):
     VIEW = PhysicalServersView
     prerequisite = NavigateToAttribute("appliance.server", "LoggedIn")

--- a/cfme/physical/physical_server.py
+++ b/cfme/physical/physical_server.py
@@ -278,7 +278,7 @@ class PhysicalServerCollection(BaseCollection):
         view.toolbar.power.item_select("Power Off", handle_alert=True)
 
 
-@navigator.register(PhysicalServerCollection)
+@navigator.register(PhysicalServerCollection, 'All')
 class All(CFMENavigateStep):
     VIEW = PhysicalServersView
     prerequisite = NavigateToAttribute("appliance.server", "LoggedIn")

--- a/cfme/physical/provider/__init__.py
+++ b/cfme/physical/provider/__init__.py
@@ -88,6 +88,21 @@ class All(CFMENavigateStep):
         # Reset view and selection
         pass
 
+@navigator.register(PhysicalProvider, 'Details')
+class Details(CFMENavigateStep):
+    VIEW = PhysicalProviderDetailsView
+    prerequisite = NavigateToSibling('All')
+
+    def step(self):
+        self.prerequisite_view.entities.get_entity(by_name=self.obj.name, surf_pages=True).click()
+
+    def resetter(self):
+        # Reset view and selection
+        if version.current_version() >= '5.7':  # no view selector in 5.6
+            view_selector = self.view.toolbar.view_selector
+            if view_selector.selected != 'Summary View':
+                view_selector.select('Summary View')
+
 
 @navigator.register(PhysicalProvider, 'Details')
 class Details(CFMENavigateStep):

--- a/cfme/physical/provider/__init__.py
+++ b/cfme/physical/provider/__init__.py
@@ -88,6 +88,7 @@ class All(CFMENavigateStep):
         # Reset view and selection
         pass
 
+
 @navigator.register(PhysicalProvider, 'Details')
 class Details(CFMENavigateStep):
     VIEW = PhysicalProviderDetailsView
@@ -98,10 +99,16 @@ class Details(CFMENavigateStep):
 
     def resetter(self):
         # Reset view and selection
-        if version.current_version() >= '5.7':  # no view selector in 5.6
-            view_selector = self.view.toolbar.view_selector
-            if view_selector.selected != 'Summary View':
-                view_selector.select('Summary View')
+        pass
+
+
+@navigator.register(PhysicalProvider, 'Edit')
+class Edit(CFMENavigateStep):
+    VIEW = PhysicalProviderEditView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        self.prerequisite_view.toolbar.configuration.item_select('Edit this Infrastructure Provider')
 
 
 @navigator.register(PhysicalProvider, 'Details')

--- a/cfme/tests/physical_infrastructure/test_physical_server.py
+++ b/cfme/tests/physical_infrastructure/test_physical_server.py
@@ -20,7 +20,6 @@ def test_physical_servers_view_displayed(physical_server_collection):
     physical_servers_view = navigate_to(physical_server_collection, 'All')
     assert physical_servers_view.is_displayed
 
-
 def test_physical_servers_view_dropdowns(physical_server_collection):
     """Navigate to the physical servers page and verify that the dropdown menus are present"""
     physical_servers_view = navigate_to(physical_server_collection, 'All')

--- a/cfme/tests/physical_infrastructure/test_physical_server.py
+++ b/cfme/tests/physical_infrastructure/test_physical_server.py
@@ -3,9 +3,11 @@ import pytest
 
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.physical.provider.lenovo import LenovoProvider
+from cfme import test_requirements
 
 pytestmark = [pytest.mark.tier(3), pytest.mark.provider([LenovoProvider], scope="module")]
 
+pytest_generate_tests = testgen.generate([LenovoProvider], scope="module")
 
 @pytest.fixture(scope="module")
 def physical_server_collection(appliance, provider, setup_provider_modscope):

--- a/cfme/tests/physical_infrastructure/test_physical_server_api.py
+++ b/cfme/tests/physical_infrastructure/test_physical_server_api.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from cfme.utils import testgen
+from cfme.physical.provider.lenovo import LenovoProvider
+from cfme.utils.wait import wait_for
+from cfme.utils.log import logger
+
+pytestmark = [pytest.mark.tier(3)]
+
+pytest_generate_tests = testgen.generate([LenovoProvider], scope="module")
+
+"""
+The max time that a single test has to perform the entire cycle of action
+"""
+TIMEOUT = 10000 # in seconds
+"""
+The time interval to perform a verification of state change
+"""
+DELAY = 10 # in seconds
+
+@pytest.yield_fixture(scope="module")
+def physical_server(provider, appliance):
+    if not provider.exists:
+        provider.create_rest()
+        provider.refresh_provider_relationships
+        physical_server = appliance.rest_api.collections.physical_servers[0]
+    yield physical_server
+
+
+def do_post_physical_server(params, appliance, physical_server):
+    """
+    Do post againist a single physical server
+    """
+    appliance.rest_api.post(physical_server.href, **params)
+    return appliance.rest_api.response.ok
+
+
+def perform_physical_server_action(action, appliance, physical_server):
+    """
+    Perform an action againist a single physical server
+    """
+    payload = {
+        "action" : action
+    }
+    return do_post_physical_server(payload, appliance, physical_server)
+
+
+def get_server_attr(attr_name, appliance, physical_server):
+    physical_server.reload()
+    return physical_server[attr_name]
+
+
+def wait_for_power_state_change(state, appliance, server):
+    wait_for(
+        lambda: get_server_attr("power_state", appliance, server) == state, num_sec=TIMEOUT, delay=DELAY
+    )
+
+
+def wait_for_loc_led_state_change(state, appliance, server):
+    wait_for(
+        lambda: get_server_attr("location_led_state", appliance, server) == state, num_sec=TIMEOUT, delay=DELAY
+    )
+
+
+def verify_attribute(server, attribute, value):
+    server.reload()
+    return server[attribute] == value
+
+
+def test_refresh_physical_server(appliance, physical_server):
+    assert perform_physical_server_action("refresh", appliance, physical_server)
+
+
+@pytest.mark.parametrize("action, desired_state",[
+    ("power_on", "on"),
+    ("power_off", "off"),
+    ("power_off_now", "off"),
+    ("restart", "on"),
+    ("restart_now", "on"),
+    ("restart_to_sys_setup", "on"),
+    ("restart_mgmt_controller", "on")
+])
+def test_server_actions(physical_server, appliance, action, desired_state):
+    assert perform_physical_server_action(action, appliance, physical_server)
+    wait_for_power_state_change(desired_state, appliance, physical_server)
+    assert verify_attribute(physical_server, "power_state", desired_state)
+
+
+@pytest.mark.parametrize("action, desired_state",[
+    ("blink_loc_led", "Blinking"),
+    ("turn_on_loc_led", "On"),
+    ("turn_off_loc_led", "Off")
+])
+def test_server_led_actions(physical_server, appliance, action, desired_state):
+    assert perform_physical_server_action(action, appliance, physical_server)
+    wait_for_loc_led_state_change(desired_state, appliance, physical_server)
+    assert verify_attribute(physical_server, "location_led_state" ,desired_state)

--- a/conf/cfme_data.yaml.template
+++ b/conf/cfme_data.yaml.template
@@ -166,9 +166,16 @@ management_systems:
     lenovo:
         name: lenovo
         type: lenovo
+        tags:
+            - default
+        excluded_tests_flags: []
+        credentials: lenovo
+        hostname: 10.0.0.1
+        ipaddress: 10.0.0.1
         endpoints:
             default:
                 credentials: lenovo
+                hostname: 10.0.0.1
                 ipaddress: 10.0.0.1
                 api_port: 3000
     nuage:


### PR DESCRIPTION
This PR adds some tests for the Physical Server API actions:
- Power actions:
  -  refresh;
  -  power_on;
  -  power_off;
  -  power_off_now;
  -  restart;
  -  restart_now;
  -  restart_to_sys_setup;
  -  restart_mgmt_controller.
- Led actions:
  -  blink_loc_led;
  -  turn_on_loc_led;
  -  turn_off_loc_led.