### PR TITLE
Fixed test_middleware_topology.py

### DIFF
--- a/cfme/tests/middleware/test_middleware_topology.py
+++ b/cfme/tests/middleware/test_middleware_topology.py
@@ -12,8 +12,8 @@ from cfme.middleware.deployment import MiddlewareDeployment
 
 
 pytestmark = [
-    pytest.skip('Skipped until Topology is refactored for WT'),
-    pytest.mark.uncollectif(lambda: current_version() < '5.7'),
+    # pytest.mark.uncollectif(lambda: current_version() < '5.7'),
+    pytest.mark.uncollectif(lambda: True, reason='Skipped until Topology is refactored for WT'),
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.provider([MiddlewareProvider], scope='function'),
 ]


### PR DESCRIPTION
Whole test suite failed during collecting due: Using pytest.skip outside of a test is not allowed. To decorate a test function, use the @pytest.mark.skip or @pytest.mark.skipif decorators instead, and to skip a module use `pytestmark = pytest.mark.{skip,skipif}.