### PR TITLE
[RFR] make sync_template_trackerbot script ignore templates with empty name

### DIFF
--- a/scripts/sync_template_tracker.py
+++ b/scripts/sync_template_tracker.py
@@ -105,7 +105,7 @@ def main(trackerbot_url, mark_usable=None, selected_provider=None):
 
     # Remove templates that aren't on any providers anymore
     for template in trackerbot.depaginate(api, api.template.get())['objects']:
-        if not template['providers']:
+        if not template['providers'] and template['name'].strip():
             logger.info("Deleting template %s (no providers)", template['name'])
             api.template(template['name']).delete()
 

--- a/scripts/sync_template_tracker.py
+++ b/scripts/sync_template_tracker.py
@@ -59,6 +59,12 @@ def main(trackerbot_url, mark_usable=None, selected_provider=None):
         template_name = str(template_name)
         template_info = TemplateName.parse_template(template_name)
 
+        # it turned out that some providers like ec2 may have templates w/o names.
+        # this is easy protection against such issue.
+        if not template_name.strip():
+            logger.warn('Ignoring template w/o name on provider %s', provider_key)
+            continue
+
         # Don't want sprout templates
         if template_info.group_name in ('sprout', 'rhevm-internal'):
             logger.info('Ignoring %s from group %s', template_name, template_info.group_name)


### PR DESCRIPTION
it turned out that some providers have templates w/o name. 
When such templates are processed by sync_template_tracker script, those are 1. added to trackerbot; 2. all templates are removed  from trackerbot.
this PR adds some protection from such templates.