### PR TITLE
[WIPTEST] Workaround to create an unpartitioned disk on appliance

### DIFF
--- a/cfme/tests/cli/test_appliance_cli.py
+++ b/cfme/tests/cli/test_appliance_cli.py
@@ -15,6 +15,10 @@ def test_appliance_console_cli_set_hostname(appliance):
 def test_appliance_console_cli_internal_fetch_key(
         app_creds, temp_appliance_unconfig_funcscope, appliance):
     fetch_key_ip = appliance.hostname
+
+    if not temp_appliance_unconfig_funcscope.unpartitioned_disks:
+        temp_appliance_unconfig_funcscope.configure_rhos_db_disk()
+
     temp_appliance_unconfig_funcscope.appliance_console_cli.configure_appliance_internal_fetch_key(
         0, 'localhost', app_creds['username'], app_creds['password'], 'vmdb_production',
         temp_appliance_unconfig_funcscope.unpartitioned_disks[0], fetch_key_ip,


### PR DESCRIPTION
Purpose
=================

__Fixing__ cfme/tests/test_appliance_cli::test_appliance_console_cli_internal_fetch_key to create an unpartitioned disk on any provider.

I have tried to __specify__ provider type and add an extra volume only for OpenStack providers, but it seems no other provider have unpartitioned disks either.

{{pytest: cfme/tests/test_appliance_cli::test_appliance_console_cli_internal_fetch_key}}