### PR TITLE
[1LP][RFR] fix ui button name to add Physical Infrastructure Provider

### DIFF
--- a/cfme/physical/provider/__init__.py
+++ b/cfme/physical/provider/__init__.py
@@ -157,5 +157,5 @@ class Add(CFMENavigateStep):
 
     def step(self):
         self.prerequisite_view.toolbar.configuration.item_select(
-            'Add a New Physical Provider'
+            'Add a New Physical Infrastructure Provider'
         )


### PR DESCRIPTION
this PR fixes the name of the button the test should click to add a new physical provider