### PR TITLE
[1LP][RFR] fix MoveTargetOutOfBoundsException for provider discovery

### DIFF
--- a/cfme/tests/infrastructure/test_provider_discovery.py
+++ b/cfme/tests/infrastructure/test_provider_discovery.py
@@ -1,4 +1,5 @@
 import pytest
+from widgetastic.exceptions import MoveTargetOutOfBoundsException
 from itertools import combinations
 
 from cfme.utils import testgen
@@ -90,7 +91,12 @@ def delete_providers_after_test():
 @pytest.mark.usefixtures('has_no_infra_providers', 'delete_providers_after_test')
 def test_discover_infra(providers_for_discover, start_ip, max_range):
     for provider in providers_for_discover:
-        discover(provider, False, start_ip, max_range)
+        try:
+            discover(provider, False, start_ip, max_range)
+        except MoveTargetOutOfBoundsException:
+            # TODO: Remove once fixed 1475303
+            provider.browser.refresh()
+            discover(provider, False, start_ip, max_range)
 
     @wait_for_decorator(num_sec=count_timeout(start_ip, max_range), delay=5)
     def _wait_for_all_providers():


### PR DESCRIPTION
Purpose or Intent
=================
- try to add hot fix for `MoveTargetOutOfBoundsException`. To do remove it after https://bugzilla.redhat.com/show_bug.cgi?id=1475303 fix. 

{{py.test: -sqvv cfme/tests/infrastructure/test_provider_discovery.py --use-provider complete}}