### PR TITLE
[1LP][RFR] Added test_custom_button_order_ansible_playbook_service

### DIFF
--- a/cfme/automate/buttons.py
+++ b/cfme/automate/buttons.py
@@ -3,8 +3,8 @@ import re
 
 from navmazing import NavigateToSibling, NavigateToAttribute
 
-from widgetastic.utils import VersionPick
-from widgetastic.widget import Text, Checkbox
+from widgetastic.utils import ParametrizedString, VersionPick
+from widgetastic.widget import Text, Checkbox, ParametrizedView
 from widgetastic_manageiq import SummaryFormItem, FonticonPicker, PotentiallyInvisibleTab
 from widgetastic_patternfly import BootstrapSelect, Button, Input
 
@@ -272,9 +272,13 @@ class ButtonFormCommon(AutomateCustomizationView):
         system = BootstrapSelect('instance_name')
         message = Input(name='object_message')
         request = Input(name='object_request')
-        # TODO: AVP and Visibility
-        attribute_1 = Input(name='attribute_1')
-        value_1 = Input(name='value_1')
+
+        @ParametrizedView.nested
+        class attribute(ParametrizedView):  # noqa
+            PARAMETERS = ('number', )
+            key = Input(name=ParametrizedString('attribute_{number}'))
+            value = Input(name=ParametrizedString('value_{number}'))
+
         # TODO: Role Access
 
     cancel = Button('Cancel')
@@ -369,9 +373,8 @@ class Button(Updateable, Navigatable):
         'request': 'advanced',
     }
 
-    def __init__(self, group=None, text=None,
-                 hover=None, dialog=None,
-                 system=None, request=None, image=None, open_url=None, appliance=None):
+    def __init__(self, group=None, text=None, hover=None, dialog=None, system=None, request=None,
+                 image=None, open_url=None, attributes=None, appliance=None):
         Navigatable.__init__(self, appliance=appliance)
         self.group = group
         self.text = text
@@ -386,6 +389,7 @@ class Button(Updateable, Navigatable):
         else:
             self.image = 'fa-user'
         self.open_url = open_url
+        self.attributes = attributes
 
     @classmethod
     def _categorize_fill_dict(cls, d):
@@ -413,8 +417,11 @@ class Button(Updateable, Navigatable):
             'image': self.image,
             'open_url': self.open_url,
             'system': self.system,
-            'request': self.request,
+            'request': self.request
         }))
+        if self.attributes is not None:
+            for i, dict_ in enumerate(self.attributes, 1):
+                view.advanced.attribute(i).fill(dict_)
         view.add_button.click()
         view = self.create_view(ButtonGroupDetailView, self.group)
         # TODO: Enable this

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -8,10 +8,15 @@ from copy import copy
 import fauxfactory
 import re
 from navmazing import NavigateToSibling, NavigateToAttribute
-from widgetastic.utils import partial_match, VersionPick, Version
-from widgetastic.widget import Text, View, TextInput, Checkbox, NoSuchElementException
+from widgetastic.widget import (
+    Text, View, TextInput, Checkbox, NoSuchElementException, ParametrizedView)
 from widgetastic_patternfly import (
     Button, BootstrapSelect, BootstrapSwitch, Dropdown, Input as WInput, Tab)
+from widgetastic_manageiq import (
+    Accordion, ConditionalSwitchableView, ManageIQTree, CheckableManageIQTree, NonJSPaginationPane,
+    SummaryTable, Table, TimelinesView, CompareToolBarActionsView)
+from widgetastic_manageiq.vm_reconfigure import DisksTable
+from widgetastic.utils import partial_match, Parameter, VersionPick, Version
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.common.vm import VM, Template as BaseTemplate
@@ -28,10 +33,6 @@ from cfme.utils.conf import cfme_data
 from cfme.utils.log import logger
 from cfme.utils.pretty import Pretty
 from cfme.utils.wait import wait_for
