### PR TITLE
[1LP][RFR] Add browser refresh to provider 'All' resetters

### DIFF
--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -132,6 +132,7 @@ class All(CFMENavigateStep):
         self.prerequisite_view.navigation.select('Compute', 'Clouds', 'Providers')
 
     def resetter(self):
+        self.appliance.browser.widgetastic.browser.refresh()
         tb = self.view.toolbar
         if 'Grid View' not in tb.view_selector.selected:
             tb.view_selector.select('Grid View')

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -207,6 +207,7 @@ class All(CFMENavigateStep):
 
     def resetter(self):
         # Reset view and selection
+        self.appliance.browser.widgetastic.browser.refresh()
         tb = self.view.toolbar
         if 'Grid View' not in tb.view_selector.selected:
             tb.view_selector.select('Grid View')


### PR DESCRIPTION
I was hitting `MoveTargetOutofBounds` exceptions in PR #6814, and found that it was always occuring on the Providers 'All' destination, when trying to click the dropdown to add a new provider.  The screenshots showed that it was on the 'All' destination, and a provider quadicon was there with a flash message that it had been deleted - indicating no navigation/refresh between the fixture  cleanup of the provider and the next test case.

Not considering this a 'fix-framework' PR since this is more a workaround than a fix for the `MoveTargetOutofBounds` occuring when the widget is visible.

{{ pytest: -k test_provider_crud --use-provider complete }}