### PR TITLE
[RFR] Remove testgen from services (part 1)

### DIFF
--- a/cfme/tests/services/test_add_remove_vm_to_service.py
+++ b/cfme/tests/services/test_add_remove_vm_to_service.py
@@ -9,7 +9,6 @@ from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.services.myservice import MyService
 
-from cfme.utils import testgen
 from cfme.utils.log import logger
 
 
@@ -20,11 +19,9 @@ pytestmark = [
     pytest.mark.usefixtures('uses_infra_providers'),
     pytest.mark.long_running,
     pytest.mark.meta(server_roles="+automate"),
-    pytest.mark.tier(3)
+    pytest.mark.tier(3),
+    pytest.mark.provider([VMwareProvider], scope="module"),
 ]
-
-
-pytest_generate_tests = testgen.generate([VMwareProvider], scope="module")
 
 
 @pytest.fixture(scope="function")

--- a/cfme/tests/services/test_cloud_service_catalogs.py
+++ b/cfme/tests/services/test_cloud_service_catalogs.py
@@ -7,19 +7,17 @@ from cfme.cloud.provider import CloudProvider
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme import test_requirements
-from cfme.utils import testgen
 from cfme.utils.log import logger
 
 
 pytestmark = [
     test_requirements.service,
     pytest.mark.meta(server_roles="+automate"),
-    pytest.mark.tier(2)
+    pytest.mark.tier(2),
+    pytest.mark.provider([CloudProvider],
+                         required_fields=[['provisioning', 'image']],
+                         scope="module"),
 ]
-
-
-pytest_generate_tests = testgen.generate(
-    [CloudProvider], required_fields=[['provisioning', 'image']], scope="module")
 
 
 def test_cloud_catalog_item(appliance, setup_provider, provider, dialog, catalog, request,

--- a/cfme/tests/services/test_different_dialogs_in_catalogs.py
+++ b/cfme/tests/services/test_different_dialogs_in_catalogs.py
@@ -9,7 +9,6 @@ from cfme.services.catalogs.catalog import Catalog
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.infrastructure.provider import InfraProvider
 from cfme.common.provider import cleanup_vm
-from cfme.utils import testgen
 from cfme.utils.log import logger
 from cfme.utils.blockers import BZ
 
@@ -19,15 +18,13 @@ pytestmark = [
     pytest.mark.ignore_stream("upstream"),
     pytest.mark.usefixtures('vm_name', 'catalog_item', 'uses_infra_providers'),
     test_requirements.service,
-    pytest.mark.long_running
+    pytest.mark.long_running,
+    pytest.mark.provider([InfraProvider],
+                         required_fields=[['provisioning', 'template'],
+                                          ['provisioning', 'host'],
+                                          ['provisioning', 'datastore']],
+                         scope="module")
 ]
-
-
-pytest_generate_tests = testgen.generate([InfraProvider], required_fields=[
-    ['provisioning', 'template'],
-    ['provisioning', 'host'],
-    ['provisioning', 'datastore']
-], scope="module")
 
 
 @pytest.yield_fixture(scope="function")

--- a/cfme/tests/services/test_myservice.py
+++ b/cfme/tests/services/test_myservice.py
@@ -9,7 +9,7 @@ from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.services.myservice import MyService
 from cfme.services.myservice.ui import MyServiceDetailView
 
-from cfme.utils import browser, testgen, version
+from cfme.utils import browser, version
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.browser import ensure_browser_open
 from cfme.utils.log import logger
@@ -23,7 +23,8 @@ pytestmark = [
     pytest.mark.meta(server_roles="+automate"),
     pytest.mark.long_running,
     test_requirements.service,
-    pytest.mark.tier(2)
+    pytest.mark.tier(2),
+    pytest.mark.provider([VMwareProvider], scope="module"),
 ]
 
 
@@ -36,9 +37,6 @@ def needs_firefox():
     ensure_browser_open()
     if browser.browser().name != "firefox":
         pytest.skip(msg="This test needs firefox to run")
-
-
-pytest_generate_tests = testgen.generate([VMwareProvider], scope="module")
 
 
 @pytest.yield_fixture(scope='function')

--- a/cfme/tests/services/test_orchestration_template.py
+++ b/cfme/tests/services/test_orchestration_template.py
@@ -3,13 +3,20 @@ import fauxfactory
 import pytest
 from cfme.cloud.provider import CloudProvider
 from cfme.services.catalogs.orchestration_template import OrchestrationTemplate
-from cfme.utils import testgen, error
+from cfme.utils import error
 from cfme.utils.update import update
 from cfme import test_requirements
 from cfme.utils.appliance.implementations.ui import navigate_to
 
 
-pytestmark = [test_requirements.stack, pytest.mark.tier(2)]
+pytestmark = [
+    test_requirements.stack,
+    pytest.mark.tier(2),
+    pytest.mark.provider([CloudProvider],
+                         required_fields=[['provisioning', 'stack_provisioning']],
+                         scope="module")
+]
+
 
 METHOD_TORSO = """
 {  "AWSTemplateFormatVersion" : "2010-09-09",
@@ -40,12 +47,6 @@ METHOD_TORSO_copied = """
   }
 }
 """
-
-
-pytest_generate_tests = testgen.generate([CloudProvider],
-    required_fields=[
-        ['provisioning', 'stack_provisioning']
-], scope="module")
 
 
 @pytest.yield_fixture(scope="function")


### PR DESCRIPTION
__Updating tests.__ Replace testgen with pytest.mark.provider.