### PR TITLE
[1LP][RFR][NOTEST]adding stack removal for ec2

### DIFF
--- a/scripts/ec2cleanup.py
+++ b/scripts/ec2cleanup.py
@@ -2,7 +2,6 @@ import argparse
 import sys
 from datetime import datetime, timedelta
 from tabulate import tabulate
-from time import sleep
 
 from cfme.utils.path import log_path
 from cfme.utils.providers import list_provider_keys, get_mgmt
@@ -23,7 +22,7 @@ def parse_cmd_line():
     parser.add_argument('--exclude-enis', nargs='+',
                         help='List of ENIs, which should be excluded. ENI ID is allowed.')
     parser.add_argument('--exclude_stacks', nargs='+',
-                       help='List of Stacks, which should be exclude')
+                       help='List of Stacks, which should be excluded')
     parser.add_argument("--output", dest="output", help="target file name, default "
                                                         "'cleanup_ec2.log' in utils.path.log_path",
                         default=log_path.join('cleanup_ec2.log').strpath)
@@ -146,8 +145,6 @@ def delete_stacks(provider_mgmt, excluded_stacks, output):
                 if stack.creation_time < some_date:
                     stack_list.append([provider_name, stack.stack_name])
                     provider_mgmt.delete_stack(stack.stack_name)
-                    # TODO: Remove once we have reliable Trottling-resistant aproach
-                    sleep(5)
         logger.info("  Deleted CloudFormation Stacks: %r", stack_list)
         with open(output, 'a+') as report:
             if stack_list:
@@ -191,4 +188,4 @@ def ec2cleanup(exclude_volumes, exclude_eips, exclude_elbs, exclude_enis, exclud
 if __name__ == "__main__":
     args = parse_cmd_line()
     sys.exit(ec2cleanup(args.exclude_volumes, args.exclude_eips, args.exclude_elbs,
-                        args.exclude_stacks, args.exclude_enis, args.output))
+                        args.exclude_enis, args.exclude_stacks, args.output))

--- a/scripts/ec2cleanup.py
+++ b/scripts/ec2cleanup.py
@@ -148,7 +148,11 @@ def delete_stacks(provider_mgmt, excluded_stacks, stack_template, output):
                 some_date = today - timedelta(days=1)
                 if stack.creation_time < some_date:
                     stack_list.append([provider_name, stack.stack_name])
-                    provider_mgmt.delete_stack(stack.stack_name)
+                    try:
+                        provider_mgmt.delete_stack(stack.stack_name)
+                    except Exception as e:
+                        logger.error(e)
+                        continue
         logger.info("  Deleted CloudFormation Stacks: %r", stack_list)
         with open(output, 'a+') as report:
             if stack_list:

--- a/scripts/ec2cleanup.py
+++ b/scripts/ec2cleanup.py
@@ -23,6 +23,8 @@ def parse_cmd_line():
                         help='List of ENIs, which should be excluded. ENI ID is allowed.')
     parser.add_argument('--exclude_stacks', nargs='+',
                        help='List of Stacks, which should be excluded')
+    parser.add_argument('--stack-template',
+                        help='Stack name template to be removed', default="test", type=str)
     parser.add_argument("--output", dest="output", help="target file name, default "
                                                         "'cleanup_ec2.log' in utils.path.log_path",
                         default=log_path.join('cleanup_ec2.log').strpath)
@@ -131,12 +133,14 @@ def delete_unused_network_interfaces(provider_mgmt, excluded_enis, output):
         logger.exception('Exception in %r', delete_unused_network_interfaces.__name__)
 
 
-def delete_stacks(provider_mgmt, excluded_stacks, output):
+def delete_stacks(provider_mgmt, excluded_stacks, stack_template, output):
     stack_list = []
     provider_name = provider_mgmt.kwargs['name']
     try:
-        for stack in provider_mgmt.list_stacks():
-            if excluded_stacks and stack.stack_name in excluded_stacks:
+        for stack in provider_mgmt.list_stack():
+            if (excluded_stacks and
+                    stack.stack_name in excluded_stacks or
+                    not stack.stack_name.startswith(stack_template)):
                 logger.info("  Excluding Stack name: %r", stack.stack_name)
                 continue
             else:
@@ -156,7 +160,8 @@ def delete_stacks(provider_mgmt, excluded_stacks, output):
         logger.exception('Exception in %r', delete_stacks.__name__)
 
 
-def ec2cleanup(exclude_volumes, exclude_eips, exclude_elbs, exclude_enis, exclude_stacks, output):
+def ec2cleanup(exclude_volumes, exclude_eips, exclude_elbs, exclude_enis, exclude_stacks,
+               stack_template, output):
     with open(output, 'w') as report:
         report.write('ec2cleanup.py, Address, Volume, LoadBalancer and Network Interface Cleanup')
         report.write("\nDate: {}\n".format(datetime.now()))
@@ -178,6 +183,7 @@ def ec2cleanup(exclude_volumes, exclude_eips, exclude_elbs, exclude_enis, exclud
         logger.info("Deleting old stacks...")
         delete_stacks(provider_mgmt=provider_mgmt,
                       excluded_stacks=exclude_stacks,
+                      stack_template=stack_template,
                       output=output)
         logger.info("Releasing addresses...")
         delete_disassociated_addresses(provider_mgmt=provider_mgmt,
@@ -188,4 +194,4 @@ def ec2cleanup(exclude_volumes, exclude_eips, exclude_elbs, exclude_enis, exclud
 if __name__ == "__main__":
     args = parse_cmd_line()
     sys.exit(ec2cleanup(args.exclude_volumes, args.exclude_eips, args.exclude_elbs,
-                        args.exclude_enis, args.exclude_stacks, args.output))
+                        args.exclude_enis, args.exclude_stacks, args.stack_template, args.output))


### PR DESCRIPTION
Purpose or Intent
=================
Removes EC2 Cloudformations - ManageIQ EC2 Stack objects

- Added Condition 1 day old stack to avoid interrupting other tests.
- Added `sleep(5)` to avoid "Rate exceeded"-issue. which probably won't ever happen unless we are not deleting 10+ stacks at a time
- Generates reports like:

```
Date: 2018-03-09 13:52:06.076403
| Provider Key   | Stack Name   |
|----------------+--------------|
| ec2-west       | testlkhom19  |
| ec2-west       | testlkhom18  |
| ec2-west       | testlkhom17  |
| ec2-west       | testlkhom16  |
| ec2-west       | testlkhom15  |
| ec2-west       | testlkhom14  |
| ec2-west       | testlkhom13  |
| ec2-west       | testlkhom12  |
| ec2-west       | testlkhom11  |
| ec2-west       | testlkhom10  |
| ec2-west       | testlkhom9   |
| ec2-west       | testlkhom8   |
| ec2-west       | testlkhom7   |
| ec2-west       | testlkhom6   |
| ec2-west       | testlkhom5   |
| ec2-west       | testlkhom4   |
| ec2-west       | testlkhom3   |
| ec2-west       | ec2          |
```