### PR TITLE
[1LP][RFR] Chargeback resource allocation : Add support for other providers

### DIFF
--- a/cfme/tests/intelligence/chargeback/test_resource_allocation.py
+++ b/cfme/tests/intelligence/chargeback/test_resource_allocation.py
@@ -13,7 +13,7 @@ test, despite the fact that these fixtures are module scoped.So, the tests have 
 parameterized.
 """
 import math
-from datetime import timedelta
+from datetime import date, timedelta
 
 import fauxfactory
 import pytest
@@ -24,7 +24,9 @@ from cfme import test_requirements
 from cfme.base.credential import Credential
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.common.vm import VM
+from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
+from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for
@@ -34,7 +36,7 @@ pytestmark = [
     pytest.mark.meta(blockers=[BZ(1511099, forced_streams=['5.9', '5.8'],
                                   unblock=lambda provider: not provider.one_of(GCEProvider)),
                                ]),
-    pytest.mark.provider([SCVMMProvider], scope='module',
+    pytest.mark.provider([InfraProvider], scope='module', selector=ONE_PER_TYPE,
                         required_fields=[(['cap_and_util', 'test_chargeback'], True)]),
     pytest.mark.usefixtures('setup_provider'),
     test_requirements.chargeback,
@@ -129,23 +131,137 @@ def verify_vm_uptime(appliance, provider):
     return appliance.utc_time() - vm_creation_time > timedelta(hours=1)
 
 
+def verify_records_rollups_table(appliance, provider):
+    """ Verify that hourly rollups are present in the metric_rollups table """
+    vm_name = provider.data['cap_and_util']['chargeback_vm']
+
+    ems = appliance.db.client['ext_management_systems']
+    rollups = appliance.db.client['metric_rollups']
+
+    with appliance.db.client.transaction:
+        result = (
+            appliance.db.client.session.query(rollups.id)
+            .join(ems, rollups.parent_ems_id == ems.id)
+            .filter(rollups.capture_interval_name == 'hourly', rollups.resource_name == vm_name,
+            ems.name == provider.name, rollups.timestamp >= date.today())
+        )
+
+    for record in appliance.db.client.session.query(rollups).filter(
+            rollups.id.in_(result.subquery())):
+        if (record.cpu_usagemhz_rate_average or
+           record.cpu_usage_rate_average or
+           record.derived_memory_used or
+           record.net_usage_rate_average or
+           record.disk_usage_rate_average):
+            return True
+    return False
+
+
+def verify_records_metrics_table(appliance, provider):
+    """Verify that rollups are present in the metric_rollups table"""
+    vm_name = provider.data['cap_and_util']['chargeback_vm']
+
+    ems = appliance.db.client['ext_management_systems']
+    metrics = appliance.db.client['metrics']
+
+    # Capture real-time C&U data
+    ret = appliance.ssh_client.run_rails_command(
+        "\"vm = Vm.where(:ems_id => {}).where(:name => {})[0];\
+        vm.perf_capture('realtime', 1.hour.ago.utc, Time.now.utc)\""
+        .format(provider.id, repr(vm_name)))
+    assert ret.success, "Failed to capture VM C&U data:".format(ret.output)
+
+    with appliance.db.client.transaction:
+        result = (
+            appliance.db.client.session.query(metrics.id)
+            .join(ems, metrics.parent_ems_id == ems.id)
+            .filter(metrics.capture_interval_name == 'realtime',
+            metrics.resource_name == vm_name,
+            ems.name == provider.name, metrics.timestamp >= date.today())
+        )
+
+    for record in appliance.db.client.session.query(metrics).filter(
+            metrics.id.in_(result.subquery())):
+        return any([record.cpu_usagemhz_rate_average,
+            record.cpu_usage_rate_average,
+            record.derived_memory_used,
+            record.net_usage_rate_average,
+            record.disk_usage_rate_average])
+    return False
+
+
 @pytest.fixture(scope="module")
 def resource_alloc(vm_ownership, appliance, provider):
-    """Retrieve resource allocation values"""
+    """Retrieve resource allocation values
+
+    Since SCVMM doesn't support C&U,the resource allocation values are fetched from
+    form Vm which is represented by rails model
+    ManageIQ::Providers::Microsoft::InfraManager::Vm .
+
+    For all other providers that support C&U, the resource allocation values are fetched
+    from the DB.
+    """
     vm_name = provider.data['cap_and_util']['chargeback_vm']
 
     if provider.one_of(SCVMMProvider):
         wait_for(verify_vm_uptime, [appliance, provider], timeout=3610,
             message='Waiting for VM to be up for at least one hour')
 
-    vm = appliance.rest_api.collections.vms.get(name=vm_name)
-    vm.reload(attributes=['allocated_disk_storage', 'cpu_total_cores', 'ram_size'])
+        vm = appliance.rest_api.collections.vms.get(name=vm_name)
+        vm.reload(attributes=['allocated_disk_storage', 'cpu_total_cores', 'ram_size'])
+        # By default,chargeback rates for storage are defined in this form: 0.01 USD/GB
+        # Hence,convert storage used in Bytes to GB
+        return {"storage_alloc": float(vm.allocated_disk_storage) * math.pow(2, -30),
+            "memory_alloc": vm.ram_size,
+            "vcpu_alloc": vm.cpu_total_cores}
+
+    metrics = appliance.db.client['metrics']
+    rollups = appliance.db.client['metric_rollups']
+    ems = appliance.db.client['ext_management_systems']
+    logger.info('Deleting METRICS DATA from metrics and metric_rollups tables')
+
+    appliance.db.client.session.query(metrics).delete()
+    appliance.db.client.session.query(rollups).delete()
+
+    wait_for(verify_records_metrics_table, [appliance, provider], timeout=600,
+        message='Waiting for VM real-time data')
+
+    # New C&U data may sneak in since 1)C&U server roles are running and 2)collection for clusters
+    # and hosts is on.This would mess up our Chargeback calculations, so we are disabling C&U
+    # collection after data has been fetched for the last hour.
+
+    appliance.server.settings.disable_server_roles(
+        'ems_metrics_coordinator', 'ems_metrics_collector')
+
+    # Perform rollup of C&U data.
+    ret = appliance.ssh_client.run_rails_command(
+        "\"vm = Vm.where(:ems_id => {}).where(:name => {})[0];\
+        vm.perf_rollup_range(1.hour.ago.utc, Time.now.utc,'realtime')\"".
+        format(provider.id, repr(vm_name)))
+    assert ret.success, "Failed to rollup VM C&U data:".format(ret.out)
+
+    wait_for(verify_records_rollups_table, [appliance, provider], timeout=600,
+        message='Waiting for hourly rollups')
+
+    # Since we are collecting C&U data for > 1 hour, there will be multiple hourly records per VM
+    # in the metric_rollups DB table.The values from these hourly records are summed up.
+
+    with appliance.db.client.transaction:
+        result = (
+            appliance.db.client.session.query(rollups.id)
+            .join(ems, rollups.parent_ems_id == ems.id)
+            .filter(rollups.capture_interval_name == 'hourly', rollups.resource_name == vm_name,
+            ems.name == provider.name, rollups.timestamp >= date.today())
+        )
+
+    record = appliance.db.client.session.query(rollups).filter(
+        rollups.id.in_(result.subquery())).first()
 
     # By default,chargeback rates for storage are defined in this form: 0.01 USD/GB
     # Hence,convert storage used in Bytes to GB
-    return {"storage_alloc": float(vm.allocated_disk_storage) * math.pow(2, -30),
-            "memory_alloc": vm.ram_size,
-            "vcpu_alloc": vm.cpu_total_cores}
+    return {"vcpu_alloc": record.derived_vm_numvcpus,
+            "memory_alloc": record.derived_memory_available,
+            "storage_alloc": record.derived_vm_allocated_disk_storage * math.pow(2, -30)}
 
 
 def resource_cost(appliance, provider, metric_description, usage, description, rate_type):
@@ -297,8 +413,7 @@ def generic_test_resource_alloc(resource_alloc, chargeback_report_custom, column
             if 'GB' in groups[column] and column == 'Memory Allocated over Time Period':
                 allocated_resource = float(allocated_resource) * math.pow(2, -10)
             resource_from_report = groups[column].replace('MB', '').replace('GB', '')
-            soft_assert(allocated_resource - DEVIATION <=
-                float(resource_from_report) <= allocated_resource + DEVIATION,
+            soft_assert(allocated_resource == resource_from_report,
                 'Estimated resource allocation and report resource allocation do not match')
 
 

--- a/cfme/tests/intelligence/chargeback/test_resource_allocation.py
+++ b/cfme/tests/intelligence/chargeback/test_resource_allocation.py
@@ -211,9 +211,9 @@ def resource_alloc(vm_ownership, appliance, provider):
         vm.reload(attributes=['allocated_disk_storage', 'cpu_total_cores', 'ram_size'])
         # By default,chargeback rates for storage are defined in this form: 0.01 USD/GB
         # Hence,convert storage used in Bytes to GB
-        return {"storage_alloc": float(vm.allocated_disk_storage) * math.pow(2, -30),
-            "memory_alloc": vm.ram_size,
-            "vcpu_alloc": vm.cpu_total_cores}
+        return {"storage_alloc": int(vm.allocated_disk_storage * math.pow(2, -30)),
+            "memory_alloc": int(vm.ram_size),
+            "vcpu_alloc": int(vm.cpu_total_cores)}
 
     metrics = appliance.db.client['metrics']
     rollups = appliance.db.client['metric_rollups']
@@ -259,9 +259,9 @@ def resource_alloc(vm_ownership, appliance, provider):
 
     # By default,chargeback rates for storage are defined in this form: 0.01 USD/GB
     # Hence,convert storage used in Bytes to GB
-    return {"vcpu_alloc": record.derived_vm_numvcpus,
-            "memory_alloc": record.derived_memory_available,
-            "storage_alloc": record.derived_vm_allocated_disk_storage * math.pow(2, -30)}
+    return {"vcpu_alloc": int(record.derived_vm_numvcpus),
+            "memory_alloc": int(record.derived_memory_available),
+            "storage_alloc": int(record.derived_vm_allocated_disk_storage * math.pow(2, -30))}
 
 
 def resource_cost(appliance, provider, metric_description, usage, description, rate_type):
@@ -411,9 +411,10 @@ def generic_test_resource_alloc(resource_alloc, chargeback_report_custom, column
         else:
             allocated_resource = resource_alloc[resource]
             if 'GB' in groups[column] and column == 'Memory Allocated over Time Period':
-                allocated_resource = float(allocated_resource) * math.pow(2, -10)
-            resource_from_report = groups[column].replace('MB', '').replace('GB', '')
-            soft_assert(allocated_resource == resource_from_report,
+                allocated_resource = allocated_resource * math.pow(2, -10)
+            resource_from_report = groups[column].replace('MB', '').replace('GB', ''). \
+                replace(' ', '')
+            soft_assert(allocated_resource == int(resource_from_report),
                 'Estimated resource allocation and report resource allocation do not match')
 
 

--- a/cfme/tests/intelligence/chargeback/test_resource_allocation.py
+++ b/cfme/tests/intelligence/chargeback/test_resource_allocation.py
@@ -47,6 +47,7 @@ from cfme.utils.wait import wait_for
 
 pytestmark = [
     pytest.mark.tier(2),
+    pytest.mark.long_running,
     pytest.mark.meta(blockers=[BZ(1511099, forced_streams=['5.9', '5.8'],
                                   unblock=lambda provider: not provider.one_of(GCEProvider)),
                                ]),
@@ -269,11 +270,11 @@ def resource_alloc(vm_ownership, appliance, provider):
             .filter(metrics.capture_interval_name == 'realtime', metrics.resource_name == vm_name,
             ems.name == provider.name, metrics.timestamp >= date.today())
         )
-    record = appliance.db.client.session.query(metrics).filter(
-        metrics.id.in_(result.subquery())).first()
-
-    logger.info('cpu {}, memory {}, storage {}'.format(record.derived_vm_numvcpus,
-        record.derived_memory_available, record.derived_vm_allocated_disk_storage))
+    for record in appliance.db.client.session.query(metrics).filter(
+            metrics.id.in_(result.subquery())):
+        if all([record.derived_vm_numvcpus, record.derived_memory_available,
+                record.derived_vm_allocated_disk_storage]):
+            break
 
     # By default,chargeback rates for storage are defined in this form: 0.01 USD/GB
     # Hence,convert storage used in Bytes to GB
@@ -408,8 +409,6 @@ def generic_test_chargeback_cost(chargeback_costs_custom, chargeback_report_cust
             estimated_resource_alloc_cost = chargeback_costs_custom[resource_alloc_cost]
             cost_from_report = groups[column]
             cost = cost_from_report.replace('$', '').replace(',', '')
-            logger.info('REPORT COST {}, ESTIMATED COST {}'.format(cost,
-                estimated_resource_alloc_cost))
             soft_assert(estimated_resource_alloc_cost - COST_DEVIATION <=
                 float(cost) <= estimated_resource_alloc_cost + COST_DEVIATION,
                 'Estimated cost and report cost do not match')
@@ -435,8 +434,6 @@ def generic_test_resource_alloc(resource_alloc, chargeback_report_custom, column
                 allocated_resource = allocated_resource * math.pow(2, -10)
             resource_from_report = groups[column].replace('MB', '').replace('GB', ''). \
                 replace(' ', '')
-            logger.info('REPORT RESOURCE {}, ESTIMATED RESOURCE {}'.format(resource_from_report,
-                allocated_resource))
             soft_assert(allocated_resource - RESOURCE_ALLOC_DEVIATION <=
                 float(resource_from_report) <= allocated_resource + RESOURCE_ALLOC_DEVIATION,
                 'Estimated resource allocation and report resource allocation do not match')


### PR DESCRIPTION
{{pytest: cfme/tests/intelligence/chargeback/test_resource_allocation.py --use-provider complete --long-running}}