### PR TITLE
[1LP][RFR] Bump pycurl to version 7.43.0.2

### DIFF
--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -222,7 +222,7 @@ pyasn1-modules==0.2.1
 pycodestyle==2.3.1
 pycparser==2.18
 pycryptodome==3.6.1
-pycurl==7.43.0.1
+pycurl==7.43.0.2
 pyflakes==1.6.0
 pygal==2.4.0
 PyGithub==1.39

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -216,7 +216,7 @@ pyasn1-modules==0.2.1
 pycodestyle==2.3.1
 pycparser==2.18
 pycryptodome==3.6.1
-pycurl==7.43.0.1
+pycurl==7.43.0.2
 pyflakes==1.6.0
 pygal==2.4.0
 PyGithub==1.39


### PR DESCRIPTION
`miq selenium-container` failed in Ubuntu 18.04, because this system only supports libssl version 1.1. The pycurl 7.43.0.1 expects the older version of openssl, so it crashes. We bump pycurl requirement to 7.43.0.2 [1] to address this.

[1] https://github.com/pycurl/pycurl/blob/01bc6af76dfec1d766857c4471076a06ec99d640/ChangeLog#L4
