### PR TITLE
[1LP][RFR] Fix get_random_instances by limit the count with the count of instances

### DIFF
--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -670,5 +670,6 @@ def refresh_and_navigate(*args, **kwargs):
 class GetRandomInstancesMixin(object):
 
     def get_random_instances(self, count=1):
+        """Getting random instances of the object."""
         all_instances = self.all()
-        return random.sample(all_instances, count)
+        return random.sample(all_instances, min(count, len(all_instances)))


### PR DESCRIPTION
{{ pytest: cfme/tests/containers/test_properties.py --use-provider cm-env2 }}
- Fix get_random_instances by limit the count with the count of instances
- Added description