### PR TITLE
[1LP][RFR] Move breadcrumb widget to patternfly

### DIFF
--- a/cfme/ansible/playbooks.py
+++ b/cfme/ansible/playbooks.py
@@ -3,14 +3,7 @@
 import attr
 from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.widget import Text, View
-from widgetastic_patternfly import Button, Dropdown
-from widgetastic_manageiq import (
-    BaseEntitiesView,
-    BreadCrumb,
-    ItemsToolBarViewSelector,
-    PaginationPane,
-    SummaryTable,
-)
+from widgetastic_patternfly import BreadCrumb, Button, Dropdown
 
 from cfme.base import Server
 from cfme.base.login import BaseLoggedInPage
@@ -18,6 +11,8 @@ from cfme.common import Taggable, TagPageView
 from cfme.exceptions import ItemNotFound
 from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.utils.appliance.implementations.ui import navigator, navigate_to, CFMENavigateStep
+from widgetastic_manageiq import (
+    BaseEntitiesView, ItemsToolBarViewSelector, PaginationPane, SummaryTable)
 
 
 class PlaybookBaseView(BaseLoggedInPage):

--- a/cfme/cloud/availability_zone.py
+++ b/cfme/cloud/availability_zone.py
@@ -3,7 +3,7 @@
 import attr
 from navmazing import NavigateToSibling, NavigateToAttribute
 from widgetastic.widget import View
-from widgetastic_patternfly import Dropdown, Button
+from widgetastic_patternfly import Dropdown, Button, BreadCrumb
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.common import Taggable
@@ -11,8 +11,8 @@ from cfme.exceptions import AvailabilityZoneNotFound, ItemNotFound
 from cfme.modeling.base import BaseEntity, BaseCollection
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator
 from widgetastic_manageiq import (
-    BaseEntitiesView, TimelinesView, ItemsToolBarViewSelector, Text, Table, BreadCrumb,
-    SummaryTable, Accordion, ManageIQTree)
+    BaseEntitiesView, TimelinesView, ItemsToolBarViewSelector, Text, Table, SummaryTable, Accordion,
+    ManageIQTree)
 
 
 class AvailabilityZoneToolBar(View):

--- a/cfme/cloud/flavor.py
+++ b/cfme/cloud/flavor.py
@@ -3,7 +3,7 @@
 import attr
 
 from navmazing import NavigateToAttribute
-from widgetastic_patternfly import Dropdown, Button, View
+from widgetastic_patternfly import Dropdown, Button, View, BreadCrumb
 
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import Taggable
@@ -12,7 +12,7 @@ from cfme.modeling.base import BaseEntity, BaseCollection
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator
 from widgetastic_manageiq import (
     BaseEntitiesView, ItemsToolBarViewSelector, SummaryTable, Text, Table, Accordion, ManageIQTree,
-    BreadCrumb, PaginationPane)
+    PaginationPane)
 
 
 class FlavorView(BaseLoggedInPage):

--- a/cfme/cloud/keypairs.py
+++ b/cfme/cloud/keypairs.py
@@ -4,7 +4,7 @@ from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.exceptions import MoveTargetOutOfBoundsException
 from widgetastic.widget import View
 from widgetastic.utils import VersionPick, Version
-from widgetastic_patternfly import Dropdown, Button
+from widgetastic_patternfly import BreadCrumb, Button, Dropdown
 
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import Taggable
@@ -13,7 +13,7 @@ from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.utils.appliance.implementations.ui import navigate_to, navigator, CFMENavigateStep
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import (
-    ItemsToolBarViewSelector, Text, TextInput, Accordion, ManageIQTree, BreadCrumb,
+    ItemsToolBarViewSelector, Text, TextInput, Accordion, ManageIQTree,
     SummaryTable, BootstrapSelect, ItemNotFound, BaseEntitiesView, PaginationPane)
 
 

--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -4,7 +4,7 @@ import attr
 from navmazing import NavigateToSibling, NavigateToAttribute
 from widgetastic.exceptions import MoveTargetOutOfBoundsException
 from widgetastic.widget import View
-from widgetastic_patternfly import Dropdown
+from widgetastic_patternfly import Dropdown, BreadCrumb
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.cloud.instance.image import Image
@@ -19,7 +19,7 @@ from cfme.utils.appliance.implementations.ui import navigator, navigate_to, CFME
 from cfme.utils.log import logger
 from cfme.utils.pretty import Pretty
 from cfme.utils.wait import wait_for
