### PR TITLE
[1LP][RFR] Update Chargeback Rates, views, navigation, and CRUD tests

### DIFF
--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -340,3 +340,7 @@ class RBACOperationBlocked(CFMEException):
     permissions. Also thrown when trying to perform actions CRUD operations on roles/groups/users
     that are CFME defaults
     """
+
+
+class ChargebackRateNotFound(CFMEException):
+    """Raised when a given chargeback (compute or storage) rate is not found during navigation"""

--- a/cfme/intelligence/chargeback/rates.py
+++ b/cfme/intelligence/chargeback/rates.py
@@ -1,51 +1,68 @@
 # -*- coding: utf-8 -*-
 # Page model for Intel->Chargeback->Rates.
+from wait_for import TimedOutError
 
 from cached_property import cached_property
 from navmazing import NavigateToSibling, NavigateToAttribute
 from widgetastic.utils import ParametrizedLocator, ParametrizedString
-from widgetastic.widget import Text, ParametrizedView
+from widgetastic.widget import Text, ParametrizedView, View
 from widgetastic_patternfly import Button, Input, Dropdown
 
+from cfme.exceptions import ChargebackRateNotFound
 from cfme.utils import ParamClassName
 from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import navigator, navigate_to, CFMENavigateStep
+from cfme.utils.blockers import BZ
 from cfme.utils.pretty import Pretty
 from cfme.utils.update import Updateable
-from widgetastic_manageiq import Select
+from widgetastic_manageiq import Select, Table
 from . import ChargebackView
 
 
 class RatesView(ChargebackView):
     title = Text("#explorer_title_text")
+    table = Table(".//div[@id='records_div' or @class='miq-data-table']/table")
+
+    @property
+    def in_rates(self):
+        """Determine if in the rates part of chargeback, includes check of in_chargeback"""
+        return(
+            self.in_chargeback and
+            self.toolbar.configuration.is_displayed and
+            self.rates.is_opened)
 
     @property
     def is_displayed(self):
+        # BZ 1532701 for singular title on redirection to this page, but not direct navigation
+        if BZ(1532701, forced_streams='5.9').blocks:
+            title_test = ("{} Chargeback Rate".format(self.context['object'].RATE_TYPE)
+                          in self.title.text)
+        else:
+            title_test = ("{} Chargeback Rates".format(self.context['object'].RATE_TYPE) ==
+                          self.title.text)
         return (
-            self.in_chargeback and self.configuration.is_displayed and
-            self.title.text == "Compute Chargeback Rates"
-        )
+            self.in_rates and
+            self.rates.tree.currently_selected == ['Rates',
+                                                   self.context['object'].RATE_TYPE] and
+            title_test)
 
-    configuration = Dropdown('Configuration')
+    @View.nested
+    class toolbar(View):  # noqa
+        configuration = Dropdown('Configuration')
 
 
-class RatesDetailView(ChargebackView):
-    title = Text("#explorer_title_text")
-
+class RatesDetailView(RatesView):
+    # TODO add widget for rate details
     @property
     def is_displayed(self):
         return (
-            self.in_chargeback and self.configuration.is_displayed and
-            self.title.text == 'Compute Chargeback Rate "{}"'.format(
-                self.context["object"].description) and
-            self.rates.is_opened and
-            self.rates.tree.currently_selected == [
-                "Compute Chargeback Rates",
-                self.context["object"].description
-            ]
-        )
-
-    configuration = Dropdown('Configuration')
+            self.in_rates and
+            self.rates.tree.currently_selected == ['Rates',
+                                                   self.context['object'].RATE_TYPE,
+                                                   self.context['object'].description] and
+            self.title.text == '{} Chargeback Rate "{}"'
+                .format(self.context['object'].RATE_TYPE,
+                        self.context['object'].description))
 
 
 class AddComputeChargebackView(RatesView):
@@ -104,14 +121,6 @@ class EditComputeChargebackView(AddComputeChargebackView):
             self.title.text == 'Compute Chargeback Rate "{}"'.format(self.obj.description))
 
 
-class StorageChargebackView(RatesView):
-    @property
-    def is_displayed(self):
-        return (
-            self.in_chargeback and
-            self.title.text == 'Storage Chargeback Rates')
-
-
 class AddStorageChargebackView(AddComputeChargebackView):
     pass
 
@@ -124,6 +133,7 @@ class EditStorageChargebackView(EditComputeChargebackView):
             self.title.text == 'Storage Chargeback Rate "{}"'.format(self.obj.description))
 
 
+# TODO Inherit BaseEntity and create a parent collection class
 class ComputeRate(Updateable, Pretty, Navigatable):
     """This class represents a Compute Chargeback rate.
 
