### PR TITLE
[1LP][RFR] Add legacy options for parametrization

### DIFF
--- a/cfme/fixtures/provider.py
+++ b/cfme/fixtures/provider.py
@@ -36,12 +36,13 @@ as a result. If this counter reaches a predefined number of failures (see ``SETU
 the failing provider will be added to the list of problematic providers and no further attempts
 to set it up will be made.
 """
-import pytest
 import random
-import six
 import sys
 from collections import Mapping
 from collections import defaultdict
+
+import pytest
+import six
 from _pytest.compat import getimfunc
 from _pytest.fixtures import call_fixture_func
 from _pytest.outcomes import TEST_OUTCOME
@@ -65,10 +66,16 @@ SETUP_FAIL_LIMIT = 3
 def pytest_addoption(parser):
     # Create the cfme option group for use in other plugins
     parser.getgroup('cfme')
+    parser.addoption('--legacy-ids', action='store_true',
+        help="Do not use type/version parametrization")
+    parser.addoption('--disable-selectors', action='store_true',
+        help="Do not use the selectors for parametrization")
     parser.addoption("--provider-limit", action="store", default=1, type=int,
         help=(
             "Number of providers allowed to coexist on appliance. 0 means no limit. "
-            "Use 1 or 2 when running on a single appliance, depending on HW configuration."))
+            "Use 1 or 2 when running on a single appliance, depending on HW configuration."
+        )
+    )
 
 
 def _artifactor_skip_providers(request, providers, skip_msg):

--- a/cfme/markers/env_markers/provider.py
+++ b/cfme/markers/env_markers/provider.py
@@ -334,24 +334,30 @@ def providers(metafunc, filters=None, selector=ALL):
         argvalues.append(pytest.param(data_prov))
 
         # Use the provider key for idlist, helps with readable parametrized test output
-        ver = data_prov.version if data_prov.version else None
-        if ver:
-            the_id = "{}-{}".format(data_prov.type_name, data_prov.version)
+        if metafunc.config.getoption('legacy_ids'):
+            the_id = "{}".format(data_prov.key)
         else:
-            the_id = "{}".format(data_prov.type_name)
+            ver = data_prov.version if data_prov.version else None
+            if ver:
+                the_id = "{}-{}".format(data_prov.type_name, data_prov.version)
+            else:
+                the_id = "{}".format(data_prov.type_name)
 
         # Now we modify the id based on what selector we chose
-        if selector == ONE:
-            if need_prov_keys:
+        if metafunc.config.getoption('disable_selectors'):
+            idlist.append(the_id)
+        else:
+            if selector == ONE:
+                if need_prov_keys:
+                    idlist.append(data_prov.type_name)
+                else:
+                    idlist.append(data_prov.category)
+            elif selector == ONE_PER_CATEGORY:
+                idlist.append(data_prov.category)
+            elif selector == ONE_PER_TYPE:
                 idlist.append(data_prov.type_name)
             else:
-                idlist.append(data_prov.category)
-        elif selector == ONE_PER_CATEGORY:
-            idlist.append(data_prov.category)
-        elif selector == ONE_PER_TYPE:
-            idlist.append(data_prov.type_name)
-        else:
-            idlist.append(the_id)
+                idlist.append(the_id)
 
         # Add provider to argnames if missing
         if 'provider' in metafunc.fixturenames and 'provider' not in argnames:


### PR DESCRIPTION
* --legacy-ids option added this will disable type/version
  parametrization
* --disable-selectors option disables the use of selectors