### PR TITLE
[WIPTEST] Added project resetter

### DIFF
--- a/cfme/containers/project.py
+++ b/cfme/containers/project.py
@@ -68,6 +68,9 @@ class Details(CFMENavigateStep):
     def step(self):
         self.prerequisite_view.entities.get_entity(name=self.obj.name).click()
 
+    def resetter(self):
+        self.view.toolbar.view_selector.select("Summary View")
+
 
 @navigator.register(Project, 'EditTags')
 class ImageRegistryEditTags(CFMENavigateStep):


### PR DESCRIPTION
{{ pytest: cfme/tests/containers/test_properties.py --use-provider cm-env2 }}
Because we assume that the project default view is summary some tests that use details page are failing.