### PR TITLE
[1LP][RFR] Fixing host fixture in test_relationships

### DIFF
--- a/cfme/tests/cloud_infra_common/test_relationships.py
+++ b/cfme/tests/cloud_infra_common/test_relationships.py
@@ -125,11 +125,11 @@ def get_obj(relationship, appliance, **kwargs):
 
 @pytest.fixture
 def host(appliance, provider):
-    host_collection = appliance.collections.hosts
+    host_collection = appliance.collections.hosts.filter({'provider': provider})
     expression = 'fill_field(Host / Node : Parent Cluster, IS NOT NULL)'
     view = navigate_to(host_collection, 'All')
     view.entities.search.advanced_search(expression)
-    return random.choice(host_collection.all(provider))
+    return random.choice(host_collection.all())
 
 
 def wait_for_relationship_refresh(provider):


### PR DESCRIPTION
Verification: https://rhv-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/cfme-5.9-rhv-4.2-integration-test-dev/135/console

This used to throw:
> TypeError: all() takes exactly 1 argument (2 given)

The reason I used `appliance.collections.hosts.filter({'provider': provider})` as opposed to `provider.hosts` is that if you call `all()` method on `provider.hosts`, the framework will navigate to Compute -> Infrastructure -> Providers -> <your_provider> -> Hosts. This is a problem, because if you view hosts in such way, you cannot apply advanced search filter and you cannot see it if it has been applied before.