### PR TITLE
[1LP][RFR] essential params for openshift appliance serialization

### DIFF
--- a/sprout/appliances/models.py
+++ b/sprout/appliances/models.py
@@ -884,6 +884,8 @@ class Appliance(MetadataMixin):
             cpu=self.cpu,
             created_on=apply_if_not_none(self.created_on, "isoformat"),
             modified_on=apply_if_not_none(self.modified_on, "isoformat"),
+            project=self.openshift_project,
+            db_host=self.openshift_ext_ip,
         )
 
     @property


### PR DESCRIPTION
Those two parameters should appear in result of sprout appliance request