### PR TITLE
[1LP][RFR] Add a fixture for sync SSL certificate between CFME and OCP

### DIFF
--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -46,7 +46,10 @@ class ContainersProviderDefaultEndpoint(DefaultEndpoint):
                'sec_protocol': self.sec_protocol}
 
         if self.sec_protocol.lower() == 'ssl trusting custom ca' and hasattr(self, 'get_ca_cert'):
-            out['trusted_ca_certificates'] = self.get_ca_cert()
+            out['trusted_ca_certificates'] = self.get_ca_cert(
+                {"username": "root",
+                 "password": self.ssh_password,
+                 "hostname": self.master_hostname})
 
         out['confirm_password'] = version.pick({
             version.LOWEST: self.token,

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -47,8 +47,8 @@ class ContainersProviderDefaultEndpoint(DefaultEndpoint):
 
         if self.sec_protocol.lower() == 'ssl trusting custom ca' and hasattr(self, 'get_ca_cert'):
             out['trusted_ca_certificates'] = self.get_ca_cert(
-                {"username": "root",
-                 "password": self.ssh_password,
+                {"username": self.ssh_creds.principal,
+                 "password": self.ssh_creds.secret,
                  "hostname": self.master_hostname})
 
         out['confirm_password'] = version.pick({

--- a/cfme/tests/containers/test_ssl_providers.py
+++ b/cfme/tests/containers/test_ssl_providers.py
@@ -4,14 +4,13 @@ from copy import copy
 from fauxfactory import gen_alphanumeric, gen_integer
 import pytest
 
+from cfme.utils import ssh
 from cfme.containers.provider import ContainersProvider
 from cfme.utils.version import current_version
 from cfme.common.provider_views import ContainerProvidersView
-from cfme.utils.blockers import GH
 
 
 pytestmark = [
-    pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:6409', upstream_only=False)]),
     pytest.mark.uncollectif(lambda: current_version() < "5.8.0.3"),
     pytest.mark.provider([ContainersProvider], scope='module')
 ]
@@ -49,9 +48,57 @@ TEST_ITEMS = (
 )
 
 
+@pytest.fixture(scope="module")
+def sync_ssl_certificate(provider, appliance):
+    """
+    fixture which sync SSL certificate between CFME and OCP
+    :param provider:  OCP provider object
+    :param appliance: CFME appliance object
+    """
+
+    # creating a ssh connection to both appliance and provider
+    provider_ip = provider.data["ipaddress"]
+    provider_cred_name = provider.data["credentials"]
+    connections_info = {"username": "root",
+                        "password": provider.get_credentials_from_config(provider_cred_name).secret,
+                        "hostname": provider_ip}
+
+    provider_ssh = ssh.SSHClient(**connections_info)
+    appliance_ssh = appliance.ssh_client()
+
+    # Connection to the applince in case of dead connection
+    if not appliance_ssh.connected:
+        appliance_ssh.connect()
+
+    # Checking if SSL is already configured between appliance and provider,
+    # by send a HTTPS request (using SSL) from the appliance to the provider,
+    # hiding the output and sending back the return code of the action
+    _, stdout, stderr = \
+        appliance_ssh.exec_command(
+            "curl https://{provider_ip}:8443 -sS > /dev/null;echo $?".format(
+                provider_ip=provider_ip))
+
+    # Do in case of failure (return code is not 0)
+    if stdout.readline().replace('\n', "") != "0":
+        cert_name = "{provider_name}.ca.crt".format(
+            provider_name=provider.provider_data.hostname.split(".")[0])
+
+        # Copy certificate to the appliance
+        provider_ssh.get_file("/etc/origin/master/ca.crt", "/tmp/ca.crt")
+        appliance_ssh.put_file("/tmp/ca.crt",
+                               "/etc/pki/ca-trust/source/anchors/{crt}".format(crt=cert_name))
+
+        appliance_ssh.exec_command("update-ca-trust")
+
+        # restarting evemserverd to apply the new SSL certificate
+        appliance.restart_evm_service()
+        appliance.wait_for_evm_service()
+        appliance.wait_for_web_ui()
+
+
 @pytest.mark.polarion('CMP-9836')
 @pytest.mark.usefixtures('has_no_containers_providers')
-def test_add_provider_naming_conventions(provider, appliance, soft_assert):
+def test_add_provider_naming_conventions(provider, appliance, soft_assert, sync_ssl_certificate):
     """" This test is checking ability to add Providers with different names:
 
     Steps:
@@ -81,7 +128,7 @@ def test_add_provider_naming_conventions(provider, appliance, soft_assert):
 
 @pytest.mark.parametrize('default_sec_protocol', DEFAULT_SEC_PROTOCOLS)
 @pytest.mark.usefixtures('has_no_containers_providers')
-def test_add_provider_ssl(provider, default_sec_protocol, soft_assert):
+def test_add_provider_ssl(provider, default_sec_protocol, soft_assert, sync_ssl_certificate):
     """ This test checks adding container providers with 3 different security protocols:
     SSL trusting custom CA, SSL without validation and SSL
     Steps:
@@ -92,7 +139,11 @@ def test_add_provider_ssl(provider, default_sec_protocol, soft_assert):
         * Assert that provider was added successfully
         """
     new_provider = copy(provider)
-    new_provider.endpoints['default'].sec_protocol = default_sec_protocol
+    endpoints = {'default': new_provider.endpoints['default']}
+    endpoints['default'].sec_protocol = default_sec_protocol
+    new_provider.endpoints = endpoints
+    new_provider.metrics_type = 'Disabled'
+
     try:
         new_provider.setup()
     except AssertionError:
@@ -108,7 +159,8 @@ def test_add_provider_ssl(provider, default_sec_protocol, soft_assert):
         ti.args[1].default_sec_protocol, ti.args[1].hawkular_sec_protocol)
     for ti in TEST_ITEMS])
 @pytest.mark.usefixtures('has_no_containers_providers')
-def test_add_hawkular_provider_ssl(provider, appliance, test_item, soft_assert):
+def test_add_hawkular_provider_ssl(provider, appliance, test_item, soft_assert,
+                                   sync_ssl_certificate):
     """This test checks adding container providers with 3 different security protocols:
     SSL trusting custom CA, SSL without validation and SSL
     The test checks the Default Endpoint as well as the Hawkular Endpoint

--- a/cfme/tests/containers/test_ssl_providers.py
+++ b/cfme/tests/containers/test_ssl_providers.py
@@ -50,10 +50,12 @@ TEST_ITEMS = (
 
 @pytest.fixture(scope="module")
 def sync_ssl_certificate(provider, appliance):
-    """
-    fixture which sync SSL certificate between CFME and OCP
-    :param provider:  OCP provider object
-    :param appliance: CFME appliance object
+    """ fixture which sync SSL certificate between CFME and OCP
+    Args:
+        provider (OpenShiftProvider):  OCP system to sync cert from
+        appliance (IPAppliance): CFME appliance to sync cert with
+    Returns:
+         None
     """
 
     # creating a ssh connection to both appliance and provider


### PR DESCRIPTION
{{ pytest: cfme/tests/containers/test_ssl_providers.py::test_add_provider_ssl --use-provider ocp-v1 }}

## summery
In the following PR I will create a new fixture for sync SSL certification between OCP and CFME

**3 steps required for sync the certificates:**
1. Get the certificate from OCP
1. Deploy the certificate to CFME
1. Run "update-ca-trust" to actually install the new certificate

FIXES #6409 