### PR TITLE
[1LP][RFR] Add test for power_on_or_off_multiple, consolidate some common code

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -724,10 +724,16 @@ class VM(BaseVM):
         vm = self.name
 
         def _suspended():
-            return mgmt.can_suspend and mgmt.is_vm_suspended(vm)
+            try:
+                return mgmt.can_suspend and mgmt.is_vm_suspended(vm)
+            except (NotImplementedError, exceptions.ActionNotSupported):
+                return False
 
         def _paused():
-            return mgmt.can_pause and mgmt.is_vm_paused(vm)
+            try:
+                return mgmt.can_pause and mgmt.is_vm_paused(vm)
+            except (NotImplementedError, exceptions.ActionNotSupported):
+                return False
 
         if state == self.STATE_ON:
             return self._handle_transition(

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -228,7 +228,7 @@ def test_quadicon_terminate(appliance, provider, testing_instance, ensure_vm_run
                                                                 timeout=1200))
 
 
-@pytest.mark.uncollectif(lambda provider: not provider.one_of(OpenStackProvider))
+@pytest.mark.uncollectif(lambda provider: not provider.one_of(AzureProvider, OpenStackProvider))
 def test_stop(appliance, provider, testing_instance, ensure_vm_running, soft_assert):
     """ Tests instance stop
 
@@ -358,8 +358,7 @@ def test_hard_reboot_unsupported(testing_instance):
     view.flash.assert_message("Reset does not apply to at least one of the selected items")
 
 
-@pytest.mark.uncollectif(lambda provider: (not provider.one_of(OpenStackProvider) and
-                                           not provider.one_of(AzureProvider)))
+@pytest.mark.uncollectif(lambda provider: not provider.one_of(AzureProvider, OpenStackProvider))
 def test_suspend(appliance, provider, testing_instance, ensure_vm_running, soft_assert):
     """ Tests instance suspend
 
@@ -394,8 +393,7 @@ def test_unpause(appliance, provider, testing_instance, ensure_vm_paused, soft_a
 
 
 
-@pytest.mark.uncollectif(lambda provider: (not provider.one_of(OpenStackProvider) and
-                                           not provider.one_of(AzureProvider)))
+@pytest.mark.uncollectif(lambda provider: not provider.one_of(AzureProvider, OpenStackProvider))
 def test_resume(appliance, provider, testing_instance, ensure_vm_suspended, soft_assert):
     """ Tests instance resume
 
@@ -467,9 +465,9 @@ class TestInstanceRESTAPI(object):
             assert success
         return success, message
 
-    @pytest.mark.uncollectif(lambda provider: provider.one_of(OpenStackProvider))
+    @pytest.mark.uncollectif(lambda provider: not provider.one_of(AzureProvider, OpenStackProvider))
     @pytest.mark.parametrize("from_detail", [True, False], ids=["from_detail", "from_collection"])
-    def testest_stop(self, provider, testing_instance, ensure_vm_running,
+    def test_stop(self, provider, testing_instance, ensure_vm_running,
             soft_assert, appliance, from_detail):
         """ Tests instance stop
 

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -17,7 +17,7 @@ pytestmark = [
     pytest.mark.tier(2),
     pytest.mark.long_running,
     test_requirements.power,
-    pytest.mark.provider([CloudProvider], scope='module', required_fields=['test_power_control']),
+    pytest.mark.provider([CloudProvider], scope='function', required_fields=['test_power_control']),
     pytest.mark.usefixtures('setup_provider'),
 ]
 
@@ -228,7 +228,6 @@ def test_quadicon_terminate(appliance, provider, testing_instance, ensure_vm_run
                                                                 timeout=1200))
 
 
-@pytest.mark.uncollectif(lambda provider: not provider.one_of(AzureProvider, OpenStackProvider))
 def test_stop(appliance, provider, testing_instance, ensure_vm_running, soft_assert):
     """ Tests instance stop
 
@@ -392,7 +391,6 @@ def test_unpause(appliance, provider, testing_instance, ensure_vm_paused, soft_a
     wait_for_instance_state(soft_assert, provider, testing_instance, state="started")
 
 
-
 @pytest.mark.uncollectif(lambda provider: not provider.one_of(AzureProvider, OpenStackProvider))
 def test_resume(appliance, provider, testing_instance, ensure_vm_suspended, soft_assert):
     """ Tests instance resume
@@ -465,7 +463,6 @@ class TestInstanceRESTAPI(object):
             assert success
         return success, message
 
