### PR TITLE
[RFR] Put real bugzilla.redhat.com URL in env template

### DIFF
--- a/conf/env.yaml.template
+++ b/conf/env.yaml.template
@@ -11,7 +11,7 @@ github:
     default_repo: foo/bar
     token: abcdef0123456789
 bugzilla:
-    url: https://bugzilla.custom-domain.com/xmlrpc.cgi
+    url: https://bugzilla.redhat.com/xmlrpc.cgi
     loose:  # Params of BugzillaBug to be converted to LooseVersion at runtime
         - target_release
         - version


### PR DESCRIPTION
PR #7672 adds a BZ check to Provider.from_config class method, which is called by get_crud within travis test execution.  This is a valid BZ use, but requires a reachable bugzilla URL