### PR TITLE
[1LP][RFR] fixed issue with floating ip entities 

### DIFF
--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -2941,8 +2941,13 @@ class EntitiesConditionalView(View, ReportDataControllerMixin):
         else:
             entities = self._invoke_cmd('get_all_items')
             for entity in entities:
-                elements.append({'name': entity['item']['cells']['Name'],
-                                 'entity_id': entity['item']['id']})
+                try:
+                    name = entity['item']['cells']['Name']
+                except KeyError:
+                    # Floating Ip view has an issue. it doesn't have Name though it should
+                    name = entity['item']['cells']['Instance name']
+
+                elements.append({'name': name, 'entity_id': entity['item']['id']})
         return elements
 
     @property


### PR DESCRIPTION
JS API should always provide Name for entities but Floating IP entities don't have it for some reason.
This is temporary patch. I'll contact devs in the meantime.

It should be tested in #6675 