### PR TITLE
[1LP][RFR] get rid of CloudInfraProvider class

### DIFF
--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -8,8 +8,8 @@ from widgetastic_patternfly import Dropdown, BreadCrumb
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.cloud.instance.image import Image
-from cfme.common import TagPageView
-from cfme.common.provider import CloudInfraProvider, provider_types
+from cfme.common import TagPageView, PolicyProfileAssignable, Taggable
+from cfme.common.provider import BaseProvider, provider_types
 from cfme.common.provider_views import (
     CloudProviderAddView, CloudProviderEditView, CloudProviderDetailsView, CloudProvidersView,
     CloudProvidersDiscoverView)
@@ -17,7 +17,9 @@ from cfme.common.vm_views import VMToolbar, VMEntities
 from cfme.modeling.base import BaseCollection
 from cfme.utils.appliance.implementations.ui import navigator, navigate_to, CFMENavigateStep
 from cfme.utils.log import logger
+from cfme.utils.net import resolve_hostname
 from cfme.utils.pretty import Pretty
+from cfme.utils.varmeth import variable
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import TimelinesView, ItemsToolBarViewSelector
 
@@ -76,7 +78,7 @@ class CloudProviderImagesView(BaseLoggedInPage):
 
 
 @attr.s(hash=False)
-class CloudProvider(Pretty, CloudInfraProvider):
+class CloudProvider(Pretty, BaseProvider, PolicyProfileAssignable, Taggable):
     """
     Abstract model of a cloud provider in cfme. See EC2Provider or OpenStackProvider.
     Args:
@@ -103,6 +105,9 @@ class CloudProvider(Pretty, CloudInfraProvider):
     template_name = "Images"
     db_types = ["CloudManager"]
     template_class = Image
+    detail_page_suffix = 'provider'
+    edit_page_suffix = 'provider_edit'
+    refresh_text = "Refresh Relationships and Power States"
 
     name = attr.ib(default=None)
     key = attr.ib(default=None)
@@ -124,6 +129,91 @@ class CloudProvider(Pretty, CloudInfraProvider):
     def discover_dict(credential):
         """Returns the discovery credentials dictionary, needs overiding"""
         raise NotImplementedError("This provider doesn't support discovery")
+
+    @property
+    def hostname(self):
+        return getattr(self.default_endpoint, "hostname", None)
+
+    @hostname.setter
+    def hostname(self, value):
+        if self.default_endpoint:
+            if value:
+                self.default_endpoint.hostname = value
+        else:
+            logger.warn("can't set hostname because default endpoint is absent")
+
+    @property
+    def ip_address(self):
+        return getattr(self.default_endpoint, "ipaddress", resolve_hostname(str(self.hostname)))
+
+    @ip_address.setter
+    def ip_address(self, value):
+        if self.default_endpoint:
+            if value:
+                self.default_endpoint.ipaddress = value
+        else:
+            logger.warn("can't set ipaddress because default endpoint is absent")
+
+    @variable(alias="db")
+    def num_template(self):
+        """ Returns the providers number of templates, as shown on the Details page."""
+        ext_management_systems = self.appliance.db.client["ext_management_systems"]
+        vms = self.appliance.db.client["vms"]
+        temlist = list(self.appliance.db.client.session.query(vms.name)
+                       .join(ext_management_systems, vms.ems_id == ext_management_systems.id)
+                       .filter(ext_management_systems.name == self.name)
+                       .filter(vms.template == True))  # NOQA
+        return len(temlist)
+
+    @num_template.variant('ui')
+    def num_template_ui(self):
+        view = navigate_to(self, "Details")
+        return int(view.entities.summary("Relationships").get_text_of(self.template_name))
+
+    @variable(alias="db")
+    def num_vm(self):
+        """ Returns the providers number of instances, as shown on the Details page."""
+        ext_management_systems = self.appliance.db.client["ext_management_systems"]
+        vms = self.appliance.db.client["vms"]
+        vmlist = list(self.appliance.db.client.session.query(vms.name)
+                      .join(ext_management_systems, vms.ems_id == ext_management_systems.id)
+                      .filter(ext_management_systems.name == self.name)
+                      .filter(vms.template == False))  # NOQA
+        return len(vmlist)
+
+    @num_vm.variant('ui')
+    def num_vm_ui(self):
+        view = navigate_to(self, "Details")
+        return int(view.entities.summary("Relationships").get_text_of(self.vm_name))
+
+    def load_all_provider_instances(self):
+        return self.load_all_provider_vms()
+
+    def load_all_provider_vms(self):
+        """ Loads the list of instances that are running under the provider.
+
+        """
+        view = navigate_to(self, 'Details')
+        if view.entities.summary("Relationships").get_text_of(self.vm_name) == "0":
+            return False
+        else:
+            view.entities.summary("Relationships").click_at(self.vm_name)
+            return True
+
+    def load_all_provider_images(self):
+        self.load_all_provider_templates()
+
+    def load_all_provider_templates(self):
+        """ Loads the list of images that are available under the provider.
+
+        """
+        # todo: replace these methods with new nav location
+        view = navigate_to(self, 'Details')
+        if view.entities.summary("Relationships").get_text_of(self.template_name) == "0":
+            return False
+        else:
+            view.entities.summary("Relationships").click_at(self.template_name)
+            return True
 
 
 @attr.s

--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -127,7 +127,7 @@ class CloudProvider(Pretty, BaseProvider, PolicyProfileAssignable, Taggable):
 
     @staticmethod
     def discover_dict(credential):
-        """Returns the discovery credentials dictionary, needs overiding"""
+        """Returns the discovery credentials dictionary, needs overriding"""
         raise NotImplementedError("This provider doesn't support discovery")
 
     @property

--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -9,7 +9,7 @@ from widgetastic_patternfly import Dropdown, BreadCrumb
 from cfme.base.login import BaseLoggedInPage
 from cfme.cloud.instance.image import Image
 from cfme.common import TagPageView, PolicyProfileAssignable, Taggable
-from cfme.common.provider import BaseProvider, provider_types
+from cfme.common.provider import BaseProvider, provider_types, CloudInfraProviderMixin
 from cfme.common.provider_views import (
     CloudProviderAddView, CloudProviderEditView, CloudProviderDetailsView, CloudProvidersView,
     CloudProvidersDiscoverView)
@@ -17,9 +17,7 @@ from cfme.common.vm_views import VMToolbar, VMEntities
 from cfme.modeling.base import BaseCollection
 from cfme.utils.appliance.implementations.ui import navigator, navigate_to, CFMENavigateStep
 from cfme.utils.log import logger
-from cfme.utils.net import resolve_hostname
 from cfme.utils.pretty import Pretty
-from cfme.utils.varmeth import variable
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import TimelinesView, ItemsToolBarViewSelector
 
@@ -78,7 +76,8 @@ class CloudProviderImagesView(BaseLoggedInPage):
 
 
 @attr.s(hash=False)
-class CloudProvider(Pretty, BaseProvider, PolicyProfileAssignable, Taggable):
+class CloudProvider(BaseProvider, CloudInfraProviderMixin, Pretty, PolicyProfileAssignable,
+                    Taggable):
     """
     Abstract model of a cloud provider in cfme. See EC2Provider or OpenStackProvider.
     Args:
