### PR TITLE
[1LP][WIPTEST] Update BZ blockers in aws RBAC/login tests

### DIFF
--- a/cfme/roles.py
+++ b/cfme/roles.py
@@ -304,7 +304,7 @@ role_access_ui_59z = {
         'Configuration': ['Management'],
         'Control': ['Import / Export', 'Log', 'Explorer', 'Simulation'],
         'Monitor': {
-            'Alerts': ['Overview', 'All Alerts', 'Most Recent Alerts']},
+            'Alerts': ['Overview', 'All Alerts']},
         'Networks': ['Subnets', 'Load Balancers', 'Providers', 'Security Groups', 'Floating IPs',
                      'Network Ports', 'Topology', 'Networks', 'Network Routers'],
         'Optimize': ['Bottlenecks', 'Planning', 'Utilization'],
@@ -346,7 +346,7 @@ role_access_ui_59z = {
             'Infrastructure': ['Datastores', 'Providers', 'Virtual Machines', 'Hosts', 'Clusters',
                                'PXE', 'Resource Pools'],
             'Physical Infrastructure': ['Servers', 'Providers']},
-        'Control': ['Log', 'Simulation'],
+        'Control': ['Explorer', 'Log', 'Simulation'],
         'Services': ['Requests', 'Workloads', 'My Services'],
     },
     'evmgroup-auditor': {
@@ -359,7 +359,7 @@ role_access_ui_59z = {
             'Infrastructure': ['Datastores', 'Providers', 'Virtual Machines', 'Hosts', 'Clusters',
                                'PXE', 'Resource Pools'],
             'Physical Infrastructure': ['Servers', 'Providers']},
-        'Control': ['Log', 'Simulation'],
+        'Control': ['Explorer', 'Log', 'Simulation'],
         'Optimize': ['Bottlenecks', 'Planning', 'Utilization'],
         'Services': ['Workloads', 'My Services']},
     'evmgroup-desktop': {
@@ -392,7 +392,7 @@ role_access_ui_59z = {
             'Infrastructure': ['Datastores', 'Providers', 'Virtual Machines', 'Hosts',
                                'Clusters', 'Resource Pools'],
             'Physical Infrastructure': ['Servers', 'Providers']},
-        'Control': ['Log', 'Simulation'],
+        'Control': ['Explorer', 'Log', 'Simulation'],
         'Services': ['My Services', 'Workloads']
     },
     'evmgroup-support': {
@@ -402,7 +402,7 @@ role_access_ui_59z = {
             'Infrastructure': ['Datastores', 'Providers', 'Virtual Machines', 'Hosts', 'Clusters',
                                'Resource Pools'],
             'Physical Infrastructure': ['Servers', 'Providers']},
-        'Control': ['Log', 'Simulation'],
+        'Control': ['Explorer', 'Log', 'Simulation'],
         'Services': ['My Services', 'Workloads']
     },
     'evmgroup-user': {

--- a/cfme/roles.py
+++ b/cfme/roles.py
@@ -447,7 +447,7 @@ role_access_ui_58z = {
         'Networks': ['Subnets', 'Load Balancers', 'Providers', 'Security Groups', 'Floating IPs',
                      'Network Ports', 'Topology', 'Networks', 'Network Routers'],
         'Optimize': ['Bottlenecks', 'Planning', 'Utilization'],
-        'Red Hat Insights': ['Rules', 'Overview', 'Inventory', 'Actions'],
+        'Red Hat Insights': ['Rules', 'Overview', 'Systems'],
         'Services': ['Requests', 'Workloads', 'Catalogs', 'My Services'],
         'Storage': {
             'Block Storage': ['Volume Snapshots', 'Managers', 'Volume Backups', 'Volumes'],

--- a/cfme/tests/integration/test_aws_iam_auth_and_roles.py
+++ b/cfme/tests/integration/test_aws_iam_auth_and_roles.py
@@ -27,6 +27,10 @@ def auth_groups():
 @pytest.mark.tier(2)
 @pytest.mark.parametrize('group_name, context', auth_groups())
 @pytest.mark.meta(blockers=[
+    BZ(1531499,
+       forced_streams=['5.8'],
+       unblock=lambda group_name: group_name not in [
+           'evmgroup-administrator', 'evmgroup-vm_user', 'evmgroup-desktop', 'evmgroup-operator']),
     BZ(1525598,
        forced_streams=['5.8'],
        unblock=lambda group_name: group_name not in

--- a/cfme/tests/integration/test_aws_iam_auth_and_roles.py
+++ b/cfme/tests/integration/test_aws_iam_auth_and_roles.py
@@ -1,11 +1,11 @@
 import pytest
-
 from deepdiff import DeepDiff
 
+from cfme.roles import role_access_ui_58z, role_access_ui_59z, role_access_ssui
 from cfme.utils.appliance import ViaUI, current_appliance
 from cfme.utils.blockers import BZ
 from cfme.utils.conf import credentials
-from cfme.roles import role_access_ui_58z, role_access_ui_59z, role_access_ssui
+from cfme.utils.log import logger
 
 
 def auth_groups():
@@ -26,9 +26,16 @@ def auth_groups():
 
 @pytest.mark.tier(2)
 @pytest.mark.parametrize('group_name, context', auth_groups())
-@pytest.mark.meta(blockers=[BZ(1525598, forced_streams=['5.8', '5.9']),
-                            BZ(1525657, forced_streams=['5.9']),
-                            BZ(1526495, forced_streams=['5.8', '5.9'])])
+@pytest.mark.meta(blockers=[
+    BZ(1525598,
+       forced_streams=['5.8'],
+       unblock=lambda group_name: group_name not in
+       ['evmgroup-security', 'evmgroup-approver', 'evmgroup-auditor', 'evmgroup-support']),
+    BZ(1530683,
+       unblock=lambda group_name: group_name not in
+       ['evmgroup-user', 'evmgroup-approver', 'evmgroup-auditor', 'evmgroup-operator',
+        'evmgroup-support', 'evmgroup-security'])
+])
 def test_group_roles(appliance, configure_aws_iam_auth_mode, group_name, context, soft_assert):
     """Basic default AWS_IAM group role auth + RBAC test
 
@@ -53,13 +60,27 @@ def test_group_roles(appliance, configure_aws_iam_auth_mode, group_name, context
     with appliance.context.use(context):
         user = appliance.collections.users.simple_user(username, password)
         view = appliance.server.login(user)
+        assert appliance.server.current_full_name() == user.name
         nav_visbility = view.navigation.nav_item_tree()
 
+        # RFE BZ 1526495 shows up as an extra requests link in nav
+        bz = BZ(1526495,
+                forced_streams=['5.8', '5.9'],
+                unblock=lambda group_name: group_name not in
+                ['evmgroup-user', 'evmgroup-approver', 'evmgroup-desktop', 'evmgroup-vm_user',
+                 'evmgroup-administrator', 'evmgroup-super_administrator'])
+        rfe_blocks = bz.blocks
         for area in group_access.keys():
             # using .get() on nav_visibility because it may not have `area` key
             diff = DeepDiff(group_access[area], nav_visbility.get(area, {}),
                             verbose_level=0,  # If any higher, will flag string vs unicode
                             ignore_order=True)
-            soft_assert(diff == {}, '{g} RBAC mismatch for {a}: {d}'.format(g=group_name,
-                                                                            a=area,
-                                                                            d=diff))
+            nav_extra = diff.get('iterable_item_added')
+
+            if nav_extra and 'Requests' in nav_extra.values() and rfe_blocks:
+                logger.warning('Skipping RBAC verification for group "%s" due to %r',
+                               group_name, bz)
+                continue
+            else:
+                soft_assert(diff == {}, '{g} RBAC mismatch for {a}: {d}'
+                                        .format(g=group_name, a=area, d=diff))


### PR DESCRIPTION
Updates to go with BZ resolutions and re-opening. Narrowing the BZ blocker scope to increase test coverage on non-impacted roles/groups.

One BZ for 'requests' showing up throughout the vertical navigation tree where there is no matching access control tree entry was marked as an RFE.  As a result I'm now checking for 'Requests' in the diff, and skipping verification.

### PRT results
* 21004: 58z failures: 2 from BZ, 1 from RBAC change for super_admin role.  2nd commit should resolve: https://github.com/ManageIQ/integration_tests/pull/6626/commits/bddc751dc4104035a4353a1ba568a4f43f8e09a4

{{ pytest: cfme/tests/integration/test_aws_iam_auth_and_roles.py  --long-running -v }}