### PR TITLE
[WIPTEST] Add Ansible role test

### DIFF
--- a/cfme/tests/containers/test_provider_configuration_menu.py
+++ b/cfme/tests/containers/test_provider_configuration_menu.py
@@ -2,13 +2,29 @@ import pytest
 
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.containers.provider import ContainersProvider
-
+from cfme.utils.wait import wait_for
 
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1),
     pytest.mark.provider([ContainersProvider], scope='function')
 ]
+
+def get_ansible_container_name(appliance):
+    return filter(lambda container: "ansible" in container.name,
+                  appliance.collections.containers.all())
+
+
+@pytest.fixture
+def get_old_ansible_containers_name(appliance):
+    return get_ansible_container_name(appliance)
+
+
+@pytest.yield_fixture
+def disable_embedded_ansible(appliance):
+    yield
+    args = ["embedded_ansible"]
+    appliance.server.settings.disable_server_roles(*args)
 
 
 @pytest.mark.polarion('CMP-9880')
@@ -44,3 +60,21 @@ def test_ocp_operator_out_of_the_box(appliance):
 
     # validate the role exist out-of-the-box
     assert is_role_found, "No {role} found".format(role=role_name_prefix)
+
+def test_start_embedded_ansible(appliance, get_old_ansible_containers_name,
+                                disable_embedded_ansible):
+    """
+    In this test ansible embedded is tested
+    Tests steps:
+        * Enable ansible embadded
+        * Wait for ansible container to start
+    """
+    def is_ansible_container_created(appliance):
+        return bool(set(get_ansible_container_name(appliance)) - set(old_conainers_name))
+    old_conainers_name = get_old_ansible_containers_name
+    # Enable embedded ansible
+    args = ["embedded_ansible"]
+    appliance.server.settings.enable_server_roles(*args)
+     # Waiting for container to start
+    assert wait_for(is_ansible_container_created, [appliance], delay=30, timeout="10m"), (
+        "No ansible container started")

--- a/cfme/tests/containers/test_provider_configuration_menu.py
+++ b/cfme/tests/containers/test_provider_configuration_menu.py
@@ -10,6 +10,7 @@ pytestmark = [
     pytest.mark.provider([ContainersProvider], scope='function')
 ]
 
+
 def get_ansible_container_name(appliance):
     return filter(lambda container: "ansible" in container.name,
                   appliance.collections.containers.all())
@@ -61,6 +62,7 @@ def test_ocp_operator_out_of_the_box(appliance):
     # validate the role exist out-of-the-box
     assert is_role_found, "No {role} found".format(role=role_name_prefix)
 
+
 def test_start_embedded_ansible(appliance, get_old_ansible_containers_name,
                                 disable_embedded_ansible):
     """
@@ -75,6 +77,7 @@ def test_start_embedded_ansible(appliance, get_old_ansible_containers_name,
     # Enable embedded ansible
     args = ["embedded_ansible"]
     appliance.server.settings.enable_server_roles(*args)
-     # Waiting for container to start
+
+    # Waiting for container to start
     assert wait_for(is_ansible_container_created, [appliance], delay=30, timeout="10m"), (
         "No ansible container started")

--- a/cfme/tests/containers/test_provider_configuration_menu.py
+++ b/cfme/tests/containers/test_provider_configuration_menu.py
@@ -79,5 +79,5 @@ def test_start_embedded_ansible(appliance, get_old_ansible_containers_name,
     appliance.server.settings.enable_server_roles(*args)
 
     # Waiting for container to start
-    assert wait_for(is_ansible_container_created, [appliance], delay=30, timeout="10m"), (
+    assert wait_for(is_ansible_container_created, [appliance], delay=30, timeout="15m"), (
         "No ansible container started")


### PR DESCRIPTION
{{ pytest: cfme/tests/containers/test_provider_configuration_menu.py::test_start_embedded_ansible --use-provider ocp-39-hawk }}
Adding test for Embedded Ansible

Test flow:

Start "Embedded Ansible" in the configuration menu
Wait for CFME see a new container starts for embedded ansible