### PR TITLE
[1LP][RFR] Fixed test_service_ansible_playbook_plays_table

### DIFF
--- a/cfme/services/myservice/ui.py
+++ b/cfme/services/myservice/ui.py
@@ -1,6 +1,6 @@
 from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.utils import Parameter, VersionPick, Version
-from widgetastic.widget import ParametrizedView, Text, View
+from widgetastic.widget import ParametrizedView, Table, Text, View
 from widgetastic_patternfly import Input, BootstrapSelect, Dropdown, Button, CandidateNotFound, Tab
 
 from cfme.base.login import BaseLoggedInPage
@@ -106,7 +106,8 @@ class MyServiceDetailView(MyServicesView):
     @View.nested
     class provisioning(Tab):  # noqa
         results = SummaryTable(title='Results')
-        plays = SummaryTable(title='Plays')
+        plays = Table('.//table[./thead/tr/th[contains(@align, "left") and '
+                      'normalize-space(.)="Plays"]]')
         details = SummaryTable(title='Details')
         credentials = SummaryTable(title='Credentials')
         standart_output = Text('.//div[@id="provisioning"]//pre')
@@ -114,7 +115,8 @@ class MyServiceDetailView(MyServicesView):
     @View.nested
     class retirement(Tab):  # noqa
         results = SummaryTable(title='Results')
-        plays = SummaryTable(title='Plays')
+        plays = Table('.//table[./thead/tr/th[contains(@align, "left") and '
+                      'normalize-space(.)="Plays"]]')
         details = SummaryTable(title='Details')
         credentials = SummaryTable(title='Credentials')
         standart_output = Text('.//div[@id="provisioning"]//pre')

--- a/cfme/tests/ansible/test_embedded_ansible_services.py
+++ b/cfme/tests/ansible/test_embedded_ansible_services.py
@@ -309,9 +309,9 @@ def test_service_ansible_playbook_plays_table(ansible_catalog_item, service_cata
     service_catalog.order()
     service_request.wait_for_request()
     view = navigate_to(service, "Details")
-    soft_assert(len(view.provisioning.plays.fields) > 1, "Plays table in provisioning tab is empty")
+    soft_assert(view.provisioning.plays.row_count > 1, "Plays table in provisioning tab is empty")
     service.retire()
-    soft_assert(len(view.retirement.plays.fields) > 1, "Plays table in retirement tab is empty")
+    soft_assert(view.provisioning.plays.row_count > 1, "Plays table in retirement tab is empty")
 
 
 @pytest.mark.tier(3)


### PR DESCRIPTION
"Plays" table in an ansible service details is not a "SummaryTable" anymore.

{{pytest: -v -k test_service_ansible_playbook_plays_table --long-running}}