### PR TITLE
[1LP][RFR] v2v: Renamed new dropdown

### DIFF
--- a/cfme/v2v/migrations.py
+++ b/cfme/v2v/migrations.py
@@ -287,8 +287,7 @@ class MigrationDashboardView(BaseLoggedInPage):
     migration_plans_not_started_list = MigrationPlansList("plans-not-started-list")
     migration_plans_completed_list = MigrationPlansList("plans-complete-list")
     infra_mapping_list = InfraMappingList("infra-mappings-list-view")
-    # TODO: Latest upstream nightly have changes in dropdown text
-    migr_dropdown = MigrationDropdown(text="Migration Plans Not Started")
+    migr_dropdown = MigrationDropdown(text="Not Started Plans")
 
     @property
     def is_displayed(self):


### PR DESCRIPTION
5.9.3.2/5.10 introduced new dropdown so changed text

```
In [1]: from widgetastic_manageiq import MigrationDropdown

In [2]: view = navigate_to(appliance.server, 'LoggedIn')

In [3]: x = MigrationDropdown(view, text='Not Started Plans')

In [4]: x.items
Out[4]: 
[u'Not Started Plans',
 u'In Progress Plans',
 u'Completed Plans',
 u'Archived Plans']
```