### PR TITLE
[1LP][RFR] Added a bz blocker for test_alert_vm_turned_on_more_than_twice_in_past_15_minutes

### DIFF
--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -7,9 +7,11 @@ from cfme import test_requirements
 from cfme.common.vm import VM
 from cfme.control.explorer import alert_profiles, policies
 from cfme.infrastructure.provider import InfraProvider
+from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.utils import ports
+from cfme.utils.blockers import BZ
 from cfme.utils.conf import cfme_data, credentials
 from cfme.utils.generators import random_vm_name
 from cfme.utils.hosts import setup_host_creds
@@ -243,6 +245,9 @@ def setup_snmp(appliance):
     appliance.ssh_client.run_command("sed -i '$ d' /etc/snmp/snmptrapd.conf")
 
 
+@pytest.mark.meta(blockers=[BZ(1533451,
+                            forced_streams=['5.8', '5.9', 'upstream'],
+                            unblock=lambda provider: not provider.one_of(RHEVMProvider))])
 @pytest.mark.provider(gen_func=providers, filters=[pf1, pf2], scope="module")
 def test_alert_vm_turned_on_more_than_twice_in_past_15_minutes(request, provider, vm, smtp_test,
         alert_collection, setup_for_alerts):


### PR DESCRIPTION
RHV provider should be skipped for this test.
{{pytest: -v -k test_alert_vm_turned_on_more_than_twice_in_past_15_minutes --long-running --use-provider complete}}