-from widgetastic_manageiq import TimelinesView, BreadCrumb, ItemsToolBarViewSelector
+from widgetastic_manageiq import TimelinesView, ItemsToolBarViewSelector
 
 
 class CloudProviderTimelinesView(TimelinesView, BaseLoggedInPage):

--- a/cfme/cloud/stack.py
+++ b/cfme/cloud/stack.py
@@ -1,8 +1,8 @@
 import attr
 from navmazing import NavigateToSibling, NavigateToAttribute
 from widgetastic.exceptions import NoSuchElementException
-from widgetastic.widget import View
-from widgetastic_patternfly import Button, Dropdown, BootstrapNav
+from widgetastic.widget import View, Text
+from widgetastic_patternfly import Button, Dropdown, BootstrapNav, BreadCrumb
 
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import Taggable
@@ -12,8 +12,7 @@ from cfme.utils.appliance.implementations.ui import navigator, navigate_to, CFME
 from cfme.utils.pretty import Pretty
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import (
-    Accordion, BreadCrumb, ItemsToolBarViewSelector, PaginationPane,
-    SummaryTable, Table, Text, BaseEntitiesView)
+    Accordion, ItemsToolBarViewSelector, PaginationPane, SummaryTable, Table, BaseEntitiesView)
 
 
 class StackToolbar(View):

--- a/cfme/cloud/tenant.py
+++ b/cfme/cloud/tenant.py
@@ -5,7 +5,7 @@ from navmazing import NavigateToSibling, NavigateToAttribute
 from widgetastic.exceptions import NoSuchElementException
 from widgetastic.utils import VersionPick
 from widgetastic.widget import View
-from widgetastic_patternfly import BootstrapNav, Button, Dropdown, Input
+from widgetastic_patternfly import BreadCrumb, BootstrapNav, Button, Dropdown, Input
 
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import Taggable
@@ -16,7 +16,7 @@ from cfme.utils.log import logger
 from cfme.utils.version import Version
 from cfme.utils.wait import wait_for, TimedOutError
 from widgetastic_manageiq import (
-    Accordion, BootstrapSelect, BreadCrumb, ItemsToolBarViewSelector, PaginationPane,
+    Accordion, BootstrapSelect, ItemsToolBarViewSelector, PaginationPane,
     SummaryTable, Table, Text, BaseNonInteractiveEntitiesView, BaseEntitiesView)
 
 

--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -4,21 +4,16 @@ import random
 from navmazing import NavigateToSibling
 from widgetastic.exceptions import NoSuchElementException, RowNotFound
 from widgetastic_patternfly import (
-    BootstrapSelect,
-    Button,
-    CheckableBootstrapTreeview,
-    DropdownItemNotFound,
-    SelectItemNotFound
-)
+    BreadCrumb, BootstrapSelect, Button, CheckableBootstrapTreeview, DropdownItemNotFound,
+    SelectItemNotFound)
 from widgetastic.widget import Table, Text, View
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.configure.configuration.region_settings import Category, Tag
 from cfme.utils.appliance.implementations.ui import navigate_to, navigator, CFMENavigateStep
-from cfme.utils.log import logger
 from cfme.utils.wait import wait_for
-from widgetastic_manageiq import BaseNonInteractiveEntitiesView, BreadCrumb
+from widgetastic_manageiq import BaseNonInteractiveEntitiesView
 
 
 class ManagePoliciesView(BaseLoggedInPage):

--- a/cfme/common/host_views.py
+++ b/cfme/common/host_views.py
@@ -2,40 +2,16 @@
 from lxml.html import document_fromstring
 from widgetastic.exceptions import NoSuchElementException
 from widgetastic.utils import (
-    Parameter,
-    Version,
-    VersionPick
-)
+    Parameter, Version, VersionPick)
 from widgetastic.widget import ParametrizedView, Text, View
 from widgetastic_patternfly import (
-    BootstrapNav,
-    BootstrapSelect,
-    CheckableBootstrapTreeview,
-    Dropdown,
-    Tab,
-)
+    BreadCrumb, BootstrapNav, BootstrapSelect, CheckableBootstrapTreeview, Dropdown, Tab)
 
 from cfme.base.login import BaseLoggedInPage
 from widgetastic_manageiq import (
-    Accordion,
-    BaseEntitiesView,
-    BaseListEntity,
-    BaseQuadIconEntity,
-    BaseTileIconEntity,
-    BreadCrumb,
-    Button,
-    Checkbox,
-    DriftComparison,
-    Input,
-    ItemsToolBarViewSelector,
-    JSBaseEntity,
-    ManageIQTree,
-    NonJSBaseEntity,
-    PaginationPane,
-    ParametrizedSummaryTable,
-    Table,
-    TimelinesView
-)
+    Accordion, BaseEntitiesView, BaseListEntity, BaseQuadIconEntity, BaseTileIconEntity, Button,
+    Checkbox, DriftComparison, Input, ItemsToolBarViewSelector, JSBaseEntity, ManageIQTree,
+    NonJSBaseEntity, PaginationPane, ParametrizedSummaryTable, Table, TimelinesView)
 
 
 class ComputeInfrastructureHostsView(BaseLoggedInPage):

