### PR TITLE
[RFR] dockerbot: use the correct user-key cli argument for sprout checkout

### DIFF
--- a/cfme/utils/dockerbot/pytestbase/setup.sh
+++ b/cfme/utils/dockerbot/pytestbase/setup.sh
@@ -255,7 +255,7 @@ then
     log "invoking complete collectonly with dummy instance before test"
     gate "collectonly.txt" "py.test --collectonly --dummy-appliance --dummy-appliance-version $SPROUT_GROUP --use-provider complete"
 
-    run_n_log "miq sprout checkout --populate-yaml --sprout-user-key sprout" &
+    run_n_log "miq sprout checkout --populate-yaml --user-key sprout" &
     sleep 5
     do_or_die "python /check_provisioned.py >> $ARTIFACTOR_DIR/setup.txt" 5 60 "Sprout failed to provision appliance"
 else


### PR DESCRIPTION
^ Make sure to prefix the Title with [WIP]/[WIPTEST]

Purpose or Intent
=================

__Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.

or

__Extending__ X because I need it to do Y so that I can update / add more test cases; PR #123 depends on it.

or

__Adding tests__ for feature X to cover cases Y and Z. They were implemented in product version 1.2.3.

or

__Updating tests__ for feature X because the behavior changed in product version 1.2.3.

--
These should serve mainly as a guideline. The more related information you provide, the better. :wink:
