### PR TITLE
[1LP][RFR] Extending test to assert FullScreen Button, Ctrl+Alt+Del Button and Connection Status, which are newly added

### DIFF
--- a/cfme/tests/infrastructure/test_webmks_console.py
+++ b/cfme/tests/infrastructure/test_webmks_console.py
@@ -2,6 +2,7 @@
 """Test for WebMKS Remote Consoles of VMware Providers."""
 import imghdr
 import pytest
+import socket
 
 from cfme.common.vm import VM
 from cfme.infrastructure.provider import InfraProvider
@@ -55,7 +56,25 @@ def ssh_client(vm_obj, console_template):
         yield vm_ssh_client
 
 
-def test_webmks_vm_console(request, appliance, provider, vm_obj,
+@pytest.fixture(scope="module")
+def configure_websocket(appliance):
+    """
+    Enable websocket role if it is disabled.
+
+    Currently the fixture cfme/fixtures/base.py,
+    disables the websocket role to avoid intrusive popups.
+    """
+    server_settings = appliance.server.settings
+    roles = server_settings.server_roles_db
+    if 'websocket' in roles and not roles['websocket']:
+        logger.info('Enabling the websocket role to allow console connections')
+        server_settings.enable_server_roles('websocket')
+        yield
+    logger.info('Disabling the websocket role to avoid intrusive popups')
+    server_settings.disable_server_roles('websocket')
+
+
+def test_webmks_vm_console(request, appliance, provider, vm_obj, configure_websocket,
         configure_vmware_console_for_test, take_screenshot, ssh_client):
     """Test the VMware WebMKS console support for a particular provider.
 
@@ -81,6 +100,9 @@ def test_webmks_vm_console(request, appliance, provider, vm_obj,
     request.addfinalizer(vm_console.close_console_window)
     request.addfinalizer(appliance.server.logout)
     try:
+        if appliance.version >= '5.9':
+            # Since connection status element is only available in latest 5.9
+            assert vm_console.wait_for_connect(180), "VM Console did not reach 'connected' state"
         # Get the login screen image, and make sure it is a jpeg file:
         screen = vm_console.get_screen(180)
         assert imghdr.what('', screen) == 'jpeg'
@@ -88,7 +110,20 @@ def test_webmks_vm_console(request, appliance, provider, vm_obj,
         assert vm_console.wait_for_text(text_to_find="login:", timeout=200),\
             "VM Console didn't prompt for Login"
 
-        result_before_login = ssh_client.run_command("who --count", ensure_user=True)
+        def _get_user_count_before_login():
+            try:
+                result = ssh_client.run_command("who --count", ensure_user=True)
+                return result.rc == 0, result
+            except socket.error as e:
+                if e.errno == socket.errno.ECONNRESET:
+                    logger.exception("Socket Error Occured: [104] Connection Reset by peer.")
+                logger.info("Trying again to perform 'who --count' over ssh.")
+                return False
+
+        result_before_login, _ = wait_for(func=_get_user_count_before_login,
+                                timeout=300, delay=5)
+        result_before_login = result_before_login[1]
+        logger.info("Output of who --count is {} before login".format(result_before_login))
         # Enter Username:
         vm_console.send_keys(console_vm_username)
 
@@ -97,22 +132,50 @@ def test_webmks_vm_console(request, appliance, provider, vm_obj,
         # Enter Password:
         vm_console.send_keys("{}\n".format(console_vm_password))
 
-        result_after_login = ssh_client.run_command("who --count", ensure_user=True)
-        # Number of users before login would be 0 and after login would be 180
-        # If below assertion would fail result_after_login is also 0, denoting login failed
-        assert (result_before_login.output.split('=')[-1].strip() <
-             result_after_login.output.split('=')[-1].strip()), "Login Failed"
-
         logger.info("Wait to get the '$' prompt")
 
         vm_console.wait_for_text(text_to_find=provider.data.templates.get('console_template')
             ['prompt_text'], timeout=200)
 
+        def _validate_login():
+            # the following try/except is required to handle the exception thrown by SSH
+            # while connecting to VMware VM.It throws "[Error 104]Connection reset by Peer".
+            try:
+                result_after_login = ssh_client.run_command("who --count",
+                                            ensure_user=True)
+                logger.info("Output of 'who --count' is {} after login"
+                .format(result_after_login))
+                return result_before_login < result_after_login
+            except socket.error as e:
+                if e.errno == socket.errno.ECONNRESET:
+                    logger.exception("Socket Error Occured: [104] Connection Reset by peer.")
+                logger.info("Trying again to perform 'who --count' over ssh.")
+                return False
+
+        # Number of users before login would be 0 and after login would be 180
+        # If below assertion would fail result_after_login is also 0,
+        # denoting login failed
+        wait_for(func=_validate_login, timeout=300, delay=5)
+
         # create file on system
         vm_console.send_keys("touch blather\n")
+        vm_console.send_keys("\n\n")
+
+        if appliance.version >= '5.9':
+            # Since these buttons are only available in latest 5.9
+            vm_console.send_ctrl_alt_delete()
+            assert vm_console.wait_for_text(text_to_find="login:", timeout=200,
+                to_disappear=True), ("Text 'login:' never disappeared, indicating failure"
+                " of CTRL+ALT+DEL button functionality, please check if OS reboots on "
+                "CTRL+ALT+DEL key combination and CTRL+ALT+DEL button on HTML5 Console is working.")
+            assert vm_console.wait_for_text(text_to_find="login:", timeout=200), ("VM Console"
+                " didn't prompt for Login")
+            assert vm_console.send_fullscreen(), ("VM Console Toggle Full Screen button does"
+                " not work")
+
         wait_for(func=ssh_client.run_command, func_args=["ls blather"],
-            func_kwargs={'ensure_user': True},
-            fail_condition=lambda result: result.rc != 0, delay=1, num_sec=10)
+            func_kwargs={'ensure_user': True}, handle_exception=True,
+            fail_condition=lambda result: result.rc != 0, delay=1, num_sec=60)
         # if file was created in previous steps it will be removed here
         # we will get instance of SSHResult
         # Sometimes Openstack drops characters from word 'blather' hence try to remove


### PR DESCRIPTION
Purpose or Intent
=================
__Updating tests__ WebMKS Console now supports "Connection Status Display", "CtrlAltDel Button" and "ToggleFullScreen" Button on latest 5.9 builds. Updating automation to support that.

These features are currently in 5.9 only. Soon to be added in CFME 5.8 as well.

{{ pytest: cfme/tests/infrastructure/test_webmks_console.py --use-provider vsphere65-nested }}

PRT Build : 19123
58z- had bug, and its fixed, but not present in current build, fix will be available probably in next build tomorrow and test should pass , https://bugzilla.redhat.com/show_bug.cgi?id=1500445
59z- works
upstream - inconsistent failure, it should really pass but it didn't, I just ran it locally and it passed with no issues.