### PR TITLE
[WIPTEST] fixed removing vms and double dash in vm names

### DIFF
--- a/cfme/fixtures/service_fixtures.py
+++ b/cfme/fixtures/service_fixtures.py
@@ -47,7 +47,7 @@ def create_catalog_item(appliance, provider, provisioning, dialog, catalog,
         catalog_name = template
         provisioning_data = {
             'catalog': {'catalog_name': {'name': catalog_name, 'provider': provider.name},
-                        'vm_name': random_vm_name('serv-fixt'),
+                        'vm_name': random_vm_name('serv'),
                         'provision_type': provision_type},
             'environment': {'host_name': {'name': host},
                             'datastore_name': {'name': datastore}},
@@ -57,7 +57,7 @@ def create_catalog_item(appliance, provider, provisioning, dialog, catalog,
         catalog_name = provisioning['image']['name']
         provisioning_data = {
             'catalog': {'catalog_name': {'name': catalog_name, 'provider': provider.name},
-                        'vm_name': random_vm_name('serv-fixt')},
+                        'vm_name': random_vm_name('serv')},
             'properties': {'instance_type': partial_match(provisioning.get('instance_type', None)),
                            'guest_keypair': provisioning.get('guest_keypair', None)},
         }

--- a/cfme/tests/services/test_add_remove_vm_to_service.py
+++ b/cfme/tests/services/test_add_remove_vm_to_service.py
@@ -51,7 +51,7 @@ def myservice(appliance, provider, catalog_item, request):
     vm_name = catalog_item.prov_data["catalog"]["vm_name"]
     collection = provider.appliance.provider_based_collection(provider)
     request.addfinalizer(
-        lambda: collection.instantiate('{}_0001'.format(vm_name), provider).cleanup_on_provider())
+        lambda: collection.instantiate('{}0001'.format(vm_name), provider).cleanup_on_provider())
     service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
     service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)

--- a/cfme/tests/services/test_iso_service_catalogs.py
+++ b/cfme/tests/services/test_iso_service_catalogs.py
@@ -96,7 +96,7 @@ def test_rhev_iso_servicecatalog(appliance, provider, setup_provider, catalog_it
     vm_name = catalog_item.prov_data['catalog']["vm_name"]
     request.addfinalizer(
         lambda: appliance.collections.infra_vms.instantiate(
-            "{}_0001".format(vm_name), provider).cleanup_on_provider()
+            "{}0001".format(vm_name), provider).cleanup_on_provider()
     )
     service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
     service_catalogs.order()

--- a/cfme/tests/services/test_pxe_service_catalogs.py
+++ b/cfme/tests/services/test_pxe_service_catalogs.py
@@ -127,7 +127,7 @@ def test_pxe_servicecatalog(appliance, setup_provider, provider, catalog_item, r
     vm_name = catalog_item.prov_data['catalog']["vm_name"]
     request.addfinalizer(
         lambda: appliance.collections.infra_vms.instantiate(
-            "{}_0001".format(vm_name), provider).cleanup_on_provider()
+            "{}0001".format(vm_name), provider).cleanup_on_provider()
     )
     service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
     service_catalogs.order()


### PR DESCRIPTION
{{ pytest: -v cfme/tests/services/test_add_remove_vm_to_service.py   --long-running }}

There was an issue: VMs with the name "test-serv-*" were not being properly cleaned up.