### PR TITLE
[1LP][RFR] Fix test_services_request_direct_url due to BZ1540731

### DIFF
--- a/cfme/tests/services/test_operations.py
+++ b/cfme/tests/services/test_operations.py
@@ -102,13 +102,13 @@ def generated_request(appliance,
 
 
 @pytest.mark.tier(3)
-def test_services_request_direct_url(appliance, generated_request, a_provider):
+def test_services_request_direct_url(appliance, generated_request):
     """Go to the request page, save the url and try to access it directly."""
     widgetastic = appliance.browser.widgetastic
     selenium = widgetastic.selenium
     assert navigate_to(generated_request, 'Details'), "could not find the request!"
     request_url = selenium.current_url
-    navigate_to(a_provider, 'Details')  # Nav to some other page
+    navigate_to(appliance.server, 'LoggedIn')  # Nav to some other page
     selenium.get(request_url)  # Ok, direct access now.
     wait_for(
         lambda: widgetastic.is_displayed("//body[contains(@onload, 'miqOnLoad')]"),

--- a/cfme/tests/services/test_operations.py
+++ b/cfme/tests/services/test_operations.py
@@ -108,7 +108,7 @@ def test_services_request_direct_url(appliance, generated_request):
     selenium = widgetastic.selenium
     assert navigate_to(generated_request, 'Details'), "could not find the request!"
     request_url = selenium.current_url
-    navigate_to(appliance.server, 'LoggedIn')  # Nav to some other page
+    navigate_to(appliance.server, 'Configuration')  # Nav to some other page
     selenium.get(request_url)  # Ok, direct access now.
     wait_for(
         lambda: widgetastic.is_displayed("//body[contains(@onload, 'miqOnLoad')]"),

--- a/cfme/tests/services/test_operations.py
+++ b/cfme/tests/services/test_operations.py
@@ -102,14 +102,14 @@ def generated_request(appliance,
 
 
 @pytest.mark.tier(3)
-def test_services_request_direct_url(appliance, generated_request):
+def test_services_request_direct_url(appliance, generated_request, a_provider):
     """Go to the request page, save the url and try to access it directly."""
     widgetastic = appliance.browser.widgetastic
     selenium = widgetastic.selenium
     assert navigate_to(generated_request, 'Details'), "could not find the request!"
     request_url = selenium.current_url
-    selenium.get(store.base_url)    # I need to flip it with something different here
-    selenium.get(request_url)        # Ok, direct access now.
+    navigate_to(a_provider, 'Details')  # Nav to some other page
+    selenium.get(request_url)  # Ok, direct access now.
     wait_for(
         lambda: widgetastic.is_displayed("//body[contains(@onload, 'miqOnLoad')]"),
         num_sec=20,


### PR DESCRIPTION
This bug breaks this test: https://bugzilla.redhat.com/show_bug.cgi?id=1540731

However, I don't think the fact that this test navigates to the base_url really affects the 'intent of the test', so I'm changing it to simply nav to another page. I think we'd be better to fix this for now, and add an additional test to properly address the above BZ and specifically test that kind of login/auth flow.