### PR TITLE
[1LP][RFR] Update server name setting, auth test BZ, auth test loop fix

### DIFF
--- a/cfme/base/__init__.py
+++ b/cfme/base/__init__.py
@@ -8,7 +8,6 @@ from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.utils import ParamClassName
 from cfme.utils.log import logger
 from cfme.utils.pretty import Pretty
-from cfme.utils.version import LATEST
 
 
 @attr.s
@@ -129,12 +128,9 @@ class ServerCollection(BaseCollection, sentaku.modeling.ElementMixin):
             name = server.name
         except AttributeError:
             logger.error('The EVM has no name, setting it to EVM')
-            if self.appliance.version == LATEST or self.appliance.is_pod:
-                name = 'EVM'
-            else:
-                name = server.name
+            name = 'EVM'
             server = self.instantiate(name=name, sid=server.id)
-            server.update_advanced_settings({'server': {'name': "EVM"}})
+            server.update_advanced_settings({'server': {'name': name}})
             return server
         return self.instantiate(name=name, sid=server.id)
 

--- a/cfme/tests/integration/test_cfme_auth.py
+++ b/cfme/tests/integration/test_cfme_auth.py
@@ -24,8 +24,8 @@ pytestmark = [
            unblock=lambda auth_mode, prov_key: not (
                auth_mode in ['external', 'ldaps'] and
                auth_data.auth_providers[prov_key].type == 'openldaps')
-           )
-    ]),
+           ),
+        BZ(1593171)]),  # 510z groups page doesn't load
     pytest.mark.usefixtures('prov_key', 'auth_mode', 'auth_provider', 'configure_auth')
 ]
 
@@ -98,7 +98,7 @@ def test_login_evm_group(appliance, request, auth_user_data, user_type, soft_ass
     # filtering on those that have evmgroup in groupname
     user_tuples = []
     for user in auth_user_data:
-        evm_matched_groups = [group for group in user.groups if 'evmgroup' in group.lower()]
+        evm_matched_groups = [group for group in user.groups or [] if 'evmgroup' in group.lower()]
         if evm_matched_groups:
             user_tuples.append(
                 (appliance.collections.users.simple_user(


### PR DESCRIPTION
Simplify the workaround for server name setting, don't call `server.name` again in an `except` block that was entered because of a call to `server.name` in the first place.

Add BZ blocker for 510z downstream to auth tests

Update auth test list comprehension to handle a user with no groups.