### PR TITLE
[1LP][RFR] Expect 200 or 204 from a REST DELETE, change to using assert_response() in most places

### DIFF
--- a/cfme/tests/configure/test_tag_category.py
+++ b/cfme/tests/configure/test_tag_category.py
@@ -5,7 +5,7 @@ import pytest
 from cfme.configure.configuration.region_settings import Category
 from cfme.rest.gen_data import categories as _categories
 from cfme.utils import error
-from cfme.utils.rest import delete_resources_from_collection
+from cfme.utils.rest import assert_response, delete_resources_from_collection
 from cfme.utils.update import update
 from cfme.utils.wait import wait_for
 
@@ -26,7 +26,7 @@ class TestCategoriesViaREST(object):
     @pytest.fixture(scope="function")
     def categories(self, request, appliance):
         response = _categories(request, appliance.rest_api, num=5)
-        assert appliance.rest_api.response.status_code == 200
+        assert_response(appliance)
         assert len(response) == 5
         return response
 
@@ -39,7 +39,7 @@ class TestCategoriesViaREST(object):
         """
         for ctg in categories:
             record = appliance.rest_api.collections.categories.get(id=ctg.id)
-            assert appliance.rest_api.response.status_code == 200
+            assert_response(appliance)
             assert record.name == ctg.name
 
     @pytest.mark.tier(3)
@@ -62,12 +62,12 @@ class TestCategoriesViaREST(object):
             for index in range(categories_len):
                 new[index].update(categories[index]._ref_repr())
             edited = collection.action.edit(*new)
-            assert appliance.rest_api.response.status_code == 200
+            assert_response(appliance)
         else:
             edited = []
             for index in range(categories_len):
                 edited.append(categories[index].action.edit(**new[index]))
-                assert appliance.rest_api.response.status_code == 200
+                assert_response(appliance)
         assert categories_len == len(edited)
         for index in range(categories_len):
             record, _ = wait_for(
@@ -86,13 +86,12 @@ class TestCategoriesViaREST(object):
         Metadata:
             test_flag: rest
         """
-        status = 204 if method == "delete" else 200
         for ctg in categories:
             ctg.action.delete(force_method=method)
-            assert appliance.rest_api.response.status_code == status
+            assert_response(appliance)
             with error.expected("ActiveRecord::RecordNotFound"):
                 ctg.action.delete(force_method=method)
-            assert appliance.rest_api.response.status_code == 404
+            assert_response(appliance, http_status=404)
 
     @pytest.mark.tier(3)
     def test_delete_categories_from_collection(self, appliance, categories):

--- a/cfme/tests/infrastructure/test_provisioning_rest.py
+++ b/cfme/tests/infrastructure/test_provisioning_rest.py
@@ -135,7 +135,7 @@ def test_provision_emails(request, provision_data, provider, appliance, smtp_tes
     provision_data["vm_fields"]["number_of_cpus"] += 1
 
     appliance.rest_api.collections.provision_requests.action.create(**provision_data)
-    assert appliance.rest_api.response.status_code == 200
+    assert_response(appliance)
 
     request = appliance.collections.requests.instantiate(description=vm_name, partial_check=True)
     request.wait_for_request()

--- a/cfme/tests/infrastructure/test_vm_ownership.py
+++ b/cfme/tests/infrastructure/test_vm_ownership.py
@@ -2,6 +2,7 @@ import pytest
 from cfme import test_requirements
 from cfme.rest.gen_data import a_provider as _a_provider
 from cfme.rest.gen_data import vm as _vm
+from cfme.utils.rest import assert_response
 
 
 pytestmark = [
@@ -33,7 +34,7 @@ class TestVmOwnershipRESTAPI(object):
             "owner": {"href": user.href}
         }
         rest_vm.action.set_ownership(**data)
-        assert appliance.rest_api.response.status_code == 200
+        assert_response(appliance)
         rest_vm.reload()
         assert hasattr(rest_vm, "evm_owner_id")
         assert rest_vm.evm_owner_id == user.id
@@ -52,7 +53,7 @@ class TestVmOwnershipRESTAPI(object):
             "group": {"href": group.href}
         }
         appliance.rest_api.collections.vms.action.set_ownership(rest_vm, **data)
-        assert appliance.rest_api.response.status_code == 200
+        assert_response(appliance)
         rest_vm.reload()
         assert hasattr(rest_vm, "miq_group_id")
         assert rest_vm.miq_group_id == group.id
@@ -79,7 +80,7 @@ class TestVmOwnershipRESTAPI(object):
             responses = [rest_vm.action.set_owner(owner="admin")]
         else:
             responses = appliance.rest_api.collections.vms.action.set_owner(rest_vm, owner="admin")
-        assert appliance.rest_api.response.status_code == 200
+        assert_response(appliance)
         for response in responses:
             assert response["success"] is True, "Could not set owner"
         rest_vm.reload()

--- a/cfme/tests/infrastructure/test_vm_retirement_rest.py
+++ b/cfme/tests/infrastructure/test_vm_retirement_rest.py
@@ -5,6 +5,7 @@ import pytest
 from cfme import test_requirements
 from cfme.rest.gen_data import a_provider as _a_provider
 from cfme.rest.gen_data import vm as _vm
+from cfme.utils.rest import assert_response
 from cfme.utils.wait import wait_for
 
 
@@ -47,7 +48,7 @@ def test_retire_vm_now(appliance, vm, from_collection):
         appliance.rest_api.collections.vms.action.retire(retire_vm)
     else:
         retire_vm.action.retire()
-    assert appliance.rest_api.response.status_code == 200
+    assert_response(appliance)
 
     def _finished():
         retire_vm.reload()
