### PR TITLE
[1LP][RFR]Added test_tagvis_provider_children for cloud and infra

### DIFF
--- a/cfme/cloud/tenant.py
+++ b/cfme/cloud/tenant.py
@@ -98,6 +98,18 @@ class TenantAllView(TenantView):
         return self.in_tenants and self.entities.title.text == 'Cloud Tenants'
 
 
+class ProviderTenantAllView(TenantAllView):
+
+    @property
+    def is_displayed(self):
+        return (
+            self.logged_in_as_current_user and
+            self.navigation.currently_selected == ['Compute', 'Clouds', 'Providers'] and
+            self.entities.title.text == '{} (All Cloud Tenants)'.format(
+                self.context['object'].name)
+        )
+
+
 class TenantDetailsView(TenantView):
     """The details page for a tenant"""
     toolbar = View.nested(TenantDetailsToolbar)

--- a/cfme/tests/cloud_infra_common/test_relationships.py
+++ b/cfme/tests/cloud_infra_common/test_relationships.py
@@ -2,11 +2,15 @@
 import pytest
 import random
 
-from cfme.cloud.availability_zone import ProviderAvailabilityZoneAllView
-from cfme.cloud.flavor import ProviderFlavorAllView
+from cfme.cloud.availability_zone import ProviderAvailabilityZoneAllView, AvailabilityZone
+from cfme.cloud.flavor import ProviderFlavorAllView, Flavor
+from cfme.cloud.instance import Instance
+from cfme.cloud.instance.image import Image
 from cfme.cloud.provider import CloudProviderImagesView, CloudProviderInstancesView
 from cfme.cloud.provider.ec2 import EC2Provider
+from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.cloud.stack import ProviderStackAllView
+from cfme.cloud.tenant import ProviderTenantAllView
 from cfme.common.host_views import ProviderAllHostsView
 from cfme.common.provider_views import InfraProviderDetailsView
 from cfme.common.vm_views import HostAllVMsView, ProviderAllVMsView
@@ -14,11 +18,11 @@ from cfme.infrastructure.cluster import ClusterDetailsView, ProviderAllClustersV
 from cfme.infrastructure.datastore import HostAllDatastoresView, ProviderAllDatastoresView
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.infrastructure.virtual_machines import (HostTemplatesOnlyAllView,
-    ProviderTemplatesOnlyAllView)
+                                                  ProviderTemplatesOnlyAllView, Vm, Template)
 from cfme.networks.views import NetworkProviderDetailsView, ProviderSecurityGroupAllView
 from cfme.storage.manager import ProviderStorageManagerAllView
 from cfme.utils.appliance.implementations.ui import navigate_to
