### PR TITLE
[1LP][RFR] Update KubeVirt with type_name and settings_key

### DIFF
--- a/cfme/infrastructure/provider/kubevirt.py
+++ b/cfme/infrastructure/provider/kubevirt.py
@@ -4,6 +4,9 @@ from . import InfraProvider
 
 
 class KubeVirtProvider(InfraProvider):
+    type_name = "kubevirt"
+    settings_key = 'ems_kubevirt'
+    mgmt_class = None
 
     def __init__(self, parent_provider, **kwargs):
 


### PR DESCRIPTION
There's no kubevirt wrapanapi class to connect to, mgmt_class=None

##  PRT doesn't run upstream

Because PRT is only running downstream, this fix won't be tested by it.

When running `cfme.utils.providers.list_providers_by_class()` against an upstream appliance, the KubeVirt provider causes an AttributeError because of missing `type_name`.


Note I've set the mgmt_class to None here, since there is no wrapanapi class.
This doesn't actually get reached/called though, because the code path when calling `KubeVirt().mgmt` fails at the `default` endpoint lookup. The KubeVirt provider only has the virtualization endpoint, and its parent_provider has the default endpoint. We'll need to resolve this parent_provider default endpoint relationship when looking up default endpoints, but I don't want to include that scope here.