### PR TITLE
[1LP][RFR] Adding test cases for project and child quota for cloud providers

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -563,7 +563,7 @@ class BaseVMCollection(BaseCollection):
                 logger.info('Waiting for cfme provision request for vm %s', vm.name)
                 if auto_approve:
                     provision_request.approve_request(method='ui', reason="Approved")
-                provision_request.wait_for_request(method='ui', num_sec=900)
+                provision_request.wait_for_request(method='ui', num_sec=2500)
                 if provision_request.is_succeeded(method='ui'):
                     logger.info('Waiting for vm %s to appear on provider %s', vm.name,
                                 provider.key)

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -563,7 +563,7 @@ class BaseVMCollection(BaseCollection):
                 logger.info('Waiting for cfme provision request for vm %s', vm.name)
                 if auto_approve:
                     provision_request.approve_request(method='ui', reason="Approved")
-                provision_request.wait_for_request(method='ui', num_sec=2500)
+                provision_request.wait_for_request(method='ui', num_sec=1200)
                 if provision_request.is_succeeded(method='ui'):
                     logger.info('Waiting for vm %s to appear on provider %s', vm.name,
                                 provider.key)

--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -317,6 +317,7 @@ class ProvisionView(BaseLoggedInPage):
     title = Text('#explorer_title_text')
     breadcrumb = BreadCrumb()
     image_table = Table('//div[@id="pre_prov_div"]//table')
+    paginator = PaginationPane()
 
     @View.nested
     class sidebar(View):  # noqa
@@ -334,6 +335,7 @@ class ProvisionView(BaseLoggedInPage):
 
         def _select_template(self, template_name, provider_name):
             try:
+                self.parent.paginator.set_items_per_page(1000)
                 row = self.parent.image_table.row(name=template_name, provider=provider_name)
                 row.click()
             except IndexError:

--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -317,7 +317,6 @@ class ProvisionView(BaseLoggedInPage):
     title = Text('#explorer_title_text')
     breadcrumb = BreadCrumb()
     image_table = Table('//div[@id="pre_prov_div"]//table')
-    paginator = PaginationPane()
 
     @View.nested
     class sidebar(View):  # noqa
@@ -335,7 +334,6 @@ class ProvisionView(BaseLoggedInPage):
 
         def _select_template(self, template_name, provider_name):
             try:
-                self.parent.paginator.set_items_per_page(1000)
                 row = self.parent.image_table.row(name=template_name, provider=provider_name)
                 row.click()
             except IndexError:

--- a/cfme/tests/cloud/test_quota.py
+++ b/cfme/tests/cloud/test_quota.py
@@ -21,11 +21,6 @@ pytestmark = [
 ]
 
 
-def new_credential():
-    return Credential(principal='uid{}'.format(fauxfactory.gen_alphanumeric(4)),
-                      secret='redhat')
-
-
 @pytest.fixture
 def prov_data(appliance, provisioning):
     instance_type = "d2s_v3" if appliance.version < "5.10" else "D2s_v3"
