### PR TITLE
[1LP][RFR] Fixed catalog_name selection

### DIFF
--- a/cfme/cloud/provider/azure.py
+++ b/cfme/cloud/provider/azure.py
@@ -1,8 +1,8 @@
 from wrapanapi.msazure import AzureSystem
 
-from . import CloudProvider
 from cfme.common.provider import DefaultEndpoint, DefaultEndpointForm
 from cfme.utils.version import pick
+from . import CloudProvider
 
 
 class AzureEndpoint(DefaultEndpoint):
@@ -26,6 +26,7 @@ class AzureProvider(CloudProvider):
      BaseProvider->CloudProvider->AzureProvider class.
      represents CFME provider and operations available in UI
     """
+    catalog_name = "Azure"
     type_name = "azure"
     mgmt_class = AzureSystem
     db_types = ["Azure::CloudManager"]

--- a/cfme/cloud/provider/ec2.py
+++ b/cfme/cloud/provider/ec2.py
@@ -2,9 +2,9 @@ from widgetastic.widget import View
 from widgetastic_patternfly import Tab, Input, Button
 from wrapanapi.ec2 import EC2System
 
-from . import CloudProvider
 from cfme.common.provider import DefaultEndpoint, DefaultEndpointForm
 from cfme.common.provider_views import BeforeFillMixin
+from . import CloudProvider
 
 
 class EC2Endpoint(DefaultEndpoint):
@@ -39,6 +39,7 @@ class EC2Provider(CloudProvider):
      BaseProvider->CloudProvider->EC2Provider class.
      represents CFME provider and operations available in UI
     """
+    catalog_name = "Amazon"
     type_name = "ec2"
     mgmt_class = EC2System
     db_types = ["Amazon::CloudManager"]

--- a/cfme/cloud/provider/gce.py
+++ b/cfme/cloud/provider/gce.py
@@ -1,6 +1,6 @@
-from wrapanapi.google import GoogleCloudSystem
 from widgetastic.widget import View
 from widgetastic_patternfly import Button, Input
+from wrapanapi.google import GoogleCloudSystem
 
 from cfme.base.credential import ServiceAccountCredential
 from cfme.common.provider import DefaultEndpoint
@@ -31,6 +31,7 @@ class GCEProvider(CloudProvider):
      BaseProvider->CloudProvider->GCEProvider class.
      represents CFME provider and operations available in UI
     """
+    catalog_name = "Google"
     type_name = "gce"
     mgmt_class = GoogleCloudSystem
     db_types = ["Google::CloudManager"]

--- a/cfme/cloud/provider/openstack.py
+++ b/cfme/cloud/provider/openstack.py
@@ -1,9 +1,9 @@
 from wrapanapi.openstack import OpenstackSystem
 
-from . import CloudProvider
 from cfme.common.provider import EventsEndpoint
-from cfme.infrastructure.provider.openstack_infra import RHOSEndpoint, OpenStackInfraEndpointForm
 from cfme.exceptions import ItemNotFound
+from cfme.infrastructure.provider.openstack_infra import RHOSEndpoint, OpenStackInfraEndpointForm
+from . import CloudProvider
 
 
 class OpenStackProvider(CloudProvider):
@@ -11,6 +11,7 @@ class OpenStackProvider(CloudProvider):
      BaseProvider->CloudProvider->OpenStackProvider class.
      represents CFME provider and operations available in UI
     """
+    catalog_name = "OpenStack"
     type_name = "openstack"
     mgmt_class = OpenstackSystem
     db_types = ["Openstack::CloudManager"]

--- a/cfme/fixtures/service_fixtures.py
+++ b/cfme/fixtures/service_fixtures.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import pytest
-
 from widgetastic.utils import partial_match
 
 from cfme.common.provider import cleanup_vm
@@ -28,9 +27,9 @@ def catalog_item(provider, provisioning, vm_name, dialog, catalog):
 
 
 def create_catalog_item(provider, provisioning, vm_name, dialog, catalog, console_template=None):
