### PR TITLE
Fix vm factory

### DIFF
--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -3,7 +3,6 @@ import pytest
 from collections import namedtuple
 
 from cfme.cloud.provider.ec2 import EC2Provider
-from cfme.common.vm import VM
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.ssh import SSHClient
@@ -29,7 +28,8 @@ def provider_app_crud(provider_class, appliance):
 def provision_vm(request, provider):
     """Function to provision appliance to the provider being tested"""
     vm_name = "test_rest_db_{}".format(fauxfactory.gen_alphanumeric())
-    vm = VM.factory(vm_name, provider)
+    coll = provider.appliance.provider_based_collection(provider, coll_type='vms')
+    vm = coll.instantiate(vm_name, provider)
     request.addfinalizer(vm.delete_from_provider)
     if not provider.mgmt.does_vm_exist(vm_name):
         logger.info("deploying %s on provider %s", vm_name, provider.key)

--- a/cfme/tests/intelligence/chargeback/test_resource_allocation.py
+++ b/cfme/tests/intelligence/chargeback/test_resource_allocation.py
@@ -37,7 +37,6 @@ import cfme.intelligence.chargeback.rates as rates
 from cfme import test_requirements
 from cfme.base.credential import Credential
 from cfme.cloud.provider.gce import GCEProvider
-from cfme.common.vm import VM
 from cfme.infrastructure.provider import CloudInfraProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.markers.env_markers.provider import ONE_PER_TYPE
@@ -80,11 +79,12 @@ def vm_ownership(enable_candu, provider, appliance):
     group_collection = appliance.collections.groups
     cb_group = group_collection.instantiate(description='EvmGroup-user')
 
-    vm = VM.factory(vm_name, provider)
+    vm = appliance.provider_based_collection(provider, coll_type='vms').instantiate(vm_name,
+                                                                                    provider)
     user = appliance.collections.users.create(
         name="{}_{}".format(provider.name, fauxfactory.gen_alphanumeric()),
         credential=Credential(principal='uid{}'.format(fauxfactory.gen_alphanumeric()),
-            secret='secret'),
+                              secret='secret'),
         email='abc@example.com',
         groups=cb_group,
         cost_center='Workload',


### PR DESCRIPTION
Replace calls to VM.factory that got merged in while I was working on VMCollections.

Simple replacement of both with a call to `appliance.provider_based_collection()`

{{ pytest: cfme/tests/intelligence/chargeback/test_resource_allocation.py cfme/tests/cli/test_appliance_console_db_restore.py --long-running }}