### PR TITLE
[1LP][RFR] Adding hostname information in cfme_data in lenovo section

### DIFF
--- a/cfme/physical/provider/__init__.py
+++ b/cfme/physical/provider/__init__.py
@@ -16,6 +16,7 @@ from cfme.utils.pretty import Pretty
 from cfme.utils.varmeth import variable
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.log import logger
+from cfme.utils.net import resolve_hostname
 
 
 class PhysicalProvider(Pretty, BaseProvider, Fillable):
@@ -36,6 +37,14 @@ class PhysicalProvider(Pretty, BaseProvider, Fillable):
         self.endpoints = self._prepare_endpoints(endpoints)
         self.name = name
         self.key = key
+
+    @property
+    def hostname(self):
+        return getattr(self.default_endpoint, "hostname", None)
+
+    @property
+    def ip_address(self):
+        return getattr(self.default_endpoint, "ipaddress", resolve_hostname(str(self.hostname)))
 
     @variable(alias='ui')
     def num_server(self):

--- a/cfme/physical/provider/lenovo.py
+++ b/cfme/physical/provider/lenovo.py
@@ -31,8 +31,6 @@ class LenovoProvider(PhysicalProvider):
         super(LenovoProvider, self).__init__(
             appliance=appliance, name=name, key=key, endpoints=endpoints
         )
-        self.hostname = self.default_endpoint.view_value_mapping['hostname']
-        self.ip_address = self.hostname
 
     @classmethod
     def from_config(cls, prov_config, prov_key, appliance=None):

--- a/conf/cfme_data.yaml.template
+++ b/conf/cfme_data.yaml.template
@@ -170,6 +170,7 @@ management_systems:
             default:
                 credentials: lenovo
                 ipaddress: 10.0.0.1
+                hostname: lenovo.hostname
                 api_port: 3000
     nuage:
         name: nuage_net


### PR DESCRIPTION
Purpose or Intent
=================

__Updating `cfme_data.yaml.template`__ adding hostname information in `lenovo` section.

__Updating__ the way that Physical Providers access the `hostname` and `ip_address` information to follow the standard on project