### PR TITLE
[1LP][RFR] Fix sdn_add_topology

### DIFF
--- a/cfme/common/topology.py
+++ b/cfme/common/topology.py
@@ -58,7 +58,8 @@ class BaseTopologyView(BaseLoggedInPage):
 
         @property
         def is_enabled(self):
-            return 'active' in self.browser.get_attribute('class', self.el)
+            el = self.browser.element('./ancestor::kubernetes-topology-icon[1]', self.el)
+            return 'active' in self.browser.get_attribute('class', el)
 
         def enable(self):
             if not self.is_enabled:

--- a/cfme/tests/networks/test_sdn_topology.py
+++ b/cfme/tests/networks/test_sdn_topology.py
@@ -1,11 +1,15 @@
 import pytest
 import random
 
+from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.ec2 import EC2Provider
+from cfme.cloud.provider.gce import GCEProvider
+from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.utils.wait import wait_for
 
 
-pytestmark = [pytest.mark.provider([EC2Provider], scope='module')]
+pytestmark = [pytest.mark.provider([EC2Provider, AzureProvider, GCEProvider, OpenStackProvider],
+                                   scope='module')]
 
 
 @pytest.yield_fixture(scope='module')
@@ -43,9 +47,9 @@ def test_topology_toggle_display(elements_collection):
     for state in (True, False):
         for legend in elements_collection.legends:
             if state:
-                elements_collection.enable_legend(legend)
-            else:
                 elements_collection.disable_legend(legend)
+            else:
+                elements_collection.enable_legend(legend)
             for element in elements_collection.all():
                 assert (
                     element.type != ''.join(legend.split()).rstrip('s') or

--- a/cfme/tests/networks/test_sdn_topology.py
+++ b/cfme/tests/networks/test_sdn_topology.py
@@ -6,7 +6,7 @@ from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.utils.wait import wait_for
-
+from cfme.utils.log import logger
 
 pytestmark = [pytest.mark.provider([EC2Provider, AzureProvider, GCEProvider, OpenStackProvider],
                                    scope='module')]
@@ -24,11 +24,13 @@ def elements_collection(setup_provider_modscope, appliance, provider):
 def test_topology_search(request, elements_collection):
     """Testing search functionality in Topology view."""
     elements = elements_collection.all()
+    logger.info(str(elements))
     element_to_search = random.choice(elements)
     search_term = element_to_search.name[:len(element_to_search.name) / 2]
     elements_collection.search(search_term)
     request.addfinalizer(elements_collection.clear_search)
     for element in elements:
+        logger.info(str(element))
         if search_term in element.name:
             assert not element.is_opaqued, (
                 'Element should be not opaqued. Search: "{}", found: "{}"'.format(


### PR DESCRIPTION
Add more providers to the test
And fix it ( it was only disabliing the items otherwise)
 {{pytest: -v -q cfme/tests/networks/test_sdn_topology.py --use-provider=complete}}