### PR TITLE
[WIPTEST] Fixed BaseVM.compliance_status in cfme/common/vm.py

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -152,7 +152,7 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, WidgetasticTaggable,
         """
         view = navigate_to(self, "Details")
         view.browser.refresh()
-        return self.get_detail("Compliance", "Status")
+        return self.get_detail(["Compliance", "Status"])
 
     @property
     def compliant(self):


### PR DESCRIPTION
__Fixing__ BaseVM.compliance_status because its return statement currently raises AttributeError.

{{pytest: --long-running cfme/tests/control/test_actions.py -k test_action_check_compliance}}