### PR TITLE
[1LP][RFR][NOTEST] Adding cloud-init test for RHV

### DIFF
--- a/cfme/tests/infrastructure/test_cloud_init_provisioning.py
+++ b/cfme/tests/infrastructure/test_cloud_init_provisioning.py
@@ -2,6 +2,8 @@
 import fauxfactory
 import pytest
 
+from widgetastic.utils import partial_match
+
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.provisioning import do_vm_provisioning
 from cfme.infrastructure.pxe import get_template_from_config
@@ -16,15 +18,15 @@ pytestmark = [
                          required_fields=[['provisioning', 'ci-template'],
                                           ['provisioning', 'ci-username'],
                                           ['provisioning', 'ci-pass'],
-                                          ['provisioning', 'image'],
+                                          ['provisioning', 'ci-image'],
                                           ['provisioning', 'vlan']],
                          scope='module'),
 ]
 
 
 @pytest.fixture(scope="module")
-def setup_ci_template(provisioning, appliance):
-    cloud_init_template_name = provisioning['ci-template']
+def setup_ci_template(provider, appliance):
+    cloud_init_template_name = provider.data['provisioning']['ci-template']
     get_template_from_config(cloud_init_template_name, create=True, appliance=appliance)
 
 
@@ -56,9 +58,10 @@ def test_provision_cloud_init(appliance, provider, vm_name, smtp_test, request, 
             'host_name': {'name': host},
             'datastore_name': {'name': datastore}},
         'network': {
-            'vlan': vlan},
+            'vlan': partial_match(vlan)},
         'customize': {
-            'custom_template': {'name': [provisioning['ci-template']]}}
+            'customize_type': 'Specification',
+            'custom_template': {'Name': provisioning['ci-template']}}
     }
 
     do_vm_provisioning(appliance, template, provider, vm_name, provisioning_data, request,

--- a/data/rootpass.cfg
+++ b/data/rootpass.cfg
@@ -1,0 +1,5 @@
+#cloud-config
+chpasswd:
+  list: |
+    root:$pass
+  expire: False


### PR DESCRIPTION
This PR __activates__ `test_provision_cloud_init` for RHV-CFME integration. 
So what's it about?
- Fixing `provisioning_data` supplied to VM provision request.
- Fixing `required_fiels` of provider.
- Providing new customization template. This probably needs some explanation. The [customization template ](https://github.com/ManageIQ/integration_tests/blob/master/data/basiccloudinit.cfg)that is already presentein integration_tests could not be reused. The reason is that no user is specified there. In such case, cloud-init changes password of the default user. That is fedora for Fedora, ubuntu for Ubuntu etc. However, RHEL (which we use as VM's OS) does not have such user. Therefore I had to provide customization template that changes root password. 

I am not providing any `{ pytest }` clause here, since I don't really know how to test it in PRT. By looking into Ostriz, it seems to me this test case is not being executed at all as of now. However, it passes in our CI, so I can provide verification link on demand.