### PR TITLE
[1LP][RFR] fixing service order() method

### DIFF
--- a/cfme/fixtures/service_fixtures.py
+++ b/cfme/fixtures/service_fixtures.py
@@ -78,9 +78,7 @@ def order_service(appliance, provider, provisioning, vm_name, dialog, catalog, r
         catalog_item = create_catalog_item(appliance, provider, provisioning,
                                            vm_name, dialog, catalog)
     service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
-    service_catalogs.order()
-    provision_request = appliance.collections.requests.instantiate(catalog_item.name,
-                                                                   partial_check=True)
+    provision_request = service_catalogs.order()
     provision_request.wait_for_request(method='ui')
     assert provision_request.is_succeeded()
     if provision_request.exists():

--- a/cfme/services/service_catalogs/ui.py
+++ b/cfme/services/service_catalogs/ui.py
@@ -103,6 +103,7 @@ def order(self):
     view = self.create_view(RequestsView)
     view.flash.assert_no_error()
     view.flash.assert_message(msg, msg_type)
+    return self.appliance.collections.requests.instantiate(self.name, partial_check=True)
 
 
 @navigator.register(Server)


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__  catalog_item.order().

https://github.com/ManageIQ/integration_tests/pull/6773/files#diff-77a8ead22c41840ab8714e03f56c5bbcL191 - introduced a gap - many tests were relying on `order()` to return Request object - all stack tests/ service PXE test/ OPS UI service tests.
`provision_request` fixture was removed almost right after but any return wasn't added into `.order()`

This PR will fix broken tests and keep up running tests which use `order_service` fixture