### PR TITLE
[1LP][RFR] Updating kickstart file RHEL7

### DIFF
--- a/cfme/tests/infrastructure/test_pxe_provisioning.py
+++ b/cfme/tests/infrastructure/test_pxe_provisioning.py
@@ -9,9 +9,13 @@ from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.infrastructure.pxe import get_pxe_server_from_config, get_template_from_config
 from cfme.provisioning import do_vm_provisioning
 from cfme.utils import testgen
+from cfme.utils.blockers import BZ
 
 pytestmark = [
-    pytest.mark.meta(server_roles="+automate +notifier"),
+    pytest.mark.meta(
+        server_roles="+automate +notifier",
+        blockers=[BZ(1519943, forced_streams=['5.9', 'upstream'])]
+    ),
     pytest.mark.usefixtures('uses_infra_providers'),
     pytest.mark.tier(2)
 ]

--- a/data/rhel7.cfg
+++ b/data/rhel7.cfg
@@ -52,7 +52,7 @@ zerombr
 clearpart --all --initlabel
 # Disk partitioning information
 autopart --fstype=ext4
-bootloader --timeout=3 --extlinux
+bootloader --location=mbr --append="rhgb quiet"
 
 repo --name=rhel-x86_64-server-7 --baseurl=$url1
 repo --name=rhel-x86_64-server-optional-7 --baseurl=$url2
@@ -67,7 +67,9 @@ autofs
 ovirt-guest-agent-common
 %end
 
-%post
+%post --log=/root/kickstart-post.log
+set -x
+
 dhclient
 
 systemctl enable ovirt-guest-agent.service


### PR DESCRIPTION
__Updating configuration__ for RHEL7 kickstart file used in PXE provisioning. 

- Changing bootloader options so that the newly-provisioned VM is able to power on
- Adding logging for post-installation step
- Adding wrapper because of regression in 5.9

{{pytest: cfme/tests/infrastructure/test_pxe_provisioning.py::test_pxe_provision_from_template --use-provider rhv41 -vv}}

As of now, the relevant test is __skipped__ because setup fails on mentioned BZ in 5.9. However I've tested this with manual assistance on my env and it worked as expected. Also the test for CFME 5.8 times out in PRT, but works OK in our env. 