### PR TITLE
[1LP][RFR][NOTEST] support for capturing historical data

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -635,6 +635,19 @@ class VM(BaseVM):
             delay=10, handle_exception=True, num_sec=timeout,
             fail_func=view.toolbar.reload.click)
 
+    def capture_historical_data(self, interval='hourly', back='6.days'):
+        """Capture historical utilization data for this VM/Instance
+
+        Args:
+            interval: Data interval (hourly/ daily)
+            back: back time interval from which you want data
+        """
+        ret = self.appliance.ssh_client.run_rails_command(
+            "\"vm = Vm.where(:ems_id => {}).where(:name => {})[0];\
+            vm.perf_capture({}, {}.ago.utc, Time.now.utc)\""
+            .format(self.provider.id, repr(self.name), repr(interval), back))
+        return ret.success
+
     def wait_for_vm_state_change(self, desired_state=None, timeout=300, from_details=False,
                                  with_relationship_refresh=True, from_any_provider=False):
         """Wait for VM to come to desired state.

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -405,6 +405,19 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Taggable):
             fail_func=view.browser.refresh
         )
 
+    def capture_historical_data(self, interval='hourly', back='6.days'):
+        """Capture historical utilization data for this Host
+
+        Args:
+            interval: Data interval (hourly/ daily)
+            back: back time interval from which you want data
+        """
+        ret = self.appliance.ssh_client.run_rails_command(
+            "\"host = Host.where(:ems_id => {}).where(:name => {})[0];\
+            host.perf_capture({}, {}.ago.utc, Time.now.utc)\""
+            .format(self.provider.id, repr(self.name), repr(interval), back))
+        return ret.success
+
     @classmethod
     def get_credentials_from_config(cls, credentials_config):
         """Retrieves the credentials from the credentials yaml.


### PR DESCRIPTION
Purpose or Intent
=================
- while working with Capacity and Utilization. I found that there must be support for capture historical data with `vm` or `host` object directly. It will help in Utilization automation. 
- Added `capture_historical_data()` method having default `6 day` back data capacity.
- Provided flexibility to modify with arguments. 