### PR TITLE
[RFR] Fix locator in SettingsGroupSubmenu

### DIFF
--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -860,7 +860,7 @@ class SettingsGroupSubmenu(NavDropdown):
         multiple groups
         """
         try:
-            self.browser.element('./.[contains(@class, "dropdown-submenu")]', parent=self)
+            self.browser.element('../*[contains(@class, "dropdown-submenu")]', parent=self)
         except NoSuchElementException:
             return False
         else:


### PR DESCRIPTION
Locator forcing the `expandable` method to return False, resulting in `items` returning 'Change Groups' when the UI was actually expandable, instead of the list of group names.

Tested locally, setting to RFR since its so small.

{{ pytest: cfme/tests/configure/test_access_control.py -k 'test_user_assign_multiple_groups or test_user_change_groups' }}