### PR TITLE
[1LP][RFR] Implement views and set_retirement_date for new retirement modes

### DIFF
--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -2,14 +2,16 @@ from navmazing import NavigateToSibling, NavigateToAttribute
 from riggerlib import recursive_update
 from widgetastic.exceptions import NoSuchElementException
 from widgetastic.widget import View
+from widgetastic.utils import VersionPick, Version
 from widgetastic_patternfly import Dropdown, Button
 from widgetastic_manageiq import ManageIQTree, TimelinesView, Accordion
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.common.vm import VM
 from cfme.common.vm_views import (
-    ProvisionView, VMToolbar, VMEntities, VMDetailsEntities, RetirementView, EditView,
-    SetOwnershipView, ManagementEngineView, PolicySimulationView)
+    ProvisionView, VMToolbar, VMEntities, VMDetailsEntities, EditView,
+    SetOwnershipView, ManagementEngineView, PolicySimulationView,
+    RetirementView, RetirementViewWithOffset)
 from cfme.exceptions import InstanceNotFound, ItemNotFound
 from cfme.services.requests import RequestsView
 from cfme.utils.appliance import Navigatable
@@ -151,10 +153,9 @@ class Instance(VM, Navigatable):
     PROVISION_CANCEL = 'Add of new VM Provision Request was cancelled by the user'
     PROVISION_START = ('VM Provision Request was Submitted, you will be notified when your VMs '
                        'are ready')
-
     REMOVE_SINGLE = 'Remove Instance'
-
     TO_OPEN_EDIT = "Edit this Instance"
+    DETAILS_VIEW_CLASS = InstanceDetailsView
 
     def __init__(self, name, provider, template_name=None, appliance=None):
         super(Instance, self).__init__(name=name, provider=provider, template_name=template_name)
@@ -420,7 +421,8 @@ class Details(CFMENavigateStep):
     def step(self):
         self.prerequisite_view.toolbar.view_selector.select('List View')
         try:
-            row = self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True)
+            row = self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True,
+                                                             use_search=True)
         except ItemNotFound:
             raise InstanceNotFound('Failed to locate instance with name "{}"'.format(self.obj.name))
         row.click()
@@ -478,7 +480,15 @@ class SetOwnership(CFMENavigateStep):
 
 @navigator.register(Instance, 'SetRetirement')
 class SetRetirement(CFMENavigateStep):
-    VIEW = RetirementView
+    def view_classes(self):
+        return VersionPick({
+            Version.lowest(): RetirementView,
+            "5.9": RetirementViewWithOffset
+        })
+
+    @property
+    def VIEW(self):  # noqa
+        return self.view_classes().pick(self.obj.appliance.version)
     prerequisite = NavigateToSibling('Details')
 
     def step(self, *args, **kwargs):

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Module containing classes with common behaviour for both VMs and Instances of all types."""
-from datetime import date
+from datetime import datetime, date, timedelta
 from functools import partial
 
 from wrapanapi import exceptions
@@ -25,7 +25,7 @@ from cfme.utils.pretty import Pretty
 from cfme.utils.timeutil import parsetime
 from cfme.utils.update import Updateable
 from cfme.utils.virtual_machines import deploy_template
-from cfme.utils.wait import wait_for, TimedOutError
+from cfme.utils.wait import wait_for
 
 from . import PolicyProfileAssignable, SummaryMixin
 
@@ -146,6 +146,7 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, WidgetasticTaggable,
                        '5.7': parsetime.american_minutes_with_utc,
                        '5.9': parsetime.saved_report_title_format}
     _param_name = ParamClassName('name')
+    DETAILS_VIEW_CLASS = None
 
     ###
     # Shared behaviour
@@ -708,42 +709,132 @@ class VM(BaseVM):
         """Check if VM exists on provider itself"""
         return self.provider.mgmt.does_vm_exist(self.name)
 
-    def set_retirement_date(self, when, warn=None):
-        """Sets the retirement date for this Vm object.
-
-        It incorporates some magic to make it work reliably since the retirement form is not very
-        pretty and it can't be just "done".
+    def set_retirement_date(self, when=None, offset=None, warn=None):
+        """Overriding common method to use widgetastic views/widgets properly
 
         Args:
-            when: When to retire. :py:class:`str` in format mm/dd/yyyy of
-                :py:class:`datetime.datetime` or :py:class:`utils.timeutil.parsetime`.
+            when: :py:class:`datetime.datetime` object, when to retire (date in future)
+            offset: :py:class:`dict` with months, weeks, days, hours keys. other keys ignored
             warn: When to warn, fills the select in the form in case the ``when`` is specified.
+
+        Note: this should be moved up to the common VM class when infra+cloud+common are all WT
+
+        If when and offset are both None, this removes retirement date
+
+        Examples:
+            # To set a specific retirement date 2 days from today
+            two_days_later = datetime.date.today() + datetime.timedelta(days=2)
+            vm.set_retirement_date(when=two_days_later)
+
+            # To set a retirement offset 2 weeks from now
+            vm.set_retirement_date(offset={weeks=2})
+
+        Offset is dict to remove ambiguity between timedelta/datetime and months/weeks/days/hours
+        timedelta supports creation with weeks, but not months
+        timedelta supports days attr, but not weeks or months
+        timedelta days attr will report a total summary, not the component that was passed to it
+        For these reasons timedelta isn't appropriate for offset
+        An enhancement to cfme.utils.timeutil extending timedelta would be great for making this a
+        bit cleaner
         """
