### PR TITLE
[1LP][RFR] Changes for jenkins

### DIFF
--- a/cfme/utils/browser.py
+++ b/cfme/utils/browser.py
@@ -289,7 +289,6 @@ class BrowserManager(object):
 
     def quit(self):
         # TODO: figure if we want to log the url key here
-        log.info('closing browser')
         self._consume_cleanups()
         try:
             self.factory.close(self.browser)

--- a/scripts/template_tester.py
+++ b/scripts/template_tester.py
@@ -17,13 +17,24 @@ import sys
 from cfme.utils import trackerbot
 
 
-def get(api, request_type=None):
-    try:
-        template, provider_key, stream, provider_type =\
-            trackerbot.templates_to_test(api, request_type=request_type, limit=1)[0]
-    except (IndexError, TypeError):
-        # No untested provider templates, all is well
+def get(api, request_type=None, template_name=None):
+    list_of_templates = trackerbot.templates_to_test(api, request_type=request_type, limit=200)
+
+    if len(list_of_templates) == 0:
+        # No templates to test for this provider type
         return 0
+
+    if not template_name:
+        # If no specific name specified, return 1st element
+        template, provider_key, stream, provider_type = list_of_templates[0]
+    else:
+        # Filter the list for only templates matching 'template_name'
+        filtered_list = [t for t in list_of_templates if t[0] == template_name]
+        if len(filtered_list) > 0:
+            template, provider_key, stream, provider_type = filtered_list[0]
+        else:
+            # No templates to test for this template name
+            return 0
 
     # Print envvar exports to be eval'd
     export(
@@ -81,14 +92,30 @@ def retest(api, provider_key, template):
     trackerbot.mark_provider_template(api, provider_key, template, tested=False)
 
 
+def check_tested(api, template_name, provider_type):
+    """
+    Check if a template has been tested and passed (marked usable) for a provider.
+
+    If not usable, mark it untested so jenkins picks it up for testing.
+    """
+    trackerbot.mark_unusable_as_untested(api, template_name, provider_type)
+    print(str(trackerbot.check_if_tested(api, template_name, provider_type)).lower())
+
+
 if __name__ == '__main__':
     parser = trackerbot.cmdline_parser()
     subs = parser.add_subparsers(title='commands', dest='command')
 
     parse_get = subs.add_parser('get', help='get a template to test')
     parse_get.set_defaults(func=get)
-    parse_get.add_argument('--request_type', dest='request_type',
-                           help='get a teamplate based on provider type')
+    parse_get.add_argument('--request_type', dest='request_type', help='provider type')
+    parse_get.add_argument('--template', dest='template', help='template name (optional)')
+
+    parse_check_tested = subs.add_parser(
+        'check_tested', help='check if template passed tests at least once on given provider type')
+    parse_check_tested.set_defaults(func=check_tested)
+    parse_check_tested.add_argument('--request_type', dest='request_type', help='provider type')
+    parse_check_tested.add_argument('--template', dest='template', help='template name')
 
     parse_latest = subs.add_parser('latest', help='get the latest usable template for a provider')
     parse_latest.set_defaults(func=latest)
@@ -112,9 +139,10 @@ if __name__ == '__main__':
     args = parser.parse_args()
     api = trackerbot.api(args.trackerbot_url)
     func_map = {
-        get: lambda: get(api, args.request_type),
+        get: lambda: get(api, args.request_type, args.template),
         latest: lambda: latest(api, args.stream, args.provider_key),
         mark: lambda: mark(api, args.provider_key, args.template, args.usable, args.diagnose),
         retest: lambda: retest(api, args.provider_key, args.template),
+        check_tested: lambda: check_tested(api, args.template, args.request_type),
     }
     sys.exit(func_map[args.func]())

--- a/scripts/template_upload_all.py
+++ b/scripts/template_upload_all.py
@@ -58,6 +58,8 @@ def parse_cmd_line():
                         help='local yaml file path, to use local provider_data & not conf/cfme_data'
                              'to be useful for template upload/deploy by non cfmeqe',
                         default=None)
+    parser.add_argument('--print-name-only', dest='print_name_only', action="store_true",
+                        default=False, help='only print the template name that will be generated')
     args = parser.parse_args()
     return args
 
@@ -411,6 +413,10 @@ def main():
                 template_parser = trackerbot.parse_template(kwargs['template_name'])
                 if template_parser.stream:
                     kwargs['stream'] = template_parser.group_name
+
+        if args.print_name_only:
+            print(kwargs['template_name'])
+            return 0
 
         logger.info("TEMPLATE_UPLOAD_ALL:-----Start of %r upload on: %r--------",
             kwargs['template_name'], provider_type)


### PR DESCRIPTION
1) Add two new methods to template tester scripts to support the new multijob flow
a) check if a template is already tested
b) simply print the template name that will be generated, so we can pass that in to method a above

2) Check installed pkgs before running dnf or yum install. This is to get around the 'transaction error check failed'/'package is already installed' dnf errors we're sporadically hitting on Jenkins runs.