### PR TITLE
[1LP][RFR] Datastore Hourly graph

### DIFF
--- a/cfme/common/candu_views.py
+++ b/cfme/common/candu_views.py
@@ -129,3 +129,33 @@ class ClusterInfraUtilizationView(View):
     def is_displayed(self):
         expected_title = "{} Capacity & Utilization".format(self.context['object'].name)
         return self.title.text == expected_title
+
+
+class DatastoreInfraUtilizationView(View):
+    """View for Infrastructure provider Datastore Utilization Hourly and Daily"""
+
+    title = Text(".//div[@id='main-content']//h1")
+    options = View.nested(OptionForm)
+    interval_type = ConditionalSwitchableView(reference="options.interval")
+
+    @interval_type.register("Hourly", default=True)
+    class DatastoreInfraHourlyUtilizationView(View):
+        datastore_used_disk_space = LineChart(id="miq_chart_parent_candu_5")
+        datastore_hosts = LineChart(id="miq_chart_parent_candu_6")
+        datastore_vms = LineChart(id="miq_chart_parent_candu_7")
+
+    @interval_type.register("Daily")
+    class DatastoreInfraDailyUtilizationView(View):
+        datastore_use_space_by_type = LineChart(id="miq_chart_parent_candu_0")
+        datastore_disk_files_space_by_type = LineChart(id="miq_chart_parent_candu_1")
+        datastore_snapshot_files_space_by_type = LineChart(id="miq_chart_parent_candu_2")
+        datastore_memory_files_space_by_type = LineChart(id="miq_chart_parent_candu_3")
+        datastore_vms_by_type = LineChart(id="miq_chart_parent_candu_4")
+        datastore_used_disk_space = LineChart(id="miq_chart_parent_candu_5")
+        datastore_hosts = LineChart(id="miq_chart_parent_candu_6")
+        datastore_vms = LineChart(id="miq_chart_parent_candu_7")
+
+    @property
+    def is_displayed(self):
+        expected_title = "{} Capacity & Utilization".format(self.context["object"].name)
+        return self.title.text == expected_title

--- a/cfme/infrastructure/datastore.py
+++ b/cfme/infrastructure/datastore.py
@@ -2,20 +2,23 @@
 """
 import attr
 from lxml.html import document_fromstring
+
 from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.exceptions import NoSuchElementException
-from widgetastic.widget import ParametrizedView, View, Text
-from widgetastic_manageiq import (ManageIQTree,
-                                  SummaryTable,
-                                  ItemsToolBarViewSelector,
-                                  BaseEntitiesView,
-                                  NonJSBaseEntity,
-                                  BaseListEntity,
-                                  BaseQuadIconEntity,
-                                  BaseTileIconEntity,
-                                  JSBaseEntity,
-                                  Search)
-from widgetastic_patternfly import Dropdown, Accordion
+from widgetastic.widget import ParametrizedView, Text, View
+from widgetastic_patternfly import Accordion, Dropdown
+from widgetastic_manageiq import (
+    BaseEntitiesView,
+    BaseListEntity,
+    BaseQuadIconEntity,
+    BaseTileIconEntity,
+    ItemsToolBarViewSelector,
+    JSBaseEntity,
+    ManageIQTree,
+    NonJSBaseEntity,
+    Search,
+    SummaryTable,
+)
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.common import Taggable
@@ -24,9 +27,9 @@ from cfme.common.host_views import HostsView
 from cfme.exceptions import ItemNotFound, MenuItemNotFound
 from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.utils import ParamClassName
-from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
+from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigate_to, navigator
 from cfme.utils.pretty import Pretty
-from cfme.utils.wait import wait_for, TimedOutError
+from cfme.utils.wait import TimedOutError, wait_for
 
 
 class DatastoreToolBar(View):

--- a/cfme/tests/candu/test_datastore_graph.py
+++ b/cfme/tests/candu/test_datastore_graph.py
@@ -50,7 +50,7 @@ def test_graph_screen(provider, interval, graph_type, enable_candu):
     view = navigate_to(datastore, "Utilization")
     view.options.interval.fill(interval)
 
-    # Check garph displayed or not
+    # Check graph displayed or not
     try:
         graph = getattr(view.interval_type, graph_type)
     except AttributeError as e:

--- a/cfme/tests/candu/test_datastore_graph.py
+++ b/cfme/tests/candu/test_datastore_graph.py
@@ -1,0 +1,77 @@
+import pytest
+
+from cfme import test_requirements
+from cfme.common.candu_views import UtilizationZoomView
+from cfme.infrastructure.provider.rhevm import RHEVMProvider
+from cfme.infrastructure.provider.virtualcenter import VMwareProvider
+from cfme.tests.candu import compare_data
+from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.log import logger
+from cfme.utils.wait import wait_for
+
+
+pytestmark = [
+    pytest.mark.tier(3),
+    test_requirements.c_and_u,
+    pytest.mark.usefixtures("setup_provider"),
+    pytest.mark.provider(
+        [VMwareProvider, RHEVMProvider],
+        required_fields=[(["cap_and_util", "capandu_vm"], "cu-24x7")],
+    ),
+]
+
+DATASTORE_GRAPHS = ["datastore_used_disk_space", "datastore_hosts", "datastore_vms"]
+
+# To-Do: Add support for Daily. Datastore not support historical data collection
+INTERVAL = ["Hourly"]
+
+
+@pytest.mark.parametrize("interval", INTERVAL)
+@pytest.mark.parametrize("graph_type", DATASTORE_GRAPHS)
+def test_graph_screen(provider, interval, graph_type, enable_candu):
+    """Test Datastore graphs for hourly
+
+    prerequisites:
+        * C&U enabled appliance
+
+    Steps:
+        * Navigate to Datastore Utilization Page
+        * Check graph displayed or not
+        * Select interval Hourly
+        * Zoom graph to get Table
+        * Compare table and graph data
+    """
+    vm_collection = provider.appliance.provider_based_collection(provider)
+    vm = vm_collection.instantiate("cu-24x7", provider)
+    datastore = vm.datastore
+
+    datastore.wait_candu_data_available(timeout=1500)
+
+    view = navigate_to(datastore, "Utilization")
+    view.options.interval.fill(interval)
+
+    # Check garph displayed or not
+    try:
+        graph = getattr(view.interval_type, graph_type)
+    except AttributeError as e:
+        logger.error(e)
+    assert graph.is_displayed
+
+    def refresh():
+        provider.browser.refresh()
+        view.options.interval.fill(interval)
+
+    # wait, some time graph take time to load
+    wait_for(lambda: bool(graph.all_legends), delay=5, timeout=200, fail_func=refresh)
+
+    graph.zoom_in()
+    view = view.browser.create_view(UtilizationZoomView)
+
+    assert view.chart.is_displayed
+    view.flush_widget_cache()
+    legends = view.chart.all_legends
+    graph_data = view.chart.all_data
+    # Clear cache of table widget before read else it will mismatch headers.
+    view.table.clear_cache()
+    table_data = view.table.read()
+    compare_data(table_data=table_data, graph_data=graph_data, legends=legends)


### PR DESCRIPTION
Purpose or Intent
=================
- Added Datastore Utilization views
- Added Utilization navigation and wait for data method
- Added test for hourly graph


Note: Daily graph not possible to automate as Datastore not support historical data collection else we have to add automation in sleep for a day at least to collect daily metrics. 

{{pytest: cfme/tests/candu/test_datastore_graph.py -v --use-provider complete}}
