### PR TITLE
[1LP][RFR] Replace get_details() for VMs

### DIFF
--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -113,7 +113,8 @@ class InstanceDetailsView(CloudInstanceView):
         expected_provider = self.context['object'].provider.name
         try:
             # Not displayed when the instance is archived
-            relationship_provider_name = self.entities.relationships.get_text_of('Cloud Provider')
+            relationships = self.entities.summary('Relationships')
+            relationship_provider_name = relationships.get_text_of('Cloud Provider')
         except (NameError, NoSuchElementException):
             logger.warning('No "Cloud Provider" Relationship, assume instance view not displayed')
             return False
@@ -257,7 +258,7 @@ class Instance(VM, Navigatable):
 
         def _looking_for_state_change():
             view = navigate_to(self, 'Details')
-            current_state = view.entities.power_management.get_text_of("Power State")
+            current_state = view.entities.summary("Power Management").get_text_of("Power State")
             logger.info('Current Instance state: {}'.format(current_state))
             logger.info('Desired Instance state: {}'.format(desired_state))
             if isinstance(desired_state, (list, tuple)):

--- a/cfme/cloud/instance/image.py
+++ b/cfme/cloud/instance/image.py
@@ -1,12 +1,12 @@
 from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.utils import VersionPick, Version
-from widgetastic.widget import View, Text
+from widgetastic.widget import View
 from widgetastic_patternfly import Button, Dropdown
 
 from cfme.common.vm import Template
 from cfme.common.vm_views import (
     EditView, SetOwnershipView, PolicySimulationView, BasicProvisionFormView,
-    VMEntities)
+    VMDetailsEntities, VMEntities)
 from cfme.exceptions import ImageNotFound
 from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import navigate_to, CFMENavigateStep, navigator
@@ -40,16 +40,8 @@ class ImageDetailsToolbar(View):
     download = Button(title='Download summary in PDF format')
 
 
