### PR TITLE
[1LP][RFR] provider_type intergration to stabilize tests and scripts

### DIFF
--- a/cfme/scripting/setup_env.py
+++ b/cfme/scripting/setup_env.py
@@ -24,7 +24,7 @@ def tot_time(string):
 def provision_appliances(count, cfme_version, provider_type, lease_time):
     sprout_client = SproutClient.from_config()
     apps, request_id = sprout_client.provision_appliances(version=str(cfme_version),
-        count=count, preconfigured=False, lease_time=lease_time, provider_tpye=provider_type)
+        count=count, preconfigured=False, lease_time=lease_time, provider_type=provider_type)
     return apps, request_id
 
 
@@ -113,7 +113,7 @@ def setup_ha_env(cfme_version, provider_type, lease, desc):
 
 @main.command('replicated', help='Sets up replicated environment')
 @click.option('--cfme-version', required=True)
-@click.option('--provider-type', default='rhemv', help='Specify sprout provider type')
+@click.option('--provider-type', default='rhevm', help='Specify sprout provider type')
 @click.option('--lease', default='3h', help='set pool lease time, example: 1d4h30m')
 @click.option('--sprout-poolid', default=None, help='Specify ID of existing pool')
 @click.option('--desc', default='Replicated appliances', help='Set description of the pool')

--- a/cfme/scripting/setup_env.py
+++ b/cfme/scripting/setup_env.py
@@ -21,10 +21,11 @@ def tot_time(string):
     return tot
 
 
-def provision_appliances(count, cfme_version, provider_type, lease_time):
+def provision_appliances(count, cfme_version, provider_type, provider, lease_time):
     sprout_client = SproutClient.from_config()
     apps, request_id = sprout_client.provision_appliances(version=str(cfme_version),
-        count=count, preconfigured=False, lease_time=lease_time, provider_type=provider_type)
+        count=count, preconfigured=False, lease_time=lease_time, provider_type=provider_type,
+        provider=provider)
     return apps, request_id
 
 
@@ -37,15 +38,17 @@ def main():
 @main.command('distributed', help='Sets up distributed environment')
 @click.option('--cfme-version', required=True)
 @click.option('--provider-type', default='rhevm', help='Specify sprout provider_type')
+@click.option('--provider', default=None, help='Specify sprout provider, overrides provider_type')
 @click.option('--lease', default='3h', help='Set pool lease time, example: 1d4h30m')
 @click.option('--desc', default='Distributed appliances', help='Set description of the pool')
-def setup_distributed_env(cfme_version, provider_type, lease, desc):
+def setup_distributed_env(cfme_version, provider_type, provider, lease, desc):
     lease_time = tot_time(lease)
+    provider_type = None if provider else provider_type
     """multi appliance single region configuration (distributed setup, 1st appliance has
     a local database and workers, 2nd appliance has workers pointing at 1st appliance)"""
     print("Provisioning and configuring distributed environment")
     apps, request_id = provision_appliances(count=2, cfme_version=cfme_version,
-        provider_type=provider_type, lease_time=lease_time)
+        provider_type=provider_type, provider=provider, lease_time=lease_time)
     sprout_client = SproutClient.from_config()
     sprout_client.set_pool_description(request_id, desc)
     opt = '5' if cfme_version >= "5.8" else '8'
@@ -69,16 +72,18 @@ def setup_distributed_env(cfme_version, provider_type, lease, desc):
 
 @main.command('ha', help='Sets up high availability environment')
 @click.option('--cfme-version', required=True)
-@click.option('--provider-type', default='rhevm', help='Specify sprout provider, must not be RHOS')
+@click.option('--provider-type', default='rhevm', help='Specify provider type, must not be RHOS')
+@click.option('--provider', default=None, help='Specify sprout provider, overrides provider_type')
 @click.option('--lease', default='3h', help='set pool lease time, example: 1d4h30m')
 @click.option('--desc', default='HA configuration', help='Set description of the pool')
