### PR TITLE
[1LP][RFR] Automate test hard reboot for azure

### DIFF
--- a/cfme/cloud/instance/azure.py
+++ b/cfme/cloud/instance/azure.py
@@ -17,6 +17,7 @@ class AzureInstance(Instance):
     })
     # CFME-only power control options
     SOFT_REBOOT = "Soft Reboot"
+    HARD_REBOOT = "Hard Reboot"  # unsupported by azure, used for negative tests
     # Provider-only power control options
     RESTART = "Restart"
 

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -248,8 +248,8 @@ def test_hard_reboot(appliance, provider, testing_instance, verify_vm_running, s
     soft_assert(provider.mgmt.is_vm_running(testing_instance.name), "instance is not running")
 
 
-@pytest.mark.providers([AzureProvider])
-def test_hard_reboot_unsupported(appliance, provider, testing_instance):
+@pytest.mark.provider([AzureProvider])
+def test_hard_reboot_unsupported(testing_instance):
     """
     Tests that hard reboot throws an 'unsupported' error message on an Azure instance
 

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -248,7 +248,7 @@ def test_hard_reboot(appliance, provider, testing_instance, verify_vm_running, s
     soft_assert(provider.mgmt.is_vm_running(testing_instance.name), "instance is not running")
 
 
-@pytest.mark.provider([AzureProvider])
+@pytest.mark.uncollectif(lambda provider: not provider.one_of(AzureProvider))
 def test_hard_reboot_unsupported(testing_instance):
     """
     Tests that hard reboot throws an 'unsupported' error message on an Azure instance

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -248,7 +248,7 @@ def test_hard_reboot(appliance, provider, testing_instance, verify_vm_running, s
     soft_assert(provider.mgmt.is_vm_running(testing_instance.name), "instance is not running")
 
 
-@pytest.mark.uncollectif(lambda provider: not provider.one_of(AzureProvider))
+@pytest.mark.providers([AzureProvider])
 def test_hard_reboot_unsupported(appliance, provider, testing_instance):
     """
     Tests that hard reboot throws an 'unsupported' error message on an Azure instance
@@ -259,19 +259,7 @@ def test_hard_reboot_unsupported(appliance, provider, testing_instance):
     view = navigate_to(testing_instance, 'All')
     testing_instance.power_control_from_cfme(
         option=testing_instance.HARD_REBOOT, from_details=False)
-    assert len(view.flash.messages) > 0, "Expected a flash error message to be displayed"
-
-    error_msg_found = False
-    # Message we are looking for is...
-    #   "Reset does not apply to at least one of the selected items"
-    # ...but we leave out 'Reset' in case that text changes in the future
-    txt = "does not apply to at least one of the selected items"
-    for message in view.flash.messages:
-        if txt in message.read():
-            error_msg_found = True
-
-    assert error_msg_found, ("Expected to see error containing text '{}' after "
-                             "attempting unsupported hard reboot".format(txt))
+    view.flash.assert_message("Reset does not apply to at least one of the selected items")
 
 
 @pytest.mark.uncollectif(lambda provider: (not provider.one_of(OpenStackProvider) and

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -248,6 +248,32 @@ def test_hard_reboot(appliance, provider, testing_instance, verify_vm_running, s
     soft_assert(provider.mgmt.is_vm_running(testing_instance.name), "instance is not running")
 
 
+@pytest.mark.uncollectif(lambda provider: not provider.one_of(AzureProvider))
+def test_hard_reboot_unsupported(appliance, provider, testing_instance):
+    """
+    Tests that hard reboot throws an 'unsupported' error message on an Azure instance
+
+    Metadata:
+        test_flag: power_control, provision
+    """
+    view = navigate_to(testing_instance, 'All')
+    testing_instance.power_control_from_cfme(
+        option=testing_instance.HARD_REBOOT, from_details=False)
+    assert len(view.flash.messages) > 0, "Expected a flash error message to be displayed"
+
+    error_msg_found = False
+    # Message we are looking for is...
+    #   "Reset does not apply to at least one of the selected items"
+    # ...but we leave out 'Reset' in case that text changes in the future
+    txt = "does not apply to at least one of the selected items"
+    for message in view.flash.messages:
+        if txt in message.read():
+            error_msg_found = True
+
+    assert error_msg_found, ("Expected to see error containing text '{}' after "
+                             "attempting unsupported hard reboot".format(txt))
+
+
 @pytest.mark.uncollectif(lambda provider: (not provider.one_of(OpenStackProvider) and
                                            not provider.one_of(AzureProvider)))
 def test_suspend(appliance, provider, testing_instance, verify_vm_running, soft_assert):


### PR DESCRIPTION
{{ pytest: -v -k test_hard_reboot_unsupported --use-provider azure --long-running cfme/tests/cloud/test_instance_power_control.py }}

This is a negative test, hard reboot is not supported in azure and an error message should be thrown by CFME.