### PR TITLE
[WIPTEST] Blocking test_edit_catalog_after_deleting_provider with BZ1609297

### DIFF
--- a/cfme/tests/services/test_service_catalogs.py
+++ b/cfme/tests/services/test_service_catalogs.py
@@ -9,14 +9,14 @@ from cfme.services.catalogs.catalog_items import EditCatalogItemView
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.services.workloads import VmsInstances
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.blockers import GH
+from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 from cfme.utils.rest import assert_response
 from cfme.utils.wait import wait_for_decorator
 
 
 pytestmark = [
-    pytest.mark.meta(server_roles="+automate", blockers=[GH('ManageIQ/integration_tests:7479')]),
+    pytest.mark.meta(server_roles="+automate"),
     pytest.mark.usefixtures('setup_provider', 'catalog_item', 'uses_infra_providers'),
     test_requirements.service,
     pytest.mark.long_running,
@@ -137,6 +137,7 @@ def test_no_template_catalog_item(provider, provisioning, dialog, catalog, appli
 
 @pytest.mark.rhv3
 @pytest.mark.tier(3)
+@pytest.mark.meta(blockers=[BZ(1609297, forced_streams=['5.9', '5.10'])])
 def test_edit_catalog_after_deleting_provider(provider, catalog_item):
     """Tests edit catalog item after deleting provider
     Metadata:


### PR DESCRIPTION
{{pytest: cfme/tests/services/test_service_catalogs.py::test_edit_catalog_after_deleting_provider --long-running -vv --use-provider rhv42}}