### PR TITLE
[1LP][RFR] Enabled SmartProxy Affinity for SSA

### DIFF
--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -10,7 +10,8 @@ from widgetastic.widget import View, Table, Text, Image, FileInput
 from widgetastic_manageiq import (ManageIQTree, Checkbox, AttributeValueForm, TimelinesView,
                                   ParametrizedSummaryTable, SummaryFormItem)
 from widgetastic_patternfly import (Accordion, Input, Button, Dropdown, DatePicker,
-                                    FlashMessages, BootstrapSelect, Tab)
+                                    FlashMessages, BootstrapSelect, Tab,
+                                    CheckableBootstrapTreeview)
 
 from cfme.base.credential import Credential
 from cfme.base.login import BaseLoggedInPage
@@ -1278,6 +1279,9 @@ class ZoneDetailsView(ZoneView):
 
 
 class ZoneSmartProxyAffinityView(ZoneView):
+    smartproxy_affinity = CheckableBootstrapTreeview(tree_id='smartproxy_affinitybox')
+    save = Button(title='Save Changes')
+
     @property
     def is_displayed(self):
         return self.smart_proxy_affinity.is_active()

--- a/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
+++ b/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
@@ -207,6 +207,20 @@ def local_setup_provider(request, setup_provider_modscope, provider, appliance):
 
 
 @pytest.fixture(scope="module")
+def enable_smartproxy_affinity(request, appliance, provider):
+    if provider.data.get('smartproxy_affinity', False):
+        view = navigate_to(appliance.server.zone, 'SmartProxyAffinity')
+        view.smartproxy_affinity.check_node(view.smartproxy_affinity.root_item.text)
+        view.save.click()
+
+        @request.addfinalizer
+        def _disable_smartproxy_affinty():
+            view = navigate_to(appliance.server.zone, 'SmartProxyAffinity')
+            view.smartproxy_affinity.uncheck_node(view.smartproxy_affinity.root_item.text)
+            view.save.click()
+
+
+@pytest.fixture(scope="module")
 def ssa_compliance_policy(appliance):
     policy = appliance.collections.policies.create(
         VMControlPolicy,
@@ -231,8 +245,8 @@ def ssa_compliance_profile(appliance, provider, ssa_compliance_policy):
 
 
 @pytest.fixture(scope="module")
-def ssa_single_vm(request, local_setup_provider, provider, vm_analysis_provisioning_data,
-           appliance, analysis_type):
+def ssa_single_vm(request, local_setup_provider, enable_smartproxy_affinity, provider,
+                  vm_analysis_provisioning_data, appliance, analysis_type):
     """ Fixture to provision instance on the provider """
     def _ssa_single_vm():
         template_name = vm_analysis_provisioning_data['image']


### PR DESCRIPTION
In our RHV integration testing environment we don't have CFME appliance imported in the provider, but is running in a different data center and our RHV GEs (providers) are also elsewhere, meaning hosts of our GEs are attached to a different storage domain than the host running the CFME appliance.

In such situation it seems that smart proxy affinity needs to be enabled for SSA to work.

Adding fixture that enables smartproxy affinity specifically for our 'rhv_cfme_integration' provider 

{{pytest: cfme/tests/cloud_infra_common/test_vm_instance_analysis.py --long-running -vv --use-provider rhv42}}