### PR TITLE
[1LP][RFR] Fixed exception error while deleting default tenant in 5.8.5.0

### DIFF
--- a/cfme/configure/access_control/__init__.py
+++ b/cfme/configure/access_control/__init__.py
@@ -1527,7 +1527,8 @@ class TenantCollection(BaseCollection):
 
         for tenant in tenants:
             try:
-                view.table.row(name=tenant.name).check()
+                row = view.table.row(name=tenant.name)
+                row[0].check()
             except Exception:
                 logger.exception('Failed to check element "%s"', tenant.name)
         else:

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -24,6 +24,7 @@ pytestmark = [
     pytest.mark.usefixtures('setup_provider')
 ]
 
+
 @pytest.fixture(scope='module')
 def group_collection(appliance):
     return appliance.collections.groups
@@ -1097,14 +1098,21 @@ def test_tenant_quota_input_validate(appliance):
 
 
 def test_delete_default_tenant(appliance):
+    """
+    Steps:
+    1. Login as an 'Administrator' user
+    2. Navigate to configuration > access control > tenants
+    3. Select default tenant('My Company') from tenants table
+    4. Delete using 'configuration > 'Delete selected items'
+    5. Check whether default tenant is deleted or not
+    """
     roottenant = appliance.collections.tenants.get_root_tenant()
+
     view = navigate_to(appliance.collections.tenants, 'All')
-    for row in view.table.rows():
-        if row.name.text == roottenant.name:
-            row[0].check()
     msg = 'Default Tenant "{}" can not be deleted'.format(roottenant.name)
-    with pytest.raises(Exception, match=msg):
-        view.toolbar.configuration.item_select('Delete selected items', handle_alert=True)
+    tenant = appliance.collections.tenants.instantiate(name=roottenant.name)
+    appliance.collections.tenants.delete(tenant)
+    assert view.flash.read()[0] == msg
 
 
 def test_copied_user_password_inheritance(appliance, group_collection, request):


### PR DESCRIPTION
Modified following files;
-  cfme/configure/access_control/__init__.py
    - Updated delete() method
-  cfme/tests/configure/test_access_control.py

{{ pytest: cfme/tests/configure/test_access_control.py::test_delete_default_tenant }}