### PR TITLE
[1LP][RFR] Update miq-openldap auth tests

### DIFF
--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -62,7 +62,7 @@ class AddProviderError(CFMEException):
 class AuthModeUnknown(CFMEException):
     """
     Raised if an invalid authenctication mode is passed to
-    :py:func:`cfme.configure.configuration.set_auth_mode`
+    :py:func:`cfme.configure.configuration.ServerAuthentication.configure_auth`
     """
     pass
 

--- a/cfme/fixtures/configure_auth_mode.py
+++ b/cfme/fixtures/configure_auth_mode.py
@@ -6,6 +6,15 @@ from cfme.utils.ext_auth import (disable_external_auth_ipa, disable_external_aut
     setup_external_auth_ipa, setup_external_auth_openldap)
 
 
+def get_auth_settings(appliance):
+    """Grab the authentication settings from the UI form, popping the title widget content out"""
+    settings = {}
+    settings['auth_mode'] = appliance.server.authentication.auth_mode
+    settings['auth_settings'] = appliance.server.authentication.auth_settings
+    settings['auth_settings'].pop('title')
+    return settings
+
+
 @pytest.fixture(scope='session')
 def available_auth_modes():
     return cfme_data.get('auth_modes', {}).keys()
@@ -17,10 +26,10 @@ def configure_ldap_auth_mode(browser, available_auth_modes):
     if 'miq_ldap' in available_auth_modes:
         auth_mode = current_appliance.server.authentication
         server_data = cfme_data.get('auth_modes', {})['miq_ldap']
-        auth_mode.set_auth_mode(**server_data)
+        auth_mode.configure_auth(**server_data)
         yield
         current_appliance.server.login_admin()
-        auth_mode.set_auth_mode()
+        auth_mode.configure_auth()
     else:
         yield
 
@@ -31,10 +40,10 @@ def configure_openldap_auth_mode(browser, available_auth_modes):
     if 'miq_openldap' in available_auth_modes:
         auth_mode = current_appliance.server.authentication
         server_data = cfme_data.get('auth_modes', {})['miq_openldap']
-        auth_mode.set_auth_mode(**server_data)
+        auth_mode.configure_auth(**server_data)
         yield
         current_appliance.server.login_admin()
-        auth_mode.set_auth_mode()
+        auth_mode.configure_auth()
     else:
         yield
 
@@ -47,10 +56,10 @@ def configure_openldap_auth_mode_default_groups(browser, available_auth_modes):
         server_data = cfme_data.get('auth_modes', {})['miq_openldap']
         server_data['get_groups'] = False
         server_data['default_groups'] = 'EvmRole-user'
-        auth_mode.set_auth_mode(**server_data)
+        auth_mode.configure_auth(**server_data)
         yield
         current_appliance.server.login_admin()
-        auth_mode.set_auth_mode()
+        auth_mode.configure_auth()
     else:
         yield
 
@@ -59,6 +68,7 @@ def configure_openldap_auth_mode_default_groups(browser, available_auth_modes):
 def configure_aws_iam_auth_mode(appliance, available_auth_modes):
     """Configure AWS IAM authentication mode"""
     if 'miq_aws_iam' in available_auth_modes:
+        # TODO use new get_auth_settings function to store original settings
         auth_settings = appliance.server.authentication
         orig_mode = auth_settings.auth_mode
         orig_settings = auth_settings.auth_settings
@@ -70,12 +80,12 @@ def configure_aws_iam_auth_mode(appliance, available_auth_modes):
             'secret_key': creds['password'],
             'get_groups': yaml_data.get('get_groups', False)}
 
-        auth_settings.set_auth_mode(auth_mode='Amazon', **fill_data)
+        auth_settings.configure_auth(auth_mode='Amazon', **fill_data)
         auth_settings.set_session_timeout(hours=yaml_data.get('timeout_h', '24'),
                                           minutes=yaml_data.get('timeout_m', '0'))
         yield
         current_appliance.server.login_admin()
