### PR TITLE
[1LP][RFR] Fix 2 bugs with dropping database

### DIFF
--- a/cfme/utils/appliance/db.py
+++ b/cfme/utils/appliance/db.py
@@ -1,13 +1,13 @@
-import attr
-from cached_property import cached_property
-import fauxfactory
 from textwrap import dedent
+
+import attr
+import fauxfactory
+from cached_property import cached_property
 
 from cfme.utils import db, conf, clear_property_cache, datafile
 from cfme.utils.conf import credentials
 from cfme.utils.path import scripts_path
 from cfme.utils.wait import wait_for
-
 from .plugin import AppliancePlugin, AppliancePluginException
 
 
@@ -81,9 +81,11 @@ class ApplianceDB(AppliancePlugin):
 
             Note: EVM service has to be stopped for this to work.
         """
+
+        self.appliance.db.restart_db_service()
+        self.appliance.ssh_client.run_command('dropdb vmdb_production', timeout=15)
+
         def _db_dropped():
-            self.appliance.db.restart_db_service
-            self.appliance.ssh_client.run_command('dropdb vmdb_production', timeout=15)
             result = self.appliance.ssh_client.run_command(
                 "psql -l | grep vmdb_production | wc -l", timeout=15)
             return result.success


### PR DESCRIPTION
* The restart_db_service call was missing parentheses, which meant that
  connections would hang open and prevent certain operations
* The dropping of the database was placed inside the wait_for, this
  could yield another issue where we try to drop a database which has
  already been dropped.