### PR TITLE
[1LP][RFR] Modify is_displayed method in every provider's Edit view

### DIFF
--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -11,8 +11,8 @@ from cfme.cloud.instance.image import Image
 from cfme.common import TagPageView
 from cfme.common.provider import CloudInfraProvider, provider_types
 from cfme.common.provider_views import (
-    CloudProviderAddView, CloudProviderEditView, CloudProviderDetailsView, CloudProvidersView,
-    CloudProvidersDiscoverView)
+    CloudProviderAddView, CloudProviderDetailsView, CloudProvidersView,
+    CloudProvidersDiscoverView, ProviderEditView)
 from cfme.common.vm_views import VMToolbar, VMEntities
 from cfme.modeling.base import BaseCollection
 from cfme.utils.appliance.implementations.ui import navigator, navigate_to, CFMENavigateStep
@@ -243,7 +243,7 @@ class Details(CFMENavigateStep):
 
 @navigator.register(CloudProvider, 'Edit')
 class Edit(CFMENavigateStep):
-    VIEW = CloudProviderEditView
+    VIEW = ProviderEditView
     prerequisite = NavigateToSibling('All')
 
     def step(self):
@@ -257,7 +257,7 @@ class Edit(CFMENavigateStep):
 
 @navigator.register(CloudProvider, 'EditFromDetails')
 class EditFromDetails(CFMENavigateStep):
-    VIEW = CloudProviderEditView
+    VIEW = ProviderEditView
     prerequisite = NavigateToSibling('Details')
 
     def step(self):

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -564,62 +564,20 @@ class ProviderEditView(ProviderAddView):
 
     @property
     def is_displayed(self):
-        return self.logged_in_as_current_user
+        provider_obj = self.context['object']
+        expected_title = ("Edit {type} Providers '{name}'".format(
+            type=provider_obj.string_name, name=provider_obj.name))
+
+        return (self.logged_in_as_current_user and
+                self.title.text == expected_title and
+                self.navigation.currently_selected == [
+                    'Compute',
+                    ('Clouds' if provider_obj.string_name == "Cloud" else provider_obj.string_name),
+                    'Providers'
+                ])
 
 
-class InfraProviderEditView(ProviderEditView):
-    """
-     represents Infra Provider Edit View
-    """
-    @property
-    def is_displayed(self):
-        expected_title = ("Edit Infrastructure Providers '{name}'".format(
-            name=self.context['object'].name))
-        return (super(InfraProviderEditView, self).is_displayed and
-                self.navigation.currently_selected == ['Compute', 'Infrastructure', 'Providers'] and
-                self.title.text == expected_title)
-
-
-class PhysicalProviderEditView(ProviderEditView):
-    """
-     represents Provider Edit View
-    """
-    @property
-    def is_displayed(self):
-        expected_title = ("Edit Physical Infrastructure Providers '{name}'"
-                          .format(name=self.context['object'].name))
-        return (super(PhysicalProviderEditView, self).is_displayed and
-                self.navigation.currently_selected ==
-                ['Compute', 'Physical Infrastructure', 'Providers'] and
-                self.title.text == expected_title)
-
-
-class CloudProviderEditView(ProviderEditView):
-    """
-     represents Cloud Provider Edit View
-    """
-    @property
-    def is_displayed(self):
-        expected_title = ("Edit Cloud Providers '{name}'".format(name=self.context['object'].name))
-        return (super(CloudProviderEditView, self).is_displayed and
-                self.navigation.currently_selected == ['Compute', 'Clouds', 'Providers'] and
-                self.title.text == expected_title)
-
-
-class ContainerProviderEditView(ProviderEditView):
-    """
-     represents Container Provider Edit View
-    """
-    @property
-    def is_displayed(self):
-        expected_title = ("Edit Container Providers '{name}'".format(
-            name=self.context['object'].name))
-        return (super(ProviderEditView, self).is_displayed and
-                self.navigation.currently_selected == ['Compute', 'Containers', 'Providers'] and
-                self.title.text == expected_title)
-
-
-class ContainerProviderEditViewUpdated(ContainerProviderEditView, ContainerProviderSettingView):
+class ContainerProviderEditViewUpdated(ProviderEditView, ContainerProviderSettingView):
     """
      Additional widgets for builds 5.9 and up
     """

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -415,6 +415,7 @@ class BeforeFillMixin(object):
     """
      this mixin is used to activate appropriate tab before filling this tab
     """
+
     def before_fill(self):
         if self.exists and not self.is_active():
             self.select()
@@ -572,9 +573,11 @@ class InfraProviderEditView(ProviderEditView):
     """
     @property
     def is_displayed(self):
+        expected_title = ("Edit Infrastructure Providers '{name}'".format(
+            name=self.context['object'].name))
         return (super(InfraProviderEditView, self).is_displayed and
                 self.navigation.currently_selected == ['Compute', 'Infrastructure', 'Providers'] and
-                self.title.text == 'Edit Infrastructure Provider')
+                self.title.text == expected_title)
 
 
 class PhysicalProviderEditView(ProviderEditView):
@@ -597,9 +600,10 @@ class CloudProviderEditView(ProviderEditView):
     """
     @property
     def is_displayed(self):
