### PR TITLE
[1LP][RFR] Update RegionView and tries() method

### DIFF
--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -966,7 +966,8 @@ class RegionView(ConfigurationView):
 
     @property
     def is_displayed(self):
-        return self.accordions.settings.tree.currently_selected == [self.obj.settings_string]
+        match_string = [self.context['object'].settings_string]
+        return self.accordions.settings.tree.currently_selected == match_string
 
 
 class RegionChangeNameView(RegionView):

--- a/cfme/utils/__init__.py
+++ b/cfme/utils/__init__.py
@@ -11,8 +11,12 @@ from functools import partial
 from cached_property import cached_property
 from werkzeug.local import LocalProxy
 
-
 on_rtd = os.environ.get('READTHEDOCS') == 'True'
+
+
+class TriesExceeded(Exception):
+    """Default exception raised when tries() method doesn't catch a func exception"""
+    pass
 
 
 class FakeObject(object):
@@ -123,15 +127,17 @@ def tries(num_tries, exceptions, f, *args, **kwargs):
     Raises:
         What ``f`` raises if the try count is exceeded.
     """
+    caught_exception = TriesExceeded('Tries were exhausted without a func exception')
     tries = 0
     while tries < num_tries:
         tries += 1
         try:
             return f(*args, **kwargs)
         except exceptions as e:
+            caught_exception = e
             pass
     else:
-        raise e
+        raise caught_exception
 
 
 # There are some environment variables that get smuggled in anyway.


### PR DESCRIPTION
View objects don't have a `obj` attribute, they store the related entity/collection in `context['object']`

When testing fix, I found that the tries() method is hitting UnboundLocalError, fixed by setting a default exception.