### PR TITLE
[WIPTEST] Fix selecting vms for 59

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -284,7 +284,9 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, WidgetasticTaggable,
     def exists(self):
         """Checks presence of the quadicon in the CFME."""
         try:
-            self.find_quadicon()
+            any_prov = version.pick({version.LOWEST: False,
+                                     '5.9': True})
+            self.find_quadicon(from_any_provider=any_prov)
             return True
         except VmOrInstanceNotFound:
             return False

--- a/cfme/web_ui/__init__.py
+++ b/cfme/web_ui/__init__.py
@@ -2285,7 +2285,7 @@ class AngularSelect(Pretty):
             new_loc = self._loc + '/../div/ul/li/a[normalize-space(.)={}]'.format(
                 unescape(quoteattr(text)))
         else:
-            new_loc = self._loc + '/../div/ul/li/a[contains(normalize-space(.), {})]'.format(
+            new_loc = '//div/ul/li/a/span[contains(normalize-space(.), {})]'.format(
                 unescape(quoteattr(text)))
         e = sel.element(new_loc)
         sel.execute_script("arguments[0].scrollIntoView();", e)


### PR DESCRIPTION
This is not a conversion of any sort. For the sake of consistency I use version.pick, because it's already used in the file. It is not my intention to refactor anything, I just want to make my automation running again.

Fixes ownership tests.

The version.pick in vm.py makes sure the automation can check for VMs that the current user can't see. The issue is that when a provider with VMs is added in the 5.9 appliance and user does not have permission to see any of the VMs, the automation breaks. In 5.9, there is no provider displayed in navigation tree in case user can't see any VMs. It was there in 5.8, but they removed it in 5.9. The fix/workaround for this is to use from_any_provider=True, which tells the automation not to look for the one provider in the navigation tree and just check all possible added providers.

The new locator in web_ui finds all occurrences of a div element with that specified subtree. For me this works for 5.9 as well as 5.8, let's see what PRT says. I've removed the self._loc prefix since it does not seem to make things better.