### PR TITLE
[1LP][RFR] ansible url fix for pod appliances

### DIFF
--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2725,6 +2725,19 @@ class Appliance(IPAppliance):
         return isinstance(self.provider, VMwareProvider.mgmt_class)
 
     @property
+    def is_on_openshift(self):
+        from cfme.containers.provider.openshift import OpenshiftProvider
+        return isinstance(self.provider, OpenshiftProvider.mgmt_class)
+
+    def set_ansible_url(self):
+        if self.is_on_openshift:
+            config_map = self.provider.get_appliance_tags(self.project)
+            url = config_map['cfme-openshift-embedded-ansible']['url']
+            tag = config_map['cfme-openshift-embedded-ansible']['tag']
+            config = {'embedded_ansible': {'container': {'image_name': url, 'image_tag': tag}}}
+            self.update_advanced_settings(config)
+
+    @property
     def _lun_name(self):
         return "{}LUNDISK".format(self.vm_name)
 

--- a/scripts/template_upload_openshift.py
+++ b/scripts/template_upload_openshift.py
@@ -135,7 +135,8 @@ def upload_template(hostname, username, password, provider, url, name, provider_
                     # url ex:
                     # brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/cloudforms46/cfme-openshift-httpd:2.4.6-14
                     tag_name, tag_value = img_url.split('/')[-1].split(':')
-                    tags[tag_name] = tag_value
+                    tag_url = img_url.rpartition(':')[-1]
+                    tags[tag_name] = {'tag': tag_value, 'url': tag_url}
                     if result.failed:
                         err_text = ("OPENSHIFT: couldn't update image stream using url "
                                     "{}, {}".format(img_url, str(result)))

--- a/sprout/appliances/tasks.py
+++ b/sprout/appliances/tasks.py
@@ -823,6 +823,7 @@ def clone_template_to_appliance(self, appliance_id, lease_time_minutes=None, yum
         clone_template_to_appliance__clone_template.si(appliance_id, lease_time_minutes),
         clone_template_to_appliance__wait_present.si(appliance_id),
         appliance_power_on.si(appliance_id),
+        appliance_set_ansible_url.si(appliance_id)
     ]
     if yum_update:
         tasks.append(appliance_yum_update.si(appliance_id))
@@ -1784,6 +1785,13 @@ def appliance_set_hostname(self, appliance_id):
     appliance = Appliance.objects.get(id=appliance_id)
     if appliance.provider.provider_data.get('type', None) == 'openstack':
         appliance.ipapp.set_resolvable_hostname()
+
+
+@singleton_task()
+def appliance_set_ansible_url(self, appliance_id):
+    appliance = Appliance.objects.get(id=appliance_id)
+    if appliance.is_openshift:
+        appliance.cfme.set_ansible_url()
 
 
 @singleton_task()


### PR DESCRIPTION
Developers removed ansible from cloudforms template in the newest downstream. Default ansible image stream url points out to access.registry.redhat.com whilst we need to use our internal repo in this case. In addition, we have to specify exact tag in such case. This PR intends to get around this change by saving image stream urls along with tags and passing them everywhere during deployment. Finally, appliance is patched with correct url and tag before usage.
Stuff to change:
1. upload template script
2. wrapanapi
3. sprout
4. IPAppliance