### PR TITLE
[WIP][NOTEST] Removing obsolete PXE wrappers

### DIFF
--- a/cfme/tests/infrastructure/test_pxe_provisioning.py
+++ b/cfme/tests/infrastructure/test_pxe_provisioning.py
@@ -10,7 +10,6 @@ from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.infrastructure.pxe import get_pxe_server_from_config, get_template_from_config
 from cfme.provisioning import do_vm_provisioning
 from cfme.utils import testgen
-from cfme.utils.blockers import GH
 
 pytestmark = [
     pytest.mark.meta(server_roles="+automate +notifier"),
@@ -94,7 +93,6 @@ def vm_name():
 
 
 @pytest.mark.rhv1
-@pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:7494')])
 def test_pxe_provision_from_template(appliance, provider, vm_name, smtp_test, setup_provider,
                                      request, setup_pxe_servers_vm_prov):
     """Tests provisioning via PXE

--- a/cfme/tests/services/test_pxe_service_catalogs.py
+++ b/cfme/tests/services/test_pxe_service_catalogs.py
@@ -8,13 +8,12 @@ from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.pxe import get_pxe_server_from_config, get_template_from_config
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils import testgen
-from cfme.utils.blockers import GH
 from cfme.utils.conf import cfme_data
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
 
 pytestmark = [
-    pytest.mark.meta(server_roles="+automate", blockers=[GH('ManageIQ/integration_tests:7479')]),
+    pytest.mark.meta(server_roles="+automate"),
     pytest.mark.usefixtures('uses_infra_providers'),
     test_requirements.service,
     pytest.mark.tier(2)
@@ -116,7 +115,6 @@ def catalog_item(appliance, provider, dialog, catalog, provisioning,
 
 
 @pytest.mark.rhv1
-@pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:7491')])
 @pytest.mark.usefixtures('setup_pxe_servers_vm_prov')
 def test_pxe_servicecatalog(appliance, setup_provider, provider, catalog_item, request):
     """Tests RHEV PXE service catalog


### PR DESCRIPTION
After adding PXE server and refreshing relationships (so that pxe images are updated), if you navigate to the individual pxe images, the page shows information about the pxe server, instead of the selected pxe image.

See https://bugzilla.redhat.com/show_bug.cgi?id=1626983 for more details.