@@ -105,9 +104,6 @@ class CloudProvider(Pretty, BaseProvider, PolicyProfileAssignable, Taggable):
     template_name = "Images"
     db_types = ["CloudManager"]
     template_class = Image
-    detail_page_suffix = 'provider'
-    edit_page_suffix = 'provider_edit'
-    refresh_text = "Refresh Relationships and Power States"
 
     name = attr.ib(default=None)
     key = attr.ib(default=None)
@@ -129,91 +125,6 @@ class CloudProvider(Pretty, BaseProvider, PolicyProfileAssignable, Taggable):
     def discover_dict(credential):
         """Returns the discovery credentials dictionary, needs overriding"""
         raise NotImplementedError("This provider doesn't support discovery")
-
-    @property
-    def hostname(self):
-        return getattr(self.default_endpoint, "hostname", None)
-
-    @hostname.setter
-    def hostname(self, value):
-        if self.default_endpoint:
-            if value:
-                self.default_endpoint.hostname = value
-        else:
-            logger.warn("can't set hostname because default endpoint is absent")
-
-    @property
-    def ip_address(self):
-        return getattr(self.default_endpoint, "ipaddress", resolve_hostname(str(self.hostname)))
-
-    @ip_address.setter
-    def ip_address(self, value):
-        if self.default_endpoint:
-            if value:
-                self.default_endpoint.ipaddress = value
-        else:
-            logger.warn("can't set ipaddress because default endpoint is absent")
-
-    @variable(alias="db")
-    def num_template(self):
-        """ Returns the providers number of templates, as shown on the Details page."""
-        ext_management_systems = self.appliance.db.client["ext_management_systems"]
-        vms = self.appliance.db.client["vms"]
-        temlist = list(self.appliance.db.client.session.query(vms.name)
-                       .join(ext_management_systems, vms.ems_id == ext_management_systems.id)
-                       .filter(ext_management_systems.name == self.name)
-                       .filter(vms.template == True))  # NOQA
-        return len(temlist)
-
-    @num_template.variant('ui')
-    def num_template_ui(self):
-        view = navigate_to(self, "Details")
-        return int(view.entities.summary("Relationships").get_text_of(self.template_name))
-
-    @variable(alias="db")
-    def num_vm(self):
-        """ Returns the providers number of instances, as shown on the Details page."""
-        ext_management_systems = self.appliance.db.client["ext_management_systems"]
-        vms = self.appliance.db.client["vms"]
-        vmlist = list(self.appliance.db.client.session.query(vms.name)
-                      .join(ext_management_systems, vms.ems_id == ext_management_systems.id)
-                      .filter(ext_management_systems.name == self.name)
-                      .filter(vms.template == False))  # NOQA
-        return len(vmlist)
-
-    @num_vm.variant('ui')
-    def num_vm_ui(self):
-        view = navigate_to(self, "Details")
-        return int(view.entities.summary("Relationships").get_text_of(self.vm_name))
-
-    def load_all_provider_instances(self):
-        return self.load_all_provider_vms()
-
-    def load_all_provider_vms(self):
-        """ Loads the list of instances that are running under the provider.
-
-        """
-        view = navigate_to(self, 'Details')
-        if view.entities.summary("Relationships").get_text_of(self.vm_name) == "0":
-            return False
-        else:
-            view.entities.summary("Relationships").click_at(self.vm_name)
-            return True
-
-    def load_all_provider_images(self):
-        self.load_all_provider_templates()
-
-    def load_all_provider_templates(self):
-        """ Loads the list of images that are available under the provider.
-
-        """
-        # todo: replace these methods with new nav location
-        view = navigate_to(self, 'Details')
-        if view.entities.summary("Relationships").get_text_of(self.template_name) == "0":
-            return False
-        else:
-            view.entities.summary("Relationships").click_at(self.template_name)
-            return True
 
 
 @attr.s

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -16,6 +16,7 @@ from cfme.utils import ParamClassName, conf
 from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import navigate_to, navigator
 from cfme.utils.log import logger
