### PR TITLE
[1LP][RFR] Adjusting test_vm_reconfig_add_remove_hw_cold memory value

### DIFF
--- a/cfme/tests/infrastructure/test_vm_reconfigure.py
+++ b/cfme/tests/infrastructure/test_vm_reconfigure.py
@@ -57,7 +57,8 @@ def test_vm_reconfig_add_remove_hw_cold(
     elif change_type == 'sockets':
         new_config.hw.sockets = new_config.hw.sockets + 1
     elif change_type == 'memory':
-        new_config.hw.mem_size = new_config.hw.mem_size_mb + 512
+        mem_diff = -512 if small_vm.provider.one_of(RHEVMProvider) else 512
+        new_config.hw.mem_size = new_config.hw.mem_size_mb + mem_diff
         new_config.hw.mem_size_unit = 'MB'
 
     small_vm.reconfigure(new_config)


### PR DESCRIPTION
__Fixing__ test_vm_reconfig_add_remove_hw_cold for memory. The reason is that rhv_cfme_integration provider uses small_template that has max memory 2048 MB. Therefore it we attempt to increase it by 512 MB, it will never happen. We can, however, decrease it instead. And it test the functionality pretty much the same way. 

{{pytest: cfme/tests/infrastructure/test_vm_reconfigure.py::test_vm_reconfig_add_remove_hw_cold[rhv41-memory] -vv --long-running}}
