### PR TITLE
[1LP][RFR] Uncollecting tests incompatible with podified appliances.

### DIFF
--- a/cfme/tests/cli/test_evmserverd.py
+++ b/cfme/tests/cli/test_evmserverd.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """This module contains tests that exercise control of evmserverd service."""
 import pytest
-from cfme.utils import version
 from cfme.utils.wait import wait_for_decorator
 
 
@@ -14,7 +13,10 @@ def start_evmserverd_after_module(appliance):
     appliance.wait_for_web_ui()
 
 
-pytestmark = [pytest.mark.usefixtures("start_evmserverd_after_module")]
+pytestmark = [
+    pytest.mark.uncollectif(lambda appliance: appliance.is_pod),
+    pytest.mark.usefixtures("start_evmserverd_after_module")
+]
 
 
 @pytest.mark.tier(1)

--- a/cfme/tests/integration/test_cfme_auth.py
+++ b/cfme/tests/integration/test_cfme_auth.py
@@ -6,6 +6,8 @@ from cfme.base.credential import Credential
 from cfme.utils.conf import cfme_data
 from cfme.utils.log import logger
 
+pytestmark = pytest.mark.uncollectif(lambda appliance: appliance.is_pod)
+
 RETRIEVE_GROUP = 'retrieve_group'
 CREATE_GROUP = 'create_group'
 

--- a/cfme/tests/optimize/test_bottlenecks.py
+++ b/cfme/tests/optimize/test_bottlenecks.py
@@ -10,6 +10,8 @@ from cfme.utils.blockers import BZ
 from cfme.utils.timeutil import parsetime
 from cfme.utils.ssh import SSHClient
 
+pytestmark = pytest.mark.uncollectif(lambda appliance: appliance.is_pod)
+
 
 @pytest.fixture(scope="module")
 def temp_appliance_extended_db(temp_appliance_preconfig):


### PR DESCRIPTION
__Updating tests__ with uncollectifs because they are incompatible with podified versions of appliance.