### PR TITLE
[1LP][RFR] This removes a_provider and replaces with equivalent provider marks

### DIFF
--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -2,7 +2,6 @@
 import fauxfactory
 from widgetastic.utils import partial_match
 
-from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.utils import version
@@ -10,7 +9,6 @@ from cfme.utils.log import logger
 from cfme.utils.rest import create_resource
 from cfme.utils.virtual_machines import deploy_template
 from cfme.utils.wait import wait_for
-from cfme.fixtures.provider import setup_one_by_class_or_skip
 
 from wrapanapi import VmState
 
@@ -197,10 +195,6 @@ def rates(request, rest_api, num=3):
         data.append(req)
 
     return _creating_skeleton(request, rest_api, 'rates', data)
-
-
-def a_provider(request):
-    return setup_one_by_class_or_skip(request, InfraProvider)
 
 
 def vm(request, a_provider, rest_api):

--- a/cfme/tests/configure/test_tag.py
+++ b/cfme/tests/configure/test_tag.py
@@ -2,8 +2,9 @@
 import fauxfactory
 import pytest
 
+from cfme.infrastructure.provider import InfraProvider
+from cfme.markers.env_markers.provider import ONE
 from cfme.rest.gen_data import (
-    a_provider as _a_provider,
     categories as _categories,
     service_templates as _service_templates,
     tags as _tags,
@@ -19,6 +20,10 @@ from cfme.utils.rest import (
 from cfme.utils.update import update
 from cfme.utils.wait import wait_for
 
+pytestmark = [
+    pytest.mark.provider(classes=[InfraProvider], selector=ONE),
+    pytest.mark.usefixtures('setup_provider')
+]
 
 @pytest.fixture
 def category(appliance):
@@ -104,16 +109,12 @@ class TestTagsViaREST(object):
         return _tenants(request, appliance.rest_api, num=1)
 
     @pytest.fixture(scope="module")
-    def a_provider(self, request):
-        return _a_provider(request)
-
-    @pytest.fixture(scope="module")
     def service_templates(self, request, appliance):
         return _service_templates(request, appliance)
 
     @pytest.fixture(scope="module")
-    def vm(self, request, a_provider, appliance):
-        return _vm(request, a_provider, appliance.rest_api)
+    def vm(self, request, provider, appliance):
+        return _vm(request, provider, appliance.rest_api)
 
     @pytest.mark.tier(2)
     def test_edit_tags_rest(self, appliance, tags):
@@ -209,7 +210,7 @@ class TestTagsViaREST(object):
         "collection_name", ["clusters", "hosts", "data_stores", "providers", "resource_pools",
         "services", "service_templates", "tenants", "vms", "availability_zones", "cloud_networks",
         "cloud_networks", "cloud_subnets", "flavors", "network_routers", "security_groups"])
-    def test_assign_and_unassign_tag(self, appliance, tags_mod, a_provider, services_mod,
+    def test_assign_and_unassign_tag(self, appliance, tags_mod, provider, services_mod,
             service_templates, tenants, vm, collection_name):
         """Tests assigning and unassigning tags.
 

--- a/cfme/tests/infrastructure/test_advanced_search_vms.py
+++ b/cfme/tests/infrastructure/test_advanced_search_vms.py
@@ -8,21 +8,18 @@ import pytest
 from widgetastic.exceptions import NoSuchElementException
 
 from cfme.infrastructure.provider import InfraProvider
+from cfme.markers.env_markers.provider import ONE
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.providers import ProviderFilter
-from cfme.fixtures.provider import setup_one_or_skip
 
-pytestmark = [pytest.mark.tier(3)]
-
-
-@pytest.fixture(scope="module")
-def a_provider(request):
-    pf = ProviderFilter(classes=[InfraProvider], required_fields=['large'])
-    setup_one_or_skip(request, filters=[pf])
+pytestmark = [
+    pytest.mark.tier(3),
+    pytest.mark.provider(classes=[InfraProvider], required_fields=['large'], selector=ONE),
+    pytest.mark.usefixtures('setup_provider')
+]
 
 
 @pytest.fixture(scope="module")
-def vms(appliance, a_provider):
+def vms(appliance, provider):
     """Ensure the infra providers are set up and get list of vms"""
     view = navigate_to(appliance.collections.infra_vms, 'VMsOnly')
     view.entities.search.remove_search_filters()

--- a/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
+++ b/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
@@ -2,27 +2,29 @@ import pytest
 
 from cfme import test_requirements
 from cfme.infrastructure.provider import InfraProvider
-from cfme.fixtures.provider import setup_one_or_skip
+from cfme.markers.env_markers.provider import ONE
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
-from cfme.utils.providers import ProviderFilter
 from cfme.utils.update import update
 
-
-pytestmark = [test_requirements.tag, pytest.mark.tier(2)]
+pytestmark = [
+    test_requirements.tag, pytest.mark.tier(2),
+    pytest.mark.provider(
+        classes=[InfraProvider],
+        required_fields=[
+            'datacenters',
+            'clusters'
+        ],
+        selector=ONE
+    ),
+    pytest.mark.usefixtures('setup_provider')
+]
 
 test_items = [
     ('clusters', None),
     ('infra_vms', 'ProviderVms'),
     ('infra_templates', 'ProviderTemplates')
 ]
-
-
-@pytest.fixture(scope='module')
-def a_provider(request):
-    prov_filter = ProviderFilter(classes=[InfraProvider],
-                                 required_fields=['datacenters', 'clusters'])
-    return setup_one_or_skip(request, filters=[prov_filter])
 
 
 @pytest.fixture(params=test_items, ids=[collection_type for collection_type, _ in test_items],

--- a/cfme/tests/infrastructure/test_rest_automation_request.py
+++ b/cfme/tests/infrastructure/test_rest_automation_request.py
@@ -1,24 +1,22 @@
 import multiprocessing as mp
 
 import pytest
-
 from manageiq_client.api import ManageIQClient as MiqApi
 
 from cfme import test_requirements
-from cfme.rest.gen_data import a_provider as _a_provider
+from cfme.fixtures.pytest_store import store
+from cfme.infrastructure.provider import InfraProvider
+from cfme.markers.env_markers.provider import ONE
 from cfme.rest.gen_data import automation_requests_data as _automation_requests_data
 from cfme.rest.gen_data import vm as _vm
 from cfme.utils.rest import assert_response, query_resource_attributes
 from cfme.utils.wait import wait_for
-from cfme.fixtures.pytest_store import store
 
-
-pytestmark = [test_requirements.rest]
-
-
-@pytest.fixture(scope='module')
-def a_provider(request):
-    return _a_provider(request)
+pytestmark = [
+    test_requirements.rest,
+    pytest.mark.provider(classes=[InfraProvider], selector=ONE),
+    pytest.mark.usefixtures('setup_provider')
+]
 
 
 @pytest.fixture(scope='module')

--- a/cfme/tests/infrastructure/test_rest_templates.py
+++ b/cfme/tests/infrastructure/test_rest_templates.py
@@ -2,7 +2,8 @@
 import pytest
 
 from cfme import test_requirements
-from cfme.rest.gen_data import a_provider as _a_provider
+from cfme.infrastructure.provider import InfraProvider
+from cfme.markers.env_markers.provider import ONE
 from cfme.rest.gen_data import mark_vm_as_template
 from cfme.rest.gen_data import vm as _vm
 from cfme.utils.blockers import BZ
@@ -13,12 +14,11 @@ from cfme.utils.rest import (
     query_resource_attributes,
 )
 
-pytestmark = [test_requirements.rest]
-
-
-@pytest.fixture(scope="module")
-def a_provider(request):
-    return _a_provider(request)
+pytestmark = [
+    test_requirements.rest,
+    pytest.mark.provider(classes=[InfraProvider], selector=ONE),
+    pytest.mark.usefixtures('setup_provider')
+]
 
 
 @pytest.fixture(scope="function")

--- a/cfme/tests/infrastructure/test_vm_ownership.py
+++ b/cfme/tests/infrastructure/test_vm_ownership.py
@@ -1,23 +1,22 @@
 import pytest
+
 from cfme import test_requirements
-from cfme.rest.gen_data import a_provider as _a_provider
+from cfme.infrastructure.provider import InfraProvider
+from cfme.markers.env_markers.provider import ONE
 from cfme.rest.gen_data import vm as _vm
 from cfme.utils.rest import assert_response
 
-
 pytestmark = [
     test_requirements.ownership,
+    pytest.mark.provider(classes=[InfraProvider], selector=ONE),
+    pytest.mark.usefixtures('setup_provider')
 ]
 
 
 class TestVmOwnershipRESTAPI(object):
     @pytest.fixture(scope="module")
-    def a_provider(self, request):
-        return _a_provider(request)
-
-    @pytest.fixture(scope="module")
-    def vm(self, request, a_provider, appliance):
-        return _vm(request, a_provider, appliance.rest_api)
+    def vm(self, request, provider, appliance):
+        return _vm(request, provider, appliance.rest_api)
 
     @pytest.mark.tier(3)
     def test_vm_set_ownership(self, appliance, vm):

--- a/cfme/tests/infrastructure/test_vm_rest.py
+++ b/cfme/tests/infrastructure/test_vm_rest.py
@@ -3,7 +3,8 @@ import fauxfactory
 import pytest
 
 from cfme import test_requirements
-from cfme.rest.gen_data import a_provider as _a_provider
+from cfme.infrastructure.provider import InfraProvider
+from cfme.markers.env_markers.provider import ONE
 from cfme.rest.gen_data import vm as _vm
 from cfme.utils.blockers import BZ
 from cfme.utils.rest import (
@@ -14,18 +15,16 @@ from cfme.utils.rest import (
 )
 from cfme.utils.wait import wait_for, wait_for_decorator
 
-
-pytestmark = [test_requirements.provision]
-
-
-@pytest.fixture(scope='function')
-def a_provider(request):
-    return _a_provider(request)
+pytestmark = [
+    test_requirements.provision,
+    pytest.mark.provider(classes=[InfraProvider], selector=ONE),
+    pytest.mark.usefixtures('setup_provider')
+]
 
 
 @pytest.fixture(scope='function')
-def vm(request, a_provider, appliance):
-    vm_name = _vm(request, a_provider, appliance.rest_api)
+def vm(request, provider, appliance):
+    vm_name = _vm(request, provider, appliance.rest_api)
     return appliance.rest_api.collections.vms.get(name=vm_name)
 
 

--- a/cfme/tests/infrastructure/test_vm_retirement_rest.py
+++ b/cfme/tests/infrastructure/test_vm_retirement_rest.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 import datetime
+
 import pytest
 
 from cfme import test_requirements
-from cfme.rest.gen_data import a_provider as _a_provider
+from cfme.infrastructure.provider import InfraProvider
+from cfme.markers.env_markers.provider import ONE
 from cfme.rest.gen_data import vm as _vm
 from cfme.utils.rest import assert_response
 from cfme.utils.wait import wait_for
 
-
-pytestmark = [test_requirements.retirement]
-
-
-@pytest.fixture(scope="function")
-def a_provider(request):
-    return _a_provider(request)
+pytestmark = [
+    test_requirements.retirement,
+    pytest.mark.provider(classes=[InfraProvider], selector=ONE),
+    pytest.mark.usefixtures('setup_provider')
+]
 
 
 @pytest.fixture(scope="function")

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -6,7 +6,9 @@ import pytest
 from manageiq_client.api import ManageIQClient as MiqApi
 
 from cfme import test_requirements
+from cfme.fixtures.pytest_store import store
 from cfme.infrastructure.provider import InfraProvider
+from cfme.markers.env_markers.provider import ONE
 from cfme.rest.gen_data import (
     TEMPLATE_TORSO,
     _creating_skeleton,
@@ -24,7 +26,6 @@ from cfme.rest.gen_data import (
     vm as _vm,
 )
 from cfme.utils.blockers import BZ
-from cfme.utils.providers import ProviderFilter
 from cfme.utils.rest import (
     assert_response,
     delete_resources_from_collection,
@@ -34,27 +35,26 @@ from cfme.utils.rest import (
 )
 from cfme.utils.update import update
 from cfme.utils.wait import wait_for
-from cfme.fixtures.provider import setup_one_or_skip
-from cfme.fixtures.pytest_store import store
 
 pytestmark = [
     pytest.mark.long_running,
     test_requirements.service,
-    pytest.mark.tier(2)
+    pytest.mark.tier(2),
+    pytest.mark.provider(
+        classes=[InfraProvider],
+        required_fields=[
+            ["provisioning", "template"],
+            ["provisioning", "host"],
+            ["provisioning", "datastore"],
+            ["provisioning", "vlan"],
+        ],
+        selector=ONE,
+    ),
+    pytest.mark.usefixtures('setup_provider')
 ]
 
 
 NUM_BUNDLE_ITEMS = 4
-
-
-@pytest.fixture(scope="module")
-def a_provider(request):
-    pf = ProviderFilter(classes=[InfraProvider], required_fields=[
-        ['provisioning', 'template'],
-        ['provisioning', 'host'],
-        ['provisioning', 'datastore'],
-        ['provisioning', 'vlan']])
-    return setup_one_or_skip(request, filters=[pf])
 
 
 def wait_for_vm_power_state(vm, resulting_state):


### PR DESCRIPTION
* The a_provider has always been problematic. The order of the providers
  in the yamls is non-determinable. The provider filter used in most of
  these cases also doesn't take into account the test flags. The problem
  manifests that a provider can be used for a test when it really should
  not.
* The change eliminates the a_provider fixture and moves towards using
  the provider marker instead. This is function scoped, but has
  protection against double setup. It also supports all the necessary
  field flags and can run with selector=ONE meaning we only get one
  provider test collected, but that the provider is known at collection
  time. This will mean that there are less provider add/remove
  operations on an appliance due to the "limit". It will also allow for
  a slight speed increase in test running in some instances because the
  first test will be sent to the correct slave that has that provider.