### PR TITLE
[1LP][RFR] New test added for checking repos

### DIFF
--- a/cfme/tests/configure/test_register_appliance.py
+++ b/cfme/tests/configure/test_register_appliance.py
@@ -178,6 +178,7 @@ def test_rh_registration(appliance, request, reg_method, reg_data, proxy_url, pr
 def test_rhsm_registration_check_repo_names(temp_appliance_preconfig_funcscope, soft_assert):
     """ Checks default rpm repos on a fresh appliance """
     ver = temp_appliance_preconfig_funcscope.version.series()
+    # TODO We need the context manager here is that RedHatUpdates doesn't yet support Collections.
     with temp_appliance_preconfig_funcscope:
         view = navigate_to(RedHatUpdates, 'Edit')
         soft_assert(

--- a/cfme/tests/configure/test_register_appliance.py
+++ b/cfme/tests/configure/test_register_appliance.py
@@ -3,6 +3,7 @@ import time
 
 from cfme.configure.configuration.region_settings import RedHatUpdates
 from cfme.utils import conf, version
+from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.conf import cfme_data
 from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
@@ -172,6 +173,20 @@ def test_rh_registration(appliance, request, reg_method, reg_data, proxy_url, pr
     )
 
     request.addfinalizer(appliance.unregister)
+
+
+def test_rhsm_registration_check_repo_names(temp_appliance_preconfig_funcscope, soft_assert):
+    """ Checks default repo on a fresh appliance and checks """
+    ver = temp_appliance_preconfig_funcscope.version.series()
+    with temp_appliance_preconfig_funcscope:
+        view = navigate_to(RedHatUpdates, 'Edit')
+        soft_assert(
+            view.repo_name.value == 'cf-me-{}-for-rhel-7-rpms rhel-server-rhscl-7-rpms'.format(ver))
+        """checks current repo names"""
+        view.repo_default_name.click()
+        """resets repos with default button and checks they are also correct"""
+        soft_assert(
+            view.repo_name.value == 'cf-me-{}-for-rhel-7-rpms rhel-server-rhscl-7-rpms'.format(ver))
 
 
 @pytest.mark.meta(blockers=[BZ(1500878, forced_streams=['5.9', 'upstream'])])

--- a/cfme/tests/configure/test_register_appliance.py
+++ b/cfme/tests/configure/test_register_appliance.py
@@ -176,7 +176,7 @@ def test_rh_registration(appliance, request, reg_method, reg_data, proxy_url, pr
 
 
 def test_rhsm_registration_check_repo_names(temp_appliance_preconfig_funcscope, soft_assert):
-    """ Checks default repo on a fresh appliance and checks """
+    """ Checks default rpm repos on a fresh appliance """
     ver = temp_appliance_preconfig_funcscope.version.series()
     with temp_appliance_preconfig_funcscope:
         view = navigate_to(RedHatUpdates, 'Edit')


### PR DESCRIPTION
Added new test to check default repos of appliance. Also checks what repos are set after clicking default button.
{{pytest: -v -k "test_rhsm_registration_check_repo_names"}}
