### PR TITLE
[1LP][RFR] Remove testgen from infrastructure (part 2)

### DIFF
--- a/cfme/tests/infrastructure/test_iso_datastore.py
+++ b/cfme/tests/infrastructure/test_iso_datastore.py
@@ -2,14 +2,13 @@ import pytest
 
 from cfme.infrastructure import pxe
 from cfme.infrastructure.provider import InfraProvider
-from cfme.utils import testgen
+
 
 pytestmark = [
     pytest.mark.usefixtures('uses_infra_providers'),
+    pytest.mark.tier(2),
+    pytest.mark.provider([InfraProvider], required_fields=['iso_datastore']),
 ]
-
-
-pytest_generate_tests = testgen.generate([InfraProvider], required_fields=['iso_datastore'])
 
 
 @pytest.fixture()
@@ -19,7 +18,6 @@ def no_iso_dss(provider):
         template_crud.delete(cancel=False)
 
 
-@pytest.mark.tier(2)
 @pytest.mark.meta(blockers=[1200783])
 def test_iso_datastore_crud(setup_provider, no_iso_dss, provider):
     """

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -15,16 +15,18 @@ from cfme.infrastructure.provider import discover, wait_for_a_provider, InfraPro
 from cfme.infrastructure.provider.rhevm import RHEVMProvider, RHEVMEndpoint
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider, VirtualCenterEndpoint
 from cfme.utils import error
-from cfme.utils import testgen
 from cfme.utils.blockers import BZ
 from cfme.utils.update import update
 
-pytest_generate_tests = testgen.generate([InfraProvider], scope="function")
+
+pytestmark = [
+    test_requirements.discovery,
+    pytest.mark.tier(3),
+    pytest.mark.provider([InfraProvider], scope="function"),
+]
 
 
-@pytest.mark.tier(3)
 @pytest.mark.sauce
-@test_requirements.discovery
 def test_empty_discovery_form_validation(appliance):
     """ Tests that the flash message is correct when discovery form is empty."""
     discover(None)
@@ -32,9 +34,7 @@ def test_empty_discovery_form_validation(appliance):
     view.flash.assert_message('At least 1 item must be selected for discovery')
 
 
-@pytest.mark.tier(3)
 @pytest.mark.sauce
-@test_requirements.discovery
 def test_discovery_cancelled_validation(appliance):
     """ Tests that the flash message is correct when discovery is cancelled."""
     discover(None, cancel=True)
@@ -43,9 +43,7 @@ def test_discovery_cancelled_validation(appliance):
                                       'Discovery was cancelled by the user')
 
 
-@pytest.mark.tier(3)
 @pytest.mark.sauce
-@test_requirements.discovery
 def test_add_cancelled_validation(appliance):
     """Tests that the flash message is correct when add is cancelled."""
     prov = VMwareProvider()
@@ -54,9 +52,7 @@ def test_add_cancelled_validation(appliance):
     view.flash.assert_success_message('Add of Infrastructure Provider was cancelled by the user')
 
 
-@pytest.mark.tier(3)
 @pytest.mark.sauce
-@test_requirements.discovery
 def test_type_required_validation():
     """Test to validate type while adding a provider"""
     prov = InfraProvider()
@@ -67,8 +63,6 @@ def test_type_required_validation():
     assert not view.add.active
 
 
-@pytest.mark.tier(3)
-@test_requirements.discovery
 def test_name_required_validation():
     """Tests to validate the name while adding a provider"""
     endpoint = VirtualCenterEndpoint(hostname=fauxfactory.gen_alphanumeric(5))
@@ -84,8 +78,6 @@ def test_name_required_validation():
     assert not view.add.active
 
 
-@pytest.mark.tier(3)
-@test_requirements.discovery
 def test_host_name_required_validation():
     """Test to validate the hostname while adding a provider"""
     endpoint = VirtualCenterEndpoint(hostname=None)
@@ -102,8 +94,6 @@ def test_host_name_required_validation():
     assert not view.add.active
 
 
-@pytest.mark.tier(3)
-@test_requirements.discovery
 def test_name_max_character_validation(request, infra_provider):
     """Test to validate max character for name field"""
     request.addfinalizer(lambda: infra_provider.delete_if_exists(cancel=False))
@@ -113,8 +103,6 @@ def test_name_max_character_validation(request, infra_provider):
     assert infra_provider.exists
 
 
-@pytest.mark.tier(3)
-@test_requirements.discovery
 def test_host_name_max_character_validation():
     """Test to validate max character for host name field"""
     endpoint = VirtualCenterEndpoint(hostname=fauxfactory.gen_alphanumeric(256))
@@ -126,8 +114,6 @@ def test_host_name_max_character_validation():
         assert view.hostname.value == prov.hostname[0:255]
 
 
-@pytest.mark.tier(3)
-@test_requirements.discovery
 def test_api_port_max_character_validation():
     """Test to validate max character for api port field"""
     endpoint = RHEVMEndpoint(hostname=fauxfactory.gen_alphanumeric(5),
@@ -145,7 +131,6 @@ def test_api_port_max_character_validation():
 
 @pytest.mark.usefixtures('has_no_infra_providers')
 @pytest.mark.tier(1)
-@test_requirements.discovery
 def test_providers_discovery(request, provider):
     """Tests provider discovery
 
