### PR TITLE
[RFR] Remove Polarion IDs from CMQE Tests

### DIFF
--- a/cfme/tests/containers/test_ad_hoc_metrics.py
+++ b/cfme/tests/containers/test_ad_hoc_metrics.py
@@ -40,14 +40,12 @@ def is_ad_hoc_greyed(provider_object):
     return view.toolbar.monitoring.item_enabled('Ad hoc Metrics')
 
 
-@pytest.mark.polarion('CMP-10643')
 def test_ad_hoc_metrics_overview(provider, metrics_up_and_running):
 
     assert is_ad_hoc_greyed(provider), (
         "Monitoring --> Ad hoc Metrics not activated despite provider was set")
 
 
-@pytest.mark.polarion('CMP-10645')
 def test_ad_hoc_metrics_select_filter(provider, metrics_up_and_running):
 
     view = navigate_to(provider, 'AdHoc')

--- a/cfme/tests/containers/test_basic_metrics.py
+++ b/cfme/tests/containers/test_basic_metrics.py
@@ -59,7 +59,6 @@ def wait_for_metrics_rollup(provider):
 # TODO This test needs to be reevaluated. This is not testing anyting in CFME.
 
 
-@pytest.mark.polarion('CMP-10205')
 def test_basic_metrics(provider):
     """ Basic Metrics availability test
         This test checks that the Metrics service is up

--- a/cfme/tests/containers/test_breadcrumbs.py
+++ b/cfme/tests/containers/test_breadcrumbs.py
@@ -42,7 +42,6 @@ def clear_search(view):
     view.entities.search.search_button.click()
 
 
-@pytest.mark.polarion('CMP-10576')
 def test_breadcrumbs(provider, appliance, soft_assert):
 
     for data_set in TESTED_OBJECTS:

--- a/cfme/tests/containers/test_cockpit.py
+++ b/cfme/tests/containers/test_cockpit.py
@@ -16,7 +16,6 @@ pytestmark = [
                          scope='function')]
 
 
-@pytest.mark.polarion('CMP-10255')
 @pytest.mark.uncollectif(lambda appliance: appliance.version < "5.9",
                          reason='Cockpit Feature is only available in 5.9 and greater')
 @pytest.mark.parametrize('cockpit', [False, True], ids=['disabled', 'enabled'])

--- a/cfme/tests/containers/test_configurable_menus.py
+++ b/cfme/tests/containers/test_configurable_menus.py
@@ -26,7 +26,6 @@ def is_monitoring_menu_visible(appliance):
     return is_menu_visible(appliance, 'Monitor')
 
 
-@pytest.mark.polarion('CMP-10614')
 def test_datawarehouse_invisible(is_datawarehouse_menu_visible):
     # This should be the default state
     # Verifies BZ#1421175
@@ -34,7 +33,6 @@ def test_datawarehouse_invisible(is_datawarehouse_menu_visible):
 
 
 @pytest.mark.uncollectif(lambda: current_version() > "5.8")
-@pytest.mark.polarion('CMP-10613')
 def test_monitoring_invisible(is_monitoring_menu_visible):
     # This should be the default state
     # Verifies BZ#1421173

--- a/cfme/tests/containers/test_containers_smartstate_analysis.py
+++ b/cfme/tests/containers/test_containers_smartstate_analysis.py
@@ -31,16 +31,10 @@ TESTED_ATTRIBUTES__openscap_on = TESTED_ATTRIBUTES__openscap_off + (
 )
 
 TEST_ITEMS = (
-    pytest.mark.polarion('CMP-9496')(
-        ContainersTestItem(Image, 'CMP-9496',
-                           is_openscap=False,
-                           tested_attr=TESTED_ATTRIBUTES__openscap_off)
-    ),
-    pytest.mark.polarion('CMP-10064')(
-        ContainersTestItem(Image, 'CMP-10064',
-                           is_openscap=True,
-                           tested_attr=TESTED_ATTRIBUTES__openscap_on)
-    )
+    ContainersTestItem(Image, 'openscap_off', is_openscap=False,
+                       tested_attr=TESTED_ATTRIBUTES__openscap_off),
+    ContainersTestItem(Image, 'openscap_on', is_openscap=True,
+                       tested_attr=TESTED_ATTRIBUTES__openscap_on)
 )
 
 NUM_SELECTED_IMAGES = 1

--- a/cfme/tests/containers/test_containers_smartstate_analysis_multiple_images.py
+++ b/cfme/tests/containers/test_containers_smartstate_analysis_multiple_images.py
@@ -31,17 +31,10 @@ TESTED_ATTRIBUTES__openscap_on = TESTED_ATTRIBUTES__openscap_off + (
 )
 
 TEST_ITEMS = (
-    pytest.mark.polarion('CMP-9497')(
-        ContainersTestItem(Image, 'CMP-9497',
-                           is_openscap=False,
-                           tested_attr=TESTED_ATTRIBUTES__openscap_off)
-    ),
-    pytest.mark.polarion('CMP-10065')(
-        ContainersTestItem(Image, 'CMP-10065',
-                           is_openscap=True,
-                           tested_attr=TESTED_ATTRIBUTES__openscap_on)
-    )
-)
+    ContainersTestItem(Image, 'openscap_multi_image_on', is_openscap=False,
+                       tested_attr=TESTED_ATTRIBUTES__openscap_off),
+    ContainersTestItem(Image, 'openscap_multi_image_off', is_openscap=True,
+                       tested_attr=TESTED_ATTRIBUTES__openscap_on))
 
 TASKS_RUN_PARALLEL = 3
 TASK_TIMEOUT = 20

--- a/cfme/tests/containers/test_containers_summary.py
+++ b/cfme/tests/containers/test_containers_summary.py
@@ -21,7 +21,6 @@ pytestmark = [
 tested_objects = [Service, Route, Project, Pod, Image, Container, ImageRegistry, Node]
 
 
-@pytest.mark.polarion('CMP-10575')
 def test_containers_summary_objects(provider, soft_assert):
     """ Containers overview page > Widgets > Widgets summary
        This test checks that the amount of a selected object in the system is shown correctly

--- a/cfme/tests/containers/test_labels.py
+++ b/cfme/tests/containers/test_labels.py
@@ -15,8 +15,8 @@ from cfme.containers.route import Route, RouteCollection
 from cfme.containers.template import Template, TemplateCollection
 
 from cfme.utils.wait import wait_for
-from cfme.utils.log import logger
 from cfme.utils.blockers import GH
