### PR TITLE
[WIP] Fix test_appliance_console_restore_db_.* tests

### DIFF
--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -514,6 +514,7 @@ def nfs_samba_share_vm(utility_vm):
     }
     nfs_smb = SSHClient(**connect_kwargs)
     setup = (
+        # Common setup.
         dedent(''' \
         cat > /etc/yum.repos.d/rhel.repo <<EOF
         [rhel]
@@ -524,9 +525,8 @@ def nfs_samba_share_vm(utility_vm):
         skip_if_unavailable=False
         EOF
         ''').format(baseurl=cfme_data['basic_info']['rhel7_updates_url']),
-
-        # Common setup.
         'yum install -y nfs-utils samba',
+        'setenforce 0',
 
         # NFS setup
         'mkdir -p /srv/export',
@@ -542,6 +542,8 @@ def nfs_samba_share_vm(utility_vm):
         'exportfs -ra',
 
         # SMB setup
+        'adduser backuper',
+        #'smbpasswd -a backuper', # TODO(jhenner) set the password!
         'mkdir -p /srv/samba',
         'chmod a=rwx /srv/samba',
         'firewall-cmd --add-port=139/tcp --permanent',
@@ -561,7 +563,6 @@ def nfs_samba_share_vm(utility_vm):
         'systemctl enable smb',
         'systemctl start smb',
     )
