### PR TITLE
[1LP][RFR] remove multimethods from utils.version and remove magical globals usage

### DIFF
--- a/cfme/markers/uncollect.py
+++ b/cfme/markers/uncollect.py
@@ -29,7 +29,7 @@ if a certain condition is evaluated to ``True``. The following is an example:
 
     .. code-block:: python
 
-        @pytest.mark.uncollectif(lambda: version.current_version() < '5.3')
+        @pytest.mark.uncollectif(lambda appliance: appliance.version < '5.3')
 
 In this case, when pytest runs the modify items hook, it will evaluate the lambda function
 and if it results in ``True``, then the test will be uncollected. Fixtures that are

--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -327,7 +327,7 @@ def service_templates_rest(request, appliance, service_dialog=None, service_cata
 
 def service_templates(request, appliance, service_dialog=None, service_catalog=None, num=4):
     # TODO: remove, because it copies service_templates_rest for supported versions.
-    # tmplt = service_templates_ui if version.current_version() < '5.8' else service_templates_rest
+    # tmplt = service_templates_ui if appliance.version < '5.8' else service_templates_rest
     return service_templates_rest(
         request, appliance, service_dialog=service_dialog, service_catalog=service_catalog, num=num)
 

--- a/cfme/tests/cli/test_appliance_cli.py
+++ b/cfme/tests/cli/test_appliance_cli.py
@@ -1,7 +1,6 @@
 import pytest
 
 from cfme.utils.log_validator import LogValidator
-from cfme.utils import version
 from wait_for import wait_for
 
 
@@ -19,8 +18,13 @@ tzs = [
     ['UTC'],
 ]
 
+requires_59 = pytest.mark.uncollectif(
+    lambda appliance: appliance.version < '5.9',
+    reason="this test requires an appliance version >= 5.9"
+)
 
-@pytest.mark.uncollectif(lambda appliance: appliance.version < '5.9')
+
+@requires_59
 def test_appliance_console_cli_datetime(temp_appliance_preconfig_funcscope):
     """Grab fresh appliance and set time and date through appliance_console_cli and check result"""
     app = temp_appliance_preconfig_funcscope
@@ -31,7 +35,7 @@ def test_appliance_console_cli_datetime(temp_appliance_preconfig_funcscope):
     wait_for(date_changed)
 
 
-@pytest.mark.uncollectif(lambda appliance: appliance.version < '5.9')
+@requires_59
 @pytest.mark.parametrize('timezone', tzs, ids=[tz[0] for tz in tzs])
 def test_appliance_console_cli_timezone(timezone, temp_appliance_preconfig_modscope):
     """Set and check timezones are set correctly through appliance conosle cli"""
@@ -40,7 +44,7 @@ def test_appliance_console_cli_timezone(timezone, temp_appliance_preconfig_modsc
     app.appliance_console.timezone_check(timezone)
 
 
-@pytest.mark.uncollectif(lambda appliance: appliance.version < '5.9')
+@requires_59
 def test_appliance_console_cli_db_maintenance_hourly(appliance_with_preset_time):
     """Test database hourly re-indexing through appliance console"""
     app = appliance_with_preset_time
@@ -130,7 +134,7 @@ def test_appliance_console_cli_ipa(ipa_crud, configured_appliance, no_ipa_config
     assert wait_for(lambda: not configured_appliance.sssd.running)
 
 
-@pytest.mark.uncollectif(lambda: version.current_version() < '5.9')
+@requires_59
 def test_appliance_console_cli_extend_storage(unconfigured_appliance):
     unconfigured_appliance.ssh_client.run_command('appliance_console_cli -t auto')
 
@@ -139,7 +143,7 @@ def test_appliance_console_cli_extend_storage(unconfigured_appliance):
     wait_for(is_storage_extended)
 
 
-@pytest.mark.uncollectif(lambda: version.current_version() < '5.9')
+@requires_59
 def test_appliance_console_cli_extend_log_storage(unconfigured_appliance):
     unconfigured_appliance.ssh_client.run_command('appliance_console_cli -l auto')
 
@@ -148,7 +152,7 @@ def test_appliance_console_cli_extend_log_storage(unconfigured_appliance):
     wait_for(is_storage_extended)
 
 
-@pytest.mark.uncollectif(lambda: version.current_version() < '5.9')
+@requires_59
 def test_appliance_console_cli_configure_dedicated_db(unconfigured_appliance, app_creds):
     unconfigured_appliance.appliance_console_cli.configure_appliance_dedicated_db(
         app_creds['username'], app_creds['password'], 'vmdb_production',
@@ -157,7 +161,9 @@ def test_appliance_console_cli_configure_dedicated_db(unconfigured_appliance, ap
     wait_for(lambda: unconfigured_appliance.db.is_dedicated_active)
 
 
-@pytest.mark.uncollectif(lambda appliance: version.current_version() < '5.9.1')
+@pytest.mark.uncollectif(
+    lambda appliance: appliance.version < '5.9.1',
+    reason="this test requires appliance version < 5.9.1")
 def test_appliance_console_cli_ha_crud(unconfigured_appliances, app_creds):
     """Tests the configuration of HA with three appliances including failover to standby node"""
     apps = unconfigured_appliances

--- a/cfme/tests/configure/test_docs.py
+++ b/cfme/tests/configure/test_docs.py
@@ -92,8 +92,8 @@ def test_contents(appliance, soft_assert):
             expected.append('manageiq')
         else:
             expected.append('cloudforms')
-            maj_min = '{}.{}'.format(cur_ver.version[0], cur_ver.version[1])
-            expected.append(version.get_product_version(maj_min))
+            assert cur_ver.product_version() is not None
+            expected.append(cur_ver.product_version())
 
         for exp_str in expected:
             soft_assert(exp_str in pdf_titlepage_text_low, "{} not in {}"

--- a/cfme/tests/configure/test_register_appliance.py
+++ b/cfme/tests/configure/test_register_appliance.py
@@ -2,7 +2,7 @@ import pytest
 import time
 
 from cfme.configure.configuration.region_settings import RedHatUpdates
-from cfme.utils import conf, version
+from cfme.utils import conf
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.conf import cfme_data
 from cfme.utils.blockers import BZ
@@ -30,8 +30,9 @@ def pytest_generate_tests(metafunc):
     argvalues = []
     idlist = []
 
-    stream = version.current_stream()
     try:
+        holder = metafunc.config.pluginmanager.get_plugin('appliance-holder')
+        stream = holder.held_appliance.version.stream()
         all_reg_data = conf.cfme_data.get('redhat_updates', {})['streams'][stream]
     except KeyError:
         logger.warning('Could not find rhsm data for stream in yaml')

--- a/cfme/tests/infrastructure/test_host_analysis.py
+++ b/cfme/tests/infrastructure/test_host_analysis.py
@@ -2,12 +2,12 @@
 import pytest
 
 from widgetastic.utils import partial_match
-
+import miq_version
 from cfme import test_requirements
 from cfme.infrastructure.host import Host
 from cfme.infrastructure.provider import InfraProvider
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils import testgen, version
+from cfme.utils import testgen
 
 pytestmark = [
     test_requirements.smartstate,
@@ -57,7 +57,8 @@ def host_with_credentials(appliance, provider, host_name):
 
 @pytest.mark.rhv1
 @pytest.mark.uncollectif(
-    lambda provider: version.current_version() == version.UPSTREAM and provider.type == 'rhevm')
+    lambda provider, appliance:
+    appliance.version == miq_version.UPSTREAM and provider.type == 'rhevm')
 def test_run_host_analysis(setup_provider_modscope, provider, host_type, host_name, register_event,
                            soft_assert, host_with_credentials):
     """ Run host SmartState analysis

--- a/cfme/tests/infrastructure/test_host_provisioning.py
+++ b/cfme/tests/infrastructure/test_host_provisioning.py
@@ -2,7 +2,7 @@ import pytest
 
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.pxe import get_pxe_server_from_config, get_template_from_config
-from cfme.utils import testgen, version
+from cfme.utils import testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.conf import cfme_data
 from cfme.utils.log import logger
@@ -45,8 +45,9 @@ def pytest_generate_tests(metafunc):
             # No host provisioning data available
             continue
 
+        holder = metafunc.config.pluginmanager.get_plugin('appliance-holder')
         stream = prov_data.get('runs_on_stream', '')
-        if not version.current_version().is_in_series(str(stream)):
+        if not holder.held_appliance.version.is_in_series(str(stream)):
             continue
 
         pxe_server_name = prov_data.get('pxe_server', '')

--- a/cfme/tests/storage/test_volume_backup.py
+++ b/cfme/tests/storage/test_volume_backup.py
@@ -3,7 +3,6 @@ import fauxfactory
 import pytest
 
 from cfme.cloud.provider.openstack import OpenStackProvider
-from cfme.utils import version
 from cfme.utils.log import logger
 
 
@@ -66,7 +65,7 @@ def test_storage_volume_backup_edit_tag_from_detail(backup):
 
 
 @pytest.mark.tier(3)
-@pytest.mark.uncollectif(lambda: version.current_version() < '5.9')
+@pytest.mark.uncollectif(lambda appliance: appliance.version < '5.9')
 def test_storage_volume_backup_delete(backup):
     """ Volume backup deletion method not support by 5.8 """
 

--- a/cfme/tests/test_db_migrate.py
+++ b/cfme/tests/test_db_migrate.py
@@ -5,7 +5,7 @@ from os import path as os_path
 from wait_for import wait_for
 
 from cfme.base.ui import navigate_to
-from cfme.utils import version, os
+from cfme.utils import os
 from cfme.utils.appliance import ApplianceException
 from cfme.utils.blockers import BZ
 from cfme.utils.conf import cfme_data, credentials
@@ -130,8 +130,8 @@ def test_db_migrate(temp_appliance_extended_db, db_url, db_version, db_desc):
 
 
 @pytest.mark.uncollectif(
-    lambda dbversion: dbversion == 'scvmm_58' and version.current_version() < "5.9" or
-    dbversion == 'ec2_5540' and version.current_version() < "5.9")
+    lambda appliance, dbversion:
+        dbversion in ('scvmm_58', 'ec2_5540') and appliance.version < "5.9")
 @pytest.mark.parametrize('dbversion', ['ec2_5540', 'azure_5620', 'rhev_57', 'scvmm_58'],
         ids=['55', '56', '57', '58'])
 def test_db_migrate_replication(temp_appliance_remote, dbversion, temp_appliance_global_region):
@@ -190,7 +190,6 @@ def test_db_migrate_replication(temp_appliance_remote, dbversion, temp_appliance
 
 def test_upgrade_single_inplace(appliance_preupdate, appliance):
     """Tests appliance upgrade between streams"""
-    ver = '95' if appliance.version >= '5.8' else '94'
     appliance_preupdate.evmserverd.stop()
     result = appliance_preupdate.ssh_client.run_command('yum update -y', timeout=3600)
     assert result.success, "update failed {}".format(result.output)

--- a/cfme/tests/test_login.py
+++ b/cfme/tests/test_login.py
@@ -18,8 +18,8 @@ pytestmark = pytest.mark.usefixtures('browser')
                                              (ViaUI, '_js_auth_fn'),
                                              (ViaSSUI, 'click_on_login'),
                                              (ViaSSUI, 'press_enter_after_password')])
-@pytest.mark.uncollectif(lambda context: context == ViaSSUI and
-                         version.current_version() == version.UPSTREAM)
+@pytest.mark.uncollectif(lambda context, appliance: context == ViaSSUI and
+                         appliance.version == version.UPSTREAM)
 def test_login(context, method, appliance):
     """ Tests that the appliance can be logged into and shows dashboard page. """
 

--- a/cfme/utils/providers.py
+++ b/cfme/utils/providers.py
@@ -16,7 +16,7 @@ from copy import copy
 from cfme.common.provider import all_types
 
 from cfme.exceptions import UnknownProviderType
-from cfme.utils import conf, version
+from cfme.utils import conf
 from cfme.utils.log import logger
 
 providers_data = conf.cfme_data.get("management_systems", {})
@@ -169,7 +169,7 @@ class ProviderFilter(object):
                     if not ver:  # This means that the operator was not found
                         continue
                     try:
-                        curr_ver = version.current_version()
+                        curr_ver = provider.appliance.version
                     except:
                         return True
                     if not comparator(curr_ver, ver):

--- a/cfme/utils/version.py
+++ b/cfme/utils/version.py
@@ -1,23 +1,12 @@
 # -*- coding: utf-8 -*-
 from datetime import date, datetime
 
-import multimethods as mm
 from miq_version import (  # noqa
     Version, LOWEST, LATEST, UPSTREAM, SPTuple, get_version,
     version_stream_product_mapping
 )
 
 from fixtures.pytest_store import store
-
-
-def get_product_version(ver):
-    """Return product version for given Version obj or version string
-    """
-    ver = Version(ver)
-    if ver.product_version() is not None:
-        return ver.product_version()
-    else:
-        raise LookupError("no matching product version found for version {}".format(ver))
 
 
 def get_stream(ver):
@@ -28,10 +17,6 @@ def get_stream(ver):
         return ver.stream()
     else:
         raise LookupError("no matching stream found for version {}".format(ver))
-
-
-def current_stream():
-    return get_stream(store.current_appliance.version)
 
 
 def current_version():
@@ -72,61 +57,11 @@ def parsedate(o):
         return date(*[int(x) for x in str(o).split("-", 2)])
 
 
-def before_date_or_version(date=None, version=None):
-    """Function for deciding based on the build date and version.
-
-    Usage:
-
-        * If both date and version are set, then two things can happen. If the appliance is
-            downstream, both date and version are checked, otherwise only the date.
-        * If only date is set, then only date is checked.
-        * if only version is set, then it checks the version if the appliance is downstream,
-            otherwise it returns ``False``
-
-    The checks are in form ``appliance_build_date() < date`` and ``current_version() < version``.
-    Therefore when used in ``if`` statement, the truthy value signalizes 'older' version and falsy
-    signalizes 'newer' version.
-    """
-    if date is not None:
-        date = parsedate(date)
-    if date is not None and version is not None:
-        if not appliance_is_downstream():
-            return appliance_build_date() < date
-        else:
-            return appliance_build_date() < date and current_version() < version
-    elif date is not None and version is None:
-        return appliance_build_date() < date
-    elif date is None and version is not None:
-        if not appliance_is_downstream():
-            return False
-        return current_version() < version
-    else:
-        raise TypeError("You have to pass either date or version, or both!")
-
-
-def since_date_or_version(*args, **kwargs):
-    """Opposite of :py:func:`before_date_or_version`"""
-    return not before_date_or_version(*args, **kwargs)
-
-
 def appliance_has_netapp():
     try:
         return store.current_appliance.has_netapp()
     except:
         return None
-
-
-def product_version_dispatch(*_args, **_kwargs):
-    """Dispatch function for use in multimethods that just ignores
-       arguments and dispatches on the current product version."""
-    return current_version()
-
-
-def dependent(default_function):
-    m = mm.MultiMethod(default_function.__name__, product_version_dispatch)
-    m.add_method(mm.Default, default_function)
-    mm._copy_attrs(default_function, m)
-    return m
 
 
 def pick(v_dict, active_version=None):
@@ -142,19 +77,3 @@ def pick(v_dict, active_version=None):
     sorted_matching_versions = sorted((v for v in versions if v <= active_version),
                                       reverse=True)
     return v_dict.get(sorted_matching_versions[0]) if sorted_matching_versions else None
-
-
-# Compare Versions using > for dispatch
-@mm.is_a.method((Version, Version))
-def _is_a_loose(x, y):
-    return x >= y
-
-
-@mm.is_a.method((str, Version))
-def _is_a_slv(x, y):
-    return mm.is_a(Version(x), y)
-
-
-@mm.is_a.method((Version, str))
-def _is_a_lvs(x, y):
-    return mm.is_a(x, Version(y))

--- a/docs/guides/tipsntricks.rst
+++ b/docs/guides/tipsntricks.rst
@@ -74,7 +74,7 @@ There are times when conditions dictate that we don't need to run a test if a ce
 is true. Imagine you don't want to run a test if the appliance version is below a certain value.
 In these instances, you can use ``uncollectif`` which is a pytest marker::
 
-    @pytest.mark.uncollectif(lambda: version.current_version() < '5.3')
+    @pytest.mark.uncollectif(lambda appliance: appliance.version < '5.9')
     def test_my_feature():
         # Test the new feature
         pass


### PR DESCRIPTION
this pr is part of removing multi-methods and part of removing the magical current_appliance globals

it removes many call sites where a better way is available

it does not yet touch version.pick and blockers

please avoid merging before i squash