### PR TITLE
[1LP][RFR] Add a --force option to link_config.py to overwrite existing symlinks/files

### DIFF
--- a/cfme/scripting/link_config.py
+++ b/cfme/scripting/link_config.py
@@ -64,7 +64,6 @@ def main(src, dest, force):
         _warn_on_unknown_encryption(element)
         target = dest.joinpath(element.name)
 
-        # the following is fragile
         if force:
             try:
                 target.symlink_to(element.resolve())

--- a/cfme/scripting/link_config.py
+++ b/cfme/scripting/link_config.py
@@ -79,12 +79,12 @@ def main(src, dest, force):
                     target.symlink_to(element.resolve())
                 else:
                     raise e
-	else:
+        else:
             if target.is_symlink():
                 # If symlink already exists and points to same src, do nothing.
                 _check_missmatching_symlink(src=element, target=target)
             elif _check_existing_file(target):
-	        target.symlink_to(element.resolve())
+                target.symlink_to(element.resolve())
                 print("Symlink created for", target.name)
 
 

--- a/cfme/scripting/link_config.py
+++ b/cfme/scripting/link_config.py
@@ -63,8 +63,8 @@ def main(src, dest, force):
     for element in filter(_is_yaml_file, src.iterdir()):
         _warn_on_unknown_encryption(element)
         target = dest.joinpath(element.name)
-        
-	# the following is fragile
+
+        # the following is fragile
         if force:
             try:
                 target.symlink_to(element.resolve())

--- a/cfme/scripting/link_config.py
+++ b/cfme/scripting/link_config.py
@@ -78,7 +78,7 @@ def main(src, dest, force):
 
                     target.symlink_to(element.resolve())
                 else:
-                    raise e
+                    raise
         else:
             if target.is_symlink():
                 # If symlink already exists and points to same src, do nothing.


### PR DESCRIPTION
Add a --force option to link_config.py to overwrite existing symlinks/files -- this makes it easier to switch back and forth between different cfme-qe-yaml dirs.

The logic is now:

* If force, rename current target "file.yaml" to "file.yaml_bak" and create new symlink
* If not force, do the same checks we did before:
-- If target "file.yaml" is a symlink:
---- and it already points to same src, we're good, do nothing.
---- and it points to somewhere else, throw error
-- If target is an existing file, throw error
-- If above checks pass, create the new symlink