### PR TITLE
[1LP][RFR] Workaround for snapshot VM suspend

### DIFF
--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -273,7 +273,7 @@ def test_operations_suspended_vm(small_test_vm, soft_assert):
     wait_for(lambda: snapshot1.active, num_sec=300, delay=20, fail_func=snapshot1.refresh,
              message="Waiting for the first snapshot to become active")
     # Suspend the VM
-    small_test_vm.power_control_from_cfme(option=small_test_vm.SUSPEND, cancel=False)
+    small_test_vm.power_control_from_provider(option=small_test_vm.SUSPEND)
     small_test_vm.wait_for_vm_state_change(desired_state=small_test_vm.STATE_SUSPENDED)
     # Create second snapshot when VM is suspended
     snapshot2 = new_snapshot(small_test_vm)


### PR DESCRIPTION
This is a fix/workaround for a known issue in automation:

"Could not do function _looking_for_state_change"

This occurs mainly when running snapshot tests where a suspend VM action is performed. For an unknown reason, when jenkins tries to suspend the testing VM, it gets powered off and an error is thrown when waiting for it to become suspended. I investigated the behaviour and could not reproduce locally nor in PRT.

The error occurs on regular basis for many runs on 5.9. In order to increase our success rate when running our test suite, a fix for this is proposed: try to suspend the VM on a provider instead of doing it via CFME UI.

The proposed fix/workaround does not interfere with the purpose of the test. Test just needs a suspended VM to perform snapshot operations on it and doesn't care how the VM got suspended. It is also not clear if this change fixes the issue. I propose we merge this, wait a few jenkins runs and see.

{{ pytest: -v --long-running --use-provider vsphere55 cfme/tests/infrastructure/test_snapshot.py -k test_operations_suspended_vm }}