### PR TITLE
[1LP][RFR] Fixing ansible service order credentials test to find correct view to look up creds dropdown

### DIFF
--- a/cfme/services/service_catalogs/ui.py
+++ b/cfme/services/service_catalogs/ui.py
@@ -63,7 +63,7 @@ class OrderForm(ServicesCatalogView):
         param_input = Input(id=ParametrizedString("param_{key}"))
         dropdown = VersionPick({
             Version.lowest(): BootstrapSelect(Parameter("key")),
-            "5.9": DialogFieldDropDownList(ParametrizedLocator(".//div[@input-id='{key|quote}']"))
+            "5.9": DialogFieldDropDownList(ParametrizedLocator(".//div[@input-id={key|quote}]"))
         })
         param_dropdown = VersionPick({
             Version.lowest(): BootstrapSelect(ParametrizedString("param_{key}")),
@@ -149,8 +149,8 @@ class OrderServiceCatalogView(OrderForm):
     @property
     def is_displayed(self):
         return (
-            self.in_explorer and self.service_catalogs.is_opened and
-            self.title.text == 'Order Service "{}"'.format(self.context['object'].name)
+            self.in_service_catalogs and self.service_catalogs.is_opened and
+            'Service "{}"'.format(self.context['object'].name) in self.title.text
         )
 
 

--- a/cfme/tests/ansible/test_embedded_ansible_services.py
+++ b/cfme/tests/ansible/test_embedded_ansible_services.py
@@ -325,11 +325,11 @@ def test_service_ansible_playbook_order_credentials(ansible_catalog_item, ansibl
             "machine_credential": ansible_credential.name
         }
     view = navigate_to(service_catalog, "Order")
-    wait_for(lambda: view.machine_credential.is_displayed, timeout=5)
+    view.wait_displayed()
     if appliance.version < "5.9":
-        options = [o.text for o in view.machine_credential.all_options]
+        options = [o.text for o in (view.fields('credential')).visible_widget.all_options]
     else:
-        options = view.machine_credential.all_options
+        options = (view.fields('credential')).visible_widget.all_options
     assert set(["<Default>", "CFME Default Credential", ansible_credential.name]) == set(options)
 
 


### PR DESCRIPTION


Purpose or Intent
=================

__Fixing__ test_service_ansible_playbook_order_credentials as it was failing due to incorrect is_displayed function, and view couldn't find args. 

{{pytest: cfme/tests/ansible/test_embedded_ansible_services.py  --long-running -s -k 'test_service_ansible_playbook_order_credentials'}}