### PR TITLE
[1LP][RFR] Removed testgen from openstack/cloud

### DIFF
--- a/cfme/tests/openstack/cloud/test_instances.py
+++ b/cfme/tests/openstack/cloud/test_instances.py
@@ -8,16 +8,15 @@ from wait_for import TimedOutError
 from cfme.cloud.instance.openstack import OpenStackInstance
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.exceptions import ItemNotFound
-from cfme.utils import testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.log import logger
 from cfme.utils.version import current_version
 
 
-pytest_generate_tests = testgen.generate([OpenStackProvider],
-                                         scope='module')
-
-pytestmark = [pytest.mark.usefixtures("setup_provider_modscope")]
+pytestmark = [
+    pytest.mark.usefixtures("setup_provider_modscope"),
+    pytest.mark.provider([OpenStackProvider], scope='module')
+]
 
 
 @pytest.yield_fixture(scope='function')

--- a/cfme/tests/openstack/cloud/test_networks.py
+++ b/cfme/tests/openstack/cloud/test_networks.py
@@ -4,16 +4,15 @@ import fauxfactory
 import pytest
 
 from cfme.cloud.provider.openstack import OpenStackProvider
-from cfme.utils import testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for
 
 
-pytest_generate_tests = testgen.generate([OpenStackProvider],
-                                         scope='module')
-
-pytestmark = [pytest.mark.usefixtures("setup_provider_modscope")]
+pytestmark = [
+    pytest.mark.usefixtures("setup_provider_modscope"),
+    pytest.mark.provider([OpenStackProvider], scope='module'),
+]
 
 
 SUBNET_CIDR = '11.11.11.0/24'

--- a/cfme/tests/openstack/cloud/test_volumes.py
+++ b/cfme/tests/openstack/cloud/test_volumes.py
@@ -4,16 +4,17 @@ import fauxfactory
 import pytest
 
 from cfme.cloud.provider.openstack import OpenStackProvider
-from cfme.utils import testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 from cfme.utils import version
 
 
-pytest_generate_tests = testgen.generate([OpenStackProvider], scope='module')
+pytestmark = [
+    pytest.mark.usefixtures("setup_provider_modscope"),
+    pytest.mark.provider([OpenStackProvider], scope='module')
+]
 
-pytestmark = [pytest.mark.usefixtures("setup_provider_modscope")]
 
 VOLUME_SIZE = 1
 


### PR DESCRIPTION
__Updating tests.__ Replace testgen with pytest.mark.provider.