### PR TITLE
[1lLP][RFR] Fix host fixture for test_relationships, Navigation

### DIFF
--- a/cfme/tests/cloud_infra_common/test_relationships.py
+++ b/cfme/tests/cloud_infra_common/test_relationships.py
@@ -124,10 +124,7 @@ def get_obj(relationship, appliance, **kwargs):
 
 @pytest.fixture
 def host(appliance, provider):
-    host_collection = appliance.collections.hosts.filter({'provider': provider})
-    expression = 'fill_field(Host / Node : Parent Cluster, IS NOT NULL)'
-    view = navigate_to(host_collection, 'All')
-    view.entities.search.advanced_search(expression)
+    host_collection = provider.hosts
     return random.choice(host_collection.all())
 
 


### PR DESCRIPTION
The fixture was getting a provider filtered collection, then applying an unrelated search filter in the UI.
This would filter without taking the provider into account, and doesn't impact what is returned by the fixture at all.

Use a provider to get HostCollection instance with a parent set
Modify the HostCollection.all() method to use provider filter in addition to parent filter


{{ pytest: cfme/tests/cloud_infra_common/test_relationships.py }}