### PR TITLE
[1LP][RFR] Removed vm/host_rising in test_utilization_metrics.

### DIFF
--- a/cfme/tests/test_utilization_metrics.py
+++ b/cfme/tests/test_utilization_metrics.py
@@ -62,10 +62,12 @@ def metrics_collection(appliance, clean_setup_provider, provider, enable_candu):
     """
     metrics_tbl = appliance.db.client['metrics']
     mgmt_systems_tbl = appliance.db.client['ext_management_systems']
+
     logger.info("Fetching provider ID for %s", provider.key)
     mgmt_system_id = appliance.db.client.session.query(mgmt_systems_tbl).filter(
         mgmt_systems_tbl.name == conf.cfme_data.get('management_systems', {})[provider.key]['name']
     ).first().id
+
     logger.info("ID fetched; testing metrics collection now")
     start_time = time.time()
     host_count = 0

--- a/cfme/tests/test_utilization_metrics.py
+++ b/cfme/tests/test_utilization_metrics.py
@@ -52,6 +52,7 @@ def clean_setup_provider(request, provider):
     yield
     BaseProvider.clear_providers()
 
+
 @pytest.fixture(scope="module")
 def metrics_collection(appliance, clean_setup_provider, provider, enable_candu):
     """Check the db is gathering collection data for the given provider.


### PR DESCRIPTION
Removed  vm/host_rising in test_utilization_metrics because it was necessary for host and vm to report metrics within 15 seconds interval. It should be sufficient to wait until non-zero number of metrics are reported by host and vm.