### PR TITLE
[1LP][RFR] Fixing clean_appliance helper script

### DIFF
--- a/cfme/utils/ssh.py
+++ b/cfme/utils/ssh.py
@@ -372,11 +372,12 @@ class SSHClient(paramiko.SSHClient):
         return self.run_command('cd /var/www/miq/vmdb; echo \"{}\" '
             '| bundle exec bin/rails c 2> /dev/null'.format(command), timeout=timeout)
 
-    def run_rake_command(self, command, timeout=RUNCMD_TIMEOUT, **kwargs):
+    def run_rake_command(self, command, timeout=RUNCMD_TIMEOUT, disable_db_check=False, **kwargs):
         logger.info("Running rake command %r", command)
+        prefix = 'DISABLE_DATABASE_ENVIRONMENT_CHECK=1 ' if disable_db_check else ''
         return self.run_command(
-            'cd /var/www/miq/vmdb; bin/rake -f /var/www/miq/vmdb/Rakefile {command}'.format(
-                command=command), timeout=timeout, **kwargs)
+            'cd /var/www/miq/vmdb; {pre}bin/rake -f /var/www/miq/vmdb/Rakefile {command}'.format(
+                command=command, pre=prefix), timeout=timeout, **kwargs)
 
     def put_file(self, local_file, remote_file='.', **kwargs):
         logger.info("Transferring local file %r to remote %r", local_file, remote_file)

--- a/scripts/clean_appliance.py
+++ b/scripts/clean_appliance.py
@@ -44,8 +44,8 @@ def main():
         # `systemctl stop evmserverd` is a little slow, and we're destroying the
         # db, so rudely killing ruby speeds things up significantly
         print('Stopping ruby processes...')
-        ssh_client.run_command('killall ruby')
-        ssh_client.run_rake_command('evm:db:reset')
+        ssh_client.run_command('systemctl stop evmserverd')
+        ssh_client.run_rake_command('evm:db:reset', disable_db_check=True)
         ssh_client.run_command('systemctl start evmserverd')
 
         # SSHClient has the smarts to get our hostname if none was provided


### PR DESCRIPTION
__Fixing__ clean_appliance.py. `evm:db:reset` is not executed if `DISABLE_DATABASE_ENVIRONMENT_CHECK=1` is not defined in environemt. It is just a quick fix and probably not the best. I suppose the correct approach would be to fine-tune this [method](https://github.com/ManageIQ/integration_tests/blob/c0962522aafed3b75180ebfe26c42580bcc71503/cfme/utils/appliance/__init__.py#L2000), but I unfortunately don't have capacity for that at the moment.