### PR TITLE
[1LP][RFR] Cleaning up VMs after some more tests

### DIFF
--- a/cfme/tests/networks/test_provision_to_virtual_network.py
+++ b/cfme/tests/networks/test_provision_to_virtual_network.py
@@ -51,10 +51,8 @@ def test_provision_vm_to_virtual_network(appliance, setup_provider, provider,
     vm_name = random_vm_name('provd')
 
     def _cleanup():
-        try:
-            provider.mgmt.get_vm(vm_name).cleanup()
-        except NotFoundError:
-            pass
+        vm = appliance.collections.infra_vms.instantiate(vm_name, provider)
+        vm.cleanup_on_provider()
 
     request.addfinalizer(_cleanup)
 

--- a/cfme/tests/services/test_different_dialogs_in_catalogs.py
+++ b/cfme/tests/services/test_different_dialogs_in_catalogs.py
@@ -96,7 +96,7 @@ def test_tagdialog_catalog_item(appliance, provider, catalog_item, request):
     vm_name = catalog_item.prov_data['catalog']["vm_name"]
     request.addfinalizer(
         lambda: appliance.collections.infra_vms.instantiate(
-            "{}_0001".format(vm_name), provider).cleanup_on_provider()
+            "{}0001".format(vm_name), provider).cleanup_on_provider()
     )
     dialog_values = {'service_level': "Gold"}
     service_catalogs = ServiceCatalogs(appliance, catalog=catalog_item.catalog,


### PR DESCRIPTION
Making some tests clean after themselves.

Verification run: https://rhv-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/cfme-5.9-rhv-4.2-integration-test-dev/173/

{{pytest:  cfme/tests/networks/test_provision_to_virtual_network.py::test_provision_vm_to_virtual_network cfme/tests/services/test_different_dialogs_in_catalogs.py::test_tagdialog_catalog_item --long-running -vv --use-provider rhv42}}