### PR TITLE
[1LP][RFR]  Add new test for provider test resume workers

### DIFF
--- a/cfme/tests/containers/test_pause_resume_workers.py
+++ b/cfme/tests/containers/test_pause_resume_workers.py
@@ -20,7 +20,6 @@ def check_ems_state_in_diagnostics(appliance, provider):
             return True
     except Exception:
         return False
-    return False
 
 
 def test_pause_and_resume_provider_workers(appliance, provider):

--- a/cfme/tests/containers/test_pause_resume_workers.py
+++ b/cfme/tests/containers/test_pause_resume_workers.py
@@ -36,7 +36,6 @@ def check_ems_state_in_diagnostics(appliance, provider):
             return True
         else:
             return False
-
     except Exception:
         return False
     return False
@@ -56,23 +55,15 @@ def test_pause_and_resume_provider_workers(appliance, provider):
         7. navigate to : User -> Configuration -> Diagnostics ->  Workers
         8. Validate the ems_ workers are started
     """
-
     view = navigate_to(provider, "Details")
-
     pause_option, resume_option = get_pause_resume_buttons(view)
-
     # pause the provider
     view.toolbar.configuration.item_select(pause_option, handle_alert=True)
-
     ems_worker_state = check_ems_state_in_diagnostics(appliance, provider)
-
     assert not ems_worker_state, "Diagnostics shows that workers are running after pause provider"
 
     view = navigate_to(provider, "Details")
-
     # resume the provider
     view.toolbar.configuration.item_select(resume_option, handle_alert=True)
-
     ems_worker_state = check_ems_state_in_diagnostics(appliance, provider)
-
     assert ems_worker_state, "Diagnostics shows that workers are not running after resume provider"

--- a/cfme/tests/containers/test_pause_resume_workers.py
+++ b/cfme/tests/containers/test_pause_resume_workers.py
@@ -1,0 +1,84 @@
+import pytest
+from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.containers.provider import ContainersProvider
+
+pytestmark = [
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.tier(1),
+    pytest.mark.provider([ContainersProvider], scope='function')
+]
+
+
+def get_pause_resume_buttons(view):
+    # ensure resume option is exist
+    resume_option = filter(lambda item: "resume" in item.lower(), view.toolbar.configuration.items)
+    assert resume_option, "Not resume provider option is available in the configuration menu"
+    resume_option = resume_option.pop()
+
+    # ensure pause option is exsit
+    pause_option = filter(lambda item: "pause" in item.lower(), view.toolbar.configuration.items)
+    assert pause_option, "Not pause provider option is available in the configuration menu"
+    pause_option = pause_option.pop()
+
+    return pause_option, resume_option
+
+
+@pytest.mark.polarion('10790', '10791')
+def test_pause_and_resume_provider_workers(appliance, provider):
+    """
+    Basic workers testing for pause and resume for a container provider
+    Tests steps:
+        1. Navigate to provider page
+        2. Pause the provider
+        3. navigate to : User -> Configuration -> Diagnostics ->  Workers
+        4. Validate the ems_ workers are not found
+        5. Navigate to provider page
+        6. Resume the provider
+        7. navigate to : User -> Configuration -> Diagnostics ->  Workers
+        8. Validate the ems_ workers are started
+    """
+
+    view = navigate_to(provider, "Details")
+
+    pause_option, resume_option = get_pause_resume_buttons(view)
+
+    # pause the provider
+    view.toolbar.configuration.item_select(pause_option, handle_alert=True)
+
+    ems_worker_state = check_ems_state_in_diagnostics(appliance, provider)
+
+    assert not ems_worker_state, "Diagnostics shows that workers are running after pause provider"
+
+    view = navigate_to(provider, "Details")
+
+    # resume the provider
+    view.toolbar.configuration.item_select(resume_option, handle_alert=True)
+
+    ems_worker_state = check_ems_state_in_diagnostics(appliance, provider)
+
+    assert ems_worker_state, "Diagnostics shows that workers are not running after resume provider"
+
+
+def check_ems_state_in_diagnostics(appliance, provider):
+    workers_view = navigate_to(appliance.collections.diagnostic_workers, 'AllDiagnosticWorkers')
+
+    workers_view.browser.refresh()
+
+    ems_worker_is_running = False
+
+    for row in workers_view.workers_table.rows():
+
+        name = getattr(row, "Name")
+
+        uri_queue_name = getattr(row, "URI / Queue Name")
+
+        assert name, "'Name' column not found in workers table"
+
+        assert uri_queue_name, "'URI / Queue Name' column not found in workers table"
+
+        if "Event Monitor for Provider" in name.text\
+                and provider.name in name.text \
+                and "ems_" in uri_queue_name.text:
+            ems_worker_is_running = True
+
+    return ems_worker_is_running

--- a/cfme/tests/containers/test_pause_resume_workers.py
+++ b/cfme/tests/containers/test_pause_resume_workers.py
@@ -1,6 +1,7 @@
-import pytest
-from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.containers.provider import ContainersProvider
+from cfme.utils.appliance.implementations.ui import navigate_to
+import pytest
+
 
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
@@ -10,17 +11,33 @@ pytestmark = [
 
 
 def get_pause_resume_buttons(view):
-    # ensure resume option is exist
+    # ensure resume option is exists
     resume_option = filter(lambda item: "resume" in item.lower(), view.toolbar.configuration.items)
     assert resume_option, "Not resume provider option is available in the configuration menu"
     resume_option = resume_option.pop()
 
-    # ensure pause option is exsit
+    # ensure pause option is exists
     pause_option = filter(lambda item: "pause" in item.lower(), view.toolbar.configuration.items)
     assert pause_option, "Not pause provider option is available in the configuration menu"
     pause_option = pause_option.pop()
 
     return pause_option, resume_option
+
+
+def check_ems_state_in_diagnostics(appliance, provider):
+    workers_view = navigate_to(appliance.collections.diagnostic_workers, 'AllDiagnosticWorkers')
+    workers_view.browser.refresh()
+    ems_worker_is_running = False
+    for row in workers_view.workers_table.rows():
+        name = getattr(row, "Name")
+        uri_queue_name = getattr(row, "URI / Queue Name")
+        assert name, "'Name' column not found in workers table"
+        assert uri_queue_name, "'URI / Queue Name' column not found in workers table"
+        if ("Event Monitor for Provider" in name.text and
+                provider.name in name.text and
+                "ems_" in uri_queue_name.text):
+            ems_worker_is_running = True
+    return ems_worker_is_running
 
 
 @pytest.mark.polarion('10790', '10791')
@@ -57,28 +74,3 @@ def test_pause_and_resume_provider_workers(appliance, provider):
     ems_worker_state = check_ems_state_in_diagnostics(appliance, provider)
 
     assert ems_worker_state, "Diagnostics shows that workers are not running after resume provider"
-
-
-def check_ems_state_in_diagnostics(appliance, provider):
-    workers_view = navigate_to(appliance.collections.diagnostic_workers, 'AllDiagnosticWorkers')
-
-    workers_view.browser.refresh()
-
-    ems_worker_is_running = False
-
-    for row in workers_view.workers_table.rows():
-
-        name = getattr(row, "Name")
-
-        uri_queue_name = getattr(row, "URI / Queue Name")
-
-        assert name, "'Name' column not found in workers table"
-
-        assert uri_queue_name, "'URI / Queue Name' column not found in workers table"
-
-        if "Event Monitor for Provider" in name.text\
-                and provider.name in name.text \
-                and "ems_" in uri_queue_name.text:
-            ems_worker_is_running = True
-
-    return ems_worker_is_running

--- a/cfme/tests/containers/test_pause_resume_workers.py
+++ b/cfme/tests/containers/test_pause_resume_workers.py
@@ -11,32 +11,13 @@ pytestmark = [
 ]
 
 
-def get_pause_resume_buttons(view):
-    resume_option = [menu_item for menu_item in view.toolbar.configuration.items if
-                     "resume this containers provider" in menu_item.lower()]
-    # ensure resume option is exists
-    assert resume_option, "No resume provider option is available in the configuration menu"
-    resume_option = resume_option.pop()
-
-    pause_option = [menu_item for menu_item in view.toolbar.configuration.items if
-                    "pause this containers provider" in menu_item.lower()]
-    # ensure pause option is exists
-    assert pause_option, "No pause provider option is available in the configuration menu"
-    pause_option = pause_option.pop()
-
-    return pause_option, resume_option
-
-
 def check_ems_state_in_diagnostics(appliance, provider):
     workers_view = navigate_to(appliance.collections.diagnostic_workers, 'AllDiagnosticWorkers')
     workers_view.browser.refresh()
     try:
-        rows = workers_view.workers_table.rows(
-            name='Event Monitor for Provider: {}'.format(provider.name))
-        for r in rows:
+        if workers_view.workers_table.rows(
+                name='Event Monitor for Provider: {}'.format(provider.name)).next():
             return True
-        else:
-            return False
     except Exception:
         return False
     return False
@@ -56,14 +37,13 @@ def test_pause_and_resume_provider_workers(appliance, provider):
         8. Validate the ems_ workers are started
     """
     view = navigate_to(provider, "Details")
