### PR TITLE
[1LP][RFR] Fixed Exception Error while deleting default tenant

### DIFF
--- a/cfme/configure/access_control/__init__.py
+++ b/cfme/configure/access_control/__init__.py
@@ -1521,10 +1521,10 @@ class TenantCollection(BaseCollection):
     def delete(self, *tenants):
 
         view = navigate_to(self, 'All')
-
         for tenant in tenants:
             try:
-                view.table.row(name=tenant.name).check()
+                row = view.table.row(name=tenant.name)
+                row[0].check()
             except Exception:
                 logger.exception('Failed to check element "%s"', tenant.name)
         else:

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -3,13 +3,14 @@ import traceback
 
 import fauxfactory
 import pytest
+from widgetastic.exceptions import NoSuchElementException
 
 from cfme import test_requirements
 from cfme.base.credential import Credential
 from cfme.common.provider import base_types
 from cfme.configure.access_control import AddUserView
 from cfme.configure.tasks import TasksView
-from cfme.exceptions import RBACOperationBlocked, CFMEException
+from cfme.exceptions import RBACOperationBlocked
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import ONE
 from cfme.services.myservice import MyService
@@ -1100,7 +1101,6 @@ def test_tenant_quota_input_validate(appliance):
 def test_delete_default_tenant(appliance):
     """
     Steps:
-
     1. Login as an 'Administrator' user
     2. Navigate to configuration > access control > tenants
     3. Select default tenant('My Company') from tenants table
@@ -1108,14 +1108,12 @@ def test_delete_default_tenant(appliance):
     5. Check whether default tenant is deleted or not
     """
     roottenant = appliance.collections.tenants.get_root_tenant()
-    view = navigate_to(appliance.collections.tenants, 'All')
     try:
-        for row in view.table.rows():
-            if row.name.text == roottenant.name:
-                row[0].check()
         msg = 'Default Tenant "{}" can not be deleted'.format(roottenant.name)
-        view.toolbar.configuration.item_select('Delete selected items', handle_alert=True)
-    except CFMEException:
+        tenant = appliance.collections.tenants.instantiate(name=roottenant.name)
+        tenant_obj = appliance.collections.tenants
+        tenant_obj.delete(tenant)
+    except NoSuchElementException:
         raise RBACOperationBlocked(match=msg)
 
 

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -3,7 +3,6 @@ import traceback
 
 import fauxfactory
 import pytest
-from widgetastic.exceptions import NoSuchElementException
 
 from cfme import test_requirements
 from cfme.base.credential import Credential
@@ -1109,13 +1108,11 @@ def test_delete_default_tenant(appliance):
     """
     view = navigate_to(appliance.collections.tenants, "All")
     roottenant = appliance.collections.tenants.get_root_tenant()
-    try:
-        msg = 'Default Tenant "{}" can not be deleted'.format(roottenant.name)
-        tenant = appliance.collections.tenants.instantiate(name=roottenant.name)
-        appliance.collections.tenants.delete(tenant)
-        assert view.flash.read()[0] == msg
-    except NoSuchElementException:
-        raise RBACOperationBlocked(match=msg)
+    msg = 'Default Tenant "{}" can not be deleted'.format(roottenant.name)
+    tenant = appliance.collections.tenants.instantiate(name=roottenant.name)
+    appliance.collections.tenants.delete(tenant)
+    assert view.flash.assert_message(msg)
+    assert roottenant.exists
 
 
 def test_copied_user_password_inheritance(appliance, group_collection, request):

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -1111,8 +1111,7 @@ def test_delete_default_tenant(appliance):
     try:
         msg = 'Default Tenant "{}" can not be deleted'.format(roottenant.name)
         tenant = appliance.collections.tenants.instantiate(name=roottenant.name)
-        tenant_obj = appliance.collections.tenants
-        tenant_obj.delete(tenant)
+        appliance.collections.tenants.delete(tenant)
     except NoSuchElementException:
         raise RBACOperationBlocked(match=msg)
 

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -1107,11 +1107,13 @@ def test_delete_default_tenant(appliance):
     4. Delete using 'configuration > Delete selected items'
     5. Check whether default tenant is deleted or not
     """
+    view = navigate_to(appliance.collections.tenants, "All")
     roottenant = appliance.collections.tenants.get_root_tenant()
     try:
         msg = 'Default Tenant "{}" can not be deleted'.format(roottenant.name)
         tenant = appliance.collections.tenants.instantiate(name=roottenant.name)
         appliance.collections.tenants.delete(tenant)
+        assert view.flash.read()[0] == msg
     except NoSuchElementException:
         raise RBACOperationBlocked(match=msg)
 

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -9,7 +9,7 @@ from cfme.base.credential import Credential
 from cfme.common.provider import base_types
 from cfme.configure.access_control import AddUserView
 from cfme.configure.tasks import TasksView
-from cfme.exceptions import RBACOperationBlocked
+from cfme.exceptions import RBACOperationBlocked, CFMEException
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import ONE
 from cfme.services.myservice import MyService
@@ -23,6 +23,7 @@ pytestmark = [
     pytest.mark.provider(classes=[VMwareProvider], selector=ONE),
     pytest.mark.usefixtures('setup_provider')
 ]
+
 
 @pytest.fixture(scope='module')
 def group_collection(appliance):
@@ -1097,14 +1098,25 @@ def test_tenant_quota_input_validate(appliance):
 
 
 def test_delete_default_tenant(appliance):
+    """
+    Steps:
+
+    1. Login as an 'Administrator' user
+    2. Navigate to configuration > access control > tenants
+    3. Select default tenant('My Company') from tenants table
+    4. Delete using 'configuration > Delete selected items'
+    5. Check whether default tenant is deleted or not
+    """
     roottenant = appliance.collections.tenants.get_root_tenant()
     view = navigate_to(appliance.collections.tenants, 'All')
-    for row in view.table.rows():
-        if row.name.text == roottenant.name:
-            row[0].check()
-    msg = 'Default Tenant "{}" can not be deleted'.format(roottenant.name)
-    with pytest.raises(Exception, match=msg):
+    try:
+        for row in view.table.rows():
+            if row.name.text == roottenant.name:
+                row[0].check()
+        msg = 'Default Tenant "{}" can not be deleted'.format(roottenant.name)
         view.toolbar.configuration.item_select('Delete selected items', handle_alert=True)
+    except CFMEException:
+        raise RBACOperationBlocked(match=msg)
 
 
 def test_copied_user_password_inheritance(appliance, group_collection, request):


### PR DESCRIPTION
Following error occured:
```
Failed: DID NOT RAISE <type 'exceptions.Exception'>
```

Shriver: expanding PRT coverage since delete method was modified.
{{ pytest: cfme/tests/configure/test_access_control.py -k 'test_delete_default_tenant or test_superadmin_tenant_crud' -vv }}