### PR TITLE
[1LP][RFR] Quota Test For Cloud: Testing tenant quota via UI and SSUI 

### DIFF
--- a/cfme/services/catalogs/catalog_items/__init__.py
+++ b/cfme/services/catalogs/catalog_items/__init__.py
@@ -20,19 +20,15 @@ from cfme.utils.wait import wait_for
 
 class EntryPoint(Input):
     def fill(self, value):
-        current_value = self.value
-        if value == current_value:
-            return False
-        # Clear and type everything
-        self.browser.click(self)
-        self.browser.clear(self)
-        self.browser.send_keys(value, self)
-        self.parent_view.modal.cancel.click()
-        # After changing default path values of 'retirement_entry_point', 'reconfigure_entry_point'
-        # or 'provisioning_entry_point'; 'Select Entry Point Instance'(pop up) occures which also
-        # helps to select these paths using tree structure. Here we have already filled these values
-        # through text input. So to ignore this pop up clicking on cancel button is required.
-        return True
+        if super(EntryPoint, self).fill(value):
+            self.parent_view.modal.cancel.click()
+            # After changing default path values of 'retirement_entry_point',
+            # 'reconfigure_entry_point' or 'provisioning_entry_point';
+            # 'Select Entry Point Instance'(pop up) occures which also helps to select these paths
+            # using tree structure. Here we have already filled these values through text input.
+            # So to ignore this pop up clicking on cancel button is required.
+            return True
+        return False
 
 
 # Views

--- a/cfme/services/catalogs/catalog_items/__init__.py
+++ b/cfme/services/catalogs/catalog_items/__init__.py
@@ -488,13 +488,13 @@ class CatalogItemsCollection(BaseCollection):
     def instantiate(self, catalog_item_class, *args, **kwargs):
         return catalog_item_class.from_collection(self, *args, **kwargs)
 
