### PR TITLE
[1LP][RFR] uncollect ansible tests for 5.8 pod appliance

### DIFF
--- a/cfme/tests/ansible/test_embedded_ansible_actions.py
+++ b/cfme/tests/ansible/test_embedded_ansible_actions.py
@@ -16,7 +16,9 @@ pytestmark = [
     pytest.mark.ignore_stream("upstream"),
     pytest.mark.long_running,
     pytest.mark.provider([VMwareProvider], selector=ONE_PER_TYPE, scope="module"),
-    test_requirements.ansible
+    test_requirements.ansible,
+    pytest.mark.uncollectif(lambda appliance: appliance.version < "5.9" and appliance.is_pod,
+                            reason="5.8 pod appliance doesn't support embedded ansible")
 ]
 
 

--- a/cfme/tests/ansible/test_embedded_ansible_automate.py
+++ b/cfme/tests/ansible/test_embedded_ansible_automate.py
@@ -20,7 +20,9 @@ pytestmark = [
     pytest.mark.long_running,
     pytest.mark.ignore_stream("upstream", "5.8"),
     pytest.mark.provider([VMwareProvider], selector=ONE_PER_TYPE, scope="module"),
-    test_requirements.ansible
+    test_requirements.ansible,
+    pytest.mark.uncollectif(lambda appliance: appliance.version < "5.9" and appliance.is_pod,
+                            reason="5.8 pod appliance doesn't support embedded ansible")
 ]
 
 

--- a/cfme/tests/ansible/test_embedded_ansible_basic.py
+++ b/cfme/tests/ansible/test_embedded_ansible_basic.py
@@ -5,15 +5,17 @@ import pytest
 from cfme import test_requirements
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.update import update
-from cfme.utils.version import current_version
 from cfme.utils.wait import wait_for
 
 pytestmark = [
     pytest.mark.long_running,
     pytest.mark.meta(server_roles=["+embedded_ansible"]),
-    pytest.mark.uncollectif(lambda: current_version() < "5.8"),
+    pytest.mark.uncollectif(lambda appliance: appliance.version < "5.8",
+                            reason="Ansible was added only in 5.8"),
     pytest.mark.ignore_stream("upstream"),
-    test_requirements.ansible
+    test_requirements.ansible,
+    pytest.mark.uncollectif(lambda appliance: appliance.version < "5.9" and appliance.is_pod,
+                            reason="5.8 pod appliance doesn't support embedded ansible")
 ]
 
 private_key = """

--- a/cfme/tests/ansible/test_embedded_ansible_crud.py
+++ b/cfme/tests/ansible/test_embedded_ansible_crud.py
@@ -1,7 +1,14 @@
 import pytest
 
-from cfme.utils.version import current_version
 from cfme.utils.wait import wait_for
+
+pytestmark = [
+    pytest.mark.uncollectif(lambda appliance: appliance.version < "5.9" and appliance.is_pod,
+                            reason="5.8 pod appliance doesn't support embedded ansible"),
+    pytest.mark.uncollectif(lambda appliance: appliance.version < "5.8",
+                            reason="Ansible was added only in 5.8"),
+    pytest.mark.ignore_stream("upstream")
+]
 
 
 @pytest.yield_fixture(scope='module')
@@ -13,8 +20,6 @@ def enabled_embedded_appliance(appliance):
     appliance.disable_embedded_ansible_role()
 
 
-@pytest.mark.ignore_stream("upstream")
-@pytest.mark.uncollectif(lambda: current_version() < "5.8")
 def test_embedded_ansible_enable(enabled_embedded_appliance):
     """Tests whether the embedded ansible role and all workers have started correctly"""
     assert wait_for(func=lambda: enabled_embedded_appliance.is_embedded_ansible_running, num_sec=30)
@@ -26,8 +31,6 @@ def test_embedded_ansible_enable(enabled_embedded_appliance):
         container=enabled_embedded_appliance._ansible_pod_name)
 
 
-@pytest.mark.ignore_stream("upstream")
-@pytest.mark.uncollectif(lambda: current_version() < "5.8")
 def test_embedded_ansible_disable(enabled_embedded_appliance):
     """Tests whether the embedded ansible role and all workers have stopped correctly"""
     assert wait_for(func=lambda: enabled_embedded_appliance.is_rabbitmq_running, num_sec=30)

--- a/cfme/tests/ansible/test_embedded_ansible_rest.py
+++ b/cfme/tests/ansible/test_embedded_ansible_rest.py
@@ -12,9 +12,12 @@ from cfme.utils.wait import wait_for
 pytestmark = [
     pytest.mark.long_running,
     pytest.mark.meta(server_roles=['+embedded_ansible']),
-    pytest.mark.uncollectif(lambda: current_version() < '5.8'),
+    pytest.mark.uncollectif(lambda appliance: appliance.version < '5.8',
+                            reason="Ansible was added only in 5.8"),
     pytest.mark.ignore_stream('upstream'),
-    test_requirements.ansible
+    test_requirements.ansible,
+    pytest.mark.uncollectif(lambda appliance: appliance.version < "5.9" and appliance.is_pod,
+                            reason="5.8 pod appliance doesn't support embedded ansible")
 ]
 
 

--- a/cfme/tests/ansible/test_embedded_ansible_rest.py
+++ b/cfme/tests/ansible/test_embedded_ansible_rest.py
@@ -6,7 +6,6 @@ import pytest
 from cfme import test_requirements
 from cfme.utils.blockers import BZ
 from cfme.utils.rest import assert_response, delete_resources_from_collection
-from cfme.utils.version import current_version
 from cfme.utils.wait import wait_for
 
 pytestmark = [
@@ -123,9 +122,7 @@ class TestReposRESTAPI(object):
         Metadata:
             test_flag: rest
         """
