### PR TITLE
[1LP][RFR] Remove cfme_data use in utils.bz

### DIFF
--- a/cfme/utils/bz.py
+++ b/cfme/utils/bz.py
@@ -51,7 +51,7 @@ class Bugzilla(object):
     def __init__(self, **kwargs):
         # __kwargs passed to _Bugzilla instantiation, pop our args out
         self.__product = kwargs.pop("product", None)
-        self.config_options = kwargs.pop('config_options', {})
+        self.__config_options = kwargs.pop('config_options', {})
         self.__kwargs = kwargs
         self.__bug_cache = {}
         self.__product_cache = {}
@@ -101,18 +101,18 @@ class Bugzilla(object):
 
     @cached_property
     def loose(self):
-        return self.config_options.get("loose", [])
+        return self.__config_options.get("loose", [])
 
     @cached_property
     def open_states(self):
-        return self.config_options.get("skip", set([]))
+        return self.__config_options.get("skip", set())
 
     @cached_property
     def upstream_version(self):
         if self.default_product is not None:
             return self.default_product.latest_version
         else:
-            return Version(self.config_options.get("upstream_version", "9.9"))
+            return Version(self.__config_options.get("upstream_version", Version.latest().vstring))
 
     def get_bug(self, id):
         id = int(id)


### PR DESCRIPTION
@jan-zmeskal found some cfme_data.yaml queries still in utils/bz.py, that I missed in earlier PR to move things to env.

DRY up the config lookups by storing the env.yaml config as an object attribute.

```
In [1]: from cfme.utils.blockers import BZ

In [2]: from cfme.utils.conf import env

In [3]: env.get('bugzilla')
Out[3]: 
AttrDict([('url', 'https://bugzilla.redhat.com/xmlrpc.cgi'),
          ('loose', ['target_release', 'version', 'fixed_in']),
          ('upstream_version', 'master'),
          ('credentials', 'bugzilla'),
          ('skip', ['ON_DEV', 'NEW', 'ASSIGNED'])])

In [4]: b = BZ(1527239)

In [5]: b.bugzilla.loose
Out[5]: ['target_release', 'version', 'fixed_in']

In [6]: b.bugzilla.open_states
Out[6]: ['ON_DEV', 'NEW', 'ASSIGNED']

In [7]: b.bugzilla.upstream_version
Out[7]: Version('master')
```
