### PR TITLE
[RFR]Added crud test for non global filters

### DIFF
--- a/cfme/ansible_tower/explorer.py
+++ b/cfme/ansible_tower/explorer.py
@@ -63,7 +63,7 @@ class TowerExplorerProvidersAllView(TowerExplorerView):
         return (
             self.in_tower_explorer and
             self.title.text == 'All Ansible Tower Providers' and
-            self.sidebar.tower_explorer_providers.is_opened
+            self.sidebar.providers.is_opened
         )
 
 
@@ -75,7 +75,7 @@ class TowerExplorerSystemsAllView(TowerExplorerView):
         return (
             self.in_tower_explorer and
             self.title.text == 'All Ansible Tower Configured Systems' and
-            self.sidebar.tower_explorer_systems.is_opened
+            self.sidebar.configured_systems.is_opened
         )
 
 
@@ -87,9 +87,8 @@ class TowerExplorerJobTemplatesAllView(TowerExplorerView):
         return (
             self.in_tower_explorer and
             self.title.text == VersionPicker({Version.lowest(): 'All Ansible Tower Job Templates',
-                                       '5.10': 'All Ansible Tower Templates'}).pick(
-                self.appliance.version) and
-            self.sidebar.tower_explorer_job_templates.is_opened
+                '5.10': 'All Ansible Tower Templates'}).pick(self.browser.product_version) and
+            self.sidebar.job_templates.is_opened
         )
 
 
@@ -158,4 +157,4 @@ class TowerExplorerJobTemplatesAll(CFMENavigateStep):
     def step(self, *args, **kwargs):
         self.view.sidebar.job_templates.tree.click_path(VersionPicker({Version.lowest():
             'All Ansible Tower Job Templates', '5.10': 'All Ansible Tower Templates'}).pick(
-            self.appliance.version))
+            self.browser.product_version))

--- a/cfme/ansible_tower/explorer.py
+++ b/cfme/ansible_tower/explorer.py
@@ -9,6 +9,7 @@ from cfme.base import Server
 from cfme.base.login import BaseLoggedInPage
 from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep
+from cfme.utils.version import Version, VersionPicker
 
 
 class TowerExplorerAccordion(View):
@@ -24,7 +25,7 @@ class TowerExplorerAccordion(View):
 
     @View.nested
     class job_templates(Accordion):  # noqa
-        ACCORDION_NAME = 'Job Templates'
+        ACCORDION_NAME = VersionPicker({Version.lowest(): 'Job Templates', '5.10': 'Templates'})
         tree = ManageIQTree()
 
 
@@ -85,7 +86,9 @@ class TowerExplorerJobTemplatesAllView(TowerExplorerView):
     def is_displayed(self):
         return (
             self.in_tower_explorer and
-            self.title.text == 'All Ansible Tower Job Templates' and
+            self.title.text == VersionPicker({Version.lowest(): 'All Ansible Tower Job Templates',
+                                       '5.10': 'All Ansible Tower Templates'}).pick(
+                self.appliance.version) and
             self.sidebar.tower_explorer_job_templates.is_opened
         )
 
@@ -153,4 +156,6 @@ class TowerExplorerJobTemplatesAll(CFMENavigateStep):
     prerequisite = NavigateToAttribute('appliance.server', 'AnsibleTowerExplorer')
 
     def step(self, *args, **kwargs):
-        self.view.sidebar.job_templates.tree.click_path('All Ansible Tower Job Templates')
+        self.view.sidebar.job_templates.tree.click_path(VersionPicker({Version.lowest():
+            'All Ansible Tower Job Templates', '5.10': 'All Ansible Tower Templates'}).pick(
+            self.appliance.version))

--- a/cfme/ansible_tower/explorer.py
+++ b/cfme/ansible_tower/explorer.py
@@ -129,6 +129,7 @@ class AnsibleTowerExplorer(CFMENavigateStep):
 
     def step(self, *args, **kwargs):
         self.prerequisite_view.navigation.select('Automation', 'Ansible Tower', 'Explorer')
+        self.view.sidebar.providers.tree.click_path('All Ansible Tower Providers')
 
 
 @navigator.register(AnsibleTowerProvidersCollection, 'All')
@@ -157,4 +158,4 @@ class TowerExplorerJobTemplatesAll(CFMENavigateStep):
     def step(self, *args, **kwargs):
         self.view.sidebar.job_templates.tree.click_path(VersionPicker({Version.lowest():
             'All Ansible Tower Job Templates', '5.10': 'All Ansible Tower Templates'}).pick(
-            self.browser.product_version))
+            self.view.browser.product_version))

--- a/cfme/ansible_tower/jobs.py
+++ b/cfme/ansible_tower/jobs.py
@@ -35,7 +35,7 @@ class TowerJobsView(BaseLoggedInPage):
 
 
 class TowerJobsDefaultView(TowerJobsView):
-    title = Text("#explorer_title_text")
+    title = Text('//div[@id="main-content"]//h1')
 
     @property
     def is_displayed(self):

--- a/cfme/ansible_tower/jobs.py
+++ b/cfme/ansible_tower/jobs.py
@@ -2,8 +2,8 @@ import attr
 
 from navmazing import NavigateToAttribute
 from widgetastic.widget import Text, View
-from widgetastic_patternfly import Dropdown
-from widgetastic_manageiq import Search, ItemsToolBarViewSelector
+from widgetastic_patternfly import Accordion, BootstrapNav, Dropdown
+from widgetastic_manageiq import ManageIQTree, Search, ItemsToolBarViewSelector
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.modeling.base import BaseEntity, BaseCollection
@@ -25,6 +25,13 @@ class TowerJobsView(BaseLoggedInPage):
     def in_jobs(self):
         return (self.logged_in_as_current_user and
                 self.navigation.currently_selected == ['Automation', 'Ansible Tower', 'Jobs'])
+
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
 
 
 class TowerJobsDefaultView(TowerJobsView):

--- a/cfme/cloud/availability_zone.py
+++ b/cfme/cloud/availability_zone.py
@@ -3,7 +3,7 @@
 import attr
 from navmazing import NavigateToSibling, NavigateToAttribute
 from widgetastic.widget import View
-from widgetastic_patternfly import Dropdown, Button, BreadCrumb
+from widgetastic_patternfly import BootstrapNav, Dropdown, Button, BreadCrumb
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.common import Taggable
@@ -81,6 +81,13 @@ class AvailabilityZoneAllView(AvailabilityZoneView):
     search = View.nested(Search)
     toolbar = View.nested(AvailabilityZoneToolBar)
     including_entities = View.include(AvailabilityZoneEntities, use_parent=True)
+
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
 
 
 class ProviderAvailabilityZoneAllView(AvailabilityZoneAllView):

--- a/cfme/cloud/flavor.py
+++ b/cfme/cloud/flavor.py
@@ -3,10 +3,11 @@
 import attr
 
 from navmazing import NavigateToAttribute, NavigateToSibling
-from widgetastic_patternfly import (BootstrapSelect, BootstrapSwitch, BreadCrumb, Button,
-                                    Dropdown, TextInput, View)
 
-from widgetastic.widget import Text, Select
+from widgetastic_patternfly import (BootstrapNav, BootstrapSelect, BootstrapSwitch, BreadCrumb,
+                                    Button, Dropdown, TextInput, View)
+from widgetastic.widget import Select
+
 
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import Taggable, TaggableCollection
@@ -69,6 +70,13 @@ class FlavorAllView(FlavorView):
     paginator = PaginationPane()
     search = View.nested(Search)
     including_entities = View.include(FlavorEntities, use_parent=True)
+
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
 
     @property
     def is_displayed(self):

--- a/cfme/cloud/host_aggregates.py
+++ b/cfme/cloud/host_aggregates.py
@@ -18,7 +18,7 @@ class HostAggregatesToolbar(View):
 
 
 class HostAggregatesView(BaseLoggedInPage):
