### PR TITLE
[RFR][1LP] Rename GroupCollection reference to .groups

### DIFF
--- a/cfme/fixtures/tag.py
+++ b/cfme/fixtures/tag.py
@@ -54,7 +54,7 @@ def group_with_tag(appliance, role, category, tag):
     """
         Returns group object with set up tag filter used in test module
     """
-    group = appliance.collections.rbac_groups.create(
+    group = appliance.collections.groups.create(
         description='grp{}'.format(fauxfactory.gen_alphanumeric()),
         role=role.name,
         tag=[category.display_name, tag.display_name]

--- a/cfme/tests/cloud_infra_common/test_vm_ownership.py
+++ b/cfme/tests/cloud_infra_common/test_vm_ownership.py
@@ -34,7 +34,7 @@ def role_only_user_owned(appliance):
 
 @pytest.yield_fixture(scope="module")
 def group_only_user_owned(appliance, role_only_user_owned):
-    group_collection = appliance.collections.rbac_groups
+    group_collection = appliance.collections.groups
     group = group_collection.create(
         description='group_only_user_owned_{}'.format(fauxfactory.gen_alphanumeric()),
         role=role_only_user_owned.name)
@@ -56,7 +56,7 @@ def role_user_or_group_owned(appliance):
 
 @pytest.yield_fixture(scope="module")
 def group_user_or_group_owned(appliance, role_user_or_group_owned):
-    group_collection = appliance.collections.rbac_groups
+    group_collection = appliance.collections.groups
     group = group_collection.create(
         description='group_user_or_group_owned_{}'.format(fauxfactory.gen_alphanumeric()),
         role=role_user_or_group_owned.name)

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -30,7 +30,7 @@ pytestmark = test_requirements.rbac
 
 @pytest.fixture(scope='module')
 def group_collection(appliance):
-    return appliance.collections.rbac_groups
+    return appliance.collections.groups
 
 
 @pytest.fixture(scope='module')

--- a/cfme/tests/infrastructure/test_quota_tagging.py
+++ b/cfme/tests/infrastructure/test_quota_tagging.py
@@ -70,7 +70,7 @@ def set_entity_quota_source(max_quota_test_instance, entity):
         max_quota_test_instance.fields = {'quota_source_type': {'value': entity}}
 
 
-@pytest.fixture(params=[('rbac_groups', 'group', 'EvmGroup-super_administrator')], scope='module')
+@pytest.fixture(params=[('groups', 'group', 'EvmGroup-super_administrator')], scope='module')
 def entities(appliance, request, max_quota_test_instance):
     collection, entity, description = request.param
     set_entity_quota_source(max_quota_test_instance, entity)

--- a/cfme/tests/integration/test_cfme_auth.py
+++ b/cfme/tests/integration/test_cfme_auth.py
@@ -35,7 +35,7 @@ def group(request, data, auth_mode, add_group, appliance):
         principal=data["username"],
         secret=data["password"],
     )
-    group_collection = appliance.collections.rbac_groups
+    group_collection = appliance.collections.groups
     user_group = None
     if add_group == RETRIEVE_GROUP:
         user_group = group_collection.instantiate(

--- a/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
+++ b/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
@@ -76,7 +76,7 @@ def vm_ownership(enable_candu, clean_setup_provider, provider, appliance):
         provider.mgmt.start_vm(vm_name)
         provider.mgmt.wait_vm_running(vm_name)
 
-    group_collection = appliance.collections.rbac_groups
+    group_collection = appliance.collections.groups
     cb_group = group_collection.instantiate(description='EvmGroup-user')
     user = ac.User(name=provider.name + fauxfactory.gen_alphanumeric(),
         credential=new_credential(),

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
             'tenants = cfme.configure.access_control:TenantCollection',
             'projects = cfme.configure.access_control:ProjectCollection',
             'candus = cfme.configure.configuration.region_settings:CANDUCollection',
-            'rbac_groups = cfme.configure.access_control:GroupCollection',
+            'groups = cfme.configure.access_control:GroupCollection',
             'nodes = cfme.containers.node:NodeCollection',
             'dashboards = cfme.dashboard:DashboardCollection',
             'clusters = cfme.infrastructure.cluster:ClusterCollection',


### PR DESCRIPTION
Renaming the appliance collections reference of GroupCollection from rbac_groups to groups

{{pytest: cfme/tests/configure/test_access_control.py}}