### PR TITLE
[WIPTEST] Change BZ resolve_blockers boolean

### DIFF
--- a/cfme/scripting/ipyshell.py
+++ b/cfme/scripting/ipyshell.py
@@ -7,7 +7,9 @@ IMPORTS = [
     'from cfme.utils import conf',
     'from cfme.fixtures.pytest_store import store',
     'from cfme.utils.appliance.implementations.ui import navigate_to',
+    'from cfme.utils.appliance import DummyAppliance',
     'from cfme.utils import providers',
+    'from cfme.utils.blockers import BZ, GH',
 ]
 
 

--- a/cfme/utils/bz.py
+++ b/cfme/utils/bz.py
@@ -193,7 +193,7 @@ class Bugzilla(object):
         for bug in filtered:
             if (isinstance(bug.version, Version) and
                 isinstance(bug.target_release, Version) and
-                check_fixed_in(bug.fixed_in, version_series) and
+                not check_fixed_in(bug.fixed_in, version_series) and
                 (bug.version.is_in_series(version_series) or
                  bug.target_release.is_in_series(version_series))):
                 return bug


### PR DESCRIPTION
resolve_blockers was returning a bug if check_fixed_in was returning true, which is backwards.

The method should return a bug if that bug is a 'blocker' and is in the right series and is _not_ fixed in the same series.

FIXES 7603

This is very odd to me, as this isn't something that has changed recently. Have we been incorrectly resolving blockers this whole time?