### PR TITLE
[1LP][RFR] Add retries to certificate copy while copy fails network issue occurs

### DIFF
--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -1,7 +1,7 @@
 import attr
 from cached_property import cached_property
 from os import path
-
+from six.moves.urllib.error import URLError
 from wrapanapi.systems.container import Openshift
 
 from cfme.common.provider import DefaultEndpoint
@@ -14,7 +14,6 @@ from cfme.utils.varmeth import variable
 from cfme.utils.wait import wait_for, TimedOutError
 from . import ContainersProvider, ContainersProviderDefaultEndpoint, ContainersProviderEndpointsForm
 
-from six.moves.urllib.error import URLError
 
 class CustomAttribute(object):
     def __init__(self, name, value, field_type=None, href=None):

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -13,7 +13,6 @@ from cfme.utils.ocp_cli import OcpCli
 from cfme.utils.varmeth import variable
 from cfme.utils.wait import wait_for, TimedOutError
 from . import ContainersProvider, ContainersProviderDefaultEndpoint, ContainersProviderEndpointsForm
-from urllib2 import URLError
 
 
 class CustomAttribute(object):

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -14,6 +14,7 @@ from cfme.utils.varmeth import variable
 from cfme.utils.wait import wait_for, TimedOutError
 from . import ContainersProvider, ContainersProviderDefaultEndpoint, ContainersProviderEndpointsForm
 
+from six.moves.urllib.error import URLError
 
 class CustomAttribute(object):
     def __init__(self, name, value, field_type=None, href=None):
@@ -336,7 +337,7 @@ class OpenshiftProvider(ContainersProvider):
                 appliance_ssh.put_file("/tmp/ca.crt",
                                        "/etc/pki/ca-trust/source/anchors/{crt}".format(
                                            crt=cert_name))
-            except Exception:
+            except URLError:
                 logger.debug("Fail to deploy certificate from Openshift to CFME")
                 is_succeed = False
             finally:

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -328,7 +328,7 @@ class OpenshiftProvider(ContainersProvider):
              None
         """
 
-        def copy_certificate():
+        def _copy_certificate():
             is_succeed = True
             try:
                 # Copy certificate to the appliance
@@ -361,7 +361,7 @@ class OpenshiftProvider(ContainersProvider):
         if stdout.readline().replace('\n', "") != "0":
             cert_name = "{provider_name}.ca.crt".format(
                 provider_name=self.provider_data.hostname.split(".")[0])
-            wait_for(copy_certificate, num_sec=600, delay=30,
+            wait_for(_copy_certificate, num_sec=600, delay=30,
                      message="Copy certificate from OCP to CFME")
             appliance_ssh.exec_command("update-ca-trust")
 

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -337,8 +337,8 @@ class OpenshiftProvider(ContainersProvider):
                 appliance_ssh.put_file("/tmp/ca.crt",
                                        "/etc/pki/ca-trust/source/anchors/{crt}".format(
                                            crt=cert_name))
-            except URLError:
-                logger.debug("Fail to copy certificate from Openshift to CFME")
+            except Exception:
+                logger.debug("Fail to deploy certificate from Openshift to CFME")
                 is_succeed = False
             finally:
                 return is_succeed

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -13,6 +13,7 @@ from cfme.utils.ocp_cli import OcpCli
 from cfme.utils.varmeth import variable
 from cfme.utils.wait import wait_for, TimedOutError
 from . import ContainersProvider, ContainersProviderDefaultEndpoint, ContainersProviderEndpointsForm
+from urllib2 import URLError
 
 
 class CustomAttribute(object):
@@ -328,6 +329,20 @@ class OpenshiftProvider(ContainersProvider):
              None
         """
 
+        def copy_certificate():
+            is_succeed = True
+            try:
+                # Copy certificate to the appliance
+                provider_ssh.get_file("/etc/origin/master/ca.crt", "/tmp/ca.crt")
+                appliance_ssh.put_file("/tmp/ca.crt",
+                                       "/etc/pki/ca-trust/source/anchors/{crt}".format(
+                                           crt=cert_name))
+            except URLError:
+                logger.debug("Fail to copy certificate from Openshift to CFME")
+                is_succeed = False
+            finally:
+                return is_succeed
+
         provider_ssh = self.cli.ssh_client
         appliance_ssh = self.appliance.ssh_client()
 
@@ -347,12 +362,8 @@ class OpenshiftProvider(ContainersProvider):
         if stdout.readline().replace('\n', "") != "0":
             cert_name = "{provider_name}.ca.crt".format(
                 provider_name=self.provider_data.hostname.split(".")[0])
