### PR TITLE
[1LP][RFR]last_message update

### DIFF
--- a/cfme/services/requests.py
+++ b/cfme/services/requests.py
@@ -40,17 +40,27 @@ class Request(BaseEntity):
     def wait_for_request(self, num_sec=1800, delay=20):
         def _finished():
             self.rest.reload()
-            return self.rest.request_state.title() in self.REQUEST_FINISHED_STATES
+            return (self.rest.request_state.title() in self.REQUEST_FINISHED_STATES and
+                    'Retry' not in self.rest.message)
 
-        wait_for(_finished, num_sec=num_sec, delay=delay, message="Request finished")
+        def last_message():
+            logger.info("Last Request message: '{}'".format(self.rest.message))
+
+        wait_for(_finished, num_sec=num_sec, delay=delay, fail_func=last_message,
+                 message="Request finished")
 
     @wait_for_request.variant('ui')
     def wait_for_request_ui(self, num_sec=1200, delay=10):
         def _finished():
             self.update(method='ui')
-            return self.row.request_state.text in self.REQUEST_FINISHED_STATES
+            return self.row.request_state.text in self.REQUEST_FINISHED_STATES and \
+                'Retry' not in self.row.last_message.text
 
-        wait_for(_finished, num_sec=num_sec, delay=delay, message="Request finished")
+        def last_message():
+            logger.info("Last Request message in UI: '{}'".format(self.row.last_message))
+
+        wait_for(_finished, num_sec=num_sec, delay=delay, fail_func=last_message,
+                 message="Request finished")
 
     @property
     def rest(self):

--- a/cfme/services/requests.py
+++ b/cfme/services/requests.py
@@ -53,8 +53,8 @@ class Request(BaseEntity):
     def wait_for_request_ui(self, num_sec=1200, delay=10):
         def _finished():
             self.update(method='ui')
-            return self.row.request_state.text in self.REQUEST_FINISHED_STATES and \
-                'Retry' not in self.row.last_message.text
+            return (self.row.request_state.text in self.REQUEST_FINISHED_STATES and
+                    'Retry' not in self.row.last_message.text)
 
         def last_message():
             logger.info("Last Request message in UI: '{}'".format(self.row.last_message))

