### PR TITLE
[WIP] Add UI tests for Policy button in the physical server page

### DIFF
--- a/cfme/common/physical_server_views.py
+++ b/cfme/common/physical_server_views.py
@@ -161,7 +161,17 @@ class PhysicalServerManagePoliciesView(BaseLoggedInPage):
 
     @property
     def is_displayed(self):
-        return False
+        return self.entities.get_id_by_name(self.context["object"].name) is not None
+
+
+class PhysicalServerEditTagView(BaseLoggedInPage):
+    """PhysicalServer's Edit Tag view"""
+    breadcrumb = BreadCrumb(locator='.//ol[@class="breadcrumb"]')
+
+    @property
+    def is_displayed(self):
+        title = "Tag Assignment"
+        return self.breadcrumb.active_location == title
 
 
 class PhysicalServersToolbar(View):

--- a/cfme/physical/physical_server.py
+++ b/cfme/physical/physical_server.py
@@ -9,6 +9,7 @@ from cfme.common import PolicyProfileAssignable, Taggable
 from cfme.common.physical_server_views import (
     PhysicalServerDetailsView,
     PhysicalServerManagePoliciesView,
+    PhysicalServerEditTagView,
     PhysicalServersView,
     PhysicalServerProvisionView,
     PhysicalServerTimelinesView
@@ -353,6 +354,15 @@ class Provision(CFMENavigateStep):
 
     def step(self):
         self.prerequisite_view.toolbar.lifecycle.item_select("Provision Physical Server")
+
+
+@navigator.register(PhysicalServer)
+class EditTag(CFMENavigateStep):
+    VIEW = PhysicalServerEditTagView
+    prerequisite = NavigateToSibling("Details")
+
+    def step(self):
+        self.prerequisite_view.toolbar.policy.item_select("Edit Tags")
 
 
 @navigator.register(PhysicalServer)

--- a/cfme/tests/physical_infrastructure/ui/test_physical_server_details_buttons.py
+++ b/cfme/tests/physical_infrastructure/ui/test_physical_server_details_buttons.py
@@ -54,6 +54,17 @@ def test_restart_immediately(physical_server, provider):
     view.flash.assert_message('Requested Server restart_now for the selected server')
 
 
+# Policy Button
+def test_manage_policies_button(physical_server):
+    view = navigate_to(physical_server, "ManagePolicies")
+    assert view.is_displayed
+
+
+def test_edit_tag_button(physical_server):
+    view = navigate_to(physical_server, "EditTag")
+    assert view.is_displayed
+
+
 # Lifecycle Button
 def test_lifecycle_provision(physical_server):
     view = navigate_to(physical_server, "Provision")


### PR DESCRIPTION
Purpose or Intent
=================
* Add new tests to cover all options in the Policy button are working on physical server details page.

Depends On: https://github.com/ManageIQ/integration_tests/pull/6898
