### PR TITLE
[1LP][RFR] Add test for checking for typos in metrics endpoint type

### DIFF
--- a/cfme/tests/containers/test_basic_metrics.py
+++ b/cfme/tests/containers/test_basic_metrics.py
@@ -120,8 +120,8 @@ def test_flash_msg_not_contains_html_tags(provider):
 
 
 def test_typo_in_metrics_endpoint_type(provider):
-        view = navigate_to(provider, "Details")
-        endpoints_table = view.entities.summary("Endpoints")
+    view = navigate_to(provider, "Details")
+    endpoints_table = view.entities.summary("Endpoints")
 
-        assert provider.metrics_type.lower() == endpoints_table.get_text_of(
-            "Metrics Type").lower(), "Incorrect endpoint type found dot metrics endpoint"
+    assert provider.metrics_type.lower() == endpoints_table.get_text_of(
+        "Metrics Type").lower(), "Incorrect endpoint type found dot metrics endpoint"

--- a/cfme/tests/containers/test_basic_metrics.py
+++ b/cfme/tests/containers/test_basic_metrics.py
@@ -117,3 +117,11 @@ def test_flash_msg_not_contains_html_tags(provider):
         is_translated_to_html = True
 
     assert is_translated_to_html, "Flash massage contains HTML tags"
+
+
+def test_typo_in_metrics_endpoint_type(provider):
+        view = navigate_to(provider, "Details")
+        endpoints_table = view.entities.summary("Endpoints")
+
+        assert provider.metrics_type.lower() == endpoints_table.get_text_of(
+            "Metrics Type").lower(), "Incorrect endpoint type found dot metrics endpoint"

--- a/cfme/tests/containers/test_basic_metrics.py
+++ b/cfme/tests/containers/test_basic_metrics.py
@@ -128,4 +128,4 @@ def test_typo_in_metrics_endpoint_type(provider):
     endpoints_table = view.entities.summary("Endpoints")
 
     assert provider.metrics_type.lower() == endpoints_table.get_text_of(
-        "Metrics Type").lower(), "Incorrect endpoint type found dot metrics endpoint"
+        "Metrics Type").lower(), "Provider metrics endpoint name from yaml and UI do not match"

--- a/cfme/tests/containers/test_basic_metrics.py
+++ b/cfme/tests/containers/test_basic_metrics.py
@@ -120,6 +120,10 @@ def test_flash_msg_not_contains_html_tags(provider):
 
 
 def test_typo_in_metrics_endpoint_type(provider):
+    """
+    This test based on bz1538948
+    """
+
     view = navigate_to(provider, "Details")
     endpoints_table = view.entities.summary("Endpoints")
 


### PR DESCRIPTION
{{ pytest : cfme/tests/containers/test_basic_metrics.py::test_typo_in_metrics_endpoint_type --use-provider ocp-39-hawk }}