### PR TITLE
[1LP][RFR]updating Vm verification

### DIFF
--- a/cfme/tests/cloud_infra_common/test_custom_attributes_rest.py
+++ b/cfme/tests/cloud_infra_common/test_custom_attributes_rest.py
@@ -53,13 +53,8 @@ def get_vm(appliance, provider, vm_obj):
 
     def _get_vm():
         if not provider.mgmt.does_vm_exist(vm_obj.name):
-            vms = collection.find_by(name=vm_obj.name)
-            if not vms:
-                vm_obj.create_on_provider(timeout=2400, find_in_cfme=True, allow_skip='default')
+            vm_obj.create_on_provider(timeout=2400, find_in_cfme=True, allow_skip='default')
         vms = collection.find_by(name=vm_obj.name)
-        if not vms:
-            provider.refresh_provider_relationships()
-            vms = collection.find_by(name=vm_obj.name)
         return vms[0]
 
     return _get_vm

--- a/cfme/tests/cloud_infra_common/test_custom_attributes_rest.py
+++ b/cfme/tests/cloud_infra_common/test_custom_attributes_rest.py
@@ -52,9 +52,13 @@ def get_vm(appliance, provider, vm_obj):
         collection = appliance.rest_api.collections.instances
 
     def _get_vm():
+        if not provider.mgmt.does_vm_exist(vm_obj.name):
+            vms = collection.find_by(name=vm_obj.name)
+            if not vms:
+                vm_obj.create_on_provider(timeout=2400, find_in_cfme=True, allow_skip='default')
         vms = collection.find_by(name=vm_obj.name)
         if not vms:
-            vm_obj.create_on_provider(timeout=2400, find_in_cfme=True, allow_skip='default')
+            provider.refresh_provider_relationships()
             vms = collection.find_by(name=vm_obj.name)
         return vms[0]
 


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ VM verification because atm module-scoped test being parallelized to different appliances might provision duplicated VMs - EC2 allows duplicated names.
1. Verify that VM with such name exists on backend
2. Check it in CFME - refresh if it's not

This leads to the EC2 cleanup issue - we had duplicated Instances which we couldn't delete

{{pytest: cfme/tests/cloud_infra_common/test_custom_attributes_rest.py --long-running --use-provider ec2 --use-sprout --sprout-group downstream-59z  --sprout-appliance 5}}