### PR TITLE
[1LP][RFR] Adding New Smart State Analysis Test 

### DIFF
--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -78,7 +78,7 @@ class PolicyProfileAssignable(object):
             assign: Wheter to assign or unassign.
             policy_profile_names: :py:class:`str` with Policy Profile names.
         """
-        view = navigate_to(self, 'ManagePoliciesFromDetails')
+        view = navigate_to(self, 'ManagePoliciesFromDetails', wait_for_view=0)
         policy_changed = False
         for policy_profile in policy_profile_names:
             if assign:

--- a/cfme/configure/tasks.py
+++ b/cfme/configure/tasks.py
@@ -67,11 +67,18 @@ class TasksView(BaseLoggedInPage):
 
     @property
     def is_displayed(self):
-        return (
-            self.tabs.mytasks.is_displayed and
-            self.tabs.myothertasks.is_displayed and
-            self.tabs.alltasks.is_displayed and
-            self.tabs.allothertasks.is_displayed)
+        if self.context['object'].appliance.version < '5.10':
+            return (
+                self.tabs.mytasks.is_displayed and
+                self.tabs.myothertasks.is_displayed and
+                self.tabs.alltasks.is_displayed and
+                self.tabs.allothertasks.is_displayed
+            )
+        else:
+            return (
+                self.tabs.mytasks.is_displayed and
+                self.tabs.alltasks.is_displayed
+            )
 
 
 @attr.s

--- a/cfme/containers/image.py
+++ b/cfme/containers/image.py
@@ -63,6 +63,21 @@ class Image(BaseEntity, Taggable, Labelable, LoadDetailsMixin, PolicyProfileAssi
     def sha256(self):
         return self.id.split('@')[-1]
 
+    @property
+    def last_scan_attempt_on(self):
+        """ Get 'Last Scan Attempt On' property for OCP Image.
+
+            Returns:
+                datetime or None.
+        """
+        try:
+            # API does not accept a unicode string, setting the image name to a string
+            return (self.appliance.rest_api.collections.container_images.
+                    get(name=str(self.name)).last_scan_attempt_on)
+        # If no scan has been performed on the image, it will return an AttributeError
+        except AttributeError:
+            return None
+
     def perform_smartstate_analysis(self, wait_for_finish=False, timeout='20M'):
         """Performing SmartState Analysis on this Image
         """
@@ -118,6 +133,17 @@ class Image(BaseEntity, Taggable, Labelable, LoadDetailsMixin, PolicyProfileAssi
             return True
         else:
             raise ValueError("{} is not a known state for compliance".format(text))
+
+    def scan(self):
+        """ Start SmartState Analysis Scan of OCP Image.
+
+            Returns:
+                API response.
+        """
+
+        # API does not accept a unicode string, setting the image name to a string
+        return (self.appliance.rest_api.collections.container_images.
+                get(name=str(self.name)).action.scan())
 
 
 @attr.s


### PR DESCRIPTION
Add new test to verify a OpenShift image can perform SmartState Anaylsis scan via the API

{{ pytest: cfme/tests/containers/test_containers_smartstate_analysis.py --use-provider ocp-39-hawk }}