### PR TITLE
[1LP][RFR] Blocking cfme.tests.containers.test_manageiq_ansible* 

### DIFF
--- a/cfme/tests/containers/test_manageiq_ansible_custom_attributes.py
+++ b/cfme/tests/containers/test_manageiq_ansible_custom_attributes.py
@@ -4,8 +4,10 @@ from cfme.containers.provider import ContainersProvider
 from cfme.utils.ansible import (setup_ansible_script, run_ansible,
     fetch_miq_ansible_module, create_tmp_directory, remove_tmp_files)
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import GH
 
 pytestmark = [
+    pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:6484')]),
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1),
     pytest.mark.provider([ContainersProvider], scope='function')]

--- a/cfme/tests/containers/test_manageiq_ansible_providers.py
+++ b/cfme/tests/containers/test_manageiq_ansible_providers.py
@@ -5,9 +5,12 @@ from cfme.utils.ansible import (setup_ansible_script, run_ansible, get_yml_value
     fetch_miq_ansible_module, create_tmp_directory, remove_tmp_files)
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.wait import wait_for
+from cfme.utils.blockers import GH
 
 
-pytestmark = [pytest.mark.provider([ContainersProvider], scope='function')]
+pytestmark = [
+    pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:6484')]),
+    pytest.mark.provider([ContainersProvider], scope='function')]
 
 providers_values_to_update = {
     'provider_api_hostname': 'something_different.redhat.com'

--- a/cfme/tests/containers/test_manageiq_ansible_tags.py
+++ b/cfme/tests/containers/test_manageiq_ansible_tags.py
@@ -4,9 +4,12 @@ from cfme.containers.provider import ContainersProvider
 from cfme.utils.ansible import (setup_ansible_script, run_ansible,
     fetch_miq_ansible_module, create_tmp_directory, remove_tmp_files)
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import GH
 
 
-pytestmark = [pytest.mark.provider([ContainersProvider], scope='function')]
+pytestmark = [
+    pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:6484')]),
+    pytest.mark.provider([ContainersProvider], scope='function')]
 
 tags_to_add = {
     'category': 'environment',

--- a/cfme/tests/containers/test_manageiq_ansible_users.py
+++ b/cfme/tests/containers/test_manageiq_ansible_users.py
@@ -4,8 +4,10 @@ from cfme.containers.provider import ContainersProvider
 from cfme.utils.ansible import (setup_ansible_script, run_ansible,
                                 fetch_miq_ansible_module, create_tmp_directory, remove_tmp_files)
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import GH
 
 pytestmark = [
+    pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:6484')]),
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.provider([ContainersProvider], scope='module')
 ]


### PR DESCRIPTION
https://github.com/ManageIQ/integration_tests/issues/6484

{{ pytest: cfme/tests/containers/test_manageiq_ansible_custom_attributes.py cfme/tests/containers/test_manageiq_ansible_providers.py cfme/tests/containers/test_manageiq_ansible_tags.py cfme/tests/containers/test_manageiq_ansible_users.py --use-provider cm-env2  }}