### PR TITLE
[WIPTEST] Adding BZ1627758 and fixing test_retirement_now

### DIFF
--- a/cfme/tests/automate/test_common_methods.py
+++ b/cfme/tests/automate/test_common_methods.py
@@ -9,6 +9,7 @@ from cfme import test_requirements
 from cfme.infrastructure.virtual_machines import InfraVmSummaryView
 from cfme.infrastructure.provider import InfraProvider
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for
@@ -50,6 +51,7 @@ def generate_retirement_date(delta=None):
 
 @pytest.mark.rhv3
 @pytest.mark.tier(3)
+@pytest.mark.meta(blockers=[BZ(1627758, forced_streams=['5.10'])])
 def test_vm_retire_extend(appliance, request, testing_vm, soft_assert):
     """ Tests extending a retirement using an AE method.
 

--- a/cfme/tests/cloud_infra_common/test_retirement.py
+++ b/cfme/tests/cloud_infra_common/test_retirement.py
@@ -8,7 +8,8 @@ from cfme import test_requirements
 from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.infrastructure.provider import InfraProvider
-from cfme.utils.appliance.implementations.ui import navigator
+from cfme.utils.appliance.implementations.ui import navigator, navigate_to
+from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
 from cfme.utils.providers import ProviderFilter
@@ -77,8 +78,7 @@ def verify_retirement_state(retire_vm):
     """
     # wait for the info block showing a date as retired date
     # Use lambda for is_retired since its a property
-    view_cls = navigator.get_class(retire_vm, 'Details').VIEW
-    view = retire_vm.appliance.browser.create_view(view_cls)
+    view = navigate_to(retire_vm, 'Details')
     assert wait_for(
         lambda: retire_vm.is_retired, delay=5, num_sec=15 * 60,
         fail_func=view.toolbar.reload.click,
@@ -188,6 +188,7 @@ def test_retirement_now_ec2_instance_backed(retire_ec2_s3_vm, tagged, appliance)
 
 
 @pytest.mark.rhv3
+@pytest.mark.meta(blockers=[BZ(1627758, forced_streams=['5.10'])])
 @pytest.mark.parametrize('warn', warnings, ids=[warning.id for warning in warnings])
 def test_set_retirement_date(retire_vm, warn):
     """Tests setting retirement date and verifies configured date is reflected in UI
@@ -202,6 +203,7 @@ def test_set_retirement_date(retire_vm, warn):
 
 
 @pytest.mark.tier(2)
+@pytest.mark.meta(blockers=[BZ(1627758, forced_streams=['5.10'])])
 @pytest.mark.parametrize('warn', warnings, ids=[warning.id for warning in warnings])
 @pytest.mark.ignore_stream('5.8')
 @pytest.mark.uncollectif(lambda provider: provider.one_of(InfraProvider))  # TODO remove when common
@@ -228,6 +230,7 @@ def test_set_retirement_offset(retire_vm, warn):
 
 
 @pytest.mark.rhv3
+@pytest.mark.meta(blockers=[BZ(1627758, forced_streams=['5.10'])])
 def test_unset_retirement_date(retire_vm):
     """Tests cancelling a scheduled retirement by removing the set date
     """
@@ -242,6 +245,7 @@ def test_unset_retirement_date(retire_vm):
 
 @pytest.mark.rhv3
 @pytest.mark.tier(2)
+@pytest.mark.meta(blockers=[BZ(1627758, forced_streams=['5.10'])])
 @pytest.mark.parametrize('remove_date', [True, False], ids=['remove_date', 'set_future_date'])
 def test_resume_retired_instance(retire_vm, provider, remove_date):
     """Test resuming a retired instance, should be supported for infra and cloud, though the


### PR DESCRIPTION
1) Why am I modifying `verify_retirement_state`?
Because in CFME 5.10, you are redirected to a view with Requests when you do Lifecycle -> Retire VM.
I did not use `VersionPicker` since call to `navigate_to(retire_vm, 'Details')` does not cause any problem in 5.9 - we're already there.

2) Why am I wrapping so many tests with [BZ1627758](https://bugzilla.redhat.com/show_bug.cgi?id=1627758)?
Recently there was a change in datepicker. Its timezone is now determined by local time zone of your browser. However, the success flash message is always displayed in UTC. Therefore we cannot really verify now that the flash message displayed after setting retirement date is correct. 

Example: I am running this test case in my time zone (CEST) and set retirement date to 12th of September 23:00. The flash message will say that it was set to 12th of September 21:00 **UTC**. That's because CEST is UTC+2. If the test case with the very same configuration is run let's say in India Standard Time (UTC+5:30), the flash message will say that retirement date was set to 13th of September 4:30. 
In the current state, we have no way how to check the flash message deterministically (at least no that I know of). 

Honestly, I think this is more of a bug than a feature. However, the dev seem to [disagree](https://bugzilla.redhat.com/show_bug.cgi?id=1626971#c10). Therefore I created this [RFE](https://bugzilla.redhat.com/show_bug.cgi?id=1627758) to make time zone of datepicker configurable. If we have this, we can set it to UTC and reliably check the flash message.

{{pytest: cfme/tests/cloud_infra_common/test_retirement.py::test_retirement_now --long-running -vv}}