### PR TITLE
[1LP][RFR] Fix test_cluster_relationships test and update wrapanapi requirements for 5.8

### DIFF
--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -308,7 +308,7 @@ Werkzeug==0.14.1
 widgetastic.core==0.21.6
 widgetastic.patternfly==0.0.37
 widgetsnbextension==3.2.1
-wrapanapi==3.0.24
+wrapanapi==3.0.25
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -297,7 +297,7 @@ Werkzeug==0.14.1
 widgetastic.core==0.21.6
 widgetastic.patternfly==0.0.37
 widgetsnbextension==3.2.1
-wrapanapi==3.0.24
+wrapanapi==3.0.25
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0


### PR DESCRIPTION
Changes introduced with this PR:
1. The name of`list_host` and `list_cluster` methods differ for `SCVMMProvider`. They're `list_hosts` and `list_clusters`. This PR fixes the test `test_cluster_relationships` by adding a fix for the issue. 
2. `test_cluster_relationships` test was also failing due to some issue with wrapanapi. A patch was merged into `wrapanapi` to solve this issue. The latest version was released yesterday, hence updating `wrapanapi` in requirements.

{{pytest: cfme/tests/intelligence/reports/test_canned_corresponds.py::test_cluster_relationships --use-provider=complete  -sqvvv}}