### PR TITLE
[1LP][RFR] Workaround for test_security_group create

### DIFF
--- a/cfme/cloud/security_groups.py
+++ b/cfme/cloud/security_groups.py
@@ -239,4 +239,7 @@ class Add(CFMENavigateStep):
     def step(self, *args, **kwargs):
         """Raises DropdownItemDisabled from widgetastic_patternfly
         if no RHOS Network manager present"""
+        # Todo remove when fixed 1520669
+        if self.prerequisite_view.flash.messages:
+            self.prerequisite_view.flash.dismiss()
         self.prerequisite_view.toolbar.configuration.item_select('Add a new Security Group')

--- a/cfme/cloud/security_groups.py
+++ b/cfme/cloud/security_groups.py
@@ -241,7 +241,7 @@ class Add(CFMENavigateStep):
         """Raises DropdownItemDisabled from widgetastic_patternfly
         if no RHOS Network manager present"""
         # Todo remove when fixed 1520669
-        if (BZ(blockers=[1520669], forced_streams='5.9').blocks and
+        if (BZ(1520669, forced_streams='5.9').blocks and
                 self.prerequisite_view.flash.messages):
             self.prerequisite_view.flash.dismiss()
         self.prerequisite_view.toolbar.configuration.item_select('Add a new Security Group')

--- a/cfme/cloud/security_groups.py
+++ b/cfme/cloud/security_groups.py
@@ -12,6 +12,7 @@ from cfme.base.ui import BaseLoggedInPage
 from cfme.exceptions import ItemNotFound, SecurityGroupsNotFound
 from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.utils.appliance.implementations.ui import navigate_to, navigator, CFMENavigateStep
+from cfme.utils.blockers import BZ
 from cfme.utils.wait import wait_for
 
 
@@ -240,6 +241,7 @@ class Add(CFMENavigateStep):
         """Raises DropdownItemDisabled from widgetastic_patternfly
         if no RHOS Network manager present"""
         # Todo remove when fixed 1520669
-        if self.prerequisite_view.flash.messages:
+        if (BZ(blockers=[1520669], forced_streams='5.9').blocks and
+                self.prerequisite_view.flash.messages):
             self.prerequisite_view.flash.dismiss()
         self.prerequisite_view.toolbar.configuration.item_select('Add a new Security Group')


### PR DESCRIPTION
Purpose or Intent
=================
One more case with MoveTargetOutOfBoundsException: Message. This time I've tried to close flash message, as some action before open configuration in toolbar(BZ 1520669).

{{pytest: cfme/tests/cloud/test_security_groups.py -vvv}}  