### PR TITLE
[1LP][RFR] Marking service test cases with RHV tier

### DIFF
--- a/cfme/tests/ssui/test_ssui_myservice.py
+++ b/cfme/tests/ssui/test_ssui_myservice.py
@@ -57,6 +57,7 @@ def test_retire_service(appliance, setup_provider,
             my_service.delete()
 
 
+@pytest.mark.rhv3
 @pytest.mark.parametrize('context', [ViaSSUI])
 def test_service_start(appliance, setup_provider, context,
                        order_service, provider, request):

--- a/cfme/tests/ssui/test_ssui_service_catalogs.py
+++ b/cfme/tests/ssui/test_ssui_service_catalogs.py
@@ -21,6 +21,7 @@ pytestmark = [
 ]
 
 
+@pytest.mark.rhv2
 @pytest.mark.parametrize('context', [ViaSSUI])
 def test_service_catalog_crud(appliance, setup_provider,
                               context, order_service):


### PR DESCRIPTION
PRT result is failed since I did not received an appliance -> SSH exception

{{pytest: cfme/tests/ssui/test_ssui_myservice.py::test_service_start cfme/tests/ssui/test_ssui_service_catalogs.py::test_service_catalog_crud -m "rhv1 or rhv2 or rhv3" --long-running --use-provider rhv41}}