### PR TITLE
[1LP][RFR] test_tagvis_combination, test_clone fixes

### DIFF
--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -281,7 +281,7 @@ class ProviderNodesView(BaseLoggedInPage):
                 self.title.text == title)
 
 
-class ProviderTemplatesView(BaseLoggedInPage):
+class ProviderVmsTemplatesView(BaseLoggedInPage):
     """
      represents Templates view (exists for Infra providers)
     """
@@ -295,6 +295,9 @@ class ProviderTemplatesView(BaseLoggedInPage):
         download = Dropdown(text='Download')
         view_selector = View.nested(ItemsToolBarViewSelector)
 
+
+class ProviderTemplatesView(ProviderVmsTemplatesView):
+
     @property
     def is_displayed(self):
         title = '{name} (All Miq Templates)'.format(name=self.context['object'].name)
@@ -302,6 +305,15 @@ class ProviderTemplatesView(BaseLoggedInPage):
                 self.navigation.currently_selected == ['Compute', 'Infrastructure', 'Providers'] and
                 self.title.text == title)
 
+
+class ProviderVmsView(ProviderVmsTemplatesView):
+
+    @property
+    def is_displayed(self):
+        title = '{name} (All Direct VMs)'.format(name=self.context['object'].name)
+        return (self.logged_in_as_current_user and
+                self.navigation.currently_selected == ['Compute', 'Infrastructure', 'Providers'] and
+                self.title.text == title)
 
 class ProviderToolBar(View):
     """

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -14,7 +14,8 @@ from cfme.common.provider_views import (InfraProviderAddView,
                                         InfraProvidersDiscoverView,
                                         InfraProvidersView,
                                         ProviderNodesView,
-                                        ProviderTemplatesView)
+                                        ProviderTemplatesView,
+                                        ProviderVmsView)
 from cfme.exceptions import DestinationNotFound
 from cfme.infrastructure.cluster import ClusterView, ClusterToolbar
 from cfme.infrastructure.host import Host
@@ -330,6 +331,15 @@ class ProviderTemplates(CFMENavigateStep):
 
     def step(self):
         self.prerequisite_view.entities.relationships.click_at('Templates')
+
+
+@navigator.register(InfraProvider, 'ProviderVms')
+class ProviderVms(CFMENavigateStep):
+    VIEW = ProviderVmsView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        self.prerequisite_view.entities.relationships.click_at('Virtual Machines')
 
 
 def get_all_providers():

--- a/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
+++ b/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
@@ -13,9 +13,9 @@ from cfme.utils.update import update
 pytestmark = [test_requirements.tag, pytest.mark.tier(2)]
 
 test_items = [
-    ('clusters', None),
-    ('vms', Vm),
-    ('templates', Template)
+    ('clusters', None, None),
+    ('vms', Vm, 'ProviderVms'),
+    ('templates', Template, 'ProviderTemplates')
 ]
 
 
@@ -26,22 +26,17 @@ def a_provider(request):
     return setup_one_or_skip(request, filters=[prov_filter])
 
 
-@pytest.fixture(params=test_items, ids=[collection_type for collection_type, __ in test_items],
+@pytest.fixture(params=test_items, ids=[collection_type for collection_type, _, _ in test_items],
                 scope='function')
 def testing_vis_object(request, a_provider, appliance):
     """ Fixture creates class object for tag visibility test
 
     Returns: class object of certain type
     """
-    collection_name, param_class = request.param
+    collection_name, param_class, destination = request.param
     if not param_class:
         param_class = getattr(appliance.collections, collection_name)
-    if collection_name == 'clusters':
-        view = navigate_to(param_class, 'All')
-    elif collection_name == 'vms':
-        view = navigate_to(a_provider, "ProviderVms")
-    else:
-        view = navigate_to(param_class, 'TemplatesOnly')
+    view = navigate_to(a_provider, destination) if destination else navigate_to(param_class, 'All')
     names = view.entities.entity_names
     if not names:
         pytest.skip("No content found for test")

--- a/cfme/tests/infrastructure/test_vm_clone.py
+++ b/cfme/tests/infrastructure/test_vm_clone.py
@@ -37,7 +37,7 @@ def create_vm(appliance, provider, setup_provider, request):
 
     if not provider.mgmt.does_vm_exist(vm.name):
         logger.info("deploying %s on provider %s", vm.name, provider.key)
-        vm.create_on_provider(allow_skip="default", find_in_cfme=False)
+        vm.create_on_provider(allow_skip="default", find_in_cfme=True)
     return vm
 
 


### PR DESCRIPTION
Purpose or Intent
=================
Updated the way we get vms, and templates, for a test.
{{pytest: -vvv -k 'test_tagvis_tag_datacenter_combination or test_vm_clone' --long-running --use-provider complete}}
  