### PR TITLE
[1LP][RFR] Add appliance_log_collector plugin

### DIFF
--- a/cfme/test_framework/pytest_plugin.py
+++ b/cfme/test_framework/pytest_plugin.py
@@ -38,6 +38,7 @@ pytest_plugins = (
     'cfme.test_framework.sprout.plugin',
     'cfme.test_framework.appliance_police',
     'cfme.test_framework.appliance',
+    'cfme.test_framework.appliance_log_collector',
     'cfme.test_framework.browser_isolation',
     'fixtures.portset',
 


### PR DESCRIPTION
Adding a pytest option for appliance log collection at session shutdown.

* New `--collect-logs` cli arg
* Gets configuration from env.yaml
  * List of logs to collect on appliances, and a local dir relative to `conf.utils.path.log_path`.
* Handles multiple appliances
* Names the file based on `appliance.hostname`
* Logging!

First time writing hookwrapper, hopefully I haven't done anything too foolish.