### PR TITLE
[WIP] Fixing do_vm_provisioning method

### DIFF
--- a/cfme/provisioning.py
+++ b/cfme/provisioning.py
@@ -19,7 +19,7 @@ def do_vm_provisioning(appliance, template_name, provider, vm_name, provisioning
             'notes': note}})
     provisioning_data['template_name'] = template_name
     provisioning_data['provider_name'] = provider.name
-    view = navigate_to(vm, 'Provision')
+    view = navigate_to(vm.parent, 'Provision')
     view.form.fill_with(provisioning_data, on_change=view.form.submit_button)
     view.flash.assert_no_error()
     if not wait:


### PR DESCRIPTION
{{pytest: cfme/tests/infrastructure/test_pxe_provisioning.py::test_pxe_provision_from_template --use-provider complete --long-running -vv}}

PRT: ERROR at setup of cfme/tests/infrastructure/test_esx_direct_host.py during collection of tests. Seems completely unrelated.

Jenkins: https://rhv-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/cfme-5.9-rhv-4.2-integration-test-dev/69/consoleFull
From the looks of it (in Jenkins run), my change actually broke more things than it fixed. Alternate approach: Look at object type of VM being used in test_pxe_provision_from_template.

Run from master: https://rhv-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/cfme-5.9-rhv-4.2-integration-flow-dev/146/