### PR TITLE
[RFR] Fix BZ instantiation for server.get_master

### DIFF
--- a/cfme/base/__init__.py
+++ b/cfme/base/__init__.py
@@ -131,8 +131,9 @@ class ServerCollection(BaseCollection, sentaku.modeling.ElementMixin):
             name = server.name
         except AttributeError:
             logger.error('The EVM has no name, setting it to EVM')
-            if (self.appliance.version == LATEST or self.appliance.is_pod
-            or BZ(1635178, forced_streams='5.9').blocks):
+            if (self.appliance.version == LATEST or
+                    self.appliance.is_pod or
+                    BZ(1635178, forced_streams=['5.9']).blocks):
                 name = 'EVM'
             else:
                 name = server.name


### PR DESCRIPTION
We're seeing a large number of automation failures from the second call to `server.name` here, but I can't yet replicate the failure locally.

At least wanted to start with  adding the list for forced_streams arg