-        collection = appliance.rest_api.collections.configuration_script_sources
-        delete_resources_from_collection(
-            collection, [repository], not_found=False, num_sec=300, delay=5)
+        delete_resources_from_collection([repository], not_found=False, num_sec=300, delay=5)
 
 
 class TestPayloadsRESTAPI(object):

--- a/cfme/tests/ansible/test_embedded_ansible_services.py
+++ b/cfme/tests/ansible/test_embedded_ansible_services.py
@@ -163,7 +163,7 @@ def custom_service_button(appliance, ansible_catalog_item):
 @pytest.mark.meta(blockers=[BZ(1515841, forced_streams=['5.9'])])
 def test_service_ansible_playbook_available(appliance):
     view = navigate_to(appliance.collections.catalog_items, "Choose Type")
-    assert "Ansible Playbook" in [option.text for option in view.catalog_item_type.all_options]
+    assert "Ansible Playbook" in [option.text for option in view.select_item_type.all_options]
 
 
 @pytest.mark.tier(1)

--- a/cfme/tests/ansible/test_embedded_ansible_services.py
+++ b/cfme/tests/ansible/test_embedded_ansible_services.py
@@ -17,7 +17,9 @@ from cfme.utils.wait import wait_for
 pytestmark = [
     pytest.mark.long_running,
     pytest.mark.ignore_stream("upstream", '5.7'),
-    test_requirements.ansible
+    test_requirements.ansible,
+    pytest.mark.uncollectif(lambda appliance: appliance.version < "5.9" and appliance.is_pod,
+                            reason="5.8 pod appliance doesn't support embedded ansible")
 ]
 
 

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -1738,9 +1738,13 @@ class IPAppliance(object):
     @property
     def _ansible_pod_name(self):
         if self.is_pod:
-            get_ansible_name = ("basename $(oc get pods -lname=ansible "
-                                "-o name --namespace={n})".format(n=self.project))
-            return str(self.ssh_client.run_command(get_ansible_name, ensure_host=True)).strip()
+            if self.version >= '5.9':
+                get_ansible_name = ("basename $(oc get pods -lname=ansible "
+                                    "-o name --namespace={n})".format(n=self.project))
+                return str(self.ssh_client.run_command(get_ansible_name, ensure_host=True)).strip()
+            else:
+                # ansible stuff lives in the same container with main app in 5.8
+                return self.container
         else:
             return None
 


### PR DESCRIPTION
1. 5.8 pod appliances don't support embedded ansible.
2. updated uncollects a bit
3. fixed some tests
