### PR TITLE
[1LP][RFR] delete_resources_from_collection - collection parameter optional

### DIFF
--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -495,14 +495,13 @@ class TestProvidersRESTAPI(object):
     @pytest.mark.tier(3)
     # arbitration_profiles were removed in versions >= 5.9'
     @pytest.mark.uncollectif(lambda: store.current_appliance.version >= '5.9')
-    def test_delete_arbitration_profiles_from_collection(self, appliance, arbitration_profiles):
+    def test_delete_arbitration_profiles_from_collection(self, arbitration_profiles):
         """Tests delete arbitration profiles from collection.
 
         Metadata:
             test_flag: rest
         """
-        collection = appliance.rest_api.collections.arbitration_profiles
-        delete_resources_from_collection(collection, arbitration_profiles)
+        delete_resources_from_collection(arbitration_profiles)
 
     @pytest.mark.tier(3)
     # arbitration_profiles were removed in versions >= 5.9'

--- a/cfme/tests/cloud_infra_common/test_custom_attributes_rest.py
+++ b/cfme/tests/cloud_infra_common/test_custom_attributes_rest.py
@@ -188,7 +188,7 @@ class TestCustomAttributesRESTAPI(object):
         resource = get_resource[collection_name]()
         attributes = add_custom_attributes(request, resource)
         collection = resource.custom_attributes
