### PR TITLE
[1LP][RFR]fix: backup error

### DIFF
--- a/cfme/tests/storage/test_volume_backup.py
+++ b/cfme/tests/storage/test_volume_backup.py
@@ -28,11 +28,13 @@ def backup(appliance, provider):
                                       provider=provider)
 
     # create new backup for crated volume
-    backup_name = fauxfactory.gen_alpha()
-    volume.create_backup(backup_name)
-    backup = backup_collection.instantiate(backup_name, provider)
-
-    yield backup
+    if volume.status == 'available':
+        backup_name = fauxfactory.gen_alpha()
+        volume.create_backup(backup_name)
+        backup = backup_collection.instantiate(backup_name, provider)
+        yield backup
+    else:
+        pytest.skip('Skipping volume backup tests, provider side volume creation fails')
 
     try:
         if backup.exists:


### PR DESCRIPTION
Purpose or Intent
=================
- Added BZ related to issue: [#1528154](https://bugzilla.redhat.com/show_bug.cgi?id=1528154)
- Some time for smaller volume and most of time for larger volume on openstack status='error'
- added `status` property in `volume.py` to check status of `volume`
- Improved `backup_create` method in `volume.py` check for `initial_cound` and then compair
- added check for status in `test_volume_backup.py` else it will skip all backup test due to volume creation fail on provider side.
 

{{pytest: cfme/tests/storage/test_volume_backup.py  -v}}

