### PR TITLE
[1LP][RFR] Override is_refreshed method in openshift provider

### DIFF
--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -14,6 +14,7 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.ocp_cli import OcpCli
 from cfme.utils.varmeth import variable
 from cfme.utils import version, ssh
+from cfme.utils.wait import TimedOutError
 
 
 class CustomAttribute(object):
@@ -384,3 +385,30 @@ class OpenshiftProvider(ContainersProvider):
             self.appliance.restart_evm_service()
             self.appliance.wait_for_evm_service()
             self.appliance.wait_for_web_ui()
+
+    @variable(alias='rest')
+    def is_refreshed(self, refresh_timer=None, refresh_delta=600):
+        """ Overrides cfme.common.provider.BaseProvider#is_refreshed.
+            Add validate_status check after provider creation,
+            In order to make sure that openshift provider data refresh completed
+                Args:
+                    refresh_timer : wait_for.RefreshTimer Object or None
+                    refresh_delta : refresh delta between times on second
+                Returns:
+                     Boolean or TimedOutError exception in case data referesh didn't completed
+        """
+        valid = False
+        # check refresh time
+        if not super(OpenshiftProvider, self).is_refreshed():
+            return valid
+
+        # check the detail page matches the Providers information
+        try:
+            self.validate_stats(ui=False)
+            valid = True
+        except TimedOutError:
+            raise TimedOutError(
+                'Timeout exceeded, openShift provider data refresh did not completed on time'
+            )
+        finally:
+            return valid


### PR DESCRIPTION
Add is_refreshed method in openshift provider,
Overrides cfme.common.provider.BaseProvider#is_refreshed.
Add validate_status check after provider creation,
In order to make sure that openShift provider data refresh completed.

{{pytest: cfme/tests/containers/test_provider_openscap_policy_attached.py -v --use-provider ocp-v1}}
