### PR TITLE
[1LP][RFR] changes in rhn_mirror, cockpit_ws

### DIFF
--- a/cfme/configure/configuration/server_settings.py
+++ b/cfme/configure/configuration/server_settings.py
@@ -251,8 +251,9 @@ class ServerInformation(Updateable, Pretty, NavigatableMixin):
         # embedded_ansible server role available from 5.8 version
         if self.appliance.version < '5.8' and 'embedded_ansible' in updates:
             updates.pop('embedded_ansible')
-        # cockpit_ws element is not present for downstream version
-        if self.appliance.version != self.appliance.version.latest() and 'cockpit_ws' in updates:
+
+        # cockpit_ws element introduced in 5.9 version
+        if self.appliance.version < 5.9 and 'cockpit_ws' in updates:
             updates.pop('cockpit_ws')
         updated = view.server_roles.fill(updates)
         self._save_action(view, updated, reset)

--- a/cfme/tests/configure/test_server_roles.py
+++ b/cfme/tests/configure/test_server_roles.py
@@ -25,6 +25,11 @@ def roles(request, all_possible_roles, appliance):
     # ansible role introduced in CFME 5.8
     if appliance.version < '5.8' and result.get('embedded_ansible'):
         del result['embedded_ansible']
+
+    # RHN Mirror role removed from CFME 5.9
+    if appliance.version > '5.9':
+        del result['rhn_mirror']
+
     return result
 
 


### PR DESCRIPTION
Purpose or Intent
=================
- test fixed
- removed `rhn_mirror` and add `cockpit_ws`

{{ pytest: -v cfme/tests/configure/test_server_roles.py }