### PR TITLE
[1LP][RFR] Add switching to Summary view for physical infrastructure provider

### DIFF
--- a/cfme/physical/provider/__init__.py
+++ b/cfme/physical/provider/__init__.py
@@ -134,6 +134,12 @@ class Details(CFMENavigateStep):
     def step(self):
         self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True).click()
 
+    def resetter(self):
+        """Reset view and selection"""
+        view_selector = self.view.toolbar.view_selector
+        if view_selector.selected != 'Summary View':
+            view_selector.select('Summary View')
+
 
 @navigator.register(PhysicalProvider, 'Edit')
 class Edit(CFMENavigateStep):


### PR DESCRIPTION
In version 5.10, the Details view for a physical infrastructure now has a choice between a Dashboard View, which is new, and a Summary View, which has been refreshed but it contains elements of the previous Details view. By default, the Dashboard View is opened, so we added a step to select the Summary View before doing the stats check.