### PR TITLE
[1LP][RFR] Fix test_rolename_required_error_validation

### DIFF
--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -578,7 +578,10 @@ def test_role_crud(appliance):
 
 @pytest.mark.tier(3)
 def test_rolename_required_error_validation(appliance):
-    with pytest.raises(Exception, match="Name can't be blank"):
+    # When trying to create a role with no name, the Add button is disabled.
+    # We are waiting for an Exception saying that there are no success
+    # or fail messages, because the Add button cannot be clicked.
+    with pytest.raises(Exception, match="Available messages: \[\]"):
         appliance.collections.roles.create(
             name=None,
             vm_restriction='Only User Owned'


### PR DESCRIPTION
This is a quick fix for existing test.

Changing only the Exception text and adding a comment about what's happening.

{{ pytest: -v --long-running cfme/tests/configure/test_access_control.py -k test_rolename_required_error_validation --use-provider vsphere67-nested }}