### PR TITLE
[1LP][RFR] Fixing test_tenant_quota

### DIFF
--- a/cfme/configure/access_control/__init__.py
+++ b/cfme/configure/access_control/__init__.py
@@ -1450,20 +1450,25 @@ class Tenant(Updateable, BaseEntity):
     def set_quota(self, **kwargs):
         """ Sets tenant quotas """
         view = navigate_to(self, 'ManageQuotas', wait_for_view=True)
-        view.form.fill({'cpu_cb': kwargs.get('cpu_cb'),
-                        'cpu_txt': kwargs.get('cpu'),
-                        'memory_cb': kwargs.get('memory_cb'),
-                        'memory_txt': kwargs.get('memory'),
-                        'storage_cb': kwargs.get('storage_cb'),
-                        'storage_txt': kwargs.get('storage'),
-                        'vm_cb': kwargs.get('vm_cb'),
-                        'vm_txt': kwargs.get('vm'),
-                        'template_cb': kwargs.get('template_cb'),
-                        'template_txt': kwargs.get('template')})
-        view.save_button.click()
+        changed = view.form.fill({'cpu_cb': kwargs.get('cpu_cb'),
+                                  'cpu_txt': kwargs.get('cpu'),
+                                  'memory_cb': kwargs.get('memory_cb'),
+                                  'memory_txt': kwargs.get('memory'),
+                                  'storage_cb': kwargs.get('storage_cb'),
+                                  'storage_txt': kwargs.get('storage'),
+                                  'vm_cb': kwargs.get('vm_cb'),
+                                  'vm_txt': kwargs.get('vm'),
+                                  'template_cb': kwargs.get('template_cb'),
+                                  'template_txt': kwargs.get('template')})
+        if changed:
+            view.save_button.click()
+            expected_msg = 'Quotas for {} "{}" were saved'.format(self.obj_type, self.name)
+        else:
+            view.cancel_button.click()
+            expected_msg = 'Manage quotas for {} "{}" was cancelled by the user'\
+                .format(self.obj_type, self.name)
         view = self.create_view(DetailsTenantView)
-        view.flash.assert_success_message('Quotas for {} "{}" were saved'.format(
-            self.obj_type, self.name))
+        view.flash.assert_success_message(expected_msg)
         assert view.is_displayed
 
     @property

--- a/cfme/tests/infrastructure/test_tenant_quota.py
+++ b/cfme/tests/infrastructure/test_tenant_quota.py
@@ -57,7 +57,7 @@ def set_roottenant_quota(request, roottenant, appliance):
 @pytest.fixture
 def catalog_item(provider, provisioning, template_name, dialog, catalog, prov_data):
     yield CatalogItem(
-        item_type=provisioning['catalog_item_type'],
+        item_type=provider.catalog_name,
         name='test_{}'.format(fauxfactory.gen_alphanumeric()),
         description="test catalog",
         display_in=True,

--- a/cfme/tests/infrastructure/test_tenant_quota.py
+++ b/cfme/tests/infrastructure/test_tenant_quota.py
@@ -10,6 +10,8 @@ from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils.generators import random_vm_name
 
+from widgetastic.utils import partial_match
+
 pytestmark = [
     test_requirements.quota,
     pytest.mark.meta(server_roles="+automate"),
@@ -34,10 +36,11 @@ def roottenant(appliance):
 
 
 @pytest.fixture
-def prov_data(vm_name):
+def prov_data(vm_name, provisioning):
     return {
         "catalog": {'vm_name': vm_name},
         "environment": {'automatic_placement': True},
+        "network": {'vlan': partial_match(provisioning['vlan'])}
     }
 
 
@@ -83,10 +86,10 @@ def small_vm(provider, small_template_modscope):
 @pytest.mark.parametrize(
     ['set_roottenant_quota', 'custom_prov_data', 'extra_msg', 'approve'],
     [
-        [('cpu', 2), {'hardware': {'num_sockets': '8'}}, '', False],
-        [('storage', 0.01), {}, '', False],
-        [('memory', 2), {'hardware': {'memory': '4096'}}, '', False],
-        [('vm', 1), {'catalog': {'num_vms': '4'}}, '###', True]
+        [('cpu', '2'), {'hardware': {'num_sockets': '8'}}, '', False],
+        [('storage', '0.01'), {}, '', False],
+        [('memory', '2'), {'hardware': {'memory': '4096'}}, '', False],
+        [('vm', '1'), {'catalog': {'num_vms': '4'}}, '###', True]
     ],
     indirect=['set_roottenant_quota'],
     ids=['max_cpu', 'max_storage', 'max_memory', 'max_vms']
@@ -116,10 +119,10 @@ def test_tenant_quota_enforce_via_lifecycle(appliance, provider, setup_provider,
 @pytest.mark.parametrize(
     ['set_roottenant_quota', 'custom_prov_data', 'extra_msg'],
     [
-        [('cpu', 2), {'hardware': {'num_sockets': '8'}}, ''],
-        [('storage', 0.01), {}, ''],
-        [('memory', 2), {'hardware': {'memory': '4096'}}, ''],
-        [('vm', 1), {'catalog': {'num_vms': '4'}}, '###']
+        [('cpu', '2'), {'hardware': {'num_sockets': '8'}}, ''],
+        [('storage', '0.01'), {}, ''],
+        [('memory', '2'), {'hardware': {'memory': '4096'}}, ''],
+        [('vm', '1'), {'catalog': {'num_vms': '4'}}, '###']
     ],
     indirect=['set_roottenant_quota'],
     ids=['max_cpu', 'max_storage', 'max_memory', 'max_vms']
@@ -153,9 +156,9 @@ def test_tenant_quota_enforce_via_service(request, appliance, provider, setup_pr
 @pytest.mark.parametrize(
     ['set_roottenant_quota', 'custom_prov_data'],
     [
-        [('cpu', 2), {'change': 'cores_per_socket', 'value': 4}],
-        [('cpu', 2), {'change': 'sockets', 'value': 4}],
-        [('memory', 2), {'change': 'mem_size', 'value': 4096}]
+        [('cpu', '2'), {'change': 'cores_per_socket', 'value': '4'}],
+        [('cpu', '2'), {'change': 'sockets', 'value': '4'}],
+        [('memory', '2'), {'change': 'mem_size', 'value': '4096'}]
     ],
     indirect=['set_roottenant_quota'],
     ids=['max_cores', 'max_sockets', 'max_memory']


### PR DESCRIPTION
This replaces #6436 based on advice from @quarckster and @mfalesni 

Two tests failed on downstream-59z because of catalog item type issue.

{{pytest: cfme/tests/infrastructure/test_tenant_quota.py -vv --use-provider rhv41}}