### PR TITLE
[1LP][RFR] Add negative test (wrong API port for container provider)

### DIFF
--- a/cfme/tests/containers/test_ssl_providers.py
+++ b/cfme/tests/containers/test_ssl_providers.py
@@ -18,7 +18,7 @@ alphanumeric_name = gen_alphanumeric(10)
 long_alphanumeric_name = gen_alphanumeric(100)
 integer_name = str(gen_integer(0, 100000000))
 provider_names = alphanumeric_name, integer_name, long_alphanumeric_name
-AVAILABLE_SEC_PROTOCOLS = ('SSL trusting custom CA','SSL without validation', 'SSL')
+AVAILABLE_SEC_PROTOCOLS = ('SSL trusting custom CA', 'SSL without validation', 'SSL')
 
 DEFAULT_SEC_PROTOCOLS = (
     pytest.mark.polarion('CMP-10598')('SSL trusting custom CA'),

--- a/cfme/tests/containers/test_ssl_providers.py
+++ b/cfme/tests/containers/test_ssl_providers.py
@@ -148,3 +148,27 @@ def test_add_mertics_provider_ssl(provider, appliance, test_item,
     else:
         new_provider.delete(cancel=False)
         new_provider.wait_for_delete()
+
+
+def test_setup_with_wrong_port(provider):
+    """
+    Negative test: set a provider with wrong api port
+    based on BZ1443520
+    """
+    new_provider = copy(provider)
+    new_provider.endpoints["default"].api_port = "1234"
+
+    is_fail = False
+    try:
+        new_provider.setup()
+    except AssertionError as ex:
+        node = new_provider.endpoints["default"].hostname
+        port = new_provider.endpoints["default"].api_port
+        assert (
+            'Credential validation was not successful: Failed to open TCP connection'
+            ' to {node}:{port} (No route to host - connect(2) for "{node}" port '
+            '{port}'.format(node=node, port=port) in ex.message), (
+            "No clear failure massage was provided for wrong api port")
+        is_fail = True
+
+    assert is_fail, "Provider was set with wrong api port"

--- a/cfme/tests/containers/test_ssl_providers.py
+++ b/cfme/tests/containers/test_ssl_providers.py
@@ -18,7 +18,9 @@ alphanumeric_name = gen_alphanumeric(10)
 long_alphanumeric_name = gen_alphanumeric(100)
 integer_name = str(gen_integer(0, 100000000))
 provider_names = alphanumeric_name, integer_name, long_alphanumeric_name
-AVAILABLE_SEC_PROTOCOLS = ('SSL trusting custom CA', 'SSL without validation', 'SSL')
+AVAILABLE_SEC_PROTOCOLS = ('SSL trusting custom CA',
+                           'SSL without validation',
+                           'SSL')
 
 DEFAULT_SEC_PROTOCOLS = (
     pytest.mark.polarion('CMP-10598')('SSL trusting custom CA'),
@@ -150,6 +152,7 @@ def test_add_mertics_provider_ssl(provider, appliance, test_item,
     else:
         new_provider.delete(cancel=False)
         new_provider.wait_for_delete()
+
 
 @pytest.mark.usefixtures('has_no_containers_providers')
 @pytest.mark.parametrize('sec_protocol', AVAILABLE_SEC_PROTOCOLS)

--- a/cfme/tests/containers/test_ssl_providers.py
+++ b/cfme/tests/containers/test_ssl_providers.py
@@ -18,6 +18,8 @@ alphanumeric_name = gen_alphanumeric(10)
 long_alphanumeric_name = gen_alphanumeric(100)
 integer_name = str(gen_integer(0, 100000000))
 provider_names = alphanumeric_name, integer_name, long_alphanumeric_name
+AVAILABLE_SEC_PROTOCOLS = ('SSL trusting custom CA','SSL without validation', 'SSL')
+
 DEFAULT_SEC_PROTOCOLS = (
     pytest.mark.polarion('CMP-10598')('SSL trusting custom CA'),
     pytest.mark.polarion('CMP-10597')('SSL without validation'),
@@ -150,13 +152,15 @@ def test_add_mertics_provider_ssl(provider, appliance, test_item,
         new_provider.wait_for_delete()
 
 
-def test_setup_with_wrong_port(provider):
+@pytest.mark.parametrize('sec_protocol', AVAILABLE_SEC_PROTOCOLS)
+def test_setup_with_wrong_port(provider, sec_protocol, sync_ssl_certificate):
     """
     Negative test: set a provider with wrong api port
     based on BZ1443520
     """
     new_provider = copy(provider)
     new_provider.endpoints["default"].api_port = "1234"
+    new_provider.endpoints["default"].sec_protocol = sec_protocol
 
     is_fail = False
     try:

--- a/cfme/tests/containers/test_ssl_providers.py
+++ b/cfme/tests/containers/test_ssl_providers.py
@@ -151,7 +151,7 @@ def test_add_mertics_provider_ssl(provider, appliance, test_item,
         new_provider.delete(cancel=False)
         new_provider.wait_for_delete()
 
-
+@pytest.mark.usefixtures('has_no_containers_providers')
 @pytest.mark.parametrize('sec_protocol', AVAILABLE_SEC_PROTOCOLS)
 def test_setup_with_wrong_port(provider, sec_protocol, sync_ssl_certificate):
     """
@@ -162,17 +162,5 @@ def test_setup_with_wrong_port(provider, sec_protocol, sync_ssl_certificate):
     new_provider.endpoints["default"].api_port = "1234"
     new_provider.endpoints["default"].sec_protocol = sec_protocol
 
-    is_fail = False
-    try:
+    with pytest.raises(AssertionError, message="Provider was set with wrong api port"):
         new_provider.setup()
-    except AssertionError as ex:
-        node = new_provider.endpoints["default"].hostname
-        port = new_provider.endpoints["default"].api_port
-        assert (
-            'Credential validation was not successful: Failed to open TCP connection'
-            ' to {node}:{port} (No route to host - connect(2) for "{node}" port '
-            '{port}'.format(node=node, port=port) in ex.message), (
-            "No clear failure massage was provided for wrong api port")
-        is_fail = True
-
-    assert is_fail, "Provider was set with wrong api port"


### PR DESCRIPTION
{{ pytest : cfme/tests/containers/test_ssl_providers.py::test_setup_with_wrong_port --use-provider ocp-39-hawk }}