### PR TITLE
[RFR] Removed current_version() from tests (part 3)

### DIFF
--- a/cfme/tests/infrastructure/test_config_management_rest.py
+++ b/cfme/tests/infrastructure/test_config_management_rest.py
@@ -5,7 +5,6 @@ import fauxfactory
 
 from cfme import test_requirements
 from cfme.configure.settings import DefaultView
-from cfme.utils import version
 from cfme.utils.rest import assert_response
 from cfme.utils.testgen import config_managers, generate
 from cfme.utils.wait import wait_for
@@ -81,9 +80,7 @@ def _check_edited_authentications(appliance, authentications, new_names):
         assert auth.name == record[0].name
 
 
-@pytest.mark.uncollectif(lambda config_manager_obj:
-        config_manager_obj.type != 'Ansible Tower' or
-        version.current_version() < '5.8')
+@pytest.mark.uncollectif(lambda config_manager_obj: config_manager_obj.type != 'Ansible Tower')
 class TestAuthenticationsRESTAPI(object):
 
     def test_authentications_edit_single(self, appliance, authentications):

--- a/cfme/tests/infrastructure/test_set_default_filter.py
+++ b/cfme/tests/infrastructure/test_set_default_filter.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from cfme.utils import version
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.infrastructure.datastore import DatastoreCollection
 
@@ -39,29 +38,6 @@ def test_clear_host_filter_results(appliance):
     view.entities.search.remove_search_filters()
     page_title = view.title.text
     assert page_title == 'Hosts', 'Clear filter results failed'
-
-
-@pytest.mark.uncollectif(lambda: version.current_version() >= "5.6")
-def test_set_default_datastore_filter(request, appliance):
-    """ Test for setting default filter for datastores."""
-
-    # I guess this test has to be redesigned
-    # Add cleanup finalizer
-    dc = DatastoreCollection(appliance)
-
-    def unset_default_datastore_filter():
-        view = navigate_to(dc, 'All')
-        view.filters.navigation.select('ALL')
-        view.default_filter_btn.click()
-    request.addfinalizer(unset_default_datastore_filter)
-
-    view = navigate_to(dc, 'All')
-    view.filters.navigation.select('Store Type / NFS')
-    view.default_filter_btn.click()
-    appliance.server.logout()
-    appliance.server.login_admin()
-    navigate_to(dc, 'All')
-    assert view.filters.navigation.currently_selected[0] == 'Store Type / NFS (Default)'
 
 
 def test_clear_datastore_filter_results(appliance):

--- a/cfme/tests/infrastructure/test_webmks_console.py
+++ b/cfme/tests/infrastructure/test_webmks_console.py
@@ -55,7 +55,6 @@ def ssh_client(vm_obj, console_template):
         yield vm_ssh_client
 
 
-@pytest.mark.uncollectif(lambda: version.current_version() < '5.8', reason='Only valid for >= 5.8')
 def test_webmks_vm_console(request, appliance, provider, vm_obj,
         configure_vmware_console_for_test, take_screenshot, ssh_client):
     """Test the VMware WebMKS console support for a particular provider.

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -245,7 +245,6 @@ class TestServiceRESTAPI(object):
             assert service.name == new_names[i]
 
     # POST method is not available on < 5.8, as described in BZ 1414852
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
     def test_delete_service_post(self, appliance, services):
         """Tests deleting services from detail using POST method.
 
@@ -413,7 +412,6 @@ class TestServiceRESTAPI(object):
         vm = appliance.rest_api.collections.vms.get(name=service_data['vm_name'])
         assert service.vms[0].id == vm.id
 
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
     def test_service_add_resource(self, request, appliance, vm):
         """Tests adding resource to service.
 
@@ -428,7 +426,6 @@ class TestServiceRESTAPI(object):
         assert_response(appliance)
         assert len(service.vms) == 1
 
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
     def test_service_remove_resource(self, request, appliance, service_data):
         """Tests removing resource from service.
 
@@ -445,7 +442,6 @@ class TestServiceRESTAPI(object):
         assert_response(appliance)
         assert len(service.vms) == vms_num - 1
 
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
     def test_service_remove_all_resources(self, request, appliance, vm, service_data):
         """Tests removing all resources from service.
 
@@ -477,10 +473,7 @@ class TestServiceRESTAPI(object):
         service = collection.action.create(service_body())[0]
         request.addfinalizer(service.action.delete)
         bodies = []
-        references = [{'id': service.id}]
-        if version.current_version() >= '5.8':
-            # referencing using href is not supported in versions < 5.8
-            references.append({'href': service.href})
+        references = [{'id': service.id}, {'href': service.href}]
         for ref in references:
             bodies.append(service_body(parent_service=ref))
         response = collection.action.create(*bodies)
@@ -668,7 +661,6 @@ class TestServiceTemplateRESTAPI(object):
         delete_resources_from_collection(collection, service_templates)
 
     # POST method is not available on < 5.8, as described in BZ 1427338
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
     def test_delete_service_template_post(self, appliance, service_templates):
         """Tests deleting service templates from detail using POST method.
 
