### PR TITLE
[RFR] Use log validator for targeted refresh

### DIFF
--- a/cfme/fixtures/networks.py
+++ b/cfme/fixtures/networks.py
@@ -1,15 +1,15 @@
 import pytest
-import re
 from argparse import Namespace
 from contextlib import contextmanager
 
 from cfme.exceptions import NeedleNotFoundInLog
 from cfme.utils.log import logger
+from cfme.utils.log_validator import LogValidator
 from cfme.utils.wait import wait_for, TimedOutError
 
 
 @pytest.fixture
-def targeted_refresh(merkyl_setup, merkyl_inspector):
+def targeted_refresh():
     """
     This fixture tests whether targeted refresh was triggered for given targets.
     It basically tails evm.log to see whether a line like this has occured:
@@ -28,19 +28,16 @@ def targeted_refresh(merkyl_setup, merkyl_inspector):
                     targeted_refresh.register_target('ref-123456', 'Subnet named TEST')
                     targeted_refresh.register_target('ref-aaaabb', 'Router named TEST')
     """
-    evm_log = '/var/www/miq/vmdb/log/evm.log'
     needle_template = r'^.*Collection of targets with id.*:ems_ref=>"{}".*$'
-    merkyl_inspector.add_log(evm_log)
-    merkyl_inspector.reset_log(evm_log)
-    targets = set()  # { (ems_ref, comment), (ems_ref, comment), ... }
+    targets = {}  # { needle: comment }
+    log_validator = LogValidator('/var/www/miq/vmdb/log/evm.log')
+    log_validator.fix_before_start()
 
     def check_log():
-        logger.info('Looking for %s needles in evm.log: %s', len(targets), [t[1] for t in targets])
-        content = merkyl_inspector.get_log(evm_log)
-        for target in set(targets):
-            if target[0].search(content):
-                logger.info('Found needle %s', target[1])
-                targets.remove(target)
+        logger.info('Looking for %s needles in evm.log: %s', len(targets), list(targets.values()))
+        log_validator.update_matched_patterns(list(targets))
+        for revealed_pattern in log_validator.validate_logs(auto_fail=False):
+            logger.info('Found needle %s', targets.pop(revealed_pattern))
         return len(targets) == 0
 
     @contextmanager
@@ -51,9 +48,9 @@ def targeted_refresh(merkyl_setup, merkyl_inspector):
             wait_for(check_log, delay=5, num_sec=60)
         except TimedOutError:
             raise NeedleNotFoundInLog('Targeted refresh did not trigger for:\n{}'.format(
-                                      ',\n'.join(map(lambda t: '- ' + t[1], targets))))
+                                      ',\n'.join(map(lambda t: '- ' + t, targets.values()))))
 
     def register_target(ems_ref, comment):
-        targets.add((re.compile(needle_template.format(ems_ref), re.MULTILINE), comment))
+        targets[needle_template.format(ems_ref)] = comment
 
     yield Namespace(register_target=register_target, timeout=timeout)

--- a/cfme/tests/networks/nuage/test_events_are_triggered.py
+++ b/cfme/tests/networks/nuage/test_events_are_triggered.py
@@ -49,11 +49,6 @@ def test_creating_entities_triggers_targeted_refresh(targeted_refresh, with_nuag
     we check whether Automation Instances are properly set to trigger targeted refresh
     when event comes.
 
-    config:
-        Before running this test you have to configure merkyl (see how in
-        cfme/fixtures/merkyl.py) and make sure you have port 8192 opened
-        on your appliance.
-
     Steps:
         * Deploy entities outside of CFME (directly in the provider)
         * Verify that targeted refreshes where triggered


### PR DESCRIPTION
Targeted refesh fixture searches `evm.log` to check if refresh  was started for specific entity. Until this commit merkyl plugin was used to tail `evm.log`, now LogValidator is used to tail it. This change was made because LogValidator is prefered over merkyl as ssh access is all you need for it. While merkyl needs daemon to run on appliance and its failure can affect targeted refresh test.

Upon migrating to the new approach, we had to enhance LogValidator a bit to support our use case. It's that until now it was always used to search logs exactly once (and fail test if not found), while we needed to periodically retry the thing and only fail test if not fulfilled by the end of timeout.

Depends on https://github.com/ManageIQ/integration_tests/pull/7858