### PR TITLE
[RFR] added provider to catalog items

### DIFF
--- a/cfme/fixtures/service_fixtures.py
+++ b/cfme/fixtures/service_fixtures.py
@@ -61,7 +61,7 @@ def create_catalog_item(appliance, provider, provisioning, dialog, catalog,
     catalog_item = appliance.collections.catalog_items.create(
         provider.catalog_item_type, name=item_name,
         description="my catalog", display_in=True, catalog=catalog,
-        dialog=dialog, prov_data=provisioning_data
+        dialog=dialog, prov_data=provisioning_data, provider=provider
     )
     return catalog_item
 

--- a/cfme/services/catalogs/catalog_items/__init__.py
+++ b/cfme/services/catalogs/catalog_items/__init__.py
@@ -307,6 +307,7 @@ class CloudInfraCatalogItem(BaseCatalogItem):
     display_in = attr.ib(default=None)
     dialog = attr.ib(default=None)
     domain = attr.ib(default='ManageIQ (Locked)')
+    provider = attr.ib(default=None)
     item_type = None
 
     @property
@@ -332,6 +333,7 @@ class NonCloudInfraCatalogItem(BaseCatalogItem):
     display_in = attr.ib(default=None)
     dialog = attr.ib(default=None)
     domain = attr.ib(default='ManageIQ (Locked)')
+    provider = attr.ib(default=None)
     item_type = None
 
     @cached_property

--- a/cfme/services/myservice/ssui.py
+++ b/cfme/services/myservice/ssui.py
@@ -210,7 +210,7 @@ def launch_vm_console(self, catalog_item):
     vm_obj = collection.instantiate(
         '{}{}'.format(catalog_item.prov_data['catalog']['vm_name'], '0001'),
         catalog_item.provider,
-        template_name=catalog_item.catalog_name
+        template_name=catalog_item.name
     )
     wait_for(
         func=lambda: vm_obj.vm_console, num_sec=30, delay=2, handle_exception=True,

--- a/cfme/tests/ssui/test_ssui_myservice.py
+++ b/cfme/tests/ssui/test_ssui_myservice.py
@@ -98,9 +98,9 @@ def test_vm_console(request, appliance, setup_provider, context, configure_webso
     """Test Myservice VM Console in SSUI."""
     catalog_item = order_service
     service_name = catalog_item.name
-    console_vm_username = credentials[catalog_item.provider.data.templates.console_template
+    console_vm_username = credentials[provider.data.templates.console_template
                             .creds].username
-    console_vm_password = credentials[catalog_item.provider.data.templates.console_template
+    console_vm_password = credentials[provider.data.templates.console_template
                             .creds].password
     with appliance.context.use(context):
         myservice = MyService(appliance, service_name)
@@ -132,7 +132,7 @@ def test_vm_console(request, appliance, setup_provider, context, configure_webso
                 vm_console.send_keys("{}".format(console_vm_password))
                 logger.info("Wait to get the '$' prompt")
                 if not provider.one_of(OpenStackProvider):
-                    vm_console.wait_for_text(text_to_find=catalog_item.provider.data.templates.
+                    vm_console.wait_for_text(text_to_find=provider.data.templates.
                         console_template.prompt_text, timeout=200)
 
                 def _validate_login():


### PR DESCRIPTION
some of collection conversions broke ssui tests because catalog items lost provider property.
This PR fixes some of such tests.
{{pytest: --use-template-cache --use-provider=rhv41 --long-running cfme/tests/ssui/test_ssui_myservice.py}}
