### PR TITLE
[1LP][RFR] Provider configuration menu test , cancel  removing selected container provider

### DIFF
--- a/cfme/tests/containers/test_provider_configuration_menu.py
+++ b/cfme/tests/containers/test_provider_configuration_menu.py
@@ -22,16 +22,3 @@ def test_edit_selected_containers_provider(provider):
     view = navigate_to(provider, 'Edit')
     assert view.is_displayed
     view.cancel.click()
-
-
-@pytest.mark.polarion('CMP-9881')
-def test_remove_selected_containers_provider(provider):
-    '''Testing Configuration -> Remove... button functionality
-    Step:
-        In Providers summary page - click configuration menu and select
-        "Remove this container provider from VMDB"
-    Expected result:
-        The user should be shown a warning message following a
-        success message that the provider has been deleted from VMDB.'''
-    provider.delete(cancel=False)
-    # The assertion of success is inside the delete function


### PR DESCRIPTION
Fixing test, by deleting the part of removing the selected container provider.

{{pytest: cfme/tests/containers/test_provider_configuration_menu.py -v --use-provider ocp-v1}}
