### PR TITLE
[1LP][RFR] fix summery download test for N/W

### DIFF
--- a/cfme/tests/networks/test_sdn_downloads.py
+++ b/cfme/tests/networks/test_sdn_downloads.py
@@ -1,10 +1,10 @@
 import pytest
+import random
 
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.cloud.provider.openstack import OpenStackProvider
-from cfme.exceptions import ManyEntitiesFound
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.version import LATEST
@@ -57,10 +57,9 @@ def test_download_lists_base(filetype, collection_type, appliance):
 def test_download_pdf_summary(appliance, collection_type, provider):
     """ Download the summary details of specific object """
     collection = getattr(appliance.collections, collection_type)
-    if collection.all():
-        random_obj = collection.all()[0].name
-        try:
-            obj = collection.instantiate(name=random_obj)
-            download_summary(obj)
-        except ManyEntitiesFound:
-            pass
+    all_entities = collection.all()
+    if all_entities:
+        random_obj = random.choice(all_entities)
+        download_summary(random_obj)
+    else:
+        pytest.skip('{} entities not available'.format(collection_type))


### PR DESCRIPTION
Purpose or Intent
=================
- No need of `instantiate` as `all()` method returning `list` of `instantiate` objects

{{pytest: cfme/tests/networks/test_sdn_downloads.py -k test_download_pdf_summary --use-provider complete}}