### PR TITLE
[RFR] Don't crash fixture if Merkyl plugin returns bad response

### DIFF
--- a/cfme/fixtures/merkyl.py
+++ b/cfme/fixtures/merkyl.py
@@ -28,7 +28,7 @@ class MerkylInspector(object):
         res = fire_art_test_hook(
             self.node, 'get_log_merkyl', ip=self.ip,
             filename=log_name, grab_result=True)
-        return res['merkyl_content']
+        return res.get('merkyl_content', '')
 
     def add_log(self, log_name):
         """ Adds a log file to the merkyl process.


### PR DESCRIPTION
With this commit we prevent crash of entire `merkyl_inspector` fixture in case Merkyl plugin timeouts. Thing is that Merkyl service on appliance sometimes timeouts before replying to our requests. And currently we crash hard when this occurs. But we shouldn't - because Merkyl service usually returns valid response upon next probe.

So with this commit we simulate empty response as opposed to crashing. The real fix, obviously, would be to fix merkyl service itself, but that's out of our current scope.