### PR TITLE
[1LP][RFR] Scvmm test fixes

### DIFF
--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -450,7 +450,11 @@ class ProviderAddView(BaseLoggedInPage):
 
     @property
     def is_displayed(self):
-        return self.logged_in_as_current_user
+        return all(
+            getattr(self, widget).is_displayed for widget in [
+                'title', 'name', 'prov_type', 'zone', 'add', 'cancel'
+            ]
+        )
 
 
 class InfraProviderAddView(ProviderAddView):

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -450,10 +450,10 @@ class ProviderAddView(BaseLoggedInPage):
 
     @property
     def is_displayed(self):
-        return all(
-            getattr(self, widget).is_displayed for widget in [
-                'title', 'name', 'prov_type', 'zone', 'add', 'cancel'
-            ]
+        return (
+            self.title.is_displayed and self.name.is_displayed and
+            self.prov_type.is_displayed and self.zone.is_displayed and
+            self.add.is_displayed and self.cancel.is_displayed
         )
 
 

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -9,6 +9,7 @@ from cfme.common.provider_views import ProviderNodesView
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
+from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.markers.env_markers.provider import ONE
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -132,6 +132,8 @@ def test_multiple_host_bad_creds(setup_provider, provider):
 
     if provider.one_of(RHEVMProvider):
         msg = 'Login failed due to a bad username or password.'
+    elif provider.one_of(SCVMMProvider):
+        msg = 'Check credentials. Remote error message: WinRM::WinRMAuthorizationError'
     else:
         msg = 'Cannot complete login due to an incorrect user name or password.'
     edit_view.flash.assert_message(msg)

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -183,7 +183,7 @@ def test_infra_provider_add_with_bad_credentials(provider):
         verify_secret='reallybad'
     )
 
-    with pytest.raises(Exception, match=provider.bad_credentials_error_msg):
+    with pytest.raises(AssertionError, match=provider.bad_credentials_error_msg):
         provider.create(validate_credentials=True)
 
 


### PR DESCRIPTION
Fixing a few issues I came across while troubleshooting SCVMM test failures in the latest 59z master test run

{{pytest: --use-provider scvmm --use-provider scvmm2016 cfme/tests/infrastructure/test_providers.py -k 'test_multiple_host_bad_creds or test_infra_provider_add_with_bad_credentials' --long-running}}