### PR TITLE
[1LP][RFR] Move cleanup_vm logic into one place, and use the same method everywhere

### DIFF
--- a/cfme/cloud/instance/azure.py
+++ b/cfme/cloud/instance/azure.py
@@ -88,7 +88,7 @@ class AzureInstance(Instance):
         super(AzureInstance, self).cleanup_on_provider()
         logger.info("cleanup: removing NICs/PIPs for VM '{}'".format(self.name))
         try:
-            self.remove_nics_by_search(self.name, self.provider.mgmt.resource_group)
-            self.remove_pips_by_search(self.name, self.provider.mgmt.resource_group)
+            self.provider.mgmt.remove_nics_by_search(self.name, self.provider.mgmt.resource_group)
+            self.provider.mgmt.remove_pips_by_search(self.name, self.provider.mgmt.resource_group)
         except Exception:
             logger.exception("cleanup: failed to cleanup NICs/PIPs for VM '{}'".format(self.name))

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -1081,15 +1081,6 @@ class CloudInfraProvider(BaseProvider, PolicyProfileAssignable, Taggable):
             return True
 
 
-def cleanup_vm(vm_name, provider):
-    try:
-        logger.info('Cleaning up VM %s on provider %s', vm_name, provider.key)
-        provider.mgmt.delete_vm(vm_name)
-    except:
-        # The mgmt_sys classes raise Exception :\
-        logger.warning('Failed to clean up VM %s on provider %s', vm_name, provider.key)
-
-
 class DefaultEndpoint(object):
     credential_class = Credential
     name = 'default'

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -793,7 +793,7 @@ class VM(BaseVM):
             "cleanup: ensuring VM '{}' on provider '{}' is powered off".format(
                 self.name, self.provider.key)
         )