--- a/cfme/common/physical_server_views.py
+++ b/cfme/common/physical_server_views.py
@@ -1,33 +1,16 @@
 # -*- coding: utf-8 -*-
 from lxml.html import document_fromstring
 from widgetastic.utils import (
-    Parameter,
-    Version,
-    VersionPick
-)
+    Parameter, Version, VersionPick)
 from widgetastic.widget import ParametrizedView, Text, View
-from widgetastic_manageiq import (
-    BaseEntitiesView,
-    NonJSBaseEntity,
-    JSBaseEntity,
-    BaseListEntity,
-    BaseQuadIconEntity,
-    BaseTileIconEntity,
-    BootstrapTreeview,
-    BreadCrumb,
-    Button,
-    ItemsToolBarViewSelector,
-    SummaryTable,
-    TimelinesView,
-    BaseNonInteractiveEntitiesView,
-    ManageIQTree
-)
 from widgetastic_patternfly import (
-    Dropdown,
-    Accordion
-)
+    BreadCrumb, Dropdown, Accordion)
 
 from cfme.base.login import BaseLoggedInPage
+from widgetastic_manageiq import (
+    BaseEntitiesView, NonJSBaseEntity, JSBaseEntity, BaseListEntity, BaseQuadIconEntity,
+    BaseTileIconEntity, BootstrapTreeview, Button, ItemsToolBarViewSelector, SummaryTable,
+    TimelinesView, BaseNonInteractiveEntitiesView, ManageIQTree)
 
 
 class ComputePhysicalInfrastructureServersView(BaseLoggedInPage):

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -4,25 +4,14 @@ from lxml.html import document_fromstring
 from widgetastic.exceptions import NoSuchElementException
 from widgetastic.utils import VersionPick, Version
 from widgetastic.widget import View, Text, ConditionalSwitchableView, ParametrizedView
-from widgetastic_patternfly import Dropdown, BootstrapSelect, Tab
+from widgetastic_patternfly import BreadCrumb, Dropdown, BootstrapSelect, Tab
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.common.host_views import HostEntitiesView
-from widgetastic_manageiq import (BreadCrumb,
-                                  ParametrizedSummaryTable,
-                                  Button,
-                                  TimelinesView,
-                                  DetailsToolBarViewSelector,
-                                  ItemsToolBarViewSelector,
-                                  Checkbox,
-                                  Input,
-                                  BaseEntitiesView,
-                                  PaginationPane,
-                                  BaseTileIconEntity,
-                                  BaseQuadIconEntity,
-                                  BaseListEntity,
-                                  NonJSBaseEntity,
-                                  JSBaseEntity)
+from widgetastic_manageiq import (
+    ParametrizedSummaryTable, Button, TimelinesView, DetailsToolBarViewSelector,
+    ItemsToolBarViewSelector, Checkbox, Input, BaseEntitiesView, PaginationPane, BaseTileIconEntity,
+    BaseQuadIconEntity, BaseListEntity, NonJSBaseEntity, JSBaseEntity)
 
 
 class ProviderQuadIconEntity(BaseQuadIconEntity):

--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -7,7 +7,7 @@ from widgetastic.exceptions import NoSuchElementException
 from widgetastic.widget import (
     View, TableRow, Text, TextInput, ParametrizedView, Image, ConditionalSwitchableView)
 from widgetastic_patternfly import (
-    Dropdown, BootstrapSelect, Tab, Input, CheckableBootstrapTreeview)
+    BreadCrumb, Dropdown, BootstrapSelect, Tab, Input, CheckableBootstrapTreeview)
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.exceptions import TemplateNotFound
@@ -15,7 +15,7 @@ from cfme.utils.log import logger
 from widgetastic_manageiq import (
     Calendar, Checkbox, Button, ItemsToolBarViewSelector, Table, MultiBoxSelect, RadioGroup,
     VersionPick, Version, BaseEntitiesView, NonJSBaseEntity, BaseListEntity, BaseQuadIconEntity,
-    BaseTileIconEntity, JSBaseEntity, BaseNonInteractiveEntitiesView, BreadCrumb, PaginationPane,
+    BaseTileIconEntity, JSBaseEntity, BaseNonInteractiveEntitiesView, PaginationPane,
     DriftComparison, ParametrizedSummaryTable
 )
 

