### PR TITLE
[RFR] Provider dashboard view with parametrized cards

### DIFF
--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -235,10 +235,11 @@ class Discover(CFMENavigateStep):
 
 @navigator.register(CloudProvider, 'Details')
 class Details(CFMENavigateStep):
+    """Nav class for summary details view"""
     VIEW = CloudProviderDetailsView
     prerequisite = NavigateToSibling('All')
 
-    def step(self):
+    def step(self, *args, **kwargs):
         self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True).click()
 
     def resetter(self):

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -8,9 +8,19 @@ from widgetastic.widget import View, Text, ConditionalSwitchableView
 from cfme.base.login import BaseLoggedInPage
 from cfme.common.host_views import HostEntitiesView
 from widgetastic_manageiq import (
-    ParametrizedSummaryTable, Button, TimelinesView, DetailsToolBarViewSelector,
-    ItemsToolBarViewSelector, Checkbox, Input, BaseEntitiesView, PaginationPane,
-    JSBaseEntity, Search)
+    ParametrizedSummaryTable,
+    Button,
+    TimelinesView,
+    DetailsToolBarViewSelector,
+    ItemsToolBarViewSelector,
+    Checkbox,
+    Input,
+    BaseEntitiesView,
+    PaginationPane,
+    JSBaseEntity,
+    Search,
+    ParametrizedStatusBox
+)
 
 
 class ProviderEntity(JSBaseEntity):
@@ -65,19 +75,18 @@ class ProviderDetailsView(BaseLoggedInPage):
         """
          represents Details page when it is switched to Dashboard aka Widgets view
         """
-        # todo: need to develop this page
-        pass
+        cards = ParametrizedStatusBox()
 
     @property
     def is_displayed(self):
-        if (not self.toolbar.view_selector.is_displayed or
-                self.toolbar.view_selector.selected == 'Summary View'):
-            subtitle = 'Summary'
-        else:
-            subtitle = 'Dashboard'
+        subtitle = 'Summary'
+        if self.toolbar.view_selector.is_displayed:
+            subtitle = self.toolbar.view_selector.selected.split(' ')[0]
 
-        title = '{name} ({subtitle})'.format(name=self.context['object'].name,
-                                             subtitle=subtitle)
+        title = '{name} ({subtitle})'.format(
+            name=self.context['object'].name,
+            subtitle=subtitle
+        )
         return (self.logged_in_as_current_user and
                 self.breadcrumb.is_displayed and
                 self.breadcrumb.active_location == title)

--- a/cfme/containers/overview.py
+++ b/cfme/containers/overview.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from navmazing import NavigateToAttribute
-from widgetastic_manageiq import StatusBox
+from widgetastic_manageiq import ParametrizedStatusBox
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator
@@ -13,15 +13,7 @@ class ContainersOverview(Navigatable):
 
 
 class ContainersOverviewView(BaseLoggedInPage):
-    providers = StatusBox('Providers')
-    nodes = StatusBox('Nodes')
-    containers = StatusBox('Containers')
-    registries = StatusBox('Registries')
-    projects = StatusBox('Projects')
-    pods = StatusBox('Pods')
-    services = StatusBox('Services')
-    images = StatusBox('Images')
-    routes = StatusBox('Routes')
+    status_cards = ParametrizedStatusBox()
     # TODO: Add widgets for utilization trends
 
     @property
@@ -39,5 +31,5 @@ class All(CFMENavigateStep):
 
     def resetter(self):
         # We should wait ~2 seconds for the StatusBox population
-        wait_for(lambda: self.view.providers.value,
+        wait_for(lambda: self.view.status_cards('Providers').value,
                  num_sec=10, delay=1, silent_failure=True)

--- a/cfme/tests/containers/test_containers_summary.py
+++ b/cfme/tests/containers/test_containers_summary.py
@@ -33,8 +33,8 @@ def test_containers_summary_objects(provider, soft_assert):
            * Checks the amount is equal
        """
     view = navigate_to(ContainersOverview, 'All')
-    # Collecting status boxes values:
-    status_box_values = {obj: getattr(view, obj.PLURAL.split(' ')[-1].lower()).value
+    # Collecting status boxes values from overview page cards
+    status_box_values = {obj: view.status_cards(obj.PLURAL.split(' ')[-1]).value
                          for obj in tested_objects}
     # Comparing to the values in the relationships tables:
     view = navigate_to(provider, 'Details')

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -688,6 +688,10 @@ class StatusBox(Widget, ClickableMixin):
         Widget.__init__(self, parent, logger=logger)
         self.name = name
 
+    @property
+    def is_displayed(self):
+        return self.card.is_displayed
+
     def click(self, *args, **kwargs):
         self.card.click(*args, **kwargs)
 
@@ -699,6 +703,25 @@ class StatusBox(Widget, ClickableMixin):
 
     def read(self):
         return {self.name: self.value}
+
+
+class ParametrizedStatusBox(ParametrizedView):
+    PARAMETERS = ("name",)
+    _card = StatusBox(name=Parameter("name"))
+
+    @property
+    def is_displayed(self):
+        return self._card.is_displayed
+
+    @property
+    def value(self):
+        return self._card.value
+
+    def click(self):
+        self._card.click()
+
+    def read(self):
+        return self._card.read()
 
 
 class Accordion(PFAccordion):


### PR DESCRIPTION
Parametrize StatusBox widget, use it in ProviderDashboard view so we don't have 10 of the same widgets with different names

These two tests are basically the same, but I don't want this PR scope to involve reducing them to a single parametrized test.


# NOTE FOR REVIEWERS

I'm seeing a mismatch on container count, CMQE team is aware, leaving a TODO for now, but adding the parameter back into the test.
`E           There is a mismatch between API and UI values: Container: 25 (API) != 30 (UI) (cfme/tests/containers/test_overview_data_integrity.py:72)`


{{ pytest: --use-provider ocp-39-hawk --long-running cfme/tests/containers/test_overview_data_integrity.py cfme/tests/containers/test_containers_summary.py }}