### PR TITLE
[RFR] fix failed tests on infrastructure test_hosts.py

### DIFF
--- a/cfme/tests/openstack/infrastructure/test_hosts.py
+++ b/cfme/tests/openstack/infrastructure/test_hosts.py
@@ -23,7 +23,7 @@ def test_host_configuration(host_collection, provider, soft_assert, appliance):
     for host in hosts:
         host.run_smartstate_analysis()
         wait_for(is_host_analysis_finished, [host.name], delay=15,
-                 timeout="10m", fail_func=appliance.browser.refresh)
+                 timeout="10m", fail_func=host.browser.refresh)
         fields = ['Packages', 'Services', 'Files']
         for field in fields:
             value = int(host.get_detail("Configuration", field))
@@ -55,7 +55,8 @@ def test_host_devices(host_collection, provider):
     hosts = host_collection.all(provider)
     assert hosts
     for host in hosts:
-        assert int(host.get_detail("Properties", "Devices")) > 0
+        result = int(host.get_detail("Properties", "Devices").split()[0])
+        assert result > 0
 
 
 def test_host_hostname(host_collection, provider, soft_assert):


### PR DESCRIPTION
Purpose or Intent
=================
Fixed 2 tests:
test_host_configuration: app.browser.refresh no more supported
test_host_devices: Not working without split()[0])

{{pytest: --use-provider=rhos_uc cfme/tests/openstack/infrastructure/test_hosts.py -k 'test_host_configuration or test_host_devices' }}