-from markers.env_markers.provider import ONE_PER_TYPE
+from markers.env_markers.provider import ONE_PER_TYPE, ONE_PER_CATEGORY
 
 
 HOST_RELATIONSHIPS = [
@@ -43,12 +47,34 @@ INFRA_PROVIDER_RELATIONSHIPS = [
 CLOUD_PROVIDER_RELATIONSHIPS = [
     ("Network Manager", NetworkProviderDetailsView),
     ("Availability zones", ProviderAvailabilityZoneAllView),
+    ("Cloud tenants", ProviderTenantAllView),
     ("Flavors", ProviderFlavorAllView),
     ("Security Groups", ProviderSecurityGroupAllView),
     ("Instances", CloudProviderInstancesView),
     ("Images", CloudProviderImagesView),
     ("Orchestration stacks", ProviderStackAllView),
     ("Storage Managers", ProviderStorageManagerAllView)
+]
+# TODO: add Host Aggregates view to CLOUD_PROVIDER_RELATIONSHIPS
+
+cloud_test_items = [
+    ("instances", Instance),
+    ("flavors", Flavor),
+    ("availability_zones", AvailabilityZone),
+    ("cloud_tenants", None),
+    ("images", Image),
+    ("security_groups", None),
+    ("stacks", None),
+    ("block_managers", None),
+    ("network_providers", None)
+]
+
+infra_test_items = [
+    ("clusters", None),
+    ("hosts", None),
+    ("datastores", None),
+    ("vms", Vm),
+    ("templates", Template)
 ]
 
 
@@ -58,6 +84,8 @@ def _fix_item(appliance, item):
         return 'Orchestration Stacks'
     elif item == 'Availability zones' and appliance.version >= '5.9':
         return 'Availability Zones'
+    elif item == 'Cloud tenants' and appliance.version >= '5.9':
+        return 'Cloud Tenants'
     else:
         return item
 
@@ -134,3 +162,75 @@ def test_cloud_provider_relationships(appliance, provider, setup_provider, relat
     provider_view.entities.relationships.click_at(relationship)
     relationship_view = appliance.browser.create_view(view, additional_context={'object': obj})
     assert relationship_view.is_displayed
+
+
+@pytest.fixture(scope='function')
+def prov_child_visibility(appliance, provider, request, tag, user_restricted):
+    def _prov_child_visibility(relationship, item_cls, visibility):
+        provider.add_tag(tag=tag)
+        if not item_cls:
+            item_cls = getattr(appliance.collections, relationship)
+        actual_visibility = _check_actual_visibility(item_cls)
+        if not actual_visibility:
+            pytest.skip("There are no relationships for {}".format(relationship))
+
+        @request.addfinalizer
+        def _finalize():
+            provider.remove_tag(tag=tag)
+
+        with user_restricted:
+            actual_visibility = _check_actual_visibility(item_cls)
+
+        assert actual_visibility == visibility
+
+    def _check_actual_visibility(item_cls):
+        view = navigate_to(item_cls, 'All')
+        try:
+            if hasattr(view.entities, 'entity_names'):
+                assert view.entities.entity_names
+            else:
+                # this case is specified for block_managers
+                if appliance.version >= '5.9':
+                    assert view.entities.read()
+                else:
+                    assert view.entities.read().get('table')
+            actual_visibility = True
+        except AssertionError:
+            actual_visibility = False
+        return actual_visibility
+
+    return _prov_child_visibility
+
+
+@pytest.mark.parametrize("relationship,item_cls", infra_test_items,
+    ids=[rel[0] for rel in infra_test_items])
+@pytest.mark.provider([VMwareProvider], selector=ONE_PER_CATEGORY)
+# used VMwareProvider to cover all relationship as they have each of them
+def test_tagvis_infra_provider_children(prov_child_visibility, setup_provider, relationship,
+                                        item_cls):
+    """ Tests that provider child's should not be visible for restricted user
+    Prerequisites:
+        Catalog, tag, role, group and restricted user should be created
+
+    Steps:
+        1. As admin add tag to provider
+        2. Login as restricted user, providers child not visible for user
+    """
+    prov_child_visibility(relationship, item_cls, visibility=False)
+
+
+@pytest.mark.parametrize("relationship,item_cls", cloud_test_items,
+    ids=[rel[0] for rel in cloud_test_items])
+@pytest.mark.provider([OpenStackProvider], selector=ONE_PER_CATEGORY)
+# used OpenStackProvider to cover all relationship as they have each of them
+def test_tagvis_cloud_provider_children(prov_child_visibility, setup_provider, relationship,
+                                        item_cls):
+    """ Tests that provider child's should not be visible for restricted user
+    Prerequisites:
+        Catalog, tag, role, group and restricted user should be created
+
+    Steps:
+        1. As admin add tag to provider
+        2. Login as restricted user, providers child not visible for user
+    """
+    prov_child_visibility(relationship, item_cls, visibility=False)

--- a/cfme/tests/cloud_infra_common/test_relationships.py
+++ b/cfme/tests/cloud_infra_common/test_relationships.py
@@ -22,7 +22,7 @@ from cfme.infrastructure.virtual_machines import (HostTemplatesOnlyAllView,
 from cfme.networks.views import NetworkProviderDetailsView, ProviderSecurityGroupAllView
 from cfme.storage.manager import ProviderStorageManagerAllView
 from cfme.utils.appliance.implementations.ui import navigate_to
-from markers.env_markers.provider import ONE_PER_TYPE, ONE_PER_CATEGORY
+from markers.env_markers.provider import ONE, ONE_PER_TYPE
 
 
 HOST_RELATIONSHIPS = [
@@ -204,7 +204,7 @@ def prov_child_visibility(appliance, provider, request, tag, user_restricted):
 
 @pytest.mark.parametrize("relationship,item_cls", infra_test_items,
     ids=[rel[0] for rel in infra_test_items])
-@pytest.mark.provider([VMwareProvider], selector=ONE_PER_CATEGORY)
+@pytest.mark.provider([VMwareProvider], selector=ONE)
 # used VMwareProvider to cover all relationship as they have each of them
 def test_tagvis_infra_provider_children(prov_child_visibility, setup_provider, relationship,
                                         item_cls):
@@ -221,7 +221,7 @@ def test_tagvis_infra_provider_children(prov_child_visibility, setup_provider, r
 
 @pytest.mark.parametrize("relationship,item_cls", cloud_test_items,
     ids=[rel[0] for rel in cloud_test_items])
-@pytest.mark.provider([OpenStackProvider], selector=ONE_PER_CATEGORY)
+@pytest.mark.provider([OpenStackProvider], selector=ONE)
 # used OpenStackProvider to cover all relationship as they have each of them
 def test_tagvis_cloud_provider_children(prov_child_visibility, setup_provider, relationship,
                                         item_cls):


### PR DESCRIPTION
Purpose 
=================
Added _test_tagvis_infra_provider_children_ and _test_tagvis_cloud_provider_children_ to check that provider child's are not be visible for restricted user. 

{{pytest: -v cfme/tests/cloud_infra_common/test_relationships.py -k provider_children}}