### PR TITLE
[1LP][RFR] Check provider for available load balancers

### DIFF
--- a/cfme/tests/networks/test_sdn_balancers.py
+++ b/cfme/tests/networks/test_sdn_balancers.py
@@ -23,9 +23,10 @@ def network_prov_with_load_balancers(appliance):
         try:
             sum_all = len(prov.balancers.all())
         except DestinationNotFound:
-            pytest.skip("No available load balancers for current provider")
+            continue
         available_prov[prov] = sum_all
-    return available_prov
+    return available_prov if available_prov else pytest.skip(
+        "No available load balancers for current providers")
 
 
 def test_prov_balances_number(network_prov_with_load_balancers):

--- a/cfme/tests/networks/test_sdn_balancers.py
+++ b/cfme/tests/networks/test_sdn_balancers.py
@@ -46,6 +46,3 @@ def test_balances_detail(provider, network_prov_with_load_balancers):
         for balancer in prov.balancers.all():
             check = balancer.health_checks
             assert check is not None
-
-    provider.delete_if_exists(cancel=False)
-    provider.wait_for_delete()

--- a/cfme/tests/networks/test_sdn_balancers.py
+++ b/cfme/tests/networks/test_sdn_balancers.py
@@ -1,7 +1,9 @@
 import pytest
+
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.openstack import OpenStackProvider
+from cfme.exceptions import DestinationNotFound
 from cfme.utils.appliance.implementations.ui import navigate_to
 
 
@@ -12,26 +14,35 @@ pytestmark = [
 ]
 
 
-def test_prov_balances_number(appliance):
+@pytest.fixture(scope='module')
+def network_prov_with_load_balancers(appliance):
+    prov_collection = appliance.collections.network_providers
+    providers = prov_collection.all()
+    available_prov = {}
+    for prov in providers:
+        try:
+            sum_all = len(prov.balancers.all())
+        except DestinationNotFound:
+            pytest.skip("No available load balancers for current provider")
+        available_prov[prov] = sum_all
+    return available_prov
+
+
+def test_prov_balances_number(network_prov_with_load_balancers):
     """
     Test number of balancers on 1 provider
     Prerequisites:
         Only one refreshed cloud provider in cfme database
     """
-    prov_collection = appliance.collections.network_providers
-    providers = prov_collection.all()
-    for prov in providers:
+    for prov, sum_all in network_prov_with_load_balancers.items():
         view = navigate_to(prov, 'Details')
         balancers_number = view.entities.relationships.get_text_of('Load Balancers')
-        sum_all = len(prov.balancers.all())
         assert int(balancers_number) == sum_all
 
 
-def test_balances_detail(provider, appliance):
+def test_balances_detail(provider, network_prov_with_load_balancers):
     """ Test of getting attribute from balancer object """
-    collection = appliance.collections.network_providers
-    providers = collection.all()
-    for prov in providers:
+    for prov, _ in network_prov_with_load_balancers.items():
         for balancer in prov.balancers.all():
             check = balancer.health_checks
             assert check is not None


### PR DESCRIPTION
Purpose or Intent
=================
Added a check for available load balancers for provider, it not found will skip the test

{{pytest: cfme/tests/networks/test_sdn_balancers.py -vvv --use-provider complete}}