### PR TITLE
[1LP][RFR] all() For Container Collection Classes

### DIFF
--- a/cfme/containers/template.py
+++ b/cfme/containers/template.py
@@ -12,6 +12,7 @@ from cfme.containers.provider import (Labelable, ContainerObjectAllBaseView,
     ContainerObjectDetailsBaseView)
 from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep
+from cfme.utils.providers import get_crud_by_name
 
 
 class TemplateAllView(ContainerObjectAllBaseView):
@@ -51,6 +52,29 @@ class TemplateCollection(BaseCollection):
     """Collection object for :py:class:`Template`."""
 
     ENTITY = Template
+
+    def all(self):
+        # container_templates table has ems_id, join with ext_mgmgt_systems on id for provider name
+        # Then join with container_projects on the id for the project
+        template_table = self.appliance.db.client['container_templates']
+        ems_table = self.appliance.db.client['ext_management_systems']
+        project_table = self.appliance.db.client['container_projects']
+        template_query = (
+            self.appliance.db.client.session
+                .query(template_table.name, project_table.name, ems_table.name)
+                .join(ems_table, template_table.ems_id == ems_table.id)
+                .join(project_table, template_table.container_project_id == project_table.id))
+        provider = None
+        # filtered
+        if self.filters.get('provider'):
+            provider = self.filters.get('provider')
+            template_query = template_query.filter(ems_table.name == provider.name)
+        templates = []
+        for name, project_name, ems_name in template_query.all():
+            templates.append(self.instantiate(name=name, project_name=project_name,
+                                              provider=provider or get_crud_by_name(ems_name)))
+
+        return templates
 
 
 @navigator.register(TemplateCollection, 'All')

--- a/cfme/containers/volume.py
+++ b/cfme/containers/volume.py
@@ -12,6 +12,7 @@ from cfme.containers.provider import (Labelable, ContainerObjectAllBaseView,
                                       ContainerObjectDetailsBaseView)
 from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator
+from cfme.utils.providers import get_crud_by_name
 
 
 class VolumeAllView(ContainerObjectAllBaseView):
@@ -50,6 +51,26 @@ class VolumeCollection(BaseCollection):
     """Collection object for :py:class:`Volume`."""
 
     ENTITY = Volume
+
+    def all(self):
+        # container_volumes table has ems_id, join with ext_mgmgt_systems on id for provider name
+        volume_table = self.appliance.db.client['container_volumes']
+        ems_table = self.appliance.db.client['ext_management_systems']
+        volume_query = (
+            self.appliance.db.client.session
+                .query(volume_table.name, ems_table.name)
+                .join(ems_table, volume_table.parent_id == ems_table.id))
+        provider = None
+        # filtered
+        if self.filters.get('provider'):
+            provider = self.filters.get('provider')
+            volume_query = volume_query.filter(ems_table.name == provider.name)
+        volumes = []
+        for name, ems_name in volume_query.all():
+            volumes.append(self.instantiate(name=name,
+                                            provider=provider or get_crud_by_name(ems_name)))
+
+        return volumes
 
 
 @navigator.register(VolumeCollection, 'All')


### PR DESCRIPTION
The scope of this PR is to create the all method for each Collection Class for all of the Container Objects. Existing all methods have been updated to support filtering.

Adding the Collection Classes for the Container objects is handled in:
https://github.com/ManageIQ/integration_tests/pull/6091 

Manual Testing, two providers were configured (Few examples):

