### PR TITLE
[1LP][RFR] Bump dump2polarion version to fix AttributeError

### DIFF
--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -33,7 +33,7 @@ docker-py==1.10.6
 docker-pycreds==0.2.1
 docutils==0.13.1
 dogpile.cache==0.6.3
-dump2polarion==0.20
+dump2polarion==0.21
 entrypoints==0.2.2
 enum34==1.1.6
 fauxfactory==2.1.0

--- a/requirements/frozen_docs.txt
+++ b/requirements/frozen_docs.txt
@@ -23,7 +23,7 @@ diaper==1.3
 docker-py==1.10.6
 docker-pycreds==0.2.1
 docutils==0.13.1
-dump2polarion==0.19
+dump2polarion==0.21
 entrypoints==0.2.2
 enum34==1.1.6
 fauxfactory==2.1.0


### PR DESCRIPTION
Fixing ``AttributeError: 'NoneType' object has no attribute 'strip'`` - like in [this Jenkins job](https://cfmeqe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/downstream-59z-tests-master/331/consoleFull) (at the very bottom).

No PRT necessary.