### PR TITLE
[1LP][RFR] Fixing test_button_on_host

### DIFF
--- a/cfme/tests/automate/test_buttons.py
+++ b/cfme/tests/automate/test_buttons.py
@@ -127,7 +127,7 @@ def test_button_on_host(appliance, request, provider, setup_provider):
         hover="btn_hvr_{}".format(fauxfactory.gen_alphanumeric()),
         system="Request", request="InspectMe")
     request.addfinalizer(button.delete_if_exists)
-    host = appliance.collections.hosts.all(provider)[0]
+    host = provider.hosts.all()[0]
     host.execute_button(buttongroup.hover, button.text, handle_alert=None)
 
 


### PR DESCRIPTION
{{pytest: cfme/tests/automate/test_buttons.py::test_button_on_host --long-running -vv --use-provider rhv42}}

It used to throw:
> host = appliance.collections.hosts.all(provider)[0]
> E TypeError: all() takes exactly 1 argument (2 given)

Verification: https://rhv-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/cfme-5.9-rhv-4.2-integration-test-dev/134/