### PR TITLE
[1LP][RFR]Adding new Test: Migration Plans Sorting type/Order

### DIFF
--- a/cfme/v2v/migrations.py
+++ b/cfme/v2v/migrations.py
@@ -318,6 +318,8 @@ class MigrationDashboardView(BaseLoggedInPage):
     migration_plans_archived_list = MigrationPlansList("plans-complete-list")
     infra_mapping_list = InfraMappingList("infra-mappings-list-view")
     migr_dropdown = MigrationDropdown(text="Not Started Plans")
+    sort_type_dropdown = Dropdown(text="Name")
+    sort_direction = Text(locator=".//span[contains(@class,'sort-direction')]")
     # TODO: XPATH requested to devel (repo:miq_v2v_ui_plugin issues:415)
     progress_card = MigrationProgressBar(locator='.//div[3]/div/div[3]/div[3]/div/div')
 


### PR DESCRIPTION
Purpose or Intent
=================

__Adding tests__ for Migration Plans Sorting type/Order and Archive plans

{{pytest: cfme/tests/v2v/test_v2v_migrations_ui.py --use-provider rhv42 --use-provider vsphere67-nested --provider-limit 2 -vvvv --long-running -k 'test_v2v_ui_migration_plan_sorting' }}