### PR TITLE
[1LP][RFR] Change sprout client default auth behavior

### DIFF
--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -6,9 +6,8 @@ from six import iteritems
 
 import cfme.utils.auth as authutil
 from cfme.test_framework.sprout.client import SproutClient
-from cfme.utils.conf import cfme_data, credentials, auth_data
+from cfme.utils.conf import credentials, auth_data
 from cfme.utils.log import logger
-from cfme.utils.version import get_stream
 from cfme.utils.wait import wait_for
 
 TimedCommand = namedtuple('TimedCommand', ['command', 'timeout'])
@@ -18,25 +17,24 @@ TimedCommand = namedtuple('TimedCommand', ['command', 'timeout'])
 
 
 @contextmanager
-def fqdn_appliance(appliance, preconfigured, count):
-    version = appliance.version.vstring
-    stream = get_stream(appliance.version)
-    sprout_client = SproutClient.from_config()
+def fqdn_appliance(appliance, preconfigured, count, config):
+    sprout_client = SproutClient.from_config(sprout_user_key=config.option.sprout_user_key or None)
     apps, request_id = sprout_client.provision_appliances(
-        provider_type='rhevm', count=count, version=version, preconfigured=preconfigured,
-        stream=stream)
+        provider_type='rhevm',
+        count=count,
+        version=appliance.version.vstring,
+        preconfigured=preconfigured,
+        stream=appliance.version.stream(),
+    )
     try:
         yield apps
     finally:
-        for app in apps:
-            app.ssh_client.close()
-        if request_id:
-            sprout_client.destroy_pool(request_id)
+        sprout_client.destroy_pool(request_id)
 
 
 @pytest.fixture()
-def unconfigured_appliance(appliance):
-    with fqdn_appliance(appliance, preconfigured=False, count=1) as apps:
+def unconfigured_appliance(appliance, pytestconfig):
+    with fqdn_appliance(appliance, preconfigured=False, count=1, config=pytestconfig) as apps:
         yield apps[0]
 
 

--- a/cfme/test_framework/sprout/client.py
+++ b/cfme/test_framework/sprout/client.py
@@ -85,9 +85,12 @@ class SproutClient(object):
     def from_config(cls, **kwargs):
         host = env.get("sprout", {}).get("hostname", "localhost")
         port = env.get("sprout", {}).get("port", 8000)
-        user = os.environ.get("SPROUT_USER", credentials.get("sprout", {}).get("username"))
-        password = os.environ.get(
-            "SPROUT_PASSWORD", credentials.get("sprout", {}).get("password"))
+        user_key = kwargs.pop('sprout_user_key') if 'sprout_user_key' in kwargs else None
+        # First choose env var creds, then look in kwargs for a sprout_user_key to lookup
+        user = (os.environ.get("SPROUT_USER") or
+                credentials.get(user_key, {}).get("username") if user_key else None)
+        password = (os.environ.get("SPROUT_PASSWORD") or
+                    credentials.get(user_key, {}).get("password") if user_key else None)
         if user and password:
             auth = user, password
         else:
@@ -96,9 +99,9 @@ class SproutClient(object):
 
     def provision_appliances(
             self, count=1, preconfigured=False, version=None, stream=None, provider=None,
-            provider_type=None, lease_time=120, ram=None, cpu=None, **kwargs):
+            provider_type=None, lease_time=60, ram=None, cpu=None, **kwargs):
         # provisioning may take more time than it is expected in some cases
-        wait_time = kwargs.get('wait_time', 300)
+        wait_time = kwargs.get('wait_time', 900)
         # If we specify version, stream is ignored because we will get that specific version
         if version:
             stream = get_stream(version)
@@ -110,9 +113,17 @@ class SproutClient(object):
             stream = get_stream(current_appliance.version)
             version = current_appliance.version.vstring
         request_id = self.call_method(
-            'request_appliances', preconfigured=preconfigured, version=version,
-            provider_type=provider_type, group=stream, provider=provider, lease_time=lease_time,
-            ram=ram, cpu=cpu, count=count, **kwargs
+            'request_appliances',
+            preconfigured=preconfigured,
+            version=version,
+            provider_type=provider_type,
+            group=stream,
+            provider=provider,
+            lease_time=lease_time,
+            ram=ram,
+            cpu=cpu,
+            count=count,
+            **kwargs
         )
         wait_for(
             lambda: self.call_method('request_check', str(request_id))['finished'],

--- a/sprout/appliances/views.py
+++ b/sprout/appliances/views.py
@@ -374,7 +374,7 @@ def my_appliances(request, show_user="my"):
     pools = pools.select_related('group', 'provider', 'owner')
     page = request.GET.get("page")
     try:
-        per_page = int(request.GET.get("per_page", 5))
+        per_page = int(request.GET.get("per_page", 25))
     except (ValueError, TypeError):
         per_page = 5
 


### PR DESCRIPTION
Remove default credentials lookup for sprout client, using only env vars or a passed creds key

This prevents groups with a credentials file that contains a 'sprout' key from defaulting to that user for anyone using the credentials file.
This was causing regular users to make sprout requests as a CI user instead of themselves.

Testing:

All changes tested locally, CI configuration changes ready, for passing `--sprout-user-key` to `miq-runtest`

