### PR TITLE
[WIPTEST]Fixing test_remove_template_provisioning

### DIFF
--- a/cfme/services/catalogs/orchestration_template.py
+++ b/cfme/services/catalogs/orchestration_template.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from widgetastic.widget import Text, Checkbox
-from widgetastic_patternfly import BootstrapSelect, Button, Input
+from widgetastic_patternfly import BootstrapSelect, Button, CandidateNotFound, Input
 from widgetastic_manageiq import ScriptBox, Table, PaginationPane
 from navmazing import NavigateToAttribute, NavigateToSibling
 from cfme.common import WidgetasticTaggable
@@ -197,6 +197,14 @@ class OrchestrationTemplate(Updateable, Pretty, Navigatable, WidgetasticTaggable
         view.flash.assert_success_message('Service Dialog "{}" was successfully created'.format(
             dialog_name))
         return template_name
+
+    @property
+    def exists(self):
+        try:
+            navigate_to(self, 'Details')
+            return True
+        except CandidateNotFound:
+            return False
 
 
 @navigator.register(OrchestrationTemplate, 'All')

--- a/cfme/tests/services/test_provision_stack.py
+++ b/cfme/tests/services/test_provision_stack.py
@@ -42,7 +42,8 @@ def template(provider, provisioning, setup_provider):
     dialog_name = "dialog_" + fauxfactory.gen_alphanumeric()
     template.create_service_dialog_from_template(dialog_name, template.template_name)
     yield template, dialog_name
-    template.delete()
+    if template.exists:
+        template.delete()
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Purpose
=================
Added _exists_ property for _OrchestrationTemplate_ class and updated template fixture due to _CandidateNotFound_ error. It was caused because template was removed as a part of test.

{{pytest: -v cfme/tests/services/test_provision_stack.py}}