### PR TITLE
[1LP][RFR] fix the import statements in order to exclude OpenStack provider

### DIFF
--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -5,22 +5,25 @@ from time import sleep
 from cfme.base.ui import Server
 from cfme.cloud.availability_zone import AvailabilityZone
 from cfme.cloud.instance import Instance
-from cfme.cloud.provider.azure import AzureProvider
-from cfme.cloud.provider.openstack import OpenStackProvider
+from cfme.cloud.provider import CloudProvider
+from cfme.utils.providers import ProviderFilter
 from cfme.cloud.provider.ec2 import EC2Provider
-from cfme.utils import version
+from cfme.cloud.provider.gce import GCEProvider
+from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for
+from markers.env_markers.provider import providers
 
 
+cloud_prov_only = ProviderFilter(classes=[CloudProvider])
+excluded = ProviderFilter(classes=[GCEProvider, OpenStackProvider], inverted=True)
 pytestmark = [
     pytest.mark.tier(2),
-    pytest.mark.uncollectif(lambda provider: provider.one_of(EC2Provider)),
-    pytest.mark.usefixtures("setup_provider_modscope"),
-    pytest.mark.provider([AzureProvider, OpenStackProvider, EC2Provider], scope="module")
+    pytest.mark.provider(gen_func=providers, filters=[excluded, cloud_prov_only], scope='module'),
+    pytest.mark.usefixtures("setup_provider_modscope")
 ]
 
 


### PR DESCRIPTION
Fix the imports and pytest.mark.provider
=================
RHOS should not be tested for the timelines, as it is done by a dedicated team. We are testing only EC2 (>= 5.8) and Azure. This PR excludes OpenStack.

{{pytest: -v -k test_cloud_instance_event --collect-only --use-provider=complete}}

  
  