### PR TITLE
[1LP][RFR] DRY the fixtures for V2V

### DIFF
--- a/cfme/fixtures/v2v.py
+++ b/cfme/fixtures/v2v.py
@@ -12,8 +12,8 @@ def migration_ui(appliance):
 
 
 @pytest.fixture(scope='function')
-def provider_setup(migration_ui, request, second_provider, provider):
-    """Fixture to setup nvc and rhv provider"""
+def v2v_providers(request, migration_ui, second_provider, provider):
+    """ Fixture to setup providers """
     setup_or_skip(request, second_provider)
     setup_or_skip(request, provider)
     yield second_provider, provider
@@ -22,9 +22,9 @@ def provider_setup(migration_ui, request, second_provider, provider):
 
 
 @pytest.fixture(scope='function')
-def host_creds(provider_setup):
+def host_creds(v2v_providers):
     """Add credentials to conversation host"""
-    provider = provider_setup[0]
+    provider = v2v_providers[0]
     host = provider.hosts.all()[0]
     host_data, = [data for data in provider.data['hosts'] if data['name'] == host.name]
     host.update_credentials_rest(credentials=host_data['credentials'])

--- a/cfme/tests/v2v/test_v2v_migrations.py
+++ b/cfme/tests/v2v/test_v2v_migrations.py
@@ -29,10 +29,14 @@ pytestmark = [
 
 def _form_data_cluster_mapping(second_provider, provider):
     # since we have only one cluster on providers
-    source_cluster = second_provider.data.get('clusters')[0]
-    target_cluster = provider.data.get('clusters')[0]
-
-    if not source_cluster or not target_cluster:
+    skip = False
+    try:
+        source_cluster = second_provider.data.get('clusters')[0]
+        target_cluster = provider.data.get('clusters')[0]
+    except TypeError:
+        skip = True
+        pass
+    if skip or not source_cluster or not target_cluster:
         pytest.skip("No data for source or target cluster in providers.")
 
     return {
@@ -133,10 +137,15 @@ def form_data_single_network(request, second_provider, provider):
 
 @pytest.fixture(scope='function')
 def form_data_dual_datastore(request, second_provider, provider):
-    vmware_nw = second_provider.data.get('vlans')[0]
-    rhvm_nw = provider.data.get('vlans')[0]
+    skip = False
+    try:
+        vmware_nw = second_provider.data.get('vlans')[0]
+        rhvm_nw = provider.data.get('vlans')[0]
+    except TypeError:
+        skip = True
+        pass
 
-    if not vmware_nw or not rhvm_nw:
+    if skip or not vmware_nw or not rhvm_nw:
         pytest.skip("No data for source or target network in providers.")
 
     form_data = (
@@ -163,7 +172,7 @@ def form_data_dual_datastore(request, second_provider, provider):
             'network': {
                 'Cluster ({})'.format(provider.data.get('clusters')[0]): {
                     'mappings': [_form_data_network_mapping(second_provider, provider,
-                        second_provider.data.get('vlans')[0], provider.data.get('vlans')[0])]
+                                                            vmware_nw, rhvm_nw)]
                 }
             }
         })

--- a/cfme/tests/v2v/test_v2v_migrations.py
+++ b/cfme/tests/v2v/test_v2v_migrations.py
@@ -192,8 +192,8 @@ def vm_list(request, appliance, second_provider, provider):
 
 @pytest.mark.parametrize('form_data_single_datastore', [['nfs', 'nfs'],
                             ['nfs', 'iscsi'], ['iscsi', 'iscsi']], indirect=True)
-def test_single_datastore_single_vm_mapping_crud(appliance, form_data_single_datastore, providers,
-                                                 conversion_tags, soft_assert):
+def test_single_datastore_single_vm_mapping_crud(appliance, form_data_single_datastore,
+                                                 v2v_providers, conversion_tags, soft_assert):
     # TODO: This test case does not support update
     # as update is not a supported feature for mapping.
     infrastructure_mapping_collection = appliance.collections.v2v_mappings
