### PR TITLE
[1LP][RFR]Temporary patch to track coverage in forked CFME processes

### DIFF
--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -11,6 +11,16 @@ class CFMEException(Exception):
     pass
 
 
+class ApplianceVersionException(CFMEException):
+    """Raised when functionality is not supported on this version of the appliance"""
+    def __init__(self, msg, version):
+        self.msg = msg
+        self.version = version
+
+    def __str__(self):
+        return "Version {} not supported.  {}".format(self.version, self.msg)
+
+
 class BugException(CFMEException):
     """Raised by methods inside the framework that are broken due to a bug"""
     def __init__(self, bug_no, operation):

--- a/scripts/data/coverage/manageiq-17302.patch
+++ b/scripts/data/coverage/manageiq-17302.patch
@@ -1,0 +1,55 @@
+From a2a49bb5633c66b280bc2cb86c0f94f2cb4483f0 Mon Sep 17 00:00:00 2001
+From: Joe Rafaniello <jrafanie@redhat.com>
+Date: Thu, 12 Apr 2018 11:01:19 -0400
+Subject: [PATCH] Load config/coverage_hook.rb at process creation
+
+If this file exists, we'll load it before the server starts and after we
+fork new workers.
+---
+ app/models/miq_worker.rb |  1 +
+ config/preinitializer.rb |  3 +++
+ lib/code_coverage.rb     | 12 ++++++++++++
+ 3 files changed, 16 insertions(+)
+ create mode 100644 lib/code_coverage.rb
+
+diff --git a/app/models/miq_worker.rb b/app/models/miq_worker.rb
+index 65d7371d77..d52d81784f 100644
+--- a/app/models/miq_worker.rb
++++ b/app/models/miq_worker.rb
+@@ -321,6 +321,7 @@ def self.after_fork
+     DRb.stop_service
+     close_drb_pool_connections
+     renice(Process.pid)
++    CodeCoverage.run_hook
+   end
+ 
+   # When we fork, the children inherits the parent's file descriptors
+diff --git a/config/preinitializer.rb b/config/preinitializer.rb
+index b965e59e1a..1b5fb0914b 100644
+--- a/config/preinitializer.rb
++++ b/config/preinitializer.rb
+@@ -3,3 +3,6 @@
+   $req_log_path = File.join(File.dirname(__FILE__), %w(.. log))
+   require 'require_with_logging'
+ end
++
++require File.join(__dir__, "..", "lib", "code_coverage")
++CodeCoverage.run_hook
+diff --git a/lib/code_coverage.rb b/lib/code_coverage.rb
+new file mode 100644
+index 0000000000..8c7a14d091
+--- /dev/null
++++ b/lib/code_coverage.rb
+@@ -0,0 +1,12 @@
++require 'pathname'
++module CodeCoverage
++  # The HOOK_FILE is responsible for starting or restarting code coverage.
++  # Child worker forks inherit the code coverage environment when the server
++  # invoked the 'run_hook' so they must reset the environment for the new process.
++  HOOK_FILE = Pathname.new(__dir__).join("..", "config", "coverage_hook.rb").freeze
++  def self.run_hook
++    # Note: We use 'load' here because require would only load the hook once,
++    # in the server but not when the child fork starts.  Shared memory is hard.
++    load HOOK_FILE if File.exist?(HOOK_FILE)
++  end
++end


### PR DESCRIPTION
We are losing coverage statistics because the way we
setup CFME to give us that data was designed around its
2014 architecture where it would launch multiple processes.
It changed at some point to launch a single process that forked.
What is happening now is there is we are only getting the statistics
from the parent and not from the children.

This is a temporary hack, to get this info until this PR is submitted
and makes it into a build:

   https://github.com/ManageIQ/manageiq/pull/17302

And even that is a temporary solution until CFME takes ownership
of generating code coverage statistics as a full feature.

{{ pytest: --use-provider rhv41 --ui-coverage  cfme/tests/cloud_infra_common/test_vm_ownership.py }}