### PR TITLE
[RFR] Missing refresh text from container providers

### DIFF
--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -180,6 +180,7 @@ class ContainersProvider(BaseProvider, Pretty):
     endpoints_form = ContainersProviderEndpointsForm
     all_view = ContainerProvidersView
     details_view = ContainerProviderDetailsView
+    refresh_text = 'Refresh items and relationships'
 
     def __init__(
             self,


### PR DESCRIPTION
This is a fix to get cfme.tests.containers.test_reload_button_provider.py working correctly. refresh_provider_relationships_ui selects the refresh based on refresh_text.

This also depends on wrapanapi PR: https://github.com/ManageIQ/wrapanapi/pull/211

Manual test:
with refresh_text
```
In [5]: juwatts = providers.get_crud('cm-juwatts')

In [6]: juwatts
Out[6]: <cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>

In [7]: juwatts.refresh_text
Out[7]: 'Refresh items and relationships'

In [8]: view = navigate_to(juwatts, 'Details')

In [9]: juwatts.refresh_provider_relationships(method='ui')
[WARNING] /home/juwatts/repos/cfme_venv/lib/python2.7/site-packages/selenium/webdriver/remote/webdriver.py:585: DeprecationWarning: use driver.switch_to.alert instead
  warnings.warn("use driver.switch_to.alert instead", DeprecationWarning)
 (/home/juwatts/repos/cfme_venv/lib/python2.7/site-packages/selenium/webdriver/remote/webdriver.py:585)

```

Without refresh_text:
```
In [2]: juwatts = providers.get_crud('cm-juwatts')
   ...: 

In [3]: juwatts.refresh_text
   ...: 
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-3-91c235937903> in <module>()
----> 1 juwatts.refresh_text

AttributeError: 'OpenshiftProvider' object has no attribute 'refresh_text'

In [4]: view = navigate_to(juwatts, 'Details')
   ...: 

In [5]: juwatts.refresh_provider_relationships(method='ui')
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-9-186b1f2f873e> in <module>()
----> 1 juwatts.refresh_provider_relationships(method='ui')

/home/juwatts/repos/integration_tests/cfme/utils/varmeth.py in caller(*args, **kwargs)
     82                     "Method {} does not have a variant for {}, valid variants are {}".format(
     83                         self._name, method, ", ".join(map(str, self._mapping.keys()))))
---> 84             return method(obj, *args, **kwargs)
     85         return caller
     86 

/home/juwatts/repos/integration_tests/cfme/common/provider.py in refresh_provider_relationships_ui(self, from_list_view)
    579             view = navigate_to(self, 'Details')
    580 
--> 581         view.toolbar.configuration.item_select(self.refresh_text, handle_alert=True)
    582 
    583     @variable(alias='rest')

AttributeError: 'OpenshiftProvider' object has no attribute 'refresh_text'

In [6]: 
```

{{ pytest: cfme/tests/containers/test_reload_button_provider.py --use-provider cm-env2 }}