### PR TITLE
[RFR] Run plugin teardown after yield fixture teardown

### DIFF
--- a/cfme/fixtures/artifactor_plugin.py
+++ b/cfme/fixtures/artifactor_plugin.py
@@ -227,6 +227,7 @@ def pytest_runtest_protocol(item):
     yield
 
 
+@pytest.mark.trylast
 def pytest_runtest_teardown(item, nextitem):
     name, location = get_test_idents(item)
     app = find_appliance(item)


### PR DESCRIPTION
I have a test that uses Merkyl plugin that checks `evm.log` content. After test method ends `pytest_runtest_teardown` executes and calls `'finish_test'`, which shuts down Merkyl plugin. Problem is that in this test I use a fixture that interacts with Merkyl fixture after the `yield`. And code block after `yield` is executed with Merkyl plugin already shut down, which results in error (because we're trying to use Merkyl)

Here is a simple example of fixture before this commit:
```python
@pytest.fixture
def simple_fixture(merkyl_inspector)
	merkly_inspector.add_log(file.name)
	yield
        # <--- at this point the 'finish_test' event is triggered hence Merkyl shuts down
        merkly_inspector.search_log('test') # <---  use merkyl
       
```
And here is an example of order after the commit:
```python
@pytest.fixture
def simple_fixture(merkyl_inspector)
        merkly_inspector.add_log(file.name)
        yield
        merkly_inspector.search_log('test') # <--- use merkyl
        # <--- at this point the 'finish_test' event is triggered hence Merkyl shuts down
```