+from cfme.utils.log import logger
 
 
 pytestmark = [
@@ -76,7 +76,6 @@ def random_labels(provider, appliance):
 
 
 @pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:7687')])
-@pytest.mark.polarion('CMP-10572')
 def test_labels_create(provider, soft_assert, random_labels):
 
     provider.refresh_provider_relationships()
@@ -97,7 +96,6 @@ def test_labels_create(provider, soft_assert, random_labels):
 
 
 @pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:7687')])
-@pytest.mark.polarion('CMP-10572')
 def test_labels_remove(provider, soft_assert, random_labels):
     # Removing the labels
     for instance, label_name, label_value, status_code, _ in random_labels:

--- a/cfme/tests/containers/test_logging.py
+++ b/cfme/tests/containers/test_logging.py
@@ -17,11 +17,8 @@ pytestmark = [
                          scope='function')]
 
 TEST_ITEMS = [
-    pytest.mark.polarion('CMP-10634')(ContainersTestItem(
-        ContainersProvider, 'CMP-10634', collection_obj=None)),
-    pytest.mark.polarion('CMP-10635')(ContainersTestItem(
-        Node, 'CMP-10635', collection_obj=NodeCollection))
-]
+    ContainersTestItem(ContainersProvider, 'test_logging_containerprovider', collection_obj=None),
+    ContainersTestItem(Node, 'test_logging_node', collection_obj=NodeCollection)]
 
 NUM_OF_DEFAULT_LOG_ROUTES = 2
 

--- a/cfme/tests/containers/test_manageiq_ansible_custom_attributes.py
+++ b/cfme/tests/containers/test_manageiq_ansible_custom_attributes.py
@@ -45,7 +45,6 @@ def verify_custom_attributes(provider, custom_attributes_to_verify):
                 str(custom_attribute['value'])))
 
 
-@pytest.mark.polarion('CMP-10559')
 def test_manageiq_ansible_add_custom_attributes(ansible_custom_attributes, provider):
     """This test checks adding a Custom Attribute using Ansible script via Manage IQ module
         Steps:
@@ -68,7 +67,6 @@ def test_manageiq_ansible_add_custom_attributes(ansible_custom_attributes, provi
     assert not view.entities.summary('Custom Attributes').is_displayed
 
 
-@pytest.mark.polarion('CMP-10560')
 def test_manageiq_ansible_edit_custom_attributes(ansible_custom_attributes, provider):
     """This test checks editing a Custom Attribute using Ansible script via Manage IQ module
         Steps:
