### PR TITLE
[1LP][RFR] Fixes tests running on removed collections

### DIFF
--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -170,6 +170,7 @@ COLLECTIONS_IN_59 = {
 
 
 COLLECTIONS_IN_UPSTREAM = COLLECTIONS_IN_59
+COLLECTIONS_IN_510 = COLLECTIONS_IN_59
 COLLECTIONS_IN_58 = (COLLECTIONS_IN_59 | COLLECTIONS_OBSOLETED_IN_59) - COLLECTIONS_NEWER_THAN_58
 COLLECTIONS_ALL = COLLECTIONS_IN_59 | COLLECTIONS_IN_58
 # non-typical collections without "id" and "resources", or additional parameters are required
@@ -180,6 +181,7 @@ def _collection_not_in_this_version(appliance, collection_name):
     return (
         (collection_name not in COLLECTIONS_IN_UPSTREAM and appliance.version.is_in_series(
             'upstream')) or
+        (collection_name not in COLLECTIONS_IN_510 and appliance.version.is_in_series('5.10')) or
         (collection_name not in COLLECTIONS_IN_59 and appliance.version.is_in_series('5.9')) or
         (collection_name not in COLLECTIONS_IN_58 and appliance.version.is_in_series('5.8'))
     )


### PR DESCRIPTION
Some collections were removed in 5.9. This fix prevents testing of these collections on 5.10 as well.

{{pytest: -v --use-provider vsphere65-nested -k "test_query_with_api_version or test_query_simple_collections or test_attributes_present" cfme/tests/test_rest.py}}