### PR TITLE
[1LP][RFR] Fix template tester upload/template cloning issues across providers

### DIFF
--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -469,7 +469,7 @@ class IPAppliance(object):
             key_address: Fetch encryption key from this address if set, generate a new key if
                          ``None`` (default ``None``)
             on_openstack: If appliance is running on Openstack provider (default ``False``)
-
+            on_gce: If appliance is running on GCE provider (default ``False``)
         """
 
         log_callback("Configuring appliance {}".format(self.hostname))
@@ -479,6 +479,7 @@ class IPAppliance(object):
         key_address = kwargs.pop('key_address', None)
         db_address = kwargs.pop('db_address', None)
         on_openstack = kwargs.pop('on_openstack', False)
+        on_gce = kwargs.pop('on_gce', False)
         with self as ipapp:
             ipapp.wait_for_ssh()
 
@@ -492,6 +493,8 @@ class IPAppliance(object):
             self.ssh_client.run_command("systemctl daemon-reload", ensure_host=True)
             self.ssh_client.run_command("service auditd restart", ensure_host=True)
 
+            ipapp.wait_for_ssh()
+
             self.deploy_merkyl(start=True, log_callback=log_callback)
             if fix_ntp_clock and not self.is_pod:
                 self.fix_ntp_clock(log_callback=log_callback)
@@ -502,6 +505,10 @@ class IPAppliance(object):
 
             self.db.setup(region=region, key_address=key_address,
                           db_address=db_address, is_pod=self.is_pod)
+
+            if on_gce:
+                # evm serverd does not auto start on GCE instance..
+                self.start_evm_service(log_callback=log_callback)
             self.wait_for_evm_service(timeout=1200, log_callback=log_callback)
 
             # Some conditionally ran items require the evm service be
@@ -595,20 +602,9 @@ class IPAppliance(object):
             logging.info("Running command: {}".format(command))
             client.run_command(command)
 
-    # TODO: this method eventually needs to be moved to provider class..
-    @logger_wrap("Configure GCE IPAppliance: {}")
     def configure_gce(self, log_callback=None):
-        self.wait_for_ssh(timeout=1200)
-        self.deploy_merkyl(start=True, log_callback=log_callback)
-        # TODO: Fix NTP on GCE instances.
-        # self.fix_ntp_clock(log_callback=log_callback)
-        self.db.enable_internal()
-        # evm serverd does not auto start on GCE instance..
-        self.start_evm_service(log_callback=log_callback)
-        self.wait_for_evm_service(timeout=1200, log_callback=log_callback)
-        self.wait_for_web_ui(timeout=1800, log_callback=log_callback)
-        self.db.loosen_pgssl()
-        self.wait_for_web_ui(timeout=1800, log_callback=log_callback)
+        # Force use of IPAppliance's configure method
+        return IPAppliance.configure(self, on_gce=True)
 
     def seal_for_templatizing(self):
         """Prepares the VM to be "generalized" for saving as a template."""
@@ -2061,7 +2057,7 @@ class IPAppliance(object):
                 raise Exception('Error obtaining config')
             try:
                 return yaml.load(base_data.output)
-            except:
+            except Exception:
                 logger.debug(base_data.output)
                 raise
 
@@ -2350,30 +2346,31 @@ class IPAppliance(object):
         self.ssh_client.put_file(cert_generator, remote_cert_generator)
 
         # Generate cert
-        command = '''
-            {cert_generator} \\
-                --C="{country}" \\
-                --ST="{state}" \\
-                --L="{city}" \\
-                --O="{organization}" \\
-                --OU="{organizational_unit}" \\
-                --keyFile="{key}" \\
-                --certFile="{cert}"
-        '''.format(
-            cert_generator=remote_cert_generator,
-            country=cert.country,
-            state=cert.state,
-            city=cert.city,
-            organization=cert.organization,
-            organizational_unit=cert.organizational_unit,
-            key=key_file,
-            cert=cert_file,
+        command = (
+            '{cert_generator}'
+            ' --C "{country}"'
+            ' --ST "{state}"'
+            ' --L "{city}"'
+            ' --O "{organization}"'
+            ' --OU "{organizational_unit}"'
+            ' --keyFile "{key}"'
+            ' --certFile "{cert}"'
+            .format(
+                cert_generator=remote_cert_generator,
+                country=cert.country,
+                state=cert.state,
+                city=cert.city,
+                organization=cert.organization,
+                organizational_unit=cert.organizational_unit,
+                key=key_file,
+                cert=cert_file,
+            )
         )
         result = self.ssh_client.run_command(command)
         if not result == 0:
             raise Exception(
                 'Failed to generate self-signed SSL cert on appliance: {}'.format(
-                    result[1]
+                    result.output
                 )
             )
 

--- a/scripts/clone_template.py
+++ b/scripts/clone_template.py
@@ -148,7 +148,7 @@ def attach_gce_disk(provider, vm_name):
             device_name = disk['deviceName']
 
     if not device_name:
-        logger.info("Instance disks: {}".format(instance['disks']))
+        logger.info('"Instance disks: %s', instance['disks'])
         raise Exception("Unable to find deviceName for attached disk.")
 
     # Mark disk for auto-delete
@@ -192,7 +192,7 @@ def main(**kwargs):
             'template': kwargs['template'],
         }
 
-    logger.info('Connecting to {}'.format(kwargs['provider']))
+    logger.info('Connecting to %s', kwargs['provider'])
 
     if kwargs.get('destroy'):
         # TODO: destroy should be its own script
@@ -235,14 +235,14 @@ def main(**kwargs):
     elif provider_type == 'openstack':
         # filter openstack flavors based on what's available
         available_flavors = provider.list_flavor()
-        logger.info("Available flavors on provider: {}".format(available_flavors))
+        logger.info("Available flavors on provider: %s", available_flavors)
         flavors = filter(lambda f: f in available_flavors, flavors)
         try:
             flavor = kwargs.get('flavor') or flavors[0]
         except IndexError:
             raise Exception('--flavor is required for RHOS instances and '
                             'default is not set or unavailable on provider')
-        logger.info("Selected flavor: {}".format(flavor))
+        logger.info('Selected flavor: %s', flavor)
 
         # flavour? Thanks, psav...
         deploy_args['flavour_name'] = flavor
@@ -277,14 +277,16 @@ def main(**kwargs):
         deploy_args["tags"] = yaml.safe_load(raw_tags.replace("u'", '"').replace("'", '"'))['TAGS']
     # Do it!
     try:
-        logger.info('Cloning {} to {} on {}'.format(deploy_args['template'], deploy_args['vm_name'],
-                                                    kwargs['provider']))
+        logger.info(
+            'Cloning %s to %s on %s',
+            deploy_args['template'], deploy_args['vm_name'], kwargs['provider']
+        )
         output = provider.deploy_template(**deploy_args)
     except Exception as e:
         logger.exception(e)
         logger.error('provider.deploy_template failed')
         if kwargs.get('cleanup'):
-            logger.info('attempting to destroy {}'.format(deploy_args['vm_name']))
+            logger.info('attempting to destroy %s', deploy_args['vm_name'])
             destroy_vm(provider, deploy_args['vm_name'])
         return 12
 
@@ -293,9 +295,9 @@ def main(**kwargs):
         return 12
 
     if provider.is_vm_running(deploy_args['vm_name']):
-        logger.info("VM {} is running".format(deploy_args['vm_name']))
+        logger.info('VM %s is running', deploy_args['vm_name'])
     else:
-        logger.error("VM is not running")
+        logger.error('VM %s is not running', deploy_args['vm_name'])
         return 10
 
     if provider_type == 'gce':
@@ -312,7 +314,7 @@ def main(**kwargs):
         try:
             ip, _ = wait_for(provider.get_ip_address, [deploy_args['vm_name']], num_sec=1200,
                              fail_condition=None)
-            logger.info('IP Address returned is {}'.format(ip))
+            logger.info('IP Address returned is %s', ip)
         except Exception as e:
             logger.exception(e)
             logger.error('IP address not returned')

--- a/scripts/clone_template.py
+++ b/scripts/clone_template.py
@@ -158,12 +158,15 @@ def main(**kwargs):
     elif provider_type == 'openstack':
         # filter openstack flavors based on what's available
         available_flavors = provider.list_flavor()
+        logger.info("Available flavors on provider: {}".format(available_flavors))
         flavors = filter(lambda f: f in available_flavors, flavors)
         try:
             flavor = kwargs.get('flavor') or flavors[0]
         except IndexError:
             raise Exception('--flavor is required for RHOS instances and '
                             'default is not set or unavailable on provider')
+        logger.info("Selected flavor: {}".format(flavor))
+
         # flavour? Thanks, psav...
         deploy_args['flavour_name'] = flavor
 

--- a/scripts/clone_template.py
+++ b/scripts/clone_template.py
@@ -149,8 +149,8 @@ def main(**kwargs):
                 'expire': False,
                 'list': '{}:{}\n'.format(cred['ssh']['username'], cred['ssh']['password'])
             },
-            'disable_root': 0,
-            'ssh_pwauth': 1
+            'disable_root': False,
+            'ssh_pwauth': True
         }
         cloud_init = "#cloud-config\n{}".format(yaml.safe_dump(cloud_init_dict,
                                                                default_flow_style=False))

--- a/scripts/template_upload_vsphere.py
+++ b/scripts/template_upload_vsphere.py
@@ -181,7 +181,8 @@ def make_kwargs_vsphere(cfmeqe_data, provider):
 
 
 def upload_template(client, hostname, username, password,
-                    provider, url, name, provider_data, stream):
+                    provider, url, name, provider_data, stream,
+                    results):
 
     try:
         if provider_data:
@@ -196,7 +197,9 @@ def upload_template(client, hostname, username, password,
 
         logger.info("VSPHERE:%r Start uploading Template: %r", provider, name)
         if not check_kwargs(**kwargs):
-            return False
+            results[provider] = False
+            return
+
         if name in client.list_template():
             logger.info("VSPHERE:%r template %r already exists", provider, name)
         else:
@@ -221,19 +224,24 @@ def upload_template(client, hostname, username, password,
                         break
                 else:
                     logger.error("VSPHERE:%r Ovftool failed upload after multiple tries", provider)
+                    results[provider] = False
                     return
 
             if kwargs.get('disk'):
                 if not add_disk(client, name, provider):
                     logger.error('"VSPHERE:%r FAILED adding disk to VM, exiting', provider)
-                    return False
+                    results[provider] = False
+                    return
+
             if kwargs.get('template'):
                 try:
                     client.mark_as_template(vm_name=name)
                     logger.info("VSPHERE:%r Successfully templatized machine", provider)
                 except Exception:
                     logger.exception("VSPHERE:%r FAILED to templatize machine", provider)
-                    return False
+                    results[provider] = False
+                    return
+
             if not provider_data:
                 logger.info("VSPHERE:%r Adding template %r to trackerbot", provider, name)
                 trackerbot.trackerbot_add_provider_template(stream, provider, name)
@@ -244,58 +252,73 @@ def upload_template(client, hostname, username, password,
             deploy_args = {'provider': provider, 'vm_name': vm_name,
                            'template': name, 'deploy': True}
             getattr(__import__('clone_template'), "main")(**deploy_args)
+
+        # If we get here without hitting an exception, we passed...
+        results[provider] = True
     except Exception:
         logger.exception('VSPHERE:%r Exception during upload_template', provider)
-        return False
+        results[provider] = False
+        return
     finally:
         logger.info("VSPHERE:%r End uploading Template: %r", provider, name)
 
 
 def run(**kwargs):
+    thread_queue = []
+    providers = list_provider_keys("virtualcenter")
+    if kwargs['provider_data']:
+        mgmt_sys = providers = kwargs['provider_data']['management_systems']
+    else:
+        mgmt_sys = cfme_data.management_systems
 
-    try:
-        thread_queue = []
-        providers = list_provider_keys("virtualcenter")
+    # Store thread results, no need to use a lock
+    # because threads will not be adding new keys
+    results = {provider: None for provider in providers}
+
+    for provider in providers:
+        # skip provider if block_upload is set
+        if (mgmt_sys[provider].get('template_upload') and
+                mgmt_sys[provider]['template_upload'].get('block_upload')):
+            logger.info('Skipping upload on {} due to block_upload'.format(provider))
+            continue
         if kwargs['provider_data']:
-            mgmt_sys = providers = kwargs['provider_data']['management_systems']
+            if mgmt_sys[provider]['type'] != 'virtualcenter':
+                continue
+            username = mgmt_sys[provider]['username']
+            password = mgmt_sys[provider]['password']
         else:
-            mgmt_sys = cfme_data.management_systems
+            creds = credentials[mgmt_sys[provider]['credentials']]
+            username = creds['username']
+            password = creds['password']
+        host_ip = mgmt_sys[provider]['ipaddress']
+        hostname = mgmt_sys[provider]['hostname']
+        client = VMWareSystem(hostname, username, password)
 
-        for provider in providers:
-            # skip provider if block_upload is set
-            if (mgmt_sys[provider].get('template_upload') and
-                    mgmt_sys[provider]['template_upload'].get('block_upload')):
-                logger.info('Skipping upload on {} due to block_upload'.format(provider))
-                continue
-            if kwargs['provider_data']:
-                if mgmt_sys[provider]['type'] != 'virtualcenter':
-                    continue
-                username = mgmt_sys[provider]['username']
-                password = mgmt_sys[provider]['password']
-            else:
-                creds = credentials[mgmt_sys[provider]['credentials']]
-                username = creds['username']
-                password = creds['password']
-            host_ip = mgmt_sys[provider]['ipaddress']
-            hostname = mgmt_sys[provider]['hostname']
-            client = VMWareSystem(hostname, username, password)
+        if not net.is_pingable(host_ip):
+            continue
+        thread = Thread(target=upload_template,
+                        args=(client, hostname, username, password, provider,
+                              kwargs.get('image_url'), kwargs.get('template_name'),
+                              kwargs['provider_data'], kwargs['stream'], results))
+        thread.daemon = True
+        thread_queue.append(thread)
+        thread.start()
 
-            if not net.is_pingable(host_ip):
-                continue
-            thread = Thread(target=upload_template,
-                            args=(client, hostname, username, password, provider,
-                                  kwargs.get('image_url'), kwargs.get('template_name'),
-                                  kwargs['provider_data'], kwargs['stream']))
-            thread.daemon = True
-            thread_queue.append(thread)
-            thread.start()
+    for thread in thread_queue:
+        thread.join()
 
-        for thread in thread_queue:
-            thread.join()
-    except Exception:
-        logger.exception('Exception during run method')
-        return False
+    failed_providers = [provider for provider, result in results.items() if result is False]
+    skipped_providers = [provider for provider, result in results.items() if result is None]
+    passed_providers = [provider for provider, result in results.items() if result]
 
+    logger.info("providers skipped: {}".format(skipped_providers))
+    logger.info("providers passed: {}".format(passed_providers))
+    logger.info("providers failed: {}".format(failed_providers))
+
+    if not passed_providers:
+        raise Exception("Template upload failed for all providers")
+    else:
+        logger.info("Upload passed for at least 1 provider... success!")
 
 if __name__ == "__main__":
     args = parse_cmd_line()

--- a/scripts/template_upload_vsphere.py
+++ b/scripts/template_upload_vsphere.py
@@ -76,8 +76,10 @@ def upload_ova(hostname, username, password, name, datastore,
     if proxy:
         cmd_args.append("--proxy={}".format(proxy))
     cmd_args.append(url)
-    cmd_args.append("'vi://{}:{}@{}/{}/host/{}'".format(username, password, hostname,
-                                                      datacenter, cluster))
+    cmd_args.append(
+        "'vi://{}:{}@{}/{}/host/{}'"
+        .format(username, password, hostname, datacenter, cluster)
+    )
     logger.info("VSPHERE:%r Running OVFTool", provider)
 
     command = ' '.join(cmd_args)
@@ -279,7 +281,7 @@ def run(**kwargs):
         # skip provider if block_upload is set
         if (mgmt_sys[provider].get('template_upload') and
                 mgmt_sys[provider]['template_upload'].get('block_upload')):
-            logger.info('Skipping upload on {} due to block_upload'.format(provider))
+            logger.info('Skipping upload on %s due to block_upload', provider)
             continue
         if kwargs['provider_data']:
             if mgmt_sys[provider]['type'] != 'virtualcenter':
@@ -311,9 +313,9 @@ def run(**kwargs):
     skipped_providers = [provider for provider, result in results.items() if result is None]
     passed_providers = [provider for provider, result in results.items() if result]
 
-    logger.info("providers skipped: {}".format(skipped_providers))
-    logger.info("providers passed: {}".format(passed_providers))
-    logger.info("providers failed: {}".format(failed_providers))
+    logger.info("providers skipped: %s", skipped_providers)
+    logger.info("providers passed: %s", passed_providers)
+    logger.info("providers failed: %s", failed_providers)
 
     if not passed_providers:
         raise Exception("Template upload failed for all providers")


### PR DESCRIPTION
* SCVMM upload was timing out, increasing wait_for timeout and also adding retries
* Storing results of VMWare and SCVMM upload attempts and failing "loudly" by raising an Exception if upload fails for all providers so that we get a red ball on the jenkins template upload jobs.
* Checking if cloud-init is done on ec2 before trying to configure appliance
* Attaching a 5gb disk to GCE instances for vmdb (needed on 5.9+)
* Switched from using ```IPAppliance.configure_gce()``` to using the same logic in ```IPAppliance.configure()``` with a couple "if" statements handled by an `on_gce` kwarg. This fixes some issues we were seeing such as internal DB trying to be setup on an upstream template (the configure method already accounts for this).

**NOTE:** I know the last 2 bullet points are messy. Out of this PR come some things to add to my backlog below. But if we can get these changes in now, template tester should hopefully be more reliable on GCE.
1) Add methods to wrapanapi in GCE to handle provisioning a template w/ extra disks, or attaching a disk to an instance, marking it for auto-delete, etc. I'll do that after the upcoming VM/template class refactor.
2) IPAppliance/Appliance configure methods could use some tweaking. There's a lot of code doing similar things, ideally '.configure()' is following similar logic everywhere, so some code should be consolidated here.