### PR TITLE
[1LP][RFR] fixes for test_vm_reconfigure

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -896,8 +896,8 @@ class Vm(VM):
                     # -- block end --
                     row[unit_column].fill(disk.size_unit)
                     row.mode.fill(mode)
+                    row.dependent.fill(dependent)
                 row.size.fill(disk.size)
-                row.dependent.fill(dependent)
                 row.actions.widget.click()
                 message = 'Add Disks'
             elif action == 'delete':

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -896,8 +896,8 @@ class Vm(VM):
                     # -- block end --
                     row[unit_column].fill(disk.size_unit)
                     row.mode.fill(mode)
-                    row.dependent.fill(dependent)
                 row.size.fill(disk.size)
+                row.dependent.fill(dependent)
                 row.actions.widget.click()
                 message = 'Add Disks'
             elif action == 'delete':

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -23,6 +23,7 @@ from cfme.exceptions import (
     VmNotFound, OptionNotAvailable, DestinationNotFound, ItemNotFound,
     VmOrInstanceNotFound)
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
+from cfme.services.requests import RequestsView
 from cfme.utils import version
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
 from cfme.utils.conf import cfme_data
@@ -884,33 +885,40 @@ class Vm(VM):
                 row.type.fill(disk.type)
                 # Unit first, then size (otherwise JS would try to recalculate the size...)
                 if self.provider.one_of(RHEVMProvider):
-                    # Workaround necessary until BZ 1524960 is resolved
+                    # TODO: Workaround necessary until BZ 1524960 is resolved
+                    # -- block start --
                     row[3].fill(disk.size_unit)
                 else:
-                    row[4].fill(disk.size_unit)
+                    if self.appliance.version < '5.9':
+                        unit_column = 4
+                    else:
+                        unit_column = 5
+                    # -- block end --
+                    row[unit_column].fill(disk.size_unit)
                     row.mode.fill(mode)
                     row.dependent.fill(dependent)
                 row.size.fill(disk.size)
                 row.actions.widget.click()
+                message = 'Add Disks'
             elif action == 'delete':
                 row = vm_recfg.disks_table.row(name=disk.filename)
-                row.delete_backing.fill(disk_change['delete_backing'])
+                # `delete_backing` removes disk from the env
+                row.delete_backing.fill(True)
                 row.actions.widget.click()
+                message = 'Remove Disks'
             else:
                 raise ValueError("Unknown disk change action; must be one of: add, delete")
 
         if cancel:
             vm_recfg.cancel_button.click()
-            # TODO Cannot use VM list view for flash messages here because we don't have one yet
-            vm_recfg.flash.assert_no_error()
-            vm_recfg.flash.assert_message('VM Reconfigure Request was cancelled by the user')
+            view = self.appliance.browser.create_view(InfraVmDetailsView)
+            view.flash.assert_success_message('VM Reconfigure Request was cancelled by the user')
         else:
             vm_recfg.submit_button.click()
-            # TODO Cannot use Requests view for flash messages here because we don't have one yet
-            vm_recfg.flash.assert_no_error()
-            vm_recfg.flash.assert_message("VM Reconfigure Request was saved")
-
-        # TODO This should (one day) return a VM reconfigure request obj that we can further use
+            view = self.appliance.browser.create_view(RequestsView)
+            view.flash.assert_success_message("VM Reconfigure Request was saved")
+            return self.appliance.collections.requests.instantiate(description="{} - {}".format(
+                self.name, message), partial_check=True)
 
     @property
     def cluster(self):

--- a/cfme/tests/infrastructure/test_vm_reconfigure.py
+++ b/cfme/tests/infrastructure/test_vm_reconfigure.py
@@ -81,7 +81,7 @@ def test_vm_reconfig_add_remove_hw_cold(
     # Disk modes cannot be specified when adding disk to VM in RHV provider
     lambda disk_mode, provider: disk_mode != 'persistent' and provider.one_of(RHEVMProvider))
 def test_vm_reconfig_add_remove_disk_cold(
-        provider, small_vm, ensure_vm_stopped, disk_type, disk_mode, soft_assert):
+        provider, small_vm, ensure_vm_stopped, disk_type, disk_mode):
 
     orig_config = small_vm.configuration.copy()
     new_config = orig_config.copy()
