### PR TITLE
[RFR] Fixed test_alert_timeline_cpu

### DIFF
--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -341,7 +341,7 @@ def test_alert_timeline_cpu(request, vm, set_performance_capture_threshold, prov
     timeline = vm.open_timelines()
     timeline.filter.fill({
         "event_category": "Alarm/Status Change/Errors",
-        "time_range": "Days",
+        "time_range": "Weeks",
         "calendar": "{dt.month}/{dt.day}/{dt.year}".format(dt=datetime.now() + timedelta(days=1))
     })
     timeline.filter.apply.click()


### PR DESCRIPTION
{{pytest: -v -k test_alert_timeline_cpu --long-running --use-provider vsphere6-nested}}