### PR TITLE
[1LP][RFR] Tweak base login and ui for exception handling

### DIFF
--- a/cfme/base/login.py
+++ b/cfme/base/login.py
@@ -44,6 +44,7 @@ class BaseLoggedInPage(View):
     @property
     def current_fullname(self):
         try:
+            # When the view isn't displayed self.settings.text is None, resulting in AttributeError
             return self.settings.text.strip().split('|', 1)[0].strip()
         except AttributeError:
             return None

--- a/cfme/base/login.py
+++ b/cfme/base/login.py
@@ -43,7 +43,10 @@ class BaseLoggedInPage(View):
 
     @property
     def current_fullname(self):
-        return self.settings.text.strip().split('|', 1)[0].strip()
+        try:
+            return self.settings.text.strip().split('|', 1)[0].strip()
+        except AttributeError:
+            return None
 
     @property
     def current_groupname(self):

--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -186,10 +186,10 @@ def login(self, user=None, method=LOGIN_METHODS[1]):
 
         login_view.log_in(user, method=method)
         logged_in_view.flush_widget_cache()
-        user.name = logged_in_view.current_fullname
         try:
             assert logged_in_view.is_displayed
             assert logged_in_view.logged_in_as_user
+            user.name = logged_in_view.current_fullname
             self.appliance.user = user
         except AssertionError:
             login_view.flash.assert_no_error()


### PR DESCRIPTION
Was producing an exception because the view isn't actually displayed.

```python
>               appliance.server.login(user, method='click_on_login')

cfme/tests/integration/test_cfme_auth.py:183: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/lib/python2.7/site-packages/sentaku/context.py:132: in __call__
    return bound_method(*k, **kw)
cfme/base/ui.py:189: in login
    user.name = logged_in_view.current_fullname
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <cfme.base.login.BaseLoggedInPage object at 0x7fcd42f2f610>

    @property
    def current_fullname(self):
>       return self.settings.text.strip().split('|', 1)[0].strip()
E       AttributeError: 'NoneType' object has no attribute 'strip'

cfme/base/login.py:46: AttributeError
```