### PR TITLE
[WIP][RFR] Add pre-setup step for openshift provider with alert endpoint

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -135,7 +135,6 @@ class BaseProvider(WidgetasticTaggable, Updateable, Navigatable):
             created = False
         else:
             created = True
-
             logger.info('Setting up Provider: %s', self.key)
             add_view = navigate_to(self, 'Add')
 

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -70,7 +70,7 @@ class ContainersProviderEndpointsForm(View):
         api_port = Input('default_api_port')
 
     @View.nested
-    class hawkular(Tab, BeforeFillMixin):  # NOQA
+    class metrics(Tab, BeforeFillMixin):  # NOQA
         TAB_NAME = VersionPick({
             Version.lowest(): 'Hawkular',
             '5.9': 'Metrics'
@@ -91,15 +91,18 @@ class ContainersProviderEndpointsForm(View):
             Version.lowest(): Input('hawkular_api_port'),
             '5.9': Input('metrics_api_port')
         })
+
         validate = Button('Validate')
 
     @View.nested
     class alerts(Tab, BeforeFillMixin):  # NOQA
         TAB_NAME = 'Alerts'
+
         sec_protocol = BootstrapSelect(id='prometheus_alerts_security_protocol')
         trusted_ca_certificates = TextInput('prometheus_alerts_tls_ca_certs')
         hostname = Input('prometheus_alerts_hostname')
         api_port = Input('prometheus_alerts_api_port')
+
         validate = Button('Validate')
 
 

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -1,20 +1,15 @@
-from cached_property import cached_property
 from os import path
+
+from cached_property import cached_property
 from wrapanapi.containers.providers.rhopenshift import Openshift
-
-from . import ContainersProvider
-
-from cfme.containers.provider import (
-    ContainersProviderDefaultEndpoint, ContainersProviderEndpointsForm
-)
 
 from cfme.common.provider import DefaultEndpoint
 from cfme.control.explorer.alert_profiles import ProviderAlertProfile, NodeAlertProfile
+from cfme.utils import ssh
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.ocp_cli import OcpCli
 from cfme.utils.varmeth import variable
-from cfme.utils import ssh
-from cfme.utils.wait import TimedOutError
+from . import ContainersProvider, ContainersProviderDefaultEndpoint, ContainersProviderEndpointsForm
 
 
 class CustomAttribute(object):

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -1,6 +1,5 @@
 from cached_property import cached_property
 from os import path
-
 from wrapanapi.containers.providers.rhopenshift import Openshift
 
 from . import ContainersProvider
@@ -10,10 +9,12 @@ from cfme.containers.provider import (
 )
 
 from cfme.common.provider import DefaultEndpoint
+from cfme.control.explorer.alert_profiles import ProviderAlertProfile, NodeAlertProfile
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.ocp_cli import OcpCli
 from cfme.utils.varmeth import variable
-from cfme.utils import version, ssh
+from cfme.utils import ssh
+from cfme.utils.wait import TimedOutError
 
 
 class CustomAttribute(object):
@@ -41,17 +42,13 @@ class OpenshiftDefaultEndpoint(ContainersProviderDefaultEndpoint):
             return str("".join(stdout.readlines()))
 
 
-class HawkularEndpoint(DefaultEndpoint):
-    """Represents Hawkular Endpoint"""
-    name = 'hawkular'
+class ServiceBasedEndpoint(DefaultEndpoint):
 
     @property
     def view_value_mapping(self):
