### PR TITLE
[1LP][RFR] additional sprout client/server fixes in order to fix the issue caused by reboot during rename vm

### DIFF
--- a/cfme/test_framework/sprout/plugin.py
+++ b/cfme/test_framework/sprout/plugin.py
@@ -233,7 +233,7 @@ class SproutManager(object):
             pytest.exit(1)
 
         log.debug("fulfilled at %f %%", result['progress'])
-        return result["fulfilled"]
+        return result["finished"]
 
     def clean_jenkins_job(self, jenkins_job):
         try:


### PR DESCRIPTION
1. sprout plugin returned appliances using pool.fulfilled attribute what is incorrect. it should use pool.finished instead.
2. rename_appliance task was made synchronous in order to get rid of cases when provided appliance is rebooted afterwards