-        self.ensure_state_on_provider(self.STOPPED)
+        self.ensure_state_on_provider(self.STATE_OFF)
         try:
             logger.info(
                 "cleanup: deleting VM '{}' on provider '{}'".format(

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -606,7 +606,7 @@ class VM(BaseVM):
             return False
 
     def delete_from_provider(self):
-        """ 
+        """
         Delete VM/instance from provider.
 
         You cannot expect additional cleanup of attached resources by calling this method. You

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -606,31 +606,31 @@ class VM(BaseVM):
             return False
 
     def delete_from_provider(self):
-        logger.info("Begin delete_from_provider")
-        if self.provider.mgmt.does_vm_exist(self.name):
-            # InfraProviders require VM to be stopped before removal
-            if self.provider.one_of(InfraProvider):
-                try:
-                    if self.provider.mgmt.is_vm_suspended(self.name):
-                        logger.debug("Powering up VM %s to shut it down correctly on %s.",
-                                    self.name, self.provider.key)
-                        self.provider.mgmt.start_vm(self.name)
-                        self.provider.mgmt.wait_vm_steady(self.name)
-                        self.provider.mgmt.stop_vm(self.name)
-                        self.provider.mgmt.wait_vm_steady(self.name)
-                except exceptions.ActionNotSupported:
-                    # Action is not supported on mgmt system. Simply continue
-                    pass
-            # One more check (for the suspended one)
-            if self.provider.mgmt.does_vm_exist(self.name):
-                try:
-                    logger.info("Mgmt System delete_vm")
-                    return self.provider.mgmt.delete_vm(self.name)
-                except exceptions.VMInstanceNotFound:
-                    # Does not exist already
-                    return True
-        else:
+        """ 
+        Delete VM/instance from provider.
+
+        You cannot expect additional cleanup of attached resources by calling this method. You
+        should use cleanup_on_provider() to guarantee that.
+        """
+        logger.info("Begin delete_from_provider for VM '{}'".format(self.name))
+        if not self.provider.mgmt.does_vm_exist(self.name):
+            logger.info("VM does '{}' not exist on provider, nothing to delete".format(self.name))
             return True
+
+        # Some providers require VM to be stopped before removal
+        logger.info(
+            "delete: ensuring VM '{}' on provider '{}' is powered off".format(
+                self.name, self.provider.key)
+        )
+        self.ensure_state_on_provider(self.STATE_OFF)
+
+        logger.info("delete: removing VM '{}'".format(self.name))
+        try:
+            return self.provider.mgmt.delete_vm(self.name)
+        except Exception:
+            logger.exception("delete for vm '{}' failed".format(self.name))
+
+        return True
 
     def create_on_provider(self, timeout=900, find_in_cfme=False, delete_on_failure=True, **kwargs):
         """Create the VM on the provider via MgmtSystem. `deploy_template` handles errors during
@@ -780,30 +780,11 @@ class VM(BaseVM):
 
         Checks that the VM exists on the provider, ensures it is in 'powered off' state,
         and deletes it. Any exceptions raised during delete will be logged only.
-        :return:
-        """
-        if not self.provider.mgmt.does_vm_exist(self.name):
-            logger.info(
-                "VM '{}' on provider '{}' does not exist, no cleanup to do".format(
-                    self.name, self.provider.key)
-            )
 
-        # Ensure the VM is in a state to be deleted
-        logger.info(
-            "cleanup: ensuring VM '{}' on provider '{}' is powered off".format(
-                self.name, self.provider.key)
-        )
-        self.ensure_state_on_provider(self.STATE_OFF)
-        try:
-            logger.info(
-                "cleanup: deleting VM '{}' on provider '{}'".format(
-                    self.name, self.provider.key)
-            )
-            self.provider.mgmt.delete_vm(self.name)
-        except Exception:
-            # The mgmt_sys classes raise Exception :\
-            logger.exception(
-                "cleanup: failed for VM '{}' on provider '{}'".format(self.name, self.provider.key))
+        This method may be overriden at the provider-specific level to delete and
+        then do some additional work afterwards (like deleting resources attached to this VM)
+        """
+        self.delete_from_provider()
 
     def set_retirement_date(self, when=None, offset=None, warn=None):
         """Overriding common method to use widgetastic views/widgets properly

--- a/cfme/fixtures/vm.py
+++ b/cfme/fixtures/vm.py
@@ -27,8 +27,7 @@ def _create_vm(request, template, provider, vm_name):
 
     @request.addfinalizer
     def _cleanup():
-        if provider.mgmt.does_vm_exist(vm_obj.name):
-            provider.mgmt.delete_vm(vm_obj.name)
+        vm_obj.cleanup_on_provider()
         provider.refresh_provider_relationships()
 
     return vm_obj

--- a/cfme/fixtures/vm_name.py
+++ b/cfme/fixtures/vm_name.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
+
+from cfme.common.vm import VM
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
 
@@ -11,13 +13,9 @@ def vm_name(provider):
     # also tries to delete the VM that gets made with this name
     vm_name = random_vm_name('scat')
     yield vm_name
-    try:
-        logger.info('Cleaning up VM %s on provider %s', vm_name, provider.key)
-        scat_vm = "{}0001".format(vm_name)
-        if scat_vm in provider.mgmt.list_vm():
-            provider.mgmt.delete_vm("{}0001".format(vm_name))
-        else:
-            provider.mgmt.delete_vm(vm_name)
-    except:
-        # The mgmt_sys classes raise Exception :\
-        logger.warning('Failed to clean up VM %s on provider %s', vm_name, provider.key)
+    scat_vm = "{}0001".format(vm_name)
+    if scat_vm in provider.mgmt.list_vm():
+        vm_name_to_cleanup = "{}0001".format(vm_name)
+    else:
+        vm_name_to_cleanup = vm_name
+    VM.factory(vm_name_to_cleanup, provider).cleanup_on_provider()

--- a/cfme/tests/automate/test_common_methods.py
+++ b/cfme/tests/automate/test_common_methods.py
@@ -38,7 +38,7 @@ def testing_vm(request, vm_name, setup_provider, provider, provisioning):
 
     def _finalize():
         try:
-            vm_obj.delete_from_provider()
+            vm_obj.cleanup_on_provider()
         except Exception:
             logger.warn('Failed deleting VM from provider: %s', vm_name)
     request.addfinalizer(_finalize)

--- a/cfme/tests/automate/test_vmware_methods.py
+++ b/cfme/tests/automate/test_vmware_methods.py
@@ -74,9 +74,7 @@ def testing_vm(request, setup_provider, provider):
         vm.create_on_provider(find_in_cfme=True, allow_skip="default")
         yield vm
     finally:
-        vm.delete_from_provider()
-        if vm.exists:
-            vm.delete()
+        vm.cleanup_on_provider()
 
 
 @pytest.mark.meta(blockers=[1211627, BZ(1311221, forced_streams=['5.5'])])

--- a/cfme/tests/cloud/test_cloud_events.py
+++ b/cfme/tests/cloud/test_cloud_events.py
@@ -71,7 +71,7 @@ def test_vm_capture(request, provider, setup_provider, register_event):
         vm.refresh_relationships()
 
     # # deferred delete vm
-    request.addfinalizer(vm.delete_from_provider)
+    request.addfinalizer(vm.cleanup_on_provider)
 
     def cmp_function(_, y):
         # In 5.9 version `y` is a dict, not a yaml stream.

--- a/cfme/tests/cloud/test_cloud_init_provisioning.py
+++ b/cfme/tests/cloud/test_cloud_init_provisioning.py
@@ -54,7 +54,7 @@ def test_provision_cloud_init(request, setup_provider, provider, provisioning,
 
     instance = Instance.factory(vm_name, provider, image)
 
-    request.addfinalizer(instance.delete_from_provider)
+    request.addfinalizer(instance.cleanup_on_provider)
     # TODO: extend inst_args for other providers except EC2 if needed
     inst_args = {
         'request': {'email': 'image_provisioner@example.com',

--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -38,7 +38,7 @@ def ec2_sleep():
 def new_instance(request, provider):
     instance = Instance.factory(random_vm_name("timelines", max_length=16), provider)
 
-    request.addfinalizer(instance.delete_from_provider)
+    request.addfinalizer(instance.cleanup_on_provider)
 
     if not provider.mgmt.does_vm_exist(instance.name):
         logger.info("deploying %s on provider %s", instance.name, provider.key)

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -48,7 +48,7 @@ def testing_instance2(provider):
     """
     instance2 = create_instance(provider)
     yield instance2
-    instance.cleanup_on_provider()
+    instance2.cleanup_on_provider()
 
 
 # This fixture must be named 'vm_name' because its tied to cfme/fixtures/virtual_machine

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -31,15 +31,6 @@ def create_instance(provider):
         provider.mgmt.set_name(
             instance.name, 'test_terminated_{}'.format(fauxfactory.gen_alphanumeric(8)))
         instance.create_on_provider(allow_skip="default", find_in_cfme=True)
-    return instance
-
-
-def cleanup_instance(provider, instance):
-    logger.info('Fixture cleanup, deleting test instance: %s', instance.name)
-    try:
-        provider.mgmt.delete_vm(instance.name)
-    except Exception:
-        logger.exception('Exception when deleting testing_instance: %s', instance.name)
 
 
 @pytest.yield_fixture(scope="function")
@@ -48,7 +39,7 @@ def testing_instance(provider):
     """
     instance = create_instance(provider)
     yield instance
-    cleanup_instance(provider, instance)
+    instance.cleanup_on_provider()
 
 
 @pytest.yield_fixture(scope="function")
@@ -57,7 +48,7 @@ def testing_instance2(provider):
     """
     instance2 = create_instance(provider)
     yield instance2
-    cleanup_instance(provider, instance2)
+    instance.cleanup_on_provider()
 
 
 # This fixture must be named 'vm_name' because its tied to cfme/fixtures/virtual_machine

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -31,6 +31,7 @@ def create_instance(provider):
         provider.mgmt.set_name(
             instance.name, 'test_terminated_{}'.format(fauxfactory.gen_alphanumeric(8)))
         instance.create_on_provider(allow_skip="default", find_in_cfme=True)
+    return instance
 
 
 @pytest.yield_fixture(scope="function")

--- a/cfme/tests/cloud/test_provisioning.py
+++ b/cfme/tests/cloud/test_provisioning.py
@@ -17,6 +17,7 @@ from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.openstack import OpenStackProvider
+from cfme.common.vm import VM
 from cfme.utils import error
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.conf import credentials
@@ -117,7 +118,7 @@ def testing_instance(request, setup_provider, provider, provisioning, vm_name, t
 
     logger.info('Fixture cleanup, deleting test instance: %s', instance.name)
     try:
-        instance.delete_from_provider()
+        instance.cleanup_on_provider()
     except Exception as ex:
         logger.warning('Exception while deleting instance fixture, continuing: {}'
                        .format(ex.message))
@@ -265,7 +266,8 @@ def test_provision_from_template_using_rest(
                              'root_password': vm_password}})
 
     request.addfinalizer(
-        lambda: provider.mgmt.delete_vm(vm_name) if provider.mgmt.does_vm_exist(vm_name) else None)
+        lambda: VM.factory(vm_name, provider).cleanup_on_provider()
+    )
 
     response = appliance.rest_api.collections.provision_requests.action.create(**provision_data)[0]
     assert_response(appliance)
@@ -417,7 +419,8 @@ def test_manual_placement_using_rest(
         provision_data['vm_fields']['cloud_tenant'] = cloud_tenant_id
 
     request.addfinalizer(
-        lambda: provider.mgmt.delete_vm(vm_name) if provider.mgmt.does_vm_exist(vm_name) else None)
+        lambda: VM.factory(vm_name, provider).cleanup_on_provider()
+    )
 
     response = appliance.rest_api.collections.provision_requests.action.create(**provision_data)[0]
     assert_response(appliance)

--- a/cfme/tests/cloud/test_provisioning.py
+++ b/cfme/tests/cloud/test_provisioning.py
@@ -528,7 +528,7 @@ def test_provision_from_template_with_attached_disks(request, testing_instance, 
             soft_assert(vm_name in provider.mgmt.volume_attachments(volume_id))
         for volume, device in device_mapping:
             soft_assert(provider.mgmt.volume_attachments(volume)[vm_name] == device)
-        instance.delete_from_provider()  # To make it possible to delete the volume
+        instance.cleanup_on_provider()  # To make it possible to delete the volume
         wait_for(lambda: not instance.does_vm_exist_on_provider(), num_sec=180, delay=5)
 
 
@@ -655,7 +655,7 @@ def test_provision_with_additional_volume(request, testing_instance, provider, s
         volume = provider.mgmt.get_volume(volume_id)
         assert volume.size == 3
     finally:
-        instance.delete_from_provider()
+        instance.cleanup_on_provider()
         wait_for(lambda: not instance.does_vm_exist_on_provider(), num_sec=180, delay=5)
         if "volume_id" in locals():  # To handle the case of 1st or 2nd assert
             if provider.mgmt.volume_exists(volume_id):

--- a/cfme/tests/cloud_infra_common/test_cockpit_server.py
+++ b/cfme/tests/cloud_infra_common/test_cockpit_server.py
@@ -21,7 +21,7 @@ def new_vm(provider, request):
         vm = Vm.factory(random_vm_name(context='cockpit'), provider)
     if not provider.mgmt.does_vm_exist(vm.name):
         vm.create_on_provider(find_in_cfme=True, allow_skip="default")
-        request.addfinalizer(vm.delete_from_provider)
+        request.addfinalizer(vm.cleanup_on_provider)
     return vm
 
 

--- a/cfme/tests/cloud_infra_common/test_custom_attributes_rest.py
+++ b/cfme/tests/cloud_infra_common/test_custom_attributes_rest.py
@@ -35,11 +35,7 @@ def vm_obj(provider, setup_provider_modscope, small_template_modscope):
 
     yield new_vm
 
-    if provider.mgmt.does_vm_exist(new_vm.name):
-        try:
-            provider.mgmt.delete_vm(new_vm.name)
-        except Exception:
-            logger.warning('Failed to delete vm `{}`.'.format(new_vm.name))
+    new_vm.cleanup_on_provider()
 
 
 @pytest.fixture(scope='module')

--- a/cfme/tests/cloud_infra_common/test_discovery.py
+++ b/cfme/tests/cloud_infra_common/test_discovery.py
@@ -73,7 +73,7 @@ def test_vm_discovery(request, setup_provider, provider, vm_crud):
 
     @request.addfinalizer
     def _cleanup():
-        vm_crud.delete_from_provider()
+        vm_crud.cleanup_on_provider()
         if_scvmm_refresh_provider(provider)
 
     vm_crud.create_on_provider(allow_skip="default")
@@ -83,6 +83,6 @@ def test_vm_discovery(request, setup_provider, provider, vm_crud):
         vm_crud.wait_to_appear(timeout=600, load_details=False)
     except TimedOutError:
         pytest.fail("VM was not found in CFME")
-    vm_crud.delete_from_provider()
+    vm_crud.cleanup_on_provider()
     if_scvmm_refresh_provider(provider)
     wait_for_vm_state_changes(vm_crud)

--- a/cfme/tests/cloud_infra_common/test_events.py
+++ b/cfme/tests/cloud_infra_common/test_events.py
@@ -29,7 +29,7 @@ def vm_crud(provider, setup_provider_modscope, small_template_modscope):
         template_name=template.name)
     yield vm
     if vm.does_vm_exist_on_provider():
-        vm.delete_from_provider()
+        vm.cleanup_on_provider()
 
 
 @pytest.mark.rhv2

--- a/cfme/tests/cloud_infra_common/test_genealogy.py
+++ b/cfme/tests/cloud_infra_common/test_genealogy.py
@@ -60,10 +60,8 @@ def test_vm_genealogy_detected(
     """
     vm_crud.create_on_provider(find_in_cfme=True, allow_skip="default")
 
-    @request.addfinalizer
-    def _():
-        if provider.mgmt.does_vm_exist(vm_crud.name):
-            provider.mgmt.delete_vm(vm_crud.name)
+    request.addfinalizer(lambda: vm_crud.cleanup_on_provider())
+
     provider.mgmt.wait_vm_steady(vm_crud.name)
 
     if from_edit:

--- a/cfme/tests/cloud_infra_common/test_retirement.py
+++ b/cfme/tests/cloud_infra_common/test_retirement.py
@@ -48,12 +48,7 @@ def retire_vm(small_template, provider):
     vm = VM.factory(random_vm_name('retire'), provider, template_name=small_template.name)
     vm.create_on_provider(find_in_cfme=True, allow_skip="default", timeout=1200)
     yield vm
-
-    try:
-        provider.mgmt.delete_vm(vm.name)
-    except Exception:
-        logger.warning('Failed to delete vm from provider: {}'.format(vm.name))
-
+    vm.cleanup_on_provider()
 
 @pytest.yield_fixture(scope="function")
 def retire_ec2_s3_vm(provider):
@@ -66,12 +61,7 @@ def retire_ec2_s3_vm(provider):
                     template_name='amzn-ami-pv-2015.03.rc-1.x86_64-s3')
     vm.create_on_provider(find_in_cfme=True, allow_skip="default", timeout=1200)
     yield vm
-
-    try:
-        provider.mgmt.delete_vm(vm.name)
-    except Exception:
-        logger.warning('Failed to delete vm from provider: {}'.format(vm.name))
-
+    vm.cleanup_on_provider()
 
 def verify_retirement_state(retire_vm):
     """Verify the vm/instance is in the 'retired' state in the UI and assert its power state

--- a/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
+++ b/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
@@ -9,7 +9,6 @@ from cfme.cloud.provider import CloudProvider, CloudInfraProvider
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.common.vm import VM, Template
-from cfme.common.provider import cleanup_vm
 from cfme.common.vm_views import DriftAnalysis
 from cfme.configure import configuration
 from cfme.configure.tasks import is_vm_analysis_finished, TasksView
@@ -169,7 +168,7 @@ def ssa_vm(request, local_setup_provider, provider, vm_analysis_provisioning_dat
     """ Fixture to provision instance on the provider """
     vm_name = 'test-ssa-{}-{}'.format(fauxfactory.gen_alphanumeric(), analysis_type)
     vm = VM.factory(vm_name, provider, template_name=vm_analysis_provisioning_data.image)
-    request.addfinalizer(lambda: cleanup_vm(vm_name, provider))
+    request.addfinalizer(lambda: vm.cleanup_on_provider())
 
     provision_data = vm_analysis_provisioning_data.copy()
     del provision_data['image']

--- a/cfme/tests/cloud_infra_common/test_vm_ownership.py
+++ b/cfme/tests/cloud_infra_common/test_vm_ownership.py
@@ -26,7 +26,7 @@ def vm_crud(provider):
     yield vm
 
     try:
-        vm.delete_from_provider()
+        vm.cleanup_on_provider()
     except Exception:
         logger.exception('Exception deleting test vm "%s" on %s', vm.name, provider.name)
 

--- a/cfme/tests/configure/test_log_depot_operation.py
+++ b/cfme/tests/configure/test_log_depot_operation.py
@@ -12,11 +12,12 @@ import pytest
 import re
 
 from cfme import test_requirements
+from cfme.common.vm import VM
 from cfme.utils import conf, testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.ftp import FTPClient
-from cfme.utils.providers import get_mgmt
+from cfme.utils.providers import get_crud
 from cfme.utils.update import update
 from cfme.utils.version import current_version
 from cfme.utils.virtual_machines import deploy_template
@@ -107,12 +108,12 @@ def depot_machine_ip():
     data = conf.cfme_data.get("log_db_operations", {})
     depot_provider_key = data["log_db_depot_template"]["provider"]
     depot_template_name = data["log_db_depot_template"]["template_name"]
-    prov = get_mgmt(depot_provider_key)
+    prov_crud = get_crud(depot_provider_key)
     deploy_template(depot_provider_key,
                     depot_machine_name,
                     template_name=depot_template_name)
-    yield prov.get_ip_address(depot_machine_name)
-    prov.delete_vm(depot_machine_name)
+    yield prov_crud.mgmt.get_ip_address(depot_machine_name)
+    VM.factory(depot_machine_name, prov_crud).cleanup_on_provider()
 
 
 @pytest.fixture(scope="module")

--- a/cfme/tests/control/test_bugs.py
+++ b/cfme/tests/control/test_bugs.py
@@ -133,7 +133,7 @@ def collections(policy_collection, condition_collection, action_collection, aler
 def vmware_vm(request, virtualcenter_provider):
     vm = VM.factory(random_vm_name("control"), virtualcenter_provider)
     vm.create_on_provider(find_in_cfme=True)
-    request.addfinalizer(vm.delete_from_provider)
+    request.addfinalizer(vm.cleanup_on_provider)
     return vm
 
 

--- a/cfme/tests/control/test_compliance.py
+++ b/cfme/tests/control/test_compliance.py
@@ -104,8 +104,7 @@ def compliance_vm(configure_fleecing, provider, full_template_modscope):
     if not vm.exists:
         vm.wait_to_appear(timeout=900)
     yield vm
-    if provider.mgmt.does_vm_exist(vm.name):
-        provider.mgmt.delete_vm(vm.name)
+    vm.cleanup_on_provider()
     provider.refresh_provider_relationships()
 
 

--- a/cfme/tests/distributed/test_appliance_replication.py
+++ b/cfme/tests/distributed/test_appliance_replication.py
@@ -99,11 +99,7 @@ def test_vm(virtualcenter_provider):
     else:
         logger.info("recycling deployed vm %r on provider %r", vm_name, virtualcenter_provider.key)
     yield vm
-
-    try:
-        virtualcenter_provider.mgmt.delete_vm(vm_name=vm_name)
-    except Exception:
-        logger.exception('Failed deleting VM "%r" on "%r"', vm_name, virtualcenter_provider.name)
+    vm.cleanup_on_provider()
 
 
 @pytest.mark.tier(2)

--- a/cfme/tests/infrastructure/test_cloud_init_provisioning.py
+++ b/cfme/tests/infrastructure/test_cloud_init_provisioning.py
@@ -2,7 +2,7 @@
 import fauxfactory
 import pytest
 
-from cfme.common.provider import cleanup_vm
+from cfme.common.vm import VM
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.provisioning import do_vm_provisioning
 from cfme.infrastructure.pxe import get_template_from_config
@@ -47,7 +47,7 @@ def test_provision_cloud_init(appliance, setup_provider, provider, setup_ci_temp
     template = provisioning.get('ci-image') or provisioning['image']['name']
     host, datastore, vlan = map(provisioning.get, ('host', 'datastore', 'vlan'))
 
-    request.addfinalizer(lambda: cleanup_vm(vm_name, provider))
+    request.addfinalizer(lambda: VM.factory(vm_name, provider).cleanup_on_provider())
 
     provisioning_data = {
         'catalog': {

--- a/cfme/tests/infrastructure/test_iso_provisioning.py
+++ b/cfme/tests/infrastructure/test_iso_provisioning.py
@@ -2,7 +2,7 @@
 import fauxfactory
 import pytest
 
-from cfme.common.provider import cleanup_vm
+from cfme.common.vm import VM
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.pxe import get_template_from_config, ISODatastore
@@ -95,7 +95,7 @@ def test_iso_provision_from_template(appliance, provider, vm_name, smtp_test, da
             ('pxe_template', 'host', 'datastore', 'iso_file', 'iso_kickstart',
              'iso_root_password', 'iso_image_type', 'vlan'))
 
-    request.addfinalizer(lambda: cleanup_vm(vm_name, provider))
+    request.addfinalizer(lambda: VM.factory(vm_name, provider).cleanup_on_provider())
 
     provisioning_data = {
         'catalog': {

--- a/cfme/tests/infrastructure/test_provisioning.py
+++ b/cfme/tests/infrastructure/test_provisioning.py
@@ -2,7 +2,7 @@
 import pytest
 
 from cfme import test_requirements
-from cfme.common.provider import cleanup_vm
+from cfme.common.vm import VM
 from cfme.infrastructure.provider import InfraProvider
 from cfme.provisioning import do_vm_provisioning
 from cfme.utils import normalize_text
@@ -52,7 +52,7 @@ def test_provision_from_template(appliance, setup_provider, provider, vm_name, s
 
     template = provisioning['template']
 
-    request.addfinalizer(lambda: cleanup_vm(vm_name, provider))
+    request.addfinalizer(lambda: VM.factory(vm_name, provider).cleanup_on_provider())
 
     provisioning_data = {
         'catalog': {
@@ -108,7 +108,7 @@ def test_provision_approval(appliance, setup_provider, provider, vm_name, smtp_t
     # It will provision two of them
     vm_names = [vm_name + "001", vm_name + "002"]
     request.addfinalizer(
-        lambda: [cleanup_vm(vmname, provider) for vmname in vm_names])
+        lambda: [VM.factory(name, provider).cleanup_on_provider() for name in vm_names])
 
     provisioning_data = {
         'catalog': {
@@ -154,13 +154,14 @@ def test_provision_approval(appliance, setup_provider, provider, vm_name, smtp_t
         provision_request.edit_request(values=modifications)
         vm_names = [new_vm_name]  # Will be just one now
         request.addfinalizer(
-            lambda: cleanup_vm(new_vm_name, provider))
+            lambda: VM.factory(new_vm_name, provider).cleanup_on_provider()
+        )
     else:
         # Manual approval
         provision_request.approve_request(method='ui', reason="Approved")
         vm_names = [vm_name + "001", vm_name + "002"]  # There will be two VMs
         request.addfinalizer(
-            lambda: [cleanup_vm(vmname, provider) for vmname in vm_names])
+            lambda: [VM.factory(name, provider).cleanup_on_provider() for name in vm_names])
     wait_for(
         lambda:
         len(filter(

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -10,7 +10,7 @@ from widgetastic_patternfly import CheckableBootstrapTreeview as CbTree
 
 from cfme import test_requirements
 from cfme.base.login import BaseLoggedInPage
-from cfme.common.provider import cleanup_vm
+from cfme.common.vm import VM
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
@@ -77,7 +77,7 @@ def provisioner(appliance, request, setup_provider, provider, vm_name):
         base_view = vm.appliance.browser.create_view(BaseLoggedInPage)
         base_view.flash.assert_no_error()
 
-        request.addfinalizer(lambda: cleanup_vm(vm_name, provider))
+        request.addfinalizer(lambda: VM.factory(vm_name, provider).cleanup_on_provider())
         request_description = 'Provision from [{}] to [{}]'.format(template, vm_name)
         provision_request = appliance.collections.requests.instantiate(
             description=request_description)

--- a/cfme/tests/infrastructure/test_pxe_provisioning.py
+++ b/cfme/tests/infrastructure/test_pxe_provisioning.py
@@ -4,8 +4,8 @@ import pytest
 
 from widgetastic.utils import partial_match
 
+from cfme.common.vm import VM
 from cfme.utils.conf import cfme_data
-from cfme.common.provider import cleanup_vm
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.infrastructure.pxe import get_pxe_server_from_config, get_template_from_config
@@ -121,7 +121,7 @@ def test_pxe_provision_from_template(appliance, provider, vm_name, smtp_test, se
         )
     )
 
-    request.addfinalizer(lambda: cleanup_vm(vm_name, provider))
+    request.addfinalizer(lambda: VM.factory(vm_name, provider).cleanup_on_provider())
 
     provisioning_data = {
         'catalog': {

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -50,22 +50,14 @@ def provision_vm(provider, template):
 def small_test_vm(setup_provider_modscope, provider, small_template_modscope, request):
     vm = provision_vm(provider, small_template_modscope)
     yield vm
-
-    try:
-        vm.delete_from_provider()
-    except Exception:
-        logger.exception('Exception deleting test vm "%s" on %s', vm.name, provider.name)
+    vm.cleanup_on_provider()
 
 
 @pytest.yield_fixture(scope="module")
 def full_test_vm(setup_provider_modscope, provider, full_template_modscope, request):
     vm = provision_vm(provider, full_template_modscope)
     yield vm
-
-    try:
-        vm.delete_from_provider()
-    except Exception:
-        logger.exception('Exception deleting test vm "%s" on %s', vm.name, provider.name)
+    vm.cleanup_on_provider()
 
 
 def new_snapshot(test_vm, has_name=True, memory=False, create_description=True):

--- a/cfme/tests/infrastructure/test_ssa_vddk.py
+++ b/cfme/tests/infrastructure/test_ssa_vddk.py
@@ -73,8 +73,7 @@ def vm(request, provider, small_template_modscope, ssa_analysis_profile):
     @request.addfinalizer
     def _finalize():
         try:
-            if provider.mgmt.does_vm_exist(vm_obj.name):
-                provider.mgmt.delete_vm(vm_obj.name)
+            vm_obj.cleanup_on_provider()
             provider.refresh_provider_relationships()
         except Exception as e:
             logger.exception(e)

--- a/cfme/tests/infrastructure/test_tenant_quota.py
+++ b/cfme/tests/infrastructure/test_tenant_quota.py
@@ -91,7 +91,7 @@ def small_vm(provider, small_template_modscope):
     vm.create_on_provider(find_in_cfme=True, allow_skip="default")
     vm.refresh_relationships()
     yield vm
-    vm.delete_from_provider()
+    vm.cleanup_on_provider()
 
 
 @pytest.mark.rhv2

--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -28,9 +28,7 @@ def new_vm(request, provider):
     logger.info('Will create  %r on Provider: %r', vm.name, vm.provider.name)
     vm.create_on_provider(find_in_cfme=False, timeout=500)
     yield vm
-    logger.debug('Fixture new_vm teardown! Name: %r Provider: %r', vm.name, vm.provider.name)
-    vm.provider.mgmt.delete_vm(vm.name)
-
+    vm.cleanup_on_provider()
 
 @pytest.fixture(scope="module")
 def mark_vm_as_appliance(new_vm, appliance):

--- a/cfme/tests/infrastructure/test_vm_clone.py
+++ b/cfme/tests/infrastructure/test_vm_clone.py
@@ -2,7 +2,6 @@
 import fauxfactory
 import pytest
 
-from cfme.common.provider import cleanup_vm
 from cfme.common.vm import VM
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.utils.log import logger
@@ -44,7 +43,7 @@ def create_vm(appliance, provider, setup_provider, request):
 @pytest.mark.usefixtures("setup_provider")
 @pytest.mark.long_running
 def test_vm_clone(appliance, provider, clone_vm_name, request, create_vm):
-    request.addfinalizer(lambda: cleanup_vm(clone_vm_name, provider))
+    request.addfinalizer(lambda: VM.factory(clone_vm_name, provider).cleanup_on_provider())
     provision_type = 'VMware'
     create_vm.clone_vm("email@xyz.com", "first", "last", clone_vm_name, provision_type)
     request_description = clone_vm_name

--- a/cfme/tests/infrastructure/test_vm_clone.py
+++ b/cfme/tests/infrastructure/test_vm_clone.py
@@ -32,7 +32,7 @@ def create_vm(appliance, provider, setup_provider, request):
 
     @request.addfinalizer
     def _cleanup():
-        vm.delete_from_provider()
+        vm.cleanup_on_provider()
 
     if not provider.mgmt.does_vm_exist(vm.name):
         logger.info("deploying %s on provider %s", vm.name, provider.key)

--- a/cfme/tests/infrastructure/test_vm_migrate.py
+++ b/cfme/tests/infrastructure/test_vm_migrate.py
@@ -29,7 +29,7 @@ def new_vm(setup_provider_modscope, provider, request):
 
     if not provider.mgmt.does_vm_exist(vm_name):
         vm.create_on_provider(find_in_cfme=True, allow_skip="default")
-        request.addfinalizer(vm.delete_from_provider)
+        request.addfinalizer(vm.cleanup_on_provider)
     return vm
 
 

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -41,7 +41,7 @@ def testing_vm(request, provider, vm_name):
     @request.addfinalizer
     def _cleanup():
         if provider.mgmt.does_vm_exist(vm.name):
-            vm.delete_from_provider()
+            vm.cleanup_on_provider()
         if_scvmm_refresh_provider(provider)
 
     if not provider.mgmt.does_vm_exist(vm.name):
@@ -74,7 +74,7 @@ def testing_vm_tools(request, provider, vm_name, full_template):
 
     @request.addfinalizer
     def _cleanup():
-        vm.delete_from_provider()
+        vm.cleanup_on_provider()
         if_scvmm_refresh_provider(provider)
 
     if not provider.mgmt.does_vm_exist(vm.name):

--- a/cfme/tests/infrastructure/test_vm_reconfigure.py
+++ b/cfme/tests/infrastructure/test_vm_reconfigure.py
@@ -25,7 +25,7 @@ def small_vm(provider, small_template_modscope):
 
     yield vm
 
-    vm.delete_from_provider()
+    vm.cleanup_on_provider()
 
 
 @pytest.fixture(scope='function')

--- a/cfme/tests/infrastructure/test_webmks_console.py
+++ b/cfme/tests/infrastructure/test_webmks_console.py
@@ -28,17 +28,13 @@ def vm_obj(request, provider, setup_provider, console_template, vm_name):
     """VM creation/deletion fixture.
 
     Create a VM on the provider with the given template, and return the vm_obj.
-    Also, remove VM from provider using nested function _delete_vm
-    after the test is completed.
+
+    Clean up VM when test is done.
     """
     vm_obj = VM.factory(vm_name, provider, template_name=console_template.name)
     vm_obj.create_on_provider(timeout=2400, find_in_cfme=True, allow_skip="default")
     yield vm_obj
-    try:
-        vm_obj.delete_from_provider()
-    except Exception:
-        logger.warning("Failed to delete vm `{}`.".format(vm_obj.name))
-
+    vm_obj.cleanup_on_provider()
 
 @pytest.yield_fixture
 def ssh_client(vm_obj, console_template):

--- a/cfme/tests/services/test_add_remove_vm_to_service.py
+++ b/cfme/tests/services/test_add_remove_vm_to_service.py
@@ -4,7 +4,6 @@ import pytest
 from cfme import test_requirements
 from cfme.automate.explorer.domain import DomainCollection
 from cfme.automate.simulation import simulate
-from cfme.common.provider import cleanup_vm
 from cfme.common.vm import VM
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.services.service_catalogs import ServiceCatalogs
@@ -31,8 +30,7 @@ def new_vm(provider, setup_provider, small_template_modscope):
     vm = VM.factory(vm_name, provider, small_template_modscope.name)
     vm.create_on_provider(find_in_cfme=True, timeout=700, allow_skip="default")
     yield vm
-    if provider.mgmt.does_vm_exist(vm.name):
-        provider.mgmt.delete_vm(vm.name)
+    vm.cleanup_on_provider()
     provider.refresh_provider_relationships()
 
 
@@ -51,7 +49,7 @@ def copy_domain(request, appliance):
 @pytest.yield_fixture(scope='function')
 def myservice(appliance, provider, catalog_item, request):
     vm_name = catalog_item.provisioning_data["catalog"]["vm_name"]
-    request.addfinalizer(lambda: cleanup_vm(vm_name + "_0001", provider))
+    request.addfinalizer(lambda: VM.factory(vm_name + "_0001", provider).cleanup_on_provider())
     service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
     service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)

--- a/cfme/tests/services/test_cloud_service_catalogs.py
+++ b/cfme/tests/services/test_cloud_service_catalogs.py
@@ -5,10 +5,10 @@ import pytest
 from riggerlib import recursive_update
 from widgetastic.utils import partial_match
 
-from cfme.common.provider import cleanup_vm
 from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.cloud.provider.azure import AzureProvider
+from cfme.common.vm import VM
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme import test_requirements
 from cfme.utils.generators import random_vm_name
@@ -39,7 +39,8 @@ def test_cloud_catalog_item(appliance, vm_name, setup_provider, provider, dialog
         test_flag: provision
     """
     wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600)
-    request.addfinalizer(lambda: cleanup_vm("{}0001".format(vm_name), provider))
+    vm = VM.factory("{}0001".format(vm_name), provider)
+    request.addfinalizer(lambda: vm.cleanup_on_provider())
     image = provisioning['image']['name']
     item_name = "{}-service-{}".format(provider.name, fauxfactory.gen_alphanumeric())
 

--- a/cfme/tests/services/test_different_dialogs_in_catalogs.py
+++ b/cfme/tests/services/test_different_dialogs_in_catalogs.py
@@ -4,8 +4,8 @@ import pytest
 from widgetastic.utils import partial_match
 
 from cfme import test_requirements
-from cfme.common.provider import cleanup_vm
 from cfme.infrastructure.provider import InfraProvider
+from cfme.common.vm import VM
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
@@ -94,7 +94,7 @@ def test_tagdialog_catalog_item(appliance, provider, catalog_item, request):
         test_flag: provision
     """
     vm_name = catalog_item.provisioning_data['catalog']["vm_name"]
-    request.addfinalizer(lambda: cleanup_vm(vm_name + "_0001", provider))
+    request.addfinalizer(lambda: VM.factory(vm_name + "_0001", provider).cleanup_on_provider())
     dialog_values = {'service_level': "Gold"}
     service_catalogs = ServiceCatalogs(appliance, catalog=catalog_item.catalog,
                                        name=catalog_item.name,

--- a/cfme/tests/services/test_iso_service_catalogs.py
+++ b/cfme/tests/services/test_iso_service_catalogs.py
@@ -5,7 +5,7 @@ import pytest
 from widgetastic.utils import partial_match
 
 from cfme import test_requirements
-from cfme.common.provider import cleanup_vm
+from cfme.common.vm import VM
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.pxe import get_template_from_config, ISODatastore
@@ -113,7 +113,7 @@ def test_rhev_iso_servicecatalog(appliance, setup_provider, provider, catalog_it
         test_flag: iso, provision
     """
     vm_name = catalog_item.provisioning_data['catalog']["vm_name"]
-    request.addfinalizer(lambda: cleanup_vm(vm_name + "_0001", provider))
+    request.addfinalizer(lambda: VM.factory(vm_name + "_0001", provider).cleanup_on_provider())
     service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
     service_catalogs.order()
     # nav to requests page happens on successful provision

--- a/cfme/tests/services/test_myservice.py
+++ b/cfme/tests/services/test_myservice.py
@@ -3,7 +3,7 @@ import pytest
 from datetime import datetime
 
 from cfme import test_requirements
-from cfme.common.provider import cleanup_vm
+from cfme.common.vm import VM
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.services.myservice import MyService
@@ -59,7 +59,7 @@ def myservice(appliance, provider, catalog_item, request):
 
     yield catalog_item.name, vm_name
 
-    cleanup_vm(vm_name, provider)
+    VM.factory(vm_name, provider).cleanup_on_provider()
 
 
 @pytest.mark.parametrize('context', [ViaUI])

--- a/cfme/tests/services/test_pxe_service_catalogs.py
+++ b/cfme/tests/services/test_pxe_service_catalogs.py
@@ -4,9 +4,9 @@ import pytest
 from widgetastic.utils import partial_match
 
 from cfme import test_requirements
-from cfme.common.provider import cleanup_vm
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.pxe import get_pxe_server_from_config, get_template_from_config
+from cfme.common.vm import VM
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils import testgen
 from cfme.utils.conf import cfme_data
@@ -122,8 +122,8 @@ def test_pxe_servicecatalog(appliance, setup_provider, provider, catalog_item, r
     Metadata:
         test_flag: pxe, provision
     """
-    vm_name = catalog_item.prov_data['catalog']["vm_name"]
-    request.addfinalizer(lambda: cleanup_vm(vm_name + "_0001", provider))
+    vm_name = catalog_item.provisioning_data['catalog']["vm_name"]
+    request.addfinalizer(lambda: VM.factory(vm_name + "_0001", provider).cleanup_on_provider())
     service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
     service_catalogs.order()
     # nav to requests page happens on successful provision

--- a/cfme/tests/services/test_request.py
+++ b/cfme/tests/services/test_request.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from cfme.common.provider import cleanup_vm
+from cfme.common.vm import VM
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme import test_requirements
@@ -21,7 +21,7 @@ pytestmark = [
 def test_copy_request(appliance, setup_provider, provider, catalog_item, request):
     """Automate BZ 1194479"""
     vm_name = catalog_item.provisioning_data["catalog"]["vm_name"]
-    request.addfinalizer(lambda: cleanup_vm(vm_name + "_0001", provider))
+    request.addfinalizer(lambda: VM.factory(vm_name + "_0001", provider).cleanup_on_provider())
     catalog_item.create()
     service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
     service_catalogs.order()

--- a/cfme/tests/services/test_service_catalogs.py
+++ b/cfme/tests/services/test_service_catalogs.py
@@ -3,7 +3,7 @@ import fauxfactory
 import pytest
 
 from cfme import test_requirements
-from cfme.common.provider import cleanup_vm
+from cfme.common.vm import VM
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.services.catalogs.catalog_items import EditCatalogItemView
@@ -39,7 +39,7 @@ def test_order_catalog_item(appliance, provider, catalog_item, request,
         test_flag: provision
     """
     vm_name = catalog_item.provisioning_data['catalog']["vm_name"]
-    request.addfinalizer(lambda: cleanup_vm(vm_name + "_0001", provider))
+    request.addfinalizer(lambda: VM.factory(vm_name + "_0001", provider).cleanup_on_provider())
 
     register_event(target_type='Service', target_name=catalog_item.name,
                    event_type='service_provisioned')
@@ -64,7 +64,7 @@ def test_order_catalog_item_via_rest(
         test_flag: provision, rest
     """
     vm_name = catalog_item.provisioning_data['catalog']["vm_name"]
-    request.addfinalizer(lambda: cleanup_vm(vm_name, provider))
+    request.addfinalizer(lambda: VM.factory(vm_name, provider).cleanup_on_provider())
     request.addfinalizer(catalog_item.delete)
     catalog = appliance.rest_api.collections.service_catalogs.find_by(name=catalog.name)
     assert len(catalog) == 1
@@ -92,7 +92,7 @@ def test_order_catalog_bundle(appliance, provider, catalog_item, request):
     """
 
     vm_name = catalog_item.provisioning_data['catalog']["vm_name"]
-    request.addfinalizer(lambda: cleanup_vm(vm_name + "_0001", provider))
+    request.addfinalizer(lambda: VM.factory(vm_name + "_0001", provider).cleanup_on_provider())
     bundle_name = fauxfactory.gen_alphanumeric()
     catalog_bundle = appliance.collections.catalog_bundles.create(
         bundle_name, description="catalog_bundle",

--- a/cfme/tests/services/test_service_manual_approval.py
+++ b/cfme/tests/services/test_service_manual_approval.py
@@ -2,7 +2,7 @@
 import fauxfactory
 import pytest
 
-from cfme.common.provider import cleanup_vm
+from cfme.common.vm import VM
 from cfme.infrastructure.provider import InfraProvider
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.automate.explorer.domain import DomainCollection
@@ -65,7 +65,7 @@ def test_service_manual_approval(appliance, provider, modify_instance,
         test_flag: provision
     """
     vm_name = catalog_item.provisioning_data['catalog']["vm_name"]
-    request.addfinalizer(lambda: cleanup_vm(vm_name + "_0001", provider))
+    request.addfinalizer(lambda: VM.factory(vm_name, provider).cleanup_on_provider())
 
     service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
     service_catalogs.order()

--- a/cfme/tests/test_db_restore.py
+++ b/cfme/tests/test_db_restore.py
@@ -22,7 +22,7 @@ def provision_vm(request, provider):
     """Function to provision appliance to the provider being tested"""
     vm_name = "test_rest_db_" + fauxfactory.gen_alphanumeric()
     vm = VM.factory(vm_name, provider)
-    request.addfinalizer(vm.delete_from_provider)
+    request.addfinalizer(vm.cleanup_on_provider)
     if not provider.mgmt.does_vm_exist(vm_name):
         logger.info("deploying %s on provider %s", vm_name, provider.key)
         vm.create_on_provider(allow_skip="default")

--- a/cfme/utils/virtual_machines.py
+++ b/cfme/utils/virtual_machines.py
@@ -2,7 +2,6 @@
 """
 import pytest
 
-from cfme.common.vm import VM
 from cfme.utils.providers import get_crud
 from fixtures.pytest_store import store
 from novaclient.exceptions import OverLimit as OSOverLimit
@@ -55,7 +54,7 @@ def deploy_template(provider_key, vm_name, template_name=None, timeout=900, **de
         except Exception as e:
             logger.error('Could not provisioning VM/instance %s (%s: %s)',
                 vm_name, type(e).__name__, str(e))
-            VM.factory(vm_name, provider_crud).cleanup_on_provider()
+            provider_crud.mgmt.delete_vm(vm_name)
             raise
     except skip_exceptions as e:
         e_c = type(e)

--- a/cfme/utils/virtual_machines.py
+++ b/cfme/utils/virtual_machines.py
@@ -2,6 +2,7 @@
 """
 import pytest
 
+from cfme.common.vm import VM
 from cfme.utils.providers import get_crud
 from fixtures.pytest_store import store
 from novaclient.exceptions import OverLimit as OSOverLimit
@@ -9,27 +10,6 @@ from ovirtsdk.infrastructure.errors import RequestError as RHEVRequestError
 from ssl import SSLError
 from cfme.utils.log import logger
 from cfme.utils.mgmt_system import exceptions
-
-
-def _vm_cleanup(mgmt, vm_name):
-    """Separated to make the logic able to propagate the exceptions directly."""
-    try:
-        logger.info("VM/Instance status: %s", mgmt.vm_status(vm_name))
-    except Exception as f:
-        logger.error(
-            "Could not retrieve VM/Instance status: %s: %s", type(f).__name__, str(f))
-    logger.info('Attempting cleanup on VM/instance %s', vm_name)
-    try:
-        if mgmt.does_vm_exist(vm_name):
-            # Stop the vm first
-            logger.warning('Destroying VM/instance %s', vm_name)
-            if mgmt.delete_vm(vm_name):
-                logger.info('VM/instance %s destroyed', vm_name)
-            else:
-                logger.error('Error destroying VM/instance %s', vm_name)
-    except Exception as f:
-        logger.error(
-            'Could not destroy VM/instance %s (%s: %s)', vm_name, type(f).__name__, str(f))
 
 
 def deploy_template(provider_key, vm_name, template_name=None, timeout=900, **deploy_args):
@@ -75,7 +55,7 @@ def deploy_template(provider_key, vm_name, template_name=None, timeout=900, **de
         except Exception as e:
             logger.error('Could not provisioning VM/instance %s (%s: %s)',
                 vm_name, type(e).__name__, str(e))
-            _vm_cleanup(provider_crud.mgmt, vm_name)
+            VM.factory(vm_name, provider_crud).cleanup_on_provider()
             raise
     except skip_exceptions as e:
         e_c = type(e)

--- a/cfme/utils/virtual_machines.py
+++ b/cfme/utils/virtual_machines.py
@@ -52,9 +52,12 @@ def deploy_template(provider_key, vm_name, template_name=None, timeout=900, **de
             vm_name = provider_crud.mgmt.deploy_template(timeout=timeout, **deploy_args)
             logger.info("Provisioned VM/instance %s", vm_name)  # instance ID in case of EC2
         except Exception as e:
-            logger.error('Could not provisioning VM/instance %s (%s: %s)',
+            logger.exception('Could not provisioning VM/instance %s (%s: %s)',
                 vm_name, type(e).__name__, str(e))
-            provider_crud.mgmt.delete_vm(vm_name)
+            try:
+                provider_crud.mgmt.delete_vm(vm_name)
+            except Exception:
+                logger.exception("Unable to clean up vm:", vm_name)
             raise
     except skip_exceptions as e:
         e_c = type(e)


### PR DESCRIPTION
We have many tests/fixtures/finalizers that are tearing down VMs in different ways.

Now, on Azure, we have some provider-specific things we want to do when tearing down a VM. We can implement this stuff in wrapanapi but I believe it might be better for the logic on "how to clean up each test VM" to live within the tests that created those test VM's. Reason being, the testers will know what objects tied to that VM are safe to delete.

I've consolidated all the VM cleanup finalizers I've found across tests into a method in cfme.common.vm:VM `cleanup_on_provider`. This will handle a couple checks and take care of deleting the VM. Provider-specific VM/Instance classes can super this and "do more stuff" if necessary. So for example on azure we will delete NICs/PIPs associated with that VM after deleting it

Note that this depends on the `ensure_state_on_provider` method from PR6784