### PR TITLE
[1LP][RFR] Automate Test: Add schedule for custom report

### DIFF
--- a/cfme/intelligence/reports/schedules.py
+++ b/cfme/intelligence/reports/schedules.py
@@ -201,13 +201,16 @@ class ScheduleCollection(BaseCollection):
         schedule = self.instantiate(name, description, filter, active=active, timer=timer,
             emails=emails, email_options=email_options)
         view = navigate_to(self, "Add")
+        # Temporary workaround for NoSuchElementException
+        view.fill({
+            "filter1": filter[0],
+            "filter2": filter[1],
+            "filter3": filter[2],
+        })
         view.fill({
             "name": name,
             "description": description,
             "active": active,
-            "filter1": filter[0],
-            "filter2": filter[1],
-            "filter3": filter[2],
             "run": timer.get("run"),
             "time_zone": timer.get("time_zone"),
             "starting_date": timer.get("starting_date"),

--- a/cfme/intelligence/reports/schedules.py
+++ b/cfme/intelligence/reports/schedules.py
@@ -201,16 +201,13 @@ class ScheduleCollection(BaseCollection):
         schedule = self.instantiate(name, description, filter, active=active, timer=timer,
             emails=emails, email_options=email_options)
         view = navigate_to(self, "Add")
-        # Temporary workaround for NoSuchElementException
-        view.fill({
-            "filter1": filter[0],
-            "filter2": filter[1],
-            "filter3": filter[2],
-        })
         view.fill({
             "name": name,
             "description": description,
             "active": active,
+            "filter1": filter[0],
+            "filter2": filter[1],
+            "filter3": filter[2],
             "run": timer.get("run"),
             "time_zone": timer.get("time_zone"),
             "starting_date": timer.get("starting_date"),

--- a/cfme/tests/intelligence/reports/test_crud.py
+++ b/cfme/tests/intelligence/reports/test_crud.py
@@ -11,7 +11,6 @@ from cfme.utils.path import data_path
 from cfme.utils.rest import assert_response
 from cfme.utils.update import update
 from cfme.utils.wait import wait_for_decorator
-from widgetastic.exceptions import NoSuchElementException, MoveTargetOutOfBoundsException
 
 
 report_crud_dir = data_path.join("reports_crud")
@@ -302,12 +301,7 @@ def test_create_custom_report_schedule(
         "Custom",
         custom_report.menu_name,
     )
-    try:
-        custom_report_schedule = appliance.collections.schedules.create(**schedule_data)
-    except (MoveTargetOutOfBoundsException, NoSuchElementException):
-        # Temporary workaround - running the `create` method first time raises exceptions,
-        # but running it again works fine.
-        custom_report_schedule = appliance.collections.schedules.create(**schedule_data)
+    custom_report_schedule = appliance.collections.schedules.create(**schedule_data)
     assert custom_report_schedule.exists
 
     request.addfinalizer(custom_report.delete)

--- a/cfme/tests/intelligence/reports/test_crud.py
+++ b/cfme/tests/intelligence/reports/test_crud.py
@@ -289,7 +289,7 @@ def test_reports_crud_schedule_for_base_report_once(appliance, request):
     assert not schedule.exists
 
 
-def test_create_custom_report_schedule(
+def test_crud_custom_report_schedule(
     appliance, request, custom_report_values, schedule_data
 ):
     """This test case creates a schedule for custom reports and tests if it was created
@@ -303,5 +303,5 @@ def test_create_custom_report_schedule(
     )
     custom_report_schedule = appliance.collections.schedules.create(**schedule_data)
     assert custom_report_schedule.exists
-
+    custom_report_schedule.delete(cancel=False)
     request.addfinalizer(custom_report.delete)

--- a/cfme/tests/intelligence/reports/test_crud.py
+++ b/cfme/tests/intelligence/reports/test_crud.py
@@ -290,9 +290,12 @@ def test_reports_crud_schedule_for_base_report_once(appliance, request):
     assert not schedule.exists
 
 
-def test_reports_create_schedule_for_custom_report(
+def test_create_custom_report_schedule(
     appliance, request, custom_report_values, schedule_data
 ):
+    """This test case creates a schedule for custom reports and tests if it was created
+    successfully.
+    """
     custom_report = appliance.collections.reports.create(**custom_report_values)
     schedule_data["filter"] = (
         "My Company (All Groups)",
@@ -302,6 +305,8 @@ def test_reports_create_schedule_for_custom_report(
     try:
         custom_report_schedule = appliance.collections.schedules.create(**schedule_data)
     except (MoveTargetOutOfBoundsException, NoSuchElementException):
+        # Temporary workaround - running the `create` method first time raises exceptions,
+        # but running it again works fine.
         custom_report_schedule = appliance.collections.schedules.create(**schedule_data)
     assert custom_report_schedule.exists
 


### PR DESCRIPTION
This PR adds a test case, which creates a custom report and checks if a schedule can be created for it.

{{pytest: cfme/tests/intelligence/reports/test_crud.py::test_crud_custom_report_schedule --use-template-cache -sqvvv }}