### PR TITLE
[1LP][WIPTEST] Changes to allow the report to be stored inside the artifact run dir

### DIFF
--- a/artifactor/__init__.py
+++ b/artifactor/__init__.py
@@ -122,10 +122,10 @@ This is how the artifact_path is returned. This hook can be removed, by running 
 
 """
 import logging
-import os
-import re
 import sys
 
+import os
+import re
 from py.path import local
 from riggerlib import Rigger, RiggerBasePlugin, RiggerClient
 
@@ -201,6 +201,9 @@ def initialize(artifactor):
         "finish_test", "pre", parse_setup_dir, name="default_finish_test"
     )
     artifactor.register_hook_callback(
+        "build_report", "pre", parse_build_dir, name="default_build_report"
+    )
+    artifactor.register_hook_callback(
         "start_session", "pre", start_session, name="default_start_session"
     )
     artifactor.register_hook_callback(
@@ -209,6 +212,7 @@ def initialize(artifactor):
     artifactor.register_hook_callback(
         "finish_session", "pre", merge_artifacts, name="merge_artifacts"
     )
+
     artifactor.initialized = True
 
 
@@ -219,13 +223,17 @@ def start_session(run_id=None):
     return None, {"run_id": run_id}
 
 
-def merge_artifacts(old_artifacts, artifacts):
+def merge_artifacts(old_artifacts, artifacts, artifactor_config, artifact_dir, run_id):
     """
     This is extremely important and merges the old_Artifacts from a composite-uncollect build
     with the new artifacts for this run
     """
+    run_type = artifactor_config.get('per_run')
+    overwrite = artifactor_config.get('reuse_dir', False)
+    report_path = setup_report_dir(root_dir=artifact_dir, run_type=run_type, run_id=run_id,
+                                   overwrite=overwrite)
     old_artifacts.update(artifacts)
-    return {"old_artifacts": old_artifacts}, None
+    return {'old_artifacts': old_artifacts, 'report_path': report_path}, None
 
 
 def parse_setup_dir(test_name, test_location, artifactor_config, artifact_dir, run_id):
@@ -246,6 +254,42 @@ def parse_setup_dir(test_name, test_location, artifactor_config, artifact_dir, r
     else:
         raise Exception("Not enough information to create artifact")
     return {"artifact_path": path}, None
+
+
+def parse_build_dir(artifactor_config, artifact_dir, run_id):
+    """
+    Convenience fire_hook for built in hook
+    """
+    run_type = artifactor_config.get('per_run')
+    overwrite = artifactor_config.get('reuse_dir', False)
+    report_path = setup_report_dir(root_dir=artifact_dir, run_type=run_type, run_id=run_id,
+                                   overwrite=overwrite)
+    return {'report_path': report_path}, None
+
+
+def setup_report_dir(root_dir=None, run_type=None, run_id=None, overwrite=True):
+    """
+    Sets up the artifact dir and returns it.
+    """
+    orig_path = os.path.abspath(root_dir)
+
+    p_args = [orig_path]
+    if run_id and run_type in ["run", "test"]:
+        p_args.append(str(run_id))
+    path = os.path.join(*p_args)
+
+    try:
+        os.makedirs(path)
+    except OSError as e:
+        if e.errno == 17 and overwrite:
+            pass
+        elif not overwrite:
+            print("Directories already existed and overwrite is set to False")
+            sys.exit(127)
+        else:
+            raise
+
+    return path
 
 
 def setup_artifact_dir(

--- a/artifactor/__init__.py
+++ b/artifactor/__init__.py
@@ -228,12 +228,13 @@ def merge_artifacts(old_artifacts, artifacts, artifactor_config, artifact_dir, r
     This is extremely important and merges the old_Artifacts from a composite-uncollect build
     with the new artifacts for this run
     """
-    run_type = artifactor_config.get('per_run')
-    overwrite = artifactor_config.get('reuse_dir', False)
-    report_path = setup_report_dir(root_dir=artifact_dir, run_type=run_type, run_id=run_id,
-                                   overwrite=overwrite)
+    run_type = artifactor_config.get("per_run")
+    overwrite = artifactor_config.get("reuse_dir", False)
+    report_path = setup_report_dir(
+        root_dir=artifact_dir, run_type=run_type, run_id=run_id, overwrite=overwrite
+    )
     old_artifacts.update(artifacts)
-    return {'old_artifacts': old_artifacts, 'report_path': report_path}, None
+    return {"old_artifacts": old_artifacts, "report_path": report_path}, None
 
 
 def parse_setup_dir(test_name, test_location, artifactor_config, artifact_dir, run_id):
@@ -260,11 +261,12 @@ def parse_build_dir(artifactor_config, artifact_dir, run_id):
     """
     Convenience fire_hook for built in hook
     """
-    run_type = artifactor_config.get('per_run')
-    overwrite = artifactor_config.get('reuse_dir', False)
-    report_path = setup_report_dir(root_dir=artifact_dir, run_type=run_type, run_id=run_id,
-                                   overwrite=overwrite)
-    return {'report_path': report_path}, None
+    run_type = artifactor_config.get("per_run")
+    overwrite = artifactor_config.get("reuse_dir", False)
+    report_path = setup_report_dir(
+        root_dir=artifact_dir, run_type=run_type, run_id=run_id, overwrite=overwrite
+    )
+    return {"report_path": report_path}, None
 
 
 def setup_report_dir(root_dir=None, run_type=None, run_id=None, overwrite=True):

