### PR TITLE
[1LP][RFR] Test OCP operator role out-of-the-box

### DIFF
--- a/cfme/tests/containers/test_provider_configuration_menu.py
+++ b/cfme/tests/containers/test_provider_configuration_menu.py
@@ -25,11 +25,22 @@ def test_edit_selected_containers_provider(provider):
 
 
 def test_ocp_operator_out_of_the_box(appliance):
+    """
+    This test checks that the container oprator role is available out-of_the_box
+    Steps:
+     1. Navigate to  Administration | EVM (on the right upper corner)--> Configuration
+     2. In the new page on the left menu select Access Control --> roles
+     3. Search for container operator role
+    """
 
+    # Navigate to all roles page
     roles_collection = appliance.collections.roles
     view = navigate_to(roles_collection, "All")
+
+    # Search for the required role
     role_name_prefix = "container_operator"
     is_role_found = bool(filter(lambda row: role_name_prefix in row.name.text.lower(),
                                 view.table.rows()))
 
+    # validate the role exist out-of-the-box
     assert is_role_found, "No {role} found".format(role=role_name_prefix)

--- a/cfme/tests/containers/test_provider_configuration_menu.py
+++ b/cfme/tests/containers/test_provider_configuration_menu.py
@@ -22,3 +22,14 @@ def test_edit_selected_containers_provider(provider):
     view = navigate_to(provider, 'Edit')
     assert view.is_displayed
     view.cancel.click()
+
+
+def test_ocp_operator_out_of_the_box(appliance):
+
+    roles_collection = appliance.collections.roles
+    view = navigate_to(roles_collection, "All")
+    role_name_prefix = "container_operator"
+    is_role_found = bool(filter(lambda row: role_name_prefix in row.name.text.lower(),
+                                view.table.rows()))
+
+    assert is_role_found, "No {role} found".format(role=role_name_prefix)


### PR DESCRIPTION
{{ pytest : cfme/tests/containers/test_provider_configuration_menu.py::test_ocp_operator_out_of_the_box --use-provider ocp-36-hawk }}