### PR TITLE
[RFR] py3 compat hack - ignore unimportable ovirtsdk

### DIFF
--- a/cfme/utils/mgmt_system/__init__.py
+++ b/cfme/utils/mgmt_system/__init__.py
@@ -9,8 +9,13 @@ from cfme.utils import conf
 from cfme.utils.log import logger
 from cfme.utils.ssh import SSHClient
 
+# todo: remove this when merging the ovirt upgrade
 # Overrides
-from ovirtsdk.xml import params
+try:
+    from ovirtsdk.xml import params
+except ImportError:
+    # there is a hack in place to survive this missing in wrapanapi itself
+    pass
 
 
 class RHEVMSystem(RHEVMSystemBase):

--- a/cfme/utils/virtual_machines.py
+++ b/cfme/utils/virtual_machines.py
@@ -2,13 +2,19 @@
 """
 import pytest
 
+import six
 from cfme.utils.providers import get_crud
 from fixtures.pytest_store import store
 from novaclient.exceptions import OverLimit as OSOverLimit
-from ovirtsdk.infrastructure.errors import RequestError as RHEVRequestError
 from ssl import SSLError
 from cfme.utils.log import logger
 from cfme.utils.mgmt_system import exceptions
+
+try:
+    from ovirtsdk.infrastructure.errors import RequestError as RHEVRequestError
+    DEFAULT_SKIP = (OSOverLimit, RHEVRequestError, exceptions.VMInstanceNotCloned, SSLError)
+except ImportError:
+    DEFAULT_SKIP = (OSOverLimit, exceptions.VMInstanceNotCloned, SSLError)
 
 
 def deploy_template(provider_key, vm_name, template_name=None, timeout=900, **deploy_args):
@@ -23,8 +29,8 @@ def deploy_template(provider_key, vm_name, template_name=None, timeout=900, **de
     if isinstance(allow_skip, dict):
         skip_exceptions = allow_skip.keys()
         callable_mapping = allow_skip
-    elif isinstance(allow_skip, basestring) and allow_skip.lower() == "default":
-        skip_exceptions = (OSOverLimit, RHEVRequestError, exceptions.VMInstanceNotCloned, SSLError)
+    elif isinstance(allow_skip, six.string_types) and allow_skip.lower() == "default":
+        skip_exceptions = DEFAULT_SKIP
         callable_mapping = {}
     else:
         skip_exceptions = allow_skip


### PR DESCRIPTION
ovirt imports break testing on py3k because our port prs are not merged yet, this is a stopgap to support py3k porting in face of the ovirt issues