### PR TITLE
[1LP][RFR] Removing infrastructure_mapping collection as we have v2v_mappings collection

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,6 @@ setup(
             'infra_providers = cfme.infrastructure.provider:InfraProviderCollection',
             'infra_templates = cfme.infrastructure.virtual_machines:InfraTemplateCollection',
             'infra_vms = cfme.infrastructure.virtual_machines:InfraVmCollection',
-            'infrastructure_mapping = cfme.v2v.migrations:InfrastructureMappingCollection',
             'map_tags = cfme.configure.configuration.region_settings:MapTagsCollection',
             'network_floating_ips = cfme.networks.floating_ips:FloatingIpCollection',
             'network_ports = cfme.networks.network_port:NetworkPortCollection',


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing setup.py__  Removing infrastructure_mapping collection as we have  v2v_mappings collection. Somehow we ended up with duplicates. 

Compare line 140 with 180 in setup.py