### PR TITLE
[1LP][RFR] remove BZ, fix test

### DIFF
--- a/cfme/tests/networks/test_sdn_balancers.py
+++ b/cfme/tests/networks/test_sdn_balancers.py
@@ -5,7 +5,6 @@ from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.exceptions import DestinationNotFound
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.blockers import BZ
 
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
@@ -40,11 +39,9 @@ def test_sdn_prov_balancers_number(network_prov_with_load_balancers):
         assert int(balancers_number) == sum_all
 
 
-@pytest.mark.meta(blockers=[BZ(1544411, forced_streams=['5.8', '5.9'],
-                               unblock=lambda provider: not provider.one_of(GCEProvider))])
 def test_sdn_balancers_detail(provider, network_prov_with_load_balancers):
     """ Test of getting attribute from balancer object """
     for prov, _ in network_prov_with_load_balancers:
         for balancer in prov.balancers.all():
-            check = balancer.health_checks
+            check = balancer.network_provider
             assert check is not None


### PR DESCRIPTION
health check field is appearing only if it is setup and it is not mandatory on GCE. LBs were created without so test failed. check for a presence of an other field.
 {{pytest: -v -q cfme/tests/networks/test_sdn_balancers.py --use-provider=complete}}