### PR TITLE
[1LP][RFR] Move Nuage fixtures

### DIFF
--- a/cfme/fixtures/networks.py
+++ b/cfme/fixtures/networks.py
@@ -1,0 +1,59 @@
+import pytest
+import re
+from argparse import Namespace
+from contextlib import contextmanager
+
+from cfme.exceptions import NeedleNotFoundInLog
+from cfme.utils.log import logger
+from cfme.utils.wait import wait_for, TimedOutError
+
+
+@pytest.fixture
+def targeted_refresh(merkyl_setup, merkyl_inspector):
+    """
+    This fixture tests whether targeted refresh was triggered for given targets.
+    It basically tails evm.log to see whether a line like this has occured:
+
+    ```
+    [Collection of targets with id: [{:ems_ref=>"b35d3afe-6f19-4da8-b1ee-b79de433cace"}, ... ]]
+    ```
+    for each target and raises an error if not.
+
+    Usage:
+
+        def test_something(targeted_refresh)
+                trigger_targeted_refresh() <- some function that will trigger
+                                              targeted refresh
+                with targeted_refresh.target_timeout():
+                    targeted_refresh.register_target('ref-123456', 'Subnet named TEST')
+                    targeted_refresh.register_target('ref-aaaabb', 'Router named TEST')
+    """
+    evm_log = '/var/www/miq/vmdb/log/evm.log'
+    needle_template = r'^.*Collection of targets with id.*:ems_ref=>"{}".*$'
+    merkyl_inspector.add_log(evm_log)
+    merkyl_inspector.reset_log(evm_log)
+    targets = set()  # { (ems_ref, comment), (ems_ref, comment), ... }
+
+    def check_log():
+        logger.info('Looking for %s needles in evm.log: %s', len(targets), [t[1] for t in targets])
+        content = merkyl_inspector.get_log(evm_log)
+        for target in set(targets):
+            if target[0].search(content):
+                logger.info('Found needle %s', target[1])
+                targets.remove(target)
+        return len(targets) == 0
+
+    @contextmanager
+    def timeout():
+        yield
+
+        try:
+            wait_for(check_log, delay=5, num_sec=60)
+        except TimedOutError:
+            raise NeedleNotFoundInLog('Targeted refresh did not trigger for:\n{}'.format(
+                                      ',\n'.join(map(lambda t: '- ' + t[1], targets))))
+
+    def register_target(ems_ref, comment):
+        targets.add((re.compile(needle_template.format(ems_ref), re.MULTILINE), comment))
+
+    yield Namespace(register_target=register_target, timeout=timeout)

