### PR TITLE
[1LP][RFR] Marked some ansible service tests as uncollected due BZ 1519275

### DIFF
--- a/cfme/tests/ansible/test_embedded_ansible_services.py
+++ b/cfme/tests/ansible/test_embedded_ansible_services.py
@@ -19,9 +19,7 @@ from cfme.utils.update import update
 
 pytestmark = [
     pytest.mark.long_running,
-    pytest.mark.meta(server_roles=["+embedded_ansible"]),
     pytest.mark.ignore_stream("upstream", '5.7'),
-    pytest.mark.uncollectif(BZ(1515841, forced_streams=['5.9']).blocks, 'BZ 1515841'),
     test_requirements.ansible
 ]
 
@@ -35,7 +33,10 @@ SERVICE_CATALOG_VALUES = [
 
 @pytest.fixture(scope="module")
 def wait_for_ansible(appliance):
+    appliance.server.settings.enable_server_roles("embedded_ansible")
     appliance.wait_for_embedded_ansible()
+    yield
+    appliance.server.settings.disable_server_roles("embedded_ansible")
 
 
 @pytest.yield_fixture(scope="module")
@@ -152,12 +153,14 @@ def custom_service_button(ansible_catalog_item):
 
 
 @pytest.mark.tier(1)
+@pytest.mark.meta(blockers=[BZ(1515841, forced_streams=['5.9'])])
 def test_service_ansible_playbook_available():
     view = navigate_to(AnsiblePlaybookCatalogItem("", "", provisioning={}), "PickItemType")
     assert "Ansible Playbook" in [option.text for option in view.catalog_item_type.all_options]
 
 
 @pytest.mark.tier(1)
+@pytest.mark.meta(blockers=[BZ(1515841, forced_streams=['5.9'])])
 def test_service_ansible_playbook_crud(ansible_repository):
     cat_item = AnsiblePlaybookCatalogItem(
         fauxfactory.gen_alphanumeric(),
@@ -185,6 +188,7 @@ def test_service_ansible_playbook_crud(ansible_repository):
     assert not cat_item.exists
 
 
+@pytest.mark.meta(blockers=[BZ(1515841, forced_streams=['5.9'])])
 def test_service_ansible_playbook_tagging(ansible_catalog_item):
     """ Tests ansible_playbook tag addition, check added tag and removal
 
@@ -203,6 +207,7 @@ def test_service_ansible_playbook_tagging(ansible_catalog_item):
 
 
 @pytest.mark.tier(2)
+@pytest.mark.meta(blockers=[BZ(1515841, forced_streams=['5.9'])])
 def test_service_ansible_playbook_negative():
     view = navigate_to(AnsiblePlaybookCatalogItem("", "", {}), "Add")
     view.fill({
@@ -213,6 +218,7 @@ def test_service_ansible_playbook_negative():
 
 
 @pytest.mark.tier(2)
+@pytest.mark.meta(blockers=[BZ(1515841, forced_streams=['5.9'])])
 def test_service_ansible_playbook_bundle(ansible_catalog_item):
     """Ansible playbooks are not designed to be part of a cloudforms service bundle."""
     view = navigate_to(CatalogBundle(), "BundleAdd")
@@ -221,6 +227,10 @@ def test_service_ansible_playbook_bundle(ansible_catalog_item):
 
 
 @pytest.mark.tier(2)
+@pytest.mark.meta(blockers=[
+    BZ(1519275, forced_streams=['5.9']),
+    BZ(1515841, forced_streams=['5.9'])
+])
 def test_service_ansible_playbook_provision_in_requests(appliance, ansible_catalog_item,
                                                         service_catalog):
     """Tests if ansible playbook service provisioning is shown in service requests."""
@@ -232,6 +242,7 @@ def test_service_ansible_playbook_provision_in_requests(appliance, ansible_catal
 
 
 @pytest.mark.tier(2)
+@pytest.mark.meta(blockers=[BZ(1515841, forced_streams=['5.9'])])
 def test_service_ansible_playbook_confirm():
     """Tests after selecting playbook additional widgets appear and are pre-populated where
     possible.
@@ -258,6 +269,10 @@ def test_service_ansible_playbook_confirm():
 @pytest.mark.parametrize("host_type,order_value,result", SERVICE_CATALOG_VALUES, ids=[
     value[0] for value in SERVICE_CATALOG_VALUES])
 @pytest.mark.parametrize("action", ["provisioning", "retirement"])
+@pytest.mark.meta(blockers=[
+    BZ(1519275, forced_streams=['5.9']),
+    BZ(1515841, forced_streams=['5.9'])
+])
 def test_service_ansible_playbook_order_retire(appliance, ansible_catalog_item, service_catalog,
         service_request, service, host_type, order_value, result, action):
     """Test ordering and retiring ansible playbook service against default host, blank field and
@@ -272,6 +287,7 @@ def test_service_ansible_playbook_order_retire(appliance, ansible_catalog_item, 
     assert result == view.provisioning.details.get_text_of("Hosts")
 
 
+@pytest.mark.meta(blockers=[BZ(1519275, forced_streams=['5.9'])])
 def test_service_ansible_playbook_plays_table(ansible_catalog_item, service_catalog,
         service_request, service, soft_assert):
     """Plays table in provisioned and retired service should contain at least one row."""
@@ -284,6 +300,10 @@ def test_service_ansible_playbook_plays_table(ansible_catalog_item, service_cata
 
 
 @pytest.mark.tier(3)
+@pytest.mark.meta(blockers=[
+    BZ(1519275, forced_streams=['5.9']),
+    BZ(1515841, forced_streams=['5.9'])
+])
 def test_service_ansible_playbook_order_credentials(ansible_catalog_item, ansible_credential,
         service_catalog):
     """Test if credentials avaialable in the dropdown in ordering ansible playbook service
@@ -300,6 +320,10 @@ def test_service_ansible_playbook_order_credentials(ansible_catalog_item, ansibl
 
 @pytest.mark.tier(3)
 @pytest.mark.parametrize("action", ["provisioning", "retirement"])
+@pytest.mark.meta(blockers=[
+    BZ(1519275, forced_streams=['5.9']),
+    BZ(1515841, forced_streams=['5.9'])
+])
 def test_service_ansible_playbook_pass_extra_vars(service_catalog, service_request, service,
         action):
     """Test if extra vars passed into ansible during ansible playbook service provision and
@@ -317,6 +341,10 @@ def test_service_ansible_playbook_pass_extra_vars(service_catalog, service_reque
 
 
 @pytest.mark.tier(3)
+@pytest.mark.meta(blockers=[
+    BZ(1519275, forced_streams=['5.9']),
+    BZ(1515841, forced_streams=['5.9'])
+])
 def test_service_ansible_execution_ttl(request, service_catalog, ansible_catalog_item, service,
          service_request):
     """Test if long running processes allowed to finish. There is a code that guarantees to have 100
@@ -344,6 +372,10 @@ def test_service_ansible_execution_ttl(request, service_catalog, ansible_catalog
 
 
 @pytest.mark.tier(3)
+@pytest.mark.meta(blockers=[
+    BZ(1519275, forced_streams=['5.9']),
+    BZ(1515841, forced_streams=['5.9'])
+])
 def test_custom_button_ansible_credential_list(custom_service_button, service_catalog, service,
         service_request, appliance):
     """Test if credential list matches when the Ansible Playbook Service Dialog is invoked from a


### PR DESCRIPTION
Purpose
=================

Automation test suite cannot find elements which don't have some unique locator like it's implemented here:
```html
<input ng-model="vm.dialogField.default_value" ng-disabled="vm.dialogField.read_only || vm.inputDisabled" ng-change="vm.changesHappened()" ng-blur="vm.validateField()" ng-model-options="{debounce: {'default': 500}}" class="form-control ng-pristine ng-untouched ng-valid ng-not-empty" uib-tooltip="" value="localhost" type="text">
```

There is no "id", "name" or another attribute which helps to locate this input on the page. So until the [BZ 1519275](https://bugzilla.redhat.com/show_bug.cgi?id=1519275) won't be fixed, some tests should be uncollected.