### PR TITLE
[1LP][RFR] Add new tests for the physical server list page

### DIFF
--- a/cfme/common/physical_server_views.py
+++ b/cfme/common/physical_server_views.py
@@ -158,10 +158,24 @@ class PhysicalServerManagePoliciesView(BaseLoggedInPage):
     save = Button("Save")
     reset = Button("Reset")
     cancel = Button("Cancel")
+    breadcrumb = BreadCrumb(locator='.//ol[@class="breadcrumb"]')
 
     @property
     def is_displayed(self):
-        return False
+        title = "'Physical Server' Policy Assignment"
+        return self.breadcrumb.active_location == title
+
+
+class PhysicalServerEditTagsView(BaseLoggedInPage):
+    """PhysicalServer's EditTags view."""
+    policies = BootstrapTreeview("protectbox")
+    entities = View.nested(BaseNonInteractiveEntitiesView)
+    breadcrumb = BreadCrumb(locator='.//ol[@class="breadcrumb"]')
+
+    @property
+    def is_displayed(self):
+        title = "Tag Assignment"
+        return self.breadcrumb.active_location == title
 
 
 class PhysicalServersToolbar(View):
@@ -173,6 +187,14 @@ class PhysicalServersToolbar(View):
     power = Dropdown(text="Power")
     identify = Dropdown(text="Identify")
     view_selector = View.nested(ItemsToolBarViewSelector)
+
+    @ParametrizedView.nested
+    class custom_button(ParametrizedView):  # noqa
+        PARAMETERS = ("button_group",)
+        _dropdown = Dropdown(text=Parameter("button_group"))
+
+        def item_select(self, button, handle_alert=False):
+            self._dropdown.item_select(button, handle_alert=handle_alert)
 
 
 class PhysicalServerSideBar(View):

