### PR TITLE
[1LP][RFR] Fix PXE-related testgen and test collection

### DIFF
--- a/cfme/utils/testgen.py
+++ b/cfme/utils/testgen.py
@@ -333,7 +333,6 @@ def pxe_servers(metafunc):
     """Provides pxe data
     """
     argnames = ['pxe_name']
-
-    items = cfme_data.get('pxe_servers', {}).keys()
-
-    return argnames, [items], items
+    argvalues = [[k] for k in sorted(cfme_data.get('pxe_servers', {}).keys())]
+    idlist = [k[0] for k in argvalues]
+    return argnames, argvalues, idlist


### PR DESCRIPTION
Fix for an issue with PXE test collection after recent refactor.

@lkhomenk @jan-zmeskal Please check that current collection (on PRT) is correct. The tests won't be executed, this affects only collection. Thanks

Edit: I decided to execute the tests, just in case.

{{pytest: cfme/tests/infrastructure/test_host_provisioning.py cfme/tests/infrastructure/test_pxe_provisioning.py cfme/tests/services/test_pxe_service_catalogs.py cfme/tests/infrastructure/test_pxe.py --use-provider complete}}