### PR TITLE
[1LP][RFR] Remove testgen from infrastructure (part 3)

### DIFF
--- a/cfme/tests/infrastructure/test_scvmm_specific.py
+++ b/cfme/tests/infrastructure/test_scvmm_specific.py
@@ -4,16 +4,13 @@ import pytest
 
 from cfme.common.vm import VM
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
-from cfme.utils import testgen
-
-
-pytest_generate_tests = testgen.generate([SCVMMProvider], scope="module")
 
 
 @pytest.mark.meta(blockers=[1178961])
 @pytest.mark.uncollectif(
     lambda provider: "host_group" in provider.data.get("provisioning", {}),
     reason="No host group")
+@pytest.mark.provider([SCVMMProvider], scope="module")
 def test_no_dvd_ruins_refresh(provider, small_template):
     host_group = provider.data["provisioning"]["host_group"]
     with provider.mgmt.with_vm(

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -10,7 +10,6 @@ from cfme.common.vm import VM
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.infrastructure.virtual_machines import Vm  # For Vm.Snapshot
-from cfme.utils import testgen
 from cfme.utils.conf import credentials
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
@@ -23,11 +22,9 @@ from cfme.utils.wait import wait_for
 pytestmark = [
     pytest.mark.long_running,
     pytest.mark.tier(2),
-    test_requirements.snapshot
+    test_requirements.snapshot,
+    pytest.mark.provider([RHEVMProvider, VMwareProvider], scope="module"),
 ]
-
-
-pytest_generate_tests = testgen.generate([RHEVMProvider, VMwareProvider], scope="module")
 
 
 @pytest.fixture(scope="module")

--- a/cfme/tests/infrastructure/test_vm_clone.py
+++ b/cfme/tests/infrastructure/test_vm_clone.py
@@ -4,22 +4,18 @@ import pytest
 
 from cfme.common.provider import cleanup_vm
 from cfme.common.vm import VM
-from cfme.infrastructure.provider import InfraProvider
-from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
-from cfme.utils import testgen
 from cfme.utils.log import logger
 
+
 pytestmark = [
-    pytest.mark.meta(roles="+automate")
+    pytest.mark.meta(roles="+automate"),
+    pytest.mark.provider([VMwareProvider],
+                         required_fields=[['provisioning', 'template'],
+                                          ['provisioning', 'host'],
+                                          ['provisioning', 'datastore']],
+                         scope="module"),
 ]
-
-
-pytest_generate_tests = testgen.generate([VMwareProvider], required_fields=[
-    ['provisioning', 'template'],
-    ['provisioning', 'host'],
-    ['provisioning', 'datastore']
-], scope="module")
 
 
 @pytest.fixture(scope="function")

--- a/cfme/tests/infrastructure/test_vm_migrate.py
+++ b/cfme/tests/infrastructure/test_vm_migrate.py
@@ -8,11 +8,14 @@ from cfme import test_requirements
 
 from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
-from cfme.utils import testgen
+
 
 pytestmark = [
     pytest.mark.meta(server_roles="+automate"),
     test_requirements.vm_migrate,
+    pytest.mark.tier(2),
+    pytest.mark.meta(blockers=[BZ(1478518, forced_streams=['5.7', '5.8', '5.9', 'upstream'])]),
+    pytest.mark.provider([VMwareProvider, RHEVMProvider], scope='module')
 ]
 
 
@@ -28,14 +31,6 @@ def new_vm(setup_provider_modscope, provider, request):
     return vm
 
 
-def pytest_generate_tests(metafunc):
-    argnames, argvalues, idlist = testgen.providers_by_class(
-        metafunc, [VMwareProvider, RHEVMProvider])
-    testgen.parametrize(metafunc, argnames, argvalues, ids=idlist, scope="module")
-
-
-@pytest.mark.tier(2)
-@pytest.mark.meta(blockers=[BZ(1478518, forced_streams=['5.7', '5.8', '5.9', 'upstream'])])
 def test_vm_migrate(appliance, new_vm, provider):
     """Tests migration of a vm
 


### PR DESCRIPTION
__Updating tests.__ Replace testgen with pytest.mark.provider.

Moved some common fixtures to pytestmark.