-def setup_ha_env(cfme_version, provider_type, lease, desc):
+def setup_ha_env(cfme_version, provider_type, provider, lease, desc):
     lease_time = tot_time(lease)
+    provider_type = None if provider else provider_type
     """multi appliance setup consisting of dedicated primary and standy databases with a single
     UI appliance."""
     print("Provisioning and configuring HA environment")
     apps, request_id = provision_appliances(count=3, cfme_version=cfme_version,
-        provider_type=provider_type, lease_time=lease_time)
+        provider_type=provider_type, provider=provider, lease_time=lease_time)
     sprout_client = SproutClient.from_config()
     sprout_client.set_pool_description(request_id, desc)
     ip0 = apps[0].hostname
@@ -114,12 +119,15 @@ def setup_ha_env(cfme_version, provider_type, lease, desc):
 @main.command('replicated', help='Sets up replicated environment')
 @click.option('--cfme-version', required=True)
 @click.option('--provider-type', default='rhevm', help='Specify sprout provider type')
+@click.option('--provider', default=None, help='Specify sprout provider, overrides provider_type')
 @click.option('--lease', default='3h', help='set pool lease time, example: 1d4h30m')
 @click.option('--sprout-poolid', default=None, help='Specify ID of existing pool')
 @click.option('--desc', default='Replicated appliances', help='Set description of the pool')
 @click.option('--remote-worker', is_flag=True, help='Add node to remote region')
-def setup_replication_env(cfme_version, provider_type, lease, sprout_poolid, desc, remote_worker):
+def setup_replication_env(cfme_version, provider_type, provider, lease, sprout_poolid, desc,
+                          remote_worker):
     lease_time = tot_time(lease)
+    provider_type = None if provider else provider_type
     """Multi appliance setup with multi region and replication from remote to global"""
     required_app_count = 2
     sprout_client = SproutClient.from_config()
@@ -145,7 +153,7 @@ def setup_replication_env(cfme_version, provider_type, lease, sprout_poolid, des
         print("Provisioning appliances")
         apps, request_id = provision_appliances(
             count=required_app_count, cfme_version=cfme_version,
-            provider_type=provider_type, lease_time=lease_time
+            provider_type=provider_type, provider=provider, lease_time=lease_time
         )
         print("Appliance pool lease time is {}".format(lease))
         sprout_client.set_pool_description(request_id, desc)

--- a/cfme/scripting/setup_env.py
+++ b/cfme/scripting/setup_env.py
@@ -21,10 +21,10 @@ def tot_time(string):
     return tot
 
 
-def provision_appliances(count, cfme_version, provider, lease_time):
+def provision_appliances(count, cfme_version, provider_type, lease_time):
     sprout_client = SproutClient.from_config()
     apps, request_id = sprout_client.provision_appliances(version=str(cfme_version),
-        count=count, preconfigured=False, lease_time=lease_time, provider=provider)
+        count=count, preconfigured=False, lease_time=lease_time, provider_tpye=provider_type)
     return apps, request_id
 
 
@@ -36,16 +36,16 @@ def main():
 
 @main.command('distributed', help='Sets up distributed environment')
 @click.option('--cfme-version', required=True)
-@click.option('--provider', default=None, help='Specify sprout provider')
+@click.option('--provider-type', default='rhevm', help='Specify sprout provider_type')
 @click.option('--lease', default='3h', help='Set pool lease time, example: 1d4h30m')
 @click.option('--desc', default='Distributed appliances', help='Set description of the pool')
-def setup_distributed_env(cfme_version, provider, lease, desc):
+def setup_distributed_env(cfme_version, provider_type, lease, desc):
     lease_time = tot_time(lease)
     """multi appliance single region configuration (distributed setup, 1st appliance has
     a local database and workers, 2nd appliance has workers pointing at 1st appliance)"""
     print("Provisioning and configuring distributed environment")
