### PR TITLE
[1LP][RFR] Update ContainerProviderEditView is_displayed to use ProviderEditView

### DIFF
--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -608,7 +608,7 @@ class ContainerProviderEditView(ProviderEditView):
     """
     @property
     def is_displayed(self):
-        return (super(ProviderEditView, self).is_displayed and
+        return (super(ContainerProviderEditView, self).is_displayed and
                 self.navigation.currently_selected == ['Compute', 'Containers', 'Providers'] and
                 'Edit Containers Provider' in self.title.text)
 


### PR DESCRIPTION
Fixing ContainerProviderEditView is_displayed method, to use ProviderEditView 
is_displayed instead of ProviderAddView one.

{{pytest: cfme/tests/containers/test_provider_configuration_menu.py -v --use-provider ocp-39-hawk}}