### PR TITLE
[1LP][RFR] Workaround: use internal disk on RHOS appliances

### DIFF
--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -540,12 +540,11 @@ class IPAppliance(object):
 
             logging.info("Creating loopback script, unit file and udev rule")
             for path, content in CONTENT:
-                # client.run_command("service auditd restart", ensure_host=True)
                 client.run_command("cat > {path} << {content}".format(path=path, content=content))
 
             for command in COMMANDS_TO_RUN:
                 logging.info("Running command: {}".format(command))
-                client.run_command("cat > {path} << {content}".format(path=path, content=content))
+                client.run_command(command)
 
     # TODO: this method eventually needs to be moved to provider class..
     @logger_wrap("Configure GCE IPAppliance: {}")

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -475,8 +475,8 @@ class IPAppliance(object):
         prov_data = conf.cfme_data.get('management_systems', {})['how to pass provider name here?']
         if prov_data['type'] == 'openstack':
 
-            LOOPBACK_SCRIPT_PATH = "/usr/local/sbin/loopbacks"
-            LOOPBACK_SCRIPT_CONTENT = """EOF
+            loopback_script_path = "/usr/local/sbin/loopbacks"
+            loopback_script_content = """EOF
             #!/bin/bash
             DB_PATH="/var/opt/rh/rh-postgresql95/db"
             DB="vmdb_db.img"
@@ -496,8 +496,8 @@ class IPAppliance(object):
             fi
             EOF"""
 
-            LOOPBACK_UNIT_PATH = "/etc/systemd/system/multi-user.target.wants/loopback.service"
-            LOOPBACK_UNIT_CONTENT = """EOF
+            loopback_unit_path = "/etc/systemd/system/multi-user.target.wants/loopback.service"
+            loopback_unit_content = """EOF
             [Unit]
             Description=Setup loop devices
             DefaultDependencies=false
@@ -516,21 +516,21 @@ class IPAppliance(object):
             Also=systemd-udev-settle.service
             EOF"""
 
-            UDEV_RULE_PATH = "/etc/udev/rules.d/75-persistent-disk.rules"
-            UDEV_RULE_CONTENT = """EOF
+            udev_rule_path = "/etc/udev/rules.d/75-persistent-disk.rules"
+            udev_rule_content = """EOF
             KERNEL=="loop0", SYMLINK+="vdb"
             KERNEL=="loop0p1", SYMLINK+="vdb1"
             EOF"""
 
-            CONTENT = [
-                (LOOPBACK_SCRIPT_PATH, LOOPBACK_SCRIPT_CONTENT),
-                (LOOPBACK_UNIT_PATH, LOOPBACK_UNIT_CONTENT),
-                (UDEV_RULE_PATH, UDEV_RULE_CONTENT)
+            content = [
+                (loopback_script_path, loopback_script_content),
+                (loopback_unit_path, loopback_unit_content),
+                (udev_rule_path, udev_rule_content)
             ]
 
             client = self.ssh_client
 
-            COMMANDS_TO_RUN = [
+            commands_to_run = [
                 "chmod ug+x /usr/local/sbin/loopbacks",
                 "chown root:root /usr/local/sbin/loopbacks",
                 "systemctl daemon-reload",
@@ -539,10 +539,10 @@ class IPAppliance(object):
             ]
 
             logging.info("Creating loopback script, unit file and udev rule")
-            for path, content in CONTENT:
+            for path, content in content:
                 client.run_command("cat > {path} << {content}".format(path=path, content=content))
 
-            for command in COMMANDS_TO_RUN:
+            for command in commands_to_run:
                 logging.info("Running command: {}".format(command))
                 client.run_command(command)
 

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -427,6 +427,7 @@ class IPAppliance(object):
             loosen_pgssl: Loosens postgres connections if ``True`` (default ``True``)
             key_address: Fetch encryption key from this address if set, generate a new key if
                          ``None`` (default ``None``)
+            on_openstack: If appliance is running on Openstack provider (default ``False``)
 
         """
 
@@ -435,6 +436,7 @@ class IPAppliance(object):
         fix_ntp_clock = kwargs.pop('fix_ntp_clock', True)
         region = kwargs.pop('region', 0)
         key_address = kwargs.pop('key_address', None)
