### PR TITLE
[1LP][RFR] excluding openshift appliances from swap check in sprout

### DIFF
--- a/sprout/appliances/tasks.py
+++ b/sprout/appliances/tasks.py
@@ -1672,8 +1672,8 @@ Sprout.
 def check_swap_in_appliances(self):
     chord_tasks = []
     for appliance in Appliance.objects.filter(
-            ready=True, power_state=Appliance.Power.ON, marked_for_deletion=False).exclude(
-            power_state=Appliance.Power.ORPHANED):
+            ready=True, power_state=Appliance.Power.ON, marked_for_deletion=False,
+            is_openshift=False).exclude(power_state=Appliance.Power.ORPHANED):
         chord_tasks.append(check_swap_in_appliance.si(appliance.id))
     chord(chord_tasks)(notify_owners.s())
 


### PR DESCRIPTION
It doesn't make sense to check openshift appliances swap. This PR adds additional filter to exclude openshift appliances. 