### PR TITLE
[WIPTEST] Prevent crash when empty pxe_servers value in cfme_data.yaml

### DIFF
--- a/cfme/utils/testgen.py
+++ b/cfme/utils/testgen.py
@@ -349,4 +349,4 @@ def pxe_servers(metafunc):
 
     items = cfme_data.get('pxe_servers', {}).keys()
 
-    return argnames, [items], items
+    return argnames, filter(None, [items]), items


### PR DESCRIPTION
With this commit we prevent test setup from crashing hard when "pxe_servers:" key is not provided in cfme_data.yaml. Problem is that following code is used all over the project:

```
pargnames, pargvalues, pidlist = testgen.pxe_servers(metafunc)
pxe_server_names = [pval[0] for pval in pargvalues]
```

but testgen.pxe_servers() was returning empty 2D list `[[]]` which resulted in runtime error when accessing pval[0].