+        on_openstack = kwargs.pop('on_openstack', False)
         with self as ipapp:
             ipapp.wait_for_ssh()
 
@@ -453,7 +455,8 @@ class IPAppliance(object):
                 self.fix_ntp_clock(log_callback=log_callback)
                 # TODO: Handle external DB setup
             # This is workaround for Openstack appliances to use only one disk for the VMDB
-            self.configure_rhos_db_disk()
+            if on_openstack:
+                self.configure_rhos_db_disk()
 
             self.db.setup(region=region, key_address=key_address)
             self.wait_for_evm_service(timeout=1200, log_callback=log_callback)
@@ -472,79 +475,76 @@ class IPAppliance(object):
             self.wait_for_web_ui(timeout=1800, log_callback=log_callback)
 
     def configure_rhos_db_disk(self):
-        prov_data = conf.cfme_data.get('management_systems', {})['how to pass provider name here?']
-        if prov_data['type'] == 'openstack':
+        loopback_script_path = "/usr/local/sbin/loopbacks"
+        loopback_script_content = """EOF
+        #!/bin/bash
+        DB_PATH="/var/opt/rh/rh-postgresql95/db"
+        DB="vmdb_db.img"
+        DB_IMG="${DB_PATH}/${DB}"
+        DB_SIZE="5GB"
 
-            loopback_script_path = "/usr/local/sbin/loopbacks"
-            loopback_script_content = """EOF
-            #!/bin/bash
-            DB_PATH="/var/opt/rh/rh-postgresql95/db"
-            DB="vmdb_db.img"
-            DB_IMG="${DB_PATH}/${DB}"
-            DB_SIZE="5GB"
+        if [ ! -f ${DB_IMG} ]; then
+            fallocate -l ${DB_SIZE} ${DB_IMG}
+        fi
 
-            if [ ! -f ${DB_IMG} ]; then
-                fallocate -l ${DB_SIZE} ${DB_IMG}
-            fi
+        if  ! losetup -l | grep ${DB} 1> /dev/null ; then
+            losetup -f ${DB_IMG}
+            partprobe /dev/vdb
+            partprobe /dev/vdc
+            systemctl restart lvm2-lvmetad.service
+            vgchange -a y vg_pg
+        fi
+        EOF"""
 
-            if  ! losetup -l | grep ${DB} 1> /dev/null ; then
-                losetup -f ${DB_IMG}
-                partprobe /dev/vdb
-                partprobe /dev/vdc
-                systemctl restart lvm2-lvmetad.service
-                vgchange -a y vg_pg
-            fi
-            EOF"""
+        loopback_unit_path = "/etc/systemd/system/multi-user.target.wants/loopback.service"
+        loopback_unit_content = """EOF
+        [Unit]
+        Description=Setup loop devices
+        DefaultDependencies=false
+        ConditionFileIsExecutable=/usr/local/sbin/loopbacks
+        After=var.mount
+        Requires=systemd-remount-fs.service
 
-            loopback_unit_path = "/etc/systemd/system/multi-user.target.wants/loopback.service"
-            loopback_unit_content = """EOF
-            [Unit]
-            Description=Setup loop devices
-            DefaultDependencies=false
-            ConditionFileIsExecutable=/usr/local/sbin/loopbacks
-            After=var.mount
-            Requires=systemd-remount-fs.service
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/local/sbin/loopbacks
+        TimeoutSec=60
+        RemainAfterExit=yes
 
-            [Service]
-            Type=oneshot
-            ExecStart=/usr/local/sbin/loopbacks
-            TimeoutSec=60
-            RemainAfterExit=yes
+        [Install]
+        WantedBy=local-fs.target
+        Also=systemd-udev-settle.service
+        EOF"""
 
-            [Install]
-            WantedBy=local-fs.target
-            Also=systemd-udev-settle.service
-            EOF"""
+        udev_rule_path = "/etc/udev/rules.d/75-persistent-disk.rules"
+        udev_rule_content = """EOF
+        KERNEL=="loop0", SYMLINK+="vdb"
+        KERNEL=="loop0p1", SYMLINK+="vdb1"
+        EOF"""
 
