### PR TITLE
[1LP][RFR] Update tests using custom users

### DIFF
--- a/cfme/configure/access_control/__init__.py
+++ b/cfme/configure/access_control/__init__.py
@@ -95,10 +95,7 @@ class DetailsUserView(ConfigurationView):
     def is_displayed(self):
         return (
             self.title.text == 'EVM User "{}"'.format(self.context['object'].name) and
-            self.accordions.accesscontrol.is_opened and
-            # tree.currently_selected returns a list of strings with each item being the text of
-            # each level of the accordion. Last element should be the User's name
-            self.accordions.accesscontrol.tree.currently_selected[-1] == self.context['object'].name
+            self.accordions.accesscontrol.is_opened
         )
 
 
@@ -496,11 +493,7 @@ class DetailsGroupView(ConfigurationView):
     def is_displayed(self):
         return (
             self.accordions.accesscontrol.is_opened and
-            self.title.text == 'EVM Group "{}"'.format(self.context['object'].description) and
-            # tree.currently_selected returns a list of strings with each item being the text of
-            # each level of the accordion. Last element should be the Group's name
-            (self.accordions.accesscontrol.tree.currently_selected[-1] ==
-             self.context['object'].description)
+            self.title.text == 'EVM Group "{}"'.format(self.context['object'].description)
         )
 
 
@@ -951,10 +944,7 @@ class DetailsRoleView(RoleForm):
     def is_displayed(self):
         return (
             self.accordions.accesscontrol.is_opened and
-            self.title.text == 'Role "{}"'.format(self.context['object'].name) and
-            # tree.currently_selected returns a list of strings with each item being the text of
-            # each level of the accordion. Last element should be the Role's name
-            self.accordions.accesscontrol.tree.currently_selected[-1] == self.context['object'].name
+            self.title.text == 'Role "{}"'.format(self.context['object'].name)
         )
 
 

