### PR TITLE
[1LP][RFR] delete vm after the test

### DIFF
--- a/cfme/tests/cloud_infra_common/test_tag_visibility.py
+++ b/cfme/tests/cloud_infra_common/test_tag_visibility.py
@@ -28,6 +28,7 @@ def tagged_vm(tag, provider):
     yield tag_vm
     tag_vm.appliance.server.login_admin()
     tag_vm.remove_tag(tag=tag)
+    tag_vm.delete()
 
 
 @pytest.mark.rhv3


### PR DESCRIPTION
Since PRT do not run on 58z, posting local results ran on CFME 5.8.5.1:

```
Appliance's streams: [5.8, downstream]
========================================================================================================================= test session starts ==========================================================================================================================
platform linux2 -- Python 2.7.5, pytest-3.4.1, py-1.5.3, pluggy-0.6.0 -- /home/anikifor/cfme/bin/python
cachedir: .pytest_cache
rootdir: /home/anikifor/projects/integration_tests, inifile:
plugins: wait-for-1.0.9, pycharm-0.5.0, manageiq-integration-tests-17.34.1.dev50+ge66806a
collected 4 items                                                                                                                                                                                                                                                      
Uncollection Stats:
 manual: 0
 uncollectif: 0
 4 tests left after all uncollections

cfme/tests/cloud_infra_common/test_tag_visibility.py::test_tag_vis_vm[virtualcenter] [WARNING] [py.warnings] /home/anikifor/cfme/lib/python2.7/site-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
  """)
 (/home/anikifor/cfme/lib/python2.7/site-packages/psycopg2/__init__.py:144)

Removing extra providers: ec2west
Trying to set up provider vsphere65-nested

[WARNING] [py.warnings] /home/anikifor/cfme/lib/python2.7/site-packages/selenium/webdriver/remote/webdriver.py:788: DeprecationWarning: use driver.switch_to.alert instead
  warnings.warn("use driver.switch_to.alert instead", DeprecationWarning)
 (/home/anikifor/cfme/lib/python2.7/site-packages/selenium/webdriver/remote/webdriver.py:788)

cfme/tests/cloud_infra_common/test_tag_visibility.py::test_tag_vis_vm[virtualcenter] PASSED
cfme/tests/cloud_infra_common/test_tag_visibility.py::test_tag_vis_vm[rhevm] 
Removing extra providers: vsphere65-nested
Trying to set up provider rhv41


cfme/tests/cloud_infra_common/test_tag_visibility.py::test_tag_vis_vm[rhevm] PASSED
cfme/tests/cloud_infra_common/test_tag_visibility.py::test_tag_vis_vm[openstack] 
Removing extra providers: rhv41
Trying to set up provider rhos11


cfme/tests/cloud_infra_common/test_tag_visibility.py::test_tag_vis_vm[openstack] PASSED
cfme/tests/cloud_infra_common/test_tag_visibility.py::test_tag_vis_vm[ec2] 
Removing extra providers: rhos11
Trying to set up provider ec2west


cfme/tests/cloud_infra_common/test_tag_visibility.py::test_tag_vis_vm[ec2] PASSED
```
There was a failure for [ec2] test: DropdownDisabled: Dropdown "Policy" is not enabled.

It happened because the previous VM was not deleted when Openstack provider was removed and it has the same name. So by searching the name there were 2 VMs and Policy was not active.