### PR TITLE
[1LP][RFR] QUOTA TEST:  To show quota used on tenant quota screen even when no quotas are set

### DIFF
--- a/cfme/configure/access_control/__init__.py
+++ b/cfme/configure/access_control/__init__.py
@@ -9,6 +9,7 @@ from widgetastic_patternfly import (
 from widgetastic_manageiq import (
     UpDownSelect, PaginationPane, SummaryFormItem, Table, SummaryForm, WaitTab)
 from widgetastic_manageiq.expression_editor import GroupTagExpressionEditor
+from widgetastic.utils import Version, VersionPick
 
 from cfme.base.credential import Credential
 from cfme.base.ui import ConfigurationView
@@ -1307,7 +1308,9 @@ class DetailsTenantView(ConfigurationView):
     name = Text('Name')
     description = Text('Description')
     parent = Text('Parent')
-    table = Table('//*[self::fieldset or @id="fieldset"]/table')
+    table = VersionPick({
+        Version.lowest(): Table('//*[self::fieldset or @id="fieldset"]/table'),
+        '5.10': Table('//div[contains(@id,"react-")]/table')})
 
     @property
     def is_displayed(self):

--- a/cfme/tests/cloud_infra_common/test_quota_with_multiple_providers.py
+++ b/cfme/tests/cloud_infra_common/test_quota_with_multiple_providers.py
@@ -29,12 +29,8 @@ def test_show_quota_used_on_tenant_screen(request, appliance, v2v_providers):
         4. Go to tenant quota table.
         5. Check whether number of VMs are equal to number of VMs in 'in use' column.
     """
-    view = navigate_to(v2v_providers.vmware_provider, "Details")
-    v2v_providers.vmware_provider.refresh_provider_relationships_ui
-    view.browser.refresh
-    view = navigate_to(v2v_providers.rhv_provider, "Details")
-    v2v_providers.rhv_provider.refresh_provider_relationships_ui
-    view.browser.refresh
+    v2v_providers.vmware_provider.refresh_provider_relationships
+    v2v_providers.rhv_provider.refresh_provider_relationships
     vm_count = v2v_providers.rhv_provider.num_vm() + v2v_providers.vmware_provider.num_vm()
     root_tenant = appliance.collections.tenants.get_root_tenant()
     view = navigate_to(root_tenant, "Details")

--- a/cfme/tests/cloud_infra_common/test_quota_with_multiple_providers.py
+++ b/cfme/tests/cloud_infra_common/test_quota_with_multiple_providers.py
@@ -1,0 +1,45 @@
+import pytest
+
+from cfme.infrastructure.provider.rhevm import RHEVMProvider
+from cfme.infrastructure.provider.virtualcenter import VMwareProvider
+from cfme.markers.env_markers.provider import ONE_PER_TYPE
+from cfme.utils.appliance.implementations.ui import navigate_to
+
+
+pytestmark = [
+    pytest.mark.provider(
+        classes=[RHEVMProvider],
+        selector=ONE_PER_TYPE,
+    ),
+    pytest.mark.provider(
+        classes=[VMwareProvider],
+        selector=ONE_PER_TYPE,
+        fixture_name='second_provider',
+    )
+]
+
+
+def test_show_quota_used_on_tenant_screen(request, appliance, v2v_providers):
+    """Test show quota used on tenant quota screen even when no quotas are set.
+
+    Steps:
+        1. Navigate to provider's 'Details' page.
+        2. Fetch the information of 'number of VMs'.
+        3. Navigate to 'Details' page of 'My Company' tenant.
+        4. Go to tenant quota table.
+        5. Check whether number of VMs are equal to number of VMs in 'in use' column.
+    """
+    view = navigate_to(v2v_providers.vmware_provider, "Details")
+    v2v_providers.vmware_provider.refresh_provider_relationships_ui
+    view.browser.refresh
+    view = navigate_to(v2v_providers.rhv_provider, "Details")
+    v2v_providers.rhv_provider.refresh_provider_relationships_ui
+    view.browser.refresh
+    vm_count = v2v_providers.rhv_provider.num_vm() + v2v_providers.vmware_provider.num_vm()
+    root_tenant = appliance.collections.tenants.get_root_tenant()
+    view = navigate_to(root_tenant, "Details")
+    for row in view.table:
+        if row[0].text == "Allocated Number of Virtual Machines":
+            num_of_vms = row[2].text
+    num_of_vms = int(num_of_vms.split()[0])
+    assert vm_count == num_of_vms


### PR DESCRIPTION
{{ pytest: cfme/tests/cloud_infra_common/test_quota_with_multiple_providers.py -k 'test_show_quota_used_on_tenant_screen'  --use-provider rhv41  --use-provider vsphere67-nested --provider-limit 2 -v }}

Ref. PR: #8020 