### PR TITLE
[1LP][RFR] Add cloud tenant quota tests to whitelist

### DIFF
--- a/fixtures/xunit_tools.py
+++ b/fixtures/xunit_tools.py
@@ -15,7 +15,7 @@ from cfme.utils.pytest_shortcuts import extract_fixtures_values
 
 whitelist = [
     r'cfme/tests/infrastructure/test_quota_tagging.py::test_.*\[.*rhe?v',
-    r'cfme/tests/infrastructure/test_tenant_quota.py::test_.*\[.*rhe?v'
+    r'test_tenant_quota.py',
 ]
 compiled_whitelist = re.compile('(' + ')|('.join(whitelist) + ')')
 


### PR DESCRIPTION
Whitelist also Open Stack tests. For this tests it's not necessary to filter providers, so simplification of the regex to match the file name works as expected.

No PRT necessary.