### PR TITLE
[1LP][RFR] Add UI tests for Identify buttons in the physical server page

### DIFF
--- a/cfme/physical/physical_server.py
+++ b/cfme/physical/physical_server.py
@@ -117,6 +117,15 @@ class PhysicalServer(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Ta
             delay=5
         )
 
+    def turn_on_led(self, **kwargs):
+        self._execute_action_button('Identify', 'Turn On LED', **kwargs)
+
+    def turn_off_led(self, **kwargs):
+        self._execute_action_button('Identify', 'Turn Off LED', **kwargs)
+
+    def turn_blink_led(self, **kwargs):
+        self._execute_action_button('Identify', 'Blink LED', **kwargs)
+
     @variable(alias='ui')
     def power_state(self):
         view = navigate_to(self, "Details")

--- a/cfme/tests/physical_infrastructure/ui/test_physical_server_details_buttons.py
+++ b/cfme/tests/physical_infrastructure/ui/test_physical_server_details_buttons.py
@@ -54,6 +54,25 @@ def test_restart_immediately(physical_server, provider):
     view.flash.assert_message('Requested Server restart_now for the selected server')
 
 
+# Identify Button
+def test_turn_on_led(physical_server, provider):
+    physical_server.turn_on_led()
+    view = provider.create_view(PhysicalServerDetailsView, physical_server)
+    view.flash.assert_message('Requested Server turn_on_loc_led for the selected server')
+
+
+def test_turn_off_led(physical_server, provider):
+    physical_server.turn_off_led()
+    view = provider.create_view(PhysicalServerDetailsView, physical_server)
+    view.flash.assert_message('Requested Server turn_off_loc_led for the selected server')
+
+
+def test_turn_blink_led(physical_server, provider):
+    physical_server.turn_blink_led()
+    view = provider.create_view(PhysicalServerDetailsView, physical_server)
+    view.flash.assert_message('Requested Server blink_loc_led for the selected server')
+
+
 # Lifecycle Button
 def test_lifecycle_provision(physical_server):
     view = navigate_to(physical_server, "Provision")


### PR DESCRIPTION
This PR is able to :

* Add new tests to cover all options in the Identify button are working on physical server details page.

Depends On: https://github.com/ManageIQ/integration_tests/pull/6898