### PR TITLE
[1LP][RFR] Fixing deploy_template to get small_template name properly

### DIFF
--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -380,7 +380,7 @@ def test_no_power_controls_on_archived_vm(testing_vm, archived_vm, soft_assert):
         * Verify the Power toolbar button is not visible
     """
     view = navigate_to(testing_vm, 'AnyProviderDetails', use_resetter=False)
-    soft_assert(not view.toolbar.power.is_displayed, "Power displayed in template details!")
+    soft_assert(not view.toolbar.power.is_displayed, "Power displayed in archived VM's details!")
 
 
 @pytest.mark.uncollectif(lambda provider: provider.one_of(SCVMMProvider) and

--- a/cfme/utils/virtual_machines.py
+++ b/cfme/utils/virtual_machines.py
@@ -58,11 +58,8 @@ def deploy_template(provider_key, vm_name, template_name=None, timeout=900, **de
         try:
             deploy_args.update(template=provider_crud.data['templates']['small_template']['name'])
         except KeyError:
-            try:
-                deploy_args.update(template=provider_crud.data['small_template'])
-            except KeyError:
-                raise ValueError('small_template not defined for Provider {} in cfme_data.yaml'
-                    .format(provider_key))
+            raise KeyError('small_template not defined for Provider {} in cfme_data.yaml'
+                .format(provider_key))
     else:
         deploy_args.update(template=template_name)
 

--- a/cfme/utils/virtual_machines.py
+++ b/cfme/utils/virtual_machines.py
@@ -56,10 +56,13 @@ def deploy_template(provider_key, vm_name, template_name=None, timeout=900, **de
 
     if template_name is None:
         try:
-            deploy_args.update(template=provider_crud.data['small_template'])
+            deploy_args.update(template=provider_crud.data['templates']['small_template']['name'])
         except KeyError:
-            raise ValueError('small_template not defined for Provider {} in cfme_data.yaml'.format(
-                provider_key))
+            try:
+                deploy_args.update(template=provider_crud.data['small_template'])
+            except KeyError:
+                raise ValueError('small_template not defined for Provider {} in cfme_data.yaml'
+                    .format(provider_key))
     else:
         deploy_args.update(template=template_name)
 


### PR DESCRIPTION
__Fixing__ deploy_template method so it is consistent with new way of defining templates:

templates:
 - small_template
    - name: my_template
    - creds: my_creds

The old way is kept for backwards compatibility.

I am getting `INTERNALERROR> Exception: SSH is unavailable` for 5.9 in PRT. However, I tested this locally and the change is pretty straightforward.

{{pytest: cfme/tests/infrastructure/test_vm_power_control.py::test_no_power_controls_on_archived_vm --use-provider rhv41-vv --long-running}}

  