### PR TITLE
[1LP][RFR] Support reset log for merkyl plugin

### DIFF
--- a/artifactor/plugins/merkyl.py
+++ b/artifactor/plugins/merkyl.py
@@ -39,6 +39,7 @@ class Merkyl(ArtifactorBasePlugin):
         self.register_plugin_hook("teardown_merkyl", self.finish_session)
         self.register_plugin_hook("get_log_merkyl", self.get_log)
         self.register_plugin_hook("add_log_merkyl", self.add_log)
+        self.register_plugin_hook("reset_log_merkyl", self.reset_log)
 
     def configure(self):
         self.files = self.data.get("log_files", [])
@@ -70,6 +71,15 @@ class Merkyl(ArtifactorBasePlugin):
         doc = requests.get(url, timeout=15)
         content = doc.content
         return {"merkyl_content": content}, None
+
+    @ArtifactorBasePlugin.check_configured
+    def reset_log(self, test_name, test_location, filename):
+        test_ident = "{location}/{name}".format(location=test_location, name=test_name)
+        ip = self.tests[test_ident].ip
+
+        _, tail = os.path.split(filename)
+        url = "http://{ip}:{port}/reset/{filename}".format(ip=ip, port=self.port, filename=tail)
+        requests.get(url, timeout=15)
 
     @ArtifactorBasePlugin.check_configured
     def add_log(self, test_name, test_location, filename):

--- a/cfme/fixtures/merkyl.py
+++ b/cfme/fixtures/merkyl.py
@@ -55,6 +55,19 @@ class MerkylInspector(object):
             self.node, 'add_log_merkyl', ip=self.ip,
             filename=log_name, grab_result=True)
 
+    def reset_log(self, log_name):
+        """ Resets log
+
+        This function clears content of a log file that merkyl is tailing.
+        Note that file stays open and merkyl keeps tailing it.
+
+        Args:
+            log_name: Full path to the log file that you want to reset
+        """
+        fire_art_test_hook(
+            self.node, 'reset_log_merkyl', ip=self.ip,
+            filename=log_name, grab_result=True)
+
     def search_log(self, needle, log_name):
         """ A simple search, test if needle is in cached log_contents.
 


### PR DESCRIPTION
With this commit we implement method that resets log for merkyl plugin. Now we can clear content of a log and continue tailing it.

This is needed when a log is tailed for a duration of the whole session and there are multiple tests being ran. For example two test can search for the same log entry. If first one succeeds and we don't clear the log content after, second one will just find the log content of the first test and succeed.
