### PR TITLE
[RFR] fixed failed test_group_crud_with_tag[tag-virtualcenter] for vsphere55 for 5.8

### DIFF
--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -411,19 +411,25 @@ def test_group_crud_with_tag(provider, tag_value, group_collection):
         * Save group
     """
     tag_for_create, tag_for_update = tag_value
+
+    if provider.key == 'vsphere55':
+        path = 'VM_Template-Folder'
+    else:
+        path = 'Discovered virtual machine'
+
     group = group_collection.create(
         description='grp{}'.format(fauxfactory.gen_alphanumeric()),
         role='EvmRole-approver',
         tag=tag_for_create,
         host_cluster=([provider.data['name']], True),
         vm_template=([provider.data['name'], provider.data['datacenters'][0],
-                     'Discovered virtual machine'], True)
+                     path], True)
     )
     with update(group):
         group.tag = tag_for_update
         group.host_cluster = ([provider.data['name']], False)
         group.vm_template = ([provider.data['name'], provider.data['datacenters'][0],
-                             'Discovered virtual machine'], False)
+                             path], False)
     group.delete()
 
 


### PR DESCRIPTION
tested locally for 5.8

PR fixes error CandidateNotFound: path: ('Datacenter', 'Discovered virtual machine'), message: Could not find the item vSphere 5.5 (nested)/Datacenter/Discovered virtual machine in Boostrap tree vat_treebox, cause: Was not found in Datacenter