### PR TITLE
[1LP][RFR] access to properties of provider summary table has changed

### DIFF
--- a/cfme/tests/openstack/infrastructure/test_resources.py
+++ b/cfme/tests/openstack/infrastructure/test_resources.py
@@ -13,15 +13,15 @@ pytestmark = [
 
 def test_number_of_cpu(provider, soft_assert):
     view_details = navigate_to(provider, 'Details')
-    v = view_details.entities.properties.get_text_of('Aggregate Node CPU Resources')
+    v = view_details.entities.summary('Properties').get_text_of('Aggregate Node CPU Resources')
     soft_assert(float(v.split()[0]) > 0, "Aggregate Node CPU Resources is 0")
-    v = view_details.entities.properties.get_text_of('Aggregate Node CPUs')
+    v = view_details.entities.summary('Properties').get_text_of('Aggregate Node CPUs')
     soft_assert(int(v) > 0, "Aggregate Node CPUs is 0")
-    v = view_details.entities.properties.get_text_of('Aggregate Node CPU Cores')
+    v = view_details.entities.summary('Properties').get_text_of('Aggregate Node CPU Cores')
     assert int(v) > 0, "Aggregate Node CPU Cores is 0"
 
 
 def test_node_memory(provider):
     view_details = navigate_to(provider, 'Details')
-    node_memory = view_details.entities.properties.get_text_of('Aggregate Node Memory')
+    node_memory = view_details.entities.summary('Properties').get_text_of('Aggregate Node Memory')
     assert float(node_memory.split()[0]) > 0


### PR DESCRIPTION
Purpose or Intent
=================
Access to properties of provider summary table is now done via view_details.entities.summary('Properties') and not view_details.entities.properties

{{ pytest: cfme/tests/openstack/infrastructure/test_resources.py }}