### PR TITLE
[1LP][RFR] Fix publish_to_template; add ownership test

### DIFF
--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -439,6 +439,19 @@ class MigrateVmView(BaseLoggedInPage):
         return False
 
 
+class PublishVmView(BaseLoggedInPage):
+    title = Text('#explorer_title_text')
+
+    @View.nested
+    class form(BasicProvisionFormView):  # noqa
+        submit_button = Button('Submit')
+        cancel_button = Button('Cancel')
+
+    @property
+    def is_displayed(self):
+        return False
+
+
 class RetirementView(BaseLoggedInPage):
     """
     Set Retirement date view for vms/instances

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -17,8 +17,9 @@ from widgetastic_patternfly import (
 from cfme.base.login import BaseLoggedInPage
 from cfme.common.vm import VM, Template as BaseTemplate
 from cfme.common.vm_views import (
-    ManagementEngineView, CloneVmView, MigrateVmView, ProvisionView, EditView, RetirementView,
-    RetirementViewWithOffset, VMDetailsEntities, VMToolbar, VMEntities, SetOwnershipView)
+    ManagementEngineView, CloneVmView, MigrateVmView, ProvisionView, EditView, PublishVmView,
+    RetirementView, RetirementViewWithOffset, VMDetailsEntities, VMToolbar, VMEntities,
+    SetOwnershipView)
 from cfme.exceptions import (
     VmNotFound, OptionNotAvailable, DestinationNotFound, ItemNotFound,
     VmOrInstanceNotFound)
@@ -749,8 +750,7 @@ class Vm(VM):
         view.form.fill_with(provisioning_data, on_change=view.form.submit_button)
 
     def publish_to_template(self, template_name, email=None, first_name=None, last_name=None):
-        view = navigate_to(self, 'Details', use_resetter=False)
-        view.toolbar.lifecycle.item_select("Publish this VM to a Template")
+        view = navigate_to(self, 'Publish')
         first_name = first_name or fauxfactory.gen_alphanumeric()
         last_name = last_name or fauxfactory.gen_alphanumeric()
         email = email or "{}@{}.test".format(first_name, last_name)
@@ -948,6 +948,7 @@ class Vm(VM):
 
 class Template(BaseTemplate):
     REMOVE_MULTI = "Remove Templates from the VMDB"
+    VM_TYPE = "Template"
 
     @property
     def genealogy(self):
@@ -1358,6 +1359,15 @@ class VmMigrate(CFMENavigateStep):
 
     def step(self, *args, **kwargs):
         self.prerequisite_view.toolbar.lifecycle.item_select("Migrate this VM")
+
+
+@navigator.register(Vm, 'Publish')
+class VmPublish(CFMENavigateStep):
+    VIEW = PublishVmView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        self.prerequisite_view.toolbar.lifecycle.item_select("Publish this VM to a Template")
 
 
 @navigator.register(Vm, 'Clone')

--- a/cfme/tests/cloud_infra_common/test_vm_ownership.py
+++ b/cfme/tests/cloud_infra_common/test_vm_ownership.py
@@ -6,6 +6,7 @@ from cfme.base.credential import Credential
 from cfme.common.provider import CloudInfraProvider
 from cfme.common.vm import VM
 from cfme.exceptions import VmOrInstanceNotFound
+from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
@@ -183,6 +184,21 @@ def test_group_ownership_on_user_or_group_role(
     vm_crud.unset_ownership()
     with user3:
         assert not check_vm_exists(vm_crud), "vm exists! but shouldn't exist"
+
+
+@pytest.mark.provider([VMwareProvider], override=True, scope="module")
+def test_template_set_ownership(request, provider, setup_provider, vm_crud):
+    """ Sets ownership to an infra template.
+
+    First publishes a template from a VM, then tries to unset an ownership of that template,
+    then sets it back and in the end removes the template.
+    VM is removed via fixture.
+    Tests BZ 1446801 in RHCF3-14353
+    """
+    template = vm_crud.publish_to_template(template_name=random_vm_name(context='ownrs'))
+    template.set_ownership('<No Owner>')
+    template.set_ownership('Administrator')
+    template.delete()
 
 
 # @pytest.mark.meta(blockers=[1202947])


### PR DESCRIPTION
Two things happening here:
1. Fix for publish_to_template method in cfme.infrastructure.virtual_machines.Vm
2. Add template ownership test which also tests the above fix

For the first point, publish_to_template navigated to a wrong view, resulting in error when trying to fill a from that wasn't in that view. So instead of navigating to 'Details', I created a new view 'PublishVmView' in cfme.common.vm_views. This view has a form from 'BasicProvisionFormView' that was already implemented and contains all the things publish_to_template needs.
I then created new navigation step 'Publish' to enable navigation to my newly created view and added that to publish_to_template method.

For the second point, I wrote a very simple ownership test that just tries to set an ownership to a template. This automates BZ 1446801. It uses the publish_to_template method to create a template from a VM.

As a bonus, there's a tiny one-line fix for cfme.infrastructure.virtual_machines.Template making the assertion for flash messages correctly work when working with templates.

Currently limited to a vmware type provider, need to test and see if I can add more providers.

{{ pytest: -v --long-running --use-provider vsphere55  cfme/tests/cloud_infra_common/test_vm_ownership.py -k test_template_set_ownership }}