### PR TITLE
[1LP][RFR] Add appliance methods for querying/modifying disabled regions

### DIFF
--- a/cfme/cloud/provider/azure.py
+++ b/cfme/cloud/provider/azure.py
@@ -32,6 +32,7 @@ class AzureProvider(CloudProvider):
     db_types = ["Azure::CloudManager"]
     endpoints_form = AzureEndpointForm
     discover_name = "Azure"
+    settings_key = 'ems_azure'
 
     def __init__(self, name=None, endpoints=None, zone=None, key=None, region=None,
                  tenant_id=None, subscription_id=None, appliance=None):

--- a/cfme/cloud/provider/ec2.py
+++ b/cfme/cloud/provider/ec2.py
@@ -45,6 +45,7 @@ class EC2Provider(CloudProvider):
     db_types = ["Amazon::CloudManager"]
     endpoints_form = EC2EndpointForm
     discover_name = "Amazon EC2"
+    settings_key = 'ems_amazon'
 
     def __init__(
             self, name=None, endpoints=None, zone=None, key=None, region=None, region_name=None,

--- a/cfme/cloud/provider/gce.py
+++ b/cfme/cloud/provider/gce.py
@@ -36,6 +36,7 @@ class GCEProvider(CloudProvider):
     mgmt_class = GoogleCloudSystem
     db_types = ["Google::CloudManager"]
     endpoints_form = GCEEndpointForm
+    settings_key = 'ems_google'
 
     def __init__(self, name=None, project=None, zone=None, region=None, region_name=None,
                  endpoints=None, key=None, appliance=None):

--- a/cfme/cloud/provider/openstack.py
+++ b/cfme/cloud/provider/openstack.py
@@ -16,6 +16,8 @@ class OpenStackProvider(CloudProvider):
     mgmt_class = OpenstackSystem
     db_types = ["Openstack::CloudManager"]
     endpoints_form = OpenStackInfraEndpointForm
+    settings_key = 'ems_openstack'
+
     # xpath locators for elements, to be used by selenium
     _console_connection_status_element = '//*[@id="noVNC_status"]'
     _canvas_element = '//*[@id="noVNC_canvas"]'

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -56,6 +56,7 @@ class BaseProvider(WidgetasticTaggable, Updateable, Navigatable):
     STATS_TO_MATCH = []
     db_types = ["Providers"]
     ems_events = []
+    settings_key = None
 
     def __hash__(self):
         return hash(self.key) ^ hash(type(self))
@@ -684,7 +685,7 @@ class BaseProvider(WidgetasticTaggable, Updateable, Navigatable):
     def wait_for_delete(self):
         try:
             provider_rest = self.appliance.rest_api.collections.providers.get(name=self.name)
-        except ValueError:
+        except (ValueError, APIException):  # if the record doesn't exist, APIException from 404
             return
 
         logger.info('Waiting for a provider to delete...')

--- a/cfme/containers/provider/kubernetes.py
+++ b/cfme/containers/provider/kubernetes.py
@@ -6,6 +6,7 @@ class KubernetesProvider(ContainersProvider):
     type_name = "kubernetes"
     mgmt_class = Kubernetes
     db_types = ["Kubernetes::ContainerManager"]
+    settings_key = 'ems_kubernetes'
 
     def __init__(self, name=None, credentials=None, key=None, zone=None, hostname=None, port=None,
                  sec_protocol=None, hawkular_sec_protocol=None, provider_data=None, appliance=None):

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -98,6 +98,7 @@ class OpenshiftProvider(ContainersProvider):
     mgmt_class = Openshift
     db_types = ["Openshift::ContainerManager"]
     endpoints_form = ContainersProviderEndpointsForm
+    settings_key = 'ems_openshift'
 
     def __init__(
             self,

--- a/cfme/infrastructure/provider/rhevm.py
+++ b/cfme/infrastructure/provider/rhevm.py
@@ -50,6 +50,7 @@ class RHEVMProvider(InfraProvider):
     db_types = ["Redhat::InfraManager"]
     endpoints_form = RHEVMEndpointForm
     discover_dict = {"rhevm": True}
+    settings_key = 'ems_redhat'
     # xpath locators for elements, to be used by selenium
     _console_connection_status_element = '//*[@id="connection-status"]|//*[@id="message-div"]'
     _canvas_element = '(//*[@id="remote-console"]/canvas|//*[@id="spice-screen"]/canvas)'

--- a/cfme/infrastructure/provider/scvmm.py
+++ b/cfme/infrastructure/provider/scvmm.py
@@ -31,6 +31,7 @@ class SCVMMProvider(InfraProvider):
         'Credential validation was not successful: '
         'Unable to connect: WinRM::WinRMAuthorizationError'
     )
+    settings_key = 'ems_scvmm'
 
     def __init__(self, name=None, endpoints=None, key=None, zone=None, hostname=None,
                  ip_address=None, start_ip=None, end_ip=None, provider_data=None, appliance=None):

--- a/cfme/infrastructure/provider/virtualcenter.py
+++ b/cfme/infrastructure/provider/virtualcenter.py
@@ -20,6 +20,7 @@ class VMwareProvider(InfraProvider):
     db_types = ["Vmware::InfraManager"]
     endpoints_form = VirtualCenterEndpointForm
     discover_dict = {"vmware": True}
+    settings_key = 'ems_vmware'
     # xpath locators for elements, to be used by selenium
     _console_connection_status_element = '//*[@id="connection-status"]|//*[@id="noVNC_status"]'
     _canvas_element = ('(//*[@id="remote-console" or @id="wmksContainer"]/canvas|'

--- a/cfme/networks/provider/nuage.py
+++ b/cfme/networks/provider/nuage.py
@@ -42,6 +42,7 @@ class NuageProvider(NetworkProvider):
     db_types = ['Nuage::NetworkManager']
     endpoints_form = NuageEndpointForm
     mgmt_class = NuageSystem
+    settings_key = 'ems_nuage'
 
     _collections = {
         'security_groups': SecurityGroupCollection,

--- a/cfme/physical/provider/lenovo.py
+++ b/cfme/physical/provider/lenovo.py
@@ -15,6 +15,7 @@ class LenovoEndpoint(DefaultEndpoint):
             'api_port': self.api_port
         }
 
+
 class LenovoEndpointForm(DefaultEndpointForm):
     api_port = Input('default_api_port')
 
@@ -26,6 +27,7 @@ class LenovoProvider(PhysicalProvider):
     mgmt_class = LenovoSystem
     refresh_text = "Refresh Relationships and Power States"
     db_types = ["Lenovo::PhysicalInfraManager"]
+    settings_key = 'ems_lenovo'
 
     def __init__(self, appliance, name=None, key=None, endpoints=None):
         super(LenovoProvider, self).__init__(

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -1856,6 +1856,60 @@ class IPAppliance(object):
         """
         return self.rest_api.get_entity_by_href(self.rest_api.server_info['server_href']).hostname
 
+    def get_disabled_regions(self, provider=None):
+        """Fetch appliance advanced config, get disabled regions for given provider's type
+
+        Only relevant for cloud providers azure and ec2 at the moment
+
+        Args:
+            provider: A BaseProvider object with settings_key attribute
+
+        Returns:
+            Default: Dict of ems_<provider> keys and values of disabled_regions map
+            when provider given: disabled_regions list from config
+            when no matching config found: None
+        """
+        ems_config = self.get_yaml_config()['ems']
+        if provider:
+            try:
+                prov_config = ems_config.get(getattr(provider, 'settings_key', None), {})  # safe
+                regions = prov_config['disabled_regions']  # KeyError
+            except KeyError:
+                regions = []
+        else:
+            regions = {ems_key: yaml['disabled_regions']
+                       for ems_key, yaml in ems_config.items()
+                       if 'disabled_regions' in yaml}
+
+        return regions
+
+    def set_disabled_regions(self, provider, *regions):
+        """Modify config to set disabled regions to given regions for the given provider's type
+
+        Only relevant for cloud providers azure and ec2 at the moment
+
+        Does NOT APPEND to the list of disabled regions, SETS it
+
+        Args:
+            provider: A BaseProvider object with settings_key attribute
+            *regions: none, one or many region names, on None enables all regions for provider type
+
+        Raises:
+            AssertionError - when the disabled regions don't match after setting
+            ApplianceException - when there's a KeyError modifying the yaml
+        """
+        yaml_conf = self.get_yaml_config()
+        try:
+            yaml_conf['ems'][getattr(provider, 'settings_key', None)]['disabled_regions'] = regions
+        except KeyError:
+            # catches not-found settings_key or 'None' when the provider doesn't have it
+            raise ApplianceException('Provider %s settings_key attribute not set '
+                                     'or not found in config %s'
+                                     .format(provider, yaml_conf['ems']))
+
+        self.set_yaml_config(yaml_conf)
+        assert self.get_disabled_regions(provider) == list(regions)  # its a tuple if empty
+
     @property
     def server_roles(self):
         """Return a dictionary of server roles from database"""


### PR DESCRIPTION
Methods to deal with disabled_regions field in advanced configuration, which is commonly used by MIQ/CFME to disable govcloud regions (or any other).

Add provider attribute for what its ems settings key is in the config
(YAML or JSON)

Lookup disabled regions for everything, or per given provider

We don't have govcloud regions available for general consumption or via PRT, running crud test to verify no failure in configuring non-govcloud regions.

## PRT Results
With #6836 this passes PRT (mostly) clean. I've pulled in 1 line from that to cloud providers in this PR.

59z passing ~83% with 3 unrelated REST test failures.

Have tested in Jenkins for govcloud, sufficient to get tests running.

{{ pytest: cfme/tests/cloud/test_providers.py --long-running --use-provider complete }}