### PR TITLE
[WIP] add lenovo provider to supportability template

### DIFF
--- a/conf/supportability.yaml.template
+++ b/conf/supportability.yaml.template
@@ -51,6 +51,8 @@
         - 3.6
         - 3.7
         - 3.9
+    physical:
+        - lenovo
 'master':
   providers:
     infra:
@@ -78,3 +80,5 @@
         - 3.6
         - 3.7
         - 3.9
+    physical:
+        - lenovo


### PR DESCRIPTION
this PR adds lenovo provider into the supportability.yaml template.
since there were no lenovo provider in 3.8, there's no need to add it there.