### PR TITLE
[RFR][NOTEST]flagging tests to avoid collection for azure_msdn

### DIFF
--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -252,6 +252,10 @@ class InstEvent(object):
 
 
 def test_cloud_timeline_create_event(new_instance, soft_assert, azone):
+    """
+    Metadata:
+        test_flag: timelines, events
+    """
     targets = (new_instance, new_instance.provider, azone)
     event = 'create'
     inst_event = InstEvent(new_instance, event)
@@ -262,6 +266,10 @@ def test_cloud_timeline_create_event(new_instance, soft_assert, azone):
 
 @pytest.mark.meta(blockers=[BZ(1542962, forced_streams=['5.8'])])
 def test_cloud_timeline_policy_event(new_instance, control_policy, soft_assert):
+    """
+    Metadata:
+        test_flag: timelines, events
+    """
     event = 'policy'
     targets = (new_instance, new_instance.provider)
     inst_event = InstEvent(new_instance, event)
@@ -271,6 +279,10 @@ def test_cloud_timeline_policy_event(new_instance, control_policy, soft_assert):
 
 
 def test_cloud_timeline_stop_event(new_instance, soft_assert, azone):
+    """
+    Metadata:
+        test_flag: timelines, events
+    """
     targets = (new_instance, new_instance.provider, azone)
     event = 'stop'
     inst_event = InstEvent(new_instance, event)
@@ -280,6 +292,10 @@ def test_cloud_timeline_stop_event(new_instance, soft_assert, azone):
 
 
 def test_cloud_timeline_start_event(new_instance, soft_assert, azone):
+    """
+    Metadata:
+        test_flag: timelines, events
+    """
     targets = (new_instance, new_instance.provider, azone)
     event = 'start'
     inst_event = InstEvent(new_instance, 'start')
@@ -289,7 +305,11 @@ def test_cloud_timeline_start_event(new_instance, soft_assert, azone):
 
 
 def test_cloud_timeline_diagnostic(new_instance, mark_vm_as_appliance, soft_assert):
-    """Check Configuration/diagnostic/timelines. """
+    """Check Configuration/diagnostic/timelines.
+
+    Metadata:
+        test_flag: timelines, events
+    """
     event = 'start'
     targets = (new_instance.appliance.server,)
     inst_event = InstEvent(new_instance, event)
