### PR TITLE
[1LP][RFR] Add leading whitespace password test

### DIFF
--- a/cfme/tests/test_login.py
+++ b/cfme/tests/test_login.py
@@ -94,3 +94,27 @@ def test_update_password(context, request, appliance):
         appliance.server.login(user)
 
     user.delete()
+
+
+@pytest.mark.parametrize('context', [ViaUI])
+def test_leading_whitespace_password(context, request, appliance):
+    """ Test password with leading whitespace """
+
+    # First, create a temporary new user
+    username = 'user_temp_{}'.format(fauxfactory.gen_alphanumeric(4).lower())
+    password = " password"
+    new_creds = Credential(principal=username, secret=password)
+    user_group = appliance.collections.groups.instantiate(description="EvmGroup-vm_user")
+    user = appliance.collections.users.create(
+        name=username,
+        credential=new_creds,
+        groups=user_group
+    )
+
+    # Try to login with new user
+    logged_in_page = appliance.server.login(user)
+    assert logged_in_page.is_displayed
+    logged_in_page.logout()
+
+    # Delete the user
+    request.addfinalizer(user.delete)


### PR DESCRIPTION
This is a new test. Adds simple test for checking if an user is able to be created & login with password containing leading space character.

I will refactor the whole file later, now just adding tests to increase coverage.

{{ pytest: -v cfme/tests/test_login.py -k test_leading_whitespace_password }}