### PR TITLE
[1LP][WIPTEST]adding GCE/Azure cloud-init tests

### DIFF
--- a/cfme/tests/cloud/test_cloud_init_provisioning.py
+++ b/cfme/tests/cloud/test_cloud_init_provisioning.py
@@ -1,14 +1,20 @@
 # -*- coding: utf-8 -*-
 # These tests don't work at the moment, due to the security_groups multi select not working
 # in selenium (the group is selected then immediately reset)
-import fauxfactory
 import pytest
+
+from riggerlib import recursive_update
+from widgetastic.utils import partial_match
 
 from cfme.cloud.instance import Instance
 from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider.openstack import OpenStackProvider
+from cfme.cloud.provider.azure import AzureProvider
+from cfme.cloud.provider.gce import GCEProvider
 from cfme.infrastructure.pxe import get_template_from_config
 from cfme.utils import ssh
+from cfme.utils.generators import random_vm_name
+from cfme.utils.conf import credentials
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for
 
@@ -18,7 +24,7 @@ pytestmark = [
         ['provisioning', 'ci-template'],
         ['provisioning', 'ci-username'],
         ['provisioning', 'ci-pass'],
-        ['provisioning', 'image']],
+        ['provisioning', 'ci-image']],
         scope="module")
 ]
 
@@ -33,7 +39,7 @@ def setup_ci_template(provider, appliance):
 
 @pytest.fixture(scope="function")
 def vm_name(request):
-    vm_name = 'test_image_prov_{}'.format(fauxfactory.gen_alphanumeric())
+    vm_name = random_vm_name('ci')
     return vm_name
 
 
@@ -46,7 +52,7 @@ def test_provision_cloud_init(request, setup_provider, provider, provisioning,
         test_flag: cloud_init, provision
     """
     image = provisioning.get('ci-image') or provisioning['image']['name']
-    note = ('Testing provisioning from image {} to vm {} on provider {}'.format(
+    note = ('Testing cloud-init provisioning from image {} to vm {} on provider {}'.format(
         image, vm_name, provider.key))
     logger.info(note)
 
@@ -55,20 +61,50 @@ def test_provision_cloud_init(request, setup_provider, provider, provisioning,
     instance = Instance.factory(vm_name, provider, image)
 
     request.addfinalizer(instance.cleanup_on_provider)
-    # TODO: extend inst_args for other providers except EC2 if needed
     inst_args = {
         'request': {'email': 'image_provisioner@example.com',
                     'first_name': 'Image',
                     'last_name': 'Provisioner',
                     'notes': note},
-        'catalog': {'vm_name': vm_name},
-        'properties': {'instance_type': provisioning['instance_type'],
-                       'guest_keypair': provisioning['guest_keypair']},
-        'environment': {'availability_zone': provisioning['availability_zone'],
-                        'cloud_network': provisioning['cloud_network'],
-                        'security_groups': [provisioning['security_group']]},
-        'customize': {'custom_template': {'name': provisioning['ci-template']}}
+        'catalog': {
+            'vm_name': vm_name},
+        'customize': {
+            'custom_template': {'name': provisioning['ci-template']}},
+        'environment': {
+            'availability_zone': provisioning.get('availability_zone', None),
+            'security_groups': [provisioning.get('security_group', None)],
+            'cloud_network': provisioning.get('cloud_network', None),
+            'cloud_subnet': provisioning.get('cloud_subnet', None),
+            'resource_groups': provisioning.get('resource_group', None)
+        },
+        'properties': {
+            'instance_type': partial_match(provisioning.get('instance_type', None)),
+            'guest_keypair': provisioning.get('guest_keypair', None)}
     }
+    # GCE specific
+    if provider.one_of(GCEProvider):
+        recursive_update(inst_args, {
+            'properties': {
+                'boot_disk_size': provisioning['boot_disk_size'],
+                'is_preemptible': True}
+        })
+
+    # Azure specific
+    if provider.one_of(AzureProvider):
+        # Azure uses different provisioning keys for some reason
+        try:
+            template = provider.data.templates.small_template
+            vm_user = credentials[template.creds].username
+            vm_password = credentials[template.creds].password
+        except AttributeError:
+            pytest.skip('Could not find small_template or credentials for {}'.format(provider.name))
+        recursive_update(inst_args, {
+            'environment': {
+                'public_ip_address': 'New',
+            },
+            'customize': {
+                'admin_username': vm_user,
+                'root_password': vm_password}})
 
     if provider.one_of(OpenStackProvider):
         floating_ip = mgmt_system.get_first_floating_ip()


### PR DESCRIPTION
Purpose or Intent
=================

__Extending__ tests because only EC2 is picked up atm, need it to do cloud-init tests on providers wich support it 
TODO: RHOS kinda works, but env is not reliable - any template with cloud-init needs around 3GB of free space. and RHOS can't afford such huge Vm for automation right now 

needs wrapanapi : https://github.com/ManageIQ/wrapanapi/pull/245 and yamls update MR486
{{pytest: --long-running --use-template-cache --use-provider gce_central --use-provider azure --use-provider ec2west -k test_provision_cloud_init }}