### PR TITLE
[1LP][RFR] Remove testgen from cloud_infra_common (part 2)

### DIFF
--- a/cfme/tests/cloud_infra_common/test_rest_providers.py
+++ b/cfme/tests/cloud_infra_common/test_rest_providers.py
@@ -3,15 +3,17 @@ import pytest
 
 from cfme import test_requirements
 from cfme.common.provider import CloudInfraProvider
-from cfme.utils import error, testgen
+from cfme.utils import error
 from cfme.utils.blockers import BZ
 from cfme.utils.rest import assert_response, delete_resources_from_collection
 from cfme.utils.wait import wait_for
 
 
-pytest_generate_tests = testgen.generate(classes=[CloudInfraProvider])
-
-pytestmark = [test_requirements.rest]
+pytestmark = [
+    test_requirements.rest,
+    pytest.mark.tier(1),
+    pytest.mark.provider([CloudInfraProvider])
+]
 
 
 def delete_provider(appliance, name):
@@ -54,7 +56,6 @@ def provider_rest(request, appliance, provider):
     return provider_rest
 
 
-@pytest.mark.tier(1)
 def test_create_provider(provider_rest):
     """Tests creating provider using REST API.
 
@@ -64,7 +65,6 @@ def test_create_provider(provider_rest):
     assert "ManageIQ::Providers::" in provider_rest.type
 
 
-@pytest.mark.tier(1)
 def test_provider_refresh(provider_rest, appliance):
     """Test checking that refresh invoked from the REST API works.
 
@@ -95,7 +95,6 @@ def test_provider_refresh(provider_rest, appliance):
         assert task.status.lower() == "ok", "Task failed with status '{}'".format(task.status)
 
 
-@pytest.mark.tier(1)
 def test_provider_edit(request, provider_rest, appliance):
     """Test editing a provider using REST API.
 
@@ -111,7 +110,6 @@ def test_provider_edit(request, provider_rest, appliance):
     assert provider_rest.name == new_name == edited.name
 
 
-@pytest.mark.tier(1)
 @pytest.mark.meta(blockers=[BZ(1501941, forced_streams=['5.9', 'upstream'])])
 @pytest.mark.parametrize("method", ["post", "delete"], ids=["POST", "DELETE"])
 def test_provider_delete_from_detail(provider_rest, appliance, method):
@@ -133,7 +131,6 @@ def test_provider_delete_from_detail(provider_rest, appliance, method):
     assert_response(appliance, http_status=404)
 
 
-@pytest.mark.tier(1)
 @pytest.mark.meta(blockers=[BZ(1501941, forced_streams=['5.9', 'upstream'])])
 def test_provider_delete_from_collection(provider_rest, appliance):
     """Tests deletion of the provider from collection using REST API.

--- a/cfme/tests/cloud_infra_common/test_snapshots_rest.py
+++ b/cfme/tests/cloud_infra_common/test_snapshots_rest.py
@@ -8,7 +8,7 @@ from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.common.vm import VM
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
-from cfme.utils import error, testgen
+from cfme.utils import error
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
 from cfme.utils.rest import assert_response, delete_resources_from_collection
@@ -17,19 +17,12 @@ from cfme.utils.wait import wait_for
 
 
 pytestmark = [
-    pytest.mark.uncollectif(
-        lambda: current_version() < '5.8'),
+    pytest.mark.uncollectif(lambda: current_version() < '5.8'),
     pytest.mark.long_running,
     pytest.mark.tier(2),
-    test_requirements.snapshot
+    test_requirements.snapshot,
+    pytest.mark.provider([VMwareProvider, OpenStackProvider], scope='module'),
 ]
-
-
-def pytest_generate_tests(metafunc):
-    argnames, argvalues, idlist = testgen.providers_by_class(
-        metafunc,
-        [VMwareProvider, OpenStackProvider])
-    testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope='module')
 
 
 @pytest.yield_fixture(scope='module')

--- a/cfme/tests/cloud_infra_common/test_tag_visibility.py
+++ b/cfme/tests/cloud_infra_common/test_tag_visibility.py
@@ -1,16 +1,15 @@
 import pytest
 
 from cfme import test_requirements
+from cfme.common.provider import BaseProvider
 from cfme.common.vm import VM
-from cfme.utils import testgen
 
 
-def pytest_generate_tests(metafunc):
-    argnames, argvalues, idlist = testgen.all_providers(metafunc, required_fields=['cap_and_util'])
-    testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope="module")
-
-
-pytestmark = [test_requirements.tag]
+pytestmark = [
+    test_requirements.tag,
+    pytest.mark.tier(3),
+    pytest.mark.provider([BaseProvider], required_fields=['cap_and_util'], scope='module')
+]
 
 
 @pytest.yield_fixture(scope="module")
@@ -23,7 +22,6 @@ def tagged_vm(tag, has_no_providers_modscope, setup_provider_modscope, provider)
     tag_vm.remove_tag(tag=tag)
 
 
-@pytest.mark.tier(3)
 def test_tag_vis_vm(tagged_vm, user_restricted):
     with user_restricted:
         assert tagged_vm.exists, "vm not found"

--- a/cfme/tests/cloud_infra_common/test_vm_ownership.py
+++ b/cfme/tests/cloud_infra_common/test_vm_ownership.py
@@ -4,20 +4,16 @@ import pytest
 import cfme.configure.access_control as ac
 from cfme import test_requirements
 from cfme.base.credential import Credential
+from cfme.common.provider import BaseProvider
 from cfme.common.vm import VM
-from cfme.utils import testgen
 from cfme.utils.blockers import BZ
-
-
-def pytest_generate_tests(metafunc):
-    argnames, argvalues, idlist = testgen.all_providers(metafunc, required_fields=['ownership_vm'])
-    testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope="module")
 
 
 pytestmark = [
     test_requirements.ownership,
     pytest.mark.meta(blockers=[BZ(1380781, forced_streams=["5.7"])]),
-    pytest.mark.tier(3)
+    pytest.mark.tier(3),
+    pytest.mark.provider([BaseProvider], required_fields=['ownership_vm'], scope='module')
 ]
 
 


### PR DESCRIPTION
__Updating tests.__ Replace testgen and pytest_generate_tests with pytest.mark.provider.