### PR TITLE
[RFR] Bump numpy to 1.14 in template requirements as well

### DIFF
--- a/requirements/frozen_docs.txt
+++ b/requirements/frozen_docs.txt
@@ -72,7 +72,7 @@ netaddr==0.7.19
 netifaces==0.10.6
 notebook==5.0.0
 ntlm-auth==1.0.4
-numpy==1.13.1
+numpy==1.14.0
 ordereddict==1.1
 oslo.i18n==3.15.3
 oslo.serialization==2.18.0

--- a/requirements/template_docs.txt
+++ b/requirements/template_docs.txt
@@ -31,7 +31,7 @@ layered-yaml-attrdict-config
 mock
 multimethods.py
 navmazing
-numpy>=1.13.1
+numpy>=1.14.0
 matplotlib>=1.5.1
 paramiko
 parsedatetime


### PR DESCRIPTION
An extension of PR #6528 -- updating version in the other needed places.