### PR TITLE
[1LP][RFR] fix ocp providers before_fill

### DIFF
--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -530,8 +530,10 @@ class ContainerProviderAddViewUpdated(ContainerProviderAddView, ContainerProvide
     virt_type = BootstrapSelect(id='virtualization_selection')
 
     def before_fill(self, values):
-        for widget in self.COND_WIDGETS:
-            getattr(self, widget).fill(values.get(widget))
+        for widget_name in self.COND_WIDGETS:
+            widget = getattr(self, widget_name)
+            if widget.is_displayed:
+                widget.fill(values.get(widget_name))
 
 
 class PhysicalProviderAddView(ProviderAddView):


### PR DESCRIPTION
It's impossible to create ocp providers in downstream because of new widget which is absent.
This PR should fix that issue.

{{pytest: --use-provider ocp-env2 cfme/tests/containers/test_reload_button_provider.py}}