### PR TITLE
[1LP][RFR] Make proxy tests working

### DIFF
--- a/cfme/tests/configure/test_proxy.py
+++ b/cfme/tests/configure/test_proxy.py
@@ -4,11 +4,13 @@ import pytest
 from cfme.cloud.provider import CloudProvider
 from cfme.markers.env_markers.provider import ONE
 from cfme.utils import conf
+from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.generators import random_vm_name
 from cfme.utils.providers import get_mgmt
 from cfme.utils.ssh import SSHClient
 from cfme.utils.virtual_machines import deploy_template
 from cfme.utils.wait import wait_for
+
 
 pytestmark = [
     pytest.mark.tier(3),
@@ -34,7 +36,7 @@ def proxy_machine():
                          depot_machine_name,
                          template_name=proxy_template_name)
     wait_for(func=lambda: vm.ip is not None, num_sec=300, delay=10,
-             message='Waiting for instance "{}" ip to be present.')
+             message='Waiting for instance "{}" ip to be present.'.format(vm.name))
 
     yield vm.ip, proxy_port
     vm.delete()
@@ -62,28 +64,95 @@ def validate_proxy_logs(provider, proxy_ssh, appliance_ip):
 
 
 @pytest.fixture(scope="function")
-def prepare_proxy(proxy_ssh, provider, appliance):
+def prepare_proxy_specific(proxy_ssh, provider, appliance, proxy_machine):
+    proxy_ip, proxy_port = proxy_machine
+    prov_type = provider.type
+    # 192.0.2.1 is from TEST-NET-1 which doesn't exist on the internet (RFC5737).
+    appliance.set_proxy('192.0.2.1', proxy_port, prov_type='default')
+    appliance.set_proxy(proxy_ip, proxy_port, prov_type=prov_type)
     proxy_ssh.run_command('echo "" > /var/log/squid/access.log')
     yield
-    appliance.set_proxy(None, None, prov_type=provider.type)
+    appliance.reset_proxy(prov_type)
+    appliance.reset_proxy()
 
 
-def test_proxy_valid(appliance, proxy_machine, proxy_ssh, prepare_proxy, provider):
+@pytest.fixture(scope="function")
+def prepare_proxy_default(proxy_ssh, provider, appliance, proxy_machine):
     proxy_ip, proxy_port = proxy_machine
     prov_type = provider.type
-    appliance.set_proxy(proxy_ip, proxy_port, prov_type=prov_type)
-    validate_proxy_logs(provider, proxy_ssh, appliance.hostname)
+    appliance.set_proxy(proxy_ip, proxy_port, prov_type='default')
+    appliance.reset_proxy(prov_type)
+    proxy_ssh.run_command('echo "" > /var/log/squid/access.log')
+    yield
+    appliance.reset_proxy()
+    appliance.reset_proxy(prov_type)
 
 
-def test_proxy_invalid(appliance, proxy_machine, prepare_proxy, provider):
-    proxy_ip, proxy_port = proxy_machine
+@pytest.fixture(scope="function")
+def prepare_proxy_invalid(provider, appliance):
     prov_type = provider.type
-    appliance.set_proxy('1.1.1.1', proxy_port, prov_type=prov_type)
+    # 192.0.2.1 is from TEST-NET-1 which doesn't exist on the internet (RFC5737).
+    appliance.set_proxy('192.0.2.1', '1234', prov_type='default')
+    appliance.set_proxy('192.0.2.1', '1234', prov_type=prov_type)
+    yield
+    appliance.reset_proxy(prov_type)
+    appliance.reset_proxy()
+
+
+def test_proxy_valid(appliance, proxy_machine, proxy_ssh, prepare_proxy_default, provider):
+    """ Check whether valid proxy settings works.
+
+    Steps:
+     * Configure appliance to use proxy for default provider.
+     * Configure appliance to use not use proxy for specific provider.
+     * Chceck whether the provider is accessed trough proxy by chceking the
+       proxy logs."""
     provider.refresh_provider_relationships()
