### PR TITLE
[1LP][RFR] Fix CMQE Persistent Volume Fixture

### DIFF
--- a/cfme/fixtures/has_persistent_volume.py
+++ b/cfme/fixtures/has_persistent_volume.py
@@ -1,30 +1,12 @@
 import pytest
 
-from wrapanapi.containers.volume import Volume as VolumeApi
-from cfme.containers.volume import Volume
 
-
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def has_persistent_volume(provider, appliance):
     """Verifying that some persistent volume exists"""
-    vols = provider.mgmt.list_volume()
+    vols = provider.mgmt.list_persistent_volume()
     vols_count = len(vols)
     if vols_count:
-        yield Volume(vols[0].name, provider, appliance)
+        yield
     else:
-        name = 'pv-{}'.format(vols_count + 1)
-        payload = {
-            'metadata': {'name': name},
-            'spec': {
-                'accessModes': ['ReadWriteOnce'],
-                'capacity': {'storage': '1Gi'},
-                'nfs': {
-                    'path': '/tmp',
-                    'server': '12.34.56.78'
-                }
-            },
-            'persistentVolumeReclaimPolicy': 'Retain'
-        }
-        volume = VolumeApi.create(provider.mgmt, payload)
-        yield Volume(volume.name, provider, appliance)
-        volume.delete()
+        pytest.skip('No Persistent Volumes Detected on OpenShift Provider {}'.format(provider.name))

--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -306,7 +306,7 @@ Werkzeug==0.14.1
 widgetastic.core==0.21.3
 widgetastic.patternfly==0.0.32
 widgetsnbextension==3.2.1
-wrapanapi==2.9.9
+wrapanapi==2.9.10
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -295,7 +295,7 @@ Werkzeug==0.14.1
 widgetastic.core==0.21.3
 widgetastic.patternfly==0.0.32
 widgetsnbextension==3.2.1
-wrapanapi==2.9.9
+wrapanapi==2.9.10
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0

--- a/requirements/template.txt
+++ b/requirements/template.txt
@@ -3,7 +3,7 @@
 
 # add what breaks on RTD
 
-wrapanapi>=2.9.9
+wrapanapi>=2.9.10
 --no-binary pycurl
 pycurl
 


### PR DESCRIPTION
Remove wrapanapi call to create a persistent volume if one no longer exists, the create method was removed in https://github.com/ManageIQ/wrapanapi/pull/255/files. 

{{ pytest: cfme/tests/containers/test_relationships.py --use-provider cmqe }}
