### PR TITLE
[1LP][RFR] Added test case to test provision of VM to OVN network.

### DIFF
--- a/cfme/networks/cloud_network.py
+++ b/cfme/networks/cloud_network.py
@@ -79,7 +79,7 @@ class CloudNetwork(Taggable, BaseEntity):
         """Delete this cloud network"""
         view = navigate_to(self, 'Details')
         view.toolbar.configuration.item_select('Delete this Cloud Network', handle_alert=True)
-        view.flash.assert_success_message('The selected Cloud Network was deleted')
+        view.flash.assert_success_message('Delete initiated for 1 Cloud Network.')
 
     @property
     def network_provider(self):

--- a/cfme/tests/networks/test_provision_to_virtual_network.py
+++ b/cfme/tests/networks/test_provision_to_virtual_network.py
@@ -1,0 +1,73 @@
+import fauxfactory
+import pytest
+from widgetastic.utils import partial_match
+
+from cfme import test_requirements
+from cfme.common.vm import VM
+from cfme.infrastructure.provider.rhevm import RHEVMProvider
+from cfme.provisioning import do_vm_provisioning
+from cfme.utils.wait import wait_for
+
+pytestmark = [
+    pytest.mark.provider([RHEVMProvider],
+                         required_fields=[['provisioning', 'template']],
+                         scope='module'
+                         ),
+    pytest.mark.uncollectif(lambda provider: provider.version < 4.2,
+                            reason='ovn functionality is limited in 4.1'),
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.ignore_stream('5.8'),
+    test_requirements.provision,
+]
+
+
+@pytest.fixture(scope='function')
+def network(provider, appliance):
+    """Test adding cloud network in ui."""
+    test_name = 'test_network_{}'.format(fauxfactory.gen_alphanumeric(6))
+    net_manager = '{} Network Manager'.format(provider.name)
+    collection = appliance.collections.network_providers
+    network_provider = collection.instantiate(name=net_manager)
+    collection = appliance.collections.cloud_networks
+    ovn_network = collection.create(test_name, 'tenant', network_provider, net_manager, 'None')
+
+    yield ovn_network
+    if ovn_network.exists:
+        ovn_network.delete()
+
+
+@pytest.mark.rhv1
+def test_provision_vm_to_virtual_network(appliance, setup_provider, provider, vm_name,
+                                         request, provisioning, network):
+    """ Tests provisioning a vm from a template to a virtual network
+
+    Metadata:
+        test_flag: provision
+    """
+
+    request.addfinalizer(
+        lambda: VM.factory(vm_name, provider).cleanup_on_provider())
+
+    template = provisioning['template']
+    provisioning_data = {
+        'catalog': {
+            'vm_name': vm_name
+        },
+        'environment': {
+            'vm_name': vm_name,
+            'automatic_placement': True
+        },
+        'network': {
+            'vlan': partial_match(network.name)
+        }
+    }
+    wait_for(
+        do_vm_provisioning,
+        [appliance, template, provider, vm_name, provisioning_data, request],
+        {'num_sec': 900, 'smtp_test': False},
+        handle_exception=True,
+        delay=50,
+        num_sec=900,
+        fail_func=appliance.server.browser.refresh,
+        message='Cannot do provision for vm {}.'.format(vm_name)
+    )


### PR DESCRIPTION
Test that VM can be provisioned to virtual network create in RHV OVN.
Test case definition in polarion: https://polarion.engineering.redhat.com/polarion/#/project/RHEVM3/wiki/CFME/4_2_cfme_ovn
Feature page: https://www.ovirt.org/blog/2016/11/ovirt-provider-ovn/
ManageIQ integration: https://www.ovirt.org/develop/release-management/features/network/manageiq_ovn/
