### PR TITLE
[WIPTEST] Fixing test_providers_summary

### DIFF
--- a/cfme/tests/intelligence/reports/test_canned_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_canned_corresponds.py
@@ -40,7 +40,9 @@ def test_providers_summary(appliance, soft_assert):
     for provider in report.data.rows:
         if provider["MS Type"] in skipped_providers:
             continue
-        details_view = navigate_to(InfraProvider(name=provider["Name"]), 'Details')
+        provider_object = appliance.collections.infra_providers.instantiate(InfraProvider,
+            name=provider["Name"])
+        details_view = navigate_to(provider_object, 'Details')
         props = details_view.entities.summary("Properties")
 
         hostname = ("Host Name", "Hostname")


### PR DESCRIPTION
Provider initialization was failing with:
 > TypeError: __init__() takes at least 2 arguments (2 given)

This initializes provider properly. At least I hope. :)

{{pytest: cfme/tests/intelligence/reports/test_canned_corresponds.py::test_providers_summary -vv}}
