### PR TITLE
[WIP] New SUI snapshot test

### DIFF
--- a/cfme/services/myservice/__init__.py
+++ b/cfme/services/myservice/__init__.py
@@ -26,6 +26,9 @@ class MyService(Updateable, Navigatable, Taggable, sentaku.modeling.ElementMixin
     reconfigure_service = sentaku.ContextualMethod()
     launch_vm_console = sentaku.ContextualMethod()
     service_power = sentaku.ContextualMethod()
+    create_snapshot = sentaku.ContextualMethod()
+    view_snapshots = sentaku.ContextualMethod()
+    does_snapshot_exist = sentaku.ContextualMethod()
 
     def __init__(self, appliance, name=None, description=None, vm_name=None):
         self.appliance = appliance

--- a/cfme/tests/ssui/test_ssui_myservice.py
+++ b/cfme/tests/ssui/test_ssui_myservice.py
@@ -30,6 +30,23 @@ pytestmark = [
 
 @pytest.mark.meta(blockers=[BZ(1544535, forced_streams=['5.9'])])
 @pytest.mark.parametrize('context', [ViaSSUI])
+@pytest.mark.uncollectif(lambda appliance: appliance.version < '5.9')
+def test_create_snapshot_via_ssui(appliance, setup_provider, context,
+                                  order_catalog_item_in_ops_ui):
+    service_name = order_catalog_item_in_ops_ui.name
+    with appliance.context.use(context):
+        my_service = MyService(appliance, service_name)
+        my_service.create_snapshot("snpsht_name", False, "snpsht_desc")
+        wait_for(
+            my_service.does_snapshot_exist,
+            func_args=["snpsht_name"],
+            num_sec=120, delay=10, message="Waiting for snapshot creation"
+        )
+        my_service.delete()
+
+
+@pytest.mark.meta(blockers=[BZ(1544535, forced_streams=['5.9'])])
+@pytest.mark.parametrize('context', [ViaSSUI])
 def test_myservice_crud(appliance, setup_provider, context, order_service):
     """Test Myservice crud in SSUI."""
     catalog_item = order_service


### PR DESCRIPTION
This is a __new test__ which creates a service, then creates a snapshot via the SUI, checks for its existence and then removes the service. It's now possible to work with snapshots in SUI using automation.

This is a first step towards automating the new Snapshot Timeline feature and a learning exercise for me at the same time.

{{ pytest: -v --long-running cfme/tests/ssui/test_ssui_myservice.py -k test_create_snapshot_via_ssui }}