-    def create(self, catalog_item_class, provider_type=None, field_entry_point=False, *args,
+    def create(self, catalog_item_class, provider, field_entry_point=False, *args,
                **kwargs):
         """Creates a catalog item in the UI.
 
         Args:
             catalog_item_class: type of a catalog item
-            provider_type: Used to distinguish default entry point path
+            provider: Used to distinguish default entry point path
             field_entry_point: Used to add default entry point
             *args: see the respectful catalog item class
             **kwargs: see the respectful catalog item class
@@ -503,19 +503,20 @@ class CatalogItemsCollection(BaseCollection):
             An instance of catalog_item_class
         """
         cat_item = self.instantiate(catalog_item_class, *args, **kwargs)
-        view = navigate_to(cat_item, 'Add')
+        view = navigate_to(cat_item, "Add")
         if field_entry_point:
-            if provider_type == 'cloud':
-                view.basic_info.field_entry_point.fill("")
-                view.basic_info.modal.tree.click_path('Datastore', 'ManageIQ (Locked)', 'Cloud',
-                                                      'VM', 'Provisioning', 'StateMachines',
-                                                      'ProvisionRequestApproval', 'Default')
-            elif provider_type == 'infra':
-                view.basic_info.field_entry_point.fill("")
-                view.basic_info.modal.tree.click_path('Datastore', 'ManageIQ (Locked)',
-                                                      'Infrastructure', 'VM', 'Provisioning',
-                                                      'StateMachines', 'ProvisionRequestApproval',
-                                                      'Default')
+            prov_type = "Cloud" if provider.category == "cloud" else "Infrastructure"
+            view.basic_info.field_entry_point.fill("")
+            view.basic_info.modal.tree.click_path(
+                "Datastore",
+                "ManageIQ (Locked)",
+                prov_type,
+                "VM",
+                "Provisioning",
+                "StateMachines",
+                "ProvisionRequestApproval",
+                "Default",
+            )
             view.basic_info.modal.include_domain.fill(True)
             view.basic_info.modal.apply.click()
         view.fill(cat_item.fill_dict)

--- a/cfme/services/catalogs/catalog_items/__init__.py
+++ b/cfme/services/catalogs/catalog_items/__init__.py
@@ -488,20 +488,25 @@ class CatalogItemsCollection(BaseCollection):
     def instantiate(self, catalog_item_class, *args, **kwargs):
         return catalog_item_class.from_collection(self, *args, **kwargs)
 
-    def create(self, catalog_item_class, provider, field_entry_point=False, *args,
-               **kwargs):
+    def create(self, catalog_item_class, *args, **kwargs):
         """Creates a catalog item in the UI.
 
         Args:
             catalog_item_class: type of a catalog item
-            provider: Used to distinguish default entry point path
-            field_entry_point: Used to add default entry point
             *args: see the respectful catalog item class
             **kwargs: see the respectful catalog item class
 
         Returns:
             An instance of catalog_item_class
         """
+        if args:
+            """args should not contain any value while instantiating cat_item.
+               Hence released 'provider' and 'field_entry_point' elements from args tuple."""
+            provider, field_entry_point = args[0], args[1]
+            release_extra_args = list(args)
+            release_extra_args.pop(1)
+            release_extra_args.pop(0)
+            args = tuple(release_extra_args)
         cat_item = self.instantiate(catalog_item_class, *args, **kwargs)
         view = navigate_to(cat_item, "Add")
         if field_entry_point:

--- a/cfme/services/catalogs/catalog_items/__init__.py
+++ b/cfme/services/catalogs/catalog_items/__init__.py
@@ -488,11 +488,14 @@ class CatalogItemsCollection(BaseCollection):
     def instantiate(self, catalog_item_class, *args, **kwargs):
         return catalog_item_class.from_collection(self, *args, **kwargs)
 
-    def create(self, catalog_item_class, *args, **kwargs):
+    def create(self, catalog_item_class, provider_type=None, field_entry_point=False, *args,
+               **kwargs):
         """Creates a catalog item in the UI.
 
         Args:
             catalog_item_class: type of a catalog item
+            provider_type: Used to distinguish default entry point path
+            field_entry_point: Used to add default entry point
             *args: see the respectful catalog item class
             **kwargs: see the respectful catalog item class
 
@@ -501,6 +504,20 @@ class CatalogItemsCollection(BaseCollection):
         """
         cat_item = self.instantiate(catalog_item_class, *args, **kwargs)
         view = navigate_to(cat_item, 'Add')
+        if field_entry_point:
+            if provider_type == 'cloud':
+                view.basic_info.field_entry_point.fill("")
+                view.basic_info.modal.tree.click_path('Datastore', 'ManageIQ (Locked)', 'Cloud',
+                                                      'VM', 'Provisioning', 'StateMachines',
+                                                      'ProvisionRequestApproval', 'Default')
+            elif provider_type == 'infra':
+                view.basic_info.field_entry_point.fill("")
+                view.basic_info.modal.tree.click_path('Datastore', 'ManageIQ (Locked)',
+                                                      'Infrastructure', 'VM', 'Provisioning',
+                                                      'StateMachines', 'ProvisionRequestApproval',
+                                                      'Default')
+            view.basic_info.modal.include_domain.fill(True)
+            view.basic_info.modal.apply.click()
         view.fill(cat_item.fill_dict)
         view.add.click()
         view = self.create_view(AllCatalogItemView)

--- a/cfme/services/catalogs/catalog_items/__init__.py
+++ b/cfme/services/catalogs/catalog_items/__init__.py
@@ -352,6 +352,12 @@ class CloudInfraCatalogItem(BaseCatalogItem):
     domain = attr.ib(default='ManageIQ (Locked)')
     provider = attr.ib(default=None)
     item_type = None
+    provisioning_entry_point = attr.ib(default=(
+        "/Service/Provisioning/StateMachines/ServiceProvision_Template/CatalogItemInitialization"))
+    retirement_entry_point = attr.ib(
+        default="/Service/Retirement/StateMachines/ServiceRetirement/Default"
+    )
+    reconfigure_entry_point = attr.ib(default=None)
 
     @property
     def fill_dict(self):
@@ -361,7 +367,10 @@ class CloudInfraCatalogItem(BaseCatalogItem):
                 'description': self.description,
                 'display': self.display_in,
                 'select_catalog': self.catalog_name,
-                'select_dialog': self.dialog
+                'select_dialog': self.dialog,
+                'provisioning_entry_point': self.provisioning_entry_point,
+                'retirement_entry_point': self.retirement_entry_point,
+                'reconfigure_entry_point': self.reconfigure_entry_point
             },
             'request_info': {'provisioning': self.prov_data}
         }
