### PR TITLE
[WIP] Fixing catalog_item_type for RHV

### DIFF
--- a/cfme/fixtures/service_fixtures.py
+++ b/cfme/fixtures/service_fixtures.py
@@ -4,10 +4,12 @@ import pytest
 from widgetastic.utils import partial_match
 
 from cfme.common.provider import cleanup_vm
+from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.rest.gen_data import dialog as _dialog
 from cfme.rest.gen_data import service_catalog_obj as _catalog
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.service_catalogs import ServiceCatalogs
+from cfme.utils import version
 from cfme.utils.log import logger
 
 
@@ -31,6 +33,11 @@ def create_catalog_item(provider, provisioning, vm_name, dialog, catalog, consol
 
     template, host, datastore, iso_file, catalog_item_type, vlan = map(provisioning.get,
         ('template', 'host', 'datastore', 'iso_file', 'catalog_item_type', 'vlan'))
+    if provider.one_of(RHEVMProvider):
+        catalog_item_type = version.pick({
+            version.LOWEST: 'RHEV',
+            '5.9.0.17': catalog_item_type
+        })
     if console_template:
         logger.info("Console template name : {}".format(console_template.name))
         template = console_template.name

--- a/cfme/fixtures/service_fixtures.py
+++ b/cfme/fixtures/service_fixtures.py
@@ -4,12 +4,10 @@ import pytest
 from widgetastic.utils import partial_match
 
 from cfme.common.provider import cleanup_vm
-from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.rest.gen_data import dialog as _dialog
 from cfme.rest.gen_data import service_catalog_obj as _catalog
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.service_catalogs import ServiceCatalogs
-from cfme.utils import version
 from cfme.utils.log import logger
 
 
@@ -33,11 +31,6 @@ def create_catalog_item(provider, provisioning, vm_name, dialog, catalog, consol
 
     template, host, datastore, iso_file, catalog_item_type, vlan = map(provisioning.get,
         ('template', 'host', 'datastore', 'iso_file', 'catalog_item_type', 'vlan'))
-    if provider.one_of(RHEVMProvider):
-        catalog_item_type = version.pick({
-            version.LOWEST: 'RHEV',
-            '5.9.0.17': catalog_item_type
-        })
     if console_template:
         logger.info("Console template name : {}".format(console_template.name))
         template = console_template.name

--- a/cfme/tests/services/test_service_catalogs.py
+++ b/cfme/tests/services/test_service_catalogs.py
@@ -113,8 +113,6 @@ def test_no_template_catalog_item(provider, provisioning, setup_provider, vm_nam
     """
     template, catalog_item_type = map(provisioning.get,
         ('template', 'catalog_item_type'))
-    if provider.type == 'rhevm':
-        catalog_item_type = "RHEV"
     item_name = fauxfactory.gen_alphanumeric()
     catalog_item = CatalogItem(item_type=catalog_item_type, name=item_name,
                   description="my catalog", display_in=True, catalog=catalog, dialog=dialog)


### PR DESCRIPTION
__Fixing__ catalog_item_type for RHV provider. So it seems that since 5.9.0.17 catalog item type is "Red Hat Virtualization" as opposed to previous "RHEV". Honestly I do not know if the proposed soluting is the best one. We need a way to keep the old name, because we will still be running automation on 5.8. And I don't think it's a good idea to change this on test case level. You would need to changed in in each test case and authors of new test cases might not be aware of that.

{{pytest: -vv cfme/tests/services/test_service_catalogs.py --use-provider rhv41 --long-running}}

5.9 will be failing until yamls repo in GitLab is updated. However, I cannot do that now, since it is unreachable. The change needed RHV provider is this:
`provisioning[catalog_item_type]` from "RHEV" to "Red Hat Virtualization".