-    title = Text("#explorer_title_text")
+    title = Text('//div[@id="main-content"]//h1')
     search = View.nested(Search)
     toolbar = View.nested(HostAggregatesToolbar)
 
@@ -36,14 +36,11 @@ class HostAggregatesView(BaseLoggedInPage):
 
 
 class HostAggregatesDefaultView(HostAggregatesView):
-    title = Text("#explorer_title_text")
+    title = Text('//div[@id="main-content"]//h1')
 
     @property
     def is_displayed(self):
-        return (
-            self.in_host_aggregates and
-            self.title.text == 'Host Aggregates'
-        )
+        return self.in_host_aggregates and self.title.is_displayed
 
 
 @attr.s

--- a/cfme/cloud/host_aggregates.py
+++ b/cfme/cloud/host_aggregates.py
@@ -2,8 +2,8 @@ import attr
 
 from navmazing import NavigateToAttribute
 from widgetastic.widget import Text, View
-from widgetastic_patternfly import Dropdown
-from widgetastic_manageiq import Search, ItemsToolBarViewSelector
+from widgetastic_patternfly import BootstrapNav, Dropdown
+from widgetastic_manageiq import Accordion, ManageIQTree, Search, ItemsToolBarViewSelector
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.modeling.base import BaseCollection, BaseEntity
@@ -26,6 +26,13 @@ class HostAggregatesView(BaseLoggedInPage):
     def in_host_aggregates(self):
         return (self.logged_in_as_current_user and
                 self.navigation.currently_selected == ['Compute', 'Clouds', 'Host Aggregates'])
+
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
 
 
 class HostAggregatesDefaultView(HostAggregatesView):

--- a/cfme/cloud/keypairs.py
+++ b/cfme/cloud/keypairs.py
@@ -3,7 +3,7 @@ import attr
 from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.exceptions import MoveTargetOutOfBoundsException
 from widgetastic.widget import View
-from widgetastic_patternfly import BreadCrumb, Button, Dropdown
+from widgetastic_patternfly import BootstrapNav, BreadCrumb, Button, Dropdown
 
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import Taggable
@@ -82,6 +82,13 @@ class KeyPairAllView(KeyPairView):
     toolbar = View.nested(KeyPairToolbar)
     search = View.nested(Search)
     including_entities = View.include(BaseEntitiesView, use_parent=True)
+
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
 
 
 class KeyPairDetailsView(KeyPairView):

--- a/cfme/cloud/stack.py
+++ b/cfme/cloud/stack.py
@@ -13,7 +13,7 @@ from cfme.utils.pretty import Pretty
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import (
     Accordion, ItemsToolBarViewSelector, PaginationPane, SummaryTable, Table, BaseEntitiesView,
-    Search)
+    Search, ManageIQTree)
 
 class StackToolbar(View):
     """The toolbar on the stacks page"""
@@ -123,6 +123,13 @@ class StackAllView(StackView):
     search = View.nested(Search)
     including_entities = View.include(StackEntities, use_parent=True)
     paginator = PaginationPane()
+
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
 
     @property
     def is_displayed(self):

--- a/cfme/cloud/tenant.py
+++ b/cfme/cloud/tenant.py
@@ -20,7 +20,8 @@ from cfme.utils.providers import get_crud_by_name
 from cfme.utils.wait import wait_for, TimedOutError
 from widgetastic_manageiq import (
     Accordion, BootstrapSelect, ItemsToolBarViewSelector, PaginationPane,
-    SummaryTable, Table, Text, BaseNonInteractiveEntitiesView, BaseEntitiesView, Search)
+    SummaryTable, Table, Text, BaseNonInteractiveEntitiesView, BaseEntitiesView, Search,
+    ManageIQTree)
 
 
 class TenantToolbar(View):
@@ -95,6 +96,13 @@ class TenantAllView(TenantView):
     including_entities = View.include(TenantEntities, use_parent=True)
     paginator = PaginationPane()
     search = View.nested(Search)
+
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
 
     @property
     def is_displayed(self):

--- a/cfme/common/host_views.py
+++ b/cfme/common/host_views.py
@@ -177,6 +177,13 @@ class HostsView(ComputeInfrastructureHostsView):
         navigation = BootstrapNav('.//div/ul')
         tree = ManageIQTree()
 
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
+
     default_filter_btn = Button(title="Set the current filter as my default")
     paginator = PaginationPane()
     search = View.nested(Search)

--- a/cfme/common/physical_server_views.py
+++ b/cfme/common/physical_server_views.py
@@ -2,12 +2,12 @@
 from lxml.html import document_fromstring
 from widgetastic.utils import Parameter
 from widgetastic.widget import ParametrizedView, Text, View
+from cfme.base.login import BaseLoggedInPage
 from widgetastic_manageiq import (
     BaseEntitiesView, JSBaseEntity, BootstrapTreeview, Button, ItemsToolBarViewSelector, Search,
     SummaryTable, TimelinesView, BaseNonInteractiveEntitiesView, ManageIQTree)
-from widgetastic_patternfly import BreadCrumb, Dropdown, Accordion
-
-from cfme.base.login import BaseLoggedInPage
+from widgetastic_patternfly import (
+    BootstrapNav, BreadCrumb, Dropdown, Accordion)
 
 
 class ComputePhysicalInfrastructureServersView(BaseLoggedInPage):
@@ -167,6 +167,13 @@ class PhysicalServersView(ComputePhysicalInfrastructureServersView):
     def is_displayed(self):
         return (self.in_compute_physical_infrastructure_servers and
                 self.title.text == "Physical Servers")
+
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
 
 
 class PhysicalServerNetworkDevicesView(ComputePhysicalInfrastructureServersView):

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -2,14 +2,15 @@
 from lxml.html import document_fromstring
 from widgetastic.utils import Version
 
-from widgetastic_patternfly import BreadCrumb, Dropdown, BootstrapSelect
 from widgetastic.exceptions import NoSuchElementException
 from widgetastic.widget import View, Text, ConditionalSwitchableView
+from widgetastic_patternfly import Accordion, BootstrapNav, BreadCrumb, Dropdown, BootstrapSelect
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.common.host_views import HostEntitiesView
 from cfme.utils.version import VersionPicker
 from widgetastic_manageiq import (
+    Accordion,
     ParametrizedSummaryTable,
     Button,
     TimelinesView,
@@ -22,7 +23,8 @@ from widgetastic_manageiq import (
     JSBaseEntity,
     Search,
     ParametrizedStatusBox,
-    WaitTab
+    WaitTab,
+    ManageIQTree
 )
 
 
@@ -310,6 +312,13 @@ class ProvidersView(BaseLoggedInPage):
     sidebar = View.nested(ProviderSideBar)
     search = View.nested(Search)
     including_entities = View.include(ProviderEntitiesView, use_parent=True)
+
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
 
 
 class ContainerProvidersView(ProvidersView):

--- a/cfme/containers/build.py
+++ b/cfme/containers/build.py
@@ -2,8 +2,8 @@ import attr
 
 from navmazing import NavigateToAttribute
 from widgetastic.widget import Text, View
-from widgetastic_patternfly import Dropdown
-from widgetastic_manageiq import Search, ItemsToolBarViewSelector
+from widgetastic_patternfly import BootstrapNav, Dropdown
+from widgetastic_manageiq import Accordion, ManageIQTree, Search, ItemsToolBarViewSelector
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.modeling.base import BaseEntity, BaseCollection
@@ -36,6 +36,13 @@ class BuildDefaultView(BuildView):
             self.in_build and
             self.title.text == 'Container Builds'
         )
+
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
 
 
 @attr.s

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -11,7 +11,7 @@ from widgetastic_manageiq import (
     WaitTab
 )
 from widgetastic_patternfly import (
-    BreadCrumb, SelectorDropdown, Dropdown, BootstrapSelect, Input, Button)
+    BootstrapNav, BreadCrumb, SelectorDropdown, Dropdown, BootstrapSelect, Input, Button)
 from widgetastic.widget import Text, View, TextInput
 
 from cfme.base.credential import TokenCredential
