### PR TITLE
[1LP][RFR] Rename Infrastructure.virtual_machines.Vm to InfraVm

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -649,7 +649,7 @@ class VM(BaseVM):
         except Exception as e:
             logger.warn("Couldn't find VM or Instance in CMFE")
             if delete_on_failure:
-                logger.info("Removing Vm from mgmt system")
+                logger.info("Removing VM or Instance from mgmt system")
                 self.provider.mgmt.delete_vm(self.name)
             raise e
 

--- a/cfme/provisioning.py
+++ b/cfme/provisioning.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from cfme.infrastructure.virtual_machines import Vm
+from cfme.infrastructure.virtual_machines import InfraVm
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for
@@ -8,7 +8,7 @@ from cfme.utils.wait import wait_for
 def do_vm_provisioning(appliance, template_name, provider, vm_name, provisioning_data, request,
                        smtp_test, num_sec=1500, wait=True):
     # generate_tests makes sure these have values
-    vm = Vm(name=vm_name, provider=provider, template_name=template_name)
+    vm = InfraVm(name=vm_name, provider=provider, template_name=template_name)
     note = ('template {} to vm {} on provider {}'.format(template_name, vm_name, provider.key))
     provisioning_data.update({
         'request': {

--- a/cfme/tests/cloud_infra_common/test_cockpit_server.py
+++ b/cfme/tests/cloud_infra_common/test_cockpit_server.py
@@ -7,7 +7,7 @@ from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.common.provider import CloudInfraProvider
-from cfme.infrastructure.virtual_machines import Vm
+from cfme.infrastructure.virtual_machines import InfraVm
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.generators import random_vm_name
 from cfme.utils.wait import wait_for
@@ -18,7 +18,7 @@ def new_vm(provider, request):
     if provider.one_of(CloudProvider):
         vm = Instance.factory(random_vm_name(context='cockpit'), provider)
     else:
-        vm = Vm.factory(random_vm_name(context='cockpit'), provider)
+        vm = InfraVm.factory(random_vm_name(context='cockpit'), provider)
     if not provider.mgmt.does_vm_exist(vm.name):
         vm.create_on_provider(find_in_cfme=True, allow_skip="default")
         request.addfinalizer(vm.cleanup_on_provider)

--- a/cfme/tests/cloud_infra_common/test_relationships.py
+++ b/cfme/tests/cloud_infra_common/test_relationships.py
@@ -21,7 +21,7 @@ from cfme.infrastructure.datastore import HostAllDatastoresView, ProviderAllData
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.infrastructure.virtual_machines import (HostTemplatesOnlyAllView,
-                                                  ProviderTemplatesOnlyAllView, Vm, Template)
+                                                  ProviderTemplatesOnlyAllView, InfraVm, Template)
 from cfme.markers.env_markers.provider import ONE, ONE_PER_TYPE
 from cfme.networks.views import NetworkProviderDetailsView, ProviderSecurityGroupAllView
 from cfme.storage.manager import ProviderStorageManagerAllView
@@ -77,7 +77,7 @@ infra_test_items = [
     ("clusters", None),
     ("hosts", None),
     ("datastores", None),
-    ("vms", Vm),
+    ("vms", InfraVm),
     ("templates", Template)
 ]
 

--- a/cfme/tests/cloud_infra_common/test_tag_objects.py
+++ b/cfme/tests/cloud_infra_common/test_tag_objects.py
@@ -9,7 +9,7 @@ from cfme.cloud.instance.image import Image
 from cfme.cloud.keypairs import KeyPair
 from cfme.cloud.provider import CloudProvider
 from cfme.infrastructure.provider import InfraProvider
-from cfme.infrastructure.virtual_machines import Vm, Template
+from cfme.infrastructure.virtual_machines import InfraVm, Template
 from fixtures.provider import setup_one_or_skip
 from cfme.utils.providers import ProviderFilter
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -21,7 +21,7 @@ pytestmark = [
 
 infra_test_items = [
     ('infra_provider', InfraProvider, None),
-    ('vms', Vm, 'ProviderVms'),
+    ('vms', InfraVm, 'ProviderVms'),
     ('templates', Template, 'ProviderTemplates'),
     ('hosts', None, None),
     ('clusters', None, None),

--- a/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
+++ b/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
@@ -17,7 +17,7 @@ from cfme.control.explorer.policies import VMControlPolicy
 from cfme.infrastructure.host import Host
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
-from cfme.infrastructure.virtual_machines import Vm
+from cfme.infrastructure.virtual_machines import InfraVm
 from cfme.utils import ssh, safe_string, testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.log import logger
@@ -213,7 +213,7 @@ def ssa_vm(request, local_setup_provider, provider, vm_analysis_provisioning_dat
     # TODO:  if rhev and iscsi, it need direct_lun
     if provider.type == 'rhevm':
         logger.info("Setting a relationship between VM and appliance")
-        cfme_rel = Vm.CfmeRelationship(vm)
+        cfme_rel = InfraVm.CfmeRelationship(vm)
         cfme_rel.set_relationship(appliance.server.name, appliance.server_id())
 
     yield vm

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -602,16 +602,16 @@ def test_assign_user_to_new_group(appliance, group_collection):
 
 def _test_vm_provision(appliance):
     logger.info("Checking for provision access")
-    view = navigate_to(vms.Vm, 'VMsOnly')
+    view = navigate_to(vms.InfraVm, 'VMsOnly')
     view.toolbar.lifecycle.item_enabled('Provision VMs')
 
 # this fixture is used in disabled tests. it should be updated along with tests
 # def _test_vm_power_on():
 #     """Ensures power button is shown for a VM"""
 #     logger.info("Checking for power button")
-#     vm_name = vms.Vm.get_first_vm()
+#     vm_name = vms.InfraVm.get_first_vm()
 #     logger.debug("VM " + vm_name + " selected")
-#     if not vms.is_pwr_option_visible(vm_name, option=vms.Vm.POWER_ON):
+#     if not vms.is_pwr_option_visible(vm_name, option=vms.InfraVm.POWER_ON):
 #         raise OptionNotAvailable("Power button does not exist")
 
 
@@ -648,7 +648,7 @@ def test_permission_edit(appliance, request, product_features):
     user = new_user(appliance, [group])
     with user:
             # Navigation should succeed with valid permissions
-            navigate_to(vms.Vm, 'VMsOnly')
+            navigate_to(vms.InfraVm, 'VMsOnly')
 
     appliance.server.login_admin()
     role.update({'product_features': [(['Everything'], True)] +
@@ -656,7 +656,7 @@ def test_permission_edit(appliance, request, product_features):
                  })
     with user:
         with pytest.raises(Exception, message='Permissions have not been updated'):
-            navigate_to(vms.Vm, 'VMsOnly')
+            navigate_to(vms.InfraVm, 'VMsOnly')
 
     @request.addfinalizer
     def _delete_user_group_role():

--- a/cfme/tests/configure/test_default_filters.py
+++ b/cfme/tests/configure/test_default_filters.py
@@ -41,7 +41,7 @@ def test_infrastructurevms_defaultfilters(appliance):
     filters = [['Infrastructure', 'Virtual Machines', 'VMs', 'Platform / VMware']]
     tree_path = ['All VMs', 'Global Filters', 'Platform / VMware']
     appliance.user.my_settings.default_filters.update({'filters': [(k, True) for k in filters]})
-    view = navigate_to(vms.Vm, 'VMsOnly')
+    view = navigate_to(vms.InfraVm, 'VMsOnly')
     assert view.sidebar.vms.tree.has_path(*tree_path), 'Default Filter settings Failed!'
 
 

--- a/cfme/tests/configure/test_default_views_infra.py
+++ b/cfme/tests/configure/test_default_views_infra.py
@@ -3,7 +3,7 @@ import pytest
 
 from cfme import test_requirements
 from cfme.infrastructure.provider import InfraProvider
-from cfme.infrastructure.virtual_machines import Vm
+from cfme.infrastructure.virtual_machines import InfraVm
 from cfme.services.myservice import MyService
 from cfme.services.workloads import VmsInstances, TemplatesImages
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -21,7 +21,7 @@ pytestmark = [pytest.mark.tier(3),
 
 gtl_params = {
     'Infrastructure Providers': InfraProvider,
-    'VMs': Vm,
+    'VMs': InfraVm,
     'My Services': MyService,
     'VMs & Instances': VmsInstances,
     'Templates & Images': TemplatesImages
@@ -41,7 +41,7 @@ def set_and_test_default_view(appliance, group_name, view, page):
 
 
 def check_vm_visibility(check=False):
-    view = navigate_to(Vm, 'All')
+    view = navigate_to(InfraVm, 'All')
     value = view.sidebar.vmstemplates.tree.read_contents()
     # Below steps assigns last name of the last list to vm_name variable.
     vm_name = value[-1]
@@ -87,7 +87,7 @@ def set_and_test_compare_view(appliance, group_name, expected_view, selector_typ
     default_views = appliance.user.my_settings.default_views
     old_default = default_views.get_default_view(group_name)
     default_views.set_default_view(group_name, expected_view)
-    vm_view = navigate_to(Vm, 'All')
+    vm_view = navigate_to(InfraVm, 'All')
     [e.check() for e in vm_view.entities.get_all()[:2]]
     vm_view.toolbar.configuration.item_select('Compare Selected items')
     selected_view = getattr(vm_view.actions, selector_type).selected

--- a/cfme/tests/configure/test_visual_infra.py
+++ b/cfme/tests/configure/test_visual_infra.py
@@ -19,7 +19,7 @@ pytestmark = [pytest.mark.tier(3),
 # navigation to navmazing. all items have to be put back once navigation change is fully done
 
 
-@pytest.fixture(scope='module', params=['datastores', 'hosts', InfraProvider, vms.Vm])
+@pytest.fixture(scope='module', params=['datastores', 'hosts', InfraProvider, vms.InfraVm])
 def page(request):
     return request.param
 
@@ -270,7 +270,7 @@ def test_vm_noquads(request, set_vm_quad):
         This test checks that VM Quadrant when switched off from Mysetting page under
         Visual Tab under "Show VM Quadrants" option works properly.
     """
-    view = navigate_to(vms.Vm, 'VMsOnly')
+    view = navigate_to(vms.InfraVm, 'VMsOnly')
     view.toolbar.view_selector.select('Grid View')
     # Here data property will return an empty dict when the Quadrants option is deactivated.
     assert not view.entities.get_first_entity().data

--- a/cfme/tests/control/test_bugs.py
+++ b/cfme/tests/control/test_bugs.py
@@ -12,7 +12,7 @@ from cfme.control.explorer.alerts import AlertDetailsView
 from cfme.control.explorer.conditions import VMCondition
 from cfme.control.explorer.policies import VMCompliancePolicy, VMControlPolicy
 from cfme.exceptions import CFMEExceptionOccured
-from cfme.infrastructure.virtual_machines import Vm
+from cfme.infrastructure.virtual_machines import InfraVm
 from cfme.utils.appliance import get_or_create_current_appliance
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
@@ -166,11 +166,11 @@ def test_scope_windows_registry_stuck(request, appliance, infra_provider, policy
     )
     request.addfinalizer(lambda: profile.delete() if profile.exists else None)
     # Now assign this malformed profile to a VM
-    vm = VM.factory(Vm.get_first_vm(provider=infra_provider).name, infra_provider)
+    vm = VM.factory(InfraVm.get_first_vm(provider=infra_provider).name, infra_provider)
     vm.assign_policy_profiles(profile.description)
     # It should be screwed here, but do additional check
     navigate_to(appliance.server, 'Dashboard')
-    view = navigate_to(Vm, 'All')
+    view = navigate_to(InfraVm, 'All')
     assert "except" not in view.entities.title.text.lower()
     vm.unassign_policy_profiles(profile.description)
 

--- a/cfme/tests/infrastructure/test_advanced_search_vms.py
+++ b/cfme/tests/infrastructure/test_advanced_search_vms.py
@@ -9,7 +9,7 @@ from widgetastic.exceptions import NoSuchElementException
 
 from cfme.infrastructure import virtual_machines
 from cfme.infrastructure.provider import InfraProvider
-from cfme.infrastructure.virtual_machines import Vm
+from cfme.infrastructure.virtual_machines import InfraVm
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.providers import ProviderFilter
 from fixtures.provider import setup_one_or_skip
@@ -26,7 +26,7 @@ def a_provider(request):
 @pytest.fixture(scope="module")
 def vms(a_provider):
     """Ensure the infra providers are set up and get list of vms"""
-    view = navigate_to(Vm, 'VMsOnly')
+    view = navigate_to(InfraVm, 'VMsOnly')
     view.entities.search.remove_search_filters()
     return virtual_machines.get_all_vms()
 
@@ -47,7 +47,7 @@ def expression_for_vms_subset(subset_of_vms):
 
 @pytest.fixture(scope="function")
 def vm_advanced_search():
-    view = navigate_to(Vm, 'VMsOnly')
+    view = navigate_to(InfraVm, 'VMsOnly')
     assert view.entities.search.is_advanced_search_possible, (
         "Cannot do advanced view.entities.search here!")
     yield view
@@ -175,7 +175,7 @@ def test_vm_filter_save_and_load_cancel(request, vms, subset_of_vms, vm_advanced
 
 
 def test_quick_search_without_vm_filter(request, vms, subset_of_vms):
-    view = navigate_to(Vm, 'VMsOnly')
+    view = navigate_to(InfraVm, 'VMsOnly')
     view.flash.assert_no_error()
     vm = sample(subset_of_vms, 1)[0]
     # Make sure that we empty the regular view.entities.search field after the test

--- a/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
+++ b/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
@@ -2,7 +2,7 @@ import pytest
 
 from cfme import test_requirements
 from cfme.infrastructure.provider import InfraProvider
-from cfme.infrastructure.virtual_machines import Vm, Template
+from cfme.infrastructure.virtual_machines import InfraVm, Template
 from fixtures.provider import setup_one_or_skip
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
@@ -14,7 +14,7 @@ pytestmark = [test_requirements.tag, pytest.mark.tier(2)]
 
 test_items = [
     ('clusters', None, None),
-    ('vms', Vm, 'ProviderVms'),
+    ('vms', InfraVm, 'ProviderVms'),
     ('templates', Template, 'ProviderTemplates')
 ]
 

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -15,7 +15,7 @@ from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
-from cfme.infrastructure.virtual_machines import Vm
+from cfme.infrastructure.virtual_machines import InfraVm
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
@@ -71,7 +71,7 @@ def prov_data(provisioning, provider):
 def provisioner(appliance, request, setup_provider, provider, vm_name):
 
     def _provisioner(template, provisioning_data, delayed=None):
-        vm = Vm(name=vm_name, provider=provider, template_name=template)
+        vm = InfraVm(name=vm_name, provider=provider, template_name=template)
         view = navigate_to(vm, 'Provision')
         view.form.fill_with(provisioning_data, on_change=view.form.submit_button)
         base_view = vm.appliance.browser.create_view(BaseLoggedInPage)

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -8,7 +8,8 @@ from cfme.automate.simulation import simulate
 from cfme.common.vm import VM
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
-from cfme.infrastructure.virtual_machines import InfraVmSnapshotAddView, InfraVmSnapshotView, Vm
+from cfme.infrastructure.virtual_machines import (
+    InfraVmSnapshotAddView, InfraVmSnapshotView, InfraVm)
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.conf import credentials
@@ -60,7 +61,7 @@ def full_test_vm(setup_provider_modscope, provider, full_template_modscope, requ
 
 def new_snapshot(test_vm, has_name=True, memory=False, create_description=True):
     name = fauxfactory.gen_alphanumeric(8)
-    return Vm.Snapshot(
+    return InfraVm.Snapshot(
         name="snpshot_{}".format(name) if has_name else None,
         description="snapshot_{}".format(name) if create_description else None,
         memory=memory,
@@ -409,7 +410,7 @@ def test_create_snapshot_via_ae(appliance, request, domain, small_test_vm):
 
     # SIMULATE
     snap_name = fauxfactory.gen_alpha()
-    snapshot = Vm.Snapshot(name=snap_name, parent_vm=small_test_vm)
+    snapshot = InfraVm.Snapshot(name=snap_name, parent_vm=small_test_vm)
     simulate(
         instance="Request",
         request="snapshot",

--- a/cfme/tests/services/test_operations.py
+++ b/cfme/tests/services/test_operations.py
@@ -6,7 +6,7 @@ from widgetastic.utils import partial_match
 
 from cfme import test_requirements
 from cfme.infrastructure.provider import InfraProvider
-from cfme.infrastructure.virtual_machines import Vm
+from cfme.infrastructure.virtual_machines import InfraVm
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.browser import browser
 from cfme.utils.wait import wait_for
@@ -58,7 +58,7 @@ def generated_request(appliance,
     notes = fauxfactory.gen_alphanumeric()
     e_mail = "{}@{}.test".format(first_name, last_name)
     host, datastore = map(provisioning.get, ('host', 'datastore'))
-    vm = Vm(name=vm_name, provider=a_provider, template_name=template_name)
+    vm = InfraVm(name=vm_name, provider=a_provider, template_name=template_name)
     view = navigate_to(vm, 'Provision')
 
     provisioning_data = {

--- a/cfme/tests/webui/test_splitter.py
+++ b/cfme/tests/webui/test_splitter.py
@@ -6,7 +6,7 @@ import pytest
 # from cfme.infrastructure.config_management import ConfigManager
 # from cfme.infrastructure.datastore import DatastoreCollection
 # from cfme.infrastructure.pxe import ISODatastore
-# from cfme.infrastructure.virtual_machines import Vm
+# from cfme.infrastructure.virtual_machines import InfraVm
 # from cfme.intelligence.chargeback.rates import ComputeRate
 # from cfme.intelligence.reports.reports import CustomReport
 from cfme.base.ui import Server
@@ -23,7 +23,7 @@ from widgetastic_manageiq import Splitter
 # LOCATIONS = [
 #     (Server, 'ControlExplorer'), (Server, 'AutomateExplorer'), (Server, 'AutomateCustomization'),
 #     (MyService, 'All'), (Server, 'ServiceCatalogsDefault'), (Server, 'WorkloadsDefault'),
-#     (CustomReport, 'All'), (ComputeRate, 'All'), (Instance, 'All'), (Vm, 'VMsOnly'),
+#     (CustomReport, 'All'), (ComputeRate, 'All'), (Instance, 'All'), (InfraVm, 'VMsOnly'),
 #     (ISODatastore, 'All'), (Server, 'Configuration'), (DatastoreCollection, 'All'),
 #     (ConfigManager, 'All'), (Utilization, 'All'), (InfraNetworking, 'All'), (Bottlenecks, 'All')
 # ]

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2591,12 +2591,12 @@ class Appliance(IPAppliance):
 
             # if rhev, set relationship
             if self.is_on_rhev:
-                from cfme.infrastructure.virtual_machines import Vm  # For Vm.CfmeRelationship
+                from cfme.infrastructure.virtual_machines import InfraVm
                 log_callback('Setting up CFME VM relationship...')
                 from cfme.common.vm import VM
                 from cfme.utils.providers import get_crud
                 vm = VM.factory(self.vm_name, get_crud(self.provider_key))
-                cfme_rel = Vm.CfmeRelationship(vm)
+                cfme_rel = InfraVm.CfmeRelationship(vm)
                 cfme_rel.set_relationship(str(self.server.name), self.server.sid)
 
     def does_vm_exist(self):

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         ],
         'manageiq.vm_categories':
         [
-            'infra = cfme.infrastructure.virtual_machines:Vm',
+            'infra = cfme.infrastructure.virtual_machines:InfraVm',
             'cloud = cfme.cloud.instance:Instance'
         ],
         'manageiq.vm_types.cloud':

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -3107,8 +3107,8 @@ class EntitiesConditionalView(View, ReportDataControllerMixin):
         :return: list of entities
 
         Ex:
-            from cfme.infrastructure.virtual_machines import Vm
-            view = navigate_to(Vm, 'All')
+            from cfme.infrastructure.virtual_machines import InfraVm
+            view = navigate_to(InfraVm, 'All')
             entities = view.entities.apply(func=lambda e: e.check(),
                                            conditions=[{'name': 'cu-24x7'},
                                                        {'name': 'env-win81-ie11'},


### PR DESCRIPTION
There are a ton of tests collected due to the scope of this change. I'm not aiming to fix any test issues here, just an enhancement against the `virtual_machines.Vm` class name.

## PRT Results

PRT run 23306 executed about 1100 tests, with ~90% passing.  No failures look related to this rename.

{{ pytest: --use-provider scvmm --use-provider onprem }}