### PR TITLE
[1LP][RFR] fix provider api port test

### DIFF
--- a/cfme/tests/openstack/infrastructure/test_provider.py
+++ b/cfme/tests/openstack/infrastructure/test_provider.py
@@ -13,8 +13,9 @@ pytestmark = [
 
 
 def test_api_port(provider):
+    view_details = navigate_to(provider, 'Details')
     port = provider.data['endpoints']['default']['api_port']
-    assert provider.summary.properties.api_port.value == port, 'Invalid API Port'
+    assert int(view_details.entities.properties.get_text_of('API Port')) == port, 'Invalid API Port'
 
 
 def test_credentials_quads(provider):


### PR DESCRIPTION
Purpose or Intent
=================
Replaced access to provider api port through details view instead of provider.summary.properties.api_port.value 

{{ pytest: cfme/tests/openstack/infrastructure/test_provider.py::test_api_port }}