-    apps, request_id = provision_appliances(count=2, cfme_version=cfme_version, provider=provider,
-        lease_time=lease_time)
+    apps, request_id = provision_appliances(count=2, cfme_version=cfme_version,
+        provider_type=provider_type, lease_time=lease_time)
     sprout_client = SproutClient.from_config()
     sprout_client.set_pool_description(request_id, desc)
     opt = '5' if cfme_version >= "5.8" else '8'
@@ -69,17 +69,16 @@ def setup_distributed_env(cfme_version, provider, lease, desc):
 
 @main.command('ha', help='Sets up high availability environment')
 @click.option('--cfme-version', required=True)
-@click.option('--provider', default=cfme_data.get('basic_info', {}).get('ha_provider'),
-    help='Specify sprout provider, must not be RHOS')
+@click.option('--provider-type', default='rhevm', help='Specify sprout provider, must not be RHOS')
 @click.option('--lease', default='3h', help='set pool lease time, example: 1d4h30m')
 @click.option('--desc', default='HA configuration', help='Set description of the pool')
-def setup_ha_env(cfme_version, provider, lease, desc):
+def setup_ha_env(cfme_version, provider_type, lease, desc):
     lease_time = tot_time(lease)
     """multi appliance setup consisting of dedicated primary and standy databases with a single
     UI appliance."""
     print("Provisioning and configuring HA environment")
-    apps, request_id = provision_appliances(count=3, cfme_version=cfme_version, provider=provider,
-        lease_time=lease_time)
+    apps, request_id = provision_appliances(count=3, cfme_version=cfme_version,
+        provider_type=provider_type, lease_time=lease_time)
     sprout_client = SproutClient.from_config()
     sprout_client.set_pool_description(request_id, desc)
     ip0 = apps[0].hostname
@@ -114,12 +113,12 @@ def setup_ha_env(cfme_version, provider, lease, desc):
 
 @main.command('replicated', help='Sets up replicated environment')
 @click.option('--cfme-version', required=True)
-@click.option('--provider', default=None, help='Specify sprout provider')
+@click.option('--provider-type', default='rhemv', help='Specify sprout provider type')
 @click.option('--lease', default='3h', help='set pool lease time, example: 1d4h30m')
 @click.option('--sprout-poolid', default=None, help='Specify ID of existing pool')
 @click.option('--desc', default='Replicated appliances', help='Set description of the pool')
 @click.option('--remote-worker', is_flag=True, help='Add node to remote region')
-def setup_replication_env(cfme_version, provider, lease, sprout_poolid, desc, remote_worker):
+def setup_replication_env(cfme_version, provider_type, lease, sprout_poolid, desc, remote_worker):
     lease_time = tot_time(lease)
     """Multi appliance setup with multi region and replication from remote to global"""
     required_app_count = 2
@@ -146,7 +145,7 @@ def setup_replication_env(cfme_version, provider, lease, sprout_poolid, desc, re
         print("Provisioning appliances")
         apps, request_id = provision_appliances(
             count=required_app_count, cfme_version=cfme_version,
-            provider=provider, lease_time=lease_time
+            provider_type=provider_type, lease_time=lease_time
         )
         print("Appliance pool lease time is {}".format(lease))
         sprout_client.set_pool_description(request_id, desc)

--- a/cfme/test_framework/sprout/client.py
+++ b/cfme/test_framework/sprout/client.py
@@ -96,7 +96,7 @@ class SproutClient(object):
 
     def provision_appliances(
             self, count=1, preconfigured=False, version=None, stream=None, provider=None,
-            lease_time=120, ram=None, cpu=None):
+            provider_type=None, lease_time=120, ram=None, cpu=None):
         # If we specify version, stream is ignored because we will get that specific version
         if version:
             stream = get_stream(version)
