### PR TITLE
[1LP][RFR] Initial setup for v2v

### DIFF
--- a/cfme/fixtures/v2v.py
+++ b/cfme/fixtures/v2v.py
@@ -1,0 +1,45 @@
+import pytest
+
+from cfme.fixtures.provider import setup_or_skip
+from cfme.utils.hosts import setup_host_creds
+
+
+@pytest.fixture(scope="function")
+def migration_ui(appliance):
+    """Fixture to enable migration UI"""
+    appliance.enable_migration_ui()
+    yield
+    appliance.disable_migration_ui()
+
+
+@pytest.fixture(scope='function')
+def provider_setup(migration_ui, request, second_provider, provider):
+    """Fixture to setup nvc and rhv provider"""
+    setup_or_skip(request, second_provider)
+    setup_or_skip(request, provider)
+    yield second_provider, provider
+    second_provider.delete_if_exists(cancel=False)
+    provider.delete_if_exists(cancel=False)
+
+
+@pytest.fixture(scope='function')
+def host_creds(provider_setup):
+    """Add credentials to conversation host"""
+    host = provider_setup[0].hosts[0]
+    setup_host_creds(provider_setup[0], host.name)
+    yield host
+    setup_host_creds(provider_setup[0], host.name, remove_creds=True)
+
+
+@pytest.fixture(scope='function')
+def conversion_tags(appliance, host_creds):
+    """Assigning tags to conversation host"""
+    tag1 = appliance.collections.categories.instantiate(
+        display_name='V2V - Transformation Host *').collections.tags.instantiate(
+        display_name='t')
+    tag2 = appliance.collections.categories.instantiate(
+        display_name='V2V - Transformation Method').collections.tags.instantiate(
+        display_name='VDDK')
+    host_creds.add_tags(tags=(tag1, tag2))
+    yield
+    host_creds.remove_tags(tags=(tag1, tag2))

--- a/cfme/test_framework/pytest_plugin.py
+++ b/cfme/test_framework/pytest_plugin.py
@@ -103,6 +103,7 @@ pytest_plugins = (
     'cfme.fixtures.tccheck',
     'cfme.fixtures.pxe',
     'cfme.fixtures.candu',
+    'cfme.fixtures.v2v',
 
     'cfme.metaplugins',
 )

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2495,10 +2495,12 @@ class IPAppliance(object):
         self.wait_for_web_ui()
 
     def enable_migration_ui(self):
-        self._switch_migration_ui(True)
+        if not self.advanced_settings['product']['transformation']:
+            self._switch_migration_ui(True)
 
     def disable_migration_ui(self):
-        self. _switch_migration_ui(False)
+        if self.advanced_settings['product']['transformation']:
+            self. _switch_migration_ui(False)
 
 
 class Appliance(IPAppliance):


### PR DESCRIPTION
Currently executing via,
```pytest test_v2v.py --use-provider complete --provider-limit 2 --use-template-cache```

Tasks done:
	1. Added mutli-provider usage
	2. Removed pytest_generate_tests from tests
        3. Moved common fixtures to v2v.py

Steps:
        1.Add rhvm and nvc providers and return provider objects
        2.Validate host credentials
        3.Assign tags to conversation host
        ~~4.Import automate domain via github repo~~


{{pytest: cfme/tests/v2v/test_v2v.py --use-template-cache --use-provider rhv42 --use-provider vsphere6-nested --provider-limit 2 -vvvv}}