+        expected_title = ("Edit Cloud Providers '{name}'".format(name=self.context['object'].name))
         return (super(CloudProviderEditView, self).is_displayed and
                 self.navigation.currently_selected == ['Compute', 'Clouds', 'Providers'] and
-                self.title.text == 'Edit Cloud Provider')
+                self.title.text == expected_title)
 
 
 class ContainerProviderEditView(ProviderEditView):
@@ -608,9 +612,11 @@ class ContainerProviderEditView(ProviderEditView):
     """
     @property
     def is_displayed(self):
-        return (super(ContainerProviderEditView, self).is_displayed and
+        expected_title = ("Edit Container Providers '{name}'".format(
+            name=self.context['object'].name))
+        return (super(ProviderEditView, self).is_displayed and
                 self.navigation.currently_selected == ['Compute', 'Containers', 'Providers'] and
-                'Edit Containers Provider' in self.title.text)
+                self.title.text == expected_title)
 
 
 class ContainerProviderEditViewUpdated(ContainerProviderEditView, ContainerProviderSettingView):

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -22,10 +22,10 @@ from cfme.common import TagPageView, PolicyProfileAssignable
 from cfme.common.candu_views import OptionForm
 from cfme.common.provider import BaseProvider, DefaultEndpoint, DefaultEndpointForm, provider_types
 from cfme.common.provider_views import (
-    BeforeFillMixin, ContainerProviderAddView, ContainerProvidersView,
-    ContainerProviderEditView, ContainerProviderEditViewUpdated, ProvidersView,
-    ContainerProviderAddViewUpdated, ProviderSideBar,
-    ProviderDetailsToolBar, ProviderDetailsView, ProviderToolBar)
+    BeforeFillMixin, ContainerProviderAddViewUpdated,
+    ContainerProviderEditViewUpdated, ContainerProvidersView,
+    ProviderDetailsToolBar, ProviderDetailsView,
+    ProviderSideBar, ProviderToolBar, ProvidersView)
 from cfme.modeling.base import BaseCollection
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
 from cfme.utils.browser import browser
@@ -647,6 +647,7 @@ class ContainersTestItem(object):
 class LoadDetailsMixin(object):
     """Embed load details functionality for objects -
     required for some classes like PolicyProfileAssignable"""
+
     def load_details(self, refresh=False):
         view = navigate_to(self, 'Details')
         if refresh:
@@ -662,7 +663,6 @@ class Labelable(object):
         return self.mgmt.list_labels()
 
     def set_label(self, name, value):
-
         """Sets a label to the object instance
 
         Args:

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -12,9 +12,9 @@ from cfme.common import TagPageView
 from cfme.common.host_views import ProviderAllHostsView
 from cfme.common.provider import CloudInfraProvider, provider_types
 from cfme.common.provider_views import (
-    InfraProviderAddView, InfraProviderEditView, InfraProviderDetailsView, ProviderTimelinesView,
-    InfraProvidersDiscoverView, InfraProvidersView, ProviderNodesView, ProviderTemplatesView,
-    ProviderVmsView)
+    InfraProviderAddView, InfraProviderDetailsView, InfraProvidersDiscoverView,
+    InfraProvidersView, ProviderEditView, ProviderNodesView,
+    ProviderTemplatesView, ProviderTimelinesView, ProviderVmsView)
 from cfme.exceptions import DestinationNotFound
 from cfme.infrastructure.cluster import ClusterView, ClusterToolbar
 from cfme.infrastructure.host import HostsCollection
@@ -354,7 +354,7 @@ class EditTags(CFMENavigateStep):
 
 @navigator.register(InfraProvider, 'Edit')
 class Edit(CFMENavigateStep):
-    VIEW = InfraProviderEditView
+    VIEW = ProviderEditView
     prerequisite = NavigateToSibling('All')
 
     def step(self):

--- a/cfme/networks/views.py
+++ b/cfme/networks/views.py
@@ -105,7 +105,7 @@ class NetworkProviderEditView(ProviderEditView):
     """ Represents Network Provider Edit View """
     @property
     def is_displayed(self):
-        return (super(NetworkProviderEditView, self).is_displayed and
+        return (self.logged_in_as_current_user and
                 self.navigation.currently_selected == ['Networks', 'Providers'] and
                 self.title.text.startswith('Edit Network Provider'))
 

--- a/cfme/physical/provider/__init__.py
+++ b/cfme/physical/provider/__init__.py
@@ -9,7 +9,7 @@ from cfme.common.provider import BaseProvider, provider_types
 from cfme.common.provider_views import (PhysicalProviderAddView,
                                         PhysicalProvidersView,
                                         PhysicalProviderDetailsView,
-                                        PhysicalProviderEditView)
+                                        ProviderEditView)
 from cfme.modeling.base import BaseCollection
 from cfme.utils.appliance.implementations.ui import navigate_to, navigator, CFMENavigateStep
 from cfme.utils.log import logger
@@ -137,7 +137,7 @@ class Details(CFMENavigateStep):
 
 @navigator.register(PhysicalProvider, 'Edit')
 class Edit(CFMENavigateStep):
-    VIEW = PhysicalProviderEditView
+    VIEW = ProviderEditView
     prerequisite = NavigateToSibling('Details')
 
     def step(self):


### PR DESCRIPTION
Modified `is_displayed` methods inside the following edit views:
1. `InfraProviderEditView`
2. `PhysicalProviderEditView`
3. `ContainerProviderEditView`

This change was made to fix the `is_displayed` methods of the above mentioned views, which returned `False` even if the page was displayed.