### PR TITLE
[1LP][RFR] Removed testgen from middleware (part 3)

### DIFF
--- a/cfme/tests/middleware/test_middleware_server_group.py
+++ b/cfme/tests/middleware/test_middleware_server_group.py
@@ -4,7 +4,6 @@ from cfme.middleware.domain import MiddlewareDomain
 from cfme.middleware.provider import get_random_list
 from cfme.middleware.provider.hawkular import HawkularProvider
 from cfme.middleware.server_group import MiddlewareServerGroup
-from cfme.utils import testgen
 from cfme.utils.version import current_version
 from server_group_methods import (
     verify_server_group_stopped, verify_server_group_running,
@@ -19,11 +18,12 @@ from deployment_methods import WAR_EXT, RESOURCE_WAR_NAME_NEW
 from deployment_methods import RESOURCE_WAR_CONTENT, RESOURCE_WAR_CONTENT_NEW
 from server_methods import get_domain_container_server
 
+
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.uncollectif(lambda: current_version() < '5.7'),
+    pytest.mark.provider([HawkularProvider], scope="function"),
 ]
-pytest_generate_tests = testgen.generate([HawkularProvider], scope="function")
 
 ITEMS_LIMIT = 1  # when we have big list, limit number of items to test
 

--- a/cfme/tests/middleware/test_middleware_tags.py
+++ b/cfme/tests/middleware/test_middleware_tags.py
@@ -8,14 +8,14 @@ from cfme.middleware.domain import MiddlewareDomain
 from cfme.middleware.server_group import MiddlewareServerGroup
 from cfme.middleware.messaging import MiddlewareMessaging
 from random_methods import get_random_object
-from cfme.utils import testgen
 from cfme.utils.version import current_version
+
 
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.uncollectif(lambda: current_version() < '5.7'),
+    pytest.mark.provider([HawkularProvider], scope="function"),
 ]
-pytest_generate_tests = testgen.generate([HawkularProvider], scope="function")
 
 tags = [
     Tag(category=Category(display_name='Environment', single_value=True), display_name='Test'),

--- a/cfme/tests/middleware/test_middleware_topology.py
+++ b/cfme/tests/middleware/test_middleware_topology.py
@@ -1,7 +1,6 @@
 import pytest
 
 from cfme.middleware.provider import MiddlewareProvider
-from cfme.utils import testgen
 from cfme.utils import version
 from cfme.utils.version import current_version
 from cfme.middleware.server import MiddlewareServer
@@ -14,8 +13,9 @@ from cfme.middleware.deployment import MiddlewareDeployment
 
 pytestmark = [
     pytest.mark.uncollectif(lambda: current_version() < '5.7'),
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.provider([MiddlewareProvider], scope='function'),
 ]
-pytest_generate_tests = testgen.generate([MiddlewareProvider], scope='function')
 
 TOPOLOGY_TYPES = {"servers": {"MiddlewareServer"},
                   "deployments": {"MiddlewareDeployment",
@@ -29,7 +29,6 @@ TOPOLOGY_TYPES = {"servers": {"MiddlewareServer"},
                   "server_groups": {"MiddlewareServerGroup"}}
 
 
-@pytest.mark.usefixtures('setup_provider')
 def test_topology(provider):
     """Tests topology page from provider page
 
@@ -75,7 +74,6 @@ def test_topology(provider):
 
 
 @pytest.mark.uncollectif(current_version() != version.UPSTREAM)
-@pytest.mark.usefixtures('setup_provider')
 def test_topology_details(provider):
     """Tests items details in topology page from provider page
 
@@ -113,7 +111,6 @@ def test_topology_details(provider):
     verify_elements_match(MiddlewareDeployment.deployments_in_db(), deployments)
 
 
-@pytest.mark.usefixtures('setup_provider')
 def test_topology_filter(provider):
     """Tests filters in topology page from provider page
 
@@ -138,7 +135,6 @@ def test_topology_filter(provider):
             verify_elements_shown(provider.topology, type)
 
 
-@pytest.mark.usefixtures('setup_provider')
 def test_topology_server_hierarchy(provider):
     """Tests all server's hierarchical content in topology
 

--- a/cfme/tests/middleware/test_middleware_utilization.py
+++ b/cfme/tests/middleware/test_middleware_utilization.py
@@ -5,14 +5,14 @@ from cfme.middleware.provider.hawkular import HawkularProvider
 from cfme.middleware.server import MiddlewareServer
 from cfme.web_ui.utilization import Option
 from random_methods import get_random_object
-from cfme.utils import testgen
 from cfme.utils.version import current_version
+
 
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.uncollectif(lambda: current_version() < '5.7'),
+    pytest.mark.provider([HawkularProvider], scope="function"),
 ]
-pytest_generate_tests = testgen.generate([HawkularProvider], scope="function")
 
 
 @pytest.mark.parametrize("object_type", [MiddlewareServer,

--- a/cfme/tests/middleware/test_provider_timelines.py
+++ b/cfme/tests/middleware/test_provider_timelines.py
@@ -2,7 +2,6 @@ import pytest
 from datetime import datetime
 
 from cfme.middleware.provider.hawkular import HawkularProvider
-from cfme.utils import testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.version import current_version
 from cfme.utils.wait import wait_for
@@ -28,8 +27,8 @@ from server_methods import get_eap_server
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.uncollectif(lambda: current_version() < '5.7'),
+    pytest.mark.provider([HawkularProvider], scope="function"),
 ]
-pytest_generate_tests = testgen.generate([HawkularProvider], scope="function")
 
 DEPLOYMENT_OK_EVENT = 'hawkular_deployment.ok'
 UNDEPLOYMENT_OK_EVENT = 'hawkular_deployment_remove.ok'


### PR DESCRIPTION
__Updating tests.__ Replace testgen with pytest.mark.provider.

{{pytest: --use-provider hawkular cfme/tests/middleware/test_middleware_server_group.py cfme/tests/middleware/test_middleware_tags.py cfme/tests/middleware/test_middleware_topology.py cfme/tests/middleware/test_middleware_utilization.py cfme/tests/middleware/test_provider_timelines.py}}