### PR TITLE
[1LP][RFR] Fixed test_service_ansible_playbook_order_credentials

### DIFF
--- a/cfme/tests/ansible/test_embedded_ansible_services.py
+++ b/cfme/tests/ansible/test_embedded_ansible_services.py
@@ -341,7 +341,7 @@ def test_service_ansible_playbook_order_credentials(ansible_catalog_item, ansibl
     view = navigate_to(service_catalog, "Order")
     view.wait_displayed()
     options = [o.text for o in (view.fields('credential')).visible_widget.all_options]
-    assert set(["<Default>", "CFME Default Credential", ansible_credential.name]) == set(options)
+    assert ansible_credential.name in set(options)
 
 
 @pytest.mark.tier(3)


### PR DESCRIPTION
{{pytest: -v -k test_service_ansible_playbook_order_credentials --long-running}}