-    @pytest.mark.uncollectif(lambda provider: not provider.one_of(AzureProvider, OpenStackProvider))
     @pytest.mark.parametrize("from_detail", [True, False], ids=["from_detail", "from_collection"])
     def test_stop(self, provider, testing_instance, ensure_vm_running,
             soft_assert, appliance, from_detail):

--- a/cfme/tests/cloud_infra_common/test_power_control_rest.py
+++ b/cfme/tests/cloud_infra_common/test_power_control_rest.py
@@ -76,7 +76,7 @@ def verify_action_result(rest_api, assert_success=True):
 
 
 @pytest.mark.rhv2
-def test_stop_vm_rest(appliance, vm_obj, verify_vm_running, soft_assert, from_detail):
+def test_stop_vm_rest(appliance, vm_obj, ensure_vm_running, soft_assert, from_detail):
     """Test stop of vm
 
     Prerequisities:
@@ -107,7 +107,7 @@ def test_stop_vm_rest(appliance, vm_obj, verify_vm_running, soft_assert, from_de
 
 
 @pytest.mark.rhv2
-def test_start_vm_rest(appliance, vm_obj, verify_vm_stopped, soft_assert, from_detail):
+def test_start_vm_rest(appliance, vm_obj, ensure_vm_stopped, soft_assert, from_detail):
     """Test start vm
 
     Prerequisities:
@@ -138,7 +138,7 @@ def test_start_vm_rest(appliance, vm_obj, verify_vm_stopped, soft_assert, from_d
 
 
 @pytest.mark.rhv2
-def test_suspend_vm_rest(appliance, vm_obj, verify_vm_running, soft_assert, from_detail):
+def test_suspend_vm_rest(appliance, vm_obj, ensure_vm_running, soft_assert, from_detail):
     """Test suspend vm
 
     Prerequisities:

--- a/cfme/tests/distributed/test_appliance_replication.py
+++ b/cfme/tests/distributed/test_appliance_replication.py
@@ -303,7 +303,7 @@ def test_appliance_replicate_database_disconnection_with_backlog(request, virtua
 
 @pytest.mark.tier(2)
 @pytest.mark.ignore_stream("upstream", "5.7")  # no config->diagnostics->replication tab in 5.7
-def test_distributed_vm_power_control(request, test_vm, virtualcenter_provider, verify_vm_running,
+def test_distributed_vm_power_control(request, test_vm, virtualcenter_provider, ensure_vm_running,
                                       register_event, soft_assert):
     """Tests that a replication parent appliance can control the power state of a
     VM being managed by a replication child appliance.

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -151,7 +151,7 @@ def wait_for_vm_tools(vm, timeout=300):
 class TestControlOnQuadicons(object):
 
     @pytest.mark.rhv3
-    def test_power_off_cancel(self, testing_vm, verify_vm_running, soft_assert):
+    def test_power_off_cancel(self, testing_vm, ensure_vm_running, soft_assert):
         """Tests power off cancel
 
         Metadata:
@@ -168,7 +168,7 @@ class TestControlOnQuadicons(object):
             testing_vm.provider.mgmt.is_vm_running(testing_vm.name), "vm not running")
 
     @pytest.mark.rhv1
-    def test_power_off(self, appliance, testing_vm, verify_vm_running, soft_assert):
+    def test_power_off(self, appliance, testing_vm, ensure_vm_running, soft_assert):
         """Tests power off
 
         Metadata:
@@ -188,7 +188,7 @@ class TestControlOnQuadicons(object):
             not testing_vm.provider.mgmt.is_vm_running(testing_vm.name), "vm running")
 
     @pytest.mark.rhv3
-    def test_power_on_cancel(self, testing_vm, verify_vm_stopped, soft_assert):
+    def test_power_on_cancel(self, testing_vm, ensure_vm_stopped, soft_assert):
         """Tests power on cancel
 
         Metadata:
@@ -205,7 +205,7 @@ class TestControlOnQuadicons(object):
 
     @pytest.mark.rhv1
     @pytest.mark.tier(1)
-    def test_power_on(self, appliance, testing_vm, verify_vm_stopped, soft_assert):
+    def test_power_on(self, appliance, testing_vm, ensure_vm_stopped, soft_assert):
         """Tests power on
 
         Metadata:
@@ -228,7 +228,7 @@ class TestControlOnQuadicons(object):
 class TestVmDetailsPowerControlPerProvider(object):
 
     @pytest.mark.rhv3
