### PR TITLE
[1LP][RFR] Update ext-auth tests to handle multiple groups

### DIFF
--- a/cfme/fixtures/authentication.py
+++ b/cfme/fixtures/authentication.py
@@ -41,7 +41,8 @@ def auth_user_data(auth_provider, user_type):
           username: ldapuser2
           password: mysecretpassworddontguess
           fullname: Ldap User2
-          groupname: customgroup1
+          groups:
+            - customgroup1
           providers:
             - freeipa01
           user_types:


### PR DESCRIPTION
Yaml change already merged, PRT should pass?

There will be 2nd PR with new switch-groups test for ext auth, wanted to keep this scope small to cover the multiple-groups support.

## NOTE
PRT failures aren't related to these changes, but to login failure or provider configuration.


{{ pytest: cfme/tests/integration/test_cfme_auth.py --long-running }}