### PR TITLE
[WIP] Add support for deleting multiple RBAC user/group/roles via Access Control checklist

### DIFF
--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -138,6 +138,9 @@ def test_user_delete_multiple(appliance, group_collection):
     users = [new_user(appliance, group), new_user(appliance, group), new_user(appliance, group), ]
     appliance.collections.users.delete(*users)
 
+    for user in users:
+        assert not user.exists, "Failed to delete user using the Access Control EVM Users checklist"
+
 
 # @pytest.mark.meta(blockers=[1035399]) # work around instead of skip
 @pytest.mark.tier(2)
@@ -373,6 +376,10 @@ def test_group_delete_multiple(group_collection):
 
     group_collection.delete(*groups)
 
+    for group in groups:
+        assert not group.exists, (
+            "Failed to delete group using the Access Control EVM Groups checklist")
+
 
 @pytest.mark.sauce
 @pytest.mark.tier(2)
@@ -602,6 +609,17 @@ def test_delete_roles_with_assigned_group(appliance, group_collection):
 
     with pytest.raises(RBACOperationBlocked):
         role.delete()
+
+
+@pytest.mark.tier(2)
+def test_role_delete_multiple(appliance):
+    """ Test that we can successfully delete roles using the Access Control Roles checklist
+    """
+    roles = [new_role(appliance), new_role(appliance), new_role(appliance), ]
+    appliance.collections.roles.delete(*roles)
+
+    for role in roles:
+        assert not role.exists, "Failed to delete role using the Access Control Roles checklist"
 
 
 @pytest.mark.tier(3)

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -129,6 +129,15 @@ def test_user_assign_multiple_groups(appliance, request, group_collection):
         "User's assigned groups are different from expected groups")
 
 
+@pytest.mark.tier(2)
+def test_multiple_user_delete(appliance, group_collection):
+    group_name = 'EvmGroup-user'
+    group = group_collection.instantiate(description=group_name)
+
+    users = [new_user(appliance, group), new_user(appliance, group), new_user(appliance, group),]
+    appliance.collections.users.delete(*users)
+
+
 # @pytest.mark.meta(blockers=[1035399]) # work around instead of skip
 @pytest.mark.tier(2)
 def test_user_login(appliance, group_collection):

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -129,12 +129,13 @@ def test_user_assign_multiple_groups(appliance, request, group_collection):
         "User's assigned groups are different from expected groups")
 
 
-@pytest.mark.tier(2)
-def test_multiple_user_delete(appliance, group_collection):
+def test_user_delete_multiple(appliance, group_collection):
+    """ Test that we can successfully delete user using the Access Control EVM Users checklist
+    """
     group_name = 'EvmGroup-user'
     group = group_collection.instantiate(description=group_name)
 
-    users = [new_user(appliance, group), new_user(appliance, group), new_user(appliance, group),]
+    users = [new_user(appliance, group), new_user(appliance, group), new_user(appliance, group), ]
     appliance.collections.users.delete(*users)
 
 
@@ -354,6 +355,23 @@ def test_group_crud(group_collection):
     with update(group):
         group.description = "{}edited".format(group.description)
     group.delete()
+
+
+@pytest.mark.tier(2)
+def test_group_delete_multiple(group_collection):
+    """ Test that we can successfully delete groups using the Access Control EVM Groups checklist
+    """
+    role = 'EvmRole-user'
+
+    groups = [
+        group_collection.create(
+            description='grp{}'.format(fauxfactory.gen_alphanumeric()), role=role),
+        group_collection.create(
+            description='grp{}'.format(fauxfactory.gen_alphanumeric()), role=role),
+        group_collection.create(
+            description='grp{}'.format(fauxfactory.gen_alphanumeric()), role=role), ]
+
+    group_collection.delete(*groups)
 
 
 @pytest.mark.sauce


### PR DESCRIPTION
Add delete methods to access_control UserCollection, GroupCollection and RoleCollection to support deleting multiple RBAC objects using the respective Access Control checklist

{{ pytest: -v cfme/tests/configure/test_access_control.py -k 'delete_multiple' }}