### PR TITLE
[1LP][RFR] Adding Physical Servers Inventory API Tests

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -492,7 +492,7 @@ class BaseProvider(WidgetasticTaggable, Updateable, Navigatable):
         Sets up the provider robustly
         """
         # TODO: Eventually this will become Sentakuified, but only after providers is CEMv3
-        if self.category in ['cloud', 'infra']:
+        if self.category in ['cloud', 'infra', 'physical']:
             return self.create_rest(check_existing=True, validate_inventory=True)
         else:
             return self.create(cancel=False, validate_credentials=True,

--- a/cfme/physical/provider/lenovo.py
+++ b/cfme/physical/provider/lenovo.py
@@ -18,11 +18,14 @@ class LenovoProvider(PhysicalProvider):
     string_name = 'Physical Infrastructure'
     mgmt_class = LenovoSystem
     refresh_text = "Refresh Relationships and Power States"
+    db_types = ["Lenovo::PhysicalInfraManager"]
 
     def __init__(self, appliance, name=None, key=None, endpoints=None):
         super(LenovoProvider, self).__init__(
             appliance=appliance, name=name, key=key, endpoints=endpoints
         )
+        self.hostname = self.default_endpoint.view_value_mapping['hostname']
+        self.ip_address = self.hostname
 
     @classmethod
     def from_config(cls, prov_config, prov_key, appliance=None):

--- a/cfme/tests/physical_infrastructure/api/test_physical_server_inventory_api.py
+++ b/cfme/tests/physical_infrastructure/api/test_physical_server_inventory_api.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from cfme.physical.provider.lenovo import LenovoProvider
+from cfme.utils.rest import assert_response
+
+pytestmark = [
+    pytest.mark.tier(3),
+    pytest.mark.provider([LenovoProvider], scope='module')
+]
+
+
+@pytest.fixture(scope="module")
+def physical_server(setup_provider_modscope, appliance):
+    physical_server = appliance.rest_api.collections.physical_servers[0]
+    return physical_server
+
+
+def test_get_hardware(appliance, physical_server):
+    physical_server.reload(attributes=['hardware'])
+    assert_response(appliance)
+    assert physical_server.hardware is not None
+
+
+@pytest.mark.parametrize('attribute', ['firmwares', 'nics', 'ports'])
+def test_get_hardware_attributes(appliance, physical_server, attribute):
+    expanded_attribute = 'hardware.{}'.format(attribute)
+    physical_server.reload(attributes=[expanded_attribute])
+    assert_response(appliance)
+    assert physical_server.hardware[attribute] is not None
+
+
+def test_get_asset_details(appliance, physical_server):
+    physical_server.reload(attributes=['asset_details'])
+    assert_response(appliance)
+    assert physical_server.asset_details is not None


### PR DESCRIPTION
__Adding tests__ for get physical servers inventory data by rest API:
- test_get_hardware
- test_get_hardware_attributes (firmwares, nics and ports)
- test_get_asset_details

This PR also adapt the `LenovoProvider` class to work properly with `create_rest` method