### PR TITLE
[1LP][RFR] SystemImage and ISO datastore changes

### DIFF
--- a/cfme/infrastructure/pxe.py
+++ b/cfme/infrastructure/pxe.py
@@ -678,21 +678,33 @@ class PXESystemImageTypeEditView(PXESystemImageTypeForm):
     cancel = Button('Cancel')
 
 
-class SystemImage(Updateable, Navigatable):
+@attr.s
+class SystemImage(Updateable, BaseEntity):
+    """Model of an ISO System Image in CFME.
 
-    def __init__(self, name=None, image_type=None, datastore=None, appliance=None):
-        Navigatable.__init__(self, appliance=appliance)
-        self.name = name
-        self.image_type = image_type
-        self.datastore = datastore
+    Args:
+        name: The name of the System Image. It's the same as ISO filename in ISO domain
+        image_type: SystemImageType object
+        datastore: ISODatastore object
+    """
+    name = attr.ib(default=None)
+    image_type = attr.ib(default=None)
+    datastore = attr.ib(default=None)
 
     def set_image_type(self):
+        """Changes the Type field in Basic Information table for System Image in UI."""
         view = navigate_to(self, 'Edit')
-        changed = view.image_type.fill_with(self.image_type)
+        changed = view.image_type.fill_with(self.image_type.name)
         if changed:
             view.save.click()
         else:
             view.cancel.click()
+
+
+@attr.s
+class SystemImageCollection(BaseCollection):
+
+    ENTITY = SystemImage
 
 
 class PXESystemImageDeatilsView(PXEMainView):
@@ -702,7 +714,7 @@ class PXESystemImageDeatilsView(PXEMainView):
         return self.sidebar.datastores.tree.read()[-1] == self.context['object'].name
 
     @View.nested
-    class entities(View):  # noqa
+    class entities(View):
         basic_information = SummaryTable(title="Basic Information")
 
 

--- a/cfme/infrastructure/pxe.py
+++ b/cfme/infrastructure/pxe.py
@@ -714,7 +714,7 @@ class PXESystemImageDeatilsView(PXEMainView):
         return self.sidebar.datastores.tree.read()[-1] == self.context['object'].name
 
     @View.nested
-    class entities(View):
+    class entities(View):  # noqa
         basic_information = SummaryTable(title="Basic Information")
 
 

--- a/cfme/infrastructure/pxe.py
+++ b/cfme/infrastructure/pxe.py
@@ -678,6 +678,68 @@ class PXESystemImageTypeEditView(PXESystemImageTypeForm):
     cancel = Button('Cancel')
 
 
+class SystemImage(Updateable, Navigatable):
+
+    def __init__(self, name=None, image_type=None, datastore=None, appliance=None):
+        Navigatable.__init__(self, appliance=appliance)
+        self.name = name
+        self.image_type = image_type
+        self.datastore = datastore
+
+    def set_image_type(self):
+        view = navigate_to(self, 'Edit')
+        changed = view.image_type.fill_with(self.image_type)
+        if changed:
+            view.save.click()
+        else:
+            view.cancel.click()
+
+
+class PXESystemImageDeatilsView(PXEMainView):
+
+    @property
+    def is_displayed(self):
+        return self.sidebar.datastores.tree.read()[-1] == self.context['object'].name
+
+    @View.nested
+    class entities(View):  # noqa
+        basic_information = SummaryTable(title="Basic Information")
+
+
+class PXESystemImageEditView(PXEMainView):
+
+    @property
+    def is_displayed(self):
+        return False
+
+    image_type = BootstrapSelect(id='image_typ')
+    save = Button('Save')
+    reset = Button('Reset')
+    cancel = Button('Cancel')
+
+
+@navigator.register(SystemImage, 'Details')
+class SystemImageDetails(CFMENavigateStep):
+    VIEW = PXESystemImageDeatilsView
+    prerequisite = NavigateToSibling('PXEMainPage')
+
+    def step(self):
+        self.view.sidebar.datastores.tree.click_path(
+            'All ISO Datastores',
+            self.view.context['object'].datastore.provider,
+            'ISO Images',
+            self.view.context['object'].name)
+
+
+@navigator.register(SystemImage, 'Edit')
+class SystemImageEdit(CFMENavigateStep):
+    VIEW = PXESystemImageEditView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        self.view.toolbar.configuration.item_select('Edit this ISO Image')
+
+
 @attr.s
 class SystemImageType(Updateable, Pretty, BaseEntity):
     """Model of a System Image Type in CFME.
@@ -999,6 +1061,7 @@ class ISODatastoreDetails(CFMENavigateStep):
         self.view.sidebar.datastores.tree.click_path("All ISO Datastores", self.obj.provider)
 
 
+@navigator.register(SystemImage, 'PXEMainPage')
 @navigator.register(PXEServer, 'PXEMainPage')
 @navigator.register(CustomizationTemplateCollection, 'PXEMainPage')
 @navigator.register(SystemImageTypeCollection, 'PXEMainPage')

--- a/cfme/tests/infrastructure/test_iso_datastore.py
+++ b/cfme/tests/infrastructure/test_iso_datastore.py
@@ -7,7 +7,7 @@ from cfme.infrastructure.provider import InfraProvider
 pytestmark = [
     pytest.mark.usefixtures('uses_infra_providers'),
     pytest.mark.tier(2),
-    pytest.mark.provider([InfraProvider], required_fields=['iso_datastore']),
+    pytest.mark.provider([InfraProvider], required_fields=[('iso_datastore', True)]),
 ]
 
 
@@ -19,7 +19,6 @@ def no_iso_dss(provider):
 
 
 @pytest.mark.rhv1
-@pytest.mark.meta(blockers=[1200783])
 def test_iso_datastore_crud(setup_provider, no_iso_dss, provider):
     """
     Basic CRUD test for ISO datastores.

