### PR TITLE
[1LP][RFR] ParametrizedSummaryTable.is_displayed support

### DIFF
--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -603,6 +603,9 @@ class ParametrizedSummaryTable(ParametrizedView):
     PARAMETERS = ("title", )
     _table = SummaryTable(title=Parameter("title"))
 
+    def __locator__(self):
+        return self._table.ROOT
+
     @property
     def fields(self):
         return self._table.fields


### PR DESCRIPTION
I see two ways to fix this:
1. add __locator__
2. copy SummaryTable.BASELOC to ParametrizedSummaryTable.ROOT + ParametrizedString

I chose first way.