### PR TITLE
[1LP][RFR] assign_compute_cluster_fix

### DIFF
--- a/cfme/intelligence/chargeback/assignments.py
+++ b/cfme/intelligence/chargeback/assignments.py
@@ -91,16 +91,16 @@ class Assign(Updateable, Pretty, Navigatable):
         was_change = self._fill(view)
         if was_change:
             view.save_button.click()
-        view.flash.assert_no_error()
-        view.flash.assert_message('Rate Assignments saved')
+            view.flash.assert_no_error()
+            view.flash.assert_message('Rate Assignments saved')
 
     def computeassign(self):
         view = navigate_to(self, 'Compute')
         was_change = self._fill(view)
         if was_change:
             view.save_button.click()
-        view.flash.assert_no_error()
-        view.flash.assert_message('Rate Assignments saved')
+            view.flash.assert_no_error()
+            view.flash.assert_message('Rate Assignments saved')
 
     def _fill(self, view):
         """This function prepares the values and fills the form."""

--- a/cfme/tests/intelligence/test_chargeback_assignments.py
+++ b/cfme/tests/intelligence/test_chargeback_assignments.py
@@ -50,7 +50,8 @@ def test_assign_compute_provider(appliance, virtualcenter_provider):
 def test_assign_compute_cluster(appliance, virtualcenter_provider):
     view = navigate_to(appliance.server, 'Chargeback')
 
-    cluster_name = random.choice(virtualcenter_provider.data["clusters"])
+    cluster_name = "{}/{}".format(virtualcenter_provider.name,
+                                  random.choice(virtualcenter_provider.data["clusters"]))
 
     cluster = cb.Assign(
         assign_to='Selected Cluster / Deployment Roles',
@@ -60,6 +61,7 @@ def test_assign_compute_cluster(appliance, virtualcenter_provider):
     cluster.computeassign()
 
     assign_view = view.browser.create_view(AssignmentsView)
+
     row = assign_view.selections.row(name=cluster_name)
     selected_option = row.rate.widget.selected_option
     assert selected_option == "Default", 'Selection does not match'


### PR DESCRIPTION
Purpose or Intent
=================
- row name changed its combination of provider name and cluster name


{{py.test: -vv cfme/tests/intelligence/test_chargeback_assignments.py -k 'test_assign_compute_cluster'}}