### PR TITLE
[1LP][RFR] Adding wrappers for BZ1591606 and BZ1592430

### DIFF
--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -388,6 +388,8 @@ def test_no_template_power_control(provider, soft_assert):
 @pytest.mark.rhv3
 @pytest.mark.uncollectif(lambda provider: provider.one_of(SCVMMProvider) and
                          BZ(1520489, forced_streams=['5.9']).blocks, 'BZ 1520489')
+@pytest.mark.meta(blockers=[BZ(1592430, forced_streams=['5.8', '5.9', '5.10'],
+    unblock=lambda provider: not provider.one_of(RHEVMProvider))])
 def test_no_power_controls_on_archived_vm(testing_vm, archived_vm, soft_assert):
     """ Ensures that no power button is displayed from details view of archived vm
 
@@ -406,6 +408,8 @@ def test_no_power_controls_on_archived_vm(testing_vm, archived_vm, soft_assert):
 @pytest.mark.rhv3
 @pytest.mark.uncollectif(lambda provider: provider.one_of(SCVMMProvider) and
                          BZ(1520489, forced_streams=['5.9']).blocks, 'BZ 1520489')
+@pytest.mark.meta(blockers=[BZ(1592430, forced_streams=['5.8', '5.9', '5.10'],
+    unblock=lambda provider: not provider.one_of(RHEVMProvider))])
 def test_archived_vm_status(testing_vm, archived_vm):
     """Tests archived vm status
 

--- a/cfme/tests/infrastructure/test_vm_reconfigure.py
+++ b/cfme/tests/infrastructure/test_vm_reconfigure.py
@@ -2,7 +2,7 @@ import pytest
 
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
-from cfme.utils.blockers import GH
+from cfme.utils.blockers import BZ, GH
 from cfme.utils.wait import wait_for
 from cfme.utils.generators import random_vm_name
 
@@ -75,6 +75,7 @@ def ensure_vm_running(small_vm):
 
 
 @pytest.mark.rhv1
+@pytest.mark.meta(blockers=[BZ(1591606, forced_streams=['5.9', '5.10'])])
 @pytest.mark.parametrize('change_type', ['cores_per_socket', 'sockets', 'memory'])
 def test_vm_reconfig_add_remove_hw_cold(provider, small_vm, ensure_vm_stopped, change_type):
     orig_config = small_vm.configuration.copy()
@@ -147,6 +148,7 @@ def test_reconfig_vm_negative_cancel(provider, small_vm, ensure_vm_stopped):
 @pytest.mark.rhv1
 @pytest.mark.uncollectif(lambda provider: provider.one_of(VMwareProvider))
 @pytest.mark.parametrize('change_type', ['sockets', 'memory'])
+@pytest.mark.meta(blockers=[BZ(1591606, forced_streams=['5.9', '5.10'])])
 def test_vm_reconfig_add_remove_hw_hot(provider, small_vm, ensure_vm_running, change_type):
     """Change number of CPU sockets and amount of memory while VM is runnng.
         Chaning number of cores per socket on running VM is not supported by RHV."""


### PR DESCRIPTION
PRT: Test failed for virtualcenter-6.5. However it seems pretty much unconnected to the bug. The failure happens during test teardown when deleteing VM from provider. However, I cannot really fix wrapanapi methods for VMWare.

{{pytest: cfme/tests/infrastructure/test_vm_power_control.py::test_archived_vm_status -vv --long-running}}