### PR TITLE
[1LP][RFR] reload button title has been changed in 5.8.3.4

### DIFF
--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -89,7 +89,7 @@ class ProviderDetailsToolBar(View):
     """
     monitoring = Dropdown(text='Monitoring')
     configuration = Dropdown(text='Configuration')
-    reload = Button(title=VersionPick({Version.lowest(): 'Reload current display',
+    reload = Button(title=VersionPick({Version.lowest(): 'Reload Current Display',
                                        '5.9': 'Refresh this page'}))
     policy = Dropdown(text='Policy')
     authentication = Dropdown(text='Authentication')


### PR DESCRIPTION
{{pytest: --use-provider=scvmm2016 cfme/tests/cloud_infra_common/test_events.py}}

we also need to double check the rest of places