### PR TITLE
[1LP][RFR] Fixing table of tasks in Tasks view

### DIFF
--- a/cfme/configure/tasks.py
+++ b/cfme/configure/tasks.py
@@ -47,6 +47,12 @@ TABS_DATA_PER_PROVIDER = {
 }
 
 
+class TasksTable(Table):
+
+    def wait_displayed(self, timeout=10, delay=2, fail_func=None):
+        wait_for(lambda: self.is_displayed, timeout=timeout, delay=delay, fail_func=fail_func)
+
+
 def is_vm_analysis_finished(name, **kwargs):
     return is_analysis_finished(name=name, task_type='vm', **kwargs)
 
@@ -125,6 +131,7 @@ def check_tasks_have_no_errors(task_name, task_type, expected_num_of_tasks, sile
     # expected_status change from str to support also regular expression pattern
     expected_status = re.compile(expected_status, re.IGNORECASE)
 
+    tab_view.table.wait_displayed(fail_func=view.reload.click)
     try:
         rows = list(tab_view.table.rows(task_name=task_name, state=expected_status))
     except IndexError:
@@ -220,24 +227,24 @@ class TasksView(BaseLoggedInPage):
         class mytasks(Tab):  # noqa
             TAB_NAME = VersionPick({Version.lowest(): 'My VM and Container Analysis Tasks',
                                     '5.9': 'My Tasks'})
-            table = Table(table_loc)
+            table = TasksTable(table_loc)
 
         @View.nested
         class myothertasks(Tab):  # noqa
             TAB_NAME = VersionPick({'5.9': 'My Tasks',
                                     Version.lowest(): 'My Other UI Tasks'})
-            table = Table(table_loc)
+            table = TasksTable(table_loc)
 
         @View.nested
         class alltasks(Tab):  # noqa
             TAB_NAME = VersionPick({'5.9': 'All Tasks',
                                     Version.lowest(): "All VM and Container Analysis Tasks"})
-            table = Table(table_loc)
+            table = TasksTable(table_loc)
 
         @View.nested
         class allothertasks(Tab):  # noqa
             TAB_NAME = "All Other Tasks"
-            table = Table(table_loc)
+            table = TasksTable(table_loc)
 
     @property
     def is_displayed(self):

--- a/cfme/configure/tasks.py
+++ b/cfme/configure/tasks.py
@@ -47,12 +47,6 @@ TABS_DATA_PER_PROVIDER = {
 }
 
 
-class TasksTable(Table):
-
-    def wait_displayed(self, timeout=10, delay=2, fail_func=None):
-        wait_for(lambda: self.is_displayed, timeout=timeout, delay=delay, fail_func=fail_func)
-
-
 def is_vm_analysis_finished(name, **kwargs):
     return is_analysis_finished(name=name, task_type='vm', **kwargs)
 
@@ -131,7 +125,12 @@ def check_tasks_have_no_errors(task_name, task_type, expected_num_of_tasks, sile
     # expected_status change from str to support also regular expression pattern
     expected_status = re.compile(expected_status, re.IGNORECASE)
 
-    tab_view.table.wait_displayed(fail_func=view.reload.click)
+    wait_for(
+        lambda: tab_view.table.is_displayed,
+        timeout=10,
+        delay=2,
+        fail_func=view.reload.click
+    )
     try:
         rows = list(tab_view.table.rows(task_name=task_name, state=expected_status))
     except IndexError:
@@ -227,24 +226,24 @@ class TasksView(BaseLoggedInPage):
         class mytasks(Tab):  # noqa
             TAB_NAME = VersionPick({Version.lowest(): 'My VM and Container Analysis Tasks',
                                     '5.9': 'My Tasks'})
-            table = TasksTable(table_loc)
+            table = Table(table_loc)
 
         @View.nested
         class myothertasks(Tab):  # noqa
             TAB_NAME = VersionPick({'5.9': 'My Tasks',
                                     Version.lowest(): 'My Other UI Tasks'})
-            table = TasksTable(table_loc)
+            table = Table(table_loc)
 
         @View.nested
         class alltasks(Tab):  # noqa
             TAB_NAME = VersionPick({'5.9': 'All Tasks',
                                     Version.lowest(): "All VM and Container Analysis Tasks"})
-            table = TasksTable(table_loc)
+            table = Table(table_loc)
 
         @View.nested
         class allothertasks(Tab):  # noqa
             TAB_NAME = "All Other Tasks"
-            table = TasksTable(table_loc)
+            table = Table(table_loc)
 
     @property
     def is_displayed(self):

--- a/cfme/tests/infrastructure/test_host_analysis.py
+++ b/cfme/tests/infrastructure/test_host_analysis.py
@@ -32,9 +32,9 @@ def pytest_generate_tests(metafunc):
                 'host type must be set to [{}] for smartstate analysis tests'.format(
                     '|'.join(HOST_TYPES)))
 
-            argvalues[index] = argvalues[index] + [test_host['type'], test_host['name']]
-            test_id = '{}-{}'.format(args['provider'].key, test_host['type'])
-            new_argvalues.append(argvalues[index])
+            new_argvalue_list = [args['provider'], test_host['type'], test_host['name']]
+            test_id = '{}-{}-{}'.format(args['provider'].key, test_host['type'], test_host['name'])
+            new_argvalues.append(new_argvalue_list)
             new_idlist.append(test_id)
     testgen.parametrize(metafunc, argnames, new_argvalues, ids=new_idlist, scope="module")
 


### PR DESCRIPTION
_Fixing_ test_host_drift_analysis.py. I recently re-activated this module in RHV-CFME integration suite and found out it failes seemingly randomly. After some digging I discovered that the reason for failure was this:
-  FW runs SSA on host
- Then goes to Administration -> Tasks view
- Then it tries to check the task of SSA was completed successfully

However, at this point it sometimes happen that the task is not even displayed yet in the table of tasks. Therefore any attempt to operate on it resulted `NoSuchElementException`. The only way AFAIK to get task's updated status is to refresh the whole view. I achieved that by overloading `wait_displayed` method of Table, but I don't know if this is the right way. Please share your ideas with me. 

Addendum:
I also discovered that test collection for test_host_analysis was not working if a provider had more than one host, so I fixed that. I think it should not break anything (I tried collection with more providers), but honestly pytest/FW test parametrization is black magic to me.

{{pytest: cfme/tests/infrastructure/test_host_drift_analysis.py cfme/tests/infrastructure/test_host_analysis.py -vv}}