-            udev_rule_path = "/etc/udev/rules.d/75-persistent-disk.rules"
-            udev_rule_content = """EOF
-            KERNEL=="loop0", SYMLINK+="vdb"
-            KERNEL=="loop0p1", SYMLINK+="vdb1"
-            EOF"""
+        content = [
+            (loopback_script_path, loopback_script_content),
+            (loopback_unit_path, loopback_unit_content),
+            (udev_rule_path, udev_rule_content)
+        ]
 
-            content = [
-                (loopback_script_path, loopback_script_content),
-                (loopback_unit_path, loopback_unit_content),
-                (udev_rule_path, udev_rule_content)
-            ]
+        client = self.ssh_client
 
-            client = self.ssh_client
+        commands_to_run = [
+            "chmod ug+x /usr/local/sbin/loopbacks",
+            "chown root:root /usr/local/sbin/loopbacks",
+            "systemctl daemon-reload",
+            "udevadm control --reload-rules && udevadm trigger",
+            "/usr/local/sbin/loopbacks"
+        ]
 
-            commands_to_run = [
-                "chmod ug+x /usr/local/sbin/loopbacks",
-                "chown root:root /usr/local/sbin/loopbacks",
-                "systemctl daemon-reload",
-                "udevadm control --reload-rules && udevadm trigger",
-                "/usr/local/sbin/loopbacks"
-            ]
+        logging.info("Creating loopback script, unit file and udev rule")
+        for path, content in content:
+            client.run_command("cat > {path} << {content}".format(path=path, content=content))
 
-            logging.info("Creating loopback script, unit file and udev rule")
-            for path, content in content:
-                client.run_command("cat > {path} << {content}".format(path=path, content=content))
-
-            for command in commands_to_run:
-                logging.info("Running command: {}".format(command))
-                client.run_command(command)
+        for command in commands_to_run:
+            logging.info("Running command: {}".format(command))
+            client.run_command(command)
 
     # TODO: this method eventually needs to be moved to provider class..
     @logger_wrap("Configure GCE IPAppliance: {}")

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -477,7 +477,8 @@ class IPAppliance(object):
 
     def configure_rhos_db_disk(self):
         loopback_script_path = "/usr/local/sbin/loopbacks"
-        loopback_script_content = dedent("""EOF
+        loopback_script_content = dedent("""
+        EOF
         #!/bin/bash
         DB_PATH="/var/opt/rh/rh-postgresql95/db"
         DB="vmdb_db.img"
@@ -495,10 +496,12 @@ class IPAppliance(object):
             systemctl restart lvm2-lvmetad.service
             vgchange -a y vg_pg
         fi
-        EOF""")
+        EOF
+        """).strip()
 
         loopback_unit_path = "/etc/systemd/system/multi-user.target.wants/loopback.service"
-        loopback_unit_content = dedent("""EOF
+        loopback_unit_content = dedent("""
+        EOF
         [Unit]
         Description=Setup loop devices
         DefaultDependencies=false
@@ -515,13 +518,16 @@ class IPAppliance(object):
         [Install]
         WantedBy=local-fs.target
         Also=systemd-udev-settle.service
-        EOF""")
+        EOF
+        """).strip()
 
         udev_rule_path = "/etc/udev/rules.d/75-persistent-disk.rules"
-        udev_rule_content = dedent("""EOF
+        udev_rule_content = dedent("""
+        EOF
         KERNEL=="loop0", SYMLINK+="vdb"
         KERNEL=="loop0p1", SYMLINK+="vdb1"
-        EOF""")
+        EOF
+        """).strip()
 
         content = [
             (loopback_script_path, loopback_script_content),

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from tempfile import NamedTemporaryFile
 from time import sleep, time
 from urlparse import urlparse
+from textwrap import dedent
 
 import attr
 import dateutil.parser
@@ -476,7 +477,7 @@ class IPAppliance(object):
 
     def configure_rhos_db_disk(self):
         loopback_script_path = "/usr/local/sbin/loopbacks"
-        loopback_script_content = """EOF
+        loopback_script_content = dedent("""EOF
         #!/bin/bash
         DB_PATH="/var/opt/rh/rh-postgresql95/db"
         DB="vmdb_db.img"
@@ -494,10 +495,10 @@ class IPAppliance(object):
             systemctl restart lvm2-lvmetad.service
             vgchange -a y vg_pg
         fi
-        EOF"""
+        EOF""")
 
         loopback_unit_path = "/etc/systemd/system/multi-user.target.wants/loopback.service"
