### PR TITLE
[1LP][RFR] browser fixture: handle when exception traceback paths are plain strings

### DIFF
--- a/fixtures/browser.py
+++ b/fixtures/browser.py
@@ -57,7 +57,7 @@ def pytest_exception_interact(node, call, report):
         slaveid=store.slaveid)
     exception_name = call.excinfo.type.__name__
     exception_lineno = call.excinfo.traceback[-1].lineno
-    exception_filename = call.excinfo.traceback[-1].path.strpath.replace(
+    exception_filename = str(call.excinfo.traceback[-1].path).replace(
         project_path.strpath + "/", ''
     )
     exception_location = "{}:{}".format(exception_filename, exception_lineno)


### PR DESCRIPTION
unfortunately an trace back entry path may be a plain string sometimes