### PR TITLE
[WIP] Fixing test_provider_refresh_relationship

### DIFF
--- a/cfme/tests/cloud_infra_common/test_relationships.py
+++ b/cfme/tests/cloud_infra_common/test_relationships.py
@@ -2,6 +2,7 @@
 import pytest
 import random
 
+from cfme.utils.log import logger
 from cfme.cloud.availability_zone import ProviderAvailabilityZoneAllView, AvailabilityZone
 from cfme.cloud.flavor import ProviderFlavorAllView, Flavor
 from cfme.cloud.instance import Instance


### PR DESCRIPTION
__Fixing__ test_provider_refresh_relationship. It was failing with:
`E NameError: global name 'logger' is not defined`

BTW this is the commit that broke it: https://github.com/ManageIQ/integration_tests/commit/5ce5b71e7bd1587785e9947073b5c42b91525459#diff-aca79b1b6b865442b3876393a4a0d855

{{pytest: cfme/tests/cloud_infra_common/test_relationships.py::test_provider_refresh_relationship --use-provider rhv41 -vv}}
