### PR TITLE
[WIPTEST] Do not assume "Provider" noun

### DIFF
--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -96,7 +96,7 @@ class CloudProvider(Pretty, CloudInfraProvider):
     category = "cloud"
     pretty_attrs = ['name', 'credentials', 'zone', 'key']
     STATS_TO_MATCH = ['num_template', 'num_vm']
-    string_name = "Cloud"
+    string_name = "Cloud Provider"
     templates_destination_name = "Images"
     vm_name = "Instances"
     template_name = "Images"

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -187,7 +187,7 @@ class BaseProvider(WidgetasticTaggable, Updateable, Navigatable):
             if cancel:
                 created = False
                 add_view.cancel.click()
-                cancel_text = ('Add of {} Provider was '
+                cancel_text = ('Add of {} was '
                                'cancelled by the user'.format(self.string_name))
 
                 main_view.flash.assert_message(cancel_text)
@@ -195,7 +195,7 @@ class BaseProvider(WidgetasticTaggable, Updateable, Navigatable):
             else:
                 add_view.add.click()
                 if main_view.is_displayed:
-                    success_text = '{} Providers "{}" was saved'.format(self.string_name,
+                    success_text = '{}s "{}" was saved'.format(self.string_name,
                                                                         self.name)
                     main_view.flash.assert_message(success_text)
                 else:
@@ -431,7 +431,7 @@ class BaseProvider(WidgetasticTaggable, Updateable, Navigatable):
 
         if cancel:
             edit_view.cancel.click()
-            cancel_text = 'Edit of {type} Provider "{name}" ' \
+            cancel_text = 'Edit of {type} "{name}" ' \
                           'was cancelled by the user'.format(type=self.string_name,
                                                              name=self.name)
             main_view.flash.assert_message(cancel_text)
@@ -444,7 +444,7 @@ class BaseProvider(WidgetasticTaggable, Updateable, Navigatable):
             if updates:
                 self.name = updates.get('name', self.name)
 
-            success_text = '{} Provider "{}" was saved'.format(self.string_name, self.name)
+            success_text = '{} "{}" was saved'.format(self.string_name, self.name)
             if main_view.is_displayed:
                 # since 5.8.1 main view is displayed when edit starts from main view
                 main_view.flash.assert_message(success_text)
@@ -464,12 +464,12 @@ class BaseProvider(WidgetasticTaggable, Updateable, Navigatable):
             cancel: Whether to cancel the deletion, defaults to True
         """
         view = navigate_to(self, 'Details')
-        item_title = version.pick({'5.9': 'Remove this {} Provider from Inventory',
-                                   version.LOWEST: 'Remove this {} Provider'})
+        item_title = version.pick({'5.9': 'Remove this {} from Inventory',
+                                   version.LOWEST: 'Remove this {}'})
         view.toolbar.configuration.item_select(item_title.format(self.string_name),
                                                handle_alert=not cancel)
         if not cancel:
-            msg = ('Delete initiated for 1 {} Provider from '
+            msg = ('Delete initiated for 1 {} from '
                    'the {} Database'.format(self.string_name, self.appliance.product_name))
             view.flash.assert_success_message(msg)
 

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -169,7 +169,7 @@ class ContainersProvider(BaseProvider, Pretty):
         'num_image_registry',
         'num_container']
     # TODO add 'num_volume'
-    string_name = "Containers"
+    string_name = "Containers Provider"
     detail_page_suffix = 'provider_detail'
     edit_page_suffix = 'provider_edit_detail'
     quad_name = None

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -66,7 +66,7 @@ class InfraProvider(Pretty, CloudInfraProvider, Fillable):
     category = "infra"
     pretty_attrs = ['name', 'key', 'zone']
     STATS_TO_MATCH = ['num_template', 'num_vm', 'num_datastore', 'num_host', 'num_cluster']
-    string_name = "Infrastructure"
+    string_name = "Infrastructure Provider"
     templates_destination_name = "Templates"
     db_types = ["InfraManager"]
     hosts_menu_item = "Hosts"

--- a/cfme/networks/provider/__init__.py
+++ b/cfme/networks/provider/__init__.py
@@ -35,7 +35,7 @@ class NetworkProvider(BaseProvider, WidgetasticTaggable, BaseEntity):
           only automaticaly with cloud provider
     """
     STATS_TO_MATCH = []
-    string_name = 'Network'
+    string_name = 'Network Manager'
     in_version = ('5.8', version.LATEST)
     edit_page_suffix = ''
     refresh_text = 'Refresh Relationships and Power States'

--- a/cfme/physical/provider/__init__.py
+++ b/cfme/physical/provider/__init__.py
@@ -25,7 +25,7 @@ class PhysicalProvider(Pretty, BaseProvider, Fillable):
     category = "physical"
     pretty_attrs = ['name']
     STATS_TO_MATCH = ['num_server']
-    string_name = "Physical Infrastructure"
+    string_name = "Physical Infrastructure Provider"
     page_name = "infrastructure"
     db_types = ["PhysicalInfraManager"]
 

--- a/cfme/physical/provider/lenovo.py
+++ b/cfme/physical/provider/lenovo.py
@@ -15,7 +15,7 @@ class LenovoEndpointForm(DefaultEndpointForm):
 class LenovoProvider(PhysicalProvider):
     type_name = 'lenovo'
     endpoints_form = LenovoEndpointForm
-    string_name = 'Physical Infrastructure'
+    string_name = 'Physical Infrastructure Provider'
     mgmt_class = LenovoSystem
     refresh_text = "Refresh Relationships and Power States"
 

--- a/docs/guides/newprovider.rst
+++ b/docs/guides/newprovider.rst
@@ -68,7 +68,7 @@ This
         category = "physical"
         pretty_attrs = ['name']
         STATS_TO_MATCH = ['num_server']
-        string_name = "Physical Infrastructure"
+        string_name = "Physical Infrastructure Provider"
 
         def __init__(
                 self, appliance=None, name=None, key=None, endpoints=None):
@@ -139,7 +139,7 @@ the providers as a whole, or the even within the category of the provider, is re
     class BigBadProvider(PhysicalProvider):
         type_name = 'bigbad'
         endpoints_form = BigBadEndpointForm
-        string_name = "Ems Physical Infras"
+        string_name = "Ems Physical Infras Provider"
         mgmt_class = BigBadSystem                                     # The reference to wrapanapi
 
         def __init__(self, appliance, name=None, key=None, endpoints=None):


### PR DESCRIPTION
Currently, all Providers contain `string_name` attribute (e.g. `"Cloud"`) which is then concatenated with a hard-coded string `" Provider"`, which results in names like "Cloud Provider", "Infrastructure Provider" etc. As of Nuage provider this is no longer valid since Nuage uses following name: "Network Manager".

With this commit we update all providers to contain both parts in its `string_name`. In other words, instead:

```
string_name = "Cloud"
```

we now use

```
string_name = "Cloud Provider"
```

which makes it possible to use "Network Manager" in case of Nuage provider.
