### PR TITLE
[RFR] Update Bugzilla.open_states, return set

### DIFF
--- a/cfme/utils/bz.py
+++ b/cfme/utils/bz.py
@@ -105,7 +105,7 @@ class Bugzilla(object):
 
     @cached_property
     def open_states(self):
-        return self.__config_options.get("skip", set())
+        return set(self.__config_options.get("skip", []))
 
     @cached_property
     def upstream_version(self):


### PR DESCRIPTION
~~We were seeing BugWrapper().is_opened calls resolve via `__getattr__` instead of the property.
Moving this definition below all the properties~~

This is real strange behavior, @psav and I looked at it together.

The property was raising an AttributeError, which was triggering the __getattr__ call.

{{ pytest: --long-running --use-provider rhv41 cfme/tests/infrastructure/test_vm_power_control.py -k test_no_template_power_control }}