### PR TITLE
[WIPTEST] Jenkins failure Name_is_required fix

### DIFF
--- a/cfme/services/catalogs/orchestration_template.py
+++ b/cfme/services/catalogs/orchestration_template.py
@@ -151,9 +151,11 @@ class OrchestrationTemplate(Updateable, Pretty, Navigatable, WidgetasticTaggable
                    'template_type': temp_type,
                    'content': content})
         view.add_button.click()
-        view = self.create_view(DetailsTemplateView)
-        view.flash.assert_success_message('Orchestration Template '
-                                          '"{}" was saved'.format(self.template_name))
+        try:
+            view.flash.assert_no_error()
+        except AssertionError:
+            view.fill({'name': self.template_name})
+            view.add_button.click()
 
     def update(self, updates):
         view = navigate_to(self, "Edit")

--- a/cfme/tests/services/test_orchestration_template.py
+++ b/cfme/tests/services/test_orchestration_template.py
@@ -6,7 +6,7 @@ from cfme.services.catalogs.orchestration_template import OrchestrationTemplate
 from cfme.utils import error
 from cfme.utils.update import update
 from cfme import test_requirements
-from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.appliance.implementations.ui import navigate_to, navigator
 
 
 pytestmark = [
@@ -61,6 +61,10 @@ def test_orchestration_template_crud(provisioning, create_template):
                                      template_name=fauxfactory.gen_alphanumeric(),
                                      description="my template")
     template.create(create_template)
+    view_cls = navigator.get_class(template, 'AddTemplate').VIEW
+    view = template.appliance.browser.create_view(view_cls)
+    view.flash.assert_message('Orchestration Template '
+                              '"{}" was saved'.format(template.template_name))
     with update(template):
         template.description = "my edited description"
     template.delete()


### PR DESCRIPTION
After filling the orchestration template form , the name field becomes empty sometimes and throws assertion error "Name is required" .
This PR is to try and fix that failure .
