### PR TITLE
[1LP][RFR] Update wt.patternfly.CheckableBootstrapTreeview fill() calls 

### DIFF
--- a/cfme/configure/access_control/__init__.py
+++ b/cfme/configure/access_control/__init__.py
@@ -3,7 +3,7 @@ from navmazing import NavigateToSibling, NavigateToAttribute
 from widgetastic.utils import VersionPick, Version
 from widgetastic.widget import Checkbox, View, Text
 from widgetastic_patternfly import (
-    BootstrapSelect, Button, Input, Tab, CheckableBootstrapTreeview as CBTree,
+    BootstrapSelect, Button, Input, Tab, CheckableBootstrapTreeview as CbTree,
     BootstrapSwitch, CandidateNotFound, Dropdown)
 
 from cfme.base.credential import Credential
@@ -474,19 +474,19 @@ class GroupForm(ConfigurationView):
         """ Represents 'My company tags' tab in Group Form """
         TAB_NAME = "My Company Tags"
         tree_locator = 'tags_treebox'
-        tree = CBTree(tree_locator)
+        tree = CbTree(tree_locator)
 
     @View.nested
     class hosts_and_clusters(Tab):  # noqa
         """ Represents 'Hosts and Clusters' tab in Group Form """
         TAB_NAME = "Hosts & Clusters"
-        tree = CBTree('hac_treebox')
+        tree = CbTree('hac_treebox')
 
     @View.nested
     class vms_and_templates(Tab):  # noqa
         """ Represents 'VM's and Templates' tab in Group Form """
         TAB_NAME = "VMs & Templates"
-        tree = CBTree('vat_treebox')
+        tree = CbTree('vat_treebox')
 
 
 class AddGroupView(GroupForm):
@@ -988,7 +988,7 @@ class RoleForm(ConfigurationView):
     """ Role Form for CFME UI """
     name_txt = Input(name='name')
     vm_restriction_select = BootstrapSelect(id='vm_restriction')
-    features_tree = CBTree("features_treebox")
+    features_tree = CbTree("features_treebox")
 
     cancel_button = Button('Cancel')
 
@@ -1172,7 +1172,7 @@ class Role(Updateable, Pretty, BaseEntity):
 
             changes = [
                 view.fill({
-                    'features_tree': CBTree.CheckNode(path) if option else CBTree.UncheckNode(path)
+                    'features_tree': CbTree.CheckNode(path) if option else CbTree.UncheckNode(path)
                 })
                 for path, option in product_features
             ]

--- a/cfme/configure/access_control/__init__.py
+++ b/cfme/configure/access_control/__init__.py
@@ -3,7 +3,7 @@ from navmazing import NavigateToSibling, NavigateToAttribute
 from widgetastic.utils import VersionPick, Version
 from widgetastic.widget import Checkbox, View, Text
 from widgetastic_patternfly import (
-    BootstrapSelect, Button, Input, Tab, CheckableBootstrapTreeview,
+    BootstrapSelect, Button, Input, Tab, CheckableBootstrapTreeview as CBTree,
     BootstrapSwitch, CandidateNotFound, Dropdown)
 
 from cfme.base.credential import Credential
@@ -474,19 +474,19 @@ class GroupForm(ConfigurationView):
         """ Represents 'My company tags' tab in Group Form """
         TAB_NAME = "My Company Tags"
         tree_locator = 'tags_treebox'
-        tree = CheckableBootstrapTreeview(tree_locator)
+        tree = CBTree(tree_locator)
 
     @View.nested
     class hosts_and_clusters(Tab):  # noqa
         """ Represents 'Hosts and Clusters' tab in Group Form """
         TAB_NAME = "Hosts & Clusters"
-        tree = CheckableBootstrapTreeview('hac_treebox')
+        tree = CBTree('hac_treebox')
 
     @View.nested
     class vms_and_templates(Tab):  # noqa
         """ Represents 'VM's and Templates' tab in Group Form """
         TAB_NAME = "VMs & Templates"
-        tree = CheckableBootstrapTreeview('vat_treebox')
+        tree = CBTree('vat_treebox')
 
 
 class AddGroupView(GroupForm):
