### PR TITLE
[WIPTEST] Standard template naming

### DIFF
--- a/cfme/utils/trackerbot.py
+++ b/cfme/utils/trackerbot.py
@@ -1,16 +1,19 @@
 import argparse
 import json
 import re
+import time
+import urllib
 import urlparse
 from collections import defaultdict, namedtuple
 from datetime import date
-import urllib
 
 import slumber
 import requests
-import time
+from attr import attr
+from bs4 import BeautifulSoup
 
 from cfme.utils.conf import env
+from cfme.utils.log import logger
 from cfme.utils.providers import providers_data
 from cfme.utils.version import get_stream
 
@@ -324,6 +327,80 @@ def composite_uncollect(build, source='jenkins'):
     except Exception as e:
         print(e)
         return {'tests': []}
+
+
+@attr.s
+class TemplateName(object):
+    """Generate a template name from given link, a timestamp, and optional version string
+    This method should handle naming templates from the following URL types:
+        - http://<build-server-address>/builds/manageiq/master/latest/
+        - http://<build-server-address>/builds/manageiq/gaprindashvili/stable/
+        - http://<build-server-address>/builds/manageiq/fine/stable/
+        - http://<build-server-address>/builds/cfme/5.8/stable/
+        - http://<build-server-address>/builds/cfme/5.9/latest/
+
+    These builds fall into a few categories:
+        - MIQ nightly (master/latest)  (upstream)
+        - MIQ stable (<name>/stable)  (upstream_stable, upstream_fine, etc)
+        - CFME nightly (<stream>/latest)  (downstream-nightly)
+        - CFME stream (<stream>/stable)  (downstream-<stream>)
+
+    The generated template names should follow the syntax with 5 digit version numbers:
+        - MIQ nightly: miq-nightly-<yyyymmdd>  (miq-nightly-201711212330)
+        - MIQ stable: miq-stable-<name>-<number>-yyyymmdd  (miq-stable-fine-4-20171024)
+        - CFME nightly: cfme-nightly-<version>-<yyyymmdd>  (cfme-nightly-59000-20170901)
+        - CFME stream: cfme-<version>-<yyyymmdd>  (cfme-57402-20171202)
+
+    Release names for upstream will be truncated to 5 letters (thanks gaprindashvili...)
+    """
+    build_url = attr.ib()  # URL to the build folder with ova/vhd/qc2/etc images
+
+    def build_version(self):
+        """Version string from version file in build folder (cfme)
+        padded in the build number to 5 digit total (5.9.0.1 -> 59001)
+
+        Raises:
+            ValueError if unable to parse version string from file
+
+        Returns:  TODO parse MIQ name from a build image here
+            None if no version string available
+            String 5-digit version number
+        """
+        v = requests.get('/'.join([self.image_url, 'version']))
+        if v.ok:
+            logger.info('version file found, parsing dotted version string')
+            match = re.search(
+                '^(?P<major>\d)\.?(?P<minor>\d)\.?(?P<patch>\d)\.?(?P<build>\d{1,2})',
+                v.content)
+            if match:
+                return ''.join([match.group('major'),
+                                match.group('minor'),
+                                match.group('patch'),
+                                match.group('build').zfill(2)])  # zero left-pad
+            else:
+                raise ValueError('Unable to match version string in %s/version: %s',
+                                 self.build_url, v.content)
+        else:
+            logger.info('No version file found in %s, pulling build name from image file',
+                        self.build_url)
+            build_dir = requests.get(self.build_url)
+            dir_parser = BeautifulSoup(build_dir.text, 'html.parser')
+            # Find image file links, use first one to pattern match name
+            images = [node.get('href')
+                      for node in dir_parser.find_all('a')
+                      if node.get('href').endswith('ova') or node.get('href').endswith('qc2')]
+            if images:
+                match = re.search('manageiq-(?:[\w]+?)-(?P<release>[\w]+?)-(?P<number>\d)-\d{3,}',
+                                  str(images[0]))
+                if match:
+                    return '-'.join([match.group('release')[:5],
+                                     match.group('number')])
+                else:
+                    raise ValueError('Unable to match version string in image file: %s',
+                                     str(images[0]))
+            else:
+                raise ValueError('No image of ova or qc2 type found to parse version from in %s',
+                                 self.build_url)
 
 
 # Dict subclasses to help with JSON serialization

