### PR TITLE
[1LP][RFR] Fixed provider and hosts relationships

### DIFF
--- a/cfme/infrastructure/openstack_node.py
+++ b/cfme/infrastructure/openstack_node.py
@@ -3,7 +3,7 @@
 
 import attr
 
-from cfme.infrastructure.host import Host, HostCollection
+from cfme.infrastructure.host import Host, HostsCollection
 from cfme.utils.appliance.implementations.ui import navigate_to
 
 
@@ -37,7 +37,7 @@ class OpenstackNode(Host):
 
 
 @attr.s
-class OpenstackNodeCollection(HostCollection):
+class OpenstackNodeCollection(HostsCollection):
     """Collection object for the :py:class:`cfme.infrastructure.openstack_node.OpenstackNode`."""
 
     ENTITY = OpenstackNode

--- a/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
+++ b/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
@@ -139,19 +139,16 @@ def vm_analysis_provisioning_data(provider, analysis_type):
 
 
 def set_hosts_credentials(appliance, request, provider):
-    hosts_collection = appliance.collections.hosts
-    host_list = provider.hosts
-    host_names = [host.name for host in host_list]
-    for host_name in host_names:
-        test_host = hosts_collection.instantiate(name=host_name, provider=provider)
-        host_data = [host for host in host_list if host.name == host_name][0]
-        test_host.update_credentials_rest(credentials=host_data.credentials)
+    hosts = provider.hosts.all()
+    for host in hosts:
+        host_data, = [host for host in provider.data['hosts'] if host['name'] == host.name]
+        host.update_credentials_rest(credentials=host_data['credentials'])
 
     @request.addfinalizer
     def _hosts_remove_creds():
-        for host_name in host_names:
-            test_host = appliance.collections.hosts.instantiate(name=host_name, provider=provider)
-            test_host.update_credentials_rest(credentials=Host.Credential(principal="", secret=""))
+        for host in hosts:
+            host.update_credentials_rest(
+                credentials={'default': Host.Credential(principal="", secret="")})
 
 
 @pytest.fixture(scope="module")