-
-    template, host, datastore, iso_file, catalog_item_type, vlan = map(provisioning.get,
-        ('template', 'host', 'datastore', 'iso_file', 'catalog_item_type', 'vlan'))
+    catalog_item_type = provider.catalog_name
+    template, host, datastore, iso_file, vlan = map(provisioning.get,
+        ('template', 'host', 'datastore', 'iso_file', 'vlan'))
     if console_template:
         logger.info("Console template name : {}".format(console_template.name))
         template = console_template.name

--- a/cfme/infrastructure/provider/rhevm.py
+++ b/cfme/infrastructure/provider/rhevm.py
@@ -1,12 +1,12 @@
 from widgetastic.widget import View, Text
 from widgetastic_patternfly import Tab, Input, BootstrapSwitch, Button
-
-from cfme.common.provider_views import BeforeFillMixin
-from cfme.utils import version
-from . import InfraProvider
-from cfme.common.provider import CANDUEndpoint, DefaultEndpoint, DefaultEndpointForm
 from wrapanapi.rhevm import RHEVMSystem
+
+from cfme.common.provider import CANDUEndpoint, DefaultEndpoint, DefaultEndpointForm
+from cfme.common.provider_views import BeforeFillMixin
 from cfme.exceptions import ItemNotFound
+from cfme.utils import version, deferred_verpick
+from . import InfraProvider
 
 
 class RHEVMEndpoint(DefaultEndpoint):
@@ -41,6 +41,10 @@ class RHEVMEndpointForm(View):
 
 
 class RHEVMProvider(InfraProvider):
+    catalog_name = deferred_verpick({
+        version.LOWEST: 'RHEV',
+        '5.9.0.17': 'Red Hat Virtualization',
+    })
     type_name = "rhevm"
     mgmt_class = RHEVMSystem
     db_types = ["Redhat::InfraManager"]

--- a/cfme/infrastructure/provider/scvmm.py
+++ b/cfme/infrastructure/provider/scvmm.py
@@ -1,8 +1,8 @@
 from widgetastic_patternfly import BootstrapSelect, Input
+from wrapanapi.scvmm import SCVMMSystem
 
 from cfme.common.provider import DefaultEndpoint, DefaultEndpointForm
 from . import InfraProvider
-from wrapanapi.scvmm import SCVMMSystem
 
 
 class SCVMMEndpoint(DefaultEndpoint):
@@ -20,6 +20,7 @@ class SCVMMEndpointForm(DefaultEndpointForm):
 
 
 class SCVMMProvider(InfraProvider):
+    catalog_name = "SCVMM"
     STATS_TO_MATCH = ['num_template', 'num_vm']
     type_name = "scvmm"
     mgmt_class = SCVMMSystem

--- a/cfme/infrastructure/provider/virtualcenter.py
+++ b/cfme/infrastructure/provider/virtualcenter.py
@@ -1,8 +1,8 @@
 from wrapanapi.virtualcenter import VMWareSystem
 
 from cfme.common.provider import DefaultEndpoint, DefaultEndpointForm
-from . import InfraProvider
 from cfme.exceptions import ItemNotFound
+from . import InfraProvider
 
 
 class VirtualCenterEndpoint(DefaultEndpoint):
@@ -14,6 +14,7 @@ class VirtualCenterEndpointForm(DefaultEndpointForm):
 
 
 class VMwareProvider(InfraProvider):
+    catalog_name = "VMware"
     type_name = "virtualcenter"
     mgmt_class = VMWareSystem
     db_types = ["Vmware::InfraManager"]

--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -6,13 +6,12 @@ from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.services.catalogs.catalog import Catalog
 from cfme.services.catalogs.catalog_item import CatalogItem
-from fixtures.provider import setup_one_by_class_or_skip
 from cfme.utils import version
 from cfme.utils.log import logger
 from cfme.utils.rest import create_resource, get_vms_in_service
 from cfme.utils.virtual_machines import deploy_template
 from cfme.utils.wait import wait_for
