### PR TITLE
[1LP][RFR] RHV tier analyzer

### DIFF
--- a/scripts/tier_analyzer.py
+++ b/scripts/tier_analyzer.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+"""This simple script lists all tests generated for the given provider. Then it lists all the tests
+marked with given tier marker(s). In the end it simply compares those two list, showing you tests
+that are generated for provider but NOT marked with the tier(s)."""
+
 import argparse
 import re
 import subprocess
@@ -7,15 +11,22 @@ import sys
 
 
 def check_virtualenv():
-    """Check if we are in virtualenv and if not, exit."""
+    """Check if we are in virtualenv and if not, raise an error."""
     if not hasattr(sys, 'real_prefix'):
-        print('You must activate CFME virtualenv in oder to run this script.')
-        sys.exit(1)
+        raise EnvironmentError('You must activate CFME virtualenv in oder to run this script.')
 
 
-def get_pytest_output(args, use_tier_marker=False):
-    """Get string output of pytest command."""
-    print('Getting pytest output {} tier marker.'.format('with' if use_tier_marker else 'without'))
+def get_pytest_collect_only_output(args, use_tier_marker=False):
+    """
+    Get a string that is returned by pytest after invoking it with --collect-only argument.
+    If use_tier_marker is set to False (default), all the tests for given provider are collected.
+    If use_tier_marker is set to True, only the marked tests are collected.
+    """
+    print('Getting pytest --collect-only output for provider {} {} tier marker {}.'
+        .format(
+            args.provider,
+            'with' if use_tier_marker else 'without',
+            args.tier_marker))
     pytest_args = ['pytest',
         args.test_path,
         '--collect-only',
@@ -31,12 +42,13 @@ def get_pytest_output(args, use_tier_marker=False):
     return subprocess.check_output(pytest_args)
 
 
-def parse_pytest_output(output):
-    """Parse raw pytest output to get list of parametrized test cases."""
+def get_testcases_from_pytest_output(output):
+    """Parse raw pytest --collect-only output to get list of parametrized test cases."""
     test_cases = []
-    tc_regex = re.compile(r"\s*<Function '(?P<test_case_name>test_\w+)(?P<parameters>\[.+\])?'>")
+    testcase_regex = \
+        re.compile(r"\s*<Function '(?P<test_case_name>test_\w+)(?P<parameters>\[.+\])?'>")
     for line in output.splitlines():
-        match = re.match(pattern=tc_regex, string=line)
+        match = re.match(pattern=testcase_regex, string=line)
         if match:
             test_cases.append('{}{}'.format(
                 match.group('test_case_name'),
@@ -45,7 +57,7 @@ def parse_pytest_output(output):
     return test_cases
 
 
-def compare_parsed_outputs(all, tiers):
+def get_diff_from_lists(all, tiers):
     """Get sorted list of test cases that are not marked with tiers."""
     diff = set(all).difference(set(tiers))
     return sorted(diff)
@@ -75,10 +87,7 @@ def print_message(args, diff, all_parsed, all_count, tiers_parsed, tiers_count):
 
 if __name__ == '__main__':
 
-    parser = argparse.ArgumentParser(description="""This simple script lists all tests generated
-    for the given provider. Then it lists all the tests makred with given tier marker(s).
-    In the end it simply compares thhose two list, showing you tests that are generated for provider
-    but NOT marked with the tier(s).""")
+    parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('-v', '--verbose', action='store_true')
     parser.add_argument('-p', '--provider', action='store', default='rhv_cfme_integration')
     parser.add_argument('-t', '--test-path', action='store', default='cfme/tests')
@@ -87,14 +96,14 @@ if __name__ == '__main__':
 
     check_virtualenv()
 
-    output_with_tiers = get_pytest_output(args, use_tier_marker=True)
-    output_without_tiers = get_pytest_output(args, use_tier_marker=False)
-    tiers_parsed = parse_pytest_output(output_with_tiers)
-    all_parsed = parse_pytest_output(output_without_tiers)
+    output_with_tiers = get_pytest_collect_only_output(args, use_tier_marker=True)
+    output_without_tiers = get_pytest_collect_only_output(args, use_tier_marker=False)
+    tiers_parsed = get_testcases_from_pytest_output(output_with_tiers)
+    all_parsed = get_testcases_from_pytest_output(output_without_tiers)
 
     tiers_count = len(tiers_parsed)
     all_count = len(all_parsed)
 
-    final_diff = compare_parsed_outputs(all_parsed, tiers_parsed)
+    final_diff = get_diff_from_lists(all_parsed, tiers_parsed)
 
     print_message(args, final_diff, all_parsed, all_count, tiers_parsed, tiers_count)

--- a/scripts/tier_analyzer.py
+++ b/scripts/tier_analyzer.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+
+import argparse
+import re
+import subprocess
+import sys
+
+
+def check_virtualenv():
+    """Check if we are in virtualenv and if not, exit."""
+    if not hasattr(sys, 'real_prefix'):
+        print('You must activate CFME virtualenv in oder to run this script.')
+        sys.exit(1)
+
+
+def get_pytest_output(args, use_tier_marker=False):
+    """Get string output of pytest command."""
+    print('Getting pytest output {} tier marker.'.format('with' if use_tier_marker else 'without'))
+    pytest_args = ['pytest',
+        args.test_path,
+        '--collect-only',
+        '--long-running',
+        '--use-provider',
+        args.provider,
+        '-m']
+    if use_tier_marker:
+        pytest_args.append(args.tier_marker)
+    else:
+        pytest_args.append('uses_testgen')
+
+    return subprocess.check_output(pytest_args)
+
+
+def parse_pytest_output(output):
+    """Parse raw pytest output to get list of parametrized test cases."""
+    test_cases = []
+    tc_regex = re.compile(r"\s*<Function '(?P<test_case_name>test_\w+)(?P<parameters>\[.+\])?'>")
+    for line in output.splitlines():
+        match = re.match(pattern=tc_regex, string=line)
+        if match:
+            test_cases.append('{}{}'.format(
+                match.group('test_case_name'),
+                match.group('parameters') if match.group('parameters') else ''))
+
+    return test_cases
+
+
+def compare_parsed_outputs(all, tiers):
+    """Get sorted list of test cases that are not marked with tiers."""
+    diff = set(all).difference(set(tiers))
+    return sorted(diff)
+
+
+def print_message(args, diff, all_parsed, all_count, tiers_parsed, tiers_count):
+    """Human-readable output."""
+    def sep():
+        print('*' * 60)
+
+    if args.verbose:
+        sep()
+        print('There are {} test_cases run for {} provider:\n'.format(all_count, args.provider))
+        for test_case in all_parsed:
+            print(test_case)
+        sep()
+        print('There are {} test_cases marked with "{}":\n'.format(tiers_count, args.tier_marker))
+        for test_case in tiers_parsed:
+            print(test_case)
+
+    sep()
+    print('There are {} test cases not marked with "{}":\n'.format(len(diff), args.tier_marker))
+    for test_case in diff:
+        print(test_case)
+    sep()
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(description="""This simple script lists all tests generated
+    for the given provider. Then it lists all the tests makred with given tier marker(s).
+    In the end it simply compares thhose two list, showing you tests that are generated for provider
+    but NOT marked with the tier(s).""")
+    parser.add_argument('-v', '--verbose', action='store_true')
+    parser.add_argument('-p', '--provider', action='store', default='rhv_cfme_integration')
+    parser.add_argument('-t', '--test-path', action='store', default='cfme/tests')
+    parser.add_argument('-m', '--tier-marker', action='store', default='rhv1 or rhv2 or rhv3')
+    args = parser.parse_args()
+
+    check_virtualenv()
+
+    output_with_tiers = get_pytest_output(args, use_tier_marker=True)
+    output_without_tiers = get_pytest_output(args, use_tier_marker=False)
+    tiers_parsed = parse_pytest_output(output_with_tiers)
+    all_parsed = parse_pytest_output(output_without_tiers)
+
+    tiers_count = len(tiers_parsed)
+    all_count = len(all_parsed)
+
+    final_diff = compare_parsed_outputs(all_parsed, tiers_parsed)
+
+    print_message(args, final_diff, all_parsed, all_count, tiers_parsed, tiers_count)


### PR DESCRIPTION
This little __utility script__ is to be used by RHV-CFME integration team to compare
-  All the tests run for our provider with
- Tests that are marked with RHV tier 1, 2 or 3.

It's quite useful for us since from time to time we need to assign tiers to new tests. I am not sure if you're okay with having this in your repository. If not, we can store it somewhere else. But I thought this would be the most intuitive location.

PRT: There is SSH exception once again for downstream-58z

Example output:

************************************************************
There are 40 test cases not marked with "-m rhv1 or rhv2 or rhv3":

test_action_create_snapshot_and_delete_last[rhv_cfme_integration]
test_action_create_snapshots_and_delete_them[rhv_cfme_integration]
test_advanced_search_registry_element[rhv_cfme_integration]
test_cockpit_server_role[rhv_cfme_integration-disabled]
test_cockpit_server_role[rhv_cfme_integration-enabled]
test_create_snapshot[rhv_cfme_integration]
test_create_without_description[rhv_cfme_integration]
test_delete_snapshot_from_collection[rhv_cfme_integration]
test_delete_snapshot_from_detail[rhv_cfme_integration-DELETE]
test_delete_snapshot_from_detail[rhv_cfme_integration-POST]
test_delete_snapshot_race[rhv_cfme_integration]
test_drift_analysis[rhv_cfme_integration-rhel-xfs]
test_host_relationships[rhv_cfme_integration-Cluster]
test_host_relationships[rhv_cfme_integration-Datastores]
test_host_relationships[rhv_cfme_integration-Infrastructure Provider]
test_host_relationships[rhv_cfme_integration-Templates]
test_host_relationships[rhv_cfme_integration-VMs]
test_infra_provider_relationships[rhv_cfme_integration-Clusters]
test_infra_provider_relationships[rhv_cfme_integration-Datastores]
test_infra_provider_relationships[rhv_cfme_integration-Hosts]
test_infra_provider_relationships[rhv_cfme_integration-Templates]
test_infra_provider_relationships[rhv_cfme_integration-Virtual Machines]
test_monthly_charges[rhv_cfme_integration-ViaSSUI]
test_myservice_crud[rhv_cfme_integration-ViaSSUI]
test_provider_refresh_relationship[rhv_cfme_integration]
test_reconfig_vm_negative_cancel[rhv_cfme_integration]
test_retire_service[rhv_cfme_integration-ViaSSUI]
test_revert_on_running_vm[rhv_cfme_integration]
test_revert_snapshot[rhv_cfme_integration]
test_service_catalog_crud[rhv_cfme_integration-ViaSSUI]
test_service_start[rhv_cfme_integration-ViaSSUI]
test_snapshot_history_btn[rhv_cfme_integration]
test_ssa_files[rhv_cfme_integration-rhel-xfs]
test_ssa_groups[rhv_cfme_integration-rhel-xfs]
test_ssa_packages[rhv_cfme_integration-rhel-xfs]
test_ssa_schedule[rhv_cfme_integration-rhel-xfs]
test_ssa_template[rhv_cfme_integration-rhel-xfs]
test_ssa_users[rhv_cfme_integration-rhel-xfs]
test_total_services[rhv_cfme_integration-ViaSSUI]
test_vm_clone_neg[rhv_cfme_integration]
************************************************************

{{pytest: cfme/tests --collect-only}}