### PR TITLE
[1LP][RFR][NOTEST] Added descriptions for wait_for functions

### DIFF
--- a/cfme/tests/control/__init__.py
+++ b/cfme/tests/control/__init__.py
@@ -39,11 +39,13 @@ def do_scan(vm, additional_item_check=None, rediscover=True):
     logger.info("Scan initiated")
     wait_for(
         lambda: _scan() != original,
-        num_sec=300, delay=5, fail_func=vm_details_view.toolbar.reload.click)
+        num_sec=300, delay=5, fail_func=vm_details_view.toolbar.reload.click,
+        message="Check if Last Analyzed field changed")
     if additional_item_check is not None:
         title, field = additional_item_check
         get_text_of = vm_details_view.entities.summary(title).get_text_of
         wait_for(
             lambda: get_text_of(field) != original_item,
-            num_sec=120, delay=5, fail_func=vm_details_view.toolbar.reload.click)
+            num_sec=120, delay=5, fail_func=vm_details_view.toolbar.reload.click,
+            message="Check if Last Analyzed field changed")
     logger.info("Scan finished")

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -336,7 +336,7 @@ def test_action_start_virtual_machine_after_stopping(request, vm, vm_on, policy_
     vm.stop_vm()
     # Wait for VM powered on by CFME
     try:
-        wait_for(vm.is_vm_running, num_sec=600, delay=5)
+        wait_for(vm.is_vm_running, num_sec=600, delay=5, message="Check if a vm is running")
     except TimedOutError:
         pytest.fail("CFME did not power on the VM {}".format(vm.name))
 
@@ -362,7 +362,7 @@ def test_action_stop_virtual_machine_after_starting(request, vm, vm_off, policy_
     vm.start_vm()
     # Wait for VM powered off by CFME
     try:
-        wait_for(vm.is_vm_stopped, num_sec=600, delay=5)
+        wait_for(vm.is_vm_stopped, num_sec=600, delay=5, message="Check if a vm is stopped")
     except TimedOutError:
         pytest.fail("CFME did not power off the VM {}".format(vm.name))
 
@@ -387,7 +387,7 @@ def test_action_suspend_virtual_machine_after_starting(request, vm, vm_off, poli
     vm.start_vm()
     # Wait for VM be suspended by CFME
     try:
-        wait_for(vm.is_vm_suspended, num_sec=600, delay=5)
+        wait_for(vm.is_vm_suspended, num_sec=600, delay=5, message="Check if a vm is suspended")
     except TimedOutError:
         pytest.fail("CFME did not suspend the VM {}".format(vm.name))
 
@@ -412,7 +412,7 @@ def test_action_prevent_event(request, vm, vm_off, policy_for_testing):
     # Request VM's start (through UI)
     vm.crud.power_control_from_cfme(option=vm.crud.POWER_ON, cancel=False)
     try:
-        wait_for(vm.is_vm_running, num_sec=600, delay=5)
+        wait_for(vm.is_vm_running, num_sec=600, delay=5, message="Check if vm is running")
     except TimedOutError:
         pass  # VM did not start, so that's what we want
     else:
@@ -435,7 +435,8 @@ def test_action_prevent_vm_retire(request, vm, vm_on, policy_for_testing):
     request.addfinalizer(policy_for_testing.assign_events)
     vm.crud.retire()
     try:
-        wait_for(lambda: vm.crud.is_retired, num_sec=600, delay=15)
+        wait_for(lambda: vm.crud.is_retired, num_sec=600, delay=15,
+                 message="Waiting for vm retiring")
     except TimedOutError:
         pass
     else:
@@ -490,7 +491,8 @@ def test_action_prevent_host_ssa(request, appliance, host, host_policy):
     try:
         wait_for(
             lambda: _scan() != original,
-            num_sec=60, delay=5, fail_func=view.browser.refresh)
+            num_sec=60, delay=5, fail_func=view.browser.refresh,
+            message="Check if Drift History field is changed")
     except TimedOutError:
             rc, _ = appliance.ssh_client.run_command("grep 'Prevent current event from proceeding.*"
                 "Host Analysis Request.*{}' /var/www/miq/vmdb/log/policy.log".format(host.name))

--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -271,10 +271,12 @@ def test_alert_vm_turned_on_more_than_twice_in_past_15_minutes(request, provider
     vm.wait_for_vm_state_change(vm.STATE_OFF)
     for i in range(5):
         vm.power_control_from_cfme(option=vm.POWER_ON, cancel=False)
-        wait_for(lambda: provider.mgmt.is_vm_running(vm.name), num_sec=300)
+        wait_for(lambda: provider.mgmt.is_vm_running(vm.name), num_sec=300,
+                 message="Check if vm is running")
         vm.wait_for_vm_state_change(vm.STATE_ON)
         vm.power_control_from_cfme(option=vm.POWER_OFF, cancel=False)
-        wait_for(lambda: provider.mgmt.is_vm_stopped(vm.name), num_sec=300)
+        wait_for(lambda: provider.mgmt.is_vm_stopped(vm.name), num_sec=300,
+                 message="Check if vm is stopped")
         vm.wait_for_vm_state_change(vm.STATE_OFF)
 
     wait_for_alert(smtp_test, alert, delay=16 * 60)

--- a/cfme/tests/control/test_rest_control.py
+++ b/cfme/tests/control/test_rest_control.py
@@ -58,7 +58,8 @@ class TestConditionsRESTAPI(object):
                 lambda: not appliance.rest_api.collections.conditions.find_by(
                     name=condition.name),
                 num_sec=100,
-                delay=5
+                delay=5,
+                message="Check if a condition deleted"
             )
 
             with error.expected('ActiveRecord::RecordNotFound'):
@@ -105,6 +106,7 @@ class TestConditionsRESTAPI(object):
                     description=new[index]['description']) or False,
                 num_sec=100,
                 delay=5,
+                message="Find a test condition"
             )
             condition.reload()
             assert condition.description == edited[index].description == record[0].description
@@ -142,10 +144,10 @@ class TestPoliciesRESTAPI(object):
             assert_response(appliance)
 
             wait_for(
-                lambda: not appliance.rest_api.collections.policies.find_by(
-                    name=policy.name),
+                lambda: not appliance.rest_api.collections.policies.find_by(name=policy.name),
                 num_sec=100,
-                delay=5
+                delay=5,
+                message="Check if a policy doesn't exist"
             )
 
             with error.expected('ActiveRecord::RecordNotFound'):
@@ -216,6 +218,7 @@ class TestPoliciesRESTAPI(object):
                     description=new[index]['description']) or False,
                 num_sec=100,
                 delay=5,
+                message="Find a policy"
             )
             policy.reload()
             assert policy.description == edited[index].description == record[0].description


### PR DESCRIPTION
Purpose
=================

In order to make `TimedOutError` more readable and clear, we should provider descriptions for `wait_for` functions.