### PR TITLE
[1LP][RFR][NOTEST] Add BZ wrapper for test host credentials

### DIFF
--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -92,6 +92,8 @@ def test_discover_host(request, provider, appliance, host_ips):
 
 @pytest.mark.rhv2
 # Tests to automate BZ 1201092
+@pytest.mark.meta(blockers=[BZ(1619626, forced_streams=['5.9', '5.10'],
+                               unblock=lambda provider: not provider.one_of(RHEVMProvider))])
 @pytest.mark.parametrize("creds", ["default", "remote_login", "web_services"],
                          ids=["default", "remote", "web"])
 @pytest.mark.uncollectif(
@@ -125,7 +127,8 @@ def test_multiple_host_good_creds(setup_provider, provider, creds):
 
 
 @pytest.mark.rhv3
-@pytest.mark.meta(blockers=[BZ(1524411, forced_streams=['5.9', 'upstream'])])
+@pytest.mark.meta(blockers=[BZ(1619626, forced_streams=['5.9', '5.10'],
+                               unblock=lambda provider: not provider.one_of(RHEVMProvider))])
 def test_multiple_host_bad_creds(setup_provider, provider):
     """    Tests multiple host credentialing with bad credentials """
     if len(provider.data.get('hosts', {})) < 2:

--- a/cfme/tests/infrastructure/test_individual_host_creds.py
+++ b/cfme/tests/infrastructure/test_individual_host_creds.py
@@ -47,7 +47,9 @@ def get_host_data_by_name(provider_key, host_name):
                      unblock=lambda creds: creds == 'default'),
                   BZ(1584280, forced_streams=['5.9'],
                      unblock=lambda provider, creds: not provider.one_of(RHEVMProvider) or
-                     creds != 'web_services')])
+                     creds != 'web_services'),
+                  BZ(1619626, forced_streams=['5.9', '5.10'],
+                     unblock=lambda provider: not provider.one_of(RHEVMProvider))])
 @pytest.mark.parametrize("creds", ["default", "remote_login", "web_services"],
                          ids=["default", "remote", "web"])
 @pytest.mark.uncollectif(
@@ -105,7 +107,9 @@ def test_host_good_creds(appliance, request, setup_provider, provider, creds):
                   BZ(1584246, forced_streams=['5.8', '5.9'],
                      unblock=lambda provider: not provider.one_of(VMwareProvider)),
                   BZ(1584261, forced_streams=['5.8'],
-                     unblock=lambda creds: creds == 'default')])
+                     unblock=lambda creds: creds == 'default'),
+                  BZ(1619626, forced_streams=['5.9', '5.10'],
+                     unblock=lambda provider: not provider.one_of(RHEVMProvider))])
 @pytest.mark.parametrize("creds", ["default", "remote_login", "web_services"],
                          ids=["default", "remote", "web"])
 @pytest.mark.uncollectif(


### PR DESCRIPTION
Wrapping host creds validation tests because of [this BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1619626).

The problem is that when SSH keys change on hosts, CFME fails to accept the new one. Once the bug is fixed, the next step would be to update the tests so that if an alert informing about new ssh keys shows up, 'OK' button is clicked and new keys accepted.