### PR TITLE
[1LP][RFR] Changed tag name because of a recent change

### DIFF
--- a/cfme/tests/services/test_myservice.py
+++ b/cfme/tests/services/test_myservice.py
@@ -101,7 +101,7 @@ def test_crud_set_ownership_and_edit_tags(appliance, context, myservice):
     with appliance.context.use(context):
         myservice = MyService(appliance, name=service_name, vm_name=vm_name)
         myservice.set_ownership("Administrator", "EvmGroup-administrator")
-        myservice.add_tag("Cost Center *", "Cost Center 001")
+        myservice.add_tag("Cost Center", "Cost Center 001")
         with update(myservice):
             myservice.description = "my edited description"
         myservice.delete()


### PR DESCRIPTION
In a recent change all tags are suffixed by * ,
so removing it from the test here .