### PR TITLE
[1LP][RFR] Skipping test: hypervisors IPs don't match Hosts IPs

### DIFF
--- a/cfme/tests/openstack/cloud/test_instances.py
+++ b/cfme/tests/openstack/cloud/test_instances.py
@@ -167,22 +167,3 @@ def test_delete_instance(new_instance):
         assert False, "entity still exists"
     except ItemNotFound:
         pass
-
-
-def test_list_vms_infra_node(appliance, provider, soft_assert):
-    if not getattr(provider, 'infra_provider', None):
-        pytest.skip("Provider {prov} doesn't have infra provider set".format(prov=provider.name))
-
-    host_collection = appliance.collections.hosts
-    # Match hypervisors by IP with count of running VMs
-    hvisors = {hv.host_ip: hv.running_vms for hv in provider.mgmt.api.hypervisors.list()}
-
-    # Skip non-compute nodes
-    hosts = [host for host in host_collection.all(provider) if 'Compute' in host.name]
-    assert hosts
-    for host in hosts:
-        view = navigate_to(host, 'Details')
-        host_ip = view.entities.summary('Properties').get_text_of('IP Address')
-        vms = int(view.entities.summary('Relationships').get_text_of('VMs'))
-        soft_assert(vms == hvisors[host_ip],
-                    'Number of instances on UI does not match with real value')


### PR DESCRIPTION
Purpose or Intent
IP Addresses returned by hypervisors list don't match IP Addresses returned by hosts, So under current implementation this test will always fail and should be skipped

{{ pytest: cfme/tests/openstack/cloud/test_instances.py::test_list_vms_infra_node }}