### PR TITLE
[1LP][RFR] Update Taggable.add_tag nav error handling

### DIFF
--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -405,7 +405,7 @@ class Taggable(TaggableCommonBase):
         try:
             view = navigate_to(self, 'Details')
         except (NavigationDestinationNotFound, DestinationNotFound):
-            raise ItemNotFound('Details page does not exit for: {}'.format(self))
+            raise ItemNotFound('Details page does not exist for: {}'.format(self))
         except TimedOutError:
             raise ItemNotFound('Timed out navigating to details for: {}'.format(self))
         tags = []


### PR DESCRIPTION
Raise common exception when nav to Details fails for a Taggable entity

Right now we're hitting a `TimedOutError` on Taggable entities that are returning `False` for `is_displayed` on their `Details` view, I think its more fit to raise an ItemNotFound error here consistently. Happens to handle case where Taggable class doesn't have details nav defined either.
