### PR TITLE
[1LP][RFR] Add support for adding a user to multiple RBAC groups

### DIFF
--- a/cfme/base/login.py
+++ b/cfme/base/login.py
@@ -15,6 +15,9 @@ class BaseLoggedInPage(View):
     )
     help = NavDropdown('.//li[./a[@id="dropdownMenu1"]]|.//li[./a[@id="help-menu"]]')
     settings = NavDropdown('.//li[./a[@id="dropdownMenu2"]]')
+    # 5.9 Locator for Settings item that replaces current group name when user has multiple groups
+    group_list_locator = (
+        './/ul/li[contains(@class, "dropdown-submenu") and contains(., "Change Group")]')
     navigation = VerticalNavigation('#maintab')
 
     @property
@@ -44,7 +47,33 @@ class BaseLoggedInPage(View):
 
     @property
     def current_groupname(self):
-        return self.settings.items[1].strip()
+        # 5.9 Locators for finding current group when user has multiple groups
+        current_group_locator = '{}/ul/li/a[@title="Currently Selected Group"]'.format(
+            self.group_list_locator)
+        current_group_marker = ' (Current Group)'
+        try:
+            current_group = self.browser.element(current_group_locator)
+            return self.browser.text(current_group).replace(current_group_marker, '')
+        except NoSuchElementException:
+            return self.settings.items[1].strip()
+
+    @property
+    def group_names(self):
+        """ Return a list of the logged in user's assigned groups.
+
+        Returns:
+            Version >= 5.9 - list off all groups the logged in user is assigned to
+            Version < 5.9 - single item list containing the user's current group
+        """
+        group_list_locator = '{}/ul/li'.format(self.group_list_locator)
+        current_group_marker = ' (Current Group)'
+
+        group_list = self.browser.elements(group_list_locator)
+        if group_list:
+            return [
+                self.browser.text(group).replace(current_group_marker, '') for group in group_list]
+        else:
+            return [self.current_groupname]
 
     @property
     def logged_in(self):

--- a/cfme/base/login.py
+++ b/cfme/base/login.py
@@ -62,7 +62,7 @@ class BaseLoggedInPage(View):
         """ Return a list of the logged in user's assigned groups.
 
         Returns:
-            Version >= 5.9 - list off all groups the logged in user is assigned to
+            Version >= 5.9 - list of all groups the logged in user is assigned to
             Version < 5.9 - single item list containing the user's current group
         """
         group_list_locator = '{}/ul/li'.format(self.group_list_locator)

--- a/cfme/base/login.py
+++ b/cfme/base/login.py
@@ -47,6 +47,7 @@ class BaseLoggedInPage(View):
 
     @property
     def current_groupname(self):
+        # TODO: Move these locators and accessors to a widget "Group Dropdown" widget
         # 5.9 Locators for finding current group when user has multiple groups
         current_group_locator = '{}/ul/li/a[@title="Currently Selected Group"]'.format(
             self.group_list_locator)
@@ -65,6 +66,7 @@ class BaseLoggedInPage(View):
             Version >= 5.9 - list of all groups the logged in user is assigned to
             Version < 5.9 - single item list containing the user's current group
         """
+        # TODO: Move these locators and accessors to a widget "Group Dropdown" widget
         group_list_locator = '{}/ul/li'.format(self.group_list_locator)
         current_group_marker = ' (Current Group)'
 

--- a/cfme/fixtures/tag.py
+++ b/cfme/fixtures/tag.py
@@ -77,7 +77,7 @@ def user_restricted(appliance, group_with_tag, new_credential):
         name='user{}'.format(fauxfactory.gen_alphanumeric()),
         credential=new_credential,
         email='xyz@redhat.com',
-        group=group_with_tag,
+        groups=[group_with_tag],
         cost_center='Workload',
         value_assign='Database')
     yield user

--- a/cfme/tests/cloud_infra_common/test_vm_ownership.py
+++ b/cfme/tests/cloud_infra_common/test_vm_ownership.py
@@ -1,7 +1,6 @@
 import fauxfactory
 import pytest
 
-import cfme.configure.access_control as ac
 from cfme import test_requirements
 from cfme.base.credential import Credential
 from cfme.common.provider import CloudInfraProvider
@@ -115,7 +114,7 @@ def new_user(appliance, group_only_user_owned):
         name='user_' + fauxfactory.gen_alphanumeric(),
         credential=new_credential(),
         email='abc@redhat.com',
-        group=group_only_user_owned,
+        groups=[group_only_user_owned],
         cost_center='Workload',
         value_assign='Database'
     )
@@ -163,7 +162,9 @@ def test_user_ownership_crud(request, user1, setup_provider, provider, vm_crud):
 
 @pytest.mark.rhv3
 def test_group_ownership_on_user_only_role(request, user2, setup_provider, provider, vm_crud):
-    vm_crud.set_ownership(group=user2.group.description)
+    # user is only a member of a single group so it will always be the current group
+    user_group_name = user2.groups[0].description
+    vm_crud.set_ownership(group=user_group_name)
     with user2:
         assert not check_vm_exists(vm_crud), "vm exists! but shouldn't exist"
     vm_crud.set_ownership(user=user2.name)
@@ -174,7 +175,9 @@ def test_group_ownership_on_user_only_role(request, user2, setup_provider, provi
 @pytest.mark.rhv3
 def test_group_ownership_on_user_or_group_role(
         request, user3, setup_provider, provider, vm_crud):
-    vm_crud.set_ownership(group=user3.group.description)
+    # user is only a member of a single group so it will always be the current group
+    user_group_name = user3.groups[0].description
+    vm_crud.set_ownership(group=user_group_name)
     with user3:
         assert vm_crud.exists, "vm not found"
     vm_crud.unset_ownership()

--- a/cfme/tests/intelligence/reports/test_metering_report.py
+++ b/cfme/tests/intelligence/reports/test_metering_report.py
@@ -56,7 +56,7 @@ def vm_ownership(enable_candu, clean_setup_provider, provider, appliance):
         credential=Credential(principal='uid' + '{}'.format(fauxfactory.gen_alphanumeric()),
             secret='secret'),
         email='abc@example.com',
-        group=cb_group,
+        groups=cb_group,
         cost_center='Workload',
         value_assign='Database')
 

--- a/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
+++ b/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
@@ -70,7 +70,7 @@ def vm_ownership(enable_candu, clean_setup_provider, provider, appliance):
             name=provider.name + fauxfactory.gen_alphanumeric(),
             credential=new_credential(),
             email='abc@example.com',
-            group=cb_group,
+            groups=cb_group,
             cost_center='Workload',
             value_assign='Database')
         vm.set_ownership(user=user.name)


### PR DESCRIPTION
Add support for adding a user to multiple RBAC groups. Supported in version >= 5.9

access_control.UserCollection.create will allow you to create a user that is a member of multiple groups.
You can now check the currently assigned group and all assigned groups properly in 5.9

{{pytest: -v -k 'test_user_group_test_user_crud or test_user_assign_multiple_groups or test_user_group_error_validation or test_group_ownership_on_user_or_group_role or test_group_ownership_on_user_only_role'}}