### PR TITLE
[1LP][RFR]V2v migration with special chars name

### DIFF
--- a/cfme/fixtures/v2v.py
+++ b/cfme/fixtures/v2v.py
@@ -91,8 +91,8 @@ def _tag_cleanup(host_obj, tag1, tag2):
     # are not subset of valid tags, we still remove them.
     if len(tags_set) < 2 or not tags_set.issubset(valid_tags):
         host_obj.remove_tags(tags=tags)
-        return True
-    return False
+        return False
+    return True
 
 
 @pytest.fixture(scope='function')

--- a/cfme/fixtures/v2v.py
+++ b/cfme/fixtures/v2v.py
@@ -91,8 +91,8 @@ def _tag_cleanup(host_obj, tag1, tag2):
     # are not subset of valid tags, we still remove them.
     if len(tags_set) < 2 or not tags_set.issubset(valid_tags):
         host_obj.remove_tags(tags=tags)
-        return False
-    return True
+        return True
+    return False
 
 
 @pytest.fixture(scope='function')

--- a/cfme/tests/v2v/test_v2v_migrations.py
+++ b/cfme/tests/v2v/test_v2v_migrations.py
@@ -55,7 +55,7 @@ def test_single_datastore_single_vm_migration(request, appliance, v2v_providers,
         fail_func=src_vm_obj.refresh_relationships,
         delay=5, timeout=300)
 