@@ -300,6 +320,10 @@ def test_cloud_timeline_diagnostic(new_instance, mark_vm_as_appliance, soft_asse
 @pytest.mark.meta(blockers=[BZ(1537520, forced_streams=['5.8'])])
 @pytest.mark.provider([EC2Provider], override=True, scope='function')
 def test_cloud_timeline_rename_event(new_instance, soft_assert, azone):
+    """
+    Metadata:
+        test_flag: timelines, events
+    """
     event = 'rename'
     targets = (new_instance, new_instance.provider, azone)
     inst_event = InstEvent(new_instance, event)
@@ -311,6 +335,10 @@ def test_cloud_timeline_rename_event(new_instance, soft_assert, azone):
 @pytest.mark.uncollectif(lambda provider, appliance: provider.one_of(EC2Provider) and
                          appliance.version < "5.9")
 def test_cloud_timeline_delete_event(new_instance, soft_assert, azone):
+    """
+    Metadata:
+        test_flag: timelines, events
+    """
     event = 'delete'
     targets = (new_instance, new_instance.provider, azone)
     inst_event = InstEvent(new_instance, event)

--- a/cfme/tests/networks/test_sdn_balancers.py
+++ b/cfme/tests/networks/test_sdn_balancers.py
@@ -68,6 +68,9 @@ def test_sdn_balancers_tagvis(check_item_visibility, visibility, network_prov_wi
         2. Login as restricted user, item is visible for user
         3. As admin remove tag
         4. Login as restricted user, item is not visible for user
+
+    Metadata:
+        test_flag: tag, sdn
     """
     network_prov = random.choice(network_prov_with_load_balancers)[0]
     balancers_for_provider = network_prov.balancers.all()

--- a/cfme/tests/networks/test_sdn_inventory_collection.py
+++ b/cfme/tests/networks/test_sdn_inventory_collection.py
@@ -17,7 +17,7 @@ def test_sdn_api_inventory_networks(provider, appliance):
     results. If Similar, then test is successful
 
     Metadata:
-        test_flag: sdn
+        test_flag: sdn, inventory
     """
     prov_networks = sorted(provider.mgmt.list_network())
     cfme_networks = sorted([nt.name for nt in appliance.collections.cloud_networks.all()])
@@ -42,7 +42,7 @@ def test_sdn_api_inventory_routers(provider, appliance):
     results. If Similar, then test is successful
 
     Metadata:
-        test_flag: sdn
+        test_flag: sdn, inventory
     """
     prov_routers = sorted(provider.mgmt.list_router())
     cfme_routers = sorted([rt.name for rt in appliance.collections.network_routers.all()])
@@ -56,7 +56,7 @@ def test_sdn_api_inventory_subnets(provider, appliance):
     results. If Similar, then test is successful
 
     Metadata:
-        test_flag: sdn
+        test_flag: sdn, inventory
     """
     prov_subnets = []
     cfme_subnets = [sb.name for sb in appliance.collections.network_subnets.all()]
@@ -78,7 +78,7 @@ def test_sdn_api_inventory_security_groups(provider, appliance):
     the 2 results. If Similar, then test is successful
 
     Metadata:
-        test_flag: sdn
+        test_flag: sdn, inventory
     """
     prov_sec_gp = sorted(provider.mgmt.list_security_group())
     cfme_sec_gp = sorted([sec.name for sec in appliance.collections.network_security_groups.all()])
@@ -93,7 +93,7 @@ def test_sdn_api_inventory_loadbalancers(provider, appliance):
     results. If Similar, then test is successful
 
     Metadata:
-        test_flag: sdn
+        test_flag: sdn, inventory
     """
     prov_load_balancers = sorted(provider.mgmt.list_load_balancer())
     cfme_load_balancers = sorted([lb.name for lb in appliance.collections.balancers.all()])

--- a/cfme/tests/networks/test_sdn_navigation.py
+++ b/cfme/tests/networks/test_sdn_navigation.py
@@ -19,7 +19,7 @@ pytestmark = [
 def test_sdn_provider_relationships_navigation(provider, tested_part, appliance):
     """
     Metadata:
-        test_flag: sdn
+        test_flag: sdn, relationship
     """
     view = navigate_to(provider, 'Details')
     net_prov_name = view.entities.summary("Relationships").get_text_of("Network Manager")
@@ -36,7 +36,7 @@ def test_sdn_provider_relationships_navigation(provider, tested_part, appliance)
 def test_provider_topology_navigation(provider, appliance):
     """
     Metadata:
-        test_flag: sdn
+        test_flag: relationship
     """
     view = navigate_to(provider, 'Details')
     net_prov_name = view.entities.summary("Relationships").get_text_of("Network Manager")

--- a/cfme/tests/ssui/test_ssui_myservice.py
+++ b/cfme/tests/ssui/test_ssui_myservice.py
@@ -33,7 +33,11 @@ pytestmark = [
     GH('ManageIQ/integration_tests:7297')])
 @pytest.mark.parametrize('context', [ViaSSUI])
 def test_myservice_crud(appliance, setup_provider, context, order_service):
-    """Test Myservice crud in SSUI."""
+    """Test Myservice crud in SSUI.
+
+    Metadata:
+        test_flag: ssui, services
+    """
     catalog_item = order_service
     with appliance.context.use(context):
         my_service = MyService(appliance, catalog_item.name)
@@ -49,7 +53,11 @@ def test_myservice_crud(appliance, setup_provider, context, order_service):
 @pytest.mark.parametrize('context', [ViaSSUI])
 def test_retire_service_ssui(appliance, setup_provider,
                         context, order_service, request):
-    """Test retire service."""
+    """Test retire service.
+
+    Metadata:
+        test_flag: ssui, services
+    """
     catalog_item = order_service
     with appliance.context.use(context):
         my_service = MyService(appliance, catalog_item.name)
@@ -64,7 +72,11 @@ def test_retire_service_ssui(appliance, setup_provider,
 @pytest.mark.parametrize('context', [ViaSSUI])
 def test_service_start(appliance, setup_provider, context,
                        order_service, provider, request):
-    """Test service stop"""
+    """Test service stop
+
+    Metadata:
+        test_flag: ssui, services
+    """
     catalog_item = order_service
     with appliance.context.use(context):
         my_service = MyService(appliance, catalog_item.name)
@@ -91,7 +103,11 @@ def test_service_start(appliance, setup_provider, context,
 def test_vm_console(request, appliance, setup_provider, context, configure_websocket,
         configure_console_vnc, order_service, take_screenshot,
         console_template, provider):
-    """Test Myservice VM Console in SSUI."""
+    """Test Myservice VM Console in SSUI.
+
+    Metadata:
+        test_flag: ssui
+    """
     if (provider.one_of(VMwareProvider) and provider.version >= 6.5 or
             'html5_console' in provider.data.get('excluded_test_flags', [])):
         pytest.skip('VNC consoles are unsupported on VMware ESXi 6.5 and later')

--- a/cfme/tests/ssui/test_ssui_service_catalogs.py
+++ b/cfme/tests/ssui/test_ssui_service_catalogs.py
@@ -25,7 +25,11 @@ pytestmark = [
 @pytest.mark.parametrize('context', [ViaSSUI])
 def test_service_catalog_crud_ssui(appliance, setup_provider,
                                    context, order_service):
-    """Tests Service Catalog in SSUI."""
+    """Tests Service Catalog in SSUI.
+
+    Metadata:
+        test_flag: ssui
+    """
 
     catalog_item = order_service
     with appliance.context.use(context):


### PR DESCRIPTION
Purpose or Intent
=================

__Updating tests__  by adding test_flag. main reason - we don't want to collect\run these test on azure_msdn. another PR will be into yamls