@@ -94,7 +95,7 @@ def test_retire_vm_future(appliance, vm, from_collection):
         appliance.rest_api.collections.vms.action.retire(future)
     else:
         retire_vm.action.retire(**future)
-    assert appliance.rest_api.response.status_code == 200
+    assert_response(appliance)
 
     def _finished():
         retire_vm.reload()

--- a/cfme/tests/intelligence/reports/test_crud.py
+++ b/cfme/tests/intelligence/reports/test_crud.py
@@ -13,6 +13,7 @@ from cfme.intelligence.reports.widgets.report_widgets import ReportWidget
 from cfme.intelligence.reports.widgets.rss_widgets import RSSFeedWidget
 from cfme.utils.blockers import BZ
 from cfme.utils.path import data_path
+from cfme.utils.rest import assert_response
 from cfme.utils.update import update
 from cfme.utils.wait import wait_for_decorator
 
@@ -190,7 +191,7 @@ def test_dashboard_crud():
 def test_run_report(appliance):
     report = appliance.rest_api.collections.reports.get(name='VM Disk Usage')
     response = report.action.run()
-    assert appliance.rest_api.response.status_code == 200
+    assert_response(appliance)
 
     @wait_for_decorator(timeout="5m", delay=5)
     def rest_running_report_finishes():
@@ -220,11 +221,11 @@ def test_import_report(appliance):
         'options': {'save': 'true'}
     }
     response, = appliance.rest_api.collections.reports.action.execute_action("import", data)
-    assert appliance.rest_api.response.status_code == 200
+    assert_response(appliance)
     assert response['message'] == 'Imported Report: [{}]'.format(menu_name)
     report = appliance.rest_api.collections.reports.get(name=menu_name)
     assert report.name == menu_name
 
     response, = appliance.rest_api.collections.reports.action.execute_action("import", data)
-    assert appliance.rest_api.response.status_code == 200
+    assert_response(appliance)
     assert response['message'] == 'Skipping Report (already in DB): [{}]'.format(menu_name)

--- a/cfme/tests/perf/workloads/test_provisioning.py
+++ b/cfme/tests/perf/workloads/test_provisioning.py
@@ -6,6 +6,7 @@ from cfme.utils.conf import cfme_performance
 from cfme.utils.grafana import get_scenario_dashboard_urls
 from cfme.utils.log import logger
 from cfme.utils.providers import get_crud
+from cfme.utils.rest import assert_response
 from cfme.utils.smem_memory_monitor import add_workload_quantifiers, test_ts, SmemMemoryMonitor
 from cfme.utils.wait import wait_for
 from cfme.utils.workloads import get_provisioning_scenarios
@@ -153,7 +154,7 @@ def test_provisioning(appliance, request, scenario):
         provision_data = get_provision_data(appliance.rest_api, prov, template.name)
         vm_name = provision_data["vm_fields"]["vm_name"]
         response = appliance.rest_api.collections.provision_requests.action.create(**provision_data)
-        assert appliance.rest_api.response.status_code == 200
+        assert_response(appliance)
         provision_request = response[0]
 
         def _finished():

--- a/cfme/tests/services/test_generic_service_catalogs.py
+++ b/cfme/tests/services/test_generic_service_catalogs.py
@@ -9,7 +9,7 @@ from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils import error
 from cfme.utils.log import logger
-from cfme.utils.rest import delete_resources_from_collection
+from cfme.utils.rest import assert_response, delete_resources_from_collection
 from selenium.common.exceptions import NoSuchElementException
 
 
@@ -131,13 +131,12 @@ class TestServiceCatalogViaREST(object):
         Metadata:
             test_flag: rest
         """
-        status = 204 if method == "delete" else 200
         for scl in service_catalogs:
             scl.action.delete(force_method=method)
-            assert appliance.rest_api.response.status_code == status
+            assert_response(appliance)
             with error.expected("ActiveRecord::RecordNotFound"):
                 scl.action.delete(force_method=method)
-            assert appliance.rest_api.response.status_code == 404
+            assert_response(appliance, http_status=404)
 
     def test_delete_service_catalogs(self, appliance, service_catalogs):
         """Tests delete service catalogs via rest.
@@ -161,7 +160,7 @@ class TestServiceCatalogViaREST(object):
         for ctl in service_catalogs:
             new_name = fauxfactory.gen_alphanumeric()
             response = ctl.action.edit(name=new_name)
-            assert appliance.rest_api.response.status_code == 200
+            assert_response(appliance)
             assert response.name == new_name
             ctl.reload()
             assert ctl.name == new_name
@@ -188,7 +187,7 @@ class TestServiceCatalogViaREST(object):
                 "name": new_name,
             })
         response = appliance.rest_api.collections.service_catalogs.action.edit(*scls_data_edited)
-        assert appliance.rest_api.response.status_code == 200
+        assert_response(appliance)
         assert len(response) == len(new_names)
         for index, resource in enumerate(response):
             assert resource.name == new_names[index]

--- a/cfme/tests/services/test_service_catalogs.py
+++ b/cfme/tests/services/test_service_catalogs.py
@@ -12,6 +12,7 @@ from cfme.services.workloads import VmsInstances
 from cfme.utils import error
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.log import logger
+from cfme.utils.rest import assert_response
 from cfme.utils.wait import wait_for_decorator
 
 
@@ -73,7 +74,7 @@ def test_order_catalog_item_via_rest(
     assert len(template) == 1
     template, = template
     req = template.action.order()
-    assert appliance.rest_api.response.status_code == 200
+    assert_response(appliance)
 
     @wait_for_decorator(timeout="15m", delay=5)
     def request_finished():


### PR DESCRIPTION
These tests were failing due to MIQ API returning a 200 OK after calling delete. Technically, this is acceptable according to https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html section 9.7