### PR TITLE
[RFR] New dump2polarion version with support for v2.0.12 of Importers

### DIFF
--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -30,7 +30,7 @@ docker-py==1.10.6
 docker-pycreds==0.2.1
 docutils==0.13.1
 dogpile.cache==0.6.3
-dump2polarion==0.21
+dump2polarion==0.22
 entrypoints==0.2.2
 enum34==1.1.6
 fauxfactory==2.1.0

--- a/requirements/frozen_docs.txt
+++ b/requirements/frozen_docs.txt
@@ -23,7 +23,7 @@ diaper==1.3
 docker-py==1.10.6
 docker-pycreds==0.2.1
 docutils==0.13.1
-dump2polarion==0.21
+dump2polarion==0.22
 entrypoints==0.2.2
 enum34==1.1.6
 fauxfactory==2.1.0


### PR DESCRIPTION
Other improvements:
* parametrization support
* new auth support (not yet in Polarion prod)

@mshriver @sbulage The version 2.0.12 of Polarion Importers broke checks if the data were successfully imported, because it can split data into several jobs and returns list of IDs. This version of dump2polarion fixes this and should be used by our Jenkins ASAP.