-from widgetastic_manageiq import (
-    Accordion, ConditionalSwitchableView, ManageIQTree, CheckableManageIQTree, NonJSPaginationPane,
-    SummaryTable, TimelinesView, Table, CompareToolBarActionsView)
-from widgetastic_manageiq.vm_reconfigure import DisksTable
 
 
 def has_child(tree, text, parent_item=None):
@@ -74,6 +75,14 @@ class InfraGenericDetailsToolbar(View):
     monitoring = Dropdown("Monitoring")
     download = Button(title='Download summary in PDF format')
     lifecycle = Dropdown('Lifecycle')
+
+    @ParametrizedView.nested
+    class custom_button(ParametrizedView):  # noqa
+        PARAMETERS = ("button_group", )
+        _dropdown = Dropdown(text=Parameter("button_group"))
+
+        def item_select(self, button, handle_alert=None):
+            self._dropdown.item_select(button, handle_alert=handle_alert)
 
 
 class InfraVmDetailsToolbar(InfraGenericDetailsToolbar):

--- a/cfme/tests/ansible/test_embedded_ansible_automate.py
+++ b/cfme/tests/ansible/test_embedded_ansible_automate.py
@@ -1,23 +1,36 @@
 # -*- coding: utf-8 -*-
 import fauxfactory
 import pytest
+from widgetastic_patternfly import Button as WButton
 
 from cfme import test_requirements
+from cfme.automate.buttons import Button, ButtonGroup
 from cfme.automate.simulation import simulate
+from cfme.common.vm import VM
+from cfme.infrastructure.provider.virtualcenter import VMwareProvider
+from cfme.services.catalogs.ansible_catalog_item import AnsiblePlaybookCatalogItem
+from cfme.services.myservice import MyService
+from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.generators import random_vm_name
 from cfme.utils.update import update
+from cfme.utils.wait import wait_for
+from markers.env_markers.provider import ONE_PER_TYPE
 
 
 pytestmark = [
     pytest.mark.long_running,
-    pytest.mark.meta(server_roles=["+embedded_ansible"]),
-    pytest.mark.ignore_stream("upstream", "5.7", "5.8"),
+    pytest.mark.ignore_stream("upstream", "5.8"),
+    pytest.mark.provider([VMwareProvider], selector=ONE_PER_TYPE, scope="module"),
     test_requirements.ansible
 ]
 
 
 @pytest.fixture(scope="module")
 def wait_for_ansible(appliance):
+    appliance.server.settings.enable_server_roles("embedded_ansible")
     appliance.wait_for_embedded_ansible()
+    yield
+    appliance.server.settings.disable_server_roles("embedded_ansible")
 
 
 @pytest.yield_fixture(scope="module")
@@ -27,6 +40,10 @@ def ansible_repository(appliance, wait_for_ansible):
         name=fauxfactory.gen_alpha(),
         url="https://github.com/quarckster/ansible_playbooks",
         description=fauxfactory.gen_alpha())
+    wait_for(
+        lambda: repository.get_detail("Properties", "Status", refresh=True) == "successful",
+        timeout=60
+    )
     yield repository
 
     if repository.exists:
@@ -81,6 +98,88 @@ def instance(klass, method):
         fields={"execute": {"value": method.name}})
 
 
