### PR TITLE
[WIPTEST] Fix sprout's check_swap_in_appliances

### DIFF
--- a/sprout/appliances/tasks.py
+++ b/sprout/appliances/tasks.py
@@ -1675,8 +1675,10 @@ Sprout.
 def check_swap_in_appliances(self):
     chord_tasks = []
     for appliance in Appliance.objects.filter(
-            ready=True, power_state=Appliance.Power.ON, marked_for_deletion=False,
-            is_openshift=False).exclude(power_state=Appliance.Power.ORPHANED):
+            ready=True, power_state=Appliance.Power.ON,
+            marked_for_deletion=False).exclude(power_state=Appliance.Power.ORPHANED):
+        if appliance.is_openshift:
+            continue
         chord_tasks.append(check_swap_in_appliance.si(appliance.id))
     chord(chord_tasks)(notify_owners.s())
 


### PR DESCRIPTION
it turned out that django doesn't support dynamic object fields in filter. So, it was replaced with regular python condition.