### PR TITLE
[1LP][RFR] Fix reading host credentials from yaml to reflect recent changes

### DIFF
--- a/cfme/tests/infrastructure/test_individual_host_creds.py
+++ b/cfme/tests/infrastructure/test_individual_host_creds.py
@@ -50,6 +50,11 @@ def get_host_data_by_name(provider_key, host_name):
                      creds != 'web_services')])
 @pytest.mark.parametrize("creds", ["default", "remote_login", "web_services"],
                          ids=["default", "remote", "web"])
+@pytest.mark.uncollectif(
+    lambda provider, creds:
+        creds in ['remote_login', 'web_services'] and provider.one_of(RHEVMProvider),
+    reason="Not relevant for RHEVM Provider."
+)
 def test_host_good_creds(appliance, request, setup_provider, provider, creds):
     """
     Tests host credentialing  with good credentials
@@ -103,6 +108,11 @@ def test_host_good_creds(appliance, request, setup_provider, provider, creds):
                      unblock=lambda creds: creds == 'default')])
 @pytest.mark.parametrize("creds", ["default", "remote_login", "web_services"],
                          ids=["default", "remote", "web"])
+@pytest.mark.uncollectif(
+    lambda provider, creds:
+        creds in ['remote_login', 'web_services'] and provider.one_of(RHEVMProvider),
+    reason="Not relevant for RHEVM Provider."
+)
 def test_host_bad_creds(appliance, request, setup_provider, provider, creds):
     """
     Tests host credentialing  with bad credentials


### PR DESCRIPTION
Format of credentials of hosts in yamls has changed recently. Example:
credentials:
    default: vspherehost-nested
    remote_login: vspherehost-nested
    web_services: vspherehost-nested

Fixed access to these credentials in test_host.py and extended the test to run for all credential types.

Additionally, uncollecting tests for 'remote_login' and 'web_services' for RHV provider, as these are not relevant for RHV. (https://bugzilla.redhat.com/show_bug.cgi?id=1591228)

{{ pytest: cfme/tests/infrastructure/test_host.py cfme/tests/infrastructure/test_individual_host_creds.py }}