```
In [2]: snaim
Out[2]: <cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>

In [3]: juwatts
Out[3]: <cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>

In [4]: coll_image_reg = appliance.collections.container_image_registries

In [5]: coll_image_reg.all()
Out[5]: 
[ImageRegistry(host=u'registry.access.redhat.com', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 ImageRegistry(host=u'docker.io', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 ImageRegistry(host=u'docker-registry.default.svc', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 ImageRegistry(host=u'registry.access.redhat.com', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>)]

In [6]: coll_image_reg_snaim = appliance.collections.container_image_registries.filter({'provider':snaim})

In [7]: coll_image_reg_snaim.all()
Out[7]: [ImageRegistry(host=u'registry.access.redhat.com', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>)]

In [8]: coll_image_reg_juwatts = appliance.collections.container_image_registries.filter({'provider':juwatts})

In [9]: coll_image_reg_juwatts.all()
Out[9]: 
[ImageRegistry(host=u'registry.access.redhat.com', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 ImageRegistry(host=u'docker-registry.default.svc', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 ImageRegistry(host=u'docker.io', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>)]

In [10]: 


In [2]: coll_volume = appliance.collections.container_volumes

In [3]: coll_volume.all()
Out[3]: [Volume(name=u'logging-volume', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>)]

In [4]: coll_volume_snaim = appliance.collections.container_volumes.filter({'provider':snaim})

In [5]: coll_volume_snaim.all()
Out[5]: []

In [8]: coll_volume_juwatts = appliance.collections.container_volumes.filter({'provider':juwatts})

In [9]: coll_volume_juwatts.all()
Out[9]: [Volume(name=u'logging-volume', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>)]

In [10]: 

In [10]: coll_routes = appliance.collections.container_routes

In [11]: coll_routes.all()
Out[11]: 
[Route(name=u'docker-registry', project_name=u'default', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Route(name=u'nationalparks-katacoda', project_name=u'default', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Route(name=u'parksmap-katacoda', project_name=u'default', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Route(name=u'registry-console', project_name=u'default', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Route(name=u'docker-registry', project_name=u'default', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Route(name=u'registry-console', project_name=u'default', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Route(name=u'logging-kibana', project_name=u'logging', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Route(name=u'logging-kibana-ops', project_name=u'logging', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Route(name=u'nationalparks-katacoda', project_name=u'park-maps', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Route(name=u'parksmap-katacoda', project_name=u'park-maps', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Route(name=u'hawkular-metrics', project_name=u'openshift-infra', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Route(name=u'logging-kibana', project_name=u'logging', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Route(name=u'hawkular-metrics', project_name=u'openshift-infra', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>)]

In [12]: coll_routes_snaim = appliance.collections.container_routes.filter({'provider':snaim})

In [13]: coll_routes_snaim.all()
Out[13]: 
[Route(name=u'registry-console', project_name=u'default', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Route(name=u'docker-registry', project_name=u'default', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Route(name=u'logging-kibana-ops', project_name=u'logging', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Route(name=u'logging-kibana', project_name=u'logging', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Route(name=u'hawkular-metrics', project_name=u'openshift-infra', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>)]

In [14]: coll_routes_juwatts = appliance.collections.container_routes.filter({'provider':juwatts})

In [15]: coll_routes_juwatts.all()
Out[15]: 
[Route(name=u'registry-console', project_name=u'default', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Route(name=u'parksmap-katacoda', project_name=u'default', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Route(name=u'nationalparks-katacoda', project_name=u'default', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Route(name=u'docker-registry', project_name=u'default', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Route(name=u'logging-kibana', project_name=u'logging', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Route(name=u'hawkular-metrics', project_name=u'openshift-infra', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Route(name=u'parksmap-katacoda', project_name=u'park-maps', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Route(name=u'nationalparks-katacoda', project_name=u'park-maps', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>)]

In [16]: 

In [10]: coll_nodes = appliance.collections.container_nodes

In [11]: coll_nodes.all()
Out[11]: 
[Node(name=u'snaim-ocp-3-6-master.cfme2.lab.eng.rdu2.redhat.com', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Node(name=u'snaim-ocp-3-6-node01.cfme2.lab.eng.rdu2.redhat.com', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Node(name=u'juwatts-ocp-3-6-master.cfme2.lab.eng.rdu2.redhat.com', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Node(name=u'juwatts-ocp-3-6-node01.cfme2.lab.eng.rdu2.redhat.com', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Node(name=u'juwatts-ocp-3-6-node02.cfme2.lab.eng.rdu2.redhat.com', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Node(name=u'juwatts-ocp-3-6-node03.cfme2.lab.eng.rdu2.redhat.com', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Node(name=u'snaim-ocp-3-6-node02.cfme2.lab.eng.rdu2.redhat.com', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>)]

In [12]: coll_nodes_snaim = appliance.collections.container_nodes.filter({'provider':snaim})

In [13]: coll_nodes_snaim.all()
Out[13]: 
[Node(name=u'snaim-ocp-3-6-master.cfme2.lab.eng.rdu2.redhat.com', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Node(name=u'snaim-ocp-3-6-node01.cfme2.lab.eng.rdu2.redhat.com', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Node(name=u'snaim-ocp-3-6-node02.cfme2.lab.eng.rdu2.redhat.com', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>)]

In [14]: coll_nodes_juwatts = appliance.collections.container_nodes.filter({'provider':juwatts})

In [15]: coll_nodes_juwatts.all()
Out[15]: 
[Node(name=u'juwatts-ocp-3-6-master.cfme2.lab.eng.rdu2.redhat.com', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Node(name=u'juwatts-ocp-3-6-node01.cfme2.lab.eng.rdu2.redhat.com', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Node(name=u'juwatts-ocp-3-6-node02.cfme2.lab.eng.rdu2.redhat.com', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Node(name=u'juwatts-ocp-3-6-node03.cfme2.lab.eng.rdu2.redhat.com', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>)]

In [16]: 

In [51]: coll = appliance.collections.containers

In [52]: coll.all()
Out[52]: 
[Container(name=u'elasticsearch', pod=u'logging-es-data-master-1zlpxbqs-1-d4wpf', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'deployment', pod=u'logging-es-ops-data-master-2yp9mp9e-1-deploy', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'fluentd-elasticsearch', pod=u'logging-fluentd-w5tq4', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'kibana', pod=u'logging-kibana-1-93hxv', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'sti-build', pod=u'nationalparks-katacoda-1-build', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'nationalparks-katacoda', pod=u'nationalparks-katacoda-1-f9z46', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'fluentd-elasticsearch', pod=u'logging-fluentd-2q9jm', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'fluentd-elasticsearch', pod=u'logging-fluentd-lcgl4', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'fluentd-elasticsearch', pod=u'logging-fluentd-nll8j', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'nationalparks-katacoda', pod=u'nationalparks-katacoda-1-gtg8f', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'parksmap-katacoda', pod=u'parksmap-katacoda-1-q07h2', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'registry-console', pod=u'registry-console-1-xmrr5', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'router', pod=u'router-2-lk4nd', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'kibana-proxy', pod=u'logging-kibana-1-93hxv', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'kibana-proxy', pod=u'logging-kibana-1-zl1fk', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'kibana', pod=u'logging-kibana-ops-1-sshs3', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'kibana-proxy', pod=u'logging-kibana-ops-1-sshs3', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'registry', pod=u'docker-registry-1-n2hr7', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'router', pod=u'router-2-ng500', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'curator', pod=u'logging-curator-1-jk429', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'elasticsearch', pod=u'logging-es-data-master-z2yths8j-1-d6bf5', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'fluentd-elasticsearch', pod=u'logging-fluentd-65vhh', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'fluentd-elasticsearch', pod=u'logging-fluentd-j7z3s', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'hawkular-metrics', pod=u'hawkular-metrics-bndrl', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'sti-build', pod=u'nationalparks-katacoda-1-build', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'registry-console', pod=u'registry-console-1-6tlwz', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'fluentd-elasticsearch', pod=u'logging-fluentd-q8g7b', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'kibana', pod=u'logging-kibana-1-zl1fk', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'router', pod=u'router-2-nwdg9', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'hawkular-metrics', pod=u'hawkular-metrics-f5czf', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'curator', pod=u'logging-curator-1-qxhck', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'curator', pod=u'logging-curator-ops-1-06s1b', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'sti-build', pod=u'nationalparks-katacoda-2-build', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'hawkular-cassandra-1', pod=u'hawkular-cassandra-1-fkb4r', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'hawkular-cassandra-1', pod=u'hawkular-cassandra-1-x9nb8', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'registry', pod=u'docker-registry-1-gjjgs', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'heapster', pod=u'heapster-rknxh', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'heapster', pod=u'heapster-txklm', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>)]

In [53]: coll = appliance.collections.containers.filter({'provider':snaim})

In [54]: coll.all()
Out[54]: 
[Container(name=u'elasticsearch', pod=u'logging-es-data-master-1zlpxbqs-1-d4wpf', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'deployment', pod=u'logging-es-ops-data-master-2yp9mp9e-1-deploy', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'kibana-proxy', pod=u'logging-kibana-1-zl1fk', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'kibana', pod=u'logging-kibana-ops-1-sshs3', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'kibana-proxy', pod=u'logging-kibana-ops-1-sshs3', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'registry', pod=u'docker-registry-1-n2hr7', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'router', pod=u'router-2-ng500', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'fluentd-elasticsearch', pod=u'logging-fluentd-65vhh', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'fluentd-elasticsearch', pod=u'logging-fluentd-j7z3s', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'hawkular-metrics', pod=u'hawkular-metrics-bndrl', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'registry-console', pod=u'registry-console-1-6tlwz', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'fluentd-elasticsearch', pod=u'logging-fluentd-q8g7b', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'kibana', pod=u'logging-kibana-1-zl1fk', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'curator', pod=u'logging-curator-1-qxhck', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'curator', pod=u'logging-curator-ops-1-06s1b', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'hawkular-cassandra-1', pod=u'hawkular-cassandra-1-x9nb8', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>),
 Container(name=u'heapster', pod=u'heapster-txklm', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM SNAIM 36', key='cm-snaim-36', zone='default', metrics_type='Hawkular'>)]

In [55]: coll = appliance.collections.containers.filter({'provider':juwatts})

In [56]: coll.all()
Out[56]: 
[Container(name=u'fluentd-elasticsearch', pod=u'logging-fluentd-w5tq4', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'kibana', pod=u'logging-kibana-1-93hxv', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'sti-build', pod=u'nationalparks-katacoda-1-build', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'nationalparks-katacoda', pod=u'nationalparks-katacoda-1-f9z46', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'fluentd-elasticsearch', pod=u'logging-fluentd-2q9jm', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'fluentd-elasticsearch', pod=u'logging-fluentd-lcgl4', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'fluentd-elasticsearch', pod=u'logging-fluentd-nll8j', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'nationalparks-katacoda', pod=u'nationalparks-katacoda-1-gtg8f', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'parksmap-katacoda', pod=u'parksmap-katacoda-1-q07h2', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'registry-console', pod=u'registry-console-1-xmrr5', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'router', pod=u'router-2-lk4nd', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'kibana-proxy', pod=u'logging-kibana-1-93hxv', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'curator', pod=u'logging-curator-1-jk429', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'elasticsearch', pod=u'logging-es-data-master-z2yths8j-1-d6bf5', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'sti-build', pod=u'nationalparks-katacoda-1-build', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'router', pod=u'router-2-nwdg9', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'hawkular-metrics', pod=u'hawkular-metrics-f5czf', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'sti-build', pod=u'nationalparks-katacoda-2-build', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'hawkular-cassandra-1', pod=u'hawkular-cassandra-1-fkb4r', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'registry', pod=u'docker-registry-1-gjjgs', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>),
 Container(name=u'heapster', pod=u'heapster-rknxh', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular'>)]

In [57]: 
Database:
vmdb_production=# SELECT containers.name, ext_management_systems.name, container_groups.name from containers JOIN ext_management_systems ON (containers.ems_id = ext_management_systems.id) JOIN container_groups ON (containers.container_group_id = container_groups.id);
          name          |    name     |                     name                     
------------------------+-------------+----------------------------------------------
 elasticsearch          | CM SNAIM 36 | logging-es-data-master-1zlpxbqs-1-d4wpf
 deployment             | CM SNAIM 36 | logging-es-ops-data-master-2yp9mp9e-1-deploy
 fluentd-elasticsearch  | CM JUWATTS  | logging-fluentd-w5tq4
 kibana                 | CM JUWATTS  | logging-kibana-1-93hxv
 sti-build              | CM JUWATTS  | nationalparks-katacoda-1-build
 nationalparks-katacoda | CM JUWATTS  | nationalparks-katacoda-1-f9z46
 fluentd-elasticsearch  | CM JUWATTS  | logging-fluentd-2q9jm
 fluentd-elasticsearch  | CM JUWATTS  | logging-fluentd-lcgl4
 fluentd-elasticsearch  | CM JUWATTS  | logging-fluentd-nll8j
 nationalparks-katacoda | CM JUWATTS  | nationalparks-katacoda-1-gtg8f
 parksmap-katacoda      | CM JUWATTS  | parksmap-katacoda-1-q07h2
 registry-console       | CM JUWATTS  | registry-console-1-xmrr5
 router                 | CM JUWATTS  | router-2-lk4nd
 kibana-proxy           | CM JUWATTS  | logging-kibana-1-93hxv
 kibana-proxy           | CM SNAIM 36 | logging-kibana-1-zl1fk
 kibana                 | CM SNAIM 36 | logging-kibana-ops-1-sshs3
 kibana-proxy           | CM SNAIM 36 | logging-kibana-ops-1-sshs3
 registry               | CM SNAIM 36 | docker-registry-1-n2hr7
 router                 | CM SNAIM 36 | router-2-ng500
 fluentd-elasticsearch  | CM SNAIM 36 | logging-fluentd-65vhh
 fluentd-elasticsearch  | CM SNAIM 36 | logging-fluentd-j7z3s
 curator                | CM JUWATTS  | logging-curator-1-jk429
 elasticsearch          | CM JUWATTS  | logging-es-data-master-z2yths8j-1-d6bf5
 hawkular-metrics       | CM SNAIM 36 | hawkular-metrics-bndrl
 sti-build              | CM JUWATTS  | nationalparks-katacoda-1-build
 registry-console       | CM SNAIM 36 | registry-console-1-6tlwz
 fluentd-elasticsearch  | CM SNAIM 36 | logging-fluentd-q8g7b
 kibana                 | CM SNAIM 36 | logging-kibana-1-zl1fk
 router                 | CM JUWATTS  | router-2-nwdg9
 hawkular-metrics       | CM JUWATTS  | hawkular-metrics-f5czf
 curator                | CM SNAIM 36 | logging-curator-1-qxhck
 curator                | CM SNAIM 36 | logging-curator-ops-1-06s1b
 sti-build              | CM JUWATTS  | nationalparks-katacoda-2-build
 hawkular-cassandra-1   | CM JUWATTS  | hawkular-cassandra-1-fkb4r
 hawkular-cassandra-1   | CM SNAIM 36 | hawkular-cassandra-1-x9nb8
 registry               | CM JUWATTS  | docker-registry-1-gjjgs
 heapster               | CM JUWATTS  | heapster-rknxh
 heapster               | CM SNAIM 36 | heapster-txklm
(38 rows)

vmdb_production=# 



```
{{ pytest: cfme/tests/containers/test_cockpit.py cfme/tests/containers/test_node.py --use-provider cm-env2 --long-running }}

PRT has failures due to the test, not due to the changes in this PR