### PR TITLE
[1LP][RFR] Various fixes and workarounds for embedded ansible tests

### DIFF
--- a/cfme/ansible/repositories.py
+++ b/cfme/ansible/repositories.py
@@ -120,7 +120,10 @@ class Repository(BaseEntity, Fillable):
     def get_detail(self, title, field, refresh=False):
         view = navigate_to(self, "Details")
         if refresh:
-            view.refresh.click()
+            if self.appliance.version < "5.9":
+                view.browser.refresh()
+            else:
+                view.refresh.click()
         return getattr(view.entities, title.lower().replace(" ", "_")).get_text_of(field)
 
     @property

--- a/cfme/automate/explorer/method.py
+++ b/cfme/automate/explorer/method.py
@@ -378,8 +378,7 @@ class MethodCollection(BaseCollection):
             return None
         else:
             add_page.add_button.click()
-            msg = 'Automate Method "{}" was added'.format(name)
-            add_page.flash.assert_success_message(msg)
+            add_page.flash.assert_no_error()
             return self.instantiate(
                 name=name,
                 display_name=display_name,

--- a/cfme/tests/ansible/test_embedded_ansible_actions.py
+++ b/cfme/tests/ansible/test_embedded_ansible_actions.py
@@ -8,7 +8,6 @@ from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.services.catalogs.ansible_catalog_item import AnsiblePlaybookCatalogItem
 from cfme.services.myservice import MyService
 from cfme.utils import ports
-from cfme.utils.blockers import BZ
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.conf import credentials
 from cfme.utils.generators import random_vm_name
@@ -61,6 +60,10 @@ def ansible_repository(appliance, wait_for_ansible):
         name=fauxfactory.gen_alpha(),
         url="https://github.com/quarckster/ansible_playbooks",
         description=fauxfactory.gen_alpha())
+    wait_for(
+        lambda: repository.get_detail("Properties", "Status", refresh=True) == "successful",
+        timeout=60
+    )
     yield repository
 
     if repository.exists:

--- a/cfme/tests/ansible/test_embedded_ansible_basic.py
+++ b/cfme/tests/ansible/test_embedded_ansible_basic.py
@@ -83,7 +83,10 @@ def ansible_repository(appliance):
         fauxfactory.gen_alpha(),
         REPOSITORIES[0],
         description=fauxfactory.gen_alpha())
-
+    wait_for(
+        lambda: repository.get_detail("Properties", "Status", refresh=True) == "successful",
+        timeout=60
+    )
     yield repository
 
     if repository.exists:

--- a/cfme/tests/ansible/test_embedded_ansible_services.py
+++ b/cfme/tests/ansible/test_embedded_ansible_services.py
@@ -15,6 +15,7 @@ from cfme.services.myservice import MyService
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.update import update
+from cfme.utils.wait import wait_for
 
 
 pytestmark = [
@@ -46,6 +47,10 @@ def ansible_repository(appliance, wait_for_ansible):
         name=fauxfactory.gen_alpha(),
         url="https://github.com/quarckster/ansible_playbooks",
         description=fauxfactory.gen_alpha())
+    wait_for(
+        lambda: repository.get_detail("Properties", "Status", refresh=True) == "successful",
+        timeout=60
+    )
     yield repository
 
     if repository.exists:


### PR DESCRIPTION
Purpose
=================

In the recent builds it takes a while until ansible playbooks appeared in the ui, we should wait until repository status will be "successful".  Also in some cases "Add New Repository" item is disabled, but embedded ansible role is enabled. I couldn't reproduce it locally, so it will be sort of experiment.

{{pytest: -v -k "test_automate_ansible_playbook_method_type_crud" --long-running}}