### PR TITLE
[1LP][RFR] Adding test_provision_cloud_init_payload for RHEVM

### DIFF
--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -337,19 +337,21 @@ class BasicProvisionFormView(View):
     class customize(Tab):  # noqa
         TAB_NAME = 'Customize'
         # Common
-        dns_servers = Input(name='customize__dns_servers')
-        dns_suffixes = Input(name='customize__dns_suffixes')
         customize_type = BootstrapSelect('customize__sysprep_enabled')
-        specification_name = Table('//div[@id="prov_vc_div"]/table')
-        admin_username = Input(name='customize__root_username')
         root_password = Input(name='customize__root_password')
-        linux_host_name = Input(name='customize__linux_host_name')
-        linux_domain_name = Input(name='customize__linux_domain_name')
+        address_mode = RadioGroup(locator=('//div[@id="customize"]'
+                                           '//div[./div[contains(@class, "radio")]]'))
+        hostname = Input(name='customize__hostname')
         ip_address = Input(name='customize__ip_addr')
         subnet_mask = Input(name='customize__subnet_mask')
         gateway = Input(name='customize__gateway')
+        dns_servers = Input(name='customize__dns_servers')
+        dns_suffixes = Input(name='customize__dns_suffixes')
+        specification_name = Table('//div[@id="prov_vc_div"]/table')
+        admin_username = Input(name='customize__root_username')
+        linux_host_name = Input(name='customize__linux_host_name')
+        linux_domain_name = Input(name='customize__linux_domain_name')
         custom_template = SelectTable('//div[@id="prov_template_div"]/table')
-        hostname = Input(name='customize__hostname')
 
     @View.nested
     class schedule(Tab):  # noqa

--- a/cfme/tests/cloud_infra_common/test_cloud_init_provisioning.py
+++ b/cfme/tests/cloud_infra_common/test_cloud_init_provisioning.py
@@ -8,6 +8,7 @@ from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.infrastructure.provider import InfraProvider
+from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.infrastructure.pxe import get_template_from_config
@@ -27,6 +28,22 @@ pytestmark = [
     pytest.mark.meta(server_roles="+automate"),
     pytest.mark.provider(gen_func=providers, filters=[pf1, pf2], scope="module")
 ]
+
+
+def find_global_ipv6(vm):
+    """
+    Find global IPv6 on a VM if present.
+
+    Args:
+        vm: InfraVm object
+
+    Returns: IPv6 as a string if found, False otherwise
+    """
+    all_ips = vm.mgmt.all_ips
+    for ip in all_ips:
+        if ':' in ip and not ip.startswith('fe80'):
+            return ip
+    return False
 
 
 @pytest.fixture(scope="module")