--- a/cfme/configure/settings.py
+++ b/cfme/configure/settings.py
@@ -5,7 +5,7 @@ from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.utils import Version, VersionPick
 from widgetastic.widget import View
 from widgetastic_patternfly import (
-    BootstrapSwitch, Button, CheckableBootstrapTreeview, Dropdown, Input, Tab)
+    BreadCrumb, BootstrapSwitch, Button, CheckableBootstrapTreeview, Dropdown, Input, Tab)
 
 from cfme.base import BaseEntity, BaseCollection
 from cfme.base.login import BaseLoggedInPage
@@ -14,7 +14,7 @@ from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep,
 from cfme.utils.log import logger
 from cfme.utils.pretty import Pretty
 from cfme.utils.update import Updateable
-from widgetastic_manageiq import Table, BootstrapSelect, BreadCrumb, Text, ViewButtonGroup
+from widgetastic_manageiq import Table, BootstrapSelect, Text, ViewButtonGroup
 
 
 class TimeProfileForm(View):

--- a/cfme/containers/node.py
+++ b/cfme/containers/node.py
@@ -6,7 +6,7 @@ from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.exceptions import NoSuchElementException
 from widgetastic.utils import VersionPick, Version
 from widgetastic.widget import View
-from widgetastic_manageiq import Button, Text, TimelinesView, BreadCrumb
+from widgetastic_patternfly import BreadCrumb
 
 from cfme.common import Taggable, TagPageView, PolicyProfileAssignable
 from cfme.common.vm_console import ConsoleMixin
@@ -18,6 +18,7 @@ from cfme.utils.appliance.implementations.ui import (CFMENavigateStep, navigator
                                                      navigate_to)
 from cfme.common.provider_views import ProviderDetailsToolBar
 from cfme.utils.providers import get_crud_by_name
+from widgetastic_manageiq import Button, Text, TimelinesView
 
 
 class NodeDetailsToolBar(ProviderDetailsToolBar):

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -12,8 +12,7 @@ from widgetastic_manageiq import StatusBox, ContainerSummaryTable
 from widgetastic.utils import VersionPick, Version
 from widgetastic.widget import Text, View, TextInput
 from widgetastic_patternfly import (
-    SelectorDropdown, Dropdown, BootstrapSelect, Input, Button, Tab
-)
+    BreadCrumb, SelectorDropdown, Dropdown, BootstrapSelect, Input, Button, Tab)
 from wrapanapi.utils import eval_strings
 
 from cfme import exceptions
@@ -36,8 +35,7 @@ from cfme.utils.pretty import Pretty
 from cfme.utils.varmeth import variable
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import (
-    SummaryTable, BreadCrumb, Accordion, ManageIQTree, LineChart
-)
+    SummaryTable, Accordion, ManageIQTree, LineChart)
 
 
 class ContainersProviderDefaultEndpoint(DefaultEndpoint):

--- a/cfme/infrastructure/cluster.py
+++ b/cfme/infrastructure/cluster.py
@@ -4,7 +4,7 @@
 import attr
 from navmazing import NavigateToSibling, NavigateToAttribute
 from widgetastic.widget import View
-from widgetastic_patternfly import Button, Dropdown
+from widgetastic_patternfly import BreadCrumb, Button, Dropdown
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.common import Taggable
@@ -14,8 +14,9 @@ from cfme.utils.appliance.implementations.ui import navigate_to, navigator, CFME
 from cfme.utils.log import logger
 from cfme.utils.pretty import Pretty
 from cfme.utils.wait import wait_for, TimedOutError
-from widgetastic_manageiq import (Accordion, BreadCrumb, ItemsToolBarViewSelector, ManageIQTree,
-                                  SummaryTable, Text, TimelinesView, BaseEntitiesView)
+from widgetastic_manageiq import (
+    Accordion, ItemsToolBarViewSelector, ManageIQTree, SummaryTable, Text, TimelinesView,
+    BaseEntitiesView)
 
 
 # TODO: since Cluster always requires provider, it will use only one way to get to Cluster Detail's

