### PR TITLE
[WIPTEST] fix cloud provider crud test for 5.10

### DIFF
--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -228,6 +228,9 @@ def test_cloud_provider_crud(provider, enable_regions):
         test_flag: crud
     """
     provider.create()
+    if provider.appliance.version > '5.10.0.4':
+        view = navigate_to(provider, "Details")
+        view.toolbar.view_selector.select('Summary View')
     provider.validate_stats(ui=True)
 
     old_name = provider.name


### PR DESCRIPTION
This PR fixes failing test `test_cloud_provider_crud`. 5.10.0.6 introduced Dashboard on the provider's Details page. By default, `Dashboard View` is loaded, and so the test fails while validating UI statistics. The test fix checks if the appliance version is greater than 5.10.0.6, and if True, it sets `view_selector` to `Summary View`.

{{pytest: cfme/tests/cloud/test_providers.py::test_cloud_provider_crud -sqvvv}}