### PR TITLE
[1LP][RFR] storage Manager provider cleanup

### DIFF
--- a/cfme/storage/manager.py
+++ b/cfme/storage/manager.py
@@ -151,8 +151,12 @@ class StorageManager(BaseEntity, Taggable, PolicyProfileAssignable):
     def delete(self):
         """Delete storage manager"""
         view = navigate_to(self, 'Details')
-        view.toolbar.configuration.item_select(
-            'Remove this {} from Inventory'.format(self.storage_title), handle_alert=True)
+
+        if self.appliance.version < '5.9':
+            remove_item = 'Remove this {}'.format(self.storage_title)
+        else:
+            remove_item = 'Remove this {} from Inventory'.format(self.storage_title)
+        view.toolbar.configuration.item_select(remove_item, handle_alert=True)
 
         view = self.create_view(StorageManagerDetailsView)
         view.flash.assert_no_error()

--- a/cfme/tests/storage/test_manager.py
+++ b/cfme/tests/storage/test_manager.py
@@ -2,7 +2,6 @@
 import pytest
 
 from cfme import test_requirements
-from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.storage.manager import StorageManagerDetailsView
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -22,7 +21,7 @@ MANAGER_TYPE = ['Swift Manager', 'Cinder Manager']
 @pytest.yield_fixture(scope='module')
 def provider_cleanup():
     yield
-    CloudProvider.clear_providers()
+    OpenStackProvider.clear_providers()
 
 
 @pytest.yield_fixture(params=MANAGER_TYPE,

--- a/cfme/tests/storage/test_manager.py
+++ b/cfme/tests/storage/test_manager.py
@@ -21,7 +21,8 @@ MANAGER_TYPE = ['Swift Manager', 'Cinder Manager']
 @pytest.yield_fixture(scope='module')
 def provider_cleanup(provider):
     yield
-    provider.delete()
+    provider.delete_rest()
+    provider.wait_for_delete()
 
 
 @pytest.yield_fixture(params=MANAGER_TYPE,

--- a/cfme/tests/storage/test_manager.py
+++ b/cfme/tests/storage/test_manager.py
@@ -2,6 +2,7 @@
 import pytest
 
 from cfme import test_requirements
+from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.storage.manager import StorageManagerDetailsView
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -11,11 +12,17 @@ pytestmark = [
     pytest.mark.tier(3),
     test_requirements.storage,
     pytest.mark.usefixtures('setup_provider'),
-    pytest.mark.provider([OpenStackProvider])
+    pytest.mark.provider([OpenStackProvider], scope='module')
 ]
 
 
 MANAGER_TYPE = ['Swift Manager', 'Cinder Manager']
+
+
+@pytest.yield_fixture(scope='module')
+def provider_cleanup():
+    yield
+    CloudProvider.clear_providers()
 
 
 @pytest.yield_fixture(params=MANAGER_TYPE,
@@ -65,7 +72,7 @@ def test_storage_manager_edit_tag(collection_manager):
     assert not tag_available
 
 
-def test_storage_manager_delete(collection_manager):
+def test_storage_manager_delete(collection_manager, provider_cleanup):
     """ Test delete storage manager
 
     prerequisites:

--- a/cfme/tests/storage/test_manager.py
+++ b/cfme/tests/storage/test_manager.py
@@ -19,9 +19,9 @@ MANAGER_TYPE = ['Swift Manager', 'Cinder Manager']
 
 
 @pytest.yield_fixture(scope='module')
-def provider_cleanup():
+def provider_cleanup(provider):
     yield
-    OpenStackProvider.clear_providers()
+    provider.delete()
 
 
 @pytest.yield_fixture(params=MANAGER_TYPE,


### PR DESCRIPTION
Purpose or Intent
=================
 - I found that in Jenkins run for `storage`. It first run `test_manager.py` in that `test_storage_manager_delete` causes deletion of `child providers`. Its continue with that brocken provider for other files causes `NoSuchElementException`. 
- best to clear that `CloudProvider`

{{pytest: cfme/tests/storage/ -v}}