### PR TITLE
[1LP][RFR] Add/Resume OCP Provider API Test

### DIFF
--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -341,6 +341,32 @@ class ContainersProviderCollection(BaseCollection):
         obj.create(**create_kwargs)
         return obj
 
+    def pause_providers(self, *providers):
+        """ Pause the OCP providers.
+            Args:
+                *providers: Provider objects to be paused
+
+            Returns:
+                API response.
+         """
+        prov_entities = [self.appliance.rest_api.collections.providers.get(name=provider.name)
+                         for provider in providers]
+
+        return self.appliance.rest_api.collections.providers.action.pause(*prov_entities)
+
+    def resume_providers(self, *providers):
+        """ Resume the OCP providers.
+            Args:
+                *providers: Provider objects to be resumed
+
+            Returns:
+                API response.
+         """
+        prov_entities = [self.appliance.rest_api.collections.providers.get(name=provider.name)
+                         for provider in providers]
+
+        return self.appliance.rest_api.collections.providers.action.resume(*prov_entities)
+
 
 @navigator.register(ContainersProviderCollection, 'All')
 @navigator.register(ContainersProvider, 'All')

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -158,6 +158,10 @@ class OpenshiftProvider(ContainersProvider, ConsoleMixin):
 
         return mapping
 
+    @property
+    def is_provider_enabled(self):
+        return self.appliance.rest_api.collections.providers.get(name=self.name).enabled
+
     @variable(alias='db')
     def num_route(self):
         return self._num_db_generic('container_routes')
@@ -431,3 +435,19 @@ class OpenshiftProvider(ContainersProvider, ConsoleMixin):
             result = False
         finally:
             return result
+
+    def pause(self):
+        """ Pause the OCP provider.
+
+            Returns:
+                API response.
+        """
+        return self.appliance.rest_api.collections.providers.get(name=self.name).action.pause()
+
+    def resume(self):
+        """ Resume the OCP provider.
+
+            Returns:
+                API response.
+        """
+        return self.appliance.rest_api.collections.providers.get(name=self.name).action.resume()


### PR DESCRIPTION
Add new test to verify a OpenShift provider can be paused and resumed via the API

{{ pytest: cfme/tests/containers/test_pause_resume_workers.py --use-provider ocp-39-hawk }}
