### PR TITLE
[WIP] Fixing test_service_manual_approval

### DIFF
--- a/cfme/tests/services/test_service_manual_approval.py
+++ b/cfme/tests/services/test_service_manual_approval.py
@@ -13,7 +13,7 @@ from cfme.utils.update import update
 
 pytestmark = [
     pytest.mark.meta(server_roles="+automate"),
-    pytest.mark.usefixtures('vm_name', 'catalog_item', 'uses_infra_providers'),
+    pytest.mark.usefixtures('vm_name', 'uses_infra_providers'),
     test_requirements.service,
     pytest.mark.long_running,
     pytest.mark.provider([InfraProvider],
@@ -65,7 +65,6 @@ def test_service_manual_approval(appliance, provider, setup_provider, modify_ins
     """
     vm_name = catalog_item.provisioning_data['catalog']["vm_name"]
     request.addfinalizer(lambda: cleanup_vm(vm_name + "_0001", provider))
-    catalog_item.create()
 
     service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
     service_catalogs.order()


### PR DESCRIPTION
__Fixing__ test_service_manual_approval after this [commit](https://github.com/ManageIQ/integration_tests/commit/463a1f2292282cdc210cb8d28a7cd87d2e16a844) was merged.

{{pytest: cfme/tests/services/test_service_manual_approval.py::test_service_manual_approval --use-provider rhv41 -vv --long-running}}