### PR TITLE
[1LP][RFR] Fixed all() method error in host advanced search

### DIFF
--- a/cfme/tests/infrastructure/test_advanced_search_host.py
+++ b/cfme/tests/infrastructure/test_advanced_search_host.py
@@ -187,7 +187,7 @@ def test_host_filter_save_and_load_cancel(
 
 
 def test_quick_search_without_host_filter(host_collection, request, hosts, hosts_with_vm_count,
-                                     host_with_median_vm, infra_provider):
+                                          host_with_median_vm, infra_provider):
     view = navigate_to(host_collection, 'All')
     view.entities.search.remove_search_filters()
     view.flash.assert_no_error()
@@ -197,12 +197,12 @@ def test_quick_search_without_host_filter(host_collection, request, hosts, hosts
     request.addfinalizer(view.entities.search.clear_simple_search)
     view.flash.assert_no_error()
     # Check it is there
-    all_hosts_visible = view.entities.get_all()
-    assert len(all_hosts_visible) == 1 and median_host in [host.name for host in all_hosts_visible]
+    all_hosts_visible = view.entities.entity_names
+    assert len(all_hosts_visible) == 1 and median_host in all_hosts_visible
 
 
 def test_quick_search_with_host_filter(host_collection, request, hosts, hosts_with_vm_count,
-                                  host_with_median_vm, infra_provider):
+                                       host_with_median_vm, infra_provider):
     view = navigate_to(host_collection, 'All')
     median_host, median_vm_count = host_with_median_vm
     view.entities.search.advanced_search(get_expression(False, ">=").format(median_vm_count))
@@ -213,8 +213,8 @@ def test_quick_search_with_host_filter(host_collection, request, hosts, hosts_wi
     view.entities.search.simple_search(median_host)
     view.flash.assert_no_error()
     # Check it is there
-    all_hosts_visible = view.entities.get_all()
-    assert len(all_hosts_visible) == 1 and median_host in [host.name for host in all_hosts_visible]
+    all_hosts_visible = view.entities.entity_names
+    assert len(all_hosts_visible) == 1 and median_host in all_hosts_visible
 
 
 def test_can_delete_host_filter(host_collection, hosts_advanced_search):

--- a/cfme/tests/infrastructure/test_advanced_search_host.py
+++ b/cfme/tests/infrastructure/test_advanced_search_host.py
@@ -5,7 +5,6 @@ from itertools import dropwhile
 import fauxfactory
 import pytest
 from widgetastic_patternfly import SelectItemNotFound
-from widgetastic.exceptions import NoSuchElementException
 
 from cfme.common.host_views import HostsView
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -198,7 +197,7 @@ def test_quick_search_without_host_filter(host_collection, request, hosts, hosts
     request.addfinalizer(view.entities.search.clear_simple_search)
     view.flash.assert_no_error()
     # Check it is there
-    all_hosts_visible = host_collection.all(infra_provider)
+    all_hosts_visible = view.entities.get_all()
     assert len(all_hosts_visible) == 1 and median_host in [host.name for host in all_hosts_visible]
 
 
@@ -214,7 +213,7 @@ def test_quick_search_with_host_filter(host_collection, request, hosts, hosts_wi
     view.entities.search.simple_search(median_host)
     view.flash.assert_no_error()
     # Check it is there
-    all_hosts_visible = host_collection.all(infra_provider)
+    all_hosts_visible = view.entities.get_all()
     assert len(all_hosts_visible) == 1 and median_host in [host.name for host in all_hosts_visible]
 
 


### PR DESCRIPTION
{{ pytest: cfme/tests/infrastructure/test_advanced_search_host.py::test_quick_search_without_host_filter cfme/tests/infrastructure/test_advanced_search_host.py::test_quick_search_with_host_filter }}