@@ -149,6 +159,7 @@ class ComputeRate(Updateable, Pretty, Navigatable):
 
     pretty_attrs = ['description']
     _param_name = ParamClassName('description')
+    RATE_TYPE = 'Compute'
 
     def __init__(self, description=None,
                  currency=None,
@@ -163,17 +174,27 @@ class ComputeRate(Updateable, Pretty, Navigatable):
     def __getitem__(self, name):
         return self.fields.get(name)
 
+    @property
+    def exists(self):
+        try:
+            navigate_to(self, 'Details', wait_for_view=True)
+        except (ChargebackRateNotFound, TimedOutError):
+            return False
+        else:
+            return True
+
     def create(self):
         # Create a rate in UI
-        view = navigate_to(self, 'New')
+        view = navigate_to(self, 'Add')
         view.fill_with({'description': self.description,
                         'currency': self.currency,
                         'fields': self.fields},
                        on_change=view.add_button,
                        no_change=view.cancel_button)
 
-        view.flash.assert_success_message('Chargeback Rate "{}" was added'.format(
-            self.description))
+        view = self.create_view(navigator.get_class(self, 'All').VIEW)
+        assert view.is_displayed
+        view.flash.assert_no_error()
 
     def copy(self, *args, **kwargs):
         new_rate = ComputeRate(*args, **kwargs)
@@ -190,24 +211,29 @@ class ComputeRate(Updateable, Pretty, Navigatable):
         # Update a rate in UI
         view = navigate_to(self, 'Edit')
         view.fill_with(updates,
-                    on_change=view.save_button,
-                    no_change=view.cancel_button)
+                       on_change=view.save_button,
+                       no_change=view.cancel_button)
 
-        view.flash.assert_success_message('Chargeback Rate "{}" was saved'.format(
-            updates.get('description')))
+        view = self.create_view(navigator.get_class(self, 'Details').VIEW)
+        view.flash.assert_no_error()
 
-    def delete(self):
-        # Delete a rate in UI
-        view = navigate_to(self, 'Details')
-        view.configuration.item_select('Remove from the VMDB', handle_alert=True)
-        view.flash.assert_success_message('Chargeback Rate "{}": Delete successful'.format(
-            self.description))
+    def delete(self, cancel=False):
+        """Delete a CB rate in the UI
+        Args:
+            cancel: boolean, whether to cancel the action on alert
+        """
+        view = navigate_to(self, 'Details', wait_for_view=True)
+        view.toolbar.configuration.item_select('Remove from the VMDB', handle_alert=(not cancel))
+        view = self.create_view(navigator.get_class(self, 'All').VIEW)
+        assert view.is_displayed
+        view.flash.assert_no_error()
 
 
 class StorageRate(ComputeRate):
     # Methods and form for this are similar to that of ComputeRate, but navigation is different
     # from that of ComputeRate.
     pretty_attrs = ['description']
+    RATE_TYPE = 'Storage'
 
 
 @navigator.register(ComputeRate, 'All')
@@ -222,13 +248,13 @@ class ComputeRateAll(CFMENavigateStep):
         )
 
 
-@navigator.register(ComputeRate, 'New')
+@navigator.register(ComputeRate, 'Add')
 class ComputeRateNew(CFMENavigateStep):
     VIEW = AddComputeChargebackView
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.view.configuration.item_select("Add a new Chargeback Rate")
+        self.view.toolbar.configuration.item_select("Add a new Chargeback Rate")
 
 
 @navigator.register(ComputeRate, 'Details')
