### PR TITLE
[1LP][RFR] fix end of file of the entry_points.txt

### DIFF
--- a/entry_points.txt
+++ b/entry_points.txt
@@ -162,4 +162,3 @@ openstack = cfme.cloud.instance.openstack:OpenStackInstance
 
 [pytest11]
 cfme = cfme.test_framework.pytest_plugin
-


### PR DESCRIPTION
the introduction of this file was in a race with the introduction of stricter linting
thus the failure was missed