--- a/cfme/roles.py
+++ b/cfme/roles.py
@@ -508,6 +508,7 @@ role_access_ui_58z = {
     },
     'evmgroup-operator': {
         'Automation': {
+            'Ansible': ['Credentials', 'Repositories', 'Playbooks'],
             'Ansible Tower': ['Explorer']},
         'Cloud Intel': ['Timelines', 'RSS', 'Dashboard', 'Reports', 'Chargeback'],
         'Compute': {
@@ -545,6 +546,7 @@ role_access_ui_58z = {
     },
     'evmgroup-vm_user': {
         'Automation': {
+            'Ansible': ['Credentials', 'Repositories', 'Playbooks'],
             'Ansible Tower': ['Explorer']},
         'Compute': {
             'Clouds': ['Instances'],

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -122,10 +122,12 @@ def test_user_assign_multiple_groups(appliance, request, group_collection):
     request.addfinalizer(user.delete)
     request.addfinalizer(user.appliance.server.login_admin)
 
-    view = appliance.server.login(user)
-
-    assert set(view.group_names) == set(group_names), (
-        "User's assigned groups are different from expected groups")
+    with user:
+        view = navigate_to(appliance.server, 'LoggedIn')
+        assigned_groups = view.group_names
+        assert set(assigned_groups) == set(group_names), (
+            "User {} assigned groups {} are different from expected groups {}"
+            .format(user, view.group_names, group_names))
 
 
 # @pytest.mark.meta(blockers=[1035399]) # work around instead of skip
@@ -137,7 +139,7 @@ def test_user_login(appliance, group_collection):
     user = new_user(appliance, [group])
     try:
         with user:
-            navigate_to(appliance.server, 'Dashboard')
+            navigate_to(appliance.server, 'LoggedIn')
     finally:
         user.appliance.server.login_admin()
 
@@ -747,7 +749,7 @@ def test_permissions(appliance, product_features, allowed_actions, disallowed_ac
     fails = {}
     try:
         with user:
-            appliance.server.login(user)
+            navigate_to(appliance.server, 'LoggedIn')
             # TODO: split this test into 2 parameterized tests
             for name, action_thunk in sorted(allowed_actions.items()):
                 try:
@@ -852,7 +854,7 @@ def test_user_change_password(appliance, request):
     request.addfinalizer(appliance.server.login_admin)
     with user:
         appliance.server.logout()
-        appliance.server.login(user)
+        navigate_to(appliance.server, 'LoggedIn')
         assert appliance.server.current_full_name() == user.name
     appliance.server.login_admin()
     with update(user):
@@ -863,7 +865,7 @@ def test_user_change_password(appliance, request):
         )
     with user:
         appliance.server.logout()
-        appliance.server.login(user)
+        navigate_to(appliance.server, 'LoggedIn')
         assert appliance.server.current_full_name() == user.name
 
 

--- a/cfme/tests/integration/test_cfme_auth.py
+++ b/cfme/tests/integration/test_cfme_auth.py
@@ -3,7 +3,7 @@ import pytest
 from six import iteritems
 
 from cfme.base.credential import Credential
-from cfme.base.login import BaseLoggedInPage
+from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.auth import (
     OpenLDAPAuthProvider, OpenLDAPSAuthProvider, ActiveDirectoryAuthProvider, FreeIPAAuthProvider,
     AmazonAuthProvider
@@ -117,12 +117,9 @@ def test_login_evm_group(appliance, auth_mode, prov_key, user_type, auth_provide
     for user, groupname in user_tuples:
         with user:
             # use appliance.server methods for UI context instead of view directly
-            appliance.server.login(user, method='click_on_login')
-            view = appliance.browser.create_view(BaseLoggedInPage)
-            assert view.is_displayed
+            navigate_to(appliance.server, 'LoggedIn', wait_for_view=True)
             assert appliance.server.current_full_name() == user.name
             assert groupname.lower() in [name.lower() for name in appliance.server.group_names()]
-            appliance.server.logout()
 
     # split loop to reduce number of logins
     appliance.server.login_admin()
@@ -192,13 +189,10 @@ def test_login_retrieve_group(appliance, request, prov_key, auth_mode, auth_prov
     for user, group in user_group_tuples:
         with user:
             request.addfinalizer(lambda: _group_cleanup(group))
-            appliance.server.login(user, method='click_on_login')
-            view = appliance.browser.create_view(BaseLoggedInPage)
-            assert view.is_displayed
+            navigate_to(appliance.server, 'LoggedIn', wait_for_view=True)
             assert appliance.server.current_full_name() == user.name
             assert group.description.lower() in [name.lower() for
                                                  name in appliance.server.group_names()]
-            appliance.server.logout()
 
     appliance.server.login_admin()
     for user, _ in user_group_tuples:

--- a/cfme/tests/integration/test_ldap_auth_and_roles.py
+++ b/cfme/tests/integration/test_ldap_auth_and_roles.py
@@ -1,5 +1,6 @@
 import pytest
 
+from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.conf import credentials
 from cfme.utils.testgen import auth_groups, generate
 
@@ -35,5 +36,6 @@ def test_group_roles(
         pytest.fail('No match in credentials file for group "{}"'.format(group_name))
 
     user = appliance.collections.users.simple_user(username, password)
-    appliance.server.login(user)
+    with user:
+        navigate_to(appliance.server, 'LoggedIn')
     # assert set(menu.nav.visible_pages()) == set(group_data)


### PR DESCRIPTION
We are seeing test failures that surface as a ValueError, when trying to navigate (primarily with the 'Configuration' dropdown).

Debugging with @psav we found that some tests were specifically logging in with an `appliance.server.login()` command, both within and outside of user contexts.

This was causing interaction between tests, where some tests wouldn't "cleanup" and return to superadmin login for the appliance. Subsequent tests would be on a non-admin user, and would be missing permissions for some action required for the test.

This PR addresses a few actions across a few different tests:
1. Replace uses of direct login calls with a specific user with a `navigate_to()` call
2. Have a context manager for any custom users

## PRT
running...

{{ pytest: --long-running -k 'test_user_assign_multiple_groups or test_permissions or test_user_change_password or test_group_roles or test_login_evm_group or test_login_retrieve_group' }}