### PR TITLE
[1LP][RFR] Fixed test_permissions_catalog_add

### DIFF
--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -7,7 +7,7 @@ import pytest
 from cfme import test_requirements
 from cfme.base.credential import Credential
 from cfme.common.provider import base_types
-from cfme.configure import tasks
+from cfme.configure.tasks import TasksView
 from cfme.exceptions import RBACOperationBlocked
 from cfme.infrastructure import virtual_machines as vms
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
@@ -200,7 +200,7 @@ def test_user_password_required_error_validation(appliance, group_collection):
     check = "Password can't be blank"
 
     with error.expected(check):
-        user = appliance.collections.users.create(
+        appliance.collections.users.create(
             name='user{}'.format(fauxfactory.gen_alphanumeric()),
             credential=Credential(
                 principal='uid{}'.format(fauxfactory.gen_alphanumeric()), secret=None),
@@ -659,9 +659,8 @@ def _go_to(cls_or_obj, dest='All'):
                 [['Everything', 'Settings', 'Tasks'], True]
             ],
             {  # allowed_actions
-                'tasks': lambda appliance: appliance.browser.widgetastic.click(
-                    tasks.buttons.default
-                )
+                'tasks':
+                    lambda appliance: appliance.browser.create_view(TasksView).tabs.default.click()
             },
             {  # disallowed actions
                 'my services': _go_to(MyService),
@@ -714,13 +713,13 @@ def test_permissions(appliance, product_features, allowed_actions, disallowed_ac
         with user:
             appliance.server.login(user)
 
-            for name, action_thunk in allowed_actions.items():
+            for name, action_thunk in sorted(allowed_actions.items()):
                 try:
                     action_thunk(appliance)
                 except Exception:
                     fails[name] = "{}: {}".format(name, traceback.format_exc())
 
-            for name, action_thunk in disallowed_actions.items():
+            for name, action_thunk in sorted(disallowed_actions.items()):
                 try:
                     with error.expected(Exception):
                         action_thunk(appliance)

--- a/cfme/tests/services/test_catalog.py
+++ b/cfme/tests/services/test_catalog.py
@@ -4,6 +4,7 @@ import pytest
 
 import cfme.tests.configure.test_access_control as tac
 from cfme.utils import error
+from cfme.utils.blockers import BZ
 from cfme import test_requirements
 from cfme.services.catalogs.catalog import Catalog
 from cfme.utils.update import update
@@ -31,12 +32,20 @@ def test_catalog_duplicate_name():
     cat.delete()
 
 
+@pytest.mark.meta(blockers=[BZ(1460891, forced_streams=['5.8', '5.9', 'upstream'])])
 @pytest.mark.sauce
 def test_permissions_catalog_add(appliance):
     """ Tests that a catalog can be added only with the right permissions"""
     cat = Catalog(name=fauxfactory.gen_alphanumeric(),
                   description="my catalog")
 
-    tac.single_task_permission_test(appliance,
-                                    [['Everything', 'Services', 'Catalogs Explorer', 'Catalogs']],
-                                    {'Add Catalog': cat.create})
+    test_product_features = [['Everything', 'Services', 'Catalogs Explorer', 'Catalogs']]
+
+    # Since we try to create the catalog with the same name, we obliged to delete it after creation
+    # in order to avoid "Name has already been taken" error which makes this test "blind" to the
+    # fact, that disallowed action actually can be performed.
+    # TODO: remove this workaround with "lambda"
+    test_actions = {'Add Catalog': lambda _: cat.create(),
+                    'Delete Catalog': lambda _: cat.delete()}
+
+    tac.single_task_permission_test(appliance, test_product_features, test_actions)


### PR DESCRIPTION
Purpose
=================

__Fixing__ _cfme/tests/configure/test_access_control.py::test_permissions_ which failed with error:
```AttributeError: 'module' object has no attribute 'buttons'```

__Fixing__ _cfme/tests/services/test_catalog.py::test_permissions_catalog_add_ which failed with error:
```TypeError: create() takes exactly 1 argument (2 given)```

__Now__ _test_permissions_catalog_add_ __fails__ because user without proper permissions can add new Service Catalog [(link to BZ)](https://bugzilla.redhat.com/show_bug.cgi?id=1460891)

{{pytest: -v cfme/tests/services/test_catalog.py::test_permissions_catalog_add cfme/tests/configure/test_access_control.py::test_permissions}}