### PR TITLE
[RFR]Updating CFME Version in server settings in order to copy the SDK on 5.8 appliances as well

### DIFF
--- a/cfme/configure/configuration/server_settings.py
+++ b/cfme/configure/configuration/server_settings.py
@@ -330,7 +330,7 @@ class ServerInformation(Updateable, Pretty):
                         product_name=self.appliance.product_name,
                         version=self.appliance.version
                     )
-                if value == 'VMware WebMKS' and self.appliance.version >= '5.9':
+                if value == 'VMware WebMKS' and self.appliance.version >= '5.8':
                     self.appliance.ssh_client.run_command('curl {} -o WebMKS_SDK.zip'
                         .format(conf.cfme_data.vm_console.webmks_console.webmks_sdk_download_url))
                     self.appliance.ssh_client.run_command('unzip ~/WebMKS_SDK.zip -d {}'


### PR DESCRIPTION

Purpose or Intent
=================

__Fixing__  CFME Version in server settings in order to copy the SDK on 5.8 appliances as well


{{ pytest: cfme/tests/infrastructure/test_webmks_console.py --use-provider vsphere65-nested }}