### PR TITLE
[1LP][RFR] Cleaning test_provision_approval and making it more strict

### DIFF
--- a/cfme/tests/infrastructure/test_provisioning.py
+++ b/cfme/tests/infrastructure/test_provisioning.py
@@ -8,7 +8,6 @@ from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.provisioning import do_vm_provisioning
 from cfme.utils import normalize_text
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for
@@ -17,9 +16,6 @@ from widgetastic.utils import partial_match
 pytestmark = [
     pytest.mark.meta(server_roles="+automate +notifier"),
     pytest.mark.usefixtures('uses_infra_providers'),
-    pytest.mark.meta(blockers=[
-        BZ(1265466, unblock=lambda provider: not provider.one_of(RHEVMProvider))
-    ]),
     pytest.mark.tier(2),
     test_requirements.provision,
     pytest.mark.provider([InfraProvider],
@@ -126,7 +122,6 @@ def test_provision_approval(appliance, setup_provider, provider, vm_name, smtp_t
             'vlan': partial_match(provisioning['vlan'])
         }
     }
-
     do_vm_provisioning(appliance, template, provider, vm_name, provisioning_data, request,
                        smtp_test, wait=False)
     wait_for(

--- a/cfme/tests/infrastructure/test_provisioning.py
+++ b/cfme/tests/infrastructure/test_provisioning.py
@@ -122,6 +122,9 @@ def test_provision_approval(appliance, setup_provider, provider, vm_name, smtp_t
             'vlan': partial_match(provisioning['vlan'])
         }
     }
+    # WA until https://github.com/RedHatQE/widgetastic.core/issues/74 is fixed
+    if provider.one_of(RHEVMProvider):
+        provisioning_data['network']['vlan'] = '{0} ({0})'.format(provisioning['vlan'])
     do_vm_provisioning(appliance, template, provider, vm_name, provisioning_data, request,
                        smtp_test, wait=False)
     wait_for(

--- a/cfme/tests/infrastructure/test_provisioning.py
+++ b/cfme/tests/infrastructure/test_provisioning.py
@@ -122,7 +122,7 @@ def test_provision_approval(appliance, setup_provider, provider, vm_name, smtp_t
             'vlan': partial_match(provisioning['vlan'])
         }
     }
-    # WA until https://github.com/RedHatQE/widgetastic.core/issues/74 is fixed
+    # WA until https://github.com/RedHatQE/widgetastic.patternfly/pull/40 is merged
     if provider.one_of(RHEVMProvider):
         provisioning_data['network']['vlan'] = '{0} ({0})'.format(provisioning['vlan'])
     do_vm_provisioning(appliance, template, provider, vm_name, provisioning_data, request,


### PR DESCRIPTION
This PR has 4 points:

- Removing old unnecessary blocker
- Little refactoring of provisioning_data
- Workaround for widgetastic [issue](https://github.com/RedHatQE/widgetastic.core/issues/74)
- Probably most important is making check for number of received e-mails more strict. This is necessary to automate verification of [BZ 1422208](https://bugzilla.redhat.com/show_bug.cgi?id=1422208)

{{pytest: cfme/tests/infrastructure/test_provisioning.py::test_provision_approval -vv --use-provider rhv41}}

__Note to PRT result:__ The failure on 5.8 looks like env problem - missing storage?