### PR TITLE
[RFR] uncollect host tests against 5.10

### DIFF
--- a/cfme/tests/candu/test_gap_collection.py
+++ b/cfme/tests/candu/test_gap_collection.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from cfme import test_requirements
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import BZ
 from cfme.utils.wait import wait_for
 
 
@@ -13,7 +14,8 @@ pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.provider([VMwareProvider],
     scope='module',
-    required_fields=[(['cap_and_util', 'capandu_vm'], 'cu-24x7')])
+    required_fields=[(['cap_and_util', 'capandu_vm'], 'cu-24x7')]),
+    pytest.mark.meta(blockers=[BZ(1636120, forced_streams=['5.10'])])
 ]
 
 

--- a/cfme/tests/candu/test_host_graph.py
+++ b/cfme/tests/candu/test_host_graph.py
@@ -7,6 +7,7 @@ from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.tests.candu import compare_data, compare_data_with_unit
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for
 
@@ -16,7 +17,8 @@ pytestmark = [
     test_requirements.c_and_u,
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.provider([VMwareProvider, RHEVMProvider],
-                         required_fields=[(['cap_and_util', 'capandu_vm'], 'cu-24x7')])
+                         required_fields=[(['cap_and_util', 'capandu_vm'], 'cu-24x7')]),
+    pytest.mark.meta(blockers=[BZ(1636120, forced_streams=['5.10'])])
 ]
 
 

--- a/cfme/tests/infrastructure/test_host_drift_analysis.py
+++ b/cfme/tests/infrastructure/test_host_drift_analysis.py
@@ -7,11 +7,13 @@ from cfme.infrastructure.host import Host
 from cfme.infrastructure.provider import InfraProvider
 from cfme.utils import testgen
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import BZ
 from cfme.utils.wait import wait_for
 
 pytestmark = [
     test_requirements.drift,
-    pytest.mark.tier(3)
+    pytest.mark.tier(3),
+    pytest.mark.meta(blockers=[BZ(1636120, forced_streams=['5.10'])]),
 ]
 
 

--- a/cfme/tests/infrastructure/test_individual_host_creds.py
+++ b/cfme/tests/infrastructure/test_individual_host_creds.py
@@ -16,7 +16,8 @@ from cfme.utils.wait import wait_for
 
 pytestmark = [
     pytest.mark.tier(3),
-    pytest.mark.provider([InfraProvider], required_fields=['hosts'], scope='module')
+    pytest.mark.provider([InfraProvider], required_fields=['hosts'], scope='module'),
+    pytest.mark.meta(blockers=[BZ(1636120, forced_streams=['5.10'])]),
 ]
 
 

--- a/cfme/tests/v2v/test_csv_import.py
+++ b/cfme/tests/v2v/test_csv_import.py
@@ -36,7 +36,7 @@ def migration_plan(appliance, infra_map, csv=False):
     """Function to create migration plan and select csv import option"""
     plan_name = "map_{}".format(fauxfactory.gen_alpha(10))
     plan_obj = appliance.collections.v2v_plans
-    view = navigate_to(plan_obj, 'Add', wait_for_view=True)
+    view = navigate_to(plan_obj, 'Add')
     view.general.fill({
         'infra_map': infra_map.name,
         'name': plan_name,

--- a/cfme/tests/v2v/test_v2v_migrations_ui.py
+++ b/cfme/tests/v2v/test_v2v_migrations_ui.py
@@ -254,7 +254,7 @@ def test_migration_rbac(appliance, new_credential, conversion_tags, host_creds, 
     product_features = [(['Everything', 'Compute', 'Migration'], False)]
     role.update({'product_features': product_features})
     with user:
-        view = navigate_to(appliance.server, 'Dashboard', wait_for_view=True)
+        view = navigate_to(appliance.server, 'Dashboard')
         nav_tree = view.navigation.nav_item_tree()
         # Checks migration option is disabled in navigation
         assert 'Migration' not in nav_tree['Compute'], ('Migration found in nav tree, '


### PR DESCRIPTION
1. uncollected host tests because host view summary page is broken
2. removed wait_for_view=True because it is always enabled now
