### PR TITLE
[1LP][RFR] Add BZ blocker for category in fixtures/tag.py

### DIFF
--- a/cfme/fixtures/tag.py
+++ b/cfme/fixtures/tag.py
@@ -15,7 +15,8 @@ def category():
         Object can be used in all test run session
     """
     if BZ(1517285, forced_streams='5.9').blocks:
-        display_name = 'test-{}'.format(fauxfactory.gen_alphanumeric(length=32))
+        display_name = 'test-{}'.format(fauxfactory.gen_alphanumeric(length=27))
+    # display_name should be with max length of 32
     else:
         display_name = fauxfactory.gen_alphanumeric(length=32)
     cg = Category(name=fauxfactory.gen_alpha(8).lower(),

--- a/cfme/fixtures/tag.py
+++ b/cfme/fixtures/tag.py
@@ -15,13 +15,12 @@ def category():
         Object can be used in all test run session
     """
     if BZ(1517285, forced_streams='5.9').blocks:
-        cg = Category(name=fauxfactory.gen_alpha(8).lower(),
-                      description=fauxfactory.gen_alphanumeric(length=32),
-                      display_name='test-{}'.format(fauxfactory.gen_alphanumeric(length=32)))
+        display_name = 'test-{}'.format(fauxfactory.gen_alphanumeric(length=32))
     else:
-        cg = Category(name=fauxfactory.gen_alpha(8).lower(),
-                      description=fauxfactory.gen_alphanumeric(length=32),
-                      display_name=fauxfactory.gen_alphanumeric(length=32))
+        display_name = fauxfactory.gen_alphanumeric(length=32)
+    cg = Category(name=fauxfactory.gen_alpha(8).lower(),
+                  description=fauxfactory.gen_alphanumeric(length=32),
+                  display_name=display_name)
     cg.create()
     yield cg
     cg.delete(False)

--- a/cfme/fixtures/tag.py
+++ b/cfme/fixtures/tag.py
@@ -4,6 +4,7 @@ import pytest
 from cfme.base.credential import Credential
 from cfme.configure.configuration.region_settings import Category, Tag
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 
 
@@ -13,9 +14,14 @@ def category():
         Returns random created category object
         Object can be used in all test run session
     """
-    cg = Category(name=fauxfactory.gen_alpha(8).lower(),
-                  description=fauxfactory.gen_alphanumeric(length=32),
-                  display_name=fauxfactory.gen_alphanumeric(length=32))
+    if BZ(1517285, forced_streams='5.9').blocks:
+        cg = Category(name=fauxfactory.gen_alpha(8).lower(),
+                      description=fauxfactory.gen_alphanumeric(length=32),
+                      display_name='test-{}'.format(fauxfactory.gen_alphanumeric(length=32)))
+    else:
+        cg = Category(name=fauxfactory.gen_alpha(8).lower(),
+                      description=fauxfactory.gen_alphanumeric(length=32),
+                      display_name=fauxfactory.gen_alphanumeric(length=32))
     cg.create()
     yield cg
     cg.delete(False)


### PR DESCRIPTION
Purpose
=================
In case if Category name starts from digit it will be on the top of the list and selected by default as the first one. Because of [BZ#1517285](https://bugzilla.redhat.com/show_bug.cgi?id=1517285), it will have other Tags than preconfigured for this Category.

{{pytest: -v cfme/tests/cloud_infra_common/test_tag_objects.py -k test_tag_infra_objects}} 