### PR TITLE
[HOLD] Clean out many get_or_create_current_appliance usages

### DIFF
--- a/cfme/tests/configure/test_docs.py
+++ b/cfme/tests/configure/test_docs.py
@@ -16,7 +16,6 @@ from pdfminer.pdfinterp import PDFPageInterpreter, PDFResourceManager
 from cfme.utils import version
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.log import logger
-from cfme.fixtures.pytest_store import store
 
 # This is list of tested links expected to be on the documentation page
 # Keys here correspond to nested view names from configure.documentation.LinksView
@@ -103,7 +102,8 @@ def test_contents(appliance, soft_assert):
 @pytest.mark.tier(3)
 @pytest.mark.sauce
 @pytest.mark.ignore_stream("upstream")
-@pytest.mark.uncollectif(lambda: store.current_appliance.version >= '5.9')  # no sense in 5.9
+@pytest.mark.uncollectif(lambda appliance: appliance.version >= '5.9',
+                         reason="doesn't apply to 5.9")
 def test_info(appliance, soft_assert):
     """
     Test the alt/title and href attributes.


### PR DESCRIPTION
removes get_or_create_current_appliance in various places where its already possible, this ensures better code behaviour
