### PR TITLE
[1LP][RFR] Update all Method to allow Querying of All, Active, or Archived DB Entries

### DIFF
--- a/cfme/containers/container.py
+++ b/cfme/containers/container.py
@@ -69,6 +69,7 @@ class ContainerCollection(GetRandomInstancesMixin, BaseCollection):
     def all(self):
         # containers table has ems_id, join with ext_mgmgt_systems on id for provider name
         # Then join with container_groups on the id for the pod
+        # TODO Update to use REST API instead of DB queries
         container_table = self.appliance.db.client['containers']
         ems_table = self.appliance.db.client['ext_management_systems']
         pod_table = self.appliance.db.client['container_groups']
@@ -82,6 +83,10 @@ class ContainerCollection(GetRandomInstancesMixin, BaseCollection):
                 .query(container_table.name, pod_table.name, ems_table.name)
                 .join(ems_table, container_table.ems_id == ems_table.id)
                 .join(pod_table, container_pod_id == pod_table.id))
+        if self.filters.get('archived'):
+            container_query = container_query.filter(container_table.deleted_on.isnot(None))
+        if self.filters.get('active'):
+            container_query = container_query.filter(container_table.deleted_on.is_(None))
         provider = None
         # filtered
         if self.filters.get('provider'):

--- a/cfme/containers/image.py
+++ b/cfme/containers/image.py
@@ -122,12 +122,17 @@ class ImageCollection(GetRandomInstancesMixin, BaseCollection, PolicyProfileAssi
 
     def all(self):
         # container_images has ems_id, join with ext_mgmgt_systems on id for provider name
+        # TODO Update to use REST API instead of DB queries
         image_table = self.appliance.db.client['container_images']
         ems_table = self.appliance.db.client['ext_management_systems']
         image_query = (
             self.appliance.db.client.session
                 .query(image_table.name, image_table.image_ref, ems_table.name)
                 .join(ems_table, image_table.ems_id == ems_table.id))
+        if self.filters.get('archived'):
+            image_query = image_query.filter(image_table.deleted_on.isnot(None))
+        if self.filters.get('active'):
+            image_query = image_query.filter(image_table.deleted_on.is_(None))
         provider = None
         # filtered
         if self.filters.get('provider'):

--- a/cfme/containers/node.py
+++ b/cfme/containers/node.py
@@ -86,12 +86,17 @@ class NodeCollection(GetRandomInstancesMixin, BaseCollection):
 
     def all(self):
         # container_nodes table has ems_id, join with ext_mgmgt_systems on id for provider name
+        # TODO Update to use REST API instead of DB queries
         node_table = self.appliance.db.client['container_nodes']
         ems_table = self.appliance.db.client['ext_management_systems']
         node_query = (
             self.appliance.db.client.session
                 .query(node_table.name, ems_table.name)
                 .join(ems_table, node_table.ems_id == ems_table.id))
+        if self.filters.get('archived'):
+            node_query = node_query.filter(node_table.deleted_on.isnot(None))
+        if self.filters.get('active'):
+            node_query = node_query.filter(node_table.deleted_on.is_(None))
         provider = None
         # filtered
         if self.filters.get('provider'):

--- a/cfme/containers/pod.py
+++ b/cfme/containers/pod.py
@@ -54,6 +54,7 @@ class PodCollection(GetRandomInstancesMixin, BaseCollection):
     def all(self):
         # container_groups table has ems_id, join with ext_mgmgt_systems on id for provider name
         # Then join with container_projects on the id for the project
+        # TODO Update to use REST API instead of DB queries
         pod_table = self.appliance.db.client['container_groups']
         ems_table = self.appliance.db.client['ext_management_systems']
         project_table = self.appliance.db.client['container_projects']
@@ -62,6 +63,10 @@ class PodCollection(GetRandomInstancesMixin, BaseCollection):
                 .query(pod_table.name, project_table.name, ems_table.name)
                 .join(ems_table, pod_table.ems_id == ems_table.id)
                 .join(project_table, pod_table.container_project_id == project_table.id))
+        if self.filters.get('archived'):
+            pod_query = pod_query.filter(pod_table.deleted_on.isnot(None))
+        if self.filters.get('active'):
+            pod_query = pod_query.filter(pod_table.deleted_on.is_(None))
         provider = None
         # filtered
         if self.filters.get('provider'):

--- a/cfme/containers/project.py
+++ b/cfme/containers/project.py
@@ -45,12 +45,17 @@ class ProjectCollection(GetRandomInstancesMixin, BaseCollection):
 
     def all(self):
         # container_projects table has ems_id, join with ext_mgmgt_systems on id for provider name
+        # TODO Update to use REST API instead of DB queries
         project_table = self.appliance.db.client['container_projects']
         ems_table = self.appliance.db.client['ext_management_systems']
         project_query = (
             self.appliance.db.client.session
                 .query(project_table.name, ems_table.name)
                 .join(ems_table, project_table.ems_id == ems_table.id))
+        if self.filters.get('archived'):
+            project_query = project_query.filter(project_table.deleted_on.isnot(None))
+        if self.filters.get('active'):
+            project_query = project_query.filter(project_table.deleted_on.is_(None))
         provider = None
         # filtered
         if self.filters.get('provider'):


### PR DESCRIPTION
Problem:
CloudForms archives the following resources:

app/models/container.rb:  include ArchivedMixin
app/models/container_group.rb:  include ArchivedMixin
app/models/container_image.rb:  include ArchivedMixin
app/models/container_node.rb:  include ArchivedMixin
app/models/container_project.rb:  include ArchivedMixin

Solution:
Allow user to query on all, active, archived entries. 

{{ pytest: cfme/tests/containers/test_cockpit.py --use-provider cm-env2 --long-running }}

Manual Testing:
container_projects:
```
In [2]: dc = appliance.collections.container_projects

In [3]: dc.all()
Out[3]: 
[Project(name=u'muihvefzcm', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Project(name=u'default', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Project(name=u'kube-public', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Project(name=u'kube-system', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Project(name=u'logging', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Project(name=u'management-infra', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Project(name=u'openshift', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Project(name=u'openshift-infra', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Project(name=u'park-maps', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>)]

In [6]: filter_dc = dc.filter({'archived':True})

In [7]: filter_dc.all()
Out[7]: [Project(name=u'muihvefzcm', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>)]

In [8]: filter_dc = dc.filter({'active':True})

In [9]: filter_dc.all()
Out[9]: 
[Project(name=u'park-maps', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Project(name=u'openshift-infra', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Project(name=u'openshift', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Project(name=u'management-infra', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Project(name=u'logging', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Project(name=u'kube-system', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Project(name=u'kube-public', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>),
 Project(name=u'default', provider=<cfme.containers.provider.openshift.OpenshiftProvider name='CM JUWATTS', key='cm-juwatts', zone='default', metrics_type='Hawkular', alerts_type='Disabled'>)]

In [10]: filter_dc = dc.filter({'active':True, 'archived':True})

In [11]: filter_dc.all()
Out[11]: []

In [12]: 
```
