### PR TITLE
[1LP][RFR] Fixed test_permissions_vm_provisioning

### DIFF
--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -562,8 +562,8 @@ def test_assign_user_to_new_group(appliance, group_collection):
 
 def _test_vm_provision(appliance):
     logger.info("Checking for provision access")
-    navigate_to(vms.Vm, 'VMsOnly')
-    vms.lcl_btn("Provision VMs")
+    view = navigate_to(vms.Vm, 'VMsOnly')
+    view.toolbar.lifecycle.item_enabled('Provision VMs')
 
 # this fixture is used in disabled tests. it should be updated along with tests
 # def _test_vm_power_on():
@@ -743,15 +743,8 @@ def single_task_permission_test(appliance, product_features, actions):
     test_prod_features = [(['Everything'], False)] + [(f, True) for f in product_features]
     test_permissions(appliance, test_prod_features, actions, {})
 
-    # Enable everything but specified product features
-    test_prod_features = [(['Everything'], True)]
-    # CFME 5.7 - New roles have the checkbox for 'Everything' checked but the
-    # only child item checked is 'Access Rules for all Virtual Machines' so
-    # clear 'Everything' so all child items can be enabled to start
-    if appliance.version < "5.8":
-        test_prod_features = [(['Everything'], False)] + test_prod_features
-
-    test_prod_features += [(f, False) for f in product_features]
+    # Enable everything except product features
+    test_prod_features = [(['Everything'], True)] + [(f, False) for f in product_features]
     test_permissions(appliance, test_prod_features, {}, actions)
 
 
@@ -765,7 +758,7 @@ def test_permissions_role_crud(appliance):
 
 
 @pytest.mark.tier(3)
-def test_permissions_vm_provisioning(appliance):
+def test_permissions_vm_provisioning(appliance, a_provider):
     features = [
         ['Everything', 'Compute', 'Infrastructure', 'Virtual Machines', 'Accordions'],
         ['Everything', 'Access Rules for all Virtual Machines', 'VM Access Rules', 'Modify',


### PR DESCRIPTION
Purpose
=================
Refactored and fixed test_permissions_vm_provisioning.

{{pytest: -v cfme/tests/configure/test_access_control.py -k test_permissions_vm_provisioning}}