### PR TITLE
Wrapanapi 2.5.2

### DIFF
--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -198,7 +198,7 @@ Werkzeug==0.12.2
 widgetastic.core==0.20.3
 widgetastic.patternfly==0.0.27
 widgetsnbextension==2.0.0
-wrapanapi==2.5.0
+wrapanapi==2.5.2
 wrapt==1.10.10
 xmltodict==0.11.0
 yaycl==0.2.0


### PR DESCRIPTION
Moving `stats` to WrapanapiAPIBase fixes container tests and is needed for the new SDN work.