### PR TITLE
[1LP][RFR] fix for quadicon

### DIFF
--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -118,15 +118,6 @@ class InstanceEntity(JSBaseEntity):
                 policy = None
 
             data_dict['policy'] = policy
-        else:
-            data_dict['os'] = data_dict['quad']['topLeft']['tooltip']
-            data_dict['vendor'] = data_dict['quad']['bottomLeft']['tooltip']
-            try:
-                data_dict['no_snapshots'] = data_dict['total_snapshots']
-            # openstack instances require this
-            except KeyError:
-                data_dict['no_snapshots'] = data_dict['quad']['bottomRight']['tooltip']
-            data_dict['state'] = data_dict['quad']['topRight']['tooltip']
 
         return data_dict
 


### PR DESCRIPTION
{{ pytest: -v cfme/tests/cloud_infra_common/ --use-provider complete }}

This commit undo some changes in #7502 as 'quadicon' property is accessible again.
The removed lines didn't work if page is opened in List view and it is opened in this view by default for Images, so the test test_tag_cloud_objects was broken.