-        loopback_unit_content = """EOF
+        loopback_unit_content = dedent("""EOF
         [Unit]
         Description=Setup loop devices
         DefaultDependencies=false
@@ -514,13 +515,13 @@ class IPAppliance(object):
         [Install]
         WantedBy=local-fs.target
         Also=systemd-udev-settle.service
-        EOF"""
+        EOF""")
 
         udev_rule_path = "/etc/udev/rules.d/75-persistent-disk.rules"
-        udev_rule_content = """EOF
+        udev_rule_content = dedent("""EOF
         KERNEL=="loop0", SYMLINK+="vdb"
         KERNEL=="loop0p1", SYMLINK+="vdb1"
-        EOF"""
+        EOF""")
 
         content = [
             (loopback_script_path, loopback_script_content),

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -482,15 +482,15 @@ class IPAppliance(object):
         #!/bin/bash
         DB_PATH="/var/opt/rh/rh-postgresql95/db"
         DB="vmdb_db.img"
-        DB_IMG="${DB_PATH}/${DB}"
+        DB_IMG="\\${DB_PATH}/\\${DB}"
         DB_SIZE="5GB"
 
-        if [ ! -f ${DB_IMG} ]; then
-            fallocate -l ${DB_SIZE} ${DB_IMG}
+        if [ ! -f \\${DB_IMG} ]; then
+            fallocate -l \\${DB_SIZE} \\${DB_IMG}
         fi
 
-        if  ! losetup -l | grep ${DB} 1> /dev/null ; then
-            losetup -f ${DB_IMG}
+        if  ! losetup -l | grep \\${DB} 1> /dev/null ; then
+            losetup -f \\${DB_IMG}
             partprobe /dev/vdb
             partprobe /dev/vdc
             systemctl restart lvm2-lvmetad.service
@@ -746,7 +746,7 @@ class IPAppliance(object):
     def unpartitioned_disks(self):
         """Returns a list of disk devices that are not mounted."""
         disks_and_partitions = self.ssh_client.run_command(
-            "cat /proc/partitions | awk '{ print $4 }' | egrep '^[sv]d[a-z][0-9]?'").output.strip()
+            "ls -1 /dev/ | egrep '^[sv]d[a-z][0-9]?'").output.strip()
         disks_and_partitions = re.split(r'\s+', disks_and_partitions)
         partition_regexp = re.compile('^[sv]d[a-z][0-9]$')
         disks = set()


### PR DESCRIPTION
Purpose or Intent
=================
Currently we have problems running CFME appliances in RHOS environment. 
The issue is that before CFME appliance image is used by Sprout system, we start the image on each provider and do pre-configuration of that image. Pre-configuration involves setup of the VMDB database. appliance_console script requires that you have new block device available for the DB. Currently we start appliances on Openstack with ephemeral disk which is then visible in the system as vdb device. Once we are done with pre-configuration we shut down the instance down and make snapshots of it. Then this snapshot is ready for use. But the problem is that ephemeral disks are deleted on instance stop and snaphots cannot be done for them. Until we come with proper solution for openstack (heatstack templates/use volume and not ephemeral disk), this PR should provide workaround so we can use appliances on RHOS providers with just one disk.

This fix do these actions during image pre-configuration phase:

- allocates 5GB file into /var mountpoint
- maps this file as loopback interface
- adds udev rule which creates symlink for loop0, loop0p1 devices to vdb, vdb1
- appliance_console script the recognize vdb block device and configures DB on it
- adds systemd unit file which makes sure that loop0 is mapped during boot, it is recognized by LVM and all this is done after /var is mounted

There will be another PR to yamls repo to change the flavor to not use ephemeral disk.


