### PR TITLE
[1LP][RFR] Resolving Timeout Error caused by handle_alert

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -287,7 +287,7 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, WidgetasticTaggable, N
         return getattr(view.entities, properties[0].lower().replace(' ', '_')).get_text_of(
             properties[1])
 
-    def open_console(self, console='VM Console', invokes_alert=False, cancel=False):
+    def open_console(self, console='VM Console', invokes_alert=None):
         """
         Initiates the opening of one of the console types supported by the Access
         button.   Presently we only support VM Console, which is the HTML5 Console.
@@ -300,7 +300,6 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, WidgetasticTaggable, N
             console: one of the supported console types given by the Access button.
             invokes_alert: If the particular console will invoke a CFME popup/alert
                            setting this to true will handle this.
-            cancel: Allows one to cancel the operation if the popup/alert occurs.
         """
         # TODO: implement vmrc vm console
         if console not in ['VM Console']:
@@ -309,7 +308,7 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, WidgetasticTaggable, N
         view = navigate_to(self, 'Details')
 
         # Click console button given by type
-        view.toolbar.access.item_select(console, handle_alert=not invokes_alert)
+        view.toolbar.access.item_select(console, handle_alert=invokes_alert)
         self.vm_console
 
     def open_details(self, properties=None):

--- a/cfme/tests/cloud_infra_common/test_html5_vm_console.py
+++ b/cfme/tests/cloud_infra_common/test_html5_vm_console.py
@@ -187,12 +187,12 @@ def test_html5_vm_console(appliance, provider, configure_websocket, vm_obj,
             # file using partial file name. Known issue, being worked on.
             command_result = ssh_client.run_command("rm blather", ensure_user=True)
             assert command_result
-    except:
+    except Exception as e:
         # Take a screenshot if an exception occurs
         vm_console.switch_to_console()
         take_screenshot("ConsoleScreenshot")
         vm_console.switch_to_appliance()
-        raise
+        raise e
     finally:
         vm_console.close_console_window()
         # Logout is required because when running the Test back 2 back against RHV and VMware


### PR DESCRIPTION


Purpose or Intent
=================

__Fixing__ item_select in open_console which was causing timeout error as given in RHCFQE-6568. It was occurring because it was taking False as the default value and it would wait for 10 sec to find an alert and timeout, it should rather take none, but during WT conversion someone changed that logic as it seems based on git history. 

Removed the cancel parameter from the function since it was not being used at all and I do not see a use case for it at this moment. 

{{ pytest: cfme/tests/cloud_infra_common/test_html5_vm_console.py --use-provider vsphere6-nested }}
