### PR TITLE
[1LP][RFR] Change sprout client default auth behavior

### DIFF
--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -6,9 +6,8 @@ from six import iteritems
 
 import cfme.utils.auth as authutil
 from cfme.test_framework.sprout.client import SproutClient
-from cfme.utils.conf import cfme_data, credentials, auth_data
+from cfme.utils.conf import credentials, auth_data
 from cfme.utils.log import logger
-from cfme.utils.version import get_stream
 from cfme.utils.wait import wait_for
 
 TimedCommand = namedtuple('TimedCommand', ['command', 'timeout'])
@@ -18,43 +17,42 @@ TimedCommand = namedtuple('TimedCommand', ['command', 'timeout'])
 
 
 @contextmanager
-def fqdn_appliance(appliance, preconfigured, count):
-    version = appliance.version.vstring
-    stream = get_stream(appliance.version)
+def fqdn_appliance(appliance, preconfigured, count, config):
+    sprout_client = SproutClient.from_config(sprout_user_key=config.option.sprout_user_key or None)
+    apps, request_id = sprout_client.provision_appliances(
+        provider_type='rhevm',
+        count=count,
+        version=appliance.version.vstring,
+        preconfigured=preconfigured,
+        stream=appliance.version.stream(),
+    )
     try:
-        sprout_client = SproutClient.from_config()
-        apps, request_id = sprout_client.provision_appliances(
-            provider_type='rhevm', count=count, version=version, preconfigured=preconfigured,
-            stream=stream)
         yield apps
     finally:
-        for app in apps:
-            app.ssh_client.close()
-        if request_id:
-            sprout_client.destroy_pool(request_id)
+        sprout_client.destroy_pool(request_id)
 
 
 @pytest.fixture()
-def unconfigured_appliance(appliance):
-    with fqdn_appliance(appliance, preconfigured=False, count=1) as apps:
+def unconfigured_appliance(appliance, pytestconfig):
+    with fqdn_appliance(appliance, preconfigured=False, count=1, config=pytestconfig) as apps:
         yield apps[0]
 
 
 @pytest.fixture()
-def unconfigured_appliance_secondary(appliance):
-    with fqdn_appliance(appliance, preconfigured=False, count=1) as apps:
+def unconfigured_appliance_secondary(appliance, pytestconfig):
+    with fqdn_appliance(appliance, preconfigured=False, count=1, config=pytestconfig) as apps:
         yield apps[0]
 
 
 @pytest.fixture()
-def unconfigured_appliances(appliance):
-    with fqdn_appliance(appliance, preconfigured=False, count=3) as apps:
+def unconfigured_appliances(appliance, pytestconfig):
+    with fqdn_appliance(appliance, preconfigured=False, count=3, config=pytestconfig) as apps:
         yield apps
 
 
 @pytest.fixture()
-def configured_appliance(appliance):
-    with fqdn_appliance(appliance, preconfigured=True, count=1) as apps:
+def configured_appliance(appliance, pytestconfig):
+    with fqdn_appliance(appliance, preconfigured=True, count=1, config=pytestconfig) as apps:
         yield apps[0]
 
 

--- a/cfme/test_framework/sprout/client.py
+++ b/cfme/test_framework/sprout/client.py
@@ -88,9 +88,9 @@ class SproutClient(object):
         user_key = kwargs.pop('sprout_user_key') if 'sprout_user_key' in kwargs else None
         # First choose env var creds, then look in kwargs for a sprout_user_key to lookup
         user = (os.environ.get("SPROUT_USER") or
-                credentials.get(user_key, {}).get("username") if user_key else None)
+                (credentials.get(user_key, {}).get("username") if user_key else None))
         password = (os.environ.get("SPROUT_PASSWORD") or
-                    credentials.get(user_key, {}).get("password") if user_key else None)
+                    (credentials.get(user_key, {}).get("password") if user_key else None))
         if user and password:
             auth = user, password
         else:

--- a/cfme/test_framework/sprout/client.py
+++ b/cfme/test_framework/sprout/client.py
@@ -85,9 +85,12 @@ class SproutClient(object):
     def from_config(cls, **kwargs):
         host = env.get("sprout", {}).get("hostname", "localhost")
         port = env.get("sprout", {}).get("port", 8000)
-        user = os.environ.get("SPROUT_USER", credentials.get("sprout", {}).get("username"))
-        password = os.environ.get(
-            "SPROUT_PASSWORD", credentials.get("sprout", {}).get("password"))
+        user_key = kwargs.pop('sprout_user_key') if 'sprout_user_key' in kwargs else None
+        # First choose env var creds, then look in kwargs for a sprout_user_key to lookup
+        user = (os.environ.get("SPROUT_USER") or
+                credentials.get(user_key, {}).get("username") if user_key else None)
+        password = (os.environ.get("SPROUT_PASSWORD") or
+                    credentials.get(user_key, {}).get("password") if user_key else None)
         if user and password:
             auth = user, password
         else:
@@ -96,9 +99,9 @@ class SproutClient(object):
 
     def provision_appliances(
             self, count=1, preconfigured=False, version=None, stream=None, provider=None,
-            provider_type=None, lease_time=120, ram=None, cpu=None, **kwargs):
+            provider_type=None, lease_time=60, ram=None, cpu=None, **kwargs):
         # provisioning may take more time than it is expected in some cases
-        wait_time = kwargs.get('wait_time', 300)
+        wait_time = kwargs.get('wait_time', 900)
         # If we specify version, stream is ignored because we will get that specific version
         if version:
             stream = get_stream(version)
