### PR TITLE
[WIPTEST] Adding BZ wrappers for Customize bugs

### DIFF
--- a/cfme/tests/infrastructure/test_pxe_provisioning.py
+++ b/cfme/tests/infrastructure/test_pxe_provisioning.py
@@ -98,6 +98,7 @@ def vm_name():
 
 
 @pytest.mark.rhv1
+@pytest.mark.meta(blockers=[BZ(1561934, forced_streams=['5.8', '5.9'])])
 def test_pxe_provision_from_template(appliance, provider, vm_name, smtp_test, setup_provider,
                                      request, setup_pxe_servers_vm_prov):
     """Tests provisioning via PXE

--- a/cfme/tests/services/test_pxe_service_catalogs.py
+++ b/cfme/tests/services/test_pxe_service_catalogs.py
@@ -5,10 +5,12 @@ from widgetastic.utils import partial_match
 
 from cfme import test_requirements
 from cfme.infrastructure.provider import InfraProvider
+from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.pxe import get_pxe_server_from_config, get_template_from_config
 from cfme.common.vm import VM
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils import testgen
+from cfme.utils.blockers import BZ
 from cfme.utils.conf import cfme_data
 from cfme.utils.log import logger
 
@@ -115,6 +117,8 @@ def catalog_item(appliance, provider, vm_name, dialog, catalog, provisioning,
 
 
 @pytest.mark.rhv1
+@pytest.mark.meta(blockers=[BZ(1562012, forced_streams=['5.8', '5.9'],
+    unblock=lambda provider: not provider.one_of(RHEVMProvider))])
 @pytest.mark.usefixtures('setup_pxe_servers_vm_prov')
 def test_pxe_servicecatalog(appliance, setup_provider, provider, catalog_item, request):
     """Tests RHEV PXE service catalog


### PR DESCRIPTION
Automation run on CFME 5.9.2.0 encountered two bugs with Customize tab. I reported them and __wrapped__ affected test cases.

{{pytest: cfme/tests/services/test_pxe_service_catalogs.py::test_pxe_servicecatalog cfme/tests/infrastructure/test_pxe_provisioning.py::test_pxe_provision_from_template --long-running -vv --use-provider rhv41}}