### PR TITLE
[1LP][RFR][notest] quickstart RHEL7 debuginfo-install fix

### DIFF
--- a/cfme/scripting/quickstart.py
+++ b/cfme/scripting/quickstart.py
@@ -60,12 +60,14 @@ INSTALL_COMMAND = None
 # FIXME define install commands separately in config/ini file
 DEBUG_INSTALL_COMMAND = None
 
+# Concerning debuginfo-install, on dnf has it as plugin,
+# whereas yum has completely separate command that calls yum.
 if HAS_DNF:
     INSTALL_COMMAND = 'dnf install -y'
     DEBUG_INSTALL_COMMAND = 'dnf debuginfo-install -y'
 elif HAS_YUM:
     INSTALL_COMMAND = 'yum install -y'
-    DEBUG_INSTALL_COMMAND = 'yum debuginfo-install -y'
+    DEBUG_INSTALL_COMMAND = 'debuginfo-install -y'
 elif HAS_APT:
     INSTALL_COMMAND = 'apt install -y'
     # No separate debuginfo for apt
@@ -124,19 +126,21 @@ REDHAT_PACKAGES_SPECS = [
      " libxslt-devel zeromq3-devel libcurl-devel"
      " redhat-rpm-config gcc-c++ openssl-devel"
      " libffi-devel python-devel tesseract"
-     " libpng-devel freetype-devel"),
+     " libpng-devel freetype-devel yum-utils"),
     ("Red Hat Enterprise Linux Server release 7", "nss",
      " python-virtualenv gcc postgresql-devel libxml2-devel"
      " libxslt-devel zeromq3-devel libcurl-devel"
      " redhat-rpm-config gcc-c++ openssl-devel"
      " libffi-devel python-devel tesseract"
-     " libpng-devel freetype-devel python-debuginfo"),
+     " libpng-devel freetype-devel python-debuginfo"
+     " yum-utils"),
     ("Red Hat Enterprise Linux Workstation release 7", "nss",
      " python-virtualenv gcc postgresql-devel libxml2-devel"
      " libxslt-devel zeromq3-devel libcurl-devel"
      " redhat-rpm-config gcc-c++ openssl-devel"
      " libffi-devel python-devel tesseract"
-     " libpng-devel freetype-devel python-debuginfo")
+     " libpng-devel freetype-devel python-debuginfo"
+     " yum-utils")
 ]
 
 OS_PACKAGES_SPECS = [


### PR DESCRIPTION
It seems that:

    yum debuginfo-install -y python

on RHEL 7 does not work.  In fact the RHEL 7 docs show calling
debuginfo-install the exectuable directly as in:

    debuginfo-install -y python

It also seems that dnf has debuginfo-install baked into, without the
need for an external package.

This commit then does:

   1) Change systems with yum to call debuginfo-install directly.
   2) Install on RHEL7 systems the yum-utils package that contains
      debuginfo-install.

**TEST RESULTS on RHEL 7:**

```
[root@dhcp-8-198-201 integration_tests]# cat /etc/redhat-release 
Red Hat Enterprise Linux Server release 7.5 (Maipo)
[root@dhcp-8-198-201 integration_tests]# python -m cfme.scripting.quickstart
QS $ yum install -y python-virtualenv gcc postgresql-devel libxml2-devel libxslt-devel zeromq3-devel libcurl-devel redhat-rpm-config gcc-c++ openssl-devel libffi-devel python-devel tesseract libpng-devel freetype-devel  yum-utils
Warning: RPMDB altered outside of yum.
QS $ debuginfo-install -y python
QS $ virtualenv ../cfme_venv
QS $ ../cfme_venv/bin/pip install -U pip wheel setuptools setuptools_scm docutils pbr
QS $ ../cfme_venv/bin/pip install -r requirements/frozen.txt --no-binary pycurl
boto3 1.6.6 has requirement botocore<1.10.0,>=1.9.6, but you'll have botocore 1.10.11 which is incompatible.
wrapanapi 2.8.9 has requirement botocore==1.9.6, but you'll have botocore 1.10.11 which is incompatible.
QS $ ../cfme_venv/bin/python -m cfme.scripting.disable_bytecode
QS $ ../cfme_venv/bin/pip install -q -e .
boto3 1.6.6 has requirement botocore<1.10.0,>=1.9.6, but you'll have botocore 1.10.11 which is incompatible.
wrapanapi 2.8.9 has requirement botocore==1.9.6, but you'll have botocore 1.10.11 which is incompatible.
QS $ ../cfme_venv/bin/python -m cfme.scripting.link_config ../cfme-qe-yamls/complete/ conf
QS $ ../cfme_venv/bin/python -c 'import curl'
INFO: please remember to activate the virtualenv via
      . ../cfme_venv/bin/activate
```
**TEST RESULTS ON Fedora 27:**

```
[root@dhcp-8-198-201 integration_tests]# python -m cfme.scripting.quickstart
QS $ yum install -y python-virtualenv gcc postgresql-devel libxml2-devel libxslt-devel zeromq3-devel libcurl-devel redhat-rpm-config gcc-c++ openssl-devel libffi-devel python-devel tesseract libpng-devel freetype-devel  yum-utils
Warning: RPMDB altered outside of yum.
QS $ debuginfo-install -y python
QS $ virtualenv ../cfme_venv
QS $ ../cfme_venv/bin/pip install -U pip wheel setuptools setuptools_scm docutils pbr
QS $ ../cfme_venv/bin/pip install -r requirements/frozen.txt --no-binary pycurl
boto3 1.6.6 has requirement botocore<1.10.0,>=1.9.6, but you'll have botocore 1.10.11 which is incompatible.
wrapanapi 2.8.9 has requirement botocore==1.9.6, but you'll have botocore 1.10.11 which is incompatible.
QS $ ../cfme_venv/bin/python -m cfme.scripting.disable_bytecode
QS $ ../cfme_venv/bin/pip install -q -e .
boto3 1.6.6 has requirement botocore<1.10.0,>=1.9.6, but you'll have botocore 1.10.11 which is incompatible.
wrapanapi 2.8.9 has requirement botocore==1.9.6, but you'll have botocore 1.10.11 which is incompatible.
QS $ ../cfme_venv/bin/python -m cfme.scripting.link_config ../cfme-qe-yamls/complete/ conf
QS $ ../cfme_venv/bin/python -c 'import curl'
INFO: please remember to activate the virtualenv via
      . ../cfme_venv/bin/activate
```