### PR TITLE
[WIPTEST] Removing Skip in cfme.tests.containers.test_table_sort

### DIFF
--- a/cfme/tests/containers/test_tables_sort.py
+++ b/cfme/tests/containers/test_tables_sort.py
@@ -29,7 +29,6 @@ TEST_ITEMS = [
 
 @pytest.mark.parametrize('test_item', TEST_ITEMS,
                          ids=[ti.args[1].pretty_id() for ti in TEST_ITEMS])
-@pytest.mark.skip(reason='https://github.com/ManageIQ/integration_tests/issues/6385')
 def test_tables_sort(test_item, soft_assert, appliance):
 
     current_view = navigate_to((test_item.obj if test_item.obj is ContainersProvider


### PR DESCRIPTION
This test was blocked due to https://github.com/ManageIQ/integration_tests/issues/6385, this issue has been closed. 

{{ pytest: cfme/tests/containers/test_tables_sort.py --use-provider ocp-v2 }}