### PR TITLE
[1LP][RFR] Update appliance get/set_yaml_config to property

### DIFF
--- a/cfme/base/__init__.py
+++ b/cfme/base/__init__.py
@@ -68,25 +68,26 @@ class Server(BaseEntity, sentaku.modeling.ElementMixin):
             [self.appliance.rest_api.collections.servers._href, str(self.sid), 'settings']
         )
 
-    def get_yaml_config(self):
+    @property
+    def advanced_settings(self):
         """GET servers/:id/settings api endpoint to query server configuration"""
         return self.appliance.rest_api.get(url=self._api_settings_url)
 
-    def set_yaml_config(self, data_dict):
+    def update_advanced_settings(self, settings_dict):
         """PATCH settings from the server's api/server/:id/settings endpoint
 
         Args:
-            data_dict: dictionary of the changes to be made to the yaml configuration
-                       JSON dumps data_dict to pass as raw hash data to rest_api session
+            settings_dict: dictionary of the changes to be made to the yaml configuration
+                       JSON dumps settings_dict to pass as raw hash data to rest_api session
         Raises:
             AssertionError: On an http result >=400 (RequestsResponse.ok)
         """
-        # Calling the _session patch method because the core patch will wrap data_dict in a list
-        # Failing with some data_dict, like 'authentication'
+        # Calling the _session patch method because the core patch will wrap settings_dict in a list
+        # Failing with some settings_dict, like 'authentication'
         # https://bugzilla.redhat.com/show_bug.cgi?id=1553394
         result = self.appliance.rest_api._session.patch(
             url=self._api_settings_url,
-            data=json.dumps(data_dict)
+            data=json.dumps(settings_dict)
         )
         assert result.ok
 
@@ -163,23 +164,24 @@ class Zone(Pretty, BaseEntity, sentaku.modeling.ElementMixin):
     def _api_settings_url(self):
         return '/'.join([self.appliance.rest_api.collections.zones._href, str(self.id), 'settings'])
 
-    def get_yaml_config(self):
+    @property
+    def advanced_settings(self):
         """"GET zones/:id/settings api endpoint to query zone configuration"""
         return self.appliance.rest_api.get(self._api_settings_url)
 
-    def set_yaml_config(self, data_dict):
+    def update_advanced_settings(self, settings_dict):
         """PATCH settings from the zone's api/zones/:id/settings endpoint
 
         Args:
-            data_dict: dictionary of the changes to be made to the yaml configuration
-                       JSON dumps data_dict to pass as raw hash data to rest_api session
+            settings_dict: dictionary of the changes to be made to the yaml configuration
+                       JSON dumps settings_dict to pass as raw hash data to rest_api session
         Raises:
             AssertionError: On an http result >=400 (RequestsResponse.ok)
         """
-        # Calling the _session patch method because the core patch will wrap data_dict in a list
+        # Calling the _session patch method because the core patch will wrap settings_dict in a list
         result = self.appliance.rest_api._session.patch(
             url=self._api_settings_url,
-            data=json.dumps(data_dict)
+            data=json.dumps(settings_dict)
         )
         assert result.ok
 
@@ -247,23 +249,24 @@ class Region(BaseEntity, sentaku.modeling.ElementMixin):
                          str(region_id),
                          'settings'])
 
-    def get_yaml_config(self):
+    @property
+    def advanced_settings(self):
         """"GET zones/:id/settings api endpoint to query region configuration"""
         return self.appliance.rest_api.get(self._api_settings_url)
 
-    def set_yaml_config(self, data_dict):
+    def update_advanced_settings(self, settings_dict):
         """PATCH settings from the zone's api/zones/:id/settings endpoint
 
         Args:
-            data_dict: dictionary of the changes to be made to the yaml configuration
-                       JSON dumps data_dict to pass as raw hash data to rest_api session
+            settings_dict: dictionary of the changes to be made to the yaml configuration
+                       JSON dumps settings_dict to pass as raw hash data to rest_api session
         Raises:
             AssertionError: On an http result >=400 (RequestsResponse.ok)
         """
-        # Calling the _session patch method because the core patch will wrap data_dict in a list
+        # Calling the _session patch method because the core patch will wrap settings_dict in a list
         result = self.appliance.rest_api._session.patch(
             url=self._api_settings_url,
-            data=json.dumps(data_dict)
+            data=json.dumps(settings_dict)
         )
         assert result.ok
 
@@ -279,6 +282,7 @@ class RegionCollection(BaseCollection, sentaku.modeling.ElementMixin):
         region_collection = self.appliance.rest_api.collections.regions
         regions = [self.instantiate(region.region) for region in region_collection]
         return regions
+
 
 from . import ui, ssui, rest  # NOQA last for import cycles
 importscan.scan(ui)

--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -185,10 +185,10 @@ def setup_for_alerts(alert_profile_collection, action_collection, policy_collect
 @pytest.yield_fixture(scope="module")
 def set_performance_capture_threshold(appliance):
     yaml_data = {"performance": {"capture_threshold_with_alerts": {"vm": "3.minutes"}}}
-    appliance.set_yaml_config(yaml_data)
+    appliance.update_advanced_settings(yaml_data)
     yield
     yaml_data = {"performance": {"capture_threshold_with_alerts": {"vm": "20.minutes"}}}
-    appliance.set_yaml_config(yaml_data)
+    appliance.update_advanced_settings(yaml_data)
 
 
 @pytest.yield_fixture(scope="module")
@@ -379,11 +379,11 @@ def test_alert_snmp(request, appliance, provider, setup_snmp, setup_candu, full_
     setup_for_alerts(request, [alert])
 
     def _snmp_arrived():
-        rc, stdout = appliance.ssh_client.run_command(
+        result = appliance.ssh_client.run_command(
             "journalctl --no-pager /usr/sbin/snmptrapd | grep {}".format(match_string))
-        if rc != 0:
+        if result.failed:
             return False
-        elif stdout:
+        elif result.output:
             return True
         else:
             return False

--- a/cfme/utils/perf.py
+++ b/cfme/utils/perf.py
@@ -99,14 +99,15 @@ def set_rails_loglevel(level, validate_against_worker='MiqUiWorker'):
     ui_worker_pid = '#{}'.format(get_worker_pid(validate_against_worker))
 
     logger.info('Setting log level_rails on appliance to {}'.format(level))
-    yaml = store.current_appliance.get_yaml_config()
+    yaml = store.current_appliance.advanced_settings
     if not str(yaml['log']['level_rails']).lower() == level.lower():
         logger.info('Opening /var/www/miq/vmdb/log/evm.log for tail')
         evm_tail = SSHTail('/var/www/miq/vmdb/log/evm.log')
         evm_tail.set_initial_file_end()
 
-        yaml_data = {'log': {'level_rails': level}}
-        store.current_appliance.set_yaml_config(yaml_data)
+        log_yaml = yaml.get('log', {})
+        log_yaml['level_rails'] = level
+        store.current_appliance.update_advanced_settings({'log': log_yaml})
 
         attempts = 0
         detected = False


### PR DESCRIPTION
Update appliance `get_yaml_config`/`set_yaml_config` methods, rewrite to be an `advanced_settings` property with a setter.

Slight enhancement to appliance's yaml configuration methods, a property is a better means to represent the appliance configuration.

Updating all uses of the old methods to instead use correct property+setter syntax.

{{ pytest: cfme/tests/configure/test_ntp_server.py cfme/tests/control/test_alerts.py cfme/tests/configure/test_server_roles.py --long-running -v}}