### PR TITLE
[1LP][RFR] Removed testgen from middleware (part 2)

### DIFF
--- a/cfme/tests/middleware/test_middleware_downloads.py
+++ b/cfme/tests/middleware/test_middleware_downloads.py
@@ -8,15 +8,15 @@ from cfme.middleware.server_group import MiddlewareServerGroup
 from cfme.middleware.messaging import MiddlewareMessaging
 from random_methods import get_random_object, get_random_domain
 from random_methods import get_random_server, get_random_server_group
-from cfme.utils import testgen
 from cfme.utils import version
 from cfme.utils.version import current_version
+
 
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.uncollectif(lambda: current_version() < '5.7'),
+    pytest.mark.provider([HawkularProvider], scope="function"),
 ]
-pytest_generate_tests = testgen.generate([HawkularProvider], scope="function")
 FILETYPES = ["txt", "csv", "pdf"]
 
 

--- a/cfme/tests/middleware/test_middleware_drivers.py
+++ b/cfme/tests/middleware/test_middleware_drivers.py
@@ -1,17 +1,17 @@
 import pytest
 from cfme.middleware.provider.hawkular import HawkularProvider
-from cfme.utils import testgen
 from cfme.utils.version import current_version
 from server_methods import get_eap_server
 from jdbc_driver_methods import download_jdbc_driver, deploy_jdbc_driver
 from jdbc_driver_methods import ORACLE_12C_JDBC, DB2_105_JDBC, MSSQL_2014_JDBC, MYSQL_57_JDBC
 from jdbc_driver_methods import POSTGRESPLUS_94_JDBC, POSTGRESQL_94_JDBC, SYBASE_157_JDBC
 
+
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.uncollectif(lambda: current_version() < '5.7'),
+    pytest.mark.provider([HawkularProvider], scope="function"),
 ]
-pytest_generate_tests = testgen.generate([HawkularProvider], scope="function")
 ITEMS_LIMIT = 5  # when we have big list, limit number of items to test
 
 DRIVERS = [ORACLE_12C_JDBC,

--- a/cfme/tests/middleware/test_middleware_messagings.py
+++ b/cfme/tests/middleware/test_middleware_messagings.py
@@ -3,15 +3,15 @@ import pytest
 from cfme.middleware.messaging import MiddlewareMessaging
 from cfme.middleware.provider import get_random_list
 from cfme.middleware.provider.hawkular import HawkularProvider
-from cfme.utils import testgen
 from cfme.utils.version import current_version
 from server_methods import get_hawkular_server
+
 
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.uncollectif(lambda: current_version() < '5.7'),
+    pytest.mark.provider([HawkularProvider], scope="function"),
 ]
-pytest_generate_tests = testgen.generate([HawkularProvider], scope="function")
 ITEMS_LIMIT = 1  # when we have big list, limit number of items to test
 
 

--- a/cfme/tests/middleware/test_middleware_provider.py
+++ b/cfme/tests/middleware/test_middleware_provider.py
@@ -11,15 +11,14 @@ from cfme.common.provider_views import (MiddlewareProviderAddView,
 from cfme.middleware.provider import MiddlewareProvider
 from cfme.middleware.provider.hawkular import HawkularProvider
 from cfme.utils import error
-from cfme.utils import testgen
 from cfme.utils.update import update
 from cfme.utils.version import current_version
 
 
 pytestmark = [
     pytest.mark.uncollectif(lambda: current_version() < '5.8'),
+    pytest.mark.provider([MiddlewareProvider], scope='function'),
 ]
-pytest_generate_tests = testgen.generate([MiddlewareProvider], scope='function')
 
 
 @pytest.mark.usefixtures('has_no_middleware_providers')

--- a/cfme/tests/middleware/test_middleware_server.py
+++ b/cfme/tests/middleware/test_middleware_server.py
@@ -1,7 +1,6 @@
 import pytest
 from cfme.middleware.provider.hawkular import HawkularProvider
 from cfme.middleware.server import MiddlewareServer
-from cfme.utils import testgen
 from cfme.utils.version import current_version
 from server_methods import verify_server_running, verify_server_stopped
 from server_methods import get_servers_set, verify_server_suspended
@@ -9,11 +8,12 @@ from server_methods import get_eap_server, get_hawkular_server
 from server_methods import verify_server_starting, verify_server_stopping
 from server_methods import get_eap_container_server
 
+
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.uncollectif(lambda: current_version() < '5.7'),
+    pytest.mark.provider([HawkularProvider], scope="function"),
 ]
-pytest_generate_tests = testgen.generate([HawkularProvider], scope="function")
 
 
 @pytest.yield_fixture(scope="function")


### PR DESCRIPTION
__Updating tests.__ Replace testgen with pytest.mark.provider.