### PR TITLE
[1LP][RFR] added collections to DummyAppliance

### DIFF
--- a/cfme/modeling/tests/test_collections.py
+++ b/cfme/modeling/tests/test_collections.py
@@ -11,13 +11,6 @@ import pytest
 
 
 @attr.s
-class DummyApplianceWithCollection(DummyAppliance):
-    def __attrs_post_init__(self):
-        from cfme.modeling.base import EntityCollections
-        self.collections = EntityCollections.for_appliance(self)
-
-
-@attr.s
 class MyEntity(BaseEntity):
     name = attr.ib()
 
@@ -49,7 +42,7 @@ class MyNewCollection(BaseCollection):
 
 @pytest.fixture
 def dummy_appliance():
-    return DummyApplianceWithCollection()
+    return DummyAppliance()
 
 
 def test_appliance_collections_dir(dummy_appliance):
@@ -103,11 +96,11 @@ def test_parent_walker(dummy_appliance):
     obj = MyNewCollection(dummy_appliance).instantiate('name')
     new_obj = obj.collections.entities.instantiate('boop')
     assert parent_of_type(new_obj, MyNewEntity) == obj
-    assert parent_of_type(new_obj, DummyApplianceWithCollection) == dummy_appliance
+    assert parent_of_type(new_obj, DummyAppliance) == dummy_appliance
 
 
 def test_declared_entity_collections(dummy_appliance):
     obj = MyEntityWithDeclared(dummy_appliance)
     new_obj = obj.collections.entities.instantiate('boop')
     assert parent_of_type(new_obj, MyEntityWithDeclared) is obj
-    assert parent_of_type(new_obj, DummyApplianceWithCollection) is dummy_appliance
+    assert parent_of_type(new_obj, DummyAppliance) is dummy_appliance

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2863,6 +2863,11 @@ def _version_for_version_or_stream(version_or_stream, sprout_client=None):
     raise LookupError(version_or_stream)
 
 
+def collections_for_appliance(appliance):
+    from cfme.modeling.base import EntityCollections
+    return EntityCollections.for_appliance(appliance)
+
+
 @attr.s
 class DummyAppliance(object):
     """a dummy with minimal attribute set"""
@@ -2874,6 +2879,7 @@ class DummyAppliance(object):
     is_dev = False
     build = 'missing :)'
     managed_known_providers = []
+    collections = attr.ib(default=attr.Factory(collections_for_appliance, takes_self=True))
 
     @classmethod
     def from_config(cls, pytest_config):


### PR DESCRIPTION
collections property is necessary for DummyAppliance until we get rid of provider object instantiation during test session setup. So, this PR adds such property for a while.