### PR TITLE
[RFR][1LP] Remove deprecated use of base_url in env appliance configuration

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -709,7 +709,6 @@ class BaseProvider(WidgetasticTaggable, Updateable, Navigatable):
         """
         domain = credential_dict.get('domain')
         token = credential_dict.get('token')
-        print str(credential_dict)
         if not cred_type:
             return Credential(principal=credential_dict['username'],
                               secret=credential_dict['password'],

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -709,6 +709,7 @@ class BaseProvider(WidgetasticTaggable, Updateable, Navigatable):
         """
         domain = credential_dict.get('domain')
         token = credential_dict.get('token')
+        print str(credential_dict)
         if not cred_type:
             return Credential(principal=credential_dict['username'],
                               secret=credential_dict['password'],

--- a/cfme/scripting/sprout.py
+++ b/cfme/scripting/sprout.py
@@ -100,13 +100,14 @@ def populate_config_from_appliances(appliance_data):
 
     y_data['appliances'] = []
     for app in appliance_data:
-        y_data['appliances'].append({'base_url': 'https://{}/'.format(app['ip_address'])})
+        app_config = dict(
+            hostname=app['ip_address'],
+            ui_protocol="https",
+        )
+        y_data['appliances'].append(app_config)
     with open(file_name, 'w') as f:
-        try:
-            del y_data['base_url']
-        except KeyError:
-            pass
-        yaml.dump(y_data, f, default_flow_style=False)
+        # Use safe dump to avoid !!python/unicode tags
+        yaml.safe_dump(y_data, f, default_flow_style=False)
 
 
 if __name__ == "__main__":

--- a/cfme/test_framework/sprout/plugin.py
+++ b/cfme/test_framework/sprout/plugin.py
@@ -19,7 +19,7 @@ this option can be specified more than once, and must be specified at least two 
 def pytest_addoption(parser):
     group = parser.getgroup("cfme")
     group._addoption(
-        '--appliance', dest='appliances', action='append', metavar='base_url', help=_appliance_help,
+        '--appliance', dest='appliances', action='append', metavar='appliance_url', help=_appliance_help,
         default=[])
     group._addoption('--use-sprout', dest='use_sprout', action='store_true',
         default=False, help="Use Sprout for provisioning appliances.")
@@ -78,9 +78,6 @@ def mangle_in_sprout_appliances(config):
         log.info("- %s is %s", url, appliance['name'])
 
     mgr.reset_timer()
-    # Set the base_url for collection purposes on the first appliance
-    conf.runtime["env"]["base_url"] = appliances[0]
-    # Retrieve and print the template_name for Jenkins to pick up
     template_name = requested_appliances[0]["template_name"]
     conf.runtime["cfme_data"]["basic_info"]["appliance_template"] = template_name
     log.info("appliance_template: %s", template_name)

--- a/cfme/test_framework/sprout/plugin.py
+++ b/cfme/test_framework/sprout/plugin.py
@@ -19,8 +19,8 @@ this option can be specified more than once, and must be specified at least two 
 def pytest_addoption(parser):
     group = parser.getgroup("cfme")
     group._addoption(
-        '--appliance', dest='appliances', action='append', metavar='appliance_url', help=_appliance_help,
-        default=[])
+        '--appliance', dest='appliances', action='append', metavar='appliance_url',
+        help=_appliance_help, default=[])
     group._addoption('--use-sprout', dest='use_sprout', action='store_true',
         default=False, help="Use Sprout for provisioning appliances.")
     group._addoption('--sprout-appliances', dest='sprout_appliances', type=int,

--- a/cfme/tests/services/test_operations.py
+++ b/cfme/tests/services/test_operations.py
@@ -95,7 +95,7 @@ def generated_request(appliance,
     provision_request = appliance.collections.requests.instantiate(cells=request_cells)
     yield provision_request
 
-    browser().get(store.base_url)
+    browser().get(store.current_appliance.url)
     appliance.server.login_admin()
 
     provision_request.remove_request()

--- a/cfme/tests/services/test_operations.py
+++ b/cfme/tests/services/test_operations.py
@@ -95,7 +95,7 @@ def generated_request(appliance,
     provision_request = appliance.collections.requests.instantiate(cells=request_cells)
     yield provision_request
 
-    browser().get(store.current_appliance.url)
+    browser().get(appliance.url)
     appliance.server.login_admin()
 
     provision_request.remove_request()

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -233,7 +233,6 @@ class IPAppliance(object):
         'db_port': 'db_port',
         'ssh_port': 'ssh_port',
         'project': 'project',
-        'ui_protocol': 'ui_protocol',
     }
     CONFIG_NONGLOBAL = {'hostname'}
     PROTOCOL_PORT_MAPPING = {'http': 80, 'https': 443}
@@ -746,7 +745,6 @@ class IPAppliance(object):
         If the ports do not correspond the protocols' default port numbers, then the ports are
         explicitly specified as well.
         """
-        # If address wasn't set in __init__, use the hostname from base_url
         show_port = self.PROTOCOL_PORT_MAPPING[self.ui_protocol] != self.ui_port
         if show_port:
             return '{}://{}:{}/'.format(self.ui_protocol, self.hostname, self.ui_port)
@@ -2616,13 +2614,6 @@ def load_appliances(appliance_list, global_kwargs):
 
         if kwargs.pop('dummy', False):
             result.append(DummyAppliance(**kwargs))
-            continue
-        if 'base_url' in kwargs:
-            warnings.warn(
-                'Your appliance specification has old-style base_url, please change',
-                category=DeprecationWarning, stacklevel=2)
-            url = kwargs.pop('base_url')
-            appliance = IPAppliance.from_url(url, **kwargs)
         else:
             appliance = IPAppliance(**{IPAppliance.CONFIG_MAPPING[k]: v for k, v in kwargs.items()})
         result.append(appliance)
@@ -2671,35 +2662,25 @@ class DummyAppliance(object):
 
 
 def load_appliances_from_config(config):
-    """Backwards-compatible config loader.
+    """
+    Instantiate IPAppliance objects based on data in ``appliances`` section of config.
 
     The ``config`` contains some global values and ``appliances`` key which contains a list of dicts
-    that have the same keys as ``IPAppliance.CONFIG_MAPPING``'s keys. If ``appliances`` key is not
-    present, it is assumed it is old-format definition and the whole dict is used as a reference
-    for one single appliance.
+    that have the same keys as ``IPAppliance.CONFIG_MAPPING``'s keys.
 
-    The global values in the root of the dict (in case of ``appliances`` present) have lesser
-    priority than the values in appliance definitions themselves
+    The global values in the root of the dict have lesser priority than the values in appliance definitions themselves
 
     Args:
         config: A dictionary with the configuration
     """
     if 'appliances' not in config:
-        # old-style setup
-        warnings.warn(
-            'Your conf.env has old-style base_url', category=DeprecationWarning, stacklevel=2)
-        appliances = [{
-            k: config[k]
-            for k in IPAppliance.CONFIG_MAPPING.keys()
-            if k in config}]
-        global_kwargs = {}
-    else:
-        # new-style setup
-        appliances = config['appliances']
-        global_kwargs = {
-            k: config[k]
-            for k in IPAppliance.CONFIG_MAPPING.keys()
-            if k not in IPAppliance.CONFIG_NONGLOBAL and k in config}
+        raise ValueError("Invalid config: missing an 'appliances' section")
+    appliances = config['appliances']
+
+    global_kwargs = {
+        k: config[k]
+        for k in IPAppliance.CONFIG_MAPPING.keys()
+        if k not in IPAppliance.CONFIG_NONGLOBAL and k in config}
 
     return load_appliances(appliances, global_kwargs)
 

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2607,7 +2607,7 @@ def load_appliances(appliance_list, global_kwargs):
         List of :py:class:`IPAppliance`
     """
     result = []
-    for appliance_kwargs in appliance_list:
+    for num, appliance_kwargs in enumerate(appliance_list):
         kwargs = {}
         kwargs.update(global_kwargs)
         kwargs.update(appliance_kwargs)
@@ -2615,7 +2615,14 @@ def load_appliances(appliance_list, global_kwargs):
         if kwargs.pop('dummy', False):
             result.append(DummyAppliance(**kwargs))
         else:
-            appliance = IPAppliance(**{IPAppliance.CONFIG_MAPPING[k]: v for k, v in kwargs.items()})
+            mapping = IPAppliance.CONFIG_MAPPING
+
+            if not any(k in mapping for k in kwargs):
+                raise ValueError(
+                    "No valid IPAppliance kwargs found in config for appliance #{}".format(num)
+                )
+                
+            appliance = IPAppliance(**{mapping[k]: v for k, v in kwargs.items() if k in mapping})
         result.append(appliance)
     return result
 

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2668,7 +2668,8 @@ def load_appliances_from_config(config):
     The ``config`` contains some global values and ``appliances`` key which contains a list of dicts
     that have the same keys as ``IPAppliance.CONFIG_MAPPING``'s keys.
 
-    The global values in the root of the dict have lesser priority than the values in appliance definitions themselves
+    The global values in the root of the dict have lesser priority than the values in appliance
+    definitions themselves
 
     Args:
         config: A dictionary with the configuration

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2621,8 +2621,8 @@ def load_appliances(appliance_list, global_kwargs):
                 raise ValueError(
                     "No valid IPAppliance kwargs found in config for appliance #{}".format(num)
                 )
-                
             appliance = IPAppliance(**{mapping[k]: v for k, v in kwargs.items() if k in mapping})
+
         result.append(appliance)
     return result
 

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2607,7 +2607,7 @@ def load_appliances(appliance_list, global_kwargs):
         List of :py:class:`IPAppliance`
     """
     result = []
-    for num, appliance_kwargs in enumerate(appliance_list):
+    for idx, appliance_kwargs in enumerate(appliance_list):
         kwargs = {}
         kwargs.update(global_kwargs)
         kwargs.update(appliance_kwargs)
@@ -2619,7 +2619,7 @@ def load_appliances(appliance_list, global_kwargs):
 
             if not any(k in mapping for k in kwargs):
                 raise ValueError(
-                    "No valid IPAppliance kwargs found in config for appliance #{}".format(num)
+                    "No valid IPAppliance kwargs found in config for appliance #{}".format(idx)
                 )
             appliance = IPAppliance(**{mapping[k]: v for k, v in kwargs.items() if k in mapping})
 

--- a/cfme/utils/browser.py
+++ b/cfme/utils/browser.py
@@ -232,7 +232,7 @@ class BrowserManager(object):
         self._browser_renew_thread = None
 
     def coerce_url_key(self, key):
-        return key or store.base_url
+        return key or store.current_appliance.url
 
     @classmethod
     def from_conf(cls, browser_conf):

--- a/cfme/utils/browser.py
+++ b/cfme/utils/browser.py
@@ -232,7 +232,7 @@ class BrowserManager(object):
         self._browser_renew_thread = None
 
     def coerce_url_key(self, key):
-        return key or store.current_appliance.url
+        return key or store.current_appliance.url  # TODO: don't rely on store.current_appliance
 
     @classmethod
     def from_conf(cls, browser_conf):

--- a/cfme/utils/net.py
+++ b/cfme/utils/net.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 import socket
 import os
 import re
-import urlparse
 from fixtures.pytest_store import store
 
 from cfme.utils.log import logger
@@ -63,7 +62,7 @@ def net_check(port, addr=None, force=False):
     """Checks the availablility of a port"""
     port = int(port)
     if not addr:
-        addr = urlparse.urlparse(store.base_url).hostname
+        addr = store.current_appliance.hostname
     if port not in _ports[addr] or force:
         # First try DNS resolution
         try:
@@ -88,7 +87,7 @@ def net_check_remote(port, addr=None, machine_addr=None, ssh_creds=None, force=F
         addr = my_ip_address()
     if port not in _ports[addr] or force:
         if not machine_addr:
-            machine_addr = urlparse.urlparse(store.base_url).hostname
+            machine_addr = store.current_appliance.hostname
         if not ssh_creds:
             ssh_client = store.current_appliance.ssh_client
         else:

--- a/cfme/utils/ssh.py
+++ b/cfme/utils/ssh.py
@@ -131,12 +131,11 @@ class SSHClient(paramiko.SSHClient):
         }
         # Load credentials and destination from confs, if connect_kwargs is empty
         if not connect_kwargs.get('hostname'):
-            parsed_url = urlparse(store.base_url)
-            default_connect_kwargs["port"] = ports.SSH
+            default_connect_kwargs['hostname'] = store.current_appliance.hostname
+            default_connect_kwargs['port'] = ports.SSH
             default_connect_kwargs['username'] = conf.credentials['ssh']['username']
             default_connect_kwargs['password'] = conf.credentials['ssh']['password']
-            default_connect_kwargs['hostname'] = parsed_url.hostname
-        default_connect_kwargs["port"] = connect_kwargs.pop('port', ports.SSH)
+        default_connect_kwargs['port'] = connect_kwargs.pop('port', ports.SSH)
 
         # Overlay defaults with any passed-in kwargs and store
         default_connect_kwargs.update(connect_kwargs)

--- a/cfme/utils/tests/test_ipappliance.py
+++ b/cfme/utils/tests/test_ipappliance.py
@@ -21,17 +21,6 @@ def test_ipappliance_from_url():
     assert ip_a.hostname == address
 
 
-# INVALID TEST CASE. You should always provide the hostname, unless you are an Appliance
-# def test_ipappliance_use_baseurl(appliance):
-#     if isinstance(appliance, DummyAppliance):
-#         pytest.xfail("Dummy appliance cant provide base_url")
-#     ip_a = IPAppliance()
-#     ip_a_parsed = urlparse(ip_a.url)
-#     env_parsed = urlparse(store.base_url)
-#     assert (ip_a_parsed.scheme, ip_a_parsed.netloc) == (env_parsed.scheme, env_parsed.netloc)
-#     assert ip_a.address in store.base_url
-
-
 @pytest.mark.skipif(pytest.config.getoption('--dummy-appliance'),
                     reason="infra_provider cant support dummy instance")
 def test_ipappliance_managed_providers(appliance, infra_provider):

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -46,8 +46,8 @@ Obtaining what you need (Project Setup)
           you the port numbers it is using and you should be able to VNC to it to see what is happening.
 
 * After all this, you should be able to run ``miq shell`` and or ``miq-runtest --collect-only``. Be
-  aware that you will also have to add your appliance to the ``env.yaml`` in either the
-  ``base_url``(deprecated) section, or in the newer ``appliances`` list.
+  aware that you will also have to add your appliance to the ``env.yaml`` in the ``appliances`` list. Support
+  for using ``base_url`` in ``env.yaml`` to specify an appliance has been removed.
 
 * You will also need to run the configuration script against the appliance that you intend to test
   if you didn't get it from sprout. All external usage of this framework will be non-sprout unless
@@ -128,7 +128,7 @@ started as quickly as possible:
 * ``cfme_tests`` expects an appliance, with an IP visible to the machine that runs ``cfme_tests``
 
   * If this is not the case (eg. CFME behind NAT, a container, whatever), you MUST specify the
-    ``base_url`` in configuration with a port, which is quite obvious, but people tend to forget
+    appliance in env configuration with a port, which is quite obvious, but people tend to forget
     ``cfme_tests`` also uses SSH and Postgres extensively, therefore you MUST have those services
     accessible and ideally on the expected ports. If you don't have them running on the expected
     ports, you MUST specify them manually using ``--port-ssh`` and ``--port-db`` command-line
@@ -180,12 +180,12 @@ started as quickly as possible:
 * Using :py:class:`utils.appliance.Appliance` only makes sense for appliances on providers that
   are specified in ``cfme_data.yaml``.
 
-* If you want to test a single appliance, set the ``base_url`` in the ``conf/env.yaml``
+* If you want to test a single appliance, set the ``hostname`` in the first list item under ``appliances``
+  in the ``conf/env.yaml``
 
 * If you want to test against multiple appliances, use the ``--appliance w.x.y.z`` parameter. Eg. if
   you have appliances ``1.2.3.4`` and ``2.3.4.5``, then append ``--appliance 1.2.3.4 --appliance 2.3.4.5``
-  to the ``miq-runtest`` command. Due to a glitch that has not been resolved yet, you should set the
-  ``base_url`` to the first appliance.
+  to the ``miq-runtest`` command.
 
 * If you have access to Sprout, you can request a fresh appliance to run your tests, you can use
   command like this one:

--- a/docs/guides/browser_configuration.rst
+++ b/docs/guides/browser_configuration.rst
@@ -73,16 +73,17 @@ For example::
       (e.g. ``browserName`` does not become ``browser_name``).
 
 
-base_url
+Appliance hostname
 --------
 
-Regardless of which Webdriver you use, ``base_url`` must be set. It is assumed that the website
-at the ``base_url`` will be a working CFME UI.
+Regardless of which Webdriver you use, ``hostname`` must be set for each appliance listed in ``appliances``.
+It is assumed that the website at the ``hostname`` will be a working CFME UI. You can specify ``ui_protocol``
+or ``ui_port`` to switch between http/https or change the web server port, respectively.
 
 .. note ::
 
-    ``base_url`` is not solely used by the browser. Other functionality, such as the SSH and SOAP
-    clients, derive their destination addresses from the ``base_url``.
+    ``hostname`` is not solely used by the browser. Other functionality, such as the SSH and SOAP
+    clients, derive their destination addresses from the ``hostname``.
 
 Firefox
 -------

--- a/docs/guides/container.rst
+++ b/docs/guides/container.rst
@@ -23,7 +23,8 @@ Finally, you have to put ``container`` in the ``env.yaml`` so it looks something
 
 .. code-block:: yaml
 
-    base_url: https://1.2.3.4/
+    appliances:
+        - hostname: 1.2.3.4
     container: cfme
     whatever: else_is_required
 

--- a/docs/guides/tipsntricks.rst
+++ b/docs/guides/tipsntricks.rst
@@ -94,11 +94,11 @@ Running commands on another appliance
              As this is now the case, it is unlikely that the context manager will be needed for
              much longer.
 
-We implement a small appliance stack in the framework. When a test first starts it loads up the
-base_url appliance as the first appliance in the stack. From then on, all the browsing operations,
-database operations and ssh commands are run on the top appliance in the stack. From time to time
-it becomes necessary to run commands on another appliance. Let's say you were trying to get two
-appliances to talk to each other, in this case, you would use the context manager for appliances.
+We implement a small appliance stack in the framework. When a test first starts it loads up the first
+appliance in the stack. From then on, all the browsing operations, database operations and ssh commands
+are run on the top appliance in the stack. From time to time it becomes necessary to run commands on
+another appliance. Let's say you were trying to get two appliances to talk to each other, in this case,
+you would use the context manager for appliances.
 
 By default, even if you add a new appliance onto the stack, the browser operations will keep
 happening on the last appliance that was used, however, there is a simple way to steal the browsers

--- a/docs/guides/vnc_selenium.rst
+++ b/docs/guides/vnc_selenium.rst
@@ -142,7 +142,8 @@ An example of the yaml is below:
 
 .. code-block:: yaml
 
-   base_url: https://10.11.12.13
+   appliances:
+       - hostname: 10.11.12.13
    browser:
        webdriver: Remote
        webdriver_options:

--- a/fixtures/parallelizer/__init__.py
+++ b/fixtures/parallelizer/__init__.py
@@ -4,7 +4,8 @@ The Workflow
 ------------
 
 - Master py.test process starts up, inspects config to decide how many slave to start, if at all
-- py.test config.option.appliances and the related --appliance cmdline flag are used to count no. of needed slaves
+- py.test config.option.appliances and the related --appliance cmdline flag are used to count
+  the number of needed slaves
 - Slaves are started
 - Master runs collection, blocks until slaves report their collections
 - Slaves each run collection and submit them to the master, then block inside their runtest loop,

--- a/fixtures/parallelizer/__init__.py
+++ b/fixtures/parallelizer/__init__.py
@@ -4,12 +4,7 @@ The Workflow
 ------------
 
 - Master py.test process starts up, inspects config to decide how many slave to start, if at all
-
-  - env['parallel_base_urls'] is inspected first
-  - py.test config.option.appliances and the related --appliance cmdline flag are used
-    if env['parallel_base_urls'] isn't set
-  - if neither are set, no parallelization happens
-
+- py.test config.option.appliances and the related --appliance cmdline flag are used to count no. of needed slaves
 - Slaves are started
 - Master runs collection, blocks until slaves report their collections
 - Slaves each run collection and submit them to the master, then block inside their runtest loop,

--- a/fixtures/parallelizer/remote.py
+++ b/fixtures/parallelizer/remote.py
@@ -19,7 +19,7 @@ class SlaveManager(object):
         self.session = None
         self.collection = None
         self.slaveid = conf.runtime['env']['slaveid'] = slaveid
-        self.appliance_config = conf.runtime['env']['appliances'] = appliance_config
+        self.appliance_config = conf.runtime['env']['appliances'][0] = appliance_config
         self.log = cfme.utils.log.logger
         conf.clear()
         # Override the logger in utils.log

--- a/fixtures/parallelizer/remote.py
+++ b/fixtures/parallelizer/remote.py
@@ -1,3 +1,4 @@
+import json
 import signal
 
 import zmq
@@ -13,12 +14,12 @@ SLAVEID = None
 
 class SlaveManager(object):
     """SlaveManager which coordinates with the master process for parallel testing"""
-    def __init__(self, config, slaveid, base_url, zmq_endpoint):
+    def __init__(self, config, slaveid, appliance_config, zmq_endpoint):
         self.config = config
         self.session = None
         self.collection = None
         self.slaveid = conf.runtime['env']['slaveid'] = slaveid
-        self.base_url = conf.runtime['env']['base_url'] = base_url
+        self.appliance_config = conf.runtime['env']['appliances'] = appliance_config
         self.log = cfme.utils.log.logger
         conf.clear()
         # Override the logger in utils.log
@@ -208,7 +209,14 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     from cfme.utils.appliance import IPAppliance, stack
-    appliance = IPAppliance.from_json(args.appliance_json)
+
+    try:
+        appliance_config = json.loads(args.appliance_json)
+    except ValueError:
+        self.log.error("Error parsing appliance json")
+        raise
+
+    appliance = IPAppliance(**appliance_config)
     stack.push(appliance)
 
     # overwrite the default logger before anything else is imported,
@@ -233,7 +241,7 @@ if __name__ == '__main__':
         conf.runtime["cfme_data"]["basic_info"]["appliance_template"] = template_name
         conf.runtime["cfme_data"]["basic_info"]["appliances_provider"] = provider_name
     config = _init_config(slave_options, slave_args)
-    slave_manager = SlaveManager(config, args.slaveid, appliance.url,
+    slave_manager = SlaveManager(config, args.slaveid, appliance_config,
         conf.slave_config['zmq_endpoint'])
     config.pluginmanager.register(slave_manager, 'slave_manager')
     config.hook.pytest_cmdline_main(config=config)

--- a/fixtures/parallelizer/remote.py
+++ b/fixtures/parallelizer/remote.py
@@ -210,19 +210,20 @@ if __name__ == '__main__':
 
     from cfme.utils.appliance import IPAppliance, stack
 
-    try:
-        appliance_config = json.loads(args.appliance_json)
-    except ValueError:
-        self.log.error("Error parsing appliance json")
-        raise
-
-    appliance = IPAppliance(**appliance_config)
-    stack.push(appliance)
-
     # overwrite the default logger before anything else is imported,
     # to get our best chance at having everything import the replaced logger
     import cfme.utils.log
     cfme.utils.log.setup_for_worker(args.slaveid)
+    slave_log = cfme.utils.log.logger
+
+    try:
+        appliance_config = json.loads(args.appliance_json)
+    except ValueError:
+        slave_log.error("Error parsing appliance json")
+        raise
+
+    appliance = IPAppliance(**appliance_config)
+    stack.push(appliance)
 
     from fixtures import terminalreporter
     from fixtures.pytest_store import store

--- a/fixtures/parallelizer/remote.py
+++ b/fixtures/parallelizer/remote.py
@@ -208,6 +208,8 @@ if __name__ == '__main__':
     parser.add_argument('ts', help='The timestap to use for collections')
     args = parser.parse_args()
 
+    # TODO: clean the logic up here
+
     from cfme.utils.appliance import IPAppliance, stack
 
     # overwrite the default logger before anything else is imported,

--- a/fixtures/pytest_store.py
+++ b/fixtures/pytest_store.py
@@ -87,12 +87,6 @@ class Store(object):
     def has_config(self):
         return self.config is not None
 
-    @property
-    def base_url(self):
-        """ If there is a current appliance the base url of that appliance is returned
-            else, the base_url from the config is returned."""
-        return self.current_appliance.url
-
     def _maybe_get_plugin(self, name):
         """ returns the plugin if the pluginmanager is availiable and the plugin exists"""
         return self.pluginmanager and self.pluginmanager.getplugin(name)

--- a/notebooks/Browser Session.ipynb
+++ b/notebooks/Browser Session.ipynb
@@ -24,7 +24,7 @@
       "from utils.appliance.implementations.ui import navigate_to\n",
       "from utils import providers, version, conf\n",
       "from cfme.configure import configuration \n",
-      "# conf.env['base_url'] = 'http://10.8.59.157'\n",
+      "# conf.env['appliances'][0]['hostname'] = '10.8.59.157'\n",
       "navigate_to(current_appliance.server, 'Dashboard')\n",
       "\n",
       "\n",

--- a/scripts/dockerbot/pytestbase/setup.sh
+++ b/scripts/dockerbot/pytestbase/setup.sh
@@ -189,7 +189,7 @@ log "use_sprout: $USE_SPROUT"
 # Now fill out the env yaml with ALL THE THINGS
 cat > $CFME_REPO_DIR/conf/env.local.yaml <<EOF
 appliances:
-  - base_url: $APPLIANCE
+  - hostname: $IP_ADDRESS
 $BROWSER_SECTION
 
 artifactor:

--- a/scripts/wait_for_appliance_ui.py
+++ b/scripts/wait_for_appliance_ui.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python2
 
-"""Wait for an appliance UI to be usable
+"""
+Wait for an appliance UI to be usable
 
 Specifically, it will block until the specified URL returns status code 200.
-
-It will use base_url from conf.env by default.
-
 """
 import argparse
 import sys


### PR DESCRIPTION
Purpose or Intent
=================
Defining an appliance in env.yaml like this:
```yaml
base_url: https://1.2.3.4
```
...or like this...
```yaml
appliances:
    - base_url: https://1.2.3.4
```
is deprecated.

Our code was written to support both the "old way" (base_url) or "new way" (list of appliances). We've decided to clean up support for base_url entirely. Corresponding docs/scripts/plugins that reference or create env YAML files are also updated. Moving forward, env.yaml *must* be set up in the "new way", e.g.:
```yaml
appliances:
    - hostname: 1.2.3.4
    - hostname: 3.4.5.6
```
...or optionally other kwargs used when instantiating IPAppliance could be defined...
```yaml
appliances:
    - hostname: 1.2.3.4
      ui_port: 80
      ui_protocol: http
```