-    def test_power_off(self, appliance, testing_vm, verify_vm_running, soft_assert):
+    def test_power_off(self, appliance, testing_vm, ensure_vm_running, soft_assert):
         """Tests power off
 
         Metadata:
@@ -256,7 +256,7 @@ class TestVmDetailsPowerControlPerProvider(object):
                         "ui: {} should ==  orig: {}".format(new_last_boot_time, last_boot_time))
 
     @pytest.mark.rhv3
-    def test_power_on(self, appliance, testing_vm, verify_vm_stopped, soft_assert):
+    def test_power_on(self, appliance, testing_vm, ensure_vm_stopped, soft_assert):
         """Tests power on
 
         Metadata:
@@ -277,7 +277,7 @@ class TestVmDetailsPowerControlPerProvider(object):
             testing_vm.provider.mgmt.is_vm_running(testing_vm.name), "vm not running")
 
     @pytest.mark.rhv3
-    def test_suspend(self, appliance, testing_vm, verify_vm_running, soft_assert):
+    def test_suspend(self, appliance, testing_vm, ensure_vm_running, soft_assert):
         """Tests suspend
 
         Metadata:
@@ -412,21 +412,21 @@ def test_orphaned_vm_status(testing_vm, orphaned_vm):
 
 @pytest.mark.rhv1
 @pytest.mark.uncollectif(lambda provider: provider.one_of(RHEVMProvider))
-def test_power_options_from_on(provider, soft_assert, testing_vm, verify_vm_running):
+def test_power_options_from_on(provider, soft_assert, testing_vm, ensure_vm_running):
     testing_vm.wait_for_vm_state_change(
         desired_state=testing_vm.STATE_ON, timeout=720, from_details=True)
     check_power_options(provider, soft_assert, testing_vm, testing_vm.STATE_ON)
 
 
 @pytest.mark.rhv3
-def test_power_options_from_off(provider, soft_assert, testing_vm, verify_vm_stopped):
+def test_power_options_from_off(provider, soft_assert, testing_vm, ensure_vm_stopped):
     testing_vm.wait_for_vm_state_change(
         desired_state=testing_vm.STATE_OFF, timeout=720, from_details=True)
     check_power_options(provider, soft_assert, testing_vm, testing_vm.STATE_OFF)
 
 
 @pytest.mark.uncollectif(lambda provider: not provider.one_of(VMwareProvider))
-def test_guest_os_reset(appliance, testing_vm_tools, verify_vm_running, soft_assert):
+def test_guest_os_reset(appliance, testing_vm_tools, ensure_vm_running, soft_assert):
     testing_vm_tools.wait_for_vm_state_change(
         desired_state=testing_vm_tools.STATE_ON, timeout=720, from_details=True)
     wait_for_vm_tools(testing_vm_tools)
@@ -445,7 +445,7 @@ def test_guest_os_reset(appliance, testing_vm_tools, verify_vm_running, soft_ass
 
 
 @pytest.mark.uncollectif(lambda provider: not provider.one_of(VMwareProvider))
-def test_guest_os_shutdown(appliance, testing_vm_tools, verify_vm_running, soft_assert):
+def test_guest_os_shutdown(appliance, testing_vm_tools, ensure_vm_running, soft_assert):
     testing_vm_tools.wait_for_vm_state_change(
         desired_state=testing_vm_tools.STATE_ON, timeout=720, from_details=True)
     wait_for_vm_tools(testing_vm_tools)


### PR DESCRIPTION
{{ pytest: -v --ui-coverage --long-running -k test_hard_reboot -k test_hard_reboot_unsupported -k  test_suspend -k test_unpause -k test_resume -k test_suspend_resume -k test_pause_unpause -k test_power_on_or_off_multiple --use-provider azure --use-provider openstack cfme/tests/cloud/test_instance_power_control.py }}

This PR is for automating the 'power_on_or_off_multiple" test case (which tests selecting multiple instances from the quadicons/collections view and performing a power action on them)

While writing this I ran into some code I needed to re-factor
1) I needed 2 occurences of the `testing_instance` fixture, so I pulled the logic for creating the instance out into its own method (`create_instance`) to re-use it twice. If I had to create more than 2 maybe I'd do something craftier but keeping it simple for now.

2) The tests in this file re-used the same code to verify instances moved into 'started'/'stopped' state so I moved that duplicate code into a method. This is improving the soft_asserts that were randomly failing in some tests.

3) The `verify_vm_running`, `verify_vm_stopped`, etc. fixtures from `fixtures.virtual_machine` only work on 1 VM (since they depend on the `vm_name` fixture). I needed to use this functionality for 2 VM's without relying on a fixture, so I pulled out the logic and put it into cfme.common.provider. While I did that, I also consolidated the 4 methods into 1, since they were 4 very similar methods with the same logic flow. Not sure if the way I've implemented it now is an approach people like, let me know if it is too over-lambda'd and you'd rather just have 4 methods again ;)