### PR TITLE
[1LP][WIPTEST] Test: azure_provider_discovery_error

### DIFF
--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -186,11 +186,11 @@ class CloudProviderCollection(BaseCollection):
             view.start.click()
 
     # todo: combine with discover ?
-    def wait_for_new_provider(self):
+    def wait_for_new_provider(self, timeout=1000):
         view = navigate_to(self, 'All')
         logger.info('Waiting for a provider to appear...')
         wait_for(lambda: int(view.entities.paginator.items_amount), fail_condition=0,
-                 message="Wait for any provider to appear", num_sec=1000,
+                 message="Wait for any provider to appear", num_sec=timeout,
                  fail_func=view.browser.refresh)
 
 

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -9,7 +9,6 @@ from widgetastic.exceptions import MoveTargetOutOfBoundsException
 
 from cfme import test_requirements
 from cfme.base.credential import Credential
-from cfme.cloud.instance import Instance
 from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.ec2 import EC2Provider
@@ -97,8 +96,8 @@ def test_discovery_password_mismatch_validation_cloud(appliance):
 
 
 @pytest.mark.tier(3)
-@pytest.mark.uncollectif(lambda: store.current_appliance.version >= '5.9',
-                         reason='no more support for cloud provider discovery')
+@pytest.mark.uncollectif(lambda appliance: appliance.version >= '5.9',
+                        reason='no more support for cloud provider discovery')
 def test_discovery_error_azure_cloud(appliance):
     """ Test Azure discovery with feck data
 

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -19,7 +19,6 @@ from cfme.common.provider_views import (
 from cfme.rest.gen_data import _creating_skeleton as creating_skeleton
 from cfme.rest.gen_data import arbitration_profiles as _arbitration_profiles
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.log import logger
 from cfme.utils.providers import list_providers, ProviderFilter
 from cfme.utils.rest import (
     assert_response,
@@ -125,10 +124,10 @@ def test_discovery_error_azure_cloud(appliance):
     view = appliance.browser.create_view(CloudProvidersView)
     view.flash.assert_success_message('Cloud Providers: Discovery successfully initiated')
 
-    try:
+    # While waiting for new provider, TimeOutError will come (Negative Test)
+    with pytest.raises(TimedOutError):
         collection.wait_for_new_provider()
-    except TimedOutError:
-        logger.warning('Timed out waiting for new provider, continuing')
+
     assert len(view.entities.entity_names) <= initial_count
 
 

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -20,6 +20,7 @@ from cfme.common.provider_views import (
 from cfme.rest.gen_data import _creating_skeleton as creating_skeleton
 from cfme.rest.gen_data import arbitration_profiles as _arbitration_profiles
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.log import logger
 from cfme.utils.providers import list_providers, ProviderFilter
 from cfme.utils.rest import (
     assert_response,
@@ -27,6 +28,7 @@ from cfme.utils.rest import (
     delete_resources_from_detail,
 )
 from cfme.utils.update import update
+from cfme.utils.wait import TimedOutError
 from cfme.fixtures.provider import enable_provider_regions
 from cfme.fixtures.pytest_store import store
 
@@ -92,6 +94,43 @@ def test_discovery_password_mismatch_validation_cloud(appliance):
     collection.discover(cred, EC2Provider)
     view = appliance.browser.create_view(CloudProvidersView)
     view.flash.assert_message('Password/Verify Password do not match')
+
+
+@pytest.mark.tier(3)
+@pytest.mark.uncollectif(lambda: store.current_appliance.version >= '5.9',
+                         reason='no more support for cloud provider discovery')
+def test_discovery_error_azure_cloud(appliance):
+    """ Test Azure discovery with feck data
+
+    prerequisites:
+        * appliance supporting discovery
+
+    Steps:
+        * Navigate Cloud provider discovery and select Azure
+        * Fill all fields with feck data
+        * Start Discovery
+        * Even with wrong data discovery will start with the proper flash message assert it
+        * Check for provider should not discover
+    """
+    cred = Credential(
+        principal=fauxfactory.gen_alphanumeric(5),
+        secret=fauxfactory.gen_alphanumeric(8),
+        tenant_id=fauxfactory.gen_alphanumeric(10),
+        subscription_id=fauxfactory.gen_alphanumeric(10))
+
+    collection = appliance.collections.cloud_providers
+    view = navigate_to(collection, 'All')
+    initial_count = len(view.entities.entity_names)
+
+    collection.discover(cred, AzureProvider)
+    view = appliance.browser.create_view(CloudProvidersView)
+    view.flash.assert_success_message('Cloud Providers: Discovery successfully initiated')
+
+    try:
+        collection.wait_for_new_provider()
+    except TimedOutError:
+        logger.warning('Timed out waiting for new provider, continuing')
+    assert len(view.entities.entity_names) <= initial_count
 
 
 @pytest.mark.tier(3)

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -98,14 +98,14 @@ def test_discovery_password_mismatch_validation_cloud(appliance):
 @pytest.mark.uncollectif(lambda appliance: appliance.version >= '5.9',
                         reason='no more support for cloud provider discovery')
 def test_discovery_error_azure_cloud(appliance):
-    """ Test Azure discovery with feck data
+    """ Test Azure discovery with fake data
 
     prerequisites:
         * appliance supporting discovery
 
     Steps:
         * Navigate Cloud provider discovery and select Azure
-        * Fill all fields with feck data
+        * Fill all fields with fake data
         * Start Discovery
         * Even with wrong data discovery will start with the proper flash message assert it
         * Check for provider should not discover
@@ -126,7 +126,7 @@ def test_discovery_error_azure_cloud(appliance):
 
     # While waiting for new provider, TimeOutError will come (Negative Test)
     with pytest.raises(TimedOutError):
-        collection.wait_for_new_provider()
+        collection.wait_for_new_provider(timeout=120)
 
     assert len(view.entities.entity_names) <= initial_count
 


### PR DESCRIPTION
Purpose or Intent
=================
- Automating test  RHCF3-11608 
- This test similar to the provider discovery, only with false data also discovery will start but provider will not apper. 
 
{{pytest: cfme/tests/cloud/test_providers.py::test_discovery_error_azure_cloud}}