-    src_vm_obj = form_data_vm_obj_single_datastore[1][0]
+    src_vm_obj = form_data_vm_obj_single_datastore.vm_obj[0]
     wait_for(lambda: src_vm_obj.ip_address is not None,
         message="Waiting for VM to display IP in CFME",
         fail_func=src_vm_obj.refresh_relationships,

--- a/cfme/tests/v2v/test_v2v_migrations.py
+++ b/cfme/tests/v2v/test_v2v_migrations.py
@@ -55,6 +55,14 @@ def test_single_datastore_single_vm_migration(request, appliance, v2v_providers,
         fail_func=src_vm_obj.refresh_relationships,
         delay=5, timeout=300)
 
+    src_vm_obj = form_data_vm_obj_single_datastore[1][0]
+    wait_for(lambda: src_vm_obj.ip_address is not None,
+        message="Waiting for VM to display IP in CFME",
+        fail_func=src_vm_obj.refresh_relationships,
+        delay=5, timeout=300)
+
+    src_vm_ip_addr = src_vm_obj.ip_address
+
     migration_plan_collection = appliance.collections.v2v_plans
     migration_plan = migration_plan_collection.create(
         name="plan_{}".format(fauxfactory.gen_alphanumeric()), description="desc_{}"

--- a/cfme/tests/v2v/test_v2v_migrations.py
+++ b/cfme/tests/v2v/test_v2v_migrations.py
@@ -50,18 +50,6 @@ def test_single_datastore_single_vm_migration(request, appliance, v2v_providers,
         infrastructure_mapping_collection.delete(mapping)
     # vm_obj is a list, with only 1 VM object, hence [0]
     src_vm_obj = form_data_vm_obj_single_datastore.vm_list[0]
-    wait_for(lambda: src_vm_obj.ip_address is not None,
-        message="Waiting for VM to display IP in CFME",
-        fail_func=src_vm_obj.refresh_relationships,
-        delay=5, timeout=300)
-
-    src_vm_obj = form_data_vm_obj_single_datastore.vm_obj[0]
-    wait_for(lambda: src_vm_obj.ip_address is not None,
-        message="Waiting for VM to display IP in CFME",
-        fail_func=src_vm_obj.refresh_relationships,
-        delay=5, timeout=300)
-
-    src_vm_ip_addr = src_vm_obj.ip_address
 
     migration_plan_collection = appliance.collections.v2v_plans
     migration_plan = migration_plan_collection.create(
@@ -514,3 +502,53 @@ def test_multi_host_multi_vm_migration(request, appliance, v2v_providers, host_c
     for vm in vms:
         soft_assert(request_details_list.is_successful(vm) and
          not request_details_list.is_errored(vm))
+
+
+@pytest.mark.parametrize('form_data_vm_obj_single_datastore', [['nfs', 'nfs', rhel7_minimal]],
+                        indirect=True)
+def test_migration_special_char_name(request, appliance, v2v_providers, host_creds, conversion_tags,
+                                    form_data_vm_obj_single_datastore):
+    """Tests migration where name of migration plan is comprised of special non-alphanumeric
+       characters, such as '@#$(&#@('."""
+    infrastructure_mapping_collection = appliance.collections.v2v_mappings
+    mapping = infrastructure_mapping_collection.create(form_data_vm_obj_single_datastore.form_data)
+
+    @request.addfinalizer
+    def _cleanup():
+        infrastructure_mapping_collection.delete(mapping)
+
+    src_vm_obj = form_data_vm_obj_single_datastore.vm_obj[0]
+    wait_for(lambda: src_vm_obj.ip_address is not None,
+        message="Waiting for VM to display IP in CFME",
+        fail_func=src_vm_obj.refresh_relationships,
+        delay=5, timeout=300)
+
+    migration_plan_collection = appliance.collections.v2v_plans
+    # fauxfactory.gen_special() used here to create special character string e.g. #$@#@
+    migration_plan = migration_plan_collection.create(
+        name="{}".format(fauxfactory.gen_special()), description="desc_{}"
+        .format(fauxfactory.gen_alphanumeric()), infra_map=mapping.name,
+        vm_list=form_data_vm_obj_single_datastore.vm_obj, start_migration=True)
+
+    # explicit wait for spinner of in-progress status card
+    view = appliance.browser.create_view(navigator.get_class(migration_plan_collection, 'All').VIEW)
+    wait_for(func=view.progress_card.is_plan_started, func_args=[migration_plan.name],
+        message="migration plan is starting, be patient please", delay=5, num_sec=150,
+        handle_exception=True)
+
+    # wait until plan is in progress
+    wait_for(func=view.plan_in_progress, func_args=[migration_plan.name],
+        message="migration plan is in progress, be patient please",
+        delay=5, num_sec=1800)
+
+    view.migr_dropdown.item_select("Completed Plans")
+    view.wait_displayed()
+    logger.info("For plan %s, migration status after completion: %s, total time elapsed: %s",
+        migration_plan.name, view.migration_plans_completed_list.get_vm_count_in_plan(
+            migration_plan.name), view.migration_plans_completed_list.get_clock(
+            migration_plan.name))
+    # validate MAC address matches between source and target VMs
+    assert view.migration_plans_completed_list.is_plan_succeeded(migration_plan.name)
+    src_vm = form_data_vm_obj_single_datastore.vm_obj[0]
+    migrated_vm = get_migrated_vm_obj(src_vm, v2v_providers.rhv_provider)
+    assert src_vm.mac_address == migrated_vm.mac_address

--- a/cfme/tests/v2v/test_v2v_migrations_ui.py
+++ b/cfme/tests/v2v/test_v2v_migrations_ui.py
@@ -92,9 +92,9 @@ def test_v2v_ui_set1(appliance, v2v_providers, form_data_single_datastore, soft_
         ['mappings'][0]['target'])
 
     # Test Datacenter name in source and destination mapping select list:
-    soft_assert(v2v_providers[0].data['datacenters'][0]
+    soft_assert(v2v_providers.vmware_provider.data['datacenters'][0]
                 in view.form.cluster.source_clusters.all_items[0])
-    soft_assert(v2v_providers[1].data['datacenters'][0]
+    soft_assert(v2v_providers.rhv_provider.data['datacenters'][0]
                 in view.form.cluster.target_clusters.all_items[0])
 
     # Assert Add Mapping button is enabled before selecting source and target clusters
@@ -145,8 +145,8 @@ def test_v2v_ui_no_providers(appliance, v2v_providers, soft_assert):
     infrastructure_mapping_collection = appliance.collections.v2v_mappings
     view = navigate_to(infrastructure_mapping_collection, 'All')
     soft_assert(view.create_infrastructure_mapping.is_displayed)
-    is_provider_1_deleted = v2v_providers[0].delete_if_exists(cancel=False)
-    is_provider_2_deleted = v2v_providers[1].delete_if_exists(cancel=False)
+    is_provider_1_deleted = v2v_providers.vmware_provider.delete_if_exists(cancel=False)
+    is_provider_2_deleted = v2v_providers.rhv_provider.delete_if_exists(cancel=False)
     # Test after removing Providers, users cannot Create Infrastructure Mapping
     view = navigate_to(infrastructure_mapping_collection, 'All')
     soft_assert(view.configure_providers.is_displayed)
@@ -155,9 +155,9 @@ def test_v2v_ui_no_providers(appliance, v2v_providers, soft_assert):
     # soft_assert(not view.create_migration_plan.is_displayed)
     # Following leaves to appliance in the state it was before this test deleted provider_setup
     if is_provider_1_deleted:
-        v2v_providers[0].create(validate_inventory=True)
+        v2v_providers.vmware_provider.create(validate_inventory=True)
     if is_provider_2_deleted:
-        v2v_providers[1].create(validate_inventory=True)
+        v2v_providers.rhv_provider.create(validate_inventory=True)
 
 
 @pytest.mark.parametrize('form_data_single_datastore', [['nfs', 'nfs']], indirect=True)


### PR DESCRIPTION

Purpose or Intent
=================

__Adding tests__v2v migration where migration plan name includes only special characters.


{{pytest: cfme/tests/v2v/test_v2v_migrations.py --use-provider rhv42 --use-provider vsphere65-nested --provider-limit 2 -vvvv --long-running -k 'test_migration_special_char_name' }}
