### PR TITLE
[1LP][RFR] adding search support to entities.get_entity()

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -12,7 +12,7 @@ from cfme.exceptions import (
 from cfme.fixtures import pytest_selenium as sel
 from cfme.web_ui import (
     AngularCalendarInput, AngularSelect, Form, InfoBlock, Input, Select, fill, flash,
-    form_buttons, toolbar, PagedTable, search, CheckboxTable,
+    form_buttons, toolbar, PagedTable, CheckboxTable,
     DriftGrid, BootstrapTreeview
 )
 import cfme.web_ui.toolbar as tb
@@ -325,11 +325,8 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, WidgetasticTaggable,
         if 'Grid View' != view.toolbar.view_selector.selected:
             view.toolbar.view_selector.select('Grid View')
 
-        if use_search:
-            search.normal_search(self.name)
-
         try:
-            return view.entities.get_entity(name=self.name, surf_pages=True)
+            return view.entities.get_entity(name=self.name, surf_pages=True, use_search=True)
         except ItemNotFound:
             raise VmOrInstanceNotFound("VM '{}' not found in UI!".format(self.name))
 

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -326,7 +326,7 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, WidgetasticTaggable,
             view.toolbar.view_selector.select('Grid View')
 
         try:
-            return view.entities.get_entity(name=self.name, surf_pages=True, use_search=True)
+            return view.entities.get_entity(name=self.name, surf_pages=True, use_search=use_search)
         except ItemNotFound:
             raise VmOrInstanceNotFound("VM '{}' not found in UI!".format(self.name))
 

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -2619,6 +2619,7 @@ class EntitiesConditionalView(View, ReportDataControllerMixin):
         Args:
             keys: only entity which matches to keys will be returned
             surf_pages (bool): current page entity if False, all entities otherwise
+            use_search (bool): it filters out all entities except entity with name passed in keys
 
         Returns: matched entity (QuadIcon/etc.)
         """

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -2614,7 +2614,7 @@ class EntitiesConditionalView(View, ReportDataControllerMixin):
                                 for el in self._current_page_elements])
             return entities
 
-    def get_entity(self, surf_pages=False, **keys):
+    def get_entity(self, surf_pages=False, use_search=False, **keys):
         """ obtains one entity matched to by_name and stops on that page
         Args:
             keys: only entity which matches to keys will be returned
@@ -2622,6 +2622,10 @@ class EntitiesConditionalView(View, ReportDataControllerMixin):
 
         Returns: matched entity (QuadIcon/etc.)
         """
+        if use_search and 'name' in keys:
+            self.search.clear_search()
+            self.search.search(text=keys['name'])
+
         for _ in self.paginator.pages():
             if len(keys) == 1 and 'name' in keys:
                 entity_id = self.get_id_by_name(name=keys['name'])


### PR DESCRIPTION
This PR doesn't add any search reset functionality. 
test owner should take of it by himself. 
For example add view.entities.search.clear_search() to nav destination->resetter()