### PR TITLE
[1LP][RFR]Updated BZ id for Category delete flash msg

### DIFF
--- a/cfme/configure/configuration/region_settings.py
+++ b/cfme/configure/configuration/region_settings.py
@@ -155,7 +155,7 @@ class Category(Pretty, Navigatable, Updateable):
         row.actions.click()
         view.browser.handle_alert(cancel=cancel)
         if not cancel:
-            if not BZ(1510473, forced_streams=['5.9']).blocks:
+            if not BZ(1525929, forced_streams=['5.9']).blocks:
                 view.flash.assert_success_message(
                     'Category "{}": Delete successful'.format(self.name))
 


### PR DESCRIPTION
Purpose or Intent
=================
Updating BZ id to [1525929](https://bugzilla.redhat.com/show_bug.cgi?id=1525929) because flash message is missing after deleting category.

{{pytest: -v cfme/tests/infrastructure/test_infra_tag_filters_combination.py -k test_tagvis_tag_datacenter_combination[clusters-visible]}}