-    pause_option, resume_option = get_pause_resume_buttons(view)
     # pause the provider
-    view.toolbar.configuration.item_select(pause_option, handle_alert=True)
+    view.toolbar.configuration.item_select(provider.pause_provider_text, handle_alert=True)
     ems_worker_state = check_ems_state_in_diagnostics(appliance, provider)
     assert not ems_worker_state, "Diagnostics shows that workers are running after pause provider"
 
     view = navigate_to(provider, "Details")
     # resume the provider
-    view.toolbar.configuration.item_select(resume_option, handle_alert=True)
+    view.toolbar.configuration.item_select(provider.resume_provider_text, handle_alert=True)
     ems_worker_state = check_ems_state_in_diagnostics(appliance, provider)
     assert ems_worker_state, "Diagnostics shows that workers are not running after resume provider"

--- a/cfme/tests/containers/test_pause_resume_workers.py
+++ b/cfme/tests/containers/test_pause_resume_workers.py
@@ -1,6 +1,7 @@
+import pytest
+
 from cfme.containers.provider import ContainersProvider
 from cfme.utils.appliance.implementations.ui import navigate_to
-import pytest
 
 
 pytestmark = [
@@ -41,7 +42,6 @@ def check_ems_state_in_diagnostics(appliance, provider):
     return False
 
 
-@pytest.mark.polarion('10790', '10791')
 def test_pause_and_resume_provider_workers(appliance, provider):
     """
     Basic workers testing for pause and resume for a container provider


### PR DESCRIPTION
{{ pytest : cfme/tests/containers/test_pause_resume_workers.py --use-provider ocp-39-hawk }}
Add new test for provider test resume workers.
This is an implementation for Polarion test cases '10790',  '10791'