### PR TITLE
[1LP][RFR] Replacement get_detail() for providers

### DIFF
--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -222,7 +222,7 @@ class Instances(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self, *args, **kwargs):
-        self.prerequisite_view.entities.relationships.click_at('Instances')
+        self.prerequisite_view.entities.summary("Relationships").click_at('Instances')
 
 
 @navigator.register(CloudProvider, 'Images')
@@ -231,7 +231,7 @@ class Images(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self, *args, **kwargs):
-        self.prerequisite_view.entities.relationships.click_at('Images')
+        self.prerequisite_view.entities.summary("Relationships").click_at('Images')
 
 
 def get_all_providers():

--- a/cfme/cloud/provider/vcloud.py
+++ b/cfme/cloud/provider/vcloud.py
@@ -5,6 +5,7 @@ from wrapanapi.vcloud import VmwareCloudSystem
 from cfme.common.provider import DefaultEndpoint, DefaultEndpointForm, Credential
 from cfme.common.provider_views import BeforeFillMixin
 from cfme.utils import version
+from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.varmeth import variable
 from . import CloudProvider
 
@@ -88,7 +89,8 @@ class VmwareCloudProvider(CloudProvider):
 
     @num_availability_zone.variant('ui')
     def num_availability_zone_ui(self):
-        return int(self.get_detail("Relationships", "Availability Zones"))
+        view = navigate_to(self, "Details")
+        return int(view.entities.summary("Relationships").get_text_of("Availability Zones"))
 
     @variable(alias="db")
     def num_orchestration_stack(self):
@@ -96,4 +98,5 @@ class VmwareCloudProvider(CloudProvider):
 
     @num_orchestration_stack.variant('ui')
     def num_orchestration_stack_ui(self):
-        return int(self.get_detail("Relationships", "Orchestration Stacks"))
+        view = navigate_to(self, "Details")
+        return int(view.entities.summary("Relationships").get_text_of("Orchestration Stacks"))

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -8,12 +8,10 @@ from widgetastic_patternfly import Button, Input
 from cfme.base.credential import (
     Credential, EventsCredential, TokenCredential, SSHCredential, CANDUCredential)
 from cfme.common import WidgetasticTaggable
-from cfme.exceptions import (
-    ProviderHasNoKey, HostStatsNotContains, ProviderHasNoProperty, ItemNotFound)
+from cfme.exceptions import ProviderHasNoKey, HostStatsNotContains, ProviderHasNoProperty
 from cfme.utils import ParamClassName, version, conf
 from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import navigate_to, navigator
-from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 from cfme.utils.net import resolve_hostname
 from cfme.utils.stats import tol_check
@@ -689,21 +687,6 @@ class BaseProvider(WidgetasticTaggable, Updateable, Navigatable):
             view.toolbar.reload.click()
         return view
 
-    def get_detail(self, *ident):
-        """ Gets details from the details infoblock
-
-        The function first ensures that we are on the detail page for the specific provider.
-
-        Args:
-            *ident: An SummaryTable title, followed by the Key name, e.g. "Relationships", "Images"
-
-
-        Returns: A string representing the contents of passed field value.
-        """
-        view = self.load_details()
-        block, field = ident
-        return getattr(view.entities, block.lower()).get_text_of(field)
-
     @classmethod
     def get_credentials(cls, credential_dict, cred_type=None):
         """Processes a credential dictionary into a credential object.
@@ -1036,7 +1019,8 @@ class CloudInfraProvider(BaseProvider, PolicyProfileAssignable, WidgetasticTagga
 
     @num_template.variant('ui')
     def num_template_ui(self):
-        return int(self.get_detail("Relationships", self.template_name))
+        view = navigate_to(self, "Details")
+        return int(view.entities.summary("Relationships").get_text_of(self.template_name))
 
     @variable(alias="db")
     def num_vm(self):
@@ -1051,7 +1035,8 @@ class CloudInfraProvider(BaseProvider, PolicyProfileAssignable, WidgetasticTagga
 
     @num_vm.variant('ui')
     def num_vm_ui(self):
-        return int(self.get_detail("Relationships", self.vm_name))
+        view = navigate_to(self, "Details")
+        return int(view.entities.summary("Relationships").get_text_of(self.vm_name))
 
     def load_all_provider_instances(self):
         return self.load_all_provider_vms()
@@ -1061,10 +1046,10 @@ class CloudInfraProvider(BaseProvider, PolicyProfileAssignable, WidgetasticTagga
 
         """
         view = navigate_to(self, 'Details')
