### PR TITLE
[1LP][RFR] Update Container test overview data integrity according to wrapanapi changes

### DIFF
--- a/cfme/tests/containers/test_overview_data_integrity.py
+++ b/cfme/tests/containers/test_overview_data_integrity.py
@@ -41,7 +41,7 @@ def get_api_object_counts(appliance):
             out[ContainersProvider] += 1
             # TODO Add back in with Node
             # out[Node] += len(provider.mgmt.list_node())
-            out[Pod] += len(provider.mgmt.list_container_group())
+            out[Pod] += len(provider.mgmt.list_pods())
             out[Service] += len(provider.mgmt.list_service())
             out[Project] += len(provider.mgmt.list_project())
             out[Route] += len(provider.mgmt.list_route())


### PR DESCRIPTION
Update get_api_object_counts, change old method list_container_group to new list_pods method.

{{pytest: cfme/tests/containers/test_projects_dashboard.py -v --use-provider ocp-36-hawk}}