### PR TITLE
[1LP][RFR] Remove testgen from openstack/infrastructure (part 2)

### DIFF
--- a/cfme/tests/openstack/infrastructure/test_provider.py
+++ b/cfme/tests/openstack/infrastructure/test_provider.py
@@ -3,13 +3,13 @@
 import pytest
 
 from cfme.infrastructure.provider.openstack_infra import OpenstackInfraProvider
-from cfme.utils import testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
 
 
-pytest_generate_tests = testgen.generate([OpenstackInfraProvider],
-                                         scope='module')
-pytestmark = [pytest.mark.usefixtures("setup_provider_modscope")]
+pytestmark = [
+    pytest.mark.usefixtures("setup_provider_modscope"),
+    pytest.mark.provider([OpenstackInfraProvider], scope='module'),
+]
 
 
 def test_api_port(provider):

--- a/cfme/tests/openstack/infrastructure/test_relationships.py
+++ b/cfme/tests/openstack/infrastructure/test_relationships.py
@@ -8,15 +8,14 @@ import pytest
 import cfme.fixtures.pytest_selenium as sel
 from cfme.infrastructure.provider.openstack_infra import OpenstackInfraProvider
 from cfme.web_ui import InfoBlock, Table
-from cfme.utils import testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
 
 
-pytestmark = [pytest.mark.meta(server_roles='+smartproxy +smartstate'),
-              pytest.mark.usefixtures("setup_provider_modscope")]
-
-
-pytest_generate_tests = testgen.generate([OpenstackInfraProvider], scope='module')
+pytestmark = [
+    pytest.mark.meta(server_roles='+smartproxy +smartstate'),
+    pytest.mark.usefixtures("setup_provider_modscope"),
+    pytest.mark.provider([OpenstackInfraProvider], scope='module'),
+]
 
 
 def test_assigned_roles(provider):

--- a/cfme/tests/openstack/infrastructure/test_resources.py
+++ b/cfme/tests/openstack/infrastructure/test_resources.py
@@ -2,15 +2,13 @@ import pytest
 
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.infrastructure.provider.openstack_infra import OpenstackInfraProvider
-from cfme.utils import testgen
 
 
-pytestmark = [pytest.mark.meta(server_roles='+smartproxy +smartstate'),
-              pytest.mark.usefixtures("setup_provider_modscope")]
-
-
-pytest_generate_tests = testgen.generate([OpenstackInfraProvider],
-                                         scope='module')
+pytestmark = [
+    pytest.mark.meta(server_roles='+smartproxy +smartstate'),
+    pytest.mark.usefixtures("setup_provider_modscope"),
+    pytest.mark.provider([OpenstackInfraProvider], scope='module')
+]
 
 
 def test_number_of_cpu(provider, soft_assert):

--- a/cfme/tests/openstack/infrastructure/test_roles.py
+++ b/cfme/tests/openstack/infrastructure/test_roles.py
@@ -3,14 +3,14 @@ from random import choice
 
 from cfme.configure.tasks import is_host_analysis_finished
 from cfme.infrastructure.provider.openstack_infra import OpenstackInfraProvider
-from cfme.utils import testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.wait import wait_for
 
 
-pytest_generate_tests = testgen.generate([OpenstackInfraProvider],
-                                         scope='module')
-pytestmark = [pytest.mark.usefixtures("setup_provider_modscope")]
+pytestmark = [
+    pytest.mark.usefixtures("setup_provider_modscope"),
+    pytest.mark.provider([OpenstackInfraProvider], scope='module'),
+]
 
 
 ROLES = ['NovaCompute', 'Controller', 'Compute', 'BlockStorage', 'SwiftStorage',


### PR DESCRIPTION
__Updating tests__ Replace testgen with pytest.mark.provider.