### PR TITLE
[1LP][RFR] fix of NoMoreFloatingIPs issue for tests against RHOS11

### DIFF
--- a/cfme/tests/cloud_infra_common/test_html5_vm_console.py
+++ b/cfme/tests/cloud_infra_common/test_html5_vm_console.py
@@ -9,7 +9,7 @@ from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.common.provider import CloudInfraProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.common.vm import VM
-from cfme.utils import version, ssh
+from cfme.utils import ssh
 from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 from cfme.utils.conf import credentials
@@ -47,9 +47,10 @@ def vm_obj(request, provider, setup_provider, console_template, vm_name):
 
     vm_obj.create_on_provider(timeout=2400, find_in_cfme=True, allow_skip="default")
     if provider.one_of(OpenStackProvider):
-        # Assign FloatingIP to Openstack Instance from pool 'public'
+        # Assign FloatingIP to Openstack Instance from pool
         # so that we can SSH to it
-        provider.mgmt.assign_floating_ip(vm_obj.name, 'public')
+        public_net = provider.data['public_network']
+        provider.mgmt.assign_floating_ip(vm_obj.name, public_net)
     return vm_obj
 
 

--- a/cfme/tests/infrastructure/test_instance_analysis.py
+++ b/cfme/tests/infrastructure/test_instance_analysis.py
@@ -10,6 +10,7 @@ from cfme.common.vm import VM, Template
 from cfme.common.provider import cleanup_vm
 from cfme.common.vm_views import DriftAnalysis, DriftHistory
 from cfme.cloud.provider import CloudProvider
+from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.configure import configuration
 from cfme.configure.configuration.analysis_profile import AnalysisProfile
 from cfme.configure.tasks import is_vm_analysis_finished, TasksView
@@ -216,8 +217,9 @@ def instance(request, local_setup_provider, provider, vm_name, vm_analysis_data,
     del provision_data['image']
     vm.create_on_provider(find_in_cfme=True, **provision_data)
 
-    if provider.type == "openstack":
-        vm.provider.mgmt.assign_floating_ip(vm.name, 'public')
+    if provider.one_of(OpenStackProvider):
+        public_net = provider.data['public_network']
+        vm.provider.mgmt.assign_floating_ip(vm.name, public_net)
 
     logger.info("VM %s provisioned, waiting for IP address to be assigned", vm_name)
 


### PR DESCRIPTION
{{pytest: --long-running cfme/tests/infrastructure/test_instance_analysis.py cfme/tests/cloud_infra_common/test_html5_vm_console.py}}

fix includes:

1.  updated RHOS11 floating ips configuration (wrong ext subnet was used for obtaining ips)
2. updated yamls. rhos7-ga and rhos11 have public_network now.
3. hardcoded network for openstack providers is removed from tests and replaced with yaml value