### PR TITLE
[RFR] Fixed test_no_power_controls_on_archieved_vm

### DIFF
--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -380,7 +380,7 @@ def test_no_power_controls_on_archived_vm(testing_vm, archived_vm, soft_assert):
         * Verify the Power toolbar button is not visible
     """
     view = navigate_to(testing_vm, 'AnyProviderDetails', use_resetter=False)
-    soft_assert(not view.toolbar.power.is_enabled, "Power displayed in template details!")
+    soft_assert(not view.toolbar.power.is_displayed, "Power displayed in template details!")
 
 
 @pytest.mark.uncollectif(lambda provider: provider.one_of(SCVMMProvider) and


### PR DESCRIPTION
__Fixing__ test to check the presence of a power dropdown.

{{pytest: --long-running cfme/tests/infrastructure/test_vm_power_control.py -k test_no_power_controls_on_archived_vm}}