### PR TITLE
[1LP][RFR] Container image compliance check with attach policy from provider view

### DIFF
--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -26,6 +26,22 @@ class ManagePoliciesView(BaseLoggedInPage):
     def is_displayed(self):
         return False
 
+    def check_policy_assign_unassign(self, assign, *policy_profile_names):
+        """ check if at list one of the given policy profiles,
+        need to be assign or unassign.
+
+        Args:
+            assign: Wheter to assign or unassign policy.
+            policy_profile_names: :py:class:`str` with Policy Profile names.
+        """
+
+        for policy_profile in policy_profile_names:
+            leaf = self.policy_profiles.expand_path(policy_profile)
+            if self.policy_profiles.is_checked(leaf) != assign:
+                return True
+
+        return False
+
 
 class PolicyProfileAssignable(object):
     """This class can be inherited by anything that provider load_details method.
@@ -75,18 +91,17 @@ class PolicyProfileAssignable(object):
             policy_profile_names: :py:class:`str` with Policy Profile names.
         """
         view = navigate_to(self, 'ManagePoliciesFromDetails')
-        for policy_profile in policy_profile_names:
-            if assign:
-
-                view.policy_profiles.check_node(policy_profile)
-            else:
-                view.policy_profiles.uncheck_node(policy_profile)
         # Save button will be disabled in case of no changes done to policy,
-        # In this case click on Cancel
-        if view.save.disabled:
-            view.cancel.click()
-        else:
+        # check if need at list one policy changes, else click on Cancel
+        if view.check_policy_assign_unassign(assign, *policy_profile_names):
+            for policy_profile in policy_profile_names:
+                if assign:
+                    view.policy_profiles.check_node(policy_profile)
+                else:
+                    view.policy_profiles.uncheck_node(policy_profile)
             view.save.click()
+        else:
+            view.cancel.click()
         details_view = self.create_view(navigator.get_class(self, 'Details').VIEW)
         details_view.flash.assert_no_error()
 

--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -81,7 +81,12 @@ class PolicyProfileAssignable(object):
                 view.policy_profiles.check_node(policy_profile)
             else:
                 view.policy_profiles.uncheck_node(policy_profile)
-        view.save.click()
+        # Save button will be disabled in case of no changes done to policy,
+        # In this case click on Cancel
+        if view.save.disabled:
+            view.cancel.click()
+        else:
+            view.save.click()
         details_view = self.create_view(navigator.get_class(self, 'Details').VIEW)
         details_view.flash.assert_no_error()
 

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -14,7 +14,7 @@ from wrapanapi.utils import eval_strings
 from cfme import exceptions
 from cfme.base.credential import TokenCredential
 from cfme.base.login import BaseLoggedInPage
-from cfme.common import TagPageView
+from cfme.common import TagPageView, PolicyProfileAssignable
 from cfme.common.provider import BaseProvider, DefaultEndpoint, DefaultEndpointForm
 from cfme.common.provider_views import (
     BeforeFillMixin, ContainerProviderAddView, ContainerProvidersView,
@@ -152,7 +152,7 @@ class ContainerProviderDetailsView(ProviderDetailsView, LoggingableView):
                 self.navigation.currently_selected == ['Compute', 'Containers', 'Providers'])
 
 
-class ContainersProvider(BaseProvider, Pretty):
+class ContainersProvider(BaseProvider, Pretty, PolicyProfileAssignable):
     PLURAL = 'Providers'
     provider_types = {}
     in_version = ('5.5', version.LATEST)

--- a/cfme/tests/containers/test_provider_openscap_policy_attached.py
+++ b/cfme/tests/containers/test_provider_openscap_policy_attached.py
@@ -1,13 +1,35 @@
 import random
+from collections import namedtuple
+
+import dateparser
 import pytest
 
-from cfme.containers.provider import ContainersProvider
+from cfme.configure.tasks import delete_all_tasks
+from cfme.containers.provider import (ContainersProvider, refresh_and_navigate)
+from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.wait import wait_for
+
 
 pytestmark = [
     pytest.mark.meta(server_roles='+smartproxy'),
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1),
     pytest.mark.provider([ContainersProvider], scope='function')]
