### PR TITLE
[1LP][RFR] Use specific keyserver.

### DIFF
--- a/cfme/utils/dockerbot/pytestbase/get_keys.py
+++ b/cfme/utils/dockerbot/pytestbase/get_keys.py
@@ -6,8 +6,8 @@ import sys
 
 def main():
     key_list = [key[-9:].replace(' ', '') for key in conf['gpg']['allowed_keys']]
-
-    proc = subprocess.Popen(['gpg', '--recv-keys'] + key_list)
+    proc = subprocess.Popen(
+        ['gpg', '--recv-keys', '--keyserver', 'keys.fedoraproject.org'] + key_list)
     proc.wait()
     sys.exit(proc.returncode)
 


### PR DESCRIPTION
The fedoraproject keyserver seems to always answer even repetetive
queries contrary to whatever is in the servers pool which is used by default.