+    validate_proxy_logs(provider, proxy_ssh, appliance.hostname)
     wait_for(
         provider.is_refreshed,
         func_kwargs={"refresh_delta": 120},
         fail_condition=True,
-        num_sec=240,
+        num_sec=300,
         delay=30
     )
+
+
+def test_proxy_override(appliance, proxy_ssh, prepare_proxy_specific, provider):
+    """ Check whether invalid default and valid specific provider proxy settings
+    results in provider refresh working.
+
+    Steps:
+     * Configure default proxy to invalid entry.
+     * Configure specific proxy to valid entry.
+     * Check whether the provider is accessed trough proxy by checking the proxy logs.
+     * Wait for the provider refresh to complete to check the settings worked.
+    """
+    provider.refresh_provider_relationships()
+    validate_proxy_logs(provider, proxy_ssh, appliance.hostname)
+    wait_for(
+        provider.is_refreshed,
+        func_kwargs={"refresh_delta": 120},
+        fail_condition=True,
+        num_sec=300,
+        delay=30
+    )
+
+
+def test_proxy_invalid(appliance, prepare_proxy_invalid, provider):
+    """ Check whether invalid default and invalid specific provider proxy settings
+     results in porovider refresh not working.
+
+    Steps:
+     * Configure default proxy to invalid entry.
+     * Configure specific proxy to invalid entry.
+     * Wait for the provider refresh to complete to check the settings causes error.
+    """
+    provider.refresh_provider_relationships()
+    view = navigate_to(provider, 'Details')
+
+    def last_refresh_failed():
+        'Timed out connecting to server' in (
+            view.entities.summary('Status').get_text_of('Last Refresh'))
+
+    wait_for(last_refresh_failed, num_sec=240, delay=30)

--- a/cfme/tests/configure/test_proxy.py
+++ b/cfme/tests/configure/test_proxy.py
@@ -30,11 +30,14 @@ def proxy_machine():
     proxy_template_name = data["template_name"]
     proxy_port = data['port']
     prov = get_mgmt(proxy_provider_key)
-    deploy_template(proxy_provider_key,
-                    depot_machine_name,
-                    template_name=proxy_template_name)
-    yield prov.get_ip_address(depot_machine_name), proxy_port
-    prov.delete_vm(depot_machine_name)
+    vm = deploy_template(proxy_provider_key,
+                         depot_machine_name,
+                         template_name=proxy_template_name)
+    wait_for(func=lambda: vm.ip is not None, num_sec=300, delay=10,
+             message='Waiting for instance "{}" ip to be present.')
+
+    yield vm.ip, proxy_port
+    vm.delete()
 
 
 @pytest.fixture(scope='module')

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2134,6 +2134,12 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
             raise ApplianceException('Impossible to create proxy with current provider type')
         self.update_advanced_settings(vmdb_config)
 
+    def reset_proxy(self, prov_type=None):
+        vmdb_config = self.advanced_settings
+        proxy_type = prov_type or 'default'
+        vmdb_config['http_proxy'][proxy_type] = False
+        self.update_advanced_settings(vmdb_config)
+
     def set_session_timeout(self, timeout=86400, quiet=True):
         """Sets the timeout of UI timeout.
 

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2137,7 +2137,7 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
     def reset_proxy(self, prov_type=None):
         vmdb_config = self.advanced_settings
         proxy_type = prov_type or 'default'
-        vmdb_config['http_proxy'][proxy_type] = False
+        vmdb_config['http_proxy'][proxy_type] = False if self.version < "5.10" else "<<reset>>"
         self.update_advanced_settings(vmdb_config)
 
     def set_session_timeout(self, timeout=86400, quiet=True):


### PR DESCRIPTION
Update tests for provider proxy. Make them working.
 * The IP has to be waited for
 * Fixturize the changes to the appliance config, making sure the changes are "undone" after the tests by setting proxy to False instead of sub-dictionary.
 * Added docstrings.

{{pytest: -v cfme/tests/configure/test_proxy.py --use-provider azure }}