### PR TITLE
[1LP][RFR] Move console handle check and change exception type

### DIFF
--- a/cfme/common/vm_console.py
+++ b/cfme/common/vm_console.py
@@ -40,6 +40,8 @@ class ConsoleMixin(object):
                 # FIXME: Add code to verify the tab has the correct widget
                 #      for a console tab.
                 return handle
+        else:
+            raise ValueError("Console handle should not be None")
 
     @property
     def vm_console(self):
@@ -47,9 +49,6 @@ class ConsoleMixin(object):
         the VMConsole object aside.
         """
         console_handle = self.console_handle(self.appliance.browser)
-
-        if console_handle is None:
-            raise TypeError("Console handle should not be None")
 
         appliance_handle = self.appliance.browser.widgetastic.window_handle
         logger.info("Creating VMConsole:")


### PR DESCRIPTION
vm_console was checking the state of console_handle, instead of console_handle checking its own value before returning None.

Allows for some more pythonic use of console_handle classmethod and uses a more appropriate ValueError

Found during VMCollection work in #7107  and pulled out for separate consideration.