### PR TITLE
[1LP][RFR] Fixing getting retirement state

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -22,6 +22,7 @@ from cfme.utils.pretty import Pretty
 from cfme.utils.rest import assert_response
 from cfme.utils.timeutil import parsetime
 from cfme.utils.update import Updateable
+from cfme.utils.version import LOWEST, VersionPicker
 from cfme.utils.virtual_machines import deploy_template
 from cfme.utils.wait import wait_for
 from . import PolicyProfileAssignable
@@ -183,7 +184,11 @@ class BaseVM(BaseEntity, Pretty, Updateable, PolicyProfileAssignable, Taggable, 
         view = navigate_to(self, "Details", use_resetter=False)
         if view.entities.summary('Lifecycle').get_text_of('Retirement Date').lower() != 'never':
             try:
-                status = view.entities.summary('Lifecycle').get_text_of('Retirement state').lower()
+                retirement_state = VersionPicker({
+                    LOWEST: 'Retirement state',
+                    '5.10': 'Retirement State'
+                })
+                status = view.entities.summary('Lifecycle').get_text_of(retirement_state).lower()
                 return status == 'retired'
             except NameError:
                 return False

--- a/cfme/tests/cloud_infra_common/test_retirement.py
+++ b/cfme/tests/cloud_infra_common/test_retirement.py
@@ -19,6 +19,7 @@ from cfme.markers.env_markers.provider import providers
 
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.meta(blockers=[BZ(1626971, forced_streams=['5.10'])]),
     pytest.mark.tier(1),
     pytest.mark.long_running,
     test_requirements.retirement,


### PR DESCRIPTION
Main point of this PR is the fact that field 'Retirement state' in VM details view has been changed to 'Retirement State' in 5.10. However, once I fixed that I also encountered a product [bug](https://bugzilla.redhat.com/show_bug.cgi?id=1626971), that is influencing all tests that invoke [set_retirement_date](https://github.com/ManageIQ/integration_tests/blob/401acc6d20e8860710799ae95bd57eb6eeb5ada9/cfme/common/vm.py#L764) method. Therefore providing a BZ wrapper.

Jenkins: https://rhv-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/CFME-DEV/job/cfme-5.9-rhv-4.2-integration-flow-dev/332/console