### PR TITLE
[1LP][RFR] Adding RHV tests for snapshots

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -336,7 +336,7 @@ class InfraVmSnapshotAddView(InfraVmView):
     @property
     def is_displayed(self):
         """Is this view being displayed"""
-        return self.in_infra_vms and self.title.text == 'Adding a new Snapshot'
+        return False
 
 
 class InfraVmGenealogyToolbar(View):

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -590,10 +590,13 @@ class Vm(VM):
                 snapshot_dict["snapshot_vm_memory"] = self.memory
             view.fill(snapshot_dict)
             view.create.click()
-            list_view = self.vm.create_view(InfraVmSnapshotView)
-            wait_for(lambda: self.exists, num_sec=300, delay=20,
-                     fail_func=list_view.toolbar.reload.click, handle_exception=True,
-                     message="Waiting for snapshot create")
+            if not self.description:
+                view.flash.assert_message('Description is required')
+                view.cancel.click()
+            else:
+                list_view = self.vm.create_view(InfraVmSnapshotView)
+                wait_for(lambda: self.exists, num_sec=300, delay=20,
+                        fail_func=list_view.toolbar.reload.click, handle_exception=True)
 
         def delete(self, cancel=False):
             title = self.description if self.vm.provider.one_of(RHEVMProvider) else self.name

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -588,6 +588,8 @@ class Vm(VM):
                 snapshot_dict['name'] = self.name
             if force_check_memory or self.vm.provider.mgmt.is_vm_running(self.vm.name):
                 snapshot_dict["snapshot_vm_memory"] = self.memory
+            if force_check_memory and not view.snapshot_vm_memory.is_displayed:
+                raise NoSuchElementException('Snapshot VM memory checkbox not present')
             view.fill(snapshot_dict)
             view.create.click()
             if not self.description:

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -336,7 +336,7 @@ class InfraVmSnapshotAddView(InfraVmView):
     @property
     def is_displayed(self):
         """Is this view being displayed"""
-        return False
+        return self.in_infra_vms and self.title.text == 'Adding a new Snapshot'
 
 
 class InfraVmGenealogyToolbar(View):
@@ -592,13 +592,11 @@ class Vm(VM):
                 raise NoSuchElementException('Snapshot VM memory checkbox not present')
             view.fill(snapshot_dict)
             view.create.click()
-            if not self.description:
-                view.flash.assert_message('Description is required')
-                view.cancel.click()
-            else:
-                list_view = self.vm.create_view(InfraVmSnapshotView)
-                wait_for(lambda: self.exists, num_sec=300, delay=20,
-                        fail_func=list_view.toolbar.reload.click, handle_exception=True)
+            view.flash.assert_no_error()
+            list_view = self.vm.create_view(InfraVmSnapshotView)
+            wait_for(lambda: self.exists, num_sec=300, delay=20,
+                     fail_func=list_view.toolbar.reload.click, handle_exception=True,
+                     message="Waiting for snapshot create")
 
         def delete(self, cancel=False):
             title = self.description if self.vm.provider.one_of(RHEVMProvider) else self.name

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -256,6 +256,7 @@ def test_revert_on_running_vm(small_test_vm):
     snapshot = new_snapshot(small_test_vm, has_name=False)
     snapshot.create()
     small_test_vm.power_control_from_cfme(option=small_test_vm.POWER_ON, cancel=False)
+    small_test_vm.wait_for_vm_state_change(desired_state=small_test_vm.STATE_ON)
     with error.expected('Could not find an element.*@title="Revert to selected snapshot"'):
         snapshot.revert_to()
 

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -68,10 +68,11 @@ def full_test_vm(setup_provider_modscope, provider, full_template_modscope, requ
         logger.exception('Exception deleting test vm "%s" on %s', vm.name, provider.name)
 
 
-def new_snapshot(test_vm, has_name=True, memory=False, description=True):
+def new_snapshot(test_vm, has_name=True, memory=False, create_description=True):
+    name = fauxfactory.gen_alphanumeric(8)
     return Vm.Snapshot(
-        name="snpshot_{}".format(fauxfactory.gen_alphanumeric(8)) if has_name else None,
-        description="snapshot_{}".format(fauxfactory.gen_alphanumeric(8)) if description else None,
+        name="snpshot_{}".format(name) if has_name else None,
+        description="snapshot_{}".format(name) if create_description else None,
         memory=memory,
         parent_vm=test_vm
     )
@@ -127,11 +128,10 @@ def test_create_without_description(small_test_vm):
     Metadata:
         test_flag: snapshot, provision
     """
-    snapshot = new_snapshot(small_test_vm, has_name=False, description=False)
+    snapshot = new_snapshot(small_test_vm, has_name=False, create_description=False)
     with pytest.raises(AssertionError):
         snapshot.create()
     view = snapshot.vm.create_view(InfraVmSnapshotAddView)
-    assert view.is_displayed
     view.flash.assert_message('Description is required')
 
 


### PR DESCRIPTION
__Adding tests__ for snapshot functionality for RHV provider. It's basically automation of [RHEVM-17102](https://polarion.engineering.redhat.com/polarion/redirect/project/RHEVM3/workitem?id=RHEVM-17102) and [RHEVM-17137](https://polarion.engineering.redhat.com/polarion/redirect/project/RHEVM3/workitem?id=RHEVM-17137) from Polarion.

These are actually my first tests written in CFME QE framework. Therefore I am not sure if I am using things  the right way and putting them in correct places.

{{pytest: cfme/tests/infrastructure/test_snapshot.py::test_create_without_description cfme/tests/infrastructure/test_snapshot.py::test_revert_on_running_vm --use-provider rhv41 -vv --long-running}}