### PR TITLE
[1LP][RFR] Refactor server auth settings views/methods

### DIFF
--- a/cfme/configure/access_control/__init__.py
+++ b/cfme/configure/access_control/__init__.py
@@ -613,7 +613,7 @@ class Group(BaseEntity):
         """ Retrive ldap user groups
             return: AddGroupView
         """
-        view = navigate_to(self, 'Add')
+        view = navigate_to(self.parent, 'Add')
         view.fill({'lookup_ldap_groups_chk': True,
                    'user_to_look_up': self.user_to_lookup,
                    'username': self.ldap_credentials.principal,
@@ -625,7 +625,7 @@ class Group(BaseEntity):
         """ Retrive external authorization user groups
             return: AddGroupView
         """
-        view = navigate_to(self, 'Add')
+        view = navigate_to(self.parent, 'Add')
         view.fill({'lookup_ldap_groups_chk': True,
                    'user_to_look_up': self.user_to_lookup})
         view.retrieve_button.click()

--- a/cfme/configure/configuration/server_settings.py
+++ b/cfme/configure/configuration/server_settings.py
@@ -16,6 +16,10 @@ from cfme.utils.update import Updateable
 class ServerInformationView(View):
     """ Class represents full Server tab view"""
     title = Text("//div[@id='settings_server']/h3[1]")
+    # Local Flash widget for validation since class nested under a class inheriting BaseLoggedInPage
+    flash = FlashMessages('.//div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
+                          'contains(@class, "flash_text_div")] | '
+                          './/div[starts-with(@class, "flash_text_div") or @id="flash_text_div"]')
     save = Button('Save')
     reset = Button('Reset')
 

--- a/cfme/fixtures/configure_auth_mode.py
+++ b/cfme/fixtures/configure_auth_mode.py
@@ -59,16 +59,25 @@ def configure_openldap_auth_mode_default_groups(browser, available_auth_modes):
 def configure_aws_iam_auth_mode(appliance, available_auth_modes):
     """Configure AWS IAM authentication mode"""
     if 'miq_aws_iam' in available_auth_modes:
-        auth_mode = appliance.server.authentication
-        fill_data = cfme_data.auth_modes.miq_aws_iam.copy()
-        creds = credentials[fill_data.pop('credentials')]  # remove cred key from fill_data with pop
-        fill_data.update(
-            {'access_key': creds['username'],
-             'secret_key': creds['password']})
-        auth_mode.set_auth_mode(**fill_data)
+        auth_settings = appliance.server.authentication
+        orig_mode = auth_settings.auth_mode
+        orig_settings = auth_settings.auth_settings
+        orig_settings.pop('title')
+        yaml_data = cfme_data.auth_modes.miq_aws_iam.copy()
+        creds = credentials[yaml_data.pop('credentials')]  # remove cred key from fill_data with pop
+        fill_data = {
+            'access_key': creds['username'],
+            'secret_key': creds['password'],
+            'get_groups': yaml_data.get('get_groups', False)}
+
+        auth_settings.set_auth_mode(auth_mode='Amazon', **fill_data)
+        auth_settings.set_session_timeout(hours=yaml_data.get('timeout_h', '24'),
+                                          minutes=yaml_data.get('timeout_m', '0'))
         yield
         current_appliance.server.login_admin()
-        auth_mode.set_auth_mode()
+        auth_settings.set_auth_mode(auth_mode=orig_mode, **orig_settings)
+        auth_settings.set_session_timeout(hours=orig_settings.get('hours_timeout', '24'),
+                                          minutes=orig_settings.get('minutes_timeout', '0'))
     else:
         # Need this configuration data to test, can't make up aws_iam account.
         pytest.skip('miq_aws_iam yaml configuration not available for configure_aws_iam_auth_mode')
@@ -88,13 +97,13 @@ def configure_auth(request, auth_mode):
     elif auth_mode in ['miq_openldap', 'miq_ldap']:
         auth_settings.set_auth_mode(**data)
         request.addfinalizer(current_appliance.server.login_admin)
-        request.addfinalizer(auth_settings.set_auth_mode())
+        request.addfinalizer(auth_settings.set_auth_mode)
     elif auth_mode == 'miq_aws_iam':
         aws_iam_creds = credentials[data.pop('credentials')]
         data['access_key'] = aws_iam_creds['username']
         data['secret_key'] = aws_iam_creds['password']
         auth_settings.set_auth_mode(**data)
         request.addfinalizer(current_appliance.server.login_admin)
-        request.addfinalizer(auth_settings.set_auth_mode())
+        request.addfinalizer(auth_settings.set_auth_mode)
     else:
         pytest.skip("auth_mode specified is not a expected value for cfme_auth tests")

--- a/cfme/tests/integration/test_aws_iam_auth_and_roles.py
+++ b/cfme/tests/integration/test_aws_iam_auth_and_roles.py
@@ -67,7 +67,6 @@ def test_group_roles(appliance, configure_aws_iam_auth_mode, group_name, context
             diff = DeepDiff(group_access[area], nav_visbility.get(area, {}),
                             verbose_level=0,  # If any higher, will flag string vs unicode
                             ignore_order=True)
-            soft_assert(diff == {}, 'Possible BZs: 1525598, 1525657\n'
-                                    '{g} RBAC mismatch for {a}: {d}'.format(g=group_name,
+            soft_assert(diff == {}, '{g} RBAC mismatch for {a}: {d}'.format(g=group_name,
                                                                             a=area,
                                                                             d=diff))

--- a/cfme/tests/integration/test_cfme_auth.py
+++ b/cfme/tests/integration/test_cfme_auth.py
@@ -92,7 +92,7 @@ def test_auth_configure(appliance, request, configure_auth, group, user, data):
 
     request.addfinalizer(appliance.server.login_admin)
     with user:
-        appliance.server.login(user, submit_method='click_on_login')
+        appliance.server.login(user)
         assert appliance.server.current_full_name() == data['fullname']
         appliance.server.logout()
     appliance.server.login_admin()


### PR DESCRIPTION
Create a conditionalswitchable view and remove navigation destinations
that were modifying the authentication tab form.

refactor methods for getting/setting auth configuration


  # Note to reviewers
I am addressing failures in `test_cfme_auth.py` that are related to my changes, but am not currently trying to fix all the tests there. I plan to address these tests within the stabilization phase, but after getting these view/navigation updates for `Server`, `ServerInformation`, and `ServerAuthentication` approved and merged.

The `test_aws_iam_auth_and_roles` is currently blocked by a few BZs that should be fixed in the next 2 weeks.