@@ -513,20 +522,8 @@ class CatalogItemsCollection(BaseCollection):
         Returns:
             An instance of catalog_item_class
         """
-        provisioning_entry_point = kwargs.pop("provisioning_entry_point", None)
-        reconfigure_entry_point = kwargs.pop("reconfigure_entry_point", None)
-        retirement_entry_point = kwargs.pop("retirement_entry_point", None)
         cat_item = self.instantiate(catalog_item_class, *args, **kwargs)
         view = navigate_to(cat_item, "Add")
-        if provisioning_entry_point:
-            view.basic_info.provisioning_entry_point.fill(provisioning_entry_point)
-
-        if reconfigure_entry_point:
-            view.basic_info.reconfigure_entry_point.fill(reconfigure_entry_point)
-
-        if retirement_entry_point:
-            view.basic_info.retirement_entry_point.fill(retirement_entry_point)
-
         view.fill(cat_item.fill_dict)
         view.add.click()
         view = self.create_view(AllCatalogItemView)

--- a/cfme/services/catalogs/catalog_items/__init__.py
+++ b/cfme/services/catalogs/catalog_items/__init__.py
@@ -34,6 +34,7 @@ class BasicInfoForm(ServicesCatalogView):
     subtype = BootstrapSelect('generic_subtype')
     field_entry_point = Input(name='fqname')
     retirement_entry_point = Input(name='retire_fqname')
+    reconfigure_entry_point = Input(name='reconfigure_fqname')
     select_resource = BootstrapSelect('resource_id')
 
     @View.nested
@@ -499,33 +500,26 @@ class CatalogItemsCollection(BaseCollection):
         Returns:
             An instance of catalog_item_class
         """
-        if kwargs:
-            provider = kwargs.get("provider", None)
-            field_entry_point = kwargs.get("field_entry_point", None)
-            if provider and field_entry_point:
-                """kwargs should not contain value of 'provider' and 'field_entry_point'
-                    while instantiating cat_item. Hence released 'provider' and 'field_entry_point'
-                    elements from kwargs.
-                """
-                kwargs.pop("provider")
-                kwargs.pop("field_entry_point")
+        provisioning_entry_point = kwargs.get("provisioning_entry_point", None)
+        reconfigure_entry_point = kwargs.get("reconfigure_entry_point", None)
+        retirement_entry_point = kwargs.get("retirement_entry_point", None)
+        kwargs.pop("provisioning_entry_point")
+        kwargs.pop("reconfigure_entry_point")
+        kwargs.pop("retirement_entry_point")
         cat_item = self.instantiate(catalog_item_class, *args, **kwargs)
         view = navigate_to(cat_item, "Add")
-        if field_entry_point:
-            prov_type = "Cloud" if provider.category == "cloud" else "Infrastructure"
-            view.basic_info.field_entry_point.fill("")
-            view.basic_info.modal.tree.click_path(
-                "Datastore",
-                "ManageIQ (Locked)",
-                prov_type,
-                "VM",
-                "Provisioning",
-                "StateMachines",
-                "ProvisionRequestApproval",
-                "Default",
-            )
-            view.basic_info.modal.include_domain.fill(True)
-            view.basic_info.modal.apply.click()
+        if provisioning_entry_point:
+            view.basic_info.field_entry_point.fill(provisioning_entry_point)
+            view.basic_info.modal.cancel.click()
+
+        if reconfigure_entry_point:
+            view.basic_info.reconfigure_entry_point.fill(reconfigure_entry_point)
+            view.basic_info.modal.cancel.click()
+
+        if retirement_entry_point:
+            view.basic_info.retirement_entry_point.fill(retirement_entry_point)
+            view.basic_info.modal.cancel.click()
+
         view.fill(cat_item.fill_dict)
         view.add.click()
         view = self.create_view(AllCatalogItemView)