-        # TODO: refactor for retirement nav destinations and widget form fill when child classes
-        self.load_details()
-        lcl_btn("Set Retirement Date")
-        if callable(self.retire_form.date_retire):
-            # It is the old functiton
-            sel.wait_for_element("#miq_date_1")
+        new_retire = self.appliance.version >= "5.9"
+        view = navigate_to(self, 'SetRetirement')
+        fill_date = None
+        fill_offset = None
+
+        # explicit is/not None use here because of empty strings and dicts
+
+        if when is not None and offset is not None:
+            raise ValueError('set_retirement_date takes when or offset, but not both')
+        if not new_retire and offset is not None:
+            raise ValueError('Offset retirement only available in CFME 59z+ or miq-gaprindashvili')
+        if when is not None and not isinstance(when, (datetime, date)):
+            raise ValueError('when argument must be a datetime object')
+
+        # due to major differences between the forms and their interaction, I'm splitting this
+        # method into two major blocks, one for each version. As a result some patterns will be
+        # repeated in both blocks
+        # This will allow for making changes to one version or the other without strange
+        # interaction in the logic
+
+        # format the date
+        # needs 4 digit year for fill
+        # displayed 2 digit year for flash message
+        if new_retire:
+            # 59z/G-release retirement
+            if when is not None and offset is None:
+                # Specific datetime retire, H+M are 00:00 by default if just date passed
+                fill_date = when.strftime('%m/%d/%Y %H:%M')  # 4 digit year
+                msg_date = when.strftime('%m/%d/%y %H:%M UTC')  # two digit year and timestamp
+                msg = 'Retirement date set to {}'.format(msg_date)
+            elif when is None and offset is None:
+                # clearing retirement date with empty string in textinput
+                fill_date = ''
+                msg = 'Retirement date removed'
+            elif offset is not None:
+                # retirement by offset
+                fill_date = None
+                fill_offset = {k: v for k, v in offset.items() if k in ['months',
+                                                                        'weeks',
+                                                                        'days',
+                                                                        'hours']}
+                # hack together an offset
+                # timedelta can take weeks, but not months
+                # copy and pop, only used to generate message, not used for form fill
+                offset_copy = fill_offset.copy()
+                if 'months' in offset_copy:
+                    new_weeks = offset_copy.get('weeks', 0) + int(offset_copy.pop('months', 0)) * 4
+                    offset_copy.update({'weeks': new_weeks})
+
+                msg_date = datetime.utcnow() + timedelta(**offset_copy)
+                msg = 'Retirement date set to {}'.format(msg_date.strftime('%m/%d/%y %H:%M UTC'))
+            # TODO move into before_fill when no need to click away from datetime picker
+            view.form.fill({
+                'retirement_mode':
+                    'Time Delay from Now' if fill_offset else 'Specific Date and Time'})
+            view.flush_widget_cache()  # since retirement_date is conditional widget
+            if fill_date is not None:  # specific check because of empty string
+                # two part fill, widget seems to block warn selection when open
+                changed_date = view.form.fill({
+                    'retirement_date': {'datetime_select': fill_date}})
+                view.title.click()  # close datetime widget
+                changed_warn = view.form.fill({'retirement_warning': warn})
+                changed = changed_date or changed_warn
+            elif fill_offset:
+                changed = view.form.fill({
+                    'retirement_date': fill_offset, 'retirement_warning': warn})
+
         else:
