### PR TITLE
[1LP][RFR] Remove undesirable uncollections

### DIFF
--- a/cfme/tests/containers/test_ad_hoc_metrics.py
+++ b/cfme/tests/containers/test_ad_hoc_metrics.py
@@ -2,12 +2,10 @@ import pytest
 import requests
 from cfme.utils.log import logger
 from cfme.containers.provider import ContainersProvider
-from cfme.utils.version import current_version
 from cfme.utils.appliance.implementations.ui import navigate_to
 
 
 pytestmark = [
-    pytest.mark.uncollectif(lambda provider: current_version() < "5.8"),
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1),
     pytest.mark.provider([ContainersProvider], scope='function')]

--- a/cfme/tests/containers/test_basic_metrics.py
+++ b/cfme/tests/containers/test_basic_metrics.py
@@ -1,11 +1,9 @@
 import pytest
 import re
 from cfme.containers.provider import ContainersProvider
-from cfme.utils.version import current_version
 
 
 pytestmark = [
-    pytest.mark.uncollectif(lambda provider: current_version() < "5.6"),
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1),
     pytest.mark.provider([ContainersProvider], scope='function')]

--- a/cfme/tests/containers/test_cockpit.py
+++ b/cfme/tests/containers/test_cockpit.py
@@ -2,7 +2,6 @@ import pytest
 
 from cfme.containers.provider import ContainersProvider
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.blockers import BZ
 
 
 pytestmark = [
@@ -12,7 +11,6 @@ pytestmark = [
 
 
 @pytest.mark.polarion('CMP-10255')
-@pytest.mark.meta(blockers=[BZ(1406772, forced_streams=["5.7", "5.8"])])
 def test_cockpit_button_access(provider, appliance, soft_assert):
     """ The test verifies the existence of cockpit "Web Console"
         button on master node, then presses on the button and


### PR DESCRIPTION
{{ pytest: cfme/tests/containers/test_ad_hoc_metrics.py cfme/tests/containers/test_basic_metrics.py cfme/tests/containers/test_cockpit.py cfme/tests/containers/test_containers_summary.py cfme/tests/containers/test_configurable_menus.py --use-provider ocp-v1 }}
- Remove undesirable uncollections
- configurable menus should be invisible by default - changed the name
  to test_invisible_menus
- Updated skippers for test_cockpit
  
  
  