### PR TITLE
[1LP][RFR]removal of new templates from test_modules_importable.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,10 @@ env:
 install:
   - pip install -U setuptools pip
   - python -m cfme.scripting.quickstart
+  # not sure it makes sense to put this into quickstart. so, it is added here
+  - cp conf/cfme_data.yaml.template conf/cfme_data.yaml
+  - cp conf/env.yaml.template conf/env.yaml
+  - cp conf/credentials.yaml.template conf/credentials.yaml
 script:
 - pytest cfme/utils/tests cfme/modeling/tests requirements  -v --dummy-appliance
 - pytest -p no:cfme cfme/tests/test_modules_importable.py

--- a/cfme/networks/provider/__init__.py
+++ b/cfme/networks/provider/__init__.py
@@ -316,6 +316,9 @@ class NetworkProviderCollection(BaseCollection):
         obj.create(**create_kwargs)
         return obj
 
+    def instantiate(self, prov_class, *args, **kwargs):
+        return prov_class.from_collection(self, *args, **kwargs)
+
 
 @navigator.register(NetworkProvider, 'All')  # To be removed once all CEMv3
 @navigator.register(NetworkProviderCollection, 'All')

--- a/cfme/tests/test_modules_importable.py
+++ b/cfme/tests/test_modules_importable.py
@@ -19,15 +19,6 @@ KNOWN_FAILURES = set(ROOT.dirpath().join(x) for x in[
     'cfme/fixtures/widgets.py',
     'cfme/dashboard.py',
     'cfme/configure/tasks.py',
-    'cfme/utils/template/template_upload.py',
-    'cfme/utils/template/ec2.py',
-    'cfme/utils/template/gce.py',
-    'cfme/utils/template/openstack.py',
-    'cfme/utils/template/rhevm.py',
-    'cfme/utils/template/rhopenshift.py',
-    'cfme/utils/template/scvmm.py',
-    'cfme/utils/template/virtualcenter.py',
-    'cfme/utils/template/base.py',
 ])
 
 

--- a/conf/cfme_data.yaml.template
+++ b/conf/cfme_data.yaml.template
@@ -147,18 +147,6 @@ management_systems:
         network: defaultnetwork
         test_vm_power_control:
             - pwr-ctl-vm-1-dnd
-    hawkular:
-        name: hawkular-01
-        type: hawkular
-        credentials: hawkular
-        hostname: livingontheedge.hawkular.org
-        api_port: 80
-        endpoints:
-            default:
-                hostname: livingontheedge.hawkular.org
-                api_port: 80
-                credentials: hawkular
-                security_protocol: Non-SSL
     lenovo:
         name: lenovo
         type: lenovo

--- a/conf/cfme_data.yaml.template
+++ b/conf/cfme_data.yaml.template
@@ -1,5 +1,7 @@
 basic_info:
     app_version: 5.2.0
+    cfme_images_url:
+        downstream-59z: http://some-host.com/builds/
 management_systems:
     vsphere5:
         name: vsphere 5
@@ -156,77 +158,6 @@ management_systems:
                 ipaddress: 10.0.0.1
                 hostname: lenovo.hostname
                 api_port: 3000
-    nuage:
-        name: nuage_net
-        type: nuage
-        endpoints:
-            default:
-                hostname: 10.0.0.1
-                credentials: nuage
-                security_protocol: Non-SSL
-                api_port: 5000
-            events:
-                event_stream: AMQP
-                hostname: 10.0.0.1
-                api_port: 5672
-                security_protocol: Non-SSL
-                credentials: nuage_events
-    openshift:
-        name: openshift
-        type: openshift
-        version: x.x
-        tags:
-            - tag
-        excluded_test_flags:
-        since_version:
-        server_zone:
-        hostname:
-        ipaddress:
-        port:
-        credentials:
-        ssh_creds:
-        authenticate:
-        rest_protocol:
-        sec_protocol:
-        metrics_type:
-        alerts_type :
-        provisioning:
-            node:
-            image:
-        cleanup:
-        cap_and_util:
-            resource_pool:
-            test_chargeback:
-            chargeback_vm:
-            capandu_vm:
-        hosts:
-            - name: name1
-            - name: name2
-        endpoints:
-            default:
-                hostname:
-                api_port:
-                sec_protocol:
-                credentials:
-            hawkular:
-                hostname:
-                api_port:
-                sec_protocol:
-            alerts:
-                hostname:
-                api_port:
-                sec_protocol:
-        settings:
-            proxy:
-                http_proxy:
-            advanced:
-                adv_http:
-                adv_https:
-                no_proxy:
-                image_repo:
-                image_reg:
-                image_tag:
-                cve_loc:
     nuage:
         name: nuage_net
         type: nuage


### PR DESCRIPTION
It turns out that templates are innocent. Travis just doesn't have yamls. 
So, I think we have to remove templates from ignore list and make travis create basic yamls from templates instead.