### PR TITLE
[1LP][RFR]Automate test: Resetting changes on Default Filters page

### DIFF
--- a/cfme/configure/settings.py
+++ b/cfme/configure/settings.py
@@ -264,6 +264,7 @@ class DefaultViewsForm(View):
 class DefaultFiltersForm(View):
     tree = CheckableBootstrapTreeview('df_treebox')
     save = Button('Save')
+    reset = Button('Reset')
 
 
 class TimeProfilesView(BaseLoggedInPage):

--- a/cfme/tests/configure/test_default_filters.py
+++ b/cfme/tests/configure/test_default_filters.py
@@ -10,6 +10,15 @@ pytestmark = [pytest.mark.tier(3),
               pytest.mark.usefixtures('infra_provider')]
 
 
+def test_default_filters_reset(appliance):
+    tree_path = ['Cloud', 'Instances', 'Images', 'Platform / Openstack']
+    view = navigate_to(appliance.user.my_settings, "DefaultFilters")
+    node = view.tabs.default_filters.tree.CheckNode(tree_path)
+    view.tabs.default_filters.tree.fill(node)
+    view.tabs.default_filters.reset.click()
+    assert view.flash.assert_message('All changes have been reset')
+
+
 def test_cloudimage_defaultfilters(appliance):
     filters = [['Cloud', 'Instances', 'Images', 'Platform / Amazon']]
     tree_path = ['All Images', 'Global Filters', 'Platform / Amazon']


### PR DESCRIPTION
This PR adds a test case, which checks if resetting a change on Default Filters page works. It also adds a Reset Button to `DefaultFiltersForm`.

{{pytest: cfme/tests/configure/test_default_filters.py::test_default_filters_reset --use-template-cache -sqvvv}}