### PR TITLE
[RFR] Make ssh.py's run_command work for all programs

### DIFF
--- a/cfme/utils/ssh.py
+++ b/cfme/utils/ssh.py
@@ -4,8 +4,6 @@ import sys
 from collections import namedtuple
 from subprocess import check_call
 
-import select
-
 import diaper
 import fauxfactory
 import iso8601


### PR DESCRIPTION
Some programs put out a small amount of output, and we will receive the
exit code before transport thread that unencrypts the data from
stdout and stderr has time to do so.   In that case checking
recv_ready() is the wrong thing to do because recv_ready in
paramiko's ssh implementation only returns True if there is
unencrypted data in the buffer.   However for programs producing
lots of output just doing reads without first checking whether there
is data to be read may put your process in a blocked state if the
file will never have output (e.g. stderr).   Even programs
producing lots of output on both stderr and stdout can experience this
because if for a bit its not producing output on one file while
it is on the other, the one it is producing output on may fill
up its remote buffer causing the remote program to block on a write.

The way to solve this, or at least it seems to work, is to use
recv_ready() before doing reads up until you detect the remote program
has exited.  At this point its OK to do reads without waiting for
recv_ready() to return true, the blocking on an empty file will end
when it is marked as closed by the thread that fills the unencrypted
data buffer.    So for programs with little output they don't miss their
output because we catch it on exit, and programs with lots of output
we only read from the file buffers when there is something to be read
avoiding a dead lock, and on exit they still drain the remaining data.

Note, some of the issues mentioned are clearly described in this 
paramiko issue:

   https://github.com/paramiko/paramiko/issues/1091