### PR TITLE
[RFR] fixed some AttributeError and DropdownItemNotFound for 5.8

### DIFF
--- a/cfme/control/explorer/conditions.py
+++ b/cfme/control/explorer/conditions.py
@@ -9,6 +9,7 @@ from cfme.utils import ParamClassName
 from cfme.utils.appliance.implementations.ui import navigator, navigate_to, CFMENavigateStep
 from cfme.utils.pretty import Pretty
 from cfme.utils.update import Updateable
+from cfme.utils.wait import wait_for
 from widgetastic_manageiq.expression_editor import ExpressionEditor
 from . import ControlExplorerView
 
@@ -332,19 +333,18 @@ class VMCondition(BaseCondition):
 
 class ReplicatorCondition(BaseCondition):
 
-    TREE_NODE = "Replicator"
-    PRETTY = FIELD_VALUE = "Container Replicator"
+    TREE_NODE = PRETTY = FIELD_VALUE = "Replicator"
 
 
 class PodCondition(BaseCondition):
 
-    TREE_NODE = "Pod"
-    PRETTY = FIELD_VALUE = "Container Pod"
+    TREE_NODE = PRETTY = FIELD_VALUE = "Pod"
 
 
 class ContainerNodeCondition(BaseCondition):
 
-    TREE_NODE = PRETTY = FIELD_VALUE = "Container Node"
+    TREE_NODE = "Container Node"
+    PRETTY = FIELD_VALUE = "Node"
 
 
 class ContainerImageCondition(BaseCondition):

--- a/cfme/tests/control/test_basic.py
+++ b/cfme/tests/control/test_basic.py
@@ -308,9 +308,9 @@ def condition_for_expressions(request, condition_collection, appliance):
         condition_class,
         fauxfactory.gen_alphanumeric(),
         expression="fill_field({} : Name, IS NOT EMPTY)".format(
-            condition_class.FIELD_VALUE.pick(appliance.version)),
+            condition_class.FIELD_VALUE),
         scope="fill_field({} : Name, INCLUDES, {})".format(
-            condition_class.FIELD_VALUE.pick(appliance.version), fauxfactory.gen_alpha())
+            condition_class.FIELD_VALUE, fauxfactory.gen_alpha())
     )
     yield condition
     condition.delete()
@@ -320,11 +320,11 @@ def condition_for_expressions(request, condition_collection, appliance):
 def condition_prerequisites(request, condition_collection, appliance):
     condition_class = request.param
     expression = "fill_field({} : Name, =, {})".format(
-        condition_class.FIELD_VALUE.pick(appliance.version),
+        condition_class.FIELD_VALUE,
         fauxfactory.gen_alphanumeric()
     )
     scope = "fill_field({} : Name, =, {})".format(
-        condition_class.FIELD_VALUE.pick(appliance.version),
+        condition_class.FIELD_VALUE,
         fauxfactory.gen_alphanumeric()
     )
     return condition_class, scope, expression
@@ -390,7 +390,7 @@ def policy_and_condition(request, policy_collection, condition_collection, appli
     if policy_class in PHYS_POLICIES and appliance.version < "5.9":
         pytest.skip("Physical Infrastructure Policies are available in CFME 5.9 and newer.")
     expression = "fill_field({} : Name, =, {})".format(
-        condition_class.FIELD_VALUE.pick(appliance.version),
+        condition_class.FIELD_VALUE,
         fauxfactory.gen_alphanumeric()
     )
     condition = condition_collection.create(


### PR DESCRIPTION
Tested locally 
cfme/tests/control/test_basic.py::test_modify_condition_expression
cfme/tests/control/test_basic.py::test_assign_condition_to_control_policy

The PR fixes
1. AttributeError: 'str' object has no attribute 'pick'
2. DropdownItemNotFound: Item 'Add a New Container Replicator Compliance Policy' not found. These items are present: Add a New Replicator Compliance Policy and similar errors for dropdown elements