### PR TITLE
[1LP][RFR] Update KubeVirt provider class db_types

### DIFF
--- a/cfme/infrastructure/provider/kubevirt.py
+++ b/cfme/infrastructure/provider/kubevirt.py
@@ -9,6 +9,7 @@ from . import InfraProvider
 class KubeVirtProvider(InfraProvider):
     type_name = "kubevirt"
     settings_key = 'ems_kubevirt'
+    db_types = ["Kubevirt::InfraManager"]
     mgmt_class = None
 
     parent_provider = attr.ib(default=None)


### PR DESCRIPTION
This was causing non-Kube providers to get the wrong class.

Before, with rhevm and vmware provider configured:
```
In [12]: coll = app.collections.infra_providers

In [13]: coll.all()
Out[13]: 
[RHEVMProvider(endpoints={}, name=u'rhv42', key=None, zone=None, start_ip=None, end_ip=None, provider_data=None),
 KubeVirtProvider(endpoints={}, name=u'vSphere 6.5 (nested)', key=None, zone=None, start_ip=None, end_ip=None, provider_data=None, parent_provider=None)]
```

After, with kubevirt and vmware providers configured:
```
In[4]: app.collections.infra_providers.all()
Out[4]: 
[KubeVirtProvider(endpoints={}, name=u'openshift-kubevirt Virtualization Manager', key=None, zone=None, start_ip=None, end_ip=None, provider_data=None, parent_provider=None),
 VMwareProvider(endpoints={}, name=u'vSphere 6.5 (nested)', key=None, zone=None, start_ip=None, end_ip=None, provider_data=None)]
```