### PR TITLE
[1LP][RFR] Adding some more RHV markers

### DIFF
--- a/cfme/services/myservice/ssui.py
+++ b/cfme/services/myservice/ssui.py
@@ -166,6 +166,7 @@ def set_ownership(self, owner, group):
     else:
         assert view.notification.assert_message("{} ownership was saved."
                                                 .format(self.name))
+    view.browser.refresh()  # WA until ManageIQ/integration_tests:7157 is solved
 
 
 @MiqImplementationContext.external_for(MyService.edit_tags, ViaSSUI)

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -113,8 +113,8 @@ def test_snapshot_crud(small_test_vm, provider):
     snapshot.delete()
 
 
+@pytest.mark.rhv3
 @pytest.mark.uncollectif(lambda provider: not provider.one_of(RHEVMProvider))
-@pytest.mark.meta(automates=[BZ(1384517)])
 def test_create_without_description(small_test_vm):
     """
     Test that we get an error message when we try to create a snapshot with

--- a/cfme/tests/infrastructure/test_vm_reconfigure.py
+++ b/cfme/tests/infrastructure/test_vm_reconfigure.py
@@ -122,6 +122,8 @@ def test_vm_reconfig_add_remove_disk_cold(
     assert small_vm.configuration.num_disks == orig_config.num_disks, msg
 
 
+@pytest.mark.rhv3
+@pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:6996')])
 def test_reconfig_vm_negative_cancel(provider, small_vm, ensure_vm_stopped):
     """ Cancel reconfiguration changes """
     config_vm = small_vm.configuration.copy()

--- a/cfme/tests/ssui/test_ssui_myservice.py
+++ b/cfme/tests/ssui/test_ssui_myservice.py
@@ -28,6 +28,7 @@ pytestmark = [
 ]
 
 
+@pytest.mark.rhv1
 @pytest.mark.meta(blockers=[BZ(1544535, forced_streams=['5.9'])])
 @pytest.mark.parametrize('context', [ViaSSUI])
 def test_myservice_crud(appliance, setup_provider, context, order_service):


### PR DESCRIPTION
Yet another pull request for __RHV markers__. There is also a little __workaround__ that is needed until #7157 is fixed.

{{pytest: cfme/tests/ssui/test_ssui_myservice.py::test_myservice_crud --long-running --use-provider rhv41}}