--- a/cfme/infrastructure/deployment_roles.py
+++ b/cfme/infrastructure/deployment_roles.py
@@ -5,32 +5,19 @@ import attr
 from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.exceptions import NoSuchElementException
 from widgetastic.utils import Version, VersionPick
-from widgetastic.widget import ParametrizedView, View
-from widgetastic_patternfly import (BootstrapNav,
-                                    Button,
-                                    Dropdown
-                                    )
+from widgetastic.widget import ParametrizedView, View, Text
+from widgetastic_patternfly import (
+    BreadCrumb, BootstrapNav, Button, Dropdown)
 
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import PolicyProfileAssignable
 from cfme.exceptions import ItemNotFound, RoleNotFound
 from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
-from widgetastic_manageiq import (Accordion,
-                                  BaseEntitiesView,
-                                  BaseListEntity,
-                                  BaseQuadIconEntity,
-                                  BaseTileIconEntity,
-                                  BootstrapSelect,
-                                  BreadCrumb,
-                                  CompareToolBarActionsView,
-                                  ItemsToolBarViewSelector,
-                                  JSBaseEntity,
-                                  NonJSBaseEntity,
-                                  SummaryTable,
-                                  Table,
-                                  Text
-                                  )
+from widgetastic_manageiq import (
+    Accordion, BaseEntitiesView, BaseListEntity, BaseQuadIconEntity, BaseTileIconEntity,
+    BootstrapSelect, CompareToolBarActionsView, ItemsToolBarViewSelector, JSBaseEntity,
+    NonJSBaseEntity, SummaryTable, Table)
 
 
 class DeploymentRoleToolbar(View):

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -5,6 +5,7 @@ import attr
 from navmazing import NavigateToSibling, NavigateToAttribute
 from widgetastic.exceptions import MoveTargetOutOfBoundsException
 from widgetastic.utils import Fillable
+from widgetastic_patternfly import BreadCrumb
 
 from cfme.base.ui import Server
 from cfme.common import TagPageView
@@ -23,7 +24,7 @@ from cfme.utils.log import logger
 from cfme.utils.pretty import Pretty
 from cfme.utils.varmeth import variable
 from cfme.utils.wait import wait_for
-from widgetastic_manageiq import BreadCrumb, BaseEntitiesView, View, NoSuchElementException
+from widgetastic_manageiq import BaseEntitiesView, View, NoSuchElementException
 
 
 class ProviderClustersView(ClusterView):

--- a/cfme/infrastructure/resource_pool.py
+++ b/cfme/infrastructure/resource_pool.py
@@ -2,8 +2,8 @@
 import attr
 from navmazing import NavigateToAttribute
 
-from widgetastic.widget import View
-from widgetastic_patternfly import Button, Dropdown
+from widgetastic.widget import View, Text
+from widgetastic_patternfly import BreadCrumb, Button, Dropdown
 
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import Taggable
@@ -13,13 +13,7 @@ from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep,
 from cfme.utils.pretty import Pretty
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import (
-    Accordion,
-    BaseEntitiesView,
-    BreadCrumb,
-    ItemsToolBarViewSelector,
-    ManageIQTree,
-    SummaryTable,
-    Text)
+    Accordion, BaseEntitiesView, ItemsToolBarViewSelector, ManageIQTree, SummaryTable)
 
 
 class ResourcePoolToolbar(View):

--- a/cfme/services/requests.py
+++ b/cfme/services/requests.py
@@ -5,8 +5,8 @@ import attr
 
 from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.widget import Text, Table, Checkbox, View
-from widgetastic_manageiq import BreadCrumb, SummaryForm, SummaryFormItem, PaginationPane, Button
-from widgetastic_patternfly import Input, Tab, BootstrapTreeview
+from widgetastic_manageiq import SummaryForm, SummaryFormItem, PaginationPane, Button
+from widgetastic_patternfly import BreadCrumb, Input, Tab, BootstrapTreeview
 from widgetastic.utils import Version, VersionPick
 
 from cfme.base.login import BaseLoggedInPage