@@ -237,10 +263,15 @@ class ComputeRateDetails(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.view.rates.tree.click_path(
-            "Rates",
-            "Compute", self.obj.description
-        )
+        try:
+            self.view.rates.tree.click_path(
+                "Rates",
+                "Compute", self.obj.description
+            )
+        except Exception as ex:
+            # TODO don't diaper here
+            raise ChargebackRateNotFound('Exception navigating to ComputeRate {} "Details": {}'
+                                         .format(self.obj.description, ex))
 
 
 @navigator.register(ComputeRate, 'Copy')
@@ -249,7 +280,7 @@ class ComputeRateCopy(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        self.view.configuration.item_select('Copy this Chargeback Rate')
+        self.view.toolbar.configuration.item_select('Copy this Chargeback Rate')
 
 
 @navigator.register(ComputeRate, 'Edit')
@@ -258,12 +289,12 @@ class ComputeRateEdit(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        self.view.configuration.item_select("Edit this Chargeback Rate")
+        self.view.toolbar.configuration.item_select("Edit this Chargeback Rate")
 
 
 @navigator.register(StorageRate, 'All')
 class StorageRateAll(CFMENavigateStep):
-    VIEW = StorageChargebackView
+    VIEW = RatesView
     prerequisite = NavigateToAttribute('appliance.server', 'IntelChargeback')
 
     def step(self):
@@ -273,13 +304,13 @@ class StorageRateAll(CFMENavigateStep):
         )
 
 
-@navigator.register(StorageRate, 'New')
+@navigator.register(StorageRate, 'Add')
 class StorageRateNew(CFMENavigateStep):
     VIEW = AddStorageChargebackView
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.view.configuration.item_select("Add a new Chargeback Rate")
+        self.view.toolbar.configuration.item_select("Add a new Chargeback Rate")
 
 
 @navigator.register(StorageRate, 'Details')
@@ -288,10 +319,15 @@ class StorageRateDetails(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self):
-        self.view.rates.tree.click_path(
-            "Rates",
-            "Storage", self.obj.description
-        )
+        try:
+            self.view.rates.tree.click_path(
+                "Rates",
+                "Storage", self.obj.description
+            )
+        except Exception as ex:
+            # TODO don't diaper here
+            raise ChargebackRateNotFound('Exception navigating to StorageRate {} "Details": {}'
+                                         .format(self.obj.description, ex))
 
 
 @navigator.register(StorageRate, 'Edit')
@@ -300,4 +336,4 @@ class StorageRateEdit(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self):
-        self.view.configuration.item_select("Edit this Chargeback Rate")
+        self.view.toolbar.configuration.item_select("Edit this Chargeback Rate")

--- a/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
+++ b/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
@@ -554,8 +554,8 @@ def test_validate_default_rate_storage_usage_cost(chargeback_costs_default,
             break
 
 
-@pytest.mark.uncollectif(
-    lambda provider: provider.category == 'cloud')
+@pytest.mark.uncollectif(lambda provider: provider.category == 'cloud')
+@pytest.mark.meta(blockers=[BZ(1532368, forced_streams='5.9')])
 def test_validate_custom_rate_cpu_usage_cost(chargeback_costs_custom, chargeback_report_custom):
     """Test to validate CPU usage cost.
        Calculation is based on custom Chargeback rate.
@@ -571,8 +571,8 @@ def test_validate_custom_rate_cpu_usage_cost(chargeback_costs_custom, chargeback
             break
 
 
-@pytest.mark.uncollectif(
-    lambda provider: provider.one_of(GCEProvider))
+@pytest.mark.uncollectif(lambda provider: provider.one_of(GCEProvider))
+@pytest.mark.meta(blockers=[BZ(1532368, forced_streams='5.9')])
 def test_validate_custom_rate_memory_usage_cost(chargeback_costs_custom, chargeback_report_custom):
     """Test to validate memory usage cost.
        Calculation is based on custom Chargeback rate.
@@ -588,6 +588,7 @@ def test_validate_custom_rate_memory_usage_cost(chargeback_costs_custom, chargeb
             break
 
 
+@pytest.mark.meta(blockers=[BZ(1532368, forced_streams='5.9')])
 def test_validate_custom_rate_network_usage_cost(chargeback_costs_custom, chargeback_report_custom):
     """Test to validate network usage cost.
        Calculation is based on custom Chargeback rate.
@@ -603,6 +604,7 @@ def test_validate_custom_rate_network_usage_cost(chargeback_costs_custom, charge
             break
 
 
+@pytest.mark.meta(blockers=[BZ(1532368, forced_streams='5.9')])
 def test_validate_custom_rate_disk_usage_cost(chargeback_costs_custom, chargeback_report_custom):
     """Test to validate disk usage cost.
        Calculation is based on custom Chargeback rate.
@@ -618,8 +620,8 @@ def test_validate_custom_rate_disk_usage_cost(chargeback_costs_custom, chargebac
             break
 
 
-def test_validate_custom_rate_storage_usage_cost(chargeback_costs_custom,
-        chargeback_report_custom):
+@pytest.mark.meta(blockers=[BZ(1532368, forced_streams='5.9')])
+def test_validate_custom_rate_storage_usage_cost(chargeback_costs_custom, chargeback_report_custom):
     """Test to validate stoarge usage cost.
        Calculation is based on custom Chargeback rate.
     """


### PR DESCRIPTION
Some refactoring of the chargeback rates views and CRUD methods, moving flash message assertions into the tests.

Only parametrized one test to highlight a BZ blocker, @nachandr will be following up with more parametrization of the test case, reducing the separate create/edit/delete tests to a single function.

{{ pytest: cfme/tests/intelligence/test_chargeback.py --use-provider vsphere65-nested --long-running }} 
  
# PRT Results
The test_validate_chargeback_reports is currently blocked from BZ's.

Test skips from blockers, passing otherwise.
  
  