--- a/cfme/services/catalogs/catalog_items/__init__.py
+++ b/cfme/services/catalogs/catalog_items/__init__.py
@@ -499,14 +499,16 @@ class CatalogItemsCollection(BaseCollection):
         Returns:
             An instance of catalog_item_class
         """
-        if args:
-            """args should not contain any value while instantiating cat_item.
-               Hence released 'provider' and 'field_entry_point' elements from args tuple."""
-            provider, field_entry_point = args[0], args[1]
-            release_extra_args = list(args)
-            release_extra_args.pop(1)
-            release_extra_args.pop(0)
-            args = tuple(release_extra_args)
+        if kwargs:
+            provider = kwargs.get("provider", None)
+            field_entry_point = kwargs.get("field_entry_point", None)
+            if provider and field_entry_point:
+                """kwargs should not contain value of 'provider' and 'field_entry_point'
+                    while instantiating cat_item. Hence released 'provider' and 'field_entry_point'
+                    elements from kwargs.
+                """
+                kwargs.pop("provider")
+                kwargs.pop("field_entry_point")
         cat_item = self.instantiate(catalog_item_class, *args, **kwargs)
         view = navigate_to(cat_item, "Add")
         if field_entry_point:

--- a/cfme/tests/cloud/test_tenant_quota.py
+++ b/cfme/tests/cloud/test_tenant_quota.py
@@ -25,14 +25,15 @@ def set_default(provider, request):
        must be used in all tests of quota which are related to services where catalog item needs to
        be created with specific values for these entries.
     """
+    with_prov = (
+        "/ManageIQ (Locked)/{}/VM/Provisioning/StateMachines/ProvisionRequestApproval/Default"
+        .format(provider.string_name)
+    )
+    default = (
+        "/Service/Provisioning/StateMachines/ServiceProvision_Template/CatalogItemInitialization"
+    )
 
-    provisioning_entry_point = (
-        "/Service/Provisioning/StateMachines/ServiceProvision_Template/CatalogItemInitialization")
-    if request.param:
-        provisioning_entry_point = ("/ManageIQ (Locked)/" + provider.string_name
-                                + "/VM/Provisioning/StateMachines/ProvisionRequestApproval/Default")
-
-    return provisioning_entry_point
+    return with_prov if request.param else default
 
 
 @pytest.fixture
