### PR TITLE
[1LP][RFR] Add TemplateName class to cfme/utils/trackerbot

### DIFF
--- a/cfme/utils/trackerbot.py
+++ b/cfme/utils/trackerbot.py
@@ -28,20 +28,32 @@ stream_matchers = (
     (get_stream('5.4'), r'^cfme-54.*-(?P<month>\d{2})(?P<day>\d{2})'),
     (get_stream('5.5'), r'^cfme-55.*-(?P<month>\d{2})(?P<day>\d{2})'),
     (get_stream('5.6'), r'^cfme-56.*-(?P<month>\d{2})(?P<day>\d{2})'),
-    (get_stream('5.7'), r'^cfme-57.*-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})'),
-    (get_stream('5.8'), r'^cfme-58.*-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})'),
-    (get_stream('5.9'), r'^cfme-59.*-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})'),
+    (get_stream('5.7'), r'^cfme-57.*-(?P<month>\d{2})(?P<day>\d{2})'),
+    (get_stream('5.8'), r'^cfme-58.*-(?P<month>\d{2})(?P<day>\d{2})'),
+    (get_stream('5.9'), r'^cfme-59.*-(?P<month>\d{2})(?P<day>\d{2})'),
+    ('upstream_stable', r'^miq-stable-(?P<release>gapri[-\w]*?)'  # release name limit to 5 chars
+                        r'-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})'),
+    ('upstream_euwe', r'^miq-stable-(?P<release>euwe[-\w]*?)'
+                      r'-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})'),
+    ('upstream_fine', r'^miq-stable-(?P<release>fine[-\w]*?)'
+                      r'-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})'),
+    # new format, TODO remove with TemplateName update, no more CFME nightly
+    ('downstream-nightly', r'^cfme-nightly-\d*-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})'),
+
+    # Regex for standardized dates using TemplateName class below
+    # TODO swap these in when TemplateName is in use
+    # (get_stream('5.7'), r'^cfme-57.*-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})')
+    # (get_stream('5.8'), r'^cfme-58.*-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})')
+    # (get_stream('5.9'), r'^cfme-59.*-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})')
     # Nightly builds have potentially multiple version streams bound to them so we
     # cannot use get_stream()
-    ('upstream_stable', r'^miq-(?P<release>gapri[-\w]*?)'  # release name limit to 5 chars
-                        r'-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})'),
-    ('upstream_euwe', r'^miq-(?P<release>euwe[-\w]*?)'
-                      r'-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})'),
-    ('upstream_fine', r'^miq-(?P<release>fine[-\w]*?)'
-                      r'-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})'),
-    ('downstream-nightly', r'^cfme-nightly-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})'),
-    # new format
-    ('downstream-nightly', r'^cfme-nightly-\d*-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})'),
+    # ('upstream_stable', r'^miq-(?P<release>gapri[-\w]*?)'
+    #                    r'-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})')
+    # ('upstream_euwe', r'^miq-(?P<release>euwe[-\w]*?)'
+    #                  r'-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})')
+    # ('upstream_fine', r'^miq-(?P<release>fine[-\w]*?)'
+    #                  r'-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})')
+
 )
 generic_matchers = (
     ('sprout', r'^s_tpl'),

--- a/cfme/utils/trackerbot.py
+++ b/cfme/utils/trackerbot.py
@@ -1,16 +1,18 @@
 import argparse
 import json
 import re
+import time
+import urllib
 import urlparse
 from collections import defaultdict, namedtuple
-from datetime import date
-import urllib
+from datetime import date, datetime
 
+import attr
 import slumber
 import requests
-import time
-
+from lxml import html
 from cfme.utils.conf import env
+from cfme.utils.log import logger
 from cfme.utils.providers import providers_data
 from cfme.utils.version import get_stream
 
@@ -26,16 +28,16 @@ stream_matchers = (
     (get_stream('5.4'), r'^cfme-54.*-(?P<month>\d{2})(?P<day>\d{2})'),
     (get_stream('5.5'), r'^cfme-55.*-(?P<month>\d{2})(?P<day>\d{2})'),
     (get_stream('5.6'), r'^cfme-56.*-(?P<month>\d{2})(?P<day>\d{2})'),
-    (get_stream('5.7'), r'^cfme-57.*-(?P<month>\d{2})(?P<day>\d{2})'),
-    (get_stream('5.8'), r'^cfme-58.*-(?P<month>\d{2})(?P<day>\d{2})'),
-    (get_stream('5.9'), r'^cfme-59.*-(?P<month>\d{2})(?P<day>\d{2})'),
+    (get_stream('5.7'), r'^cfme-57.*-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})'),
+    (get_stream('5.8'), r'^cfme-58.*-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})'),
+    (get_stream('5.9'), r'^cfme-59.*-(?P<year>\d{4})?(?P<month>\d{2})(?P<day>\d{2})'),
     # Nightly builds have potentially multiple version streams bound to them so we
     # cannot use get_stream()
-    ('upstream_stable', r'^miq-stable-(?P<release>gapri[-\w]*?)'  # release name limit to 5 chars
+    ('upstream_stable', r'^miq-(?P<release>gapri[-\w]*?)'  # release name limit to 5 chars
                         r'-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})'),
-    ('upstream_euwe', r'^miq-stable-(?P<release>euwe[-\w]*?)'
+    ('upstream_euwe', r'^miq-(?P<release>euwe[-\w]*?)'
                       r'-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})'),
-    ('upstream_fine', r'^miq-stable-(?P<release>fine[-\w]*?)'
+    ('upstream_fine', r'^miq-(?P<release>fine[-\w]*?)'
                       r'-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})'),
     ('downstream-nightly', r'^cfme-nightly-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})'),
     # new format
@@ -376,6 +378,109 @@ def composite_uncollect(build, source='jenkins'):
     except Exception as e:
         print(e)
         return {'tests': []}
+
+
+@attr.s
+class TemplateName(object):
+    """Generate a template name from given link, a timestamp, and optional version string
+    This method should handle naming templates from the following URL types:
+        - http://<build-server-address>/builds/manageiq/master/latest/
+        - http://<build-server-address>/builds/manageiq/gaprindashvili/stable/
+        - http://<build-server-address>/builds/manageiq/fine/stable/
+        - http://<build-server-address>/builds/cfme/5.8/stable/
+        - http://<build-server-address>/builds/cfme/5.9/latest/
+
+    These builds fall into a few categories:
+        - MIQ nightly (master/latest)  (upstream)
+        - MIQ stable (<name>/stable)  (upstream_stable, upstream_fine, etc)
+        - CFME nightly (<stream>/latest)  (downstream-nightly)
+        - CFME stream (<stream>/stable)  (downstream-<stream>)
+
+    The generated template names should follow the syntax with 5 digit version numbers:
+        - MIQ nightly: miq-nightly-<yyyymmdd>  (miq-nightly-201711212330)
+        - MIQ stable: miq-<name>-<number>-yyyymmdd  (miq-fine-4-20171024, miq-gapri-20180130)
+        - CFME nightly: cfme-nightly-<version>-<yyyymmdd>  (cfme-nightly-59000-20170901)
+        - CFME stream: cfme-<version>-<yyyymmdd>  (cfme-57402-20171202)
+
+    Release names for upstream will be truncated to 5 letters (thanks gaprindashvili...)
+    """
+    SHA = 'SHA256SUM'
+    CFME_ID = 'cfme'
+    MIQ_ID = 'manageiq'
+    build_url = attr.ib()  # URL to the build folder with ova/vhd/qc2/etc images
+
+    @property
+    def build_version(self):
+        """Version string from version file in build folder (cfme)
+        release name and build number from an image file (MIQ)
+
+        Will substitute 'nightly' for master URLs
+
+        Raises:
+            ValueError if unable to parse version string or release name from files
+
+        Returns:
+            String 5-digit version number or release name for MIQ
+        """
+        v = requests.get('/'.join([self.build_url, 'version']))
+        if v.ok:
+            logger.info('version file found, parsing dotted version string')
+            match = re.search(
+                '^(?P<major>\d)\.?(?P<minor>\d)\.?(?P<patch>\d)\.?(?P<build>\d{1,2})',
+                v.content)
+            if match:
+                return ''.join([match.group('major'),
+                                match.group('minor'),
+                                match.group('patch'),
+                                match.group('build').zfill(2)])  # zero left-pad
+            else:
+                raise ValueError('Unable to match version string in %s/version: {}'
+                                 .format(self.build_url, v.content))
+        else:
+            logger.info('No version file found in %s, pulling build name from image file',
+                        self.build_url)
+            build_dir = requests.get(self.build_url)
+            link_parser = html.fromstring(build_dir.content)
+            # Find image file links, use first one to pattern match name
+            # iterlinks returns tuple of (element, attribute, link, position)
+            images = [l
+                      for _, a, l, _ in link_parser.iterlinks()
+                      if a == 'href' and l.endswith('.ova') or l.endswith('.vhd')]
+            if images:
+                # pull release and its possible number (with -) from image string
+                # examples: miq-prov-fine-4-date-hash.vhd, miq-prov-gaprindashvilli-date-hash.vhd
+                match = re.search(
+                    'manageiq-(?:[\w]+?)-(?P<release>[\w]+?)(?P<number>-\d)?-\d{''3,}',
+                    str(images[0]))
+                if match:
+                    # if its a master image, version is 'nightly', otherwise use release+number
+                    return ('nightly'
+                            if 'master' in match.group('release')
+                            else '{}{}'.format(match.group('release')[:5], match.group('number')))
+                else:
+                    raise ValueError('Unable to match version string in image file: {}'
+                                     .format(images[0]))
+            else:
+                raise ValueError('No image of ova or vhd type found to parse version from in {}'
+                                 .format(self.build_url))
+
+    @property
+    def build_date(self):
+        """Get a build date from the SHA256SUM"""
+        r = requests.get('/'.join([self.build_url, self.SHA]))
+        if r.ok:
+            timestamp = datetime.strptime(r.headers.get('Last-Modified'),
+                                          "%a, %d %b %Y %H:%M:%S %Z")
+            return timestamp.strftime('%Y%m%d')
+        else:
+            raise ValueError('{} file not found in {}'.format(self.SHA, self.build_url))
+
+    @property
+    def template_name(self):
+        """Actually construct the template name"""
+        return '-'.join([self.CFME_ID if self.CFME_ID in self.build_url else self.MIQ_ID,
+                         self.build_version,
+                         self.build_date])
 
 
 # Dict subclasses to help with JSON serialization


### PR DESCRIPTION
Class for generating trackerbot/sprout friendly template names from the CFME build server URLs.

This is intended as a replacement for what is currently in template_upload_all generating template names for us.  The current naming scheme is inconsistent, and uses different date timestamps sometimes for the same build of MIQ/CFME.  Timestamps also were not consistent across streams.

To be used in new template_upload flow that @ohiliazo is working on.

Testing against several CFME/MIQ build URLs, including the URLs that until now have not been able to run through template_upload_all:

http://pastebin.test.redhat.com/558699