### PR TITLE
[1LP][RFR] Get rid off get_detail() in ansible repositories

### DIFF
--- a/cfme/tests/ansible/test_embedded_ansible_actions.py
+++ b/cfme/tests/ansible/test_embedded_ansible_actions.py
@@ -40,9 +40,15 @@ def ansible_repository(appliance, wait_for_ansible):
         name=fauxfactory.gen_alpha(),
         url="https://github.com/quarckster/ansible_playbooks",
         description=fauxfactory.gen_alpha())
+    view = navigate_to(repository, "Details")
+    if appliance.version < "5.9":
+        refresh = view.browser.refresh
+    else:
+        refresh = view.toolbar.refresh.click
     wait_for(
-        lambda: repository.get_detail("Properties", "Status", refresh=True) == "successful",
-        timeout=60
+        lambda: view.entities.summary("Properties").get_text_of("Status") == "successful",
+        timeout=60,
+        fail_func=refresh
     )
     yield repository
 

--- a/cfme/tests/ansible/test_embedded_ansible_automate.py
+++ b/cfme/tests/ansible/test_embedded_ansible_automate.py
@@ -40,9 +40,15 @@ def ansible_repository(appliance, wait_for_ansible):
         name=fauxfactory.gen_alpha(),
         url="https://github.com/quarckster/ansible_playbooks",
         description=fauxfactory.gen_alpha())
+    view = navigate_to(repository, "Details")
+    if appliance.version < "5.9":
+        refresh = view.browser.refresh
+    else:
+        refresh = view.toolbar.refresh.click
     wait_for(
-        lambda: repository.get_detail("Properties", "Status", refresh=True) == "successful",
-        timeout=60
+        lambda: view.entities.summary("Properties").get_text_of("Status") == "successful",
+        timeout=60,
+        fail_func=refresh
     )
     yield repository
 

--- a/cfme/tests/ansible/test_embedded_ansible_basic.py
+++ b/cfme/tests/ansible/test_embedded_ansible_basic.py
@@ -83,9 +83,15 @@ def ansible_repository(appliance):
         fauxfactory.gen_alpha(),
         REPOSITORIES[0],
         description=fauxfactory.gen_alpha())
+    view = navigate_to(repository, "Details")
+    if appliance.version < "5.9":
+        refresh = view.browser.refresh
+    else:
+        refresh = view.toolbar.refresh.click
     wait_for(
-        lambda: repository.get_detail("Properties", "Status", refresh=True) == "successful",
-        timeout=60
+        lambda: view.entities.summary("Properties").get_text_of("Status") == "successful",
+        timeout=60,
+        fail_func=refresh
     )
     yield repository
 

--- a/cfme/tests/ansible/test_embedded_ansible_services.py
+++ b/cfme/tests/ansible/test_embedded_ansible_services.py
@@ -47,9 +47,15 @@ def ansible_repository(appliance, wait_for_ansible):
         name=fauxfactory.gen_alpha(),
         url="https://github.com/quarckster/ansible_playbooks",
         description=fauxfactory.gen_alpha())
+    view = navigate_to(repository, "Details")
+    if appliance.version < "5.9":
+        refresh = view.browser.refresh
+    else:
+        refresh = view.toolbar.refresh.click
     wait_for(
-        lambda: repository.get_detail("Properties", "Status", refresh=True) == "successful",
-        timeout=60
+        lambda: view.entities.summary("Properties").get_text_of("Status") == "successful",
+        timeout=60,
+        fail_func=refresh
     )
     yield repository
 

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -598,6 +598,28 @@ class NestedSummaryTable(SummaryTable):
         return [{key: col.text for key, col in row} for row in self]
 
 
+class ParametrizedSummaryTable(ParametrizedView):
+
+    PARAMETERS = ("title", )
+    _table = SummaryTable(title=Parameter("title"))
+
+    @property
+    def fields(self):
+        return self._table.fields
+
+    def get_field(self, field_name):
+        return self._table.get_field(field_name)
+
+    def get_text_of(self, field_name):
+        return self._table.get_text_of(field_name)
+
+    def get_img_of(self, field_name):
+        return self._table.get_img_of(field_name)
+
+    def click_at(self, field_name):
+        return self._table.click_at(field_name)
+
+
 class StatusBox(Widget, ClickableMixin):
     card = Text(ParametrizedLocator('.//div[@pf-aggregate-status-card and (normalize-space'
                                     '(.//h2/a/span[contains(@class, '


### PR DESCRIPTION
Intent
=================

We should replace `get_detail()` method in our objects by a parametrized summary table in respectful detail views.

{{pytest: -v -k "test_control_action_run_ansible_playbook_in_requests or test_embedded_ansible_repository_crud or test_automate_ansible_playbook_method_type_crud or test_service_ansible_playbook_crud" --long-running}}