### PR TITLE
[RFR] generic shepherd fix for openshift

### DIFF
--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -308,7 +308,7 @@ Werkzeug==0.14.1
 widgetastic.core==0.21.6
 widgetastic.patternfly==0.0.37
 widgetsnbextension==3.2.1
-wrapanapi==3.0.22
+wrapanapi==3.0.23
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -297,7 +297,7 @@ Werkzeug==0.14.1
 widgetastic.core==0.21.6
 widgetastic.patternfly==0.0.37
 widgetsnbextension==3.2.1
-wrapanapi==3.0.22
+wrapanapi==3.0.23
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0


### PR DESCRIPTION
It turned out that last changes made generic shepherd choose wrong template for app name generation. therefore, wrong appliance name was generated for ocp appliances. 
This commit should fix such issue.

This change needs some local testing before merge.