### PR TITLE
[1LP][RFR] Automate test: Create schedule for base report

### DIFF
--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -11,7 +11,7 @@ from widgetastic_manageiq import (PaginationPane, Table, ReportToolBarViewSelect
 from widgetastic_manageiq.expression_editor import ExpressionEditor
 from widgetastic_patternfly import Button, Input, BootstrapSelect, Tab, CandidateNotFound
 
-from cfme.intelligence.reports.schedules import NewScheduleView
+from cfme.intelligence.reports.schedules import SchedulesFormCommon
 from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.utils import ParamClassName
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
@@ -225,6 +225,24 @@ class AllCustomReportsView(CloudIntelReportsView):
             self.title.text == "Custom Reports"
         )
 
+
+class ReportScheduleView(SchedulesFormCommon):
+    add_button = Button("Add")
+
+    @property
+    def is_displayed(self):
+        report_obj = self.context["object"]
+        return (
+            self.in_intel_reports
+            and self.title.text == "Adding a new Schedule"
+            and self.reports.tree.currently_selected
+            == [
+                "All Reports",
+                report_obj.type,
+                report_obj.subtype,
+                report_obj.menu_name,
+            ]
+        )
 
 @attr.s
 class Report(BaseEntity, Updateable):
@@ -595,7 +613,7 @@ class ReportDetails(CFMENavigateStep):
 
 @navigator.register(Report, "ScheduleReport")
 class ReportSchedule(CFMENavigateStep):
-    VIEW = NewScheduleView
+    VIEW = ReportScheduleView
     prerequisite = NavigateToAttribute("appliance.server", "CloudIntelReports")
 
     def step(self):

--- a/cfme/tests/intelligence/reports/test_crud.py
+++ b/cfme/tests/intelligence/reports/test_crud.py
@@ -4,7 +4,6 @@ import pytest
 import yaml
 
 from cfme import test_requirements
-from cfme.intelligence.reports.schedules import NewScheduleView, ScheduleCollection
 from cfme.intelligence.reports.widgets import AllDashboardWidgetsView
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
@@ -272,15 +271,18 @@ def test_reports_create_schedule_for_base_report_once(appliance, request):
         subtype="Virtual Machines",
         menu_name="Hardware Information for VMs",
     )
-    view = navigate_to(report, "Details")
-    view.configuration.item_select("Add a new Schedule")
-    add_view = report.create_view(NewScheduleView)
-    data = {"hour": "12", "minute": "10"}
-    add_view.fill(data)
-    add_view.add_button.click()
-    assert view.flash.assert_message('Schedule "{}" was added'.format(report.menu_name))
+    data = {
+        "timer": {"hour": "12", "minute": "10"},
+        "emails": "test@example.com",
+        "email_options": {
+            "send_if_empty": True,
+            "send_pdf": True,
+            "send_csv": True,
+            "send_txt": True,
+        },
+    }
+    schedule = report.create_schedule(**data)
 
-    def _finalize():
-        view.configuration.item_select("Delete this Schedule", handle_alert=True)
+    assert schedule.enabled
 
-    request.addfinalizer(_finalize)
+    request.addfinalizer(schedule.delete)

--- a/cfme/tests/intelligence/reports/test_crud.py
+++ b/cfme/tests/intelligence/reports/test_crud.py
@@ -265,7 +265,7 @@ def test_reports_delete_saved_report(appliance, request):
     assert not report.exists
 
 
-def test_reports_create_schedule_for_base_report_once(appliance, request):
+def test_reports_crud_schedule_for_base_report_once(appliance, request):
     report = appliance.collections.reports.instantiate(
         type="Configuration Management",
         subtype="Virtual Machines",
@@ -284,5 +284,5 @@ def test_reports_create_schedule_for_base_report_once(appliance, request):
     schedule = report.create_schedule(**data)
 
     assert schedule.enabled
-
-    request.addfinalizer(schedule.delete)
+    schedule.delete(cancel=False)
+    assert not schedule.exists

--- a/cfme/tests/intelligence/reports/test_crud.py
+++ b/cfme/tests/intelligence/reports/test_crud.py
@@ -4,7 +4,7 @@ import pytest
 import yaml
 
 from cfme import test_requirements
-from cfme.intelligence.reports.schedules import ScheduleCollection
+from cfme.intelligence.reports.schedules import NewScheduleView, ScheduleCollection
 from cfme.intelligence.reports.widgets import AllDashboardWidgetsView
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
@@ -264,3 +264,23 @@ def test_reports_delete_saved_report(appliance, request):
     view.configuration.item_select(
         item='Delete selected Saved Reports', handle_alert=True)
     assert not report.exists
+
+
+def test_reports_create_schedule_for_base_report_once(appliance, request):
+    report = appliance.collections.reports.instantiate(
+        type="Configuration Management",
+        subtype="Virtual Machines",
+        menu_name="Hardware Information for VMs",
+    )
+    view = navigate_to(report, "Details")
+    view.configuration.item_select("Add a new Schedule")
+    add_view = report.create_view(NewScheduleView)
+    data = {"hour": "12", "minute": "10"}
+    add_view.fill(data)
+    add_view.add_button.click()
+    assert view.flash.assert_message('Schedule "{}" was added'.format(report.menu_name))
+
+    def _finalize():
+        view.configuration.item_select("Delete this Schedule", handle_alert=True)
+
+    request.addfinalizer(_finalize)


### PR DESCRIPTION
This PR adds a test case, which creates a schedule for a base report and asserts the schedule was created without any error.

{{pytest: cfme/tests/intelligence/reports/test_crud.py::test_reports_crud_schedule_for_base_report_once --use-template-cache -sqvvv}}