### PR TITLE
[1LP][RFR] Enhancements to test_provisioning_rest

### DIFF
--- a/cfme/tests/infrastructure/test_provisioning_rest.py
+++ b/cfme/tests/infrastructure/test_provisioning_rest.py
@@ -2,19 +2,18 @@ import fauxfactory
 import pytest
 
 from cfme import test_requirements
-from cfme.common.vm import VM
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
-from cfme.utils.version import current_version
+from cfme.utils.rest import assert_response, query_resource_attributes
 from cfme.utils.wait import wait_for
 
 
 pytestmark = [
     test_requirements.provision,
     pytest.mark.tier(2),
-    pytest.mark.meta(server_roles="+automate"),
-    pytest.mark.usefixtures("setup_provider"),
-    pytest.mark.provider([VMwareProvider, RHEVMProvider], scope="module")
+    pytest.mark.meta(server_roles='+automate'),
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.provider([VMwareProvider, RHEVMProvider], scope='module')
 ]
 
 
@@ -29,7 +28,7 @@ def get_provision_data(rest_api, provider, template_name, auto_approve=True):
             guid = template.guid
             break
     else:
-        raise Exception("No such template {} on provider!".format(template_name))
+        raise Exception('No such template {} on provider!'.format(template_name))
 
     result = {
         "version": "1.1",
@@ -62,26 +61,29 @@ def get_provision_data(rest_api, provider, template_name, auto_approve=True):
     }
 
     if provider.one_of(RHEVMProvider):
-        result["vm_fields"]["provision_type"] = "native_clone"
+        result['vm_fields']['provision_type'] = 'native_clone'
         if provider.appliance.version > '5.9.0.16':
-            result["vm_fields"]["vlan"] = "<Template>"
+            result['vm_fields']['vlan'] = '<Template>'
 
     return result
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope='module')
 def provision_data(appliance, provider, small_template_modscope):
     return get_provision_data(appliance.rest_api, provider, small_template_modscope.name)
 
 
-def clean_vm(vm_name, provider):
-    vm_obj = VM.factory(vm_name=vm_name, provider=provider)
-    vm_obj.delete_from_provider()
+def clean_vm(appliance, vm_name):
+    found_vms = appliance.rest_api.collections.vms.find_by(name=vm_name)
+    if found_vms:
+        vm = found_vms[0]
+        vm.action.delete()
+        vm.wait_not_exists(num_sec=15, delay=2)
 
 
 # Here also available the ability to create multiple provision request, but used the save
 # href and method, so it doesn't make any sense actually
-def test_provision(request, provision_data, provider, appliance):
+def test_provision(request, appliance, provision_data):
     """Tests provision via REST API.
     Prerequisities:
         * Have a provider set up with templates suitable for provisioning.
@@ -92,17 +94,23 @@ def test_provision(request, provision_data, provider, appliance):
     Metadata:
         test_flag: rest, provision
     """
-    vm_name = provision_data["vm_fields"]["vm_name"]
-    request.addfinalizer(lambda: clean_vm(vm_name, provider))
-    appliance.rest_api.collections.provision_requests.action.create(**provision_data)
-    assert appliance.rest_api.response.status_code == 200
-    request = appliance.collections.requests.instantiate(description=vm_name, partial_check=True)
-    request.wait_for_request()
+    vm_name = provision_data['vm_fields']['vm_name']
+    request.addfinalizer(lambda: clean_vm(appliance, vm_name))
+    prov_request, = appliance.rest_api.collections.provision_requests.action.create(
+        **provision_data)
+    assert_response(appliance)
+    prov_request.reload()
+    wait_for(
+        lambda: prov_request.request_state == 'finished',
+        fail_func=prov_request.reload,
+        num_sec=600,
+        delay=10)
+    assert prov_request.status.lower() == 'ok'
+    found_vms = appliance.rest_api.collections.vms.find_by(name=vm_name)
+    assert found_vms, 'VM `{}` not found'.format(vm_name)
 
-    assert provider.mgmt.does_vm_exist(vm_name), "The VM {} does not exist!".format(vm_name)
 
-
-def test_create_pending_provision_requests(appliance, provider, small_template):
+def test_create_pending_provision_requests(request, appliance, provider, small_template):
     """Tests creation and and auto-approval of pending provision request
     using /api/provision_requests.
 
@@ -111,25 +119,31 @@ def test_create_pending_provision_requests(appliance, provider, small_template):
     """
     provision_data = get_provision_data(
         appliance.rest_api, provider, small_template.name, auto_approve=False)
-    response = appliance.rest_api.collections.provision_requests.action.create(**provision_data)
-    assert appliance.rest_api.response.status_code == 200
+    vm_name = provision_data['vm_fields']['vm_name']
+    request.addfinalizer(lambda: clean_vm(appliance, vm_name))
+    prov_request, = appliance.rest_api.collections.provision_requests.action.create(
+        **provision_data)
+    assert_response(appliance)
     # check that the `approval_state` is pending_approval
-    for prov_request in response:
-        assert prov_request.options['auto_approve'] is False
-        assert prov_request.approval_state == 'pending_approval'
+    assert prov_request.options['auto_approve'] is False
+    assert prov_request.approval_state == 'pending_approval'
     # The Automate approval process is running as part of the request workflow.
     # The request is within the specified parameters so it shall be auto-approved.
-    for prov_request in response:
-        prov_request.reload()
-        wait_for(
-            lambda: prov_request.approval_state == 'approved',
-            fail_func=prov_request.reload,
-            num_sec=300,
-            delay=10)
+    prov_request.reload()
+    wait_for(
+        lambda: prov_request.approval_state == 'approved',
+        fail_func=prov_request.reload,
+        num_sec=300,
+        delay=10)
+    # Wait for provisioning to finish
+    wait_for(
+        lambda: prov_request.request_state == 'finished',
+        fail_func=prov_request.reload,
+        num_sec=600,
+        delay=10)
 
 
-@pytest.mark.uncollectif(lambda: current_version() < '5.8')
-def test_provision_attributes(appliance, provider, small_template):
+def test_provision_attributes(appliance, provider, small_template, soft_assert):
     """Tests that it's possible to display additional attributes in /api/provision_requests/:id.
 
     Metadata:
@@ -137,11 +151,9 @@ def test_provision_attributes(appliance, provider, small_template):
     """
     provision_data = get_provision_data(
         appliance.rest_api, provider, small_template.name, auto_approve=False)
-    response = appliance.rest_api.collections.provision_requests.action.create(**provision_data)
-    assert appliance.rest_api.response.status_code == 200
-    provision_request = response[0]
+    provision_request, = appliance.rest_api.collections.provision_requests.action.create(
+        **provision_data)
+    assert_response(appliance)
     # workaround for BZ1437689 to make sure the vm is not provisioned
-    provision_request.action.deny(reason="denied")
-    provision_request.reload(attributes=('v_workflow_class', 'v_allowed_tags'))
-    assert provision_request.v_workflow_class
-    assert provision_request.v_allowed_tags
+    provision_request.action.deny(reason='denied')
+    query_resource_attributes(provision_request, soft_assert=soft_assert)


### PR DESCRIPTION
* more complete attributes checks
* replace some UI actions with REST counterparts
* better cleanup
* better results checking

{{pytest: -v --use-provider rhv41 cfme/tests/infrastructure/test_provisioning_rest.py}}