### PR TITLE
[WIPTEST] Fixing provider create for RHV and CFME < 5.8.0.8

### DIFF
--- a/cfme/infrastructure/provider/rhevm.py
+++ b/cfme/infrastructure/provider/rhevm.py
@@ -78,8 +78,7 @@ class RHEVMProvider(InfraProvider):
     def view_value_mapping(self):
         return {
             'name': self.name,
-            'prov_type': version.pick({version.LOWEST: 'Red Hat Virtualization Manager',
-                                       '5.8.0.10': 'Red Hat Virtualization'}),
+            'prov_type': 'Red Hat Virtualization'
         }
 
     def deployment_helper(self, deploy_args):


### PR DESCRIPTION


{{pytest: cfme/tests/infrastructure/test_providers.py::test_provider_crud --use-provider rhv41}}