### PR TITLE
[1LP][RFR][NOTEST] Need to separate out Managers  from provider

### DIFF
--- a/cfme/infrastructure/cluster.py
+++ b/cfme/infrastructure/cluster.py
@@ -334,7 +334,7 @@ class ClusterCollection(BaseCollection):
             providers_db = {
                 prov.id: get_crud_by_name(prov.name)
                 for prov in providers
-                if "Manager" not in prov.name
+                if not getattr(prov, "parent_ems_id", False)
             }
             cluster_obj = [
                 self.instantiate(name=cluster.name, provider=providers_db[cluster.ems_id])

--- a/cfme/infrastructure/cluster.py
+++ b/cfme/infrastructure/cluster.py
@@ -331,7 +331,11 @@ class ClusterCollection(BaseCollection):
             ]
         else:
             providers = self.appliance.rest_api.collections.providers
-            providers_db = {prov.id: get_crud_by_name(prov.name) for prov in providers}
+            providers_db = {
+                prov.id: get_crud_by_name(prov.name)
+                for prov in providers
+                if "Manager" not in prov.name
+            }
             cluster_obj = [
                 self.instantiate(name=cluster.name, provider=providers_db[cluster.ems_id])
                 for cluster in clusters

--- a/cfme/infrastructure/datastore.py
+++ b/cfme/infrastructure/datastore.py
@@ -4,8 +4,7 @@ import attr
 from lxml.html import document_fromstring
 
 from navmazing import NavigateToAttribute, NavigateToSibling
-from widgetastic.exceptions import NoSuchElementException
-from widgetastic.widget import ParametrizedView, Text, View
+from widgetastic.widget import Text, View
 from widgetastic_patternfly import Accordion, Dropdown
 from widgetastic_manageiq import (
     BaseEntitiesView,
@@ -338,6 +337,7 @@ class DatastoreCollection(BaseCollection):
         provider_db = {
             prov.id: get_crud_by_name(prov.name)
             for prov in self.appliance.rest_api.collections.providers.all
+            if not getattr(prov, "parent_ems_id", False)
         }
         datastores = [
             self.instantiate(name=name, provider=provider_db[prov_id])


### PR DESCRIPTION
Purpose or Intent
=================
- We  are getting error like this
```
    def get_crud_by_name(provider_name):
        """ Creates a Provider object given a management_system name in cfme_data.
    
        Usage:
            get_crud_by_name('My RHEV 3.6 Provider')
    
        Returns: A Provider object that has methods that operate on CFME
        """
        for provider_key, provider_data in providers_data.items():
            if provider_data.get("name") == provider_name:
                return get_crud(provider_key)
>       raise NameError("Could not find provider {}".format(provider_name))
E       NameError: Could not find provider Embedded Ansible Automation Manager
```
- we have seperate out all manager those are `child provider` not `main provider`

Note: Test not adding as will not reproduce with fresh appliance... need a proper run or cloud provider with infra having cluster :D
