### PR TITLE
[1LP][WIP]Fix for test_permissions_catalog_add.

### DIFF
--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -596,7 +596,7 @@ def _mk_role(appliance, name=None, vm_restriction=None, product_features=None):
 
     """
     name = name or fauxfactory.gen_alphanumeric()
-    return appliance.collections.roles.instantiate(
+    return appliance.collections.roles.create(
         name=name,
         vm_restriction=vm_restriction,
         product_features=product_features
@@ -678,14 +678,14 @@ def test_permissions(appliance, product_features, allowed_actions, disallowed_ac
 
             for name, action_thunk in allowed_actions.items():
                 try:
-                    action_thunk(appliance)
+                    action_thunk()
                 except Exception:
                     fails[name] = "{}: {}".format(name, traceback.format_exc())
 
             for name, action_thunk in disallowed_actions.items():
                 try:
                     with error.expected(Exception):
-                        action_thunk(appliance)
+                        action_thunk()
                 except error.UnexpectedSuccessException:
                     fails[name] = "{}: {}".format(name, traceback.format_exc())
 

--- a/cfme/tests/services/test_catalog.py
+++ b/cfme/tests/services/test_catalog.py
@@ -3,10 +3,13 @@ import fauxfactory
 import pytest
 
 import cfme.tests.configure.test_access_control as tac
-from cfme.utils import error
+
 from cfme import test_requirements
 from cfme.services.catalogs.catalog import Catalog
+from cfme.utils import error
+from cfme.utils.blockers import BZ
 from cfme.utils.update import update
+from cfme.utils.version import current_version
 
 pytestmark = [test_requirements.service, pytest.mark.tier(2)]
 
@@ -31,6 +34,9 @@ def test_catalog_duplicate_name():
     cat.delete()
 
 
+# Un-collecting for 5.8 because of BZ: 1486041
+@pytest.mark.uncollectif(lambda: current_version() < '5.9')
+@pytest.mark.meta(blockers=[BZ(1529079, forced_streams=['upstream'])])
 @pytest.mark.sauce
 def test_permissions_catalog_add(appliance):
     """ Tests that a catalog can be added only with the right permissions"""

--- a/cfme/tests/services/test_catalog.py
+++ b/cfme/tests/services/test_catalog.py
@@ -9,7 +9,9 @@ from cfme.services.catalogs.catalog import Catalog
 from cfme.utils import error
 from cfme.utils.blockers import BZ
 from cfme.utils.update import update
-from cfme.utils.version import current_version
+
+from fixtures.pytest_store import store
+
 
 pytestmark = [test_requirements.service, pytest.mark.tier(2)]
 
@@ -35,7 +37,7 @@ def test_catalog_duplicate_name():
 
 
 # Un-collecting for 5.8 because of BZ: 1486041
-@pytest.mark.uncollectif(lambda: current_version() < '5.9')
+@pytest.mark.uncollectif(lambda: store.current_appliance.version < '5.9')
 @pytest.mark.meta(blockers=[BZ(1529079, forced_streams=['upstream'])])
 @pytest.mark.sauce
 def test_permissions_catalog_add(appliance):


### PR DESCRIPTION
Purpose or Intent
=================
There were issues with the role creation and unnecessary argument passing to catalog.create(), which is fixed in this PR.

{{pytest: -v -k 'test_permissions_catalog_add or test_permissions'}}