@@ -988,7 +988,7 @@ class RoleForm(ConfigurationView):
     """ Role Form for CFME UI """
     name_txt = Input(name='name')
     vm_restriction_select = BootstrapSelect(id='vm_restriction')
-    product_features_tree = CheckableBootstrapTreeview("features_treebox")
+    features_tree = CBTree("features_treebox")
 
     cancel_button = Button('Cancel')
 
@@ -1168,15 +1168,17 @@ class Role(Updateable, Pretty, BaseEntity):
             view: AddRoleView or EditRoleView
             product_features: list of product features with options to select
         """
-        feature_update = False
         if product_features is not None and isinstance(product_features, (list, tuple, set)):
-            for path, option in product_features:
-                if option:
-                    view.product_features_tree.check_node(*path)
-                else:
-                    view.product_features_tree.uncheck_node(*path)
-            feature_update = True
-        return feature_update
+
+            changes = [
+                view.fill({
+                    'features_tree': CBTree.CheckNode(path) if option else CBTree.UncheckNode(path)
+                })
+                for path, option in product_features
+            ]
+            return True in changes
+        else:
+            return False
 
 
 @attr.s

--- a/cfme/configure/settings.py
+++ b/cfme/configure/settings.py
@@ -3,7 +3,7 @@ from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.utils import Version, VersionPick
 from widgetastic.widget import View
 from widgetastic_patternfly import (
-    BootstrapSwitch, Input, Button, CheckableBootstrapTreeview as CBTree, Dropdown)
+    BootstrapSwitch, Input, Button, CheckableBootstrapTreeview as CbTree, Dropdown)
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.base.ui import MySettingsView
@@ -384,7 +384,7 @@ class VisualAll(CFMENavigateStep):
 
 
 class DefaultFilterForm(MySettingsView):
-    tree = CBTree('df_treebox')
+    tree = CbTree('df_treebox')
     save = Button('Save')
 
 
@@ -407,7 +407,7 @@ class DefaultFilter(Updateable, Pretty, Navigatable):
         """
         view = navigate_to(self, 'All')
         for path, check in updates['filters']:
-            fill_value = CBTree.CheckNode(path) if check else CBTree.UncheckNode(path)
+            fill_value = CbTree.CheckNode(path) if check else CbTree.UncheckNode(path)
             if view.tree.fill(fill_value):
                 view.save.click()
             else:

--- a/cfme/configure/settings.py
+++ b/cfme/configure/settings.py
@@ -2,13 +2,14 @@ import re
 from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.utils import Version, VersionPick
 from widgetastic.widget import View
-from widgetastic_patternfly import (BootstrapSwitch,
-                                    Input, Button, CheckableBootstrapTreeview, Dropdown)
+from widgetastic_patternfly import (
+    BootstrapSwitch, Input, Button, CheckableBootstrapTreeview as CBTree, Dropdown)
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.base.ui import MySettingsView
 from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
+from cfme.utils.log import logger
 from cfme.utils.pretty import Pretty
 from cfme.utils.update import Updateable
 from widgetastic_manageiq import Table, BootstrapSelect, BreadCrumb, Text, ViewButtonGroup
@@ -383,7 +384,7 @@ class VisualAll(CFMENavigateStep):
 
 
 class DefaultFilterForm(MySettingsView):
-    tree = CheckableBootstrapTreeview('df_treebox')
+    tree = CBTree('df_treebox')
     save = Button('Save')
 
 
@@ -397,11 +398,20 @@ class DefaultFilter(Updateable, Pretty, Navigatable):
         self.filters = filters or []
 
     def update(self, updates):
+        """
+        Args:
+            updates: Dictionary containing 'filters' key. Values are tuples of ([path], bool)
+                Where bool is whether to check or uncheck the filter
+
+        Returns: None
+        """
         view = navigate_to(self, 'All')
-        for value in updates['filters']:
-            for path in value:
-                if isinstance(path, list) and view.tree.fill(path):
-                    view.save.click()
+        for path, check in updates['filters']:
+            fill_value = CBTree.CheckNode(path) if check else CBTree.UncheckNode(path)
+            if view.tree.fill(fill_value):
+                view.save.click()
+            else:
+                logger.info('No change to filter on update, not saving form.')
 
 
 @navigator.register(DefaultFilter, 'All')

