### PR TITLE
[1LP][RFR] Used provider.nodes.all()

### DIFF
--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -193,11 +193,11 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Taggable):
             desired_state (str): 'on' or 'off'
             timeout (int): Specify amount of time (in seconds) to wait until TimedOutError is raised
         """
-        view = navigate_to(self.parent, "All")
+        view = navigate_to(self, "Details")
 
         def _looking_for_state_change():
-            entity = view.entities.get_entity(name=self.name)
-            return entity.data['state'] == desired_state
+            current_state = view.entities.summary('Properties').get_text_of('Power State')
+            return current_state == desired_state
 
         return wait_for(
             _looking_for_state_change,

--- a/cfme/tests/openstack/infrastructure/test_host_power_control.py
+++ b/cfme/tests/openstack/infrastructure/test_host_power_control.py
@@ -19,7 +19,7 @@ def host_collection(appliance):
 @pytest.fixture(scope='module')
 def host_on(host_collection, provider):
     try:
-        my_host_on = host_collection.all(provider)[0]
+        my_host_on = provider.nodes.all().pop()
     except IndexError:
         assert False, "Missing nodes in provider's details"
 
@@ -32,7 +32,7 @@ def host_on(host_collection, provider):
 @pytest.fixture(scope='module')
 def host_off(host_collection, provider):
     try:
-        my_host_off = host_collection.all(provider)[0]
+        my_host_off = provider.nodes.all().pop()
     except IndexError:
         assert False, "Missing nodes in provider's details"
 


### PR DESCRIPTION
Purpose or Intent
=================
Used provider.nodes.all() and fixed wait_for_host_state_change method

{{ pytest: cfme/tests/openstack/infrastructure/test_host_power_control.py }}