-        auth_settings.set_auth_mode(auth_mode=orig_mode, **orig_settings)
+        auth_settings.configure_auth(auth_mode=orig_mode, **orig_settings)
         auth_settings.set_session_timeout(hours=orig_settings.get('hours_timeout', '24'),
                                           minutes=orig_settings.get('minutes_timeout', '0'))
     else:
@@ -85,25 +95,25 @@ def configure_aws_iam_auth_mode(appliance, available_auth_modes):
 
 # TODO remove this fixture, its doing what the above fixtures are doing but taking an argument
 @pytest.fixture()
-def configure_auth(request, auth_mode):
+def configure_auth(appliance, request, auth_mode):
     data = cfme_data['auth_modes'].get(auth_mode, {})
-    auth_settings = current_appliance.server.authentication
+    app_auth = appliance.server.authentication
     if auth_mode == 'ext_ipa':
         request.addfinalizer(disable_external_auth_ipa)
         setup_external_auth_ipa(**data)
     elif auth_mode == 'ext_openldap':
         request.addfinalizer(disable_external_auth_openldap)
-        setup_external_auth_openldap(**data)
+        setup_external_auth_openldap(appliance, **data)
     elif auth_mode in ['miq_openldap', 'miq_ldap']:
-        auth_settings.set_auth_mode(**data)
+        app_auth.configure_auth(**data)
         request.addfinalizer(current_appliance.server.login_admin)
-        request.addfinalizer(auth_settings.set_auth_mode)
+        request.addfinalizer(app_auth.configure_auth)
     elif auth_mode == 'miq_aws_iam':
         aws_iam_creds = credentials[data.pop('credentials')]
         data['access_key'] = aws_iam_creds['username']
         data['secret_key'] = aws_iam_creds['password']
-        auth_settings.set_auth_mode(**data)
+        app_auth.configure_auth(**data)
         request.addfinalizer(current_appliance.server.login_admin)
-        request.addfinalizer(auth_settings.set_auth_mode)
+        request.addfinalizer(app_auth.configure_auth)
     else:
         pytest.skip("auth_mode specified is not a expected value for cfme_auth tests")

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2137,42 +2137,44 @@ class IPAppliance(object):
         except IndexError:
             raise KeyError("No such Domain: {}".format(domain))
 
-    def configure_appliance_for_openldap_ext_auth(self):
+    def configure_openldap(self):
         """This method changes the /etc/sssd/sssd.conf and /etc/openldap/ldap.conf files to set
             up the appliance for an external authentication with OpenLdap.
             Apache file configurations are updated, for webui to take effect.
 
-           arguments:
-                appliance_name: FQDN for the appliance.
-
         """
-        openldap_domain1 = conf.cfme_data['auth_modes']['ext_openldap']
-        self.ssh_client.run_command('echo "{}\t{}" > /etc/hosts'.format(
-            openldap_domain1['ipaddress'], openldap_domain1['hostname']))
-        self.ssh_client.put_file(
-            local_file=conf_path.join(openldap_domain1['cert_filename']).strpath,
-            remote_file=openldap_domain1['cert_filepath'])
-        ldap_conf_data = conf.cfme_data['auth_modes']['ext_openldap']['ldap_conf']
-        sssd_conf_data = conf.cfme_data['auth_modes']['ext_openldap']['sssd_conf']
-        command1 = 'echo "{}"  > /etc/openldap/ldap.conf'.format(ldap_conf_data)
-        command2 = 'echo "{}" > /etc/sssd/sssd.conf && chown -R root:root /etc/sssd/sssd.conf && ' \
-                   'chmod 600 /etc/sssd/sssd.conf'.format(sssd_conf_data)
-        assert self.ssh_client.run_command(command1)
-        assert self.ssh_client.run_command(command2)
+        ldap_yaml = conf.cfme_data.auth_modes.ext_openldap
+        # write /etc/hosts entry for ldap hostname  TODO DNS
+        self.ssh_client.run_command('echo "{}    {}" >> /etc/hosts'
+                                    .format(ldap_yaml.ipaddress, ldap_yaml.hostname))
+        # place cert from local conf directory on ldap server
+        self.ssh_client.put_file(local_file=conf_path.join(ldap_yaml.cert_filename).strpath,
+                                 remote_file=ldap_yaml.cert_filepath)
+        # configure ldap and sssd with conf file content from yaml
+        assert self.ssh_client.run_command('echo "{}"  > /etc/openldap/ldap.conf'
+                                           .format(ldap_yaml.ldap_conf))
+        assert self.ssh_client.run_command('echo "{}" > /etc/sssd/sssd.conf'
+                                           .format(ldap_yaml.sssd_conf))
+        assert self.ssh_client.run_command('chown -R root:root /etc/sssd/sssd.conf')
+        assert self.ssh_client.run_command('chmod 600 /etc/sssd/sssd.conf')
+        # copy miq/cfme template files for httpd ext auth config
         template_dir = '/opt/rh/cfme-appliance/TEMPLATE'
         if self.version == 'master':
             template_dir = '/var/www/miq/system/TEMPLATE'
