### PR TITLE
[1LP][RFR] Fixed get_template_from_config()

### DIFF
--- a/cfme/infrastructure/pxe.py
+++ b/cfme/infrastructure/pxe.py
@@ -962,7 +962,7 @@ class PXEMainPage(CFMENavigateStep):
         self.prerequisite_view.navigation.select('Compute', 'Infrastructure', 'PXE')
 
 
-def get_template_from_config(template_config_name):
+def get_template_from_config(template_config_name, create=False):
     """
     Convenience function to grab the details for a template from the yamls and create template.
     """
@@ -975,17 +975,16 @@ def get_template_from_config(template_config_name):
     script_data = script_data.read()
     appliance = get_or_create_current_appliance()
     collection = appliance.collections.customization_templates
-    customization_template = collection.instantiate(name=template_config['name'],
-                                                    description=template_config['description'],
-                                                    image_type=template_config['image_type'],
-                                                    script_type=template_config['script_type'],
-                                                    script_data=script_data)
-    if not customization_template.exists():
-        return collection.create(name=template_config['name'],
-                                 description=template_config['description'],
-                                 image_type=template_config['image_type'],
-                                 script_type=template_config['script_type'],
-                                 script_data=script_data)
+    kwargs = {
+        'name': template_config['name'],
+        'description': template_config['description'],
+        'image_type': template_config['image_type'],
+        'script_type': template_config['script_type'],
+        'script_data': script_data
+    }
+    customization_template = collection.instantiate(**kwargs)
+    if create and not customization_template.exists():
+        return collection.create(**kwargs)
     return customization_template
 
 

--- a/cfme/tests/cloud/test_cloud_init_provisioning.py
+++ b/cfme/tests/cloud/test_cloud_init_provisioning.py
@@ -26,9 +26,7 @@ pytestmark = [
 @pytest.fixture(scope="module")
 def setup_ci_template(provider):
     cloud_init_template_name = provider.data['provisioning']['ci-template']
-    cloud_init_template = get_template_from_config(cloud_init_template_name)
-    if not cloud_init_template.exists():
-        cloud_init_template.create()
+    get_template_from_config(cloud_init_template_name, create=True)
 
 
 @pytest.fixture(scope="function")

--- a/cfme/tests/infrastructure/test_cloud_init_provisioning.py
+++ b/cfme/tests/infrastructure/test_cloud_init_provisioning.py
@@ -26,9 +26,7 @@ pytestmark = [
 @pytest.fixture(scope="module")
 def setup_ci_template(provisioning):
     cloud_init_template_name = provisioning['ci-template']
-    cloud_init_template = get_template_from_config(cloud_init_template_name)
-    if not cloud_init_template.exists:
-        cloud_init_template.create()
+    get_template_from_config(cloud_init_template_name, create=True)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Purpose
=================

`get_template_from_config()` is located not only in the fixtures, but also in `pytest_generate_tests()`. After merging #5872 customization templates are created also during the tests collecting. This fix adds `create` boolean argument into `get_template_from_config()`.