### PR TITLE
[1LP][RFR]Fix stack exeption message and fixture update

### DIFF
--- a/cfme/cloud/stack.py
+++ b/cfme/cloud/stack.py
@@ -273,8 +273,8 @@ class Stack(Pretty, BaseEntity, WidgetasticTaggable):
         row[0].check()
         view.toolbar.lifecycle.item_select('Retire selected Orchestration Stacks',
                                            handle_alert=True)
-        view.flash.assert_success_message('Retirement initiated for 1 Orchestration'
-                                                   ' Stack from the CFME Database')
+        view.flash.assert_success_message(
+            'Retirement initiated for 1 Orchestration Stack from the CFME Database')
         if wait:
             def refresh():
                 """Refresh the view"""
@@ -369,7 +369,7 @@ class RelationshipsSecurityGroups(CFMENavigateStep):
             self.prerequisite_view.sidebar.relationships.nav.select(
                 title='Show all Security Groups')
         except NoSuchElementException:
-            raise CandidateNotFound('No security groups for stack, cannot navigate')
+            raise CandidateNotFound({'No security groups for stack': 'cannot navigate'})
 
 
 @navigator.register(Stack, 'RelationshipParameters')
@@ -382,7 +382,7 @@ class RelationshipParameters(CFMENavigateStep):
         try:
             self.prerequisite_view.sidebar.relationships.nav.select(title='Show all Parameters')
         except NoSuchElementException:
-            raise CandidateNotFound('No parameters for stack, cannot navigate')
+            raise CandidateNotFound({'No parameters for stack': 'cannot navigate'})
 
 
 @navigator.register(Stack, 'RelationshipOutputs')
@@ -395,7 +395,7 @@ class RelationshipOutputs(CFMENavigateStep):
         try:
             self.prerequisite_view.sidebar.relationships.nav.select(title='Show all Outputs')
         except NoSuchElementException:
-            raise CandidateNotFound('No outputs for stack, cannot navigate')
+            raise CandidateNotFound({'No outputs for stack': 'cannot navigate'})
 
 
 @navigator.register(Stack, 'RelationshipResources')
@@ -408,4 +408,4 @@ class RelationshipResources(CFMENavigateStep):
         try:
             self.prerequisite_view.sidebar.relationships.nav.select(title='Show all Resources')
         except NoSuchElementException:
-            raise CandidateNotFound('No resources for stack, cannot navigate')
+            raise CandidateNotFound({'No resources for stack': 'cannot navigate'})

--- a/cfme/cloud/stack.py
+++ b/cfme/cloud/stack.py
@@ -88,7 +88,16 @@ class StackOutputsEntities(View):
     """The entities of the resources page"""
     breadcrumb = BreadCrumb()
     title = Text('//div[@id="main-content"]//h1')
-    outputs = Table('//div[@id="list_grid"]//table')
+    outputs = Table('//div[@id="gtl_div"]//table')
+
+
+class StackOutputsDetails(BaseLoggedInPage):
+    title = Text('//div[@id="main-content"]//h1')
+
+    @property
+    def is_displayed(self):
+        """Is this page currently being displayed"""
+        return self.in_stacks and self.entities.title.is_displayed
 
 
 class StackResourcesEntities(View):

--- a/cfme/cloud/stack.py
+++ b/cfme/cloud/stack.py
@@ -168,7 +168,7 @@ class StackSecurityGroupsView(StackView):
     @property
     def is_displayed(self):
         """Is this page currently being displayed"""
-        expected_title = '{} (Security Groups)'.format(self.context['object'].name)
+        expected_title = '{} (All Security Groups)'.format(self.context['object'].name)
         return (
             self.in_stacks and
             self.entities.title.text == expected_title and

--- a/cfme/tests/cloud/test_stack.py
+++ b/cfme/tests/cloud/test_stack.py
@@ -15,17 +15,17 @@ pytestmark = [
 ]
 
 
-@pytest.yield_fixture(scope="module")
+@pytest.fixture(scope="module")
 def stack(setup_provider_modscope, provider, appliance):
     collection = appliance.collections.stacks
-    stack = collection.instantiate(provider.data['provisioning']['stacks'][0], provider=provider)
-    stack.wait_for_exists()
-    yield stack
-
-    try:
-        stack.delete()
-    except Exception:
-        pass
+    for stack_name in provider.data.provisioning.stacks:
+        stack = collection.instantiate(stack_name, provider=provider)
+        try:
+            stack.wait_for_exists()
+            return stack
+        except Exception:
+            pass
+    pytest.skip("No available stacks found for test")
 
 
 @pytest.mark.tier(3)

--- a/cfme/tests/cloud/test_stack.py
+++ b/cfme/tests/cloud/test_stack.py
@@ -1,12 +1,10 @@
-from xml.sax.saxutils import quoteattr
-
 import pytest
 
 from cfme import test_requirements
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.exceptions import CandidateNotFound
 from cfme.utils.appliance.implementations.ui import navigate_to
-from widgetastic_manageiq import Table
+from cfme.cloud.stack import StackOutputsDetails
 
 pytestmark = [
     pytest.mark.ignore_stream("upstream"),
@@ -79,11 +77,10 @@ def test_outputs_link_url(appliance, stack):
         assert view.sidebar.relationships.nav.is_disabled('Outputs (0)')
     else:
         # Outputs is a table with clickable rows
-        # TODO: Need to come back to this one
-        table = Table('//div[@id="list_grid"]//table[contains(@class, "table-selectable")]')
-        table.click_row_by_cells({'Key': 'WebsiteURL'}, 'Key')
-        loc = "//*[normalize-space(text())={}]".format(quoteattr("WebsiteURL"))
-        assert appliance.browser.widgetastic.selenium.is_displayed(loc)
+        key_value = view.entities.outputs[0].key.text
+        view.entities.outputs[0].click()
+        view = appliance.browser.create_view(StackOutputsDetails)
+        assert view.title.text == key_value
 
 
 @pytest.mark.tier(3)

--- a/cfme/tests/cloud/test_stack.py
+++ b/cfme/tests/cloud/test_stack.py
@@ -37,7 +37,7 @@ def test_security_group_link(stack):
     else:
         # Navigation successful, stack had security groups
         assert view.is_displayed
-        assert view.entities.title.text == '{} (Security Groups)'.format(stack.name)
+        assert view.entities.title.text == '{} (All Security Groups)'.format(stack.name)
 
 
 @pytest.mark.tier(3)


### PR DESCRIPTION
Purpose or Intent
=================
Updated CandidateNotFound message type, and stack fixture: removed stack deletion, as we use existing ones, and also add a check to look for available stack not just the first one from yamls.

{{pytest: cfme/tests/cloud/test_stack.py}}