### PR TITLE
[1LP][RFR] Fix appliance server and server name test, remove caching

### DIFF
--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -493,7 +493,7 @@ class Details(CFMENavigateStep):
         self.prerequisite_view.accordions.settings.tree.click_path(
             self.obj.zone.region.settings_string,
             "Zones",
-            "Zone: {} (current)".format(self.obj.appliance.zone_description),
+            "Zone: {} (current)".format(self.obj.appliance.server.zone.description),
             "Server: {} [{}] (current)".format(self.obj.appliance.server.name,
                 self.obj.sid))
 

--- a/cfme/configure/configuration/diagnostics_settings.py
+++ b/cfme/configure/configuration/diagnostics_settings.py
@@ -460,7 +460,7 @@ class DiagnosticsCollectLogsSlave(CFMENavigateStep):
         slave_server = self.appliance.server.slave_servers[0]
         self.prerequisite_view.accordions.diagnostics.tree.click_path(
             self.appliance.server_region_string(),
-            "Zone: {} (current)".format(self.appliance.zone_description),
+            "Zone: {} (current)".format(self.appliance.server.zone.description),
             "Server: {} [{}]".format(slave_server.name,
                                      int(slave_server.sid)))
         self.prerequisite_view.collectlogs.select()

--- a/cfme/configure/configuration/server_settings.py
+++ b/cfme/configure/configuration/server_settings.py
@@ -472,7 +472,6 @@ class ServerInformation(Updateable, Pretty, NavigatableMixin):
                 logger.warning('No values was changed')
         elif updated_result:
             view.save_button.click()
-            self.appliance.server_details_changed()
             view.flash.assert_no_error()
         else:
             logger.info('Settings were not changed')

--- a/cfme/configure/configuration/server_settings.py
+++ b/cfme/configure/configuration/server_settings.py
@@ -473,13 +473,7 @@ class ServerInformation(Updateable, Pretty, NavigatableMixin):
         elif updated_result:
             view.save_button.click()
             self.appliance.server_details_changed()
-            flash_message = (
-                'Configuration settings saved for {} Server "{} [{}]" in Zone "{}"'.format(
-                    self.appliance.product_name,
-                    self.appliance.server.name,
-                    self.appliance.server.sid,
-                    self.appliance.server.zone.name))
-            view.flash.assert_message(flash_message)
+            view.flash.assert_no_error()
         else:
             logger.info('Settings were not changed')
 


### PR DESCRIPTION
8+ tests

`appliance.server_name()` would get invalidated but `appliance.server.name` wouldn't. This takes care of that issue.

I'm leaving the deprecated methods in, just in case. I believe they could be just removed, but I'd prefer to do it the nice way, as planned by whoever added the deprecation messages.

Edit:
Removed all caching. Also removed `zone_description` in favor of `zone.description`. There is no mention of `zone_description` in the whole codebase, except the 2 changes I've made, so I believe it is safe to just remove, without deprecating it first.

{pytest: cfme/tests/configure/test_server_name.py}}