### PR TITLE
[WIPTEST] Remove unneeded BZ blockers from custom attributes tests

### DIFF
--- a/cfme/tests/cloud_infra_common/test_custom_attributes_rest.py
+++ b/cfme/tests/cloud_infra_common/test_custom_attributes_rest.py
@@ -84,7 +84,7 @@ def get_service(appliance):
     try:
         service = appliance.rest_api.collections.services.get(name=name)
         service.delete()
-    except AttributeError:
+    except (AttributeError, ValueError):
         pass
 
 
@@ -262,12 +262,6 @@ class TestCustomAttributesRESTAPI(object):
         _uncollectif(appliance, provider, collection_name)
     )
     @pytest.mark.parametrize("collection_name", COLLECTIONS)
-    @pytest.mark.meta(blockers=[
-        BZ(
-            1516762,
-            forced_streams=['5.9', 'upstream'],
-            unblock=lambda collection_name: collection_name not in ('vms', 'instances')
-        )])
     @pytest.mark.parametrize('from_detail', [True, False], ids=['from_detail', 'from_collection'])
     def test_bad_section_edit(self, request, from_detail, collection_name, appliance, get_resource):
         """Test that editing custom attributes using REST API and adding invalid section fails.
@@ -299,12 +293,6 @@ class TestCustomAttributesRESTAPI(object):
         _uncollectif(appliance, provider, collection_name)
     )
     @pytest.mark.parametrize("collection_name", COLLECTIONS)
-    @pytest.mark.meta(blockers=[
-        BZ(
-            1516762,
-            forced_streams=['5.9', 'upstream'],
-            unblock=lambda collection_name: collection_name not in ('vms', 'instances')
-        )])
     def test_bad_section_add(self, request, collection_name, appliance, get_resource):
         """Test adding custom attributes with invalid section to resource using REST API.
 


### PR DESCRIPTION
The BZ is mentioned in a comment (few lines above) so the information is not lost.

{{pytest: -v --long-running -k test_bad_section_ cfme/tests/cloud_infra_common/test_custom_attributes_rest.py}}