+@pytest.yield_fixture(scope="module")
+def ansible_catalog_item(ansible_repository):
+    cat_item = AnsiblePlaybookCatalogItem(
+        fauxfactory.gen_alphanumeric(),
+        fauxfactory.gen_alphanumeric(),
+        display_in_catalog=True,
+        provisioning={
+            "repository": ansible_repository.name,
+            "playbook": "dump_all_variables.yml",
+            "machine_credential": "CFME Default Credential",
+            "create_new": True,
+            "provisioning_dialog_name": fauxfactory.gen_alphanumeric(),
+            "extra_vars": [("some_var", "some_value")]
+        }
+    )
+    cat_item.create()
+    yield cat_item
+
+    if cat_item.exists:
+        cat_item.delete()
+
+
+@pytest.yield_fixture
+def custom_vm_button(ansible_catalog_item):
+    buttongroup = ButtonGroup(
+        text=fauxfactory.gen_alphanumeric(),
+        hover="btn_desc_{}".format(fauxfactory.gen_alphanumeric()))
+    buttongroup.type = buttongroup.VM_INSTANCE
+    buttongroup.create()
+    button = Button(
+        group=buttongroup,
+        text=fauxfactory.gen_alphanumeric(),
+        hover="btn_hvr_{}".format(fauxfactory.gen_alphanumeric()),
+        dialog=ansible_catalog_item.provisioning["provisioning_dialog_name"],
+        system="Request",
+        request="Order_Ansible_Playbook",
+        attributes=[
+            {"key": "hosts", "value": "localhost"},
+            {"key": "service_template_name", "value": ansible_catalog_item.name}
+        ]
+    )
+    button.create()
+    yield button
+    button.delete_if_exists()
+    buttongroup.delete_if_exists()
+
+
+@pytest.yield_fixture(scope="module")
+def vmware_vm(full_template_modscope, provider):
+    vm_obj = VM.factory(random_vm_name("ansible"), provider,
+                        template_name=full_template_modscope.name)
+    vm_obj.create_on_provider(allow_skip="default")
+    provider.mgmt.start_vm(vm_obj.name)
+    provider.mgmt.wait_vm_running(vm_obj.name)
+    if not vm_obj.exists:
+        provider.refresh_provider_relationships()
+        vm_obj.wait_to_appear()
+    yield vm_obj
+    if provider.mgmt.does_vm_exist(vm_obj.name):
+        provider.mgmt.delete_vm(vm_obj.name)
+    provider.refresh_provider_relationships()
+
+
+@pytest.yield_fixture
+def service_request(appliance, ansible_catalog_item):
+    request_desc = "Provisioning Service [{0}] from [{0}]".format(ansible_catalog_item.name)
+    service_request_ = appliance.collections.requests.instantiate(request_desc)
+    yield service_request_
+
+    if service_request_.exists:
+        service_request_.remove_request()
+
+
+@pytest.yield_fixture
+def service(appliance, ansible_catalog_item):
+    service_ = MyService(appliance, ansible_catalog_item.name)
+    yield service_
+
+    if service_.exists:
+        service_.delete()
+
+
 def test_automate_ansible_playbook_method_type_crud(appliance, ansible_repository, domain,
         namespace, klass):
     """CRUD test for ansible playbook method."""
@@ -113,3 +212,16 @@ def test_automate_ansible_playbook_method_type(request, appliance, domain, names
     request.addfinalizer(lambda: appliance.ssh_client.run_command(
         "if [ -f \"/var/tmp/modified-release\" ]; then rm \"/var/tmp/modified-release\""))
     assert appliance.ssh_client.run_command("[ -f \"/var/tmp/modified-release\" ]").success
+
+
+def test_custom_button_order_ansible_playbook_service(setup_provider, vmware_vm, custom_vm_button,
+        service_request, service, appliance):
+    view = navigate_to(vmware_vm, "Details")
+    view.toolbar.custom_button(custom_vm_button.group.text).item_select(custom_vm_button.text)
+    submit_button = WButton(appliance.browser.widgetastic, "Submit")
+    submit_button.click()
+    wait_for(service_request.exists, num_sec=600)
+    service_request.wait_for_request()
+    view = navigate_to(service, "Details")
+    assert view.provisioning.details.get_text_of("Hosts") == "localhost"
+    assert view.provisioning.results.get_text_of("Status") == "successful"


### PR DESCRIPTION
Intent
=================

__Adding test__  for ordering ansible service via a custom button. That feature implemented in version 5.9.

{{pytest: -v -k "test_custom_button_order_ansible_playbook_service" --long-running}}