### PR TITLE
[1LP][RFR] reduced number of retrieved existing templates to certain provider templates

### DIFF
--- a/cfme/utils/trackerbot.py
+++ b/cfme/utils/trackerbot.py
@@ -265,7 +265,7 @@ def trackerbot_add_provider_template(stream, provider, template_name, custom_dat
         existing_provider_templates = [
             pt['id']
             for pt in depaginate(
-                api(), api().providertemplate.get())['objects']]
+                api(), api().providertemplate.get(provider=provider))['objects']]
         if '{}_{}'.format(template_name, provider) in existing_provider_templates:
             print('Template {} already tracked for provider {}'.format(
                 template_name, provider))


### PR DESCRIPTION
Fix for trackerbot.trackerbot_add_provider_template which tried to load ~6000 templates from trackerbot in order to check whether passed template name already exists. 