### PR TITLE
[1LP][RFR] Add initial support for redfish provider testing

### DIFF
--- a/cfme/physical/provider/redfish.py
+++ b/cfme/physical/provider/redfish.py
@@ -1,0 +1,66 @@
+import attr
+import copy
+
+from widgetastic_patternfly import BootstrapSelect, Input
+from wrapanapi.systems import RedfishSystem
+
+from cfme.common.provider import DefaultEndpoint, DefaultEndpointForm
+from . import PhysicalProvider
+
+
+class RedfishEndpoint(DefaultEndpoint):
+    api_port = 443
+    security_protocol = 'SSL'
+
+    @property
+    def view_value_mapping(self):
+        return {
+            'security_protocol': self.security_protocol,
+            'hostname': self.hostname,
+            'api_port': self.api_port
+        }
+
+
+class RedfishEndpointForm(DefaultEndpointForm):
+    security_protocol = BootstrapSelect('default_security_protocol')
+    api_port = Input('default_api_port')
+
+
+@attr.s(hash=False)
+class RedfishProvider(PhysicalProvider):
+    STATS_TO_MATCH = ['num_server']
+    type_name = 'redfish'
+    endpoints_form = RedfishEndpointForm
+    string_name = 'Physical Infrastructure'
+    mgmt_class = RedfishSystem
+    refresh_text = "Refresh Relationships and Power States"
+    db_types = ["Redfish::PhysicalInfraManager"]
+    settings_key = 'ems_redfish'
+    log_name = 'redfish'
+
+    @property
+    def mgmt(self):
+        from cfme.utils.providers import get_mgmt
+        d = copy.deepcopy(self.data)
+        d['type'] = self.type_name
+        d['hostname'] = self.default_endpoint.hostname
+        d['api_port'] = self.default_endpoint.api_port
+        d['security_protocol'] = self.default_endpoint.security_protocol
+        d['credentials'] = self.default_endpoint.credentials
+        return get_mgmt(d)
+
+    @classmethod
+    def from_config(cls, prov_config, prov_key):
+        endpoint = RedfishEndpoint(**prov_config['endpoints']['default'])
+        return cls.appliance.collections.physical_providers.instantiate(
+            prov_class=cls,
+            name=prov_config['name'],
+            endpoints={endpoint.name: endpoint},
+            key=prov_key)
+
+    @property
+    def view_value_mapping(self):
+        return {
+            'name': self.name,
+            'prov_type': 'Redfish'
+        }

--- a/cfme/tests/physical_infrastructure/test_redfish_providers.py
+++ b/cfme/tests/physical_infrastructure/test_redfish_providers.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+import fauxfactory
+
+from cfme.physical.provider.redfish import RedfishProvider
+from cfme.utils.update import update
+
+import pytest
+
+pytestmark = [
+    pytest.mark.provider([RedfishProvider], scope="function")
+]
+
+
+def test_redfish_provider_crud(provider, has_no_physical_providers):
+    """Tests provider add with good credentials"""
+    provider.create()
+
+    provider.validate_stats(ui=True)
+
+    old_name = provider.name
+    with update(provider):
+        provider.name = fauxfactory.gen_alphanumeric(8)  # random uuid
+
+    with update(provider):
+        provider.name = old_name  # old name
+
+    provider.delete(cancel=False)
+    provider.wait_for_delete()

--- a/conf/cfme_data.yaml.template
+++ b/conf/cfme_data.yaml.template
@@ -158,6 +158,15 @@ management_systems:
                 ipaddress: 10.0.0.1
                 hostname: lenovo.hostname
                 api_port: 3000
+    redfish:
+        name: redfish
+        type: redfish
+        endpoints:
+            default:
+                credentials: redfish
+                hostname: redfish.hostname
+                security_protocol: SSL
+                api_port: 443
     nuage:
         name: nuage_net
         type: nuage

--- a/conf/credentials.yaml.template
+++ b/conf/credentials.yaml.template
@@ -29,6 +29,9 @@ hawkular:
 lenovo:
     username: admin
     password: smartvm
+redfish:
+    username: admin
+    password: smartvm
 nuage:
     username: admin
     password: smartvm

--- a/conf/supportability.yaml.template
+++ b/conf/supportability.yaml.template
@@ -84,5 +84,6 @@
         - 3.9
     physical:
         - lenovo
+        - redfish
     networks:
         - nuage

--- a/entry_points.txt
+++ b/entry_points.txt
@@ -150,6 +150,7 @@ nuage = cfme.networks.provider.nuage:NuageProvider
 
 [manageiq.provider_types.physical]
 lenovo = cfme.physical.provider.lenovo:LenovoProvider
+redfish = cfme.physical.provider.redfish:RedfishProvider
 
 [manageiq.template_categories]
 cloud = cfme.cloud.instance.image:Image

--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -308,7 +308,7 @@ Werkzeug==0.14.1
 widgetastic.core==0.21.6
 widgetastic.patternfly==0.0.37
 widgetsnbextension==3.2.1
-wrapanapi==3.0.22
+wrapanapi==3.0.23
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -297,7 +297,7 @@ Werkzeug==0.14.1
 widgetastic.core==0.21.6
 widgetastic.patternfly==0.0.37
 widgetsnbextension==3.2.1
-wrapanapi==3.0.22
+wrapanapi==3.0.23
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0


### PR DESCRIPTION
__Adding tests__ for Redfish Physical Infrastructure Provider.

This commit introduces integration testing for the Redfish type of the [Physical Infrastructure provider](https://github.com/ManageIQ/manageiq-providers-redfish).  In the initial version, we support checking for creating a new provider, checking the number of servers, and updating the provider.
    
This implementation relies on the corresponding Redfish API implementation of the RedfishSystem wrapanapi class.

There are two commits in this PR, where the first commit updates the label string for adding physical infrastructure provider to the one actually used in the UI.

Depends on: https://github.com/ManageIQ/integration_tests/pull/7629

/cc @gberginc @tadeboro
