### PR TITLE
[1LP][RFR] Fix credentials template indent

### DIFF
--- a/conf/credentials.yaml.template
+++ b/conf/credentials.yaml.template
@@ -30,15 +30,15 @@ lenovo:
     username: admin
     password: smartvm
 nuage:
-  username: admin
-  password: smartvm
+    username: admin
+    password: smartvm
 nuage_events:
-  username: admin@system
-  password: smartvm
+    username: admin@system
+    password: smartvm
 vcloud:
-  username: admin
-  organization: admin
-  password: smartvm
+    username: admin
+    organization: admin
+    password: smartvm
 ssh:
     username: root
     password: password


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ credentials template indent by using 4 spaces because the entire project use that indent size and just a few lines are using 2 spaces.