### PR TITLE
[1LP][RFR] Checks Password field empty or not after invalid login attempt

### DIFF
--- a/cfme/tests/test_login.py
+++ b/cfme/tests/test_login.py
@@ -2,6 +2,7 @@ import pytest
 
 from cfme import test_requirements
 from cfme.base.credential import Credential
+from cfme.base.ui import LoginPage
 from cfme.utils.appliance import ViaSSUI, ViaUI
 from cfme.utils import conf, error, version
 
@@ -51,3 +52,6 @@ def test_bad_password(context, request, appliance):
     with appliance.context.use(context):
         with error.expected(error_message):
             appliance.server.login(user)
+        if appliance.version >= '5.9':
+            view = appliance.browser.create_view(LoginPage)
+            assert view.password.read() == '' and view.username.read() == ''


### PR DESCRIPTION
This test will fail in 5.8 due to this bz 1089786.This bz is only fixed in 5.9. 
{{pytest: -v cfme/tests/test_login.py -k test_bad_password}}