### PR TITLE
[1LP][RFR] Remove testgen from cloud_infra_common (part 1)

### DIFF
--- a/cfme/tests/cloud_infra_common/test_discovery.py
+++ b/cfme/tests/cloud_infra_common/test_discovery.py
@@ -1,20 +1,21 @@
 # -*- coding: utf-8 -*-
 import pytest
 import time
+from cfme.common.provider import BaseProvider
 from cfme.common.vm import VM
 from cfme.exceptions import CFMEException
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
-from cfme.utils import testgen
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
 from cfme.utils.wait import TimedOutError
 from cfme import test_requirements
 
 
-def pytest_generate_tests(metafunc):
-    # Filter out providers without provisioning data or hosts defined
-    argnames, argvalues, idlist = testgen.all_providers(metafunc)
-    testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope="module")
+pytestmark = [
+    pytest.mark.tier(2),
+    test_requirements.discovery,
+    pytest.mark.provider([BaseProvider], scope='module')
+]
 
 
 @pytest.fixture(scope="module")
@@ -53,8 +54,6 @@ def wait_for_vm_state_changes(vm, timeout=600):
         raise CFMEException("VM should be Archived but it is Orphaned now.")
 
 
-@pytest.mark.tier(2)
-@test_requirements.discovery
 def test_vm_discovery(request, setup_provider, provider, vm_crud):
     """ Tests whether cfme will discover a vm change (add/delete) without being manually refreshed.
 

--- a/cfme/tests/cloud_infra_common/test_events.py
+++ b/cfme/tests/cloud_infra_common/test_events.py
@@ -3,23 +3,21 @@
 import fauxfactory
 import pytest
 
+from cfme.common.provider import BaseProvider
 from cfme.common.vm import VM
 from cfme.control.explorer.policies import VMControlPolicy
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
-from cfme.utils import testgen
 from cfme.utils.blockers import BZ
 from cfme.utils.wait import wait_for
 
 
 pytestmark = [
     pytest.mark.usefixtures('uses_infra_providers', 'uses_cloud_providers'),
-    pytest.mark.tier(2)
+    pytest.mark.tier(2),
+    pytest.mark.provider([BaseProvider],
+                         required_fields=['provisioning'],
+                         scope='module'),
 ]
-
-
-def pytest_generate_tests(metafunc):
-    argnames, argvalues, idlist = testgen.all_providers(metafunc, required_fields=['provisioning'])
-    testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope="module")
 
 
 @pytest.yield_fixture(scope="function")

--- a/cfme/tests/cloud_infra_common/test_html5_vm_console.py
+++ b/cfme/tests/cloud_infra_common/test_html5_vm_console.py
@@ -9,20 +9,22 @@ from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.common.provider import CloudInfraProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.common.vm import VM
-from cfme.utils import testgen, version, ssh
+from cfme.utils import version, ssh
 from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 from cfme.utils.conf import credentials
 from cfme.utils.providers import ProviderFilter
 from wait_for import wait_for
+from markers.env_markers.provider import providers
 
-pytestmark = pytest.mark.usefixtures('setup_provider')
 
-pytest_generate_tests = testgen.generate(
-    gen_func=testgen.providers,
-    filters=[ProviderFilter(classes=[CloudInfraProvider], required_flags=['html5_console'])],
-    scope='module'
-)
+pytestmark = [
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.provider(gen_func=providers,
+                         filters=[ProviderFilter(classes=[CloudInfraProvider],
+                                                 required_flags=['html5_console'])],
+                         scope='module'),
+]
 
 
 @pytest.fixture(scope="function")

--- a/cfme/tests/cloud_infra_common/test_power_control_rest.py
+++ b/cfme/tests/cloud_infra_common/test_power_control_rest.py
@@ -2,8 +2,8 @@
 import pytest
 
 from cfme import test_requirements
+from cfme.common.provider import BaseProvider
 from cfme.common.vm import VM
-from cfme.utils import testgen
 from cfme.utils.generators import random_vm_name
 from cfme.utils.wait import wait_for
 from cfme.utils.log import logger
@@ -16,13 +16,10 @@ from cfme.infrastructure.provider.rhevm import RHEVMProvider
 pytestmark = [
     test_requirements.power,
     pytest.mark.usefixtures('uses_infra_providers', 'uses_cloud_providers'),
-    pytest.mark.tier(2)
+    pytest.mark.tier(2),
+    pytest.mark.provider([BaseProvider], scope='module'),
+    pytest.mark.parametrize("from_detail", [True, False], ids=["from_detail", "from_collection"]),
 ]
-
-
-def pytest_generate_tests(metafunc):
-    argnames, argvalues, idlist = testgen.all_providers(metafunc)
-    testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope="module")
 
 
 @pytest.fixture(scope='function')
@@ -76,7 +73,6 @@ def verify_action_result(rest_api, assert_success=True):
     return success, message
 
 
-@pytest.mark.parametrize("from_detail", [True, False], ids=["cfrom_detail", "from_collection"])
 def test_stop_vm_rest(appliance, vm_obj, verify_vm_running, soft_assert, from_detail):
     """Test stop of vm
 
@@ -107,7 +103,6 @@ def test_stop_vm_rest(appliance, vm_obj, verify_vm_running, soft_assert, from_de
     soft_assert(not verify_vm_power_state(vm, vm_obj.STATE_ON), "vm still running")
 
 
-@pytest.mark.parametrize("from_detail", [True, False], ids=["from_detail", "from_collection"])
 def test_start_vm_rest(appliance, vm_obj, verify_vm_stopped, soft_assert, from_detail):
     """Test start vm
 
@@ -138,7 +133,6 @@ def test_start_vm_rest(appliance, vm_obj, verify_vm_stopped, soft_assert, from_d
     soft_assert(verify_vm_power_state(vm, vm_obj.STATE_ON), "vm not running")
 
 
-@pytest.mark.parametrize("from_detail", [True, False], ids=["from_detail", "from_collection"])
 def test_suspend_vm_rest(appliance, vm_obj, verify_vm_running, soft_assert, from_detail):
     """Test suspend vm
 
@@ -176,7 +170,6 @@ def test_suspend_vm_rest(appliance, vm_obj, verify_vm_running, soft_assert, from
 
 @pytest.mark.uncollectif(lambda provider: provider.one_of(RHEVMProvider),
                          reason='Not supported for RHV provider')
-@pytest.mark.parametrize("from_detail", [True, False], ids=["from_detail", "from_collection"])
 def test_reset_vm_rest(vm_obj, verify_vm_running, from_detail, appliance):
     """
     Test reset vm


### PR DESCRIPTION
__Updating tests.__ Replace testgen and pytest_generate_tests with pytest.mark.provider.

Test collections seem to be the same as before.