+from cfme.utils.net import resolve_hostname
 from cfme.utils.stats import tol_check
 from cfme.utils.update import Updateable
 from cfme.utils.varmeth import variable
@@ -1047,6 +1048,97 @@ class BaseProvider(Taggable, Updateable, Navigatable, BaseEntity):
                         inner_tuple += (provider,)
                         result_list.append(inner_tuple)
         return result_list
+
+
+class CloudInfraProviderMixin(object):
+    detail_page_suffix = 'provider'
+    edit_page_suffix = 'provider_edit'
+    refresh_text = "Refresh Relationships and Power States"
+
+    @property
+    def hostname(self):
+        return getattr(self.default_endpoint, "hostname", None)
+
+    @hostname.setter
+    def hostname(self, value):
+        if self.default_endpoint:
+            if value:
+                self.default_endpoint.hostname = value
+        else:
+            logger.warn("can't set hostname because default endpoint is absent")
+
+    @property
+    def ip_address(self):
+        return getattr(self.default_endpoint, "ipaddress", resolve_hostname(str(self.hostname)))
+
+    @ip_address.setter
+    def ip_address(self, value):
+        if self.default_endpoint:
+            if value:
+                self.default_endpoint.ipaddress = value
+        else:
+            logger.warn("can't set ipaddress because default endpoint is absent")
+
+    @variable(alias="db")
+    def num_template(self):
+        """ Returns the providers number of templates, as shown on the Details page."""
+        ext_management_systems = self.appliance.db.client["ext_management_systems"]
+        vms = self.appliance.db.client["vms"]
+        temlist = list(self.appliance.db.client.session.query(vms.name)
+                       .join(ext_management_systems, vms.ems_id == ext_management_systems.id)
+                       .filter(ext_management_systems.name == self.name)
+                       .filter(vms.template == True))  # NOQA
+        return len(temlist)
+
+    @num_template.variant('ui')
+    def num_template_ui(self):
+        view = navigate_to(self, "Details")
+        return int(view.entities.summary("Relationships").get_text_of(self.template_name))
+
+    @variable(alias="db")
+    def num_vm(self):
+        """ Returns the providers number of instances, as shown on the Details page."""
+        ext_management_systems = self.appliance.db.client["ext_management_systems"]
+        vms = self.appliance.db.client["vms"]
+        vmlist = list(self.appliance.db.client.session.query(vms.name)
+                      .join(ext_management_systems, vms.ems_id == ext_management_systems.id)
+                      .filter(ext_management_systems.name == self.name)
+                      .filter(vms.template == False))  # NOQA
+        return len(vmlist)
+
+    @num_vm.variant('ui')
+    def num_vm_ui(self):
+        view = navigate_to(self, "Details")
+        return int(view.entities.summary("Relationships").get_text_of(self.vm_name))
+
+    def load_all_provider_instances(self):
+        return self.load_all_provider_vms()
+
+    def load_all_provider_vms(self):
+        """ Loads the list of instances that are running under the provider.
+
+        """
+        view = navigate_to(self, 'Details')
+        if view.entities.summary("Relationships").get_text_of(self.vm_name) == "0":
+            return False
+        else:
+            view.entities.summary("Relationships").click_at(self.vm_name)
+            return True
+
+    def load_all_provider_images(self):
+        self.load_all_provider_templates()
+
+    def load_all_provider_templates(self):
+        """ Loads the list of images that are available under the provider.
+
+        """
+        # todo: replace these methods with new nav location
+        view = navigate_to(self, 'Details')
+        if view.entities.summary("Relationships").get_text_of(self.template_name) == "0":
+            return False
+        else:
+            view.entities.summary("Relationships").click_at(self.template_name)
+            return True
 
 
 class DefaultEndpoint(object):

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -8,9 +8,9 @@ from widgetastic.utils import Fillable
 from widgetastic_patternfly import BreadCrumb
 
 from cfme.base.ui import Server
