### PR TITLE
[RFR] Fix 5.8.3.0 workaround for RHEVMProvider in common

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -146,7 +146,8 @@ class BaseProvider(WidgetasticTaggable, Updateable, SummaryMixin, Navigatable):
 
             if not cancel or (cancel and any(self.view_value_mapping.values())):
                 # Workaround for BZ#1526050
-                if self.appliance.version == '5.8.3.0':
+                from cfme.infrastructure.provider.virtualcenter import VMwareProvider
+                if self.appliance.version == '5.8.3.0' and self.one_of(VMwareProvider):
                     add_view.fill({'prov_type': 'Red Hat Virtualization'})
                 elif '5.8.3.0' < self.appliance.version < '5.9':
                     import warnings


### PR DESCRIPTION
Fixes a bug in the workaround introduced in #6182 

I've tested locally by configuring ec2west, rhv41, and vsphere65-nested providers.

vsphere65-nested configuration fails because the VMRC tab is required and we don't have these values in the YAML to fill with, not related to this workaround fix.