### PR TITLE
[1LP][RFR] Remove 'with pytest.raises' statement in test_permission_edit

### DIFF
--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -627,7 +627,9 @@ def _test_vm_removal():
          ['Everything', 'Compute', 'Infrastructure', 'Virtual Machines', 'Accordions']]])
 def test_permission_edit(appliance, request, product_features):
     """
-    Ensures that changes in permissions are enforced on next login
+    Ensures that changes in permissions are enforced on next login by attempting to navigate to
+    a page with and without permissions to access that page
+
     Args:
         appliance: cfme appliance fixture
         request: pytest request fixture
@@ -643,8 +645,9 @@ def test_permission_edit(appliance, request, product_features):
     group = group_collection(appliance).create(description=group_description, role=role.name)
     user = new_user(appliance, [group])
     with user:
-        with pytest.raises(Exception, message='Incorrect permissions set'):
+            # Navigation should succeed with valid permissions
             navigate_to(vms.Vm, 'VMsOnly')
+
     appliance.server.login_admin()
     role.update({'product_features': [(['Everything'], True)] +
                                      [(k, False) for k in product_features]


### PR DESCRIPTION
The initial navigate_to() statement is wrapped in a 'with pytest.raises'
incorrectly (#6994) since the statement is expected to succeed. Added comments
to explain that the navigation should succeed on the initial attempt
with valid permissions

{{ pytest: -v cfme/tests/configure/test_access_control.py -k 'test_permission_edit' }}