### PR TITLE
[1LP][RFR] Use version.lowest instead of 5.9

### DIFF
--- a/cfme/tests/integration/test_aws_iam_auth_and_roles.py
+++ b/cfme/tests/integration/test_aws_iam_auth_and_roles.py
@@ -7,7 +7,7 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.conf import credentials
 from cfme.utils.log import logger
-from cfme.utils.version import VersionPicker
+from cfme.utils.version import VersionPicker, Version
 
 
 def pytest_generate_tests(metafunc):
@@ -22,7 +22,7 @@ def pytest_generate_tests(metafunc):
     id_list = []
     # TODO: Include SSUI role_access dict and VIASSUI context
     role_access_ui = VersionPicker({
-        '5.9': role_access_ui_59z,
+        Version.lowest(): role_access_ui_59z,
         '5.10': role_access_ui_510z
     }).pick(appliance.version)
     logger.info('Using the role access dict: %s', role_access_ui)


### PR DESCRIPTION
@quarckster I'm thinking in the future when we remove deprecated CFME versions from the pickers, we replace with Version.lowest() instead of a specific version - When an older appliance version is run against this, it ends up getting None from the `.pick()` call and fails in odd ways during collection.

In this case if you're running against 5.8, you get a 'wrong' version of the role_dict, but that's more expected as you're running against unsupported version.

Thoughts? Not something I feel too strongly about, but hit it while template_tester was running against an older appliance version, from the master branch.