### PR TITLE
[1LP][RFR]Network tag visibility tests

### DIFF
--- a/cfme/networks/floating_ips.py
+++ b/cfme/networks/floating_ips.py
@@ -72,9 +72,14 @@ class Details(CFMENavigateStep):
 
     def step(self):
         # as for 5.9 floating ip doesn't have name att, will get id for navigation
+        # as for 5.8 floating ip doesn't found in table with name att, only with address
         if self.obj.appliance.version < '5.9':
-            element = self.prerequisite_view.entities.get_entity(
-                name=self.obj.address, surf_pages=True)
+            try:
+                element = self.prerequisite_view.entities.get_entity(
+                    name=self.obj.address, surf_pages=True)
+            except ItemNotFound:
+                element = self.prerequisite_view.entities.get_entity(
+                    address=self.obj.address, surf_pages=True)
         else:
             all_items = self.prerequisite_view.entities.get_all(surf_pages=True)
             for entity in all_items:

--- a/cfme/networks/floating_ips.py
+++ b/cfme/networks/floating_ips.py
@@ -72,7 +72,8 @@ class Details(CFMENavigateStep):
 
     def step(self):
         # as for 5.9 floating ip doesn't have name att, will get id for navigation
-        # as for 5.8 floating ip doesn't found in table with name att, only with address
+        # for 5.8 floating ip table view doesn't have name to search for,
+        # in this case we will use address
         if self.obj.appliance.version < '5.9':
             try:
                 element = self.prerequisite_view.entities.get_entity(

--- a/cfme/tests/networks/test_sdn_balancers.py
+++ b/cfme/tests/networks/test_sdn_balancers.py
@@ -47,8 +47,10 @@ def test_sdn_balancers_detail(provider, network_prov_with_load_balancers):
             assert check is not None
 
 
+# only one provider is needed for that test, used Azure as it has balancers
+@pytest.mark.provider([AzureProvider], scope='module', override=True)
 @pytest.mark.parametrize('visibility', [True, False], ids=['visible', 'notVisible'])
-def test_sdn_balancers_tagvis(check_item_visibility, visibility):
+def test_sdn_balancers_tagvis(check_item_visibility, visibility, network_prov_with_load_balancers):
     """ Tests network provider and its items honors tag visibility
     Prerequisites:
         Catalog, tag, role, group and restricted user should be created

--- a/cfme/tests/networks/test_sdn_balancers.py
+++ b/cfme/tests/networks/test_sdn_balancers.py
@@ -45,3 +45,19 @@ def test_sdn_balancers_detail(provider, network_prov_with_load_balancers):
         for balancer in prov.balancers.all():
             check = balancer.network_provider
             assert check is not None
+
+
+@pytest.mark.parametrize('visibility', [True, False], ids=['visible', 'notVisible'])
+def test_sdn_balancers_tagvis(check_item_visibility, visibility):
+    """ Tests network provider and its items honors tag visibility
+    Prerequisites:
+        Catalog, tag, role, group and restricted user should be created
+
+    Steps:
+        1. As admin add tag
+        2. Login as restricted user, item is visible for user
+        3. As admin remove tag
+        4. Login as restricted user, iten is not visible for user
+    """
+    balancers_for_provider = network_prov_with_load_balancers[0].balancers.all()
+    check_item_visibility(balancers_for_provider[0], visibility)

--- a/cfme/tests/networks/test_sdn_balancers.py
+++ b/cfme/tests/networks/test_sdn_balancers.py
@@ -59,7 +59,7 @@ def test_sdn_balancers_tagvis(check_item_visibility, visibility, network_prov_wi
         1. As admin add tag
         2. Login as restricted user, item is visible for user
         3. As admin remove tag
-        4. Login as restricted user, iten is not visible for user
+        4. Login as restricted user, item is not visible for user
     """
     balancers_for_provider = network_prov_with_load_balancers[0].balancers.all()
     check_item_visibility(balancers_for_provider[0], visibility)

--- a/cfme/tests/networks/test_tag_tagvis.py
+++ b/cfme/tests/networks/test_tag_tagvis.py
@@ -95,6 +95,3 @@ def test_network_tagvis(check_item_visibility, test_entity, visibility):
         4. Login as restricted user, iten is not visible for user
     """
     check_item_visibility(test_entity, visibility)
-
-
-


### PR DESCRIPTION
Purpose or Intent
=================
Covers tag visibility for network items
{{pytest:: -k (test_network_tagvis or test_sdn_balancers_tagvis) -vvv --use-provider complete}