### PR TITLE
[RFR] Remove testgen from services (part 2)

### DIFF
--- a/cfme/tests/services/test_provision_stack.py
+++ b/cfme/tests/services/test_provision_stack.py
@@ -11,7 +11,6 @@ from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.stack import StackCollection
 from cfme import test_requirements
-from cfme.utils import testgen
 from cfme.utils.conf import credentials
 from cfme.utils.path import orchestration_path
 from cfme.utils.datafile import load_data_file
@@ -23,15 +22,11 @@ pytestmark = [
     pytest.mark.meta(server_roles="+automate"),
     pytest.mark.ignore_stream("upstream"),
     test_requirements.stack,
-    pytest.mark.tier(2)
+    pytest.mark.tier(2),
+    pytest.mark.provider([CloudProvider],
+                         required_fields=[['provisioning', 'stack_provisioning']],
+                         scope="module"),
 ]
-
-
-pytest_generate_tests = testgen.generate(
-    [CloudProvider], required_fields=[
-        ['provisioning', 'stack_provisioning']
-    ],
-    scope="module")
 
 
 @pytest.yield_fixture(scope="function")

--- a/cfme/tests/services/test_request.py
+++ b/cfme/tests/services/test_request.py
@@ -5,19 +5,17 @@ from cfme.common.provider import cleanup_vm
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme import test_requirements
-from cfme.utils import testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
+
 
 pytestmark = [
     pytest.mark.meta(server_roles="+automate"),
     pytest.mark.usefixtures('vm_name', 'uses_infra_providers', 'catalog_item'),
     pytest.mark.long_running,
     test_requirements.service,
-    pytest.mark.tier(3)
+    pytest.mark.tier(3),
+    pytest.mark.provider([VMwareProvider], scope="module"),
 ]
-
-
-pytest_generate_tests = testgen.generate([VMwareProvider], scope="module")
 
 
 def test_copy_request(appliance, setup_provider, provider, catalog_item, request):

--- a/cfme/tests/services/test_service_catalogs.py
+++ b/cfme/tests/services/test_service_catalogs.py
@@ -10,22 +10,20 @@ from cfme.services.service_catalogs import ServiceCatalogs
 from cfme import test_requirements
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for_decorator
-from cfme.utils import testgen, error
+from cfme.utils import error
 
 
 pytestmark = [
     pytest.mark.meta(server_roles="+automate"),
     pytest.mark.usefixtures('vm_name', 'catalog_item', 'uses_infra_providers'),
     test_requirements.service,
-    pytest.mark.long_running
+    pytest.mark.long_running,
+    pytest.mark.provider([InfraProvider],
+                         required_fields=[['provisioning', 'template'],
+                                          ['provisioning', 'host'],
+                                          ['provisioning', 'datastore']],
+                         scope="module"),
 ]
-
-
-pytest_generate_tests = testgen.generate([InfraProvider], required_fields=[
-    ['provisioning', 'template'],
-    ['provisioning', 'host'],
-    ['provisioning', 'datastore']
-], scope="module")
 
 
 @pytest.mark.tier(2)

--- a/cfme/tests/services/test_service_manual_approval.py
+++ b/cfme/tests/services/test_service_manual_approval.py
@@ -9,22 +9,19 @@ from cfme.automate.explorer.domain import DomainCollection
 from cfme import test_requirements
 from cfme.utils.log import logger
 from cfme.utils.update import update
-from cfme.utils import testgen
 
 
 pytestmark = [
     pytest.mark.meta(server_roles="+automate"),
     pytest.mark.usefixtures('vm_name', 'catalog_item', 'uses_infra_providers'),
     test_requirements.service,
-    pytest.mark.long_running
+    pytest.mark.long_running,
+    pytest.mark.provider([InfraProvider],
+                         required_fields=[['provisioning', 'template'],
+                                          ['provisioning', 'host'],
+                                          ['provisioning', 'datastore']],
+                         scope="module"),
 ]
-
-
-pytest_generate_tests = testgen.generate([InfraProvider], required_fields=[
-    ['provisioning', 'template'],
-    ['provisioning', 'host'],
-    ['provisioning', 'datastore']
-], scope="module")
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
__Updating tests.__ Replace testgen with pytest.mark.provider.