### PR TITLE
[RFR] Bump dump2polarion version

### DIFF
--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -33,7 +33,7 @@ docker-py==1.10.6
 docker-pycreds==0.2.1
 docutils==0.13.1
 dogpile.cache==0.6.3
-dump2polarion==0.17
+dump2polarion==0.19
 entrypoints==0.2.2
 enum34==1.1.6
 fauxfactory==2.1.0


### PR DESCRIPTION
* adds support for CMP Polarion project
* removes support for legacy CI message bus (will stop working from February)
* adds new way for verifying that testcases were updated in Polarion

Needs to be merged together with MR https://gitlab.cee.redhat.com/cfme-qe/cfme-qe-yamls/merge_requests/431