### PR TITLE
[1LP][RFR]Add partial_match for network select

### DIFF
--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import fauxfactory
+from widgetastic.utils import partial_match
 
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
@@ -289,10 +290,10 @@ def service_templates_ui(request, appliance, service_dialog=None, service_catalo
 
             if a_provider.one_of(RHEVMProvider):
                 provisioning_data['catalog']['provision_type'] = 'Native Clone'
-                provisioning_data['network']['vlan'] = vlan
+                provisioning_data['network']['vlan'] = partial_match(vlan)
             elif a_provider.one_of(VMwareProvider):
                 provisioning_data['catalog']['provision_type'] = 'VMware'
-                provisioning_data['network']['vlan'] = vlan
+                provisioning_data['network']['vlan'] = partial_match(vlan)
 
             provisioning_args = dict(
                 catalog_name=template,

--- a/cfme/tests/infrastructure/test_pxe_provisioning.py
+++ b/cfme/tests/infrastructure/test_pxe_provisioning.py
@@ -2,6 +2,8 @@
 import fauxfactory
 import pytest
 
+from widgetastic.utils import partial_match
+
 from cfme.utils.conf import cfme_data
 from cfme.common.provider import cleanup_vm
 from cfme.infrastructure.provider import InfraProvider
@@ -133,7 +135,7 @@ def test_pxe_provision_from_template(appliance, provider, vm_name, smtp_test, se
             'custom_template': {'name': pxe_kickstart},
             'root_password': pxe_root_password},
         'network': {
-            'vlan': pxe_vlan}}
+            'vlan': partial_match(pxe_vlan)}}
 
     do_vm_provisioning(appliance, pxe_template, provider, vm_name, provisioning_data, request,
                        smtp_test, num_sec=3600)


### PR DESCRIPTION
Purpose or Intent
=================
Added partial_match for network select to tests, as value was not found in dropdown
{{pytest: cfme/tests/services/test_rest_services.py cfme/tests/infrastructure/test_pxe_provisioning.py --use-provider rhevm --long-running}} 