-
+from fixtures.provider import setup_one_by_class_or_skip
 
 TEMPLATE_TORSO = """{
   "AWSTemplateFormatVersion" : "2010-09-09",
@@ -266,16 +265,16 @@ def service_templates_ui(request, appliance, service_dialog=None, service_catalo
     if not service_catalog:
         service_catalog = service_catalog_obj(request, appliance.rest_api)
 
-    catalog_item_type = 'Generic'
+    catalog_item_type = a_provider.catalog_name if a_provider else 'Generic'
     provisioning_args = {}
 
     catalog_items = []
     new_names = []
     for _ in range(num):
         if a_provider:
-            template, host, datastore, vlan, catalog_item_type = map(
+            template, host, datastore, vlan = map(
                 a_provider.data.get('provisioning').get,
-                ('template', 'host', 'datastore', 'vlan', 'catalog_item_type'))
+                ('template', 'host', 'datastore', 'vlan'))
 
             vm_name = 'test_rest_{}'.format(fauxfactory.gen_alphanumeric())
 
@@ -291,7 +290,6 @@ def service_templates_ui(request, appliance, service_dialog=None, service_catalo
             if a_provider.one_of(RHEVMProvider):
                 provisioning_data['catalog']['provision_type'] = 'Native Clone'
                 provisioning_data['network']['vlan'] = vlan
-                catalog_item_type = 'RHEV'
             elif a_provider.one_of(VMwareProvider):
                 provisioning_data['catalog']['provision_type'] = 'VMware'
                 provisioning_data['network']['vlan'] = vlan

--- a/cfme/tests/services/test_different_dialogs_in_catalogs.py
+++ b/cfme/tests/services/test_different_dialogs_in_catalogs.py
@@ -1,18 +1,16 @@
 # -*- coding: utf-8 -*-
 import fauxfactory
 import pytest
-
 from widgetastic.utils import partial_match
 
 from cfme import test_requirements
-from cfme.services.service_catalogs import ServiceCatalogs
+from cfme.common.provider import cleanup_vm
+from cfme.infrastructure.provider import InfraProvider
 from cfme.services.catalogs.catalog import Catalog
 from cfme.services.catalogs.catalog_item import CatalogItem
-from cfme.infrastructure.provider import InfraProvider
-from cfme.common.provider import cleanup_vm
-from cfme.utils.log import logger
+from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils.blockers import BZ
-
+from cfme.utils.log import logger
 
 pytestmark = [
     pytest.mark.meta(server_roles="+automate"),
@@ -64,8 +62,8 @@ def catalog():
 
 @pytest.fixture(scope="function")
 def catalog_item(provider, provisioning, vm_name, tagcontrol_dialog, catalog):
-    template, host, datastore, iso_file, catalog_item_type, vlan = map(provisioning.get,
-        ('template', 'host', 'datastore', 'iso_file', 'catalog_item_type', 'vlan'))
+    template, host, datastore, iso_file, vlan = map(provisioning.get,
+        ('template', 'host', 'datastore', 'iso_file', 'vlan'))
 
     provisioning_data = {
         'catalog': {'vm_name': vm_name,
@@ -82,7 +80,7 @@ def catalog_item(provider, provisioning, vm_name, tagcontrol_dialog, catalog):
     elif provider.type == 'virtualcenter':
         provisioning_data['catalog']['provision_type'] = 'VMware'
     item_name = fauxfactory.gen_alphanumeric()
-    catalog_item = CatalogItem(item_type=catalog_item_type, name=item_name,
+    catalog_item = CatalogItem(item_type=provider.catalog_name, name=item_name,
                   description="my catalog", display_in=True, catalog=catalog,
                   dialog=tagcontrol_dialog, catalog_name=template,
                   provider=provider, prov_data=provisioning_data)

--- a/cfme/tests/services/test_pxe_service_catalogs.py
+++ b/cfme/tests/services/test_pxe_service_catalogs.py
@@ -1,18 +1,17 @@
 # -*- coding: utf-8 -*-
 import fauxfactory
 import pytest
-
 from widgetastic.utils import partial_match
 
+from cfme import test_requirements
 from cfme.common.provider import cleanup_vm
-from cfme.services.catalogs.catalog_item import CatalogItem
-from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.pxe import get_pxe_server_from_config, get_template_from_config
-from cfme import test_requirements
+from cfme.services.catalogs.catalog_item import CatalogItem
+from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils import testgen
-from cfme.utils.log import logger
 from cfme.utils.conf import cfme_data
+from cfme.utils.log import logger
 
 pytestmark = [
     pytest.mark.meta(server_roles="+automate"),
@@ -87,10 +86,10 @@ def setup_pxe_servers_vm_prov(pxe_server, pxe_cust_template, provisioning):
 def catalog_item(provider, vm_name, dialog, catalog, provisioning, setup_pxe_servers_vm_prov):
     # generate_tests makes sure these have values
     pxe_template, host, datastore, pxe_server, pxe_image, pxe_kickstart, pxe_root_password,\
-        pxe_image_type, pxe_vlan, catalog_item_type = map(
+        pxe_image_type, pxe_vlan = map(
             provisioning.get, (
                 'pxe_template', 'host', 'datastore', 'pxe_server', 'pxe_image', 'pxe_kickstart',
-                'pxe_root_password', 'pxe_image_type', 'vlan', 'catalog_item_type'
+                'pxe_root_password', 'pxe_image_type', 'vlan'
             )
         )
 
@@ -111,7 +110,7 @@ def catalog_item(provider, vm_name, dialog, catalog, provisioning, setup_pxe_ser
     }
 
     item_name = fauxfactory.gen_alphanumeric()
-    catalog_item = CatalogItem(item_type=catalog_item_type, name=item_name,
+    catalog_item = CatalogItem(item_type=provider.catalog_name, name=item_name,
                   description="my catalog", display_in=True, catalog=catalog,
                   dialog=dialog, catalog_name=pxe_template,
                   provider=provider, prov_data=provisioning_data)

--- a/cfme/tests/services/test_service_catalogs.py
+++ b/cfme/tests/services/test_service_catalogs.py
@@ -2,16 +2,15 @@
 import fauxfactory
 import pytest
 
+from cfme import test_requirements
 from cfme.common.provider import cleanup_vm
 from cfme.infrastructure.provider import InfraProvider
-from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.catalogs.catalog_item import CatalogBundle
+from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.service_catalogs import ServiceCatalogs
-from cfme import test_requirements
+from cfme.utils import error
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for_decorator
-from cfme.utils import error
-
 
 pytestmark = [
     pytest.mark.meta(server_roles="+automate"),
@@ -111,12 +110,8 @@ def test_no_template_catalog_item(provider, provisioning, setup_provider, vm_nam
     Metadata:
         test_flag: provision
     """
-    template, catalog_item_type = map(provisioning.get,
-        ('template', 'catalog_item_type'))
-    if provider.type == 'rhevm':
-        catalog_item_type = "RHEV"
     item_name = fauxfactory.gen_alphanumeric()
-    catalog_item = CatalogItem(item_type=catalog_item_type, name=item_name,
+    catalog_item = CatalogItem(item_type=provider.catalog_name, name=item_name,
                   description="my catalog", display_in=True, catalog=catalog, dialog=dialog)
     with error.expected("'Catalog/Name' is required"):
         catalog_item.create()


### PR DESCRIPTION
* This value used to be obtained via the yaml files as part of the
  provisioning data.
* As the catalog_name is provider specific it should be stored in the
  provider module.
* This includes a fix to make 5.9 work properly as the string changed

These values can now be removed from the cfme_data.yaml