### PR TITLE
[1LP][RFR] Fix success message for snapshot test

### DIFF
--- a/cfme/automate/explorer/method.py
+++ b/cfme/automate/explorer/method.py
@@ -378,10 +378,7 @@ class MethodCollection(BaseCollection):
             return None
         else:
             add_page.add_button.click()
-            if self.appliance.version < "5.9":
-                msg = 'Automate Method "{}" was added'.format(name)
-            else:
-                msg = 'Automate Method "{}" was saved'.format(name)
+            msg = 'Automate Method "{}" was added'.format(name)
             add_page.flash.assert_success_message(msg)
             return self.instantiate(
                 name=name,


### PR DESCRIPTION
This is a quick fix for test_create_snapshot_via_ae.

They seem to have reverted the success message for 5.9 to the string that is in use also for 5.8.

{{pytest: -v --long-running --use-provider vsphere65-nested -k "test_create_snapshot_via_ae"}}