@@ -533,6 +533,13 @@ class ContainerObjectAllBaseView(ProvidersView):
     download = Dropdown('Download')
     toolbar = View.nested(ProviderToolBar)
     SUMMARY_TEXT = None
+
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
 
     @property
     def summary_text(self):

--- a/cfme/infrastructure/cluster.py
+++ b/cfme/infrastructure/cluster.py
@@ -4,7 +4,7 @@
 import attr
 from navmazing import NavigateToSibling, NavigateToAttribute
 from widgetastic.widget import View
-from widgetastic_patternfly import BreadCrumb, Button, Dropdown
+from widgetastic_patternfly import BootstrapNav, BreadCrumb, Button, Dropdown
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.common import CustomButtonEventsMixin, Taggable
@@ -90,6 +90,13 @@ class ClusterAllView(ClusterView):
     toolbar = View.nested(ClusterToolbar)
     search = View.nested(Search)
     including_entities = View.include(BaseEntitiesView, use_parent=True)
+
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
 
 
 class ProviderAllClustersView(ClusterAllView):

--- a/cfme/infrastructure/config_management.py
+++ b/cfme/infrastructure/config_management.py
@@ -168,7 +168,8 @@ class ConfigSystemAllView(ConfigManagementAllView):
 
     @property
     def is_displayed(self):
-        if self.context['object'].type == 'Ansible Tower':
+        if hasattr(self.context['object'], 'type') and self.context['object'].type == \
+                'Ansible Tower':
             title_text = 'All Ansible Tower Configured Systems'
         else:
             title_text = 'All Configured Systems'
@@ -681,14 +682,13 @@ class SysAll(CFMENavigateStep):
     prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
 
     def step(self):
-        nav_select = self.prerequisite_view.navigation.select
-        sidebar_path = self.view.sidebar.configured_systems.tree.click_path
-        if self.obj.type == 'Ansible Tower':
-            nav_select(['Automation', 'Ansible Tower', 'Explorer'])
-            sidebar_path('All Ansible Tower Configured Systems')
+        if hasattr(self.obj, 'type') and self.obj.type == 'Ansible Tower':
+            self.prerequisite_view.navigation.select('Automation', 'Ansible Tower', 'Explorer')
+            self.view.sidebar.configured_systems.tree.click_path(
+                'All Ansible Tower Configured Systems')
         else:
-            nav_select('Configuration', 'Management')
-            sidebar_path('All Configured Systems')
+            self.prerequisite_view.navigation.select('Configuration', 'Management')
+            self.view.sidebar.configured_systems.tree.click_path("All Configured Systems")
 
 
 @navigator.register(ConfigSystem, 'EditTags')

--- a/cfme/infrastructure/resource_pool.py
+++ b/cfme/infrastructure/resource_pool.py
@@ -3,7 +3,7 @@ import attr
 from navmazing import NavigateToAttribute
 
 from widgetastic.widget import View, Text
-from widgetastic_patternfly import BreadCrumb, Button, Dropdown
+from widgetastic_patternfly import BootstrapNav, BreadCrumb, Button, Dropdown
 
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import Taggable
@@ -77,6 +77,12 @@ class ResourcePoolAllView(ResourcePoolView):
     search = View.nested(Search)
     including_entities = View.include(BaseEntitiesView, use_parent=True)
 
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
 
 class ResourcePoolDetailsView(ResourcePoolView):
     """The details page of a resource pool"""

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -14,6 +14,7 @@ from widgetastic.widget import (
     Text, View, TextInput, Checkbox, NoSuchElementException, ParametrizedView)
 from widgetastic_patternfly import (
     Button,
+    BootstrapNav,
     BootstrapSelect,
     BootstrapSwitch,
     CheckableBootstrapTreeview,
@@ -210,6 +211,12 @@ class VmsOnlyAllView(InfraVmView):
     sidebar = View.nested(VmsTemplatesAccordion)
     search = View.nested(Search)
     including_entities = View.include(VMEntities, use_parent=True)
+
+    @View.nested
+    class filters(Accordion):  # noqa
+        ACCORDION_NAME = "All VMs"
+
+        tree = ManageIQTree()
 
     @property
     def is_displayed(self):

--- a/cfme/networks/views.py
+++ b/cfme/networks/views.py
@@ -1,5 +1,6 @@
 from widgetastic.widget import View, Text, Select
 from widgetastic_patternfly import (
+    BootstrapNav,
     Dropdown,
     Accordion,
     Button,
@@ -88,6 +89,13 @@ class NetworkProviderView(BaseLoggedInPage):
                 self.navigation.currently_selected == ['Networks', 'Providers'] and
                 self.entities.title.text == 'Network Managers')
 
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
+
 
 class NetworkProviderDetailsView(BaseLoggedInPage):
     """ Represents detail view of network provider """
@@ -171,6 +179,13 @@ class BalancerView(BaseLoggedInPage):
                 self.navigation.currently_selected == ['Networks', 'Load Balancers'] and
                 self.entities.title.text == 'Load Balancers')
 
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
+
 
 class BalancerDetailsView(BaseLoggedInPage):
     """ Represents detail view of network provider """
@@ -241,6 +256,13 @@ class CloudNetworkView(BaseLoggedInPage):
         return (super(BaseLoggedInPage, self).is_displayed and
                 self.navigation.currently_selected == ['Networks', 'Networks'] and
                 self.entities.title.text == 'Cloud Networks')
+
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
 
 
 class CloudNetworkDetailsView(BaseLoggedInPage):
@@ -339,6 +361,13 @@ class NetworkPortView(BaseLoggedInPage):
                 self.navigation.currently_selected == ['Networks', 'Network Ports'] and
                 self.entities.title.text == 'Network Ports')
 
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
+
 
 class NetworkPortDetailsView(BaseLoggedInPage):
     """ Represents detail view of network provider """
@@ -410,6 +439,13 @@ class NetworkRouterView(BaseLoggedInPage):
         return (super(BaseLoggedInPage, self).is_displayed and
                 self.navigation.currently_selected == ['Networks', 'Network Routers'] and
                 self.entities.title.text == 'Network Routers')
+
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
 
 
 class NetworkRouterDetailsView(BaseLoggedInPage):
@@ -514,6 +550,13 @@ class SecurityGroupView(BaseLoggedInPage):
         return (super(BaseLoggedInPage, self).is_displayed and
                 self.navigation.currently_selected == ['Networks', 'Security Groups'] and
                 self.entities.title.text == 'Security Groups')
+
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
 
 
 class ProviderSecurityGroupAllView(SecurityGroupView):
@@ -624,6 +667,13 @@ class SubnetView(BaseLoggedInPage):
         return (super(BaseLoggedInPage, self).is_displayed and
                 self.navigation.currently_selected == ['Networks', 'Subnets'] and
                 self.entities.title.text == 'Cloud Subnets')
+
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
 
 
 class SubnetDetailsView(BaseLoggedInPage):
@@ -819,6 +869,13 @@ class FloatingIpView(BaseLoggedInPage):
     def is_displayed(self):
         return (self.navigation.currently_selected == ['Networks', 'Floating IPs'] and
                 self.entities.title.text == 'Floating IPs')
+
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
 
 
 class FloatingIpDetailsView(BaseLoggedInPage):

--- a/cfme/storage/object_store_container.py
+++ b/cfme/storage/object_store_container.py
@@ -2,7 +2,7 @@
 import attr
 
 from navmazing import NavigateToSibling, NavigateToAttribute
-from widgetastic_patternfly import BreadCrumb, Button, Dropdown
+from widgetastic_patternfly import BootstrapNav, BreadCrumb, Button, Dropdown
 from widgetastic_manageiq import Search
 from widgetastic.widget import View, Text, NoSuchElementException
 
