### PR TITLE
[WIPTEST] Snapshots: reproducing issue from spreadsheet

### DIFF
--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -274,6 +274,7 @@ def test_operations_suspended_vm(small_test_vm, soft_assert):
              message="Waiting for the first snapshot to become active")
     # Suspend the VM
     small_test_vm.power_control_from_cfme(option=small_test_vm.SUSPEND, cancel=False)
+    # TODO here it fails and I need to reproduce it
     small_test_vm.wait_for_vm_state_change(desired_state=small_test_vm.STATE_SUSPENDED)
     # Create second snapshot when VM is suspended
     snapshot2 = new_snapshot(small_test_vm)


### PR DESCRIPTION
I need to run PRT with one of the snapshot tests and see if I can reproduce the issue that occurs in jenkins. Can't reproduce locally.

{{ pytest: -v --long-running --use-provider vsphere6-nested -k test_operations_suspended_vm }}