### PR TITLE
[WIPTEST] Add new test to remove dialog element

### DIFF
--- a/cfme/automate/dialogs/dialog_element.py
+++ b/cfme/automate/dialogs/dialog_element.py
@@ -162,6 +162,18 @@ class Element(BaseEntity):
         assert view.is_displayed
         view.flash.assert_no_error()
 
+    def remove_elements(self, elements):
+        """Method to remove elements from section.
+
+        Args:
+            elements: list of elements to be removed from section.
+        """
+        view = navigate_to(self, 'Edit')
+        for element in elements:
+            label = element.get('element_information').get("ele_label")
+            view.element.remove_element(element_name=label)
+        view.save_button.click()
+        view.flash.assert_no_error()
 
 @attr.s
 class ElementCollection(BaseCollection):

--- a/cfme/tests/automate/test_service_dialog.py
+++ b/cfme/tests/automate/test_service_dialog.py
@@ -239,3 +239,37 @@ def test_radiobutton_dialog_element(appliance, request):
     }
     dialog, element = create_dialog(appliance, element_data)
     request.addfinalizer(dialog.delete_if_exists)
+
+
+def test_remove_dialog_element(appliance, request):
+    """Tests remove dialog element
+
+    Testing BZ 1522870.
+    """
+    element_1_data = {
+        'element_information': {
+            'ele_label': "ele_label_" + fauxfactory.gen_alphanumeric(),
+            'ele_name': fauxfactory.gen_alphanumeric(),
+            'ele_desc': fauxfactory.gen_alphanumeric(),
+            'choose_type': "Text Box",
+        }
+    }
+    element_2_data = {
+        'element_information': {
+            'ele_label': "ele_" + fauxfactory.gen_alphanumeric(),
+            'ele_name': fauxfactory.gen_alphanumeric(),
+            'ele_desc': fauxfactory.gen_alphanumeric(),
+            'choose_type': "Radio Button",
+
+        }
+    }
+    service_dialog = appliance.collections.service_dialogs
+    sd = service_dialog.create(label='label_' + fauxfactory.gen_alphanumeric(),
+                               description="my dialog")
+    tab = sd.tabs.create(tab_label='tab_' + fauxfactory.gen_alphanumeric(),
+                         tab_desc="my tab desc")
+    box = tab.boxes.create(box_label='box_' + fauxfactory.gen_alphanumeric(),
+                           box_desc="my box desc")
+    element = box.elements.create(element_data=[element_1_data, element_2_data])
+    request.addfinalizer(sd.delete_if_exists)
+    element.remove_elements(elements=[element_1_data])

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -1423,6 +1423,13 @@ class DialogElement(Widget, ClickableMixin):
             )
         )
 
+        remove_icon = Text(
+            ParametrizedLocator(
+                ".//div[contains(normalize-space(.), {element_name|quote})]"
+                '/div/button/span/i[contains(@class, "fa-times")]'
+            )
+        )
+
         def edit_icon_click(self):
             """Clicks the edit icon with this name."""
             wait_for(
@@ -1440,6 +1447,23 @@ class DialogElement(Widget, ClickableMixin):
             )
             return self.edit_icon.click()
 
+        def remove_icon_click(self):
+            """Clicks the edit icon with this name."""
+            wait_for(
+                lambda: self.ele_label.is_displayed,
+                delay=5,
+                num_sec=30,
+                message="waiting for element to be displayed",
+            )
+            self.ele_label.click()
+            wait_for(
+                lambda: self.remove_icon.is_displayed,
+                delay=5,
+                num_sec=30,
+                message="waiting for element to be displayed",
+            )
+            return self.remove_icon.click()
+
     def edit_element(self, element_name):
         """Clicks the edit_icon_click.
 
@@ -1447,6 +1471,14 @@ class DialogElement(Widget, ClickableMixin):
             element_name: Name of the element
         """
         return self.element(element_name).edit_icon_click()
+
+    def remove_element(self, element_name):
+        """Clicks the remove_icon_click.
+
+        Args:
+            element_name: Name of the element
+        """
+        return self.element(element_name).remove_icon_click()
 
     def drag_and_drop(self, dragged_widget, dropped_widget):
         dragged_widget_el = self.element(dragged_widget).drag_drop_div


### PR DESCRIPTION
{{pytest: cfme/tests/automate/test_service_dialog.py::test_remove_dialog_element }}

Following are the steps 
1. Add service dialog with fields
2. Edit service dialog editor
3. Remove any dialog field/element and save dialog