--- a/cfme/tests/cloud/test_provisioning.py
+++ b/cfme/tests/cloud/test_provisioning.py
@@ -577,9 +577,9 @@ def test_provision_with_boot_volume(request, testing_instance, provider, soft_as
             logger.info(
                 "Provision failed {}: {}".format(e, provision_request.request_state))
             raise e
-        assert provision_request.is_succeeded(method='ui'), (
-            "Provisioning failed with the message {}".format(
-                provision_request.row.last_message.text))
+        msg = "Provisioning failed with the message {}".format(
+            provision_request.row.last_message.text)
+        assert provision_request.is_succeeded(method='ui'), msg
         soft_assert(instance.name in provider.mgmt.volume_attachments(volume))
         soft_assert(provider.mgmt.volume_attachments(volume)[instance.name] == "/dev/vda")
         instance.delete_from_provider()  # To make it possible to delete the volume

--- a/cfme/tests/infrastructure/test_provisioning.py
+++ b/cfme/tests/infrastructure/test_provisioning.py
@@ -175,8 +175,8 @@ def test_provision_approval(appliance, setup_provider, provider, vm_name, smtp_t
         handle_exception=True, num_sec=600)
 
     provision_request.wait_for_request(method='ui')
-    assert provision_request.is_succeeded(method='ui'), \
-        ("Provisioning failed with the message {}".format(provision_request.row.last_message.text))
+    msg = "Provisioning failed with the message {}".format(provision_request.row.last_message.text)
+    assert provision_request.is_succeeded(method='ui'), msg
 
     # Wait for e-mails to appear
     def verify():

--- a/cfme/tests/infrastructure/test_provisioning.py
+++ b/cfme/tests/infrastructure/test_provisioning.py
@@ -4,7 +4,6 @@ import pytest
 from cfme import test_requirements
 from cfme.common.provider import cleanup_vm
 from cfme.infrastructure.provider import InfraProvider
-from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.provisioning import do_vm_provisioning
 from cfme.utils import normalize_text
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -176,7 +175,8 @@ def test_provision_approval(appliance, setup_provider, provider, vm_name, smtp_t
         handle_exception=True, num_sec=600)
 
     provision_request.wait_for_request(method='ui')
-    assert provision_request.is_succeeded(method='ui')
+    assert provision_request.is_succeeded(method='ui'), \
+        ("Provisioning failed with the message {}".format(provision_request.row.last_message.text))
 
     # Wait for e-mails to appear
     def verify():

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -100,7 +100,8 @@ def provisioner(appliance, request, setup_provider, provider, vm_name):
         # nav to requests page happens on successful provision
         logger.info('Waiting for cfme provision request for vm %s', vm_name)
         provision_request.wait_for_request()
-        assert provision_request.is_succeeded(method='ui')
+        assert provision_request.is_succeeded(), \
+            "Provisioning failed with the message {}".format(provision_request.rest.message)
         return vm
 
     return _provisioner

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -100,8 +100,8 @@ def provisioner(appliance, request, setup_provider, provider, vm_name):
         # nav to requests page happens on successful provision
         logger.info('Waiting for cfme provision request for vm %s', vm_name)
         provision_request.wait_for_request()
-        assert provision_request.is_succeeded(), \
-            "Provisioning failed with the message {}".format(provision_request.rest.message)
+        msg = "Provisioning failed with the message {}".format(provision_request.rest.message)
+        assert provision_request.is_succeeded(), msg
         return vm
 
     return _provisioner

--- a/cfme/tests/infrastructure/test_provisioning_rest.py
+++ b/cfme/tests/infrastructure/test_provisioning_rest.py
@@ -101,9 +101,9 @@ def test_provision(request, appliance, provision_data):
     provision_request = appliance.collections.requests.instantiate(description=vm_name,
                                                                    partial_check=True)
     provision_request.wait_for_request()
-
-    assert provision_request.is_succeeded(), ("Provisioning failed with the message {}".format(
-        provision_request.rest.message))
+    msg = "Provisioning failed with the message {}".format(
+        provision_request.rest.message)
+    assert provision_request.is_succeeded(), msg
     found_vms = appliance.rest_api.collections.vms.find_by(name=vm_name)
     assert found_vms, 'VM `{}` not found'.format(vm_name)
 

--- a/cfme/tests/infrastructure/test_vm_clone.py
+++ b/cfme/tests/infrastructure/test_vm_clone.py
@@ -51,5 +51,5 @@ def test_vm_clone(appliance, provider, clone_vm_name, request, create_vm):
     request_row = appliance.collections.requests.instantiate(request_description,
                                                              partial_check=True)
     request_row.wait_for_request(method='ui')
-    assert request_row.is_succeeded(method='ui'), ("Request failed with the message {}".format(
-        request_row.row.last_message.text))
+    msg = "Request failed with the message {}".format(request_row.row.last_message.text)
+    assert request_row.is_succeeded(method='ui'), msg

--- a/cfme/tests/infrastructure/test_vm_clone.py
+++ b/cfme/tests/infrastructure/test_vm_clone.py
@@ -51,4 +51,5 @@ def test_vm_clone(appliance, provider, clone_vm_name, request, create_vm):
     request_row = appliance.collections.requests.instantiate(request_description,
                                                              partial_check=True)
     request_row.wait_for_request(method='ui')
-    assert request_row.is_succeeded(method='ui')
+    assert request_row.is_succeeded(method='ui'), ("Request failed with the message {}".format(
+        request_row.row.last_message.text))

--- a/cfme/tests/infrastructure/test_vm_migrate.py
+++ b/cfme/tests/infrastructure/test_vm_migrate.py
@@ -53,4 +53,5 @@ def test_vm_migrate(appliance, new_vm, provider):
     migrate_request = appliance.collections.requests.instantiate(request_description, cells=cells,
                                                                  partial_check=True)
     migrate_request.wait_for_request(method='ui')
-    assert migrate_request.is_succeeded(method='ui')
+    assert migrate_request.is_succeeded(method='ui'),\
+        ("Request failed with the message {}".format(migrate_request.row.last_message.text))

--- a/cfme/tests/infrastructure/test_vm_migrate.py
+++ b/cfme/tests/infrastructure/test_vm_migrate.py
@@ -53,5 +53,5 @@ def test_vm_migrate(appliance, new_vm, provider):
     migrate_request = appliance.collections.requests.instantiate(request_description, cells=cells,
                                                                  partial_check=True)
     migrate_request.wait_for_request(method='ui')
-    assert migrate_request.is_succeeded(method='ui'),\
-        ("Request failed with the message {}".format(migrate_request.row.last_message.text))
+    msg = "Request failed with the message {}".format(migrate_request.row.last_message.text)
+    assert migrate_request.is_succeeded(method='ui'), msg

--- a/cfme/tests/services/test_cloud_service_catalogs.py
+++ b/cfme/tests/services/test_cloud_service_catalogs.py
@@ -91,5 +91,5 @@ def test_cloud_catalog_item(appliance, vm_name, setup_provider, provider, dialog
     provision_request = appliance.collections.requests.instantiate(request_description,
                                                                    partial_check=True)
     provision_request.wait_for_request()
-    assert provision_request.is_succeeded(), ("Request failed with the message {}".format(
-        provision_request.rest.message))
+    msg = "Request failed with the message {}".format(provision_request.rest.message)
+    assert provision_request.is_succeeded(), msg

--- a/cfme/tests/services/test_cloud_service_catalogs.py
+++ b/cfme/tests/services/test_cloud_service_catalogs.py
@@ -91,4 +91,5 @@ def test_cloud_catalog_item(appliance, vm_name, setup_provider, provider, dialog
     provision_request = appliance.collections.requests.instantiate(request_description,
                                                                    partial_check=True)
     provision_request.wait_for_request()
-    assert provision_request.is_succeeded()
+    assert provision_request.is_succeeded(), ("Request failed with the message {}".format(
+        provision_request.rest.message))

--- a/cfme/tests/services/test_config_provider_servicecatalogs.py
+++ b/cfme/tests/services/test_config_provider_servicecatalogs.py
@@ -78,7 +78,8 @@ def test_order_tower_catalog_item(appliance, catalog_item, request):
     cells = {'Description': catalog_item.name}
     order_request = appliance.collections.requests.instantiate(cells=cells, partial_check=True)
     order_request.wait_for_request(method='ui')
-    assert order_request.is_succeeded(method='ui')
+    assert order_request.is_succeeded(method='ui'),\
+        ("Request failed with the message {}".format(order_request.row.last_message.text))
     DefaultView.set_default_view("Configuration Management Providers", "List View")
 
 
@@ -96,6 +97,7 @@ def test_retire_ansible_service(appliance, catalog_item, request):
     cells = {'Description': catalog_item.name}
     order_request = appliance.collections.requests.instantiate(cells=cells, partial_check=True)
     order_request.wait_for_request(method='ui')
-    assert order_request.is_succeeded(method='ui')
+    assert order_request.is_succeeded(method='ui'), \
+        ("Request failed with the message {}".format(order_request.row.last_message.text))
     myservice = MyService(appliance, catalog_item.name)
     myservice.retire()

--- a/cfme/tests/services/test_config_provider_servicecatalogs.py
+++ b/cfme/tests/services/test_config_provider_servicecatalogs.py
@@ -78,8 +78,8 @@ def test_order_tower_catalog_item(appliance, catalog_item, request):
     cells = {'Description': catalog_item.name}
     order_request = appliance.collections.requests.instantiate(cells=cells, partial_check=True)
     order_request.wait_for_request(method='ui')
-    assert order_request.is_succeeded(method='ui'),\
-        ("Request failed with the message {}".format(order_request.row.last_message.text))
+    msg = "Request failed with the message {}".format(order_request.row.last_message.text)
+    assert order_request.is_succeeded(method='ui'), msg
     DefaultView.set_default_view("Configuration Management Providers", "List View")
 
 
@@ -97,7 +97,7 @@ def test_retire_ansible_service(appliance, catalog_item, request):
     cells = {'Description': catalog_item.name}
     order_request = appliance.collections.requests.instantiate(cells=cells, partial_check=True)
     order_request.wait_for_request(method='ui')
-    assert order_request.is_succeeded(method='ui'), \
-        ("Request failed with the message {}".format(order_request.row.last_message.text))
+    msg = "Request failed with the message {}".format(order_request.row.last_message.text)
+    assert order_request.is_succeeded(method='ui'), msg
     myservice = MyService(appliance, catalog_item.name)
     myservice.retire()

--- a/cfme/tests/services/test_different_dialogs_in_catalogs.py
+++ b/cfme/tests/services/test_different_dialogs_in_catalogs.py
@@ -108,5 +108,5 @@ def test_tagdialog_catalog_item(appliance, provider, setup_provider, catalog_ite
     provision_request = appliance.collections.requests.instantiate(request_description,
                                                                    partial_check=True)
     provision_request.wait_for_request()
-    assert provision_request.is_succeeded(), ("Request failed with the message {}".format(
-        provision_request.rest.message))
+    msg = "Request failed with the message {}".format(provision_request.rest.message)
+    assert provision_request.is_succeeded(), msg

--- a/cfme/tests/services/test_different_dialogs_in_catalogs.py
+++ b/cfme/tests/services/test_different_dialogs_in_catalogs.py
@@ -108,4 +108,5 @@ def test_tagdialog_catalog_item(appliance, provider, setup_provider, catalog_ite
     provision_request = appliance.collections.requests.instantiate(request_description,
                                                                    partial_check=True)
     provision_request.wait_for_request()
-    assert provision_request.is_succeeded()
+    assert provision_request.is_succeeded(), ("Request failed with the message {}".format(
+        provision_request.rest.message))

--- a/cfme/tests/services/test_generic_service_catalogs.py
+++ b/cfme/tests/services/test_generic_service_catalogs.py
@@ -79,8 +79,8 @@ def test_service_generic_catalog_bundle(appliance, catalog_item):
     provision_request = appliance.collections.requests.instantiate(request_description,
                                                                    partial_check=True)
     provision_request.wait_for_request()
-    assert provision_request.is_succeeded(),\
-        ("Request failed with the message {}".format(provision_request.rest.message))
+    msg = "Request failed with the message {}".format(provision_request.rest.message)
+    assert provision_request.is_succeeded(), msg
 
 
 def test_bundles_in_bundle(appliance, catalog_item):
@@ -106,8 +106,8 @@ def test_bundles_in_bundle(appliance, catalog_item):
     provision_request = appliance.collections.requests.instantiate(request_description,
                                                                    partial_check=True)
     provision_request.wait_for_request()
-    assert provision_request.is_succeeded(),\
-        ("Request failed with the message {}".format(provision_request.rest.message))
+    msg = "Request failed with the message {}".format(provision_request.rest.message)
+    assert provision_request.is_succeeded(), msg
 
 
 def test_delete_dialog_before_parent_item(appliance, catalog_item):

--- a/cfme/tests/services/test_generic_service_catalogs.py
+++ b/cfme/tests/services/test_generic_service_catalogs.py
@@ -79,7 +79,8 @@ def test_service_generic_catalog_bundle(appliance, catalog_item):
     provision_request = appliance.collections.requests.instantiate(request_description,
                                                                    partial_check=True)
     provision_request.wait_for_request()
-    assert provision_request.is_succeeded()
+    assert provision_request.is_succeeded(),\
+        ("Request failed with the message {}".format(provision_request.rest.message))
 
 
 def test_bundles_in_bundle(appliance, catalog_item):
@@ -105,7 +106,8 @@ def test_bundles_in_bundle(appliance, catalog_item):
     provision_request = appliance.collections.requests.instantiate(request_description,
                                                                    partial_check=True)
     provision_request.wait_for_request()
-    assert provision_request.is_succeeded()
+    assert provision_request.is_succeeded(),\
+        ("Request failed with the message {}".format(provision_request.rest.message))
 
 
 def test_delete_dialog_before_parent_item(appliance, catalog_item):

--- a/cfme/tests/services/test_iso_service_catalogs.py
+++ b/cfme/tests/services/test_iso_service_catalogs.py
@@ -124,5 +124,5 @@ def test_rhev_iso_servicecatalog(appliance, setup_provider, provider, catalog_it
     provision_request = appliance.collections.requests.instantiate(request_description,
                                                                    partial_check=True)
     provision_request.wait_for_request()
-    assert provision_request.is_succeeded(),\
-        "Provisioning failed with the message {}".format(provision_request.rest.message)
+    msg = "Provisioning failed with the message {}".format(provision_request.rest.message)
+    assert provision_request.is_succeeded(), msg

--- a/cfme/tests/services/test_iso_service_catalogs.py
+++ b/cfme/tests/services/test_iso_service_catalogs.py
@@ -124,4 +124,5 @@ def test_rhev_iso_servicecatalog(appliance, setup_provider, provider, catalog_it
     provision_request = appliance.collections.requests.instantiate(request_description,
                                                                    partial_check=True)
     provision_request.wait_for_request()
-    assert provision_request.is_succeeded()
+    assert provision_request.is_succeeded(),\
+        "Provisioning failed with the message {}".format(provision_request.rest.message)

--- a/cfme/tests/services/test_myservice.py
+++ b/cfme/tests/services/test_myservice.py
@@ -55,7 +55,8 @@ def myservice(appliance, setup_provider, provider, catalog_item, request):
     service_request = appliance.collections.requests.instantiate(request_description,
                                                                  partial_check=True)
     service_request.wait_for_request()
-    assert service_request.is_succeeded()
+    assert service_request.is_succeeded(),\
+        ("Request failed with the message {}".format(service_request.rest.message))
 
     yield catalog_item.name, vm_name
 

--- a/cfme/tests/services/test_provision_stack.py
+++ b/cfme/tests/services/test_provision_stack.py
@@ -151,8 +151,8 @@ def test_provision_stack(appliance, setup_provider, provider, provisioning, cata
     provision_request = appliance.collections.requests.instantiate(request_description,
                                                                    partial_check=True)
     provision_request.wait_for_request()
-    assert provision_request.is_succeeded(),\
-        ("Request failed with the message {}".format(provision_request.rest.message))
+    msg = "Request failed with the message {}".format(provision_request.rest.message)
+    assert provision_request.is_succeeded(), msg
 
 
 def test_reconfigure_service(appliance, provider, provisioning, catalog, catalog_item, request,
@@ -176,8 +176,8 @@ def test_reconfigure_service(appliance, provider, provisioning, catalog, catalog
     provision_request = appliance.collections.requests.instantiate(request_description,
                                                                    partial_check=True)
     provision_request.wait_for_request(method='ui')
-    assert provision_request.is_succeeded(method='ui'),\
-        ("Request failed with the message {}".format(provision_request.row.last_message.text))
+    msg = "Request failed with the message {}".format(provision_request.row.last_message.text)
+    assert provision_request.is_succeeded(method='ui'), msg
     last_message = provision_request.get_request_row_from_ui()['Last Message'].text
     service_name = last_message.split()[2].strip('[]')
     myservice = MyService(appliance, service_name)
@@ -228,8 +228,8 @@ def test_retire_stack(appliance, provider, provisioning, catalog, catalog_item, 
     provision_request = appliance.collections.requests.instantiate(request_description,
                                                                    partial_check=True)
     provision_request.wait_for_request()
-    assert provision_request.is_succeeded(), \
-        ("Request failed with the message {}".format(provision_request.rest.message))
+    msg = "Request failed with the message {}".format(provision_request.rest.message)
+    assert provision_request.is_succeeded(), msg
     stack = StackCollection(appliance).instantiate(stack_data['stack_name'], provider=provider)
     stack.wait_for_exists()
     stack.retire_stack()

--- a/cfme/tests/services/test_provision_stack.py
+++ b/cfme/tests/services/test_provision_stack.py
@@ -151,7 +151,8 @@ def test_provision_stack(appliance, setup_provider, provider, provisioning, cata
     provision_request = appliance.collections.requests.instantiate(request_description,
                                                                    partial_check=True)
     provision_request.wait_for_request()
-    assert provision_request.is_succeeded()
+    assert provision_request.is_succeeded(),\
+        ("Request failed with the message {}".format(provision_request.rest.message))
 
 
 def test_reconfigure_service(appliance, provider, provisioning, catalog, catalog_item, request,
@@ -175,7 +176,8 @@ def test_reconfigure_service(appliance, provider, provisioning, catalog, catalog
     provision_request = appliance.collections.requests.instantiate(request_description,
                                                                    partial_check=True)
     provision_request.wait_for_request(method='ui')
-    assert provision_request.is_succeeded()
+    assert provision_request.is_succeeded(method='ui'),\
+        ("Request failed with the message {}".format(provision_request.row.last_message.text))
     last_message = provision_request.get_request_row_from_ui()['Last Message'].text
     service_name = last_message.split()[2].strip('[]')
     myservice = MyService(appliance, service_name)
@@ -226,7 +228,8 @@ def test_retire_stack(appliance, provider, provisioning, catalog, catalog_item, 
     provision_request = appliance.collections.requests.instantiate(request_description,
                                                                    partial_check=True)
     provision_request.wait_for_request()
-    assert provision_request.is_succeeded()
+    assert provision_request.is_succeeded(), \
+        ("Request failed with the message {}".format(provision_request.rest.message))
     stack = StackCollection(appliance).instantiate(stack_data['stack_name'], provider=provider)
     stack.wait_for_exists()
     stack.retire_stack()

--- a/cfme/tests/services/test_pxe_service_catalogs.py
+++ b/cfme/tests/services/test_pxe_service_catalogs.py
@@ -135,5 +135,5 @@ def test_pxe_servicecatalog(appliance, setup_provider, provider, catalog_item, r
     provision_request = appliance.collections.requests.instantiate(request_description,
                                                                    partial_check=True)
     provision_request.wait_for_request(num_sec=3600)
-    assert provision_request.is_succeeded(),\
-        "Provisioning failed with the message {}".format(provision_request.rest.message)
+    msg = "Provisioning failed with the message {}".format(provision_request.rest.message)
+    assert provision_request.is_succeeded(), msg

--- a/cfme/tests/services/test_pxe_service_catalogs.py
+++ b/cfme/tests/services/test_pxe_service_catalogs.py
@@ -135,4 +135,5 @@ def test_pxe_servicecatalog(appliance, setup_provider, provider, catalog_item, r
     provision_request = appliance.collections.requests.instantiate(request_description,
                                                                    partial_check=True)
     provision_request.wait_for_request(num_sec=3600)
-    assert provision_request.is_succeeded()
+    assert provision_request.is_succeeded(),\
+        "Provisioning failed with the message {}".format(provision_request.rest.message)

--- a/cfme/tests/services/test_service_catalogs.py
+++ b/cfme/tests/services/test_service_catalogs.py
@@ -9,7 +9,6 @@ from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.services.catalogs.catalog_item import CatalogBundle, CatalogItem, EditCatalogItemView
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils import error
-from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for_decorator
 
@@ -47,8 +46,8 @@ def test_order_catalog_item(appliance, provider, setup_provider, catalog_item, r
     provision_request = appliance.collections.requests.instantiate(request_description,
                                                                    partial_check=True)
     provision_request.wait_for_request()
-    assert provision_request.is_succeeded(), \
-        "Provisioning failed with the message {}".format(provision_request.rest.message)
+    msg = "Provisioning failed with the message {}".format(provision_request.rest.message)
+    assert provision_request.is_succeeded(), msg
 
 
 @pytest.mark.tier(2)
@@ -101,8 +100,8 @@ def test_order_catalog_bundle(appliance, provider, setup_provider, catalog_item,
     provision_request = appliance.collections.requests.instantiate(request_description,
                                                                    partial_check=True)
     provision_request.wait_for_request()
-    assert provision_request.is_succeeded(),\
-        "Provisioning failed with the message {}".format(provision_request.rest.message)
+    msg = "Provisioning failed with the message {}".format(provision_request.rest.message)
+    assert provision_request.is_succeeded(), msg
 
 
 # Note here this needs to be reduced, doesn't need to test against all providers

--- a/cfme/tests/services/test_service_catalogs.py
+++ b/cfme/tests/services/test_service_catalogs.py
@@ -47,7 +47,8 @@ def test_order_catalog_item(appliance, provider, setup_provider, catalog_item, r
     provision_request = appliance.collections.requests.instantiate(request_description,
                                                                    partial_check=True)
     provision_request.wait_for_request()
-    assert provision_request.is_succeeded()
+    assert provision_request.is_succeeded(), \
+        "Provisioning failed with the message {}".format(provision_request.rest.message)
 
 
 @pytest.mark.tier(2)
@@ -100,7 +101,8 @@ def test_order_catalog_bundle(appliance, provider, setup_provider, catalog_item,
     provision_request = appliance.collections.requests.instantiate(request_description,
                                                                    partial_check=True)
     provision_request.wait_for_request()
-    assert provision_request.is_succeeded()
+    assert provision_request.is_succeeded(),\
+        "Provisioning failed with the message {}".format(provision_request.rest.message)
 
 
 # Note here this needs to be reduced, doesn't need to test against all providers


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__  error logging for faulty provision requests. When we get  "Error" state of request, message requires some time to be updated
{{pytest: --long-running --use-provider complete cfme/tests/cloud/test_provisioning.py cfme/tests/infrastructure/test_provisioning_rest.py cfme/tests/infrastructure/test_provisioning.py cfme/tests/services/test_service_catalogs.py }}