-        delete_resources_from_collection(collection, attributes, not_found=True)
+        delete_resources_from_collection(attributes, collection=collection, not_found=True)
 
     @pytest.mark.uncollectif(lambda appliance, provider, collection_name:
         _uncollectif(appliance, provider, collection_name)
@@ -204,7 +204,7 @@ class TestCustomAttributesRESTAPI(object):
         attributes = add_custom_attributes(request, resource)
         attribute = attributes[0]
         collection = resource.custom_attributes
-        delete_resources_from_collection(collection, [attribute], not_found=True)
+        delete_resources_from_collection([attribute], collection=collection, not_found=True)
 
     @pytest.mark.uncollectif(lambda appliance, provider, collection_name:
         _uncollectif(appliance, provider, collection_name)

--- a/cfme/tests/cloud_infra_common/test_rest_providers.py
+++ b/cfme/tests/cloud_infra_common/test_rest_providers.py
@@ -158,7 +158,7 @@ def test_provider_delete_from_detail(provider_rest, method):
 
 
 @pytest.mark.rhv3
-def test_provider_delete_from_collection(provider_rest, appliance):
+def test_provider_delete_from_collection(provider_rest):
     """Tests deletion of the provider from collection using REST API.
 
     Testing BZs 1525498, 1501941
@@ -166,5 +166,4 @@ def test_provider_delete_from_collection(provider_rest, appliance):
     Metadata:
         test_flag: rest
     """
-    collection = appliance.rest_api.collections.providers
-    delete_resources_from_collection(collection, [provider_rest], num_sec=50)
+    delete_resources_from_collection([provider_rest], num_sec=50)

--- a/cfme/tests/configure/test_rest_access_control.py
+++ b/cfme/tests/configure/test_rest_access_control.py
@@ -14,6 +14,7 @@ from cfme.utils.blockers import BZ
 from cfme.utils.rest import (
     assert_response,
     delete_resources_from_collection,
+    delete_resources_from_detail,
     query_resource_attributes,
 )
 from cfme.utils.wait import wait_for
@@ -90,31 +91,22 @@ class TestTenantsViaREST(object):
 
     @pytest.mark.tier(3)
     @pytest.mark.parametrize("method", ["post", "delete"], ids=["POST", "DELETE"])
-    def test_delete_tenants_from_detail(self, appliance, tenants, method):
+    def test_delete_tenants_from_detail(self, tenants, method):
         """Tests deleting tenants from detail.
 
         Metadata:
             test_flag: rest
         """
-        for tenant in tenants:
-            del_action = getattr(tenant.action.delete, method.upper())
-            del_action()
-            assert_response(appliance)
-
-            tenant.wait_not_exists(num_sec=10, delay=2)
-            with pytest.raises(Exception, match="ActiveRecord::RecordNotFound"):
-                del_action()
-            assert_response(appliance, http_status=404)
+        delete_resources_from_detail(tenants, method=method)
 
     @pytest.mark.tier(3)
-    def test_delete_tenants_from_collection(self, appliance, tenants):
+    def test_delete_tenants_from_collection(self, tenants):
         """Tests deleting tenants from collection.
 
         Metadata:
             test_flag: rest
         """
-        collection = appliance.rest_api.collections.tenants
-        delete_resources_from_collection(collection, tenants)
+        delete_resources_from_collection(tenants)
 
 
 class TestRolesViaREST(object):
@@ -184,31 +176,22 @@ class TestRolesViaREST(object):
 
     @pytest.mark.tier(3)
     @pytest.mark.parametrize("method", ["post", "delete"], ids=["POST", "DELETE"])
-    def test_delete_roles_from_detail(self, appliance, roles, method):
+    def test_delete_roles_from_detail(self, roles, method):
         """Tests deleting roles from detail.
 
         Metadata:
             test_flag: rest
         """
-        for role in roles:
-            del_action = getattr(role.action.delete, method.upper())
-            del_action()
-            assert_response(appliance)
-
-            role.wait_not_exists(num_sec=10, delay=2)
-            with pytest.raises(Exception, match="ActiveRecord::RecordNotFound"):
-                del_action()
-            assert_response(appliance, http_status=404)
+        delete_resources_from_detail(roles, method=method)
 
     @pytest.mark.tier(3)
-    def test_delete_roles_from_collection(self, appliance, roles):
+    def test_delete_roles_from_collection(self, roles):
         """Tests deleting roles from collection.
 
         Metadata:
             test_flag: rest
         """
-        collection = appliance.rest_api.collections.roles
-        delete_resources_from_collection(collection, roles)
+        delete_resources_from_collection(roles)
 
     @pytest.mark.tier(3)
     def test_add_delete_role(self, appliance):
@@ -330,31 +313,22 @@ class TestGroupsViaREST(object):
 
     @pytest.mark.tier(3)
     @pytest.mark.parametrize("method", ["post", "delete"], ids=["POST", "DELETE"])
-    def test_delete_groups_from_detail(self, appliance, groups, method):
+    def test_delete_groups_from_detail(self, groups, method):
         """Tests deleting groups from detail.
 
         Metadata:
             test_flag: rest
         """
-        for group in groups:
-            del_action = getattr(group.action.delete, method.upper())
-            del_action()
-            assert_response(appliance)
-
-            group.wait_not_exists(num_sec=10, delay=2)
-            with pytest.raises(Exception, match="ActiveRecord::RecordNotFound"):
-                del_action()
-            assert_response(appliance, http_status=404)
+        delete_resources_from_detail(groups, method=method)
 
     @pytest.mark.tier(3)
-    def test_delete_groups_from_collection(self, appliance, groups):
+    def test_delete_groups_from_collection(self, groups):
         """Tests deleting groups from collection.
 
         Metadata:
             test_flag: rest
         """
-        collection = appliance.rest_api.collections.groups
-        delete_resources_from_collection(collection, groups, not_found=True)
+        delete_resources_from_collection(groups, not_found=True)
 
 
 class TestUsersViaREST(object):
@@ -697,28 +671,19 @@ class TestUsersViaREST(object):
 
     @pytest.mark.tier(3)
     @pytest.mark.parametrize("method", ["post", "delete"], ids=["POST", "DELETE"])
-    def test_delete_users_from_detail(self, appliance, users, method):
+    def test_delete_users_from_detail(self, users, method):
         """Tests deleting users from detail.
 
         Metadata:
             test_flag: rest
         """
-        for user in users:
-            del_action = getattr(user.action.delete, method.upper())
-            del_action()
-            assert_response(appliance)
-
-            user.wait_not_exists(num_sec=10, delay=2)
-            with pytest.raises(Exception, match="ActiveRecord::RecordNotFound"):
-                del_action()
-            assert_response(appliance, http_status=404)
+        delete_resources_from_detail(users, method=method)
 
     @pytest.mark.tier(3)
-    def test_delete_users_from_collection(self, appliance, users):
+    def test_delete_users_from_collection(self, users):
         """Tests deleting users from collection.
 
         Metadata:
             test_flag: rest
         """
-        collection = appliance.rest_api.collections.users
-        delete_resources_from_collection(collection, users)
+        delete_resources_from_collection(users)

--- a/cfme/tests/configure/test_tag.py
+++ b/cfme/tests/configure/test_tag.py
@@ -172,14 +172,13 @@ class TestTagsViaREST(object):
         delete_resources_from_detail(tags, method=method)
 
     @pytest.mark.tier(3)
-    def test_delete_tags_from_collection(self, appliance, tags):
+    def test_delete_tags_from_collection(self, tags):
         """Tests deleting tags from collection.
 
         Metadata:
             test_flag: rest
         """
-        collection = appliance.rest_api.collections.tags
-        delete_resources_from_collection(collection, tags, not_found=True)
+        delete_resources_from_collection(tags, not_found=True)
 
     @pytest.mark.tier(3)
     def test_create_tag_with_wrong_arguments(self, appliance):

--- a/cfme/tests/configure/test_tag_category.py
+++ b/cfme/tests/configure/test_tag_category.py
@@ -92,11 +92,10 @@ class TestCategoriesViaREST(object):
         delete_resources_from_detail(categories, method=method)
 
     @pytest.mark.tier(3)
-    def test_delete_categories_from_collection(self, appliance, categories):
+    def test_delete_categories_from_collection(self, categories):
         """Tests deleting categories from collection.
 
         Metadata:
             test_flag: rest
         """
-        collection = appliance.rest_api.collections.categories
-        delete_resources_from_collection(collection, categories, not_found=True)
+        delete_resources_from_collection(categories, not_found=True)

--- a/cfme/tests/control/test_rest_control.py
+++ b/cfme/tests/control/test_rest_control.py
@@ -56,14 +56,13 @@ class TestConditionsRESTAPI(object):
         """
         delete_resources_from_detail(conditions, method=method, num_sec=100, delay=5)
 
-    def test_delete_conditions_from_collection(self, conditions, appliance):
+    def test_delete_conditions_from_collection(self, conditions):
         """Tests delete conditions from collection.
 
         Metadata:
             test_flag: rest
         """
-        collection = appliance.rest_api.collections.conditions
-        delete_resources_from_collection(collection, conditions, num_sec=100, delay=5)
+        delete_resources_from_collection(conditions, num_sec=100, delay=5)
 
     @pytest.mark.parametrize(
         'from_detail', [True, False],
@@ -146,14 +145,13 @@ class TestPoliciesRESTAPI(object):
         """
         delete_resources_from_detail(policies, method='DELETE', num_sec=100, delay=5)
 
-    def test_delete_policies_from_collection(self, policies, appliance):
+    def test_delete_policies_from_collection(self, policies):
         """Tests delete policies from collection.
 
         Metadata:
             test_flag: rest
         """
-        collection = appliance.rest_api.collections.policies
-        delete_resources_from_collection(collection, policies, num_sec=100, delay=5)
+        delete_resources_from_collection(policies, num_sec=100, delay=5)
 
     @pytest.mark.parametrize(
         'from_detail', [True, False],

--- a/cfme/tests/infrastructure/test_rest_templates.py
+++ b/cfme/tests/infrastructure/test_rest_templates.py
@@ -113,11 +113,10 @@ def test_delete_template_from_detail_delete(template):
 
 
 @pytest.mark.tier(2)
-def test_delete_template_from_collection(appliance, template):
+def test_delete_template_from_collection(template):
     """Tests deletion of template from collection.
 
     Metadata:
         test_flag: rest
     """
-    collection = appliance.rest_api.collections.templates
-    delete_resources_from_collection(collection, [template])
+    delete_resources_from_collection([template])

--- a/cfme/tests/infrastructure/test_vm_rest.py
+++ b/cfme/tests/infrastructure/test_vm_rest.py
@@ -111,6 +111,5 @@ def test_delete_vm_from_detail(vm, method):
 
 
 @pytest.mark.tier(3)
-def test_delete_vm_from_collection(vm, appliance):
-    collection = appliance.rest_api.collections.vms
-    delete_resources_from_collection(collection, [vm], not_found=True, num_sec=300, delay=10)
+def test_delete_vm_from_collection(vm):
+    delete_resources_from_collection([vm], not_found=True, num_sec=300, delay=10)

--- a/cfme/tests/intelligence/test_chargeback.py
+++ b/cfme/tests/intelligence/test_chargeback.py
@@ -253,11 +253,10 @@ class TestRatesViaREST(object):
         delete_resources_from_detail(rates, method=method)
 
     @pytest.mark.tier(3)
-    def test_delete_rates_from_collection(self, appliance, rates):
+    def test_delete_rates_from_collection(self, rates):
         """Tests deleting rates from collection.
 
         Metadata:
             test_flag: rest
         """
-        collection = appliance.rest_api.collections.rates
-        delete_resources_from_collection(collection, rates)
+        delete_resources_from_collection(rates)

--- a/cfme/tests/services/test_generic_service_catalogs.py
+++ b/cfme/tests/services/test_generic_service_catalogs.py
@@ -138,14 +138,13 @@ class TestServiceCatalogViaREST(object):
         """
         delete_resources_from_detail(service_catalogs, method=method)
 
-    def test_delete_service_catalogs(self, appliance, service_catalogs):
+    def test_delete_service_catalogs(self, service_catalogs):
         """Tests delete service catalogs via rest.
 
         Metadata:
             test_flag: rest
         """
-        collection = appliance.rest_api.collections.service_catalogs
-        delete_resources_from_collection(collection, service_catalogs)
+        delete_resources_from_collection(service_catalogs)
 
     def test_edit_service_catalog(self, appliance, service_catalogs):
         """Tests editing a service catalog via rest.

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -300,14 +300,13 @@ class TestServiceRESTAPI(object):
         """
         delete_resources_from_detail(services, method='DELETE')
 
-    def test_delete_services(self, appliance, services):
+    def test_delete_services(self, services):
         """Tests deleting services from collection.
 
         Metadata:
             test_flag: rest
         """
-        collection = appliance.rest_api.collections.services
-        delete_resources_from_collection(collection, services)
+        delete_resources_from_collection(services)
 
     @pytest.mark.parametrize(
         "from_detail", [True, False],
@@ -698,14 +697,13 @@ class TestServiceDialogsRESTAPI(object):
         """
         delete_resources_from_detail(service_dialogs, method=method)
 
-    def test_delete_service_dialogs(self, appliance, service_dialogs):
+    def test_delete_service_dialogs(self, service_dialogs):
         """Tests deleting service dialogs from collection.
 
         Metadata:
             test_flag: rest
         """
-        collection = appliance.rest_api.collections.service_dialogs
-        delete_resources_from_collection(collection, service_dialogs)
+        delete_resources_from_collection(service_dialogs)
 
 
 class TestServiceTemplateRESTAPI(object):
@@ -746,14 +744,13 @@ class TestServiceTemplateRESTAPI(object):
             service_template.reload()
             assert service_template.name == new_name
 
-    def test_delete_service_templates(self, appliance, service_templates):
+    def test_delete_service_templates(self, service_templates):
         """Tests deleting service templates from collection.
 
         Metadata:
             test_flag: rest
         """
-        collection = appliance.rest_api.collections.service_templates
-        delete_resources_from_collection(collection, service_templates)
+        delete_resources_from_collection(service_templates)
 
     # POST method is not available on < 5.8, as described in BZ 1427338
     def test_delete_service_template_post(self, service_templates):
@@ -1034,14 +1031,13 @@ class TestServiceCatalogsRESTAPI(object):
         """
         delete_resources_from_detail(service_catalogs, method=method, num_sec=100, delay=5)
 
-    def test_delete_catalog_from_collection(self, appliance, service_catalogs):
+    def test_delete_catalog_from_collection(self, service_catalogs):
         """Tests delete service catalogs from detail using REST API.
 
         Metadata:
             test_flag: rest
         """
-        collection = appliance.rest_api.collections.service_catalogs
-        delete_resources_from_collection(collection, service_catalogs, num_sec=300, delay=5)
+        delete_resources_from_collection(service_catalogs, num_sec=300, delay=5)
 
 
 class TestPendingRequestsRESTAPI(object):
@@ -1147,14 +1143,13 @@ class TestPendingRequestsRESTAPI(object):
         """
         delete_resources_from_detail([pending_request], method=method)
 
-    def test_delete_pending_request_from_collection(self, appliance, pending_request):
+    def test_delete_pending_request_from_collection(self, pending_request):
         """Tests deleting pending service request from detail using the REST API.
 
         Metadata:
             test_flag: rest
         """
-        collection = appliance.rest_api.collections.service_requests
-        delete_resources_from_collection(collection, [pending_request])
+        delete_resources_from_collection([pending_request])
 
     def test_order_manual_approval(self, request, appliance, pending_request):
         """Tests ordering single catalog item with manual approval using the REST API.
@@ -1323,14 +1318,13 @@ class TestBlueprintsRESTAPI(object):
         delete_resources_from_detail(blueprints, method=method)
 
     @pytest.mark.tier(3)
-    def test_delete_blueprints_from_collection(self, appliance, blueprints):
+    def test_delete_blueprints_from_collection(self, blueprints):
         """Tests deleting blueprints from collection.
 
         Metadata:
             test_flag: rest
         """
-        collection = appliance.rest_api.collections.blueprints
-        delete_resources_from_collection(collection, blueprints)
+        delete_resources_from_collection(blueprints)
 
     @pytest.mark.tier(3)
     @pytest.mark.parametrize(
@@ -1396,15 +1390,13 @@ class TestOrchestrationTemplatesRESTAPI(object):
             assert record.type == template.type
 
     @pytest.mark.tier(3)
-    def test_delete_orchestration_templates_from_collection(
-            self, appliance, orchestration_templates):
+    def test_delete_orchestration_templates_from_collection(self, orchestration_templates):
         """Tests deleting orchestration templates from collection.
 
         Metadata:
             test_flag: rest
         """
-        collection = appliance.rest_api.collections.orchestration_templates
-        delete_resources_from_collection(collection, orchestration_templates, not_found=True)
+        delete_resources_from_collection(orchestration_templates, not_found=True)
 
     @pytest.mark.tier(3)
     @pytest.mark.meta(blockers=[BZ(1414881, forced_streams=['5.7', '5.8', 'upstream'])])
@@ -1748,11 +1740,10 @@ class TestServiceOrderCart(object):
         delete_resources_from_detail([cart], method=method)
 
     @pytest.mark.tier(3)
-    def test_delete_cart_from_collection(self, appliance, cart):
+    def test_delete_cart_from_collection(self, cart):
         """Tests deleting cart from collection.
 
         Metadata:
             test_flag: rest
         """
-        collection = appliance.rest_api.collections.service_orders
-        delete_resources_from_collection(collection, [cart])
+        delete_resources_from_collection([cart])

--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -851,14 +851,13 @@ class TestArbitrationSettingsRESTAPI(object):
         """
         delete_resources_from_detail(arbitration_settings, method=method)
 
-    def test_delete_arbitration_settings_from_collection(self, appliance, arbitration_settings):
+    def test_delete_arbitration_settings_from_collection(self, arbitration_settings):
         """Tests delete arbitration settings from collection.
 
         Metadata:
             test_flag: rest
         """
-        collection = appliance.rest_api.collections.arbitration_settings
-        delete_resources_from_collection(collection, arbitration_settings)
+        delete_resources_from_collection(arbitration_settings)
 
     @pytest.mark.parametrize(
         "from_detail", [True, False],
@@ -927,14 +926,13 @@ class TestArbitrationRulesRESTAPI(object):
         """
         delete_resources_from_detail(arbitration_rules, method='POST')
 
-    def test_delete_arbitration_rules_from_collection(self, arbitration_rules, appliance):
+    def test_delete_arbitration_rules_from_collection(self, arbitration_rules):
         """Tests delete arbitration rules from collection.
 
         Metadata:
             test_flag: rest
         """
-        collection = appliance.rest_api.collections.arbitration_rules
-        delete_resources_from_collection(collection, arbitration_rules)
+        delete_resources_from_collection(arbitration_rules)
 
     @pytest.mark.parametrize(
         'from_detail', [True, False],
@@ -1028,9 +1026,8 @@ class TestNotificationsRESTAPI(object):
         Metadata:
             test_flag: rest
         """
-        collection = appliance.rest_api.collections.notifications
-        notifications = collection.all[-3:]
-        delete_resources_from_collection(collection, notifications)
+        notifications = appliance.rest_api.collections.notifications.all[-3:]
+        delete_resources_from_collection(notifications)
 
 
 class TestEventStreamsRESTAPI(object):

--- a/cfme/utils/rest.py
+++ b/cfme/utils/rest.py
@@ -154,8 +154,10 @@ def create_resource(rest_api, col_name, col_data, col_action='create', substr_se
 
 
 def delete_resources_from_collection(
-        collection, resources, not_found=None, num_sec=10, delay=2, check_response=True):
+        resources, collection=None, not_found=None, num_sec=10, delay=2, check_response=True):
     """Checks that delete from collection works as expected."""
+    collection = collection or resources[0].collection
+
     def _assert_response(*args, **kwargs):
         if check_response:
             assert_response(collection._api, *args, **kwargs)


### PR DESCRIPTION
{{pytest: -v --long-running -k test_delete_ cfme/tests/cloud/test_providers.py cfme/tests/cloud_infra_common/test_custom_attributes_rest.py cfme/tests/cloud_infra_common/test_rest_providers.py cfme/tests/configure/test_rest_access_control.py cfme/tests/configure/test_tag.py cfme/tests/configure/test_tag_category.py cfme/tests/control/test_rest_control.py cfme/tests/infrastructure/test_rest_templates.py cfme/tests/infrastructure/test_vm_rest.py cfme/tests/intelligence/test_chargeback.py cfme/tests/services/test_generic_service_catalogs.py cfme/tests/services/test_rest_services.py cfme/tests/test_rest.py}}

**PRT**
Timeout error, not related to changes in this PR.