### PR TITLE
[1LP][RFR] Fixed test_permission_edit

### DIFF
--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -35,7 +35,12 @@ def a_provider(request):
 
 
 def new_credential():
-    return Credential(principal='uid{}'.format(fauxfactory.gen_alphanumeric()), secret='redhat')
+    if BZ(1487199, forced_streams=['5.8']).blocks:
+        return Credential(principal='uid{}'.format(fauxfactory.gen_alphanumeric().lower()),
+                          secret='redhat')
+    else:
+        return Credential(principal='uid{}'.format(fauxfactory.gen_alphanumeric()),
+                          secret='redhat')
 
 
 def new_user(appliance, group, name=None, credential=None):

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -13,7 +13,6 @@ from cfme.infrastructure import virtual_machines as vms
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.services.myservice import MyService
 from cfme.utils import error
-from cfme.utils import version
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
@@ -558,6 +557,10 @@ def _test_vm_provision(appliance):
     vms.lcl_btn("Provision VMs")
 
 
+def _test_vm_view(appliance):
+    logger.info("Checking for vms view access")
+    navigate_to(vms.Vm, 'VMsOnly')
+
 # this fixture is used in disabled tests. it should be updated along with tests
 # def _test_vm_power_on():
 #     """Ensures power button is shown for a VM"""
@@ -578,11 +581,9 @@ def _test_vm_removal():
 @pytest.mark.tier(3)
 @pytest.mark.parametrize(
     'product_features, action',
-    [({version.LOWEST: [
-        ['Everything', 'Compute', 'Infrastructure', 'Virtual Machines', 'Accordions'],
-        ['Everything', 'Access Rules for all Virtual Machines', 'VM Access Rules', 'Modify',
-         'Provision VMs']], },
-      _test_vm_provision)])
+    [([['Everything', 'Access Rules for all Virtual Machines', 'VM Access Rules', 'View'],
+       ['Everything', 'Compute', 'Infrastructure', 'Virtual Machines', 'Accordions']],
+      _test_vm_view)])
 def test_permission_edit(appliance, request, product_features, action):
     """
     Ensures that changes in permissions are enforced on next login
@@ -592,8 +593,6 @@ def test_permission_edit(appliance, request, product_features, action):
         product_features: product features to set for test role
         action: reference to a function to execute under the test user context
     """
-    product_features = version.pick(product_features)
-    request.addfinalizer(appliance.server.login_admin)
     role_name = fauxfactory.gen_alphanumeric()
     role = appliance.collections.roles.create(name=role_name,
                 vm_restriction=None,
@@ -604,7 +603,7 @@ def test_permission_edit(appliance, request, product_features, action):
     user = new_user(appliance, group=group)
     with user:
         try:
-            action()
+            action(appliance)
         except Exception:
             pytest.fail('Incorrect permissions set')
     appliance.server.login_admin()
@@ -614,9 +613,14 @@ def test_permission_edit(appliance, request, product_features, action):
     with user:
         try:
             with error.expected(Exception):
-                action()
+                action(appliance)
         except error.UnexpectedSuccessException:
             pytest.fail('Permissions have not been updated')
+
+    @request.addfinalizer
+    def _delete_user_group_role():
+        for item in [user, group, role]:
+            item.delete()
 
 
 def _mk_role(appliance, name=None, vm_restriction=None, product_features=None):

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -585,11 +585,10 @@ def _test_vm_removal():
 
 @pytest.mark.tier(3)
 @pytest.mark.parametrize(
-    'product_features, action',
-    [([['Everything', 'Access Rules for all Virtual Machines', 'VM Access Rules', 'View'],
-       ['Everything', 'Compute', 'Infrastructure', 'Virtual Machines', 'Accordions']],
-      _test_vm_view)])
-def test_permission_edit(appliance, request, product_features, action):
+    'product_features', [
+        [['Everything', 'Access Rules for all Virtual Machines', 'VM Access Rules', 'View'],
+         ['Everything', 'Compute', 'Infrastructure', 'Virtual Machines', 'Accordions']]])
+def test_permission_edit(appliance, request, product_features):
     """
     Ensures that changes in permissions are enforced on next login
     Args:
@@ -608,7 +607,7 @@ def test_permission_edit(appliance, request, product_features, action):
     user = new_user(appliance, group=group)
     with user:
         try:
-            action(appliance)
+            _test_vm_view(appliance)
         except Exception:
             pytest.fail('Incorrect permissions set')
     appliance.server.login_admin()
@@ -618,7 +617,7 @@ def test_permission_edit(appliance, request, product_features, action):
     with user:
         try:
             with error.expected(Exception):
-                action(appliance)
+                _test_vm_view(appliance)
         except error.UnexpectedSuccessException:
             pytest.fail('Permissions have not been updated')
 

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -561,11 +561,6 @@ def _test_vm_provision(appliance):
     navigate_to(vms.Vm, 'VMsOnly')
     vms.lcl_btn("Provision VMs")
 
-
-def _test_vm_view(appliance):
-    logger.info("Checking for vms view access")
-    navigate_to(vms.Vm, 'VMsOnly')
-
 # this fixture is used in disabled tests. it should be updated along with tests
 # def _test_vm_power_on():
 #     """Ensures power button is shown for a VM"""
@@ -607,7 +602,7 @@ def test_permission_edit(appliance, request, product_features):
     user = new_user(appliance, group=group)
     with user:
         try:
-            _test_vm_view(appliance)
+            navigate_to(vms.Vm, 'VMsOnly')
         except Exception:
             pytest.fail('Incorrect permissions set')
     appliance.server.login_admin()
@@ -617,7 +612,7 @@ def test_permission_edit(appliance, request, product_features):
     with user:
         try:
             with error.expected(Exception):
-                _test_vm_view(appliance)
+                navigate_to(vms.Vm, 'VMsOnly')
         except error.UnexpectedSuccessException:
             pytest.fail('Permissions have not been updated')
 


### PR DESCRIPTION
Purpose 
=================
Refactored test, added new action to view VMs insted of provisioning VM as there is  a separate test for provisioning.

{{pytest: -v cfme/tests/configure/test_access_control.py -k test_permission_edit}}
  