### PR TITLE
[RFR] Fix collection on auth tests, auth_data.yaml

### DIFF
--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -2,7 +2,7 @@ from cfme.utils.version import get_stream
 from collections import namedtuple
 from contextlib import contextmanager
 from cfme.test_framework.sprout.client import SproutClient
-from cfme.utils.conf import cfme_data, credentials
+from cfme.utils.conf import cfme_data, credentials, auth_data
 from cfme.utils.log import logger
 import pytest
 from wait_for import wait_for
@@ -103,7 +103,7 @@ def app_creds_modscope():
 
 @pytest.fixture()
 def ipa_creds():
-    fqdn = cfme_data['auth_modes']['ext_ipa']['ipaserver'].split('.', 1)
+    fqdn = auth_data['auth_providers']['ext_ipa']['ipaserver'].split('.', 1)
     creds_key = cfme_data['auth_modes']['ext_ipa']['credentials']
     return{
         'hostname': fqdn[0],

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -103,13 +103,17 @@ def app_creds_modscope():
 
 @pytest.fixture()
 def ipa_creds():
-    fqdn = auth_data['auth_providers']['ext_ipa']['ipaserver'].split('.', 1)
-    creds_key = cfme_data['auth_modes']['ext_ipa']['credentials']
+    try:
+        ext_ipa = auth_data['auth_providers']['ext_ipa']
+    except KeyError:
+        pytest.skip('Missing auth_providers.ext_ipa in auth_data.yaml')
+    fqdn = ext_ipa['ipaserver'].split('.', 1)
+    creds_key = ext_ipa['credentials']
     return{
         'hostname': fqdn[0],
         'domain': fqdn[1],
-        'realm': cfme_data['auth_modes']['ext_ipa']['iparealm'],
-        'ipaserver': cfme_data['auth_modes']['ext_ipa']['ipaserver'],
+        'realm': ext_ipa['iparealm'],
+        'ipaserver': ext_ipa['ipaserver'],
         'username': credentials[creds_key]['principal'],
         'password': credentials[creds_key]['password']
     }

--- a/cfme/fixtures/configure_auth_mode.py
+++ b/cfme/fixtures/configure_auth_mode.py
@@ -67,13 +67,13 @@ def configure_openldap_auth_mode_default_groups(browser, available_auth_modes):
 @pytest.yield_fixture(scope='module')
 def configure_aws_iam_auth_mode(appliance, available_auth_modes):
     """Configure AWS IAM authentication mode"""
-    if 'miq_aws_iam' in available_auth_modes:
+    if 'miq_aws' in available_auth_modes:
         # TODO use new get_auth_settings function to store original settings
         auth_settings = appliance.server.authentication
         orig_mode = auth_settings.auth_mode
         orig_settings = auth_settings.auth_settings
         orig_settings.pop('title')
-        yaml_data = cfme_data.auth_modes.miq_aws_iam.copy()
+        yaml_data = cfme_data.auth_modes.miq_aws.copy()
         creds = credentials[yaml_data.pop('credentials')]  # remove cred key from fill_data with pop
         fill_data = {
             'access_key': creds['username'],
@@ -90,7 +90,7 @@ def configure_aws_iam_auth_mode(appliance, available_auth_modes):
                                           minutes=orig_settings.get('minutes_timeout', '0'))
     else:
         # Need this configuration data to test, can't make up aws_iam account.
-        pytest.skip('miq_aws_iam yaml configuration not available for configure_aws_iam_auth_mode')
+        pytest.skip('miq_aws yaml configuration not available for configure_aws_iam_auth_mode')
 
 
 # TODO remove this fixture, its doing what the above fixtures are doing but taking an argument
@@ -108,7 +108,7 @@ def configure_auth(appliance, request, auth_mode):
         app_auth.configure_auth(**data)
         request.addfinalizer(current_appliance.server.login_admin)
         request.addfinalizer(app_auth.configure_auth)
-    elif auth_mode == 'miq_aws_iam':
+    elif auth_mode == 'miq_aws':
         aws_iam_creds = credentials[data.pop('credentials')]
         data['access_key'] = aws_iam_creds['username']
         data['secret_key'] = aws_iam_creds['password']

--- a/cfme/tests/integration/test_aws_iam_auth_and_roles.py
+++ b/cfme/tests/integration/test_aws_iam_auth_and_roles.py
@@ -4,7 +4,7 @@ from deepdiff import DeepDiff
 
 from cfme.utils.appliance import ViaUI, current_appliance
 from cfme.utils.blockers import BZ
-from cfme.utils.conf import cfme_data, credentials
+from cfme.utils.conf import credentials
 from cfme.roles import role_access_ui_58z, role_access_ui_59z, role_access_ssui
 
 
@@ -14,16 +14,13 @@ def auth_groups():
         tuple containing (group_name, context)
         where group_name is a string and context is ViaUI/SSUI
     """
-    if 'miq_aws_iam' not in cfme_data.get('auth_modes'):
-        pytest.skip('No yaml entry for "miq_aws_iam" in cfme_data.auth_modes')
-    else:
-        parameter_list = []
-        # TODO: Include SSUI role_access dict and VIASSUI context
-        roles_and_context = [(
-            role_access_ui_59z if current_appliance.version >= '5.9' else role_access_ui_58z, ViaUI)
-        ]
-        for group_dict, context in roles_and_context:
-            parameter_list.extend([(group, context) for group in group_dict.keys()])
+    parameter_list = []
+    # TODO: Include SSUI role_access dict and VIASSUI context
+    roles_and_context = [(
+        role_access_ui_59z if current_appliance.version >= '5.9' else role_access_ui_58z, ViaUI)
+    ]
+    for group_dict, context in roles_and_context:
+        parameter_list.extend([(group, context) for group in group_dict.keys()])
     return parameter_list
 
 

--- a/cfme/tests/integration/test_cfme_auth.py
+++ b/cfme/tests/integration/test_cfme_auth.py
@@ -4,7 +4,7 @@ from widgetastic_patternfly import CandidateNotFound
 
 from cfme.base.credential import Credential
 from cfme.utils.blockers import GH
-from cfme.utils.conf import cfme_data
+from cfme.utils.conf import auth_data
 from cfme.utils.log import logger
 
 pytestmark = pytest.mark.uncollectif(lambda appliance: appliance.is_pod)
@@ -14,7 +14,7 @@ CREATE_GROUP = 'create_group'
 
 
 def pytest_generate_tests(metafunc):
-    auth_modes = cfme_data.get('auth_test_data')
+    auth_modes = auth_data.get('auth_providers')
     if not auth_modes:
         return
     argvalues = [[authmode] for authmode in auth_modes]
@@ -24,10 +24,10 @@ def pytest_generate_tests(metafunc):
 
 @pytest.fixture()
 def data(request, auth_mode, add_group):
-    auth_data = cfme_data['auth_test_data'].get(auth_mode, {})
+    yaml_data = auth_data['auth_test'].get(auth_mode, {})
     if add_group == 'evm_default_group':
-        auth_data['get_groups'] = False
-    return auth_data
+        yaml_data['get_groups'] = False
+    return yaml_data
 
 
 @pytest.fixture()
@@ -89,9 +89,9 @@ def test_auth_configure(appliance, request, configure_auth, group, user, data):
        authmodes tested as part of this test: ext_ipa, ext_openldap, miq_openldap
        e.g. test_auth[ext-ipa_create-group]
         Prerequisities:
-            * ``cfme_data.yaml`` file
+            * ``auth_data.yaml`` file
         Steps:
-            * Make sure corresponding auth_modes data is updated to ``cfme_data.yaml``
+            * Make sure corresponding auth_modes data is updated to ``auth_data.yaml``
             * this test fetches the auth_modes from yaml and generates tests per auth_mode.
     """
 


### PR DESCRIPTION
Fix collection for auth tests, a change to cfme_data.yaml (moving things to auth_data.yaml) broke collection.

I have #6538 open to actually do some auth test refactoring, this is fix for collection.

Only looking for collect-only to be fixed - there likely will be auth test failures, see #6538 for any of those fixes.