### PR TITLE
[1LP][WIPTEST]skip unsupported hardware warning during PXE provision

### DIFF
--- a/data/rhel6.cfg
+++ b/data/rhel6.cfg
@@ -46,7 +46,7 @@ logging --level=info
 poweroff
 # System timezone
 timezone  America/New_York
-# Skip Unsupported Hardware warning
+# Skip Unsupported Hardware warning - https://bugzilla.redhat.com/show_bug.cgi?id=824963
 unsupported_hardware
 # System bootloader configuration
 # Clear the Master Boot Record

--- a/data/rhel6.cfg
+++ b/data/rhel6.cfg
@@ -46,6 +46,8 @@ logging --level=info
 poweroff
 # System timezone
 timezone  America/New_York
+# Skip Unsupported Hardware warning
+unsupported_hardware
 # System bootloader configuration
 # Clear the Master Boot Record
 zerombr


### PR DESCRIPTION
Purpose or Intent
=================
Recent image is rhel63 is a bit outdated. PXE provision on rhv41 stucks on "Unsupported hardware warning" message. with MR will pass it safely 
{{pytest: -k "test_pxe_provision" --long-running --use-provider complete}}