### PR TITLE
[1LP][RFR] Allow plugins to return value

### DIFF
--- a/cfme/fixtures/artifactor_plugin.py
+++ b/cfme/fixtures/artifactor_plugin.py
@@ -150,12 +150,12 @@ def fire_art_hook(config, hook, **hook_args):
     if client is None:
         assert UNDER_TEST, 'missing artifactor is only valid for inprocess tests'
     else:
-        client.fire_hook(hook, **hook_args)
+        return client.fire_hook(hook, **hook_args)
 
 
 def fire_art_test_hook(node, hook, **hook_args):
     name, location = get_test_idents(node)
-    fire_art_hook(
+    return fire_art_hook(
         node.config, hook,
         test_name=name,
         test_location=location,


### PR DESCRIPTION
Artifactor gets triggered by `fire_art_hook` to handle events after they happen, Artifactor then tells plugin that certain event has occurred and the plugin then reacts accordingly, while `fire_art_hook` does not expect any response. So in other words we tell plugin to do something and then we expect nothing to be returned. But in some cases plugin does return some value, which we expect immediately. With this commit `fire_art_hook` and `fire_art_test_hook` now return value that they get from plugins.

For example we can look at Merkyl plugin that checks log content, which was logged after test started. Merkyl has `merkyl_inspector` fixture that has `get_log` method. This method uses `fire_art_test_hook` to tell plugin to get log content, plugin does return that content but then it gets lost in `fire_art_hook`.
