### PR TITLE
[1LP][RFR] fixed AttributeError in test_paginator.py tests

### DIFF
--- a/cfme/tests/configure/test_paginator.py
+++ b/cfme/tests/configure/test_paginator.py
@@ -89,8 +89,8 @@ def schedule(appliance):
     schedule.delete()
 
 
-@pytest.mark.meta(blockers=[
-                  BZ(1623091, forced_streams=['5.10'])])
+@pytest.mark.meta(blockers=[BZ(1623091, forced_streams=['5.10'],
+                  unblock=lambda place_info: 'Database' not in place_info[2])])
 @pytest.mark.parametrize('place_info', general_list_pages,
                          ids=['{}_{}'.format(set_type[0], set_type[2].lower())
                               for set_type in general_list_pages])


### PR DESCRIPTION
{{ pytest: -v cfme/tests/configure/test_paginator.py }}

Fixed AttributeError but test doesn't work for 5.10 due to BZ. So also added blocker for test_paginator