### PR TITLE
[1LP][RFR] Fixed Multiple requests error in ansible services tests

### DIFF
--- a/cfme/ansible/repositories.py
+++ b/cfme/ansible/repositories.py
@@ -174,7 +174,10 @@ class Repository(BaseEntity, Fillable):
         repo_list_page.flash.assert_no_error()
         repo_list_page.flash.assert_message(
             'Delete of Repository "{}" was successfully initiated.'.format(self.name))
-        wait_for(lambda: not self.exists, delay=10,
+        wait_for(
+            lambda: not self.exists,
+            delay=10,
+            timeout=120,
             fail_func=repo_list_page.browser.selenium.refresh)
 
     def refresh(self):


### PR DESCRIPTION
Intent
=================

`test_service_ansible_playbook_provision_in_requests` didn't contain a teardown and that affected on other tests.

{{pytest: -v -k "test_service_ansible_playbook_provision_in_requests or test_service_ansible_playbook_plays_table" --long-running}}