--- a/cfme/tests/configure/test_schedule_operations.py
+++ b/cfme/tests/configure/test_schedule_operations.py
@@ -28,7 +28,7 @@ run_types = (
 @pytest.fixture(scope='module')
 def host_with_credentials(appliance, provider):
     """ Add credentials to hosts """
-    host = provider.hosts[0]
+    host = provider.hosts.all()[0]
     setup_host_creds(provider, host.name)
     yield host
     setup_host_creds(provider, host.name, remove_creds=True)

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -257,7 +257,7 @@ def policy_for_testing(provider, vm_name, policy_name, policy_profile_name, comp
 
 @pytest.fixture(scope="module")
 def host(provider, setup_provider_modscope):
-    return provider.hosts[0]
+    return provider.hosts.all()[0]
 
 
 @pytest.fixture(scope="module")

--- a/cfme/tests/control/test_compliance.py
+++ b/cfme/tests/control/test_compliance.py
@@ -50,7 +50,7 @@ def policy_profile_name():
 
 @pytest.fixture
 def host(provider, setup_provider):
-    return provider.hosts[0]
+    return provider.hosts.all()[0]
 
 
 @pytest.fixture

--- a/cfme/tests/infrastructure/test_esx_direct_host.py
+++ b/cfme/tests/infrastructure/test_esx_direct_host.py
@@ -73,14 +73,14 @@ def pytest_generate_tests(metafunc):
 def host_provider(_host_provider, provider):
     if provider.exists:
         # Delete original provider's hosts first
-        for host in provider.hosts:
+        for host in provider.hosts.all():
             if host.exists:
                 host.delete(cancel=False)
         # Get rid of the original provider, it would make a mess.
         provider.delete(cancel=False)
         provider.wait_for_delete()
     yield _host_provider
-    for host in _host_provider.hosts:
+    for host in _host_provider.hosts.all():
         if host.exists:
             host.delete(cancel=False)
     _host_provider.delete(cancel=False)

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -148,8 +148,7 @@ def test_multiple_host_bad_creds(setup_provider, provider):
 @pytest.mark.provider([InfraProvider], override=True, selector=ONE, scope='module')
 def test_tag_host_after_provider_delete(provider, appliance, setup_provider, request):
     """Test if host can be tagged after delete"""
-    host_data = provider.hosts[0]
-    host = appliance.collections.hosts.instantiate(name=host_data.name, provider=provider)
+    host = provider.hosts.all()[0]
     provider.delete(cancel=False)
     provider.wait_for_delete()
     tag = host.add_tag()

--- a/cfme/tests/infrastructure/test_host_analysis.py
+++ b/cfme/tests/infrastructure/test_host_analysis.py
@@ -44,16 +44,14 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.fixture(scope='module')
-def host_with_credentials(appliance, provider, host_name):
+def host_with_credentials(provider, host_name):
     """ Add credentials to hosts """
-    hosts_collection = appliance.collections.hosts
-    host_list = provider.hosts
-    test_host = hosts_collection.instantiate(name=host_name, provider=provider)
-    host_data = [host for host in host_list if host.name == host_name][0]
-    test_host.update_credentials_rest(credentials=host_data.credentials)
+    host, = [host for host in provider.hosts.all() if host.name == host_name]
+    host_data, = [data for data in provider.data['hosts'] if data['name'] == host.name]
+    host.update_credentials_rest(credentials=host_data['credentials'])
 
-    yield test_host
-    test_host.update_credentials_rest(credentials=Host.Credential(principal="", secret=""))
+    yield host
+    host.update_credentials_rest(credentials={'default': Host.Credential(principal="", secret="")})
 
 
 @pytest.mark.rhv1

--- a/cfme/tests/infrastructure/test_host_drift_analysis.py
+++ b/cfme/tests/infrastructure/test_host_drift_analysis.py
@@ -45,14 +45,12 @@ def a_host(host, appliance, provider):
 
 @pytest.fixture(scope='module')
 def set_host_credentials(provider, a_host, setup_provider_modscope):
-    host_list = provider.hosts
-    host_names = [host.name for host in host_list]
-    for host_name in host_names:
-        host_data = [host for host in host_list if host.name == host_name][0]
-        a_host.update_credentials_rest(credentials=host_data.credentials)
+    host_data, = [data for data in provider.data['hosts'] if data['name'] == a_host.name]
+    a_host.update_credentials_rest(credentials=host_data['credentials'])
 
     yield
-    a_host.update_credentials_rest(credentials=Host.Credential(principal="", secret=""))
+    a_host.update_credentials_rest(
+        credentials={'default': Host.Credential(principal='', secret='')})
 
 
 @pytest.mark.rhv3

--- a/cfme/tests/infrastructure/test_vm_migrate.py
+++ b/cfme/tests/infrastructure/test_vm_migrate.py
@@ -46,7 +46,7 @@ def test_vm_migrate(appliance, new_vm, provider):
     # auto_test_services should exist to test migrate VM
     view = navigate_to(new_vm, 'Details')
     vm_host = view.entities.summary('Relationships').get_text_of('Host')
-    hosts = [vds.name for vds in provider.hosts if vds.name not in vm_host]
+    hosts = [vds.name for vds in provider.hosts.all() if vds.name not in vm_host]
     if hosts:
         migrate_to = hosts[0]
     else:

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ setup(
                 'cfme.generic_objects.definition:GenericObjectDefinitionCollection'),
             'generic_objects = cfme.generic_objects.instance:GenericObjectInstanceCollection',
             'groups = cfme.configure.access_control:GroupCollection',
-            'hosts = cfme.infrastructure.host:HostCollection',
+            'hosts = cfme.infrastructure.host:HostsCollection',
             'infra_providers = cfme.infrastructure.provider:InfraProviderCollection',
             'infra_templates = cfme.infrastructure.virtual_machines:InfraTemplateCollection',
             'infra_vms = cfme.infrastructure.virtual_machines:InfraVmCollection',


### PR DESCRIPTION
Purpose
=================

`provider.hosts` should return a hosts collection filtered out by the provider.

{{pytest: -v -k "test_schedule_timer or test_vm_migrate or test_host_drift_analysis" --long-running}}