+
+AttributeToVerify = namedtuple('AttributeToVerify', ['table', 'attr', 'verifier'])
+
+TESTED_ATTRIBUTES__openscap = (
+    AttributeToVerify('configuration', 'OpenSCAP Results', bool),
+    AttributeToVerify('configuration', 'OpenSCAP HTML', lambda val: val == 'Available'),
+    AttributeToVerify('configuration', 'Last scan', dateparser.parse),
+    AttributeToVerify('compliance', 'Status', lambda val: val.lower() != 'never verified'),
+    AttributeToVerify('compliance', 'History', lambda val: val == 'Available')
+)
+
+
+@pytest.fixture(scope='function')
+def delete_all_container_tasks():
+    delete_all_tasks('AllTasks')
 
 
 @pytest.fixture(scope='function')
@@ -16,16 +38,56 @@ def random_image_instance(appliance):
     return random.sample(collection.all(), 1).pop()
 
 
-@pytest.mark.polarion('10068')
-def test_check_compliance_provider_policy(provider, random_image_instance):
+@pytest.yield_fixture(scope='function')
+def openscap_assigned_rand_image(provider, random_image_instance):
+    """Returns random Container image that have assigned OpenSCAP policy from provider view.
+    teardown remove this assignment from provider view.
+    """
     # unassign OpenSCAP policy from chosen Image
     random_image_instance.unassign_policy_profiles('OpenSCAP profile')
-
     # assign policy from provider view
     provider.assign_policy_profiles('OpenSCAP profile')
-
-    # check Image compliance
-    random_image_instance.check_compliance()
-
-    # unassign OpenSCAP policy from provider view
+    yield random_image_instance
     provider.unassign_policy_profiles('OpenSCAP profile')
+
+
+def get_table_attr(instance, table_name, attr):
+    # Trying to read the table <table_name> attribute <attr>
+    view = refresh_and_navigate(instance, 'Details')
+    table = getattr(view.entities, table_name, None)
+    if table:
+        return table.read().get(attr)
+
+
+@pytest.mark.polarion('10068')
+def test_check_compliance_provider_policy(provider, soft_assert, delete_all_container_tasks,
+                                          openscap_assigned_rand_image):
+
+    # Perform SSA Scan then check compliance with last know configuration
+    openscap_assigned_rand_image.perform_smartstate_analysis(wait_for_finish=True, timeout='20M')
+
+    view = navigate_to(openscap_assigned_rand_image, 'Details')
+    for tbl, attr, verifier in TESTED_ATTRIBUTES__openscap:
+
+        table = getattr(view.entities, tbl)
+        table_data = {k.lower(): v for k, v in table.read().items()}
+
+        if not soft_assert(attr.lower() in table_data, '{} table has missing attribute \'{}\''
+                           .format(tbl, attr)):
+            continue
+        provider.refresh_provider_relationships()
+        wait_for_retval = wait_for(
+            get_table_attr,
+            func_args=[openscap_assigned_rand_image, tbl, attr],
+            message='Trying to get attribute "{}" of table "{}"'.format(attr, tbl),
+            delay=5,
+            num_sec=120,
+            silent_failure=True
+        )
+        if not wait_for_retval:
+            soft_assert(False, 'Could not get attribute "{}" for "{}" table.'
+                        .format(attr, tbl))
+            continue
+        value = wait_for_retval.out
+        soft_assert(verifier(value), '{}.{} attribute has unexpected value ({})'
+                    .format(tbl, attr, value))

--- a/cfme/tests/containers/test_provider_openscap_policy_attached.py
+++ b/cfme/tests/containers/test_provider_openscap_policy_attached.py
@@ -1,0 +1,31 @@
+import random
+import pytest
+
+from cfme.containers.provider import ContainersProvider
+
+pytestmark = [
+    pytest.mark.meta(server_roles='+smartproxy'),
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.tier(1),
+    pytest.mark.provider([ContainersProvider], scope='function')]
+
+
+@pytest.fixture(scope='function')
+def random_image_instance(appliance):
+    collection = appliance.collections.container_images
+    return random.sample(collection.all(), 1).pop()
+
+
+@pytest.mark.polarion('10068')
+def test_check_compliance_provider_policy(provider, random_image_instance):
+    # unassign OpenSCAP policy from chosen Image
+    random_image_instance.unassign_policy_profiles('OpenSCAP profile')
+
+    # assign policy from provider view
+    provider.assign_policy_profiles('OpenSCAP profile')
+
+    # check Image compliance
+    random_image_instance.check_compliance()
+
+    # unassign OpenSCAP policy from provider view
+    provider.unassign_policy_profiles('OpenSCAP profile')


### PR DESCRIPTION
This PR comes to check Container Image compliance check in case that the policy profile is attach from provider view (and not from Image).

{{pytest: cfme/tests/containers/test_provider_openscap_policy_attached.py -v --use-provider cm-env2 }}
  