### PR TITLE
[1LP][RFR] Enabling test_vm_reconfig_add_remove_disk_cold for RHV provider

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -154,7 +154,7 @@ class VmsTemplatesAllView(InfraVmView):
     def is_displayed(self):
         return (
             self.in_infra_vms and
-            self.sidebar.vmstemplates.tree.currently_selected == 'All VMs & Templates' and
+            self.sidebar.vmstemplates.tree.currently_selected == ['All VMs & Templates'] and
             self.entities.title.text == 'All VMs & Templates')
 
     def reset_page(self):
@@ -913,11 +913,15 @@ class Vm(VM):
                     dependent = True
                 row = vm_recfg.disks_table.click_add_disk()
                 row.type.fill(disk.type)
-                row.mode.fill(mode)
                 # Unit first, then size (otherwise JS would try to recalculate the size...)
-                row[4].fill(disk.size_unit)
+                if self.provider.one_of(RHEVMProvider):
+                    # Workaround necessary until BZ 1524960 is resolved
+                    row[3].fill(disk.size_unit)
+                else:
+                    row[4].fill(disk.size_unit)
+                    row.mode.fill(mode)
+                    row.dependent.fill(dependent)
                 row.size.fill(disk.size)
-                row.dependent.fill(dependent)
                 row.actions.widget.click()
             elif action == 'delete':
                 row = vm_recfg.disks_table.row(name=disk.filename)

--- a/cfme/tests/infrastructure/test_vm_reconfigure.py
+++ b/cfme/tests/infrastructure/test_vm_reconfigure.py
@@ -76,7 +76,9 @@ def test_vm_reconfig_add_remove_hw_cold(
 @pytest.mark.parametrize('disk_type', ['thin', 'thick'])
 @pytest.mark.parametrize(
     'disk_mode', ['persistent', 'independent_persistent', 'independent_nonpersistent'])
-@pytest.mark.uncollectif(lambda provider: provider.one_of(RHEVMProvider))
+@pytest.mark.uncollectif(
+    # Disk modes cannot be specified when adding disk to VM in RHV provider
+    lambda disk_mode, provider: disk_mode != 'persistent' and provider.one_of(RHEVMProvider))
 def test_vm_reconfig_add_remove_disk_cold(
         provider, small_vm, ensure_vm_stopped, disk_type, disk_mode):
 

--- a/widgetastic_manageiq/vm_reconfigure.py
+++ b/widgetastic_manageiq/vm_reconfigure.py
@@ -27,7 +27,9 @@ class DisksTable(VanillaTable):
         'Type': BootstrapSelect(id='hdType'),
         'Mode': BootstrapSelect(id='hdMode'),
         'Size': Input(id='dvcSize'),
+        # Workaround necessary until BZ 1524960 is resolved
         4: BootstrapSelect(id='hdUnit'),
+        3: BootstrapSelect(id='hdUnit'),
         'Dependent': BootstrapSwitch(name='cb_dependent'),
         'Delete Backing': BootstrapSwitch(name='cb_deletebacking'),
         'Actions': Button()


### PR DESCRIPTION
__Adding test__ test_vm_reconfig_add_remove_disk_cold for RHV provider. Until now, it was available only for VMware. However, the same thing can be done for RHV and therefore should be tested. 

When the test case is parametrized for `disk_mode` = 'independent_persistent' or 'independent_nonpersistent', it is uncollected for RHV. It is because disk mode cannot be specified at all when adding RHV provider.

This test case has not been working properly for VMware before and I am pretty sure I did not break it any more than it was. If anything, the change of `is_displayed()` method of `VmsTemplatesAllView` class causes that it does not fail at the very beginning.

{{pytest: -vv -rs cfme/tests/infrastructure/test_vm_reconfigure.py::test_vm_reconfig_add_remove_disk_cold --use-provider rhv41 --long-running}}

