### PR TITLE
[1LP][RFR] Fix PolicyCollection.PRETTY and PoliciesAllView.is_displayed

### DIFF
--- a/cfme/control/explorer/conditions.py
+++ b/cfme/control/explorer/conditions.py
@@ -67,10 +67,9 @@ class ConditionsAllView(ControlExplorerView):
     def is_displayed(self):
         return (
             self.in_control_explorer and
-            self.title.text == "All {} Conditions".format(self.context["object"].FIELD_VALUE) and
+            self.title.text == "All Conditions" and
             self.conditions.is_opened and
-            self.conditions.tree.currently_selected == ["All Conditions",
-                "{} Conditions".format(self.context["object"].TREE_NODE)]
+            self.conditions.tree.currently_selected == ["All Conditions"]
         )
 
 
@@ -90,12 +89,15 @@ class NewConditionView(ConditionFormCommon):
 
     @property
     def is_displayed(self):
+        expected_tree = [
+            "All Conditions",
+            "{} Conditions".format(self.context["object"].TREE_NODE)
+        ]
         return (
             self.in_control_explorer and
             self.title.text == "Adding a new Condition" and
             self.conditions.is_opened and
-            self.conditions.tree.currently_selected == ["All Conditions",
-                "{} Condition".format(self.context["object"].TREE_NODE)]
+            self.conditions.tree.currently_selected == expected_tree
         )
 
 

--- a/cfme/control/explorer/policy_profiles.py
+++ b/cfme/control/explorer/policy_profiles.py
@@ -29,7 +29,7 @@ class NewPolicyProfileView(PolicyProfileFormCommon):
     def is_displayed(self):
         return (
             self.in_control_explorer and
-            self.title.text == "Adding a New Policy Profile" and
+            self.title.text == "Adding a new Policy Profile" and
             self.policy_profiles.tree.currently_selected == ["All Policy Profiles"]
         )
 


### PR DESCRIPTION
is_displayed raises exception because PolicyCollection has no `PRETTY` attribute.

Added `PRETTY=None` and updated `is_displayed` because the collection page doesn't have a unique title.

{{ pytest: cfme/tests/control/test_actions.py -k test_action_start_virtual_machine_after_stopping --long-running }}