-        out = {
-            'hostname': self.hostname,
-            'api_port': self.api_port,
-            'sec_protocol': self.sec_protocol
-        }
+        out = {'hostname': self.hostname,
+               'api_port': self.api_port,
+               'sec_protocol': self.sec_protocol}
 
         if out['sec_protocol'] and self.sec_protocol.lower() == 'ssl trusting custom ca':
             out['trusted_ca_certificates'] = OpenshiftDefaultEndpoint.get_ca_cert(
@@ -62,32 +59,14 @@ class HawkularEndpoint(DefaultEndpoint):
         return out
 
 
-class AlertsEndpoint(DefaultEndpoint):
+class MetricsEndpoint(ServiceBasedEndpoint):
+    """Represents metrics Endpoint"""
+    name = 'metrics'
+
+
+class AlertsEndpoint(ServiceBasedEndpoint):
     """Represents Alerts Endpoint"""
     name = 'alerts'
-
-    @property
-    def view_value_mapping(self):
-
-        out = {}
-
-        out['hostname'] = version.pick({
-            version.LOWEST: None,
-            '5.9': self.hostname})
-        out['api_port'] = version.pick({
-            version.LOWEST: None,
-            '5.9': self.api_port})
-        out['sec_protocol'] = version.pick({
-            version.LOWEST: None,
-            '5.9': self.sec_protocol})
-
-        if out['sec_protocol'] and self.sec_protocol.lower() == 'ssl trusting custom ca':
-            out['trusted_ca_certificates'] = OpenshiftDefaultEndpoint.get_ca_cert(
-                {"username": self.ssh_creds.principal,
-                 "password": self.ssh_creds.secret,
-                 "hostname": self.master_hostname})
-
-        return out
 
 
 class OpenshiftProvider(ContainersProvider):
@@ -136,6 +115,23 @@ class OpenshiftProvider(ContainersProvider):
             alerts_type=alerts_type,
             endpoints=endpoints,
             appliance=appliance)
+
+    def create(self, **kwargs):
+
+        # Enable alerts collection before adding the provider to avoid missing active
+        # alert after adding the provider
+        # For more info: https://bugzilla.redhat.com/show_bug.cgi?id=1514950
+        if self.appliance.version >= '5.9' and getattr(self, "alerts_type") == "Prometheus":
+            alert_profiles = self.appliance.collections.alert_profiles
+            provider_profile = alert_profiles.instantiate(ProviderAlertProfile,
+                                                          "Prometheus Provider Profile")
+            node_profile = alert_profiles.instantiate(NodeAlertProfile,
+                                                      "Prometheus node Profile")
+
+            for profile in [provider_profile, node_profile]:
+                profile.assign_to("The Enterprise")
+
+        super(OpenshiftProvider, self).create(**kwargs)
 
     @cached_property
     def cli(self):
@@ -217,11 +213,10 @@ class OpenshiftProvider(ContainersProvider):
             if OpenshiftDefaultEndpoint.name == endp:
                 prov_config['endpoints'][endp]['token'] = token_creds.token
                 endpoints[endp] = OpenshiftDefaultEndpoint(**prov_config['endpoints'][endp])
-            elif HawkularEndpoint.name == endp:
-                endpoints[endp] = HawkularEndpoint(**prov_config['endpoints'][endp])
+            elif MetricsEndpoint.name == endp:
+                endpoints[endp] = MetricsEndpoint(**prov_config['endpoints'][endp])
             elif AlertsEndpoint.name == endp:
                 endpoints[endp] = AlertsEndpoint(**prov_config['endpoints'][endp])
-            # TODO Add Prometheus and logic for having to select or the other based on metrcis_type
             else:
                 raise Exception('Unsupported endpoint type "{}".'.format(endp))
 

--- a/cfme/control/explorer/alert_profiles.py
+++ b/cfme/control/explorer/alert_profiles.py
@@ -304,3 +304,8 @@ class ServerAlertProfile(BaseAlertProfile):
 class VMInstanceAlertProfile(BaseAlertProfile):
 
     TYPE = "VM and Instance"
+
+
+class NodeAlertProfile(BaseAlertProfile):
+
+    TYPE = "Node"

--- a/cfme/tests/containers/test_alerts.py
+++ b/cfme/tests/containers/test_alerts.py
@@ -1,0 +1,20 @@
+import pytest
+
+from cfme.containers.provider import ContainersProvider
+from cfme.utils.version import current_version
+
+
+pytestmark = [
+    pytest.mark.uncollectif(lambda: current_version() < "5.9"),
+    pytest.mark.provider([ContainersProvider], scope='module')
+]
+
+
+@pytest.fixture
+def ensure_alerts(provider):
+    if 'alerts' not in provider.endpoints:
+        pytest.skip('No alerts endpoint found for this provider')
+
+
+def test_add_alerts_provider(ensure_alerts, provider):
+    provider.setup()


### PR DESCRIPTION
In this PR I added a pre-step for openshift provider setup.

In case an OpenShift provider has Prometheus alerts endpoint pre-setup steps are required.

I added the assignment of alert's profile (both node and provider) to "The Enterprise", so CFME will not ignore alerts that raise after adding the endpoint.

This PR can't run in PRT because it requires yamls change see https://gitlab.cee.redhat.com/cfme-qe/cfme-qe-yamls/merge_requests/466