### PR TITLE
[1LP][RFR][NOTEST] fix for historical data with unicode and str

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -3,6 +3,7 @@
 from datetime import datetime, date, timedelta
 
 import attr
+import json
 from cached_property import cached_property
 from riggerlib import recursive_update
 
@@ -666,9 +667,12 @@ class VM(BaseVM):
             back: back time interval from which you want data
         """
         ret = self.appliance.ssh_client.run_rails_command(
-            "\"vm = Vm.where(:ems_id => {prov_id}).where(:name => '{vm_name}')[0];\
-            vm.perf_capture('{interval}', {back}.ago.utc, Time.now.utc)\"".format(
-                prov_id=self.provider.id, vm_name=self.name, interval=interval, back=back
+            "'vm = Vm.where(:ems_id => {prov_id}).where(:name => {vm_name})[0];\
+            vm.perf_capture({interval}, {back}.ago.utc, Time.now.utc)'".format(
+                prov_id=self.provider.id,
+                vm_name=json.dumps(self.name),
+                interval=json.dumps(interval),
+                back=back,
             )
         )
         return ret.success

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -5,7 +5,6 @@ from datetime import datetime, date, timedelta
 import attr
 from cached_property import cached_property
 from riggerlib import recursive_update
-from wrapanapi.exceptions import NotFoundError
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.common import Taggable
@@ -659,7 +658,7 @@ class VM(BaseVM):
             delay=10, handle_exception=True, num_sec=timeout,
             fail_func=view.toolbar.reload.click)
 
-    def capture_historical_data(self, interval='hourly', back='6.days'):
+    def capture_historical_data(self, interval="hourly", back="6.days"):
         """Capture historical utilization data for this VM/Instance
 
         Args:
@@ -667,9 +666,11 @@ class VM(BaseVM):
             back: back time interval from which you want data
         """
         ret = self.appliance.ssh_client.run_rails_command(
-            "\"vm = Vm.where(:ems_id => {}).where(:name => {})[0];\
-            vm.perf_capture({}, {}.ago.utc, Time.now.utc)\""
-            .format(self.provider.id, repr(self.name), repr(interval), back))
+            "\"vm = Vm.where(:ems_id => {prov_id}).where(:name => '{vm_name}')[0];\
+            vm.perf_capture('{interval}', {back}.ago.utc, Time.now.utc)\"".format(
+                prov_id=self.provider.id, vm_name=self.name, interval=interval, back=back
+            )
+        )
         return ret.success
 
     def wait_for_vm_state_change(self, desired_state=None, timeout=300, from_details=False,

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -2,6 +2,7 @@
 """A model of an Infrastructure Host in CFME."""
 import attr
 import six
+import json
 
 from manageiq_client.api import APIException
 from navmazing import NavigateToSibling, NavigateToAttribute
@@ -426,9 +427,12 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Taggable):
             back: back time interval from which you want data
         """
         ret = self.appliance.ssh_client.run_rails_command(
-            "\"host = Host.where(:ems_id => {prov_id}).where(:name => '{host_name}')[0];\
-            host.perf_capture('{interval}', {back}.ago.utc, Time.now.utc)\"".format(
-                prov_id=self.provider.id, host_name=self.name, interval=interval, back=back
+            "'host = Host.where(:ems_id => {prov_id}).where(:name => {host_name})[0];\
+            host.perf_capture({interval}, {back}.ago.utc, Time.now.utc)'".format(
+                prov_id=self.provider.id,
+                host_name=json.dumps(self.name),
+                interval=json.dumps(interval),
+                back=back,
             )
         )
         return ret.success

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -418,7 +418,7 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Taggable):
             fail_func=view.browser.refresh
         )
 
-    def capture_historical_data(self, interval='hourly', back='6.days'):
+    def capture_historical_data(self, interval="hourly", back="6.days"):
         """Capture historical utilization data for this Host
 
         Args:
@@ -426,9 +426,11 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Taggable):
             back: back time interval from which you want data
         """
         ret = self.appliance.ssh_client.run_rails_command(
-            "\"host = Host.where(:ems_id => {}).where(:name => {})[0];\
-            host.perf_capture({}, {}.ago.utc, Time.now.utc)\""
-            .format(self.provider.id, repr(self.name), repr(interval), back))
+            "\"host = Host.where(:ems_id => {prov_id}).where(:name => '{host_name}')[0];\
+            host.perf_capture('{interval}', {back}.ago.utc, Time.now.utc)\"".format(
+                prov_id=self.provider.id, host_name=self.name, interval=interval, back=back
+            )
+        )
         return ret.success
 
     @classmethod


### PR DESCRIPTION
Purpose or Intent
=================
- removed `repr` so compartable with `unicode` and `str`
- F401 'wrapanapi.exceptions.NotFoundError' imported but unused :+1: 


Shriver adding pytest:

{{ pytest: cfme/tests/candu/test_vm_graph.py cfme/tests/candu/test_host_graph.py }}