### PR TITLE
[1LP][RFR] Rude evm restart is now less rude but still thorough

### DIFF
--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -1365,10 +1365,24 @@ class IPAppliance(object):
         store.terminalreporter.write_line('evmserverd is being restarted, be patient please')
         with self.ssh_client as ssh:
             if rude:
-                log_callback('restarting evm service by killing processes')
+                self._evm_service_command(
+                    "stop", expected_exit_code=0, log_callback=log_callback)
+                log_callback('Waiting for evm service to stop')
+                try:
+                    wait_for(
+                        self.is_evm_service_running, num_sec=120, fail_condition=True, delay=10,
+                        message='evm service to stop')
+                except TimedOutError:
+                    # Don't care if it's still running
+                    pass
+                log_callback('killing any remaining processes and restarting postgres')
                 status, msg = ssh.run_command(
-                    'killall -9 ruby; systemctl restart {}-postgresql'.format(
-                        self.db.postgres_version))
+                    'killall -9 ruby; systemctl restart {}-postgresql'
+                    .format(self.db.postgres_version))
+                log_callback('Waiting for database to be available')
+                wait_for(
+                    lambda: self.db.is_online, num_sec=90, delay=10, fail_condition=False,
+                    message="database to be available")
                 self._evm_service_command("start", expected_exit_code=0, log_callback=log_callback)
             else:
                 self._evm_service_command(

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -1365,8 +1365,7 @@ class IPAppliance(object):
         store.terminalreporter.write_line('evmserverd is being restarted, be patient please')
         with self.ssh_client as ssh:
             if rude:
-                self._evm_service_command(
-                    "stop", expected_exit_code=0, log_callback=log_callback)
+                self.evmserverd.stop()
                 log_callback('Waiting for evm service to stop')
                 try:
                     wait_for(
@@ -1383,10 +1382,9 @@ class IPAppliance(object):
                 wait_for(
                     lambda: self.db.is_online, num_sec=90, delay=10, fail_condition=False,
                     message="database to be available")
-                self._evm_service_command("start", expected_exit_code=0, log_callback=log_callback)
+                self.evmserverd.start()
             else:
-                self._evm_service_command(
-                    "restart", expected_exit_code=0, log_callback=log_callback)
+                self.evmserverd.restart()
         self.server_details_changed()
 
     @logger_wrap("Waiting for EVM service: {}")


### PR DESCRIPTION
`--ui-coverage` uses rude evm restart and it kills ~40% appliances per test run; I wasn't able to reproduce it locally, but this should take care of the issue.

If not, I'll revisit after next jenkins run.

Tested locally, works fine.