--- a/cfme/control/explorer/alert_profiles.py
+++ b/cfme/control/explorer/alert_profiles.py
@@ -4,7 +4,8 @@ import attr
 from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.utils import VersionPick, Version
 from widgetastic.widget import Text, TextInput
-from widgetastic_patternfly import BootstrapSelect, Button, Input, CBTree
+from widgetastic_patternfly import (
+    BootstrapSelect, Button, Input, CheckableBootstrapTreeview as CbTree)
 
 from . import ControlExplorerView
 from cfme.utils import ParamClassName
@@ -83,7 +84,7 @@ class AlertProfilesEditAssignmentsView(ControlExplorerView):
     title = Text("#explorer_title_text")
     assign_to = BootstrapSelect("chosen_assign_to")
     tag_category = BootstrapSelect("chosen_cat")
-    selections = CBTree(VersionPick({
+    selections = CbTree(VersionPick({
         Version.lowest(): "obj_treebox",
         "5.9": "object_treebox"
     }))
@@ -183,7 +184,7 @@ class BaseAlertProfile(BaseEntity, Updateable, Pretty):
         changed = []
         # separate fill calls, checkable tree fills one path at a time
         changed.append(view.fill({"assign_to": assign, "tag_category": tag_category}))
-        changed.extend([view.selections.fill(CBTree.CheckNode(path)) for path in selections])
+        changed.extend([view.selections.fill(CbTree.CheckNode(path)) for path in selections])
         if changed:
             view.save_button.click()
         else:

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -6,7 +6,7 @@ import fauxfactory
 import pytest
 import re
 from widgetastic.utils import partial_match
-from widgetastic_patternfly import CheckableBootstrapTreeview as CBTree
+from widgetastic_patternfly import CheckableBootstrapTreeview as CbTree
 
 from cfme import test_requirements
 from cfme.base.login import BaseLoggedInPage
@@ -235,7 +235,7 @@ def test_tag(provisioner, prov_data, provider, vm_name):
         test_flag: provision
     """
     prov_data['catalog']['vm_name'] = vm_name
-    prov_data['purpose']["apply_tags"] = CBTree.CheckNode(path=("Service Level *", "Gold"))
+    prov_data['purpose']["apply_tags"] = CbTree.CheckNode(path=("Service Level *", "Gold"))
     template_name = provider.data['provisioning']['template']
 
     vm = provisioner(template_name, prov_data)

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -6,6 +6,7 @@ import fauxfactory
 import pytest
 import re
 from widgetastic.utils import partial_match
+from widgetastic_patternfly import CheckableBootstrapTreeview as CBTree
 
 from cfme import test_requirements
 from cfme.base.login import BaseLoggedInPage
@@ -234,7 +235,7 @@ def test_tag(provisioner, prov_data, provider, vm_name):
         test_flag: provision
     """
     prov_data['catalog']['vm_name'] = vm_name
-    prov_data['purpose']["apply_tags"] = ("Service Level *", "Gold")
+    prov_data['purpose']["apply_tags"] = CBTree.CheckNode(path=("Service Level *", "Gold"))
     template_name = provider.data['provisioning']['template']
 
     vm = provisioner(template_name, prov_data)


### PR DESCRIPTION
Tied to wt.patternfly [#43](https://github.com/RedHatQE/widgetastic.patternfly/pull/43) updates to the CheckableBootstrapTreeview.

I'm mainly looking at the failure for places where the form fill of the `CheckableBootstrapTreeview` failed. I will not be addressing all test failures here unless related to my changes.

# Note
Widgetastic has been updated past 0.0.28 outside of this PR, and these calls are now broken in the framework until this is merged. 

{{ pytest: cfme/tests/infrastructure/test_provisioning_dialog.py cfme/tests/configure/test_default_filters.py cfme/tests/control/test_alerts.py cfme/tests/control/test_basic.py --long-running -v }}