### PR TITLE
[WIPTEST]Automate tests: download report as pdf and fix skipped tests

### DIFF
--- a/cfme/utils/browser.py
+++ b/cfme/utils/browser.py
@@ -39,7 +39,7 @@ WHARF_OUTER_RETRIES = 2
 
 def _load_firefox_profile():
     # create a firefox profile using the template in data/firefox_profile.js.template
-
+    global firefox_profile_tmpdir
     # Make a new firefox profile dir if it's unset or doesn't exist for some reason
     firefox_profile_tmpdir = mkdtemp(prefix='firefox_profile_')
     log.debug("created firefox profile")

--- a/data/firefox_profile.js.template
+++ b/data/firefox_profile.js.template
@@ -5,5 +5,6 @@
     "browser.download.dir": "$profile_dir",
     "browser.helperApps.neverAsk.saveToDisk": "application/txt,application/csv,application/pdf,application/octet-stream,text/csv,text/plain",
     "network.http.max-persistent-connections-per-server": 20,
-    "security.dialog_enable_delay": 0
+    "security.dialog_enable_delay": 0,
+    "pdfjs.disabled": true
 }


### PR DESCRIPTION
Automation tests to download report were skipped, which has now been undone and errors have been fixed. Also, automate download report as pdf test.

{{ pytest:  cfme/tests/intelligence/test_download_report.py }}