### PR TITLE
[RFR] Fix ovirt template upload failure

### DIFF
--- a/cfme/utils/template/base.py
+++ b/cfme/utils/template/base.py
@@ -22,8 +22,6 @@ from cfme.utils.log import logger
 from cfme.utils.providers import get_mgmt
 from cfme.utils.ssh import SSHClient
 
-import pytest
-
 NUM_OF_TRIES = 3
 lock = Lock()
 
@@ -127,7 +125,7 @@ class ProviderTemplateUpload(object):
             raise TemplateUploadException("Cannot get image URL.")
         else:
             image_name = self.image_pattern.findall(string_from_url)
-            if len(image_name) == 1:
+            if len(image_name):
                 # return 0th element of image_name, likely multiple formats for same provider type
                 return '/'.join([self.image_url, image_name[0]])  # TODO support multiple formats
 

--- a/cfme/utils/template/base.py
+++ b/cfme/utils/template/base.py
@@ -125,9 +125,18 @@ class ProviderTemplateUpload(object):
             raise TemplateUploadException("Cannot get image URL.")
         else:
             image_name = self.image_pattern.findall(string_from_url)
-            if len(image_name):
+            if len(image_name) == 1:
                 # return 0th element of image_name, likely multiple formats for same provider type
                 return '/'.join([self.image_url, image_name[0]])  # TODO support multiple formats
+            elif len(image_name) > 1:
+                if 'manageiq' in self.image_url:  # Upstream ovirt build
+                    index = (i for i, string in enumerate(image_name) if 'ovirt' in string
+                        and 'qc2' in string).next()
+                    return '/'.join([self.image_url, image_name[index]])
+                elif 'cfme' in self.image_url:     # Downstream RHV build
+                    index = (i for i, string in enumerate(image_name) if 'rhevm' in string
+                        and 'qcow2' in string).next()
+                    return '/'.join([self.image_url, image_name[index]])
 
     @property
     def image_name(self):

--- a/cfme/utils/template/base.py
+++ b/cfme/utils/template/base.py
@@ -22,6 +22,8 @@ from cfme.utils.log import logger
 from cfme.utils.providers import get_mgmt
 from cfme.utils.ssh import SSHClient
 
+import pytest
+
 NUM_OF_TRIES = 3
 lock = Lock()
 
@@ -128,15 +130,6 @@ class ProviderTemplateUpload(object):
             if len(image_name) == 1:
                 # return 0th element of image_name, likely multiple formats for same provider type
                 return '/'.join([self.image_url, image_name[0]])  # TODO support multiple formats
-            elif len(image_name) > 1:
-                if 'manageiq' in self.image_url:  # Upstream ovirt build
-                    index = (i for i, string in enumerate(image_name) if 'ovirt' in string
-                        and 'qc2' in string).next()
-                    return '/'.join([self.image_url, image_name[index]])
-                elif 'cfme' in self.image_url:     # Downstream RHV build
-                    index = (i for i, string in enumerate(image_name) if 'rhevm' in string
-                        and 'qcow2' in string).next()
-                    return '/'.join([self.image_url, image_name[index]])
 
     @property
     def image_name(self):

--- a/cfme/utils/template/rhevm.py
+++ b/cfme/utils/template/rhevm.py
@@ -12,7 +12,8 @@ from cfme.utils.log import logger
 class RHEVMTemplateUpload(ProviderTemplateUpload):
     provider_type = 'rhevm'
     log_name = 'RHEVM'
-    image_pattern = re.compile(r'<a href="?\'?([^"\']*(?:ovirt|rhevm)[^"\'>]*)')
+    image_pattern = re.compile(
+        r'<a href="?\'?([^"\']*(?:(?:rhevm|ovirt)[^"\']*\.(?:qcow2|qc2))[^"\'>]*)')
 
     @log_wrap('add glance to rhevm provider')
     def add_glance_to_provider(self):

--- a/cfme/utils/template/rhevm.py
+++ b/cfme/utils/template/rhevm.py
@@ -12,7 +12,7 @@ from cfme.utils.log import logger
 class RHEVMTemplateUpload(ProviderTemplateUpload):
     provider_type = 'rhevm'
     log_name = 'RHEVM'
-    image_pattern = re.compile(r'<a href="?\'?([^"\']*(?:rhevm[^"\']*\.[qcow2|ova])[^"\'>]*)')
+    image_pattern = re.compile(r'<a href="?\'?([^"\']*(?:ovirt|rhevm)[^"\'>]*)')
 
     @log_wrap('add glance to rhevm provider')
     def add_glance_to_provider(self):


### PR DESCRIPTION
The ovirt templates were not being uploaded to the Sprout providers.

I have made changes to cfme/utils/template/rhevm.py so that the regular expression matches both ovirt and rhevm.

Ovirt template files  are named like this 
manageiq-ovirt-master-201809272000-96d0b65c0f.qc2
 
RHV template files are named like this:
cfme-rhevm-5.10.0.17-1.x86_64.qcow2

I have also tested the PR locally .