### PR TITLE
[1LP][RFR] Fix cloud event listener

### DIFF
--- a/cfme/scripting/quickstart.py
+++ b/cfme/scripting/quickstart.py
@@ -120,6 +120,12 @@ OS_PACKAGES_SPECS = [
      " python-virtualenv gcc postgresql libxml2-dev"
      " libxslt1-dev libzmq3-dev libcurl4-openssl-dev"
      " g++ openssl libffi-dev python-dev libtesseract3"
+     " libpng-dev libfreetype6-dev libssl-dev"),
+
+    ("Ubuntu", "16.04.4 LTS (Xenial Xerus)", "openssl",
+     " python-virtualenv gcc postgresql libxml2-dev"
+     " libxslt1-dev libzmq3-dev libcurl4-openssl-dev"
+     " g++ openssl libffi-dev python-dev libtesseract3"
      " libpng-dev libfreetype6-dev libssl-dev")
 ]
 
@@ -202,7 +208,7 @@ def pip_json_list(venv):
 
 
 def install_system_packages():
-    if INSTALL_COMMAND:
+    if INSTALL_COMMAND and REQUIRED_PACKAGES:
         run_cmd_or_exit(INSTALL_COMMAND + REQUIRED_PACKAGES, shell=True)
     else:
         print("WARNING: unknown distribution,",

--- a/cfme/tests/cloud/test_cloud_events.py
+++ b/cfme/tests/cloud/test_cloud_events.py
@@ -25,7 +25,9 @@ def test_manage_nsg_group(provider, setup_provider, register_event):
     # we need to check raw data by regexps, since many azure events aren't parsed by CFME yet
 
     def add_cmp(_, y):
+        # In 5.9 version `y` is a dict, not a yaml stream.
         data = yaml.load(y) if provider.appliance.version < '5.9' else y
+
         return (data['resourceId'].endswith(nsg_name) and
                 (data['status']['value'] == 'Accepted' and
                  data['subStatus']['value'] == 'Created') or
@@ -39,7 +41,9 @@ def test_manage_nsg_group(provider, setup_provider, register_event):
                    event_type='networkSecurityGroups_write_EndRequest')
 
     def rm_cmp(_, y):
+        # In 5.9 version `y` is a dict, not a yaml stream.
         data = yaml.load(y) if provider.appliance.version < '5.9' else y
+
         return data['resourceId'].endswith(nsg_name) and data['status']['value'] == 'Succeeded'
 
     fd_rm_attr = {'full_data': 'will be ignored',
@@ -70,7 +74,9 @@ def test_vm_capture(request, provider, setup_provider, register_event):
     request.addfinalizer(vm.delete_from_provider)
 
     def cmp_function(_, y):
+        # In 5.9 version `y` is a dict, not a yaml stream.
         data = yaml.load(y) if provider.appliance.version < '5.9' else y
+
         return data['resourceId'].endswith(vm.name) and data['status']['value'] == 'Succeeded'
 
     full_data_attr = {'full_data': 'will be ignored',

--- a/cfme/tests/cloud/test_cloud_events.py
+++ b/cfme/tests/cloud/test_cloud_events.py
@@ -7,7 +7,6 @@ from cfme.common.vm import VM
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.utils.generators import random_vm_name
 
-
 pytestmark = [
     pytest.mark.tier(3),
     pytest.mark.provider([AzureProvider], scope='module')
@@ -26,7 +25,7 @@ def test_manage_nsg_group(provider, setup_provider, register_event):
     # we need to check raw data by regexps, since many azure events aren't parsed by CFME yet
 
     def add_cmp(_, y):
-        data = yaml.load(y)
+        data = yaml.load(y) if provider.appliance.version < '5.9' else y
         return (data['resourceId'].endswith(nsg_name) and
                 (data['status']['value'] == 'Accepted' and
                  data['subStatus']['value'] == 'Created') or
@@ -40,7 +39,7 @@ def test_manage_nsg_group(provider, setup_provider, register_event):
                    event_type='networkSecurityGroups_write_EndRequest')
 
     def rm_cmp(_, y):
-        data = yaml.load(y)
+        data = yaml.load(y) if provider.appliance.version < '5.9' else y
         return data['resourceId'].endswith(nsg_name) and data['status']['value'] == 'Succeeded'
 
     fd_rm_attr = {'full_data': 'will be ignored',
@@ -71,8 +70,9 @@ def test_vm_capture(request, provider, setup_provider, register_event):
     request.addfinalizer(vm.delete_from_provider)
 
     def cmp_function(_, y):
-        data = yaml.load(y)
+        data = yaml.load(y) if provider.appliance.version < '5.9' else y
         return data['resourceId'].endswith(vm.name) and data['status']['value'] == 'Succeeded'
+
     full_data_attr = {'full_data': 'will be ignored',
                       'cmp_func': cmp_function}
 

--- a/cfme/utils/events.py
+++ b/cfme/utils/events.py
@@ -247,18 +247,17 @@ class RestEventListener(Thread):
         Returns None if there is no matched events."""
         evt.process_id()
 
-        if 'target_id' in evt.event_attrs:
-            q = Q('id', '>', self._last_processed_id)  # ensure we get only new events
+        q = Q('id', '>', self._last_processed_id)  # ensure we get only new events
 
-            used_filters = set(self.FILTER_ATTRS).intersection(set(evt.event_attrs))
-            for filter_attr in used_filters:
-                evt_attr = evt.event_attrs[filter_attr]
-                if evt_attr.value:
-                    q &= Q(filter_attr, '=', evt_attr.value)
-            result = self.event_streams.filter(q)
+        used_filters = set(self.FILTER_ATTRS).intersection(set(evt.event_attrs))
+        for filter_attr in used_filters:
+            evt_attr = evt.event_attrs[filter_attr]
+            if evt_attr.value:
+                q &= Q(filter_attr, '=', evt_attr.value)
+        result = self.event_streams.filter(q)
 
-            if len(result):
-                return result
+        if len(result):
+            return result
 
     @property
     def got_events(self):


### PR DESCRIPTION
PURPOSE
=================

__Fixing__ quickstart script because it was failing when the OS version wasn't recognized.
__Fixing__ test_cloud_events because now in 5.9 the response is dict instead of yaml stream.
__Minor changes__ to REST event listener get_next_portion func.

Shriver:
{{ pytest: cfme/tests/cloud/test_cloud_events.py --long-running --use-provider azure}}