### PR TITLE
[RFR] AnalysisProfile creation in SSA

### DIFF
--- a/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
+++ b/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
@@ -339,15 +339,17 @@ def ssa_analysis_profile(appliance):
 
     analysis_profile_name = 'default'
     analysis_profiles_collection = appliance.collections.analysis_profiles
-    analysis_profile = analysis_profiles_collection(
+    profile_kwargs = dict(
         name=analysis_profile_name,
         description=analysis_profile_name,
         profile_type=analysis_profiles_collection.VM_TYPE,
         categories=["System", "Software", "Services", "User Accounts", "VM Configuration"],
-        files=collected_files)
+        files=collected_files
+    )
+    analysis_profile = analysis_profiles_collection.instantiate(**profile_kwargs)
     if analysis_profile.exists:
         analysis_profile.delete()
-    analysis_profile.create()
+    analysis_profile = analysis_profiles_collection.create(**profile_kwargs)
     yield analysis_profile
     if analysis_profile.exists:
         analysis_profile.delete()


### PR DESCRIPTION
#7614 is hitting this too, but I think more than just the init call needs to be changed.

# Note to reviewers
PRT results aren't clean - many tests are skipped because of host credentials setting.

At least one testcase gets to the point where the fixture structure has executed, and this block of code to create the analysis profile was executed without error.