### PR TITLE
[WIP] Adding navigation step for InfraVm to Provision.

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -1412,6 +1412,7 @@ class TemplatesAll(CFMENavigateStep):
 
 
 @navigator.register(InfraVmCollection, 'Provision')
+@navigator.register(InfraVm, 'Provision')
 class ProvisionVM(CFMENavigateStep):
     VIEW = ProvisionView
     prerequisite = NavigateToSibling('All')


### PR DESCRIPTION
Currently our Provision test cases fail because InfraVm doesn't have Provision navigation target.
There may be a better way to fix this, because I'm not really sure why this stopped working. So I'm open to suggestions. 

{{pytest: cfme/tests/infrastructure/test_pxe_provisioning.py::test_pxe_provision_from_template --use-provider complete --long-running -vv}}