### PR TITLE
[1LP][RFR] fix for quadicons in 5.8

### DIFF
--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -2652,11 +2652,11 @@ class BaseQuadIconEntity(ParametrizedView, ClickableMixin):
     It is expected that some properties like "data" will be overridden in its children
 
     """
-    ENTITY_XPATH = ('./tbody/tr/td/*[(self::a or self::span) and '
-                    '((contains(@href, "?") and substring(substring-before(@href, "?"), '
-                    'string-length(substring-before(@href, "?"))-string-length("/{entity_id}"+1))='
+    ENTITY_XPATH = ('./tbody/tr/td/*[(self::a or self::span) and ((contains(@href, "?") '
+                    'and substring(substring-before(@href, "?"), '
+                    'string-length(substring-before(@href, "?"))-string-length("/{entity_id}")+1)='
                     '"/{entity_id}") or substring(@href, string-length(@href)-'
-                    'string-length("/{entity_id}"+1))="/{entity_id}")]')
+                    'string-length("/{entity_id}")+1)="/{entity_id}")]')
     PARAMETERS = ('entity_id',)
     ROOT = ParametrizedLocator('.//table[{xpath}]'.format(xpath=ENTITY_XPATH))
     LIST = '//dl[contains(@class, "tile")]/*[self::dt or self::dd]'
@@ -2726,7 +2726,7 @@ class BaseTileIconEntity(ParametrizedView):
         return self.quad_icon(self.context['entity_id']).name
 
     def click(self):
-        self.quad_icon.click()
+        self.quad_icon(self.context['entity_id']).click()
 
     @property
     def data(self):

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -2652,16 +2652,15 @@ class BaseQuadIconEntity(ParametrizedView, ClickableMixin):
     It is expected that some properties like "data" will be overridden in its children
 
     """
+    ENTITY_XPATH = ('./tbody/tr/td/*[(self::a or self::span) and '
+                    '((contains(@href, "?") and substring(substring-before(@href, "?"), '
+                    'string-length(substring-before(@href, "?"))-string-length("/{entity_id}"+1))='
+                    '"/{entity_id}") or substring(@href, string-length(@href)-'
+                    'string-length("/{entity_id}"+1))="/{entity_id}")]')
     PARAMETERS = ('entity_id',)
-    ROOT = ParametrizedLocator('.//table[./tbody/tr/td/*[(self::a or self::span) and '
-                               'substring(substring-before(@href, "?"), '
-                               'string-length(substring-before(@href, "?"))'
-                               '-string-length("/{entity_id}")+1)="/{entity_id}"]]')
+    ROOT = ParametrizedLocator('.//table[{xpath}]'.format(xpath=ENTITY_XPATH))
     LIST = '//dl[contains(@class, "tile")]/*[self::dt or self::dd]'
-    label = Text(locator=ParametrizedLocator('./tbody/tr/td/*[(self::a or self::span) and '
-                                             'substring(substring-before(@href, "?"), '
-                                             'string-length(substring-before(@href, "?"))-'
-                                             'string-length("/{entity_id}")+1)="/{entity_id}"]'))
+    label = Text(locator=ParametrizedLocator(ENTITY_XPATH))
     checkbox = Checkbox(locator='./tbody/tr/td/input[@type="checkbox"]')
     QUADRANT = './/div[@class="flobj {pos}72"]/*[self::p or self::img or self::div]'
 
@@ -2708,10 +2707,7 @@ class BaseTileIconEntity(ParametrizedView):
 
     """
     PARAMETERS = ('entity_id',)
-    ROOT = ParametrizedLocator('.//table[.//table[./tbody/tr/td/*[(self::a or self::span) and '
-                               'substring(substring-before(@href, "?"), '
-                               'string-length(substring-before(@href, "?"))-'
-                               'string-length("/{entity_id}")+1)="/{entity_id}"]]]')
+    ROOT = ParametrizedLocator('.//table[.//table[{}]]'.format(BaseQuadIconEntity.ENTITY_XPATH))
     LIST = '//dl[contains(@class, "tile")]/*[self::dt or self::dd]'
     quad_icon = ParametrizedView.nested(BaseQuadIconEntity)
 
@@ -2728,6 +2724,9 @@ class BaseTileIconEntity(ParametrizedView):
     @property
     def name(self):
         return self.quad_icon(self.context['entity_id']).name
+
+    def click(self):
+        self.quad_icon.click()
 
     @property
     def data(self):


### PR DESCRIPTION
Quadicons have been broken recently by my changes. 
This change should fix the issue. 
To be honest, the best way would be to get rid of ParametrizedLocator in QuadIcon classes since xpath gets more and more sophisticated. However, I believe Quadicons 5.8 will go away soon along with 5.8.
So, I left ParametrizedLocator with that compex xpath

In addition, I bumped into issue with click in TileIcon and fixed it toghether with the rest of stuff.

I tested it locally. 