### PR TITLE
[RFR] fix accordion dimmed method

### DIFF
--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -727,9 +727,7 @@ class ParametrizedStatusBox(ParametrizedView):
 class Accordion(PFAccordion):
     @property
     def is_dimmed(self):
-        return bool(
-            self.browser.elements('.//div[contains(@id, "tree") and contains(@class, "dimmed")]')
-        )
+        return bool(self.root_browser.elements(".//div[contains(@class, 'sidebar-disabled')]"))
 
 
 class Calendar(TextInput):


### PR DESCRIPTION
Purpose or Intent
=================
-  Accordion `is_dimmed` method used in some of `is_displayed` method. Found that it's returning always `False` due to a bad locator. 
- I  think in 5.9 and 5.10 `dimmed` is removed and the total sidebar is hidden. I found below locator with which, we can decide Accordion is dimmed or not.

Reviewers:
I am not adding any test as is not directly use. other checks of displayed also failing... So you can test it with `miq shell`. Some checkpoints
1. Tagging any object on All page Accordion dimmed
2. Add new button group 