### PR TITLE
[RFR] Require numpy 1.14.0

### DIFF
--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -90,7 +90,7 @@ netaddr==0.7.19
 netifaces==0.10.6
 notebook==5.0.0
 ntlm-auth==1.0.4
-numpy==1.13.1
+numpy==1.14.0
 oauth2client==4.1.1
 openstacksdk==0.9.16
 ordereddict==1.1


### PR DESCRIPTION
This gets us around RunTimeError's seen while pytest imports plugins. I ran into this after setting up a fresh test environment on fedora27

```
RuntimeError: module compiled against API version 0xc but this version of numpy is 0xb
```
```
ImportError: Error importing plugin "fixtures.version_info": numpy.core.multiarray failed to import
```