### PR TITLE
[RFR][1LP] removing retry from check template task because it produces many failed tasks for invalid providers

### DIFF
--- a/sprout/appliances/tasks.py
+++ b/sprout/appliances/tasks.py
@@ -1169,7 +1169,6 @@ def check_templates_in_provider(self, provider_id):
         self.logger.warning("Provider will be marked as not working because of %s", err)
         provider.working = False
         provider.save(update_fields=['working'])
-        self.retry(args=(provider_id,), countdown=15, max_retries=3)
     else:
         provider.working = True
         provider.save(update_fields=['working'])


### PR DESCRIPTION
REQUIRES: https://github.com/ManageIQ/wrapanapi/pull/253