### PR TITLE
[1LP][RFR] Fix clicking checkboxes on HostDriftHistory view

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -883,7 +883,7 @@ class VM(BaseVM):
         Args:
             drift_section (str): Title text of the row to compare
             section (str): Accordion section where the change happened
-            indexes: Indexes of results to compare starting with 0 for first row (latest result).
+            indexes: Indexes of results to compare starting with 1 for first row (latest result).
                      Compares all available drifts, if left empty (default)
 
         Note:

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -340,7 +340,7 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Taggable):
         Args:
             drift_section (str): Title text of the row to compare
             section (str): Accordion section where the change happened
-            indexes: Indexes of results to compare starting with 0 for first row (latest result).
+            indexes: Indexes of results to compare starting with 1 for first row (latest result).
                      Compares all available drifts, if left empty (default)
 
         Note:

--- a/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
+++ b/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
@@ -3,6 +3,7 @@ import pytest
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from widgetastic_patternfly import NoSuchElementException
+from widgetastic.utils import partial_match
 from wrapanapi import VmState
 
 from cfme import test_requirements
@@ -236,9 +237,10 @@ def ssa_single_vm(request, local_setup_provider, provider, vm_analysis_provision
         provision_data = vm_analysis_provisioning_data.copy()
         del provision_data['image']
 
-        if "test_ssa_compliance" in request._pyfuncitem.name:
+        if "test_ssa_compliance" in request._pyfuncitem.name or provider.one_of(RHEVMProvider):
             provisioning_data = {"catalog": {'vm_name': vm_name},
-                                 "environment": {'automatic_placement': True}}
+                                 "environment": {'automatic_placement': True},
+                                 "network": {'vlan': partial_match(provision_data['vlan'])}}
             do_vm_provisioning(vm_name=vm_name, appliance=appliance, provider=provider,
                                provisioning_data=provisioning_data, template_name=template_name,
                                request=request, smtp_test=False, num_sec=2500)
@@ -808,7 +810,7 @@ def test_drift_analysis(request, ssa_vm, soft_assert, appliance):
     )
     # check drift difference
     soft_assert(ssa_vm.equal_drift_results(
-        '{} (1)'.format(added_tag.category.display_name), 'My Company Tags', 0, 1),
+        '{} (1)'.format(added_tag.category.display_name), 'My Company Tags', 1, 2),
         "Drift analysis results are equal when they shouldn't be")
 
     # Test UI features that modify the drift grid

--- a/cfme/tests/infrastructure/test_host_drift_analysis.py
+++ b/cfme/tests/infrastructure/test_host_drift_analysis.py
@@ -109,7 +109,6 @@ def test_host_drift_analysis(appliance, request, a_host, soft_assert, set_host_c
         message="Waiting for Drift History count to increase",
         fail_func=appliance.server.browser.refresh
     )
-
     # check drift difference
     soft_assert(a_host.equal_drift_results(
         '{} (1)'.format(added_tag.category.display_name), 'My Company Tags', 0, 1),


### PR DESCRIPTION
Host drift analysis fails on:
E       assert False
E        +  where False = <cfme.common.host_views.HostDriftAnalysis object at 0x7f20545a7ad0>.is_displayed

The problem begins on the following line:
https://github.com/ManageIQ/integration_tests/blob/5f4466953e7b0007b7810fbec30018e65115be56/cfme/tests/infrastructure/test_host_drift_analysis.py#L115

This line is supposed to check first two rows representing latest 2 analysis. What actually happens is that no line is selected. The reason is that indexes 0 and 1 both point to the first row, so the first row is selected and deselected afterwards.

Now, at this point I changed the indexes from 0,1 to 1,2 so that first and second row is selected correctly.

Better way to deal with this may be fixing the selection logic instead.

{{ pytest: cfme/tests/infrastructure/test_host_drift_analysis.py cfme/tests/cloud_infra_common/test_vm_instance_analysis.py::test_drift_analysis }}