### PR TITLE
[WIPTEST] restoring parsing quad removed by PR #7758

### DIFF
--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -118,6 +118,16 @@ class InstanceEntity(JSBaseEntity):
                 policy = None
 
             data_dict['policy'] = policy
+        elif data_dict.get('quad'):
+            # 5.10 doesn't have quadicon
+            data_dict['os'] = data_dict['quad']['topLeft']['tooltip']
+            data_dict['vendor'] = data_dict['quad']['bottomLeft']['tooltip']
+            try:
+                data_dict['no_snapshots'] = data_dict['total_snapshots']
+            # openstack instances require this
+            except KeyError:
+                data_dict['no_snapshots'] = data_dict['quad']['bottomRight']['tooltip']
+            data_dict['state'] = data_dict['quad']['topRight']['tooltip']
 
         return data_dict
 


### PR DESCRIPTION
quadicon was removed replaced wit quad in 5.10. So, this code should definitely be restored.

{{ pytest: -v cfme/tests/cloud_infra_common/ --use-provider complete }}