### PR TITLE
[1LP][RFR] Cover provision cases with vlan profiles <No Profile> and <Use template nics>

### DIFF
--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -302,7 +302,8 @@ def test_provisioning_schedule(provisioner, provider, prov_data, vm_name):
                                        ['provisioning', 'host'],
                                        ['provisioning', 'datastore']],
                       override=True)
-@pytest.mark.parametrize('vnic_profile', ['<No Profile>', '<Use template nics>'])
+@pytest.mark.parametrize('vnic_profile', ['<No Profile>', '<Use template nics>'],
+                         ids=['no_profile', 'use_template_nics'])
 def test_provisioning_vnic_profiles(provisioner, provider, prov_data, vm_name, vnic_profile):
     """ Tests provision VM with other than specific vnic profile selected - <No Profile>
         and <Use template nics>.
@@ -327,7 +328,7 @@ def test_provisioning_vnic_profiles(provisioner, provider, prov_data, vm_name, v
 
     wait_for(
         lambda: vm.exists_on_provider,
-        num_sec=240, delay=5
+        num_sec=300, delay=5
     )
 
     if vnic_profile == '<No Profile>':

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -294,3 +294,47 @@ def test_provisioning_schedule(provisioner, provider, prov_data, vm_name):
     template_name = provider.data['provisioning']['template']
 
     provisioner(template_name, prov_data, delayed=provision_time)
+
+
+@pytest.mark.rhv2
+@pytest.mark.provider([RHEVMProvider],
+                      required_fields=[['provisioning', 'template'],
+                                       ['provisioning', 'host'],
+                                       ['provisioning', 'datastore']],
+                      override=True)
+@pytest.mark.parametrize('vnic_profile', ['<No Profile>', '<Use template nics>'])
+def test_provisioning_vnic_profiles(provisioner, provider, prov_data, vm_name, vnic_profile):
+    """ Tests provision VM with other than specific vnic profile selected - <No Profile>
+        and <Use template nics>.
+
+    Prerequisities:
+        * A provider set up, supporting provisioning in CFME
+
+    Steps:
+        * Open the provisioning dialog.
+        * Apart from the usual provisioning settings, set vlan
+          to values <No Profile>/<Use template nics>
+        * Submit the provisioning request, it should provision the vm successfully.
+        * Check NIC configuration of provisioned VM
+    Metadata:
+        test_flag: provision
+    """
+    prov_data['catalog']['vm_name'] = vm_name
+    prov_data['network'] = {'vlan': vnic_profile}
+    template_name = provider.data['provisioning']['template']
+
+    vm = provisioner(template_name, prov_data)
+
+    wait_for(
+        lambda: vm.exists_on_provider,
+        num_sec=240, delay=5
+    )
+
+    if vnic_profile == '<No Profile>':
+        # Check the VM vNIC
+        nics = vm.mgmt.get_nics()
+        assert nics, 'The VM should have a NIC attached.'
+
+        # Check the vNIC network profile
+        profile = nics[0].vnic_profile
+        assert not profile, 'The vNIC profile should be empty.'

--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -273,7 +273,7 @@ selenium==3.12.0
 selenium-smart-locator==0.2.0
 Send2Trash==1.5.0
 sentaku==0.6.2
-setuptools-scm==3.0.6
+setuptools-scm==3.1.0
 shyaml==0.5.2
 simplegeneric==0.8.1
 simplejson==3.15.0
@@ -308,7 +308,7 @@ Werkzeug==0.14.1
 widgetastic.core==0.21.6
 widgetastic.patternfly==0.0.37
 widgetsnbextension==3.2.1
-wrapanapi==3.0.23
+wrapanapi==3.0.24
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0

--- a/requirements/frozen_docs.py2.txt
+++ b/requirements/frozen_docs.py2.txt
@@ -143,7 +143,7 @@ selenium==3.12.0
 selenium-smart-locator==0.2.0
 Send2Trash==1.5.0
 sentaku==0.6.2
-setuptools-scm==3.0.6
+setuptools-scm==3.1.0
 shyaml==0.5.2
 simplegeneric==0.8.1
 simplejson==3.15.0
@@ -173,6 +173,7 @@ Werkzeug==0.14.1
 widgetastic.core==0.21.6
 widgetastic.patternfly==0.0.37
 widgetsnbextension==3.2.1
+wrapanapi==3.0.24
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0


### PR DESCRIPTION
Extending test_provision_dialog to include test cases that provision VM with vnic profiles 'No Profile' and 'Use template nics'. 

For RFE page refer to https://bugzilla.redhat.com/show_bug.cgi?id=1449157, comment #4.

{{pytest: cfme/tests/infrastructure/test_provisioning_dialog.py::test_provisioning_vnic_profiles --long-running}}