### PR TITLE
[RFR] modified the name of cluster for 5.8

### DIFF
--- a/cfme/tests/candu/test_cluster_graph.py
+++ b/cfme/tests/candu/test_cluster_graph.py
@@ -69,12 +69,16 @@ def test_graph_screen(provider, cluster, host, graph_type, interval, enable_cand
         * Compare table and graph data
     """
     host.capture_historical_data()
+    if provider.one_of(VMwareProvider):
+        cluster.name = '{} in {}'.format(cluster.name, provider.data['datacenters'][0])
+    else:
+        cluster.name = '{} in {}'.format(cluster.name, provider.data['default_cluster'])
     cluster.wait_candu_data_available(timeout=1200)
 
     view = navigate_to(cluster, "Utilization")
     view.options.interval.fill(interval)
 
-    # Check garph displayed or not
+    # Check graph displayed or not
     try:
         graph = getattr(view, graph_type)
     except AttributeError as e:


### PR DESCRIPTION
Fixed ItemNotFound: Entity {'name': 'Cluster'} isn't found on this page for 5.8.

In UI 5.9 the clusters's name is Cluster
![image](https://user-images.githubusercontent.com/42433123/45739027-31fdda80-bbf2-11e8-8c9e-1897ee20d82f.png)

But in 5.8 it is displayed as Cluster in Datacenter (for VMware)
![image](https://user-images.githubusercontent.com/42433123/45739093-5c4f9800-bbf2-11e8-914c-f3ceb8968f31.png)

Tested locally