### PR TITLE
[RFR] Fixed failing tests due to role not created

### DIFF
--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -1249,7 +1249,7 @@ class RoleDetails(CFMENavigateStep):
     prerequisite = NavigateToAttribute('parent', 'All')
 
     def step(self):
-        self.prerequisite_view.browser.refresh() # workaround for 5.9 issue of role now shown
+        self.prerequisite_view.browser.refresh()  # workaround for 5.9 issue of role now shown
         self.prerequisite_view.accordions.accesscontrol.tree.click_path(
             self.obj.appliance.server_region_string(), 'Roles', self.obj.name)
 

--- a/cfme/configure/access_control.py
+++ b/cfme/configure/access_control.py
@@ -1078,7 +1078,6 @@ class Role(Updateable, Pretty, BaseEntity):
         """
         flash_blocked_msg = "Read Only Role \"{}\" can not be edited".format(self.name)
         edit_role_txt = 'Edit this Role'
-
         view = navigate_to(self, 'Details')
         if not view.toolbar.configuration.item_enabled(edit_role_txt):
             raise RBACOperationBlocked("Configuration action '{}' is not enabled".format(
@@ -1250,6 +1249,7 @@ class RoleDetails(CFMENavigateStep):
     prerequisite = NavigateToAttribute('parent', 'All')
 
     def step(self):
+        self.prerequisite_view.browser.refresh() # workaround for 5.9 issue of role now shown
         self.prerequisite_view.accordions.accesscontrol.tree.click_path(
             self.obj.appliance.server_region_string(), 'Roles', self.obj.name)
 

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -596,7 +596,7 @@ def _mk_role(appliance, name=None, vm_restriction=None, product_features=None):
 
     """
     name = name or fauxfactory.gen_alphanumeric()
-    return appliance.collections.roles.instantiate(
+    return appliance.collections.roles.create(
         name=name,
         vm_restriction=vm_restriction,
         product_features=product_features


### PR DESCRIPTION
Purpose or Intent
=================
Changed `instantiate` to `create` so that the test can use it to create group with that role. This fixes the `NoSuchElement found` exception occurring due to the dummy instantiated role not found in the create group view.
{{ pytest: -vvv cfme/tests/configure/test_access_control.py -k test_role_crud }}