### PR TITLE
[RFR] Remove testgen from openstack/infrastructure (part 1)

### DIFF
--- a/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
+++ b/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
@@ -3,14 +3,14 @@ import pytest
 from cfme.exceptions import HostNotFound
 from cfme.infrastructure.openstack_node import OpenstackNode
 from cfme.infrastructure.provider.openstack_infra import OpenstackInfraProvider
-from cfme.utils import testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.wait import wait_for
 
 
-pytest_generate_tests = testgen.generate([OpenstackInfraProvider],
-                                         scope='module')
-pytestmark = [pytest.mark.usefixtures("setup_provider_modscope")]
+pytestmark = [
+    pytest.mark.usefixtures("setup_provider_modscope"),
+    pytest.mark.provider([OpenstackInfraProvider], scope='module')
+]
 
 
 @pytest.fixture(scope='module')

--- a/cfme/tests/openstack/infrastructure/test_host_power_control.py
+++ b/cfme/tests/openstack/infrastructure/test_host_power_control.py
@@ -1,14 +1,14 @@
 import pytest
 
 from cfme.infrastructure.provider.openstack_infra import OpenstackInfraProvider
-from cfme.utils import testgen
 from cfme.utils.version import current_version
 
-pytest_generate_tests = testgen.generate([OpenstackInfraProvider],
-                                         scope='module')
 
-pytestmark = [pytest.mark.uncollectif(lambda: current_version() < '5.7'),
-              pytest.mark.usefixtures("setup_provider_modscope")]
+pytestmark = [
+    pytest.mark.uncollectif(lambda: current_version() < '5.7'),
+    pytest.mark.usefixtures("setup_provider_modscope"),
+    pytest.mark.provider([OpenstackInfraProvider], scope='module'),
+]
 
 
 @pytest.fixture(scope="module")

--- a/cfme/tests/openstack/infrastructure/test_hosts.py
+++ b/cfme/tests/openstack/infrastructure/test_hosts.py
@@ -3,14 +3,14 @@ import pytest
 from cfme.configure.tasks import is_host_analysis_finished
 from cfme.infrastructure.provider.openstack_infra import OpenstackInfraProvider
 from cfme.web_ui import toolbar
-from cfme.utils import testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.wait import wait_for
 
 
-pytest_generate_tests = testgen.generate([OpenstackInfraProvider],
-                                         scope='module')
-pytestmark = [pytest.mark.usefixtures("setup_provider_modscope")]
+pytestmark = [
+    pytest.mark.usefixtures("setup_provider_modscope"),
+    pytest.mark.provider([OpenstackInfraProvider], scope='module'),
+]
 
 
 @pytest.fixture(scope="module")

--- a/cfme/tests/openstack/infrastructure/test_networks.py
+++ b/cfme/tests/openstack/infrastructure/test_networks.py
@@ -4,13 +4,13 @@ import pytest
 
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.infrastructure.provider.openstack_infra import OpenstackInfraProvider
-from cfme.utils import testgen
 
 
-pytest_generate_tests = testgen.generate([OpenStackProvider, OpenstackInfraProvider],
-                                         scope='module')
-
-pytestmark = [pytest.mark.usefixtures("setup_provider_modscope")]
+pytestmark = [
+    pytest.mark.usefixtures("setup_provider_modscope"),
+    pytest.mark.provider([OpenStackProvider, OpenstackInfraProvider],
+                         scope='module'),
+]
 
 
 def test_list_networks(provider, appliance):


### PR DESCRIPTION
__Updating tests.__ Replace testgen with pytest.mark.provider.