### PR TITLE
[RFR] Update sync_template_tracker, ignore AMI

### DIFF
--- a/cfme/utils/template/base.py
+++ b/cfme/utils/template/base.py
@@ -238,11 +238,29 @@ class ProviderTemplateUpload(object):
 
     @log_wrap("add template to trackerbot")
     def track_template(self, **kwargs):
-        trackerbot.trackerbot_add_provider_template(self.stream,
-                                                    self.provider_key,
-                                                    self.template_name,
-                                                    **kwargs)
-        return True
+        """Call trackerbot API to create the providertemplate record
+
+        Returns:
+            None - when template already existed
+            bool - true when record added, false when record add fails (without exception)
+        """
+        result = trackerbot.add_provider_template(
+            kwargs.pop('stream', self.stream),
+            kwargs.pop('provider_key', self.provider_key),
+            kwargs.pop('template_name', self.template_name),
+            **kwargs
+        )
+        if result:
+            logger.info('Added trackerbot record: [%s] / [%s] / [%s]',
+                        self.stream, self.provider_key, self.template_name)
+        elif result is None:
+            logger.warning('Trackerbot record already existed: [%s] / [%s] / [%s]',
+                           self.stream, self.provider_key, self.template_name)
+        else:
+            logger.error('FAILED adding trackerbot record:  [%s] / [%s] / [%s]',
+                         self.stream, self.provider_key, self.template_name)
+
+        return result
 
     @log_wrap("deploy template")
     def deploy_template(self):

--- a/cfme/utils/template/rhopenshift.py
+++ b/cfme/utils/template/rhopenshift.py
@@ -1,7 +1,6 @@
 import os
 import re
 
-from cfme.utils import trackerbot
 from cfme.utils.log import logger
 from cfme.utils.template.base import log_wrap
 from cfme.utils.template.base import ProviderTemplateUpload
@@ -128,11 +127,6 @@ yaml.safe_dump(data, stream=open("{file}", "w"))'"""
                                               .format(t=cur_template))
         return result.success
 
-    @log_wrap("add template to trackerbot")
-    def track_template(self, *args, **kwargs):
-        trackerbot.trackerbot_add_provider_template(*args, **kwargs)
-        return True
-
     def run(self):
         if 'podtesting' not in self.provider_data.get('tags', []):
             logger.info("%s:%s No podtesting tag.", self.log_name, self.provider_key)
@@ -162,7 +156,13 @@ yaml.safe_dump(data, stream=open("{file}", "w"))'"""
             return False
 
         for template in self.templates:
-            self.track_template(self.stream, self.provider_key, template['name'],
-                                custom_data={'TAGS': self.tags})
+            result = self.track_template(
+                stream=self.stream,
+                provider_key=self.provider_key,
+                template_name=template['name'],
+                custom_data={'TAGS': self.tags}
+            )
+            if result is False:
+                return False
 
         return True

--- a/scripts/sync_template_tracker.py
+++ b/scripts/sync_template_tracker.py
@@ -1,122 +1,214 @@
-#!/usr/bin/env python
-"""Populate template tracker with information based on cfme_data"""
+#!/usr/bin/env python3
+"""Populate template tracker with information based on cfme_data
+uses Pool.starmap, which is py3 only
+"""
 import sys
 from collections import defaultdict
-from threading import Lock
-from threading import Thread
+from collections import namedtuple
+from multiprocessing import Manager
+from multiprocessing.pool import ThreadPool
 
 from miq_version import TemplateName
-from slumber.exceptions import SlumberHttpBaseException
+from tabulate import tabulate
+from wrapanapi import EC2System
 from wrapanapi import Openshift
 
-from cfme.utils import net
 from cfme.utils import trackerbot
 from cfme.utils.conf import cfme_data
 from cfme.utils.log import add_stdout_handler
 from cfme.utils.log import logger
+from cfme.utils.path import log_path
 from cfme.utils.providers import get_mgmt
