### PR TITLE
[1LP][RFR] Fix for quadicon states

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 """Module containing classes with common behaviour for both VMs and Instances of all types."""
-from cached_property import cached_property
 from datetime import datetime, date, timedelta
 
 import attr
+from cached_property import cached_property
 from riggerlib import recursive_update
+from wrapanapi.exceptions import NotFoundError
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.common import Taggable
@@ -23,7 +24,6 @@ from cfme.utils.update import Updateable
 from cfme.utils.virtual_machines import deploy_template
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import VersionPick
-from wrapanapi.exceptions import NotFoundError
 from . import PolicyProfileAssignable
 
 
@@ -670,8 +670,8 @@ class VM(BaseVM):
                 current_state = view.entities.summary("Power Management").get_text_of("Power State")
                 return current_state == desired_state
             else:
-                return 'currentstate-' + desired_state in self.find_quadicon(
-                    from_any_provider=from_any_provider).data['state']
+                return self.find_quadicon(
+                    from_any_provider=from_any_provider).data['state'] == desired_state
 
         return wait_for(
             _looking_for_state_change,

--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from time import sleep
-import os
 
+import os
 from lxml.html import document_fromstring
 from widgetastic.exceptions import NoSuchElementException
 from widgetastic.widget import (
@@ -99,6 +99,7 @@ class JSInstanceEntity(JSBaseEntity):
                     state = state.split("'")[1]
                 state = os.path.split(state)[1]
                 state = os.path.splitext(state)[0]
+                state = state.split("-")[1]
             except IndexError:
                 state = ''
 
@@ -110,6 +111,11 @@ class JSInstanceEntity(JSBaseEntity):
                 policy = None
 
             data_dict['policy'] = policy
+        else:
+            data_dict['os'] = data_dict['quad']['topLeft']['tooltip']
+            data_dict['vendor'] = data_dict['quad']['bottomLeft']['tooltip']
+            data_dict['no_snapshots'] = data_dict['total_snapshots']
+            data_dict['state'] = data_dict['quad']['topRight']['tooltip']
 
         return data_dict
 

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -195,7 +195,7 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Taggable):
 
         def _looking_for_state_change():
             entity = view.entities.get_entity(name=self.name)
-            return "currentstate-{}".format(desired_state) in entity.data['state']
+            return entity.data['state'] == desired_state
 
         return wait_for(
             _looking_for_state_change,

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import fauxfactory
 import pytest
+from wrapanapi import VmState
 
 from cfme import test_requirements
 from cfme.base.login import BaseLoggedInPage
@@ -13,8 +14,6 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for, TimedOutError, RefreshTimer
-
-from wrapanapi import VmState
 
 pytestmark = [
     pytest.mark.tier(2),
@@ -202,7 +201,7 @@ def test_quadicon_terminate_cancel(provider, testing_instance, ensure_vm_running
     testing_instance.power_control_from_cfme(option=testing_instance.TERMINATE,
                                              cancel=True,
                                              from_details=False)
-    soft_assert('currentstate-on' in testing_instance.find_quadicon().data['state'])
+    soft_assert(testing_instance.find_quadicon().data['state'] == 'on')
 
 
 def test_quadicon_terminate(appliance, provider, testing_instance, ensure_vm_running, soft_assert):

--- a/cfme/tests/distributed/test_appliance_replication.py
+++ b/cfme/tests/distributed/test_appliance_replication.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-import pytest
-
 from time import sleep
+
+import pytest
 from six.moves.urllib.parse import urlparse
 
+from cfme import test_requirements
 from cfme.base.ui import ServerView
 from cfme.utils.appliance import provision_appliance
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -12,9 +13,6 @@ from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
 from cfme.utils.ssh import SSHClient
 from cfme.utils.wait import wait_for
-
-from cfme import test_requirements
-
 
 pytestmark = [
     pytest.mark.long_running,
@@ -329,7 +327,7 @@ def test_distributed_vm_power_control(request, test_vm, virtualcenter_provider, 
         test_vm.power_control_from_cfme(option=test_vm.POWER_OFF, cancel=False)
         navigate_to(test_vm.provider, 'Details')
         test_vm.wait_for_vm_state_change(desired_state=test_vm.STATE_OFF, timeout=900)
-        soft_assert(test_vm.find_quadicon().data['state'] == 'currentstate-off')
+        soft_assert(test_vm.find_quadicon().data['state'] == 'off')
         soft_assert(
             not test_vm.mgmt.is_running,
             "vm running")

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -164,7 +164,7 @@ class TestControlOnQuadicons(object):
         # TODO: assert no event.
         time.sleep(60)
         vm_state = testing_vm.find_quadicon().data['state']
-        soft_assert('currentstate-on' in vm_state)
+        soft_assert(vm_state == 'on')
         soft_assert(
             testing_vm.mgmt.is_running, "vm not running")
 
@@ -184,7 +184,7 @@ class TestControlOnQuadicons(object):
         if_scvmm_refresh_provider(testing_vm.provider)
         testing_vm.wait_for_vm_state_change(desired_state=testing_vm.STATE_OFF, timeout=900)
         vm_state = testing_vm.find_quadicon().data['state']
-        soft_assert('currentstate-off' in vm_state)
+        soft_assert(vm_state == 'off')
         soft_assert(not testing_vm.mgmt.is_running, "vm running")
 
     @pytest.mark.rhv3
@@ -199,7 +199,7 @@ class TestControlOnQuadicons(object):
         if_scvmm_refresh_provider(testing_vm.provider)
         time.sleep(60)
         vm_state = testing_vm.find_quadicon().data['state']
-        soft_assert('currentstate-off' in vm_state)
+        soft_assert(vm_state == 'off')
         soft_assert(not testing_vm.mgmt.is_running, "vm running")
 
     @pytest.mark.rhv1
@@ -219,7 +219,7 @@ class TestControlOnQuadicons(object):
         if_scvmm_refresh_provider(testing_vm.provider)
         testing_vm.wait_for_vm_state_change(desired_state=testing_vm.STATE_ON, timeout=900)
         vm_state = testing_vm.find_quadicon().data['state']
-        soft_assert('currentstate-on' in vm_state)
+        soft_assert(vm_state == 'on')
         soft_assert(testing_vm.mgmt.is_running, "vm not running")
 
 
@@ -409,7 +409,7 @@ def test_archived_vm_status(testing_vm, archived_vm):
         test_flag: inventory
     """
     vm_state = testing_vm.find_quadicon(from_any_provider=True).data['state']
-    assert ('currentstate-archived' in vm_state)
+    assert (vm_state == 'archived')
 
 
 @pytest.mark.rhv3
@@ -420,7 +420,7 @@ def test_orphaned_vm_status(testing_vm, orphaned_vm):
         test_flag: inventory
     """
     vm_state = testing_vm.find_quadicon(from_any_provider=True).data['state']
-    assert ('currentstate-orphaned' in vm_state)
+    assert (vm_state == 'orphaned')
 
 
 @pytest.mark.rhv1


### PR DESCRIPTION
Later CFME versions drop the ability to access 'quadicon' attribute. So
in order to fix this, we now access each corner through the tooltips.
This meant that it made more sense to do actual comparisons instead of
looking for substrings.

{{pytest: cfme/tests/infrastructure/test_vm_power_control.py -k TestControlOnQuadicons.test_power_on_cancel --long-running}}