-            sel.wait_for_element(self.retire_form.date_retire)
-        if when is None:
-            try:
-                wait_for(lambda: sel.is_displayed(retire_remove_button), num_sec=5, delay=0.2)
-                sel.click(retire_remove_button)
-                wait_for(lambda: not sel.is_displayed(retire_remove_button), num_sec=10, delay=0.2)
-                sel.click(form_buttons.save)
-            except TimedOutError:
-                pass
+            # 58z/euwe retirement
+            if when:
+                fill_date = when.strftime('%m/%d/%Y')  # 4 digit year
+                msg_date = when.strftime('%m/%d/%y 00:00 UTC')  # two digit year and default 0 UTC
+                msg = 'Retirement date set to {}'.format(msg_date)
+            else:
+                fill_date = None
+                msg = 'Retirement date removed'
+            if fill_date:
+                changed = view.form.fill({'retirement_date': fill_date, 'retirement_warning': warn})
+            else:
+                if view.form.remove_date.is_displayed:
+                    view.form.remove_date.click()
+                    changed = True
+                else:
+                    # no date set, nothing to change
+                    logger.info('Retirement date not set, cannot clear, canceling form')
+                    changed = False
+
+        # Form save and flash messages are the same between versions
+        if changed:
+            view.form.save.click()
         else:
-            if sel.is_displayed(retire_remove_button):
-                sel.click(retire_remove_button)
-                wait_for(lambda: not sel.is_displayed(retire_remove_button), num_sec=15, delay=0.2)
-            fill(self.retire_form.date_retire, when)
-            wait_for(lambda: sel.is_displayed(retire_remove_button), num_sec=15, delay=0.2)
-            if warn is not None:
-                fill(self.retire_form.warn, warn)
-            sel.click(form_buttons.save)
+            logger.info('No form changes for setting retirement, clicking cancel')
+            view.form.cancel.click()
+            msg = 'Set/remove retirement date was cancelled by the user'
+        if self.DETAILS_VIEW_CLASS is not None:
+            view = self.create_view(self.DETAILS_VIEW_CLASS)
+            assert view.is_displayed
+        view.flash.assert_success_message(msg)
 
     def equal_drift_results(self, row_text, section, *indexes):
         """ Compares drift analysis results of a row specified by it's title text

--- a/cfme/tests/cloud_infra_common/test_retirement.py
+++ b/cfme/tests/cloud_infra_common/test_retirement.py
@@ -9,7 +9,6 @@ from cfme.common.provider import CloudInfraProvider
 from cfme.common.vm import VM
 from cfme.infrastructure.provider import InfraProvider
 from cfme.web_ui import toolbar as tb
-from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
 from cfme.utils.providers import ProviderFilter
@@ -229,11 +228,7 @@ def test_unset_retirement_date(retire_vm):
     num_days = 3
     retire_date = generate_retirement_date(delta=num_days)
     retire_vm.set_retirement_date(retire_date)
-    if BZ(1419150, forced_streams=['5.6']).blocks:
-        # The date is wrong, but we can still test unset
-        logger.warning('Skipping test step verification for BZ 1419150')
-    else:
-        verify_retirement_date(retire_vm, expected_date=retire_date)
+    verify_retirement_date(retire_vm, expected_date=retire_date)
 
     retire_vm.set_retirement_date(None)
     verify_retirement_date(retire_vm, expected_date='Never')
@@ -257,9 +252,5 @@ def test_resume_retired_instance(retire_vm, provider, remove_date):
     retire_date = None if remove_date else generate_retirement_date(delta=num_days)
     retire_vm.set_retirement_date(retire_date)
 
-    # if BZ(1419150, forced_streams=['5.6']).blocks and not remove_date:
-    #     # The date is wrong in 5.6, but we can still test unset
-    #     logger.warning('Skipping test step verification for BZ 1419150')
-    # else:
     verify_retirement_date(retire_vm, expected_date=retire_date if retire_date else 'Never')
     assert retire_vm.is_retired is False

--- a/cfme/tests/cloud_infra_common/test_retirement.py
+++ b/cfme/tests/cloud_infra_common/test_retirement.py
@@ -9,7 +9,7 @@ from cfme.common.provider import CloudInfraProvider
 from cfme.common.vm import VM
 from cfme.infrastructure.provider import InfraProvider
 from cfme.web_ui import toolbar as tb
-from cfme.utils.blockers import BZ, JIRA
+from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
 from cfme.utils.providers import ProviderFilter
@@ -48,7 +48,7 @@ def retire_vm(small_template, provider):
         provider: provider crud object from fixture
     """
     vm = VM.factory(random_vm_name('retire'), provider, template_name=small_template.name)
