### PR TITLE
[RFR] Flash message after ordering catalog is success now

### DIFF
--- a/cfme/services/service_catalogs/ui.py
+++ b/cfme/services/service_catalogs/ui.py
@@ -10,6 +10,7 @@ from cfme.services.service_catalogs import ServiceCatalogs, BaseOrderForm
 from cfme.utils.appliance import MiqImplementationContext
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to, ViaUI
 from cfme.utils.blockers import BZ
+from cfme.utils.version import VersionPicker, LOWEST
 
 
 class ServicesCatalogsView(BaseLoggedInPage):
@@ -88,7 +89,10 @@ def order(self):
     if self.ansible_dialog_values:
         view.fill(self.ansible_dialog_values)
     msg = "Order Request was Submitted"
-    msg_type = "info"
+    msg_type = VersionPicker({
+        LOWEST: "success",
+        "5.10": "info"
+    }).pick()
     view.submit_button.click()
     view = self.create_view(RequestsView)
     view.flash.assert_no_error()

--- a/cfme/tests/services/test_service_catalogs.py
+++ b/cfme/tests/services/test_service_catalogs.py
@@ -15,9 +15,7 @@ from cfme.utils.wait import wait_for_decorator
 
 
 pytestmark = [
-    pytest.mark.meta(server_roles="+automate",
-                     blockers=[BZ(1633540, forced_streams=['5.10'],
-                        unblock=lambda provider: not provider.one_of(RHEVMProvider))]),
+    pytest.mark.meta(server_roles="+automate"),
     pytest.mark.usefixtures('setup_provider', 'catalog_item', 'uses_infra_providers'),
     test_requirements.service,
     pytest.mark.long_running,


### PR DESCRIPTION
Flash message that is displayed after ordering Service Catalog is `success` in 5.9 and `info` in 5.10, therefore applying `VersionPicker`. 

PRT does not really seem to be working, therefore providing verification from Jenkins.

{{pytest: cfme/tests/services/test_service_catalogs.py::test_order_catalog_item --long-running -vv}}

Jenkins: https://rhv-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/cfme-5.9-rhv-4.2-integration-test-dev/209/console