### PR TITLE
[1LP][RFR] Added filter for PersistentVolume to containers.volume.all()

### DIFF
--- a/cfme/containers/volume.py
+++ b/cfme/containers/volume.py
@@ -50,7 +50,8 @@ class VolumeCollection(GetRandomInstancesMixin, BaseCollection):
         volume_query = (
             self.appliance.db.client.session
                 .query(volume_table.name, ems_table.name)
-                .join(ems_table, volume_table.parent_id == ems_table.id))
+                .join(ems_table, volume_table.parent_id == ems_table.id)
+                .filter(volume_table.type == 'PersistentVolume'))
         provider = None
         # filtered
         if self.filters.get('provider'):


### PR DESCRIPTION
Added a filter to only return volumes with the type "PersistentVolume". This matches what is displayed in the GUI.

Manual Testing:
Pre filter:
```
In [2]: coll = appliance.collections.container_volumes

In [3]: coll.all()
Out[3]: 
[Volume(name=u'pv-10', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='ose3-master.ksi83.cmqe.eng.bos.redhat.com', key='ose3-master.ksi83.cmqe.eng.bos.redhat.com', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Volume(name=u'pv-9', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='ose3-master.ksi83.cmqe.eng.bos.redhat.com', key='ose3-master.ksi83.cmqe.eng.bos.redhat.com', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Volume(name=u'pv-8', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='ose3-master.ksi83.cmqe.eng.bos.redhat.com', key='ose3-master.ksi83.cmqe.eng.bos.redhat.com', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Volume(name=u'registry-token-89hf5', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='ose3-master.ksi83.cmqe.eng.bos.redhat.com', key='ose3-master.ksi83.cmqe.eng.bos.redhat.com', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Volume(name=u'registry-certificates', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='ose3-master.ksi83.cmqe.eng.bos.redhat.com', key='ose3-master.ksi83.cmqe.eng.bos.redhat.com', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Volume(name=u'registry-storage', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='ose3-master.ksi83.cmqe.eng.bos.redhat.com', key='ose3-master.ksi83.cmqe.eng.bos.redhat.com', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Volume(name=u'pv-7', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='ose3-master.ksi83.cmqe.eng.bos.redhat.com', key='ose3-master.ksi83.cmqe.eng.bos.redhat.com', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Volume(name=u'pv-6', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='ose3-master.ksi83.cmqe.eng.bos.redhat.com', key='ose3-master.ksi83.cmqe.eng.bos.redhat.com', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Volume(name=u'pv-5', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='ose3-master.ksi83.cmqe.eng.bos.redhat.com', key='ose3-master.ksi83.cmqe.eng.bos.redhat.com', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Volume(name=u'pv-4', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='ose3-master.ksi83.cmqe.eng.bos.redhat.com', key='ose3-master.ksi83.cmqe.eng.bos.redhat.com', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Volume(name=u'pv-3', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='ose3-master.ksi83.cmqe.eng.bos.redhat.com', key='ose3-master.ksi83.cmqe.eng.bos.redhat.com', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Volume(name=u'pv-2', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='ose3-master.ksi83.cmqe.eng.bos.redhat.com', key='ose3-master.ksi83.cmqe.eng.bos.redhat.com', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Volume(name=u'brq-nfs-01', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='ose3-master.ksi83.cmqe.eng.bos.redhat.com', key='ose3-master.ksi83.cmqe.eng.bos.redhat.com', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>)]

In [4]: 

```
Post filter:
```
In [2]: coll = appliance.collections.container_volumes

In [3]: coll.all()
Out[3]: 
[Volume(name=u'brq-nfs-01', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='ose3-master.ksi83.cmqe.eng.bos.redhat.com', key='ose3-master.ksi83.cmqe.eng.bos.redhat.com', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Volume(name=u'pv-2', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='ose3-master.ksi83.cmqe.eng.bos.redhat.com', key='ose3-master.ksi83.cmqe.eng.bos.redhat.com', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Volume(name=u'pv-3', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='ose3-master.ksi83.cmqe.eng.bos.redhat.com', key='ose3-master.ksi83.cmqe.eng.bos.redhat.com', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Volume(name=u'pv-4', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='ose3-master.ksi83.cmqe.eng.bos.redhat.com', key='ose3-master.ksi83.cmqe.eng.bos.redhat.com', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Volume(name=u'pv-5', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='ose3-master.ksi83.cmqe.eng.bos.redhat.com', key='ose3-master.ksi83.cmqe.eng.bos.redhat.com', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Volume(name=u'pv-6', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='ose3-master.ksi83.cmqe.eng.bos.redhat.com', key='ose3-master.ksi83.cmqe.eng.bos.redhat.com', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Volume(name=u'pv-7', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='ose3-master.ksi83.cmqe.eng.bos.redhat.com', key='ose3-master.ksi83.cmqe.eng.bos.redhat.com', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Volume(name=u'pv-8', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='ose3-master.ksi83.cmqe.eng.bos.redhat.com', key='ose3-master.ksi83.cmqe.eng.bos.redhat.com', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Volume(name=u'pv-9', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='ose3-master.ksi83.cmqe.eng.bos.redhat.com', key='ose3-master.ksi83.cmqe.eng.bos.redhat.com', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Volume(name=u'pv-10', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='ose3-master.ksi83.cmqe.eng.bos.redhat.com', key='ose3-master.ksi83.cmqe.eng.bos.redhat.com', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>)]

In [4]: 

```
{{ pytest: cfme/tests/containers/test_node.py --use-provider cm-env2 --long-running }}