### PR TITLE
[1LP][RFR] Making sure SSUI Tests are not skipped 

### DIFF
--- a/cfme/fixtures/service_fixtures.py
+++ b/cfme/fixtures/service_fixtures.py
@@ -2,7 +2,6 @@
 import pytest
 from widgetastic.utils import partial_match
 
-from cfme.common.provider import cleanup_vm
 from cfme.cloud.provider import CloudProvider
 from cfme.infrastructure.provider import InfraProvider
 from cfme.rest.gen_data import dialog as _dialog
@@ -10,6 +9,7 @@ from cfme.rest.gen_data import service_catalog_obj as _catalog
 from cfme.services.catalogs.catalog_item import CatalogItem
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils.log import logger
+from fixtures.provider import console_template
 
 
 @pytest.fixture(scope="function")
@@ -28,13 +28,20 @@ def catalog_item(provider, provisioning, vm_name, dialog, catalog):
     return catalog_item
 
 
-def create_catalog_item(provider, provisioning, vm_name, dialog, catalog, console_template=None):
+def create_catalog_item(provider, provisioning, vm_name, dialog, catalog, console_test=False):
+    """Method that creates catalog item for given provider type.
+
+        Args:
+            console_test: Variable to tell if test is console test or not. True or False. By
+                default False.
+            Other args are fixtures.
+    """
     catalog_item_type = provider.catalog_name
     provision_type, template, host, datastore, iso_file, vlan = map(provisioning.get,
         ('provision_type', 'template', 'host', 'datastore', 'iso_file', 'vlan'))
-    if console_template:
-        logger.info("Console template name : {}".format(console_template.name))
-        template = console_template.name
+    if console_test:
+        template = console_template(provider).name
+        logger.info("Console template name : {}".format(template))
     item_name = dialog.label
     if provider.one_of(InfraProvider):
         catalog_name = template
@@ -64,26 +71,21 @@ def create_catalog_item(provider, provisioning, vm_name, dialog, catalog, consol
 
 
 @pytest.fixture
-def order_service(appliance, provider, provisioning, vm_name,
-                  dialog, catalog, console_template, request):
+def order_service(appliance, provider, provisioning, vm_name, dialog, catalog, request):
     """ Orders service once the catalog item is created"""
+
     if hasattr(request, 'param'):
-        catalog_item = create_catalog_item(provider, provisioning, vm_name, dialog, catalog,
-                                           console_template if 'console_test' in request.param else None)
+        catalog_item = create_catalog_item(
+            provider, provisioning, vm_name, dialog, catalog,
+            console_test=True if 'console_test' in request.param else None
+        )
     else:
         catalog_item = create_catalog_item(provider, provisioning, vm_name, dialog, catalog)
-    service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog,
-                                       catalog_item.name)
+    service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
     service_catalogs.order()
-    return catalog_item
-
-
-@pytest.fixture
-def provision_request(appliance, order_service):
-    """Checks if the service request is completed and provisioned"""
-    catalog_item = order_service
     provision_request = appliance.collections.requests.instantiate(catalog_item.name,
-                                                                   partial_check=True)
+        partial_check=True)
     provision_request.wait_for_request(method='ui')
+    assert provision_request.is_succeeded()
     return catalog_item, provision_request
 # TODO - remove request finally

--- a/cfme/tests/ssui/test_ssui_myservice.py
+++ b/cfme/tests/ssui/test_ssui_myservice.py
@@ -53,16 +53,16 @@ def test_retire_service(appliance, setup_provider, context, provision_request):
 
 @pytest.mark.meta(blockers=[BZ(1544535, forced_streams=['5.9'])])
 @pytest.mark.parametrize('context', [ViaSSUI])
-@pytest.mark.parametrize('provision_request', [['console_test']], indirect=True)
+@pytest.mark.parametrize('order_service', [['console_test']], indirect=True)
 @pytest.mark.uncollectif(lambda provider:
     provider.one_of(VMwareProvider) and provider.version >= 6.5 or
     'html5_console' in provider.data.excluded_test_flags,
     'VNC consoles are unsupported on VMware ESXi 6.5 and later')
 def test_vm_console(request, appliance, setup_provider, context, configure_websocket,
-        configure_console_vnc, provision_request, take_screenshot,
+        configure_console_vnc, order_service, take_screenshot,
         console_template, provider):
     """Test Myservice VM Console in SSUI."""
-    catalog_item, provision_request = provision_request
+    catalog_item, provision_request = order_service
     service_name = catalog_item.name
     console_vm_username = credentials[catalog_item.provider.data.templates.console_template
                             .creds].username
@@ -135,4 +135,3 @@ def test_vm_console(request, appliance, setup_provider, context, configure_webso
                 take_screenshot("ConsoleScreenshot")
                 vm_console.switch_to_appliance()
                 raise e
-


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ order_service and create_catalog_item Moved console_template out of function signature to avoid tests being skipped incorrectly due to 'console_template' not being found in provider data

**trackerbot/pr/run/22397 refer to this PRT run. latest run will skip due to bz. 59z failed due to regression BZ see comment below. 58z passed.**

{{pytest: -v --long-running cfme/tests/ssui/test_ssui_myservice.py -k 'test_vm_console'  --use-provider vsphere6-nested }}