### PR TITLE
[1LP][RFR] exists() method converted to a property

### DIFF
--- a/cfme/services/myservice/__init__.py
+++ b/cfme/services/myservice/__init__.py
@@ -17,7 +17,7 @@ class MyService(Updateable, Navigatable, WidgetasticTaggable, sentaku.modeling.E
     update = sentaku.ContextualMethod()
     retire = sentaku.ContextualMethod()
     retire_on_date = sentaku.ContextualMethod()
-    exists = sentaku.ContextualMethod()
+    exists = sentaku.ContextualProperty()
     delete = sentaku.ContextualMethod()
     set_ownership = sentaku.ContextualMethod()
     edit_tags = sentaku.ContextualMethod()

--- a/cfme/services/myservice/ui.py
+++ b/cfme/services/myservice/ui.py
@@ -241,7 +241,7 @@ def update(self, updates):
     assert view.is_displayed
 
 
-@MiqImplementationContext.external_for(MyService.exists, ViaUI)
+@MiqImplementationContext.external_for(MyService.exists.getter, ViaUI)
 def exists(self):
     try:
         navigate_to(self, 'Details')


### PR DESCRIPTION
Purpose
=================

MyService class should have `exists` property, not a method. This property is heavily used in ansible tests.

{{pytest: -v -k "test_custom_button_ansible_credential_list" --long-running}}
