### PR TITLE
[1LP][WIP] Add a test for redfish physical server details

### DIFF
--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -512,7 +512,7 @@ class PhysicalProviderAddView(ProviderAddView):
         return (super(PhysicalProviderAddView, self).is_displayed and
                 self.navigation.currently_selected == [
                     'Compute', 'Physical Infrastructure', 'Providers'] and
-                self.title.text == 'Add New Ems Physical Infra')
+                self.title.text == 'Add New Physical Infrastructure Provider')
 
 
 class ProviderEditView(ProviderAddView):

--- a/cfme/physical/physical_server.py
+++ b/cfme/physical/physical_server.py
@@ -51,6 +51,7 @@ class PhysicalServer(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Ta
     pretty_attrs = ['name', 'hostname', 'ip_address', 'custom_ident']
 
     name = attr.ib()
+    ems_ref = attr.ib(default=None)
     provider = attr.ib(default=None)
     hostname = attr.ib(default=None)
     ip_address = attr.ib(default=None)
@@ -302,7 +303,7 @@ class PhysicalServerCollection(BaseCollection):
         ems_table = self.appliance.db.client['ext_management_systems']
         physical_server_query = (
             self.appliance.db.client.session
-                .query(physical_server_table.name, ems_table.name)
+                .query(physical_server_table.name, physical_server_table.ems_ref, ems_table.name)
                 .join(ems_table, physical_server_table.ems_id == ems_table.id))
         provider = None
 
@@ -310,8 +311,8 @@ class PhysicalServerCollection(BaseCollection):
             provider = self.filters.get('provider')
             physical_server_query = physical_server_query.filter(ems_table.name == provider.name)
         physical_servers = []
-        for name, ems_name in physical_server_query.all():
-            physical_servers.append(self.instantiate(name=name,
+        for name, ems_ref, ems_name in physical_server_query.all():
+            physical_servers.append(self.instantiate(name=name, ems_ref=ems_ref,
                                     provider=provider or get_crud_by_name(ems_name)))
         return physical_servers
 

--- a/cfme/physical/provider/redfish.py
+++ b/cfme/physical/provider/redfish.py
@@ -5,6 +5,9 @@ from widgetastic_patternfly import BootstrapSelect, Input
 from wrapanapi.systems import RedfishSystem
 
 from cfme.common.provider import DefaultEndpoint, DefaultEndpointForm
+from cfme.physical.physical_server import (
+    PhysicalServer,
+    PhysicalServerCollection)
 from . import PhysicalProvider
 
 
@@ -64,3 +67,15 @@ class RedfishProvider(PhysicalProvider):
             'name': self.name,
             'prov_type': 'Redfish'
         }
+
+
+@attr.s
+class RedfishPhysicalServer(PhysicalServer):
+
+    INVENTORY_TO_MATCH = ['power_state']
+    STATS_TO_MATCH = ['cores_capacity', 'memory_capacity']
+
+
+@attr.s
+class RedfishPhysicalServerCollection(PhysicalServerCollection):
+    ENTITY = RedfishPhysicalServer

--- a/cfme/tests/physical_infrastructure/test_redfish_physical_server_details.py
+++ b/cfme/tests/physical_infrastructure/test_redfish_physical_server_details.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from cfme.physical.provider.redfish import RedfishProvider
+
+pytestmark = [pytest.mark.provider([RedfishProvider], scope="function")]
+
+
+@pytest.fixture(scope="function")
+def physical_server(appliance, provider, setup_provider_funcscope):
+    # Get and return the first physical server
+    yield appliance.collections.redfish_physical_servers.all(provider)[0]
+
+
+def test_redfish_physical_server_details_stats(physical_server):
+    """Navigate to the physical server details page and verify that the stats match"""
+    physical_server.validate_stats(ui=True)

--- a/entry_points.txt
+++ b/entry_points.txt
@@ -90,6 +90,7 @@ policies = cfme.control.explorer.policies:PolicyCollection
 policy_profiles = cfme.control.explorer.policy_profiles:PolicyProfileCollection
 projects = cfme.configure.access_control:ProjectCollection
 provisioning_dialogs = cfme.automate.provisioning_dialogs:ProvisioningDialogsCollection
+redfish_physical_servers = cfme.physical.provider.redfish:RedfishPhysicalServerCollection
 regions = cfme.base:RegionCollection
 report_dashboards = cfme.intelligence.reports.dashboards:DashboardsCollection
 reports = cfme.intelligence.reports.reports:ReportsCollection


### PR DESCRIPTION
This test validates the statistics of a selected physical server that has been inventorised by the Redfish provider as it is shown in the GUI. It checks the displayed values against the ones accessible through the Redfish API client.

To enable the proper retrieval of a physical server's resource from the API server, we extended the `PhysicalServer` class to include the database field `ems_ref`. Thanks, @miha-plesko!

Depends on the following PRs:
* https://github.com/ManageIQ/wrapanapi/pull/328
* https://github.com/ManageIQ/integration_tests/pull/7629

/cc @miha-plesko 