### PR TITLE
[1LP][RFR] custom sprout request time

### DIFF
--- a/cfme/test_framework/sprout/client.py
+++ b/cfme/test_framework/sprout/client.py
@@ -101,7 +101,7 @@ class SproutClient(object):
             self, count=1, preconfigured=False, version=None, stream=None, provider=None,
             provider_type=None, lease_time=60, ram=None, cpu=None, **kwargs):
         # provisioning may take more time than it is expected in some cases
-        wait_time = kwargs.get('wait_time', 900)
+        wait_time = kwargs.pop('wait_time', 900)
         # If we specify version, stream is ignored because we will get that specific version
         if version:
             stream = get_stream(version)

--- a/cfme/test_framework/sprout/plugin.py
+++ b/cfme/test_framework/sprout/plugin.py
@@ -218,6 +218,7 @@ class SproutManager(object):
             'cpu': provision_request.cpu,
             'ram': provision_request.ram,
             'stream': provision_request.group,
+            'wait_time': provision_request.provision_timeout * 60
         }
         if provision_request.template_type:
             kargs['template_type'] = provision_request.template_type


### PR DESCRIPTION
default sprout client request time has been decreased to 15 min what isn't enough for provisioning appliance pool from scratch