### PR TITLE
[1LP][RFR] Removed testgen from intelligence

### DIFF
--- a/cfme/tests/intelligence/reports/test_canned_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_canned_corresponds.py
@@ -7,16 +7,17 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.net import ip_address, resolve_hostname
 from cfme.utils.providers import get_crud_by_name
-from cfme.utils import testgen
 from cfme import test_requirements
 
 
-pytest_generate_tests = testgen.generate(classes=[InfraProvider], scope='module')
+pytestmark = [
+    pytest.mark.tier(3),
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.provider(classes=[InfraProvider], scope='module'),
+    test_requirements.report,
+]
 
 
-@pytest.mark.tier(3)
-@pytest.mark.usefixtures('setup_provider')
-@test_requirements.report
 def test_providers_summary(soft_assert):
     """Checks some informations about the provider. Does not check memory/frequency as there is
     presence of units and rounding."""
@@ -41,9 +42,6 @@ def test_providers_summary(soft_assert):
                     "Physical CPU count does not match at {}".format(provider["Name"]))
 
 
-@pytest.mark.tier(3)
-@pytest.mark.usefixtures('setup_provider')
-@test_requirements.report
 def test_cluster_relationships(soft_assert):
     path = ["Relationships", "Virtual Machines, Folders, Clusters", "Cluster Relationships"]
     report = CannedSavedReport.new(path)
@@ -86,9 +84,6 @@ def test_cluster_relationships(soft_assert):
             soft_assert(False, "Hostname {} not found in {}".format(host_name, provider_name))
 
 
-@pytest.mark.tier(3)
-@test_requirements.report
-@pytest.mark.usefixtures('setup_provider')
 @pytest.mark.meta(blockers=[BZ(1504010, forced_streams=['5.7', '5.8', 'upstream'])])
 def test_operations_vm_on(soft_assert, appliance):
 
@@ -128,9 +123,6 @@ def test_operations_vm_on(soft_assert, appliance):
                  item['Last Analysis Time'] == ''))
 
 
-@pytest.mark.tier(3)
-@test_requirements.report
-@pytest.mark.usefixtures('setup_provider')
 def test_datastores_summary(soft_assert, appliance):
     """Checks Datastores Summary report with DB data. Checks all data in report, even rounded
     storage sizes."""

--- a/cfme/tests/intelligence/reports/test_generate_report.py
+++ b/cfme/tests/intelligence/reports/test_generate_report.py
@@ -10,15 +10,16 @@ import pytest
 
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.intelligence.reports.reports import CannedSavedReport
-from cfme.utils import testgen
 from cfme import test_requirements
 # from utils.log import logger
 
-pytestmark = [pytest.mark.tier(3),
-              test_requirements.report,
-              pytest.mark.usefixtures('setup_provider')]
 
-pytest_generate_tests = testgen.generate([VMwareProvider], scope='module')
+pytestmark = [
+    pytest.mark.tier(3),
+    test_requirements.report,
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.provider([VMwareProvider], scope='module'),
+]
 
 
 report_path = [

--- a/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
+++ b/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
@@ -19,7 +19,6 @@ from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.intelligence.reports.reports import CustomReport
 from datetime import date
 from fixtures.provider import setup_or_skip
-from cfme.utils import testgen
 from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for
@@ -31,25 +30,11 @@ pytestmark = [
                                BZ(1468729, forced_streams=["5.9"]),
                                BZ(1486529, forced_streams=["5.7", "5.8"],
                                   unblock=lambda provider: not provider.one_of(GCEProvider))]),
-    test_requirements.chargeback
+    pytest.mark.provider([VMwareProvider, RHEVMProvider, AzureProvider, GCEProvider],
+                         scope='module',
+                         required_fields=[(['cap_and_util', 'test_chargeback'], True)]),
+    test_requirements.chargeback,
 ]
-
-
-def pytest_generate_tests(metafunc):
-    # Filter out providers not meant for Chargeback Testing
-    argnames, argvalues, idlist = testgen.providers_by_class(
-        metafunc, [VMwareProvider, RHEVMProvider, AzureProvider, GCEProvider],
-        required_fields=[(['cap_and_util', 'test_chargeback'], True)]
-    )
-
-    new_argvalues = []
-    new_idlist = []
-    for i, argvalue_tuple in enumerate(argvalues):
-
-        new_idlist.append(idlist[i])
-        new_argvalues.append(argvalues[i])
-
-    testgen.parametrize(metafunc, argnames, new_argvalues, ids=new_idlist, scope="module")
 
 
 @pytest.yield_fixture(scope="module")

--- a/cfme/tests/intelligence/reports/test_views.py
+++ b/cfme/tests/intelligence/reports/test_views.py
@@ -8,17 +8,17 @@ from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.intelligence.reports.reports import CannedSavedReport
-from cfme.utils import testgen
 from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 
-pytestmark = [pytest.mark.tier(3),
-              test_requirements.report,
-              pytest.mark.usefixtures('setup_provider')]
 
-pytest_generate_tests = testgen.generate(
-    [OpenStackProvider, EC2Provider, RHEVMProvider, VMwareProvider],
-    scope='module')
+pytestmark = [
+    pytest.mark.tier(3),
+    test_requirements.report,
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.provider([OpenStackProvider, EC2Provider, RHEVMProvider, VMwareProvider],
+                         scope='module')
+]
 
 
 @pytest.yield_fixture(scope='module')


### PR DESCRIPTION
__Updating tests__: replace testgen with pytest.mark.provider.