### PR TITLE
[1LP][RFR] fix 2 tests from test_resources

### DIFF
--- a/cfme/tests/openstack/infrastructure/test_resources.py
+++ b/cfme/tests/openstack/infrastructure/test_resources.py
@@ -22,6 +22,6 @@ def test_number_of_cpu(provider, soft_assert):
 
 
 def test_node_memory(provider):
-    detailed_view = navigate_to(provider, 'Details')
-    node_memory = detailed_view.entities.properties.get_text_of('Aggregate Node Memory')
+    view_details = navigate_to(provider, 'Details')
+    node_memory = view_details.entities.properties.get_text_of('Aggregate Node Memory')
     assert float(node_memory.split()[0]) > 0

--- a/cfme/tests/openstack/infrastructure/test_resources.py
+++ b/cfme/tests/openstack/infrastructure/test_resources.py
@@ -12,16 +12,16 @@ pytestmark = [
 
 
 def test_number_of_cpu(provider, soft_assert):
-    navigate_to(provider, 'Details')
-    v = provider.get_detail('Properties', 'Aggregate Node CPU Resources')
+    view_details = navigate_to(provider, 'Details')
+    v = view_details.entities.properties.get_text_of('Aggregate Node CPU Resources')
     soft_assert(float(v.split()[0]) > 0, "Aggregate Node CPU Resources is 0")
-    v = provider.get_detail('Properties', 'Aggregate Node CPUs')
+    v = view_details.entities.properties.get_text_of('Aggregate Node CPUs')
     soft_assert(int(v) > 0, "Aggregate Node CPUs is 0")
-    v = provider.get_detail('Properties', 'Aggregate Node CPU Cores')
+    v = view_details.entities.properties.get_text_of('Aggregate Node CPU Cores')
     assert int(v) > 0, "Aggregate Node CPU Cores is 0"
 
 
 def test_node_memory(provider):
-    navigate_to(provider, 'Details')
-    node_memory = provider.get_detail('Properties', 'Aggregate Node Memory')
+    detailed_view = navigate_to(provider, 'Details')
+    node_memory = detailed_view.entities.properties.get_text_of('Aggregate Node Memory')
     assert float(node_memory.split()[0]) > 0


### PR DESCRIPTION
Replaced obsolete WebUI get_detail with view_details.entities.properties.get_text_of

{{ pytest: cfme/tests/openstack/infrastructure/test_resources.py }}

  