### PR TITLE
[1LP][RFR] Create template if not exist 

### DIFF
--- a/cfme/tests/services/test_pxe_service_catalogs.py
+++ b/cfme/tests/services/test_pxe_service_catalogs.py
@@ -73,7 +73,7 @@ def pxe_server(appliance, provider):
 def pxe_cust_template(appliance, provider):
     provisioning_data = provider.data['provisioning']
     pxe_cust_template = provisioning_data['pxe_kickstart']
-    return get_template_from_config(pxe_cust_template, appliance=appliance)
+    return get_template_from_config(pxe_cust_template, create=True, appliance=appliance)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
PXE tests are failing on jenkins because create option is not provided for customization template .

Create=True added for customization template .
If template does not exist , create template