-    import ipdb; ipdb.set_trace()
     for line in setup:
         assert nfs_smb.run_command(line).success
     return {'hostname': utility_vm['ip'],
@@ -604,6 +605,7 @@ def test_appliance_console_restore_db_nfs(request, get_appliances_with_providers
     interaction.send('4')
     interaction.expect('Choose the restore database file: |1| ')
     interaction.send('2')
+    import ipdb; ipdb.set_trace()
     interaction.expect('Enter the location of the remote backup file\n.*db.backup: ')
     interaction.send(nfs_dump)
     interaction.expect('Are you sure you would like to restore the database\? \(Y/N\): ')
@@ -661,6 +663,7 @@ def test_appliance_console_restore_db_samba(request, get_appliances_with_provide
     interaction.send('')
     interaction.expect('Are you sure you would like to restore the database\? \(Y/N\): ')
     interaction.send('y')
+    import ipdb; ipdb.set_trace()
     interaction.expect('Restoring the database\.\.\.')
     interaction.expect('Database restore succeed.*Press any key to continue.', timeout=20)
 

--- a/cfme/tests/configure/test_proxy.py
+++ b/cfme/tests/configure/test_proxy.py
@@ -179,7 +179,6 @@ def test_proxy_override(appliance, proxy_ssh, prepare_proxy_specific, provider):
     )
 
 
-@pytest.mark.meta(blockers=[BZ(1623550, forced_streams=['5.9', '5.10'])])
 def test_proxy_invalid(appliance, prepare_proxy_invalid, provider):
     """ Check whether invalid default and invalid specific provider proxy settings
      results in provider refresh not working.
@@ -202,7 +201,8 @@ def test_proxy_invalid(appliance, prepare_proxy_invalid, provider):
 
     def last_refresh_failed():
         view.toolbar.reload.click()
-        return 'Timed out connecting to server' in (
-            view.entities.summary('Status').get_text_of('Last Refresh'))
+        status = view.entities.summary('Status').get_text_of('Last Refresh')
+        return any(('Timed out connecting to server' in status,
+                   'execution expired' in status))
 
     wait_for(last_refresh_failed, fail_condition=False, num_sec=240, delay=5)

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -958,8 +958,9 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
             The credentials default to those found under ``ssh`` key in ``credentials.yaml``.
 
         """
-        if not self.is_ssh_running:
-            raise Exception('SSH is unavailable')
+        logger.debug('Waiting for SSH.')
+        self.wait_for_ssh()
+        logger.debug('SSH ready.')
 
         # IPAppliance.ssh_client only connects to its address
         if self.openshift_creds:

--- a/scripts/prepare_utility_vm.py
+++ b/scripts/prepare_utility_vm.py
@@ -1,0 +1,74 @@
+from wrapanapi.systems.openstack import OpenstackSystem
+from cfme.utils.conf import credentials, cfme_data
+from textwrap import dedent
+from cfme.utils.ssh import SSHClient
+
+
+def create_utility_template(base_template, key):
+    data = cfme_data[key]
+    OpenstackSystem(
+        tenant=data.credentials['tenant'],
+        username=data.credentials['username'],
+        password=data.credentials['password'],
+        auth_url=data.auth_url)
+
+
+def configure(hostname, username, password):
+    connect_kwargs = {
+        'hostname': hostname,
+        'username': username,
+        'password': password
+    }
+    setup = (
+        # Common setup.
+        dedent(''' \
+        cat > /etc/yum.repos.d/rhel.repo <<EOF
+        [rhel]
+        name=RHEL 7.5-Update
+        baseurl={baseurl}
+        enabled=1
+        gpgcheck=0
+        skip_if_unavailable=False
+        EOF
+        ''').format(baseurl=cfme_data['basic_info']['rhel7_updates_url']),
+        'yum install -y nfs-utils samba',
+        'setenforce 0',
+
+        # NFS setup
+        'mkdir -p /srv/export',
+        'chmod a=rwx /srv/export',
+        'echo "/srv/export *(ro)" >> /etc/exports',
+        'firewall-cmd --add-port=2049/udp --permanent',
+        'firewall-cmd --add-port=2049/tcp --permanent',
+        'firewall-cmd --add-port=111/udp --permanent',
+        'firewall-cmd --add-port=111/tcp --permanent',
+        'firewall-cmd --reload',
+        'systemctl enable nfs',
+        'systemctl start nfs',
+        'exportfs -ra',
+
+        # SMB setup
+        'adduser backuper',
+        #'smbpasswd -a backuper', # TODO(jhenner) set the password!
+        'mkdir -p /srv/samba',
+        'chmod a=rwx /srv/samba',
+        'firewall-cmd --add-port=139/tcp --permanent',
+        'firewall-cmd --add-port=445/tcp --permanent',
+        'firewall-cmd --reload',
+        dedent('''\
+            cat >> /etc/samba/smb.conf <<EOF
+            [public]
+            comment = Public Stuff
+            path = /srv/samba
+            public = yes
+            writable = no
+            printable = no
+            write list = +staff
+            EOF
+            '''),
+        'systemctl enable smb',
+        'systemctl start smb',
+    )
+    vm_ssh = SSHClient(**connect_kwargs)
+    for line in setup:
+        assert vm_ssh.run_command(line).success

--- a/scripts/utility-vm/Makefile
+++ b/scripts/utility-vm/Makefile
@@ -28,7 +28,7 @@ ifndef DOWNLOAD_LINK
 endif
 	curl -Sf "${DOWNLOAD_LINK}" -o $@
 
-cloud_init.iso: user-data.yaml meta-data
+cloud_init.iso: user-data meta-data
 	genisoimage -output "$@" -volid cidata -joliet -rock $^
 
 user-data: user-data.yaml

--- a/scripts/utility-vm/Makefile
+++ b/scripts/utility-vm/Makefile
@@ -11,7 +11,8 @@ snapshot.qcow2: ${SOURCE_IMAGE} customization-script.sh rhel7.repo rhel8.repo
 		           -a ${TMP_DISK} \
 				   --upload rhel7.repo:/tmp/rhel7.repo \
 				   --upload rhel8.repo:/tmp/rhel8.repo \
-				   --run customization-script.sh \
+				   --upload customization-script.sh:/tmp/customization-script.sh \
+				   --run-command "/bin/bash /tmp/customization-script.sh '${SHARE_PASSWORD}'" \
 				   --selinux-relabel
 	mv ${TMP_DISK} $@
 

--- a/scripts/utility-vm/Makefile
+++ b/scripts/utility-vm/Makefile
@@ -1,0 +1,40 @@
+SOURCE_IMAGE=rhel-guest-image.qcow2
+TMP_DISK=disk.qcow2.tmp
+
+utility_vm.qcow2: snapshot.qcow2
+	qemu-img convert -O qcow2 -p $< $@
+
+snapshot.qcow2: ${SOURCE_IMAGE} customization-script.sh rhel7.repo rhel8.repo
+	-rm ${TMP_DISK}
+	qemu-img create -f qcow2 -o backing_file=`pwd`/$< ${TMP_DISK}
+	virt-customize --network \
+		           -a ${TMP_DISK} \
+				   --upload rhel7.repo:/tmp/rhel7.repo \
+				   --upload rhel8.repo:/tmp/rhel8.repo \
+				   --run customization-script.sh \
+				   --selinux-relabel
+	mv ${TMP_DISK} $@
+
+%.repo: %.repo.template
+ifndef RHEL_REPO_BASE
+	$(error The env variable RHEL_REPO_BASE is undefined)
+endif
+	sed 's|RHEL_REPO_BASE|${RHEL_REPO_BASE}|g' $< >$@
+
+${SOURCE_IMAGE}:
+ifndef DOWNLOAD_LINK
+	$(error The env variable DOWNLOAD_LINK is undefined)
+endif
+	curl -Sf "${DOWNLOAD_LINK}" -o $@
+
+cloud_init.iso: user-data.yaml meta-data
+	genisoimage -output "$@" -volid cidata -joliet -rock $^
+
+user-data: user-data.yaml
+	write-mime-multipart $< > $@
+
+clean:
+	-rm user-data cloud_init.iso rhel8.repo rhel7.repo utility_vm.qcow2 \
+		${TMP_DISK} snapshot.qcow2
+
+.PHONY: clean

--- a/scripts/utility-vm/README
+++ b/scripts/utility-vm/README
@@ -1,9 +1,23 @@
 usage
 =====
 
+SHARE_PASSWORD=changeme \
 RHEL_REPO_BASE=http://download.lab.bos.redhat.com/rel-eng  \
 DOWNLOAD_LINK=http://download.eng.brq.redhat.com/brewroot/packages/rhel-guest-image/8.1/68/images/rhel-guest-image-8.1-68.x86_64.qcow2 \
 make
 
-After make you should have utility_vm.qcow2 file in the current directory which
-you can upload to the provider.
+After the make finishes, you should have utility_vm.qcow2 file in the current
+directory which you can upload to the provider.
+
+To check the created image you may build an iso which will enable you to log-in
+using password "changeme" as user "root" or "cloud-user"
+
+$ make cloud_init.iso
+
+$ qemu-kvm -nographic -m 1G \
+         -drive file=utility_vm.qcow2 \
+         -cdrom cloud_init.iso \
+         -net nic,model=virtio \
+         -net user,hostfwd=tcp::2222-:22
+
+Note that this act will modify the image.

--- a/scripts/utility-vm/README
+++ b/scripts/utility-vm/README
@@ -1,0 +1,9 @@
+usage
+=====
+
+RHEL_REPO_BASE=http://download.lab.bos.redhat.com/rel-eng  \
+DOWNLOAD_LINK=http://download.eng.brq.redhat.com/brewroot/packages/rhel-guest-image/8.1/68/images/rhel-guest-image-8.1-68.x86_64.qcow2 \
+make
+
+After make you should have utility_vm.qcow2 file in the current directory which
+you can upload to the provider.

--- a/scripts/utility-vm/customization-script.sh
+++ b/scripts/utility-vm/customization-script.sh
@@ -25,7 +25,6 @@ rhel7y && mv /tmp/rhel7.repo /etc/yum.repos.d/rhel.repo
 rhel8y && mv /tmp/rhel8.repo /etc/yum.repos.d/rhel.repo
 
 yum install -y nfs-utils samba vsftpd
-#setenforce 0
 
 # NFS setup
 mkdir -p /srv/export
@@ -63,6 +62,6 @@ yum -y install squid
 systemctl enable squid
 
 # Turn selinux off
-echo SELINUXTYPE=targeted > /etc/selinux/config
+sed  -i 's/SELINUX=.*/SELINUX=permissive/' /etc/selinux/config
 
 touch /.unconfigured

--- a/scripts/utility-vm/customization-script.sh
+++ b/scripts/utility-vm/customization-script.sh
@@ -51,4 +51,7 @@ systemctl enable vsftpd
 systemctl start vsftpd
 echo changeme | passwd --stdin backuper
 
+# Turn selinux off
+echo SELINUXTYPE=targeted > /etc/selinux/config
+
 touch /.unconfigured

--- a/scripts/utility-vm/customization-script.sh
+++ b/scripts/utility-vm/customization-script.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -x -e
+
+function rhel7y {
+    RHEL_7_Y_IDENTIFIER="Red Hat Enterprise Linux Server release 7\.. .* (Maipo)"
+    grep -q "$RHEL_7_Y_IDENTIFIER" /etc/redhat-release
+}
+
+function rhel8y {
+    RHEL_8_Y_IDENTIFIER="Red Hat Enterprise Linux release 8\.. .* (Ootpa)"
+    grep -q "$RHEL_8_Y_IDENTIFIER" /etc/redhat-release
+}
+
+sed -i'.orig' -e's/without-password/yes/' /etc/ssh/sshd_config
+
+rhel7y && mv /tmp/rhel7.repo /etc/yum.repos.d/rhel.repo
+rhel8y && mv /tmp/rhel8.repo /etc/yum.repos.d/rhel.repo
+
+yum install -y nfs-utils samba vsftpd
+#setenforce 0
+
+# NFS setup
+mkdir -p /srv/export
+chmod a=rwx /srv/export
+echo "/srv/export *(rw)" >> /etc/exports
+rhel7y && ( systemctl enable nfs; systemctl start nfs )
+rhel8y && ( systemctl enable nfs-server; systemctl start nfs-server )
+
+# SMB setup
+adduser backuper
+echo -e 'changeme\nchangeme' | smbpasswd -sa backuper
+mkdir -p /srv/samba
+chmod a=rwx /srv/samba
+
+cat >> /etc/samba/smb.conf <<EOF
+[public]
+comment = Public Stuff
+path = /srv/samba
+public = yes
+writable = yes
+printable = no
+write list = +staff
+EOF
+
+systemctl enable smb
+systemctl start smb
+
+# FTP setup
+systemctl enable vsftpd
+systemctl start vsftpd
+echo changeme | passwd --stdin backuper
+
+touch /.unconfigured

--- a/scripts/utility-vm/meta-data
+++ b/scripts/utility-vm/meta-data
@@ -1,0 +1,2 @@
+instance-id: Utility-vm-test
+local-hostname: utility-vm-test

--- a/scripts/utility-vm/rhel7.repo.template
+++ b/scripts/utility-vm/rhel7.repo.template
@@ -1,0 +1,6 @@
+[rhel]
+name=RHEL 7.0
+baseurl=RHEL_REPO_BASE/latest-RHEL-7/compose/Server/x86_64/os/
+enabled=1
+gpgcheck=0
+skip_if_unavailable=False

--- a/scripts/utility-vm/rhel8.repo.template
+++ b/scripts/utility-vm/rhel8.repo.template
@@ -1,0 +1,13 @@
+[rhel-BaseOS]
+name=RHEL 8.0
+baseurl=RHEL_REPO_BASE/latest-RHEL-8/compose/BaseOS/x86_64/os/
+enabled=1
+gpgcheck=0
+skip_if_unavailable=False
+
+[rhel-AppStream]
+name=RHEL 8.0 AppStream
+baseurl=RHEL_REPO_BASE/latest-RHEL-8/compose/AppStream/x86_64/os/
+enabled=1
+gpgcheck=0
+skip_if_unavailable=False

--- a/scripts/utility-vm/user-data.yaml
+++ b/scripts/utility-vm/user-data.yaml
@@ -6,6 +6,6 @@ ssh_pwauth: True
 disable_root: false
 chpasswd:
   list: |
-    root:password
-    cloud-user:password
+    root:changeme
+    cloud-user:changeme
   expire: false

--- a/scripts/utility-vm/user-data.yaml
+++ b/scripts/utility-vm/user-data.yaml
@@ -1,0 +1,11 @@
+#cloud-config
+# vim:syntax=yaml
+
+debug: True
+ssh_pwauth: True
+disable_root: false
+chpasswd:
+  list: |
+    root:password
+    cloud-user:password
+  expire: false


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__  test_appliance_console_restore_db_.* tests which failed because of
1) timeout was too short when issuing the ap command
2) the VM providing the NFS share didn't exist.

Fixed by starting using paramiko_expect and creating the required VM on demand.

{{ pytest: -v cfme/tests/cli/test_appliance_console_db_restore.py::test_appliance_console_restore_db_samba cfme/tests/cli/test_appliance_console_db_restore.py::test_appliance_console_restore_db_nfs }}