@@ -109,7 +109,8 @@ class SproutClient(object):
             version = current_appliance.version.vstring
         request_id = self.call_method(
             'request_appliances', preconfigured=preconfigured, version=version,
-            group=stream, provider=provider, lease_time=lease_time, ram=ram, cpu=cpu, count=count
+            provider_type=provider_type, group=stream, provider=provider, lease_time=lease_time,
+            ram=ram, cpu=cpu, count=count
         )
         wait_for(
             lambda: self.call_method('request_check', str(request_id))['finished'], num_sec=300,

--- a/cfme/tests/test_db_migrate.py
+++ b/cfme/tests/test_db_migrate.py
@@ -46,13 +46,13 @@ def temp_appliance_remote(temp_appliance_preconfig_funcscope):
 
 
 @pytest.fixture(scope="function")
-def temp_appliance_global_region(temp_appliance_unconfig_funcscope):
-    temp_appliance_unconfig_funcscope.appliance_console_cli.configure_appliance_internal(
+def temp_appliance_global_region(temp_appliance_unconfig_funcscope_rhevm):
+    temp_appliance_unconfig_funcscope_rhevm.appliance_console_cli.configure_appliance_internal(
         99, 'localhost', credentials['database']['username'], credentials['database']['password'],
-        'vmdb_production', temp_appliance_unconfig_funcscope.unpartitioned_disks[0])
-    temp_appliance_unconfig_funcscope.wait_for_evm_service()
-    temp_appliance_unconfig_funcscope.wait_for_web_ui()
-    return temp_appliance_unconfig_funcscope
+        'vmdb_production', temp_appliance_unconfig_funcscope_rhevm.unpartitioned_disks[0])
+    temp_appliance_unconfig_funcscope_rhevm.wait_for_evm_service()
+    temp_appliance_unconfig_funcscope_rhevm.wait_for_web_ui()
+    return temp_appliance_unconfig_funcscope_rhevm
 
 
 @pytest.yield_fixture(scope="function")
@@ -126,7 +126,8 @@ def test_db_migrate(temp_appliance_extended_db, db_url, db_version, db_desc):
 
 
 @pytest.mark.uncollectif(
-    lambda dbversion: dbversion == 'ec2_5540' and version.current_version() < "5.9")
+    lambda dbversion: dbversion == 'scvmm_58' and version.current_version() < "5.9" or
+    dbversion == 'ec2_5540' and version.current_version() < "5.9")
 @pytest.mark.parametrize('dbversion', ['ec2_5540', 'azure_5620', 'rhev_57', 'scvmm_58'],
         ids=['55', '56', '57', '58'])
 def test_db_migrate_replication(temp_appliance_remote, dbversion, temp_appliance_global_region):

--- a/fixtures/appliance.py
+++ b/fixtures/appliance.py
@@ -19,7 +19,7 @@ from cfme.test_framework.sprout.client import SproutClient
 
 
 @contextmanager
-def temp_appliances(count=1, preconfigured=True, lease_time=180, stream=None):
+def temp_appliances(count=1, preconfigured=True, lease_time=180, stream=None, provider_type=None):
     """ Provisions one or more appliances for testing
 
     Args:
@@ -31,7 +31,7 @@ def temp_appliances(count=1, preconfigured=True, lease_time=180, stream=None):
     request_id = None
     try:
         sprout_client = SproutClient.from_config()
-        apps, request_id = sprout_client.provision_appliances(
+        apps, request_id = sprout_client.provision_appliances(provider_type=provider_type,
             count=count, lease_time=lease_time, preconfigured=preconfigured, stream=stream)
         yield apps
     finally:
@@ -95,6 +95,12 @@ def temp_appliance_unconfig_clsscope():
 @pytest.yield_fixture(scope="function")
 def temp_appliance_unconfig_funcscope():
     with temp_appliances(preconfigured=False) as appliances:
+        yield appliances[0]
+
+
+@pytest.yield_fixture(scope="function")
+def temp_appliance_unconfig_funcscope_rhevm():
+    with temp_appliances(preconfigured=False, provider_type='rhevm') as appliances:
         yield appliances[0]
 
 


### PR DESCRIPTION
Added the usage of provider_type to make migration tests and setup-env script more reliable to prevent unusable templates causing errors.
{{pytest: -v -k "test_db_migrate_replication"}}
