### PR TITLE
[RFR] remove bad json deserialization statements in sprout and etc

### DIFF
--- a/scripts/clone_template.py
+++ b/scripts/clone_template.py
@@ -234,7 +234,7 @@ def main(**kwargs):
         raw_tags = trackerbot.providertemplate().get(provider=kwargs['provider'],
                                                      template=deploy_args['template'])['objects']
         raw_tags = raw_tags[-1]['template'].get('custom_data', "{}")
-        deploy_args["tags"] = yaml.safe_load(raw_tags.replace("u'", '"').replace("'", '"'))['TAGS']
+        deploy_args["tags"] = yaml.safe_load(raw_tags)['TAGS']
     # Do it!
     try:
         logger.info(

--- a/sprout/appliances/tasks.py
+++ b/sprout/appliances/tasks.py
@@ -272,11 +272,8 @@ def poke_trackerbot(self):
         template_name = template["template"]["name"]
         ga_released = template['template']['ga_released']
 
-        # nasty trackerbot slightly corrupts json data and it is parsed in wrong way
-        # as a result
         custom_data = template['template'].get('custom_data', "{}")
-        processed_custom_data = custom_data.replace("u'", '"').replace("'", '"')
-        processed_custom_data = yaml.safe_load(processed_custom_data)
+        processed_custom_data = yaml.safe_load(custom_data)
 
         template_info = TemplateName.parse_template(template_name)
         if not template_info.datestamp:


### PR DESCRIPTION
trackerbot's issue with wrong parsing JSONField's data has been fixed. Trackerbot should provide custom data in correct format. So, old bad decode statements aren't necessary now and can be removed