### PR TITLE
[1LP][RFR] Blocking test_pxe_provision_from_template by #7494

### DIFF
--- a/cfme/tests/infrastructure/test_pxe_provisioning.py
+++ b/cfme/tests/infrastructure/test_pxe_provisioning.py
@@ -10,13 +10,10 @@ from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.infrastructure.pxe import get_pxe_server_from_config, get_template_from_config
 from cfme.provisioning import do_vm_provisioning
 from cfme.utils import testgen
-from cfme.utils.blockers import BZ
+from cfme.utils.blockers import GH
 
 pytestmark = [
-    pytest.mark.meta(
-        server_roles="+automate +notifier",
-        blockers=[BZ(1519943, forced_streams=['5.9', 'upstream'])]
-    ),
+    pytest.mark.meta(server_roles="+automate +notifier"),
     pytest.mark.usefixtures('uses_infra_providers'),
     pytest.mark.tier(2)
 ]
@@ -97,6 +94,7 @@ def vm_name():
 
 
 @pytest.mark.rhv1
+@pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:7494')])
 def test_pxe_provision_from_template(appliance, provider, vm_name, smtp_test, setup_provider,
                                      request, setup_pxe_servers_vm_prov):
     """Tests provisioning via PXE


### PR DESCRIPTION
{{pytest: cfme/tests/infrastructure/test_pxe_provisioning.py::test_pxe_provision_from_template --long-running --use-provider rhv41}}