### PR TITLE
[WIPTEST][NOTEST] Modify ContainerProviderEditViewUpdated view

### DIFF
--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -578,4 +578,5 @@ class ContainerProviderEditViewUpdated(ProviderEditView, ContainerProviderSettin
 
     def before_fill(self, values):
         for widget in self.COND_WIDGETS:
-            getattr(self, widget).fill(values.get(widget))
+            if values.get(widget):
+                getattr(self, widget).fill(values.get(widget))


### PR DESCRIPTION
This PR fixes issues with `ContainerProviderEditViewUpdated`. The `update` method for a container provider fails when the values for widgets inside the `COND_WIDGETS` are not passed inside the `values` dictionary. This code change fixes those issues.