### PR TITLE
[1LP][RFR] Parameterize default and compare views tests for clouds

### DIFF
--- a/cfme/tests/configure/test_default_views_cloud.py
+++ b/cfme/tests/configure/test_default_views_cloud.py
@@ -56,7 +56,17 @@ def test_default_view(appliance, group_name, expected_view):
     default_views.set_default_view(group_name, old_default, fieldset='Clouds')
 
 
-def set_and_test_compare_view(appliance, group_name, expected_view, selector_type):
+@pytest.mark.parametrize('expected_view',
+                         ['Expanded View', 'Compressed View', 'Details Mode', 'Exists Mode'])
+def test_compare_view(appliance, expected_view):
+    """This test changes the default view/mode for comparison between provider instances
+    and asserts the change."""
+
+    if expected_view in ['Expanded View', 'Compressed View']:
+        group_name, selector_type = 'Compare', 'views_selector'
+    else:
+        group_name, selector_type = 'Compare Mode', 'modes_selector'
+
     default_views = appliance.user.my_settings.default_views
     old_default = default_views.get_default_view(group_name)
     default_views.set_default_view(group_name, expected_view)
@@ -66,15 +76,3 @@ def set_and_test_compare_view(appliance, group_name, expected_view, selector_typ
     selected_view = getattr(inst_view.actions, selector_type).selected
     assert expected_view == selected_view, '{} setting failed'.format(expected_view)
     default_views.set_default_view(group_name, old_default)
-
-
-@pytest.mark.parametrize('view', ['Expanded View', 'Compressed View'])
-def test_cloud_views(appliance, request, view):
-    """This test case checks the comparison between provider instances in different views."""
-    set_and_test_compare_view(appliance, 'Compare', view, 'views_selector')
-
-
-@pytest.mark.parametrize('mode', ['Details Mode', 'Exists Mode'])
-def test_cloud_modes(appliance, request, mode):
-    """This test case checks the comparison between provider instances in different modes."""
-    set_and_test_compare_view(appliance, 'Compare Mode', mode, 'modes_selector')

--- a/cfme/tests/configure/test_default_views_cloud.py
+++ b/cfme/tests/configure/test_default_views_cloud.py
@@ -41,7 +41,11 @@ def test_default_view_cloud_reset(appliance):
     assert not view.tabs.default_views.reset.disabled
 
 
-def set_and_test_default_view(appliance, group_name, expected_view, page):
+@pytest.mark.parametrize('group_name', gtl_params.keys())
+@pytest.mark.parametrize('expected_view', ['List View', 'Tile View', 'Grid View'])
+def test_default_view(appliance, group_name, expected_view):
+    """This test case changes the default view of a page and asserts the change."""
+    page = gtl_params[group_name]
     default_views = appliance.user.my_settings.default_views
     old_default = default_views.get_default_view(group_name, fieldset='Clouds')
     default_views.set_default_view(group_name, expected_view, fieldset='Clouds')
@@ -52,22 +56,7 @@ def set_and_test_default_view(appliance, group_name, expected_view, page):
     default_views.set_default_view(group_name, old_default, fieldset='Clouds')
 
 
-@pytest.mark.parametrize('key', gtl_params, scope="module")
-def test_cloud_tile_defaultview(appliance, request, key):
-    set_and_test_default_view(appliance, key, 'Tile View', gtl_params[key])
-
-
-@pytest.mark.parametrize('key', gtl_params, scope="module")
-def test_cloud_list_defaultview(appliance, request, key):
-    set_and_test_default_view(appliance, key, 'List View', gtl_params[key])
-
-
-@pytest.mark.parametrize('key', gtl_params, scope="module")
-def test_cloud_grid_defaultview(appliance, request, key):
-    set_and_test_default_view(appliance, key, 'Grid View', gtl_params[key])
-
-
-def set_and_test_compare_view(appliance, group_name, expected_view, selector_type='views_selector'):
+def set_and_test_compare_view(appliance, group_name, expected_view, selector_type):
     default_views = appliance.user.my_settings.default_views
     old_default = default_views.get_default_view(group_name)
     default_views.set_default_view(group_name, expected_view)
@@ -79,17 +68,13 @@ def set_and_test_compare_view(appliance, group_name, expected_view, selector_typ
     default_views.set_default_view(group_name, old_default)
 
 
-def test_cloud_expanded_view(appliance, request):
-    set_and_test_compare_view(appliance, 'Compare', 'Expanded View')
+@pytest.mark.parametrize('view', ['Expanded View', 'Compressed View'])
+def test_cloud_views(appliance, request, view):
+    """This test case checks the comparison between provider instances in different views."""
+    set_and_test_compare_view(appliance, 'Compare', view, 'views_selector')
 
 
-def test_cloud_compressed_view(appliance, request):
-    set_and_test_compare_view(appliance, 'Compare', 'Compressed View')
-
-
-def test_cloud_details_mode(appliance, request):
-    set_and_test_compare_view(appliance, 'Compare Mode', 'Details Mode', 'modes_selector')
-
-
-def test_cloud_exists_mode(appliance, request):
-    set_and_test_compare_view(appliance, 'Compare Mode', 'Exists Mode', 'modes_selector')
+@pytest.mark.parametrize('mode', ['Details Mode', 'Exists Mode'])
+def test_cloud_modes(appliance, request, mode):
+    """This test case checks the comparison between provider instances in different modes."""
+    set_and_test_compare_view(appliance, 'Compare Mode', mode, 'modes_selector')

--- a/cfme/tests/configure/test_default_views_cloud.py
+++ b/cfme/tests/configure/test_default_views_cloud.py
@@ -43,8 +43,8 @@ def test_default_view_cloud_reset(appliance):
 
 @pytest.mark.parametrize('group_name', gtl_params.keys())
 @pytest.mark.parametrize('expected_view', ['List View', 'Tile View', 'Grid View'])
-def test_default_view(appliance, group_name, expected_view):
-    """This test case changes the default view of a page and asserts the change."""
+def test_cloud_default_view_cloud(appliance, group_name, expected_view):
+    """This test case changes the default view of a cloud related page and asserts the change."""
     page = gtl_params[group_name]
     default_views = appliance.user.my_settings.default_views
     old_default = default_views.get_default_view(group_name, fieldset='Clouds')
@@ -58,8 +58,8 @@ def test_default_view(appliance, group_name, expected_view):
 
 @pytest.mark.parametrize('expected_view',
                          ['Expanded View', 'Compressed View', 'Details Mode', 'Exists Mode'])
-def test_compare_view(appliance, expected_view):
-    """This test changes the default view/mode for comparison between provider instances
+def test_cloud_compare_view(appliance, expected_view):
+    """This test changes the default view/mode for comparison between cloud provider instances
     and asserts the change."""
 
     if expected_view in ['Expanded View', 'Compressed View']:


### PR DESCRIPTION
Shriver edited to include infra module:

{{ pytest: cfme/tests/configure/test_default_views_cloud.py cfme/tests/configure/test_default_views_infra.py }}

Changes introduces with this PR:

1. Modify `set_and_test_default_view` by parametrizing it and changing the name to `test_default_views`.
2. Remove `test_cloud_tile_defaultview`, `test_cloud_grid_defaultview` and `test_cloud_list_defaultview` tests.
3. Replace `test_cloud_expanded_view` and `test_cloud_compressed_view` tests with the parametrized `test_cloud_views` test.
4. Replace `test_cloud_exists_mode` and `test_cloud_details_mode` tests with the parametrized `test_cloud_modes` test.
5. Add doc-strings in tests. 