### PR TITLE
[1LP][RFR] - Missing flash message - Order Request was Submitted

### DIFF
--- a/cfme/services/service_catalogs/ui.py
+++ b/cfme/services/service_catalogs/ui.py
@@ -99,7 +99,8 @@ def order(self):
         view.submit_button.click()
     view = self.create_view(RequestsView)
     view.flash.assert_no_error()
-    view.flash.assert_message(msg, msg_type)
+    if not BZ(1605102, forced_streams=['5.10']).blocks:
+        view.flash.assert_message(msg, msg_type)
     return self.appliance.collections.requests.instantiate(self.name, partial_check=True)
 
 


### PR DESCRIPTION
Purpose or Intent
=================
Multiple services tests re failing due to missing flash message 'Order Request was Submitted'. BZ for 5.10 is created and this fix should block asserting flash message. 

11 tests are failing because of missing flash message.