### PR TITLE
[1LP][RFR] Turn eventing ON for Nuage provider

### DIFF
--- a/cfme/networks/views.py
+++ b/cfme/networks/views.py
@@ -3,7 +3,7 @@ from widgetastic_patternfly import (Dropdown, Accordion, Button, TextInput,
                                     BootstrapSwitch, BootstrapSelect)
 
 from cfme.base.login import BaseLoggedInPage
-from cfme.common.provider_views import ProviderAddView
+from cfme.common.provider_views import ProviderAddView, ProviderEditView
 from widgetastic_manageiq import (ManageIQTree, SummaryTable, ItemsToolBarViewSelector,
                                   BaseEntitiesView)
 
@@ -93,6 +93,15 @@ class NetworkProviderDetailsView(BaseLoggedInPage):
         return (super(BaseLoggedInPage, self).is_displayed and
                 self.navigation.currently_selected == ['Networks', 'Providers'] and
                 self.title.text == '{name} (Summary)'.format(name=self.context['object'].name))
+
+
+class NetworkProviderEditView(ProviderEditView):
+    """ Represents Network Provider Edit View """
+    @property
+    def is_displayed(self):
+        return (super(NetworkProviderEditView, self).is_displayed and
+                self.navigation.currently_selected == ['Networks', 'Providers'] and
+                self.title.text.startswith('Edit Network Provider'))
 
 
 class BalancerToolBar(View):

--- a/cfme/tests/networks/test_network_providers.py
+++ b/cfme/tests/networks/test_network_providers.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
+import fauxfactory
 import pytest
 from widgetastic.exceptions import MoveTargetOutOfBoundsException
 
 from cfme.utils import error
+from cfme.utils.update import update
 from cfme.utils.blockers import BZ
 from cfme.common.provider_views import NetworkProvidersView
 from cfme import test_requirements
@@ -47,7 +49,7 @@ def test_provider_add_with_bad_credentials(provider):
 
 
 @pytest.mark.smoke
-def test_provider_create_new_then_delete(provider, has_no_networks_providers):
+def test_provider_crud(provider, has_no_networks_providers):
     """ Tests provider add with good credentials
 
     Metadata:
@@ -55,5 +57,13 @@ def test_provider_create_new_then_delete(provider, has_no_networks_providers):
     """
     provider.create()
     provider.validate_stats(ui=True)
+
+    old_name = provider.name
+    with update(provider):
+        provider.name = fauxfactory.gen_alphanumeric(8)
+
+    with update(provider):
+        provider.name = old_name  # old name
+
     provider.delete(cancel=False)
     provider.wait_for_delete()

--- a/conf/cfme_data.yaml.template
+++ b/conf/cfme_data.yaml.template
@@ -180,6 +180,12 @@ management_systems:
                 credentials: nuage
                 security_protocol: Non-SSL
                 api_port: 5000
+            events:
+                event_stream: AMQP
+                hostname: 10.0.0.1
+                api_port: 5672
+                security_protocol: Non-SSL
+                credentials: nuage_events
     openshift:
         name: openshift
         type: openshift

--- a/conf/credentials.yaml.template
+++ b/conf/credentials.yaml.template
@@ -32,6 +32,9 @@ lenovo:
 nuage:
   username: admin
   password: smartvm
+nuage_events:
+  username: admin@system
+  password: smartvm
 vcloud:
   username: admin
   organization: admin


### PR DESCRIPTION
With this commit we extend Nuage provider so that it now inputs AMQP credentials upon creation as well. Until now we were only inputing the Default credentials.

Also, with this commit we update test that was only testing
- CREATE
- RETRIEVE
- DELETE

of Nuage provider to now also validate

- UPDATE

which gives us a complete CRUD test in the end.