@@ -213,7 +213,7 @@ def test_single_datastore_single_vm_mapping_crud(appliance, form_data_single_dat
 
 @pytest.mark.parametrize('form_data_single_network', [['VM Network', 'ovirtmgmt'],
                             ['DPortGroup', 'ovirtmgmt']], indirect=True)
-def test_single_network_single_vm_mapping_crud(appliance, conversion_tags, providers,
+def test_single_network_single_vm_mapping_crud(appliance, conversion_tags, v2v_providers,
                                                form_data_single_network):
     # TODO: This test case does not support update
     # as update is not a supported feature for mapping.
@@ -234,8 +234,8 @@ def test_single_network_single_vm_mapping_crud(appliance, conversion_tags, provi
 
 @pytest.mark.parametrize('form_data_dual_datastore', [[['nfs', 'nfs'], ['iscsi', 'iscsi']],
                             [['nfs', 'local'], ['iscsi', 'iscsi']]], indirect=True)
-def test_dual_datastore_dual_vm_mapping_crud(appliance, form_data_dual_datastore, migration_ui,
-                                             providers):
+def test_dual_datastore_dual_vm_mapping_crud(appliance, form_data_dual_datastore,
+                                             v2v_providers):
     # TODO: Add "Delete" method call.This test case does not support update/delete
     # as update is not a supported feature for mapping,
     # and delete is not supported in our automation framework.
@@ -257,7 +257,7 @@ def test_dual_datastore_dual_vm_mapping_crud(appliance, form_data_dual_datastore
 @pytest.mark.parametrize('vm_list', ['NFS_Datastore_1', 'iSCSI_Datastore_1'], ids=['NFS', 'ISCSI'],
                          indirect=True)
 @pytest.mark.parametrize('form_data_single_datastore', [['nfs', 'nfs']], indirect=True)
-def test_end_to_end_migration(appliance, migration_ui, providers, form_data_single_datastore,
+def test_end_to_end_migration(appliance, v2v_providers, form_data_single_datastore,
                               vm_list):
     infrastructure_mapping_collection = appliance.collections.v2v_mappings
     mapping = infrastructure_mapping_collection.create(form_data_single_datastore)
@@ -274,7 +274,7 @@ def test_end_to_end_migration(appliance, migration_ui, providers, form_data_sing
     assert view._get_status(coll.name) == "Completed Plans"
 
 
-def test_conversion_host_tags(appliance, providers):
+def test_conversion_host_tags(appliance, v2v_providers):
     """Tests following cases:
 
     1)Test Attribute in UI indicating host has/has not been configured as conversion host like Tags
@@ -288,7 +288,7 @@ def test_conversion_host_tags(appliance, providers):
             display_name='V2V - Transformation Method')
             .collections.tags.instantiate(display_name='VDDK'))
 
-    host = providers[1].hosts[0]
+    host = v2v_providers[1].hosts[0]
     # Remove any prior tags
     host.remove_tags(host.get_tags())
 

--- a/cfme/tests/v2v/test_v2v_migrations.py
+++ b/cfme/tests/v2v/test_v2v_migrations.py
@@ -29,8 +29,8 @@ pytestmark = [
 
 def _form_data_cluster_mapping(second_provider, provider):
     # since we have only one cluster on providers
-    source_cluster = second_provider.data.get('clusters', [None])[0]
-    target_cluster = provider.data.get('clusters', [None])[0]
+    source_cluster = second_provider.data.get('clusters', [False])[0]
+    target_cluster = provider.data.get('clusters', [False])[0]
     if not source_cluster or not target_cluster:
         pytest.skip("No data for source or target cluster in providers.")
 
@@ -41,8 +41,8 @@ def _form_data_cluster_mapping(second_provider, provider):
 
 
 def _form_data_datastore_mapping(second_provider, provider, source_type, target_type):
-    source_datastores_list = second_provider.data.get('datastores')
-    target_datastores_list = provider.data.get('datastores')
+    source_datastores_list = second_provider.data.get('datastores', [])
+    target_datastores_list = provider.data.get('datastores', [])
     # assuming, we just have 1 datastore of each type
     source_datastore = [d.name for d in source_datastores_list if d.type == source_type]
     target_datastore = [d.name for d in target_datastores_list if d.type == target_type]
@@ -57,8 +57,8 @@ def _form_data_datastore_mapping(second_provider, provider, source_type, target_
 
 
 def _form_data_network_mapping(second_provider, provider, source_network_name, target_network_name):
-    source_vlans_list = second_provider.data.get('vlans')
-    target_vlans_list = provider.data.get('vlans')
+    source_vlans_list = second_provider.data.get('vlans', [])
+    target_vlans_list = provider.data.get('vlans', [])
     # assuming there will be only 1 network matching given name
     source_network = [v for v in source_vlans_list if v == source_network_name]
     target_network = [v for v in target_vlans_list if v == target_network_name]

--- a/cfme/tests/v2v/test_v2v_migrations.py
+++ b/cfme/tests/v2v/test_v2v_migrations.py
@@ -29,14 +29,9 @@ pytestmark = [
 
 def _form_data_cluster_mapping(second_provider, provider):
     # since we have only one cluster on providers
-    skip = False
-    try:
-        source_cluster = second_provider.data.get('clusters')[0]
-        target_cluster = provider.data.get('clusters')[0]
-    except TypeError:
-        skip = True
-        pass
-    if skip or not source_cluster or not target_cluster:
+    source_cluster = second_provider.data.get('clusters', [None])[0]
+    target_cluster = provider.data.get('clusters', [None])[0]
+    if not source_cluster or not target_cluster:
         pytest.skip("No data for source or target cluster in providers.")
 
     return {
@@ -48,34 +43,31 @@ def _form_data_cluster_mapping(second_provider, provider):
 def _form_data_datastore_mapping(second_provider, provider, source_type, target_type):
     source_datastores_list = second_provider.data.get('datastores')
     target_datastores_list = provider.data.get('datastores')
-
-    if not source_datastores_list or not target_datastores_list:
-        pytest.skip("No data for source or target cluster in providers.")
-
     # assuming, we just have 1 datastore of each type
-    source_datastore = [d.name for d in source_datastores_list if d.type == source_type][0]
-    target_datastore = [d.name for d in target_datastores_list if d.type == target_type][0]
+    source_datastore = [d.name for d in source_datastores_list if d.type == source_type]
+    target_datastore = [d.name for d in target_datastores_list if d.type == target_type]
+    if (not source_datastores_list or not target_datastores_list or
+            not source_datastore or not target_datastore):
+        pytest.skip("No data for source or target datastore in providers.")
 
     return {
-        'sources': [partial_match(source_datastore)],
-        'target': [partial_match(target_datastore)]
+        'sources': [partial_match(source_datastore[0])],
+        'target': [partial_match(target_datastore[0])]
     }
 
 
 def _form_data_network_mapping(second_provider, provider, source_network_name, target_network_name):
     source_vlans_list = second_provider.data.get('vlans')
     target_vlans_list = provider.data.get('vlans')
-
-    if not source_vlans_list or not target_vlans_list:
+    # assuming there will be only 1 network matching given name
+    source_network = [v for v in source_vlans_list if v == source_network_name]
+    target_network = [v for v in target_vlans_list if v == target_network_name]
+    if not source_vlans_list or not target_vlans_list or not source_network or not target_network:
         pytest.skip("No data for source or target cluster in providers.")
 
-    # assuming there will be only 1 network matching given name
-    source_network = [v for v in source_vlans_list if v == source_network_name][0]
-    target_network = [v for v in target_vlans_list if v == target_network_name][0]
-
     return {
-        'sources': [partial_match(source_network)],
-        'target': [partial_match(target_network)]
+        'sources': [partial_match(source_network[0])],
+        'target': [partial_match(target_network[0])]
     }
 
 
@@ -137,15 +129,10 @@ def form_data_single_network(request, second_provider, provider):
 
 @pytest.fixture(scope='function')
 def form_data_dual_datastore(request, second_provider, provider):
-    skip = False
-    try:
-        vmware_nw = second_provider.data.get('vlans')[0]
-        rhvm_nw = provider.data.get('vlans')[0]
-    except TypeError:
-        skip = True
-        pass
+    vmware_nw = second_provider.data.get('vlans', [None])[0]
+    rhvm_nw = provider.data.get('vlans', [None])[0]
 
-    if skip or not vmware_nw or not rhvm_nw:
+    if not vmware_nw or not rhvm_nw:
         pytest.skip("No data for source or target network in providers.")
 
     form_data = (

--- a/cfme/tests/v2v/test_v2v_migrations_ui.py
+++ b/cfme/tests/v2v/test_v2v_migrations_ui.py
@@ -27,15 +27,10 @@ pytestmark = [
 
 def _form_data_cluster_mapping(second_provider, provider):
     # since we have only one cluster on providers
-    skip = False
-    try:
-        source_cluster = second_provider.data.get('clusters')[0]
-        target_cluster = provider.data.get('clusters')[0]
-    except TypeError:
-        skip = True
-        pass
+    source_cluster = second_provider.data.get('clusters', [None])[0]
+    target_cluster = provider.data.get('clusters', [None])[0]
 
-    if skip or not source_cluster or not target_cluster:
+    if not source_cluster or not target_cluster:
         pytest.skip("No data for source or target cluster in providers.")
 
     return {
@@ -47,34 +42,31 @@ def _form_data_cluster_mapping(second_provider, provider):
 def _form_data_datastore_mapping(second_provider, provider, source_type, target_type):
     source_datastores_list = second_provider.data.get('datastores')
     target_datastores_list = provider.data.get('datastores')
-
-    if not source_datastores_list or not target_datastores_list:
-        pytest.skip("No data for source or target cluster in providers.")
-
     # assuming, we just have 1 datastore of each type
-    source_datastore = [d.name for d in source_datastores_list if d.type == source_type][0]
-    target_datastore = [d.name for d in target_datastores_list if d.type == target_type][0]
+    source_datastore = [d.name for d in source_datastores_list if d.type == source_type]
+    target_datastore = [d.name for d in target_datastores_list if d.type == target_type]
+    if (not source_datastores_list or not target_datastores_list or
+            not source_datastore or not target_datastore):
+        pytest.skip("No data for source or target datastore in providers.")
 
     return {
-        'sources': [partial_match(source_datastore)],
-        'target': [partial_match(target_datastore)]
+        'sources': [partial_match(source_datastore[0])],
+        'target': [partial_match(target_datastore[0])]
     }
 
 
 def _form_data_network_mapping(second_provider, provider, source_network_name, target_network_name):
     source_vlans_list = second_provider.data.get('vlans')
     target_vlans_list = provider.data.get('vlans')
-
-    if not source_vlans_list or not target_vlans_list:
-        pytest.skip("No data for source or target cluster in providers.")
-
     # assuming there will be only 1 network matching given name
-    source_network = [v for v in source_vlans_list if v == source_network_name][0]
-    target_network = [v for v in target_vlans_list if v == target_network_name][0]
+    source_network = [v for v in source_vlans_list if v == source_network_name]
+    target_network = [v for v in target_vlans_list if v == target_network_name]
+    if not source_vlans_list or not target_vlans_list or not source_network or not target_network:
+        pytest.skip("No data for source or target network in providers.")
 
     return {
-        'sources': [partial_match(source_network)],
-        'target': [partial_match(target_network)]
+        'sources': [partial_match(source_network[0])],
+        'target': [partial_match(target_network[0])]
     }
 
 

--- a/cfme/tests/v2v/test_v2v_migrations_ui.py
+++ b/cfme/tests/v2v/test_v2v_migrations_ui.py
@@ -165,9 +165,9 @@ def test_v2v_ui_set1(appliance, v2v_providers, form_data_single_datastore, soft_
 
     # Test Datacenter name in source and destination mapping select list:
     soft_assert(v2v_providers[0].data['datacenters'][0]
-     in view.form.cluster.source_clusters.all_items[0])
+                in view.form.cluster.source_clusters.all_items[0])
     soft_assert(v2v_providers[1].data['datacenters'][0]
-     in view.form.cluster.target_clusters.all_items[0])
+                in view.form.cluster.target_clusters.all_items[0])
 
     # Assert Add Mapping button is enabled before selecting source and target clusters
     soft_assert(not view.form.cluster.add_mapping.root_browser.

--- a/cfme/tests/v2v/test_v2v_migrations_ui.py
+++ b/cfme/tests/v2v/test_v2v_migrations_ui.py
@@ -27,8 +27,8 @@ pytestmark = [
 
 def _form_data_cluster_mapping(second_provider, provider):
     # since we have only one cluster on providers
-    source_cluster = second_provider.data.get('clusters', [None])[0]
-    target_cluster = provider.data.get('clusters', [None])[0]
+    source_cluster = second_provider.data.get('clusters', [False])[0]
+    target_cluster = provider.data.get('clusters', [False])[0]
 
     if not source_cluster or not target_cluster:
         pytest.skip("No data for source or target cluster in providers.")
@@ -40,8 +40,8 @@ def _form_data_cluster_mapping(second_provider, provider):
 
 
 def _form_data_datastore_mapping(second_provider, provider, source_type, target_type):
-    source_datastores_list = second_provider.data.get('datastores')
-    target_datastores_list = provider.data.get('datastores')
+    source_datastores_list = second_provider.data.get('datastores', [])
+    target_datastores_list = provider.data.get('datastores', [])
     # assuming, we just have 1 datastore of each type
     source_datastore = [d.name for d in source_datastores_list if d.type == source_type]
     target_datastore = [d.name for d in target_datastores_list if d.type == target_type]
@@ -56,12 +56,13 @@ def _form_data_datastore_mapping(second_provider, provider, source_type, target_
 
 
 def _form_data_network_mapping(second_provider, provider, source_network_name, target_network_name):
-    source_vlans_list = second_provider.data.get('vlans')
-    target_vlans_list = provider.data.get('vlans')
+    source_vlans_list = second_provider.data.get('vlans', [])
+    target_vlans_list = provider.data.get('vlans', [])
     # assuming there will be only 1 network matching given name
     source_network = [v for v in source_vlans_list if v == source_network_name]
     target_network = [v for v in target_vlans_list if v == target_network_name]
-    if not source_vlans_list or not target_vlans_list or not source_network or not target_network:
+    if (not source_vlans_list or not target_vlans_list or
+            not source_network or not target_network):
         pytest.skip("No data for source or target network in providers.")
 
     return {

--- a/cfme/tests/v2v/test_v2v_migrations_ui.py
+++ b/cfme/tests/v2v/test_v2v_migrations_ui.py
@@ -27,10 +27,15 @@ pytestmark = [
 
 def _form_data_cluster_mapping(second_provider, provider):
     # since we have only one cluster on providers
-    source_cluster = second_provider.data.get('clusters')[0]
-    target_cluster = provider.data.get('clusters')[0]
+    skip = False
+    try:
+        source_cluster = second_provider.data.get('clusters')[0]
+        target_cluster = provider.data.get('clusters')[0]
+    except TypeError:
+        skip = True
+        pass
 
-    if not source_cluster or not target_cluster:
+    if skip or not source_cluster or not target_cluster:
         pytest.skip("No data for source or target cluster in providers.")
 
     return {

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2553,11 +2553,11 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
         self.wait_for_web_ui()
 
     def enable_migration_ui(self):
-        if not self.advanced_settings['product']['transformation']:
+        if not self.advanced_settings.get('product', {}).get('transformation'):
             self._switch_migration_ui(True)
 
     def disable_migration_ui(self):
-        if self.advanced_settings['product']['transformation']:
+        if self.advanced_settings.get('product', {}).get('transformation'):
             self. _switch_migration_ui(False)
 
 


### PR DESCRIPTION
```
file /var/ci/workspace/downstream-59z-tests-master/integration_tests/cfme/tests/v2v/test_v2v_migrations.py, line 235
  @pytest.mark.parametrize('form_data_dual_datastore', [[['nfs', 'nfs'], ['iscsi', 'iscsi']],
                              [['nfs', 'local'], ['iscsi', 'iscsi']]], indirect=True)
  def test_dual_datastore_dual_vm_mapping_crud(appliance, form_data_dual_datastore, migration_ui,
E       fixture 'providers' not found
```

DRY up the fixtures for the V2V modules, there was duplication and ambiguous fixture names causing confusion between the 2 test modules.

There are some open V2V PRs, but I want to get these simple fixes in for scope mismatches and such into the downstream-stable release.

# NOTE TO REVIEWERS
There are some PRT failures to locate the provider record (its via rest), but this is outside of the scope of exceptions that I'm trying to resolve here.  Thoughts for more 'stable' release?

{{ pytest: cfme/tests/v2v/test_v2v_migrations.py cfme/tests/v2v/test_v2v_migrations_ui.py --use-provider complete --long-running }}