### PR TITLE
[WIP] Validate Nuage subnet inventory

### DIFF
--- a/cfme/networks/subnet.py
+++ b/cfme/networks/subnet.py
@@ -197,3 +197,12 @@ class EditSubnet(CFMENavigateStep):
 
     def step(self):
         self.prerequisite_view.toolbar.configuration.item_select('Edit this Cloud Subnet')
+
+
+@navigator.register(Subnet, 'DetailsThroughProvider')
+class SubnetThroughProvider(CFMENavigateStep):
+    VIEW = SubnetDetailsView
+    prerequisite = NavigateToAttribute('provider_obj', 'CloudSubnets')
+
+    def step(self):
+        self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True).click()

--- a/cfme/networks/views.py
+++ b/cfme/networks/views.py
@@ -656,6 +656,7 @@ class OneProviderComponentsToolbar(View):
 
 class OneProviderSubnetView(BaseLoggedInPage):
     """ Represents whole All Subnets page """
+    title = Text('//div[@id="main-content"]//h1')
     toolbar = View.nested(OneProviderComponentsToolbar)
     sidebar = View.nested(SubnetSideBar)
     including_entities = View.include(SubnetEntities, use_parent=True)

--- a/cfme/tests/networks/nuage/test_nuage_inventory.py
+++ b/cfme/tests/networks/nuage/test_nuage_inventory.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+import pytest
+from netaddr import IPAddress
+
+from cfme.networks.provider.nuage import NuageProvider
+from cfme.utils.log import logger
+from cfme.utils.wait import wait_for
+
+pytestmark = [pytest.mark.provider([NuageProvider], scope="module")]
+
+
+def test_subnet_details_stats(provider, with_nuage_sandbox):
+    """
+    This test creates Nuage enterprise and its entities, including subnet.
+    Then it validates inventory of created subnet.
+
+    Steps:
+        * Deploy some entities outside of MIQ (directly in the provider)
+        * Create dictionary with stats that will be validated
+        * Find created subnet in database and validate its stats
+    """
+    sandbox = with_nuage_sandbox
+    cidr = '{address}/{netmask}'.format(
+        address=sandbox['subnet'].address,
+        netmask=IPAddress(sandbox['subnet'].netmask).netmask_bits()
+    )
+    domain = sandbox['subnet'].parent_object.parent_object
+    subnet_stats = {
+        'name_value': sandbox['subnet'].name,
+        'type_value': 'ManageIQ/Providers/Nuage/Network Manager/Cloud Subnet/L3',
+        'cidr_value': cidr,
+        'gateway_value': sandbox['subnet'].gateway,
+        'network_protocol_value': sandbox['subnet'].ip_type.lower(),
+        'network_manager_value': provider.name,
+        'cloud_tenant_value': domain.parent_object.name,
+        'network_router_value': domain.name,
+        'network_ports_num': len(sandbox['subnet'].vports),
+        'security_groups_num': sum(len(port.policy_groups) for port in sandbox['subnet'].vports),
+    }
+    provider.refresh_provider_relationships()
+    subnet = object_in_vmdb_with_timeout('nuage_network_subnets', provider, sandbox['subnet'].id)
+    subnet.validate_stats(subnet_stats)
+
+
+def object_in_vmdb_with_timeout(table, provider, ems_ref):
+
+    def object_from_vmdb():
+        logger.info('Looking for {table} with ems_ref {ems_ref} in the VMDB...'.format(
+            table=table, ems_ref=ems_ref))
+        return getattr(provider.appliance.collections, table).find_by_ems_ref(ems_ref, provider)
+
+    obj, _ = wait_for(
+        object_from_vmdb,
+        num_sec=60,
+        delay=5,
+        fail_condition=None
+    )
+    return obj

--- a/entry_points.txt
+++ b/entry_points.txt
@@ -76,6 +76,7 @@ network_routers = cfme.networks.network_router:NetworkRouterCollection
 network_security_groups = cfme.networks.security_group:SecurityGroupCollection
 network_subnets = cfme.networks.subnet:SubnetCollection
 network_topology_elements = cfme.networks.topology:NetworkTopologyElementsCollection
+nuage_network_subnets = cfme.networks.provider.nuage:NuageSubnetCollection
 object_managers = cfme.storage.manager:ObjectManagerCollection
 object_store_containers = cfme.storage.object_store_container:ObjectStoreContainerCollection
 object_store_objects = cfme.storage.object_store_object:ObjectStoreObjectCollection


### PR DESCRIPTION
With this commit we create NuageSubnet and NuageSubnetCollection, which we then use to validate details page of Nuage Subnet.

We use `with_nuage_sandbox` to create Nuage enterprise and its entities, including subnet. Sandbox then gives us values to compare with later.

NuageSubnetCollection has `find_by_ems_ref` function that finds requested NuageSubnet in database by ems_ref and returns it.

ValidateStatsMixin has `validate_stats` that uses ui methods from NuageSubnet to get details page values. These are then compared to those acquired from sandbox.

We also use different steps to navigate to details page. We go through provider using steps like this:
```Nertwork -> Providers -> Provider (by name) -> Cloud Subnets -> Subnet (by name)```
By using this steps we make sure that we are on the details page of Nuage Cloud Subnet.

Depends on: https://github.com/ManageIQ/integration_tests/pull/7858