--- a/cfme/tests/infrastructure/test_iso_provisioning.py
+++ b/cfme/tests/infrastructure/test_iso_provisioning.py
@@ -6,7 +6,7 @@ from widgetastic.utils import partial_match
 
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
-from cfme.infrastructure.pxe import get_template_from_config, ISODatastore, SystemImage
+from cfme.infrastructure.pxe import get_template_from_config, ISODatastore
 from cfme.provisioning import do_vm_provisioning
 from cfme.utils import testgen
 from cfme.utils.blockers import BZ

--- a/cfme/tests/infrastructure/test_iso_provisioning.py
+++ b/cfme/tests/infrastructure/test_iso_provisioning.py
@@ -9,7 +9,7 @@ from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.pxe import get_template_from_config, ISODatastore, SystemImage
 from cfme.provisioning import do_vm_provisioning
 from cfme.utils import testgen
-from cfme.utils.blockers import GH
+from cfme.utils.blockers import BZ
 from cfme.utils.conf import cfme_data
 
 pytestmark = [
@@ -78,8 +78,8 @@ def vm_name():
 
 @pytest.mark.rhv1
 @pytest.mark.tier(2)
-# @pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:6692',
-#                                unblock=lambda provider: not provider.one_of(RHEVMProvider))])
+@pytest.mark.meta(blockers=[BZ(1584675, forced_streams=['5.8', '5.9'],
+                               unblock=lambda provider: not provider.one_of(RHEVMProvider))])
 def test_iso_provision_from_template(appliance, provider, vm_name, datastore_init,
                                      request, smtp_test):
     """Tests ISO provisioning

--- a/cfme/tests/infrastructure/test_iso_provisioning.py
+++ b/cfme/tests/infrastructure/test_iso_provisioning.py
@@ -2,6 +2,8 @@
 import fauxfactory
 import pytest
 
+from widgetastic.utils import partial_match
+
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.pxe import get_template_from_config, ISODatastore, SystemImage
@@ -79,7 +81,7 @@ def vm_name():
 # @pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:6692',
 #                                unblock=lambda provider: not provider.one_of(RHEVMProvider))])
 def test_iso_provision_from_template(appliance, provider, vm_name, datastore_init,
-                                     request, setup_provider):
+                                     request, setup_provider, smtp_test):
     """Tests ISO provisioning
 
     Metadata:
@@ -109,6 +111,6 @@ def test_iso_provision_from_template(appliance, provider, vm_name, datastore_ini
             'custom_template': {'name': iso_kickstart},
             'root_password': iso_root_password},
         'network': {
-            'vlan': vlan}}
+            'vlan': partial_match(vlan)}}
     do_vm_provisioning(appliance, iso_template, provider, vm_name, provisioning_data, request,
                        smtp_test, num_sec=1500)

--- a/cfme/tests/infrastructure/test_iso_provisioning.py
+++ b/cfme/tests/infrastructure/test_iso_provisioning.py
@@ -4,7 +4,7 @@ import pytest
 
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
-from cfme.infrastructure.pxe import get_template_from_config, ISODatastore
+from cfme.infrastructure.pxe import get_template_from_config, ISODatastore, SystemImage
 from cfme.provisioning import do_vm_provisioning
 from cfme.utils import testgen
 from cfme.utils.blockers import GH
@@ -52,7 +52,7 @@ def pytest_generate_tests(metafunc):
 @pytest.fixture(scope="module")
 def iso_cust_template(provider, appliance):
     iso_cust_template = provider.data['provisioning']['iso_kickstart']
-    return get_template_from_config(iso_cust_template, appliance=appliance)
+    return get_template_from_config(iso_cust_template, create=True, appliance=appliance)
 
 
 @pytest.fixture(scope="module")
@@ -64,10 +64,8 @@ def iso_datastore(provider, appliance):
 def datastore_init(iso_cust_template, iso_datastore, provisioning):
     if not iso_datastore.exists():
         iso_datastore.create()
-    # Fails on upstream, BZ1109256
-    iso_datastore.set_iso_image_type(provisioning['iso_file'], provisioning['iso_image_type'])
-    if not iso_cust_template.exists():
-        iso_cust_template.create()
+    iso_image = SystemImage(provisioning['iso_file'], provisioning['iso_image_type'], iso_datastore)
+    iso_image.set_image_type()
 
 
 @pytest.fixture(scope="function")