-from cfme.utils.providers import list_provider_keys
+
+# manager for thread queues, instead of locking
+manager = Manager()
+
+ProvTemplate = namedtuple('ProvTemplate', 'provider_key, template_name')
+
+GROUPS_TO_IGNORE = ('sprout', 'rhevm-internal', 'unknown')
 
 
-add_stdout_handler(logger)
+def parse_cmdline():
+    parser = trackerbot.cmdline_parser()
+    parser.add_argument(
+        '--mark-usable',
+        default=None,
+        action='store_true',
+        help="Mark all added templates as usable",
+    )
+    parser.add_argument(
+        '--provider-key',
+        default=None,
+        dest='selected_provider',
+        nargs='*',
+        help='A specific provider key to sync for',
+    )
+    parser.add_argument(
+        '--outfile',
+        dest='outfile',
+        default=log_path.join('sync_template_tracker_report.log').strpath,
+        help='Output file for tabulated reports on ProviderTemplate actions'
+    )
+    parser.add_argument(
+        '--verbose',
+        default=False,
+        action='store_true',
+        help='Log to stdout'
+    )
+    args = parser.parse_args()
+    return dict(args._get_kwargs())
 
 
-def main(trackerbot_url, mark_usable=None, selected_provider=None):
-    api = trackerbot.api(trackerbot_url)
+def main(trackerbot_url, mark_usable=None, selected_provider=None, **kwargs):
+    tb_api = trackerbot.api(trackerbot_url)
 
-    thread_q = []
-    thread_lock = Lock()
-    template_providers = defaultdict(list)
-    all_providers = (set(list_provider_keys())
-                     if not selected_provider
-                     else set(selected_provider))
-    unresponsive_providers = set()
-    # Queue up list_template calls
-    for provider_key in all_providers:
-        ipaddress = cfme_data.management_systems[provider_key].get('ipaddress')
-        if ipaddress and not net.is_pingable(ipaddress):
-            continue
-        thread = Thread(target=get_provider_templates,
-            args=(provider_key, template_providers, unresponsive_providers, thread_lock))
-        thread_q.append(thread)
-        thread.start()
+    all_providers = set(
+        selected_provider
+        or [key for key, data in cfme_data.management_systems.items()
+            if 'disabled' not in data.get('tags', [])])
 
-    # Join the queued calls
-    for thread in thread_q:
-        thread.join()
+    bad_providers = manager.Queue()
+    # starmap the list of provider_keys into templates_on_provider
+    # return is list of ProvTemplate tuples
+    with ThreadPool(8) as pool:
+        mgmt_templates = pool.starmap(
+            templates_on_provider,
+            ((provider_key, bad_providers) for provider_key in all_providers)
+        )
 
-    seen_templates = set()
+    # filter out the misbehaving providers
+    bad_provider_keys = []
+    while not bad_providers.empty():
+        bad_provider_keys.append(bad_providers.get())
+    logger.warning('Filtering out providers that failed template query: %s', bad_provider_keys)
+    working_providers = set([key for key in all_providers if key not in bad_provider_keys])
 
-    if mark_usable is None:
-        usable = {}
-    else:
-        usable = {'usable': mark_usable}
+    # Flip mgmt_templates into dict keyed on template name, listing providers
+    # [
+    #   {prov1: [t1, t2]},
+    #   {prov2: [t1, t3]},
+    # ]
+    #
+    # mgmt_providertemplates should look like:
+    # {
+    #   t1: [prov1, prov2],
+    #   t2: [prov1],
+    #   t3: [prov2]
+    # }
+    mgmt_providertemplates = defaultdict(list)
+    # filter out any empty results from pulling mgmt_templates
+    for prov_templates in [mt for mt in mgmt_templates if mt is not None]:
+        # expecting one key (provider), one value (list of templates)
+        for prov_key, templates in prov_templates.items():
+            for template in templates:
+                mgmt_providertemplates[template].append(prov_key)
 
-    existing_provider_templates = [
-        pt['id']
-        for pt
-        in trackerbot.depaginate(api, api.providertemplate.get())['objects']]
+    logger.debug('DEBUG: template_providers: %r', mgmt_providertemplates)
+    logger.debug('DEBUG: working_providers: %r', working_providers)
 
-    # Find some templates and update the API
-    for template_name, providers in template_providers.items():
-        template_name = str(template_name)
+    usable = {'usable': mark_usable} if mark_usable is not None else {}
+
+    # init these outside conditions/looping to be safe in reporting
+    ignored_providertemplates = defaultdict(list)
+    tb_pts_to_add = list()
+    tb_pts_to_delete = list()
+    tb_templates_to_delete = list()
+
+    # ADD PROVIDERTEMPLATES
+    # add all parseable providertemplates from what is actually on providers
+    for template_name, provider_keys in mgmt_providertemplates.items():
+        # drop empty names, or sprout groups
+        # go over templates pulled from provider mgmt interfaces,
+        if template_name.strip() == '':
+            logger.info('Ignoring empty name template on providers %s', provider_keys)
         template_info = TemplateName.parse_template(template_name)