--- a/cfme/physical/physical_server.py
+++ b/cfme/physical/physical_server.py
@@ -11,7 +11,8 @@ from cfme.common.physical_server_views import (
     PhysicalServerManagePoliciesView,
     PhysicalServersView,
     PhysicalServerProvisionView,
-    PhysicalServerTimelinesView
+    PhysicalServerTimelinesView,
+    PhysicalServerEditTagsView
 )
 from cfme.exceptions import (
     ItemNotFound,
@@ -327,6 +328,10 @@ class PhysicalServerCollection(BaseCollection):
         view = self.select_entity_rows(physical_servers)
         view.toolbar.power.item_select("Power Off", handle_alert=True)
 
+    def custom_button_action(self, button, option, physical_servers, handle_alert=True):
+        view = self.select_entity_rows(physical_servers)
+        view.toolbar.custom_button(button).item_select(option, handle_alert=handle_alert)
+
 
 @navigator.register(PhysicalServerCollection)
 class All(CFMENavigateStep):
@@ -335,6 +340,33 @@ class All(CFMENavigateStep):
 
     def step(self):
         self.prerequisite_view.navigation.select("Compute", "Physical Infrastructure", "Servers")
+
+
+@navigator.register(PhysicalServerCollection)
+class ManagePoliciesCollection(CFMENavigateStep):
+    VIEW = PhysicalServerManagePoliciesView
+    prerequisite = NavigateToSibling("All")
+
+    def step(self):
+        self.prerequisite_view.toolbar.policy.item_select("Manage Policies")
+
+
+@navigator.register(PhysicalServerCollection)
+class EditTagsCollection(CFMENavigateStep):
+    VIEW = PhysicalServerEditTagsView
+    prerequisite = NavigateToSibling("All")
+
+    def step(self):
+        self.prerequisite_view.toolbar.policy.item_select("Edit Tags")
+
+
+@navigator.register(PhysicalServerCollection)
+class ProvisionCollection(CFMENavigateStep):
+    VIEW = PhysicalServerProvisionView
+    prerequisite = NavigateToSibling("All")
+
+    def step(self):
+        self.prerequisite_view.toolbar.lifecycle.item_select("Provision Physical Server")
 
 
 @navigator.register(PhysicalServer)

--- a/cfme/tests/physical_infrastructure/ui/test_physical_server_list.py
+++ b/cfme/tests/physical_infrastructure/ui/test_physical_server_list.py
@@ -23,26 +23,58 @@ def test_physical_servers_view_dropdowns(physical_server_collection):
     """Navigate to the physical servers page and verify that the dropdown menus are present"""
     physical_servers_view = navigate_to(physical_server_collection, 'All')
 
-    configuration_items = physical_servers_view.toolbar.configuration.items
-    assert "Refresh Relationships and Power States" in configuration_items
+    toolbar = physical_servers_view.toolbar
 
-    power_items = physical_servers_view.toolbar.power.items
-    assert "Power On" in power_items
-    assert "Power Off" in power_items
-    assert "Power Off Immediately" in power_items
-    assert "Restart" in power_items
-    assert "Restart Immediately" in power_items
-    assert "Restart to System Setup" in power_items
-    assert "Restart Management Controller" in power_items
+    assert toolbar.configuration.is_enabled
+    assert toolbar.power.is_enabled
+    assert toolbar.identify.is_enabled
+    assert toolbar.policy.is_enabled
+    assert toolbar.lifecycle.is_enabled
 
-    identify_items = physical_servers_view.toolbar.identify.items
-    assert "Blink LED" in identify_items
-    assert "Turn On LED" in identify_items
-    assert "Turn Off LED" in identify_items
+    configuration_items = toolbar.configuration.items
+    configuration_options = [
+        "Refresh Relationships and Power States",
+    ]
+    for option in configuration_options:
+        assert option in configuration_items
+        assert not toolbar.configuration.item_enabled(option)
 
-    policy_items = physical_servers_view.toolbar.policy.items
-    assert "Manage Policies" in policy_items
-    assert "Edit Tags" in policy_items
+    power_items = toolbar.power.items
+    power_options = [
+        "Power On",
+        "Power Off",
+        "Power Off Immediately",
+        "Restart",
+        "Restart Immediately"
 
-    lifecycle_items = physical_servers_view.toolbar.lifecycle.items
-    assert "Provision Physical Server" in lifecycle_items
+    ]
+    for option in power_options:
+        assert option in power_items
+        assert not toolbar.power.item_enabled(option)
+
+    identify_items = toolbar.identify.items
+    identify_options = [
+        "Blink LED",
+        "Turn On LED",
+        "Turn Off LED",
+    ]
+    for option in identify_options:
+        assert option in identify_items
+        assert not toolbar.identify.item_enabled(option)
+
+    policy_items = toolbar.policy.items
+    policy_options = [
+        "Manage Policies",
+        "Edit Tags"
+    ]
+    for option in policy_options:
+        assert option in policy_items
+        assert not toolbar.policy.item_enabled(option)
+
+    lifecycle_items = toolbar.lifecycle.items
+    lifecycle_options = [
+        "Provision Physical Server",
+    ]
+    for option in lifecycle_options:
+        assert option in lifecycle_items
+        assert not toolbar.lifecycle.item_enabled(option)

--- a/cfme/tests/physical_infrastructure/ui/test_physical_server_list_buttons.py
+++ b/cfme/tests/physical_infrastructure/ui/test_physical_server_list_buttons.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+import collections
+import pytest
+
+from cfme.common.physical_server_views import PhysicalServersView
+from cfme.physical.provider.lenovo import LenovoProvider
+from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.wait import wait_for
+
+pytestmark = [pytest.mark.tier(3), pytest.mark.provider([LenovoProvider], scope="module")]
+
+
+@pytest.fixture(scope="function")
+def physical_servers(appliance, provider, setup_provider):
+    # Get and return all the physical servers
+    return appliance.collections.physical_servers.all(provider)
+
+
+@pytest.fixture(scope="function")
+def physical_servers_collection(appliance):
+    # Get and return collection of the physical servers
+    return appliance.collections.physical_servers
+
+
+# Configuration Button
+def test_refresh_relationships(physical_servers_collection, physical_servers, provider):
+    view = navigate_to(physical_servers_collection, "All")
+    last_refresh = provider.last_refresh_date()
+    item = "Refresh Relationships and Power States"
+    physical_servers_collection.custom_button_action("Configuration", item, physical_servers)
+    out, time = wait_for(
+        lambda: last_refresh != provider.last_refresh_date(),
+        fail_func=view.browser.refresh,
+        message="Wait for the servers to be refreshed...",
+        num_sec=300,
+        delay=5
+    )
+    assert out
+
+
+Action = collections.namedtuple('Action', 'button item method')
+actions = [
+    Action("Power", "Power Off", "power_off"),
+    Action("Power", "Power On", "power_on"),
+    Action("Power", "Power Off Immediately", "power_off_now"),
+    Action("Power", "Restart", "restart"),
+    Action("Power", "Restart Immediately", "restart_now"),
+    Action("Power", "Restart to System Setup", "restart_to_sys_setup"),
+    Action("Power", "Restart Management Controller", "restart_mgmt_controller"),
+    Action("Identify", "Blink LED", "blink_loc_led"),
+    Action("Identify", "Turn Off LED", "turn_off_loc_led"),
+    Action("Identify", "Turn On LED", "turn_on_loc_led")
+]
+
+
+# Power / Identify Buttons
+@pytest.mark.parametrize("button, item, method",
+                         actions, ids=[action.item for action in actions])
+def test_server_actions(physical_servers_collection, physical_servers, provider,
+                        button, item, method):
+    """ Test the physical server actions are creating a handler alert to each action of the a collection
+    of physical servers.
+    Params:
+        * button: the button to be performed on the physical server list page
+        * item: the item to be selected inside the dropdrown button
+        * method: the name of the method that most be used to compare if was invoked the
+        current method on the manageIQ.
+    Metadata:
+        test_flag: crud
+    """
+    view = provider.create_view(PhysicalServersView)
+
+    last_part = 's' if len(physical_servers) > 1 else ''
+    message = 'Requested Server {} for the selected server{}'.format(method, last_part)
+    physical_servers_collection.custom_button_action(button, item, physical_servers)
+
+    def assert_handler_displayed():
+        if view.flash.is_displayed:
+            return view.flash.messages[0].text == message
+
+        return False
+
+    wait_for(
+        assert_handler_displayed,
+        message="Wait for the handler alert to appear...",
+        num_sec=20,
+        delay=5
+    )
+    view.browser.refresh()
+
+
+# Policy Button
+def test_manage_button(physical_servers_collection, physical_servers):
+    physical_servers_collection.select_entity_rows(physical_servers)
+    view = navigate_to(physical_servers_collection, "ManagePoliciesCollection")
+    assert view.is_displayed
+
+
+def test_edit_tag(physical_servers_collection, physical_servers):
+    physical_servers_collection.select_entity_rows(physical_servers)
+    view = navigate_to(physical_servers_collection, "EditTagsCollection")
+    assert view.is_displayed
+
+
+# Lifecycle Button
+def test_lifecycle_provision(physical_servers_collection, physical_servers):
+    physical_servers_collection.select_entity_rows(physical_servers)
+    view = navigate_to(physical_servers_collection, "ProvisionCollection")
+    assert view.is_displayed


### PR DESCRIPTION
This PR is able to:
* Add new tests for the physical server `list` page to test the buttons of a collection.
* Add new tests cases inside the `test_pyhsical_server_list.py` file.