@@ -92,12 +92,14 @@ def test_vm_reconfig_add_remove_disk_cold(
     wait_for(add_disk_request.is_succeeded, timeout=360, delay=45,
              fail_func=small_vm.refresh_relationships,
              message="confirm that disk was added")
-    soft_assert(lambda: small_vm.configuration == new_config, "Disk wasn't added to VM config")
+    assert small_vm.configuration.num_disks == new_config.num_disks,\
+        "Disk wasn't added to VM config"
     remove_disk_request = small_vm.reconfigure(orig_config)
     wait_for(remove_disk_request.is_succeeded, timeout=360, delay=45,
              fail_func=small_vm.refresh_relationships,
              message="confirm that previously-added disk was removed")
-    soft_assert(lambda: small_vm.configuration == orig_config, "Disk wasn't removed from VM config")
+    assert small_vm.configuration.num_disks == orig_config.num_disks,\
+        "Disk wasn't removed from VM config"
 
 
 def test_reconfig_vm_negative_cancel(provider, small_vm, ensure_vm_stopped):

--- a/cfme/tests/infrastructure/test_vm_reconfigure.py
+++ b/cfme/tests/infrastructure/test_vm_reconfigure.py
@@ -89,15 +89,25 @@ def test_vm_reconfig_add_remove_disk_cold(
         size=500, size_unit='MB', type=disk_type, mode=disk_mode)
 
     add_disk_request = small_vm.reconfigure(new_config)
+    # Add disk request verification
     wait_for(add_disk_request.is_succeeded, timeout=360, delay=45,
-             fail_func=small_vm.refresh_relationships,
              message="confirm that disk was added")
+    # Add disk UI verification
+    wait_for(
+        lambda: small_vm.configuration.num_disks == new_config.num_disks, timeout=360, delay=45,
+        fail_func=small_vm.refresh_relationships,
+        message="confirm that disk was added")
     assert small_vm.configuration.num_disks == new_config.num_disks,\
         "Disk wasn't added to VM config"
     remove_disk_request = small_vm.reconfigure(orig_config)
+    # Remove disk request verification
     wait_for(remove_disk_request.is_succeeded, timeout=360, delay=45,
-             fail_func=small_vm.refresh_relationships,
              message="confirm that previously-added disk was removed")
+    # Remove disk UI verification
+    wait_for(
+        lambda: small_vm.configuration.num_disks == orig_config.num_disks, timeout=360, delay=45,
+        fail_func=small_vm.refresh_relationships,
+        message="confirm that previously-added disk was removed")
     assert small_vm.configuration.num_disks == orig_config.num_disks,\
         "Disk wasn't removed from VM config"
 

--- a/cfme/tests/infrastructure/test_vm_reconfigure.py
+++ b/cfme/tests/infrastructure/test_vm_reconfigure.py
@@ -97,8 +97,8 @@ def test_vm_reconfig_add_remove_disk_cold(
         lambda: small_vm.configuration.num_disks == new_config.num_disks, timeout=360, delay=45,
         fail_func=small_vm.refresh_relationships,
         message="confirm that disk was added")
-    assert small_vm.configuration.num_disks == new_config.num_disks,\
-        "Disk wasn't added to VM config"
+    msg = "Disk wasn't added to VM config"
+    assert small_vm.configuration.num_disks == new_config.num_disks, msg
     remove_disk_request = small_vm.reconfigure(orig_config)
     # Remove disk request verification
     wait_for(remove_disk_request.is_succeeded, timeout=360, delay=45,
@@ -108,8 +108,8 @@ def test_vm_reconfig_add_remove_disk_cold(
         lambda: small_vm.configuration.num_disks == orig_config.num_disks, timeout=360, delay=45,
         fail_func=small_vm.refresh_relationships,
         message="confirm that previously-added disk was removed")
-    assert small_vm.configuration.num_disks == orig_config.num_disks,\
-        "Disk wasn't removed from VM config"
+    msg = "Disk wasn't removed from VM config"
+    assert small_vm.configuration.num_disks == orig_config.num_disks, msg
 
 
 def test_reconfig_vm_negative_cancel(provider, small_vm, ensure_vm_stopped):

--- a/widgetastic_manageiq/vm_reconfigure.py
+++ b/widgetastic_manageiq/vm_reconfigure.py
@@ -29,7 +29,7 @@ class DisksTable(VanillaTable):
         'Mode': BootstrapSelect(id='hdMode'),
         'Size': Input(id='dvcSize'),
         'ControllerType': BootstrapSelect(id='Controller'),
-        # Workaround necessary until BZ 1524960 is resolved
+        # TODO: Workaround necessary until BZ 1524960 is resolved
         5: BootstrapSelect(id='hdUnit'),  # for VMware in 5.9
         4: BootstrapSelect(id='hdUnit'),  # for VMware in 5.8
         3: BootstrapSelect(id='hdUnit'),  # for RHEVM in 5.9

--- a/widgetastic_manageiq/vm_reconfigure.py
+++ b/widgetastic_manageiq/vm_reconfigure.py
@@ -28,11 +28,13 @@ class DisksTable(VanillaTable):
         'Type': BootstrapSelect(id='hdType'),
         'Mode': BootstrapSelect(id='hdMode'),
         'Size': Input(id='dvcSize'),
+        'ControllerType': BootstrapSelect(id='Controller'),
         # Workaround necessary until BZ 1524960 is resolved
-        4: BootstrapSelect(id='hdUnit'),
-        3: BootstrapSelect(id='hdUnit'),
-        'Dependent': BootstrapSwitch(
-            name=VersionPick({Version.lowest(): 'cb_dependent', '5.9': 'vm.cb_dependent'})),
+        5: BootstrapSelect(id='hdUnit'),  # for VMware in 5.9
+        4: BootstrapSelect(id='hdUnit'),  # for VMware in 5.8
+        3: BootstrapSelect(id='hdUnit'),  # for RHEVM in 5.9
+        'Dependent': VersionPick({Version.lowest(): BootstrapSwitch(name='cb_dependent'),
+                                  '5.9': BootstrapSwitch(name='vm.cb_dependent')}),
         'Delete Backing': BootstrapSwitch(name='cb_deletebacking'),
         'Actions': Button()
     }


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ test_vm_reconfig_add_remove_disk_cold because it is currently doesn't remove disks that were added to VM from the env
+ Resolving few TODOs

{{pytest: --long-running --use-provider vsphere65-nested --use-provider rhv41 -k test_vm_reconfig_add_remove_disk_cold cfme/tests/infrastructure/test_vm_reconfigure.py}}