### PR TITLE
[1LP][RFR]Fix for advance search failure: test_delete_button_should_appear_after_save

### DIFF
--- a/cfme/tests/infrastructure/test_advanced_search_host.py
+++ b/cfme/tests/infrastructure/test_advanced_search_host.py
@@ -228,8 +228,6 @@ def test_delete_button_should_appear_after_save(host_collection, hosts_advanced_
 
     @request.addfinalizer
     def cleanup():
-        # Now delete button is available without load in the UI.
-        # hosts_advanced_search.entities.search.load_filter(filter_name)
         hosts_advanced_search.entities.search.delete_filter()
 
     if not hosts_advanced_search.entities.search.delete_filter():

--- a/cfme/tests/infrastructure/test_advanced_search_host.py
+++ b/cfme/tests/infrastructure/test_advanced_search_host.py
@@ -228,7 +228,8 @@ def test_delete_button_should_appear_after_save(host_collection, hosts_advanced_
 
     @request.addfinalizer
     def cleanup():
-        hosts_advanced_search.entities.search.load_filter(filter_name)
+        # Now delete button is available without load in the UI.
+        # hosts_advanced_search.entities.search.load_filter(filter_name)
         hosts_advanced_search.entities.search.delete_filter()
 
     if not hosts_advanced_search.entities.search.delete_filter():

--- a/cfme/tests/infrastructure/test_advanced_search_vms.py
+++ b/cfme/tests/infrastructure/test_advanced_search_vms.py
@@ -222,7 +222,8 @@ def test_delete_button_should_appear_after_save(request, vm_advanced_search):
 
     @request.addfinalizer
     def cleanup():
-        vm_advanced_search.entities.search.load_filter(filter_name)
+        # Now delete button is available without load in the UI.
+        # vm_advanced_search.entities.search.load_filter(filter_name)
         vm_advanced_search.entities.search.delete_filter()
 
     # Returns False if the button is not present

--- a/cfme/tests/infrastructure/test_advanced_search_vms.py
+++ b/cfme/tests/infrastructure/test_advanced_search_vms.py
@@ -222,8 +222,6 @@ def test_delete_button_should_appear_after_save(request, vm_advanced_search):
 
     @request.addfinalizer
     def cleanup():
-        # Now delete button is available without load in the UI.
-        # vm_advanced_search.entities.search.load_filter(filter_name)
         vm_advanced_search.entities.search.delete_filter()
 
     # Returns False if the button is not present


### PR DESCRIPTION
Purpose or Intent
================
There is a change in UI, now the save button appears before load option hence causing failure, which is fixed in this PR.

{{pytest: -v -k 'test_delete_button_should_appear_after_save'}}