-    vm.create_on_provider(find_in_cfme=True, allow_skip="default")
+    vm.create_on_provider(find_in_cfme=True, allow_skip="default", timeout=1200)
     yield vm
 
     try:
@@ -67,7 +67,7 @@ def retire_ec2_s3_vm(provider):
     """
     vm = VM.factory(random_vm_name('retire'), provider,
                     template_name='amzn-ami-pv-2015.03.rc-1.x86_64-s3')
-    vm.create_on_provider(find_in_cfme=True, allow_skip="default")
+    vm.create_on_provider(find_in_cfme=True, allow_skip="default", timeout=1200)
     yield vm
 
     try:
@@ -97,8 +97,7 @@ def verify_retirement_date(retire_vm, expected_date='Never'):
     """Verify the retirement date for a variety of situations
 
     Args:
-        expected_date: a :py:class: `str` or :py:class: `parsetime` date
-            or a dict of :py:class: `parsetime` dates with 'start' and 'end' keys.
+        expected_date: a string, datetime, or a dict datetime dates with 'start' and 'end' keys.
     """
     if isinstance(expected_date, dict):
         # convert to a parsetime object for comparsion, function depends on version
@@ -185,20 +184,45 @@ def test_retirement_now_ec2_instance_backed(retire_ec2_s3_vm, tagged):
     verify_retirement_date(retire_ec2_s3_vm, expected_date=retire_times)
 
 
-@pytest.mark.meta(blockers=[JIRA('RHCFQE-5912')])
 @pytest.mark.parametrize('warn', warnings, ids=[warning.id for warning in warnings])
 def test_set_retirement_date(retire_vm, warn):
     """Tests setting retirement date and verifies configured date is reflected in UI
 
     Note we cannot control the retirement time, just day, so we cannot wait for the VM to retire
     """
+    # TODO retirement supports datetime (no tz) in gaprindashvili/59z, update accordingly
     num_days = 2
     retire_date = generate_retirement_date(delta=num_days)
     retire_vm.set_retirement_date(retire_date, warn=warn.string)
     verify_retirement_date(retire_vm, expected_date=retire_date)
 
 
-@pytest.mark.meta(blockers=[JIRA('RHCFQE-5912')])
+@pytest.mark.tier(2)
+@pytest.mark.parametrize('warn', warnings, ids=[warning.id for warning in warnings])
+@pytest.mark.ignore_stream('5.8')
+@pytest.mark.uncollectif(lambda provider: provider.one_of(InfraProvider))  # TODO remove when common
+def test_set_retirement_offset(retire_vm, warn):
+    """Tests setting the retirement by offset
+
+    Minimum is 1 hour, just testing that it is set like test_set_retirement_date
+    """
+    num_hours = 3
+    num_days = 1
+    num_weeks = 2
+    num_months = 0  # leave at zero for now, TODO implement months->weeks calc for expected_dates
+    retire_offset = {'months': num_months, 'weeks': num_weeks, 'days': num_days, 'hours': num_hours}
+    timedelta_offset = retire_offset.copy()
+    timedelta_offset.pop('months')  # for timedelta use
+    # pad pre-retire timestamp by 30s
+    expected_dates = {'start': datetime.utcnow() + timedelta(seconds=-30, **timedelta_offset)}
+    retire_vm.set_retirement_date(offset=retire_offset, warn=warn.string)
+
+    # pad post-retire timestamp by 30s
+    expected_dates['end'] = datetime.utcnow() + timedelta(seconds=30, **timedelta_offset)
+    verify_retirement_date(retire_vm,
+                           expected_date=expected_dates)
+
+
 def test_unset_retirement_date(retire_vm):
     """Tests cancelling a scheduled retirement by removing the set date
     """
@@ -216,9 +240,6 @@ def test_unset_retirement_date(retire_vm):
 
 
 @pytest.mark.tier(2)
-@pytest.mark.meta(blockers=[JIRA('RHCFQE-5912'),
-                            BZ(1430373, forced_streams=['5.6'],
-                               unblock=lambda provider: provider.one_of(InfraProvider))])
 @pytest.mark.parametrize('remove_date', [True, False], ids=['remove_date', 'set_future_date'])
 def test_resume_retired_instance(retire_vm, provider, remove_date):
     """Test resuming a retired instance, should be supported for infra and cloud, though the
