### PR TITLE
[1LP][RFR]Fix some ui tests

### DIFF
--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -400,7 +400,7 @@ def test_display_network_topology(appliance, openstack_provider):
     """
     floating_ips_collection = appliance.collections.network_floating_ips
     view = navigate_to(floating_ips_collection, "All")
-    if view.entities.entity_names:
+    if not view.entities.get_all():
         pytest.skip("No Floating IPs needed for this test")
 
     topology_col = appliance.collections.network_topology_elements

--- a/cfme/tests/configure/test_database_ui.py
+++ b/cfme/tests/configure/test_database_ui.py
@@ -23,6 +23,8 @@ def test_configure_vmdb_last_start_time(appliance):
                 "journalctl -u {}-postgresql.service  --boot=0 | sed '4!d'".format(item))
 
     ui_last_start_time = parser.parse(view.summary('Properties').get_text_of('Last Start Time'))
+    # timedatectl is used here as we will get full timezone name, like 'US/Eastern',
+    #  which is easier and safer(to omit UnknownTimeZoneError) to use later
     tz = pytz.timezone(appliance.ssh_client.run_command("timedatectl | grep 'Time zone'")
                        .output.strip().split(' ')[2])
     ui_last_start_updated = ui_last_start_time.replace(

--- a/cfme/tests/configure/test_database_ui.py
+++ b/cfme/tests/configure/test_database_ui.py
@@ -23,8 +23,8 @@ def test_configure_vmdb_last_start_time(appliance):
                 "journalctl -u {}-postgresql.service  --boot=0 | sed '4!d'".format(item))
 
     ui_last_start_time = parser.parse(view.summary('Properties').get_text_of('Last Start Time'))
-
-    tz = pytz.timezone(appliance.ssh_client.run_command("date +'%Z'").output.strip())
+    tz = pytz.timezone(appliance.ssh_client.run_command("timedatectl | grep 'Time zone'")
+                       .output.strip().split(' ')[2])
     ui_last_start_updated = ui_last_start_time.replace(
         tzinfo=ui_last_start_time.tzinfo).astimezone(tz)
     assert ui_last_start_updated.strftime('%Y-%m-%d %H:%M:%S %Z') in logs_last_start_time.output


### PR DESCRIPTION
Purpose or Intent
=================
1. Corrected timezone format, got incorrest one
2. Updated entities check as floating ips have only address

{{pytest: -k 'test_display_network_topology or test_configure_vmdb_last_start_time'}}