### PR TITLE
[WIPTEST] Cleaning appliance by rake commands

### DIFF
--- a/scripts/clean_appliance.py
+++ b/scripts/clean_appliance.py
@@ -40,14 +40,10 @@ def main():
         ssh_kwargs['hostname'] = args.hostname
 
     with SSHClient(stream_output=True, **ssh_kwargs) as ssh_client:
-        # Graceful stop is done here even though it is slower than killing ruby processes.
-        # Problem with killing ruby is that evm_watchdog gets spawned right after being killed
-        # and then prevents you from destroying the DB.
-        # Graceful stop makes sure there are no active connections to the DB left.
         print('Stopping evmserverd...')
-        ssh_client.run_command('systemctl stop evmserverd')
+        ssh_client.run_rake_command('evm:kill')
         ssh_client.run_rake_command('evm:db:reset', disable_db_check=True)
-        ssh_client.run_command('systemctl start evmserverd')
+        ssh_client.run_rake_command('evm:start')
 
         # SSHClient has the smarts to get our hostname if none was provided
         # Soon, utils.appliance.Appliance will be able to do all of this


### PR DESCRIPTION
__Changing__ clean_appliance.py utility script. Killing appliance by rake command here is 
a) faster
b) more reliable - no connections to the DB are left
