### PR TITLE
[1LP][RFR][NOTEST] Related datastore for VM

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -951,6 +951,15 @@ class InfraVm(VM):
         return host
 
     @property
+    def datastore(self):
+        vm_api = self.appliance.rest_api.collections.vms.get(name=self.name)
+        vm_api.reload(attributes=['v_datastore_path'])
+        datastore_name = vm_api.v_datastore_path.split('/')[0]
+        return self.appliance.collections.datastores.instantiate(
+            name=datastore_name, provider=self.provider
+        )
+
+    @property
     def vm_default_args(self):
         """Represents dictionary used for Vm/Instance provision with mandatory default args"""
         provisioning = self.provider.data['provisioning']


### PR DESCRIPTION
Purpose or Intent
=================
- Added one property to `VM` for collecting related `datastore`
- I need it for automating graphs stuff related to `datastore` and avoid redundant navigation to fetch name for relationship table.


In [1]: v = vm(provider=vsphere55)
In [2]: v.datastore
Out[2]: Datastore(name=u'h03-ds2', provider=VMwareProvider(endpoints={'default': <cfme.infrastructure.provider.virtualcenter.........)