### PR TITLE
[1LP][RFR] Fix test_host_drift_analysis

### DIFF
--- a/cfme/tests/infrastructure/test_host_drift_analysis.py
+++ b/cfme/tests/infrastructure/test_host_drift_analysis.py
@@ -117,7 +117,7 @@ def test_host_drift_analysis(appliance, request, a_host, soft_assert, set_host_c
     drift_analysis_view.toolbar.same_values_attributes.click()
     soft_assert(
         not drift_analysis_view.drift_analysis.check_section_attribute_availability(
-            'Department (1)'), "Department (1) row should be hidden, but not")
+            'Department'), "Department row should not have any attributes available.")
 
     # Accounting tag should be displayed now
     drift_analysis_view.toolbar.different_values_attributes.click()


### PR DESCRIPTION
If you use 'Department (1)' as arg for `drift_analysis_view.drift_analysis.check_section_attribute_availability`, the underlying method `DriftComparison.check_section_attribute_availability` returns `IndexError`, as opposed to `AttributeError` that is actually handled. I am not sure if handling `IndexError` is correct there. But I believe that checking for 'Department' in that case is more correct. The reason is that you don't want to check how many changes are in field 'Department'. You want to check that none of the attributes of that field are not available.

PRT failure: SSH exception

{{pytest: cfme/tests/infrastructure/test_host_drift_analysis.py::test_host_drift_analysis --use-provider rhv41}}