### PR TITLE
[1LP][RFR] Create custom role in quota tests instead of super_admin

### DIFF
--- a/cfme/tests/infrastructure/test_project_quota.py
+++ b/cfme/tests/infrastructure/test_project_quota.py
@@ -60,10 +60,20 @@ def new_project(appliance):
 
 
 @pytest.fixture(scope='module')
-def new_group(appliance, new_project):
+def new_role(appliance):
+    collection = appliance.collections.roles
+    role = collection.create(name='role_{}'.format(fauxfactory.gen_alphanumeric()),
+                             vm_restriction=None,
+                             product_features=[(['Everything'], True)])
+    yield role
+    role.delete()
+
+
+@pytest.fixture(scope='module')
+def new_group(appliance, new_project, new_role):
     collection = appliance.collections.groups
     group = collection.create(description='group_{}'.format(fauxfactory.gen_alphanumeric()),
-                              role='EvmRole-super_administrator',
+                              role=new_role.name,
                               tenant='My Company/{}'.format(new_project.name))
     yield group
     group.delete()


### PR DESCRIPTION
__Added__ custom role instead of using super_administrator role. 
Motivation behind the change is comment 6 in the following BZ https://bugzilla.redhat.com/show_bug.cgi?id=1636958#c6 .

TL;DR
Quotas should not be applied to Super_administrator role because of possible (and quite real) unpredictable behaviour.

juwatts:
{{ pytest: cfme/tests/infrastructure/test_project_quota.py --use-provider complete --long-running }}