### PR TITLE
[WIPTEST] Fixing test_delete_snapshot_from_collection

### DIFF
--- a/cfme/tests/cloud_infra_common/test_snapshots_rest.py
+++ b/cfme/tests/cloud_infra_common/test_snapshots_rest.py
@@ -125,7 +125,7 @@ class TestRESTSnapshots(object):
         """
         vm, snapshot = vm_snapshot
         delete_resources_from_collection(
-            vm.snapshots, [snapshot], not_found=True, num_sec=300, delay=5)
+            [snapshot], vm.snapshots, not_found=True, num_sec=300, delay=5)
 
     @pytest.mark.meta(
         blockers=[BZ(1550551, forced_streams=['5.8', '5.9', 'upstream'],


### PR DESCRIPTION
__Fixing__ test_delete_snapshot_from_collection. The first two args to [delete_resources_from_collection](https://github.com/ManageIQ/integration_tests/blob/cf7a3ba454e0490c850f95019a6591802fa47373/cfme/utils/rest.py#L156) were actually provided in the wrong order. 

{{pytest: cfme/tests/cloud_infra_common/test_snapshots_rest.py::TestRESTSnapshots::test_delete_snapshot_from_collection --long-running}}