-from cfme.common import TagPageView
+from cfme.common import TagPageView, Taggable, PolicyProfileAssignable
 from cfme.common.host_views import ProviderAllHostsView
-from cfme.common.provider import CloudInfraProvider, provider_types
+from cfme.common.provider import BaseProvider, provider_types
 from cfme.common.provider_views import (
     InfraProviderAddView, InfraProviderEditView, InfraProviderDetailsView, ProviderTimelinesView,
     InfraProvidersDiscoverView, InfraProvidersView, ProviderNodesView, ProviderTemplatesView,
@@ -22,6 +22,7 @@ from cfme.infrastructure.virtual_machines import InfraVm, InfraTemplate
 from cfme.modeling.base import BaseCollection
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
 from cfme.utils.log import logger
+from cfme.utils.net import resolve_hostname
 from cfme.utils.pretty import Pretty
 from cfme.utils.varmeth import variable
 from cfme.utils.wait import wait_for
@@ -43,7 +44,7 @@ class ProviderClustersView(ClusterView):
 
 
 @attr.s(hash=False)
-class InfraProvider(Pretty, CloudInfraProvider, Fillable):
+class InfraProvider(Pretty, Fillable, BaseProvider, PolicyProfileAssignable, Taggable):
     """
     Abstract model of an infrastructure provider in cfme. See VMwareProvider or RHEVMProvider.
 
@@ -76,6 +77,9 @@ class InfraProvider(Pretty, CloudInfraProvider, Fillable):
     db_types = ["InfraManager"]
     hosts_menu_item = "Hosts"
     vm_name = "Virtual Machines"
+    detail_page_suffix = 'provider'
+    edit_page_suffix = 'provider_edit'
+    refresh_text = "Refresh Relationships and Power States"
 
     name = attr.ib(default=None)
     key = attr.ib(default=None)
@@ -91,6 +95,91 @@ class InfraProvider(Pretty, CloudInfraProvider, Fillable):
     def __attrs_post_init__(self):
         super(InfraProvider, self).__attrs_post_init__()
         self.parent = self.appliance.collections.infra_providers
+
+    @property
+    def hostname(self):
+        return getattr(self.default_endpoint, "hostname", None)
+
+    @hostname.setter
+    def hostname(self, value):
+        if self.default_endpoint:
+            if value:
+                self.default_endpoint.hostname = value
+        else:
+            logger.warn("can't set hostname because default endpoint is absent")
+
+    @property
+    def ip_address(self):
+        return getattr(self.default_endpoint, "ipaddress", resolve_hostname(str(self.hostname)))
+
+    @ip_address.setter
+    def ip_address(self, value):
+        if self.default_endpoint:
+            if value:
+                self.default_endpoint.ipaddress = value
+        else:
+            logger.warn("can't set ipaddress because default endpoint is absent")
+
+    @variable(alias="db")
+    def num_template(self):
+        """ Returns the providers number of templates, as shown on the Details page."""
+        ext_management_systems = self.appliance.db.client["ext_management_systems"]
+        vms = self.appliance.db.client["vms"]
+        temlist = list(self.appliance.db.client.session.query(vms.name)
+                       .join(ext_management_systems, vms.ems_id == ext_management_systems.id)
+                       .filter(ext_management_systems.name == self.name)
+                       .filter(vms.template == True))  # NOQA
+        return len(temlist)
+
+    @num_template.variant('ui')
+    def num_template_ui(self):
+        view = navigate_to(self, "Details")
+        return int(view.entities.summary("Relationships").get_text_of(self.template_name))
+
+    @variable(alias="db")
+    def num_vm(self):
+        """ Returns the providers number of instances, as shown on the Details page."""
+        ext_management_systems = self.appliance.db.client["ext_management_systems"]
+        vms = self.appliance.db.client["vms"]
+        vmlist = list(self.appliance.db.client.session.query(vms.name)
+                      .join(ext_management_systems, vms.ems_id == ext_management_systems.id)
+                      .filter(ext_management_systems.name == self.name)
+                      .filter(vms.template == False))  # NOQA
+        return len(vmlist)
+
+    @num_vm.variant('ui')
+    def num_vm_ui(self):
+        view = navigate_to(self, "Details")
+        return int(view.entities.summary("Relationships").get_text_of(self.vm_name))
+
+    def load_all_provider_instances(self):
+        return self.load_all_provider_vms()
+
+    def load_all_provider_vms(self):
+        """ Loads the list of instances that are running under the provider.
+
+        """
+        view = navigate_to(self, 'Details')
+        if view.entities.summary("Relationships").get_text_of(self.vm_name) == "0":
+            return False
+        else:
+            view.entities.summary("Relationships").click_at(self.vm_name)
+            return True
+
+    def load_all_provider_images(self):
+        self.load_all_provider_templates()
+
+    def load_all_provider_templates(self):
+        """ Loads the list of images that are available under the provider.
+
+        """
+        # todo: replace these methods with new nav location
+        view = navigate_to(self, 'Details')
+        if view.entities.summary("Relationships").get_text_of(self.template_name) == "0":
+            return False
+        else:
+            view.entities.summary("Relationships").click_at(self.template_name)
+            return True
 
     @variable(alias='db')
     def num_datastore(self):

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -84,8 +84,6 @@ class InfraProvider(Pretty, Fillable, BaseProvider, PolicyProfileAssignable, Tag
     name = attr.ib(default=None)
     key = attr.ib(default=None)
     zone = attr.ib(default=None)
-    # hostname = attr.ib(default=None) # defined in CloudInfraProvider class
-    # ip_address = attr.ib(default=None) # defined in CloudInfraProvider class
     start_ip = attr.ib(default=None)
     end_ip = attr.ib(default=None)
     provider_data = attr.ib(default=None)

--- a/cfme/tests/cloud_infra_common/test_cloud_init_provisioning.py
+++ b/cfme/tests/cloud_infra_common/test_cloud_init_provisioning.py
@@ -3,7 +3,7 @@
 # in selenium (the group is selected then immediately reset)
 import pytest
 
-from cfme.cloud.provider import CloudInfraProvider
+from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.cloud.provider.openstack import OpenStackProvider
@@ -19,7 +19,8 @@ from cfme.utils.providers import ProviderFilter
 from cfme.utils.wait import wait_for
 
 
-pf1 = ProviderFilter(classes=[CloudInfraProvider], required_flags=['provision', 'cloud_init'])
+pf1 = ProviderFilter(classes=[CloudProvider, InfraProvider], required_flags=['provision',
+                                                                             'cloud_init'])
 pf2 = ProviderFilter(classes=[SCVMMProvider], inverted=True)  # SCVMM doesn't support cloud-init
 pytestmark = [
     pytest.mark.meta(server_roles="+automate"),

--- a/cfme/tests/cloud_infra_common/test_cockpit_server.py
+++ b/cfme/tests/cloud_infra_common/test_cockpit_server.py
@@ -3,7 +3,7 @@ import pytest
 
 from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider.gce import GCEProvider
-from cfme.common.provider import CloudInfraProvider
+from cfme.infrastructure.provider import InfraProvider
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.generators import random_vm_name
 from cfme.utils.wait import wait_for
@@ -26,7 +26,7 @@ def new_vm(appliance, provider, request):
 @pytest.mark.rhv3
 @pytest.mark.uncollectif(
     lambda appliance, provider: appliance.version < "5.9" or provider.one_of(GCEProvider))
-@pytest.mark.provider([CloudInfraProvider])
+@pytest.mark.provider([CloudProvider, InfraProvider])
 @pytest.mark.parametrize('enable', [False, True], ids=['disabled', 'enabled'])
 def test_cockpit_server_role(appliance, provider, setup_provider, new_vm, enable):
     """ The test checks the cockpit "Web Console" button enable and disabled working.

--- a/cfme/tests/cloud_infra_common/test_custom_attributes_rest.py
+++ b/cfme/tests/cloud_infra_common/test_custom_attributes_rest.py
@@ -5,7 +5,7 @@ import fauxfactory
 
 from cfme import test_requirements
 from cfme.cloud.provider import CloudProvider
-from cfme.infrastructure.provider import CloudInfraProvider, InfraProvider
+from cfme.infrastructure.provider import InfraProvider
 from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
 from cfme.utils.rest import (
@@ -18,7 +18,7 @@ from cfme.utils.rest import (
 pytestmark = [
     pytest.mark.long_running,
     pytest.mark.tier(2),
-    pytest.mark.provider([CloudInfraProvider], scope='module'),
+    pytest.mark.provider([CloudProvider, InfraProvider], scope='module'),
     test_requirements.rest,
     pytest.mark.rhv3
 ]

--- a/cfme/tests/cloud_infra_common/test_html5_vm_console.py
+++ b/cfme/tests/cloud_infra_common/test_html5_vm_console.py
@@ -5,8 +5,9 @@ import imghdr
 import time
 import re
 
+from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider.openstack import OpenStackProvider
-from cfme.common.provider import CloudInfraProvider
+from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.utils import ssh
 from cfme.utils.blockers import BZ
@@ -21,7 +22,7 @@ from cfme.markers.env_markers.provider import providers
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.provider(gen_func=providers,
-                         filters=[ProviderFilter(classes=[CloudInfraProvider],
+                         filters=[ProviderFilter(classes=[CloudProvider, InfraProvider],
                                                  required_flags=['html5_console'])],
                          scope='module'),
 ]

--- a/cfme/tests/cloud_infra_common/test_provisioning.py
+++ b/cfme/tests/cloud_infra_common/test_provisioning.py
@@ -9,10 +9,11 @@ from riggerlib import recursive_update
 from widgetastic_patternfly import CheckableBootstrapTreeview as Check_tree
 
 from cfme import test_requirements
-from cfme.cloud.provider import CloudInfraProvider
+from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.cloud.provider.openstack import OpenStackProvider
+from cfme.infrastructure.provider import InfraProvider
 from cfme.markers.env_markers.provider import providers
 from cfme.utils import normalize_text
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -26,7 +27,7 @@ pytestmark = [
     pytest.mark.meta(server_roles="+automate +notifier"),
     test_requirements.provision, pytest.mark.tier(2),
     pytest.mark.provider(gen_func=providers,
-                         filters=[ProviderFilter(classes=[CloudInfraProvider],
+                         filters=[ProviderFilter(classes=[CloudProvider, InfraProvider],
                                                  required_flags=['provision'])],
                          scope="function"),
     pytest.mark.usefixtures('setup_provider')

--- a/cfme/tests/cloud_infra_common/test_relationships.py
+++ b/cfme/tests/cloud_infra_common/test_relationships.py
@@ -12,7 +12,6 @@ from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.cloud.stack import ProviderStackAllView
 from cfme.cloud.tenant import ProviderTenantAllView
 from cfme.common.host_views import ProviderAllHostsView
-from cfme.common.provider import CloudInfraProvider
 from cfme.common.provider_views import InfraProviderDetailsView
 from cfme.common.vm_views import HostAllVMsView, ProviderAllVMsView
 from cfme.infrastructure.cluster import ClusterDetailsView, ProviderAllClustersView
@@ -267,7 +266,7 @@ def test_tagvis_cloud_provider_children(prov_child_visibility, setup_provider, r
 
 
 @pytest.mark.rhv1
-@pytest.mark.provider([CloudInfraProvider])
+@pytest.mark.provider([CloudProvider, InfraProvider])
 def test_provider_refresh_relationship(provider, setup_provider):
     """Tests provider refresh
 

--- a/cfme/tests/cloud_infra_common/test_rest_providers.py
+++ b/cfme/tests/cloud_infra_common/test_rest_providers.py
@@ -2,7 +2,7 @@ import fauxfactory
 import pytest
 
 from cfme import test_requirements
-from cfme.common.provider import CloudInfraProvider
+from cfme.cloud.provider import CloudProvider
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.utils.blockers import BZ
@@ -18,7 +18,7 @@ from cfme.utils.wait import wait_for
 pytestmark = [
     test_requirements.rest,
     pytest.mark.tier(1),
-    pytest.mark.provider([CloudInfraProvider])
+    pytest.mark.provider([CloudProvider, InfraProvider])
 ]
 
 

--- a/cfme/tests/cloud_infra_common/test_retirement.py
+++ b/cfme/tests/cloud_infra_common/test_retirement.py
@@ -5,8 +5,8 @@ from datetime import date, timedelta, datetime
 import pytest
 
 from cfme import test_requirements
+from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider.ec2 import EC2Provider
-from cfme.common.provider import CloudInfraProvider
 from cfme.infrastructure.provider import InfraProvider
 from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.generators import random_vm_name
@@ -22,7 +22,7 @@ pytestmark = [
     pytest.mark.long_running,
     test_requirements.retirement,
     pytest.mark.provider(gen_func=providers,
-                         filters=[ProviderFilter(classes=[CloudInfraProvider],
+                         filters=[ProviderFilter(classes=[CloudProvider, InfraProvider],
                                                  required_flags=['provision', 'retire'])]),
 ]
 

--- a/cfme/tests/cloud_infra_common/test_tag_visibility.py
+++ b/cfme/tests/cloud_infra_common/test_tag_visibility.py
@@ -2,7 +2,7 @@ import fauxfactory
 import pytest
 
 from cfme import test_requirements
-from cfme.common.provider import CloudInfraProvider
+from cfme.cloud.provider import CloudProvider
 from cfme.exceptions import VmOrInstanceNotFound
 from cfme.infrastructure.provider import InfraProvider
 from cfme.markers.env_markers.provider import ONE, ONE_PER_TYPE
@@ -13,7 +13,7 @@ pytestmark = [
     test_requirements.tag,
     pytest.mark.tier(3),
     pytest.mark.provider(
-        [CloudInfraProvider], required_fields=['cap_and_util'], selector=ONE_PER_TYPE
+        [CloudProvider, InfraProvider], required_fields=['cap_and_util'], selector=ONE_PER_TYPE
     ),
     pytest.mark.usefixtures('setup_provider')
 ]

--- a/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
+++ b/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
@@ -7,12 +7,13 @@ from widgetastic.utils import partial_match
 from wrapanapi import VmState
 
 from cfme import test_requirements
-from cfme.cloud.provider import CloudProvider, CloudInfraProvider
+from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider.ec2 import EC2Provider, EC2EndpointForm
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.common.vm_views import DriftAnalysis
 from cfme.control.explorer.policies import VMControlPolicy
 from cfme.infrastructure.host import Host
+from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.infrastructure.virtual_machines import InfraVm
@@ -96,7 +97,7 @@ ssa_expect_files = [
 
 def pytest_generate_tests(metafunc):
     argnames, argvalues, idlist = testgen.providers_by_class(
-        metafunc, [CloudInfraProvider], required_fields=['vm_analysis_new'])
+        metafunc, [CloudProvider, InfraProvider], required_fields=['vm_analysis_new'])
     argnames.append('analysis_type')
     new_idlist = []
     new_argvalues = []

--- a/cfme/tests/cloud_infra_common/test_vm_ownership.py
+++ b/cfme/tests/cloud_infra_common/test_vm_ownership.py
@@ -3,8 +3,9 @@ import pytest
 
 from cfme import test_requirements
 from cfme.base.credential import Credential
-from cfme.common.provider import CloudInfraProvider
+from cfme.cloud.provider import CloudProvider
 from cfme.exceptions import VmOrInstanceNotFound
+from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
@@ -14,7 +15,7 @@ pytestmark = [
     test_requirements.ownership,
     pytest.mark.meta(blockers=[BZ(1380781, forced_streams=["5.7"])]),
     pytest.mark.tier(3),
-    pytest.mark.provider([CloudInfraProvider], scope='module')
+    pytest.mark.provider([CloudProvider, InfraProvider], scope='module')
 ]
 
 

--- a/cfme/tests/intelligence/chargeback/test_resource_allocation.py
+++ b/cfme/tests/intelligence/chargeback/test_resource_allocation.py
@@ -37,8 +37,9 @@ import cfme.intelligence.chargeback.assignments as cb
 import cfme.intelligence.chargeback.rates as rates
 from cfme import test_requirements
 from cfme.base.credential import Credential
+from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider.gce import GCEProvider
-from cfme.infrastructure.provider import CloudInfraProvider
+from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.utils.blockers import BZ
@@ -51,8 +52,8 @@ pytestmark = [
     pytest.mark.meta(blockers=[BZ(1511099, forced_streams=['5.9', '5.8'],
                                   unblock=lambda provider: not provider.one_of(GCEProvider)),
                                ]),
-    pytest.mark.provider([CloudInfraProvider], scope='module', selector=ONE_PER_TYPE,
-                        required_fields=[(['cap_and_util', 'test_chargeback'], True)]),
+    pytest.mark.provider([CloudProvider, InfraProvider], scope='module', selector=ONE_PER_TYPE,
+                         required_fields=[(['cap_and_util', 'test_chargeback'], True)]),
     pytest.mark.usefixtures('has_no_providers_modscope', 'setup_provider'),
     test_requirements.chargeback,
 ]

--- a/cfme/tests/intelligence/reports/test_metering_report.py
+++ b/cfme/tests/intelligence/reports/test_metering_report.py
@@ -19,7 +19,7 @@ from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.common.provider import BaseProvider
-from cfme.common.provider import CloudInfraProvider
+from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.markers.env_markers.provider import providers
 from cfme.utils.blockers import BZ
@@ -27,8 +27,8 @@ from cfme.utils.log import logger
 from cfme.utils.providers import ProviderFilter
 from cfme.utils.wait import wait_for
 
-pf1 = ProviderFilter(classes=[CloudInfraProvider],
-    required_fields=[(['cap_and_util', 'test_chargeback'], True)])
+pf1 = ProviderFilter(classes=[CloudProvider, InfraProvider],
+                     required_fields=[(['cap_and_util', 'test_chargeback'], True)])
 pf2 = ProviderFilter(classes=[SCVMMProvider], inverted=True)  # SCVMM doesn't support C&U
 
 pytestmark = [

--- a/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
+++ b/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
@@ -34,7 +34,7 @@ from cfme.base.credential import Credential
 from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.gce import GCEProvider
-from cfme.common.provider import CloudInfraProvider
+from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.markers.env_markers.provider import providers
 from cfme.utils.blockers import BZ
@@ -44,7 +44,7 @@ from cfme.utils.wait import wait_for
 
 from wrapanapi import VmState
 
-pf1 = ProviderFilter(classes=[CloudInfraProvider],
+pf1 = ProviderFilter(classes=[CloudProvider, InfraProvider],
     required_fields=[(['cap_and_util', 'test_chargeback'], True)])
 pf2 = ProviderFilter(classes=[SCVMMProvider], inverted=True)  # SCVMM doesn't support C&U
 


### PR DESCRIPTION
1. CloudInfraProvider class is removed.
2. All its methods are added to both Cloud and Infra providers.
3. All CloudInfraProvider calls are replaced with CloudProvider and InfraProvider.