### PR TITLE
[WIP] Update SSA test check active container images from redHat registry

### DIFF
--- a/cfme/tests/containers/test_containers_smartstate_analysis.py
+++ b/cfme/tests/containers/test_containers_smartstate_analysis.py
@@ -54,7 +54,9 @@ def delete_all_container_tasks():
 @pytest.fixture(scope='function')
 def random_image_instance(appliance):
     collection = appliance.collections.container_images
-    return random.sample(collection.all(), NUM_SELECTED_IMAGES).pop()
+    # add filter for select only active(not archived) images from redHat registry
+    filter_image_collection = collection.filter({'active': True, 'redhat_registry': True})
+    return random.sample(filter_image_collection.all(), NUM_SELECTED_IMAGES).pop()
 
 
 @pytest.mark.polarion('10030')


### PR DESCRIPTION
Updating test since smart state analysis (SSA) on container images, is able to check only images from redHat registry, the test will filter active images from redHat registry.

Same as Merged PR https://github.com/ManageIQ/integration_tests/pull/7177 , just test update. 

{{pytest: cfme/tests/containers/test_containers_smartstate_analysis_multiple_images.py -v --use-provider ocp-v1 }}