--- a/cfme/storage/manager.py
+++ b/cfme/storage/manager.py
@@ -4,9 +4,7 @@ from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.utils import VersionPick, Version
 from widgetastic.widget import View, NoSuchElementException, Text
 from widgetastic_patternfly import (
-    Button,
-    Dropdown
-)
+    BreadCrumb, Button, Dropdown)
 
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import TagPageView, Taggable, PolicyProfileAssignable
@@ -14,13 +12,7 @@ from cfme.exceptions import ItemNotFound
 from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
 from widgetastic_manageiq import (
-    Accordion,
-    BreadCrumb,
-    ManageIQTree,
-    PaginationPane,
-    SummaryTable,
-    Table
-)
+    Accordion, ManageIQTree, PaginationPane, SummaryTable, Table)
 
 
 class StorageManagerToolbar(View):

--- a/cfme/storage/object_store_container.py
+++ b/cfme/storage/object_store_container.py
@@ -2,15 +2,7 @@
 import attr
 
 from navmazing import NavigateToSibling, NavigateToAttribute
-from widgetastic_manageiq import (
-    Accordion,
-    BaseEntitiesView,
-    BreadCrumb,
-    ItemsToolBarViewSelector,
-    ManageIQTree,
-    SummaryTable,
-)
-from widgetastic_patternfly import Button, Dropdown
+from widgetastic_patternfly import BreadCrumb, Button, Dropdown
 from widgetastic.widget import View, Text, NoSuchElementException
 
 from cfme.base.ui import BaseLoggedInPage
@@ -18,6 +10,8 @@ from cfme.common import TagPageView, Taggable
 from cfme.exceptions import ItemNotFound
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
 from cfme.modeling.base import BaseCollection, BaseEntity
+from widgetastic_manageiq import (
+    Accordion, BaseEntitiesView, ItemsToolBarViewSelector, ManageIQTree, SummaryTable)
 
 
 class ObjectStoreContainerToolbar(View):

--- a/cfme/storage/object_store_object.py
+++ b/cfme/storage/object_store_object.py
@@ -2,7 +2,7 @@
 import attr
 from navmazing import NavigateToSibling, NavigateToAttribute
 from widgetastic.widget import View, Text, NoSuchElementException
-from widgetastic_patternfly import Button, Dropdown
+from widgetastic_patternfly import BreadCrumb, Button, Dropdown
 
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import TagPageView, Taggable
@@ -11,13 +11,7 @@ from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator, navigate_to
 from cfme.utils.providers import get_crud_by_name
 from widgetastic_manageiq import (
-    Accordion,
-    BaseEntitiesView,
-    BreadCrumb,
-    ItemsToolBarViewSelector,
-    ManageIQTree,
-    SummaryTable
-)
+    Accordion, BaseEntitiesView, ItemsToolBarViewSelector, ManageIQTree, SummaryTable)
 
 
 class ObjectStoreObjectToolbar(View):

--- a/cfme/storage/volume.py
+++ b/cfme/storage/volume.py
@@ -2,18 +2,8 @@
 import attr
 
 from navmazing import NavigateToSibling, NavigateToAttribute
-from widgetastic_manageiq import (
-    Accordion,
-    BaseEntitiesView,
-    BootstrapSelect,
-    BootstrapSwitch,
-    BreadCrumb,
-    ItemsToolBarViewSelector,
-    ManageIQTree,
-    SummaryTable,
-    TextInput,
-)
-from widgetastic_patternfly import Button, Dropdown
+from widgetastic.widget import TextInput
+from widgetastic_patternfly import BreadCrumb, Button, Dropdown
 from widgetastic.widget import View, Text, NoSuchElementException
 
 from cfme.base.ui import BaseLoggedInPage
@@ -25,6 +15,9 @@ from cfme.utils.log import logger
 from cfme.utils.providers import get_crud_by_name
 from cfme.utils.update import Updateable
 from cfme.utils.wait import wait_for, TimedOutError
+from widgetastic_manageiq import (
+    Accordion, BaseEntitiesView, BootstrapSelect, BootstrapSwitch, ItemsToolBarViewSelector,
+    ManageIQTree, SummaryTable)
 
 
 class VolumeToolbar(View):

--- a/cfme/storage/volume_backup.py
+++ b/cfme/storage/volume_backup.py
@@ -5,7 +5,7 @@ import attr
 from navmazing import NavigateToSibling, NavigateToAttribute
 
 from widgetastic.widget import View, Text, NoSuchElementException
