### PR TITLE
[WIPTEST] Fixing schedule_ssa fixture

### DIFF
--- a/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
+++ b/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
@@ -306,7 +306,7 @@ def schedule_ssa(appliance, ssa_vm, ssa_profile, wait_for_task_result=True):
         'run_every': None,
         'time_zone': "(GMT+00:00) UTC",
         'start_hour': hour,
-        'start_min': minute
+        'start_minute': minute
     }
     ss = appliance.collections.system_schedules.create(**schedule_args)
     ss.enable()


### PR DESCRIPTION
`appliance.collections.system_schedules.create` expects `start_minute` param as opposed to `start_min`.

{{pytest: cfme/tests/cloud_infra_common/test_vm_instance_analysis.py::test_ssa_schedule --long-running}}