### PR TITLE
[1LP][RFR] Remove mgmt method from CMQE object classes

### DIFF
--- a/cfme/containers/image.py
+++ b/cfme/containers/image.py
@@ -3,7 +3,6 @@ import attr
 from cached_property import cached_property
 
 from navmazing import NavigateToSibling, NavigateToAttribute
-from wrapanapi.containers.image import Image as ApiImage
 
 from cfme.common import (Taggable, PolicyProfileAssignable,
                          TagPageView)
@@ -49,10 +48,6 @@ class Image(BaseEntity, Taggable, Labelable, LoadDetailsMixin, PolicyProfileAssi
     name = attr.ib()
     id = attr.ib()
     provider = attr.ib()
-
-    @cached_property
-    def mgmt(self):
-        return ApiImage(self.provider.mgmt, self.name, self.sha256)
 
     @cached_property
     def sha256(self):

--- a/cfme/containers/image_registry.py
+++ b/cfme/containers/image_registry.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 import attr
-from cached_property import cached_property
 
 from navmazing import NavigateToSibling, NavigateToAttribute
 from widgetastic.utils import VersionPick, Version
-from wrapanapi.containers.image_registry import ImageRegistry as ApiImageRegistry
 
 from cfme.common import Taggable, TagPageView
 from cfme.containers.provider import (ContainerObjectAllBaseView,
@@ -41,10 +39,6 @@ class ImageRegistry(BaseEntity, Taggable, Navigatable):
 
     host = attr.ib()
     provider = attr.ib()
-
-    @cached_property
-    def mgmt(self):
-        return ApiImageRegistry(self.provider.mgmt, self.name, self.host, None)
 
     @property
     def name(self):

--- a/cfme/containers/node.py
+++ b/cfme/containers/node.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 # added new list_tbl definition
 import attr
-from cached_property import cached_property
-
-from wrapanapi.containers.node import Node as ApiNode
 
 from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.exceptions import NoSuchElementException
@@ -74,11 +71,6 @@ class Node(BaseEntity, Taggable, Labelable, PolicyProfileAssignable, ConsoleMixi
 
     name = attr.ib()
     provider = attr.ib()
-
-    @cached_property
-    def mgmt(self):
-        """API to use for Nodes"""
-        return ApiNode(self.provider.mgmt, self.name)
 
     @property
     def exists(self):

--- a/cfme/containers/pod.py
+++ b/cfme/containers/pod.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 import attr
-from cached_property import cached_property
 
 from navmazing import NavigateToAttribute, NavigateToSibling
-from wrapanapi.containers.pod import Pod as ApiPod
 from widgetastic_manageiq import NestedSummaryTable, SummaryTable
 from widgetastic.utils import VersionPick, Version
 from widgetastic.widget import View
@@ -50,10 +48,6 @@ class Pod(BaseEntity, Taggable, Labelable):
     name = attr.ib()
     project_name = attr.ib()
     provider = attr.ib()
-
-    @cached_property
-    def mgmt(self):
-        return ApiPod(self.provider.mgmt, self.name, self.project_name)
 
 
 @attr.s

--- a/cfme/containers/project.py
+++ b/cfme/containers/project.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 import attr
-from cached_property import cached_property
 
 from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.utils import VersionPick, Version
-from wrapanapi.containers.project import Project as ApiProject
 
 
 from cfme.common import Taggable, TagPageView
@@ -45,10 +43,6 @@ class Project(BaseEntity, Taggable, Labelable):
 
     name = attr.ib()
     provider = attr.ib()
-
-    @cached_property
-    def mgmt(self):
-        return ApiProject(self.provider.mgmt, self.name)
 
 
 @attr.s

--- a/cfme/containers/replicator.py
+++ b/cfme/containers/replicator.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 import attr
-from cached_property import cached_property
 
 from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.utils import VersionPick, Version
-from wrapanapi.containers.replicator import Replicator as ApiReplicator
 
 from cfme.common import Taggable, TagPageView
 from cfme.containers.provider import (Labelable, ContainerObjectAllBaseView,
@@ -40,10 +38,6 @@ class Replicator(BaseEntity, Taggable, Labelable):
     name = attr.ib()
     project_name = attr.ib()
     provider = attr.ib()
-
-    @cached_property
-    def mgmt(self):
-        return ApiReplicator(self.provider.mgmt, self.name, self.project_name)
 
 
 @attr.s

--- a/cfme/containers/route.py
+++ b/cfme/containers/route.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 import attr
-from cached_property import cached_property
 
 from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.utils import VersionPick, Version
-from wrapanapi.containers.route import Route as ApiRoute
 
 from cfme.common import Taggable, TagPageView
 from cfme.containers.provider import (Labelable, ContainerObjectAllBaseView,
@@ -40,10 +38,6 @@ class Route(BaseEntity, Taggable, Labelable):
     name = attr.ib()
     project_name = attr.ib()
     provider = attr.ib()
-
-    @cached_property
-    def mgmt(self):
-        return ApiRoute(self.provider.mgmt, self.name, self.project_name)
 
 
 @attr.s

--- a/cfme/containers/service.py
+++ b/cfme/containers/service.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 import attr
-from cached_property import cached_property
 
 from navmazing import NavigateToAttribute, NavigateToSibling
-
-from wrapanapi.containers.service import Service as ApiService
 
 from cfme.common import Taggable, TagPageView
 from cfme.containers.provider import (Labelable, ContainerObjectAllBaseView,
@@ -34,10 +31,6 @@ class Service(BaseEntity, Taggable, Labelable):
     name = attr.ib()
     project_name = attr.ib()
     provider = attr.ib()
-
-    @cached_property
-    def mgmt(self):
-        return ApiService(self.provider.mgmt, self.name, self.project_name)
 
 
 @attr.s

--- a/cfme/containers/template.py
+++ b/cfme/containers/template.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 import attr
-from cached_property import cached_property
 
 from navmazing import NavigateToAttribute, NavigateToSibling
-from wrapanapi.containers.template import Template as ApiTemplate
 
 from cfme.common import Taggable, TagPageView
 from cfme.containers.provider import (Labelable, ContainerObjectAllBaseView,
@@ -33,10 +31,6 @@ class Template(BaseEntity, Taggable, Labelable):
     name = attr.ib()
     project_name = attr.ib()
     provider = attr.ib()
-
-    @cached_property
-    def mgmt(self):
-        return ApiTemplate(self.provider.mgmt, self.name, self.project_name)
 
 
 @attr.s

--- a/cfme/containers/volume.py
+++ b/cfme/containers/volume.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 import attr
-from cached_property import cached_property
 
 from navmazing import NavigateToSibling, NavigateToAttribute
-from wrapanapi.containers.volume import Volume as ApiVolume
 
 from cfme.common import Taggable, TagPageView
 from cfme.containers.provider import (Labelable, ContainerObjectAllBaseView,
@@ -33,10 +31,6 @@ class Volume(BaseEntity, Taggable, Labelable):
 
     name = attr.ib()
     provider = attr.ib()
-
-    @cached_property
-    def mgmt(self):
-        return ApiVolume(self.provider.mgmt, self.name)
 
 
 @attr.s


### PR DESCRIPTION
With the updates coming in https://github.com/ManageIQ/wrapanapi/pull/255/files, there is no need to have a separate method to access the mgmt interface. It should be access using `provider.mgmt`.

The mgmt method was not used in any of the cmqe tests

{{ pytest: cfme/tests/containers/test_alerts.py cfme/tests/containers/test_node.py cfme/tests/containers/test_start_page.py --use-provider ocp-36-hawk }}