### PR TITLE
[1LP][RFR] Automate test for help menu

### DIFF
--- a/cfme/tests/configure/test_help_menu.py
+++ b/cfme/tests/configure/test_help_menu.py
@@ -1,8 +1,12 @@
 import fauxfactory
+
 from cfme.utils.appliance.implementations.ui import navigate_to
 
 
 def test_update_help_menu(appliance):
+    """Test case to check if editing items in help menu actually
+    updates the help menu.
+    """
     region = appliance.collections.regions.instantiate()
     updates = {'documentation_title': fauxfactory.gen_alpha()}
     view = region.set_help_menu_configuration(updates)

--- a/cfme/tests/configure/test_help_menu.py
+++ b/cfme/tests/configure/test_help_menu.py
@@ -1,0 +1,11 @@
+import fauxfactory
+from cfme.utils.appliance.implementations.ui import navigate_to
+
+
+def test_update_help_menu(appliance):
+    region = appliance.collections.regions.instantiate()
+    updates = {'documentation_title': fauxfactory.gen_alpha()}
+    view = region.set_help_menu_configuration(updates)
+    view = navigate_to(appliance.server, 'Dashboard')
+    view.help.click()
+    assert view.help.has_item(updates['documentation_title'])


### PR DESCRIPTION
Add a new test case to check if editing items in the help menu actually updates the help menu.
{{ pytest: cfme/tests/configure/test_help_menu.py }}

Note: This test runs and passes successfully on my local environment, but fails here, since my gpg key hasn't been merged into cfme-qe-yamls yet.