### PR TITLE
[1LP][RFR] Containers images collection,add ability to filter active images from redHat registry

### DIFF
--- a/cfme/tests/containers/test_containers_smartstate_analysis_multiple_images.py
+++ b/cfme/tests/containers/test_containers_smartstate_analysis_multiple_images.py
@@ -56,7 +56,9 @@ def delete_all_container_tasks():
 @pytest.fixture(scope='function')
 def random_image_instances(appliance):
     collection = appliance.collections.container_images
-    return random.sample(collection.all(), NUM_SELECTED_IMAGES)
+    # add filter for select only active(not archived) images from redHat registry
+    filter_image_collection = collection.filter({'active': True, 'redhat_registry': True})
+    return random.sample(filter_image_collection.all(), NUM_SELECTED_IMAGES)
 
 
 @pytest.mark.polarion('10031')


### PR DESCRIPTION
Since smart state analysis (SSA) on container images, is able to check only images from redHat registry, 
I add an ability to filter active images from redHat registry, on containers image collection.

{{pytest: cfme/tests/containers/test_containers_smartstate_analysis_multiple_images.py -v --use-provider ocp-v1 }}