### PR TITLE
[RFR] Removed cfme_exception

### DIFF
--- a/cfme/tests/infrastructure/test_advanced_search_host.py
+++ b/cfme/tests/infrastructure/test_advanced_search_host.py
@@ -236,8 +236,7 @@ def test_delete_button_should_appear_after_save(host_collection, hosts_advanced_
         pytest.fail("Could not delete filter right after saving!")
 
 
-def test_cannot_delete_more_than_once(host_collection, hosts_advanced_search,
-                                      nuke_browser_after_test):
+def test_cannot_delete_more_than_once(host_collection, hosts_advanced_search):
     """When Delete button appars, it does not want to go away"""
     filter_name = fauxfactory.gen_alphanumeric()
     hosts_advanced_search.entities.search.save_filter(get_expression(False).format(0), filter_name)

--- a/cfme/tests/infrastructure/test_advanced_search_host.py
+++ b/cfme/tests/infrastructure/test_advanced_search_host.py
@@ -5,7 +5,6 @@ import pytest
 from itertools import dropwhile
 from widgetastic.exceptions import NoSuchElementException
 
-from cfme.web_ui.cfme_exception import is_cfme_exception, cfme_exception_text
 from cfme.utils.appliance.implementations.ui import navigate_to
 
 
@@ -250,9 +249,4 @@ def test_cannot_delete_more_than_once(host_collection, hosts_advanced_search,
     hosts_advanced_search.flash.assert_no_error()
     # Try it second time
     # If the button is there, it says True
-    if hosts_advanced_search.entities.search.delete_filter():
-        # This should not happen
-        msg = "Delete twice accepted!"
-        if is_cfme_exception():
-            msg += " CFME Exception text: `{}`".format(cfme_exception_text())
-        pytest.fail(msg)
+    assert not hosts_advanced_search.entities.search.delete_filter(), 'Delete twice accepted!'

--- a/cfme/tests/infrastructure/test_advanced_search_providers.py
+++ b/cfme/tests/infrastructure/test_advanced_search_providers.py
@@ -211,9 +211,5 @@ def test_cannot_delete_more_than_once(advanced_search_view):
         pytest.fail("Could not delete the filter even first time!")
         advanced_search_view.flash.assert_no_error()
     # Try it second time
-    if advanced_search_view.entities.search.delete_filter():  # If the button is there, it says True
-        # This should not happen
-        msg = "Delete twice accepted!"
-        if is_cfme_exception():
-            msg += " CFME Exception text: `{}`".format(cfme_exception_text())
-        pytest.fail(msg)
+    assert not advanced_search_view.entities.search.delete_filter(), "Delete twice accepted!"
+    advanced_search_view.flash.assert_no_error()

--- a/cfme/tests/infrastructure/test_advanced_search_providers.py
+++ b/cfme/tests/infrastructure/test_advanced_search_providers.py
@@ -10,7 +10,6 @@ from cfme.infrastructure.provider import InfraProvider
 from fixtures.pytest_store import store
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.log import logger
-from cfme.web_ui.cfme_exception import is_cfme_exception, cfme_exception_text
 
 
 pytestmark = [
@@ -211,5 +210,4 @@ def test_cannot_delete_more_than_once(advanced_search_view):
         pytest.fail("Could not delete the filter even first time!")
         advanced_search_view.flash.assert_no_error()
     # Try it second time
-    assert not advanced_search_view.entities.search.delete_filter(), "Delete twice accepted!"
-    advanced_search_view.flash.assert_no_error()
+    assert not advanced_search_view.entities.search.delete_filter(), 'Delete twice accepted!'

--- a/cfme/tests/infrastructure/test_advanced_search_vms.py
+++ b/cfme/tests/infrastructure/test_advanced_search_vms.py
@@ -228,7 +228,7 @@ def test_delete_button_should_appear_after_save(request, vm_advanced_search):
         pytest.fail("Could not delete filter right after saving!")
 
 
-def test_cannot_delete_more_than_once(vm_advanced_search, nuke_browser_after_test):
+def test_cannot_delete_more_than_once(vm_advanced_search):
     """When Delete button appars, it does not want to go away"""
     filter_name = fauxfactory.gen_alphanumeric()
     vm_advanced_search.entities.search.save_filter(

--- a/cfme/tests/infrastructure/test_advanced_search_vms.py
+++ b/cfme/tests/infrastructure/test_advanced_search_vms.py
@@ -9,7 +9,6 @@ from cfme.infrastructure import virtual_machines
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.virtual_machines import Vm
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.web_ui.cfme_exception import is_cfme_exception, cfme_exception_text
 from cfme.utils.providers import ProviderFilter
 from fixtures.provider import setup_one_or_skip
 
@@ -241,9 +240,4 @@ def test_cannot_delete_more_than_once(vm_advanced_search, nuke_browser_after_tes
         pytest.fail("Could not delete the filter even first time!")
     vm_advanced_search.flash.assert_no_error()
     # Try it second time
-    if vm_advanced_search.entities.search.delete_filter():  # If the button is there, it says True
-        # This should not happen reduntant
-        msg = "Delete twice accepted!"
-        if is_cfme_exception():
-            msg += " CFME Exception text: `{}`".format(cfme_exception_text())
-        pytest.fail(msg)
+    assert not vm_advanced_search.entities.search.delete_filter(), 'Delete twice accepted!'


### PR DESCRIPTION
__Updating tests__ for using flash messages instead of cfme_exceptions.

{{pytest: cfme/tests/infrastructure/test_advanced_search_host.py::test_cannot_delete_more_than_once cfme/tests/infrastructure/test_advanced_search_providers.py::test_cannot_delete_more_than_once cfme/tests/infrastructure/test_advanced_search_vms.py::test_cannot_delete_more_than_once}}