+        template_group = template_info.group_name
 
-        # it turned out that some providers like ec2 may have templates w/o names.
-        # this is easy protection against such issue.
-        if not template_name.strip():
-            logger.warn('Ignoring template w/o name on provider %s', provider_key)
+        # Don't want sprout templates, or templates that aren't parsable cfme/MIQ
+        if template_group in GROUPS_TO_IGNORE:
+            ignored_providertemplates[template_group].append(template_name)
             continue
 
-        # Don't want sprout templates
-        if template_info.group_name in ('sprout', 'rhevm-internal'):
-            logger.info('Ignoring %s from group %s', template_name, template_info.group_name)
-            continue
+        tb_pts_to_add = [
+            (template_group,
+             provider_key,
+             template_name,
+             None,  # custom_data
+             usable)
+            for provider_key in provider_keys
+        ]
 
-        seen_templates.add(template_name)
-        group = trackerbot.Group(template_info.group_name, stream=template_info.stream)
-        try:
-            template = trackerbot.Template(template_name, group, template_info.datestamp)
-        except ValueError:
-            logger.exception('Failure parsing provider %s template: %s',
-                             provider_key, template_name)
-            continue
+        logger.info('Threading add providertemplate records to trackerbot for %s', template_name)
 
-        for provider_key in providers:
-            provider = trackerbot.Provider(provider_key)
+        with ThreadPool(8) as pool:
+            # thread for each template, passing the list of providers with the template
+            add_results = pool.starmap(
+                trackerbot.add_provider_template,
+                tb_pts_to_add
+            )
 
-            if '{}_{}'.format(template_name, provider_key) in existing_provider_templates:
-                logger.info('Template %s already tracked for provider %s',
-                            template_name, provider_key)
-                continue
+    if not all([True if result in [None, True] else False for result in add_results]):
+        # ignore results that are None, warn for any false results from adding
+        logger.warning('Trackerbot providertemplate add failed, see logs')
 
-            try:
-                trackerbot.mark_provider_template(api, provider, template, **usable)
-                logger.info('Added %s template %s on provider %s (datestamp: %s)',
-                            template_info.group_name,
-                            template_name,
-                            provider_key,
-                            template_info.datestamp)
-            except SlumberHttpBaseException:
-                logger.exception('%s: exception marking template %s', provider, template)
+    for group, names in ignored_providertemplates.items():
+        logger.info('Skipped group [%s] templates %r', group, names)
 
+    # REMOVE PROVIDERTEMPLATES
     # Remove provider relationships where they no longer exist, skipping unresponsive providers,
     # and providers not known to this environment
-    for pt in trackerbot.depaginate(api, api.providertemplate.get())['objects']:
-        key, template_name = pt['provider']['key'], pt['template']['name']
-        if key not in template_providers[template_name] and key not in unresponsive_providers:
-            if key in all_providers:
-                logger.info("Cleaning up template %s on %s", template_name, key)
-                trackerbot.delete_provider_template(api, key, template_name)
-            else:
-                logger.info("Skipping template cleanup %s on unknown provider %s",
-                            template_name, key)
+    logger.info('Querying providertemplate records from Trackerbot for ones to delete')
+    pts = trackerbot.depaginate(
+        tb_api,
+        tb_api.providertemplate.get(provider_in=working_providers)
+    )['objects']
+    for pt in pts:
+        key = pt['provider']['key']
+        pt_name, pt_group = pt['template']['name'], pt['template']['group']['name']
+        if pt_group in GROUPS_TO_IGNORE or key not in mgmt_providertemplates[pt_name]:
+            logger.info("Marking trackerbot providertemplate for delete: %s::%s",
+                        key, pt_name)
+            tb_pts_to_delete.append(ProvTemplate(key, pt_name))
 
+    with ThreadPool(8) as pool:
+        # thread for each delete_provider_template call
+        pool.starmap(
+            trackerbot.delete_provider_template,
+            ((tb_api, pt.provider_key, pt.template_name) for pt in tb_pts_to_delete))
+
+    # REMOVE TEMPLATES
     # Remove templates that aren't on any providers anymore
