### PR TITLE
[1LP][RFR] Adding FAQ to docs

### DIFF
--- a/docs/guides/faq.rst
+++ b/docs/guides/faq.rst
@@ -1,0 +1,34 @@
+Frequently Asked Questions
+==========================
+
+How do I increase logging level of the testing framework?
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+You can put logging entry into your env.local.yaml like this:
+
+.. code-block:: yaml
+
+    logging:
+        level: DEBUG
+
+Can I run tests in interactive mode?
+""""""""""""""""""""""""""""""""""""
+
+Yes, you can. Just call IPython's method ``embed()`` wherever you need the execution
+to enter an interactive mode. Example:
+
+.. code-block:: python
+
+    def test_foo(bar):
+        x = do_something()
+        from IPython import embed; embed()
+        assert x
+
+Then you can run your test with -s parameter: ``pytest -s cfme/tests/test_foo.py::test_foo``.
+Once the execution reaches the "breakpoint", you will be presented with IPython's
+interactive prompt.
+
+How do I build this documentation?
+""""""""""""""""""""""""""""""""""
+Go to cfme_tests/integration_tests/docs and run ``make clean && make html``.
+Then go to _build/html. You can open and view the HTML files in your browser.


### PR DESCRIPTION
__Adding FAQ section__ to the docs.

OK, I don't really know if these questions are asked frequently. But it is better name than "Questions That Have Been Asked in the Past and Might Be Asked Again". Imagine the acronym. 

- __Why?__ As a new guy working with the framework, those are some of the questions I have encountered. Therefore there's a chance that the next new guy might ask them as well.
- __Why not put those into Development Tips and Tricks?__ Because they aren't really about developing the framework or tests. They are more about using it. But if you think this belongs there, I am okay with that.
- __Another benefit?__ I think this could be a convenient place to gather some cool tips that can be found in mailing threads from time to time. 

There's not many of them, but if you think this idea makes sense, I will expand this doc with other Q&As.
