### PR TITLE
[1LP][RFR] Fixing getting VM state for 5.8

### DIFF
--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -35,7 +35,7 @@ class InstanceQuadIconEntity(BaseQuadIconEntity):
                 state = br.get_attribute('src', self.QUADRANT.format(pos='b'))
 
             state = os.path.split(state)[1]
-            state = os.path.splitext(state)[0]
+            state = state.split("-")[1]
         except NoSuchElementException:
             return {}
         except IndexError:

--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -247,7 +247,7 @@ python-string-utils==0.6.0
 python-swiftclient==3.5.0
 pytz==2018.4
 pyvcloud==19.1.2
-pyvmomi==6.7.0
+pyvmomi==6.7.0.2018.9
 pywinrm==0.3.0
 PyYAML==3.12
 pyzmq==17.0.0

--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -273,7 +273,7 @@ selenium==3.12.0
 selenium-smart-locator==0.2.0
 Send2Trash==1.5.0
 sentaku==0.6.2
-setuptools-scm==3.0.6
+setuptools-scm==3.1.0
 shyaml==0.5.2
 simplegeneric==0.8.1
 simplejson==3.15.0
@@ -308,7 +308,7 @@ Werkzeug==0.14.1
 widgetastic.core==0.21.6
 widgetastic.patternfly==0.0.37
 widgetsnbextension==3.2.1
-wrapanapi==3.0.23
+wrapanapi==3.0.24
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -241,7 +241,7 @@ python-string-utils==0.6.0
 python-swiftclient==3.5.0
 pytz==2018.4
 pyvcloud==19.1.2
-pyvmomi==6.7.0
+pyvmomi==6.7.0.2018.9
 pywinrm==0.3.0
 PyYAML==3.12
 pyzmq==17.0.0

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -265,7 +265,7 @@ selenium==3.12.0
 selenium-smart-locator==0.2.0
 Send2Trash==1.5.0
 sentaku==0.6.2
-setuptools-scm==3.0.6
+setuptools-scm==3.1.0
 shyaml==0.5.2
 simplegeneric==0.8.1
 simplejson==3.15.0
@@ -297,7 +297,7 @@ Werkzeug==0.14.1
 widgetastic.core==0.21.6
 widgetastic.patternfly==0.0.37
 widgetsnbextension==3.2.1
-wrapanapi==3.0.23
+wrapanapi==3.0.24
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0

--- a/requirements/frozen_docs.py2.txt
+++ b/requirements/frozen_docs.py2.txt
@@ -143,7 +143,7 @@ selenium==3.12.0
 selenium-smart-locator==0.2.0
 Send2Trash==1.5.0
 sentaku==0.6.2
-setuptools-scm==3.0.6
+setuptools-scm==3.1.0
 shyaml==0.5.2
 simplegeneric==0.8.1
 simplejson==3.15.0
@@ -173,6 +173,7 @@ Werkzeug==0.14.1
 widgetastic.core==0.21.6
 widgetastic.patternfly==0.0.37
 widgetsnbextension==3.2.1
+wrapanapi==3.0.24
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0

--- a/requirements/frozen_docs.py2.txt
+++ b/requirements/frozen_docs.py2.txt
@@ -173,7 +173,6 @@ Werkzeug==0.14.1
 widgetastic.core==0.21.6
 widgetastic.patternfly==0.0.37
 widgetsnbextension==3.2.1
-wrapanapi==3.0.24
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -135,7 +135,7 @@ selenium==3.12.0
 selenium-smart-locator==0.2.0
 Send2Trash==1.5.0
 sentaku==0.6.2
-setuptools-scm==3.0.6
+setuptools-scm==3.1.0
 shyaml==0.5.2
 simplegeneric==0.8.1
 simplejson==3.15.0


### PR DESCRIPTION
The name of file that is used to get VM state is different in 5.8. I am not using `VersionPicker` because this fix is specific for 5.8-breakpoint-patched branch.

Jenkins verification: https://rhv-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/cfme-5.8-rhv-4.2-integration-flow-dev/92/