### PR TITLE
[WIPTEST] Catch KeyError in _get_template()

### DIFF
--- a/cfme/fixtures/provider.py
+++ b/cfme/fixtures/provider.py
@@ -341,7 +341,7 @@ def _get_template(provider, template_type_name):
     """
     try:
         template_type = provider.data.templates.get(template_type_name)
-    except AttributeError:
+    except (AttributeError, KeyError):
         logger.error("Wanted template %s on %s but it is not there!", template, provider.key)
         pytest.skip('No {} for provider {}'.format(template_type_name, provider.key))
     if not isinstance(template_type, Mapping):


### PR DESCRIPTION
{{ pytest: cfme/tests/cloud_infra_common/test_power_control_rest.py --use-provider kubevirt }}