-        httpd_auth = '/etc/pam.d/httpd-auth'
         manageiq_ext_auth = '/etc/httpd/conf.d/manageiq-external-auth.conf'
-        apache_config = """
-        cp {template_dir}/etc/pam.d/httpd-auth  {httpd_auth} &&
-        cp {template_dir}/etc/httpd/conf.d/manageiq-remote-user.conf /etc/httpd/conf.d/ &&
-        cp {template_dir}/etc/httpd/conf.d/manageiq-external-auth.conf.erb {manageiq_ext_auth}
-    """.format(template_dir=template_dir, httpd_auth=httpd_auth,
-               manageiq_ext_auth=manageiq_ext_auth)
-        assert self.ssh_client.run_command(apache_config)
-        self.ssh_client.run_command(
-            'setenforce 0 && systemctl restart sssd && systemctl restart httpd')
+        assert self.ssh_client.run_command(
+            'cp {template_dir}/etc/pam.d/httpd-auth /etc/pam.d/httpd-auth'
+            .format(template_dir=template_dir))
+        assert self.ssh_client.run_command(
+            'cp {template_dir}/etc/httpd/conf.d/manageiq-remote-user.conf /etc/httpd/conf.d/'
+            .format(template_dir=template_dir))
+        assert self.ssh_client.run_command(
+            'cp {template_dir}/etc/httpd/conf.d/manageiq-external-auth.conf.erb {manageiq_ext_auth}'
+            .format(template_dir=template_dir,
+                    manageiq_ext_auth=manageiq_ext_auth))
+        self.ssh_client.run_command('setenforce 0 && '
+                                    'systemctl restart sssd && '
+                                    'systemctl restart httpd')
         self.wait_for_web_ui()
 
     @logger_wrap("Configuring VM Console: {}")

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2137,7 +2137,7 @@ class IPAppliance(object):
         except IndexError:
             raise KeyError("No such Domain: {}".format(domain))
 
-    def configure_appliance_for_openldap_ext_auth(self, appliance_fqdn):
+    def configure_appliance_for_openldap_ext_auth(self):
         """This method changes the /etc/sssd/sssd.conf and /etc/openldap/ldap.conf files to set
             up the appliance for an external authentication with OpenLdap.
             Apache file configurations are updated, for webui to take effect.
@@ -2147,7 +2147,6 @@ class IPAppliance(object):
 
         """
         openldap_domain1 = conf.cfme_data['auth_modes']['ext_openldap']
