### PR TITLE
[1LP][RFR] Metering Reports: Support for cloud providers

### DIFF
--- a/cfme/tests/intelligence/reports/test_metering_report.py
+++ b/cfme/tests/intelligence/reports/test_metering_report.py
@@ -2,6 +2,8 @@
 # All providers that support C&U support Metering Reports.SCVMM doesn't support C&U.
 # Metering reports differ from Chargeback reports in that Metering reports report
 # only resource usage and not costs.
+#
+# Metering Reports have been introduced in 59.
 
 import fauxfactory
 import math

--- a/cfme/tests/intelligence/reports/test_metering_report.py
+++ b/cfme/tests/intelligence/reports/test_metering_report.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+# All providers that support C&U support Metering Reports.SCVMM doesn't support C&U.
+# Metering reports differ from Chargeback reports in that Metering reports report
+# only resource usage and not costs.
+
 import fauxfactory
 import math
 import pytest
@@ -283,7 +287,7 @@ def test_validate_cpu_usage(resource_usage, metering_report):
 @pytest.mark.uncollectif(
     lambda provider: provider.one_of(EC2Provider) or provider.one_of(GCEProvider))
 def test_validate_memory_usage(resource_usage, metering_report):
-    """Test to validate memory usage."""
+    """Test to validate memory usage.This metric is not collected for GCE, EC2."""
     for groups in metering_report:
         if groups["Memory Used"]:
             estimated_memory_usage = resource_usage['memory_used']

--- a/cfme/tests/intelligence/reports/test_metering_report.py
+++ b/cfme/tests/intelligence/reports/test_metering_report.py
@@ -285,7 +285,7 @@ def test_validate_cpu_usage(resource_usage, metering_report):
 
 
 @pytest.mark.uncollectif(
-    lambda provider: provider.one_of(EC2Provider) or provider.one_of(GCEProvider))
+    lambda provider: provider.one_of(EC2Provider, GCEProvider))
 def test_validate_memory_usage(resource_usage, metering_report):
     """Test to validate memory usage.This metric is not collected for GCE, EC2."""
     for groups in metering_report:

--- a/cfme/tests/intelligence/reports/test_metering_report.py
+++ b/cfme/tests/intelligence/reports/test_metering_report.py
@@ -15,6 +15,7 @@ from cfme.base.credential import Credential
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.common.provider import CloudInfraProvider
+from cfme.cloud.provider import CloudProvider
 from cfme.common.vm import VM
 from cfme.common.provider import BaseProvider
 from cfme.intelligence.reports.reports import CustomReport
@@ -269,7 +270,7 @@ def metering_report(vm_ownership, provider):
 # Tests to validate usage reported in the Metering report for various metrics.
 # The usage reported in the report should be approximately equal to the
 # usage estimated in the resource_usage fixture, therefore a small deviation is fine.
-@pytest.mark.uncollectif(lambda provider: provider.category == 'cloud')
+@pytest.mark.uncollectif(lambda provider: provider.one_of(CloudProvider))
 def test_validate_cpu_usage(resource_usage, metering_report):
     """Test to validate CPU usage.This metric is not collected for cloud providers."""
     for groups in metering_report:

--- a/cfme/tests/intelligence/reports/test_metering_report.py
+++ b/cfme/tests/intelligence/reports/test_metering_report.py
@@ -8,6 +8,9 @@ from datetime import date
 
 from cfme import test_requirements
 from cfme.base.credential import Credential
+from cfme.cloud.provider.azure import AzureProvider
+from cfme.cloud.provider.ec2 import EC2Provider
+from cfme.cloud.provider.gce import GCEProvider
 from cfme.common.vm import VM
 from cfme.common.provider import BaseProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
@@ -20,7 +23,8 @@ from cfme.utils.wait import wait_for
 pytestmark = [
     pytest.mark.tier(2),
     pytest.mark.ignore_stream('5.8'),
-    pytest.mark.provider([VMwareProvider, RHEVMProvider],
+    pytest.mark.provider([VMwareProvider, RHEVMProvider, AzureProvider, GCEProvider,
+        EC2Provider],
                          scope='module',
                          required_fields=[(['cap_and_util', 'test_chargeback'], True)]),
     test_requirements.chargeback,
@@ -261,6 +265,7 @@ def metering_report(vm_ownership, provider):
 # Tests to validate usage reported in the Metering report for various metrics.
 # The usage reported in the report should be approximately equal to the
 # usage estimated in the resource_usage fixture, therefore a small deviation is fine.
+@pytest.mark.uncollectif(lambda provider: provider.category == 'cloud')
 def test_validate_cpu_usage(resource_usage, metering_report):
     """Test to validate CPU usage."""
     for groups in metering_report:


### PR DESCRIPTION
{{pytest: cfme/tests/intelligence/reports/test_metering_report.py --use-provider complete}}

PRT results:
58 - Tests were skipped, like expected
59 - All the tests, including the ones for cloud providers passed , except for test_validate_storage_usage[vsphere65-nested] 

I could investigate and fix that failure with a follow up PR.