### PR TITLE
[1LP][RFR]Fix test_tagvis_tag_datacenter_combination

### DIFF
--- a/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
+++ b/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
@@ -49,7 +49,8 @@ def testing_vis_object(request, a_provider, appliance):
 @pytest.fixture(scope='module')
 def group_tag_datacenter_combination(group_with_tag, a_provider):
     with update(group_with_tag):
-        group_with_tag.host_cluster = [a_provider.data['name'], a_provider.data['datacenters'][0]]
+        group_with_tag.host_cluster = ([a_provider.data['name'],
+                                        a_provider.data['datacenters'][0]], True)
 
 
 @pytest.mark.meta(blockers=[BZ(1533391, forced_streams=["5.9", "upstream"])])


### PR DESCRIPTION
Purpose
=================
Fixed test_tagvis_tag_datacenter_combination due to checknode, unchecknode issue.

{{pytest: -v cfme/tests/infrastructure/test_infra_tag_filters_combination.py -k test_tagvis_tag_datacenter_combination[clusters-visible]}}

