### PR TITLE
[RFR] update flash message of edit subnet

### DIFF
--- a/cfme/networks/subnet.py
+++ b/cfme/networks/subnet.py
@@ -44,7 +44,7 @@ class Subnet(WidgetasticTaggable, BaseEntity):
         view.fill({'subnet_name': new_name,
                    'gateway': gateway})
         view.save.click()
-        view.flash.assert_success_message('Network Subnet "{}" updated'.format(new_name))
+        view.flash.assert_success_message('Cloud Subnet "{}" updated'.format(new_name))
         self.name = new_name
 
     def delete(self):


### PR DESCRIPTION
Purpose or Intent
The flash message of edit subnet was changed from Network Subnet "subnet" updated to Cloud Subnet "subnet" updated which fails assert_success_message operation

{{ pytest: cfme/tests/openstack/cloud/test_networks.py::test_edit_subnet }}