### PR TITLE
[1LP][RFR] Fixing clod tests for supporting the CFME 5.10 automation

### DIFF
--- a/cfme/networks/cloud_network.py
+++ b/cfme/networks/cloud_network.py
@@ -42,7 +42,10 @@ class CloudNetwork(Taggable, BaseEntity):
     def parent_provider(self):
         """ Return object of parent cloud provider """
         view = navigate_to(self, 'Details')
-        provider_name = view.entities.relationships.get_text_of('Parent ems cloud')
+        if self.appliance.version >= '5.10':
+            provider_name = view.entities.relationships.get_text_of('Parent Cloud Provider')
+        else:
+            provider_name = view.entities.relationships.get_text_of('Parent ems cloud')
         return providers.get_crud_by_name(provider_name)
 
     @property

--- a/cfme/networks/views.py
+++ b/cfme/networks/views.py
@@ -427,7 +427,7 @@ class NetworkRouterAddView(BaseLoggedInPage):
     """ Represents Add NetworkRouters page """
     network_manager = Select(id='ems_id')
     router_name = TextInput(name='name')
-    ext_gateway = BootstrapSwitch(id='network_router_external_gateway')
+    ext_gateway = BootstrapSwitch(name='external_gateway')
     network_name = Select(name='cloud_network_id')
     subnet_name = Select(name='cloud_subnet_id')
     cloud_tenant = Select(name='cloud_tenant_id')
@@ -441,7 +441,7 @@ class NetworkRouterAddView(BaseLoggedInPage):
 class NetworkRouterEditView(BaseLoggedInPage):
     """ Represents Edit NetworkRouters page """
     router_name = TextInput(name='name')
-    ext_gateway = BootstrapSwitch(id='network_router_external_gateway')
+    ext_gateway = BootstrapSwitch(name='external_gateway')
     network_name = Select(name='cloud_network_id')
     subnet_name = Select(name='cloud_subnet_id')
     save = Button('Save')
@@ -565,7 +565,7 @@ class SubnetDetailsToolBar(View):
 class SubnetAddView(BaseLoggedInPage):
     """ Represents Add view of subnet """
     title = Text('//div[@id="main-content"]//h1')
-    network_manager = Select(id='ems_id')
+    network_manager = Select(name='ems_id')
     cloud_tenant = Select(name='cloud_tenant_id')
     network = Select(name='network_id')
     subnet_name = TextInput(name='name')

--- a/cfme/tests/openstack/cloud/test_networks.py
+++ b/cfme/tests/openstack/cloud/test_networks.py
@@ -52,7 +52,7 @@ def create_subnet(appliance, provider, network):
 def create_router(appliance, provider, ext_gw, ext_network=None, ext_subnet=None):
     collection = appliance.collections.network_routers
     router = collection.create(name=fauxfactory.gen_alpha(),
-                               tenant=provider.data['tenant'],
+                               tenant=provider.data['provisioning']['cloud_tenant'],
                                provider=provider,
                                network_manager='{} Network Manager'.format(provider.name),
                                has_external_gw=ext_gw,
@@ -114,7 +114,7 @@ def test_create_network(network, provider):
     """Creates private cloud network and verifies it's relationships"""
     assert network.exists
     assert network.parent_provider.name == provider.name
-    assert network.cloud_tenant == provider.data['tenant']
+    assert network.cloud_tenant == provider.data['provisioning']['cloud_tenant']
 
 
 def test_edit_network(network):
@@ -138,7 +138,7 @@ def test_create_subnet(subnet, provider):
     """Creates private subnet and verifies it's relationships"""
     assert subnet.exists
     assert subnet.parent_provider.name == provider.name
-    assert subnet.cloud_tenant == provider.data['tenant']
+    assert subnet.cloud_tenant == provider.data['provisioning']['cloud_tenant']
     assert subnet.cidr == SUBNET_CIDR
     assert subnet.cloud_network == subnet.network
     assert subnet.net_protocol == 'ipv4'
@@ -164,13 +164,13 @@ def test_delete_subnet(subnet):
 def test_create_router(router, provider):
     """Create router without gateway"""
     assert router.exists
-    assert router.cloud_tenant == provider.data['tenant']
+    assert router.cloud_tenant == provider.data['provisioning']['cloud_tenant']
 
 
 def test_create_router_with_gateway(router_with_gw, provider):
     """Creates router with gateway (external network)"""
     assert router_with_gw.exists
-    assert router_with_gw.cloud_tenant == provider.data['tenant']
+    assert router_with_gw.cloud_tenant == provider.data['provisioning']['cloud_tenant']
     assert router_with_gw.cloud_network == router_with_gw.ext_network
 
 


### PR DESCRIPTION
Were fixed selectors for correct working automation tests not only with CFME 5.8 and CFME 5.9 but with CFME 5.10 too.
Was updated returning object of parent cloud provider regarding version of the CFME

{{ pytest: cfme/tests/openstack/cloud/test_networks.py -k 'test_create_network or test_create_subnet or test_create_router_with_gateway or test_clear_router_gateway or test_add_gateway_to_router' }}