### PR TITLE
[WIPTEST] fixed delete network and delete subnet tests

### DIFF
--- a/cfme/networks/cloud_network.py
+++ b/cfme/networks/cloud_network.py
@@ -79,7 +79,7 @@ class CloudNetwork(Taggable, BaseEntity):
         """Delete this cloud network"""
         view = navigate_to(self, 'Details')
         view.toolbar.configuration.item_select('Delete this Cloud Network', handle_alert=True)
-        view.flash.assert_success_message('The selected Cloud Network was deleted')
+        view.flash.assert_message('Delete initiated for 1 Cloud Network.')
 
     @property
     def network_provider(self):

--- a/cfme/tests/openstack/cloud/test_networks.py
+++ b/cfme/tests/openstack/cloud/test_networks.py
@@ -131,6 +131,8 @@ def test_delete_network(network):
     network.delete()
     wait_for(network.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
              delay=10)
+    network.browser.refresh()
+    navigate_to(network.appliance.collections.cloud_networks, 'All')
     assert not network.exists
 
 
@@ -158,6 +160,7 @@ def test_delete_subnet(subnet):
     wait_for(subnet.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
              delay=10)
     subnet.browser.refresh()
+    navigate_to(subnet.appliance.collections.network_subnets, 'All')
     assert not subnet.exists
 
 


### PR DESCRIPTION
Purpose or Intent
=================
Flash message was changed from "The selected Cloud Network was deleted" to 
"Delete initiated for 1 Cloud Network.'

{{ pytest: cfme/tests/openstack/cloud/test_networks.py::test_delete_network cfme/tests/openstack/cloud/test_networks.py::test_delete_subnet }}