### PR TITLE
[1LP][RFR] Increased timeout for wait scvmm to retire

### DIFF
--- a/cfme/tests/cloud_infra_common/test_retirement.py
+++ b/cfme/tests/cloud_infra_common/test_retirement.py
@@ -85,7 +85,7 @@ def verify_retirement_state(retire_vm):
     # Use lambda for is_retired since its a property
     view_cls = navigator.get_class(retire_vm, 'Details').VIEW
     view = retire_vm.appliance.browser.create_view(view_cls)
-    assert wait_for(lambda: retire_vm.is_retired, delay=5, num_sec=10 * 60,
+    assert wait_for(lambda: retire_vm.is_retired, delay=5, num_sec=15 * 60,
                     fail_func=view.toolbar.reload.click,
              message="Wait for VM '{}' to enter retired state".format(retire_vm.name))
 


### PR DESCRIPTION
__Fixing__ test_resume_retired_instance to wait a bit longer for SCVMM to retire, because it takes more than 10 min.

#### Shriver: 
without a line to specify what provider to use, it will collect against 'default' providers, which doesn't include scvmm.

Leaving this here for you to see and know, but your PR's small timeout change doesn't warrant needing to verify all the results. 
{{ pytest: cfme/tests/cloud_infra_common/test_retirement.py -k test_retirement_now --use-provider scvmm --long-running }}