-class ImageDetailsEntities(View):
-    title = Text('//div[@id="main-content"]//h1//span[@id="explorer_title_text"]')
-    properties = SummaryTable(title='Properties')
-    lifecycle = SummaryTable(title='Lifecycle')
-    relationships = SummaryTable(title='Relationships')
-    compliance = SummaryTable(title='Compliance')
-    power_management = SummaryTable(title='Power Management')
-    security = SummaryTable(title='Security')
-    configuration = SummaryTable(title='Configuration')
-    smart_management = SummaryTable(title='Smart Management')
+class ImageDetailsEntities(VMDetailsEntities):
+    pass
 
 
 class ImageAllView(CloudInstanceView):

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -241,7 +241,7 @@ class BaseVM(Pretty, Updateable, PolicyProfileAssignable, WidgetasticTaggable, N
     def is_retired(self):
         """Check retirement status of vm"""
         view = navigate_to(self, "Details", use_resetter=False)
-        if view.entities.lifecycle.get_text_of('Retirement Date').lower() != 'never' != 'never':
+        if view.entities.lifecycle.get_text_of('Retirement Date').lower() != 'never':
             try:
                 status = view.entities.summary('Lifecycle').get_text_of('Retirement state').lower()
                 return status == 'retired'

--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -13,7 +13,6 @@ from cfme.base.login import BaseLoggedInPage
 from cfme.exceptions import TemplateNotFound
 from widgetastic_manageiq import (Calendar,
                                   Checkbox,
-                                  SummaryTable,
                                   Button,
                                   ItemsToolBarViewSelector,
                                   Table,
@@ -30,7 +29,8 @@ from widgetastic_manageiq import (Calendar,
                                   BaseNonInteractiveEntitiesView,
                                   BreadCrumb,
                                   PaginationPane,
-                                  DriftComparison)
+                                  DriftComparison,
+                                  ParametrizedSummaryTable)
 
 
 class InstanceQuadIconEntity(BaseQuadIconEntity):
@@ -239,18 +239,7 @@ class VMDetailsEntities(View):
     VM's have 3-4 more tables, should inherit and add them there.
     """
     title = Text('//div[@id="main-content"]//h1//span[@id="explorer_title_text"]')
-    properties = SummaryTable(title='Properties')
-    lifecycle = SummaryTable(title='Lifecycle')
-    relationships = SummaryTable(title='Relationships')
-    vmsafe = SummaryTable(title='VMsafe')
-    attributes = SummaryTable(title='Custom Attributes')  # Only displayed when assigned
-    compliance = SummaryTable(title='Compliance')
-    power_management = SummaryTable(title='Power Management')
-    security = SummaryTable(title='Security')
-    configuration = SummaryTable(title='Configuration')
-    diagnostics = SummaryTable(title='Diagnostics')
-    smart_management = SummaryTable(title='Smart Management')
-    datastore_allocation_summary = SummaryTable(title='Datastore Allocation Summary')
+    summary = ParametrizedView.nested(ParametrizedSummaryTable)
 
 
 class VMPropertyDetailView(View):

--- a/cfme/tests/cloud/test_provisioning.py
+++ b/cfme/tests/cloud/test_provisioning.py
@@ -18,6 +18,7 @@ from cfme.cloud.provider.gce import GCEProvider
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.utils import error
+from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.conf import credentials
 from cfme.utils.rest import assert_response
 from cfme.utils.generators import random_vm_name
@@ -197,8 +198,9 @@ def test_gce_preemptible_provision(provider, testing_instance, soft_assert):
              num_sec=1000,
              delay=60,
              handle_exception=True)
-    soft_assert('Yes' in instance.get_detail(
-        properties=("Properties", "Preemptible")), "GCE Instance isn't Preemptible")
+    view = navigate_to(instance, "Details")
+    preemptible = view.entities.summary("Properties").get_text_of("Preemptible")
+    soft_assert('Yes' in preemptible, "GCE Instance isn't Preemptible")
     soft_assert(instance.does_vm_exist_on_provider(), "Instance wasn't provisioned")
 
 

--- a/cfme/tests/control/__init__.py
+++ b/cfme/tests/control/__init__.py
@@ -28,10 +28,11 @@ def do_scan(vm, additional_item_check=None, rediscover=True):
             vm.assign_policy_profiles(*vm.assigned_policy_profiles)
 
     def _scan():
-        return vm.get_detail(properties=("Lifecycle", "Last Analyzed")).lower()
+        return vm_details_view.entities.summary("Lifecycle").get_text_of("Last Analyzed")
     original = _scan()
     if additional_item_check is not None:
-        original_item = vm.get_detail(properties=additional_item_check)
+        title, field = additional_item_check
+        original_item = vm_details_view.entities.summary(title).get_text_of(field)
     vm.smartstate_scan(cancel=False, from_details=True)
     vm_details_view.flash.assert_success_message(
         "Analysis initiated for 1 VM and Instance from the CFME Database")
@@ -40,7 +41,9 @@ def do_scan(vm, additional_item_check=None, rediscover=True):
         lambda: _scan() != original,
         num_sec=300, delay=5, fail_func=vm_details_view.toolbar.reload.click)
     if additional_item_check is not None:
+        title, field = additional_item_check
+        get_text_of = vm_details_view.entities.summary(title).get_text_of
         wait_for(
-            lambda: vm.get_detail(properties=additional_item_check) != original_item,
+            lambda: get_text_of(field) != original_item,
             num_sec=120, delay=5, fail_func=vm_details_view.toolbar.reload.click)
     logger.info("Scan finished")

--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -11,6 +11,7 @@ from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.utils import ports
+from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.conf import cfme_data, credentials
 from cfme.utils.generators import random_vm_name
@@ -116,7 +117,8 @@ def vddk_url(provider):
 
 @pytest.yield_fixture(scope="function")
 def configure_fleecing(appliance, provider, vm, vddk_url):
-    host = vm.get_detail(properties=("Relationships", "Host"))
+    view = navigate_to(vm, "Details")
+    host = view.entities.summary("Relationships").get_text_of("Host")
     setup_host_creds(provider, host)
     appliance.install_vddk(vddk_url=vddk_url)
     yield

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -129,7 +129,8 @@ def test_change_cpu_ram(provisioner, soft_assert, provider, prov_data, vm_name):
     vm = provisioner(template_name, prov_data)
 
     # Go to the VM info
-    data = vm.get_detail(properties=("Properties", "Container")).strip()
+    view = navigate_to(vm, "Details")
+    data = view.entities.summary("Properties").get_text_of("Container").strip()
     # No longer possible to use version pick because of cherrypicking?
     regexes = map(re.compile, [
         r"^[^(]*(\d+) CPUs?.*, ([^)]+)[^)]*$",

--- a/cfme/tests/infrastructure/test_vm_migrate.py
+++ b/cfme/tests/infrastructure/test_vm_migrate.py
@@ -6,6 +6,7 @@ from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme import test_requirements
 
+from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
 
@@ -39,7 +40,8 @@ def test_vm_migrate(appliance, new_vm, provider):
         test_flag: migrate, provision
     """
     # auto_test_services should exist to test migrate VM
-    vm_host = new_vm.get_detail(properties=('Relationships', 'Host'))
+    view = navigate_to(new_vm, 'Details')
+    vm_host = view.entities.summary('Relationships').get_text_of('Host')
     migrate_to = [vds.name for vds in provider.hosts if vds.name not in vm_host][0]
     new_vm.migrate_vm("email@xyz.com", "first", "last", host_name=migrate_to)
     request_description = new_vm.name

--- a/cfme/tests/openstack/cloud/test_instances.py
+++ b/cfme/tests/openstack/cloud/test_instances.py
@@ -45,14 +45,12 @@ def new_instance(provider):
 
 def test_create_instance(new_instance, soft_assert):
     """Creates an instance and verifies it appears on UI"""
-    navigate_to(new_instance, 'Details')
+    view = navigate_to(new_instance, 'Details')
     prov_data = new_instance.provider.data['provisioning']
-    power_state = new_instance.get_detail(properties=('Power Management',
-                                                      'Power State'))
+    power_state = view.entities.summary('Power Management').get_text_of('Power State')
     assert power_state == OpenStackInstance.STATE_ON
 
-    vm_tmplt = new_instance.get_detail(properties=('Relationships',
-                                                   'VM Template'))
+    vm_tmplt = view.entities.summary('Relationships').get_text_of('VM Template')
     soft_assert(vm_tmplt == prov_data['image']['name'])
 
     # Assert other relationships in a loop
@@ -64,7 +62,7 @@ def test_create_instance(new_instance, soft_assert):
         props.append(('Virtual Private Cloud', 'cloud_network'))
 
     for p in props:
-        v = new_instance.get_detail(properties=('Relationships', p[0]))
+        v = view.entities.summary('Relationships').get_text_of(p[0])
         soft_assert(v == prov_data[p[1]])
 
 
@@ -72,8 +70,8 @@ def test_stop_instance(new_instance):
     new_instance.power_control_from_cfme(from_details=True,
                                          option=OpenStackInstance.STOP)
     new_instance.wait_for_instance_state_change(OpenStackInstance.STATE_OFF)
-    state = new_instance.get_detail(properties=('Power Management',
-                                                'Power State'))
+    view = navigate_to(new_instance, 'Details')
+    state = view.entities.summary('Power Management').get_text_of('Power State')
     assert state == OpenStackInstance.STATE_OFF
 
 
@@ -81,7 +79,8 @@ def test_suspend_instance(new_instance):
     new_instance.power_control_from_cfme(from_details=True,
                                          option=OpenStackInstance.SUSPEND)
     new_instance.wait_for_instance_state_change(OpenStackInstance.STATE_SUSPENDED)
-    state = new_instance.get_detail(properties=('Power Management', 'Power State'))
+    view = navigate_to(new_instance, 'Details')
+    state = view.entities.summary('Power Management').get_text_of('Power State')
     assert state == OpenStackInstance.STATE_SUSPENDED
 
 
@@ -89,8 +88,8 @@ def test_pause_instance(new_instance):
     new_instance.power_control_from_cfme(from_details=True,
                                          option=OpenStackInstance.PAUSE)
     new_instance.wait_for_instance_state_change(OpenStackInstance.STATE_PAUSED)
-    state = new_instance.get_detail(properties=('Power Management',
-                                                'Power State'))
+    view = navigate_to(new_instance, 'Details')
+    state = view.entities.summary('Power Management').get_text_of('Power State')
     assert state == OpenStackInstance.STATE_PAUSED
 
 
@@ -101,9 +100,8 @@ def test_shelve_instance(new_instance):
         new_instance.wait_for_instance_state_change(OpenStackInstance.STATE_SHELVED)
     except TimedOutError:
         logger.warning("Timeout when waiting for instance state: 'shelved'. Skipping")
-
-    state = new_instance.get_detail(properties=('Power Management',
-                                                'Power State'))
+    view = navigate_to(new_instance, 'Details')
+    state = view.entities.summary('Power Management').get_text_of('Power State')
     assert state in (OpenStackInstance.STATE_SHELVED_OFFLOAD,
                      OpenStackInstance.STATE_SHELVED)
 
@@ -119,8 +117,8 @@ def test_shelve_offload_instance(new_instance):
         logger.warning("Timeout when initiating power state 'Shelve Offload'. Skipping")
 
     new_instance.wait_for_instance_state_change(OpenStackInstance.STATE_SHELVED_OFFLOAD)
-    state = new_instance.get_detail(properties=('Power Management',
-                                                'Power State'))
+    view = navigate_to(new_instance, 'Details')
+    state = view.entities.summary('Power Management').get_text_of('Power State')
     assert state == OpenStackInstance.STATE_SHELVED_OFFLOAD
 
 
@@ -130,8 +128,8 @@ def test_start_instance(new_instance):
     new_instance.power_control_from_cfme(from_details=True,
                                          option=OpenStackInstance.START)
     new_instance.wait_for_instance_state_change(OpenStackInstance.STATE_ON)
-    state = new_instance.get_detail(properties=('Power Management',
-                                                'Power State'))
+    view = navigate_to(new_instance, 'Details')
+    state = view.entities.summary('Power Management').get_text_of('Power State')
     assert state == OpenStackInstance.STATE_ON
 
 
@@ -140,7 +138,8 @@ def test_soft_reboot_instance(new_instance):
                                          option=OpenStackInstance.SOFT_REBOOT)
     new_instance.wait_for_instance_state_change(OpenStackInstance.STATE_REBOOTING)
 
-    state = new_instance.get_detail(properties=('Power Management', 'Power State'))
+    view = navigate_to(new_instance, 'Details')
+    state = view.entities.summary('Power Management').get_text_of('Power State')
     assert state in (OpenStackInstance.STATE_ON,
                      OpenStackInstance.STATE_REBOOTING)
 
@@ -150,8 +149,8 @@ def test_hard_reboot_instance(new_instance):
                                          option=OpenStackInstance.HARD_REBOOT)
     new_instance.wait_for_instance_state_change(OpenStackInstance.STATE_REBOOTING)
 
-    state = new_instance.get_detail(properties=('Power Management',
-                                                'Power State'))
+    view = navigate_to(new_instance, 'Details')
+    state = view.entities.summary('Power Management').get_text_of('Power State')
     assert state in (OpenStackInstance.STATE_ON,
                      OpenStackInstance.STATE_REBOOTING)
 


### PR DESCRIPTION
Intent
=========
Continuation of replacing `get_detail()` method by calling `ParametrizedSummaryTable` in respectful views.

{{pytest: -v -k "test_soft_reboot or test_gce_preemptible_provision or test_ssa_template or test_change_cpu_ram or test_vm_migrate or test_suspend or test_create_instance"  --long-running}}