### PR TITLE
[1LP][RFR] Fixing CFME5.10 new instance creation

### DIFF
--- a/cfme/tests/openstack/cloud/test_instances.py
+++ b/cfme/tests/openstack/cloud/test_instances.py
@@ -34,7 +34,8 @@ def new_instance(provider):
                     'last_name': fauxfactory.gen_alpha()},
         'catalog': {'num_vms': '1',
                     'vm_name': fauxfactory.gen_alpha()},
-        'environment': {'cloud_network': prov_data['cloud_network']},
+        'environment': {'cloud_network': prov_data['cloud_network'],
+                        'cloud_tenant': prov_data['cloud_tenant']},
         'properties': {'instance_type': partial_match(prov_data['instance_type'])},
     }
 


### PR DESCRIPTION
In the CFME 5.10 during new instance creation cloud_tenant at the environment tab is required

{{ pytest: cfme/tests/openstack/cloud/test_instances.py::test_create_instance }}
