### PR TITLE
[1LP][WIP] Enable C&U while adding openshift provider with metrics endpoint

### DIFF
--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -114,7 +114,7 @@ class OpenshiftProvider(ContainersProvider):
     def create(self, **kwargs):
 
         # Enable C&U for any provider with metrics provider
-        if getattr(self, "metrics_type") != "Disabled":
+        if self.metrics_type != "Disabled":
             self.appliance.server.settings.enable_server_roles(
                 'ems_metrics_coordinator', 'ems_metrics_collector', 'ems_metrics_processor')
 

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -113,10 +113,10 @@ class OpenshiftProvider(ContainersProvider):
 
     def create(self, **kwargs):
 
+        # Enable C&U for any provider with metrics provider
         if getattr(self, "metrics_type") != "Disabled":
-            server = self.appliance.server.settings
-            server.enable_server_roles('ems_metrics_coordinator', 'ems_metrics_collector',
-                                       'ems_metrics_processor')
+            self.appliance.server.settings.enable_server_roles(
+                'ems_metrics_coordinator', 'ems_metrics_collector', 'ems_metrics_processor')
 
         # Enable alerts collection before adding the provider to avoid missing active
         # alert after adding the provider

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -113,6 +113,11 @@ class OpenshiftProvider(ContainersProvider):
 
     def create(self, **kwargs):
 
+        if getattr(self, "metrics_type") != "Disabled":
+            server = self.appliance.server.settings
+            server.enable_server_roles('ems_metrics_coordinator', 'ems_metrics_collector',
+                                       'ems_metrics_processor')
+
         # Enable alerts collection before adding the provider to avoid missing active
         # alert after adding the provider
         # For more info: https://bugzilla.redhat.com/show_bug.cgi?id=1514950


### PR DESCRIPTION
{{ pytest: cfme/tests/containers/test_alerts.py::test_add_alerts_provider --use-provider ocp-v3 }}
Enable C&U while adding openshift provider with metrics endpoint