### PR TITLE
[1LP][RFR] circumvent issue when ssh.run_command hangs if appliance suddenly got unavailable 

### DIFF
--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -128,6 +128,7 @@ funcsigs==1.0.2
 functools32==3.2.3.post2
 future==0.16.0
 futures==3.0.5
+gevent==1.3.4
 gitdb2==2.0.3
 GitPython==2.1.10
 google-api-python-client==1.6.7

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -121,6 +121,7 @@ flake8==3.5.0
 flufl.enum==4.1.1
 funcsigs==1.0.2
 future==0.16.0
+gevent==1.3.4
 gitdb2==2.0.3
 GitPython==2.1.10
 google-api-python-client==1.6.7


### PR DESCRIPTION
paramiko's _ready calls hang if out of the blue destination host  gets unavailable.
This PR is going to handle this issue.