### PR TITLE
[1LP][RFR]Changing the way of selecting instances for test_group_ownership

### DIFF
--- a/cfme/tests/cloud_infra_common/test_vm_ownership.py
+++ b/cfme/tests/cloud_infra_common/test_vm_ownership.py
@@ -6,11 +6,7 @@ from cfme import test_requirements
 from cfme.base.credential import Credential
 from cfme.common.provider import BaseProvider
 from cfme.common.vm import VM
-<<<<<<< 68a63981a292aaee5095f0925b359f35cf05c84d
-=======
 from cfme.exceptions import VmOrInstanceNotFound
-from cfme.utils import testgen
->>>>>>> Changing user_ownership_vm.exists to group_ownership_vm.find_quadicon(from_any_provider=True) for restricted user
 from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 
@@ -134,7 +130,7 @@ def test_user_ownership_crud(request, user1, setup_provider, provider):
     with user1:
         try:
             user_ownership_vm.find_quadicon(from_any_provider=True)
-            pytest.fail("vm found! but shouldn\'t")
+            pytest.fail("vm found! but shouldn't")
         except VmOrInstanceNotFound:
             logger.debug("vm not found as expected")
 
@@ -146,7 +142,7 @@ def test_group_ownership_on_user_only_role(request, user2, setup_provider, provi
     with user2:
         try:
             group_ownership_vm.find_quadicon(from_any_provider=True)
-            pytest.fail("vm found! but shouldn\'t")
+            pytest.fail("vm found! but shouldn't")
         except VmOrInstanceNotFound:
             logger.debug("vm not found as expected")
     group_ownership_vm.set_ownership(user=user2.name)
@@ -165,7 +161,7 @@ def test_group_ownership_on_user_or_group_role(
     with user3:
         try:
             group_ownership_vm.find_quadicon(from_any_provider=True)
-            pytest.fail("vm found! but shouldn\'t")
+            pytest.fail("vm found! but shouldn't")
         except VmOrInstanceNotFound:
             logger.debug("vm not found as expected")
 

--- a/cfme/tests/cloud_infra_common/test_vm_ownership.py
+++ b/cfme/tests/cloud_infra_common/test_vm_ownership.py
@@ -106,10 +106,13 @@ def new_user(group_only_user_owned):
 
 
 def check_vm_exists(vm_ownership):
-    """
-        Checks if VM exists through All Instances tab.
-        Args:
-            vm_ownership: VM object for ownership test
+    """ Checks if VM exists through All Instances tab.
+
+    Args:
+        vm_ownership: VM object for ownership test
+
+    Returns:
+        :py:class:`bool`
     """
     try:
         vm_ownership.find_quadicon(from_any_provider=True)

--- a/cfme/tests/cloud_infra_common/test_vm_ownership.py
+++ b/cfme/tests/cloud_infra_common/test_vm_ownership.py
@@ -6,7 +6,13 @@ from cfme import test_requirements
 from cfme.base.credential import Credential
 from cfme.common.provider import BaseProvider
 from cfme.common.vm import VM
+<<<<<<< 68a63981a292aaee5095f0925b359f35cf05c84d
+=======
+from cfme.exceptions import VmOrInstanceNotFound
+from cfme.utils import testgen
+>>>>>>> Changing user_ownership_vm.exists to group_ownership_vm.find_quadicon(from_any_provider=True) for restricted user
 from cfme.utils.blockers import BZ
+from cfme.utils.log import logger
 
 
 pytestmark = [
@@ -126,7 +132,11 @@ def test_user_ownership_crud(request, user1, setup_provider, provider):
         assert user_ownership_vm.exists, "vm not found"
     user_ownership_vm.unset_ownership()
     with user1:
-        assert not user_ownership_vm.exists, "vm exists"
+        try:
+            user_ownership_vm.find_quadicon(from_any_provider=True)
+            pytest.fail("vm found! but shouldn\'t")
+        except VmOrInstanceNotFound:
+            logger.debug("vm not found as expected")
 
 
 def test_group_ownership_on_user_only_role(request, user2, setup_provider, provider):
@@ -134,7 +144,11 @@ def test_group_ownership_on_user_only_role(request, user2, setup_provider, provi
     group_ownership_vm = VM.factory(ownership_vm, provider)
     group_ownership_vm.set_ownership(group=user2.group.description)
     with user2:
-        assert not group_ownership_vm.exists, "vm not found"
+        try:
+            group_ownership_vm.find_quadicon(from_any_provider=True)
+            pytest.fail("vm found! but shouldn\'t")
+        except VmOrInstanceNotFound:
+            logger.debug("vm not found as expected")
     group_ownership_vm.set_ownership(user=user2.name)
     with user2:
         assert group_ownership_vm.exists, "vm exists"
@@ -149,7 +163,11 @@ def test_group_ownership_on_user_or_group_role(
         assert group_ownership_vm.exists, "vm not found"
     group_ownership_vm.unset_ownership()
     with user3:
-        assert not group_ownership_vm.exists, "vm exists"
+        try:
+            group_ownership_vm.find_quadicon(from_any_provider=True)
+            pytest.fail("vm found! but shouldn\'t")
+        except VmOrInstanceNotFound:
+            logger.debug("vm not found as expected")
 
 
 # @pytest.mark.meta(blockers=[1202947])


### PR DESCRIPTION
Purpose or Intent
=================
Changing user_ownership_vm.exists to group_ownership_vm.find_quadicon(from_any_provider=True) for restricted user, due to error "Could not find the item Instances by Provider/ec2-west in Boostrap tree instances_tree" because restricted user doesn't have permission to see Instances by Provider/ec2-west, another way is to search through All Instances.


{{pytest: -v cfme/tests/cloud_infra_common/test_vm_ownership.py -k 'test_user_ownership_crud or test_group_ownership'}}