### PR TITLE
[WIPTEST] Decreasing timeout for SSA of VM and host

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -339,7 +339,7 @@ class BaseVM(BaseEntity, Pretty, Updateable, PolicyProfileAssignable, Taggable, 
         if wait_for_task_result:
             task = self.appliance.collections.tasks.instantiate(
                 name='Scan from Vm {}'.format(self.name), tab='AllTasks')
-            task.wait_for_finished()
+            task.wait_for_finished(timeout='3m')
             return task
 
     def wait_to_disappear(self, timeout=600):

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -295,7 +295,7 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Taggable):
         if wait_for_task_result:
             task = self.appliance.collections.tasks.instantiate(
                 name="SmartState Analysis for '{}'".format(self.name), tab='MyOtherTasks')
-            task.wait_for_finished()
+            task.wait_for_finished(timeout='3m')
             return task
 
     def check_compliance(self, timeout=240):


### PR DESCRIPTION
SSA of VM/Host should not need 15 minutes (that is default for task) to finish successfully. In my experience, three minutes should be plenty of time.

{{pytest: cfme/tests/cloud_infra_common/test_vm_instance_analysis.py::test_ssa_vm --long-running -vv}}