### PR TITLE
[1LP][RFR] Using default vNIC profile in REST VM provision

### DIFF
--- a/cfme/tests/infrastructure/test_provisioning_rest.py
+++ b/cfme/tests/infrastructure/test_provisioning_rest.py
@@ -15,6 +15,9 @@ pytestmark = [
     pytest.mark.meta(server_roles="+automate"),
     pytest.mark.usefixtures("setup_provider"),
     pytest.mark.provider([VMwareProvider, RHEVMProvider], scope="module"),
+    pytest.mark.meta(blockers=[BZ(1541036,
+                     forced_streams=['5.9', 'upstream'],
+                     unblock=lambda provider: provider.one_of(RHEVMProvider))])
 ]
 
 
@@ -54,7 +57,8 @@ def get_provision_data(rest_api, provider, template_name, auto_approve=True):
             "cc": "001"
         },
         "additional_values": {
-            "request_id": "1001"
+            "request_id": "1001",
+            "placement_auto": "true"
         },
         "ems_custom_attributes": {},
         "miq_custom_attributes": {}

--- a/cfme/tests/infrastructure/test_provisioning_rest.py
+++ b/cfme/tests/infrastructure/test_provisioning_rest.py
@@ -14,10 +14,7 @@ pytestmark = [
     pytest.mark.tier(2),
     pytest.mark.meta(server_roles="+automate"),
     pytest.mark.usefixtures("setup_provider"),
-    pytest.mark.provider([VMwareProvider, RHEVMProvider], scope="module"),
-    pytest.mark.meta(blockers=[BZ(1541036,
-                     forced_streams=['5.9', 'upstream'],
-                     unblock=lambda provider: provider.one_of(RHEVMProvider))])
+    pytest.mark.provider([VMwareProvider, RHEVMProvider], scope="module")
 ]
 
 

--- a/cfme/tests/infrastructure/test_provisioning_rest.py
+++ b/cfme/tests/infrastructure/test_provisioning_rest.py
@@ -65,8 +65,9 @@ def get_provision_data(rest_api, provider, template_name, auto_approve=True):
     }
 
     if provider.one_of(RHEVMProvider):
-        result["vm_fields"]["vlan"] = "<Template>"
         result["vm_fields"]["provision_type"] = "native_clone"
+        if current_version() > '5.9.0.16':
+            result["vm_fields"]["vlan"] = "<Template>"
 
     return result
 

--- a/cfme/tests/infrastructure/test_provisioning_rest.py
+++ b/cfme/tests/infrastructure/test_provisioning_rest.py
@@ -72,6 +72,13 @@ def provision_data(appliance, provider, small_template_modscope):
     return get_provision_data(appliance.rest_api, provider, small_template_modscope.name)
 
 
+def clean_vm(provider, vm_name):
+    if not provider.mgmt.is_vm_stopped(vm_name):
+        provider.mgmt.stop_vm(vm_name)
+        provider.mgmt.wait_vm_stopped(vm_name)
+    provider.mgmt.delete_vm(vm_name)
+
+
 # Here also available the ability to create multiple provision request, but used the save
 # href and method, so it doesn't make any sense actually
 def test_provision(request, provision_data, provider, appliance):
@@ -87,8 +94,8 @@ def test_provision(request, provision_data, provider, appliance):
     """
 
     vm_name = provision_data["vm_fields"]["vm_name"]
-    request.addfinalizer(
-        lambda: provider.mgmt.delete_vm(vm_name) if provider.mgmt.does_vm_exist(vm_name) else None)
+    request.addfinalizer(lambda: clean_vm(provider, vm_name) if provider.mgmt.does_vm_exist(vm_name)
+        else None)
     response = appliance.rest_api.collections.provision_requests.action.create(**provision_data)
     assert appliance.rest_api.response.status_code == 200
     provision_request = response[0]

--- a/cfme/tests/infrastructure/test_provisioning_rest.py
+++ b/cfme/tests/infrastructure/test_provisioning_rest.py
@@ -15,9 +15,6 @@ pytestmark = [
     pytest.mark.meta(server_roles="+automate"),
     pytest.mark.usefixtures("setup_provider"),
     pytest.mark.provider([VMwareProvider, RHEVMProvider], scope="module"),
-    pytest.mark.meta(blockers=[BZ(1541036,
-                     forced_streams=['5.9', 'upstream'],
-                     unblock=lambda provider: not provider.one_of(RHEVMProvider))]),
 ]
 
 
@@ -64,7 +61,9 @@ def get_provision_data(rest_api, provider, template_name, auto_approve=True):
     }
 
     if provider.one_of(RHEVMProvider):
+        result["vm_fields"]["vlan"] = "<Template>"
         result["vm_fields"]["provision_type"] = "native_clone"
+
     return result
 
 


### PR DESCRIPTION
This PR has three parts:
1) __Fixing__ provisioning data in `test_provisioning_rest.py` to be compliant with new definition of vlan attribute: https://bugzilla.redhat.com/show_bug.cgi?id=1541036#c4

2) __Moving__ some helper functions from test_provision to module level, since I will need them for future tests as well and don't want to duplicate code.

3) __Removing__ BZ wrapper. The referenced BZ is still not solved, but it became clear that it is not actually a blocker.

Note: This still does not work for vsphere. I tried to do a quick fix but it didn't work. Unfortunately I don't really have the resources for fixing vsphere.