### PR TITLE
[1LP][RFR] Fix for azure enviroment vars partial match

### DIFF
--- a/cfme/tests/cloud/test_provisioning.py
+++ b/cfme/tests/cloud/test_provisioning.py
@@ -6,6 +6,7 @@ import pytest
 
 from riggerlib import recursive_update
 from textwrap import dedent
+from widgetastic.utils import partial_match
 
 from cfme import test_requirements
 from cfme.automate.explorer.domain import DomainCollection
@@ -113,10 +114,10 @@ def testing_instance(request, setup_provider, provider, provisioning, vm_name, t
         recursive_update(inst_args, {
             'environment': {
                 'automatic_placement': auto,
-                'cloud_network': None if auto else provisioning['virtual_net'],
-                'cloud_subnet': None if auto else provisioning['subnet_range'],
-                'security_groups': None if auto else [provisioning['network_nsg']],
-                'resource_groups': None if auto else provisioning['resource_group']
+                'cloud_network': None if auto else partial_match(provisioning['virtual_net']),
+                'cloud_subnet': None if auto else partial_match(provisioning['subnet_range']),
+                'security_groups': None if auto else [partial_match(provisioning['network_nsg'])],
+                'resource_groups': None if auto else partial_match(provisioning['resource_group'])
             },
             'properties': {
                 'instance_type': provisioning['vm_size'].lower()},


### PR DESCRIPTION
Purpose or Intent
=================
added `partial_match` to solve `NoSuchElementException` ([Traceback](https://cfmeqe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/Downstream-59z/job/downstream-59z-tests-master/223/Artifactor_Report/cfme/tests/cloud/test_provisioning.py/test_provision_from_template[azure-Manual]/filedump-traceback.log), [Screenshot](https://cfmeqe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/Downstream-59z/job/downstream-59z-tests-master/223/Artifactor_Report/cfme/tests/cloud/test_provisioning.py/test_provision_from_template[azure-Manual]/filedump-exception_screenshot.png))

{{ pytest: -vvvv cfme/tests/cloud/test_provisioning.py -k test_provision_from_template --use-provider azure }}