### PR TITLE
[WIP]Replaced appliance.rest_api.collections to appliance.collections

### DIFF
--- a/cfme/fixtures/tag.py
+++ b/cfme/fixtures/tag.py
@@ -103,7 +103,7 @@ def check_item_visibility(tag, user_restricted):
             vis_object.add_tag(tag=tag)
         else:
             tags = vis_object.get_tags()
-            tag_assigned = (
+            tag_assigned = any(
                 object_tags.category.display_name == tag.category.display_name and
                 object_tags.display_name == tag.display_name for object_tags in tags
             )

--- a/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
+++ b/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
@@ -5,16 +5,16 @@ from cfme.infrastructure.cluster import ClusterCollection
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.virtual_machines import Vm, Template
 from fixtures.provider import setup_one_or_skip
-from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.providers import ProviderFilter
 from cfme.utils.update import update
+
 
 pytestmark = [test_requirements.tag, pytest.mark.tier(2)]
 
 test_items = [
     ('clusters', ClusterCollection),
-    ('VMs', Vm),
-    ('Templates', Template)
+    ('vms', Vm),
+    ('templates', Template)
 ]
 
 
@@ -33,26 +33,19 @@ def testing_vis_object(request, a_provider, appliance):
     Returns: class object of certain type
     """
     collection_name, param_class = request.param
+    collection_rest = getattr(appliance.rest_api.collections, collection_name)
 
     if not test_items:
         pytest.skip('No content found for test!')
 
-    if collection_name in ['Templates', 'VMs']:
-        destination = collection_name + 'Only'
-        view = navigate_to(param_class, destination)
-        names = view.entities.entity_names
-        if names:
-            return param_class(name=names[0], provider=a_provider)
-        else:
-            pytest.fail('No {} found for test'.format(collection_name))
+    if collection_name in ['templates', 'vms']:
+        item_type = a_provider.data['provisioning']['catalog_item_type'].lower()
+        for resource in collection_rest:
+            if resource.vendor == item_type:
+                return param_class(name=resource.name, provider=a_provider)
     else:
-        collection = getattr(appliance.collections, collection_name)
-        view = navigate_to(collection, 'All')
-        names = view.entities.entity_names
-        if names:
-            return param_class(appliance).instantiate(name=names[0], provider=a_provider)
-        else:
-            pytest.fail('No {} found for test'.format(collection_name))
+        return param_class(appliance).instantiate(
+            name='{} in Datacenter'.format(collection_rest[0].name), provider=a_provider)
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
Purpose
=================
Changed creation of class object from using appliance.rest api.collections which causes [API Exceptions](https://cfmeqe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/Downstream-59z/job/downstream-59z-tests-master/139/Artifactor_Report/cfme/tests/infrastructure/test_infra_tag_filters_combination.py/test_tagvis_tag_datacenter_combination[clusters-visible]/filedump-traceback.log), to use appliance.collections thought UI.

{{pytest: -v cfme/tests/infrastructure/test_infra_tag_filters_combination.py -k test_tagvis_tag_datacenter_combination}}