### PR TITLE
[RFR] add logging and retry for enable/disable provider check in sprout

### DIFF
--- a/sprout/appliances/tasks.py
+++ b/sprout/appliances/tasks.py
@@ -1165,9 +1165,11 @@ def check_templates_in_provider(self, provider_id):
     # Get templates and update metadata
     try:
         templates = map(str, provider.api.list_template())
-    except Exception:
+    except Exception as err:
+        self.logger.warning("Provider will be marked as not working because of %s", err)
         provider.working = False
         provider.save(update_fields=['working'])
+        self.retry(args=(provider_id,), countdown=15, max_retries=3)
     else:
         provider.working = True
         provider.save(update_fields=['working'])


### PR DESCRIPTION
it should help to find out why some providers become disabled for some time