### PR TITLE
[1LP][RFR] Ansible tower type is different in 5.9

### DIFF
--- a/cfme/services/catalogs/catalog_item.py
+++ b/cfme/services/catalogs/catalog_item.py
@@ -112,6 +112,11 @@ class CatalogForm(BasicInfoForm):
     def before_filling(self):
         item_type = self.context['object'].provider_type or \
             self.context['object'].item_type or 'Generic'
+        if item_type == 'AnsibleTower':
+            item_type = VersionPick({
+                Version.lowest(): "AnsibleTower",
+                "5.9": "Ansible Tower"
+            })
         self.select_item_type.select_by_visible_text(item_type)
         self.flush_widget_cache()
 


### PR DESCRIPTION
{{pytest: -v  --long-running cfme/tests/services/test_config_provider_servicecatalogs.py}}

while creating catalog item , the Ansible tower text is different in 5.9 .
Did a version pick.