### PR TITLE
[WIPTEST]Updating test_datastores_summary

### DIFF
--- a/cfme/tests/intelligence/reports/test_canned_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_canned_corresponds.py
@@ -142,20 +142,11 @@ def test_datastores_summary(soft_assert, appliance, request):
     vms = adb['vms']
     host_storages = adb['host_storages']
 
-    path = ["Configuration Management", "Storage", "Datastores Summary"]
-    report = CannedSavedReport.new(path)
+    storages_in_db_list = []
+    report_rows_list = []
 
     storages_in_db = adb.session.query(storages.store_type, storages.free_space,
                                        storages.total_space, storages.name, storages.id).all()
-
-    assert len(storages_in_db) == len(list(report.data.rows))
-
-    @request.addfinalizer
-    def _finalize():
-        report.delete()
-
-    storages_in_db_list = []
-    report_rows_list = []
 
     for store in storages_in_db:
 
@@ -176,6 +167,15 @@ def test_datastores_summary(soft_assert, appliance, request):
         }
 
         storages_in_db_list.append(store_dict)
+
+    path = ["Configuration Management", "Storage", "Datastores Summary"]
+    report = CannedSavedReport.new(path)
+
+    assert len(storages_in_db) == len(list(report.data.rows))
+
+    @request.addfinalizer
+    def _finalize():
+        report.delete()
 
     for row in report.data.rows:
 


### PR DESCRIPTION
Purpose
=================
Updating _test_datastores_summary_ to decrease the delay between creating a report via UI and querying db. Because time to time while running regression we are able to see different values in a report and in the database which causes failure of the test. It could be caused by other slaves which provision VM at that time.

{{pytest: -vvv cfme/tests/intelligence/reports/test_canned_corresponds.py -k test_datastores_summary --use-provider complete --long-running}}
