### PR TITLE
[1LP][RFR] Wrapping test_vm_reconfig_add_remove_hw_cold with BZ for 5.8

### DIFF
--- a/cfme/tests/infrastructure/test_vm_reconfigure.py
+++ b/cfme/tests/infrastructure/test_vm_reconfigure.py
@@ -47,8 +47,9 @@ def ensure_vm_running(small_vm):
         raise Exception("Unknown power state - unable to continue!")
 
 
-@pytest.mark.meta(blockers=[BZ(1534520, forced_streams=['5.9'],
-    unblock=lambda provider: not provider.one_of(RHEVMProvider))])
+@pytest.mark.meta(blockers=[BZ(1534520, forced_streams=['5.8', '5.9'],
+    unblock=lambda provider, change_type:
+        not provider.one_of(RHEVMProvider) or change_type != 'memory')])
 @pytest.mark.parametrize('change_type', ['cores_per_socket', 'sockets', 'memory'])
 def test_vm_reconfig_add_remove_hw_cold(
         provider, small_vm, ensure_vm_stopped, change_type):


### PR DESCRIPTION
__Wrapping__ test_vm_reconfig_add_remove_hw_cold in a way that
1) Skips it on 5.8 as well. This bug was not seen in 5.8 before but I encountered it in 5.8.3.4
2) It is executed when it is not parametrized with `change_type == memory`. Other variants should run because the referenced bug is affecting solely memory reconfiguration.

{{pytest:  cfme/tests/infrastructure/test_vm_reconfigure.py::test_vm_reconfig_add_remove_hw_cold -vv --long-running}}