### PR TITLE
[WIP] Add ad-hoc test support for node object

### DIFF
--- a/cfme/containers/node.py
+++ b/cfme/containers/node.py
@@ -11,7 +11,7 @@ from cfme.common import Taggable, TagPageView, PolicyProfileAssignable
 from cfme.common.vm_console import ConsoleMixin
 from cfme.containers.provider import (Labelable,
     ContainerObjectAllBaseView, LoggingableView, ContainerObjectDetailsBaseView,
-    GetRandomInstancesMixin)
+    GetRandomInstancesMixin, AdHocMetricsView)
 from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.utils.appliance.implementations.ui import (CFMENavigateStep, navigator,
                                                      navigate_to)
@@ -190,5 +190,13 @@ class Timelines(CFMENavigateStep):
         """Navigate to the Timelines page"""
         self.prerequisite_view.toolbar.monitoring.item_select('Timelines')
 
-# TODO Need Ad hoc Metrics
+
+@navigator.register(Node, 'AdHoc')
+class AdHocMain(CFMENavigateStep):
+    VIEW = AdHocMetricsView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        self.prerequisite_view.toolbar.monitoring.item_select('Ad hoc Metrics')
+
 # TODO Need External Logging

--- a/cfme/tests/containers/test_ad_hoc_metrics.py
+++ b/cfme/tests/containers/test_ad_hoc_metrics.py
@@ -1,11 +1,10 @@
 import pytest
 import requests
 
-from cfme.utils.log import logger
-from cfme.containers.provider import ContainersProvider, ContainersProviderCollection
-from cfme.containers.node import NodeCollection
+from cfme.containers.provider import ContainersProvider
 from cfme.markers.env_markers.provider import providers
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.log import logger
 from cfme.utils.providers import ProviderFilter
 
 pytestmark = [
@@ -17,12 +16,13 @@ pytestmark = [
                          scope='function')
 ]
 
-TEST_ITEMS = [ContainersProviderCollection, NodeCollection]
+TEST_ITEMS = ["containers_providers", "container_nodes"]
 
 
 def get_test_object(appliance, provider, test_item):
-    return (
-        provider if test_item is ContainersProviderCollection else test_item(appliance).all().pop())
+
+    return (provider if test_item == "containers_providers" else
+            getattr(appliance.collections, test_item).all().pop())
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Add parametrization for ad hoc metrics to support testing for both provider and node objects

{{ pytest : cfme/tests/containers/test_ad_hoc_metrics.py --use-provider ocp-39-hawk }}