### PR TITLE
[RFR][1LP] Fixed tests for Azure provider in test_provision_stack.py

### DIFF
--- a/cfme/services/requests.py
+++ b/cfme/services/requests.py
@@ -76,7 +76,7 @@ class Request(BaseEntity):
     def get_request_row_from_ui(self):
         """Opens CFME UI and return table_row object"""
         view = navigate_to(self.parent, 'All')
-        self.row = view.find_request(self.rest.description, partial_check=False)
+        self.row = view.find_request(self.cells, partial_check=False)
         return self.row
 
     def get_request_id(self):

--- a/cfme/services/service_catalogs/ui.py
+++ b/cfme/services/service_catalogs/ui.py
@@ -52,7 +52,7 @@ class OrderForm(ServicesCatalogView):
     class fields(ParametrizedView):  # noqa
         PARAMETERS = ("key",)
         input = Input(id=Parameter("key"))
-        ansible_input = Input(id=ParametrizedString("param_{key}"))
+        param_input = Input(id=ParametrizedString("param_{key}"))
         dropdown = VersionPick({
             Version.lowest(): BootstrapSelect(Parameter("key")),
             "5.9": DialogFieldDropDownList(ParametrizedLocator(".//div[@input-id='{key|quote}']"))
@@ -64,8 +64,8 @@ class OrderForm(ServicesCatalogView):
                 return self.input
             elif self.dropdown.is_displayed:
                 return self.dropdown
-            elif self.ansible_input.is_displayed:
-                return self.ansible_input
+            elif self.param_input.is_displayed:
+                return self.param_input
 
         def read(self):
             return self.visible_widget.read()
@@ -90,31 +90,6 @@ class OrderForm(ServicesCatalogView):
 
         self.after_fill(was_change)
         return was_change
-
-
-class AzureOrderForm(ServicesCatalogView):
-    """This view available only in 5.8"""
-    title = Text('#explorer_title_text')
-    dialog_title = Text('.//div[@id="main_div"]//h3')
-
-    stack_name = Input(name='stack_name')
-    resource_group = BootstrapSelect('resource_group')
-    mode = BootstrapSelect('deploy_mode')
-    vm_name = Input(name='param_virtualMachineName')
-    vm_user = Input(name='param_adminUserName')
-    vm_password = Input(name='param_adminPassword__protected')
-    user_image = BootstrapSelect('param_userImageName')
-    os_type = BootstrapSelect('param_operatingSystemType')
-    vm_size = BootstrapSelect('param_virtualMachineSize')
-
-    submit_button = Button('Submit')
-
-    @property
-    def is_displayed(self):
-        return (
-            self.in_explorer and self.service_catalogs.is_opened and
-            self.title.text == 'Order Service "{}"'.format(self.context['object'].name)
-        )
 
 
 class ServiceCatalogsView(ServicesCatalogView):
@@ -169,8 +144,6 @@ def order(self):
     view = navigate_to(self, 'Order')
     wait_for(lambda: view.dialog_title.is_displayed, timeout=10)
     if self.stack_data:
-        if "user_image" in self.stack_data and self.appliance.version < "5.9":
-            view = self.create_view(AzureOrderForm)
         view.fill(self.stack_data)
     if self.dialog_values:
         view.fill(self.dialog_values)

--- a/cfme/services/service_catalogs/ui.py
+++ b/cfme/services/service_catalogs/ui.py
@@ -40,6 +40,14 @@ class ServicesCatalogView(BaseLoggedInPage):
 
 
 class OrderForm(ServicesCatalogView):
+    """Represents the order form of a service.
+    This form doesn't have a static set of elements apart from titles and buttons. In the most cases
+    the fields can be either regular inputs or dropdowns. Their locators depend on field names. In
+    order to find and fill required fields a parametrized view is used here. The keys of a fill
+    dictionary should match ids of the fields. For instance there is a field with such html
+    <input id="some_key"></input>, so a fill dictionary should look like that:
+    {"some_key": "some_value"}
+    """
     title = Text('#explorer_title_text')
     dialog_title = Text(
         VersionPick({

--- a/cfme/services/service_catalogs/ui.py
+++ b/cfme/services/service_catalogs/ui.py
@@ -57,6 +57,11 @@ class OrderForm(ServicesCatalogView):
             Version.lowest(): BootstrapSelect(Parameter("key")),
             "5.9": DialogFieldDropDownList(ParametrizedLocator(".//div[@input-id='{key|quote}']"))
         })
+        param_dropdown = VersionPick({
+            Version.lowest(): BootstrapSelect(ParametrizedString("param_{key}")),
+            "5.9": DialogFieldDropDownList(
+                ParametrizedLocator(".//div[@input-id='param_{key}']"))
+        })
 
         @property
         def visible_widget(self):
@@ -66,6 +71,8 @@ class OrderForm(ServicesCatalogView):
                 return self.dropdown
             elif self.param_input.is_displayed:
                 return self.param_input
+            elif self.param_dropdown.is_displayed:
+                return self.param_dropdown
 
         def read(self):
             return self.visible_widget.read()

--- a/cfme/tests/services/test_provision_stack.py
+++ b/cfme/tests/services/test_provision_stack.py
@@ -89,15 +89,14 @@ def stack_data(appliance, provider, provisioning):
 
         _stack_data = {
             'stack_name': stackname,
-            'vm_name': vm_name,
             'resource_group': provisioning.get('resource_group'),
             'deploy_mode': provisioning.get('mode'),
-            'vm_user': vm_user,
-            'vm_password__protected': vm_password,
-            'vm_size': provisioning.get('vm_size'),
-            'cloud_network': provisioning.get('cloud_network'),
-            'cloud_subnet': provisioning.get('cloud_subnet'),
-            'location': provisioning.get('region_api')
+            'virtualMachineName': vm_name,
+            'adminUserName': vm_user,
+            'adminPassword__protected': vm_password,
+            'userImageName': 'linux_generic | {}'.format(template.name),
+            'operatingSystemType': 'Linux',
+            'virtualMachineSize': provisioning.get('vm_size')
         }
     elif provider.type == 'openstack':
         stack_prov = provisioning['stack_provisioning']

--- a/data/orchestration/azure_vm_template.json
+++ b/data/orchestration/azure_vm_template.json
@@ -1,100 +1,150 @@
 {
-    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "location": {
-            "type": "string"
-        },
-        "vm_name": {
-            "type": "string",
-            "metadata": {
-                "description": "Name of the virtual machine template is CFMETemplateName"
-                        }
-        },
-        "vm_size": {
-            "type": "string"
-        },
-        "vm_user": {
-            "type": "string"
-        },
-        "cloud_network": {
-            "type": "string"
-        },
-        "vm_password": {
-            "type": "securestring"
-        },
-        "cloud_subnet": {
-            "type": "string"
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "virtualMachineName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the virtual machine template is CFMETemplateName"
+      }
     },
-    "variables": {
-        "vnetId": "[resourceId('Automation','Microsoft.Network/virtualNetworks', parameters('cloud_network'))]",
-        "nicName": "[concat(parameters('vm_name'),'-nic')]",
-        "subnetRef": "[concat(variables('vnetId'), '/subnets/', parameters('cloud_subnet'))]"
+    "adminUserName": {
+      "type": "string",
+      "metadata": {
+        "description": "Administrator user name for the virtual machine"
+      }
     },
-    "resources": [
-        {
-            "name": "[parameters('vm_name')]",
-            "type": "Microsoft.Compute/virtualMachines",
-            "apiVersion": "2016-04-30-preview",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
-            ],
-            "properties": {
-                "osProfile": {
-                    "computerName": "[parameters('vm_name')]",
-                    "adminUsername": "[parameters('vm_user')]",
-                    "adminPassword": "[parameters('vm_password')]"
-                },
-                "hardwareProfile": {
-                    "vmSize": "[parameters('vm_size')]"
-                },
-                "storageProfile": {
-                    "imageReference": {
-                        "id": "/subscriptions/c9e72ccc-b20e-48bd-a0c8-879c6dbcbfbb/resourceGroups/Automation/providers/Microsoft.Compute/images/ubuntuserver1704-image"
-                    },
-                    "osDisk": {
-                        "createOption": "fromImage",
-                        "managedDisk": {
-                            "storageAccountType": "Standard_LRS"
-                        }
-                    }
-                },
-                "networkProfile": {
-                    "networkInterfaces": [
-                        {
-                            "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
-                        }
-                    ]
-                }
-            }
-        },
-        {
-            "name": "[variables('nicName')]",
-            "type": "Microsoft.Network/networkInterfaces",
-            "apiVersion": "2016-09-01",
-            "location": "[parameters('location')]",
-            "dependsOn": [],
-            "properties": {
-                "ipConfigurations": [
-                    {
-                        "name": "ipconfig1",
-                        "properties": {
-                            "subnet": {
-                                "id": "[variables('subnetRef')]"
-                            },
-                            "privateIPAllocationMethod": "Dynamic"
-                        }
-                    }
-                ]
-            }
-        }
-    ],
-    "outputs": {
-        "adminUsername": {
-            "type": "string",
-            "value": "[parameters('vm_user')]"
-        }
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Password for the administrator"
+      }
+    },
+    "userImageName": {
+      "type": "string",
+      "metadata": {
+        "description": "The image used to provision the virtual machine"
+      }
+    },
+    "operatingSystemType": {
+      "type": "string",
+      "allowedValues": [
+        "Windows",
+        "Linux"
+      ],
+      "metadata": {
+        "description": "Operating system of the virtual machine"
+      }
+    },
+    "virtualMachineSize": {
+      "type": "string",
+      "metadata": {
+        "description": "Standard size of the virtual machine"
+      }
     }
+  },
+  "variables": {
+    "location": "[resourceGroup().location]",
+    "virtualNetworkName": "myVNET",
+    "nicName": "[concat(parameters('virtualMachineName'),'-nic')]",
+    "addressPrefix": "10.0.0.0/16",
+    "subnet1Name": "Subnet-1",
+    "subnet1Prefix": "10.0.0.0/24",
+    "publicIPAddressType": "Dynamic",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+    "subnet1Ref": "[concat(variables('vnetID'),'/subnets/',variables('subnet1Name'))]",
+    "storageAccount": "[split(parameters('userImageName'),'.')[0]]",
+    "osDiskVhdName": "[concat(variables('storageAccount'),'.blob.core.windows.net/vhds/',parameters('virtualMachineName'),'-osDisk.vhd')]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('addressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('subnet1Name')]",
+            "properties": {
+              "addressPrefix": "[variables('subnet1Prefix')]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('nicName')]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('subnet1Ref')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[parameters('virtualMachineName')]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('virtualMachineSize')]"
+        },
+        "osProfile": {
+          "computername": "[parameters('virtualMachineName')]",
+          "adminUsername": "[parameters('adminUserName')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "osDisk": {
+            "name": "[concat(parameters('virtualMachineName'),'-osDisk')]",
+            "osType": "[parameters('operatingSystemType')]",
+            "caching": "ReadWrite",
+            "createOption": "FromImage",
+            "image": {
+              "uri": "[parameters('userImageName')]"
+            },
+            "vhd": {
+              "uri": "[variables('osDiskVhdName')]"
+            }
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+            }
+          ]
+        },
+        "diagnosticsProfile": {
+          "bootDiagnostics": {
+             "enabled": "true",
+             "storageUri": "[concat(variables('storageAccount'),'.blob.core.windows.net')]"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/data/orchestration/azure_vm_template.json
+++ b/data/orchestration/azure_vm_template.json
@@ -1,150 +1,100 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-  "contentVersion": "1.0.0.0",
-  "parameters": {
-    "virtualMachineName": {
-      "type": "string",
-      "metadata": {
-        "description": "Name of the virtual machine template is CFMETemplateName"
-      }
-    },
-    "adminUserName": {
-      "type": "string",
-      "metadata": {
-        "description": "Administrator user name for the virtual machine"
-      }
-    },
-    "adminPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "Password for the administrator"
-      }
-    },
-    "userImageName": {
-      "type": "string",
-      "metadata": {
-        "description": "The image used to provision the virtual machine"
-      }
-    },
-    "operatingSystemType": {
-      "type": "string",
-      "allowedValues": [
-        "windows",
-        "linux"
-      ],
-      "metadata": {
-        "description": "Operating system of the virtual machine"
-      }
-    },
-    "virtualMachineSize": {
-      "type": "string",
-      "metadata": {
-        "description": "Standard size of the virtual machine"
-      }
-    }
-  },
-  "variables": {
-    "location": "[resourceGroup().location]",
-    "virtualNetworkName": "myVNET",
-    "nicName": "[concat(parameters('virtualMachineName'),'-nic')]",
-    "addressPrefix": "10.0.0.0/16",
-    "subnet1Name": "Subnet-1",
-    "subnet1Prefix": "10.0.0.0/24",
-    "publicIPAddressType": "Dynamic",
-    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
-    "subnet1Ref": "[concat(variables('vnetID'),'/subnets/',variables('subnet1Name'))]",
-    "storageAccount": "[split(parameters('userImageName'),'.')[0]]",
-    "osDiskVhdName": "[concat(variables('storageAccount'),'.blob.core.windows.net/vhds/',parameters('virtualMachineName'),'-osDisk.vhd')]"
-  },
-  "resources": [
-    {
-      "apiVersion": "2015-05-01-preview",
-      "type": "Microsoft.Network/virtualNetworks",
-      "name": "[variables('virtualNetworkName')]",
-      "location": "[variables('location')]",
-      "properties": {
-        "addressSpace": {
-          "addressPrefixes": [
-            "[variables('addressPrefix')]"
-          ]
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "location": {
+            "type": "string"
         },
-        "subnets": [
-          {
-            "name": "[variables('subnet1Name')]",
-            "properties": {
-              "addressPrefix": "[variables('subnet1Prefix')]"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "apiVersion": "2015-05-01-preview",
-      "type": "Microsoft.Network/networkInterfaces",
-      "name": "[variables('nicName')]",
-      "location": "[variables('location')]",
-      "dependsOn": [
-        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
-      ],
-      "properties": {
-        "ipConfigurations": [
-          {
-            "name": "ipconfig1",
-            "properties": {
-              "privateIPAllocationMethod": "Dynamic",
-              "subnet": {
-                "id": "[variables('subnet1Ref')]"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "apiVersion": "2015-06-15",
-      "type": "Microsoft.Compute/virtualMachines",
-      "name": "[parameters('virtualMachineName')]",
-      "location": "[variables('location')]",
-      "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
-      ],
-      "properties": {
-        "hardwareProfile": {
-          "vmSize": "[parameters('virtualMachineSize')]"
+        "vm_name": {
+            "type": "string",
+            "metadata": {
+                "description": "Name of the virtual machine template is CFMETemplateName"
+                        }
         },
-        "osProfile": {
-          "computername": "[parameters('virtualMachineName')]",
-          "adminUsername": "[parameters('adminUserName')]",
-          "adminPassword": "[parameters('adminPassword')]"
+        "vm_size": {
+            "type": "string"
         },
-        "storageProfile": {
-          "osDisk": {
-            "name": "[concat(parameters('virtualMachineName'),'-osDisk')]",
-            "osType": "[parameters('operatingSystemType')]",
-            "caching": "ReadWrite",
-            "createOption": "FromImage",
-            "image": {
-              "uri": "[parameters('userImageName')]"
-            },
-            "vhd": {
-              "uri": "[variables('osDiskVhdName')]"
-            }
-          }
+        "vm_user": {
+            "type": "string"
         },
-        "networkProfile": {
-          "networkInterfaces": [
-            {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
-            }
-          ]
+        "cloud_network": {
+            "type": "string"
         },
-        "diagnosticsProfile": {
-          "bootDiagnostics": {
-             "enabled": "true",
-             "storageUri": "[concat(variables('storageAccount'),'.blob.core.windows.net')]"
-          }
+        "vm_password": {
+            "type": "securestring"
+        },
+        "cloud_subnet": {
+            "type": "string"
         }
-      }
+    },
+    "variables": {
+        "vnetId": "[resourceId('Automation','Microsoft.Network/virtualNetworks', parameters('cloud_network'))]",
+        "nicName": "[concat(parameters('vm_name'),'-nic')]",
+        "subnetRef": "[concat(variables('vnetId'), '/subnets/', parameters('cloud_subnet'))]"
+    },
+    "resources": [
+        {
+            "name": "[parameters('vm_name')]",
+            "type": "Microsoft.Compute/virtualMachines",
+            "apiVersion": "2016-04-30-preview",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+            ],
+            "properties": {
+                "osProfile": {
+                    "computerName": "[parameters('vm_name')]",
+                    "adminUsername": "[parameters('vm_user')]",
+                    "adminPassword": "[parameters('vm_password')]"
+                },
+                "hardwareProfile": {
+                    "vmSize": "[parameters('vm_size')]"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "id": "/subscriptions/c9e72ccc-b20e-48bd-a0c8-879c6dbcbfbb/resourceGroups/Automation/providers/Microsoft.Compute/images/ubuntuserver1704-image"
+                    },
+                    "osDisk": {
+                        "createOption": "fromImage",
+                        "managedDisk": {
+                            "storageAccountType": "Standard_LRS"
+                        }
+                    }
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "[variables('nicName')]",
+            "type": "Microsoft.Network/networkInterfaces",
+            "apiVersion": "2016-09-01",
+            "location": "[parameters('location')]",
+            "dependsOn": [],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "subnet": {
+                                "id": "[variables('subnetRef')]"
+                            },
+                            "privateIPAllocationMethod": "Dynamic"
+                        }
+                    }
+                ]
+            }
+        }
+    ],
+    "outputs": {
+        "adminUsername": {
+            "type": "string",
+            "value": "[parameters('vm_user')]"
+        }
     }
-  ]
 }

--- a/data/orchestration/azure_vm_template.json
+++ b/data/orchestration/azure_vm_template.json
@@ -1,150 +1,115 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-  "contentVersion": "1.0.0.0",
-  "parameters": {
-    "virtualMachineName": {
-      "type": "string",
-      "metadata": {
-        "description": "Name of the virtual machine template is CFMETemplateName"
-      }
-    },
-    "adminUserName": {
-      "type": "string",
-      "metadata": {
-        "description": "Administrator user name for the virtual machine"
-      }
-    },
-    "adminPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "Password for the administrator"
-      }
-    },
-    "userImageName": {
-      "type": "string",
-      "metadata": {
-        "description": "The image used to provision the virtual machine"
-      }
-    },
-    "operatingSystemType": {
-      "type": "string",
-      "allowedValues": [
-        "Windows",
-        "Linux"
-      ],
-      "metadata": {
-        "description": "Operating system of the virtual machine"
-      }
-    },
-    "virtualMachineSize": {
-      "type": "string",
-      "metadata": {
-        "description": "Standard size of the virtual machine"
-      }
-    }
-  },
-  "variables": {
-    "location": "[resourceGroup().location]",
-    "virtualNetworkName": "myVNET",
-    "nicName": "[concat(parameters('virtualMachineName'),'-nic')]",
-    "addressPrefix": "10.0.0.0/16",
-    "subnet1Name": "Subnet-1",
-    "subnet1Prefix": "10.0.0.0/24",
-    "publicIPAddressType": "Dynamic",
-    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
-    "subnet1Ref": "[concat(variables('vnetID'),'/subnets/',variables('subnet1Name'))]",
-    "storageAccount": "[split(parameters('userImageName'),'.')[0]]",
-    "osDiskVhdName": "[concat(variables('storageAccount'),'.blob.core.windows.net/vhds/',parameters('virtualMachineName'),'-osDisk.vhd')]"
-  },
-  "resources": [
-    {
-      "apiVersion": "2015-05-01-preview",
-      "type": "Microsoft.Network/virtualNetworks",
-      "name": "[variables('virtualNetworkName')]",
-      "location": "[variables('location')]",
-      "properties": {
-        "addressSpace": {
-          "addressPrefixes": [
-            "[variables('addressPrefix')]"
-          ]
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "location": {
+            "type": "String"
         },
-        "subnets": [
-          {
-            "name": "[variables('subnet1Name')]",
-            "properties": {
-              "addressPrefix": "[variables('subnet1Prefix')]"
+        "vmname": {
+            "type": "String",
+            "metadata": {
+                "description": "Name of the virtual machine template is CFMETemplateName"
             }
-          }
-        ]
-      }
-    },
-    {
-      "apiVersion": "2015-05-01-preview",
-      "type": "Microsoft.Network/networkInterfaces",
-      "name": "[variables('nicName')]",
-      "location": "[variables('location')]",
-      "dependsOn": [
-        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
-      ],
-      "properties": {
-        "ipConfigurations": [
-          {
-            "name": "ipconfig1",
-            "properties": {
-              "privateIPAllocationMethod": "Dynamic",
-              "subnet": {
-                "id": "[variables('subnet1Ref')]"
-              }
+        },
+        "vmsize": {
+            "type": "String"
+        },
+        "vmuser": {
+            "type": "String"
+        },
+        "vmpassword": {
+            "type": "SecureString"
+        },
+        "cloudnetwork": {
+            "type": "String"
+        },
+        "cloudsubnet": {
+            "type": "String"
+        },
+        "ubuntuosversion": {
+            "defaultValue": "16.04.0-LTS",
+            "allowedValues": [
+                "12.04.5-LTS",
+                "14.04.5-LTS",
+                "15.10",
+                "16.04.0-LTS"
+            ],
+            "type": "String",
+            "metadata": {
+                "description": "The Ubuntu version for the VM. This will pick a fully patched image of this given Ubuntu version."
             }
-          }
-        ]
-      }
-    },
-    {
-      "apiVersion": "2015-06-15",
-      "type": "Microsoft.Compute/virtualMachines",
-      "name": "[parameters('virtualMachineName')]",
-      "location": "[variables('location')]",
-      "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
-      ],
-      "properties": {
-        "hardwareProfile": {
-          "vmSize": "[parameters('virtualMachineSize')]"
-        },
-        "osProfile": {
-          "computername": "[parameters('virtualMachineName')]",
-          "adminUsername": "[parameters('adminUserName')]",
-          "adminPassword": "[parameters('adminPassword')]"
-        },
-        "storageProfile": {
-          "osDisk": {
-            "name": "[concat(parameters('virtualMachineName'),'-osDisk')]",
-            "osType": "[parameters('operatingSystemType')]",
-            "caching": "ReadWrite",
-            "createOption": "FromImage",
-            "image": {
-              "uri": "[parameters('userImageName')]"
-            },
-            "vhd": {
-              "uri": "[variables('osDiskVhdName')]"
-            }
-          }
-        },
-        "networkProfile": {
-          "networkInterfaces": [
-            {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
-            }
-          ]
-        },
-        "diagnosticsProfile": {
-          "bootDiagnostics": {
-             "enabled": "true",
-             "storageUri": "[concat(variables('storageAccount'),'.blob.core.windows.net')]"
-          }
         }
-      }
+    },
+    "variables": {
+        "imagePublisher": "Canonical",
+        "imageOffer": "UbuntuServer",
+        "nicName": "[concat(parameters('vmname'),'-nic')]",
+        "vnetID": "[resourceId(resourcegroup().name,'Microsoft.Network/virtualNetworks',parameters('cloudnetwork'))]",
+        "subnetRef": "[concat(variables('vnetID'),'/subnets/',parameters('cloudsubnet'))]"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Network/networkInterfaces",
+            "name": "[variables('nicName')]",
+            "apiVersion": "2016-09-01",
+            "location": "[parameters('location')]",
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "subnet": {
+                                "id": "[variables('subnetRef')]"
+                            }
+                        }
+                    }
+                ]
+            },
+            "dependsOn": []
+        },
+        {
+            "type": "Microsoft.Compute/virtualMachines",
+            "name": "[parameters('vmname')]",
+            "apiVersion": "2016-04-30-preview",
+            "location": "[parameters('location')]",
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[parameters('vmsize')]"
+                },
+                "osProfile": {
+                    "computerName": "[parameters('vmname')]",
+                    "adminUsername": "[parameters('vmuser')]",
+                    "adminPassword": "[parameters('vmpassword')]"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "publisher": "[variables('imagePublisher')]",
+                        "offer": "[variables('imageOffer')]",
+                        "sku": "[parameters('ubuntuosversion')]",
+                        "version": "latest"
+                    },
+                    "osDisk": {
+                        "createOption": "FromImage"
+                    }
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+                        }
+                    ]
+                }                
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+            ]
+        }
+    ],
+    "outputs": {
+        "adminUsername": {
+            "type": "String",
+            "value": "[parameters('vmuser')]"
+        }
     }
-  ]
 }


### PR DESCRIPTION
Purpose
=================

"azure-single-vm-from-user-image" service dialog has been removed in CFME 5.9. This PR requires updated cfme_data.yaml. Also, it can potentially break other services test, but without refactoring `OrderForm` fixing test_provision_stack.py cannot proceed.

{{pytest: -v cfme/tests/services/test_provision_stack.py --use-provider azure}}