### PR TITLE
[1LP][RFR] Replacement get_detail() for hosts

### DIFF
--- a/cfme/common/host_views.py
+++ b/cfme/common/host_views.py
@@ -3,7 +3,6 @@ from lxml.html import document_fromstring
 from widgetastic.exceptions import NoSuchElementException
 from widgetastic.utils import (
     Parameter,
-    ParametrizedLocator,
     Version,
     VersionPick
 )
@@ -19,23 +18,24 @@ from widgetastic_patternfly import (
 from cfme.base.login import BaseLoggedInPage
 from widgetastic_manageiq import (
     Accordion,
-    ManageIQTree,
     BaseEntitiesView,
-    NonJSBaseEntity,
-    JSBaseEntity,
     BaseListEntity,
     BaseQuadIconEntity,
     BaseTileIconEntity,
     BreadCrumb,
     Button,
     Checkbox,
+    DriftComparison,
     Input,
     ItemsToolBarViewSelector,
+    JSBaseEntity,
+    ManageIQTree,
+    NonJSBaseEntity,
     PaginationPane,
+    ParametrizedSummaryTable,
     SummaryTable,
     Table,
-    TimelinesView,
-    DriftComparison
+    TimelinesView
 )
 
 
@@ -131,14 +131,7 @@ class HostDetailsToolbar(View):
 
 class HostDetailsEntities(View):
     """Represents Details page."""
-    properties = SummaryTable(title="Properties")
-    relationships = SummaryTable(title="Relationships")
-    compliance = SummaryTable(title="Compliance")
-    configuration = SummaryTable(title="Configuration")
-    smart_management = SummaryTable(title="Smart Management")
-    security = SummaryTable(title="Security")
-    authentication_status = SummaryTable(title="Authentication Status")
-    openstack_hardware = SummaryTable(title="Openstack Hardware")
+    summary = ParametrizedView.nested(ParametrizedSummaryTable)
 
 
 class HostDetailsView(ComputeInfrastructureHostsView):

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -166,7 +166,8 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, WidgetasticT
         view.toolbar.power.item_select("Power Off", handle_alert=True)
 
     def get_power_state(self):
-        return self.get_detail("Properties", "Power State")
+        view = navigate_to(self, "Details")
+        return view.entities.summary("Properties").get_text_of("Power State")
 
     def refresh(self, cancel=False):
         """Perform 'Refresh Relationships and Power States' for the host.
@@ -205,18 +206,6 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, WidgetasticT
             password=self.ipmi_credentials.secret,
             interface_type=self.interface_type
         )
-
-    def get_detail(self, title, field):
-        """Gets details from the details summary tables.
-
-        Args:
-            title (str): Summary Table title
-            field (str): Summary table field name
-
-        Returns: A string representing the entities of the SummaryTable's value.
-        """
-        view = navigate_to(self, "Details")
-        return getattr(view.entities, title.lower().replace(" ", "_")).get_text_of(field)
 
     @property
     def exists(self):
@@ -266,7 +255,7 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, WidgetasticT
         Returns: :py:class:`list` of datastores names
         """
         host_details_view = navigate_to(self, "Details")
-        host_details_view.entities.relationships.click_at("Datastores")
+        host_details_view.entities.summary("Relationships").click_at("Datastores")
         datastores_view = self.create_view(HostAllDatastoresView)
         assert datastores_view.is_displayed
         return [entity.name for entity in datastores_view.entites.get_all_()]
@@ -315,7 +304,7 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, WidgetasticT
         """
         view = navigate_to(self, "Details")
         view.browser.refresh()
-        return self.get_detail("Compliance", "Status")
+        return view.entities.summary("Compliance").get_text_of("Status")
 
     @property
     def is_compliant(self):
@@ -354,7 +343,7 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, WidgetasticT
 
         # mark by indexes or mark all
         details_view = navigate_to(self, "Details")
-        details_view.entities.relationships.click_at("Drift History")
+        details_view.entities.summary("Relationships").click_at("Drift History")
         drift_history_view = self.create_view(HostDriftHistory)
         assert drift_history_view.is_displayed
         if indexes:

--- a/cfme/tests/cloud_infra_common/test_relationships.py
+++ b/cfme/tests/cloud_infra_common/test_relationships.py
@@ -75,7 +75,8 @@ def get_obj(relationship, appliance, **kwargs):
         cluster_col = appliance.collections.clusters
         host = kwargs.get("host")
         provider = kwargs.get("provider")
-        cluster_name = host.get_detail("Relationships", "Cluster")
+        view = navigate_to(host, "Details")
+        cluster_name = view.entities.summary("Relationships").get_text_of("Cluster")
         obj = cluster_col.instantiate(name=cluster_name, provider=provider)
     elif relationship in ["Datastores", "VMs", "Templates"]:
         obj = kwargs.get("host")
@@ -99,10 +100,10 @@ def host(appliance, provider):
 def test_host_relationships(appliance, provider, setup_provider, host, relationship, view):
     """Tests relationship navigation for a host"""
     host_view = navigate_to(host, "Details")
-    if host.get_detail("Relationships", relationship) == "0":
+    if host_view.entities.summary("Relationships").get_text_of(relationship) == "0":
         pytest.skip("There are no relationships for {}".format(relationship))
     obj = get_obj(relationship, appliance, provider=provider, host=host)
-    host_view.entities.relationships.click_at(relationship)
+    host_view.entities.summary("Relationships").click_at(relationship)
     relationship_view = appliance.browser.create_view(view, additional_context={'object': obj})
     assert relationship_view.is_displayed
 

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -483,7 +483,7 @@ def test_action_prevent_host_ssa(request, appliance, host, host_policy):
     view = navigate_to(host, "Details")
 
     def _scan():
-        return host.get_detail("Relationships", "Drift History")
+        return view.entities.summary("Relationships").get_text_of("Drift History")
 
     original = _scan()
     view.toolbar.configuration.item_select("Perform SmartState Analysis", handle_alert=True)

--- a/cfme/tests/infrastructure/test_host_analysis.py
+++ b/cfme/tests/infrastructure/test_host_analysis.py
@@ -68,23 +68,23 @@ def test_run_host_analysis(setup_provider_modscope, provider, host_type, host_na
     host_with_credentials.run_smartstate_analysis(wait_for_task_result=True)
 
     # Check results of the analysis
-    drift_history = host_with_credentials.get_detail('Relationships', 'Drift History')
+    view = navigate_to(host_with_credentials, 'Details')
+    drift_history = view.entities.summary('Relationships').get_text_of('Drift History')
     soft_assert(drift_history != '0', 'No drift history change found')
 
     if provider.type == "rhevm":
-        soft_assert(host_with_credentials.get_detail('Configuration', 'Services') != '0',
+        soft_assert(view.entities.summary('Configuration').get_text_of('Services') != '0',
                     'No services found in host detail')
 
     if host_type in ('rhel', 'rhev'):
-        soft_assert(host_with_credentials.get_detail('Configuration', 'Packages') != '0',
+        soft_assert(view.entities.summary('Configuration').get_text_of('Packages') != '0',
                     'No packages found in host detail')
-        soft_assert(host_with_credentials.get_detail('Configuration', 'Files') != '0',
+        soft_assert(view.entities.summary('Configuration').get_text_of('Files') != '0',
                     'No files found in host detail')
 
     elif host_type in ('esx', 'esxi'):
-        soft_assert(host_with_credentials.get_detail('Configuration', 'Advanced Settings') != '0',
+        soft_assert(view.entities.summary('Configuration').get_text_of('Advanced Settings') != '0',
                     'No advanced settings found in host detail')
-        view = navigate_to(host_with_credentials, 'Details')
         view.security_accordion.navigation.select('Firewall Rules')
         # Page get updated if rules value is not 0, and title is update
         soft_assert("(Firewall Rules)" in view.title.text, (

--- a/cfme/tests/infrastructure/test_host_drift_analysis.py
+++ b/cfme/tests/infrastructure/test_host_drift_analysis.py
@@ -7,6 +7,7 @@ from cfme.common.host_views import HostDriftAnalysis
 from cfme.infrastructure.host import Host
 from cfme.infrastructure.provider import InfraProvider
 from cfme.utils import testgen
+from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.wait import wait_for
 
 pytestmark = [
@@ -66,7 +67,8 @@ def test_host_drift_analysis(appliance, request, a_host, soft_assert, set_host_c
     destination = 'AllTasks' if appliance.version >= '5.9' else 'AllOtherTasks'
 
     # get drift history num
-    drift_num_orig = int(a_host.get_detail('Relationships', 'Drift History'))
+    view = navigate_to(a_host, 'Details')
+    drift_num_orig = int(view.entities.summary('Relationships').get_text_of('Drift History'))
 
     # clear table
     delete_all_tasks(destination)
@@ -75,8 +77,10 @@ def test_host_drift_analysis(appliance, request, a_host, soft_assert, set_host_c
     a_host.run_smartstate_analysis(wait_for_task_result=True)
 
     # wait for for drift history num+1
+    navigate_to(a_host, 'Details')
     wait_for(
-        lambda: a_host.get_detail('Relationships', 'Drift History') == str(drift_num_orig + 1),
+        lambda: (view.entities.summary('Relationships').get_text_of('Drift History') ==
+                 str(drift_num_orig + 1)),
         delay=20,
         num_sec=360,
         message="Waiting for Drift History count to increase",
@@ -91,8 +95,10 @@ def test_host_drift_analysis(appliance, request, a_host, soft_assert, set_host_c
     a_host.run_smartstate_analysis(wait_for_task_result=True)
 
     # wait for for drift history num+2
+    navigate_to(a_host, 'Details')
     wait_for(
-        lambda: a_host.get_detail('Relationships', 'Drift History') == str(drift_num_orig + 2),
+        lambda: (view.entities.summary('Relationships').get_text_of('Drift History') ==
+                 str(drift_num_orig + 2)),
         delay=20,
         num_sec=360,
         message="Waiting for Drift History count to increase",

--- a/cfme/tests/infrastructure/test_host_provisioning.py
+++ b/cfme/tests/infrastructure/test_host_provisioning.py
@@ -186,10 +186,11 @@ def test_host_provisioning(appliance, setup_provider, cfme_data, host_provisioni
     assert host_request.row.status.text != 'Error'
 
     # Navigate to host details page and verify Provider and cluster names
-    assert test_host.get_detail('Relationships', 'Infrastructure Provider') ==\
+    view = navigate_to(test_host, 'Details')
+    assert view.entities.summary('Relationships').get_text_of('Infrastructure Provider') ==\
         provider.name, 'Provider name does not match'
 
-    assert test_host.get_detail('Relationships', 'Cluster') ==\
+    assert view.entities.summary('Relationships').get_text_of('Cluster') ==\
         host_provisioning['cluster'], 'Cluster does not match'
 
     # Navigate to host datastore page and verify that the requested datastore has been assigned

--- a/cfme/tests/openstack/cloud/test_instances.py
+++ b/cfme/tests/openstack/cloud/test_instances.py
@@ -181,7 +181,8 @@ def test_list_vms_infra_node(appliance, provider, soft_assert):
     hosts = [host for host in host_collection.all(provider) if 'Compute' in host.name]
     assert hosts
     for host in hosts:
-        host_ip = host.get_detail('Properties', 'IP Address')
-        vms = int(host.get_detail('Relationships', 'VMs'))
+        view = navigate_to(host, 'Details')
+        host_ip = view.entities.summary('Properties').get_text_of('IP Address')
+        vms = int(view.entities.summary('Relationships').get_text_of('VMs'))
         soft_assert(vms == hvisors[host_ip],
                     'Number of instances on UI does not match with real value')

--- a/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
+++ b/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
@@ -42,14 +42,16 @@ def test_scale_provider_down(provider, host, has_mistral_service):
     wait_for(lambda: provider.mgmt.iapi.node.get(host_uuid).maintenance, timeout=600, delay=5)
     wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600)
     host.browser.refresh()
-    assert host.get_detail('Properties', 'Maintenance Mode') == 'Enabled'
+    view = navigate_to(host, 'Details')
+    assert view.entities.summary('Properties').get_text_of('Maintenance Mode') == 'Enabled'
     provider.scale_down()
     wait_for(lambda: provider.mgmt.iapi.node.get(host_uuid).provision_state == 'available', delay=5,
              timeout=1200)
     wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600)
     host.name = host_uuid  # host's name is changed after scale down
     host.browser.refresh()
-    assert host.get_detail('Openstack Hardware', 'Provisioning State') == 'available'
+    prov_state = view.entities.summary('Openstack Hardware').get_text_of('Provisioning State')
+    assert prov_state == 'available'
 
 
 def test_delete_host(appliance, host, provider, has_mistral_service):
@@ -94,7 +96,8 @@ def test_introspect_host(host, provider, has_mistral_service):
              timeout=600)
     wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600)
     host.browser.refresh()
-    assert host.get_detail('Openstack Hardware', 'Introspected') == 'true'
+    view = navigate_to(host, 'Details')
+    assert view.entities.summary('Openstack Hardware').get_text_of('Introspected') == 'true'
 
 
 def test_provide_host(host, provider, has_mistral_service):
@@ -106,7 +109,9 @@ def test_provide_host(host, provider, has_mistral_service):
              timeout=300)
     wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600)
     host.browser.refresh()
-    assert host.get_detail('Openstack Hardware', 'Provisioning State') == 'available'
+    view = navigate_to(host, 'Details')
+    prov_state = view.entities.summary('Openstack Hardware').get_text_of('Provisioning State')
+    assert prov_state == 'available'
 
 
 def test_scale_provider_out(host, provider, has_mistral_service):
@@ -125,4 +130,6 @@ def test_scale_provider_out(host, provider, has_mistral_service):
     host.name += ' (NovaCompute)'  # Host will change it's name after successful scale out
     host.browser.refresh()
     assert host.exists
-    assert host.get_detail('Openstack Hardware', 'Provisioning State') == 'active'
+    view = navigate_to(host, 'Details')
+    prov_state = view.entities.summary('Openstack Hardware').get_text_of('Provisioning State')
+    assert prov_state == 'active'

--- a/cfme/tests/openstack/infrastructure/test_hosts.py
+++ b/cfme/tests/openstack/infrastructure/test_hosts.py
@@ -25,8 +25,9 @@ def test_host_configuration(host_collection, provider, soft_assert, appliance):
         wait_for(is_host_analysis_finished, [host.name], delay=15,
                  timeout="10m", fail_func=host.browser.refresh)
         fields = ['Packages', 'Services', 'Files']
+        view = navigate_to(host, 'Details')
         for field in fields:
-            value = int(host.get_detail("Configuration", field))
+            value = int(view.entities.summary('Configuration').get_text_of(field))
             soft_assert(value > 0, 'Nodes number of {} is 0'.format(field))
 
 
@@ -36,8 +37,9 @@ def test_host_cpu_resources(host_collection, provider, soft_assert):
     for host in hosts:
         fields = ['Number of CPUs', 'Number of CPU Cores',
                   'CPU Cores Per Socket']
+        view = navigate_to(host, 'Details')
         for field in fields:
-            value = int(host.get_detail("Properties", field))
+            value = int(view.entities.summary('Properties').get_text_of(field))
             soft_assert(value > 0, "Aggregate Node {} is 0".format(field))
 
 
@@ -45,8 +47,9 @@ def test_host_auth(host_collection, provider, soft_assert):
     hosts = host_collection.all(provider)
     assert hosts
     for host in hosts:
-        navigate_to(host, 'Details')
-        auth_status = host.get_detail('Authentication Status', 'SSH Key Pair Credentials')
+        view = navigate_to(host, 'Details')
+        auth_status = view.entities.summary('Authentication Status').get_text_of(
+            'SSH Key Pair Credentials')
         soft_assert(auth_status == 'Valid',
                     'Incorrect SSH authentication status {}'.format(auth_status))
 
@@ -55,7 +58,8 @@ def test_host_devices(host_collection, provider):
     hosts = host_collection.all(provider)
     assert hosts
     for host in hosts:
-        result = int(host.get_detail("Properties", "Devices").split()[0])
+        view = navigate_to(host, 'Details')
+        result = int(view.entities.summary('Properties').get_text_of('Devices').split()[0])
         assert result > 0
 
 
@@ -63,7 +67,8 @@ def test_host_hostname(host_collection, provider, soft_assert):
     hosts = host_collection.all(provider)
     assert hosts
     for host in hosts:
-        result = host.get_detail("Properties", "Hostname")
+        view = navigate_to(host, 'Details')
+        result = view.entities.summary('Properties').get_text_of('Hostname')
         soft_assert(result, "Missing hostname in: " + str(result))
 
 
@@ -71,7 +76,8 @@ def test_host_memory(host_collection, provider):
     hosts = host_collection.all(provider)
     assert hosts
     for host in hosts:
-        result = int(host.get_detail("Properties", "Memory").split()[0])
+        view = navigate_to(host, 'Details')
+        result = int(view.entities.summary('Properties').get_text_of('Memory').split()[0])
         assert result > 0
 
 
@@ -79,12 +85,13 @@ def test_host_security(host_collection, provider, soft_assert):
     hosts = host_collection.all(provider)
     assert hosts
     for host in hosts:
+        view = navigate_to(host, 'Details')
         soft_assert(
-            int(host.get_detail("Security", "Users")) > 0,
+            int(view.entities.summary('Security').get_text_of('Users')) > 0,
             'Nodes number of Users is 0')
 
         soft_assert(
-            int(host.get_detail("Security", "Groups")) > 0,
+            int(view.entities.summary('Security').get_text_of('Groups')) > 0,
             'Nodes number of Groups is 0')
 
 
@@ -93,8 +100,8 @@ def test_host_smbios_data(host_collection, provider, soft_assert):
     hosts = host_collection.all(provider)
     assert hosts
     for host in hosts:
-        navigate_to(host, 'Details')
-        res = host.get_detail('Properties', 'Manufacturer / Model')
+        view = navigate_to(host, 'Details')
+        res = view.entities.summary('Properties').get_text_of('Manufacturer / Model')
         soft_assert(res, 'Manufacturer / Model value are empty')
         soft_assert(res != 'N/A')
 
@@ -103,5 +110,6 @@ def test_host_zones_assigned(host_collection, provider):
     hosts = host_collection.all(provider)
     assert hosts
     for host in hosts:
-        result = host.get_detail('Relationships', 'Availability Zone')
+        view = navigate_to(host, 'Details')
+        result = view.entities.summary('Relationships').get_text_of('Availability Zone')
         assert result, "Availability zone doesn't specified"


### PR DESCRIPTION
Intent
=================

Continuation of replacement get_detail() method by calling ParametrizedSummaryTable in respectful views.

{{pytest: -v -k "test_host_relationships or test_run_host_analysis or test_host_drift_analysis or test_host_provisioning or test_host_configuration" --long-running}}