### PR TITLE
[1LP][RFR] browser manager: handle all exceptions and ensure wharf containrs are…

### DIFF
--- a/cfme/utils/browser.py
+++ b/cfme/utils/browser.py
@@ -33,6 +33,9 @@ from cfme.utils.path import data_path
 FIVE_MINUTES = 5 * 60
 THIRTY_SECONDS = 30
 
+BROWSER_ERRORS = URLError, WebDriverException
+WHARF_OUTER_RETRIES = 3
+
 
 def _load_firefox_profile():
     # create a firefox profile using the template in data/firefox_profile.js.template
@@ -216,7 +219,12 @@ class WharfFactory(BrowserFactory):
                 log.exception(ex)
                 self.wharf.checkin()
                 raise
-        return tries(10, URLError, inner)
+            except Exception:
+                log.exception("failure on webdriver usage, returning container")
+                self.wharf.checkin()
+                raise
+
+        return tries(WHARF_OUTER_RETRIES, BROWSER_ERRORS, inner)
 
     def close(self, browser):
         try:

--- a/cfme/utils/browser.py
+++ b/cfme/utils/browser.py
@@ -34,7 +34,7 @@ FIVE_MINUTES = 5 * 60
 THIRTY_SECONDS = 30
 
 BROWSER_ERRORS = URLError, WebDriverException
-WHARF_OUTER_RETRIES = 3
+WHARF_OUTER_RETRIES = 2
 
 
 def _load_firefox_profile():

--- a/cfme/utils/browser.py
+++ b/cfme/utils/browser.py
@@ -156,7 +156,7 @@ class BrowserFactory(object):
     def create(self, url_key):
         try:
             browser = tries(
-                3, WebDriverException,
+                2, WebDriverException,
                 self.webdriver_class, **self.processed_browser_args())
         except URLError as e:
             if e.reason.errno == 111:


### PR DESCRIPTION
… returned on all errors not just urlerrors

code is yet to be tested in the condition that triggers the issue
due to not handling all exceptions we recently started to trigger a condition on wharf that led to countless started browsers due to requesting unsupported capabilities,

this was elevated by the fact that the error that looped around was also not handling all exceptions and we ended up with a lot of browsers being started and not being used