### PR TITLE
[1LP][RFR] test_discover_infra[rhevm-virtualcenter] teardown failure 

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -770,16 +770,18 @@ class BaseProvider(WidgetasticTaggable, Updateable, Navigatable):
         # cfme 5.9 doesn't allow to remove provider thru api
         bz_blocked = BZ(1501941, forced_streams=['5.9']).blocks
         if app.version < '5.9' or (app.version >= '5.9' and not bz_blocked):
-            for prov in app.rest_api.collections.providers.all:
+            providers = app.rest_api.collections.providers.all
+            for prov in providers:
                 try:
                     if any(db_type in prov.type for db_type in cls.db_types):
                         logger.info('Deleting provider: %s', prov.name)
                         prov.action.delete()
-                        prov.wait_not_exists()
                 except APIException as ex:
                     # Provider is already gone (usually caused by NetworkManager objs)
                     if 'RecordNotFound' not in str(ex):
                         raise ex
+            wait_for(lambda: not bool(set(app.rest_api.collections.providers.all) & set(providers)),
+                     fail_func=app.rest_api.collections.providers.reload())
         else:
             # Delete all matching
             for prov in app.managed_known_providers:

--- a/cfme/tests/infrastructure/test_provider_discovery.py
+++ b/cfme/tests/infrastructure/test_provider_discovery.py
@@ -95,6 +95,7 @@ def test_discover_infra(providers_for_discover, start_ip, max_range):
     @wait_for_decorator(num_sec=count_timeout(start_ip, max_range), delay=5)
     def _wait_for_all_providers():
         for provider in providers_for_discover:
+            provider.browser.refresh()
             # When the provider is discovered, its name won't match what would be expected from
             # the crud objects generated from yaml data. The name in CFME will contain an IP
             # which should uniquely identify the resource


### PR DESCRIPTION
Purpose or Intent
=================
- Its fix for teardown TimedOut error in `test_discover_infra[rhevm-virtualcenter]`
- For REST `clear_provider()` method we are using individual provider `wait_for_delete()`. As its REST adding common check for it. It will be fast and effective check for collective multiple provider deletion. 
- For diffrent types of provider discovery at single time take time to appear on UI. so refreshing browser. 
- refresh witll fix ssvm discovery problem as well

{{py.test: cfme/tests/infrastructure/test_provider_discovery.py -vvv}}