### PR TITLE
[1LP][RFR] Marikng test_cockpit_server_role with RHV tier

### DIFF
--- a/cfme/tests/cloud_infra_common/test_cockpit_server.py
+++ b/cfme/tests/cloud_infra_common/test_cockpit_server.py
@@ -25,6 +25,7 @@ def new_vm(provider, request):
     return vm
 
 
+@pytest.mark.rhv3
 @pytest.mark.uncollectif(
     lambda appliance, provider: appliance.version < "5.9" or provider.one_of(GCEProvider))
 @pytest.mark.provider([CloudInfraProvider])


### PR DESCRIPTION
{{pytest: cfme/tests/cloud_infra_common/test_cockpit_server.py --use-provider rhv41 -m "rhv3" -vv}}