### PR TITLE
[RFR] Adding pytest-repeat to requirements

### DIFF
--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -132,6 +132,7 @@ Pygments==2.2.0
 PyJWT==1.5.0
 pyparsing==2.2.0
 pytest==3.2.0
+pytest-repeat==0.4.1
 pytesseract==0.1.7
 python-bugzilla==2.1.0
 python-cinderclient==2.2.0

--- a/requirements/template.txt
+++ b/requirements/template.txt
@@ -8,3 +8,4 @@ ovirt-engine-sdk-python<4.0.0
 pycurl
 
 virtualenv
+pytest-repeat


### PR DESCRIPTION
__Extending__ requirements of the FW. Here's a rationale why I think we could benefit from including this package:

__Use case 1__: You want to really verify your new test case and make sure it is solid and does not get broken by some random occurrences. You can run it 10 times with:
`pytest test_stuff.py --count 10`

__Use case 2__: You know that some test case fails in very specific condition, but you don't know what precisely is that and want to reproduce the failure. With this package you can do:
`pytest --count=1000 -x test_stuff.py`

I know I can just install this locally and be happy with it. However including this in virtualenv would make it easy to do the same thing on Jenkins. Also, the package has like 4KB, so it's not like we're slowing down the installation.

pytest-repeat link: https://pypi.python.org/pypi/pytest-repeat#downloads

Addendum: 
The repeating is achieved by parametrization. Example here:
`miq-runtest cfme/tests/test_login.py::test_login --count=5`

> cfme/tests/test_login.py::test_login[1/5-ViaUI-click_on_login] PASSED
> cfme/tests/test_login.py::test_login[1/5-ViaUI-press_enter_after_password] PASSED
> cfme/tests/test_login.py::test_login[1/5-ViaUI-_js_auth_fn] PASSED
> cfme/tests/test_login.py::test_login[1/5-ViaSSUI-click_on_login] PASSED
> cfme/tests/test_login.py::test_login[1/5-ViaSSUI-press_enter_after_password] PASSED
> cfme/tests/test_login.py::test_login[2/5-ViaUI-click_on_login] PASSED
> cfme/tests/test_login.py::test_login[2/5-ViaUI-press_enter_after_password] PASSED
> cfme/tests/test_login.py::test_login[2/5-ViaUI-_js_auth_fn] PASSED
> cfme/tests/test_login.py::test_login[2/5-ViaSSUI-click_on_login] PASSED
> cfme/tests/test_login.py::test_login[2/5-ViaSSUI-press_enter_after_password] PASSED
> cfme/tests/test_login.py::test_login[3/5-ViaUI-click_on_login] PASSED
> cfme/tests/test_login.py::test_login[3/5-ViaUI-press_enter_after_password] PASSED
> cfme/tests/test_login.py::test_login[3/5-ViaUI-_js_auth_fn] PASSED
> cfme/tests/test_login.py::test_login[3/5-ViaSSUI-click_on_login] PASSED
> cfme/tests/test_login.py::test_login[3/5-ViaSSUI-press_enter_after_password] PASSED
> cfme/tests/test_login.py::test_login[4/5-ViaUI-click_on_login] PASSED
> cfme/tests/test_login.py::test_login[4/5-ViaUI-press_enter_after_password] PASSED
> cfme/tests/test_login.py::test_login[4/5-ViaUI-_js_auth_fn] PASSED
> cfme/tests/test_login.py::test_login[4/5-ViaSSUI-click_on_login] PASSED
> cfme/tests/test_login.py::test_login[4/5-ViaSSUI-press_enter_after_password] PASSED
> cfme/tests/test_login.py::test_login[5/5-ViaUI-click_on_login] PASSED
> cfme/tests/test_login.py::test_login[5/5-ViaUI-press_enter_after_password] PASSED
> cfme/tests/test_login.py::test_login[5/5-ViaUI-_js_auth_fn] PASSED
> cfme/tests/test_login.py::test_login[5/5-ViaSSUI-click_on_login] PASSED
> cfme/tests/test_login.py::test_login[5/5-ViaSSUI-press_enter_after_password] PASSED

PRT fails: provider_crud failed for some providers in PRT, which seems pretty random and unrealted.