### PR TITLE
[1LP][RFR] Custom Button: Azone support and all method

### DIFF
--- a/cfme/tests/automate/custom_button/test_cloud_objects.py
+++ b/cfme/tests/automate/custom_button/test_cloud_objects.py
@@ -15,7 +15,7 @@ pytestmark = [
     pytest.mark.provider([OpenStackProvider], selector=ONE_PER_TYPE),
 ]
 
-CLOUD_OBJECTS = ["PROVIDER", "VM_INSTANCE"]
+CLOUD_OBJECTS = ["PROVIDER", "VM_INSTANCE", "AZONE"]
 
 DISPLAY_NAV = {
     "Single entity": ["Details"],
@@ -49,6 +49,10 @@ def setup_objs(button_group, provider):
         obj = [provider, network_manager]
     elif obj_type == "VM_INSTANCE":
         obj = [provider.appliance.provider_based_collection(provider).all()[0]]
+    elif obj_type == "AZONE":
+        obj = [
+            provider.appliance.collections.cloud_av_zones.filter({"provider": provider}).all()[0]
+        ]
     else:
         logger.error("No object collected for custom button object type '{}'".format(obj_type))
     return obj

--- a/cfme/tests/automate/custom_button/test_cloud_objects.py
+++ b/cfme/tests/automate/custom_button/test_cloud_objects.py
@@ -23,6 +23,20 @@ DISPLAY_NAV = {
     "Single and list": ["All", "Details"],
 }
 
+OBJ_TYPE_59 = [
+    "CLOUD_TENANT",
+    "CLOUD_VOLUME",
+    "CLUSTER",
+    "CONTAINER_NODE",
+    "CONTAINER_PROJECT",
+    "DATASTORE",
+    "GENERIC",
+    "HOST",
+    "PROVIDER",
+    "SERVICE",
+    "TEMPLATE",
+    "VM_INSTANCE"]
+
 
 @pytest.fixture(
     params=CLOUD_OBJECTS, ids=[obj.capitalize() for obj in CLOUD_OBJECTS], scope="module"
@@ -58,10 +72,14 @@ def setup_objs(button_group, provider):
     return obj
 
 
+@pytest.mark.uncollectif(
+    lambda appliance, button_group: not bool([obj for obj in OBJ_TYPE_59 if obj in button_group])
+    and appliance.version < "5.10"
+)
 @pytest.mark.parametrize(
     "display", DISPLAY_NAV.keys(), ids=["_".join(item.split()) for item in DISPLAY_NAV.keys()]
 )
-def test_custom_button_display(request, display, setup_objs, button_group):
+def test_custom_button_display(appliance, request, display, setup_objs, button_group):
     """ Test custom button display on a targeted page
 
     prerequisites:


### PR DESCRIPTION
Purpose or Intent
=================
- Added all  method for Azone with REST
- Added support of Azone to custum button  file
{{pytest: cfme/tests/automate/custom_button/test_cloud_objects.py -v --use-provider complete}}