### PR TITLE
[RFR] Clone template rhos flavor

### DIFF
--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -20,7 +20,6 @@ from cfme import test_requirements
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.control.explorer import conditions, policies
-from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
@@ -135,7 +134,7 @@ def _get_vm(request, provider, template_name, vm_name):
     elif provider.one_of(OpenStackProvider):
         kwargs = {}
         if 'small_template' in provider.data.templates:
-            kwargs = {"flavour_name": provider.data.provisioning.get('instance_type')}
+            kwargs = {"flavor_name": provider.data.provisioning.get('instance_type')}
     elif provider.one_of(SCVMMProvider):
         kwargs = {
             "host_group": provider.data.get("provisioning", {}).get("host_group", "All Hosts")}

--- a/scripts/clone_template.py
+++ b/scripts/clone_template.py
@@ -195,16 +195,18 @@ def main(**kwargs):
         # filter openstack flavors based on what's available
         available_flavors = provider.list_flavor()
         logger.info("Available flavors on provider: %s", available_flavors)
-        flavors = filter(lambda f: f in available_flavors, flavors)
+        generic_flavors = filter(lambda f: f in available_flavors, flavors)
+
         try:
-            flavor = kwargs.get('flavor') or flavors[0]
+            flavor = (kwargs.get('flavor') or
+                      provider_dict.get('sprout', {}).get('flavor_name') or
+                      generic_flavors[0])
         except IndexError:
             raise Exception('--flavor is required for RHOS instances and '
                             'default is not set or unavailable on provider')
         logger.info('Selected flavor: %s', flavor)
 
-        # flavour? Thanks, psav...
-        deploy_args['flavour_name'] = flavor
+        deploy_args['flavor_name'] = flavor
 
         if 'network' in provider_dict:
             # support rhos4 network names


### PR DESCRIPTION
Use `flavor_name`, yaml change already merged.

wrapanapi 3.0 changed this arg spelling so we can't pass it as 'flavour_name' anymore.