### PR TITLE
[1LP][RFR] widgetastic.core 0.20.1

### DIFF
--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -195,7 +195,7 @@ wcwidth==0.1.7
 webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.12.2
-widgetastic.core==0.20.0
+widgetastic.core==0.20.1
 widgetastic.patternfly==0.0.26
 widgetsnbextension==2.0.0
 wrapanapi==2.5.0


### PR DESCRIPTION
This update should fix "AttributeError: This is not an instance of fields. You need to call this object and pass the required parameters of the view."

{{pytest: -v -k test_automate_ansible_playbook_method_type_crud --long-running}}