### PR TITLE
[RFR] fix relative import in parallelizer

### DIFF
--- a/fixtures/parallelizer/__init__.py
+++ b/fixtures/parallelizer/__init__.py
@@ -64,7 +64,7 @@ if not conf.runtime['env'].get('ts'):
 
 
 def pytest_addhooks(pluginmanager):
-    import hooks
+    from . import hooks
     pluginmanager.add_hookspecs(hooks)
 
 


### PR DESCRIPTION
this wont need a test using the plugin, since the hooks are added in all cases