### PR TITLE
[WIPTEST]Add custom report to existing report menu

### DIFF
--- a/cfme/tests/intelligence/reports/test_menus.py
+++ b/cfme/tests/intelligence/reports/test_menus.py
@@ -1,10 +1,16 @@
 # -*- coding: utf-8 -*-
 import pytest
 import random
+import yaml
 
+from cfme import test_requirements
 from cfme.intelligence.reports import menus
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
+from cfme.utils.path import data_path
+
+
+report_crud_dir = data_path.join("reports_crud")
 
 # EvmGroup-super_administrator -> user `admin`
 # If we add more, will need relogin + user creation
@@ -26,6 +32,22 @@ def report_menus(group):
     report_menus = menus.ReportMenu()
     yield report_menus
     report_menus.reset_to_default(group)
+
+
+def crud_files_reports():
+    result = []
+    if not report_crud_dir.exists:
+        report_crud_dir.mkdir()
+    for file_name in report_crud_dir.listdir():
+        if file_name.isfile() and file_name.basename.endswith(".yaml"):
+            result.append(file_name.basename)
+    return result
+
+
+@pytest.fixture(params=crud_files_reports())
+def custom_report_values(request):
+    with report_crud_dir.join(request.param).open(mode="r") as rep_yaml:
+        return yaml.load(rep_yaml)
 
 
 @pytest.mark.tier(3)
@@ -54,7 +76,8 @@ def test_shuffle_first_level(appliance, group, report_menus):
     tree = view.reports.tree.read_contents()[1]
     # Select some folder that has at least 3 children
     folders = map(lambda item: item[0],
-                filter(lambda item: isinstance(item[1], list) and len(item[1]) >= 3, tree))
+                  filter(lambda item: isinstance(item[1], list) and len(item[1]) >= 3, tree))
+
     selected_folder = random.choice(folders)
     # Shuffle the order
     with report_menus.manage_folder(group, selected_folder) as folder:
@@ -66,3 +89,22 @@ def test_shuffle_first_level(appliance, group, report_menus):
     view.reports.tree.click_path("All Reports", selected_folder)
     table = [row["Name"].text for row in view.reports_table]
     assert table == order, "The order differs!"
+
+
+@pytest.mark.tier(3)
+@pytest.mark.parametrize("group", GROUPS)
+@test_requirements.report
+def test_add_reports_to_available_reports_menu(appliance, request, group,
+                                               report_menus, custom_report_values):
+    """This test case moves custom menu to existing menus"""
+
+    custom_report = appliance.collections.reports.create(**custom_report_values)
+    request.addfinalizer(custom_report.delete)
+    folder = random.choice(report_menus.get_folders(group))
+    sub_folder = random.choice(report_menus.get_subfolders(group, folder))
+    with report_menus.manage_subfolder(group, folder, sub_folder) as selected:
+        selected.available_options.fill(custom_report.menu_name)
+        selected.move_into_button.click()
+    report = appliance.collections.reports.instantiate(
+        type=folder, subtype=sub_folder, menu_name=custom_report.menu_name)
+    assert report.exists


### PR DESCRIPTION
This automation test creates a custom report, selects a random subfolder within folder, moves the custom report to that menu and asserts if the report has been moved.

Note:  A fixture has been added from 
`cfme/tests/intelligence/reports/test_crud.py` to create a custom report using `data/reports_crud/basic01.yaml`.

{{ pytest: cfme/tests/intelligence/reports/test_menus.py -k test_add_reports_to_available_reports_menu }}