### PR TITLE
[1LP][RFR] fix cloud_timelines->diagnostic view test

### DIFF
--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -309,7 +309,7 @@ def test_cloud_timeline_diagnostic(new_instance, mark_vm_as_appliance, soft_asse
     Metadata:
         test_flag: timelines, events
     """
-    event = 'start'
+    event = 'create'
     targets = (new_instance.appliance.server,)
     inst_event = InstEvent(new_instance, event)
     logger.info('Will generate event %r on machine %r', event, new_instance.name)


### PR DESCRIPTION
When azure or ec2 instance is created, it is already created up and running.
So, there is no "start" event. This test can be fixed either by adding instance stop and start or making it check for "create" event instead.

{{pytest: --long-running --use-provider=azure cfme/tests/cloud/test_cloud_timelines.py::test_cloud_timeline_diagnostic }}