@@ -98,3 +115,78 @@ def test_provision_cloud_init(appliance, request, setup_provider, provider, prov
     with ssh.SSHClient(hostname=connect_ip, username=provisioning['ci-username'],
                        password=provisioning['ci-pass']) as ssh_client:
         wait_for(ssh_client.uptime, num_sec=200, handle_exception=True)
+
+
+@pytest.mark.rhv3
+@pytest.mark.uncollectif(lambda provider, appliance:
+    not provider.one_of(RHEVMProvider) or appliance.version < '5.10.0.12',
+    reason='Required customization template is only available in CFME 5.10.0.12 or greater.')
+def test_provision_cloud_init_payload(appliance, request, setup_provider, provider, provisioning,
+                                      vm_name):
+    """
+    Tests that options specified in VM provisioning dialog in UI are properly passed as a cloud-init
+    payload to the newly provisioned VM.
+
+    Metadata:
+        test_flag: cloud_init, provision
+    """
+    image = provisioning.get('ci-image', None)
+    if not image:
+        pytest.skip('No ci-image found in provider specification.')
+    note = ('Testing provisioning from image {image} to vm {vm} on provider {provider}'.format(
+        image=image, vm=vm_name, provider=provider.key))
+    logger.info(note)
+
+    ci_payload = {
+        'root_password': 'mysecret',
+        'address_mode': 'Static',
+        'hostname': 'cimachine',
+        'ip_address': '169.254.0.1',
+        'subnet_mask': '29',
+        'gateway': '169.254.0.2',
+        'dns_servers': '169.254.0.3',
+        'dns_suffixes': 'virt.lab.example.com',
+        'custom_template': {'name': 'oVirt cloud-init'}
+    }
+
+    inst_args = {
+        'request': {'notes': note},
+        'customize': {'customize_type': 'Specification'},
+        'template_name': image
+    }
+
+    inst_args['customize'].update(ci_payload)
+    logger.info('Instance args: {}'.format(inst_args))
+
+    # Provision VM
+    collection = appliance.provider_based_collection(provider)
+    instance = collection.create(vm_name, provider, form_values=inst_args)
+    request.addfinalizer(instance.cleanup_on_provider)
+    provision_request = provider.appliance.collections.requests.instantiate(vm_name,
+                                                                            partial_check=True)
+    provision_request.wait_for_request()
+
+    connect_ip = wait_for(find_global_ipv6, func_args=[instance], num_sec=600, delay=20).out
+    logger.info('Connect IP: {}'.format(connect_ip))
+
+    # Connect to the newly provisioned VM
+    with ssh.SSHClient(hostname=connect_ip,
+                       username='root',
+                       password=ci_payload['root_password']) as ssh_client:
+        # Check that correct hostname has been set
+        hostname_cmd = ssh_client.run_command('hostname')
+        assert hostname_cmd.success
+        assert hostname_cmd.output.strip() == ci_payload['hostname']
+
+        # Obtain network configuration script for eth0 and store it in a list
+        network_cfg_cmd = ssh_client.run_command('cat /etc/sysconfig/network-scripts/ifcfg-eth0')
+        assert network_cfg_cmd.success
+        config_list = network_cfg_cmd.output.split('\n')
+
+        # Compare contents of network script with cloud-init payload
+        assert 'BOOTPROTO=none' in config_list, 'Address mode was not set to static'
+        assert 'IPADDR={}'.format(ci_payload['ip_address']) in config_list
+        assert 'PREFIX={}'.format(ci_payload['subnet_mask']) in config_list
+        assert 'GATEWAY={}'.format(ci_payload['gateway']) in config_list
+        assert 'DNS1={}'.format(ci_payload['dns_servers']) in config_list
+        assert 'DOMAIN={}'.format(ci_payload['dns_suffixes']) in config_list

--- a/cfme/utils/net.py
+++ b/cfme/utils/net.py
@@ -66,8 +66,9 @@ def net_check(port, addr=None, force=False):
     if port not in _ports[addr] or force:
         # First try DNS resolution
         try:
-            addr = socket.gethostbyname(addr)
-
+            addr_info = socket.getaddrinfo(addr, port)[0]
+            sockaddr = addr_info[4]
+            addr = sockaddr[0]
             # Then try to connect to the port
             try:
                 socket.create_connection((addr, port), timeout=10)


### PR DESCRIPTION
I believe the test case (and its docstring) are pretty self-explanatory. What is maybe not so clear are changes in cfme/common/vm_views.py. They are two:
- I added RadioGroup for Address Mode
- I rearranged the button definitions so they are in the same order as in UI. This can be significant because some of the "later" fields are dependent on Customize Type.

Also, what might not be very clear is that why I am not specifying Customization Template. The reason is that there is already one pre-defined (`oVirt cloud-init`) that perfectly suits this purpose.

Also, why am I using pure `paramiko` as opposed to `cfme.utils.ssh`? The reason is that I need to SSH to the provisioned VM using IPv6 and I just could not get it to work with `SSHClient` from `cfme.utils.ssh`.

Jenkins verification: https://rhv-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/cfme-5.9-rhv-4.2-integration-test-dev/187

New verification (after changes to `net_check`): https://rhv-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/cfme-5.9-rhv-4.2-integration-test-dev/202/

New verification after comments from @digitronik and @mshriver: https://rhv-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/cfme-5.10-rhv-4.2-integration-test-dev/27/console