### PR TITLE
[WIPTEST] Fixed test_pagination by changing number logic   

### DIFF
--- a/cfme/tests/automate/test_customization_paginator.py
+++ b/cfme/tests/automate/test_customization_paginator.py
@@ -81,9 +81,9 @@ def test_paginator(some_dialogs, soft_assert, appliance):
         current_rec_offset = view.paginator.min_item
         current_rec_end = view.paginator.max_item
 
-        assert int(current_rec_offset) <= int(current_rec_end) <= int(current_total), \
-            "Incorrect paginator value, expected {0} <= {1} <= {2}".format(
-                current_rec_offset, current_rec_end, current_total)
+        assert ((int(current_rec_end) - int(current_rec_offset)) + 1) <= int(current_total), \
+            "Incorrect paginator value, expected (({0} - {1}) + 1) <= {2}".format(
+                current_rec_end, current_rec_offset, current_total)
 
     assert {dlg.label for dlg in some_dialogs} <= dialogs_found, \
         "Could not find all dialogs by clicking the paginator!"


### PR DESCRIPTION
{{pytest: -v cfme/tests/automate/test_customization_paginator.py -k test_paginator}}

During second iteration, it was comparing values with wrong assumption, I changed this logic with this PR. 

Before: 

```
    assert int(current_rec_offset) <= int(current_rec_end) <= int(current_total), \
        "Incorrect paginator value, expected {0} <= {1} <= {2}".format(
            current_rec_offset, current_rec_end, current_total)
```

After:

```
    assert ((int(current_rec_end) - int(current_rec_offset)) + 1) <= int(current_total), \
        "Incorrect paginator value, expected (({0}-{1})+1) <= {2}".format(
            current_rec_end, current_rec_offset, current_total)
```

I am still hating this ```(({0}-{1})+1) <= {2}``` ugly thing here. Reviewers: please respond back if you have any optimum logic than this! 👍 