### PR TITLE
[RFR] Update vm name for perf workloads

### DIFF
--- a/cfme/tests/perf/workloads/test_provisioning.py
+++ b/cfme/tests/perf/workloads/test_provisioning.py
@@ -143,7 +143,7 @@ def test_provisioning(appliance, request, scenario):
         for i in range(number_of_vms):
             total_provisioned_vms += 1
             provisioned_vms += 1
-            vm_to_provision = '{}-provision-{}'.format(
+            vm_to_provision = 'test-{}-prov-{}'.format(
                 test_ts, str(total_provisioned_vms).zfill(4))
             guid_to_provision, provider_name = next(guid_cycle)
             provision_order.append((vm_to_provision, provider_name))


### PR DESCRIPTION
So that it gets cleaned up by cleanup scripts.

The test doesn't have direct provider objects or vm objects, so cleanup within the test will require a larger scope.