### PR TITLE
[RFR] Add support for RHEVM snapshots REST testing

### DIFF
--- a/cfme/utils/rest.py
+++ b/cfme/utils/rest.py
@@ -53,7 +53,9 @@ def assert_response(
                 num_sec=task_wait,
                 message='task state finished',
             )
-            assert task.status.lower() == 'ok', 'Task failed with status "{}"'.format(task.status)
+            task_message = getattr(task, 'message', '')
+            assert task.status.lower() == 'ok', (
+                'Task failed with status "{}", message "{}"'.format(task.status, task_message))
 
     if 'results' in content:
         results = content['results']


### PR DESCRIPTION
* support for testing snapshots on RHEVM
* test for BZ 1550551

{{pytest: -v --long-running cfme/tests/cloud_infra_common/test_snapshots_rest.py}}