### PR TITLE
[1LP][RFR] Fix for managed_provider call

### DIFF
--- a/fixtures/log.py
+++ b/fixtures/log.py
@@ -4,6 +4,7 @@ import pytest
 
 from cfme.utils import log
 from cfme.utils.appliance import get_or_create_current_appliance
+
 #: A dict of tests, and their state at various test phases
 test_tracking = collections.defaultdict(dict)
 
@@ -36,7 +37,7 @@ def pytest_runtest_logreport(report):
     #      test_tracking['test_name']['teardown'] = 'failed'
     yield
     test_tracking[_format_nodeid(report.nodeid, False)][report.when] = report.outcome
-    if report.when == 'teardown':
+    if report.when == 'teardown' and pytest.store.parallelizer_role == 'master':
         path, lineno, domaininfo = report.location
         test_status = _test_status(_format_nodeid(report.nodeid, False))
         if test_status == "failed":


### PR DESCRIPTION
* The call to managed_provider could cause INTERNALERROR because it
  used current_appliance. This usually points to the first slave in the
  case of the master in a parallelized setup. The problem is that if
  slave00 dies/shutdown and something fails in teardown, we can't get
  managed_provider calls to work because the appliance has gone.
* We now only run this on the master if we are not running in a
  parallelized setup. If we are in a parallelized setup we now run it
  in the client process instead. This means we can access the slaves
  own appliance instead of get_current_appliance of the master. This
  should always get us a good appliance and if the appliance isn't good
  then subsequent tests will fail anyway.