### PR TITLE
[WIPTEST] Fix navigation to timelines

### DIFF
--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -455,7 +455,7 @@ class SetRetirement(CFMENavigateStep):
 @navigator.register(Instance, 'Timelines')
 class Timelines(CFMENavigateStep):
     VIEW = InstanceTimelinesView
-    prerequisite = NavigateToSibling('Details')
+    prerequisite = NavigateToSibling('ArchiveDetails')
 
     def step(self, *args, **kwargs):
         self.prerequisite_view.toolbar.monitoring.item_select('Timelines')


### PR DESCRIPTION

Purpose or Intent
=================
Fix navigation to timelines. Instead of going thru Instances by provider, goes thru All instances. 
This way it is possible to navigate to the deleted VM's TL. #6364 #6149 are dependent on this one. 

 {{pytest: -v -q cfme/tests/infrastructure/test_timelines.py --use-provider=vsphere6-nested}}