### PR TITLE
[WIP] Implementing fix for "Name can't be blank issue".

### DIFF
--- a/cfme/automate/explorer/domain.py
+++ b/cfme/automate/explorer/domain.py
@@ -289,6 +289,8 @@ class DomainCollection(BaseCollection):
             k: v
             for k, v in {'name': name, 'description': description, 'enabled': enabled}.items()
             if v is not None}
+        #   Workaround for solving automation issue.
+        add_page.name.fill(name)
         add_page.fill(fill_dict)
         if cancel:
             add_page.cancel_button.click()


### PR DESCRIPTION
Purpose or Intent
=================
To implement fix for test_quota_tagging which is failing due to "name can't be blank issue."
It's a selenium issue, resolving with workaround.

{{pytest: cfme/tests/infrastructure/test_quota_tagging.py -v }}
