### PR TITLE
[1LP][RFR] Removed network provider class use and added use of collection filtering

### DIFF
--- a/cfme/tests/networks/test_tag_tagvis.py
+++ b/cfme/tests/networks/test_tag_tagvis.py
@@ -2,7 +2,6 @@ import pytest
 
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.markers.env_markers.provider import ONE_PER_CATEGORY
-from cfme.networks.provider import NetworkProvider
 from cfme.networks.views import (CloudNetworkView, SubnetView, NetworkRouterView, SecurityGroupView,
                                  NetworkPortView, BalancerView, FloatingIpView)
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -55,12 +54,10 @@ def child_visibility(appliance, network_provider, relationship, view):
                          ids=[rel[0] for rel in network_test_items])
 def test_tagvis_network_provider_children(provider, appliance, request, relationship, view,
                                           tag, user_restricted):
-    prov_view = navigate_to(provider, 'Details')
-    net_prov_name = prov_view.entities.summary("Relationships").get_text_of("Network Manager")
-    collection = appliance.collections.network_providers
-    network_provider = collection.instantiate(prov_class=NetworkProvider, name=net_prov_name)
-    network_provider.add_tag(tag=tag)
+    collection = appliance.collections.network_providers.filter({'provider': provider})
+    network_provider = collection.all()[0]
 
+    network_provider.add_tag(tag=tag)
     request.addfinalizer(lambda: network_provider.remove_tag(tag=tag))
 
     actual_visibility = child_visibility(appliance, network_provider, relationship, view)


### PR DESCRIPTION
Purpose or Intent
=================
Fix for:
```
TypeError: __init__() got an unexpected keyword argument 'prov_class'
```
{{pytest: cfme/tests/networks/test_tag_tagvis.py -k test_tagvis_network_provider_children}}

Maybe teardown will fails as it using OpenStack provider :D