### PR TITLE
[1LP][RFR] Extending clean_appliance.py

### DIFF
--- a/scripts/clean_appliance.py
+++ b/scripts/clean_appliance.py
@@ -18,6 +18,7 @@ import sys
 from cfme.utils.conf import credentials
 from cfme.utils.path import scripts_path
 from cfme.utils.ssh import SSHClient
+from cfme.utils.wait import wait_for_decorator
 
 
 def main():
@@ -29,6 +30,8 @@ def main():
                         help='SSH username for target appliance')
     parser.add_argument('password', nargs='?', default=credentials['ssh']['password'],
                         help='SSH password for target appliance')
+    parser.add_argument('-q', '--quiet', action='store_true', default=False,
+                        help='Do not print output of SSH commnads')
 
     args = parser.parse_args()
 
@@ -39,13 +42,23 @@ def main():
     if args.hostname is not None:
         ssh_kwargs['hostname'] = args.hostname
 
-    with SSHClient(stream_output=True, **ssh_kwargs) as ssh_client:
+    with SSHClient(stream_output=not args.quiet, **ssh_kwargs) as ssh_client:
         # Graceful stop is done here even though it is slower than killing ruby processes.
         # Problem with killing ruby is that evm_watchdog gets spawned right after being killed
         # and then prevents you from destroying the DB.
         # Graceful stop makes sure there are no active connections to the DB left.
         print('Stopping evmserverd...')
         ssh_client.run_command('systemctl stop evmserverd')
+
+        @wait_for_decorator(num_sec=60, delay=5)
+        def check_no_db_connections():
+            psql_cmd = '/opt/rh/rh-postgresql95/root/usr/bin/psql'
+            query = 'SELECT numbackends FROM pg_stat_database WHERE datname = \'vmdb_production\''
+            db = 'postgres'
+            response = ssh_client.run_command('{} -c "{}" -d "{}" -t'.format(psql_cmd, query, db))
+            db_connections = int(response.output.strip())
+            return db_connections == 0
+
         ssh_client.run_rake_command('evm:db:reset', disable_db_check=True)
         ssh_client.run_command('systemctl start evmserverd')
 

--- a/scripts/clean_appliance.py
+++ b/scripts/clean_appliance.py
@@ -15,6 +15,7 @@ import argparse
 import subprocess
 import sys
 
+from cfme.utils.appliance import IPAppliance
 from cfme.utils.conf import credentials
 from cfme.utils.path import scripts_path
 from cfme.utils.ssh import SSHClient
@@ -41,6 +42,12 @@ def main():
     }
     if args.hostname is not None:
         ssh_kwargs['hostname'] = args.hostname
+        appliance = IPAppliance(args.hostname)
+        if appliance.version < '5.9':
+            # Running evm:db:reset on CFME 5.8 sometimes leaves it in a state
+            # where it is unable to start again
+            print('EXITING: This script does not work reliably for CFME 5.8')
+            return 1
 
     with SSHClient(stream_output=not args.quiet, **ssh_kwargs) as ssh_client:
         # Graceful stop is done here even though it is slower than killing ruby processes.


### PR DESCRIPTION
__Extending__ clean_appliance.py utility script.
1) `-q` argument for quiet
2) Waiting for closing all DB connections. If you try to call evm:db:reset and some connections are still active, the call will fail
3) I noticed that evm:db:reset sometimes leaves appliance in a state from where it cannot be started using `systemctl start evmserverd`. AFAIK this only happens with 5.8. Therefore handling this with condition.