### PR TITLE
[1LP][RFR] fixed test_group_crud_with_tag for vsphere55

### DIFF
--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -411,10 +411,7 @@ def test_group_crud_with_tag(provider, tag_value, group_collection):
     """
     tag_for_create, tag_for_update = tag_value
 
-    if provider.key == 'vsphere55':
-        path = 'VM_Template-Folder'
-    else:
-        path = 'Discovered virtual machine'
+    path = 'VM_Template-Folder' if provider.key == 'vsphere55' else 'Discovered virtual machine'
 
     group = group_collection.create(
         description='grp{}'.format(fauxfactory.gen_alphanumeric()),

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -410,19 +410,25 @@ def test_group_crud_with_tag(provider, tag_value, group_collection):
         * Save group
     """
     tag_for_create, tag_for_update = tag_value
+
+    if provider.key == 'vsphere55':
+        path = 'VM_Template-Folder'
+    else:
+        path = 'Discovered virtual machine'
+
     group = group_collection.create(
         description='grp{}'.format(fauxfactory.gen_alphanumeric()),
         role='EvmRole-approver',
         tag=tag_for_create,
         host_cluster=([provider.data['name']], True),
         vm_template=([provider.data['name'], provider.data['datacenters'][0],
-                     'Discovered virtual machine'], True)
+                     path], True)
     )
     with update(group):
         group.tag = tag_for_update
         group.host_cluster = ([provider.data['name']], False)
         group.vm_template = ([provider.data['name'], provider.data['datacenters'][0],
-                             'Discovered virtual machine'], False)
+                             path], False)
     group.delete()
 
 


### PR DESCRIPTION
{{ pytest: -v cfme/tests/configure/test_access_control.py::test_group_crud_with_tag --use-provider complete }}