@@ -110,9 +113,17 @@ class SproutClient(object):
             stream = get_stream(current_appliance.version)
             version = current_appliance.version.vstring
         request_id = self.call_method(
-            'request_appliances', preconfigured=preconfigured, version=version,
-            provider_type=provider_type, group=stream, provider=provider, lease_time=lease_time,
-            ram=ram, cpu=cpu, count=count, **kwargs
+            'request_appliances',
+            preconfigured=preconfigured,
+            version=version,
+            provider_type=provider_type,
+            group=stream,
+            provider=provider,
+            lease_time=lease_time,
+            ram=ram,
+            cpu=cpu,
+            count=count,
+            **kwargs
         )
         wait_for(
             lambda: self.call_method('request_check', str(request_id))['finished'],

--- a/cfme/test_framework/sprout/plugin.py
+++ b/cfme/test_framework/sprout/plugin.py
@@ -1,14 +1,17 @@
 import re
+from threading import Timer
+
 import pytest
 import random
 import attr
+from cached_property import cached_property
 from six.moves.urllib.parse import urlparse
-from threading import Timer
+
 from cfme.utils import at_exit, conf
 # todo: use own logger after logfix merge
 from cfme.utils.log import logger as log
 from cfme.utils.path import project_path
-from .client import SproutClient, SproutException
+from .client import SproutClient, SproutException, AuthException
 from cfme.utils.wait import wait_for
 
 
@@ -50,6 +53,9 @@ def pytest_addoption(parser):
     group._addoption('--sprout-ignore-preconfigured', dest='sprout_template_preconfigured',
                      default=True, action="store_false",
                      help="Allows to use not preconfigured templates")
+    group._addoption('--sprout-user-key', default=None,
+                     help='Key for sprout user in credentials yaml, '
+                          'alternatively set SPROUT_USER and SPROUT_PASSWORD env vars')
 
 
 def dump_pool_info(log, pool_data):
@@ -74,8 +80,12 @@ def mangle_in_sprout_appliances(config):
     """
     provision_request = SproutProvisioningRequest.from_config(config)
 
-    mgr = config._sprout_mgr = SproutManager()
-    requested_appliances = mgr.request_appliances(provision_request)
+    mgr = config._sprout_mgr = SproutManager(config.option.sprout_user_key)
+    try:
+        requested_appliances = mgr.request_appliances(provision_request)
+    except AuthException:
+        log.exception('Sprout client not authenticated, please provide env vars or sprout_user_key')
+        raise
     config.option.appliances[:] = []
     appliances = config.option.appliances
     log.info("Appliances were provided:")
@@ -119,19 +129,19 @@ class SproutProvisioningRequest(object):
     """data holder for provisioning metadata"""
 
     group = attr.ib()
-    count = attr.ib()
-    version = attr.ib()
-    provider = attr.ib()
-    provider_type = attr.ib()
-    template_type = attr.ib()
-    preconfigured = attr.ib()
-    date = attr.ib()
-    lease_time = attr.ib()
-    desc = attr.ib()
-    provision_timeout = attr.ib()
+    count = attr.ib(default=1)
+    version = attr.ib(default=None)
+    provider = attr.ib(default=None)
+    provider_type = attr.ib(default=None)
+    template_type = attr.ib(default=None)
+    preconfigured = attr.ib(default=True)
+    date = attr.ib(default=None)
+    lease_time = attr.ib(default=60)
+    desc = attr.ib(default=None)
+    provision_timeout = attr.ib(default=60)
 
-    cpu = attr.ib()
-    ram = attr.ib()
+    cpu = attr.ib(default=0)
+    ram = attr.ib(default=0)
 
     @classmethod
     def from_config(cls, config):
@@ -154,10 +164,15 @@ class SproutProvisioningRequest(object):
 
 @attr.s
 class SproutManager(object):
-    client = attr.ib(default=attr.Factory(SproutClient.from_config))
+    sprout_user_key = attr.ib(default=None)
     pool = attr.ib(init=False, default=None)
     lease_time = attr.ib(init=False, default=None, repr=False)
     timer = attr.ib(init=False, default=None, repr=False)
+
+    @cached_property
+    def client(self):
+        """Provide additional kwargs to from_config for auth passing"""
+        return SproutClient.from_config(sprout_user_key=self.sprout_user_key)
 
     def request_appliances(self, provision_request):
         self.request_pool(provision_request)
@@ -202,13 +217,13 @@ class SproutManager(object):
             'lease_time': provision_request.lease_time,
             'cpu': provision_request.cpu,
             'ram': provision_request.ram,
+            'stream': provision_request.group,
         }
         if provision_request.template_type:
             kargs['template_type'] = provision_request.template_type
 
-        self.pool = self.client.request_appliances(
-            provision_request.group, **kargs
-        )
+        apps, pool_id = self.client.provision_appliances(**kargs)
+        self.pool = pool_id
         log.info("Pool %s. Waiting for fulfillment ...", self.pool)
 
         if provision_request.desc is not None:


### PR DESCRIPTION
Remove default credentials lookup for sprout client, using only env vars or a passed creds key

This prevents groups with a credentials file that contains a 'sprout' key from defaulting to that user for anyone using the credentials file.
This was causing regular users to make sprout requests as a CI user instead of themselves.

Bad tuple unpacking was setting pool attribute to tuple of IPAppliance.from_json call and the pool ID.

This is PR 7756 and 7773, backported via cherry-pick and squashed, for the 58-breakpoint-patched branch, in order for consistent CI config.