@@ -105,7 +100,8 @@ def new_user_child(appliance, new_group_child):
     """This fixture creates new user which assigned to new child tenant"""
     user = appliance.collections.users.create(
         name="user_{}".format(fauxfactory.gen_alphanumeric().lower()),
-        credential=new_credential(),
+        credential=Credential(principal='uid{}'.format(fauxfactory.gen_alphanumeric(4)),
+                              secret='{password}'.format(password=fauxfactory.gen_alphanumeric(4))),
         email=fauxfactory.gen_email(),
         groups=new_group_child,
         cost_center="Workload",
@@ -132,7 +128,7 @@ def new_project(appliance):
 
 @pytest.fixture(scope="module")
 def new_group_project(appliance, new_project):
-    """This fixture creates new group and assigned by new peoject"""
+    """This fixture creates new group and assigned by new project"""
     group = appliance.collections.groups.create(
         description="group_{}".format(fauxfactory.gen_alphanumeric()),
         role="EvmRole-super_administrator",
@@ -148,7 +144,8 @@ def new_user_project(appliance, new_group_project):
     """This fixture creates new user which is assigned to new group and project"""
     user = appliance.collections.users.create(
         name="user_{}".format(fauxfactory.gen_alphanumeric().lower()),
-        credential=new_credential(),
+        credential=Credential(principal='uid{}'.format(fauxfactory.gen_alphanumeric(4)),
+                              secret='{password}'.format(password=fauxfactory.gen_alphanumeric(4))),
         email=fauxfactory.gen_email(),
         groups=new_group_project,
         cost_center="Workload",

--- a/cfme/tests/cloud/test_quota.py
+++ b/cfme/tests/cloud/test_quota.py
@@ -1,0 +1,324 @@
+# -*- coding: utf-8 -*-
+import fauxfactory
+import pytest
+from riggerlib import recursive_update
+from widgetastic.utils import partial_match
+from cfme import test_requirements
+from cfme.base.credential import Credential
+from cfme.cloud.provider.azure import AzureProvider
+from cfme.cloud.provider.openstack import OpenStackProvider
+from cfme.utils.generators import random_vm_name
+
+
+pytestmark = [
+    test_requirements.quota,
+    pytest.mark.long_running,
+    pytest.mark.provider(
+        [AzureProvider, OpenStackProvider],
+        required_fields=[["provisioning", "image"]],
+        scope="function",
+    ),
+]
+
+
+def new_credential():
+    return Credential(principal='uid{}'.format(fauxfactory.gen_alphanumeric(4)),
+                      secret='redhat')
+
+
+@pytest.fixture
+def vm_name():
+    return random_vm_name(context="quota")
+
+
+@pytest.fixture
+def template_name(provisioning):
+    return provisioning["image"]["name"]
+
+
+@pytest.fixture(scope="module")
+def roottenant(appliance):
+    return appliance.collections.tenants.get_root_tenant()
+
+
+@pytest.fixture
+def prov_data(appliance, provider, provisioning, vm_name):
+    if provider.one_of(OpenStackProvider):
+        return {
+            "catalog": {"vm_name": vm_name},
+            "environment": {"automatic_placement": True},
+            "properties": {"instance_type": partial_match("m1.large")},
+        }
+    if provider.one_of(AzureProvider):
+        instance_type = "d2s_v3" if appliance.version < "5.10" else "D2s_v3"
+        return {
+            "catalog": {"vm_name": vm_name},
+            "environment": {"automatic_placement": True},
+            "properties": {"instance_type": partial_match(instance_type)},
+            "customize": {
+                "admin_username": provisioning["customize_username"],
+                "root_password": provisioning["customize_password"],
+            },
+        }
+
+
+@pytest.fixture
+def set_child_tenant_quota(request, appliance, new_child):
+    """This fixture assigns quota to child tenant"""
+    field, value = request.param
+    new_child.set_quota(**{"{}_cb".format(field): True, field: value})
+    yield
+    # will refresh page as navigation to configuration is blocked if alerts are on the page
+    appliance.server.login_admin()
+    appliance.server.browser.refresh()
+    new_child.set_quota(**{"{}_cb".format(field): False})
+
+
+@pytest.fixture
+def set_project_quota(request, appliance, new_project):
+    """This fixture assigns quota to project"""
+    field, value = request.param
+    new_project.set_quota(**{"{}_cb".format(field): True, field: value})
+    yield
+    # will refresh page as navigation to configuration is blocked if alerts are on the page
+    appliance.server.login_admin()
+    appliance.server.browser.refresh()
+    new_project.set_quota(**{"{}_cb".format(field): False})
+
+
+@pytest.fixture(scope="module")
+def new_tenant(appliance):
+    """This fixture creates new tenant under root tenant(My Company)"""
+    collection = appliance.collections.tenants
+    tenant = collection.create(
+        name="tenant{}".format(fauxfactory.gen_alphanumeric()),
+        description="tenant_des{}".format(fauxfactory.gen_alphanumeric()),
+        parent=collection.get_root_tenant(),
+    )
+    yield tenant
+    if tenant.exists:
+        tenant.delete()
+
+
+@pytest.fixture(scope="module")
+def new_child(appliance, new_tenant):
+    """The fixture creates new child tenant"""
+    collection = appliance.collections.tenants
+    child_tenant = collection.create(
+        name="tenant{}".format(fauxfactory.gen_alphanumeric()),
+        description="tenant_des{}".format(fauxfactory.gen_alphanumeric()),
+        parent=new_tenant,
+    )
+    yield child_tenant
+    if child_tenant.exists:
+        child_tenant.delete()
+
+
+@pytest.fixture(scope="module")
+def new_group_child(appliance, new_child, new_tenant):
+    """This fixture creates new group assigned by new child tenant"""
+    collection = appliance.collections.groups
+    group = collection.create(
+        description="group_{}".format(fauxfactory.gen_alphanumeric()),
+        role="EvmRole-super_administrator",
+        tenant="My Company/{}/{}".format(new_tenant.name, new_child.name),
+    )
+    yield group
+    if group.exists:
+        group.delete()
+
+
+@pytest.fixture(scope="module")
+def new_user_child(appliance, new_group_child):
+    """This fixture creates new user which assigned to new child tenant"""
+    collection = appliance.collections.users
+    user = collection.create(
+        name="user_{}".format(fauxfactory.gen_alphanumeric().lower()),
+        credential=new_credential(),
+        email="child_user@redhat.com",
+        groups=new_group_child,
+        cost_center="Workload",
+        value_assign="Database",
+    )
+    yield user
+    if user.exists:
+        user.delete()
+
+
+@pytest.fixture(scope="module")
+def new_project(appliance):
+    """This fixture creates new project"""
+    collection = appliance.collections.projects
+    project = collection.create(
+        name="project{}".format(fauxfactory.gen_alphanumeric()),
+        description="project_des{}".format(fauxfactory.gen_alphanumeric()),
+        parent=collection.get_root_tenant(),
+    )
+    yield project
+    if project.exists:
+        project.delete()
+
+
+@pytest.fixture(scope="module")
+def new_group_project(appliance, new_project):
+    """This fixture creates new group and assigned by new peoject"""
+    collection = appliance.collections.groups
+    group = collection.create(
+        description="group_{}".format(fauxfactory.gen_alphanumeric()),
+        role="EvmRole-super_administrator",
+        tenant="My Company/{}".format(new_project.name),
+    )
+    yield group
+    if group.exists:
+        group.delete()
+
+
+@pytest.fixture(scope="module")
+def new_user_project(appliance, new_group_project):
+    """This fixture creates new user which is assigned to new group and project"""
+    collection = appliance.collections.users
+    user = collection.create(
+        name="user_{}".format(fauxfactory.gen_alphanumeric().lower()),
+        credential=new_credential(),
+        email="project_user@redhat.com",
+        groups=new_group_project,
+        cost_center="Workload",
+        value_assign="Database",
+    )
+    yield user
+    if user.exists:
+        user.delete()
+
+
+# first arg of parametrize is the list of fixtures or parameters,
+# second arg is a list of lists, with each one a test is to be generated
+# sequence is important here
+# indirect is the list where we define which fixtures are to be passed values indirectly.
+@pytest.mark.parametrize(
+    ["set_child_tenant_quota", "custom_prov_data", "extra_msg", "approve"],
+    [
+        [("cpu", 1), {}, "", False],
+        [("storage", 0.001), {}, "", False],
+        [("memory", 2), {}, "", False],
+        [("vm", 1), {"catalog": {"num_vms": "4"}}, "###", True],
+    ],
+    indirect=["set_child_tenant_quota"],
+    ids=["max_cpu", "max_storage", "max_memory", "max_vms"],
+)
+def test_child_tenant_quota_enforce_via_lifecycle_cloud(
+    request,
+    appliance,
+    provider,
+    setup_provider,
+    new_user_child,
+    set_child_tenant_quota,
+    extra_msg,
+    approve,
+    custom_prov_data,
+    prov_data,
+    vm_name,
+    template_name,
+):
+    """Test Child Quota in UI
+     Steps:
+        1. Create a child tenant
+        2. Assign quota to child tenant
+        3. Provision instance over the assigned child's quota
+        4. Check whether quota is exceeded or not
+    """
+    with new_user_child:
+        # Without below line, service_order only works here via admin, not via user
+        # TODO: Remove below line when this behavior gets fixed
+        appliance.server.login(new_user_child)
+        recursive_update(prov_data, custom_prov_data)
+        recursive_update(
+            prov_data,
+            {"request": {"email": "test_{}@example.com".format(fauxfactory.gen_alphanumeric()),
+                "first_name": fauxfactory.gen_alphanumeric(),
+                "last_name": fauxfactory.gen_alphanumeric(),
+                "manager_name": '{} {}'.format(fauxfactory.gen_alphanumeric(),
+                    fauxfactory.gen_alphanumeric())}}
+        )
+        prov_data.update({"template_name": template_name})
+        request_description = "Provision from [{template}] to [{vm}{msg}]".format(
+            template=template_name, vm=vm_name, msg=extra_msg
+        )
+        appliance.collections.cloud_instances.create(
+            vm_name,
+            provider,
+            prov_data,
+            auto_approve=approve,
+            override=True,
+            request_description=request_description,
+        )
+        provision_request = appliance.collections.requests.instantiate(request_description)
+        provision_request.wait_for_request(method="ui")
+        assert provision_request.row.reason.text == "Quota Exceeded"
+        request.addfinalizer(provision_request.remove_request)
+
+
+# first arg of parametrize is the list of fixtures or parameters,
+# second arg is a list of lists, with each one a test is to be generated
+# sequence is important here
+# indirect is the list where we define which fixtures are to be passed values indirectly.
+@pytest.mark.parametrize(
+    ["set_project_quota", "custom_prov_data", "extra_msg", "approve"],
+    [
+        [("cpu", 1), {}, "", False],
+        [("storage", 0.001), {}, "", False],
+        [("memory", 2), {}, "", False],
+        [("vm", 1), {"catalog": {"num_vms": "4"}}, "###", True],
+    ],
+    indirect=["set_project_quota"],
+    ids=["max_cpu", "max_storage", "max_memory", "max_vms"],
+)
+def test_project_quota_enforce_via_lifecycle_cloud(
+    request,
+    appliance,
+    provider,
+    setup_provider,
+    new_user_project,
+    set_project_quota,
+    extra_msg,
+    approve,
+    custom_prov_data,
+    prov_data,
+    vm_name,
+    template_name,
+):
+    """Test Project Quota in UI
+    Steps:
+        1. Create a project
+        2. Assign quota to project
+        3. Provision instance over the assigned project's quota
+        4. Check whether quota is exceeded or not
+    """
+    with new_user_project:
+        # Without below line, service_order only works here via admin, not via user
+        # TODO: Remove below line when this behavior gets fixed
+        appliance.server.login(new_user_project)
+        recursive_update(prov_data, custom_prov_data)
+        recursive_update(
+            prov_data,
+            {"request": {"email": "test_{}@example.com".format(fauxfactory.gen_alphanumeric()),
+                "first_name": fauxfactory.gen_alphanumeric(),
+                "last_name": fauxfactory.gen_alphanumeric(),
+                "manager_name": '{} {}'.format(fauxfactory.gen_alphanumeric(),
+                    fauxfactory.gen_alphanumeric())}}
+        )
+        prov_data.update({"template_name": template_name})
+        request_description = "Provision from [{template}] to [{vm}{msg}]".format(
+            template=template_name, vm=vm_name, msg=extra_msg
+        )
+        appliance.collections.cloud_instances.create(
+            vm_name,
+            provider,
+            prov_data,
+            auto_approve=approve,
+            override=True,
+            request_description=request_description,
+        )
+        provision_request = appliance.collections.requests.instantiate(request_description)
+        provision_request.wait_for_request(method="ui")
+        assert provision_request.row.reason.text == "Quota Exceeded"
+        request.addfinalizer(provision_request.remove_request)

--- a/cfme/tests/cloud/test_quota.py
+++ b/cfme/tests/cloud/test_quota.py
@@ -3,12 +3,12 @@ import fauxfactory
 import pytest
 from riggerlib import recursive_update
 
+from widgetastic.utils import partial_match
+
 from cfme import test_requirements
 from cfme.base.credential import Credential
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.utils.generators import random_vm_name
-
-from widgetastic.utils import partial_match
 
 
 pytestmark = [
@@ -16,9 +16,7 @@ pytestmark = [
     pytest.mark.long_running,
     pytest.mark.usefixtures("setup_provider"),
     pytest.mark.provider([AzureProvider], scope='function',
-                         required_fields=[["provisioning", "image"]]),
-
-]
+                         required_fields=[["provisioning", "image"]])]
 
 
 @pytest.fixture
@@ -184,11 +182,17 @@ def test_child_tenant_quota_enforce_via_lifecycle_cloud(
     provisioning,
 ):
     """Test Child Quota in UI
-     Steps:
-        1. Create a child tenant
-        2. Assign quota to child tenant
-        3. Provision instance over the assigned child's quota
-        4. Check whether quota is exceeded or not
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: cloud
+        caseimportance: high
+        initialEstimate: 1/8h
+        testSteps:
+            1. Create a child tenant
+            2. Assign quota to child tenant
+            3. Provision instance over the assigned child's quota
+            4. Check whether quota is exceeded or not
     """
     with new_user_child:
         recursive_update(prov_data, custom_prov_data)
@@ -249,11 +253,17 @@ def test_project_quota_enforce_via_lifecycle_cloud(
     provisioning,
 ):
     """Test Project Quota in UI
-    Steps:
-        1. Create a project
-        2. Assign quota to project
-        3. Provision instance over the assigned project's quota
-        4. Check whether quota is exceeded or not
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: cloud
+        caseimportance: high
+        initialEstimate: 1/8h
+        testSteps:
+            1. Create a project
+            2. Assign quota to project
+            3. Provision instance over the assigned project's quota
+            4. Check whether quota is exceeded or not
     """
     with new_user_project:
         recursive_update(prov_data, custom_prov_data)

--- a/cfme/tests/cloud/test_quota.py
+++ b/cfme/tests/cloud/test_quota.py
@@ -21,7 +21,10 @@ pytestmark = [
 
 @pytest.fixture
 def prov_data(appliance, provisioning):
-    instance_type = "d2s_v3" if appliance.version < "5.10" else "D2s_v3"
+    """Keeping it as a fixture because we need to call 'provisioning' from this fixture as well as
+       using this same fixture in various tests.
+    """
+    instance_type = "d2s_v3" if appliance.version < "5.10" else "d2s_v3".capitalize()
     return {
         "catalog": {"vm_name": random_vm_name(context="quota")},
         "environment": {"automatic_placement": True},
@@ -221,8 +224,8 @@ def test_child_tenant_quota_enforce_via_lifecycle_cloud(
         )
         provision_request = appliance.collections.requests.instantiate(request_description)
         provision_request.wait_for_request(method="ui")
-        assert provision_request.row.reason.text == "Quota Exceeded"
         request.addfinalizer(provision_request.remove_request)
+        assert provision_request.row.reason.text == "Quota Exceeded"
 
 
 # first arg of parametrize is the list of fixtures or parameters,
@@ -292,5 +295,5 @@ def test_project_quota_enforce_via_lifecycle_cloud(
         )
         provision_request = appliance.collections.requests.instantiate(request_description)
         provision_request.wait_for_request(method="ui")
-        assert provision_request.row.reason.text == "Quota Exceeded"
         request.addfinalizer(provision_request.remove_request)
+        assert provision_request.row.reason.text == "Quota Exceeded"


### PR DESCRIPTION
**Purpose or Intent**

- Adding test case related to ```project``` and ```child-tenant``` quota for cloud providers.

{{ pytest: cfme/tests/cloud/test_quota.py --long-running  --use-provider=azure -v }}
Note: Ref. PR: #7255 