### PR TITLE
[RFR] consolidate sprout_appliance contextmanager and fixtures

### DIFF
--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -1,11 +1,10 @@
 import pytest
 
 from collections import namedtuple
-from contextlib import contextmanager
 from six import iteritems
 
 import cfme.utils.auth as authutil
-from cfme.test_framework.sprout.client import SproutClient
+from cfme.fixtures.appliance import sprout_appliances
 from cfme.utils.conf import credentials, auth_data
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for
@@ -16,43 +15,51 @@ TimedCommand = namedtuple('TimedCommand', ['command', 'timeout'])
     testing from an FQDN provider unless there are no provisions available"""
 
 
-@contextmanager
-def fqdn_appliance(appliance, preconfigured, count, config):
-    sprout_client = SproutClient.from_config(sprout_user_key=config.option.sprout_user_key or None)
-    apps, request_id = sprout_client.provision_appliances(
-        provider_type='rhevm',
-        count=count,
-        version=appliance.version.vstring,
-        preconfigured=preconfigured,
-        stream=appliance.version.stream(),
-    )
-    try:
-        yield apps
-    finally:
-        sprout_client.destroy_pool(request_id)
-
-
 @pytest.fixture()
 def unconfigured_appliance(appliance, pytestconfig):
-    with fqdn_appliance(appliance, preconfigured=False, count=1, config=pytestconfig) as apps:
+    with sprout_appliances(
+            appliance,
+            preconfigured=False,
+            count=1,
+            config=pytestconfig,
+            provider_type='rhevm',
+    ) as apps:
         yield apps[0]
 
 
 @pytest.fixture()
 def unconfigured_appliance_secondary(appliance, pytestconfig):
-    with fqdn_appliance(appliance, preconfigured=False, count=1, config=pytestconfig) as apps:
+    with sprout_appliances(
+            appliance,
+            preconfigured=False,
+            count=1,
+            config=pytestconfig,
+            provider_type='rhevm',
+    ) as apps:
         yield apps[0]
 
 
 @pytest.fixture()
 def unconfigured_appliances(appliance, pytestconfig):
-    with fqdn_appliance(appliance, preconfigured=False, count=3, config=pytestconfig) as apps:
+    with sprout_appliances(
+            appliance,
+            preconfigured=False,
+            count=3,
+            config=pytestconfig,
+            provider_type='rhevm',
+    ) as apps:
         yield apps
 
 
 @pytest.fixture()
 def configured_appliance(appliance, pytestconfig):
-    with fqdn_appliance(appliance, preconfigured=True, count=1, config=pytestconfig) as apps:
+    with sprout_appliances(
+            appliance,
+            preconfigured=True,
+            count=1,
+            config=pytestconfig,
+            provider_type='rhevm',
+    ) as apps:
         yield apps[0]
 
 

--- a/cfme/tests/pod/test_appliance_crud.py
+++ b/cfme/tests/pod/test_appliance_crud.py
@@ -5,7 +5,7 @@ import pytest
 import tempfile
 
 from cfme.containers.provider.openshift import OpenshiftProvider
-from cfme.fixtures.appliance import temp_appliances
+from cfme.fixtures.appliance import sprout_appliances
 from cfme.utils import ssh, trackerbot
 from cfme.utils.appliance import stack, IPAppliance
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -99,9 +99,15 @@ def template_tags(appliance):
 
 
 @pytest.fixture
-def temp_pod_appliance(provider, appliance_data):
-    with temp_appliances(preconfigured=False, provider_type='openshift',
-                         provider=provider.key, template_type='openshift_pod') as appliances:
+def temp_pod_appliance(appliance, provider, appliance_data, pytestconfig):
+    with sprout_appliances(
+            appliance,
+            config=pytestconfig,
+            preconfigured=False,
+            provider_type='openshift',
+            provider=provider.key,
+            template_type='openshift_pod'
+    ) as appliances:
         with appliances[0] as appliance:
             appliance.openshift_creds = appliance_data['openshift_creds']
             appliance.is_pod = True


### PR DESCRIPTION
backported https://github.com/ManageIQ/integration_tests/commit/f56606c5fae257ecd84b0bca37a530fddddb6dd0 to 5.8

fixtures/cli and fixtures/appliance had pretty much exactly the same contextmanager for checking out sprout appliances.

establish single contextmanager in cfme/fixtures/appliance, import and use it in cfme/fixtures/cli

Update direct use of the contextmanager in tests/pod/test_appliance_crud
