### PR TITLE
[1LP][RFR] Add 'Reset' button test case

### DIFF
--- a/cfme/configure/settings.py
+++ b/cfme/configure/settings.py
@@ -259,6 +259,7 @@ class DefaultViewsForm(View):
         show_vms = BootstrapSwitch('display_vms')
 
     save = Button('Save')
+    reset = Button('Reset')
 
 
 class DefaultFiltersForm(View):

--- a/cfme/tests/configure/test_default_views_cloud.py
+++ b/cfme/tests/configure/test_default_views_cloud.py
@@ -5,6 +5,7 @@ from six import string_types
 from cfme import test_requirements
 from cfme.cloud.provider import CloudProvider
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.configure.settings import DefaultViewsForm
 
 pytestmark = [pytest.mark.tier(3),
               test_requirements.settings,
@@ -20,6 +21,16 @@ gtl_params = {
 
 
 # TODO refactor for setup_provider parametrization with new 'latest' tag
+
+def test_default_view_cloud_reset(appliance, soft_assert):
+    """
+        This test case performs Reset button test.
+    """
+    navigate_to(appliance.user.my_settings, "DefaultViews")
+    view = appliance.browser.create_view(DefaultViewsForm)
+    soft_assert(view.reset.disabled is True)
+    view.clouds.availability_zones.select_button('List View')
+    soft_assert(view.reset.disabled is False)
 
 
 def set_and_test_default_view(appliance, group_name, expected_view, page):

--- a/cfme/tests/configure/test_default_views_cloud.py
+++ b/cfme/tests/configure/test_default_views_cloud.py
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
 import pytest
+import random
 from six import string_types
 
 from cfme import test_requirements
 from cfme.cloud.provider import CloudProvider
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.configure.settings import DefaultViewsForm
 
 pytestmark = [pytest.mark.tier(3),
               test_requirements.settings,
               pytest.mark.usefixtures('openstack_provider')]
+
 
 gtl_params = {
     'Cloud Providers': CloudProvider,
@@ -23,14 +24,21 @@ gtl_params = {
 # TODO refactor for setup_provider parametrization with new 'latest' tag
 
 def test_default_view_cloud_reset(appliance, soft_assert):
+    """This test case performs Reset button test.
+
+    Steps:
+        * Navigate to DefaultViews page
+        * Check Reset Button is disabled
+        * Select 'availability_zones' button from cloud region and change it's default mode
+        * Check Reset Button is enabled
     """
-        This test case performs Reset button test.
-    """
-    navigate_to(appliance.user.my_settings, "DefaultViews")
-    view = appliance.browser.create_view(DefaultViewsForm)
-    soft_assert(view.reset.disabled is True)
-    view.clouds.availability_zones.select_button('List View')
-    soft_assert(view.reset.disabled is False)
+    view = navigate_to(appliance.user.my_settings, "DefaultViews")
+    assert view.tabs.default_views.reset.disabled
+    cloud_btn = view.tabs.default_views.clouds.availability_zones
+    views = ['Tile View', 'Grid View', 'List View']
+    views.remove(cloud_btn.active_button)
+    cloud_btn.select_button(random.choice(views))
+    assert not view.tabs.default_views.reset.disabled
 
 
 def set_and_test_default_view(appliance, group_name, expected_view, page):

--- a/cfme/tests/configure/test_default_views_cloud.py
+++ b/cfme/tests/configure/test_default_views_cloud.py
@@ -23,7 +23,7 @@ gtl_params = {
 
 # TODO refactor for setup_provider parametrization with new 'latest' tag
 
-def test_default_view_cloud_reset(appliance, soft_assert):
+def test_default_view_cloud_reset(appliance):
     """This test case performs Reset button test.
 
     Steps:

--- a/cfme/tests/configure/test_default_views_infra.py
+++ b/cfme/tests/configure/test_default_views_infra.py
@@ -34,7 +34,8 @@ def test_default_view_infra_reset(appliance):
     Steps:
         * Navigate to DefaultViews page
         * Check Reset Button is disabled
-        * Select 'infrastructure_providers' button from infrastructure region and change it's default mode
+        * Select 'infrastructure_providers' button from infrastructure region
+        * Change it's default mode
         * Check Reset Button is enabled
     """
     view = navigate_to(appliance.user.my_settings, "DefaultViews")

--- a/cfme/tests/configure/test_default_views_infra.py
+++ b/cfme/tests/configure/test_default_views_infra.py
@@ -1,18 +1,17 @@
 # -*- coding: utf-8 -*-
 import pytest
+import random
 from six import string_types
 
 from cfme import test_requirements
+from cfme.exceptions import ItemNotFound
 from cfme.services.myservice import MyService
 from cfme.services.workloads import VmsInstances, TemplatesImages
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.exceptions import ItemNotFound
-from cfme.configure.settings import DefaultViewsForm
 
 pytestmark = [pytest.mark.tier(3),
               test_requirements.settings,
-              pytest.mark.usefixtures('virtualcenter_provider')
-              ]
+              pytest.mark.usefixtures('virtualcenter_provider')]
 
 
 # TODO refactor for setup_provider parametrization with new 'latest' tag
@@ -29,15 +28,22 @@ gtl_params = {
 }
 
 
-def test_default_view_infra_reset(appliance, soft_assert):
+def test_default_view_infra_reset(appliance):
+    """This test case performs Reset button test.
+
+    Steps:
+        * Navigate to DefaultViews page
+        * Check Reset Button is disabled
+        * Select 'infrastructure_providers' button from infrastructure region and change it's default mode
+        * Check Reset Button is enabled
     """
-        This test case performs Reset button test.
-    """
-    navigate_to(appliance.user.my_settings, "DefaultViews")
-    view = appliance.browser.create_view(DefaultViewsForm)
-    soft_assert(view.reset.disabled is True)
-    view.infrastructure.infrastructure_providers.select_button('Grid View')
-    soft_assert(view.reset.disabled is False)
+    view = navigate_to(appliance.user.my_settings, "DefaultViews")
+    assert view.tabs.default_views.reset.disabled
+    infra_btn = view.tabs.default_views.infrastructure.infrastructure_providers
+    views = ['Tile View', 'Grid View', 'List View']
+    views.remove(infra_btn.active_button)
+    infra_btn.select_button(random.choice(views))
+    assert not view.tabs.default_views.reset.disabled
 
 
 def set_and_test_default_view(appliance, group_name, view, page):

--- a/cfme/tests/configure/test_default_views_infra.py
+++ b/cfme/tests/configure/test_default_views_infra.py
@@ -7,10 +7,12 @@ from cfme.services.myservice import MyService
 from cfme.services.workloads import VmsInstances, TemplatesImages
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.exceptions import ItemNotFound
+from cfme.configure.settings import DefaultViewsForm
 
 pytestmark = [pytest.mark.tier(3),
               test_requirements.settings,
-              pytest.mark.usefixtures('virtualcenter_provider')]
+              pytest.mark.usefixtures('virtualcenter_provider')
+              ]
 
 
 # TODO refactor for setup_provider parametrization with new 'latest' tag
@@ -25,6 +27,17 @@ gtl_params = {
     'VMs & Instances': VmsInstances,
     'Templates & Images': TemplatesImages
 }
+
+
+def test_default_view_infra_reset(appliance, soft_assert):
+    """
+        This test case performs Reset button test.
+    """
+    navigate_to(appliance.user.my_settings, "DefaultViews")
+    view = appliance.browser.create_view(DefaultViewsForm)
+    soft_assert(view.reset.disabled is True)
+    view.infrastructure.infrastructure_providers.select_button('Grid View')
+    soft_assert(view.reset.disabled is False)
 
 
 def set_and_test_default_view(appliance, group_name, view, page):


### PR DESCRIPTION
Added test case of 'Reset' button to check whether it is enable or disable.

{{ pytest: cfme/tests/configure/test_default_views_infra.py cfme/tests/configure/test_default_views_cloud.py }}

Note: This test runs and passes successfully on my local environment, but fails here, since my gpg key hasn't been merged into cfme-qe-yamls yet.