### PR TITLE
[WIP] Fixing reconfigure method of Vm class

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -874,6 +874,11 @@ class Vm(VM):
         fill_data = {k: v for k, v in changes.iteritems() if k != 'disks'}
         vm_recfg.fill(fill_data)
 
+        if changes.get('memory') is True:
+            message = 'Memory'
+        elif changes.get('cpu') is True:
+            message = 'Processor'
+
         for disk_change in changes['disks']:
             action, disk = disk_change['action'], disk_change['disk']
             if action == 'add':


### PR DESCRIPTION
__Fixing__ `Vm.reconfigure` method. This [commit](https://github.com/ManageIQ/integration_tests/commit/d11836757673657cc7869f3ff5623818c86d8545#diff-6f41c1fa9274bafe553bb07c77254388R920) introduced following situation:
If `changes['disks']` is empty at this [point](https://github.com/ManageIQ/integration_tests/blob/14c83fd7a68eaaaf935d4e509f28753110101a33/cfme/infrastructure/virtual_machines.py#L877) it will cause `message` variable to be undefined [here](https://github.com/ManageIQ/integration_tests/blob/14c83fd7a68eaaaf935d4e509f28753110101a33/cfme/infrastructure/virtual_machines.py#L924).

Resulting error:
> UnboundLocalError: local variable 'message' referenced before assignment

The proposed way is more of a quick fix so the test does not fail than real solution. However the proper way to do it would be more complex because we can do reconfigure request with more than one item to be reconfigured.

{{pytest: cfme/tests/infrastructure/test_vm_reconfigure.py::test_vm_reconfig_add_remove_hw_cold -vv --use-provider rhv41 --long-running}}