### PR TITLE
[1LP][RFR] Uncollecting test_vm_console for RHV-CFME integration

### DIFF
--- a/cfme/tests/ssui/test_ssui_myservice.py
+++ b/cfme/tests/ssui/test_ssui_myservice.py
@@ -54,9 +54,10 @@ def test_retire_service(appliance, setup_provider, context, provision_request):
 @pytest.mark.meta(blockers=[BZ(1544535, forced_streams=['5.9'])])
 @pytest.mark.parametrize('context', [ViaSSUI])
 @pytest.mark.parametrize('provision_request', [['console_test']], indirect=True)
-@pytest.mark.uncollectif(lambda provider: provider.one_of(VMwareProvider) and
-                         provider.version >= 6.5,
-                         'VNC consoles are unsupported on VMware ESXi 6.5 and later')
+@pytest.mark.uncollectif(lambda provider:
+    provider.one_of(VMwareProvider) and provider.version >= 6.5 or
+    'html5_console' in provider.data.excluded_test_flags,
+    'VNC consoles are unsupported on VMware ESXi 6.5 and later')
 def test_vm_console(request, appliance, setup_provider, context, configure_websocket,
         configure_console_vnc, provision_request, take_screenshot,
         console_template, provider):


### PR DESCRIPTION
__Uncollecting__ test_vm_console for RHV-CFME integration. The reason is quite pragmatic. The console tests are very much browser-dependent. In order to achieve stability, we wound need to emulate CFME QE testing environment. Now in the context of scaling down of resources dedicated to this effort, we cannot really do that for the purpose of this test case.

{{pytest:  cfme/tests/ssui/test_ssui_myservice.py::test_vm_console}}