### PR TITLE
[1LP][RFR] Removed testgen from networks (part 2)

### DIFF
--- a/cfme/tests/networks/test_sdn_inventory_collection.py
+++ b/cfme/tests/networks/test_sdn_inventory_collection.py
@@ -3,13 +3,14 @@ from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.networks.cloud_network import CloudNetwork
-from cfme.utils import testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
 
 
-pytest_generate_tests = testgen.generate(
-    classes=[EC2Provider, AzureProvider, OpenStackProvider], scope='module')
-pytestmark = pytest.mark.usefixtures('setup_provider')
+pytestmark = [
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.provider([EC2Provider, AzureProvider, OpenStackProvider],
+                         scope='module'),
+]
 
 
 @pytest.mark.tier(1)

--- a/cfme/tests/networks/test_sdn_navigation.py
+++ b/cfme/tests/networks/test_sdn_navigation.py
@@ -3,13 +3,14 @@ from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.networks.provider import NetworkProviderCollection
-from cfme.utils import testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
 
 
-pytest_generate_tests = testgen.generate(
-    classes=[EC2Provider, AzureProvider, OpenStackProvider], scope='function')
-pytestmark = pytest.mark.usefixtures('setup_provider')
+pytestmark = [
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.provider([EC2Provider, AzureProvider, OpenStackProvider],
+                         scope='function')
+]
 
 
 @pytest.mark.parametrize("tested_part", ["Cloud Subnets", "Cloud Networks", "Network Routers",

--- a/cfme/tests/networks/test_sdn_ports.py
+++ b/cfme/tests/networks/test_sdn_ports.py
@@ -3,13 +3,14 @@ from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.exceptions import ManyEntitiesFound, ItemNotFound
 from cfme.networks.network_port import NetworkPortCollection
 from cfme.networks.provider import NetworkProviderCollection
-from cfme.utils import testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 
 
-pytest_generate_tests = testgen.generate(classes=[EC2Provider], scope='module')
-pytestmark = pytest.mark.usefixtures('setup_provider')
+pytestmark = [
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.provider([EC2Provider], scope='module')
+]
 
 
 @pytest.mark.meta(blockers=[BZ(1480577, forced_streams=["5.7", "5.8"])])


### PR DESCRIPTION
__Updating tests.__ Replace testgen with pytest.mark.provider.