-from widgetastic_patternfly import BootstrapSelect, Button, Dropdown
+from widgetastic_patternfly import BreadCrumb, BootstrapSelect, Button, Dropdown
 
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import TagPageView, Taggable
@@ -16,13 +16,7 @@ from cfme.utils.log import logger
 from cfme.utils.providers import get_crud_by_name
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import (
-    Accordion,
-    BaseEntitiesView,
-    BreadCrumb,
-    ItemsToolBarViewSelector,
-    ManageIQTree,
-    SummaryTable
-)
+    Accordion, BaseEntitiesView, ItemsToolBarViewSelector, ManageIQTree, SummaryTable)
 
 
 class VolumeBackupToolbar(View):

--- a/cfme/storage/volume_snapshot.py
+++ b/cfme/storage/volume_snapshot.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 import attr
 from navmazing import NavigateToSibling, NavigateToAttribute
-
-from widgetastic_patternfly import Button, Dropdown
 from widgetastic.widget import View, Text, NoSuchElementException
+from widgetastic_patternfly import BreadCrumb, Button, Dropdown
 
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import TagPageView, Taggable
@@ -14,13 +13,7 @@ from cfme.utils.log import logger
 from cfme.utils.providers import get_crud_by_name
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import (
-    Accordion,
-    BaseEntitiesView,
-    BreadCrumb,
-    ItemsToolBarViewSelector,
-    ManageIQTree,
-    SummaryTable
-)
+    Accordion, BaseEntitiesView, ItemsToolBarViewSelector, ManageIQTree, SummaryTable)
 
 
 class VolumeSnapshotToolbar(View):

--- a/cfme/tests/cloud/test_stack.py
+++ b/cfme/tests/cloud/test_stack.py
@@ -32,7 +32,7 @@ def test_security_group_link(stack):
         view = navigate_to(stack, 'RelationshipSecurityGroups')
     except CandidateNotFound:
         # Assert that the item in the menu is disabled
-        view = navigate_to(stack, 'Details')
+        view = navigate_to(stack, 'Details', wait_for_view=True)
         assert view.sidebar.relationships.nav.is_disabled('Security Groups (0)')
     else:
         # Navigation successful, stack had security groups
@@ -46,7 +46,7 @@ def test_parameters_link(stack):
         view = navigate_to(stack, 'RelationshipParameters')
     except CandidateNotFound:
         # Assert that the item in the menu is disabled
-        view = navigate_to(stack, 'Details')
+        view = navigate_to(stack, 'Details', wait_for_view=True)
         assert view.sidebar.relationships.nav.is_disabled('Parameters (0)')
     else:
         # Navigation successful, stack had parameters
@@ -60,7 +60,7 @@ def test_outputs_link(stack):
         view = navigate_to(stack, 'RelationshipOutputs')
     except CandidateNotFound:
         # Assert there is a non-clickable anchor
-        view = navigate_to(stack, 'Details')
+        view = navigate_to(stack, 'Details', wait_for_view=True)
         assert view.sidebar.relationships.nav.is_disabled('Outputs (0)')
     else:
         assert view.is_displayed
@@ -73,7 +73,7 @@ def test_outputs_link_url(appliance, stack):
         view = navigate_to(stack, 'RelationshipOutputs')
     except CandidateNotFound:
         # Assert there is a non-clickable anchor
-        view = navigate_to(stack, 'Details')
+        view = navigate_to(stack, 'Details', wait_for_view=True)
         assert view.sidebar.relationships.nav.is_disabled('Outputs (0)')
     else:
         # Outputs is a table with clickable rows
@@ -89,7 +89,7 @@ def test_resources_link(stack):
         view = navigate_to(stack, 'RelationshipResources')
     except CandidateNotFound:
         # Assert there is a non-clickable anchor
-        view = navigate_to(stack, 'Details')
+        view = navigate_to(stack, 'Details', wait_for_view=True)
         assert view.sidebar.relationships.nav.is_disabled('Resources (0)')
     else:
         assert view.is_displayed is True

--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -304,7 +304,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
 widgetastic.core==0.21.3
-widgetastic.patternfly==0.0.32
+widgetastic.patternfly==0.0.34
 widgetsnbextension==3.2.1
 wrapanapi==2.9.10
 wrapt==1.10.11

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -293,7 +293,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
 widgetastic.core==0.21.3
-widgetastic.patternfly==0.0.32
+widgetastic.patternfly==0.0.34
 widgetsnbextension==3.2.1
 wrapanapi==2.9.10
 wrapt==1.10.11

--- a/requirements/frozen_docs.py2.txt
+++ b/requirements/frozen_docs.py2.txt
@@ -170,7 +170,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
 widgetastic.core==0.21.3
