### PR TITLE
[1LP][RFR] Disable view.is_display check at the end of Role.update. Fix for BZ156198

### DIFF
--- a/cfme/configure/access_control/__init__.py
+++ b/cfme/configure/access_control/__init__.py
@@ -1006,12 +1006,13 @@ class Role(Updateable, Pretty, BaseEntity):
         view = self.create_view(DetailsRoleView, override=updates)
         view.flash.assert_message(flash_message)
 
-        # The accordion may not refresh after a role name update
+        # Typically this would be a safe check but BZ 1561698 will sometimes cause the accordion
+        #  to fail to update the role name w/o a manual refresh causing is_displayed to fail
+        # Instead of inserting a blind refresh, just disable this until the bug is resolved since
+        #  it's a good check for accordion UI failures
         # See BZ https://bugzilla.redhat.com/show_bug.cgi?id=1561698
-        if BZ(1561698, forced_streams=['5.9']).blocks:
-            self.appliance.browser.widgetastic.refresh()
-
-        assert view.is_displayed
+        if not BZ(1561698, forced_streams=['5.9']).blocks:
+            assert view.is_displayed
 
     def delete(self, cancel=True):
         """ Delete existing role


### PR DESCRIPTION
After saving a role that has it's name updated, the accordion may not update to
show the role under the new name.

[BZ 1561698](https://bugzilla.redhat.com/show_bug.cgi?id=1561698) and fix for #5984 PRT failure

{{ pytest: -vvvv cfme/tests/configure/test_access_control.py -k 'role_crud or test_edit_default_roles' }}