### PR TITLE
[1LP][RFR] Test targeted refresh for Nuage entities

### DIFF
--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -390,3 +390,7 @@ class CollectionFilteringError(CFMEException):
     def __str__(self):
         return 'Action on Collection ({}) requires a filter: ({})'\
                .format(self.collection, self.filter_key)
+
+
+class NeedleNotFoundInLog(CFMEException):
+    """Raised when log doesnt't contain needle"""


### PR DESCRIPTION
With this commit we create fixture that tails 'evm.log' to see whether targeted refresh was triggered. We then use it to test targeted refresh for Nuage.

Fixture first starts tailing the log and waits for events to occur. Then it searches the 'evm.log' for a line that looks something like this:
```
Collection of targets with id: [{:ems_ref=>"b35d3afe-6f19-4da8-b1ee-b79de433cace"}, ... ]
```
If any of the log entry is not found `NeedleNotFoundInLog` error is raised and failed entities are listed.

NOTE: The fixture actually checks whether targeted refresh was _started_ i.e. whether Automate Instances are properly configured. It does not check the result of refreshing

Depends on:  https://github.com/ManageIQ/integration_tests/pull/7797, https://github.com/ManageIQ/integration_tests/pull/7812, https://github.com/ManageIQ/integration_tests/pull/7833