### PR TITLE
[1LP][RFR] Fixing namespace collision for take screenshot

### DIFF
--- a/fixtures/screenshots.py
+++ b/fixtures/screenshots.py
@@ -14,7 +14,7 @@ If you want to take a screenshot inside your test, just do it like this:
 import fauxfactory
 import pytest
 
-from cfme.utils.browser import take_screenshot
+from cfme.utils.browser import take_screenshot as take_browser_screenshot
 from cfme.utils.log import logger
 from fixtures.artifactor_plugin import fire_art_test_hook
 from fixtures.pytest_store import store
@@ -26,7 +26,7 @@ def take_screenshot(request):
 
     def _take_screenshot(name):
         logger.info("Taking a screenshot named {}".format(name))
-        ss, ss_error = take_screenshot()
+        ss, ss_error = take_browser_screenshot()
         g_id = fauxfactory.gen_alpha(length=6)
         if ss:
             fire_art_test_hook(


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ Screenshot Namespace Collision in screenshot function.  take_screenshot() was calling itself recursively, causing failures.
http://10.16.45.124/o7ZR4HEz/artifacts/cfme/tests/cloud_infra_common/test_html5_vm_console.py/test_html5_vm_console[vsphere6-nested]/filedump-traceback.log

Shriver:
{{ pytest: cfme/tests/cloud_infra_common/test_html5_vm_console.py -k test_html5_vm_console --use-provider vsphere6-nested --long-running -vv }}
