### PR TITLE
[1LP][RFR] Minor changes to coverage_merger.rb

### DIFF
--- a/fixtures/ui_coverage.py
+++ b/fixtures/ui_coverage.py
@@ -10,8 +10,24 @@ General Notes
 simplecov can merge test results, but doesn't appear to like working in a
 multi-process environment. Specifically, it clobbers its own results when running
 simultaneously in multiple processes. To solve this, each process records its
-output to its own directory (configured in coverage_hook). All of the
-individual process' results are then manually merged (coverage_merger) into one
+output to its own directory (configured in coverage_hook).  You end up with a
+directory structure like this:
+
+    coverage-\
+             |-$ip1-\
+             .      |-$pid1-\
+             .      .       |-.resultset.json (coverage statistics)
+             .      .       |-.last_run.json  (overall coverage percentage)
+             .      .
+             .      |-$pidN
+             .
+             |-$ipN
+
+Note the .resultset.json format is documented in the ruby Coverage libraries docs:
+
+    http://ruby-doc.org/stdlib-2.1.0/libdoc/coverage/rdoc/Coverage.html
+
+All of the individual process' results are then manually merged (coverage_merger) into one
 big json result, and handed back to simplecov which generates the compiled html
 (for humans) and rcov (for jenkins) reports.
 
@@ -39,15 +55,12 @@ Post-testing (``pytest_unconfigure`` hook):
 1. Poll ``thing_toucher`` to make sure it completed; block if needed.
 2. Stop EVM, but nicely this time so the coverage atexit hooks run:
    ``systemctl stop evmserverd``
-3. Run ``coverage_merger.rb`` with the rails runner, which compiles all the individual process
-   reports and runs coverage again, additionally creating an rcov report
-4. Pull the coverage dir back for parsing and archiving
-5. For fun: Read the results from ``coverage/.last_run.json`` and print it to the test terminal/log
+3. Pull the coverage dir back for parsing and archiving
 
-Post-testing (e.g. ci environment):
+Post-testing (e.g. ci environment): *** This is changing ***
+
 1. Use the generated rcov report with the ruby stats plugin to get a coverage graph
 2. Zip up and archive the entire coverage dir for review
-
 """
 import subprocess
 from threading import Thread

--- a/scripts/data/coverage/coverage_merger.rb
+++ b/scripts/data/coverage/coverage_merger.rb
@@ -1,21 +1,85 @@
-# goes into the rails root
-# merges coverage results from multiple processes, potentially on multiple appliances
-# This expects the layout used by our coverage hook: "RAILS_ROOT/coverage/[ipaddress]/[pid]/"
+# This script merges coverage results from multiple processes, potentially on multiple appliances
+# This expects the layout used by our coverage hook: "coverage/[ipaddress]/[pid]/.resultset.json".
+# It will look for the coverage archive either under the current directory or the one specified.
 # It does the report merging manually based on that layout, and can be run at any time
-# to compile reports.
+# to compile reports.   
+#
+# The basic format of the .resultset.json files is:
+#   
+#   {
+#       "$ip-$pid": {
+#           "coverage": {
+#              "$file1": {
+#                   $coverage_data_line1,
+#                   .
+#                   .
+#                   .
+#                   $coverage_data_lineN
+#               },
+#               .
+#               .
+#               .
+#              "$fileN": {
+#                   $coverage_data_line1,
+#                   .
+#                   .
+#                   .
+#                   $coverage_data_lineN
+#               },
+#           }
+#       }
+#   } 
+#
+# Note coverage data is either:
+#
+#      - 0: line not covered
+#      - > 0: Number of times line covered.
+#      - null: Not coverable (e.g. a comment)
+#
+# The merge will actually still keep the data separate between the 
+# appliance-processes, but they are all in the same file.   sonar-scanner 
+# can apparently handle this fine.   So the file will look like:
+# 
+#   {
+#       "$ip1-$pid1": {
+#           "coverage": {
+#               ...
+#           }
+#       }
+#       .
+#       .
+#       .
+#       "$ipM-$pidN": {
+#           "coverage": {
+#               ...
+#           }
+#       }
+#   } 
+#
 require 'fileutils'
 require 'json'
+require 'optparse'
 require 'simplecov'
 require 'simplecov/result'
 
 rails_root = '/var/www/miq/vmdb'
 results = Hash.new
-coverage_root = "/var/www/miq/vmdb/coverage"
-puts "Scanning for results in #{coverage_root}"
+
+# Parse command line arguments:
+options = {}
+options[:coverage_root] = './coverage'
+OptionParser.new do |parser|
+  parser.on("-c", "--coverageRoot DIR", "Path to the coverage directory.") do |v|
+    options[:coverage_root] = v
+  end
+end.parse!
+
+puts "Scanning for results in #{options[:coverage_root]}"
 json_files = Dir.glob(
-  File.join(coverage_root, "*", "*", ".resultset.json")
+  File.join(options[:coverage_root], "*", "*", ".resultset.json")
 )
-merged_dir = File.join(coverage_root, 'merged')
+merged_dir = File.join(options[:coverage_root], 'merged')
+merged_result_set = File.join(merged_dir, '.resultset.json')
 
 for json_file in json_files
   begin
@@ -30,12 +94,12 @@ end
 if results.empty?
   abort "No results found for merging."
 else
-  puts "All results merged, compiling report."
+  puts "All results merged, compiling report: #{merged_result_set}"
 end
 
 FileUtils.mkdir_p(merged_dir)
-File.open(File.join(merged_dir, '.resultset.json'), "w") do |f|
-  JSON.dump(results, f)
+File.open(merged_result_set, "w") do |f|
+  f.puts JSON.pretty_generate(results)
 end
 
 # Set up simplecov to use the merged results, then fire off the formatters


### PR DESCRIPTION
- Update comments in script to properly explain format of
  .resultset.json files and the merged .resultset.json file.
- The location of the coverage data is no longer hard coded, and now
  defaults to ./coverage.  Also added a --coverageRoot option.
- Merged file output is now pretty printed.  I found this useful when
  I was trying to understand the file.  Someone else may also at
  some point.

Additionally some comment changes were made to fixtures/ui_coverage.py.
It has an explanation of almost the whole end to end process for
gathering and reporting coverage statistics and I wanted to make that
accurate.

One last note, the --coverageRoot option is going to be used by the process that will upload the coverage data to SonarQube (i.e. scripts/coverage_reports_jenkins.py).   That will be changed in another PR.