### PR TITLE
[1LP][RFR] fix get element id to support any region

### DIFF
--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -2934,7 +2934,7 @@ class EntitiesConditionalView(View, ReportDataControllerMixin):
         if self.browser.product_version < '5.9':
             br = self.browser
             for el in br.elements(self.elements):
-                el_id = (br.get_attribute('href', el).split('/')[-1])
+                el_id = br.get_attribute('href', el).split('/')[-1]
                 el_name = br.get_attribute('title', el)
                 elements.append({'name': el_name, 'entity_id': el_id})
         else:

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -2934,7 +2934,7 @@ class EntitiesConditionalView(View, ReportDataControllerMixin):
         if self.browser.product_version < '5.9':
             br = self.browser
             for el in br.elements(self.elements):
-                el_id = int(br.get_attribute('href', el).split('/')[-1])
+                el_id = (br.get_attribute('href', el).split('/')[-1])
                 el_name = br.get_attribute('title', el)
                 elements.append({'name': el_name, 'entity_id': el_id})
         else:


### PR DESCRIPTION
Purpose or Intent
=================
Removed integer casting from get element id because it supports only region 0
{{ pytest: cfme/tests/openstack/infrastructure/test_hosts.py::test_host_memory }}