### PR TITLE
[1LP][RFR] Changed NavigateToSibling to NavigateToAttribute for Container Details Classes

### DIFF
--- a/cfme/containers/container.py
+++ b/cfme/containers/container.py
@@ -92,7 +92,7 @@ class ContainerAll(CFMENavigateStep):
 @navigator.register(Container, 'Details')
 class ContainerDetails(CFMENavigateStep):
     VIEW = ContainerDetailsView
-    prerequisite = NavigateToSibling('parent', 'All')
+    prerequisite = NavigateToAttribute('parent', 'All')
 
     def step(self):
         self.prerequisite_view.entities.get_entity(name=self.obj.name,

--- a/cfme/containers/image.py
+++ b/cfme/containers/image.py
@@ -165,7 +165,7 @@ class All(CFMENavigateStep):
 @navigator.register(Image, 'Details')
 class Details(CFMENavigateStep):
     VIEW = ImageDetailsView
-    prerequisite = NavigateToAttribute("parent", 'All')
+    prerequisite = NavigateToAttribute('parent', 'All')
 
     def step(self):
         self.prerequisite_view.entities.get_entity(provider=self.obj.provider.name,

--- a/cfme/containers/image_registry.py
+++ b/cfme/containers/image_registry.py
@@ -73,7 +73,7 @@ class ImageRegistryAll(CFMENavigateStep):
 @navigator.register(ImageRegistry, 'Details')
 class ImageRegistryDetails(CFMENavigateStep):
     VIEW = ImageRegistryDetailsView
-    prerequisite = NavigateToSibling('parent', 'All')
+    prerequisite = NavigateToAttribute('parent', 'All')
 
     def step(self):
         self.prerequisite_view.entities.get_entity(host=self.obj.host).click()

--- a/cfme/containers/pod.py
+++ b/cfme/containers/pod.py
@@ -77,7 +77,7 @@ class All(CFMENavigateStep):
 @navigator.register(Pod, 'Details')
 class Details(CFMENavigateStep):
     VIEW = PodDetailsView
-    prerequisite = NavigateToSibling('parent', 'All')
+    prerequisite = NavigateToAttribute('parent', 'All')
 
     def step(self):
         self.prerequisite_view.entities.get_entity(name=self.obj.name,

--- a/cfme/containers/project.py
+++ b/cfme/containers/project.py
@@ -70,7 +70,7 @@ class All(CFMENavigateStep):
 @navigator.register(Project, 'Details')
 class Details(CFMENavigateStep):
     VIEW = ProjectDetailsView
-    prerequisite = NavigateToSibling('parent', 'All')
+    prerequisite = NavigateToAttribute('parent', 'All')
 
     def step(self):
         self.prerequisite_view.entities.get_entity(name=self.obj.name).click()

--- a/cfme/containers/replicator.py
+++ b/cfme/containers/replicator.py
@@ -70,7 +70,7 @@ class All(CFMENavigateStep):
 @navigator.register(Replicator, 'Details')
 class Details(CFMENavigateStep):
     VIEW = ReplicatorDetailsView
-    prerequisite = NavigateToSibling('parent', 'All')
+    prerequisite = NavigateToAttribute('parent', 'All')
 
     def step(self):
         self.prerequisite_view.entities.get_entity(name=self.obj.name,

--- a/cfme/containers/route.py
+++ b/cfme/containers/route.py
@@ -69,7 +69,7 @@ class All(CFMENavigateStep):
 
 @navigator.register(Route, 'Details')
 class Details(CFMENavigateStep):
-    prerequisite = NavigateToSibling('parent', 'All')
+    prerequisite = NavigateToAttribute('parent', 'All')
     VIEW = RouteDetailsView
 
     def step(self):

--- a/cfme/containers/service.py
+++ b/cfme/containers/service.py
@@ -70,7 +70,7 @@ class All(CFMENavigateStep):
 
 @navigator.register(Service, 'Details')
 class Details(CFMENavigateStep):
-    prerequisite = NavigateToSibling('parent', 'All')
+    prerequisite = NavigateToAttribute('parent', 'All')
     VIEW = ServiceDetailsView
 
     def step(self):

--- a/cfme/containers/template.py
+++ b/cfme/containers/template.py
@@ -69,7 +69,7 @@ class All(CFMENavigateStep):
 
 @navigator.register(Template, 'Details')
 class Details(CFMENavigateStep):
-    prerequisite = NavigateToSibling('parent', 'All')
+    prerequisite = NavigateToAttribute('parent', 'All')
     VIEW = TemplateDetailsView
 
     def step(self):

--- a/cfme/containers/volume.py
+++ b/cfme/containers/volume.py
@@ -68,7 +68,7 @@ class All(CFMENavigateStep):
 
 @navigator.register(Volume, 'Details')
 class Details(CFMENavigateStep):
-    prerequisite = NavigateToSibling('parent', 'All')
+    prerequisite = NavigateToAttribute('parent', 'All')
     VIEW = VolumeDetailsView
 
     def step(self):


### PR DESCRIPTION
Changed NavigateToSibling to NavigateToAttribute for Container Details

```
coll = appliance.collections.container_routes
route = coll.instantiate(name='docker-registry', project_name= 'default', provider=juwatts)
navigate_to(route, 'Details')
Out[7]: <cfme.containers.route.RouteDetailsView at 0x7fbec5028bd0>
```