--- a/cfme/fixtures/nuage.py
+++ b/cfme/fixtures/nuage.py
@@ -1,0 +1,53 @@
+import pytest
+
+from wrapanapi.utils.random import random_name
+
+from cfme.utils.log import logger
+
+
+@pytest.fixture
+def with_nuage_sandbox(networks_provider):
+    nuage = networks_provider.mgmt
+    sandbox = box = {}
+
+    # Create empty enterprise aka 'sandbox'.
+    enterprise = box['enterprise'] = nuage.create_enterprise()
+    logger.info('Created sandbox enterprise {} ({})'.format(enterprise.name, enterprise.id))
+
+    # Fill the sandbox with some entities.
+    # Method `create_child` returns a tuple (object, connection) and we only need object.
+    box['template'] = enterprise.create_child(
+        nuage.vspk.NUDomainTemplate(name=random_name()))[0]
+    box['domain'] = enterprise.create_child(
+        nuage.vspk.NUDomain(name=random_name(), template_id=box['template'].id))[0]
+    box['zone'] = box['domain'].create_child(
+        nuage.vspk.NUZone(name=random_name()))[0]
+    box['subnet'] = box['zone'].create_child(
+        nuage.vspk.NUSubnet(
+            name=random_name(),
+            address='192.168.0.0',
+            netmask='255.255.255.0',
+            gateway='192.168.0.1'))[0]
+    box['cont_vport'] = box['subnet'].create_child(
+        nuage.vspk.NUVPort(name=random_name(), type='CONTAINER'))[0]
+    box['vm_vport'] = box['subnet'].create_child(
+        nuage.vspk.NUVPort(name=random_name(), type='VM'))[0]
+    box['l2_template'] = enterprise.create_child(
+        nuage.vspk.NUL2DomainTemplate(name=random_name()))[0]
+    box['l2_domain'] = enterprise.create_child(
+        nuage.vspk.NUL2Domain(name=random_name(), template_id=box['l2_template'].id))[0]
+    box['l2_cont_vport'] = box['l2_domain'].create_child(
+        nuage.vspk.NUVPort(name=random_name(), type='CONTAINER'))[0]
+    box['l2_vm_vport'] = box['l2_domain'].create_child(
+        nuage.vspk.NUVPort(name=random_name(), type='VM'))[0]
+    box['group'] = box['domain'].create_child(
+        nuage.vspk.NUPolicyGroup(name=random_name()))[0]
+    box['l2_group'] = box['l2_domain'].create_child(
+        nuage.vspk.NUPolicyGroup(name=random_name()))[0]
+
+    # Let integration test do whatever it needs to do.
+    yield sandbox
+
+    # Destroy the sandbox.
+    nuage.delete_enterprise(enterprise)
+    logger.info('Destroyed sandbox enterprise {} ({})'.format(enterprise.name, enterprise.id))

--- a/cfme/test_framework/pytest_plugin.py
+++ b/cfme/test_framework/pytest_plugin.py
@@ -105,6 +105,8 @@ pytest_plugins = (
     'cfme.fixtures.pxe',
     'cfme.fixtures.candu',
     'cfme.fixtures.v2v',
+    'cfme.fixtures.networks',
+    'cfme.fixtures.nuage',
 
     'cfme.metaplugins',
 )

--- a/cfme/tests/networks/nuage/test_events_are_triggered.py
+++ b/cfme/tests/networks/nuage/test_events_are_triggered.py
@@ -1,119 +1,12 @@
 # -*- coding: utf-8 -*-
 """This module tests Nuage EMS events."""
 import pytest
-import re
-from argparse import Namespace
-from contextlib import contextmanager
 
-from wrapanapi.utils.random import random_name
-
-from cfme.exceptions import NeedleNotFoundInLog
 from cfme.networks.provider.nuage import NuageProvider
-from cfme.utils.log import logger
-from cfme.utils.wait import wait_for, TimedOutError
 
 pytestmark = [
     pytest.mark.provider([NuageProvider])
 ]
