### PR TITLE
[1LP][RFR] Fixing test_ssa_schedule for RHEL VM

### DIFF
--- a/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
+++ b/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
@@ -404,7 +404,6 @@ def test_ssa_template(local_setup_provider, provider, soft_assert, vm_analysis_p
         soft_assert(c_fs_drivers != '0', "fs drivers: '{}' != '0'".format(c_fs_drivers))
 
 
-@pytest.mark.rhv3
 @pytest.mark.tier(2)
 @pytest.mark.long_running
 def test_ssa_compliance(local_setup_provider, ssa_compliance_profile, ssa_profiled_vm,
@@ -483,8 +482,11 @@ def test_ssa_compliance(local_setup_provider, ssa_compliance_profile, ssa_profil
         soft_assert(c_fs_drivers != '0', "fs drivers: '{}' != '0'".format(c_fs_drivers))
 
 
+@pytest.mark.rhv3
 @pytest.mark.tier(2)
 @pytest.mark.long_running
+@pytest.mark.meta(blockers=[BZ(1578792, forced_streams=['5.8', '5.9'],
+    unblock=lambda provider: 'rhel' not in str(provider.data.get('vm_analysis_new').get('vms')))])
 def test_ssa_schedule(ssa_vm, schedule_ssa, soft_assert, appliance):
     """ Tests SSA can be performed and returns sane results
 
@@ -525,8 +527,10 @@ def test_ssa_schedule(ssa_vm, schedule_ssa, soft_assert, appliance):
                 c_packages, c_services)
 
     soft_assert(c_lastanalyzed != 'Never', "Last Analyzed is set to Never")
-    soft_assert(e_os_type in details_os_icon.lower(),
-                "details icon: '{}' not in '{}'".format(e_os_type, details_os_icon))
+    # RHEL has 'Red Hat' in details_os_icon, but 'redhat' in quadicon_os_icon
+    os_type = e_os_type if e_os_type != 'redhat' else 'red hat'
+    soft_assert(os_type in details_os_icon.lower(),
+                "details icon: '{}' not in '{}'".format(os_type, details_os_icon))
     soft_assert(e_os_type in quadicon_os_icon.lower(),
                 "quad icon: '{}' not in '{}'".format(e_os_type, quadicon_os_icon))
 
@@ -555,8 +559,11 @@ def test_ssa_schedule(ssa_vm, schedule_ssa, soft_assert, appliance):
 @pytest.mark.rhv1
 @pytest.mark.tier(2)
 @pytest.mark.long_running
-@pytest.mark.meta(blockers=[BZ(1551273, forced_streams=['5.8', '5.9'],
-    unblock=lambda provider: not provider.one_of(RHEVMProvider))])
+@pytest.mark.meta(blockers=[
+    BZ(1551273, forced_streams=['5.8', '5.9'],
+    unblock=lambda provider: not provider.one_of(RHEVMProvider)),
+    BZ(1578792, forced_streams=['5.8', '5.9'],
+    unblock=lambda provider: 'rhel' not in str(provider.data.get('vm_analysis_new').get('vms')))])
 def test_ssa_vm(ssa_vm, soft_assert, appliance, ssa_profiled_vm):
     """ Tests SSA can be performed and returns sane results
 
@@ -602,7 +609,7 @@ def test_ssa_vm(ssa_vm, soft_assert, appliance, ssa_profiled_vm):
     # RHEL has 'Red Hat' in details_os_icon, but 'redhat' in quadicon_os_icon
     os_type = e_os_type if e_os_type != 'redhat' else 'red hat'
     soft_assert(os_type in details_os_icon.lower(),
-                "details icon: '{}' not in '{}'".format(e_os_type, details_os_icon))
+                "details icon: '{}' not in '{}'".format(os_type, details_os_icon))
     soft_assert(e_os_type in quadicon_os_icon.lower(),
                 "quad icon: '{}' not in '{}'".format(e_os_type, quadicon_os_icon))
 


### PR DESCRIPTION
Purpose of this PR is this:
1. test_ssa_vm a special [provision](https://github.com/ManageIQ/integration_tests/blob/8624a13117640a8007d12642833c2c3ebf8c4db8/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py#L602) for RHEL VM that is missing in test_ssa_schedule, resulting in failure.
2. I found a [bug](https://bugzilla.redhat.com/show_bug.cgi?id=1578792) concerning counting number of services on RHEL VM. Because of it, results of SSA are unreliable. Therefore I blocked the test case for scenarios where RHEL VM is used. I know that `unblock` there is quite dirty, but I did not want to block it for all other scenarios. Please let me know what do you think.
3. Correction of soft_assert failure message in test_ssa_vm.

Regarding PRT: I don't really know how to test it, since `rhv41` provider does not have necessary fields for running SSA tests.

{{pytest: cfme/tests/cloud_infra_common/test_vm_instance_analysis.py::test_ssa_schedule -vv --use-provider vsphere6-nested}}