### PR TITLE
[1LP][RFR] Fixed step issue

### DIFF
--- a/cfme/utils/appliance/implementations/ui.py
+++ b/cfme/utils/appliance/implementations/ui.py
@@ -446,7 +446,15 @@ class CFMENavigateStep(NavigateStep):
         if not here:
             self.log_message("Prerequisite Needed")
             self.prerequisite_view = self.prerequisite()
-            self.check_for_badness(self.step, _tries, nav_args, *args, **kwargs)
+            try:
+                self.check_for_badness(self.step, _tries, nav_args, *args, **kwargs)
+            except Exception as e:
+                self.log_message(
+                    "Exception raised [{}] whilst running step, trying refresh".format(e),
+                    level="error"
+                )
+                self.appliance.browser.widgetastic.refresh()
+                self.check_for_badness(self.step, _tries, nav_args, *args, **kwargs)
         if nav_args['use_resetter']:
             resetter_used = True
             self.check_for_badness(self.resetter, _tries, nav_args, *args, **kwargs)

--- a/cfme/utils/appliance/implementations/ui.py
+++ b/cfme/utils/appliance/implementations/ui.py
@@ -448,10 +448,10 @@ class CFMENavigateStep(NavigateStep):
             self.prerequisite_view = self.prerequisite()
             try:
                 self.check_for_badness(self.step, _tries, nav_args, *args, **kwargs)
-            except Exception as e:
+            except (exceptions.CandidateNotFound, exceptions.ItemNotFound) as e:
                 self.log_message(
-                    "Exception raised [{}] whilst running step, trying refresh".format(e),
-                    level="error"
+                    "Item/Tree Exception raised [{}] whilst running step, trying refresh"
+                    .format(e), level="error"
                 )
                 self.appliance.browser.widgetastic.refresh()
                 self.check_for_badness(self.step, _tries, nav_args, *args, **kwargs)


### PR DESCRIPTION
Issue: Imagine we had landed on Cloud Providers page, and then via REST
       we add a cloud provider. If we now try to navigate to the Details
       page of that cloud provider it will fail because the am_i_here is
       True, but the provider is not visible on the page as it was done
       via REST.

* Added a try/except around step to retry the step operation after a
  refresh. This _could_ make some things fail, but then they were going
  to fail anyway.