### PR TITLE
[1LP][RFR] New history button test with snapshot

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -73,6 +73,7 @@ class InfraGenericDetailsToolbar(View):
     reload = Button(title=VersionPick({Version.lowest(): 'Reload current display',
                                        '5.9': 'Refresh this page',
                                        '6.0': 'Reload current display'}))
+    history = Dropdown('History')
     configuration = Dropdown('Configuration')
     policy = Dropdown('Policy')
     monitoring = Dropdown("Monitoring")
@@ -301,7 +302,7 @@ class InfraVmReconfigureView(BaseLoggedInPage):
 
 class InfraVmSnapshotToolbar(View):
     """The toolbar on the snapshots page"""
-    history = Dropdown('history')
+    history = Dropdown('History')
     reload = Button(title=VersionPick({Version.lowest(): 'Reload current display',
                                        '5.9': 'Refresh this page'}))
     create = Button(title='Create a new snapshot for this VM')
@@ -322,7 +323,8 @@ class InfraVmSnapshotView(InfraVmView):
     @property
     def is_displayed(self):
         """Is this view being displayed"""
-        return False
+        expected_title = '"Snapshots" for Virtual Machine "{}"'.format(self.context['object'].name)
+        return self.in_infra_vms and self.title.text == expected_title
 
 
 class InfraVmSnapshotAddView(InfraVmView):
@@ -342,7 +344,7 @@ class InfraVmSnapshotAddView(InfraVmView):
 
 class InfraVmGenealogyToolbar(View):
     """The toolbar on the genalogy page"""
-    history = Dropdown(title='history')
+    history = Dropdown(title='History')
     reload = Button(title=VersionPick({Version.lowest(): 'Reload current display',
                                        '5.9': 'Refresh this page'}))
     edit_tags = Button(title='Edit Tags for this VM')

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -8,7 +8,7 @@ from cfme.automate.simulation import simulate
 from cfme.common.vm import VM
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
-from cfme.infrastructure.virtual_machines import InfraVmSnapshotAddView, Vm
+from cfme.infrastructure.virtual_machines import InfraVmSnapshotAddView, InfraVmSnapshotView, Vm
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils import error
 from cfme.utils.blockers import BZ
@@ -359,6 +359,16 @@ def test_operations_powered_off_vm(small_test_vm):
     # The delete method will make sure the snapshots are indeed deleted
     snapshot1.delete()
     snapshot2.delete()
+
+
+def test_snapshot_history_btn(small_test_vm, provider):
+    snapshot = new_snapshot(small_test_vm, has_name=(not provider.one_of(RHEVMProvider)))
+    snapshot.create()
+    vm_details_view = navigate_to(small_test_vm, 'Details')
+    item = '"Snapshots" for Virtual Machine "{}"'.format(small_test_vm.name)
+    vm_details_view.toolbar.history.item_select(item)
+    snapshot_view = small_test_vm.create_view(InfraVmSnapshotView)
+    assert snapshot_view.is_displayed
 
 
 @pytest.mark.uncollectif(lambda provider: not provider.one_of(VMwareProvider),


### PR DESCRIPTION
This adds new simple test with snapshot and history toolbar button.

The test is for a polarion testcase. Creates snapshot, navigates to VM Details page, then uses the history toolbar button to go back to snapshots for that VM. Verifies the correct page is displayed.

I also corrected some pre-existing locators for the history toolbar button.

I had to define is_displayed for the InfraVmSnapshotView, I'm using title and in_infra_vms.

{{ pytest: -v --long-running cfme/tests/infrastructure/test_snapshot.py -k test_snapshot_history_btn }}