### PR TITLE
[1LP][RFR]Updated test_sdn_crud and test_sdn_navigation

### DIFF
--- a/cfme/tests/networks/test_sdn_crud.py
+++ b/cfme/tests/networks/test_sdn_crud.py
@@ -18,9 +18,8 @@ def test_sdn_crud(provider, appliance):
         and functional references to components on detail page
     Prerequisites: Cloud provider in cfme
     """
-
     view = navigate_to(provider, 'Details')
-    net_prov_name = view.entities.relationships.get_text_of("Network Manager")
+    net_prov_name = view.entities.summary("Relationships").get_text_of("Network Manager")
     collection = appliance.collections.network_providers
     network_provider = collection.instantiate(name=net_prov_name)
 

--- a/cfme/tests/networks/test_sdn_navigation.py
+++ b/cfme/tests/networks/test_sdn_navigation.py
@@ -17,7 +17,7 @@ pytestmark = [
                          "Security Groups", "Network Ports", "Load Balancers"])
 def test_provider_relationships_navigation(provider, tested_part, appliance):
     view = navigate_to(provider, 'Details')
-    net_prov_name = view.entities.relationships.get_text_of('Network Manager')
+    net_prov_name = view.entities.summary("Relationships").get_text_of("Network Manager")
 
     collection = NetworkProviderCollection(appliance)
     network_provider = collection.instantiate(name=net_prov_name)
@@ -30,7 +30,7 @@ def test_provider_relationships_navigation(provider, tested_part, appliance):
 
 def test_provider_topology_navigation(provider, appliance):
     view = navigate_to(provider, 'Details')
-    net_prov_name = view.entities.relationships.get_text_of('Network Manager')
+    net_prov_name = view.entities.summary("Relationships").get_text_of("Network Manager")
 
     collection = NetworkProviderCollection(appliance)
     network_provider = collection.instantiate(name=net_prov_name)


### PR DESCRIPTION
Purpose
=================
Updated _test_sdn_crud_ and _test_sdn_navigation_ due to get_details changes for providers view.

{{pytest: -vvv cfme/tests/networks -k "test_provider_relationships_navigation or test_provider_topology_navigation or test_sdn_crud"}}