### PR TITLE
[WIPTEST] Cleaning after REST snapshot tests

### DIFF
--- a/cfme/tests/cloud_infra_common/test_snapshots_rest.py
+++ b/cfme/tests/cloud_infra_common/test_snapshots_rest.py
@@ -54,6 +54,7 @@ def vm(provider, appliance, collection, setup_provider_modscope, small_template_
         vm = vms[0]
         vm.action.delete()
         vm.wait_not_exists(num_sec=600, delay=5)
+    new_vm.cleanup_on_provider()
 
 
 def _delete_snapshot(vm, description):


### PR DESCRIPTION
...so that the VM does not stay on the provider, leaving messy env behind.

{{pytest: cfme/tests/cloud_infra_common/test_snapshots_rest.py --use-provider rhv41 --long-running -vv}}