### PR TITLE
[1LP][RFR] Adding some fixes for UI problems in 5.8

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -32,7 +32,7 @@ from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep,
 from cfme.utils.conf import cfme_data
 from cfme.utils.pretty import Pretty
 from cfme.utils.providers import get_crud_by_name
-from cfme.utils.version import UPSTREAM, VersionPicker
+from cfme.utils.version import UPSTREAM, VersionPicker, LOWEST
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import (
     Accordion, ConditionalSwitchableView, ManageIQTree, NonJSPaginationPane,
@@ -639,6 +639,8 @@ class InfraVm(VM):
                 flash_message = VersionPicker({
                     UPSTREAM: "Delete Snapshot initiated for 1 "
                               "VM and Instance from the ManageIQ Database",
+                    LOWEST: "Remove Snapshot initiated for 1 "
+                            "VM and Instance from the CFME Database",
                     '5.9': "Delete Snapshot initiated for 1 VM and Instance from the CFME Database"
                 }).pick(self.parent_vm.appliance.version)
                 view.flash.assert_message(flash_message)

--- a/cfme/services/myservice/ssui.py
+++ b/cfme/services/myservice/ssui.py
@@ -165,7 +165,7 @@ def set_ownership(self, owner, group):
                'select_group': group})
     view.save_button.click()
     view = self.create_view(DetailsMyServiceView)
-    assert view.is_displayed
+    view.wait_displayed('15s')  # WA for StaleElementException in 5.8 testing
     # TODO - remove sleep when BZ 1518954 is fixed
     time.sleep(10)
     if self.appliance.version >= "5.8":
@@ -184,9 +184,7 @@ def edit_tags(self, tag, value):
     view.add_tag.click()
     view.save.click()
     view = self.create_view(DetailsMyServiceView)
-    assert view.is_displayed
-    # TODO - remove sleep when BZ 1518954 is fixed
-    time.sleep(10)
+    view.wait_displayed('15s')  # WA for StaleElementException in 5.8 testing
     assert view.notification.assert_message("Tagging successful.")
 
 

--- a/cfme/services/service_catalogs/ui.py
+++ b/cfme/services/service_catalogs/ui.py
@@ -88,7 +88,7 @@ def order(self):
     if self.ansible_dialog_values:
         view.fill(self.ansible_dialog_values)
     msg = "Order Request was Submitted"
-    msg_type = "info"
+    msg_type = "success"
     view.submit_button.click()
     view = self.create_view(RequestsView)
     view.flash.assert_no_error()


### PR DESCRIPTION
There are some minor differences between messages in UI in 5.8. This should take care of that. Also, at some point in SSUI, there is a notification that obscures upper right menu. I added **super-lazy workaround** using `time.sleep(15)`. I know it is ugly, but hey, it's almost deprecated branch and there's IMO no value in fixing it properly.

Jenkins verification: https://rhv-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/cfme-5.8-rhv-4.2-integration-flow-dev/95/