### PR TITLE
[1LP][RFR] Fixed test_collect_multiple_servers

### DIFF
--- a/cfme/configure/configuration/diagnostics_settings.py
+++ b/cfme/configure/configuration/diagnostics_settings.py
@@ -279,7 +279,7 @@ class CollectLogsBase(Pretty, NavigatableMixin, Updateable):
         elif self.second_server_collect:
             message = "MiqServer {} [{}]".format(
                 first_slave_server.name,
-                first_slave_server.zone.id
+                first_slave_server.sid
             )
         else:
             message = "MiqServer {} [{}]".format(

--- a/cfme/tests/configure/test_log_depot_operation.py
+++ b/cfme/tests/configure/test_log_depot_operation.py
@@ -280,10 +280,10 @@ def test_collect_multiple_servers(log_depot, temp_appliance_preconfig, depot_mac
     first_slave_server = slave_servers[0] if slave_servers else None
 
     if from_slave and zone_collect:
-        check_ftp(log_depot.ftp, first_slave_server.name, first_slave_server.zone.id)
+        check_ftp(log_depot.ftp, first_slave_server.name, first_slave_server.sid)
         check_ftp(log_depot.ftp, appliance.server.name, appliance.server.zone.id)
     elif from_slave:
-        check_ftp(log_depot.ftp, first_slave_server.name, first_slave_server.zone.id)
+        check_ftp(log_depot.ftp, first_slave_server.name, first_slave_server.sid)
     else:
         check_ftp(log_depot.ftp, appliance.server.name, appliance.server.zone.id)
 


### PR DESCRIPTION
__Fixing__ AssertionError:
```
assert  message: Log collection for CFME MiqServer EVM [1] has been initiated.
Available messages: [u'Log collection for CFME MiqServer EVM [2] has been initiated']
```

{{pytest: cfme/tests/configure/test_log_depot_operation.py::test_collect_multiple_servers}}