@@ -161,9 +146,7 @@ def test_providers_discovery(request, provider):
 
 
 @pytest.mark.uncollectif(lambda provider: provider.type == 'rhevm', 'blocker=1399622')
-@pytest.mark.tier(3)
 @pytest.mark.usefixtures('has_no_infra_providers')
-@test_requirements.discovery
 def test_provider_add_with_bad_credentials(provider):
     """Tests provider add with bad credentials
 
@@ -183,7 +166,6 @@ def test_provider_add_with_bad_credentials(provider):
 @pytest.mark.usefixtures('has_no_infra_providers')
 @pytest.mark.tier(1)
 @pytest.mark.smoke
-@test_requirements.discovery
 @pytest.mark.meta(blockers=[BZ(1450527, unblock=lambda provider: provider.type != 'scvmm')])
 def test_provider_crud(provider):
     """Tests provider add with good credentials
@@ -208,7 +190,6 @@ def test_provider_crud(provider):
 
 @pytest.mark.usefixtures('has_no_infra_providers')
 @pytest.mark.tier(1)
-@test_requirements.discovery
 @pytest.mark.parametrize('verify_tls', [False, True], ids=['no_tls', 'tls'])
 @pytest.mark.uncollectif(lambda provider:
     not (provider.one_of(RHEVMProvider) and

--- a/cfme/tests/infrastructure/test_provisioning.py
+++ b/cfme/tests/infrastructure/test_provisioning.py
@@ -6,7 +6,7 @@ from cfme.common.provider import cleanup_vm
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.provisioning import do_vm_provisioning
-from cfme.utils import normalize_text, testgen
+from cfme.utils import normalize_text
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
@@ -18,20 +18,16 @@ pytestmark = [
     pytest.mark.meta(server_roles="+automate +notifier"),
     pytest.mark.usefixtures('uses_infra_providers'),
     pytest.mark.meta(blockers=[
-        BZ(
-            1265466,
-            unblock=lambda provider: not provider.one_of(RHEVMProvider))
+        BZ(1265466, unblock=lambda provider: not provider.one_of(RHEVMProvider))
     ]),
     pytest.mark.tier(2),
-    test_requirements.provision
+    test_requirements.provision,
+    pytest.mark.provider([InfraProvider],
+                         required_fields=[['provisioning', 'template'],
+                                          ['provisioning', 'host'],
+                                          ['provisioning', 'datastore']],
+                         scope="module"),
 ]
-
-
-pytest_generate_tests = testgen.generate([InfraProvider], required_fields=[
-    ['provisioning', 'template'],
-    ['provisioning', 'host'],
-    ['provisioning', 'datastore']
-], scope="module")
 
 
 @pytest.fixture(scope="function")

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -13,12 +13,12 @@ from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.web_ui import flash
-from cfme.utils import testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for, TimedOutError
+
 
 pytestmark = [
     pytest.mark.meta(server_roles="+automate"),
@@ -26,19 +26,15 @@ pytestmark = [
     pytest.mark.long_running,
     test_requirements.provision,
     pytest.mark.meta(blockers=[
-        BZ(
-            1265466,
-            unblock=lambda provider: not provider.one_of(RHEVMProvider))
+        BZ(1265466, unblock=lambda provider: not provider.one_of(RHEVMProvider))
     ]),
-    pytest.mark.tier(3)
+    pytest.mark.tier(3),
+    pytest.mark.provider([InfraProvider],
+                         required_fields=[['provisioning', 'template'],
+                                          ['provisioning', 'host'],
+                                          ['provisioning', 'datastore']],
+                         scope="module"),
 ]
-
-
-pytest_generate_tests = testgen.generate([InfraProvider], required_fields=[
-    ['provisioning', 'template'],
-    ['provisioning', 'host'],
-    ['provisioning', 'datastore']
-], scope="module")
 
 
 @pytest.fixture(scope="function")

--- a/cfme/tests/infrastructure/test_provisioning_rest.py
+++ b/cfme/tests/infrastructure/test_provisioning_rest.py
@@ -5,13 +5,16 @@ from cfme import test_requirements
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.utils.wait import wait_for
-from cfme.utils import testgen
 from cfme.utils.version import current_version
 
 
-pytestmark = [test_requirements.provision]
-
-pytest_generate_tests = testgen.generate([VMwareProvider, RHEVMProvider], scope="module")
+pytestmark = [
+    test_requirements.provision,
+    pytest.mark.tier(2),
+    pytest.mark.meta(server_roles="+automate"),
+    pytest.mark.usefixtures("setup_provider"),
+    pytest.mark.provider([VMwareProvider, RHEVMProvider], scope="module"),
+]
 
 
 def get_provision_data(rest_api, provider, template_name, auto_approve=True):
@@ -68,9 +71,6 @@ def provision_data(appliance, provider, small_template_modscope):
 
 # Here also available the ability to create multiple provision request, but used the save
 # href and method, so it doesn't make any sense actually
-@pytest.mark.tier(2)
-@pytest.mark.meta(server_roles="+automate")
-@pytest.mark.usefixtures("setup_provider")
 def test_provision(request, provision_data, provider, appliance):
     """Tests provision via REST API.
     Prerequisities:
@@ -100,9 +100,6 @@ def test_provision(request, provision_data, provider, appliance):
     assert provider.mgmt.does_vm_exist(vm_name), "The VM {} does not exist!".format(vm_name)
 
 
-@pytest.mark.tier(2)
-@pytest.mark.meta(server_roles="+automate")
-@pytest.mark.usefixtures("setup_provider")
 def test_create_pending_provision_requests(appliance, provider, small_template):
     """Tests creation and and auto-approval of pending provision request
     using /api/provision_requests.
@@ -130,9 +127,6 @@ def test_create_pending_provision_requests(appliance, provider, small_template):
 
 
 @pytest.mark.uncollectif(lambda: current_version() < '5.8')
-@pytest.mark.tier(2)
-@pytest.mark.meta(server_roles="+automate")
-@pytest.mark.usefixtures("setup_provider")
 def test_provision_attributes(appliance, provider, small_template):
     """Tests that it's possible to display additional attributes in /api/provision_requests/:id.
 


### PR DESCRIPTION
__Updating tests.__ Replace testgen and pytest_generate_tests with pytest.mark.provider.

Moved some common fixtures to pytestmark.