### PR TITLE
[1LP][RFR] Fix clicking checkboxes on HostDriftHistory view (2. attempt)

### DIFF
--- a/cfme/tests/infrastructure/test_host_drift_analysis.py
+++ b/cfme/tests/infrastructure/test_host_drift_analysis.py
@@ -111,7 +111,7 @@ def test_host_drift_analysis(appliance, request, a_host, soft_assert, set_host_c
     )
     # check drift difference
     soft_assert(a_host.equal_drift_results(
-        '{} (1)'.format(added_tag.category.display_name), 'My Company Tags', 0, 1),
+        '{} (1)'.format(added_tag.category.display_name), 'My Company Tags', 1, 2),
         "Drift analysis results are equal when they shouldn't be")
 
     # Test UI features that modify the drift grid


### PR DESCRIPTION
This PR finishes the job that should have been done in #7568.

Thanks to @rlbabyuk for pointing out, that I forgot to change the equal_drift_results function call arguments. It would be unpleasant to see the test fail again ;).