@@ -71,6 +71,13 @@ class ObjectStoreContainerAllView(ObjectStoreContainerView):
         return (
             self.in_container and
             self.title.text == 'Cloud Object Store Containers')
+
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
 
 
 class ObjectStoreContainerDetailsView(ObjectStoreContainerView):

--- a/cfme/storage/object_store_object.py
+++ b/cfme/storage/object_store_object.py
@@ -2,7 +2,7 @@
 import attr
 from navmazing import NavigateToSibling, NavigateToAttribute
 from widgetastic.widget import View, Text, NoSuchElementException
-from widgetastic_patternfly import BreadCrumb, Button, Dropdown
+from widgetastic_patternfly import BootstrapNav, BreadCrumb, Button, Dropdown
 
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import TagPageView, Taggable
@@ -70,6 +70,13 @@ class ObjectStoreObjectAllView(ObjectStoreObjectView):
         return (
             self.in_object and
             self.title.text == 'Cloud Object Store Objects')
+
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
 
 
 class ObjectStoreObjectDetailsView(ObjectStoreObjectView):

--- a/cfme/storage/volume.py
+++ b/cfme/storage/volume.py
@@ -3,7 +3,7 @@ import attr
 
 from navmazing import NavigateToSibling, NavigateToAttribute
 from widgetastic.widget import TextInput
-from widgetastic_patternfly import BreadCrumb, Button, Dropdown, Input
+from widgetastic_patternfly import BootstrapNav, BreadCrumb, Button, Dropdown, Input
 from widgetastic_manageiq import Search
 
 from widgetastic.widget import View, Text, NoSuchElementException
@@ -74,6 +74,13 @@ class VolumeAllView(VolumeView):
             self.in_volume and
             self.entities.title.text == 'Cloud Volumes'
         )
+
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
 
 
 class VolumeDetailsView(VolumeView):

--- a/cfme/storage/volume_backup.py
+++ b/cfme/storage/volume_backup.py
@@ -5,7 +5,7 @@ import attr
 from navmazing import NavigateToSibling, NavigateToAttribute
 
 from widgetastic.widget import View, Text, NoSuchElementException
-from widgetastic_patternfly import BreadCrumb, BootstrapSelect, Button, Dropdown
+from widgetastic_patternfly import BootstrapNav, BreadCrumb, BootstrapSelect, Button, Dropdown
 
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import TagPageView, Taggable
@@ -80,6 +80,13 @@ class VolumeBackupAllView(VolumeBackupView):
         return (
             self.in_volume_backup and
             self.title.text == 'Cloud Volume Backups')
+
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
 
 
 class VolumeBackupDetailsView(VolumeBackupView):

--- a/cfme/storage/volume_snapshot.py
+++ b/cfme/storage/volume_snapshot.py
@@ -2,7 +2,7 @@
 import attr
 from navmazing import NavigateToSibling, NavigateToAttribute
 from widgetastic.widget import View, Text, NoSuchElementException
-from widgetastic_patternfly import BreadCrumb, Button, Dropdown
+from widgetastic_patternfly import BootstrapNav, BreadCrumb, Button, Dropdown
 
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import TagPageView, Taggable
@@ -77,6 +77,13 @@ class VolumeSnapshotAllView(VolumeSnapshotView):
         return (
             self.in_volume_snapshots and
             self.entities.title.text == 'Cloud Volume Snapshots')
+
+    @View.nested
+    class my_filters(Accordion):  # noqa
+        ACCORDION_NAME = "My Filters"
+
+        navigation = BootstrapNav('.//div/ul')
+        tree = ManageIQTree()
 
 
 class VolumeSnapshotDetailsView(VolumeSnapshotView):

--- a/cfme/tests/webui/test_advanced_search.py
+++ b/cfme/tests/webui/test_advanced_search.py
@@ -8,118 +8,140 @@ from cfme.services.myservice import MyService
 from cfme.services.workloads import VmsInstances, TemplatesImages
 from cfme.infrastructure.config_management import ConfigManager, ConfigSystem
 from cfme.utils.appliance.implementations.ui import navigate_to
