### PR TITLE
[1LP][RFR] Fix in the case a required field is a string

### DIFF
--- a/cfme/tests/infrastructure/test_tenant_quota.py
+++ b/cfme/tests/infrastructure/test_tenant_quota.py
@@ -254,7 +254,7 @@ def test_setting_child_quota_more_than_parent(tenants_setup, parent_quota, child
 
 @pytest.mark.long_running
 @pytest.mark.provider([VMwareProvider, RHEVMProvider], override=True, scope="module",
-                      required_fields=['templates', 'small_template'], selector=ONE_PER_TYPE)
+                      required_fields=[['templates', 'small_template']], selector=ONE_PER_TYPE)
 @pytest.mark.parametrize(
     ['set_roottenant_quota', 'custom_prov_data'],
     [

--- a/cfme/utils/providers.py
+++ b/cfme/utils/providers.py
@@ -9,12 +9,12 @@ dict and will provide you with whatever you ask for with no limitations.
 The main clue to know what is limited by the filters and what isn't is the 'filters' parameter.
 """
 import operator
-import six
 from collections import Mapping, OrderedDict
 from copy import copy
 
-from cfme.common.provider import all_types
+import six
 
+from cfme.common.provider import all_types
 from cfme.exceptions import UnknownProviderType
 from cfme.utils import conf
 from cfme.utils.log import logger
@@ -107,6 +107,8 @@ class ProviderFilter(object):
                 o = provider.data
                 try:
                     for field in field_ident:
+                        if not isinstance(o, Mapping):
+                            raise KeyError
                         o = o[field]
                     if field_value:
                         if o != field_value:


### PR DESCRIPTION
* In the case of nested keys, sometimes different providers have set
things up differently and have a string where another provider has a
set of nested keys.
* This makes that allowable when provider filtering.