-
-
-@pytest.fixture
-def with_nuage_sandbox(networks_provider):
-    nuage = networks_provider.mgmt
-    sandbox = box = {}
-
-    # Create empty enterprise aka 'sandbox'.
-    enterprise = box['enterprise'] = nuage.create_enterprise()
-    logger.info('Created sandbox enterprise {} ({})'.format(enterprise.name, enterprise.id))
-
-    # Fill the sandbox with some entities.
-    # Method `create_child` returns a tuple (object, connection) and we only need object.
-    box['template'] = enterprise.create_child(
-        nuage.vspk.NUDomainTemplate(name=random_name()))[0]
-    box['domain'] = enterprise.create_child(
-        nuage.vspk.NUDomain(name=random_name(), template_id=box['template'].id))[0]
-    box['zone'] = box['domain'].create_child(
-        nuage.vspk.NUZone(name=random_name()))[0]
-    box['subnet'] = box['zone'].create_child(
-        nuage.vspk.NUSubnet(
-            name=random_name(),
-            address='192.168.0.0',
-            netmask='255.255.255.0',
-            gateway='192.168.0.1'))[0]
-    box['cont_vport'] = box['subnet'].create_child(
-        nuage.vspk.NUVPort(name=random_name(), type='CONTAINER'))[0]
-    box['vm_vport'] = box['subnet'].create_child(
-        nuage.vspk.NUVPort(name=random_name(), type='VM'))[0]
-    box['l2_template'] = enterprise.create_child(
-        nuage.vspk.NUL2DomainTemplate(name=random_name()))[0]
-    box['l2_domain'] = enterprise.create_child(
-        nuage.vspk.NUL2Domain(name=random_name(), template_id=box['l2_template'].id))[0]
-    box['l2_cont_vport'] = box['l2_domain'].create_child(
-        nuage.vspk.NUVPort(name=random_name(), type='CONTAINER'))[0]
-    box['l2_vm_vport'] = box['l2_domain'].create_child(
-        nuage.vspk.NUVPort(name=random_name(), type='VM'))[0]
-    box['group'] = box['domain'].create_child(
-        nuage.vspk.NUPolicyGroup(name=random_name()))[0]
-    box['l2_group'] = box['l2_domain'].create_child(
-        nuage.vspk.NUPolicyGroup(name=random_name()))[0]
-
-    # Let integration test do whatever it needs to do.
-    yield sandbox
-
-    # Destroy the sandbox.
-    nuage.delete_enterprise(enterprise)
-    logger.info('Destroyed sandbox enterprise {} ({})'.format(enterprise.name, enterprise.id))
-
-
-@pytest.fixture
-def targeted_refresh(merkyl_setup, merkyl_inspector):
-    """
-    This fixture tests whether targeted refresh was triggered for given targets.
-    It basically tails evm.log to see whether a line like this has occured:
-
-    ```
-    [Collection of targets with id: [{:ems_ref=>"b35d3afe-6f19-4da8-b1ee-b79de433cace"}, ... ]]
-    ```
-    for each target and raises an error if not.
-
-    Usage:
-
-        def test_something(targeted_refresh)
-                trigger_targeted_refresh() <- some function that will trigger
-                                              targeted refresh
-                with targeted_refresh.target_timeout():
-                    targeted_refresh.register_target('ref-123456', 'Subnet named TEST')
-                    targeted_refresh.register_target('ref-aaaabb', 'Router named TEST')
-    """
-    evm_log = '/var/www/miq/vmdb/log/evm.log'
-    needle_template = r'^.*Collection of targets with id.*:ems_ref=>"{}".*$'
-    merkyl_inspector.add_log(evm_log)
-    merkyl_inspector.reset_log(evm_log)
-    targets = set()  # { (ems_ref, comment), (ems_ref, comment), ... }
-
-    def check_log():
-        logger.info('Looking for %s needles in evm.log: %s', len(targets), [t[1] for t in targets])
-        content = merkyl_inspector.get_log(evm_log)
-        for target in set(targets):
-            if target[0].search(content):
-                logger.info('Found needle %s', target[1])
-                targets.remove(target)
-        return len(targets) == 0
-
-    @contextmanager
-    def timeout():
-        yield
-
-        try:
-            wait_for(check_log, delay=5, num_sec=60)
-        except TimedOutError:
-            raise NeedleNotFoundInLog('Targeted refresh did not trigger for:\n{}'.format(
-                                      ',\n'.join(map(lambda t: '- ' + t[1], targets))))
-
-    def register_target(ems_ref, comment):
-        targets.add((re.compile(needle_template.format(ems_ref), re.MULTILINE), comment))
-
-    yield Namespace(register_target=register_target, timeout=timeout)
 
 
 def test_creating_entities_emits_events(register_event, with_nuage_sandbox):


### PR DESCRIPTION
With this commit we move two of Nuage fixtures to fixtures folder and register them. They are now available in global fixture list and can be used by multiple tests.

`with_nuage_sandbox` is very useful fixture that we want to use in multiple tests. It creates Nuage enterprise and its entities, and returns its values, which can then be compared to ui and database values. We moved it to `cfme/fixtures/nuage.py`, since its Nuage specific and will only be used by Nuage tests.

`targeted_refresh` fixture checks logs, if targeted refresh was started for specific targets. It can be used by other providers as well, so it was moved to `cfme/fixtures/networks.py`.
