### PR TITLE
[1LP][RFR] Fixing analysis profile creation for SSA tests

### DIFF
--- a/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
+++ b/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
@@ -338,17 +338,19 @@ def ssa_analysis_profile(appliance):
     for file in ssa_expect_files:
         collected_files.append({"Name": file, "Collect Contents?": True})
 
-    analysis_profile_name = 'default'
+    analysis_profile_name = 'custom'
     analysis_profiles_collection = appliance.collections.analysis_profiles
-    analysis_profile = analysis_profiles_collection(
-        name=analysis_profile_name,
-        description=analysis_profile_name,
-        profile_type=analysis_profiles_collection.VM_TYPE,
-        categories=["System", "Software", "Services", "User Accounts", "VM Configuration"],
-        files=collected_files)
+    analysis_profile_data = {
+        'name': analysis_profile_name,
+        'description': analysis_profile_name,
+        'profile_type': analysis_profiles_collection.VM_TYPE,
+        'categories': ["System", "Software", "Services", "User Accounts", "VM Configuration"],
+        'files': collected_files
+    }
+    analysis_profile = analysis_profiles_collection.instantiate(**analysis_profile_data)
     if analysis_profile.exists:
         analysis_profile.delete()
-    analysis_profile.create()
+    analysis_profile = analysis_profiles_collection.create(**analysis_profile_data)
     yield analysis_profile
     if analysis_profile.exists:
         analysis_profile.delete()


### PR DESCRIPTION
Purpose of this PR is twofold:
1. Fix instantiating/creating of analysis profile. It used to throw this:
> TypeError: 'AnalysisProfileCollection' object is not callable

2. Renaming used analysis profile to anything different than "default". SSA used to work only when "default" analysis profile was used. However, since this [bug](https://bugzilla.redhat.com/show_bug.cgi?id=1553808) has been fixed, user should be able to provide any name for their analysis profile. 
Verification run: https://rhv-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/CFME-DEV/job/cfme-5.9-rhv-4.2-integration-flow-dev/268/

{{pytest: cfme/tests/cloud_infra_common/test_vm_instance_analysis.py --long-running --use-provider rhv41}}