### PR TITLE
[1LP][RFR][NOTEST]applying partial match for vlan selection in ops ui

### DIFF
--- a/cfme/fixtures/service_fixtures.py
+++ b/cfme/fixtures/service_fixtures.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import pytest
 
+from widgetastic.utils import partial_match
+
 from cfme.common.provider import cleanup_vm
 from cfme.rest.gen_data import dialog as _dialog
 from cfme.rest.gen_data import service_catalog_obj as _catalog
@@ -40,7 +42,7 @@ def create_catalog_item(provider, provisioning, vm_name, dialog, catalog, consol
         'environment': {'host_name': {'name': host},
                         'datastore_name': {'name': datastore},
                         },
-        'network': {'vlan': vlan,
+        'network': {'vlan': partial_match(vlan),
                     },
     }
 

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -17,6 +17,7 @@ from widgetastic_manageiq import (
     Accordion, ConditionalSwitchableView, ManageIQTree,
     NonJSPaginationPane, SummaryTable, TimelinesView)
 from widgetastic_manageiq.vm_reconfigure import DisksTable
+from widgetastic.utils import partial_match
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.common.vm import VM, Template as BaseTemplate
@@ -757,7 +758,7 @@ class Vm(VM):
                 'last_name': last_name},
             'environment': {"host_name": {'name': prov_data.get("host")},
                             "datastore_name": {"name": prov_data.get("datastore")}},
-            'network': {'vlan': prov_data.get("vlan")},
+            'network': {'vlan': partial_match(prov_data.get("vlan"))},
         }
         view.form.fill_with(provisioning_data, on_change=view.form.submit_button)
 

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 """This module tests various ways how to set up the provisioning using the provisioning dialog."""
 import re
-from datetime import datetime, timedelta
-
 import fauxfactory
 import pytest
+from datetime import datetime, timedelta
+
+from widgetastic.utils import partial_match
+
 from cfme import test_requirements
 from cfme.common.provider import cleanup_vm
 from cfme.infrastructure.virtual_machines import Vm
@@ -57,7 +59,7 @@ def prov_data(provisioning, provider):
             'last_name': fauxfactory.gen_alphanumeric(),
             'manager_name': '{} {}'.format(fauxfactory.gen_alphanumeric(),
                                            fauxfactory.gen_alphanumeric())},
-        'network': {'vlan': provisioning.get('vlan')},
+        'network': {'vlan': partial_match(provisioning.get('vlan'))},
         'environment': {'datastore_name': {'name': provisioning['datastore']},
                         'host_name': {'name': provisioning['host']}},
         'catalog': {},

--- a/cfme/tests/infrastructure/test_vm_clone.py
+++ b/cfme/tests/infrastructure/test_vm_clone.py
@@ -4,11 +4,10 @@ import pytest
 
 from cfme.common.provider import cleanup_vm
 from cfme.common.vm import VM
-from cfme.infrastructure.provider import InfraProvider
-from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.utils import testgen
 from cfme.utils.log import logger
+
 
 pytestmark = [
     pytest.mark.meta(roles="+automate")

--- a/cfme/tests/services/test_different_dialogs_in_catalogs.py
+++ b/cfme/tests/services/test_different_dialogs_in_catalogs.py
@@ -2,6 +2,8 @@
 import fauxfactory
 import pytest
 
+from widgetastic.utils import partial_match
+
 from cfme import test_requirements
 from cfme.automate.service_dialogs import DialogCollection
 from cfme.services.service_catalogs import ServiceCatalogs
@@ -69,7 +71,7 @@ def catalog_item(provider, provisioning, vm_name, tagcontrol_dialog, catalog):
         'environment': {'host_name': {'name': host},
                         'datastore_name': {'name': datastore},
                         },
-        'network': {'vlan': vlan,
+        'network': {'vlan': partial_match(vlan),
                     },
     }
 

--- a/cfme/tests/services/test_iso_service_catalogs.py
+++ b/cfme/tests/services/test_iso_service_catalogs.py
@@ -2,6 +2,8 @@
 import fauxfactory
 import pytest
 
+from widgetastic.utils import partial_match
+
 from cfme.common.provider import cleanup_vm
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.service_catalogs import ServiceCatalogs
@@ -81,7 +83,7 @@ def catalog_item(setup_provider, provider, vm_name, dialog, catalog, provisionin
         'customize': {'custom_template': {'name': iso_kickstart},
                       'root_password': iso_root_password,
                       },
-        'network': {'vlan': vlan,
+        'network': {'vlan': partial_match(vlan),
                     },
     }
 

--- a/cfme/tests/services/test_operations.py
+++ b/cfme/tests/services/test_operations.py
@@ -3,6 +3,8 @@
 import fauxfactory
 import pytest
 
+from widgetastic.utils import partial_match
+
 from cfme import test_requirements
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.virtual_machines import Vm
@@ -83,7 +85,7 @@ def generated_request(appliance,
         provisioning_data['catalog']['provision_type'] = 'VMware'
 
     try:
-        provisioning_data['network'] = {'vlan': provisioning['vlan']}
+        provisioning_data['network'] = {'vlan': partial_match(provisioning['vlan'])}
     except KeyError:
         # provisioning['vlan'] is required for rhevm provisioning
         if provider_data["type"] == 'rhevm':

--- a/cfme/tests/services/test_pxe_service_catalogs.py
+++ b/cfme/tests/services/test_pxe_service_catalogs.py
@@ -2,6 +2,8 @@
 import fauxfactory
 import pytest
 
+from widgetastic.utils import partial_match
+
 from cfme.common.provider import cleanup_vm
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.service_catalogs import ServiceCatalogs
@@ -94,7 +96,7 @@ def catalog_item(provider, vm_name, dialog, catalog, provisioning, setup_pxe_ser
         'customize': {'root_password': pxe_root_password,
                       'custom_template': {'name': pxe_kickstart},
                       },
-        'network': {'vlan': pxe_vlan,
+        'network': {'vlan': partial_match(pxe_vlan),
                     },
     }
 


### PR DESCRIPTION
This PR needs ~~https://github.com/RedHatQE/widgetastic.patternfly/pull/18~~ and ~~https://gitlab.cee.redhat.com/cfme-qe/cfme-qe-yamls/merge_requests/375~~
Vlan names are different from version to version - we are adding subnets/vlan etc. SCVMM/RHEVM would appreciate having this 

local testing
```
view.form.network.vlan.read()
Out[14]: u'<None>'
view.form.network.vlan.all_options
Out[15]:
[Option(text=u'<None>', value=u'0'),
 Option(text=u'<No Profile>', value=u'1'),
 Option(text=u'ovirtmgmt (ovirtmgmt)', value=u'2')]
view.form.network.vlan.fill(partial_match('ovirt'))
Out[16]: True
```