### PR TITLE
[1LP][RFR] Filter azure out of test_reset_vm, azure doesn't support hard reset

### DIFF
--- a/cfme/tests/cloud_infra_common/test_power_control_rest.py
+++ b/cfme/tests/cloud_infra_common/test_power_control_rest.py
@@ -7,6 +7,7 @@ from cfme.common.vm import VM
 from cfme.utils.generators import random_vm_name
 from cfme.utils.wait import wait_for
 from cfme.utils.log import logger
+from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
@@ -172,8 +173,8 @@ def test_suspend_vm_rest(appliance, vm_obj, verify_vm_running, soft_assert, from
         soft_assert(verify_vm_power_state(vm, vm_obj.STATE_SUSPENDED), "vm not suspended")
 
 
-@pytest.mark.uncollectif(lambda provider: provider.one_of(RHEVMProvider),
-                         reason='Not supported for RHV provider')
+@pytest.mark.uncollectif(lambda provider: provider.one_of(RHEVMProvider, AzureProvider),
+                         reason='Not supported for RHV or Azure provider')
 def test_reset_vm_rest(vm_obj, verify_vm_running, from_detail, appliance):
     """
     Test reset vm


### PR DESCRIPTION
You can't do a 'hard reboot' from CFME UI on an azure instance, since that is unsupported by azure. So reset VM via REST shouldn't be expected to work either.