-        assert self.ssh_client.run_command('appliance_console_cli --host {}'.format(appliance_fqdn))
         self.ssh_client.run_command('echo "{}\t{}" > /etc/hosts'.format(
             openldap_domain1['ipaddress'], openldap_domain1['hostname']))
         self.ssh_client.put_file(

--- a/cfme/utils/ext_auth.py
+++ b/cfme/utils/ext_auth.py
@@ -61,7 +61,7 @@ def setup_external_auth_ipa(**data):
             current_appliance.server.settings.update_ntp_servers(
                 {'ntp_server_1': data["ipaserver"]})
             sleep(120)
-        current_appliance.server.authentication.set_auth_mode(
+        current_appliance.server.authentication.configure_auth(
             mode='external', get_groups=data.pop("get_groups", False)
         )
         creds = credentials.get(data.pop("credentials"), {})
@@ -73,7 +73,7 @@ def setup_external_auth_ipa(**data):
     current_appliance.server.login_admin()
 
 
-def setup_external_auth_openldap(**data):
+def setup_external_auth_openldap(appliance, **data):
     """Sets up the appliance for an external authentication with OpenLdap.
 
     Keywords:
@@ -87,24 +87,16 @@ def setup_external_auth_openldap(**data):
         'password': credentials['host_default']['password'],
         'hostname': data['ipaddress'],
     }
-    current_appliance = get_or_create_current_appliance()
-    appliance_name = 'cfmeappliance{}'.format(fauxfactory.gen_alpha(7).lower())
-    appliance_address = current_appliance.hostname
-    appliance_fqdn = '{}.{}'.format(appliance_name, data['domain_name'])
     with SSHClient(**connect_kwargs) as ldapserver_ssh:
-        # updating the /etc/hosts is a workaround due to the
-        # https://bugzilla.redhat.com/show_bug.cgi?id=1360928
-        command = 'echo "{}\t{}" >> /etc/hosts'.format(appliance_address, appliance_fqdn)
-        ldapserver_ssh.run_command(command)
         ldapserver_ssh.get_file(remote_file=data['cert_filepath'],
                                 local_path=conf_path.strpath)
     ensure_browser_open()
-    current_appliance.server.login_admin()
-    current_appliance.server.authentication.set_auth_mode(
-        mode='external', get_groups=data.pop("get_groups", True)
+    appliance.server.login_admin()
+    appliance.server.authentication.configure_auth(
+        auth_mode='external', get_groups=data.pop("get_groups", True)
     )
-    current_appliance.configure_appliance_for_openldap_ext_auth(appliance_fqdn)
-    current_appliance.server.logout()
+    appliance.configure_appliance_for_openldap_ext_auth()
+    appliance.server.logout()
 
 
 def disable_external_auth_ipa():
@@ -113,7 +105,7 @@ def disable_external_auth_ipa():
     with current_appliance.ssh_client as ssh:
         ensure_browser_open()
         current_appliance.server.login_admin()
-        current_appliance.server.authentication.set_auth_mode()
+        current_appliance.server.authentication.configure_auth()
         assert ssh.run_command("appliance_console_cli --uninstall-ipa")
         current_appliance.wait_for_web_ui()
     current_appliance.server.logout()
@@ -121,7 +113,7 @@ def disable_external_auth_ipa():
 
 def disable_external_auth_openldap():
     current_appliance = get_or_create_current_appliance()
-    current_appliance.server.authentication.set_auth_mode()
+    current_appliance.server.authentication.configure_auth()
     sssd_conf = '/etc/sssd/sssd.conf'
     httpd_auth = '/etc/pam.d/httpd-auth'
     manageiq_remoteuser = '/etc/httpd/conf.d/manageiq-remote-user.conf'

--- a/cfme/utils/ext_auth.py
+++ b/cfme/utils/ext_auth.py
@@ -95,7 +95,7 @@ def setup_external_auth_openldap(appliance, **data):
     appliance.server.authentication.configure_auth(
         auth_mode='external', get_groups=data.pop("get_groups", True)
     )
-    appliance.configure_appliance_for_openldap_ext_auth()
+    appliance.configure_openldap()
     appliance.server.logout()
 
 


### PR DESCRIPTION
Update ServerAuthentication.auth_mode, turn into a property

Updates throughout Appliance, ext_auth util module, and
configure_auth_mode fixture

Refactoring for test stabilization, plans are to add more test cases, and modify parametrization of existing cases.

# PRT Results
I'm filtering on just openldap tests here, ext_openldap is GH skipped, and miq_openldap should pass.  miq_ipa fails at the moment, which I'll address in a 2nd PR with further refactoring. Wanted to keep this PR scope gradual.

{{ pytest: cfme/tests/integration/test_cfme_auth.py -v -k openldap }}