### PR TITLE
[1LP][RFR] fix for SSUI tests failing on page_has_changes js 

### DIFF
--- a/cfme/utils/appliance/implementations/ui.py
+++ b/cfme/utils/appliance/implementations/ui.py
@@ -117,21 +117,26 @@ class MiqBrowserPlugin(DefaultPlugin):
         js_code = """
                     function PageHasChanges()
                     {
-                        if(ManageIQ.angular.scope)
-                        {
-                           if(angular.isDefined(ManageIQ.angular.scope.angularForm)
-                           &&ManageIQ.angular.scope.angularForm.$dirty
-                           &&!miqDomElementExists("ignore_form_changes"))
-                              return true
+                        try {
+                            if(ManageIQ.angular.scope)
+                            {
+                               if(angular.isDefined(ManageIQ.angular.scope.angularForm)
+                               &&ManageIQ.angular.scope.angularForm.$dirty
+                               &&!miqDomElementExists("ignore_form_changes"))
+                                  return true
+                            }
+                            else
+                            {
+                               if((miqDomElementExists("buttons_on")&&
+                               $("#buttons_on").is(":visible")||null!==ManageIQ.changes)
+                               &&!miqDomElementExists("ignore_form_changes"))
+                                  return true
+                            }
+                            return false
+                        } catch(err) {
+                            // ssui pages don't have ManageIQ
+                            return false
                         }
-                        else
-                        {
-                           if((miqDomElementExists("buttons_on")&&
-                           $("#buttons_on").is(":visible")||null!==ManageIQ.changes)
-                           &&!miqDomElementExists("ignore_form_changes"))
-                              return true
-                        }
-                        return false
                     };
                     return PageHasChanges();
                   """


### PR DESCRIPTION
it turned out that ManageIQ isn't present in SSUI. So, page_has_changes should probably return false in such case.

{{pytest: --long-running cfme/tests/ssui/test_ssui_dashboard.py}}