### PR TITLE
[1LP][RFR] Fix provisioning vm to virtual network

### DIFF
--- a/cfme/provisioning.py
+++ b/cfme/provisioning.py
@@ -19,7 +19,7 @@ def do_vm_provisioning(appliance, template_name, provider, vm_name, provisioning
             'notes': note}})
     provisioning_data['template_name'] = template_name
     provisioning_data['provider_name'] = provider.name
-    view = navigate_to(vm, 'Provision')
+    view = navigate_to(vm.parent, 'Provision')
     view.form.fill_with(provisioning_data, on_change=view.form.submit_button)
     view.flash.assert_no_error()
     if not wait:

--- a/cfme/tests/networks/test_provision_to_virtual_network.py
+++ b/cfme/tests/networks/test_provision_to_virtual_network.py
@@ -6,6 +6,7 @@ from cfme import test_requirements
 from cfme.common.vm import VM
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.provisioning import do_vm_provisioning
+from cfme.utils.generators import random_vm_name
 from cfme.utils.wait import wait_for
 
 pytestmark = [
@@ -37,16 +38,16 @@ def network(provider, appliance):
 
 
 @pytest.mark.rhv1
-def test_provision_vm_to_virtual_network(appliance, setup_provider, provider, vm_name,
+def test_provision_vm_to_virtual_network(appliance, setup_provider, provider,
                                          request, provisioning, network):
     """ Tests provisioning a vm from a template to a virtual network
 
     Metadata:
         test_flag: provision
     """
-
+    vm_name = random_vm_name('provd')
     request.addfinalizer(
-        lambda: VM.factory(vm_name, provider).cleanup_on_provider())
+        lambda: appliance.rest_api.collections.vms.get(name=vm_name).action.delete())
 
     template = provisioning['template']
     provisioning_data = {


### PR DESCRIPTION
The testcase for provisioning vm into virtual network requires vm_name fixture, which was probably accidentally removed during code review process.
Currently, this fix depends on  #7410, because InfraVm doesn't have navigation step to Provision.

{{pytest: --use-provider complete --long-running -vv cfme/tests/networks/test_provision_to_virtual_network.py}}