### PR TITLE
[1LP][RFR] Removing BZ wrapper for test_vm_reconfig_add_remove_hw_cold

### DIFF
--- a/cfme/tests/infrastructure/test_vm_reconfigure.py
+++ b/cfme/tests/infrastructure/test_vm_reconfigure.py
@@ -47,9 +47,6 @@ def ensure_vm_running(small_vm):
         raise Exception("Unknown power state - unable to continue!")
 
 
-@pytest.mark.meta(blockers=[BZ(1534520, forced_streams=['5.8', '5.9'],
-    unblock=lambda provider, change_type:
-        not provider.one_of(RHEVMProvider) or change_type != 'memory')])
 @pytest.mark.parametrize('change_type', ['cores_per_socket', 'sockets', 'memory'])
 def test_vm_reconfig_add_remove_hw_cold(
         provider, small_vm, ensure_vm_stopped, change_type):


### PR DESCRIPTION
__Removing__ wrapper. The bug still exists but we changed RHV-CFME integration env in a way that this test case can now be executed. I will create a test case that specifically covers this BZ afterwards.

{{pytest: cfme/tests/infrastructure/test_vm_reconfigure.py::test_vm_reconfig_add_remove_hw_cold[rhv41-memory] -vv --long-running}}