### PR TITLE
[WIPTEST] Set provider key to provider hostname

### DIFF
--- a/cfme/utils/providers.py
+++ b/cfme/utils/providers.py
@@ -387,6 +387,9 @@ def get_mgmt(provider_key, providers=None, credentials=None):
         provider_kwargs['provider_key'] = provider_key
     provider_kwargs['logger'] = logger
 
+    if isinstance(provider_key, Mapping):
+        provider_key = provider_key['hostname']
+
     if provider_key not in PROVIDER_MGMT_CACHE:
         mgmt_instance = get_class_from_type(provider_data['type']).mgmt_class(**provider_kwargs)
         PROVIDER_MGMT_CACHE[provider_key] = mgmt_instance

--- a/conf/supportability.yaml.template
+++ b/conf/supportability.yaml.template
@@ -53,6 +53,8 @@
         - 3.9
     physical:
         - lenovo
+    networks:
+        - nuage
 'master':
   providers:
     infra:
@@ -82,3 +84,5 @@
         - 3.9
     physical:
         - lenovo
+    networks:
+        - nuage

--- a/conf/supportability.yaml.template
+++ b/conf/supportability.yaml.template
@@ -53,8 +53,6 @@
         - 3.9
     physical:
         - lenovo
-    networks:
-        - nuage
 'master':
   providers:
     infra:
@@ -84,5 +82,3 @@
         - 3.9
     physical:
         - lenovo
-    networks:
-        - nuage


### PR DESCRIPTION
If you send `provider_key` as dictionary to `get_mgmt` function you get an error:
```
> if provider_key not in PROVIDER_MGMT_CACHE:
E TypeError: unhashable type: 'AttrDict'
```
So now `provider_key` is set as `provider_key['type']`

This PR is also rebased to https://github.com/ManageIQ/integration_tests/pull/7450
