### PR TITLE
[1LP][RFR] Workaround for vsphere setup in 5.8.3.0

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -145,6 +145,12 @@ class BaseProvider(WidgetasticTaggable, Updateable, SummaryMixin, Navigatable):
             add_view = navigate_to(self, 'Add')
 
             if not cancel or (cancel and any(self.view_value_mapping.values())):
+                # Workaround for BZ#1526050
+                if self.appliance.version == '5.8.3.0':
+                    add_view.fill({'prov_type': 'Red Hat Virtualization'})
+                elif '5.8.3.0' < self.appliance.version < '5.9':
+                    import warnings
+                    warnings.warn('REMOVE ME: BZ#1526050')
                 # filling main part of dialog
                 add_view.fill(self.view_value_mapping)
 


### PR DESCRIPTION
The warning will look like this, once we get 5.8.3.1:
```
[WARNING] ./cfme/common/provider.py:153: UserWarning: REMOVE ME: BZ#1526050
  warnings.warn('REMOVE ME: BZ#1526050')
 (/home/jkrocil/Workspace/cfme_tests/cfme/common/provider.py:153)
```

I didn't use BZ.blocks because it seems unnecessary. The issue is urgent and should be fixed in the next build.

Tested locally.