### PR TITLE
[1LP][RFR] Fix bug in navigation

### DIFF
--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -373,6 +373,23 @@ class Details(CFMENavigateStep):
         self.view.toolbar.reload.click()
 
 
+@navigator.register(Instance, 'ArchiveDetails')
+class ArchiveDetails(CFMENavigateStep):
+    VIEW = InstanceDetailsView
+    prerequisite = NavigateToSibling('All')
+
+    def step(self):
+        try:
+            row = self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True,
+                                                             use_search=True)
+        except ItemNotFound:
+            raise InstanceNotFound('Failed to locate instance with name "{}"'.format(self.obj.name))
+        row.click()
+
+    def resetter(self, *args, **kwargs):
+        self.view.toolbar.reload.click()
+
+
 @navigator.register(Instance, 'Edit')
 class Edit(CFMENavigateStep):
     VIEW = EditView

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -1233,6 +1233,25 @@ class VmAllWithTemplatesDetails(CFMENavigateStep):
         self.view.toolbar.reload.click()
 
 
+@navigator.register(Template, 'ArchiveDetails')
+@navigator.register(Vm, 'ArchiveDetails')
+class ArchiveDetails(CFMENavigateStep):
+    VIEW = InfraVmDetailsView
+    prerequisite = NavigateToSibling('All')
+
+    def step(self):
+        try:
+            entity_item = self.prerequisite_view.entities.get_entity(
+                name=self.obj.name, surf_pages=True)
+        except ItemNotFound:
+            raise VmOrInstanceNotFound('Failed to locate VM/Template with name "{}"'.
+                                       format(self.obj.name))
+        entity_item.click()
+
+    def resetter(self, *args, **kwargs):
+        self.view.toolbar.reload.click()
+
+
 @navigator.register(Template, 'AnyProviderDetails')
 @navigator.register(Vm, 'AnyProviderDetails')
 class VmAllWithTemplatesDetailsAnyProvider(VmAllWithTemplatesDetails):


### PR DESCRIPTION
Fix issue in Vm/Instance tree navigation
=================
Navigation to a VM/Instance was done from the provider view. Hence, it was not possible to navigate to a deleted VM/Instance because it was in the archived/orphaned folder. Changing the navigation to All fixed it. PR #6364 and #6149 are depending on this one. 

{{pytest: -v -k  test_cloud_instance_event --use-template-cache --use-provider=azure }}