### PR TITLE
[1LP][RFR]Fixed test_invalid_template_type

### DIFF
--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -1477,7 +1477,7 @@ class TestOrchestrationTemplatesRESTAPI(object):
         payload = {
             'name': 'test_{}'.format(uniq),
             'description': 'Test Template {}'.format(uniq),
-            'type': 'OrchestrationTemplateCfn',
+            'type': 'InvalidOrchestrationTemplateType',
             'orderable': False,
             'draft': False,
             'content': TEMPLATE_TORSO.replace('CloudFormation', uniq)


### PR DESCRIPTION
Purpose 
=================
Changed type of OrchestrationTemplate to invalid value as _OrchestrationTemplateCfn_ is accepted by CFME due to changes [PR#284-Temporarily allow to create deprecated orchestration template types](https://github.com/ManageIQ/manageiq-api/pull/284).

{{pytest: -v cfme/tests/services/test_rest_services.py -k test_invalid_template_type}}