### PR TITLE
[1LP][RFR] Change required to support dual browser setup in container

### DIFF
--- a/cfme/tests/test_login.py
+++ b/cfme/tests/test_login.py
@@ -4,8 +4,8 @@ import pytest
 from cfme import test_requirements
 from cfme.base.credential import Credential
 from cfme.base.ui import LoginPage
-from cfme.utils.appliance import ViaSSUI, ViaUI
 from cfme.utils import conf, version
+from cfme.utils.appliance import ViaSSUI, ViaUI
 
 pytestmark = pytest.mark.usefixtures('browser')
 
@@ -84,7 +84,7 @@ def test_update_password(context, request, appliance):
 
     # Try to login with the user with old password
     error_message = "Incorrect username or password"
-    with error.expected(error_message):
+    with pytest.raises(Exception, match=error_message):
         appliance.server.login(user)
 
     user.delete()

--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -267,7 +267,7 @@ s3transfer==0.1.13
 scandir==1.7
 scp==0.11.0
 SecretStorage==2.3.1
-selenium==2.53.6
+selenium==3.12.0
 selenium-smart-locator==0.2.0
 Send2Trash==1.5.0
 sentaku==0.6.2

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -259,7 +259,7 @@ ruamel.yaml==0.15.37
 s3transfer==0.1.13
 scp==0.11.0
 SecretStorage==3.0.1
-selenium==2.53.6
+selenium==3.12.0
 selenium-smart-locator==0.2.0
 Send2Trash==1.5.0
 sentaku==0.6.2

--- a/requirements/frozen_docs.py2.txt
+++ b/requirements/frozen_docs.py2.txt
@@ -138,7 +138,7 @@ requests-toolbelt==0.8.0
 riggerlib==3.1.5
 scandir==1.7
 scp==0.11.0
-selenium==2.53.6
+selenium==3.12.0
 selenium-smart-locator==0.2.0
 Send2Trash==1.5.0
 sentaku==0.6.2

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -130,7 +130,7 @@ requests-oauthlib==0.8.0
 requests-toolbelt==0.8.0
 riggerlib==3.1.5
 scp==0.11.0
-selenium==2.53.6
+selenium==3.12.0
 selenium-smart-locator==0.2.0
 Send2Trash==1.5.0
 sentaku==0.6.2

--- a/requirements/template_docs.txt
+++ b/requirements/template_docs.txt
@@ -58,7 +58,7 @@ requests
 riggerlib>=3.1.2
 scp
 # since 3.0 uses marionette by default
-selenium<3.0.0
+selenium==3.12.0
 shyaml
 slumber
 sqlalchemy


### PR DESCRIPTION
* Forces chrome to run in --no-sandbox mode with Remote webdriver
* Forces Marionette to False for Firefox, which is required for older
  FF versions

This is really just to allow us to support the fact that 5.10 MUST at
the moment run under Chrome, but that we want to allow original tests
of 5.9 and 5.8 to run under Firefox still.

NOTE: This is temporary and fully expected to be removed once FF 60.1
      is out.