### PR TITLE
[1LP][RFR] Catch empty object store collection

### DIFF
--- a/cfme/tests/storage/test_object_store_object.py
+++ b/cfme/tests/storage/test_object_store_object.py
@@ -15,6 +15,9 @@ pytestmark = [
 def test_object_add_remove_tag(appliance, provider):
     collection = appliance.collections.object_store_objects.filter({'provider': provider})
     all_objects = collection.all()
+    if all_objects is None:
+        pytest.skip('No object store object in collection {} for provider {}'
+                    .format(collection, provider))
     obj = random.choice(all_objects)
 
     # add tag with category Department and tag communication


### PR DESCRIPTION
This was raising a TypeError when the collection returned `None` from `all()`, skip the test since we're missing a necessary item.

{{ pytest: --use-provider rhos11 -k test_object_add_remove_tag }}