### PR TITLE
[1LP][RFR] Follow interface change

### DIFF
--- a/cfme/networks/provider/__init__.py
+++ b/cfme/networks/provider/__init__.py
@@ -96,7 +96,11 @@ class NetworkProvider(BaseProvider, Taggable):
     def security_groups(self):
         return self.collections.security_groups
 
-    def create(self, cancel=False, validate_credentials=True, validate_inventory=False):
+    def create(self, cancel=False, validate_credentials=True, validate_inventory=False,
+               check_existing=False):
+        if check_existing and self.exists:
+            return False
+
         created = True
 
         logger.info('Setting up Network Provider: %s', self.key)


### PR DESCRIPTION
The `Provider.create` method must now expect additional named parameter, `check_exisiting`. With this commit we add the parameter as well as apply it in code.

(If we didn't add it, then `networks_provider` fixture crashes. But it's good to add it event if it wouldn't crash because it brings significant performance improvement as provider now needn't be recreated everytime we run the test)

/cc @mshriver 