### PR TITLE
[1LP][RFR] Fixing wait_for_vm_state_change method

### DIFF
--- a/cfme/tests/cloud_infra_common/test_power_control_rest.py
+++ b/cfme/tests/cloud_infra_common/test_power_control_rest.py
@@ -53,7 +53,8 @@ def wait_for_vm_state_change(vm_obj, state):
         vm.reload()
         return vm.power_state == state
     wait_for(_state_changed, num_sec=num_sec, delay=45, silent_failure=True,
-        message="Wait for VM state `{}` (current state: {})".format(state, vm.power_state))
+        message="Wait for VM state `{}` (current state: {})".format(state, vm.power_state),
+        fail_func=vm_obj.refresh_relationships)
 
 
 def verify_vm_power_state(vm, state):


### PR DESCRIPTION
__Fixing__ wait_for_vm_state_change method. Without this fail_func, REST API is just returning last known power state regardless of VM's actual power state.

This refreshing of relationships is done via UI. It would probably be better to do it via REST, but I don't think such method exists in the framework. At least I could not find it. So if you know about better way, feel free to point it out to me.

{{pytest: cfme/tests/cloud_infra_common/test_power_control_rest.py  -vv --use-provider rhv41}}