-
-            # Copy certificate to the appliance
-            provider_ssh.get_file("/etc/origin/master/ca.crt", "/tmp/ca.crt")
-            appliance_ssh.put_file("/tmp/ca.crt",
-                                   "/etc/pki/ca-trust/source/anchors/{crt}".format(crt=cert_name))
-
+            wait_for(copy_certificate, num_sec=600, delay=30,
+                     message="Copy certificate from OCP to CFME")
             appliance_ssh.exec_command("update-ca-trust")
 
             # restarting evemserverd to apply the new SSL certificate

--- a/cfme/tests/containers/test_ssl_providers.py
+++ b/cfme/tests/containers/test_ssl_providers.py
@@ -52,12 +52,6 @@ def sync_ssl_certificate(provider):
     provider.sync_ssl_certificate()
 
 
-@pytest.fixture(scope="module")
-def ensure_metrics_endpoint(provider):
-    if "metrics" not in provider.endpoints:
-        pytest.skip("No metrics endpoint exist on this provider")
-
-
 @pytest.mark.polarion('CMP-9836')
 @pytest.mark.usefixtures('has_no_containers_providers')
 def test_add_provider_naming_conventions(provider, appliance, soft_assert, sync_ssl_certificate):

--- a/cfme/tests/containers/test_ssl_providers.py
+++ b/cfme/tests/containers/test_ssl_providers.py
@@ -116,7 +116,7 @@ def test_add_provider_ssl(provider, default_sec_protocol, soft_assert, sync_ssl_
         ti.args[1].default_sec_protocol, ti.args[1].metrics_sec_protocol)
     for ti in TEST_ITEMS])
 @pytest.mark.usefixtures('has_no_containers_providers')
-def test_add_mertics_provider_ssl(ensure_metrics_endpoint, provider, appliance, test_item,
+def test_add_mertics_provider_ssl(provider, appliance, test_item,
                                   soft_assert, sync_ssl_certificate):
     """This test checks adding container providers with 3 different security protocols:
     SSL trusting custom CA, SSL without validation and SSL

--- a/cfme/tests/containers/test_ssl_providers.py
+++ b/cfme/tests/containers/test_ssl_providers.py
@@ -54,8 +54,9 @@ def sync_ssl_certificate(provider):
 
 @pytest.fixture(scope="module")
 def ensure_metrics_endpoint(provider):
-    if not provider.endpoints.has_key("metrics"):
+    if "metrics" not in provider.endpoints:
         pytest.skip("No metrics endpoint exist on this provider")
+
 
 @pytest.mark.polarion('CMP-9836')
 @pytest.mark.usefixtures('has_no_containers_providers')
@@ -121,8 +122,8 @@ def test_add_provider_ssl(provider, default_sec_protocol, soft_assert, sync_ssl_
         ti.args[1].default_sec_protocol, ti.args[1].metrics_sec_protocol)
     for ti in TEST_ITEMS])
 @pytest.mark.usefixtures('has_no_containers_providers')
-def test_add_mertics_provider_ssl(ensure_metrics_endpoint, provider, appliance, test_item, soft_assert,
-                                  sync_ssl_certificate):
+def test_add_mertics_provider_ssl(ensure_metrics_endpoint, provider, appliance, test_item,
+                                  soft_assert, sync_ssl_certificate):
     """This test checks adding container providers with 3 different security protocols:
     SSL trusting custom CA, SSL without validation and SSL
     The test checks the Default Endpoint as well as the Hawkular Endpoint

--- a/cfme/tests/containers/test_ssl_providers.py
+++ b/cfme/tests/containers/test_ssl_providers.py
@@ -52,6 +52,11 @@ def sync_ssl_certificate(provider):
     provider.sync_ssl_certificate()
 
 
+@pytest.fixture(scope="module")
+def ensure_metrics_endpoint(provider):
+    if not provider.endpoints.has_key("metrics"):
+        pytest.skip("No metrics endpoint exist on this provider")
+
 @pytest.mark.polarion('CMP-9836')
 @pytest.mark.usefixtures('has_no_containers_providers')
 def test_add_provider_naming_conventions(provider, appliance, soft_assert, sync_ssl_certificate):
@@ -116,7 +121,7 @@ def test_add_provider_ssl(provider, default_sec_protocol, soft_assert, sync_ssl_
         ti.args[1].default_sec_protocol, ti.args[1].metrics_sec_protocol)
     for ti in TEST_ITEMS])
 @pytest.mark.usefixtures('has_no_containers_providers')
-def test_add_mertics_provider_ssl(provider, appliance, test_item, soft_assert,
+def test_add_mertics_provider_ssl(ensure_metrics_endpoint, provider, appliance, test_item, soft_assert,
                                   sync_ssl_certificate):
     """This test checks adding container providers with 3 different security protocols:
     SSL trusting custom CA, SSL without validation and SSL


### PR DESCRIPTION
{{ pytest: cfme/tests/containers/test_ssl_providers.py::test_add_mertics_provider_ssl --use-provider ocp-36-hawk }}
skipping add metrics endpoint test for providers without metrics endpoint