### PR TITLE
[1LP][RFR] Add messages to wait_for for snapshot tests

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -594,7 +594,8 @@ class Vm(VM):
             view.create.click()
             list_view = self.vm.create_view(InfraVmSnapshotView)
             wait_for(lambda: self.exists, num_sec=300, delay=20,
-                     fail_func=list_view.toolbar.reload.click, handle_exception=True)
+                     fail_func=list_view.toolbar.reload.click, handle_exception=True,
+                     message="Waiting for snapshot create")
 
         def delete(self, cancel=False):
             title = self.description if self.vm.provider.one_of(RHEVMProvider) else self.name
@@ -617,7 +618,8 @@ class Vm(VM):
                 })
                 view.flash.assert_message(flash_message)
 
-            wait_for(lambda: not self.exists, num_sec=300, delay=20, fail_func=view.browser.refresh)
+            wait_for(lambda: not self.exists, num_sec=300, delay=20, fail_func=view.browser.refresh,
+                     message="Waiting for snapshot delete")
 
         def delete_all(self, cancel=False):
             view = navigate_to(self.vm, 'SnapshotsAll')


### PR DESCRIPTION
This can be considered as fix for all of the existing snapshot tests.

The problem in the Automation Issues spreadsheet is that there are multiple failures like this:
"TimedOutError: Could not do function <lambda>()"
This makes it harder to detect why exactly the failure occurred. It's caused by missing attribute 'message' in function wait_for. This PR adds those messages to wait_for functions with regards to snapshot testing.

There are other snapshot issues currently being fixed, the PRT might not look good for this PR. Reviewers, please keep in mind that this PR only adds text messages to wait_for, nothing else changed.

{{ pytest: -v --long-running --use-provider vsphere55 cfme/tests/infrastructure/test_snapshot.py }}