### PR TITLE
[1LP][RFR] Fixed failing tests due to string match issue

### DIFF
--- a/cfme/tests/cloud/test_provisioning.py
+++ b/cfme/tests/cloud/test_provisioning.py
@@ -475,7 +475,7 @@ def original_request_class(appliance):
 
 @pytest.fixture(scope="module")
 def modified_request_class(request, domain, original_request_class):
-    with error.handler('error: Error during \'Automate Class copy\''):
+    with error.handler("error: Error during 'Automate Class copy'"):
         # methods of this class might have been copied by other fixture, so this error can occur
         original_request_class.copy_to(domain)
     klass = domain\


### PR DESCRIPTION
Purpose or Intent
=================
{{ pytest: -vvv cfme/tests/cloud/test_provisioning.py -k 'test_provision_with_additional_volume or test_provision_with_boot_volume' }}