### PR TITLE
[RFR] Fix test_cloud_networks_query

### DIFF
--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -435,8 +435,14 @@ class TestProvidersRESTAPI(object):
         assert_response(appliance)
         assert networks
         assert len(networks) == networks.subcount
-        assert len(networks.find_by(enabled=True)) >= 1
-        assert 'CloudNetwork' in networks[0].type
+
+        enabled_networks = 0
+        networks.reload(expand=True)
+        for network in networks:
+            assert 'CloudNetwork' in network.type
+            if network.enabled is True:
+                enabled_networks += 1
+        assert enabled_networks >= 1
 
     @pytest.mark.tier(3)
     def test_security_groups_query(self, cloud_provider, appliance):


### PR DESCRIPTION
Filtering is no longer supported on cloud_networks collection.

{{pytest: -v -k test_cloud_networks_query cfme/tests/cloud/test_providers.py}}