### PR TITLE
[1LP][RFR] Fix test_datastores_summary test on 5.8

### DIFF
--- a/cfme/tests/intelligence/reports/test_canned_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_canned_corresponds.py
@@ -222,7 +222,7 @@ def test_datastores_summary(soft_assert, appliance, request):
         row['Free Space'] = extract_num(row['Free Space'])
         row['Total Space'] = extract_num(row['Total Space'])
         row['Number of Hosts'] = int(row['Number of Hosts'])
-        row['Number of VMs'] = int(row['Number of VMs'])
+        row['Number of VMs'] = int(row['Number of VMs'].replace(',', ''))
 
         report_rows_list.append(row)
 


### PR DESCRIPTION
The test case fails when the number of VMs is greater than 999. Take for example the number of VMs is 1248. The data received by reading rows is `1,248`. Converting `1,248` to integer fails, since `int()` fails to convert a string with ',' in between. This change removes the ',', which allows successful string conversion.

{{ pytest: cfme/tests/intelligence/reports/test_canned_corresponds.py -k test_datastores_summary }}