-        if view.entities.relationships.get_text_of(self.vm_name) == "0":
+        if view.entities.summary("Relationships").get_text_of(self.vm_name) == "0":
             return False
         else:
-            view.entities.relationships.click_at(self.vm_name)
+            view.entities.summary("Relationships").click_at(self.vm_name)
             return True
 
     def load_all_provider_images(self):
@@ -1076,10 +1061,10 @@ class CloudInfraProvider(BaseProvider, PolicyProfileAssignable, WidgetasticTagga
         """
         # todo: replace these methods with new nav location
         view = navigate_to(self, 'Details')
-        if view.entities.relationships.get_text_of(self.template_name) == "0":
+        if view.entities.summary("Relationships").get_text_of(self.template_name) == "0":
             return False
         else:
-            view.entities.relationships.click_at(self.template_name)
+            view.entities.summary("Relationships").click_at(self.template_name)
             return True
 
 

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -9,7 +9,7 @@ from widgetastic_patternfly import Dropdown, BootstrapSelect, Tab
 from cfme.base.login import BaseLoggedInPage
 from cfme.common.host_views import HostEntitiesView
 from widgetastic_manageiq import (BreadCrumb,
-                                  SummaryTable,
+                                  ParametrizedSummaryTable,
                                   Button,
                                   TimelinesView,
                                   DetailsToolBarViewSelector,
@@ -22,8 +22,7 @@ from widgetastic_manageiq import (BreadCrumb,
                                   BaseQuadIconEntity,
                                   BaseListEntity,
                                   NonJSBaseEntity,
-                                  JSBaseEntity
-                                  )
+                                  JSBaseEntity)
 
 
 class ProviderQuadIconEntity(BaseQuadIconEntity):
@@ -115,12 +114,7 @@ class ProviderDetailsView(BaseLoggedInPage):
         """
         represents Details page when it is switched to Summary aka Tables view
         """
-        properties = SummaryTable(title="Properties")
-        status = SummaryTable(title="Status")
-        relationships = SummaryTable(title="Relationships")
-        overview = SummaryTable(title="Overview")
-        smart_management = SummaryTable(title="Smart Management")
-        custom_attributes = SummaryTable(title='Custom Attributes')
+        summary = ParametrizedSummaryTable()
 
     @entities.register('Dashboard View')
     class ProviderDetailsDashboardView(View):

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -217,7 +217,8 @@ class ContainersProvider(BaseProvider, Pretty, PolicyProfileAssignable):
 
     @num_project.variant('ui')
     def num_project_ui(self):
-        return int(self.get_detail("Relationships", "Projects"))
+        view = navigate_to(self, "Details")
+        return int(view.entities.summary("Relationships").get_text_of("Projects"))
 
     @variable(alias='db')
     def num_service(self):
@@ -229,7 +230,8 @@ class ContainersProvider(BaseProvider, Pretty, PolicyProfileAssignable):
             name = "Services"
         else:
             name = "Container Services"
-        return int(self.get_detail("Relationships", name))
+        view = navigate_to(self, "Details")
+        return int(view.entities.summary("Relationships").get_text_of(name))
 
     @variable(alias='db')
     def num_replication_controller(self):
@@ -237,7 +239,8 @@ class ContainersProvider(BaseProvider, Pretty, PolicyProfileAssignable):
 
     @num_replication_controller.variant('ui')
     def num_replication_controller_ui(self):
-        return int(self.get_detail("Relationships", "Replicators"))
+        view = navigate_to(self, "Details")
+        return int(view.entities.summary("Relationships").get_text_of("Replicators"))
 
     @variable(alias='db')
     def num_container_group(self):
@@ -245,7 +248,8 @@ class ContainersProvider(BaseProvider, Pretty, PolicyProfileAssignable):
 
     @num_container_group.variant('ui')
     def num_container_group_ui(self):
-        return int(self.get_detail("Relationships", "Pods"))
+        view = navigate_to(self, "Details")
+        return int(view.entities.summary("Relationships").get_text_of("Pods"))
 
     @variable(alias='db')
     def num_pod(self):
@@ -263,7 +267,8 @@ class ContainersProvider(BaseProvider, Pretty, PolicyProfileAssignable):
 
     @num_node.variant('ui')
     def num_node_ui(self):
-        return int(self.get_detail("Relationships", "Nodes"))
+        view = navigate_to(self, "Details")
+        return int(view.entities.summary("Relationships").get_text_of("Nodes"))
 
     @variable(alias='db')
     def num_container(self):
@@ -279,7 +284,8 @@ class ContainersProvider(BaseProvider, Pretty, PolicyProfileAssignable):
 
     @num_container.variant('ui')
     def num_container_ui(self):
-        return int(self.get_detail("Relationships", "Containers"))
+        view = navigate_to(self, "Details")
+        return int(view.entities.summary("Relationships").get_text_of("Containers"))
 
     @variable(alias='db')
     def num_image(self):
@@ -291,7 +297,8 @@ class ContainersProvider(BaseProvider, Pretty, PolicyProfileAssignable):
             name = "Images"
         else:
             name = "Container Images"
-        return int(self.get_detail("Relationships", name))
+        view = navigate_to(self, "Details")
+        return int(view.entities.summary("Relationships").get_text_of(name))
 
     @variable(alias='db')
     def num_image_registry(self):
@@ -299,7 +306,8 @@ class ContainersProvider(BaseProvider, Pretty, PolicyProfileAssignable):
 
     @num_image_registry.variant('ui')
     def num_image_registry_ui(self):
-        return int(self.get_detail("Relationships", "Image Registries"))
+        view = navigate_to(self, "Details")
+        return int(view.entities.summary("Relationships").get_text_of("Image Registries"))
 
     def pods_per_ready_status(self):
         """Grabing the Container Statuses Summary of the pods from API"""
@@ -576,17 +584,6 @@ class LoadDetailsMixin(object):
         view = navigate_to(self, 'Details')
         if refresh:
             view.browser.refresh()
-
-    def get_detail(self, table_name, field_name):
-        """ Gets details from the details infoblock
-        Args:
-            table_name: the name of the table to get the data from.
-            table: the name of the field to get from this table.
-        Returns: A string representing the contents of the summary's value.
-        """
-        view = navigate_to(self, 'Details')
-        table = getattr(view, table_name.lower(), getattr(view.entities, table_name.lower()))
-        return table.read().get(field_name)
 
 
 class Labelable(object):

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -10,6 +10,7 @@ from cfme.containers.provider import (
 )
 
 from cfme.common.provider import DefaultEndpoint
+from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.ocp_cli import OcpCli
 from cfme.utils.varmeth import variable
 from cfme.utils import version, ssh
@@ -185,7 +186,8 @@ class OpenshiftProvider(ContainersProvider):
 
     @num_route.variant('ui')
     def num_route_ui(self):
-        return int(self.get_detail("Relationships", "Routes"))
+        view = navigate_to(self, "Details")
+        return int(view.entities.summary("Relationships").get_text_of("Routes"))
 
     @variable(alias='db')
     def num_template(self):
@@ -193,7 +195,8 @@ class OpenshiftProvider(ContainersProvider):
 
     @num_template.variant('ui')
     def num_template_ui(self):
-        return int(self.get_detail("Relationships", "Container Templates"))
+        view = navigate_to(self, "Details")
+        return int(view.entities.summary("Relationships").get_text_of("Container Templates"))
 
     @classmethod
     def from_config(cls, prov_config, prov_key, appliance=None):

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -98,7 +98,8 @@ class InfraProvider(Pretty, CloudInfraProvider, Fillable):
 
     @num_datastore.variant('ui')
     def num_datastore_ui(self):
-            return int(self.get_detail("Relationships", "Datastores"))
+        view = navigate_to(self, "Details")
+        return int(view.entities.summary("Relationships").get_text_of("Datastores"))
 
     @variable(alias='rest')
     def num_host(self):
@@ -120,11 +121,12 @@ class InfraProvider(Pretty, CloudInfraProvider, Fillable):
 
     @num_host.variant('ui')
     def num_host_ui(self):
+        view = navigate_to(self, "Details")
         try:
-            num = self.get_detail("Relationships", 'Hosts')
+            num = view.entities.summary("Relationships").get_text_of("Hosts")
         except NoSuchElementException:
             logger.error("Couldn't find number of hosts using key [Hosts] trying Nodes")
-            num = self.get_detail("Relationships", 'Nodes')
+            num = view.entities.summary("Relationships").get_text_of("Nodes")
         return int(num)
 
     @variable(alias='rest')
@@ -149,8 +151,8 @@ class InfraProvider(Pretty, CloudInfraProvider, Fillable):
 
     @num_cluster.variant('ui')
     def num_cluster_ui(self):
-        num = self.get_detail("Relationships", 'Clusters')
-        return int(num)
+        view = navigate_to(self, "Details")
+        return int(view.entities.summary("Relationships").get_text_of("Clusters"))
 
     def discover(self):  # todo: move this to provider collections
         """

--- a/cfme/networks/provider/nuage.py
+++ b/cfme/networks/provider/nuage.py
@@ -7,6 +7,7 @@ from cfme.common.provider import DefaultEndpoint, DefaultEndpointForm
 from cfme.common.provider_views import BeforeFillMixin
 from cfme.networks.security_group import SecurityGroupCollection
 from cfme.utils import version
+from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.varmeth import variable
 from . import NetworkProvider
 
@@ -89,7 +90,8 @@ class NuageProvider(NetworkProvider):
 
     @num_security_group.variant('ui')
     def num_security_group_ui(self):
-        return int(self.get_detail('Relationships', 'Security Groups'))
+        view = navigate_to(self, "Details")
+        return int(view.entities.summary("Relationships").get_text_of("Security Groups"))
 
     @variable(alias="db")
     def num_cloud_subnet(self):
@@ -97,4 +99,5 @@ class NuageProvider(NetworkProvider):
 
     @num_cloud_subnet.variant('ui')
     def num_cloud_subnet_ui(self):
-        return int(self.get_detail('Relationships', 'Cloud Subnets'))
+        view = navigate_to(self, "Details")
+        return int(view.entities.summary("Relationships").get_text_of("Cloud Subnets"))

--- a/cfme/physical/physical_server.py
+++ b/cfme/physical/physical_server.py
@@ -27,6 +27,7 @@ from cfme.utils.update import Updateable
 from cfme.utils.varmeth import variable
 from cfme.utils.wait import wait_for
 
+
 @attr.s
 class PhysicalServer(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, WidgetasticTaggable):
     """Model of an Physical Server in cfme.
@@ -81,15 +82,18 @@ class PhysicalServer(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Wi
 
     @variable(alias='ui')
     def power_state(self):
-        return self.get_detail("Power Management", "Power State")
+        view = navigate_to(self, "Details")
+        return view.entities.summary("Power Management").get_text_of("Power State")
 
     @variable(alias='ui')
     def cores_capacity(self):
-        return self.get_detail("Properties", "CPU total cores")
+        view = navigate_to(self, "Details")
+        return view.entities.summary("Properties").get_text_of("CPU total cores")
 
     @variable(alias='ui')
     def memory_capacity(self):
-        return self.get_detail("Properties", "Total memory (mb)")
+        view = navigate_to(self, "Details")
+        return view.entities.summary("Properties").get_text_of("Total memory (mb)")
 
     def refresh(self, cancel=False):
         """Perform 'Refresh Relationships and Power States' for the server.
@@ -116,18 +120,6 @@ class PhysicalServer(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Wi
             return "currentstate-{}".format(desired_state) in entity.data['state']
 
         wait_for(_looking_for_state_change, fail_func=view.browser.refresh, num_sec=timeout)
-
-    def get_detail(self, title, field):
-        """Gets details from the details summary tables.
-
-        Args:
-            title (str): Summary Table title
-            field (str): Summary table field name
-
-        Returns: A string representing the entities of the SummaryTable's value.
-        """
-        view = navigate_to(self, "Details")
-        return getattr(view.entities, title.lower().replace(" ", "_")).get_text_of(field)
 
     @property
     def exists(self):

--- a/cfme/physical/provider/__init__.py
+++ b/cfme/physical/provider/__init__.py
@@ -17,6 +17,7 @@ from cfme.utils.varmeth import variable
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.log import logger
 
+
 class PhysicalProvider(Pretty, BaseProvider, Fillable):
     """
     Abstract model of an infrastructure provider in cfme. See VMwareProvider or RHEVMProvider.
@@ -38,8 +39,9 @@ class PhysicalProvider(Pretty, BaseProvider, Fillable):
 
     @variable(alias='ui')
     def num_server(self):
+        view = navigate_to(self, 'Details')
         try:
-            num = self.get_detail('Relationships', 'Physical Servers')
+            num = view.entities.summary('Relationships').get_text_of('Physical Servers')
         except NoSuchElementException:
             logger.error("Couldn't find number of servers")
         return int(num)
@@ -59,20 +61,6 @@ class PhysicalProvider(Pretty, BaseProvider, Fillable):
         if not cancel:
             view.flash.assert_no_error()
 
-    def get_detail(self, *ident):
-        """ Gets details from the details infoblock
-
-        The function first ensures that we are on the detail page for the specific provider.
-
-        Args:
-            *ident: An SummaryTable title, followed by the Key name, e.g. "Relationships", "Images"
-
-
-        Returns: A string representing the contents of passed field value.
-        """
-        view = self.load_details(refresh=True)
-        block, field = ident
-        return getattr(view.entities, block.lower()).get_text_of(field)
 
 @navigator.register(Server, 'PhysicalProviders')
 @navigator.register(PhysicalProvider, 'All')

--- a/cfme/tests/cloud_infra_common/test_relationships.py
+++ b/cfme/tests/cloud_infra_common/test_relationships.py
@@ -82,8 +82,9 @@ def get_obj(relationship, appliance, **kwargs):
     elif relationship == "Network Manager":
         network_providers_col = appliance.collections.network_providers
         provider = kwargs.get("provider")
-        network_provider_name = provider.get_detail("Relationships", "Network Manager")
-        obj = network_providers_col.instantiate(name=network_provider_name)
+        view = navigate_to(provider, "Details")
+        network_prov_name = view.entities.summary("Relationships").get_text_of("Network Manager")
+        obj = network_providers_col.instantiate(name=network_prov_name)
     return obj
 
 
@@ -113,9 +114,9 @@ def test_host_relationships(appliance, provider, setup_provider, host, relations
 def test_infra_provider_relationships(appliance, provider, setup_provider, relationship, view):
     """Tests relationship navigation for an infrastructure provider"""
     provider_view = navigate_to(provider, "Details")
-    if provider.get_detail("Relationships", relationship) == "0":
+    if provider_view.entities.summary("Relationships").get_text_of(relationship) == "0":
         pytest.skip("There are no relationships for {}".format(relationship))
-    provider_view.entities.relationships.click_at(relationship)
+    provider_view.entities.summary("Relationships").click_at(relationship)
     relationship_view = appliance.browser.create_view(view, additional_context={'object': provider})
     assert relationship_view.is_displayed
 
@@ -128,9 +129,9 @@ def test_cloud_provider_relationships(appliance, provider, setup_provider, relat
     # Version dependent strings
     relationship = _fix_item(appliance, relationship)
     provider_view = navigate_to(provider, "Details")
-    if provider.get_detail("Relationships", relationship) == "0":
+    if provider_view.entities.summary("Relationships").get_text_of(relationship) == "0":
         pytest.skip("There are no relationships for {}".format(relationship))
     obj = get_obj(relationship, appliance, provider=provider)
-    provider_view.entities.relationships.click_at(relationship)
+    provider_view.entities.summary("Relationships").click_at(relationship)
     relationship_view = appliance.browser.create_view(view, additional_context={'object': obj})
     assert relationship_view.is_displayed

--- a/cfme/tests/openstack/infrastructure/test_relationships.py
+++ b/cfme/tests/openstack/infrastructure/test_relationships.py
@@ -17,19 +17,19 @@ pytestmark = [
 
 
 def test_assigned_roles(provider):
-    navigate_to(provider, 'Details')
+    view = navigate_to(provider, 'Details')
     try:
-        res = provider.get_detail('Relationships', 'Deployment Roles')
+        res = view.entities.summary('Relationships').get_text_of('Deployment Roles')
     except NameError:
-        res = provider.get_detail('Relationships', 'Clusters / Deployment Roles')
+        res = view.entities.summary('Relationships').get_text_of('Clusters / Deployment Roles')
     assert int(res) > 0
 
 
 def test_nodes(provider):
-    navigate_to(provider, 'Details')
+    view = navigate_to(provider, 'Details')
     nodes = len(provider.mgmt.list_node())
 
-    assert int(provider.get_detail('Relationships', 'Nodes')) == nodes
+    assert int(view.entities.summary('Relationships').get_text_of('Nodes')) == nodes
 
 
 def test_templates(provider, soft_assert):
@@ -47,10 +47,10 @@ def test_templates(provider, soft_assert):
 
 
 def test_stacks(provider):
-    navigate_to(provider, 'Details')
+    view = navigate_to(provider, 'Details')
     """
     todo get the list of tenants from external resource and compare
     it with result - currently not 0
     """
 
-    assert int(provider.get_detail('Relationships', 'Orchestration stacks')) > 0
+    assert int(view.entities.summary('Relationships').get_text_of('Orchestration stacks')) > 0


### PR DESCRIPTION
Intent
=================

Continuation of replacement get_detail() method by calling ParametrizedSummaryTable in respectful views.

{{pytest: -v -k "test_infra_provider_relationships or test_assigned_roles" --long-running}}
