### PR TITLE
[1LP][RFR] Activating test_custom_vm_report for RHV-CFME

### DIFF
--- a/cfme/tests/intelligence/reports/test_report_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_report_corresponds.py
@@ -34,10 +34,8 @@ def report_vms(appliance, infra_provider):
 
 
 @pytest.mark.tier(3)
-@pytest.mark.meta(blockers=[
-    BZ(1244715),
-    BZ(1531600, forced_streams=['5.9'])
-])
+@pytest.mark.rhv3
+@pytest.mark.meta(blockers=[BZ(1531600, forced_streams=['5.9'])])
 @test_requirements.report
 def test_custom_vm_report(soft_assert, report_vms):
     cluster = "Cluster / Deployment Role Name"


### PR DESCRIPTION
{{pytest: cfme/tests/intelligence/reports/test_report_corresponds.py::test_custom_vm_report --use-provider rhv41 -vv}}