--- a/cfme/utils/trackerbot.py
+++ b/cfme/utils/trackerbot.py
@@ -26,9 +26,9 @@ stream_matchers = (
     (get_stream('5.4'), r'^cfme-54.*-(?P<month>\d{2})(?P<day>\d{2})'),
     (get_stream('5.5'), r'^cfme-55.*-(?P<month>\d{2})(?P<day>\d{2})'),
     (get_stream('5.6'), r'^cfme-56.*-(?P<month>\d{2})(?P<day>\d{2})'),
-    (get_stream('5.7'), r'^cfme-57.*-(?P<month>\d{2})(?P<day>\d{2})'),
-    (get_stream('5.8'), r'^cfme-58.*-(?P<month>\d{2})(?P<day>\d{2})'),
-    (get_stream('5.9'), r'^cfme-59.*-(?P<month>\d{2})(?P<day>\d{2})'),
+    (get_stream('5.7'), r'^cfme-57.*-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})'),
+    (get_stream('5.8'), r'^cfme-58.*-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})'),
+    (get_stream('5.9'), r'^cfme-59.*-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})'),
     # Nightly builds have potentially multiple version streams bound to them so we
     # cannot use get_stream()
     ('upstream_stable', r'^miq-stable-(?P<release>gapri[-\w]*?)'  # release name limit to 5 chars

--- a/scripts/template_upload_all.py
+++ b/scripts/template_upload_all.py
@@ -30,8 +30,8 @@ from cfme.utils import path, trackerbot
 from cfme.utils.conf import cfme_data
 from cfme.utils.log import logger, add_stdout_handler
 
-CFME_BREW_ID = "cfme"
-NIGHTLY_MIQ_ID = "manageiq"
+CFME_ID = "cfme"
+MIQ_ID = "manageiq"
 
 add_stdout_handler(logger)
 
@@ -62,106 +62,124 @@ def parse_cmd_line():
     return args
 
 
-def template_name(image_link, image_ts, checksum_link, version=None):
+def template_name(image_link, timestamp, version=None):
+    """Generate a template name from given link, a timestamp, and optional version string
+    This method should handle naming templates from the following URL types:
+        - http://<build-server-address>/builds/manageiq/master/latest/
+        - http://<build-server-address>/builds/manageiq/gaprindashvili/stable/
+        - http://<build-server-address>/builds/manageiq/fine/stable/
+        - http://<build-server-address>/builds/cfme/5.7/stable/
+        - http://<build-server-address>/builds/cfme/5.9/latest/
+
+    These builds fall into a few categories:
+        - MIQ nightly (master/latest)  (upstream)
+        - MIQ stable (<name>/stable)  (upstream_stable, upstream_fine, etc)
+        - CFME nightly (<stream>/latest)  (downstream-nightly)
+        - CFME stream (<stream>/stable)  (downstream-<stream>)
+
+    The generated template names should follow the syntax with 5 digit version numbers:
+        - MIQ nightly: miq-nightly-<yyyymmdd>  (miq-nightly-201711212330)
+        - MIQ stable: miq-stable-<name>-<number>-yyyymmdd  (miq-stable-fine-4-20171024)
+        - CFME nightly: cfme-nightly-<version>-<yyyymmdd>  (cfme-nightly-59000-20170901)
+        - CFME stream: cfme-<version>-<yyyymmdd>  (cfme-57402-20171202)
+
+    Release names for upstream will be truncated to 5 letters (thanks gaprindashvili...)
+    """
+
     pattern = re.compile(r'.*/(.*)')
-    image_name = pattern.findall(image_link)[0]
-    image_name = image_name.lower()
-    image_dt = get_last_modified(checksum_link)
-    # CFME brew builds
-    if CFME_BREW_ID in image_name:
+    image_name = pattern.findall(image_link)[0].lower()
+    formatted_timestamp = '{year}{month}{day}'.format(year=str(timestamp.year),
+                                                      month=str(timestamp.month).zfill(2),
+                                                      day=str(timestamp.day).zfill(2))
+    # CFME
+    if CFME_ID in image_name:
         if 'nightly' in image_name:
-            # 5.6+ nightly
-            # cfme-rhevm-5.6.0.0-nightly-20160308112121-1.x86_64.rhevm.ova
-            # => cfme-nightly-5600-201603081121 (YYYYMMDDHHmm)
-            pattern = re.compile(r'.*-nightly-(\d+).*')
-            result = pattern.findall(image_name)
-            return "cfme-nightly-{}-{}".format(version, result[0][:-2])
-        elif version:
-            # proper build
-            if len(version) == 4:
-                version = version[:-1] + '0' + version[-1:]
-            return "cfme-{}-{}{}{}".format(version, image_ts, image_dt.hour, image_dt.minute)
+            # CFME nightly
+            name = '-'.join([CFME_ID,
+                             'nightly',
+                             version,
+                             formatted_timestamp])
         else:
-            # other nightly; leaving it in in case this template-naming comes back
-            pattern = re.compile(r'[^\d]*?-(\d).(\d)-(\d).*')
-            result = pattern.findall(image_name)
-            # cfme-pppp-x.y-z.arch.[pppp].ova => cfme-nightly-x.y-z
-            return "cfme-nightly-{}.{}-{}".format(result[0][0], result[0][1], result[0][2])
-    # nightly builds MIQ
-    elif NIGHTLY_MIQ_ID in image_name:
-        if "master" in image_name:
-            pattern = re.compile(r'[^\d]*?-master-(\d*)-*')
+            # CFME stream
+            name = '-'.join([CFME_ID,
+                             version,
+                             formatted_timestamp])
+        return name
+
+    # MIQ
+    elif MIQ_ID in image_name:
+        if "master/latest" in image_link:
+            # MIQ nightly
+            name = '-'.join(['miq',
+                             'nightly',
+                             formatted_timestamp])
         else:
-            pattern = re.compile(r'[^\d]*?-(\w*)-(\d*)-(\d*)-*')
-        result = pattern.findall(image_name)
-        if version:
-            # manageiq-pppp-bbbbbb-yyyymmddhhmm.ova => miq-nightly-vvvv-yyyymmddhhmm
-            return "miq-nightly-{}-{}".format(version, result[0])
-        elif "stable" in image_link:
+            # MIQ stable
             # Handle named MIQ releases, dropping provider and capturing release and date
-            if 'master' not in image_link:
-                pattern = re.compile(r'manageiq-([^\d]|ec2)*?-(?P<release>[-.\w]*?)'
-                                     r'-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})')
-                # Use match so we can use regex group names
-                result = pattern.match(image_name)
-                return "miq-stable-{}-{}{}{}".format(result.group('release')[:5],  # keep it short
-                                                     result.group('year'),
-                                                     result.group('month'),
-                                                     result.group('day'))
-            return "miq-stable-{}-{}".format(result[0][0], result[0][2])
-        else:
-            # manageiq-pppp-bbbbbb-yyyymmddhhmm.ova => miq-nightly-yyyymmddhhmm
-            return "miq-nightly-{}".format(result[0])
+            # regex includes -\d on the end to stop the lazy capture past the release name+number
+            pattern = re.compile(r'manageiq-(?:[\w]+?)-(?P<release>[\w]+?)-(?P<number>\d)-\d{3,}')
+            # Use match so we can use regex group names
+            result = pattern.match(image_name)
+            short_release = result.group('release')[:5]
+            number = result.group('number')
+            name = '-'.join(['miq',
+                             'stable',
+                             short_release,
+                             number,
+                             formatted_timestamp])
 
+        return name
+
+    # Podified
     elif 'openshift' in image_link:
-        return 'cfme-{}-{}{}{}{}'.format(version,
-                                         image_dt.strftime('%m'),
-                                         image_dt.strftime('%d'),
-                                         image_dt.hour,
-                                         image_dt.minute)
-    # z-stream
-    else:
-        pattern = re.compile(r'[.-](\d+(?:\d+)?)')
-        result = pattern.findall(image_name)
-        if version:
-            # CloudForms-x.y-yyyy-mm-dd.i-xxx*.ova => cfme-vvvv-mmdd
-            # If build number < 10, pad it with a 0.
-            if len(version) == 4:
-                version = version[:-1] + '0' + version[-1:]
-            return "cfme-{}-{}{}{}{}".format(version, result[3], result[4],
-                                         image_dt.hour, image_dt.minute)
-        else:
-            # CloudForms-x.y-yyyy-mm-dd.i-xxx*.ova => cfme-xy-yyyymmddi
-            str_res = ''.join(result)
-            return "cfme-{}-{}".format(str_res[0:2], str_res[2:])
+        return '-'.join([CFME_ID,
+                         version,
+                         formatted_timestamp])
 
 
-def get_version(dir_url):
-    if not dir_url.endswith("/"):
-        dir_url += "/"
+def get_version_and_timestamp(dir_url):
+    """Return a tuple of version string and datetime object
 
-    version_url = dir_url + "version"
+    Version string is padded to 5 digit"""
+    version_url = '/'.join([dir_url, 'version'])
 
     try:
         urlo = urlopen(version_url)
     except Exception:
-        return None
+        logger.warning('No version file, must be upstream builds')
+        urlo = None
 
-    version = urlo.read()
+    if urlo:
+        # version string from file
+        version = urlo.read()
+        match = re.search(
+            '^(?P<major>\d{1})\.?(?P<minor>\d{1})\.?(?P<patch>\d{1})\.?(?P<build>\d{1,2})',
+            str(version)
+        )
+        version_str = ''.join([match.group('major'),
+                               match.group('minor'),
+                               match.group('patch'),
+                               match.group('build').zfill(2)])  # zero left-pad to given length
+    else:
+        # no version string file
+        version_str = None
 
-    return version.rstrip().replace('.', '')
+        # setup alternate file for timestamp query
+        keyfile_url = '/'.join([dir_url, 'manageiq_public.key'])
+        try:
+            urlo = urlopen(keyfile_url)
+        except Exception:
+            logger.warning('No manageiq_public.key file, trying for SHA256SUM file')
+            urlo = urlopen('/'.join([dir_url, 'SHA256SUM']))
 
+    logger.info('Parsed version number (empty for upstream): %s', version_str)
 
-def get_last_modified(image_url):
-    """Returns a datetime object for when the image was last modified."""
-    format = "%a, %d %b %Y %H:%M:%S %Z"
-    try:
-        urlo = urlopen(image_url)
-    except Exception:
-        return None
-
+    # build datetime from URL header
     headers = urlo.info()
-    return datetime.datetime.strptime(headers.getheader("Last-Modified"), format)
+    datetime_format = "%a, %d %b %Y %H:%M:%S %Z"
+    timestamp = datetime.datetime.strptime(headers.getheader("Last-Modified"),
+                                           datetime_format)
+    return version_str, timestamp
 
 
 def make_kwargs_rhevm(cfme_data, provider):
@@ -292,20 +310,6 @@ def browse_directory(dir_url):
     for key, val in name_dict.iteritems():
         name_dict[key] = urljoin(dir_url, val)
 
-    for key in name_dict.keys():
-        if key == 'template_upload_openshift':
-            # this is necessary because headers don't contain last-modified date for folders
-            #  cfme-template is disposed in templates everywhere except 'latest' in 5.9
-            # todo: remove this along with refactoring script
-            if '5.8' in name_dict[key] or ('5.9' in name_dict[key] and 'latest' in name_dict[key]):
-                url = urljoin(name_dict[key], 'cfme-template.yaml')
-            else:
-                url = urljoin(name_dict[key], 'templates/cfme-template.yaml')
-        else:
-            url = name_dict[key]
-        date = urlopen(url).info().getdate('last-modified')
-        name_dict[key + "_date"] = "%02d" % date[1] + "%02d" % date[2]
-
     return name_dict
 
 
@@ -400,12 +404,12 @@ def main():
             kwargs['provider_data'] = None
 
         if cfme_data['template_upload']['automatic_name_strategy']:
+            version, timestamp = get_version_and_timestamp(url)
             kwargs['template_name'] = template_name(
                 dir_files[module],
-                dir_files[module + "_date"],
-                checksum_url,
-                get_version(url)
-            )
+                timestamp,
+                version)
+            logger.info('template_name: %s', kwargs['template_name'])
             if not stream:
                 # Stream is none, using automatic naming strategy, parse stream from template name
                 template_parser = trackerbot.parse_template(kwargs['template_name'])
@@ -421,6 +425,9 @@ def main():
         logger.info("TEMPLATE_UPLOAD_ALL:------End of %r upload on: %r--------",
             kwargs['template_name'], provider_type)
         return 0
+    else:
+        logger.warning('No URL match, not calling any upload modules.')
+        return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Re-opening this since @ohiliazo is going to be taking a look at reworking the template_upload scripts to be object oriented provider actions.

There is additional impact to sprout regex, and to existing trackerbot records using the current naming convention. This may require re-creation of existing MIQ/CFME templates on RH trackerbot servers.

Can be merged into template_upload_all, but I think template naming could/should be pulled into its own utility module.