### PR TITLE
[1LP][RFR][NOTEST] Removing test_total_services from RHV suite

### DIFF
--- a/cfme/tests/ssui/test_ssui_dashboard.py
+++ b/cfme/tests/ssui/test_ssui_dashboard.py
@@ -127,7 +127,6 @@ def run_service_chargeback_report(provider, appliance, assign_chargeback_rate,
 
 
 @pytest.mark.rhel_testing
-@pytest.mark.rhv3
 @pytest.mark.parametrize('context', [ViaSSUI])
 def test_total_services(appliance, setup_provider, context, order_service):
     """Tests total services count displayed on dashboard."""


### PR DESCRIPTION
This test should not actually be a part of RHV-CFME integration regression suite, therefore removing rhv marker.