### PR TITLE
[1LP][RFR] Fix snapshot memory checkbox for 5.10

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -49,7 +49,7 @@ from cfme.utils.conf import cfme_data
 from cfme.utils.log import logger
 from cfme.utils.pretty import Pretty
 from cfme.utils.providers import get_crud_by_name
-from cfme.utils.version import UPSTREAM, VersionPicker
+from cfme.utils.version import UPSTREAM, Version, VersionPicker
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import (
     Accordion,
@@ -60,7 +60,8 @@ from widgetastic_manageiq import (
     Table,
     TimelinesView,
     CompareToolBarActionsView,
-    Search
+    Search,
+    SnapshotMemorySwitch
 )
 from widgetastic_manageiq.vm_reconfigure import DisksTable
 
@@ -386,7 +387,9 @@ class InfraVmSnapshotAddView(InfraVmView):
     title = Text('#explorer_title_text')
     name = TextInput('name')
     description = TextInput('description')
-    snapshot_vm_memory = Checkbox('snap_memory')
+    snapshot_vm_memory = VersionPicker({
+        Version.lowest(): Checkbox('snap_memory'),
+        '5.10': SnapshotMemorySwitch()})
     create = Button('Create')
     cancel = Button('Cancel')
 

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -5129,7 +5129,7 @@ class MonitorStatusCard(ParametrizedView):
         return self.click_title()
 
 
-class SnapshotMemorySwitch(Widget):
+class SnapshotMemorySwitch(Widget, ClickableMixin):
     """ This replaces the old-style checkbox when working with snapshot memory.
 
     At first glance on the page it looks like a BootstrapSwitch but it really isn't.
@@ -5140,28 +5140,26 @@ class SnapshotMemorySwitch(Widget):
     ROOT = '//div[contains(@class, "bootstrap-switch-snap_memory")]'
     ON_LOCATOR = './/div[contains(@class, "bootstrap-switch-on")]'
 
-    def switch(self):
-        self.browser.click(self.__locator__)
-
     @property
     def is_set(self):
         return bool(self.browser.elements(self.ON_LOCATOR))
 
     def switch_on(self):
         if not self.is_set:
-            self.switch()
-        return True
+            self.click()
+            return True
+        else:
+            return False
 
     def switch_off(self):
         if self.is_set:
-            self.switch()
-        return True
+            self.click()
+            return True
+        else:
+            return False
 
     def fill(self, value):
-        if value:
-            self.switch_on()
-        else:
-            self.switch_off()
+        return (self.switch_on if value else self.switch_off)()
 
     def read(self):
         return self.is_set

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -5127,3 +5127,41 @@ class MonitorStatusCard(ParametrizedView):
 
     def click(self):
         return self.click_title()
+
+
+class SnapshotMemorySwitch(Widget):
+    """ This replaces the old-style checkbox when working with snapshot memory.
+
+    At first glance on the page it looks like a BootstrapSwitch but it really isn't.
+    Basic switch controls are implemented here along with fill and read methods,
+    so this should be usable as any other widget.
+    """
+
+    ROOT = '//div[contains(@class, "bootstrap-switch-snap_memory")]'
+    ON_LOCATOR = './/div[contains(@class, "bootstrap-switch-on")]'
+
+    def switch(self):
+        self.browser.click(self.__locator__)
+
+    @property
+    def is_set(self):
+        return bool(self.browser.elements(self.ON_LOCATOR))
+
+    def switch_on(self):
+        if not self.is_set:
+            self.switch()
+        return True
+
+    def switch_off(self):
+        if self.is_set:
+            self.switch()
+        return True
+
+    def fill(self, value):
+        if value:
+            self.switch_on()
+        else:
+            self.switch_off()
+
+    def read(self):
+        return self.is_set


### PR DESCRIPTION
This is a fix for snapshot memory checkbox in appliance version 5.10 and above.

The original checkbox from 5.9 has been replaced by a something that looks like a BootstrapSwitch, but that is only a decoy. The Wigetastic BootstrapSwitch cannot be used here, the layout of divs is different and there is no input and no id. So I created new class SnapshotMemorySwitch inheriting from Widget with some basic operations defined, also with read and fill operations, so it works like any other widget.

I've put this into widgetastic_manageiq, since I suspect this kind of switch is used only in snapshots. There also exist other examples of kind-of-a-BootstrapSwitch already in different parts of the framework.

This should fix all of the snapshot failures currently appearing in jenkins for 5.10.

{{ pytest: -v --long-running cfme/tests/infrastructure/test_snapshot.py -k test_memory_checkbox --use-provider vsphere65-nested }}