@@ -78,9 +76,9 @@ def vm_name():
 
 @pytest.mark.rhv1
 @pytest.mark.tier(2)
-@pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:6692',
-                               unblock=lambda provider: not provider.one_of(RHEVMProvider))])
-def test_iso_provision_from_template(appliance, provider, vm_name, smtp_test, datastore_init,
+# @pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:6692',
+#                                unblock=lambda provider: not provider.one_of(RHEVMProvider))])
+def test_iso_provision_from_template(appliance, provider, vm_name, datastore_init,
                                      request, setup_provider):
     """Tests ISO provisioning
 
@@ -112,6 +110,5 @@ def test_iso_provision_from_template(appliance, provider, vm_name, smtp_test, da
             'root_password': iso_root_password},
         'network': {
             'vlan': vlan}}
-
     do_vm_provisioning(appliance, iso_template, provider, vm_name, provisioning_data, request,
                        smtp_test, num_sec=1500)

--- a/cfme/tests/infrastructure/test_iso_provisioning.py
+++ b/cfme/tests/infrastructure/test_iso_provisioning.py
@@ -63,10 +63,13 @@ def iso_datastore(provider, appliance):
 
 
 @pytest.fixture
-def datastore_init(iso_cust_template, iso_datastore, provisioning, setup_provider):
+def datastore_init(iso_cust_template, iso_datastore, provisioning, setup_provider, appliance):
     if not iso_datastore.exists():
         iso_datastore.create()
-    iso_image = SystemImage(provisioning['iso_file'], provisioning['iso_image_type'], iso_datastore)
+    iso_image_type = appliance.collections.system_image_types.instantiate(
+        name=provisioning['iso_image_type'])
+    iso_image = appliance.collections.system_images.instantiate(
+        name=provisioning['iso_file'], image_type=iso_image_type, datastore=iso_datastore)
     iso_image.set_image_type()
 
 

--- a/cfme/tests/infrastructure/test_iso_provisioning.py
+++ b/cfme/tests/infrastructure/test_iso_provisioning.py
@@ -63,7 +63,7 @@ def iso_datastore(provider, appliance):
 
 
 @pytest.fixture
-def datastore_init(iso_cust_template, iso_datastore, provisioning):
+def datastore_init(iso_cust_template, iso_datastore, provisioning, setup_provider):
     if not iso_datastore.exists():
         iso_datastore.create()
     iso_image = SystemImage(provisioning['iso_file'], provisioning['iso_image_type'], iso_datastore)
@@ -81,7 +81,7 @@ def vm_name():
 # @pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:6692',
 #                                unblock=lambda provider: not provider.one_of(RHEVMProvider))])
 def test_iso_provision_from_template(appliance, provider, vm_name, datastore_init,
-                                     request, setup_provider, smtp_test):
+                                     request, smtp_test):
     """Tests ISO provisioning
 
     Metadata:

--- a/entry_points.txt
+++ b/entry_points.txt
@@ -97,6 +97,7 @@ security_groups = cfme.cloud.security_groups:SecurityGroupCollection
 servers = cfme.base:ServerCollection
 service_dialogs = cfme.automate.dialog_collection_pick:collection_pick
 system_image_types = cfme.infrastructure.pxe:SystemImageTypeCollection
+system_images = cfme.infrastructure.pxe:SystemImageCollection
 system_schedules = cfme.configure.configuration.system_schedules:SystemSchedulesCollection
 tags = cfme.configure.configuration.region_settings:TagsCollection
 tasks = cfme.configure.tasks:TasksCollection


### PR DESCRIPTION
So, this PR does many things, let's look at them:

- Providing __new model__ of ISO SystemImage that can be found in ISO datastore. I mean this:
![image](https://user-images.githubusercontent.com/22600243/40837801-fa40bdf8-659b-11e8-999d-72b5e82615d4.png)
I did this because I want to be able to change `Type` of such ISO image. It might seem like an overkill. I also thought so. But then I realize I cannot really use existing models/views/navigation steps for this purpose without too much hacking. The approach that was used originally (`iso_datastore.set_iso_image_type`) simply was not working, because it was using wrong view (`ISODatastoreAll`). I believe this proposed approach is more in line with the overall philosophy of the framework and is extensible if the need arises. And it will (at least for me) in the near future.

- `test_iso_datastore_crud` now runs not only if provider definition contains `iso_datastore` key, it must also be set to `True`. This makes much more sense. Up to this point, it was executed whet a provider had `iso_datastore: False`, which I am sure was not the intention.

- `setup_provider` was used as a fixture for `test_iso_provision_from_template`. I moved it to be a fixture of `datastore_init` fixture. At that point, we already have to have provider, otherwise this fixture fails.

I hope there's no big issue with this. The reality is that `test_iso_provision_from_template` is not being executed at all at the moment. I want to get it to working state at least for RHV-CFME integration project and these are some of the prerequisities I need.

{{pytest: cfme/tests/infrastructure/test_iso_datastore.py::test_iso_datastore_crud -vv}}