### PR TITLE
[1LP][RFR]Fix for test_cluster_relationships SoftAssertionError

### DIFF
--- a/cfme/tests/intelligence/reports/test_canned_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_canned_corresponds.py
@@ -53,9 +53,8 @@ def test_cluster_relationships(soft_assert):
             continue
         provider = get_crud_by_name(provider_name).mgmt
         host_name = relation["Host Name"].strip()
-        soft_assert(name in provider.list_cluster(), "Cluster {} not found in {}".format(
-            name, provider_name
-        ))
+        verified_cluster = [item for item in provider.list_cluster() if name in item]
+        soft_assert(verified_cluster, "Cluster {} not found in {}".format(name, provider_name))
         if not host_name:
             continue  # No host name
         host_ip = resolve_hostname(host_name, force=True)


### PR DESCRIPTION
Purpose 
=================
Fix for test_cluster_relationships SoftAssertionError: Cluster hyperv_cluster not found in ms-scvmm (cfme/tests/intelligence/reports/test_canned_corresponds.py:57). 
Added to get the first element from provider.list_cluster.


{{pytest: -v cfme/tests/intelligence/reports/test_canned_corresponds.py -k test_cluster_relationships --use-provider=ms_scvmm}}
