### PR TITLE
[WIP] Change the tests to wait for the power state  of the a server be changed

### DIFF
--- a/cfme/tests/physical_infrastructure/ui/test_physical_server_details_buttons.py
+++ b/cfme/tests/physical_infrastructure/ui/test_physical_server_details_buttons.py
@@ -1,19 +1,26 @@
 # -*- coding: utf-8 -*-
 import pytest
-from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.common.physical_server_views import (
     PhysicalServerDetailsView,
 )
 from cfme.physical.provider.lenovo import LenovoProvider
+from cfme.utils.appliance.implementations.ui import navigate_to
+
+# The max time that a single test has to perform the entire cycle of action
+# in seconds (10 min)
+TIMEOUT = 600
+
+# The time interval to perform a verification of state change
+# in seconds (1 min)
+DELAY = 10
 
 pytestmark = [pytest.mark.tier(3), pytest.mark.provider([LenovoProvider], scope="module")]
 
 
-@pytest.fixture(scope="module")
-def physical_server(appliance, provider):
+@pytest.fixture(scope="function")
+def physical_server(appliance, provider, setup_provider):
     # Get and return the first physical server
-    ph_server = appliance.collections.physical_servers.all(provider)[0]
-    return ph_server
+    return appliance.collections.physical_servers.all(provider)[0]
 
 
 # Configuration Button
@@ -24,53 +31,44 @@ def test_refresh_relationships(physical_server, provider):
 
 
 # Power Button
-def test_power_off(physical_server, provider):
-    physical_server.power_off()
+def test_restart_management_controller(physical_server, provider):
+    physical_server.restart_management_controller(wait_restart_bmc=True)
     view = provider.create_view(PhysicalServerDetailsView, physical_server)
-    view.flash.assert_message('Requested Server power_off for the selected server')
+    view.flash.assert_message('Requested Server restart_mgmt_controller for the selected server')
 
 
-def test_power_on(physical_server, provider):
-    physical_server.power_on()
+actions = [
+    ("power_off", "power_state", "off"),
+    ("power_on", "power_state", "on"),
+    ("power_off_now", "power_state", "off"),
+    ("restart", "power_state", "on"),
+    ("restart_now", "power_state", "on"),
+    ("restart_to_sys_setup", "power_state", "on"),
+    ("blink_loc_led", "location_led_state", "Blinking"),
+    ("turn_off_loc_led", "location_led_state", "Off"),
+    ("turn_on_loc_led", "location_led_state", "On")
+]
+
+
+@pytest.mark.parametrize("action, attr, desired_state",
+                         actions, ids=[action[0] for action in actions])
+def test_server_actions(physical_server, provider, action, attr,
+                        desired_state):
+    """ Test the physical server actions sending the action request, waiting the task be complete on MiQ
+        and then waiting the state of the some attribute of the physical server be changed
+    Params:
+        * action:        the action to be performed against the Physical Server
+        * attr:          the physical server attribute that will be changed by the action
+        * desired_state: the value of the attribute after the action execution
+    Metadata:
+        test_flag: crud
+    """
     view = provider.create_view(PhysicalServerDetailsView, physical_server)
-    view.flash.assert_message('Requested Server power_on for the selected server')
+    getattr(physical_server, action)()
 
-
-def test_power_off_immediately(physical_server, provider):
-    physical_server.power_off_immediately()
-    view = provider.create_view(PhysicalServerDetailsView, physical_server)
-    view.flash.assert_message('Requested Server power_off_now for the selected server')
-
-
-def test_restart(physical_server, provider):
-    physical_server.restart()
-    view = provider.create_view(PhysicalServerDetailsView, physical_server)
-    view.flash.assert_message('Requested Server restart for the selected server')
-
-
-def test_restart_immediately(physical_server, provider):
-    physical_server.restart_immediately()
-    view = provider.create_view(PhysicalServerDetailsView, physical_server)
-    view.flash.assert_message('Requested Server restart_now for the selected server')
-
-
-# Identify Button
-def test_turn_on_led(physical_server, provider):
-    physical_server.turn_on_led()
-    view = provider.create_view(PhysicalServerDetailsView, physical_server)
-    view.flash.assert_message('Requested Server turn_on_loc_led for the selected server')
-
-
-def test_turn_off_led(physical_server, provider):
-    physical_server.turn_off_led()
-    view = provider.create_view(PhysicalServerDetailsView, physical_server)
-    view.flash.assert_message('Requested Server turn_off_loc_led for the selected server')
-
-
-def test_turn_blink_led(physical_server, provider):
-    physical_server.turn_blink_led()
-    view = provider.create_view(PhysicalServerDetailsView, physical_server)
-    view.flash.assert_message('Requested Server blink_loc_led for the selected server')
+    message = 'Requested Server {} for the selected server'.format(action)
+    view.flash.assert_message(message)
+    physical_server.wait_for_state_change(desired_state, attr, provider, view, TIMEOUT, DELAY)
 
 
 # Lifecycle Button


### PR DESCRIPTION
This PR is able to:
* Refactor the physical servers UI tests to wait for the power state be changed.
* Add two new tests cases  to test the `Restart to System Setup` and `Restart Management (BMC)` inside the power button on the physical server page.