### PR TITLE
[1LP][RFR] fixed provider test_api_port test

### DIFF
--- a/cfme/tests/openstack/infrastructure/test_provider.py
+++ b/cfme/tests/openstack/infrastructure/test_provider.py
@@ -15,8 +15,8 @@ pytestmark = [
 def test_api_port(provider):
     view_details = navigate_to(provider, 'Details')
     port = provider.data['endpoints']['default']['api_port']
-    assert int(view_details.entities.properties.get_text_of('API Port')) == port, 'Invalid API Port'
-
+    api_port = int(view_details.entities.summary('Properties').get_text_of('API Port'))
+    assert api_port == port, 'Invalid API Port'
 
 def test_credentials_quads(provider):
     view = navigate_to(provider, 'All')


### PR DESCRIPTION
Purpose or Intent
=================
properties attribute is no longer available under entities. used instead view_details.entities.summary('Properties').get_text_of....

{{ pytest: cfme/tests/openstack/infrastructure/test_provider.py::test_api_port }}