### PR TITLE
[1LP][RFR]scvmm upload template fixes

### DIFF
--- a/scripts/template_upload_all.py
+++ b/scripts/template_upload_all.py
@@ -416,6 +416,7 @@ def main():
 
         logger.info("TEMPLATE_UPLOAD_ALL:------End of %r upload on: %r--------",
             kwargs['template_name'], provider_type)
+        return 0
 
 
 if __name__ == "__main__":

--- a/scripts/template_upload_scvmm.py
+++ b/scripts/template_upload_scvmm.py
@@ -141,19 +141,19 @@ def make_kwargs_scvmm(cfme_data, provider, image_url, template_name):
 def run(**kwargs):
 
     for provider in list_provider_keys("scvmm"):
+        mgmt_sys = cfme_data['management_systems'][provider]
+        host_fqdn = mgmt_sys['hostname_fqdn']
+        creds = credentials[mgmt_sys['credentials']]
 
         # skip provider if block_upload is set
-        if (cfme_data[provider].get('template_upload') and
-                cfme_data[provider]['template_upload'].get('block_upload')):
+        if (mgmt_sys.get('template_upload') and
+                mgmt_sys['template_upload'].get('block_upload')):
             logger.info('Skipping upload on {} due to block_upload'.format(provider))
             continue
 
         kwargs = make_kwargs_scvmm(cfme_data, provider,
                                    kwargs.get('image_url'), kwargs.get('template_name'))
         check_kwargs(**kwargs)
-        mgmt_sys = cfme_data['management_systems'][provider]
-        host_fqdn = mgmt_sys['hostname_fqdn']
-        creds = credentials[mgmt_sys['credentials']]
 
         # For powershell to work, we need to extract the User Name from the Domain
         user = creds['username'].split('\\')


### PR DESCRIPTION
needs - 

-  https://github.com/ManageIQ/wrapanapi/pull/201

- https://gitlab.cee.redhat.com/cfme-qe/cfme-qe-yamls/merge_requests/399
```
(CFME) lkhomenk@Fuzzy ~/git/integration_tests (scvmm_upload_template_fix) $ git log -1
commit 6f61f5f06216599a8c68cc3015e33f91dabbda55
Author: Leonid Khomenko <lkhomenk@redhat.com>
Date:   Thu Dec 14 23:11:29 2017 +0200

    scvmm upload template fixes
(CFME) lkhomenk@Fuzzy ~/git/integration_tests (scvmm_upload_template_fix) $ python scripts/template_upload_all.py --provider-type scvmm --image_url http://file.cloudforms.lab.eng.rdu2.redhat.com/builds/cfme/5.9/stable/
[WARNING] ./cfme/utils/appliance/__init__.py:2739: DeprecationWarning: Using class 'CurrentAppliance' (either directly or via inheritance) is deprecated: The CurrentAppliance descriptor is being phased outin favour of collections.
  appliance = CurrentAppliance()
 (/home/lkhomenk/.virtualenvs/CFME/local/lib/python2.7/site-packages/debtcollector/_utils.py:61)
TEMPLATE_UPLOAD_ALL:-----Start of 'cfme-59013-12121358' upload on: 'scvmm'--------
Executing 'template_upload_scvmm' with the following kwargs: {'template_name': 'cfme-59013-12121358', 'image_url': 'http://file.cloudforms.lab.eng.rdu2.redhat.com/builds/cfme/5.9/stable/cfme-hyperv-5.9.0.13-1.x86_64.vhd', 'stream': 'downstream-59z', 'provider_data': None}
[WARNING] /home/lkhomenk/.virtualenvs/CFME/local/lib/python2.7/site-packages/oslo_i18n/_message.py:21: ImportWarning: Not importing directory '/home/lkhomenk/.virtualenvs/CFME/local/lib/python2.7/site-packages/oslo_i18n/locale': missing __init__.py
  import locale
 (/home/lkhomenk/.virtualenvs/CFME/local/lib/python2.7/site-packages/oslo_i18n/_message.py:21)
SCVMM:scvmm Make Template out of the VHD cfme-59013-12121358
SCVMM:scvmm Template Library: \\scvmm2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\VMMLibrary\VHDs\
SCVMM:scvmm Uploading VHD image to Library VHD folder.
SCVMM: Downloading VHD file, then updating Library

        (New-Object System.Net.WebClient).DownloadFile("http://file.cloudforms.lab.eng.rdu2.redhat.com/builds/cfme/5.9/stable/cfme-hyperv-5.9.0.13-1.x86_64.vhd", "\\scvmm2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\VMMLibrary\VHDs\cfme-59013-12121358.vhd")
    
SCVMM:scvmm Make Template out of the VHD cfme-59013-12121358
SCVMM: Adding HW Resource File and Template to Library

        $JobGroupId01 = [Guid]::NewGuid().ToString()
        $LogNet = Get-SCLogicalNetwork -Name "rhq"
        New-SCVirtualNetworkAdapter -JobGroup $JobGroupID01 -MACAddressType Dynamic `
            -LogicalNetwork $LogNet -Synthetic
        New-SCVirtualSCSIAdapter -JobGroup $JobGroupID01 -AdapterID 6 -Shared $False
        New-SCHardwareProfile -Name "cfme-59013-12121358" -Owner "CFME-QE-VMM-AD\Administrator" `
            -Description 'Temp profile used to create a VM Template' -MemoryMB 8192 `
            -CPUCount 4 -JobGroup $JobGroupID01
        $JobGroupId02 = [Guid]::NewGuid().ToString()
        $VHD = Get-SCVirtualHardDisk | where { $_.Location -eq "\\scvmm2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com\VMMLibrary\VHDs\cfme-59013-12121358.vhd" } | `
            where { $_.HostName -eq "scvmm2.cfme-qe-vmm-ad.rhq.lab.eng.bos.redhat.com" }
        New-SCVirtualDiskDrive -IDE -Bus 0 -LUN 0 -JobGroup $JobGroupID02 -VirtualHardDisk $VHD
        $HWProfile = Get-SCHardwareProfile | where { $_.Name -eq "cfme-59013-12121358" }
        $OS = Get-SCOperatingSystem | where { $_.Name -eq "Red Hat Enterprise Linux 7 (64 bit)" }
        New-SCVMTemplate -Name "cfme-59013-12121358" -Owner "CFME-QE-VMM-AD\Administrator" -HardwareProfile $HWProfile `
            -JobGroup $JobGroupID02 -RunAsynchronously -Generation 1 -NoCustomization
        Remove-HardwareProfile -HardwareProfile "cfme-59013-12121358"
    
Started function <lambda>() at 1513288760.57
Took 13.11 to do function <lambda>()
Finished function <lambda>() at 1513288760.57, 1 tries
SCVMM:scvmm template cfme-59013-12121358 uploaded success
SCVMM:scvmm Add template cfme-59013-12121358 to trackerbot
Template cfme-59013-12121358 already tracked for provider scvmm
Skipping upload on scvmm2016 due to block_upload
TEMPLATE_UPLOAD_ALL:------End of 'cfme-59013-12121358' upload on: 'scvmm'--------
closing browser

```