### PR TITLE
[1LP][RFR]fix for preemptible checkbox

### DIFF
--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -3,7 +3,7 @@ from lxml.html import document_fromstring
 import os
 from time import sleep
 
-from widgetastic.widget import View, Text, TextInput, Checkbox, ParametrizedView
+from widgetastic.widget import View, Text, TextInput, ParametrizedView
 from widgetastic_patternfly import (
     Dropdown, BootstrapSelect, Tab, FlashMessages, Input, CheckableBootstrapTreeview)
 from widgetastic_manageiq import BreadCrumb, PaginationPane
@@ -12,7 +12,8 @@ from widgetastic_manageiq import BreadCrumb, PaginationPane
 from cfme.base.login import BaseLoggedInPage
 from cfme.exceptions import TemplateNotFound
 from widgetastic_manageiq import (
-    Calendar, SummaryTable, Button, ItemsToolBarViewSelector, Table, MultiBoxSelect, RadioGroup,
+    Calendar, Checkbox, SummaryTable, Button, ItemsToolBarViewSelector, Table, MultiBoxSelect,
+    RadioGroup,
     VersionPick, Version, BaseEntitiesView, NonJSBaseEntity, BaseListEntity, BaseQuadIconEntity,
     BaseTileIconEntity, JSBaseEntity, BaseNonInteractiveEntitiesView)
 
@@ -314,7 +315,7 @@ class BasicProvisionFormView(View):
         hardware_monitoring = BootstrapSelect('hardware__monitoring')
         boot_disk_size = BootstrapSelect('hardware__boot_disk_size')
         # GCE
-        is_preemtible = Input(name='hardware__is_preemptible')
+        is_preemptible = Checkbox(name='hardware__is_preemptible')
 
     @View.nested
     class customize(Tab):  # noqa

--- a/cfme/services/requests.py
+++ b/cfme/services/requests.py
@@ -370,7 +370,7 @@ class RequestDetailsView(RequestsView):
     class properties(Tab):  # noqa
         instance_type = SummaryFormItem('Properties', 'Instance Type')
         boot_disk_size = SummaryFormItem('Properties', 'Boot Disk Size ')
-        is_preemtible = Checkbox(name='hardware__is_preemptible')
+        is_preemptible = Checkbox(name='hardware__is_preemptible')
 
     @View.nested
     class customize(Tab):  # noqa

--- a/cfme/tests/cloud/test_provisioning.py
+++ b/cfme/tests/cloud/test_provisioning.py
@@ -181,7 +181,7 @@ def test_provision_from_template(provider, provisioned_instance):
 
 @pytest.mark.uncollectif(lambda provider: not provider.one_of(GCEProvider) or
                          current_version() < "5.7")
-def test_gce_preemtible_provision(provider, testing_instance, soft_assert):
+def test_gce_preemptible_provision(provider, testing_instance, soft_assert):
     instance, inst_args, image = testing_instance
     instance.create(**inst_args)
     instance.wait_to_appear(timeout=800)


### PR DESCRIPTION
FIxing typo and widget type
{{pytest: --long-running --use-template-cache --use-provider gce_central -k preemptible cfme/tests/cloud/test_provisioning.py}}