### PR TITLE
[1LP][RFR] Blocking several service tests because of #7479

### DIFF
--- a/cfme/tests/infrastructure/test_quota_tagging.py
+++ b/cfme/tests/infrastructure/test_quota_tagging.py
@@ -10,11 +10,13 @@ from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.provisioning import do_vm_provisioning
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils.appliance import ViaSSUI, ViaUI
+from cfme.utils.blockers import GH
 from cfme.utils.generators import random_vm_name
 from cfme.utils.update import update
 
 
 pytestmark = [
+    pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:7479')]),
     pytest.mark.provider([RHEVMProvider, VMwareProvider], scope="module", selector=ONE_PER_TYPE)
 ]
 

--- a/cfme/tests/infrastructure/test_tenant_quota.py
+++ b/cfme/tests/infrastructure/test_tenant_quota.py
@@ -16,7 +16,7 @@ from cfme.utils.generators import random_vm_name
 
 pytestmark = [
     test_requirements.quota,
-    pytest.mark.meta(server_roles="+automate"),
+    pytest.mark.meta(server_roles="+automate", blockers=[GH('ManageIQ/integration_tests:7479')]),
     pytest.mark.usefixtures('uses_infra_providers'),
     pytest.mark.provider([VMwareProvider, RHEVMProvider], scope="module", selector=ONE_PER_TYPE)
 ]
