### PR TITLE
[1LP][RFR] Cloud provider discovery test

### DIFF
--- a/cfme/base/credential.py
+++ b/cfme/base/credential.py
@@ -63,11 +63,14 @@ class Credential(Pretty, Updateable, FromConfigMixin):
     """
     pretty_attrs = ['principal', 'secret']
 
-    def __init__(self, principal, secret, verify_secret=None, domain=None, **ignore):
+    def __init__(self, principal, secret, verify_secret=None, domain=None,
+                 tenant_id=None, subscription_id=None, **ignore):
         self.principal = principal
         self.secret = secret
         self.verify_secret = verify_secret
         self.domain = domain
+        self.tenant_id = tenant_id
+        self.subscription_id = subscription_id
 
     def __getattribute__(self, attr):
         if attr == 'verify_secret':

--- a/cfme/cloud/provider/ec2.py
+++ b/cfme/cloud/provider/ec2.py
@@ -81,5 +81,5 @@ class EC2Provider(CloudProvider):
         return {
             'username': getattr(credential, 'principal', None),
             'password': getattr(credential, 'secret', None),
-            'password_verify': getattr(credential, 'verify_secret', None)
+            'confirm_password': getattr(credential, 'verify_secret', None)
         }

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -16,7 +16,6 @@ from widgetastic_manageiq import (BreadCrumb,
                                   ItemsToolBarViewSelector,
                                   Checkbox,
                                   Input,
-                                  Table,
                                   BaseEntitiesView,
                                   PaginationPane,
                                   BaseTileIconEntity,
@@ -314,6 +313,7 @@ class ProviderVmsView(ProviderVmsTemplatesView):
         return (self.logged_in_as_current_user and
                 self.navigation.currently_selected == ['Compute', 'Infrastructure', 'Providers'] and
                 self.title.text == title)
+
 
 class ProviderToolBar(View):
     """


### PR DESCRIPTION
Purpose or Intent
=================
- Added Cloud provider discovery test for `Azure` and `AWS`; supported for `version  < 5.9`
- Small change in `Credential` Class for Azure support
- Fix in `discover_dis()`; changed key to `confirm_password` as per `CloudProvidersDiscoverView()`

{{py.test: -v cfme/tests/cloud/test_providers.py --use-provider complete}}