### PR TITLE
[RFR] dockerbot - switch test image to fedora 27

### DIFF
--- a/scripts/dockerbot/pytestbase/Dockerfile
+++ b/scripts/dockerbot/pytestbase/Dockerfile
@@ -1,10 +1,11 @@
-FROM fedora:25
+FROM fedora:27
 
-RUN dnf install -y gcc postgresql-devel libxml2-devel libxslt-devel zeromq3-devel git nano python-devel gnupg gnupg2 libcurl-devel redhat-rpm-config findutils libffi-devel openssl-devel tesseract freetype-devel gcc-c++ python-pip libjpeg-devel && dnf clean all
+RUN dnf install -y gcc postgresql-devel libxml2-devel libxslt-devel zeromq-devel git nano python-devel gnupg gnupg2 libcurl-devel redhat-rpm-config findutils libffi-devel openssl-devel tesseract freetype-devel gcc-c++ python-pip libjpeg-devel && dnf clean all
 ARG CFME_REPO=https://github.com/RedHatQE/cfme_tests.git
 ARG CFME_BRANCH=master
 RUN git clone -b $CFME_BRANCH $CFME_REPO /cfme_tests
-RUN cd /cfme_tests && PYCURL_SSL_LIBRARY=nss pip install -U -r /cfme_tests/requirements/frozen.txt --no-cache-dir
+RUN cd /cfme_tests && PYCURL_SSL_LIBRARY=openssl pip install -U -r /cfme_tests/requirements/frozen.txt --no-cache-dir
+RUN python -c 'import pycurl'
 ADD setup.sh /setup.sh
 ADD post_result.py /post_result.py
 ADD get_keys.py /get_keys.py


### PR DESCRIPTION
this updates the image to fedora 27, and has passing image builds, test run outstanding