### PR TITLE
[WIPTEST] Rename SDN tests and add provider

### DIFF
--- a/cfme/tests/networks/test_sdn_balancers.py
+++ b/cfme/tests/networks/test_sdn_balancers.py
@@ -2,15 +2,15 @@ import pytest
 
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.ec2 import EC2Provider
+from cfme.cloud.provider.gce import GCEProvider
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.exceptions import DestinationNotFound
 from cfme.utils.appliance.implementations.ui import navigate_to
 
-
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
-    pytest.mark.provider([AzureProvider, EC2Provider, OpenStackProvider],
-                         scope='module')
+    pytest.mark.provider(
+        [AzureProvider, EC2Provider, OpenStackProvider, GCEProvider], scope='module')
 ]
 
 
@@ -29,7 +29,7 @@ def network_prov_with_load_balancers(appliance):
         "No available load balancers for current providers")
 
 
-def test_prov_balances_number(network_prov_with_load_balancers):
+def test_sdn_prov_balances_number(network_prov_with_load_balancers):
     """
     Test number of balancers on 1 provider
     Prerequisites:
@@ -41,7 +41,7 @@ def test_prov_balances_number(network_prov_with_load_balancers):
         assert int(balancers_number) == sum_all
 
 
-def test_balances_detail(provider, network_prov_with_load_balancers):
+def test_sdn_balances_detail(provider, network_prov_with_load_balancers):
     """ Test of getting attribute from balancer object """
     for prov, _ in network_prov_with_load_balancers:
         for balancer in prov.balancers.all():

--- a/cfme/tests/networks/test_sdn_crud.py
+++ b/cfme/tests/networks/test_sdn_crud.py
@@ -1,14 +1,15 @@
 import pytest
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.ec2 import EC2Provider
+from cfme.cloud.provider.gce import GCEProvider
 from cfme.cloud.provider.openstack import OpenStackProvider
-from cfme.networks.provider import NetworkProviderCollection
 from cfme.utils.appliance.implementations.ui import navigate_to
 
 
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
-    pytest.mark.provider([EC2Provider, AzureProvider, OpenStackProvider], scope='module'),
+    pytest.mark.provider([EC2Provider, AzureProvider, OpenStackProvider, GCEProvider],
+                         scope='module'),
 ]
 
 

--- a/cfme/tests/networks/test_sdn_downloads.py
+++ b/cfme/tests/networks/test_sdn_downloads.py
@@ -1,6 +1,9 @@
 import pytest
 
 from cfme.cloud.provider.azure import AzureProvider
+from cfme.cloud.provider.ec2 import EC2Provider
+from cfme.cloud.provider.gce import GCEProvider
+from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.exceptions import ManyEntitiesFound
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
@@ -8,7 +11,8 @@ from cfme.utils.blockers import BZ
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.meta(blockers=[BZ(1480577, forced_streams=["5.7", "5.8"])]),
-    pytest.mark.provider([AzureProvider], scope="module")
+    pytest.mark.provider([EC2Provider, AzureProvider, OpenStackProvider, GCEProvider],
+                         scope="module")
 ]
 FILETYPES = ["txt", "csv", "pdf"]
 extensions_mapping = {'txt': 'Text', 'csv': 'CSV', 'pdf': 'PDF'}
@@ -35,14 +39,14 @@ def download_summary(spec_object):
 
 @pytest.mark.parametrize("filetype", FILETYPES)
 @pytest.mark.parametrize("collection_type", OBJECTCOLLECTIONS)
-def test_download_lists_base(filetype, collection_type, appliance):
+def test_sdn_download_lists_base(filetype, collection_type, appliance):
     """ Download the items from base lists. """
     collection = getattr(appliance.collections, collection_type)
     download(collection, filetype)
 
 
 @pytest.mark.parametrize("collection_type", OBJECTCOLLECTIONS)
-def test_download_pdf_summary(appliance, collection_type, provider):
+def test_sdn_download_pdf_summary(appliance, collection_type, provider):
     """ Download the summary details of specific object """
     collection = getattr(appliance.collections, collection_type)
     if collection.all():

--- a/cfme/tests/networks/test_sdn_inventory_collection.py
+++ b/cfme/tests/networks/test_sdn_inventory_collection.py
@@ -1,6 +1,7 @@
 import pytest
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.ec2 import EC2Provider
+from cfme.cloud.provider.gce import GCEProvider
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.networks.cloud_network import CloudNetwork
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -8,7 +9,7 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
-    pytest.mark.provider([EC2Provider, AzureProvider, OpenStackProvider],
+    pytest.mark.provider([EC2Provider, AzureProvider, OpenStackProvider, GCEProvider],
                          scope='module'),
 ]
 

--- a/cfme/tests/networks/test_sdn_navigation.py
+++ b/cfme/tests/networks/test_sdn_navigation.py
@@ -1,6 +1,7 @@
 import pytest
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.ec2 import EC2Provider
+from cfme.cloud.provider.gce import GCEProvider
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.networks.provider import NetworkProviderCollection
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -8,7 +9,7 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
-    pytest.mark.provider([EC2Provider, AzureProvider, OpenStackProvider],
+    pytest.mark.provider([EC2Provider, AzureProvider, OpenStackProvider, GCEProvider],
                          scope='function')
 ]
 
@@ -28,7 +29,7 @@ def test_provider_relationships_navigation(provider, tested_part, appliance):
         navigate_to(network_provider, tested_part.replace(' ', ''))
 
 
-def test_provider_topology_navigation(provider, appliance):
+def test_sdn_provider_topology_navigation(provider, appliance):
     view = navigate_to(provider, 'Details')
     net_prov_name = view.entities.relationships.get_text_of('Network Manager')
 

--- a/cfme/tests/networks/test_sdn_ports.py
+++ b/cfme/tests/networks/test_sdn_ports.py
@@ -1,5 +1,9 @@
 import pytest
+
+from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.ec2 import EC2Provider
+from cfme.cloud.provider.openstack import OpenStackProvider
+from cfme.cloud.provider.gce import GCEProvider
 from cfme.exceptions import ManyEntitiesFound, ItemNotFound
 from cfme.networks.network_port import NetworkPortCollection
 from cfme.networks.provider import NetworkProviderCollection
@@ -9,12 +13,13 @@ from cfme.utils.blockers import BZ
 
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
-    pytest.mark.provider([EC2Provider], scope='module')
+    pytest.mark.provider([EC2Provider, AzureProvider, OpenStackProvider, GCEProvider],
+                         scope='module')
 ]
 
 
 @pytest.mark.meta(blockers=[BZ(1480577, forced_streams=["5.7", "5.8"])])
-def test_port_detail_name(provider, appliance):
+def test_sdn_port_detail_name(provider, appliance):
     """ Test equality of quadicon and detail names """
     port_collection = NetworkPortCollection(appliance)
     ports = port_collection.all()
@@ -30,7 +35,7 @@ def test_port_detail_name(provider, appliance):
 
 
 @pytest.mark.meta(blockers=[BZ(1480577, forced_streams=["5.7", "5.8"])])
-def test_port_net_prov(provider, appliance):
+def test_sdn_port_net_prov(provider, appliance):
     """ Test functionality of quadicon and detail network providers"""
     prov_collection = NetworkProviderCollection(appliance)
 


### PR DESCRIPTION
Some tests were missing sdn in the name, it would be better to have them all with the same start. adding as well some missing providers. 