### PR TITLE
[1LP][RFR] Add context manager for DummyAppliance, for script use

### DIFF
--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -3060,6 +3060,15 @@ class DummyAppliance(object):
     def set_session_timeout(self, *k):
         pass
 
+    def __enter__(self):
+        """ This method will replace the current appliance in the store """
+        stack.push(self)
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        """This method will remove the appliance from the store"""
+        assert stack.pop() is self, 'Dummy appliance on stack inconsistent'
+
 
 def find_appliance(obj, require=True):
     if isinstance(obj, NavigatableMixin):

--- a/scripts/cleanup_old_vms.py
+++ b/scripts/cleanup_old_vms.py
@@ -12,6 +12,7 @@ import pytz
 from tabulate import tabulate
 from wrapanapi.exceptions import VMInstanceNotFound
 
+from cfme.utils.appliance import DummyAppliance
 from cfme.utils.log import logger, add_stdout_handler
 from cfme.utils.path import log_path
 from cfme.utils.providers import get_mgmt, list_providers, ProviderFilter
@@ -273,7 +274,8 @@ def cleanup_vms(texts, max_hours=24, providers=None, tags=None, prompt=True):
         filters.append(ProviderFilter(keys=providers))
 
     # Just want keys, use list_providers with no global filters to include disabled.
-    providers_to_scan = [prov.key for prov in list_providers(filters, use_global_filters=False)]
+    with DummyAppliance():
+        providers_to_scan = [prov.key for prov in list_providers(filters, use_global_filters=False)]
     logger.info('Potential providers for cleanup, filtered with given tags and provider keys: \n%s',
                 '\n'.join(providers_to_scan))
 

--- a/scripts/ocp_cleanup.py
+++ b/scripts/ocp_cleanup.py
@@ -4,6 +4,7 @@ import re
 import sys
 
 from cfme.containers.provider.openshift import OpenshiftProvider
+from cfme.utils.appliance import DummyAppliance
 from cfme.utils.providers import list_providers, ProviderFilter
 from cfme.utils.log import logger, add_stdout_handler
 
@@ -77,7 +78,8 @@ if __name__ == "__main__":
     args = parse_cmd_line()
     errors = 0
     pf = ProviderFilter(classes=[OpenshiftProvider], required_fields=[('use_for_sprout', True)])
-    providers = list_providers(filters=[pf], use_global_filters=False)
+    with DummyAppliance():
+        providers = list_providers(filters=[pf], use_global_filters=False)
     for prov in providers:
         # ping provider
         try:


### PR DESCRIPTION
Use in cleanup_old_vms, because we need provider objects but don't have an appliance.

