### PR TITLE
[1LP][RFR] openshift support in pytest sprout options

### DIFF
--- a/cfme/test_framework/appliance.py
+++ b/cfme/test_framework/appliance.py
@@ -28,7 +28,8 @@ def appliances_from_cli(cli_appliances):
                 "Invalid appliance url: {}".format(appliance_data)
             )
 
-        appliance = appliance_data.update(dict(
+        appliance = appliance_data.copy()
+        appliance.update(dict(
             hostname=parsed_url.hostname,
             ui_protocol=parsed_url.scheme if parsed_url.scheme else "https",
             ui_port=parsed_url.port if parsed_url.port else 443,
@@ -53,6 +54,7 @@ def pytest_configure(config):
         reporter.write_line('Retrieved these appliances from the --appliance parameters', red=True)
     elif config.getoption('--use-sprout'):
         from .sprout.plugin import mangle_in_sprout_appliances
+
         mangle_in_sprout_appliances(config)
         appliances = appliances_from_cli(config.option.appliances)
         reporter.write_line('Retrieved these appliances from the --sprout-* parameters', red=True)

--- a/cfme/test_framework/appliance.py
+++ b/cfme/test_framework/appliance.py
@@ -21,18 +21,18 @@ def pytest_addoption(parser):
 
 def appliances_from_cli(cli_appliances):
     appliance_config = dict(appliances=[])
-    for appliance_url in cli_appliances:
-        parsed_url = six.moves.urllib.parse.urlparse(appliance_url)
+    for appliance_data in cli_appliances:
+        parsed_url = six.moves.urllib.parse.urlparse(appliance_data['hostname'])
         if not parsed_url.hostname:
             raise ValueError(
-                "Invalid appliance url: {}".format(appliance_url)
+                "Invalid appliance url: {}".format(appliance_data)
             )
 
-        appliance = dict(
+        appliance = appliance_data.update(dict(
             hostname=parsed_url.hostname,
             ui_protocol=parsed_url.scheme if parsed_url.scheme else "https",
             ui_port=parsed_url.port if parsed_url.port else 443,
-        )
+        ))
 
         appliance_config['appliances'].append(appliance)
 

--- a/cfme/test_framework/sprout/plugin.py
+++ b/cfme/test_framework/sprout/plugin.py
@@ -81,8 +81,7 @@ def mangle_in_sprout_appliances(config):
     log.info("Appliances were provided:")
     for appliance in requested_appliances:
 
-        url = "https://{}/".format(appliance["ip_address"])
-        appliance_args = {'hostname': url}
+        appliance_args = {'hostname': appliance['url']}
         provider_data = conf.cfme_data['management_systems'].get(appliance['provider'])
         if provider_data and provider_data['type'] == 'openshift':
             ocp_creds = conf.credentials[provider_data['credentials']]
@@ -103,7 +102,7 @@ def mangle_in_sprout_appliances(config):
             }
             appliance_args.update(extra_args)
         appliances.append(appliance_args)
-        log.info("- %s is %s", url, appliance['name'])
+        log.info("- %s is %s", appliance['url'], appliance['name'])
 
     mgr.reset_timer()
     template_name = requested_appliances[0]["template_name"]

--- a/cfme/test_framework/sprout/plugin.py
+++ b/cfme/test_framework/sprout/plugin.py
@@ -43,6 +43,13 @@ def pytest_addoption(parser):
         default=0, help="Override CPU core count. 0 means no override.")
     group._addoption(
         '--sprout-provider', dest='sprout_provider', default=None, help="Which provider to use.")
+    group._addoption('--sprout-provider-type', dest='sprout_provider_type', default=None,
+        help="Sprout provider type - openshift, etc")
+    group._addoption('--sprout-template-type', dest='sprout_template_type', default=None,
+        help="Specifies which template type to use openshift_pod, virtual_machine, docker_vm")
+    group._addoption('--sprout-ignore-preconfigured', dest='sprout_template_preconfigured',
+                     default=True, action="store_false",
+                     help="Allows to use not preconfigured templates")
 
 
 def dump_pool_info(log, pool_data):
@@ -96,6 +103,9 @@ class SproutProvisioningRequest(object):
     count = attr.ib()
     version = attr.ib()
     provider = attr.ib()
+    provider_type = attr.ib()
+    template_type = attr.ib()
+    preconfigured = attr.ib()
     date = attr.ib()
     lease_time = attr.ib()
     desc = attr.ib()
@@ -111,6 +121,9 @@ class SproutProvisioningRequest(object):
             count=config.option.sprout_appliances,
             version=config.option.sprout_version,
             provider=config.option.sprout_provider,
+            provider_type=config.option.sprout_provider_type,
+            template_type=config.option.sprout_template_type,
+            preconfigured=config.option.sprout_template_preconfigured,
             date=config.option.sprout_date,
             lease_time=config.option.sprout_timeout,
             desc=config.option.sprout_desc,
@@ -160,15 +173,22 @@ class SproutManager(object):
             if jenkins_job:
                 self.clean_jenkins_job(jenkins_job)
 
+        kargs = {
+            'count': provision_request.count,
+            'version': provision_request.version,
+            'provider': provision_request.provider,
+            'provider_type': provision_request.provider_type,
+            'preconfigured': provision_request.preconfigured,
+            'date': provision_request.date,
+            'lease_time': provision_request.lease_time,
+            'cpu': provision_request.cpu,
+            'ram': provision_request.ram,
+        }
+        if provision_request.template_type:
+            kargs['template_type'] = provision_request.template_type
+
         self.pool = self.client.request_appliances(
-            provision_request.group,
-            count=provision_request.count,
-            version=provision_request.version,
-            provider=provision_request.provider,
-            date=provision_request.date,
-            lease_time=provision_request.lease_time,
-            cpu=provision_request.cpu,
-            ram=provision_request.ram,
+            provision_request.group, **kargs
         )
         log.info("Pool %s. Waiting for fulfillment ...", self.pool)
 

--- a/cfme/test_framework/sprout/plugin.py
+++ b/cfme/test_framework/sprout/plugin.py
@@ -80,10 +80,11 @@ def mangle_in_sprout_appliances(config):
     appliances = config.option.appliances
     log.info("Appliances were provided:")
     for appliance in requested_appliances:
-        provider_data = conf.cfme_data['management_systems'][appliance['provider']]
+
         url = "https://{}/".format(appliance["ip_address"])
         appliance_args = {'hostname': url}
-        if provider_data['type'] == 'openshift':
+        provider_data = conf.cfme_data['management_systems'].get(appliance['provider'])
+        if provider_data and provider_data['type'] == 'openshift':
             ocp_creds = conf.credentials[provider_data['credentials']]
             ssh_creds = conf.credentials[provider_data['ssh_creds']]
             extra_args = {
@@ -91,6 +92,7 @@ def mangle_in_sprout_appliances(config):
                 'db_host': appliance['db_host'],
                 'project': appliance['project'],
                 'openshift_creds': {
+                    'hostname': provider_data['hostname'],
                     'username': ocp_creds['username'],
                     'password': ocp_creds['password'],
                     'ssh': {

--- a/sprout/appliances/models.py
+++ b/sprout/appliances/models.py
@@ -907,6 +907,10 @@ class Appliance(MetadataMixin):
         return self.template.provider
 
     @property
+    def url(self):
+        return "https://{}/".format(self.ip_address)
+
+    @property
     def preconfigured(self):
         return self.template.preconfigured
 


### PR DESCRIPTION
Opeshift appliances can be requested only when preconfigured=False and template_type = 'openshift_pod'. This PR is going to make pytest's sprout plugin to request such appliances

REQUIRES: https://github.com/ManageIQ/integration_tests/pull/6905