@@ -181,11 +182,11 @@ def test_tenant_quota_enforce_via_service_cloud(request, appliance, provider, se
 
 
 # Args of parametrize is the list of navigation parameters to order catalog item.
-@pytest.mark.parametrize('context', [ViaSSUI, ViaUI])
 # first arg of parametrize is the list of fixtures or parameters,
 # second arg is a list of lists, with each one a test is to be generated,
 # sequence is important here.
 # indirect is the list where we define which fixtures are to be passed values indirectly.
+@pytest.mark.parametrize('context', [ViaSSUI, ViaUI])
 @pytest.mark.parametrize(
     ['set_roottenant_quota', 'custom_prov_data', 'extra_msg', 'set_default'],
     [

--- a/cfme/tests/cloud/test_tenant_quota.py
+++ b/cfme/tests/cloud/test_tenant_quota.py
@@ -78,7 +78,7 @@ def catalog_item(appliance, provider, provisioning, template_name, dialog, catal
                             display_in=True,
                             catalog=catalog,
                             dialog=dialog,
-                            provider_type=provider.category,
+                            provider=provider,
                             field_entry_point=set_default,
                             prov_data=prov_data)
 
@@ -187,7 +187,8 @@ def test_service_cloud_tenant_quota_with_default_entry_point(request, appliance,
                                                              set_roottenant_quota, set_default,
                                                              custom_prov_data, extra_msg,
                                                              template_name, catalog_item):
-    """Test Tenant Quota in UI and SSUI by selecting default entry point
+    """Test Tenant Quota in UI and SSUI by selecting default entry point.
+       Quota has to be checked if its working with default entry point also.
 
     Steps:
     1. Add cloud provider
@@ -204,7 +205,8 @@ def test_service_cloud_tenant_quota_with_default_entry_point(request, appliance,
             service_catalogs.add_to_shopping_cart()
         service_catalogs.order()
     # nav to requests page to check quota validation
-    request_description = 'Provisioning Service [{0}] from [{0}]'.format(catalog_item.name)
+    request_description = "Provisioning Service [{name}] from [{name}]".format(
+        name=catalog_item.name)
     provision_request = appliance.collections.requests.instantiate(request_description)
     provision_request.wait_for_request(method='ui')
     assert provision_request.row.reason.text == "Quota Exceeded"

--- a/cfme/tests/cloud/test_tenant_quota.py
+++ b/cfme/tests/cloud/test_tenant_quota.py
@@ -73,13 +73,13 @@ def catalog_item(appliance, provider, provisioning, template_name, dialog, catal
                  set_default):
     collection = appliance.collections.catalog_items
     yield collection.create(provider.catalog_item_type,
+                            provider,
+                            set_default,
                             name='test_{}'.format(fauxfactory.gen_alphanumeric()),
                             description='test catalog',
                             display_in=True,
                             catalog=catalog,
                             dialog=dialog,
-                            provider=provider,
-                            field_entry_point=set_default,
                             prov_data=prov_data)
 
 

--- a/cfme/tests/cloud/test_tenant_quota.py
+++ b/cfme/tests/cloud/test_tenant_quota.py
@@ -17,12 +17,23 @@ pytestmark = [
 
 
 @pytest.fixture
-def set_default(request):
-    value = request.param
-    if value:
-        return True
+def set_default(provider, request):
+    """This fixture is used to return paths for provisioning_entry_point, reconfigure_entry_point
+       and retirement_entry_point. These values are required while creating new catalog item in
+       'test_service_cloud_tenant_quota_with_default_entry_point' test. But other tests does not
+       require these values since those tests takes default values. Hence in this file, this fixture
+       must be used in all tests of quota which are related to services where catalog item needs to
+       be created.
+    """
+    reconfigure_entry_point = None
+    retirement_entry_point = None
+    if request.param:
+        provisioning_entry_point = ("/ManageIQ (Locked)/" + provider.string_name +
+                                 "/VM/Provisioning/StateMachines/ProvisionRequestApproval/Default")
+
     else:
-        return False
+        provisioning_entry_point = None
+    return provisioning_entry_point, reconfigure_entry_point, retirement_entry_point
 
 
 @pytest.fixture
@@ -71,6 +82,7 @@ def set_roottenant_quota(request, roottenant, appliance):
 @pytest.fixture
 def catalog_item(appliance, provider, provisioning, template_name, dialog, catalog, prov_data,
                  set_default):
+    provisioning_entry_point, reconfigure_entry_point, retirement_entry_point = set_default
     collection = appliance.collections.catalog_items
     yield collection.create(provider.catalog_item_type,
                             name='test_{}'.format(fauxfactory.gen_alphanumeric()),
@@ -79,8 +91,9 @@ def catalog_item(appliance, provider, provisioning, template_name, dialog, catal
                             catalog=catalog,
                             dialog=dialog,
                             prov_data=prov_data,
-                            provider=provider,
-                            field_entry_point=set_default
+                            provisioning_entry_point=provisioning_entry_point,
+                            reconfigure_entry_point=reconfigure_entry_point,
+                            retirement_entry_point=retirement_entry_point
                             )
 
 

--- a/cfme/tests/cloud/test_tenant_quota.py
+++ b/cfme/tests/cloud/test_tenant_quota.py
@@ -18,23 +18,21 @@ pytestmark = [
 @pytest.fixture
 def set_default(provider, request):
     """This fixture is used to return paths for provisioning_entry_point, reconfigure_entry_point
-       and retirement_entry_point. These values are required while creating new catalog item in
-       'test_service_cloud_tenant_quota_with_default_entry_point' test. But other tests does not
-       require these values since those tests takes default values hence providing None values.
-       So in this file, this fixture - 'set_default'
+       and retirement_entry_point. The value of 'provisioning_entry_point' is required while
+       creating new catalog item in 'test_service_cloud_tenant_quota_with_default_entry_point' test.
+       But other tests does not require these values since those tests takes default values hence
+       providing default value. So in this file, this fixture - 'set_default'
        must be used in all tests of quota which are related to services where catalog item needs to
        be created with specific values for these entries.
     """
 
-    provisioning_entry_point = None
-    reconfigure_entry_point = None
-    retirement_entry_point = None
+    provisioning_entry_point = (
+        "/Service/Provisioning/StateMachines/ServiceProvision_Template/CatalogItemInitialization")
     if request.param:
         provisioning_entry_point = ("/ManageIQ (Locked)/" + provider.string_name
                                 + "/VM/Provisioning/StateMachines/ProvisionRequestApproval/Default")
-        retirement_entry_point = "/Service/Retirement/StateMachines/ServiceRetirement/Default"
 
-    return provisioning_entry_point, reconfigure_entry_point, retirement_entry_point
+    return provisioning_entry_point
 
 
 @pytest.fixture
@@ -83,7 +81,6 @@ def set_roottenant_quota(request, roottenant, appliance):
 @pytest.fixture
 def catalog_item(appliance, provider, provisioning, template_name, dialog, catalog, prov_data,
                  set_default):
-    provisioning_entry_point, reconfigure_entry_point, retirement_entry_point = set_default
     collection = appliance.collections.catalog_items
     yield collection.create(provider.catalog_item_type,
                             name='test_{}'.format(fauxfactory.gen_alphanumeric()),
@@ -92,9 +89,7 @@ def catalog_item(appliance, provider, provisioning, template_name, dialog, catal
                             catalog=catalog,
                             dialog=dialog,
                             prov_data=prov_data,
-                            provisioning_entry_point=provisioning_entry_point,
-                            reconfigure_entry_point=reconfigure_entry_point,
-                            retirement_entry_point=retirement_entry_point
+                            provisioning_entry_point=set_default
                             )
 
 

--- a/cfme/tests/cloud/test_tenant_quota.py
+++ b/cfme/tests/cloud/test_tenant_quota.py
@@ -73,14 +73,15 @@ def catalog_item(appliance, provider, provisioning, template_name, dialog, catal
                  set_default):
     collection = appliance.collections.catalog_items
     yield collection.create(provider.catalog_item_type,
-                            provider,
-                            set_default,
                             name='test_{}'.format(fauxfactory.gen_alphanumeric()),
                             description='test catalog',
                             display_in=True,
                             catalog=catalog,
                             dialog=dialog,
-                            prov_data=prov_data)
+                            prov_data=prov_data,
+                            provider=provider,
+                            field_entry_point=set_default
+                            )
 
 
 # first arg of parametrize is the list of fixtures or parameters,


### PR DESCRIPTION
- This PR tests Tenant Quota in UI and SSUI by selecting default entry point(field_entry_point) while creating catalog item.
- Added new fixture:
    - **set_default()**
        - This modification applied on all tests which are creating **catalog item** from this file. 
        - This fixture used to modify **field_entry_point**
        - Some of the tests from this file do not require **field_entry_point** except new test -  ```test_service_cloud_tenant_quota_with_default_entry_point```
- **provider_type** while creating catalog item
    - It is used to differentiate ``` field_entry_point``` for provider types because field_entry_point is different for **cloud** providers and **infra** providers.



{{ pytest: cfme/tests/cloud/test_tenant_quota.py -k 'test_service_cloud_tenant_quota_with_default_entry_point or test_tenant_quota_enforce_via_service_cloud' -qsvvv }}