### PR TITLE
[1LP][RFR] Fix failure in test_edit_sequence_usergroups for 5.9.2

### DIFF
--- a/cfme/configure/access_control/__init__.py
+++ b/cfme/configure/access_control/__init__.py
@@ -700,7 +700,11 @@ class Group(BaseEntity, Taggable):
         Args:
             updated_order: group order list
         """
-        name_column = "Name"
+        if self.appliance.version < "5.9.2":
+            name_column = "Name"
+        else:
+            name_column = "Description"
+
         find_row_kwargs = {name_column: self.description}
         view = navigate_to(self.parent, 'All')
         row = view.paginator.find_row_on_pages(view.table, **find_row_kwargs)


### PR DESCRIPTION
Do a version check for specifying the column name in the RBAC Group checklist changed from "Name" to "Description".

{{ pytest: -v cfme/tests/configure/test_access_control.py -k 'test_edit_sequence_usergroups' }}