### PR TITLE
[1LP][RFR] Modify report download method for 5.10

### DIFF
--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -433,7 +433,10 @@ class SavedReport(Updateable, BaseEntity):
     def download(self, extension):
         extensions_mapping = {"txt": "Text", "csv": "CSV", "pdf": "PDF"}
         view = navigate_to(self, "Details")
-        view.download("Download as {}".format(extensions_mapping[extension]))
+        if self.appliance.version > '5.10' and extension == "pdf":
+            view.download("Print or export as {}".format(extensions_mapping[extension]))
+        else:
+            view.download("Download as {}".format(extensions_mapping[extension]))
 
     def delete(self, cancel=False):
         view = navigate_to(self, "Details")

--- a/cfme/tests/intelligence/test_download_report.py
+++ b/cfme/tests/intelligence/test_download_report.py
@@ -1,51 +1,21 @@
 # -*- coding: utf-8 -*-
 import pytest
-import os
-import shutil
-from cfme.utils.wait import wait_for
-from cfme.utils import browser
-
-
-def clean_temp_directory():
-    """ Clean the temporary directory.
-
-    """
-    for root, dirs, files in os.walk(browser.firefox_profile_tmpdir):
-        for f in files:
-            os.unlink(os.path.join(root, f))
-        for d in dirs:
-            shutil.rmtree(os.path.join(root, d))
-
-
-@pytest.fixture
-def needs_firefox():
-    """ Fixture which skips the test if not run under firefox.
-
-    I recommend putting it in the first place.
-    """
-    browser.ensure_browser_open()
-    if browser.browser().name != "firefox":
-        pytest.skip(msg="This test needs firefox to run")
 
 
 @pytest.fixture(scope="module")
 def report(appliance):
-    return appliance.collections.reports.instantiate(
+    saved_report = appliance.collections.reports.instantiate(
         type="Configuration Management",
         subtype="Virtual Machines",
-        menu_name="Hardware Information for VMs"
+        menu_name="Hardware Information for VMs",
     ).queue(wait_for_finish=True)
+    yield saved_report
+    saved_report.delete(cancel=False)
 
 
-# TODO Prevent Firefox from popping up "Save file" in order to add 'pdf' parametrization
-# Files download is unsolved, since the browser runs in a separate container
-@pytest.mark.skip
-@pytest.mark.parametrize("filetype", ["txt", "csv"])
-def test_download_report_firefox(needs_firefox, infra_provider, report, filetype):
-    """ Download the report as a file and check whether it was downloaded. """
-    extension = "." + filetype
-    clean_temp_directory()
+@pytest.mark.parametrize("filetype", ["txt", "csv", "pdf"])
+def test_download_report(infra_provider, report, filetype):
+    """
+    Download the report as a file .
+    """
     report.download(filetype)
-    wait_for(lambda: any([file.endswith(extension) for file in os.listdir(
-        browser.firefox_profile_tmpdir)]), num_sec=60.0)
-    clean_temp_directory()

--- a/cfme/tests/intelligence/test_download_report.py
+++ b/cfme/tests/intelligence/test_download_report.py
@@ -15,7 +15,5 @@ def report(appliance):
 
 @pytest.mark.parametrize("filetype", ["txt", "csv", "pdf"])
 def test_download_report(infra_provider, report, filetype):
-    """
-    Download the report as a file .
-    """
+    """Download the report as a file."""
     report.download(filetype)


### PR DESCRIPTION
This PR modifies `download` method for Report. If the appliance version is greater than 5.10, it looks for `Print or export as PDF` option while downloading a report.

{{pytest: cfme/tests/intelligence/test_download_report.py --use-template-cache -sqvvv}}