### PR TITLE
[1LP][RFR] Fix instance create in test_tenant_quota

### DIFF
--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -323,7 +323,7 @@ class InstanceCollection(VMCollection):
             Calling create on a sub-class of instance will generate the properly formatted
             dictionary when the correct fields are supplied.
         """
-        instance = self.instantiate(vm_name, provider)
+        instance = self.instantiate(vm_name, provider, form_values.get('template_name'))
         form_values.update({'provider_name': provider.name})
         view = navigate_to(self, 'Provision')
 

--- a/cfme/tests/cloud/test_tenant_quota.py
+++ b/cfme/tests/cloud/test_tenant_quota.py
@@ -94,8 +94,8 @@ def test_tenant_quota_enforce_via_lifecycle_cloud(request, appliance, provider, 
     prov_data['catalog']['vm_name'] = vm_name
     prov_data.update({
         'request': {'email': 'test_{}@example.com'.format(fauxfactory.gen_alphanumeric())}})
-    instance = appliance.collections.cloud_instances.instantiate(vm_name, provider, template_name)
-    instance.create(**prov_data)
+    prov_data.update({'template_name': template_name})
+    appliance.collections.cloud_instances.create(vm_name, provider, prov_data)
 
     # nav to requests page to check quota validation
     request_description = 'Provision from [{}] to [{}{}]'.format(template_name, vm_name, extra_msg)


### PR DESCRIPTION
Add template_name arg to instantiate call within create, pulling from form_values

{{ pytest: cfme/tests/cloud/test_tenant_quota.py --long-running -v  --use-provider complete }}