-    for template in trackerbot.depaginate(api, api.template.get())['objects']:
-        if not template['providers'] and template['name'].strip():
-            logger.info("Deleting template %s (no providers)", template['name'])
-            api.template(template['name']).delete()
+    for template in trackerbot.depaginate(tb_api, tb_api.template.get())['objects']:
+        template_name = template['name']
+        if not template['providers'] and template_name.strip():
+            logger.info("Deleting trackerbot template %s (no providers)", template_name)
+            tb_templates_to_delete.append(template_name)
+            tb_api.template(template_name).delete()
+
+    # WRITE REPORT
+    with open(kwargs.get('outfile'), 'a') as report:
+        add_header = '##### ProviderTemplate records added: #####\n'
+        del_header = '##### ProviderTemplate records deleted: #####\n'
+
+        report.write(add_header)
+        add_message = tabulate(
+            sorted([(ptadd[0], ptadd[1], ptadd[2]) for ptadd in tb_pts_to_add],
+                   key=lambda ptadd: ptadd[0]),
+            headers=['Group', 'Provider', 'Template'],
+            tablefmt='orgtbl'
+        )
+        report.write('{}\n\n'.format(add_message))
+        report.write(del_header)
+        del_message = tabulate(
+            sorted([(ptdel.provider_key, ptdel.template_name) for ptdel in tb_pts_to_delete],
+                   key=lambda ptdel: ptdel[0]),
+            headers=['Provider', 'Template'],
+            tablefmt='orgtbl'
+        )
+        report.write(del_message)
+    logger.info('%s %s', add_header, add_message)
+    logger.info('%s %s', del_header, del_message)
+    return 0
 
     # This is included in case we ever want it, but for now I think it's better to handle this
     # manually, mainly due to the unreliability of the rhevm providers. Also, we may want to mark
@@ -134,40 +226,39 @@ def main(trackerbot_url, mark_usable=None, selected_provider=None):
     #             trackerbot.set_provider_active(True)
 
 
-def get_provider_templates(provider_key, template_providers, unresponsive_providers, thread_lock):
-    # functionalized to make it easy to farm this out to threads
+def templates_on_provider(provider_key, bad_providers):
+    """List templates on specific provider"""
     try:
-        with thread_lock:
-            provider_mgmt = get_mgmt(provider_key)
+        provider_mgmt = get_mgmt(provider_key)
         # TODO: change after openshift wrapanapi refactor
-        if isinstance(provider_mgmt, Openshift):
-            templates = provider_mgmt.list_template()
-        else:
-            # By default, wrapanapi list_templates() will only list private images on gce/ec2
-            templates = [template.name for template in provider_mgmt.list_templates()]
-        print(provider_key, 'returned {} templates'.format(len(templates)))
-        with thread_lock:
-            for template in templates:
+        templates = (
+            provider_mgmt.list_template()
+            if isinstance(provider_mgmt, Openshift)
+            else [
+                template.name
+                for template in provider_mgmt.list_templates(
+                    **({'executable_by_me': False} if isinstance(provider_mgmt, EC2System) else {})
+                )
+            ]
+        )
+
+        logger.info('%s returned %s templates', provider_key, len(templates))
+
+        return {
+            provider_key: [
+                t for t in templates
                 # If it ends with 'db', skip it, it's a largedb/nodb variant
-                if template.lower().endswith('db') and not template.lower().endswith('extdb'):
-                    continue
-                template_providers[template].append(provider_key)
+                if not (t.lower().endswith('db') and not t.lower().endswith('extdb'))
+            ]
+        }
+
     except Exception:
         logger.exception('%s\t%s', provider_key, 'exception getting templates')
-        with thread_lock:
-            unresponsive_providers.add(provider_key)
-
-
-def parse_cmdline():
-    parser = trackerbot.cmdline_parser()
-    parser.add_argument('--mark-usable', default=None, action='store_true',
-        help="Mark all added templates as usable")
-    parser.add_argument('--provider-key', default=None, help='A specific provider key to sync for',
-                        dest='selected_provider', nargs='*')
-    args = parser.parse_args()
-    return dict(args._get_kwargs())
+        bad_providers.put(provider_key)
 
 
 if __name__ == '__main__':
     parsed_args = parse_cmdline()
+    if parsed_args.get('verbose', False):
+        add_stdout_handler(logger)
     sys.exit(main(**parsed_args))


### PR DESCRIPTION
Refactor of sync_template_tracker, adding in threadpools to speed things up. Optimized some of the API calls being made.  Broke some sections out into separate functions for better readability.

Some updates to provider/template selection/filtering. Ignoring amzn-ami images in particular, and not trying to run against disabled providers.

py3 only now, because of using starmap.

Will run in Jenkins to compare time.