### PR TITLE
[1LP][RFR]Extra navigation in test_sdn_crud.py

### DIFF
--- a/cfme/tests/networks/test_sdn_crud.py
+++ b/cfme/tests/networks/test_sdn_crud.py
@@ -22,7 +22,6 @@ def test_sdn_crud(provider, appliance):
     Metadata:
         test_flag: sdn
     """
-    view = navigate_to(provider, 'Details')
     collection = appliance.collections.network_providers.filter({'provider': provider})
     network_provider = collection.all()[0]
 


### PR DESCRIPTION
* This test case needs to go to details page of provider. 
  which can be done by ```view = navigate_to(network_provider, 'Details')``` - It navigates to network > providers > Details page 
* ```view = navigate_to(provider, 'Details')``` - It navigates to compute > provider  > Details Page. This   **extra navigation** is not required for this test case. Because it is not used in test execution.

{{ pytest: cfme/tests/networks/test_sdn_crud.py }}