### PR TITLE
[1LP][RFR] Removed current_version() from tests (part 2)

### DIFF
--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -18,8 +18,7 @@ from cfme.utils.wait import wait_for
 
 pytestmark = [
     pytest.mark.tier(2),
-    pytest.mark.uncollectif(lambda provider: provider.one_of(EC2Provider) and
-                            version.current_version() < '5.8'),
+    pytest.mark.uncollectif(lambda provider: provider.one_of(EC2Provider)),
     pytest.mark.usefixtures("setup_provider_modscope"),
     pytest.mark.provider([AzureProvider, OpenStackProvider, EC2Provider], scope="module")
 ]

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -294,7 +294,6 @@ class TestProvidersRESTAPI(object):
         return response
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     @pytest.mark.parametrize('from_detail', [True, False], ids=['from_detail', 'from_collection'])
     def test_cloud_networks_query(self, cloud_provider, appliance, from_detail):
         """Tests querying cloud providers and cloud_networks collection for network info.
@@ -314,7 +313,6 @@ class TestProvidersRESTAPI(object):
         assert 'CloudNetwork' in networks[0].type
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.7')
     def test_security_groups_query(self, cloud_provider, appliance):
         """Tests querying cloud networks subcollection for security groups info.
 

--- a/cfme/tests/cloud_infra_common/test_html5_vm_console.py
+++ b/cfme/tests/cloud_infra_common/test_html5_vm_console.py
@@ -76,7 +76,6 @@ def configure_websocket(appliance):
     server_settings.disable_server_roles('websocket')
 
 
-@pytest.mark.uncollectif(lambda: version.current_version() < '5.8', reason='Only valid for >= 5.8')
 def test_html5_vm_console(appliance, provider, configure_websocket, vm_obj,
         configure_vmware_console_for_test, take_screenshot):
     """

--- a/cfme/tests/configure/test_timeprofile.py
+++ b/cfme/tests/configure/test_timeprofile.py
@@ -33,17 +33,6 @@ def test_timeprofile_crud():
 
 
 @pytest.mark.sauce
-@pytest.mark.uncollectif(lambda: version.current_version() > '5.7')
-def test_timeprofile_duplicate_name():
-    nt = new_timeprofile()
-    nt.create()
-    msg = "Error during 'add': Validation failed: Description has already been taken"
-    with error.expected(msg):
-        nt.create()
-    nt.delete()
-
-
-@pytest.mark.sauce
 def test_timeprofile_name_max_character_validation():
     tp = st.Timeprofile(
         description=fauxfactory.gen_alphanumeric(50),

--- a/cfme/tests/infrastructure/test_config_management.py
+++ b/cfme/tests/infrastructure/test_config_management.py
@@ -9,8 +9,7 @@ from cfme.utils.blockers import BZ
 
 pytest_generate_tests = generate(gen_func=config_managers)
 pytestmark = [pytest.mark.uncollectif(lambda config_manager_obj:
-                                      config_manager_obj.type == "Ansible Tower" and
-                                      version.current_version() > "5.6"),
+                                      config_manager_obj.type == "Ansible Tower"),
               pytest.mark.meta(blockers=[BZ(1393987)])]
 
 
@@ -48,21 +47,11 @@ def tag(category):
 
 
 @pytest.mark.tier(3)
-@pytest.mark.meta(
-    blockers=[BZ(1388928, unblock=lambda config_manager_obj: (
-        config_manager_obj.type == "Ansible Tower" and version.current_version() > "5.7.0.9") or
-        config_manager_obj.type != "Ansible Tower")]
-)
 def test_config_manager_detail_config_btn(request, config_manager):
     config_manager.refresh_relationships()
 
 
 @pytest.mark.tier(2)
-@pytest.mark.meta(
-    blockers=[BZ(1388928, unblock=lambda config_manager_obj: (
-        config_manager_obj.type == "Ansible Tower" and version.current_version() > "5.7.0.9") or
-        config_manager_obj.type != "Ansible Tower")]
-)
 def test_config_manager_add(request, config_manager_obj):
     request.addfinalizer(config_manager_obj.delete)
     config_manager_obj.create()
@@ -98,13 +87,7 @@ def test_config_manager_edit(request, config_manager):
 
 
 @pytest.mark.tier(3)
-@pytest.mark.uncollectif(lambda config_manager_obj: config_manager_obj.type == "Ansible Tower" and
-    version.current_version() > "5.7.0.9")
-@pytest.mark.meta(
-    blockers=[BZ(1388928, unblock=lambda config_manager_obj: (
-        config_manager_obj.type == "Ansible Tower" and version.current_version() > "5.7.0.9") or
-        config_manager_obj.type != "Ansible Tower")]
-)
+@pytest.mark.uncollectif(lambda config_manager_obj: config_manager_obj.type == "Ansible Tower")
 def test_config_manager_remove(config_manager):
     config_manager.delete()
 
@@ -112,11 +95,6 @@ def test_config_manager_remove(config_manager):
 # Disable this test for Tower, no Configuration profiles can be retrieved from Tower side yet
 @pytest.mark.tier(3)
 @pytest.mark.uncollectif(lambda config_manager_obj: config_manager_obj.type == "Ansible Tower")
-@pytest.mark.meta(
-    blockers=[BZ(1388928, unblock=lambda config_manager_obj: (
-        config_manager_obj.type == "Ansible Tower" and version.current_version() > "5.7.0.9") or
-        config_manager_obj.type != "Ansible Tower")]
-)
 def test_config_system_tag(request, config_system, tag):
     config_system.add_tag(tag=tag, details=False)
     tags = config_system.get_tags()


### PR DESCRIPTION
__Updating tests__ to remove support of versions <5.8.
__Deleting tests__ with uncollectif always True for versions 5.8+.