--- a/artifactor/plugins/reporter.py
+++ b/artifactor/plugins/reporter.py
@@ -334,15 +334,15 @@ class ReporterBase(object):
 
 class Reporter(ArtifactorBasePlugin, ReporterBase):
     def plugin_initialize(self):
-        self.register_plugin_hook('report_test', self.report_test)
-        self.register_plugin_hook('finish_session', self.run_report)
-        self.register_plugin_hook('build_report', self.run_report)
-        self.register_plugin_hook('start_test', self.start_test)
-        self.register_plugin_hook('skip_test', self.skip_test)
-        self.register_plugin_hook('finish_test', self.finish_test)
-        self.register_plugin_hook('session_info', self.session_info)
-        self.register_plugin_hook('composite_pump', self.composite_pump)
-        self.register_plugin_hook('tb_info', self.tb_info)
+        self.register_plugin_hook("report_test", self.report_test)
+        self.register_plugin_hook("finish_session", self.run_report)
+        self.register_plugin_hook("build_report", self.run_report)
+        self.register_plugin_hook("start_test", self.start_test)
+        self.register_plugin_hook("skip_test", self.skip_test)
+        self.register_plugin_hook("finish_test", self.finish_test)
+        self.register_plugin_hook("session_info", self.session_info)
+        self.register_plugin_hook("composite_pump", self.composite_pump)
+        self.register_plugin_hook("tb_info", self.tb_info)
 
     def configure(self):
         self.only_failed = self.data.get("only_failed", False)

--- a/artifactor/plugins/reporter.py
+++ b/artifactor/plugins/reporter.py
@@ -28,7 +28,6 @@ from py.path import local
 
 from artifactor import ArtifactorBasePlugin
 from cfme.utils import process_pytest_path
-from cfme.utils.conf import cfme_data  # Only for the provider specific reports
 from cfme.utils.path import template_path
 
 _tests_tpl = {
@@ -68,16 +67,6 @@ class ReporterBase(object):
             ]
 
         self.render_report(template_data, "report", artifact_dir, "test_report.html")
-
-    def _run_provider_report(self, old_artifacts, artifact_dir, version=None, fw_version=None):
-        for mgmt in cfme_data["management_systems"].keys():
-            template_data = self.process_data(
-                old_artifacts, artifact_dir, version, fw_version, name_filter=mgmt
-            )
-
-            self.render_report(
-                template_data, "report_{}".format(mgmt), artifact_dir, "test_report_provider.html"
-            )
 
     def render_report(self, report, filename, log_dir, template):
         template_env = Environment(loader=FileSystemLoader(template_path.strpath))
@@ -345,16 +334,15 @@ class ReporterBase(object):
 
 class Reporter(ArtifactorBasePlugin, ReporterBase):
     def plugin_initialize(self):
-        self.register_plugin_hook("report_test", self.report_test)
-        self.register_plugin_hook("finish_session", self.run_report)
-        self.register_plugin_hook("finish_session", self.run_provider_report)
-        self.register_plugin_hook("build_report", self.run_report)
-        self.register_plugin_hook("start_test", self.start_test)
-        self.register_plugin_hook("skip_test", self.skip_test)
-        self.register_plugin_hook("finish_test", self.finish_test)
-        self.register_plugin_hook("session_info", self.session_info)
-        self.register_plugin_hook("composite_pump", self.composite_pump)
-        self.register_plugin_hook("tb_info", self.tb_info)
+        self.register_plugin_hook('report_test', self.report_test)
+        self.register_plugin_hook('finish_session', self.run_report)
+        self.register_plugin_hook('build_report', self.run_report)
+        self.register_plugin_hook('start_test', self.start_test)
+        self.register_plugin_hook('skip_test', self.skip_test)
+        self.register_plugin_hook('finish_test', self.finish_test)
+        self.register_plugin_hook('session_info', self.session_info)
+        self.register_plugin_hook('composite_pump', self.composite_pump)
+        self.register_plugin_hook('tb_info', self.tb_info)
 
     def configure(self):
         self.only_failed = self.data.get("only_failed", False)
@@ -466,9 +454,5 @@ class Reporter(ArtifactorBasePlugin, ReporterBase):
         )
 
     @ArtifactorBasePlugin.check_configured
-    def run_report(self, old_artifacts, artifact_dir, version=None, fw_version=None):
-        self._run_report(old_artifacts, artifact_dir, version, fw_version)
-
-    @ArtifactorBasePlugin.check_configured
-    def run_provider_report(self, old_artifacts, artifact_dir, version=None, fw_version=None):
-        self._run_provider_report(old_artifacts, artifact_dir, version, fw_version)
+    def run_report(self, old_artifacts, report_path, version=None, fw_version=None):
+        self._run_report(old_artifacts, report_path, version, fw_version)


### PR DESCRIPTION
* By default artifactor uses the per_test reporting mechanism. This
  allows it to continually overwrite test results in the same directory.
  It's a little odd some times as it will leave orphaned artifacts,
  but it makes it nice to successively run test reports.
* In order to allow easy bundling up of artifactor data, the report.html
  file needs to be inside the run dir. This DIDN'T happen. The
  report.html file was being saved at the artifact root. Meaning that,
  although all the artifacts were in a separate dir, the report was
  outside of that.
* These changes allow for a report_path to be passed down into the
  reporting plugin. This makes it so that the system knows where to
  store this report.