-widgetastic.patternfly==0.0.32
+widgetastic.patternfly==0.0.34
 widgetsnbextension==3.2.1
 wrapt==1.10.11
 xmltodict==0.11.0

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -161,7 +161,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
 widgetastic.core==0.21.3
-widgetastic.patternfly==0.0.32
+widgetastic.patternfly==0.0.34
 widgetsnbextension==3.2.1
 wrapt==1.10.11
 xmltodict==0.11.0

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -2,13 +2,13 @@
 import atexit
 import json
 import math
+import os
+import re
 from collections import namedtuple
 from datetime import date
 from math import ceil
 from tempfile import NamedTemporaryFile
 
-import os
-import re
 import six
 from cached_property import cached_property
 from jsmin import jsmin
@@ -17,27 +17,18 @@ from selenium.common.exceptions import WebDriverException
 from wait_for import TimedOutError, wait_for
 from widgetastic.exceptions import NoSuchElementException, WidgetOperationFailed
 from widgetastic.log import logged
-from widgetastic.utils import ParametrizedLocator, Parameter, ParametrizedString, attributize_string
-from widgetastic.utils import VersionPick, Version, partial_match
+from widgetastic.utils import (
+    ParametrizedLocator, Parameter, ParametrizedString, attributize_string, VersionPick, Version,
+    partial_match)
 from widgetastic.widget import (
-    Table as VanillaTable,
-    TableColumn as VanillaTableColumn,
-    TableRow as VanillaTableRow,
-    Widget,
-    View,
-    Select,
-    TextInput,
-    Text,
-    Checkbox,
-    ParametrizedView,
     FileInput as BaseFileInput,
-    ClickableMixin,
-    ConditionalSwitchableView,
-    do_not_read_this_widget)
+    Table as VanillaTable, TableColumn as VanillaTableColumn, TableRow as VanillaTableRow,
+    Widget, View, Select, TextInput, Text, Checkbox, ParametrizedView, ClickableMixin,
+    ConditionalSwitchableView, do_not_read_this_widget)
 from widgetastic.xpath import quote
 from widgetastic_patternfly import (
-    Accordion as PFAccordion, BootstrapSwitch, BootstrapTreeview,
-    BootstrapSelect, Button, Dropdown, Input, NavDropdown, VerticalNavigation, Tab)
+    Accordion as PFAccordion, BootstrapSwitch, BootstrapTreeview, BootstrapSelect,
+    Button, Dropdown, Input, VerticalNavigation, NavDropdown, Tab, BreadCrumb)
 
 from cfme.exceptions import ItemNotFound
 
@@ -1872,47 +1863,6 @@ class RadioGroup(Widget):
 
     def fill(self, name):
         return self.select(name)
-
-
-class BreadCrumb(Widget):
-    """ CFME BreadCrumb navigation control
-
-    .. code-block:: python
-
-        breadcrumb = BreadCrumb()
-        breadcrumb.click_location(breadcrumb.locations[0])
-    """
-    ROOT = '//ol[@class="breadcrumb"]'
-    ELEMENTS = './/li'
-
-    def __init__(self, parent, locator=None, logger=None):
-        Widget.__init__(self, parent=parent, logger=logger)
-        self._locator = locator or self.ROOT
-
-    def __locator__(self):
-        return self._locator
-
-    @property
-    def _path_elements(self):
-        return self.browser.elements(self.ELEMENTS, parent=self)
-
-    @property
-    def locations(self):
-        return [self.browser.text(loc) for loc in self._path_elements]
-
-    @property
-    def active_location(self):
-        br = self.browser
-        return next(br.text(loc) for loc in self._path_elements if 'active' in br.classes(loc))
-
-    def click_location(self, name, handle_alert=True):
-        br = self.browser
-        location = next(loc for loc in self._path_elements if br.text(loc) == name)
-        result = br.click(location, ignore_ajax=handle_alert)
-        if handle_alert:
-            self.browser.handle_alert(wait=2.0, squash=True)
-            self.browser.plugin.ensure_page_safe()
-        return result
 
 
 class ItemsToolBarViewSelector(View):


### PR DESCRIPTION
Breadcrumb is a patternfly widget, not MIQ specific.  Move to the patternfly repo and import into widgetastic_manageiq to maintain current imports.

Using cloud/test_stacks because StackDetailsView.is_displayed uses the breadcrumb. Modified to pass wait_for_view so is_displayed is called.

{{ pytest: cfme/tests/cloud/test_stack.py --use-provider ec2west --long-running -v }}