### PR TITLE
[1LP][RFR] Add Nuage to the RECOGNIZED_BY_CREDS list

### DIFF
--- a/cfme/networks/provider/__init__.py
+++ b/cfme/networks/provider/__init__.py
@@ -28,7 +28,7 @@ from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep,
 from cfme.utils.log import logger
 
 
-@attr.s
+@attr.s(hash=False)
 class NetworkProvider(BaseProvider, WidgetasticTaggable, BaseEntity):
     """ Class representing network provider in sdn
 

--- a/cfme/networks/provider/nuage.py
+++ b/cfme/networks/provider/nuage.py
@@ -29,7 +29,7 @@ class NuageEndpointForm(View):
         api_port = Input('default_api_port')
 
 
-@attr.s
+@attr.s(hash=False)
 class NuageProvider(NetworkProvider):
     """ Class representing network provider in sdn
 

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -47,7 +47,7 @@ RUNNING_UNDER_SPROUT = os.environ.get("RUNNING_UNDER_SPROUT", "false") != "false
 RECOGNIZED_BY_IP = [
     "InfraManager", "ContainerManager", "Openstack::CloudManager"
 ]
-RECOGNIZED_BY_CREDS = ["CloudManager"]
+RECOGNIZED_BY_CREDS = ["CloudManager", "Nuage::NetworkManager"]
 
 # A helper for the IDs
 SEQ_FACT = 1e12


### PR DESCRIPTION
With this commit we add Nuage provder to the RECOGNIZED_BY_CREDS in order to make fixtures work again. Doing this it turns out that Nuage provider is not hashable, which causes problems when adding it to a set(), which we also fix in this commit.