### PR TITLE
[1LP][RFR] Unique service identification fix

### DIFF
--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -9,7 +9,7 @@ from cfme.services.catalogs.catalog import Catalog
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.utils import version
 from cfme.utils.log import logger
-from cfme.utils.rest import create_resource, get_vms_in_service
+from cfme.utils.rest import create_resource
 from cfme.utils.virtual_machines import deploy_template
 from cfme.utils.wait import wait_for
 from fixtures.provider import setup_one_by_class_or_skip
@@ -198,7 +198,8 @@ def services(request, appliance, a_provider, service_dialog=None, service_catalo
 
     service_name = str(service_request.options['dialog']['dialog_service_name'])
     assert '[{}]'.format(service_name) in service_request.message
-    provisioned_service = appliance.rest_api.collections.services.get(name=service_name)
+    provisioned_service = appliance.rest_api.collections.services.get(
+        service_template_id=service_template.id)
 
     @request.addfinalizer
     def _finished():
@@ -210,12 +211,6 @@ def services(request, appliance, a_provider, service_dialog=None, service_catalo
 
     # tests expect iterable
     return [provisioned_service]
-
-
-def service_data(request, appliance, a_provider, service_dialog=None, service_catalog=None):
-    prov_service = services(request, appliance, a_provider, service_dialog, service_catalog).pop()
-    prov_vm = get_vms_in_service(appliance.rest_api, prov_service).pop()
-    return {'service_name': prov_service.name, 'vm_name': prov_vm.name}
 
 
 def rates(request, rest_api, num=3):

--- a/cfme/utils/rest.py
+++ b/cfme/utils/rest.py
@@ -71,8 +71,9 @@ def assert_response(
     rest_api.response = last_response
 
 
-def get_vms_in_service(rest_api, service):
+def get_vms_in_service(service):
     """Gets list of vm entities associated with the service."""
+    rest_api = service.collection._api
     service.vms.reload()
     # return entities under /api/vms, not under /api/services/:id/vms subcollection
     # where "actions" are not available


### PR DESCRIPTION
Service name can no longer be used to uniquely identify service when multiple services are using the same dialog (all services have the same name). Using service template id instead.
Also reworked a way how to get info about what VMs are associated with service.

{{pytest: -v --long-running --use-provider vsphere65-nested -k 'not TestServiceOrderCart' cfme/tests/services/test_rest_services.py}}

**PRT**
The only failed test is not related to changes in this PR (the bug no longer blocks the test but was not fixed in the tested version).