@@ -894,7 +886,6 @@ class TestServiceCatalogsRESTAPI(object):
         def _finished():
             appliance.rest_api.collections.services.action.delete(*new_services)
 
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
     def test_order_catalog_bundle(self, appliance, request, catalog_bundle):
         """Tests ordering catalog bundle using the REST API.
 
@@ -968,7 +959,6 @@ class TestServiceCatalogsRESTAPI(object):
         delete_resources_from_collection(collection, service_catalogs, num_sec=300, delay=5)
 
 
-@pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
 class TestPendingRequestsRESTAPI(object):
     def _get_instance(self, miq_domain):
         auto_class = (miq_domain
@@ -1384,7 +1374,6 @@ class TestOrchestrationTemplatesRESTAPI(object):
             assert orchestration_templates[i].description == new[i]['description']
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
     @pytest.mark.parametrize(
         "from_detail", [True, False],
         ids=["from_detail", "from_collection"])
@@ -1428,7 +1417,6 @@ class TestOrchestrationTemplatesRESTAPI(object):
             assert new_record.name == copied[i].name
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
     @pytest.mark.parametrize(
         "from_detail", [True, False],
         ids=["from_detail", "from_collection"])
@@ -1494,7 +1482,6 @@ class TestServiceOrderCart(object):
         return response
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
     def test_create_empty_cart(self, appliance, cart):
         """Tests creating an empty cart.
 
@@ -1506,7 +1493,6 @@ class TestServiceOrderCart(object):
         assert cart_dict['id'] == cart.id
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
     def test_create_second_cart(self, request, appliance, cart):
         """Tests that it's not possible to create second cart.
 
@@ -1539,7 +1525,6 @@ class TestServiceOrderCart(object):
         assert response['id'] == cart_dict['id']
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
     def test_add_to_cart(self, request, cart, service_templates_class):
         """Tests adding service requests to a cart.
 
@@ -1554,7 +1539,6 @@ class TestServiceOrderCart(object):
             assert service_request.source_id in templates_ids
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
     def test_delete_requests(self, appliance, cart, service_templates_class):
         """Tests that deleting service requests removes them also from a cart.
 
@@ -1574,7 +1558,6 @@ class TestServiceOrderCart(object):
         assert all_req_ids - cart_req_ids == all_req_ids
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
     def test_remove_from_cart(self, appliance, cart, service_templates_class):
         """Tests removing service requests from a cart.
 
@@ -1594,7 +1577,6 @@ class TestServiceOrderCart(object):
         assert all_req_ids - cart_req_ids == all_req_ids
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
     def test_clear_cart(self, appliance, cart, service_templates_class):
         """Tests removing all service requests from a cart.
 
@@ -1612,7 +1594,6 @@ class TestServiceOrderCart(object):
         assert all_req_ids - cart_req_ids == all_req_ids
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
     def test_copy_cart(self, appliance, cart):
         """Tests that it's not possible to copy a cart.
 
@@ -1624,7 +1605,6 @@ class TestServiceOrderCart(object):
         assert_response(appliance, http_status=400)
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
     def test_order_cart(self, request, appliance, cart, service_templates_class):
         """Tests ordering service requests in a cart.
 
@@ -1659,7 +1639,6 @@ class TestServiceOrderCart(object):
             appliance.rest_api.get('{}/cart'.format(cart.collection._href))
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
     @pytest.mark.parametrize('method', ['post', 'delete'], ids=['POST', 'DELETE'])
     def test_delete_cart_from_detail(self, appliance, cart, method):
         """Tests deleting cart from detail.
@@ -1679,7 +1658,6 @@ class TestServiceOrderCart(object):
         assert_response(appliance, http_status=404)
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
     def test_delete_cart_from_collection(self, appliance, cart):
         """Tests deleting cart from collection.
 

--- a/cfme/tests/storage/test_object_store_object.py
+++ b/cfme/tests/storage/test_object_store_object.py
@@ -13,7 +13,6 @@ pytestmark = [
 ]
 
 
-@pytest.mark.uncollectif(lambda: version.current_version() < '5.8')
 def test_object_add_remove_tag(objects, provider):
     all_objects = objects.all()  # This call here doesn't filter at all
     obj = random.choice(all_objects)


### PR DESCRIPTION
__Updating tests__ to remove support of versions <5.8.
__Deleting tests__ if they are invalid for 5.8+ versions.