### PR TITLE
[WIPTEST] Fix crud property and __slots__ for test_actions

### DIFF
--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -46,7 +46,7 @@ pytestmark = [
 
 class VMWrapper(Pretty):
     """This class binds a provider_mgmt object with VM name. Useful for on/off operation"""
-    __slots__ = ("_prov", "_vm", "api", "crud")
+    __slots__ = ("_prov", "_vm", "api")
     pretty_attrs = ['_vm', '_prov']
 
     def __init__(self, provider, vm_name, api):


### PR DESCRIPTION
Can't have a property that's in `__slots__`

Don't really care about PRT results here, this is to fix a travis failure during collection for py3.6