### PR TITLE
[WIP]Fix for TestBulkQueryRESTAPI.test_bulk_query_roles 

### DIFF
--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -670,12 +670,12 @@ class TestBulkQueryRESTAPI(object):
             test_flag: rest
         """
         collection = appliance.rest_api.collections.roles
-        data0, data1 = collection[0]._data, collection[1]._data
         response = appliance.rest_api.collections.roles.action.query(
-            {'name': data0['name']}, {'name': data1['name']})
+            {'name': collection[0]._data['name']}, {'name': collection[1]._data['name']})
         assert_response(appliance)
         assert len(response) == 2
-        assert data0 == response[0]._data and data1 == response[1]._data
+        for i in range(len(response)):
+            assert collection[i]._data <= response[i]._data.items()
 
     def test_bulk_query_groups(self, appliance):
         """Tests bulk query on 'groups' collection


### PR DESCRIPTION
Purpose
=================
Changed comparing of **_collection_** and **_response_**, because response returns dict with aditional key-value which is not included in collection. 

{{pytest: -v  cfme/tests/test_rest.py -k test_bulk_query_roles}}
 
