### PR TITLE
[1LP][RFR] Mitigate the bug in CFME where symbols are converted to strings by REST

### DIFF
--- a/cfme/tests/configure/test_ntp_server.py
+++ b/cfme/tests/configure/test_ntp_server.py
@@ -1,14 +1,14 @@
+from datetime import datetime, timedelta
 from functools import partial
 
+import fauxfactory
+import pytest
+
 from cfme import test_requirements
-from datetime import datetime, timedelta
 from cfme.utils.browser import quit
 from cfme.utils.conf import cfme_data
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for
-import fauxfactory
-import pytest
-
 
 pytestmark = [test_requirements.configuration]
 
@@ -112,12 +112,12 @@ def test_ntp_server_check(request, appliance, ntp_servers_keys, empty_ntp_dict):
         appliance.server.settings.update_ntp_servers(dict(zip(
             ntp_servers_keys, [ntp_server for ntp_server in cfme_data['clock_servers']])))
         yaml_config = appliance.get_yaml_config()
-        ntp = yaml_config.get("ntp")
-        if not ntp:
-            yaml_config["ntp"] = {}
+        ntp_updates = yaml_config.get("ntp")
+        if not ntp_updates:
+            ntp_updates = {"ntp": {}}
         # adding the ntp interval to 1 minute and updating the configuration
-        yaml_config["ntp"]["interval"] = '1.minutes'
-        appliance.set_yaml_config(yaml_config)
+        ntp_updates["ntp"]["interval"] = '1.minutes'
+        appliance.set_yaml_config(ntp_updates)
         # restarting the evmserverd for NTP to work
         appliance.restart_evm_service(rude=True)
         appliance.wait_for_web_ui(timeout=1200)

--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
+from datetime import datetime, timedelta
+
 import fauxfactory
 import pytest
-from datetime import datetime, timedelta
 
 from cfme import test_requirements
 from cfme.control.explorer import alert_profiles, policies
@@ -10,6 +11,7 @@ from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
+from cfme.markers.env_markers.provider import providers
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.conf import cfme_data, credentials
@@ -19,9 +21,7 @@ from cfme.utils.providers import ProviderFilter
 from cfme.utils.ssh import SSHClient
 from cfme.utils.update import update
 from cfme.utils.wait import wait_for
-from cfme.markers.env_markers.provider import providers
 from . import do_scan, wait_for_ssa_enabled
-
 
 pf1 = ProviderFilter(classes=[InfraProvider])
 pf2 = ProviderFilter(classes=[SCVMMProvider], inverted=True)
@@ -184,13 +184,11 @@ def setup_for_alerts(alert_profile_collection, action_collection, policy_collect
 
 @pytest.yield_fixture(scope="module")
 def set_performance_capture_threshold(appliance):
-    yaml = appliance.get_yaml_config()
-    yaml["performance"]["capture_threshold_with_alerts"]["vm"] = "3.minutes"
-    appliance.set_yaml_config(yaml)
+    yaml_data = {"performance": {"capture_threshold_with_alerts": {"vm": "3.minutes"}}}
+    appliance.set_yaml_config(yaml_data)
     yield
-    yaml = appliance.get_yaml_config()
-    yaml["performance"]["capture_threshold_with_alerts"]["vm"] = "20.minutes"
-    appliance.set_yaml_config(yaml)
+    yaml_data = {"performance": {"capture_threshold_with_alerts": {"vm": "20.minutes"}}}
+    appliance.set_yaml_config(yaml_data)
 
 
 @pytest.yield_fixture(scope="module")

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2179,16 +2179,18 @@ class IPAppliance(object):
                                 username='root', password=None):
         """Sets up rubyrep replication via advanced configuration settings yaml."""
         password = password or self._encrypt_string(conf.credentials['ssh']['password'])
-        dest = {'workers': {'worker_base': {'replication_worker': {'replication': {
+        yaml_data = {'workers': {'worker_base': {'replication_worker': {'replication': {
             'destination': {}}}}}
         }
+        dest = yaml_data['workers']['worker_base']['replication_worker']['replication'][
+            'destination']
         dest['database'] = database
         dest['username'] = username
         dest['password'] = password
         dest['port'] = port
         dest['host'] = host
-        logger.debug('Dest: {}'.format(dest))
-        self.set_yaml_config(dest)
+        logger.debug('Dest: {}'.format(yaml_data))
+        self.set_yaml_config(yaml_data)
 
     def wait_for_miq_server_workers_started(self, evm_tail=None, poll_interval=5):
         """Waits for the CFME's workers to be started by tailing evm.log for:

--- a/cfme/utils/perf.py
+++ b/cfme/utils/perf.py
@@ -1,9 +1,11 @@
 """Functions that performance tests use."""
-from fixtures.pytest_store import store
-from cfme.utils.ssh import SSHClient, SSHTail
-from cfme.utils.log import logger
-import numpy
 import time
+
+import numpy
+
+from cfme.utils.log import logger
+from cfme.utils.ssh import SSHClient, SSHTail
+from fixtures.pytest_store import store
 
 
 def collect_log(ssh_client, log_prefix, local_file_name, strip_whitespace=False):
@@ -101,8 +103,8 @@ def set_rails_loglevel(level, validate_against_worker='MiqUiWorker'):
         evm_tail = SSHTail('/var/www/miq/vmdb/log/evm.log')
         evm_tail.set_initial_file_end()
 
-        yaml['log']['level_rails'] = level
-        store.current_appliance.set_yaml_config(yaml)
+        yaml_data = {'log': {'level_rails': level}}
+        store.current_appliance.set_yaml_config(yaml_data)
 
         attempts = 0
         detected = False


### PR DESCRIPTION
* Symbols are converted to strings in REST API leading to broken config
  for OpenShift.
* Previously we would get_yaml_config, modify it and then push the
  entire config back. The getting of the yaml via the REST is what
  breaks the strings.
* We now only do full patching for 5.8. This will need to be merged
  alongside the other PR for yaml updates