### PR TITLE
[1LP][RFR] Remove testgen from control and infrastructure (part 1)

### DIFF
--- a/cfme/tests/control/test_compliance.py
+++ b/cfme/tests/control/test_compliance.py
@@ -8,7 +8,7 @@ from cfme.control.explorer.policies import HostCompliancePolicy, VMCompliancePol
 from cfme.control.explorer.conditions import VMCondition
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.configure.configuration.analysis_profile import AnalysisProfile
-from cfme.utils import testgen, conf
+from cfme.utils import conf
 from cfme.utils.blockers import BZ
 from cfme.utils.hosts import setup_providers_hosts_credentials
 from cfme.utils.update import update
@@ -20,11 +20,9 @@ pytestmark = [
     pytest.mark.ignore_stream("upstream"),
     pytest.mark.meta(server_roles=["+automate", "+smartstate", "+smartproxy"]),
     pytest.mark.tier(3),
-    test_requirements.control
+    test_requirements.control,
+    pytest.mark.provider([VMwareProvider], scope='module'),
 ]
-
-
-pytest_generate_tests = testgen.generate([VMwareProvider], scope="module")
 
 
 @pytest.fixture(scope="module")

--- a/cfme/tests/infrastructure/test_cloud_init_provisioning.py
+++ b/cfme/tests/infrastructure/test_cloud_init_provisioning.py
@@ -7,26 +7,20 @@ from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.provisioning import do_vm_provisioning
 from cfme.infrastructure.pxe import get_template_from_config
 from cfme.utils import ssh
-from cfme.utils import testgen
 from cfme.utils.wait import wait_for
+
 
 pytestmark = [
     pytest.mark.usefixtures('uses_infra_providers'),
-    pytest.mark.meta(server_roles="+automate +notifier")
+    pytest.mark.meta(server_roles="+automate +notifier"),
+    pytest.mark.provider([RHEVMProvider],
+                         required_fields=[['provisioning', 'ci-template'],
+                                          ['provisioning', 'ci-username'],
+                                          ['provisioning', 'ci-pass'],
+                                          ['provisioning', 'image'],
+                                          ['provisioning', 'vlan']],
+                         scope='module'),
 ]
-
-
-def pytest_generate_tests(metafunc):
-    # Filter out providers without provisioning data or hosts defined
-    argnames, argvalues, idlist = testgen.providers_by_class(metafunc, [RHEVMProvider],
-        required_fields=[
-            ['provisioning', 'ci-template'],
-            ['provisioning', 'ci-username'],
-            ['provisioning', 'ci-pass'],
-            ['provisioning', 'image'],
-            ['provisioning', 'vlan']
-    ])
-    testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope="module")
 
 
 @pytest.fixture(scope="module")

--- a/cfme/tests/infrastructure/test_cluster_analysis.py
+++ b/cfme/tests/infrastructure/test_cluster_analysis.py
@@ -1,17 +1,16 @@
 # -*- coding: utf-8 -*-
+import pytest
 
 # from cfme.configure.tasks import is_cluster_analysis_finished
 from cfme import test_requirements
 from cfme.infrastructure.provider import InfraProvider
 from cfme.fixtures import pytest_selenium as sel
-from cfme.utils import testgen
 from cfme.utils.wait import wait_for
 
-pytestmark = [test_requirements.smartstate]
-
-
-pytest_generate_tests = testgen.generate(
-    [InfraProvider], required_fields=['remove_test'], scope="module")
+pytestmark = [
+    test_requirements.smartstate,
+    pytest.mark.provider([InfraProvider], required_fields=['remove_test'], scope="module")
+]
 
 
 def test_run_cluster_analysis(request, setup_provider, provider, soft_assert, appliance):

--- a/cfme/tests/infrastructure/test_delete_infra_object.py
+++ b/cfme/tests/infrastructure/test_delete_infra_object.py
@@ -5,17 +5,15 @@ from cfme import test_requirements
 from cfme.common.vm import VM
 from cfme.infrastructure import resource_pool
 from cfme.infrastructure.provider import InfraProvider
-from cfme.utils import testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.wait import wait_for
 
 
-pytestmark = [pytest.mark.tier(3),
-              test_requirements.general_ui]
-
-
-pytest_generate_tests = testgen.generate(
-    [InfraProvider], required_fields=['remove_test'], scope="module")
+pytestmark = [
+    pytest.mark.tier(3),
+    test_requirements.general_ui,
+    pytest.mark.provider([InfraProvider], required_fields=['remove_test'], scope="module")
+]
 
 
 def test_delete_cluster_appear_after_refresh(setup_provider, provider, appliance):

--- a/cfme/tests/infrastructure/test_individual_host_creds.py
+++ b/cfme/tests/infrastructure/test_individual_host_creds.py
@@ -7,22 +7,20 @@ from cfme.utils import error
 from cfme.infrastructure import host
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
-from cfme.utils import testgen
 from cfme.utils.blockers import BZ
 from cfme.utils.update import update
 
-pytestmark = [pytest.mark.tier(3)]
+
+pytestmark = [
+    pytest.mark.tier(3),
+    pytest.mark.provider([VMwareProvider, RHEVMProvider], scope='module')
+]
+
 
 msgs = {
     'virtualcenter': 'Cannot complete login due to an incorrect user name or password.',
     'rhevm': 'Login failed due to a bad username or password.'
 }
-
-
-def pytest_generate_tests(metafunc):
-    argnames, argvalues, idlist = testgen.providers_by_class(
-        metafunc, [VMwareProvider, RHEVMProvider])
-    testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope="module")
 
 
 def get_host_data_by_name(provider_key, host_name):


### PR DESCRIPTION
__Updating tests.__ Replace testgen and pytest_generate_tests with pytest.mark.provider.