### PR TITLE
[1LP][RFR] Fixed test_config_manager_add_invalid_url

### DIFF
--- a/cfme/tests/infrastructure/test_config_management.py
+++ b/cfme/tests/infrastructure/test_config_management.py
@@ -59,7 +59,7 @@ def test_config_manager_add(request, config_manager_obj):
 @pytest.mark.tier(3)
 def test_config_manager_add_invalid_url(request, config_manager_obj):
     request.addfinalizer(config_manager_obj.delete)
-    config_manager_obj.url = "invalid_url"
+    config_manager_obj.url = 'https://invalid_url'
     error_message = 'getaddrinfo: Name or service not known'
     with error.expected(error_message):
         config_manager_obj.create()


### PR DESCRIPTION
Purpose
=================
Added **https** to _**invalid_url**_ to fix   _AssertionError: URL has to be HTTPS_.

{{pytest: -v cfme/tests/infrastructure/test_config_management.py -k test_config_manager_add}}

