### PR TITLE
[1LP][RFR] Fixing get_service fixture

### DIFF
--- a/cfme/tests/cloud_infra_common/test_custom_attributes_rest.py
+++ b/cfme/tests/cloud_infra_common/test_custom_attributes_rest.py
@@ -84,7 +84,7 @@ def get_service(appliance):
     try:
         service = appliance.rest_api.collections.services.get(name=name)
         service.delete()
-    except AttributeError:
+    except (AttributeError, ValueError):
         pass
 
 


### PR DESCRIPTION
__Fixing__ `get_service` fixture. Why doing this? Consider following scenario:
1) You execute a test case (or combination thereof) where the private method `_get_service` never gets actually called.
2) During the module teardown, the outer public `get_service` method continues after `yield` statement and tries to delete the service
3) None is found (remember, `_get_service` was never called!) and `Collection.get` method throws [ValueError](https://github.com/ManageIQ/manageiq-api-client-python/blob/fd3893d51a0a25daffb9db7723dc15feb2877c42/src/manageiq_client/api.py#L333).

In this scenario, you will get FAILURE during teardown after whichever test case was executed the last.

{{pytest: cfme/tests/cloud_infra_common/test_custom_attributes_rest.py::TestCustomAttributesRESTAPI::test_edit[rhv41-from_collection-vms] -vv --use-provider rhv41 --long-running}}