### PR TITLE
[RFR][1LP]Add pytest.skip in configure_vmware_console for vsphere65

### DIFF
--- a/cfme/tests/ssui/test_ssui_myservice.py
+++ b/cfme/tests/ssui/test_ssui_myservice.py
@@ -73,7 +73,8 @@ def configure_vmware_console_for_test(appliance, provider):
 
 @pytest.mark.parametrize('context', [ViaSSUI])
 @pytest.mark.parametrize('order_catalog_item_in_ops_ui', [['console_test']], indirect=True)
-@pytest.mark.uncollectif(lambda provider: provider.key >= 'vsphere65',
+@pytest.mark.uncollectif(lambda provider: provider.one_of(VMwareProvider) and
+                         provider.version >= 6.5,
                          'VNC consoles are unsupported on VMware ESXi 6.5 and later')
 def test_vm_console(request, appliance, setup_provider, context, configure_websocket,
         configure_vmware_console_for_test, order_catalog_item_in_ops_ui, take_screenshot,

--- a/cfme/tests/ssui/test_ssui_myservice.py
+++ b/cfme/tests/ssui/test_ssui_myservice.py
@@ -68,14 +68,13 @@ def test_retire_service(appliance, setup_provider, context, order_catalog_item_i
 def configure_vmware_console_for_test(appliance, provider):
     """Configure VMware Console to use VNC which is what is required for the HTML5 console."""
     if provider.one_of(VMwareProvider):
-        if provider.key >= 'vsphere65':
-            pytest.skip("VNC consoles are unsupported on VMware ESXi 6.5 and later")
-        else:
-            appliance.server.settings.update_vmware_console({'console_type': 'VNC'})
+        appliance.server.settings.update_vmware_console({'console_type': 'VNC'})
 
 
 @pytest.mark.parametrize('context', [ViaSSUI])
 @pytest.mark.parametrize('order_catalog_item_in_ops_ui', [['console_test']], indirect=True)
+@pytest.mark.uncollectif(lambda provider: provider.key >= 'vsphere65',
+                         'VNC consoles are unsupported on VMware ESXi 6.5 and later')
 def test_vm_console(request, appliance, setup_provider, context, configure_websocket,
         configure_vmware_console_for_test, order_catalog_item_in_ops_ui, take_screenshot,
         console_template):

--- a/cfme/tests/ssui/test_ssui_myservice.py
+++ b/cfme/tests/ssui/test_ssui_myservice.py
@@ -68,7 +68,10 @@ def test_retire_service(appliance, setup_provider, context, order_catalog_item_i
 def configure_vmware_console_for_test(appliance, provider):
     """Configure VMware Console to use VNC which is what is required for the HTML5 console."""
     if provider.one_of(VMwareProvider):
-        appliance.server.settings.update_vmware_console({'console_type': 'VNC'})
+        if provider.key >= 'vsphere65':
+            pytest.skip("VNC consoles are unsupported on VMware ESXi 6.5 and later")
+        else:
+            appliance.server.settings.update_vmware_console({'console_type': 'VNC'})
 
 
 @pytest.mark.parametrize('context', [ViaSSUI])


### PR DESCRIPTION
Purpose 
=================
Add pytest.skip for vsphere65, VNC consoles are unsupported on VMware ESXi 6.5 and later, which causes error _"DropdownItemDisabled: Item "VM Console" of dropdown "Access" is disabled"_

{{pytest: -v cfme/tests/ssui/test_ssui_myservice.py -k test_vm_console[vsphere65-nested-order_catalog_item_in_ops_ui0-ViaSSUI]}}
