### PR TITLE
[1LP][RFR] Add providers and rename tests

### DIFF
--- a/cfme/networks/views.py
+++ b/cfme/networks/views.py
@@ -345,7 +345,7 @@ class NetworkRouterDetailsToolBar(View):
     """ Represents provider toolbar and its controls """
     configuration = Dropdown(text='Configuration')
     policy = Dropdown(text='Policy')
-    download = Button(title='Download')
+    download = Button(title='Download summary in PDF format')
 
 
 class NetworkRouterSideBar(View):

--- a/cfme/tests/networks/test_sdn_balancers.py
+++ b/cfme/tests/networks/test_sdn_balancers.py
@@ -2,21 +2,20 @@ import pytest
 
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.ec2 import EC2Provider
-from cfme.cloud.provider.openstack import OpenStackProvider
+from cfme.cloud.provider.gce import GCEProvider
 from cfme.exceptions import DestinationNotFound
 from cfme.utils.appliance.implementations.ui import navigate_to
-
+from cfme.utils.blockers import BZ
 
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
-    pytest.mark.provider([AzureProvider, EC2Provider, OpenStackProvider],
-                         scope='module')
+    pytest.mark.provider([AzureProvider, EC2Provider, GCEProvider], scope='module')
 ]
 
 
 @pytest.fixture(scope='module')
-def network_prov_with_load_balancers(appliance):
-    prov_collection = appliance.collections.network_providers
+def network_prov_with_load_balancers(provider):
+    prov_collection = provider.appliance.collections.network_providers
     providers = prov_collection.all()
     available_prov = []
     for prov in providers:
@@ -29,7 +28,7 @@ def network_prov_with_load_balancers(appliance):
         "No available load balancers for current providers")
 
 
-def test_prov_balances_number(network_prov_with_load_balancers):
+def test_sdn_prov_balancers_number(network_prov_with_load_balancers):
     """
     Test number of balancers on 1 provider
     Prerequisites:
@@ -41,7 +40,9 @@ def test_prov_balances_number(network_prov_with_load_balancers):
         assert int(balancers_number) == sum_all
 
 
-def test_balances_detail(provider, network_prov_with_load_balancers):
+@pytest.mark.meta(blockers=[BZ(1544411, forced_streams=['5.8', '5.9'],
+                               unblock=lambda provider: not provider.one_of(GCEProvider))])
+def test_sdn_balancers_detail(provider, network_prov_with_load_balancers):
     """ Test of getting attribute from balancer object """
     for prov, _ in network_prov_with_load_balancers:
         for balancer in prov.balancers.all():

--- a/cfme/tests/networks/test_sdn_crud.py
+++ b/cfme/tests/networks/test_sdn_crud.py
@@ -1,14 +1,15 @@
 import pytest
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.ec2 import EC2Provider
+from cfme.cloud.provider.gce import GCEProvider
 from cfme.cloud.provider.openstack import OpenStackProvider
-from cfme.networks.provider import NetworkProviderCollection
 from cfme.utils.appliance.implementations.ui import navigate_to
 
 
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
-    pytest.mark.provider([EC2Provider, AzureProvider, OpenStackProvider], scope='module'),
+    pytest.mark.provider([EC2Provider, AzureProvider, OpenStackProvider, GCEProvider],
+                         scope='module'),
 ]
 
 

--- a/cfme/tests/networks/test_sdn_downloads.py
+++ b/cfme/tests/networks/test_sdn_downloads.py
@@ -1,6 +1,9 @@
 import pytest
 
 from cfme.cloud.provider.azure import AzureProvider
+from cfme.cloud.provider.ec2 import EC2Provider
+from cfme.cloud.provider.openstack import OpenStackProvider
+from cfme.cloud.provider.gce import GCEProvider
 from cfme.exceptions import ManyEntitiesFound
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
@@ -8,7 +11,8 @@ from cfme.utils.blockers import BZ
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.meta(blockers=[BZ(1480577, forced_streams=["5.7", "5.8"])]),
-    pytest.mark.provider([AzureProvider], scope="module")
+    pytest.mark.provider([AzureProvider, EC2Provider, GCEProvider, OpenStackProvider],
+                         scope="module")
 ]
 FILETYPES = ["txt", "csv", "pdf"]
 extensions_mapping = {'txt': 'Text', 'csv': 'CSV', 'pdf': 'PDF'}
@@ -19,7 +23,8 @@ OBJECTCOLLECTIONS = [
     'network_ports',
     'network_security_groups',
     'network_subnets',
-    'network_routers'
+    'network_routers',
+
 ]
 
 

--- a/cfme/tests/networks/test_sdn_navigation.py
+++ b/cfme/tests/networks/test_sdn_navigation.py
@@ -1,6 +1,7 @@
 import pytest
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.ec2 import EC2Provider
+from cfme.cloud.provider.gce import GCEProvider
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.networks.provider import NetworkProviderCollection
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -8,14 +9,14 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
-    pytest.mark.provider([EC2Provider, AzureProvider, OpenStackProvider],
+    pytest.mark.provider([EC2Provider, AzureProvider, OpenStackProvider, GCEProvider],
                          scope='function')
 ]
 
 
 @pytest.mark.parametrize("tested_part", ["Cloud Subnets", "Cloud Networks", "Network Routers",
                          "Security Groups", "Network Ports", "Load Balancers"])
-def test_provider_relationships_navigation(provider, tested_part, appliance):
+def test_sdn_provider_relationships_navigation(provider, tested_part, appliance):
     view = navigate_to(provider, 'Details')
     net_prov_name = view.entities.relationships.get_text_of('Network Manager')
 

--- a/cfme/tests/networks/test_sdn_ports.py
+++ b/cfme/tests/networks/test_sdn_ports.py
@@ -1,20 +1,23 @@
 import pytest
+
+from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.ec2 import EC2Provider
+from cfme.cloud.provider.gce import GCEProvider
+from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.exceptions import ManyEntitiesFound, ItemNotFound
 from cfme.networks.network_port import NetworkPortCollection
 from cfme.networks.provider import NetworkProviderCollection
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.blockers import BZ
 
 
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
-    pytest.mark.provider([EC2Provider], scope='module')
+    pytest.mark.provider([AzureProvider, EC2Provider, OpenStackProvider, GCEProvider],
+                         scope='module')
 ]
 
 
-@pytest.mark.meta(blockers=[BZ(1480577, forced_streams=["5.7", "5.8"])])
-def test_port_detail_name(provider, appliance):
+def test_sdn_port_detail_name(provider, appliance):
     """ Test equality of quadicon and detail names """
     port_collection = NetworkPortCollection(appliance)
     ports = port_collection.all()
@@ -29,8 +32,7 @@ def test_port_detail_name(provider, appliance):
             pass
 
 
-@pytest.mark.meta(blockers=[BZ(1480577, forced_streams=["5.7", "5.8"])])
-def test_port_net_prov(provider, appliance):
+def test_sdn_port_net_prov(provider, appliance):
     """ Test functionality of quadicon and detail network providers"""
     prov_collection = NetworkProviderCollection(appliance)
 


### PR DESCRIPTION
Renamed all tests to have them starting with sdn_*
Fix a button. 
Add more provider coverage
{{pytest: -v -q cfme/tests/networks/test_sdn_balancers.py cfme/tests/networks/test_sdn_crud.py cfme/tests/networks/test_sdn_downloads.py cfme/tests/networks/test_sdn_navigation.py cfme/tests/networks/test_sdn_ports.py --use-provider=complete}}