@@ -142,7 +142,6 @@ def test_tenant_quota_enforce_via_lifecycle_infra(appliance, provider, setup_pro
 
 
 @pytest.mark.rhv3
-@pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:7297')])
 # first arg of parametrize is the list of fixtures or parameters,
 # second arg is a list of lists, with each one a test is to be generated
 # sequence is important here

--- a/cfme/tests/services/test_different_dialogs_in_catalogs.py
+++ b/cfme/tests/services/test_different_dialogs_in_catalogs.py
@@ -6,12 +6,12 @@ from widgetastic.utils import partial_match
 from cfme import test_requirements
 from cfme.infrastructure.provider import InfraProvider
 from cfme.services.service_catalogs import ServiceCatalogs
-from cfme.utils.blockers import BZ
+from cfme.utils.blockers import GH
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
 
 pytestmark = [
-    pytest.mark.meta(server_roles="+automate"),
+    pytest.mark.meta(server_roles="+automate", blockers=[GH('ManageIQ/integration_tests:7479')]),
     pytest.mark.ignore_stream("upstream"),
     pytest.mark.usefixtures('setup_provider', 'catalog_item', 'uses_infra_providers'),
     test_requirements.service,
@@ -88,7 +88,6 @@ def catalog_item(appliance, provider, provisioning, tagcontrol_dialog, catalog):
 @pytest.mark.rhv2
 @pytest.mark.tier(2)
 @pytest.mark.ignore_stream("upstream")
-@pytest.mark.meta(blockers=[BZ(1567108, forced_streams=["5.8", "5.9"])])
 def test_tagdialog_catalog_item(appliance, provider, catalog_item, request):
     """Tests tag dialog catalog item
     Metadata:

--- a/cfme/tests/services/test_pxe_service_catalogs.py
+++ b/cfme/tests/services/test_pxe_service_catalogs.py
@@ -8,12 +8,13 @@ from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.pxe import get_pxe_server_from_config, get_template_from_config
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils import testgen
+from cfme.utils.blockers import GH
 from cfme.utils.conf import cfme_data
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
 
 pytestmark = [
-    pytest.mark.meta(server_roles="+automate"),
+    pytest.mark.meta(server_roles="+automate", blockers=[GH('ManageIQ/integration_tests:7479')]),
     pytest.mark.usefixtures('uses_infra_providers'),
     test_requirements.service,
     pytest.mark.tier(2)

--- a/cfme/tests/services/test_service_catalogs.py
+++ b/cfme/tests/services/test_service_catalogs.py
@@ -9,13 +9,14 @@ from cfme.services.catalogs.catalog_items import EditCatalogItemView
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.services.workloads import VmsInstances
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import GH
 from cfme.utils.log import logger
 from cfme.utils.rest import assert_response
 from cfme.utils.wait import wait_for_decorator
 
 
 pytestmark = [
-    pytest.mark.meta(server_roles="+automate"),
+    pytest.mark.meta(server_roles="+automate", blockers=[GH('ManageIQ/integration_tests:7479')]),
     pytest.mark.usefixtures('setup_provider', 'catalog_item', 'uses_infra_providers'),
     test_requirements.service,
     pytest.mark.long_running,

--- a/cfme/tests/services/test_service_manual_approval.py
+++ b/cfme/tests/services/test_service_manual_approval.py
@@ -6,12 +6,13 @@ from cfme.infrastructure.provider import InfraProvider
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.automate.explorer.domain import DomainCollection
 from cfme import test_requirements
+from cfme.utils.blockers import GH
 from cfme.utils.log import logger
 from cfme.utils.update import update
 
 
 pytestmark = [
-    pytest.mark.meta(server_roles="+automate"),
+    pytest.mark.meta(server_roles="+automate", blockers=[GH('ManageIQ/integration_tests:7479')]),
     pytest.mark.usefixtures('setup_provider', 'catalog_item', 'uses_infra_providers'),
     test_requirements.service,
     pytest.mark.long_running,

--- a/cfme/tests/ssui/test_ssui_ansible_service.py
+++ b/cfme/tests/ssui/test_ssui_ansible_service.py
@@ -7,7 +7,7 @@ from cfme.utils.appliance import ViaSSUI
 from cfme.utils.blockers import GH
 
 pytestmark = [
-    pytest.mark.meta(server_roles="+automate", blockers=[GH('ManageIQ/integration_tests:7297')]),
+    pytest.mark.meta(server_roles="+automate"),
     test_requirements.ssui,
     pytest.mark.long_running,
     pytest.mark.ignore_stream("upstream")

--- a/cfme/tests/ssui/test_ssui_dashboard.py
+++ b/cfme/tests/ssui/test_ssui_dashboard.py
@@ -18,7 +18,7 @@ from cfme.utils.wait import wait_for
 
 
 pytestmark = [
-    pytest.mark.meta(server_roles="+automate", blockers=[GH('ManageIQ/integration_tests:7297')]),
+    pytest.mark.meta(server_roles="+automate", blockers=[GH('ManageIQ/integration_tests:7479')]),
     pytest.mark.usefixtures('uses_infra_providers'),
     test_requirements.ssui,
     pytest.mark.long_running,

--- a/cfme/tests/ssui/test_ssui_myservice.py
+++ b/cfme/tests/ssui/test_ssui_myservice.py
@@ -21,7 +21,7 @@ from cfme.utils.providers import ProviderFilter
 from cfme.utils.wait import wait_for
 
 pytestmark = [
-    pytest.mark.meta(server_roles="+automate", blockers=[GH('ManageIQ/integration_tests:7297')]),
+    pytest.mark.meta(server_roles="+automate", blockers=[GH('ManageIQ/integration_tests:7479')]),
     test_requirements.ssui,
     pytest.mark.long_running,
     pytest.mark.provider(gen_func=providers,
@@ -31,8 +31,6 @@ pytestmark = [
 
 
 @pytest.mark.rhv1
-@pytest.mark.meta(blockers=[BZ(1544535, forced_streams=['5.9']),
-    GH('ManageIQ/integration_tests:7297')])
 @pytest.mark.parametrize('context', [ViaSSUI])
 def test_myservice_crud(appliance, setup_provider, context, order_service):
     """Test Myservice crud in SSUI.
@@ -50,8 +48,6 @@ def test_myservice_crud(appliance, setup_provider, context, order_service):
         my_service.delete()
 
 
-@pytest.mark.meta(blockers=[BZ(1544535, forced_streams=['5.9']),
-    GH('ManageIQ/integration_tests:7297')])
 @pytest.mark.parametrize('context', [ViaSSUI])
 def test_retire_service_ssui(appliance, setup_provider,
                         context, order_service, request):
@@ -106,7 +102,6 @@ def test_service_start(appliance, setup_provider, context,
             my_service.delete()
 
 
-@pytest.mark.meta(blockers=[BZ(1544535, forced_streams=['5.9'])])
 @pytest.mark.parametrize('context', [ViaSSUI])
 @pytest.mark.parametrize('order_service', [['console_test']], indirect=True)
 def test_vm_console(request, appliance, setup_provider, context, configure_websocket,

--- a/cfme/tests/ssui/test_ssui_service_catalogs.py
+++ b/cfme/tests/ssui/test_ssui_service_catalogs.py
@@ -11,7 +11,7 @@ from cfme.utils.blockers import GH
 from cfme.utils.providers import ProviderFilter
 
 pytestmark = [
-    pytest.mark.meta(server_roles="+automate", blockers=[GH('ManageIQ/integration_tests:7297')]),
+    pytest.mark.meta(server_roles="+automate", blockers=[GH('ManageIQ/integration_tests:7479')]),
     test_requirements.ssui,
     pytest.mark.long_running,
     pytest.mark.ignore_stream("upstream"),


### PR DESCRIPTION
Plus removing some old blockers that are not needed any more.

{{pytest: cfme/tests/services/test_pxe_service_catalogs.py cfme/tests/infrastructure/test_tenant_quota.py cfme/tests/infrastructure/test_quota_tagging.py cfme/tests/ssui/test_ssui_service_catalogs.py cfme/tests/ssui/test_ssui_myservice.py cfme/tests/ssui/test_ssui_dashboard.py cfme/tests/services/test_service_manual_approval.py cfme/tests/services/test_service_catalogs.py cfme/tests/services/test_different_dialogs_in_catalogs.py --use-provider rhv41 --long-running}}