-# from cfme.utils.blockers import BZ
+
+from collections import namedtuple
+from cfme.utils.blockers import BZ
+
+Param = namedtuple("Param", ["collection", "destination", "entity", "filter", "my_filters"])
 
 params_values = [
-    (MyService, 'All', 'myservices', 'Service : Name', 'myservice'),  # failing
-    (VmsInstances, 'All', 'workloads_vms', 'VM and Instance : Name',
+    Param(MyService, 'All', 'myservices', 'Service : Name', 'myservice'),
+    Param(VmsInstances, 'All', 'workloads_vms', 'VM and Instance : Name',
      ('vms', "All VMs & Instances")),
-    (TemplatesImages, 'All', 'workloads_templates', 'VM Template and Image : Name',
-     ('templates', "All Templates & Images")),  # failing
+    Param(TemplatesImages, 'All', 'workloads_templates', 'VM Template and Image : Name',
+     ('templates', "All Templates & Images")),
 
-    ('cloud_providers', 'All', 'cloudprovider', 'Cloud Provider : Name'),
-    ('cloud_av_zones', 'All', 'availabilityzone', 'Availability Zone : Name'),
-    ('cloud_host_aggregates', 'All', 'hostaggregate', 'Host Aggregate : Name'),
-    ('cloud_tenants', 'All', 'tenant', 'Cloud Tenant : Name'),
-    ('cloud_flavors', 'All', 'flavor', 'Flavor : Name'),
-    ('cloud_instances', 'All', 'instances', 'Instance : Name',
+    Param('cloud_providers', 'All', 'cloudprovider', 'Cloud Provider : Name', None),
+    Param('cloud_av_zones', 'All', 'availabilityzone', 'Availability Zone : Name', None),
+    Param('cloud_host_aggregates', 'All', 'hostaggregate', 'Host Aggregate : Name', None),
+    Param('cloud_tenants', 'All', 'tenant', 'Cloud Tenant : Name', None),
+    Param('cloud_flavors', 'All', 'flavor', 'Flavor : Name', None),
+    Param('cloud_instances', 'All', 'instances', 'Instance : Name',
      ('sidebar.instances', "All Instances")),
-    ('cloud_images', 'All', 'images', 'Image : Name', ('sidebar.images', "All Images")),
-    ('cloud_stacks', 'All', 'orchestration_stacks', 'Orchestration Stack : Name'),
-    ('cloud_keypairs', 'All', 'key_pairs', 'Key Pair : Name'),
+    Param('cloud_images', 'All', 'images', 'Image : Name', ('sidebar.images', "All Images")),
+    Param('cloud_stacks', 'All', 'orchestration_stacks', 'Orchestration Stack : Name', None),
+    Param('cloud_keypairs', 'All', 'key_pairs', 'Key Pair : Name', None),
 
-    ('infra_providers', 'All', 'infraproviders', 'Infrastructure Provider : Name'),
-    ('clusters', 'All', 'clusters', 'Cluster / Deployment Role : Name'),
-    ('hosts', 'All', 'hosts', 'Host / Node : Name'),
-    ('infra_vms', 'VMsOnly', 'vms', 'Virtual Machine : Name', ('sidebar.vms', "All VMs")),
-    ('infra_templates', 'TemplatesOnly', 'templates', 'Template : Name',
+    Param('infra_providers', 'All', 'infraproviders', 'Infrastructure Provider : Name', None),
+    Param('clusters', 'All', 'clusters', 'Cluster / Deployment Role : Name', None),
+    Param('hosts', 'All', 'hosts', 'Host / Node : Name', None),
+    Param('infra_vms', 'VMsOnly', 'vms', 'Virtual Machine : Name', ('sidebar.vms', "All VMs")),
+    Param('infra_templates', 'TemplatesOnly', 'templates', 'Template : Name',
      ('sidebar.templates', "All Templates")),
-    ('resource_pools', 'All', 'resource_pools', 'Resource Pool : Name'),
-    ('datastores', 'All', 'datastores', 'Datastore : Name',
+    Param('resource_pools', 'All', 'resource_pools', 'Resource Pool : Name', None),
+    Param('datastores', 'All', 'datastores', 'Datastore : Name',
      ('sidebar.datastores', "All Datastores")),
 
-    ('physical_providers', 'All', 'physical_providers', 'Physical Infrastructure Provider : Name'),
-    ('physical_servers', 'All', 'physical_servers', 'Physical Server : Name'),
+    Param('physical_providers', 'All', 'physical_providers',
+          'Physical Infrastructure Provider : Name', None),
+    Param('physical_servers', 'All', 'physical_servers', 'Physical Server : Name', None),
 
-    ('containers_providers', 'All', 'container_providers', 'Containers Provider : Name'),
-    ('container_projects', 'All', 'container_projects', 'Container Project : Name'),
-    ('container_routes', 'All', 'container_routes', 'Container Route : Name'),
-    ('container_services', 'All', 'container_services', 'Container Service : Name'),
-    ('container_replicators', 'All', 'container_replicators', 'Container Replicator : Name'),
-    ('container_pods', 'All', 'container_pods', 'Container Pod : Name'),
-    ('containers', 'All', 'containers', 'Container : Name'),
-    ('container_nodes', 'All', 'container_nodes', 'Container Node : Name'),
-    ('container_volumes', 'All', 'container_volumes', 'Persistent Volume : Name'),
-    ('container_builds', 'All', 'container_builds', 'Container Build : Name'),
-    ('container_image_registries', 'All', 'image_registries', 'Container Image Registry : Name'),
-    ('container_images', 'All', 'container_images', 'Container Image : Name'),
-    ('container_templates', 'All', 'container_templates', 'Container Template : Name'),
+    Param('containers_providers', 'All', 'container_providers', 'Containers Provider : Name', None),
+    Param('container_projects', 'All', 'container_projects', 'Container Project : Name', None),
+    Param('container_routes', 'All', 'container_routes', 'Container Route : Name', None),
+    Param('container_services', 'All', 'container_services', 'Container Service : Name', None),
+    Param('container_replicators', 'All', 'container_replicators', 'Container Replicator : Name',
+          None),
+    Param('container_pods', 'All', 'container_pods', 'Container Pod : Name', None),
+    Param('containers', 'All', 'containers', 'Container : Name', None),
+    Param('container_nodes', 'All', 'container_nodes', 'Container Node : Name', None),
+    Param('container_volumes', 'All', 'container_volumes', 'Persistent Volume : Name', None),
+    Param('container_builds', 'All', 'container_builds', 'Container Build : Name', None),
+    Param('container_image_registries', 'All', 'image_registries',
+          'Container Image Registry : Name', None),
+    Param('container_images', 'All', 'container_images', 'Container Image : Name', None),
+    Param('container_templates', 'All', 'container_templates', 'Container Template : Name', None),
 
-    (ConfigManager, 'All', 'configuration_management', 'Configuration Manager : Name',
+    Param(ConfigManager, 'All', 'configuration_management', 'Configuration Manager : Name',
      ('sidebar.providers', "All Configuration Management Providers")),
-    (ConfigSystem, 'All', 'configuration_management_systems',
+    Param(ConfigSystem, 'All', 'configuration_management_systems',
      'Configured System (Red Hat Satellite) : Hostname',
      ('sidebar.configured_systems', "All Configured Systems")),
 
-    ('network_providers', 'All', 'network_managers', 'Network Manager : Name'),
-    ('cloud_networks', 'All', 'network_networks', 'Cloud Network : Name'),
-    ('network_subnets', 'All', 'network_subnets', 'Cloud Subnet : Name'),
-    ('network_routers', 'All', 'network_routers', 'Network Router : Name'),
-    ('network_security_groups', 'All', 'network_security_groups', 'Security Group : Name'),
-    ('network_floating_ips', 'All', 'network_floating_ips', 'Floating IP : Address'),
-    ('network_ports', 'All', 'network_ports', 'Network Port : Name'),
-    ('balancers', 'All', 'network_load_balancers', 'Load Balancer : Name'),
+    Param('network_providers', 'All', 'network_managers', 'Network Manager : Name', None),
+    Param('cloud_networks', 'All', 'network_networks', 'Cloud Network : Name', None),
+    Param('network_subnets', 'All', 'network_subnets', 'Cloud Subnet : Name', None),
+    Param('network_routers', 'All', 'network_routers', 'Network Router : Name', None),
+    Param('network_security_groups', 'All', 'network_security_groups', 'Security Group : Name',
+          None),
+    Param('network_floating_ips', 'All', 'network_floating_ips', 'Floating IP : Address', None),
+    Param('network_ports', 'All', 'network_ports', 'Network Port : Name', None),
+    Param('balancers', 'All', 'network_load_balancers', 'Load Balancer : Name', None),
 
-    ('volumes', 'All', 'block_store_volumes', 'Cloud Volume : Name'),
-    ('volume_snapshots', 'All', 'block_store_snapshots', 'Cloud Volume Snapshot : Name'),
-    ('volume_backups', 'All', 'block_store_backups', 'Cloud Volume Backup : Name'),
+    Param('volumes', 'All', 'block_store_volumes', 'Cloud Volume : Name', None),
+    Param('volume_snapshots', 'All', 'block_store_snapshots', 'Cloud Volume Snapshot : Name', None),
+    Param('volume_backups', 'All', 'block_store_backups', 'Cloud Volume Backup : Name', None),
 
-    ('object_store_containers', 'All', 'object_store_containers',
-     'Cloud Object Store Container : Name'),
-    ('object_store_objects', 'All', 'object_store_objects',
-     'Cloud Object Store Object : Name'),
+    Param('object_store_containers', 'All', 'object_store_containers',
+     'Cloud Object Store Container : Name', None),
+    Param('object_store_objects', 'All', 'object_store_objects',
+     'Cloud Object Store Object : Name', None),
 
-    ('ansible_tower_providers', 'All', 'ansible_tower_explorer_provider',
+    Param('ansible_tower_providers', 'All', 'ansible_tower_explorer_provider',
      'Automation Manager (Ansible Tower) : Name',
      ('sidebar.providers', 'All Ansible Tower Providers')),
-    ('ansible_tower_systems', 'All', 'ansible_tower_explorer_system',
+    Param('ansible_tower_systems', 'All', 'ansible_tower_explorer_system',
      'Configured System (Ansible Tower) : Hostname',
      ('sidebar.configured_systems', 'All Ansible Tower Configured Systems')),
-    ('ansible_tower_job_templates', 'All', 'ansible_tower_explorer_job_templates',
+    Param('ansible_tower_job_templates', 'All', 'ansible_tower_explorer_job_templates',
      'Template (Ansible Tower) : Name', ('sidebar.job_templates', 'All Ansible Tower Templates')),
-    ('ansible_tower_job_templates', 'All', 'ansible_tower_explorer_job_templates',
+    Param('ansible_tower_job_templates', 'All', 'ansible_tower_explorer_job_templates',
      'Job Template (Ansible Tower) : Name',
      ('sidebar.job_templates', 'All Ansible Tower Job Templates')),
-    ('ansible_tower_jobs', 'All', 'ansible_tower_jobs', 'Ansible Tower Job : Name')
+    Param('ansible_tower_jobs', 'All', 'ansible_tower_jobs', 'Ansible Tower Job : Name', None)
 ]
 
 pytestmark = [
     pytest.mark.parametrize(
-        'params', params_values,
-        ids=['{}-{}'.format(param[2], param[1].lower()) for param in params_values]
+        'param', params_values,
+        ids=['{}-{}'.format(param.entity, param.destination.lower()) for param in params_values]
     ),
-    pytest.mark.uncollectif(lambda params, appliance: (
-        (params[0] in (MyService, 'physical_providers', 'physical_servers', 'volume_backups',
+    pytest.mark.uncollectif(lambda param, appliance: (
+        (param.collection in (MyService, 'physical_providers', 'physical_servers', 'volume_backups',
                        'volume_snapshots') and appliance.version < '5.9') or
-        (params[0] in (ConfigManager, 'ansible_tower_providers') and appliance.version > '5.10') or
-        (params[3] == 'Template (Ansible Tower) : Name' and appliance.version < '5.10') or
-        (params[3] == 'Job Template (Ansible Tower) : Name' and appliance.version > '5.10')))
+        (param.collection in (ConfigManager, 'ansible_tower_providers') and
+         appliance.version > '5.10') or
+        (param.filter == 'Template (Ansible Tower) : Name' and appliance.version < '5.10') or
+        (param.filter == 'Job Template (Ansible Tower) : Name' and appliance.version > '5.10')))
 ]
 
 
-def _navigation(params, appliance):
-    if isinstance(params[0], six.string_types):
-        view = navigate_to(getattr(appliance.collections, params[0]), params[1])
+def _navigation(param, appliance):
+    if isinstance(param.collection, six.string_types):
+        view = navigate_to(getattr(appliance.collections, param.collection), param.destination)
     else:
-        view = navigate_to(params[0], params[1])
+        view = navigate_to(param.collection, param.destination)
     return view
 
 
-def _filter_crud():
-    pass
+def _filter_displayed(filters, filter):
+    if filters.is_displayed:
+        assert filter, "Filter wasn't created!"
+    else:
+        pytest.fail("Filter wasn't created or filters tree is not displayed!")
 
 
-def test_advanced_search_button_displayed(params, appliance):
+def _select_filter(filters, filter_name, param):
+    if param.my_filters:
+        if isinstance(param.my_filters, tuple):
+            filters.tree.click_path(param.my_filters[1], "My Filters", filter_name)
+        else:
+            filters.tree.click_path("My Filters", filter_name)
+    else:
+        filters.navigation.select(filter_name)
+
+
+def test_advanced_search_button_displayed(param, appliance):
     """
     Polarion:
         assignee: anikifor
@@ -127,15 +149,15 @@ def test_advanced_search_button_displayed(params, appliance):
         caseimportance: medium
         initialEstimate: 1/30h
     """
-    view = _navigation(params, appliance)
+    view = _navigation(param, appliance)
     if not view.search.is_advanced_search_possible:
         pytest.fail(
             "Advanced search button is not displayed for {}_{}".format(
-                params[2], params[1].lower())
+                param.entity, param.destination.lower())
         )
 
 
-def test_can_open_advanced_search(params, appliance):
+def test_can_open_advanced_search(param, appliance):
     """
     Polarion:
         assignee: anikifor
@@ -143,92 +165,72 @@ def test_can_open_advanced_search(params, appliance):
         caseimportance: medium
         initialEstimate: 1/30h
     """
-    view = _navigation(params, appliance)
+    view = _navigation(param, appliance)
     view.search.open_advanced_search()
     if not view.search.is_advanced_search_opened:
         pytest.fail("Advanced search cannot be opened for {}_{}".format(
-            params[2], params[1].lower())
+            param.destination, param.entity.lower())
         )
 
 
-# @pytest.mark.uncollectif(lambda params: ((params[0] == TemplatesImages and BZ(1626579)) or
-#                                          (params[0] == MyService and BZ(1627078))))
-def test_filter_crud(params, appliance):
+@pytest.mark.uncollectif(lambda param, appliance: (
+    (param.collection in (MyService, 'physical_providers', 'physical_servers', 'volume_backups',
+                          'volume_snapshots') and appliance.version < '5.9') or
+    (param.collection in (ConfigManager, 'ansible_tower_providers') and appliance.version > '5.10')
+    or (param.filter == 'Template (Ansible Tower) : Name' and appliance.version < '5.10') or
+    (param.filter == 'Job Template (Ansible Tower) : Name' and appliance.version > '5.10'))
+    or (param.collection == TemplatesImages and BZ(1626579)) or (param.collection == MyService
+                                                                 and BZ(1627078)))
+def test_filter_crud(param, appliance):
     filter_name = fauxfactory.gen_string('alphanumeric', 10)
     filter_value = fauxfactory.gen_string('alphanumeric', 10)
     filter_value_updated = fauxfactory.gen_string('alphanumeric', 10)
-    view = _navigation(params, appliance)
+    view = _navigation(param, appliance)
     # create
     view.search.save_filter(
-        "fill_field({}, =, {})".format(params[3], filter_value), filter_name)
+        "fill_field({}, =, {})".format(param.filter, filter_value), filter_name)
     view.search.close_advanced_search()
     view.flash.assert_no_error()
     # read
-    if len(params) > 4:
-        if isinstance(params[4], tuple):
-            filters = operator.attrgetter(params[4][0])(view)
-            if filters.is_displayed:
-                if not filters.tree.has_path(params[4][1], "My Filters", filter_name):
-                    pytest.fail("Filter wasn't created!")
-            else:
-                pytest.fail("Filter wasn't created or filters tree is not displayed!")
+    if param.my_filters:
+        if isinstance(param.my_filters, tuple):
+            filters = operator.attrgetter(param.my_filters[0])(view)
+            _filter_displayed(filters, filters.tree.has_path(param.my_filters[1], "My Filters",
+                                                             filter_name))
         else:
-            filters = operator.attrgetter(params[4])(view)
-            if filters.is_displayed:
-                if not filters.tree.has_path("My Filters", filter_name):
-                    pytest.fail("Filter wasn't created!")
-            else:
-                pytest.fail("Filter wasn't created or filters tree is not displayed!")
+            filters = operator.attrgetter(param.my_filters)(view)
+            _filter_displayed(filters, filters.tree.has_path("My Filters", filter_name))
     else:
-        if view.my_filters.is_displayed:
-            if not view.my_filters.navigation.has_item(filter_name):
-                pytest.fail("Filter wasn't created!")
-        else:
-            pytest.fail("Filter wasn't created or filters tree is not displayed!")
+        filters = view.my_filters
+        _filter_displayed(filters, filters.navigation.has_item(filter_name))
     # update
-    if len(params) > 4:
-        if isinstance(params[4], tuple):
-            filters.tree.click_path(params[4][1], "My Filters", filter_name)
-        else:
-            filters.tree.click_path("My Filters", filter_name)
-    else:
-        view.my_filters.navigation.select(filter_name)
+    _select_filter(filters, filter_name, param)
     view.search.open_advanced_search()
     view.search.advanced_search_form.search_exp_editor.select_first_expression()
-    view.search.advanced_search_form.search_exp_editor.fill_field(field=params[3],
+    view.search.advanced_search_form.search_exp_editor.fill_field(field=param.filter,
                                                                   key='=',
                                                                   value=filter_value_updated)
+    # save expression
     view.search.advanced_search_form.save_filter_button.click()
+    # save filter
     view.search.advanced_search_form.save_filter_button.click()
     view.search.close_advanced_search()
-    if len(params) > 4:
-        if isinstance(params[4], tuple):
-            filters.tree.click_path(params[4][1], "My Filters", filter_name)
-        else:
-            filters.tree.click_path("My Filters", filter_name)
-    else:
-        view.my_filters.navigation.select(filter_name)
+    _select_filter(filters, filter_name, param)
     # read after update
     view.search.open_advanced_search()
     exp_text = view.search.advanced_search_form.search_exp_editor.expression_text
-    if filter_value_updated not in exp_text:
-        pytest.fail("Filter wasn't changed!")
+    assert filter_value_updated in exp_text, "Filter wasn't changed!"
     # delete
     view.search.delete_filter()
     view.search.close_advanced_search()
-    if len(params) > 4:
+    if param.my_filters:
         if filters.is_displayed:
-            if isinstance(params[4], tuple):
-                if filters.tree.has_path(params[4][1], "My Filters", filter_name):
-                    pytest.fail("Filter wasn't deleted!")
+            if isinstance(param.my_filters, tuple):
+                assert not filters.tree.has_path(param.my_filters[1], "My Filters",
+                                                 filter_name), "Filter wasn't deleted!"
             else:
-                if filters.tree.has_path("My Filters", filter_name):
-                    pytest.fail("Filter wasn't deleted!")
+                assert not filters.tree.has_path("My Filters",
+                                                 filter_name), "Filter wasn't deleted!"
     else:
         if view.my_filters.is_displayed:
-            if view.my_filters.navigation.has_item(filter_name):
-                pytest.fail("Filter wasn't deleted!")
-
-
-def test_global_filter_crud(params, appliance):
-    pass
+            assert not view.my_filters.navigation.has_item(filter_name), "Filter wasn't deleted!"

--- a/cfme/tests/webui/test_advanced_search.py
+++ b/cfme/tests/webui/test_advanced_search.py
@@ -146,7 +146,7 @@ def test_advanced_search_button_displayed(param, appliance):
     Polarion:
         assignee: anikifor
         casecomponent: WebUI
-        caseimportance: medium
+        caseimportance: high
         initialEstimate: 1/30h
     """
     view = _navigation(param, appliance)
@@ -162,7 +162,7 @@ def test_can_open_advanced_search(param, appliance):
     Polarion:
         assignee: anikifor
         casecomponent: WebUI
-        caseimportance: medium
+        caseimportance: high
         initialEstimate: 1/30h
     """
     view = _navigation(param, appliance)
@@ -182,6 +182,13 @@ def test_can_open_advanced_search(param, appliance):
     or (param.collection == TemplatesImages and BZ(1626579)) or (param.collection == MyService
                                                                  and BZ(1627078)))
 def test_filter_crud(param, appliance):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: WebUI
+        caseimportance: high
+        initialEstimate: 1/10h
+    """
     filter_name = fauxfactory.gen_string('alphanumeric', 10)
     filter_value = fauxfactory.gen_string('alphanumeric', 10)
     filter_value_updated = fauxfactory.gen_string('alphanumeric', 10)

--- a/cfme/tests/webui/test_advanced_search.py
+++ b/cfme/tests/webui/test_advanced_search.py
@@ -98,6 +98,7 @@ params_values = [
     Param('ansible_tower_job_templates', 'All', 'ansible_tower_explorer_job_templates',
      'Job Template (Ansible Tower) : Name',
      ('sidebar.job_templates', 'All Ansible Tower Job Templates')),
+
     Param('ansible_tower_jobs', 'All', 'ansible_tower_jobs', 'Ansible Tower Job : Name', None)
 ]
 
@@ -171,6 +172,7 @@ def test_can_open_advanced_search(param, appliance):
         pytest.fail("Advanced search cannot be opened for {}_{}".format(
             param.destination, param.entity.lower())
         )
+    view.search.close_advanced_search()
 
 
 @pytest.mark.uncollectif(lambda param, appliance: (
@@ -178,7 +180,11 @@ def test_can_open_advanced_search(param, appliance):
                           'volume_snapshots') and appliance.version < '5.9') or
     (param.collection in (ConfigManager, 'ansible_tower_providers') and appliance.version > '5.10')
     or (param.filter == 'Template (Ansible Tower) : Name' and appliance.version < '5.10') or
-    (param.filter == 'Job Template (Ansible Tower) : Name' and appliance.version > '5.10'))
+    (param.filter == 'Job Template (Ansible Tower) : Name' and appliance.version > '5.10') or
+    (param.collection in ('cloud_host_aggregates', 'cloud_instances', 'cloud_images', 'infra_vms',
+                          'infra_templates', 'datastores', ConfigManager, 'ansible_tower_providers',
+                          'ansible_tower_systems', 'ansible_tower_job_templates', VmsInstances)
+    and appliance.version < '5.10'))
     or (param.collection == TemplatesImages and BZ(1626579)) or (param.collection == MyService
                                                                  and BZ(1627078)))
 def test_filter_crud(param, appliance):

--- a/cfme/tests/webui/test_advanced_search.py
+++ b/cfme/tests/webui/test_advanced_search.py
@@ -1,33 +1,42 @@
+import fauxfactory
+import operator
 import pytest
 import six
+
 
 from cfme.services.myservice import MyService
 from cfme.services.workloads import VmsInstances, TemplatesImages
 from cfme.infrastructure.config_management import ConfigManager, ConfigSystem
 from cfme.utils.appliance.implementations.ui import navigate_to
+# from cfme.utils.blockers import BZ
 
 params_values = [
-    (MyService, 'All', 'myservices', 'Service : Name'),
-    (VmsInstances, 'All', 'workloads_vms', 'VM and Instance : Name'),
-    (TemplatesImages, 'All', 'workloads_templates', 'VM Template and Image : Name'),
+    (MyService, 'All', 'myservices', 'Service : Name', 'myservice'),  # failing
+    (VmsInstances, 'All', 'workloads_vms', 'VM and Instance : Name',
+     ('vms', "All VMs & Instances")),
+    (TemplatesImages, 'All', 'workloads_templates', 'VM Template and Image : Name',
+     ('templates', "All Templates & Images")),  # failing
 
     ('cloud_providers', 'All', 'cloudprovider', 'Cloud Provider : Name'),
     ('cloud_av_zones', 'All', 'availabilityzone', 'Availability Zone : Name'),
     ('cloud_host_aggregates', 'All', 'hostaggregate', 'Host Aggregate : Name'),
     ('cloud_tenants', 'All', 'tenant', 'Cloud Tenant : Name'),
     ('cloud_flavors', 'All', 'flavor', 'Flavor : Name'),
-    ('cloud_instances', 'All', 'instances', 'Instance : Name'),
-    ('cloud_images', 'All', 'images', 'Image : Name'),
+    ('cloud_instances', 'All', 'instances', 'Instance : Name',
+     ('sidebar.instances', "All Instances")),
+    ('cloud_images', 'All', 'images', 'Image : Name', ('sidebar.images', "All Images")),
     ('cloud_stacks', 'All', 'orchestration_stacks', 'Orchestration Stack : Name'),
     ('cloud_keypairs', 'All', 'key_pairs', 'Key Pair : Name'),
 
     ('infra_providers', 'All', 'infraproviders', 'Infrastructure Provider : Name'),
     ('clusters', 'All', 'clusters', 'Cluster / Deployment Role : Name'),
     ('hosts', 'All', 'hosts', 'Host / Node : Name'),
-    ('infra_vms', 'VMsOnly', 'vms', 'Virtual Machine : Name'),
-    ('infra_templates', 'TemplatesOnly', 'templates', 'Template : Name'),
+    ('infra_vms', 'VMsOnly', 'vms', 'Virtual Machine : Name', ('sidebar.vms', "All VMs")),
+    ('infra_templates', 'TemplatesOnly', 'templates', 'Template : Name',
+     ('sidebar.templates', "All Templates")),
     ('resource_pools', 'All', 'resource_pools', 'Resource Pool : Name'),
-    ('datastores', 'All', 'datastores', 'Datastore : Name'),
+    ('datastores', 'All', 'datastores', 'Datastore : Name',
+     ('sidebar.datastores', "All Datastores")),
 
     ('physical_providers', 'All', 'physical_providers', 'Physical Infrastructure Provider : Name'),
     ('physical_servers', 'All', 'physical_servers', 'Physical Server : Name'),
@@ -46,9 +55,11 @@ params_values = [
     ('container_images', 'All', 'container_images', 'Container Image : Name'),
     ('container_templates', 'All', 'container_templates', 'Container Template : Name'),
 
-    (ConfigManager, 'All', 'configuration_management', 'Configuration Manager : Name'),
+    (ConfigManager, 'All', 'configuration_management', 'Configuration Manager : Name',
+     ('sidebar.providers', "All Configuration Management Providers")),
     (ConfigSystem, 'All', 'configuration_management_systems',
-     'Configured System (Red Hat Satellite) : Hostname'),
+     'Configured System (Red Hat Satellite) : Hostname',
+     ('sidebar.configured_systems', "All Configured Systems")),
 
     ('network_providers', 'All', 'network_managers', 'Network Manager : Name'),
     ('cloud_networks', 'All', 'network_networks', 'Cloud Network : Name'),
@@ -69,12 +80,17 @@ params_values = [
      'Cloud Object Store Object : Name'),
 
     ('ansible_tower_providers', 'All', 'ansible_tower_explorer_provider',
-     'Automation Manager (Ansible Tower) : Name'),
+     'Automation Manager (Ansible Tower) : Name',
+     ('sidebar.providers', 'All Ansible Tower Providers')),
     ('ansible_tower_systems', 'All', 'ansible_tower_explorer_system',
-     'Configured System (Ansible Tower) : Hostname'),
+     'Configured System (Ansible Tower) : Hostname',
+     ('sidebar.configured_systems', 'All Ansible Tower Configured Systems')),
     ('ansible_tower_job_templates', 'All', 'ansible_tower_explorer_job_templates',
-     'Job Template (Ansible Tower) : Name'),
-    ('ansible_tower_jobs', 'All', 'ansible_tower_jobs', 'Ansible Tower Job : Name'),
+     'Template (Ansible Tower) : Name', ('sidebar.job_templates', 'All Ansible Tower Templates')),
+    ('ansible_tower_job_templates', 'All', 'ansible_tower_explorer_job_templates',
+     'Job Template (Ansible Tower) : Name',
+     ('sidebar.job_templates', 'All Ansible Tower Job Templates')),
+    ('ansible_tower_jobs', 'All', 'ansible_tower_jobs', 'Ansible Tower Job : Name')
 ]
 
 pytestmark = [
@@ -82,8 +98,12 @@ pytestmark = [
         'params', params_values,
         ids=['{}-{}'.format(param[2], param[1].lower()) for param in params_values]
     ),
-    pytest.mark.uncollectif(lambda params, appliance: params[0] in (MyService, 'physical_providers',
-        'physical_servers', 'volume_backups', 'volume_snapshots') and appliance.version < 5.9)
+    pytest.mark.uncollectif(lambda params, appliance: (
+        (params[0] in (MyService, 'physical_providers', 'physical_servers', 'volume_backups',
+                       'volume_snapshots') and appliance.version < '5.9') or
+        (params[0] in (ConfigManager, 'ansible_tower_providers') and appliance.version > '5.10') or
+        (params[3] == 'Template (Ansible Tower) : Name' and appliance.version < '5.10') or
+        (params[3] == 'Job Template (Ansible Tower) : Name' and appliance.version > '5.10')))
 ]
 
 
@@ -93,6 +113,10 @@ def _navigation(params, appliance):
     else:
         view = navigate_to(params[0], params[1])
     return view
+
+
+def _filter_crud():
+    pass
 
 
 def test_advanced_search_button_displayed(params, appliance):
@@ -125,3 +149,86 @@ def test_can_open_advanced_search(params, appliance):
         pytest.fail("Advanced search cannot be opened for {}_{}".format(
             params[2], params[1].lower())
         )
+
+
+# @pytest.mark.uncollectif(lambda params: ((params[0] == TemplatesImages and BZ(1626579)) or
+#                                          (params[0] == MyService and BZ(1627078))))
+def test_filter_crud(params, appliance):
+    filter_name = fauxfactory.gen_string('alphanumeric', 10)
+    filter_value = fauxfactory.gen_string('alphanumeric', 10)
+    filter_value_updated = fauxfactory.gen_string('alphanumeric', 10)
+    view = _navigation(params, appliance)
+    # create
+    view.search.save_filter(
+        "fill_field({}, =, {})".format(params[3], filter_value), filter_name)
+    view.search.close_advanced_search()
+    view.flash.assert_no_error()
+    # read
+    if len(params) > 4:
+        if isinstance(params[4], tuple):
+            filters = operator.attrgetter(params[4][0])(view)
+            if filters.is_displayed:
+                if not filters.tree.has_path(params[4][1], "My Filters", filter_name):
+                    pytest.fail("Filter wasn't created!")
+            else:
+                pytest.fail("Filter wasn't created or filters tree is not displayed!")
+        else:
+            filters = operator.attrgetter(params[4])(view)
+            if filters.is_displayed:
+                if not filters.tree.has_path("My Filters", filter_name):
+                    pytest.fail("Filter wasn't created!")
+            else:
+                pytest.fail("Filter wasn't created or filters tree is not displayed!")
+    else:
+        if view.my_filters.is_displayed:
+            if not view.my_filters.navigation.has_item(filter_name):
+                pytest.fail("Filter wasn't created!")
+        else:
+            pytest.fail("Filter wasn't created or filters tree is not displayed!")
+    # update
+    if len(params) > 4:
+        if isinstance(params[4], tuple):
+            filters.tree.click_path(params[4][1], "My Filters", filter_name)
+        else:
+            filters.tree.click_path("My Filters", filter_name)
+    else:
+        view.my_filters.navigation.select(filter_name)
+    view.search.open_advanced_search()
+    view.search.advanced_search_form.search_exp_editor.select_first_expression()
+    view.search.advanced_search_form.search_exp_editor.fill_field(field=params[3],
+                                                                  key='=',
+                                                                  value=filter_value_updated)
+    view.search.advanced_search_form.save_filter_button.click()
+    view.search.advanced_search_form.save_filter_button.click()
+    view.search.close_advanced_search()
+    if len(params) > 4:
+        if isinstance(params[4], tuple):
+            filters.tree.click_path(params[4][1], "My Filters", filter_name)
+        else:
+            filters.tree.click_path("My Filters", filter_name)
+    else:
+        view.my_filters.navigation.select(filter_name)
+    # read after update
+    view.search.open_advanced_search()
+    exp_text = view.search.advanced_search_form.search_exp_editor.expression_text
+    if filter_value_updated not in exp_text:
+        pytest.fail("Filter wasn't changed!")
+    # delete
+    view.search.delete_filter()
+    view.search.close_advanced_search()
+    if len(params) > 4:
+        if filters.is_displayed:
+            if isinstance(params[4], tuple):
+                if filters.tree.has_path(params[4][1], "My Filters", filter_name):
+                    pytest.fail("Filter wasn't deleted!")
+            else:
+                if filters.tree.has_path("My Filters", filter_name):
+                    pytest.fail("Filter wasn't deleted!")
+    else:
+        if view.my_filters.is_displayed:
+            if view.my_filters.navigation.has_item(filter_name):
+                pytest.fail("Filter wasn't deleted!")
+
+
+def test_global_filter_crud(params, appliance):
+    pass


### PR DESCRIPTION
Extending test_advanced_search parametrized tests.
Added filter crud test for non global filters:
1) Creates filter
2) Checks whether filter was created
3) Changes first expression element value
4) Checks whether first expression element value was changed
5) Deletes filter
6) Checks whether My Filters Accordion disappeared or filter was deleted

There are still many things which are not working correctly:
1) I need uncollectif specifically for this test, but I also need global uncollectif working - probably add to global uncollectif to uncollect only when this test is executed.
2) There is change in naming for Job Templates in 5.10. VersionPick didn't work with changing these parameters so I had to add parameters for both 5.9 and 5.10 and then uncollect them depending on appliance version. I don't think this approach is correct as it creates two parametrized tests for one parameter...
3) There are three types of possible tree views with accordion:
- One mostly used - My filters as accordion and my_filters class used for navigation
- Accordion name is different same as class used for navigation(tree is used for navigation instead) - that's reason why I had to add fifth param tuple, which has class name and also category path name.
- Last is only for My Services where it's implemented differently - Services as Accordion and tree is used for navigation. This is why I had to check whether fifth param is list or string.)
I think this could be solved better but I had no idea how to do it.
Also I thank you in advance for comments and enhancements.