@@ -236,9 +257,9 @@ def test_resume_retired_instance(retire_vm, provider, remove_date):
     retire_date = None if remove_date else generate_retirement_date(delta=num_days)
     retire_vm.set_retirement_date(retire_date)
 
-    if BZ(1419150, forced_streams=['5.6']).blocks and not remove_date:
-        # The date is wrong in 5.6, but we can still test unset
-        logger.warning('Skipping test step verification for BZ 1419150')
-    else:
-        verify_retirement_date(retire_vm, expected_date=retire_date if retire_date else 'Never')
+    # if BZ(1419150, forced_streams=['5.6']).blocks and not remove_date:
+    #     # The date is wrong in 5.6, but we can still test unset
+    #     logger.warning('Skipping test step verification for BZ 1419150')
+    # else:
+    verify_retirement_date(retire_vm, expected_date=retire_date if retire_date else 'Never')
     assert retire_vm.is_retired is False


### PR DESCRIPTION
Huge retirement changes in 59z/gaprindashvili

implemented set_retirement_date in cloud.instance since its converted to
WT via vm_views.
Update vm_views with new views/widgets/conditionals

With conversion of VM, this method should be applicable to cloud and
infra both, and can be moved up into common.vm

Fixes RHCFQE-5192

@rsnyman This will have some implications for your VM conversion PR
@jan-zmeskal  This should resolve the retirement tests that are blocked by the JIRA card
@rlbabyuk Could use your review here, know you wanted to look at this with @jan-zmeskal but when I started to look into it I determined it was way too complex and nasty for a WT introduction for @jan-zmeskal. Didn't want to start him off on something that would make him hate the framework.

## PRT Results
This aims to fix the framework problems causing test failures. PRT should be green for test_retirement.

Limiting PRT to ec2west right now, as this method has been implemented under `cfme.cloud.instance`.

{{pytest: cfme/tests/cloud_infra_common/test_retirement.py --long-running -v --use-provider rhos7-ga }}