### PR TITLE
[RFR] Update test_Dashboard, import BZ blocker class

### DIFF
--- a/cfme/tests/intelligence/test_dashboard.py
+++ b/cfme/tests/intelligence/test_dashboard.py
@@ -8,6 +8,7 @@ from random import sample
 
 from cfme import test_requirements
 from cfme.intelligence.reports.dashboards import Dashboard
+from cfme.utils.blockers import BZ
 from cfme.utils.wait import wait_for
 
 


### PR DESCRIPTION
This module was missing the BZ import, breaking test collection.