### PR TITLE
[1LP][RFR] added the reload button in InfraVmDetailsToolbar

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -90,6 +90,7 @@ class InfraVmDetailsToolbar(InfraGenericDetailsToolbar):
     """
     access = Dropdown("Access")
     power = Dropdown('VM Power Functions')
+    reload = Button(title='Reload current display')
 
 
 class VmsTemplatesAccordion(View):

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -69,7 +69,8 @@ def find_path(tree, text, parent_item=None):
 
 class InfraGenericDetailsToolbar(View):
     reload = Button(title=VersionPick({Version.lowest(): 'Reload current display',
-                                       '5.9': 'Refresh this page'}))
+                                       '5.9': 'Refresh this page',
+                                       '6.0': 'Reload current display'}))
     configuration = Dropdown('Configuration')
     policy = Dropdown('Policy')
     monitoring = Dropdown("Monitoring")
@@ -90,7 +91,6 @@ class InfraVmDetailsToolbar(InfraGenericDetailsToolbar):
     """
     access = Dropdown("Access")
     power = Dropdown('VM Power Functions')
-    reload = Button(title='Reload current display')
 
 
 class VmsTemplatesAccordion(View):


### PR DESCRIPTION
Fix navigation Issue in Upstream
==========================
{{pytest: cfme/tests/infrastructure/test_timelines.py -k "test_timeline_events" --use-provider=vsphere6-nested}}
It was impossible to navigate to the VM's Details/Timeline pages and other menu in the toolbar in Upstream. This is because it was because it was not finding the button "Reload" In the toolbar. 
PR like #6149 were failing in upstream. 