### PR TITLE
miq-version 0.1.7

### DIFF
--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -169,7 +169,7 @@ lxml==4.2.1
 manageiq-client==0.4.1
 MarkupSafe==1.0
 mccabe==0.6.1
-miq-version==0.1.6
+miq-version==0.1.7
 mistune==0.8.3
 mock==2.0.0
 monotonic==1.5

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -164,7 +164,7 @@ lxml==4.2.1
 manageiq-client==0.4.1
 MarkupSafe==1.0
 mccabe==0.6.1
-miq-version==0.1.6
+miq-version==0.1.7
 mistune==0.8.3
 mock==2.0.0
 monotonic==1.5

--- a/requirements/frozen_docs.py2.txt
+++ b/requirements/frozen_docs.py2.txt
@@ -72,7 +72,7 @@ lxml==4.2.1
 manageiq-client==0.4.1
 MarkupSafe==1.0
 mccabe==0.6.1
-miq-version==0.1.6
+miq-version==0.1.7
 mistune==0.8.3
 mock==2.0.0
 monotonic==1.5

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -66,7 +66,7 @@ lxml==4.2.1
 manageiq-client==0.4.1
 MarkupSafe==1.0
 mccabe==0.6.1
-miq-version==0.1.6
+miq-version==0.1.7
 mistune==0.8.3
 mock==2.0.0
 monotonic==1.5

--- a/sprout/requirements.txt
+++ b/sprout/requirements.txt
@@ -9,4 +9,4 @@ gunicorn
 pika
 python-memcached
 
-miq-version==0.1.6
+miq-version==0.1.7


### PR DESCRIPTION
This modifies the TemplateName ID for upstream ManageIQ to use `miq`