### PR TITLE
[RFR] uncollect anon_ftp for 5.8 and below

### DIFF
--- a/cfme/tests/configure/test_log_depot_operation.py
+++ b/cfme/tests/configure/test_log_depot_operation.py
@@ -185,9 +185,8 @@ def check_ftp(ftp, server_name, server_zone_id):
 
 @pytest.mark.tier(3)
 @pytest.mark.nondestructive
-@pytest.mark.meta(blockers=[BZ(1603163, unblock=lambda log_depot: log_depot.protocol != "anon_ftp",
-                            forced_streams=["5.6", "5.7", "5.8", "upstream"])]
-                  )
+@pytest.mark.uncollectif(lambda appliance, log_depot: appliance.version < '5.9' and
+                         log_depot.protocol == 'anon_ftp')  # BZ1341502 fixed for 5.9 and above
 def test_collect_log_depot(log_depot, appliance, configured_depot, request):
     """ Boilerplate test to verify functionality of this concept
 


### PR DESCRIPTION
1. Removed the BZ1603163 blocker. The issue described there is not the issue in the product. It was fixed by editing configs earlier. Also removed it for master, see #7805

2. Added uncollection for anonymous ftp log collection for versions below 5.9, see BZ1341502 (it was fixed in version 5.9).