### PR TITLE
[1LP][RFR] Use delete helper functions in all REST tests

### DIFF
--- a/cfme/tests/ansible/test_embedded_ansible_rest.py
+++ b/cfme/tests/ansible/test_embedded_ansible_rest.py
@@ -5,7 +5,7 @@ import pytest
 
 from cfme import test_requirements
 from cfme.utils.blockers import BZ
-from cfme.utils.rest import assert_response
+from cfme.utils.rest import assert_response, delete_resources_from_collection
 from cfme.utils.version import current_version
 from cfme.utils.wait import wait_for
 
@@ -100,11 +100,7 @@ class TestReposRESTAPI(object):
         Metadata:
             test_flag: rest
         """
-        if method == 'post':
-            del_action = repository.action.delete.POST
-        else:
-            del_action = repository.action.delete.DELETE
-
+        del_action = getattr(repository.action.delete, method.upper())
         del_action()
         assert_response(appliance)
         repository.wait_not_exists(num_sec=300, delay=5)
@@ -124,12 +120,9 @@ class TestReposRESTAPI(object):
         Metadata:
             test_flag: rest
         """
-        appliance.rest_api.collections.configuration_script_sources.action.delete.POST(repository)
-        assert_response(appliance)
-        repository.wait_not_exists(num_sec=300, delay=5)
-
-        appliance.rest_api.collections.configuration_script_sources.action.delete.POST(repository)
-        assert_response(appliance, success=False)
+        collection = appliance.rest_api.collections.configuration_script_sources
+        delete_resources_from_collection(
+            collection, [repository], not_found=False, num_sec=300, delay=5)
 
 
 class TestPayloadsRESTAPI(object):

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -20,7 +20,11 @@ from cfme.common.provider_views import (
 from cfme.rest.gen_data import arbitration_profiles as _arbitration_profiles
 from cfme.rest.gen_data import _creating_skeleton as creating_skeleton
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.rest import assert_response
+from cfme.utils.rest import (
+    assert_response,
+    delete_resources_from_collection,
+    delete_resources_from_detail,
+)
 from cfme.utils.update import update
 from fixtures.provider import enable_provider_regions
 from fixtures.pytest_store import store
@@ -474,18 +478,13 @@ class TestProvidersRESTAPI(object):
     # arbitration_profiles were removed in versions >= 5.9'
     @pytest.mark.uncollectif(lambda: store.current_appliance.version >= '5.9')
     @pytest.mark.parametrize('method', ['post', 'delete'])
-    def test_delete_arbitration_profiles_from_detail(self, appliance, arbitration_profiles, method):
+    def test_delete_arbitration_profiles_from_detail(self, arbitration_profiles, method):
         """Tests delete arbitration profiles from detail.
 
         Metadata:
             test_flag: rest
         """
-        for entity in arbitration_profiles:
-            entity.action.delete(force_method=method)
-            assert_response(appliance)
-            with pytest.raises(Exception, match='ActiveRecord::RecordNotFound'):
-                entity.action.delete(force_method=method)
-            assert_response(appliance, http_status=404)
+        delete_resources_from_detail(arbitration_profiles, method=method)
 
     @pytest.mark.tier(3)
     # arbitration_profiles were removed in versions >= 5.9'
@@ -497,11 +496,7 @@ class TestProvidersRESTAPI(object):
             test_flag: rest
         """
         collection = appliance.rest_api.collections.arbitration_profiles
-        collection.action.delete(*arbitration_profiles)
-        assert_response(appliance)
-        with pytest.raises(Exception, match='ActiveRecord::RecordNotFound'):
-            collection.action.delete(*arbitration_profiles)
-        assert_response(appliance, http_status=404)
+        delete_resources_from_collection(collection, arbitration_profiles)
 
     @pytest.mark.tier(3)
     # arbitration_profiles were removed in versions >= 5.9'

--- a/cfme/tests/cloud_infra_common/test_custom_attributes_rest.py
+++ b/cfme/tests/cloud_infra_common/test_custom_attributes_rest.py
@@ -9,7 +9,11 @@ from cfme.common.vm import VM
 from cfme.infrastructure.provider import CloudInfraProvider, InfraProvider
 from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
-from cfme.utils.rest import assert_response, delete_resources_from_collection
+from cfme.utils.rest import (
+    assert_response,
+    delete_resources_from_collection,
+    delete_resources_from_detail,
+)
 
 
 pytestmark = [
@@ -148,38 +152,28 @@ class TestCustomAttributesRESTAPI(object):
         _uncollectif(appliance, provider, collection_name)
     )
     @pytest.mark.parametrize("collection_name", COLLECTIONS)
-    def test_delete_from_detail_post(self, request, collection_name, appliance, get_resource):
+    def test_delete_from_detail_post(self, request, collection_name, get_resource):
         """Test deleting custom attributes from detail using POST method.
 
         Metadata:
             test_flag: rest
         """
         attributes = add_custom_attributes(request, get_resource[collection_name]())
-        for entity in attributes:
-            entity.action.delete.POST()
-            assert_response(appliance)
-            with pytest.raises(Exception, match='ActiveRecord::RecordNotFound'):
-                entity.action.delete.POST()
-            assert_response(appliance, http_status=404)
+        delete_resources_from_detail(attributes, method='POST')
 
     @pytest.mark.uncollectif(lambda appliance, provider, collection_name:
         appliance.version < '5.9' or  # BZ 1422596 was not fixed for versions < 5.9
         _uncollectif(appliance, provider, collection_name)
     )
     @pytest.mark.parametrize("collection_name", COLLECTIONS)
-    def test_delete_from_detail_delete(self, request, collection_name, appliance, get_resource):
+    def test_delete_from_detail_delete(self, request, collection_name, get_resource):
         """Test deleting custom attributes from detail using DELETE method.
 
         Metadata:
             test_flag: rest
         """
         attributes = add_custom_attributes(request, get_resource[collection_name]())
-        for entity in attributes:
-            entity.action.delete.DELETE()
-            assert_response(appliance)
-            with pytest.raises(Exception, match='ActiveRecord::RecordNotFound'):
-                entity.action.delete.DELETE()
-            assert_response(appliance, http_status=404)
+        delete_resources_from_detail(attributes, method='DELETE')
 
     @pytest.mark.uncollectif(lambda appliance, provider, collection_name:
         _uncollectif(appliance, provider, collection_name)

--- a/cfme/tests/cloud_infra_common/test_rest_providers.py
+++ b/cfme/tests/cloud_infra_common/test_rest_providers.py
@@ -9,6 +9,7 @@ from cfme.utils.blockers import BZ
 from cfme.utils.rest import (
     assert_response,
     delete_resources_from_collection,
+    delete_resources_from_detail,
     query_resource_attributes,
 )
 from cfme.utils.wait import wait_for
@@ -144,36 +145,26 @@ def test_provider_edit(request, provider_rest, appliance):
 
 
 @pytest.mark.rhv3
-# testing BZ1501941
 @pytest.mark.parametrize("method", ["post", "delete"], ids=["POST", "DELETE"])
-def test_provider_delete_from_detail(provider_rest, appliance, method):
+def test_provider_delete_from_detail(provider_rest, method):
     """Tests deletion of the provider from detail using REST API.
+
+    Testing BZs 1525498, 1501941
 
     Metadata:
         test_flag: rest
     """
-    if method == "delete":
-        del_action = provider_rest.action.delete.DELETE
-    else:
-        del_action = provider_rest.action.delete.POST
-
-    del_action()
-    # testing BZ1525498
-    assert_response(appliance)
-    provider_rest.wait_not_exists(num_sec=50)
-    with pytest.raises(Exception, match="ActiveRecord::RecordNotFound"):
-        del_action()
-    assert_response(appliance, http_status=404)
+    delete_resources_from_detail([provider_rest], method=method, num_sec=50)
 
 
 @pytest.mark.rhv3
-# testing BZ1501941
 def test_provider_delete_from_collection(provider_rest, appliance):
     """Tests deletion of the provider from collection using REST API.
+
+    Testing BZs 1525498, 1501941
 
     Metadata:
         test_flag: rest
     """
     collection = appliance.rest_api.collections.providers
-    # testing BZ1525498
     delete_resources_from_collection(collection, [provider_rest], num_sec=50)

--- a/cfme/tests/cloud_infra_common/test_snapshots_rest.py
+++ b/cfme/tests/cloud_infra_common/test_snapshots_rest.py
@@ -11,7 +11,11 @@ from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
-from cfme.utils.rest import assert_response, delete_resources_from_collection
+from cfme.utils.rest import (
+    assert_response,
+    delete_resources_from_collection,
+    delete_resources_from_detail,
+)
 from cfme.utils.wait import wait_for
 
 
@@ -99,23 +103,16 @@ class TestRESTSnapshots(object):
         vm.snapshots.get(description=snapshot.description)
 
     @pytest.mark.parametrize('method', ['post', 'delete'], ids=['POST', 'DELETE'])
-    def test_delete_snapshot_from_detail(self, appliance, vm_snapshot, method):
+    def test_delete_snapshot_from_detail(self, vm_snapshot, method):
         """Deletes VM/instance snapshot from detail using REST API.
+
+        Testing BZ 1466225
 
         Metadata:
             test_flag: rest
         """
         __, snapshot = vm_snapshot
-        del_action = getattr(snapshot.action.delete, method.upper())
-
-        del_action()
-        assert_response(appliance)
-        snapshot.wait_not_exists(num_sec=300, delay=5)
-
-        # testing BZ 1466225
-        with pytest.raises(Exception, match='ActiveRecord::RecordNotFound'):
-            del_action()
-        assert_response(appliance, http_status=404)
+        delete_resources_from_detail([snapshot], method=method, num_sec=300, delay=5)
 
     def test_delete_snapshot_from_collection(self, vm_snapshot):
         """Deletes VM/instance snapshot from collection using REST API.

--- a/cfme/tests/configure/test_tag.py
+++ b/cfme/tests/configure/test_tag.py
@@ -12,7 +12,11 @@ from cfme.rest.gen_data import (
     vm as _vm,
 )
 from cfme.utils.blockers import BZ
-from cfme.utils.rest import assert_response, delete_resources_from_collection
+from cfme.utils.rest import (
+    assert_response,
+    delete_resources_from_collection,
+    delete_resources_from_detail,
+)
 from cfme.utils.update import update
 from cfme.utils.wait import wait_for
 
@@ -159,18 +163,13 @@ class TestTagsViaREST(object):
 
     @pytest.mark.tier(3)
     @pytest.mark.parametrize("method", ["post", "delete"], ids=["POST", "DELETE"])
-    def test_delete_tags_from_detail(self, appliance, tags, method):
+    def test_delete_tags_from_detail(self, tags, method):
         """Tests deleting tags from detail.
 
         Metadata:
             test_flag: rest
         """
-        for tag in tags:
-            tag.action.delete(force_method=method)
-            assert_response(appliance)
-            with pytest.raises(Exception, match="ActiveRecord::RecordNotFound"):
-                tag.action.delete(force_method=method)
-            assert_response(appliance, http_status=404)
+        delete_resources_from_detail(tags, method=method)
 
     @pytest.mark.tier(3)
     def test_delete_tags_from_collection(self, appliance, tags):

--- a/cfme/tests/configure/test_tag_category.py
+++ b/cfme/tests/configure/test_tag_category.py
@@ -4,7 +4,11 @@ import pytest
 
 from cfme.configure.configuration.region_settings import Category
 from cfme.rest.gen_data import categories as _categories
-from cfme.utils.rest import assert_response, delete_resources_from_collection
+from cfme.utils.rest import (
+    assert_response,
+    delete_resources_from_collection,
+    delete_resources_from_detail,
+)
 from cfme.utils.update import update
 from cfme.utils.wait import wait_for
 
@@ -79,18 +83,13 @@ class TestCategoriesViaREST(object):
 
     @pytest.mark.tier(3)
     @pytest.mark.parametrize("method", ["post", "delete"], ids=["POST", "DELETE"])
-    def test_delete_categories_from_detail(self, appliance, categories, method):
+    def test_delete_categories_from_detail(self, categories, method):
         """Tests deleting categories from detail.
 
         Metadata:
             test_flag: rest
         """
-        for ctg in categories:
-            ctg.action.delete(force_method=method)
-            assert_response(appliance)
-            with pytest.raises(Exception, match="ActiveRecord::RecordNotFound"):
-                ctg.action.delete(force_method=method)
-            assert_response(appliance, http_status=404)
+        delete_resources_from_detail(categories, method=method)
 
     @pytest.mark.tier(3)
     def test_delete_categories_from_collection(self, appliance, categories):

--- a/cfme/tests/control/test_rest_control.py
+++ b/cfme/tests/control/test_rest_control.py
@@ -9,6 +9,7 @@ from cfme.rest.gen_data import policies as _policies
 from cfme.utils.rest import (
     assert_response,
     delete_resources_from_collection,
+    delete_resources_from_detail,
     query_resource_attributes,
 )
 from cfme.utils.version import current_version
@@ -47,26 +48,13 @@ class TestConditionsRESTAPI(object):
             assert record.description == condition.description
 
     @pytest.mark.parametrize('method', ['post', 'delete'], ids=['POST', 'DELETE'])
-    def test_delete_conditions_from_detail(self, conditions, appliance, method):
+    def test_delete_conditions_from_detail(self, conditions, method):
         """Tests delete conditions from detail.
 
         Metadata:
             test_flag: rest
         """
-        for condition in conditions:
-            del_action = getattr(condition.action.delete, method.upper())
-            del_action()
-            assert_response(appliance)
-
-            condition.wait_not_exists(
-                num_sec=100,
-                delay=5,
-                message="Check if a condition doesn't exist"
-            )
-
-            with pytest.raises(Exception, match='ActiveRecord::RecordNotFound'):
-                del_action()
-            assert_response(appliance, http_status=404)
+        delete_resources_from_detail(conditions, method=method, num_sec=100, delay=5)
 
     def test_delete_conditions_from_collection(self, conditions, appliance):
         """Tests delete conditions from collection.
@@ -139,28 +127,16 @@ class TestPoliciesRESTAPI(object):
             record = appliance.rest_api.collections.policies.get(id=policy.id)
             assert record.description == policy.description
 
-    def test_delete_policies_from_detail_post(self, policies, appliance):
+    def test_delete_policies_from_detail_post(self, policies):
         """Tests delete policies from detail using POST method.
 
         Metadata:
             test_flag: rest
         """
-        for policy in policies:
-            policy.action.delete.POST()
-            assert_response(appliance)
-
-            policy.wait_not_exists(
-                num_sec=100,
-                delay=5,
-                message="Check if a policy doesn't exist"
-            )
-
-            with pytest.raises(Exception, match='ActiveRecord::RecordNotFound'):
-                policy.action.delete.POST()
-            assert_response(appliance, http_status=404)
+        delete_resources_from_detail(policies, method='POST', num_sec=100, delay=5)
 
     @pytest.mark.uncollectif(lambda: current_version() < '5.9')
-    def test_delete_policies_from_detail_delete(self, policies, appliance):
+    def test_delete_policies_from_detail_delete(self, policies):
         """Tests delete policies from detail using DELETE method.
 
         Testing BZ 1435773
@@ -168,19 +144,7 @@ class TestPoliciesRESTAPI(object):
         Metadata:
             test_flag: rest
         """
-        for policy in policies:
-            policy.action.delete.DELETE()
-            assert_response(appliance)
-
-            policy.wait_not_exists(
-                num_sec=100,
-                delay=5,
-                message="Check if a policy doesn't exist"
-            )
-
-            with pytest.raises(Exception, match='ActiveRecord::RecordNotFound'):
-                policy.action.delete.DELETE()
-            assert_response(appliance, http_status=404)
+        delete_resources_from_detail(policies, method='DELETE', num_sec=100, delay=5)
 
     def test_delete_policies_from_collection(self, policies, appliance):
         """Tests delete policies from collection.

--- a/cfme/tests/infrastructure/test_rest_templates.py
+++ b/cfme/tests/infrastructure/test_rest_templates.py
@@ -9,6 +9,7 @@ from cfme.utils.blockers import BZ
 from cfme.utils.rest import (
     assert_response,
     delete_resources_from_collection,
+    delete_resources_from_detail,
     query_resource_attributes,
 )
 
@@ -90,7 +91,7 @@ def test_set_ownership(appliance, template, from_detail):
 
 
 @pytest.mark.tier(2)
-def test_delete_template_from_detail_post(appliance, template):
+def test_delete_template_from_detail_post(template):
     """Tests deletion of template from detail using POST method.
 
     Testing BZ1422807
@@ -98,25 +99,17 @@ def test_delete_template_from_detail_post(appliance, template):
     Metadata:
         test_flag: rest
     """
-    template.action.delete.POST()
-    assert_response(appliance)
-    with pytest.raises(Exception, match="ActiveRecord::RecordNotFound"):
-        template.action.delete.POST()
-    assert_response(appliance, http_status=404)
+    delete_resources_from_detail([template], method='POST')
 
 
 @pytest.mark.tier(2)
-def test_delete_template_from_detail_delete(appliance, template):
+def test_delete_template_from_detail_delete(template):
     """Tests deletion of template from detail using DELETE method.
 
     Metadata:
         test_flag: rest
     """
-    template.action.delete.DELETE()
-    assert_response(appliance)
-    with pytest.raises(Exception, match="ActiveRecord::RecordNotFound"):
-        template.action.delete.DELETE()
-    assert_response(appliance, http_status=404)
+    delete_resources_from_detail([template], method='DELETE')
 
 
 @pytest.mark.tier(2)

--- a/cfme/tests/infrastructure/test_vm_rest.py
+++ b/cfme/tests/infrastructure/test_vm_rest.py
@@ -9,6 +9,7 @@ from cfme.utils.blockers import BZ
 from cfme.utils.rest import (
     assert_response,
     delete_resources_from_collection,
+    delete_resources_from_detail,
     query_resource_attributes,
 )
 from cfme.utils.wait import wait_for, wait_for_decorator
@@ -105,14 +106,8 @@ def test_edit_vm(request, vm, appliance, from_detail):
 
 @pytest.mark.tier(3)
 @pytest.mark.parametrize('method', ['post', 'delete'], ids=['POST', 'DELETE'])
-def test_delete_vm_from_detail(vm, appliance, method):
-    del_action = getattr(vm.action.delete, method.upper())
-    del_action()
-    assert_response(appliance)
-    vm.wait_not_exists(num_sec=300, delay=10)
-    with pytest.raises(Exception, match='ActiveRecord::RecordNotFound'):
-        del_action()
-    assert_response(appliance, http_status=404)
+def test_delete_vm_from_detail(vm, method):
+    delete_resources_from_detail([vm], method=method, num_sec=300, delay=10)
 
 
 @pytest.mark.tier(3)

--- a/cfme/tests/intelligence/test_chargeback.py
+++ b/cfme/tests/intelligence/test_chargeback.py
@@ -8,7 +8,11 @@ import cfme.intelligence.chargeback.rates as cb
 from cfme import test_requirements
 from cfme.rest.gen_data import rates as _rates
 from cfme.utils.blockers import BZ
-from cfme.utils.rest import assert_response, delete_resources_from_collection
+from cfme.utils.rest import (
+    assert_response,
+    delete_resources_from_collection,
+    delete_resources_from_detail,
+)
 from cfme.utils.update import update
 from cfme.utils.wait import wait_for
 from cfme.utils.appliance.implementations.ui import navigator
@@ -240,18 +244,13 @@ class TestRatesViaREST(object):
 
     @pytest.mark.tier(3)
     @pytest.mark.parametrize("method", ["post", "delete"], ids=["POST", "DELETE"])
-    def test_delete_rates_from_detail(self, appliance, rates, method):
+    def test_delete_rates_from_detail(self, rates, method):
         """Tests deleting rates from detail.
 
         Metadata:
             test_flag: rest
         """
-        for rate in rates:
-            rate.action.delete(force_method=method)
-            assert_response(appliance)
-            with pytest.raises(Exception, match="ActiveRecord::RecordNotFound"):
-                rate.action.delete(force_method=method)
-            assert_response(appliance, http_status=404)
+        delete_resources_from_detail(rates, method=method)
 
     @pytest.mark.tier(3)
     def test_delete_rates_from_collection(self, appliance, rates):

--- a/cfme/tests/services/test_generic_service_catalogs.py
+++ b/cfme/tests/services/test_generic_service_catalogs.py
@@ -2,12 +2,17 @@
 import fauxfactory
 import pytest
 
+from selenium.common.exceptions import NoSuchElementException
+
 from cfme import test_requirements
 from cfme.rest.gen_data import service_catalogs as _service_catalogs
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils.log import logger
-from cfme.utils.rest import assert_response, delete_resources_from_collection
-from selenium.common.exceptions import NoSuchElementException
+from cfme.utils.rest import (
+    assert_response,
+    delete_resources_from_collection,
+    delete_resources_from_detail,
+)
 
 
 pytestmark = [
@@ -125,18 +130,13 @@ class TestServiceCatalogViaREST(object):
         return _service_catalogs(request, appliance.rest_api)
 
     @pytest.mark.parametrize("method", ["post", "delete"], ids=["POST", "DELETE"])
-    def test_delete_service_catalog(self, appliance, service_catalogs, method):
+    def test_delete_service_catalog(self, service_catalogs, method):
         """Tests delete service catalog via rest.
 
         Metadata:
             test_flag: rest
         """
-        for scl in service_catalogs:
-            scl.action.delete(force_method=method)
-            assert_response(appliance)
-            with pytest.raises(Exception, match="ActiveRecord::RecordNotFound"):
-                scl.action.delete(force_method=method)
-            assert_response(appliance, http_status=404)
+        delete_resources_from_detail(service_catalogs, method=method)
 
     def test_delete_service_catalogs(self, appliance, service_catalogs):
         """Tests delete service catalogs via rest.

--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -849,7 +849,7 @@ class TestArbitrationSettingsRESTAPI(object):
         Metadata:
             test_flag: rest
         """
-        delete_resources_from_detail(arbitration_settings, method)
+        delete_resources_from_detail(arbitration_settings, method=method)
 
     def test_delete_arbitration_settings_from_collection(self, appliance, arbitration_settings):
         """Tests delete arbitration settings from collection.
@@ -925,7 +925,7 @@ class TestArbitrationRulesRESTAPI(object):
         Metadata:
             test_flag: rest
         """
-        delete_resources_from_detail(arbitration_rules, 'post')
+        delete_resources_from_detail(arbitration_rules, method='POST')
 
     def test_delete_arbitration_rules_from_collection(self, arbitration_rules, appliance):
         """Tests delete arbitration rules from collection.
@@ -1020,7 +1020,7 @@ class TestNotificationsRESTAPI(object):
             pytest.skip("Affected by BZ1420872, cannot test.")
 
         notifications = appliance.rest_api.collections.notifications.all[-3:]
-        delete_resources_from_detail(notifications, method)
+        delete_resources_from_detail(notifications, method=method)
 
     def test_delete_notifications_from_collection(self, appliance, generate_notifications):
         """Tests delete notifications from collection.


### PR DESCRIPTION
{{pytest: -v --long-running -k test_delete_ cfme/tests/ansible/test_embedded_ansible_rest.py cfme/tests/cloud/test_providers.py cfme/tests/cloud_infra_common/test_custom_attributes_rest.py cfme/tests/cloud_infra_common/test_rest_providers.py cfme/tests/cloud_infra_common/test_snapshots_rest.py cfme/tests/configure/test_tag.py cfme/tests/configure/test_tag_category.py cfme/tests/control/test_rest_control.py cfme/tests/infrastructure/test_rest_templates.py cfme/tests/infrastructure/test_vm_rest.py cfme/tests/intelligence/test_chargeback.py cfme/tests/services/test_generic_service_catalogs.py cfme/tests/services/test_rest_services.py cfme/tests/test_rest.py}}

**PRT**
Some time out errors, nothing related to changes in this PR.