### PR TITLE
[1LP][RFR] fix for LookupErrors in generic objects

### DIFF
--- a/cfme/generic_objects/definition/rest.py
+++ b/cfme/generic_objects/definition/rest.py
@@ -77,7 +77,7 @@ def delete(self):
     self.rest_response = self.appliance.rest_api.response
 
 
-@MiqImplementationContext.external_for(GenericObjectDefinition.exists, ViaREST)
+@MiqImplementationContext.external_for(GenericObjectDefinition.exists.getter, ViaREST)
 def exists(self):
     return bool(
         self.appliance.rest_api.collections.generic_object_definitions.find_by(name=self.name))

--- a/cfme/generic_objects/instance/rest.py
+++ b/cfme/generic_objects/instance/rest.py
@@ -89,7 +89,7 @@ def delete(self):
     self.rest_response = self.appliance.rest_api.response
 
 
-@MiqImplementationContext.external_for(GenericObjectInstance.exists, ViaREST)
+@MiqImplementationContext.external_for(GenericObjectInstance.exists.getter, ViaREST)
 def exists(self):
     return bool(
         self.appliance.rest_api.collections.generic_objects.find_by(name=self.name))


### PR DESCRIPTION
{{pytest: cfme/tests/generic_objects/test_instances.py cfme/tests/generic_objects/test_definitions.py}}