@@ -91,7 +89,6 @@ def test_manageiq_ansible_edit_custom_attributes(ansible_custom_attributes, prov
     assert not view.entities.summary('Custom Attributes').is_displayed
 
 
-@pytest.mark.polarion('CMP-10561')
 def test_manageiq_ansible_add_custom_attributes_same_name(ansible_custom_attributes, provider):
     """This test checks adding a Custom Attribute with the same name
         using Ansible script via Manage IQ module
@@ -116,7 +113,6 @@ def test_manageiq_ansible_add_custom_attributes_same_name(ansible_custom_attribu
     assert not view.entities.summary('Custom Attributes').is_displayed
 
 
-@pytest.mark.polarion('CMP-10562')
 def test_manageiq_ansible_add_custom_attributes_bad_user(ansible_custom_attributes, provider):
     """This test checks adding a Custom Attribute with a bad user name
         using Ansible script via Manage IQ module
@@ -137,7 +133,6 @@ def test_manageiq_ansible_add_custom_attributes_bad_user(ansible_custom_attribut
     assert not view.entities.summary('Custom Attributes').is_displayed
 
 
-@pytest.mark.polarion('CMP-10563')
 @pytest.mark.usefixtures('setup_provider')
 def test_manageiq_ansible_remove_custom_attributes(ansible_custom_attributes, provider):
     """This test checks removing Custom Attribute using Ansible script via Manage IQ module

--- a/cfme/tests/containers/test_node.py
+++ b/cfme/tests/containers/test_node.py
@@ -11,7 +11,6 @@ pytestmark = [pytest.mark.usefixtures('setup_provider')]
 TEST_DEST = ('All', 'Details')
 
 
-@pytest.mark.polarion('CMP-10782')
 @pytest.mark.tier(3)
 @pytest.mark.provider([ContainersProvider])
 def test_nodes_navigate(soft_assert, appliance):

--- a/cfme/tests/containers/test_overview_data_integrity.py
+++ b/cfme/tests/containers/test_overview_data_integrity.py
@@ -48,7 +48,6 @@ def get_api_object_counts(appliance):
     return out
 
 
-@pytest.mark.polarion('CMP-9521')
 def test_containers_overview_data_integrity(appliance, soft_assert):
     """Test data integrity of status boxes in containers dashboard.
     Steps:

--- a/cfme/tests/containers/test_projects_dashboard.py
+++ b/cfme/tests/containers/test_projects_dashboard.py
@@ -71,7 +71,6 @@ def get_api_pods_names(provider):
     return pod_name
 
 
-@pytest.mark.polarion('CMP-10806')
 def test_projects_dashboard_pods(provider, soft_assert, container_project_instance):
     """Tests data integrity of Pods names in Pods status box in Projects Dashboard.
     Steps:
@@ -90,7 +89,6 @@ def test_projects_dashboard_pods(provider, soft_assert, container_project_instan
         )
 
 
-@pytest.mark.polarion('CMP-10805')
 def test_projects_dashboard_icons(provider, appliance, soft_assert, container_project_instance):
     """Tests data integrity of Containers/Images/Services number in
     Projects Dashboard's status boxes.

--- a/cfme/tests/containers/test_properties.py
+++ b/cfme/tests/containers/test_properties.py
@@ -17,7 +17,6 @@ from cfme.containers.volume import Volume, VolumeCollection
 from cfme.containers.container import Container, ContainerCollection
 
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.soft_get import soft_get
 
 
 pytestmark = [
@@ -28,107 +27,62 @@ pytestmark = [
 
 
 TEST_ITEMS = [
-    pytest.mark.polarion('CMP-9945')(
-        ContainersTestItem(
-            Container,
-            'CMP-9945',
-            expected_fields=[
-                'Name', 'State', 'Last State', 'Restart count', 'Backing Ref (Container ID)',
-                'Privileged'],
-            collection_object=ContainerCollection
-        )
-    ),
-    pytest.mark.polarion('CMP-10430')(
-        ContainersTestItem(
-            Project,
-            'CMP-10430',
-            expected_fields=['Name', 'Creation timestamp', 'Resource version'],
-            collection_object=ProjectCollection
-        )
-    ),
-    pytest.mark.polarion('CMP-9877')(
-        ContainersTestItem(
-            Route,
-            'CMP-9877',
-            expected_fields=['Name', 'Creation timestamp', 'Resource version', 'Host Name'],
-            collection_object=RouteCollection
-        )
-    ),
-    pytest.mark.polarion('CMP-9911')(
-        ContainersTestItem(
-            Pod,
-            'CMP-9911',
-            expected_fields=[
-                'Name', 'Status', 'Creation timestamp', 'Resource version',
-                'Restart policy', 'DNS Policy', 'IP Address'
-            ],
-            collection_object=PodCollection
-        )
-    ),
-    pytest.mark.polarion('CMP-9960')(
-        ContainersTestItem(
-            Node,
-            'CMP-9960',
-            expected_fields=[
-                'Name', 'Creation timestamp', 'Resource version', 'Number of CPU Cores',
-                'Memory', 'Max Pods Capacity', 'System BIOS UUID', 'Machine ID',
-                'Infrastructure Machine ID', 'Container runtime version',
-                'Kubernetes kubelet version', 'Kubernetes proxy version',
-                'Operating System Distribution', 'Kernel version',
-            ],
-            collection_object=NodeCollection
-        )
-    ),
-    pytest.mark.polarion('CMP-9890')(
-        ContainersTestItem(
-            Service,
-            'CMP-9890',
-            expected_fields=[
-                'Name', 'Creation timestamp', 'Resource version', 'Session affinity',
-                'Type', 'Portal IP'
-            ],
-            collection_object=ServiceCollection
-        )
-    ),
-    pytest.mark.polarion('CMP-9988')(
-        ContainersTestItem(
-            ImageRegistry,
-            'CMP-9988',
-            expected_fields=['Host'],
-            collection_object=ImageRegistryCollection
-        )
-    ),
-    pytest.mark.polarion('CMP-10316')(
-        ContainersTestItem(
-            Template,
-            'CMP-10316',
-            expected_fields=['Name', 'Creation timestamp', 'Resource version'],
-            collection_object=TemplateCollection
-        )
-    ),
-    pytest.mark.polarion('CMP-10407')(
-        ContainersTestItem(
-            Volume,
-            'CMP-10407',
-            expected_fields=[
-                'Name',
-                'Creation timestamp', 'Resource version', 'Access modes', 'Reclaim policy',
-                'Status phase', 'Volume path'],
-            collection_object=VolumeCollection
-        )
-    ),
-    pytest.mark.polarion('CMP-9978')(
-        ContainersTestItem(
-            Image,
-            'CMP-9978',
-            expected_fields=[
-                'Name', 'Image Id', 'Full Name', 'Architecture', 'Author',
-                'Command', 'Entrypoint', 'Docker Version', 'Exposed Ports', 'Size'
-            ],
-            collection_object=ImageCollection
-        )
-    )
-]
+    ContainersTestItem(
+        Container, 'test_properties_container_provider',
+        expected_fields=[
+            'Name', 'State', 'Last State', 'Restart count', 'Backing Ref (Container ID)',
+            'Privileged'],
+        collection_object=ContainerCollection),
+    ContainersTestItem(
+        Project, 'test_properties_container_project',
+        expected_fields=['Name', 'Creation timestamp', 'Resource version'],
+        collection_object=ProjectCollection),
+    ContainersTestItem(
+        Route, 'test_properties_container_route',
+        expected_fields=['Name', 'Creation timestamp', 'Resource version', 'Host Name'],
+        collection_object=RouteCollection),
+    ContainersTestItem(
+        Pod, 'test_properties_container_pod',
+        expected_fields=[
+            'Name', 'Status', 'Creation timestamp', 'Resource version',
+            'Restart policy', 'DNS Policy', 'IP Address'],
+        collection_object=PodCollection),
+    ContainersTestItem(
+        Node, 'test_properties_container_node',
+        expected_fields=[
+            'Name', 'Creation timestamp', 'Resource version', 'Number of CPU Cores',
+            'Memory', 'Max Pods Capacity', 'System BIOS UUID', 'Machine ID',
+            'Infrastructure Machine ID', 'Container runtime version',
+            'Kubernetes kubelet version', 'Kubernetes proxy version',
+            'Operating System Distribution', 'Kernel version'],
+        collection_object=NodeCollection),
+    ContainersTestItem(
+        Service, 'test_properties_container_service',
+        expected_fields=[
+            'Name', 'Creation timestamp', 'Resource version', 'Session affinity',
+            'Type', 'Portal IP'],
+        collection_object=ServiceCollection),
+    ContainersTestItem(
+        ImageRegistry, 'test_properties_container_image_registry',
+        expected_fields=['Host'],
+        collection_object=ImageRegistryCollection),
+    ContainersTestItem(
+        Template, 'test_properties_container_template',
+        expected_fields=['Name', 'Creation timestamp', 'Resource version'],
+        collection_object=TemplateCollection),
+    ContainersTestItem(
+        Volume, 'test_properties_container_volumes',
+        expected_fields=[
+            'Name',
+            'Creation timestamp', 'Resource version', 'Access modes', 'Reclaim policy',
+            'Status phase', 'Volume path'],
+        collection_object=VolumeCollection),
+    ContainersTestItem(
+        Image, 'test_properties_container_image',
+        expected_fields=[
+            'Name', 'Image Id', 'Full Name', 'Architecture', 'Author',
+            'Command', 'Entrypoint', 'Docker Version', 'Exposed Ports', 'Size'],
+        collection_object=ImageCollection)]
 
 
 @pytest.mark.parametrize('test_item', TEST_ITEMS,

--- a/cfme/tests/containers/test_provider_configuration_menu.py
+++ b/cfme/tests/containers/test_provider_configuration_menu.py
@@ -25,7 +25,6 @@ def check_buttons_status(view, pause_option, resume_option):
     return True, None
 
 
-@pytest.mark.polarion('CMP-9880')
 def test_edit_selected_containers_provider(provider):
     '''Testing Configuration -> Edit... button functionality
     Step:

--- a/cfme/tests/containers/test_provider_openscap_policy_attached.py
+++ b/cfme/tests/containers/test_provider_openscap_policy_attached.py
@@ -61,7 +61,6 @@ def get_table_attr(instance, table_name, attr):
 
 
 @pytest.mark.meta(blockers=[BZ(1620068, forced_streams=["5.9", "5.10"])])
-@pytest.mark.polarion('10068')
 def test_check_compliance_provider_policy(provider, soft_assert, delete_all_container_tasks,
                                           openscap_assigned_rand_image):
 

--- a/cfme/tests/containers/test_relationships.py
+++ b/cfme/tests/containers/test_relationships.py
@@ -20,33 +20,22 @@ pytestmark = [
 ]
 
 TEST_ITEMS = [
-    pytest.mark.polarion('CMP-9851')(ContainersTestItem(
-        ContainersProvider, 'CMP-9851', collection_obj=None)),
-    pytest.mark.polarion('CMP-9947')(ContainersTestItem(
-        Container, 'CMP-9947', collection_obj=ContainerCollection)),
-    pytest.mark.polarion('CMP-9929')(ContainersTestItem(
-        Pod, 'CMP-9929', collection_obj=PodCollection)),
-    pytest.mark.polarion('CMP-10564')(ContainersTestItem(
-        Service, 'CMP-10564', collection_obj=ServiceCollection)),
-    pytest.mark.polarion('CMP-9962')(ContainersTestItem(
-        Node, 'CMP-9962', collection_obj=NodeCollection)),
-    pytest.mark.polarion('CMP-10565')(ContainersTestItem(
-        Replicator, 'CMP-10565', collection_obj=ReplicatorCollection)),
-    pytest.mark.polarion('CMP-9980')(ContainersTestItem(
-        Image, 'CMP-9980', collection_obj=ImageCollection)),
-    pytest.mark.polarion('CMP-9994')(ContainersTestItem(
-        ImageRegistry, 'CMP-9994', collection_obj=ImageRegistryCollection)),
-    pytest.mark.polarion('CMP-9868')(ContainersTestItem(
-        Project, 'CMP-9868', collection_obj=ProjectCollection)),
-    pytest.mark.polarion('CMP-10319')(ContainersTestItem(
-        Template, 'CMP-10319', collection_obj=TemplateCollection)),
-    pytest.mark.polarion('CMP-10410')(ContainersTestItem(
-        Volume, 'CMP-10410', collection_obj=VolumeCollection))
-]
+    ContainersTestItem(ContainersProvider, 'container_provider_relationships', collection_obj=None),
+    ContainersTestItem(Container, 'container_relationships', collection_obj=ContainerCollection),
+    ContainersTestItem(Pod, 'pod_relationships', collection_obj=PodCollection),
+    ContainersTestItem(Service, 'service_relationships', collection_obj=ServiceCollection),
+    ContainersTestItem(Node, 'node_relationships', collection_obj=NodeCollection),
+    ContainersTestItem(Replicator, 'replicator_relationships', collection_obj=ReplicatorCollection),
+    ContainersTestItem(Image, 'image_relationships', collection_obj=ImageCollection),
+    ContainersTestItem(ImageRegistry, 'image_registry_relationships',
+                       collection_obj=ImageRegistryCollection),
+    ContainersTestItem(Project, 'project_relationships', collection_obj=ProjectCollection),
+    ContainersTestItem(Template, 'template_relationships', collection_obj=TemplateCollection),
+    ContainersTestItem(Volume, 'volume_relationships', collection_obj=VolumeCollection)]
 
 
 @pytest.mark.parametrize('test_item', TEST_ITEMS, scope='module',
-                         ids=[ti.args[1].pretty_id() for ti in TEST_ITEMS])
+                         ids=[ti.pretty_id() for ti in TEST_ITEMS])
 @pytest.mark.usefixtures('has_persistent_volume')
 @pytest.mark.usefixtures('setup_provider_modscope')
 def test_relationships_tables(soft_assert, provider, has_persistent_volume, appliance, test_item):
@@ -88,7 +77,6 @@ def test_relationships_tables(soft_assert, provider, has_persistent_volume, appl
         view = navigate_to(test_obj, 'Details')
 
 
-@pytest.mark.polarion('CMP-9934')
 @pytest.mark.usefixtures('setup_provider')
 def test_container_status_relationships_data_integrity(provider, appliance, soft_assert):
     """ This test verifies that the sum of running, waiting and terminated containers

--- a/cfme/tests/containers/test_reload_button_provider.py
+++ b/cfme/tests/containers/test_reload_button_provider.py
@@ -10,7 +10,6 @@ pytestmark = [
 ]
 
 
-@pytest.mark.polarion('CMP-9878')
 def test_reload_button_provider(provider):
     """ This test verifies the data integrity of the fields in
         the Relationships table after clicking the "reload"

--- a/cfme/tests/containers/test_reports.py
+++ b/cfme/tests/containers/test_reports.py
@@ -59,7 +59,6 @@ def get_report(appliance, menu_name, candu=False):
     return saved_report
 
 
-@pytest.mark.polarion('CMP-10617')
 def test_container_reports_base_on_options(soft_assert, appliance):
     """This test verifies that all containers options are available in the report 'based on'
     Dropdown in the report creation"""
@@ -84,7 +83,6 @@ def test_container_reports_base_on_options(soft_assert, appliance):
         soft_assert(option, 'Could not find option "{}" for base report on.'.format(base_on))
 
 
-@pytest.mark.polarion('CMP-9533')
 def test_report_pods_per_ready_status(appliance, soft_assert, provider):
     """Testing 'Pods per Ready Status' report, see polarion case for more info"""
     pods_per_ready_status = provider.pods_per_ready_status()
@@ -101,7 +99,6 @@ def test_report_pods_per_ready_status(appliance, soft_assert, provider):
                         .format(name, expected_readiness, readiness_ui))
 
 
-@pytest.mark.polarion('CMP-9536')
 def test_report_nodes_by_capacity(appliance, soft_assert, node_hardwares_db_data):
     """Testing 'Nodes By Capacity' report, see polarion case for more info"""
     report = get_report(appliance, 'Nodes By Capacity')
@@ -130,7 +127,6 @@ def test_report_nodes_by_capacity(appliance, soft_assert, node_hardwares_db_data
                     .format(row['Name'], memory_mb_ui, memory_mb_db))
 
 
-@pytest.mark.polarion('CMP-10033')
 def test_report_nodes_by_cpu_usage(appliance, soft_assert, vporizer):
     """Testing 'Nodes By CPU Usage' report, see polarion case for more info"""
     report = get_report(appliance, 'Nodes By CPU Usage')
@@ -145,7 +141,6 @@ def test_report_nodes_by_cpu_usage(appliance, soft_assert, vporizer):
                     .format(row['Name'], usage_db, usage_report))
 
 
-@pytest.mark.polarion('CMP-10034')
 def test_report_nodes_by_memory_usage(appliance, soft_assert, vporizer):
     """Testing 'Nodes By Memory Usage' report, see polarion case for more info"""
     report = get_report(appliance, 'Nodes By Memory Usage')
@@ -160,7 +155,6 @@ def test_report_nodes_by_memory_usage(appliance, soft_assert, vporizer):
                     .format(row['Name'], usage_db, usage_report))
 
 
-@pytest.mark.polarion('CMP-10669')
 def test_report_number_of_nodes_per_cpu_cores(appliance, soft_assert, node_hardwares_db_data):
     """Testing 'Number of Nodes per CPU Cores' report, see polarion case for more info"""
     report = get_report(appliance, 'Nodes by Number of CPU Cores')
@@ -173,7 +167,6 @@ def test_report_number_of_nodes_per_cpu_cores(appliance, soft_assert, node_hardw
                     .format(row['Name'], hw.cpu_total_cores, row['Hardware Number of CPU Cores']))
 
 
-@pytest.mark.polarion('CMP-10008')
 def test_report_projects_by_number_of_pods(appliance, soft_assert):
 
     """Testing 'Projects by Number of Pods' report, see polarion case for more info"""
@@ -195,7 +188,6 @@ def test_report_projects_by_number_of_pods(appliance, soft_assert):
 
 
 @pytest.mark.meta(blockers=[BZ(1539378, forced_streams=["5.9"])])
-@pytest.mark.polarion('CMP-10009')
 def test_report_projects_by_cpu_usage(appliance, soft_assert, vporizer):
     """Testing 'Projects By CPU Usage' report, see polarion case for more info"""
     report = get_report(appliance, 'Projects By CPU Usage')
@@ -211,7 +203,6 @@ def test_report_projects_by_cpu_usage(appliance, soft_assert, vporizer):
 
 
 @pytest.mark.meta(blockers=[BZ(1539378, forced_streams=["5.9"])])
-@pytest.mark.polarion('CMP-10010')
 def test_report_projects_by_memory_usage(appliance, soft_assert, vporizer):
     """Testing 'Projects By Memory Usage' report, see polarion case for more info"""
     report = get_report(appliance, 'Projects By Memory Usage')
@@ -226,7 +217,6 @@ def test_report_projects_by_memory_usage(appliance, soft_assert, vporizer):
                     .format(row['Name'], usage_db, usage_report))
 
 
-@pytest.mark.polarion('CMP-10272')
 def test_report_pod_counts_for_container_images_by_project(appliance, provider, soft_assert):
     """Testing 'Pod counts For Container Images by Project' report,\
     see polarion case for more info"""
@@ -256,7 +246,6 @@ def test_report_pod_counts_for_container_images_by_project(appliance, provider, 
 
 
 @pytest.mark.meta(blockers=[1529963], forced_stream=['5.8', '5.9'])
-@pytest.mark.polarion('CMP-9532')
 def test_report_recently_discovered_pods(appliance, provider, soft_assert):
     """Testing 'Recently Discovered Pods' report, see polarion case for more info"""
     report = get_report(appliance, 'Recently Discovered Pods')
@@ -268,7 +257,6 @@ def test_report_recently_discovered_pods(appliance, provider, soft_assert):
                     'Could not find pod "{}" in report.'.format(pod))
 
 
-@pytest.mark.polarion('CMP-10273')
 def test_report_number_of_images_per_node(appliance, provider, soft_assert):
     """Testing 'Number of Images per Node' report, see polarion case for more info"""
     pods_api = provider.mgmt.list_pods()
@@ -288,7 +276,6 @@ def test_report_number_of_images_per_node(appliance, provider, soft_assert):
                     .format(pod_name, node, expected_image, pod_images))
 
 
-@pytest.mark.polarion('CMP-10670')
 def test_report_projects_by_number_of_containers(appliance, provider, soft_assert):
     """Testing 'Projects by Number of Containers' report, see polarion case for more info"""
     report = get_report(appliance, 'Projects by Number of Containers')

--- a/cfme/tests/containers/test_search_bar.py
+++ b/cfme/tests/containers/test_search_bar.py
@@ -22,7 +22,6 @@ COLLECTION_NAMES = [
 ]
 
 
-@pytest.mark.polarion('CMP-10577')
 def test_search_bar(provider, appliance, soft_assert):
     """ <object> summary page - Search bar
     This test checks Search bar functionality on every object summary page

--- a/cfme/tests/containers/test_smart_management.py
+++ b/cfme/tests/containers/test_smart_management.py
@@ -26,22 +26,15 @@ pytestmark = [
 logger = create_sublogger("smart_management")
 
 TEST_ITEMS = [
-    pytest.mark.polarion('CMP-9948')(ContainersTestItem(
-        Container, 'CMP-9948', collection_obj=ContainerCollection)),
-    pytest.mark.polarion('CMP-10320')(ContainersTestItem(
-        Template, 'CMP-10320', collection_obj=TemplateCollection)),
-    pytest.mark.polarion('CMP-9992')(ContainersTestItem(
-        ImageRegistry, 'CMP-9992', collection_obj=ImageRegistryCollection)),
-    pytest.mark.polarion('CMP-9981')(ContainersTestItem(
-        Image, 'CMP-9981', collection_obj=ImageCollection)),
-    pytest.mark.polarion('CMP-9964')(ContainersTestItem(
-        Node, 'CMP-9964', collection_obj=NodeCollection)),
-    pytest.mark.polarion('CMP-9932')(ContainersTestItem(
-        Pod, 'CMP-9932', collection_obj=PodCollection)),
-    pytest.mark.polarion('CMP-9870')(ContainersTestItem(
-        Project, 'CMP-9870', collection_obj=ProjectCollection)),
-    pytest.mark.polarion('CMP-9854')(ContainersTestItem(
-        ContainersProvider, 'CMP-9854', collection_obj=None))
+    ContainersTestItem(Container, 'container_smart_man', collection_obj=ContainerCollection),
+    ContainersTestItem(Template, 'template_smart_man', collection_obj=TemplateCollection),
+    ContainersTestItem(ImageRegistry, 'image_registry_smart_man',
+                       collection_obj=ImageRegistryCollection),
+    ContainersTestItem(Image, 'image_smart_man', collection_obj=ImageCollection),
+    ContainersTestItem(Node, 'node_smart_man', collection_obj=NodeCollection),
+    ContainersTestItem(Pod, 'pod_smart_man', collection_obj=PodCollection),
+    ContainersTestItem(Project, 'project_smart_man', collection_obj=ProjectCollection),
+    ContainersTestItem(ContainersProvider, 'container_provider_smart_man', collection_obj=None)
 ]
 
 

--- a/cfme/tests/containers/test_ssa_set_cve_image_inspector_per_provider.py
+++ b/cfme/tests/containers/test_ssa_set_cve_image_inspector_per_provider.py
@@ -146,7 +146,6 @@ def verify_ssa_image_attributes(provider, soft_assert, rand_image):
 
 
 @pytest.mark.meta(blockers=[BZ(1620068, forced_streams=["5.9", "5.10"])])
-@pytest.mark.polarion('10722')
 def test_cve_location_update_value(provider, soft_assert, delete_all_container_tasks,
                                    set_cve_location, openscap_assigned_rand_image):
     """This test checks RFE BZ 1459189, Allow to specify per Provider the location of
@@ -161,7 +160,6 @@ def test_cve_location_update_value(provider, soft_assert, delete_all_container_t
 
 
 @pytest.mark.meta(blockers=[BZ(1620068, forced_streams=["5.9", "5.10"])])
-@pytest.mark.polarion('10858')
 def test_image_inspector_registry_update_value(provider, soft_assert, delete_all_container_tasks,
                                                set_image_inspector_registry,
                                                openscap_assigned_rand_image):

--- a/cfme/tests/containers/test_ssl_providers.py
+++ b/cfme/tests/containers/test_ssl_providers.py
@@ -18,37 +18,22 @@ alphanumeric_name = gen_alphanumeric(10)
 long_alphanumeric_name = gen_alphanumeric(100)
 integer_name = str(gen_integer(0, 100000000))
 provider_names = alphanumeric_name, integer_name, long_alphanumeric_name
-AVAILABLE_SEC_PROTOCOLS = ('SSL trusting custom CA',
-                           'SSL without validation',
-                           'SSL')
+AVAILABLE_SEC_PROTOCOLS = ('SSL trusting custom CA', 'SSL without validation', 'SSL')
 
-DEFAULT_SEC_PROTOCOLS = (
-    pytest.mark.polarion('CMP-10598')('SSL trusting custom CA'),
-    pytest.mark.polarion('CMP-10597')('SSL without validation'),
-    pytest.mark.polarion('CMP-10599')('SSL')
-)
+DEFAULT_SEC_PROTOCOLS = ('SSL trusting custom CA', 'SSL without validation', 'SSL')
 
 checked_item = namedtuple('TestItem', ['default_sec_protocol', 'metrics_sec_protocol'])
+
 TEST_ITEMS = (
-    pytest.mark.polarion('CMP-10593')
-    (checked_item('SSL trusting custom CA', 'SSL trusting custom CA')),
-    pytest.mark.polarion('CMP-10594')
-    (checked_item('SSL trusting custom CA', 'SSL without validation')),
-    pytest.mark.polarion('CMP-10589')
-    (checked_item('SSL trusting custom CA', 'SSL')),
-    pytest.mark.polarion('CMP-10595')
-    (checked_item('SSL without validation', 'SSL trusting custom CA')),
-    pytest.mark.polarion('CMP-10596')
-    (checked_item('SSL without validation', 'SSL without validation')),
-    pytest.mark.polarion('CMP-10590')
-    (checked_item('SSL without validation', 'SSL')),
-    pytest.mark.polarion('CMP-10588')
-    (checked_item('SSL', 'SSL trusting custom CA')),
-    pytest.mark.polarion('CMP-10592')
-    (checked_item('SSL', 'SSL without validation')),
-    pytest.mark.polarion('CMP-10588')
-    (checked_item('SSL', 'SSL')),
-)
+    checked_item('SSL trusting custom CA', 'SSL trusting custom CA'),
+    checked_item('SSL trusting custom CA', 'SSL without validation'),
+    checked_item('SSL trusting custom CA', 'SSL'),
+    checked_item('SSL without validation', 'SSL trusting custom CA'),
+    checked_item('SSL without validation', 'SSL without validation'),
+    checked_item('SSL without validation', 'SSL'),
+    checked_item('SSL', 'SSL trusting custom CA'),
+    checked_item('SSL', 'SSL without validation'),
+    checked_item('SSL', 'SSL'))
 
 
 @pytest.fixture(scope="module")
@@ -56,7 +41,6 @@ def sync_ssl_certificate(provider):
     provider.sync_ssl_certificate()
 
 
-@pytest.mark.polarion('CMP-9836')
 @pytest.mark.usefixtures('has_no_containers_providers')
 def test_add_provider_naming_conventions(provider, appliance, soft_assert, sync_ssl_certificate):
     """" This test is checking ability to add Providers with different names:
@@ -117,7 +101,7 @@ def test_add_provider_ssl(provider, default_sec_protocol, soft_assert, sync_ssl_
 
 @pytest.mark.parametrize('test_item', TEST_ITEMS, ids=[
     'Default: {} /  Metrics: {}'.format(
-        ti.args[1].default_sec_protocol, ti.args[1].metrics_sec_protocol)
+        ti.default_sec_protocol, ti.metrics_sec_protocol)
     for ti in TEST_ITEMS])
 @pytest.mark.usefixtures('has_no_containers_providers')
 def test_add_mertics_provider_ssl(provider, appliance, test_item,

--- a/cfme/tests/containers/test_start_page.py
+++ b/cfme/tests/containers/test_start_page.py
@@ -3,20 +3,20 @@ from collections import namedtuple
 
 import pytest
 
-from cfme.containers.overview import ContainersOverviewView
-from cfme.containers.node import NodeAllView
-from cfme.containers.pod import PodAllView
-from cfme.containers.service import ServiceAllView
-from cfme.containers.provider import ContainersProvider, ContainerProvidersView
-from cfme.containers.project import ProjectAllView
+from cfme.containers.container import ContainerAllView
 from cfme.containers.image_registry import ImageRegistryAllView
-from cfme.containers.template import TemplateAllView
+from cfme.containers.node import NodeAllView
+from cfme.containers.overview import ContainersOverviewView
+from cfme.containers.pod import PodAllView
+from cfme.containers.project import ProjectAllView
+from cfme.containers.provider import ContainersProvider, ContainerProvidersView
 from cfme.containers.replicator import ReplicatorAllView
 from cfme.containers.route import RouteAllView
-from cfme.containers.container import ContainerAllView
+from cfme.containers.service import ServiceAllView
+from cfme.containers.template import TemplateAllView
+from cfme.containers.volume import VolumeAllView
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.version import current_version
-from cfme.configure.settings import Visual
 
 
 pytestmark = [
@@ -38,15 +38,10 @@ data_sets = (
     DataSet(TemplateAllView, 'Compute / Containers / Container Templates'),
     DataSet(ReplicatorAllView, 'Compute / Containers / Replicators'),
     DataSet(RouteAllView, 'Compute / Containers / Routes'),
-    # https://bugzilla.redhat.com/show_bug.cgi?id=1510376
-    # from cfme.containers.volume import VolumeAllView
-    # DataSet(VolumeAllView, 'Compute / Containers / Volumes'),
-    # https://bugzilla.redhat.com/show_bug.cgi?id=1466350
-    DataSet(ContainerAllView, 'Compute / Containers / Containers')
-)
+    DataSet(VolumeAllView, 'Compute / Containers / Volumes'),
+    DataSet(ContainerAllView, 'Compute / Containers / Containers'))
 
 
-@pytest.mark.polarion('CMP-10601')
 def test_start_page(appliance, soft_assert):
 
     for data_set in data_sets:

--- a/cfme/tests/containers/test_static_custom_attributes.py
+++ b/cfme/tests/containers/test_static_custom_attributes.py
@@ -47,7 +47,6 @@ def add_delete_custom_attributes(provider):
         logger.info("No custom attributes to delete")
 
 
-@pytest.mark.polarion('CMP-10281')
 def test_add_static_custom_attributes(add_delete_custom_attributes, provider):
     """Tests adding of static custom attributes to provider
     Steps:
@@ -64,7 +63,6 @@ def test_add_static_custom_attributes(add_delete_custom_attributes, provider):
         assert custom_attr_ui.get_text_of(attr.name) == attr.value
 
 
-@pytest.mark.polarion('CMP-10286')
 def test_edit_static_custom_attributes(provider):
     """Tests editing of static custom attributes from provider
     Prerequisite:
@@ -89,7 +87,6 @@ def test_edit_static_custom_attributes(provider):
     provider.delete_custom_attributes(*edited_attribs)
 
 
-@pytest.mark.polarion('CMP-10285')
 def test_delete_static_custom_attributes(add_delete_custom_attributes, request, provider):
     """Tests deleting of static custom attributes from provider
     Steps:
@@ -127,7 +124,6 @@ def test_delete_static_custom_attributes(add_delete_custom_attributes, request, 
         assert False
 
 
-@pytest.mark.polarion('CMP-10303')
 def test_add_attribute_with_empty_name(provider):
     """Tests adding of static custom attributes with empty field
     Steps:
@@ -148,7 +144,6 @@ def test_add_attribute_with_empty_name(provider):
         assert "" not in view.entities.summary('Custom Attributes').fields
 
 
-@pytest.mark.polarion('CMP-10404')
 def test_add_date_attr_with_wrong_value(provider):
     """Trying to add attribute of type date with non-date value"""
     ca = CustomAttribute('nondate', "koko", 'Date')
@@ -162,7 +157,6 @@ def test_add_date_attr_with_wrong_value(provider):
         assert 'nondate' not in view.entities.summary('Custom Attributes').fields
 
 
-@pytest.mark.polarion('CMP-10405')
 def test_edit_non_exist_attribute(provider):
     """Trying to edit non-exist attribute"""
     ca = choice(ATTRIBUTES_DATASET)
@@ -184,7 +178,6 @@ def test_edit_non_exist_attribute(provider):
                     .format(ca.value))
 
 
-@pytest.mark.polarion('CMP-10543')
 def test_delete_non_exist_attribute(provider):
 
     ca = choice(ATTRIBUTES_DATASET)
@@ -195,7 +188,7 @@ def test_delete_non_exist_attribute(provider):
                     .format(ca.value))
 
 
-@pytest.mark.polarion('CMP-10542')
+@pytest.mark.meta(blockers=[BZ(1544800, forced_streams=["5.8", "5.9"])])
 def test_add_already_exist_attribute(provider):
     ca = choice(ATTRIBUTES_DATASET)
     provider.add_custom_attributes(ca)
@@ -209,7 +202,6 @@ def test_add_already_exist_attribute(provider):
         provider.delete_custom_attributes(ca)
 
 
-@pytest.mark.polarion('CMP-10540')
 def test_very_long_name_with_special_characters(request, provider):
     ca = CustomAttribute(get_random_string(1000), 'very_long_name', None)
     request.addfinalizer(lambda: provider.delete_custom_attributes(ca))
@@ -219,7 +211,6 @@ def test_very_long_name_with_special_characters(request, provider):
 
 
 @pytest.mark.meta(blockers=[BZ(1540647, forced_streams=["5.8", "5.9"])])
-@pytest.mark.polarion('CMP-10541')
 def test_very_long_value_with_special_characters(request, provider):
     ca = CustomAttribute('very_long_value', get_random_string(1000), None)
     request.addfinalizer(lambda: provider.delete_custom_attributes(ca))

--- a/cfme/tests/containers/test_table_views.py
+++ b/cfme/tests/containers/test_table_views.py
@@ -49,7 +49,6 @@ def random_default_views(appliance):
                                                               original_default_views.values())
 
 
-@pytest.mark.polarion('CMP-10568')
 def test_default_views(appliance, random_default_views):
     for collection_name in objects_mapping.keys():
         obj = (ContainersProvider if collection_name is ContainersProvider
@@ -62,7 +61,6 @@ def test_default_views(appliance, random_default_views):
         )
 
 
-@pytest.mark.polarion('CMP-10570')
 def test_table_views(appliance):
     for collection_name in objects_mapping.keys():
         obj = (ContainersProvider if collection_name is ContainersProvider

--- a/cfme/tests/containers/test_tables_fields.py
+++ b/cfme/tests/containers/test_tables_fields.py
@@ -19,90 +19,55 @@ pytestmark = [
 ]
 
 
-# The polarion markers below are used to mark the test item
-# with polarion test case ID.
-# TODO: future enhancement - https://github.com/pytest-dev/pytest/pull/1921
-
-
 TEST_ITEMS = [
-    pytest.mark.polarion('CMP-9859')(
-        ContainersTestItem(
-            ContainersProvider, 'CMP-9859', fields_to_verify=['hostname', 'port', 'type'],
-            collection_name=None
-        )
-    ),
-    pytest.mark.polarion('CMP-10651')(
-        ContainersTestItem(
-            Route, 'CMP-10651', fields_to_verify=['provider', 'project_name'],
-            collection_name='container_routes'
-        )
-    ),
-    pytest.mark.polarion('CMP-9943')(
-        ContainersTestItem(
-            Container, 'CMP-9943', fields_to_verify=['pod_name', 'image', 'state'],
-            collection_name='containers'
-        )
-    ),
-    pytest.mark.polarion('CMP-9909')(
-        ContainersTestItem(
-            Pod, 'CMP-9909', fields_to_verify=[
-                'provider', 'project_name', 'ready', 'containers',
-                'phase', 'restart_policy', 'dns_policy'
-            ],
-            collection_name='container_pods'
-        )
-    ),
-    pytest.mark.polarion('CMP-9889')(
-        ContainersTestItem(
-            Service, 'CMP-9889', fields_to_verify=[
-                'provider', 'project_name', 'type', 'portal_ip',
-                'session_affinity', 'pods'
-            ],
-            collection_name='container_services'
-        )
-    ),
-    pytest.mark.polarion('CMP-9967')(
-        ContainersTestItem(
-            Node, 'CMP-9967', fields_to_verify=[
-                'provider', 'ready', 'operating_system', 'kernel_version',
-                'runtime_version'
-            ],
-            collection_name='container_nodes'
-        )
-    ),
-    pytest.mark.polarion('CMP-9920')(
-        ContainersTestItem(
-            Replicator, 'CMP-9920',
-            fields_to_verify=['provider', 'project_name', 'replicas', 'current_replicas'],
-            collection_name='container_replicators'
-        )
-    ),
-    pytest.mark.polarion('CMP-9975')(
-        ContainersTestItem(
-            Image, 'CMP-9975', fields_to_verify=['provider', 'tag', 'id', 'image_registry'],
-            collection_name='container_images'
-        )
-    ),
-    pytest.mark.polarion('CMP-9985')(
-        ContainersTestItem(
-            ImageRegistry, 'CMP-9985', fields_to_verify=['port', 'provider'],
-            collection_name='container_image_registries'
-        )
-    ),
-    pytest.mark.polarion('CMP-10652')(
-        ContainersTestItem(
-            Project, 'CMP-9886', fields_to_verify=[
-                'provider', 'container_routes', 'container_services',
-                'container_replicators', 'pods', 'containers', 'images'
-            ],
-            collection_name='container_projects'
-        )
-    )
-]
+    ContainersTestItem(
+        ContainersProvider, 'container_provider_table_fields',
+        fields_to_verify=['hostname', 'port', 'type'],
+        collection_name=None),
+    ContainersTestItem(
+        Route, 'route__table_fields',
+        fields_to_verify=['provider', 'project_name'],
+        collection_name='container_routes'),
+    ContainersTestItem(
+        Container, 'container__table_fields',
+        fields_to_verify=['pod_name', 'image', 'state'],
+        collection_name='containers'),
+    ContainersTestItem(
+        Pod, 'pod__table_fields',
+        fields_to_verify=['provider', 'project_name', 'ready', 'containers', 'phase',
+                          'restart_policy', 'dns_policy'],
+        collection_name='container_pods'),
+    ContainersTestItem(
+        Service, 'service_table_fields9',
+        fields_to_verify=['provider', 'project_name', 'type', 'portal_ip', 'session_affinity',
+                          'pods'],
+        collection_name='container_services'),
+    ContainersTestItem(
+        Node, 'node_table_fields',
+        fields_to_verify=['provider', 'ready', 'operating_system', 'kernel_version',
+                          'runtime_version'],
+        collection_name='container_nodes'),
+    ContainersTestItem(
+        Replicator, 'replicator_table_fields',
+        fields_to_verify=['provider', 'project_name', 'replicas', 'current_replicas'],
+        collection_name='container_replicators'),
+    ContainersTestItem(
+        Image, 'image_table_fields',
+        fields_to_verify=['provider', 'tag', 'id', 'image_registry'],
+        collection_name='container_images'),
+    ContainersTestItem(
+        ImageRegistry, 'image_registry_table_fields',
+        fields_to_verify=['port', 'provider'],
+        collection_name='container_image_registries'),
+    ContainersTestItem(
+        Project, 'project_table_fields',
+        fields_to_verify=['provider', 'container_routes', 'container_services',
+                          'container_replicators', 'pods', 'containers', 'images'],
+        collection_name='container_projects')]
 
 
 @pytest.mark.parametrize('test_item', TEST_ITEMS,
-                         ids=[ti.args[1].pretty_id() for ti in TEST_ITEMS])
+                         ids=[ti.pretty_id() for ti in TEST_ITEMS])
 def test_tables_fields(provider, test_item, soft_assert, appliance):
 
     view = navigate_to((test_item.obj if test_item.obj is ContainersProvider

--- a/cfme/tests/containers/test_tables_sort.py
+++ b/cfme/tests/containers/test_tables_sort.py
@@ -20,17 +20,14 @@ pytestmark = [
 
 
 TEST_ITEMS = [
-    pytest.mark.polarion('CMP-9924')(ContainersTestItem(
-        ContainersProvider, 'CMP-9924', collection_name=None)),
-    pytest.mark.polarion('CMP-9926')(ContainersTestItem(
-        Route, 'CMP-9926', collection_name='container_routes')),
-    pytest.mark.polarion('CMP-9928')(ContainersTestItem(
-        Replicator, 'CMP-9928', collection_name='container_replicators'))
-]
+    ContainersTestItem(ContainersProvider, 'container_provider_table_sort', collection_name=None),
+    ContainersTestItem(Route, 'route_table_sort', collection_name='container_routes'),
+    ContainersTestItem(Replicator, 'replicator_table_sort',
+                       collection_name='container_replicators')]
 
 
 @pytest.mark.parametrize('test_item', TEST_ITEMS,
-                         ids=[ti.args[1].pretty_id() for ti in TEST_ITEMS])
+                         ids=[ti.pretty_id() for ti in TEST_ITEMS])
 def test_tables_sort(test_item, soft_assert, appliance):
 
     view = navigate_to((test_item.obj if test_item.obj is ContainersProvider

--- a/cfme/tests/containers/test_tags.py
+++ b/cfme/tests/containers/test_tags.py
@@ -9,18 +9,9 @@ pytestmark = [
 ]
 
 container_test_items = [
-    ('container_provider'),
-    ('container_projects'),
-    ('container_routes'),
-    ('container_services'),
-    ('container_replicators'),
-    ('container_pods'),
-    ('container_nodes'),
-    ('container_volumes'),
-    ('container_image_registries'),
-    ('container_images'),
-    ('container_templates')
-]
+    'container_provider', 'container_projects', 'container_routes', 'container_services',
+    'container_replicators', 'container_pods', 'container_nodes', 'container_volumes',
+    'container_image_registries', 'container_images', 'container_templates']
 
 
 def get_collection_entity(appliance, collection_name, provider):
@@ -53,7 +44,6 @@ def get_collection_entity(appliance, collection_name, provider):
         return item_collection.instantiate(**d)
 
 
-@pytest.mark.polarion('CMP-10837')
 @pytest.mark.parametrize('test_param', container_test_items, ids=[cti for cti in
                                                                   container_test_items])
 @pytest.mark.parametrize('tag_place', [True, False], ids=['details', 'list'])


### PR DESCRIPTION
Combining cmqe and cfme polarion projects, the CMP IDs are no longer needed. 