### PR TITLE
[1LP][RFR] Fix test_provision with_additional_volume and boot_volume

### DIFF
--- a/cfme/tests/cloud/test_provisioning.py
+++ b/cfme/tests/cloud/test_provisioning.py
@@ -570,6 +570,7 @@ def test_provision_with_boot_volume(request, testing_instance, provider, soft_as
                             :device_name => "vda",
                             :source_type => "volume",
                             :destination_type => "volume",
+                            :volume_size => 1,
                             :delete_on_termination => false
                         }}]
                     }}

--- a/cfme/tests/cloud/test_provisioning.py
+++ b/cfme/tests/cloud/test_provisioning.py
@@ -78,27 +78,23 @@ def testing_instance(request, setup_provider, provider, provisioning, vm_name, t
 
     # All providers other than Azure
     if not provider.one_of(AzureProvider):
+        recursive_update(inst_args, {
+            'properties': {
+                'instance_type': partial_match(provisioning['instance_type']),
+                'guest_keypair': provisioning['guest_keypair']}
+        })
         if provider.one_of(OpenStackProvider):
             recursive_update(inst_args, {
-                'properties': {
-                    'instance_type': partial_match(provisioning['instance_type']),
-                    'guest_keypair': provisioning['guest_keypair']},
                 'environment': {
-                    'automatic_placement': True
-                }
+                    'automatic_placement': True}
             })
         else:
             recursive_update(inst_args, {
-                'properties': {
-                    'instance_type': partial_match(provisioning['instance_type']),
-                    'guest_keypair': provisioning['guest_keypair']},
                 'environment': {
                     'availability_zone': None if auto else provisioning['availability_zone'],
                     'security_groups': None if auto else provisioning['security_group'],
-                    'automatic_placement': auto
-                }
+                    'automatic_placement': auto}
             })
-
 
     # GCE specific
     if provider.one_of(GCEProvider):
@@ -605,8 +601,8 @@ def test_provision_with_boot_volume(request, testing_instance, provider, soft_as
 # Not collected for EC2 in generate_tests above
 @pytest.mark.uncollectif(lambda provider: not provider.one_of(OpenStackProvider))
 def test_provision_with_additional_volume(request, testing_instance, provider, small_template,
-                                          soft_assert, copy_domains, modified_request_class,
-                                          appliance):
+                                          soft_assert, modified_request_class, appliance,
+                                          copy_domains):
     """ Tests provisioning with setting specific image from AE and then also making it create and
     attach an additional 3G volume.
 


### PR DESCRIPTION
Purpose or Intent
=================
Fixing test_provision with_additional_volume and boot_volume. Issue releted to provisioning error where fixed using Choose Automate enviroment for Openstack provider. 

{{pytest: -v cfme/tests/cloud/test_provisioning.py -k "test_provision_with_additional_volume or test_provision_with_boot_volume" --use-provider openstack --long-running}}