### PR TITLE
[1LP][RFR] replace steam regexps in favor of miq-version

### DIFF
--- a/cfme/utils/template/template_upload.py
+++ b/cfme/utils/template/template_upload.py
@@ -2,8 +2,10 @@ import argparse
 import sys
 from threading import Thread
 
+from miq_version import TemplateName
+
 import cfme.utils.conf
-from cfme.utils import path, trackerbot
+from cfme.utils import path
 from cfme.utils.conf import cfme_data
 from cfme.utils.log import logger, add_stdout_handler
 from cfme.utils.providers import list_provider_keys
@@ -147,7 +149,7 @@ if __name__ == '__main__':
         image_url = cmd_args.image_url
 
         if not cmd_args.template_name:
-            template_name = trackerbot.TemplateName(stream_url).template_name
+            template_name = TemplateName(stream_url).template_name
         else:
             template_name = "{}-{}".format(cmd_args.template_name, stream)
 

--- a/scripts/sync_template_tracker.py
+++ b/scripts/sync_template_tracker.py
@@ -51,7 +51,7 @@ def main(trackerbot_url, mark_usable=None):
     for template_name, providers in template_providers.items():
         template_name = str(template_name)
 
-        group_name, datestamp, stream = TemplateName.parse_template(template_name)
+        group_name, datestamp, stream, version = TemplateName.parse_template(template_name)
 
         # Don't want sprout templates
         if group_name in ('sprout', 'rhevm-internal'):

--- a/scripts/sync_template_tracker.py
+++ b/scripts/sync_template_tracker.py
@@ -3,9 +3,10 @@
 import sys
 import traceback
 from collections import defaultdict
+from slumber.exceptions import SlumberHttpBaseException
 from threading import Lock, Thread
 
-from slumber.exceptions import SlumberHttpBaseException
+from miq_version import TemplateName
 
 from cfme.utils import trackerbot, net
 from cfme.utils.conf import cfme_data
@@ -50,7 +51,7 @@ def main(trackerbot_url, mark_usable=None):
     for template_name, providers in template_providers.items():
         template_name = str(template_name)
 
-        group_name, datestamp, stream = trackerbot.parse_template(template_name)
+        group_name, datestamp, stream = TemplateName.parse_template(template_name)
 
         # Don't want sprout templates
         if group_name in ('sprout', 'rhevm-internal'):

--- a/scripts/template_upload_all.py
+++ b/scripts/template_upload_all.py
@@ -26,7 +26,8 @@ from six.moves.urllib.parse import urljoin
 from contextlib import closing
 from urllib2 import urlopen, HTTPError
 
-from cfme.utils import path, trackerbot
+from miq_version import TemplateName
+
 from cfme.utils.conf import cfme_data
 from cfme.utils.log import logger, add_stdout_handler
 
@@ -410,7 +411,7 @@ def main():
             )
             if not stream:
                 # Stream is none, using automatic naming strategy, parse stream from template name
-                template_parser = trackerbot.parse_template(kwargs['template_name'])
+                template_parser = TemplateName.parse_template(kwargs['template_name'])
                 if template_parser.stream:
                     kwargs['stream'] = template_parser.group_name
 


### PR DESCRIPTION
We have to get rid of many duplicate sets of regexps for version parsing. miq-version has been updated recently to support all those old regexps. So, we can eventually remove replace those regexps with miq-version calls.