### PR TITLE
[WIP]Removed TODO for test_security_group_crud

### DIFF
--- a/cfme/tests/cloud/test_security_groups.py
+++ b/cfme/tests/cloud/test_security_groups.py
@@ -35,7 +35,6 @@ def test_security_group_crud(sec_group):
         * Select Cloud Tenant.
         * Also delete it.
     """
-    # TODO: Update need to be done in future.
     assert sec_group.exists
     sec_group.delete(wait=True)
     assert not sec_group.exists


### PR DESCRIPTION
Purpose or Intent
=================
Removed TODO for test_security_group_crud because test works as expected in docstring.

{{pytest: -v cfme/tests/cloud/test_security_groups.py -k test_security_group_crud}}