### PR TITLE
[1LP][RFR] always use appliance parameter in automate simulation calls

### DIFF
--- a/cfme/automate/simulation.py
+++ b/cfme/automate/simulation.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from cfme.utils.appliance import get_or_create_current_appliance
 from cfme.utils.appliance.implementations.ui import navigate_to
 
 
@@ -7,8 +6,7 @@ def simulate(
         instance=None, message=None, request=None, target_type=None, target_object=None,
         execute_methods=None, attributes_values=None, pre_clear=True, appliance=None):
     """Runs the simulation of specified Automate object."""
-    if not appliance:
-        appliance = get_or_create_current_appliance()
+    assert appliance is not None, "must pass appliance"
     view = navigate_to(appliance.server, 'AutomateSimulation')
     if pre_clear:
         view.avp.clear()

--- a/cfme/tests/automate/test_domain_priority.py
+++ b/cfme/tests/automate/test_domain_priority.py
@@ -126,6 +126,7 @@ def test_priority(
     # FIRST SIMULATION
     #
     simulate(
+        appliance=appliance,
         instance="Request",
         message="create",
         request=original_instance.name,
@@ -156,6 +157,7 @@ def test_priority(
     # SECOND SIMULATION
     #
     simulate(
+        appliance=appliance,
         instance="Request",
         message="create",
         request=original_instance.name,
@@ -176,6 +178,7 @@ def test_priority(
     # LAST SIMULATION
     #
     simulate(
+        appliance=appliance,
         instance="Request",
         message="create",
         request=original_instance.name,

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -411,6 +411,7 @@ def test_create_snapshot_via_ae(appliance, request, domain, small_test_vm):
     snap_name = fauxfactory.gen_alpha()
     snapshot = Vm.Snapshot(name=snap_name, parent_vm=small_test_vm)
     simulate(
+        appliance=appliance,
         instance="Request",
         request="snapshot",
         target_type='VM and Instance',

--- a/cfme/tests/services/test_add_remove_vm_to_service.py
+++ b/cfme/tests/services/test_add_remove_vm_to_service.py
@@ -68,7 +68,7 @@ def myservice(appliance, provider, catalog_item, request):
 
 
 @pytest.mark.ignore_stream("upstream")
-def test_add_vm_to_service(myservice, request, copy_domain, new_vm):
+def test_add_vm_to_service(myservice, request, copy_domain, new_vm, appliance):
     """Tests adding vm to service
 
     Metadata:
@@ -100,6 +100,7 @@ def test_add_vm_to_service(myservice, request, copy_domain, new_vm):
 
     request.addfinalizer(method.delete_if_exists)
     simulate(
+        appliance=appliance,
         instance="Request",
         message="create",
         request=method.name,


### PR DESCRIPTION
it was all there and removes support for the global