### PR TITLE
[1LP][RFR] Update quickstart redhat_packages_specs with RHEL Workstation

### DIFF
--- a/cfme/scripting/quickstart.py
+++ b/cfme/scripting/quickstart.py
@@ -68,6 +68,13 @@ REDHAT_PACKAGES_SPECS = [
      " redhat-rpm-config gcc-c++ openssl-devel"
      " libffi-devel python-devel tesseract"
      " libpng-devel"
+     " freetype-devel"),
+    ("Red Hat Enterprise Linux Workstation release 7", "nss",
+     " python-virtualenv gcc postgresql-devel libxml2-devel"
+     " libxslt-devel zeromq3-devel libcurl-devel"
+     " redhat-rpm-config gcc-c++ openssl-devel"
+     " libffi-devel python-devel tesseract"
+     " libpng-devel"
      " freetype-devel")
 ]
 


### PR DESCRIPTION
{{pytest: cfme/tests/containers/test_basic_metrics.py -v --use-provider cm-env2 }}

Update quickstart redhat_packages_specs in order to suport  RHEL Workstation .
