### PR TITLE
[1LP][RFR] Deleting BZs no more needed for test_vm_create

### DIFF
--- a/cfme/tests/cloud_infra_common/test_events.py
+++ b/cfme/tests/cloud_infra_common/test_events.py
@@ -32,14 +32,9 @@ def vm_crud(provider, setup_provider_modscope, small_template_modscope):
         vm.delete_from_provider()
 
 
-@pytest.mark.uncollectif(BZ(1491576, forced_streams=['5.7']).blocks, 'BZ 1491576')
 @pytest.mark.uncollectif(lambda provider: provider.one_of(RHEVMProvider) and
                          BZ(1509020, forced_streams=['5.8', '5.9']).blocks,
                          'BZ 1509020')
-@pytest.mark.meta(blockers=[1238371], automates=[1238371])
-@pytest.mark.meta(blockers=[BZ(1514509,
-                            forced_streams=['5.7', '5.8', '5.9', 'upstream'],
-                            unblock=lambda provider: provider.type != 'rhevm')])
 def test_vm_create(request, appliance, vm_crud, provider, register_event):
     """ Test whether vm_create_complete event is emitted.
 


### PR DESCRIPTION
__Deleteing__ BZs that are not needed anymore (already in VERIFIED or CLOSED ERRATE status).

{{pytest: cfme/tests/cloud_infra_common/test_events.py::test_vm_create --use-provider rhv41}}
