### PR TITLE
[1LP][RFR] Metering Reports: Add support for storage metrics

### DIFF
--- a/cfme/tests/intelligence/reports/test_metering_report.py
+++ b/cfme/tests/intelligence/reports/test_metering_report.py
@@ -269,7 +269,7 @@ def test_validate_cpu_usage(resource_usage, metering_report):
             usage_from_report = groups["CPU Used"]
             if 'GHz' in usage_from_report:
                 estimated_cpu_usage = estimated_cpu_usage * math.pow(2, -10)
-            usage = re.sub(r'[MHz, GHz,]', r'', usage_from_report)
+            usage = re.sub(r'(MHz|GHz|,)', r'', usage_from_report)
             assert estimated_cpu_usage - DEVIATION <= float(usage) \
                 <= estimated_cpu_usage + DEVIATION, 'Estimated cost and report cost do not match'
             break
@@ -283,7 +283,7 @@ def test_validate_memory_usage(resource_usage, metering_report):
             usage_from_report = groups["Memory Used"]
             if 'GB' in usage_from_report:
                 estimated_memory_usage = estimated_memory_usage * math.pow(2, -10)
-            usage = re.sub(r'[MB, GB,]', r'', usage_from_report)
+            usage = re.sub(r'(MB|GB|,)', r'', usage_from_report)
             assert estimated_memory_usage - DEVIATION <= float(usage) \
                 <= estimated_memory_usage + DEVIATION, 'Estimated cost and report cost do not match'
             break
@@ -295,7 +295,7 @@ def test_validate_network_usage(resource_usage, metering_report):
         if groups["Network I/O Used"]:
             estimated_network_usage = resource_usage['network_io']
             usage_from_report = groups["Network I/O Used"]
-            usage = re.sub(r'[KBps,]', r'', usage_from_report)
+            usage = re.sub(r'(KBps|,)', r'', usage_from_report)
             assert estimated_network_usage - DEVIATION <= float(usage) \
                 <= estimated_network_usage + DEVIATION,\
                 'Estimated cost and report cost do not match'
@@ -308,7 +308,7 @@ def test_validate_disk_usage(resource_usage, metering_report):
         if groups["Disk I/O Used"]:
             estimated_disk_usage = resource_usage['disk_io_used']
             usage_from_report = groups["Disk I/O Used"]
-            usage = re.sub(r'[KBps,]', r'', usage_from_report)
+            usage = re.sub(r'(KBps|,)', r'', usage_from_report)
             assert estimated_disk_usage - DEVIATION <= float(usage) \
                 <= estimated_disk_usage + DEVIATION, 'Estimated cost and report cost do not match'
             break
@@ -320,7 +320,7 @@ def test_validate_storage_usage(resource_usage, metering_report):
         if groups["Storage Used"]:
             estimated_storage_usage = resource_usage['storage_used']
             usage_from_report = groups["Storage Used"]
-            usage = re.sub(r'[MB, GB,]', r'', usage_from_report)
+            usage = re.sub(r'(MB|GB|,)', r'', usage_from_report)
             assert estimated_storage_usage - DEVIATION <= float(usage) \
                 <= estimated_storage_usage + DEVIATION, \
                 'Estimated cost and report cost do not match'

--- a/cfme/tests/intelligence/reports/test_metering_report.py
+++ b/cfme/tests/intelligence/reports/test_metering_report.py
@@ -223,12 +223,6 @@ def resource_usage(vm_ownership, appliance, provider):
     # Convert storage used in Bytes to GB
     storage_used = storage_used * math.pow(2, -30)
 
-    logger.info('cpu_used {}'.format(cpu_used_in_mhz))
-    logger.info('memory_used {}'.format(memory_used_in_mb))
-    logger.info('network_io {}'.format(network_io))
-    logger.info('disk_io {}'.format(disk_io))
-    logger.info('storage_used {}'.format(storage_used))
-
     return {"cpu_used": cpu_used_in_mhz,
             "memory_used": memory_used_in_mb,
             "network_io": network_io,

--- a/cfme/tests/intelligence/reports/test_metering_report.py
+++ b/cfme/tests/intelligence/reports/test_metering_report.py
@@ -142,7 +142,7 @@ def resource_usage(vm_ownership, appliance, provider):
     # are capturing C&U data and forcing hourly rollups by running these commands through
     # the Rails console.
     #
-    # Metering reports differ from Chargeback reports in that Metering reports 1)only report
+    # Metering reports differ from Chargeback reports in that Metering reports 1)report only
     # resource usage and not costs and 2)sum total of resource usage is reported instead of
     # the average usage.For eg:If we have 24 hourly rollups, resource usage in a Metering report
     # is the sum of these 24 rollups, whereas resource usage in a Chargeback report is the
@@ -232,7 +232,7 @@ def resource_usage(vm_ownership, appliance, provider):
 
 @pytest.yield_fixture(scope="module")
 def metering_report(vm_ownership, provider):
-    # Create a Metering report based; Queue the report.
+    # Create a Metering report based on VM owner; Queue the report.
     owner = vm_ownership
     data = {
         'menu_name': 'cb_' + provider.name,

--- a/cfme/tests/intelligence/reports/test_metering_report.py
+++ b/cfme/tests/intelligence/reports/test_metering_report.py
@@ -214,26 +214,11 @@ def resource_usage(vm_ownership, appliance, provider):
 
     for record in appliance.db.client.session.query(rollups).filter(
             rollups.id.in_(result.subquery())):
-        storage_used = storage_used + record.derived_vm_used_disk_storage
         cpu_used_in_mhz = cpu_used_in_mhz + record.cpu_usagemhz_rate_average
         memory_used_in_mb = memory_used_in_mb + record.derived_memory_used
         network_io = network_io + record.net_usage_rate_average
         disk_io = disk_io + record.disk_usage_rate_average
-
-        """
-        if (record.cpu_usagemhz_rate_average or
-           record.cpu_usage_rate_average or
-           record.derived_memory_used or
-           record.net_usage_rate_average or
-           record.disk_usage_rate_average):
-            cpu_used_in_mhz = cpu_used_in_mhz + record.cpu_usagemhz_rate_average
-            memory_used_in_mb = memory_used_in_mb + record.derived_memory_used
-            network_io = network_io + record.net_usage_rate_average
-            disk_io = disk_io + record.disk_usage_rate_average
-
-        if record.derived_vm_used_disk_storage:
-            storage_used = storage_used + record.derived_vm_used_disk_storage
-        """
+        storage_used = storage_used + record.derived_vm_used_disk_storage
 
     # Convert storage used in Bytes to GB
     storage_used = storage_used * math.pow(2, -30)


### PR DESCRIPTION
{{pytest: cfme/tests/intelligence/reports/test_metering_report.py --use-provider complete}}

PRT results:
59 : Passed on RHV, Provider skips - v6, v65
58 : Tests uncollected like expected since Metering reports have been introduced in 59