### PR TITLE
[RFR] Remove http restart in auth fixture

### DIFF
--- a/cfme/fixtures/authentication.py
+++ b/cfme/fixtures/authentication.py
@@ -72,5 +72,4 @@ def configure_auth(appliance, auth_mode, auth_provider, user_type, request, fix_
     yield
     # return to original auth config
     appliance.server.authentication.auth_settings = original_config
-    appliance.httpd.restart()
     appliance.wait_for_web_ui()


### PR DESCRIPTION
causes semaphore exhaustion for following tests
