### PR TITLE
[RFR]Fix view is_displayed for services

### DIFF
--- a/cfme/services/catalogs/__init__.py
+++ b/cfme/services/catalogs/__init__.py
@@ -1,15 +1,15 @@
 from navmazing import NavigateToSibling
-from widgetastic.widget import View
 from widgetastic_patternfly import Dropdown
+from widgetastic.widget import View, Text
 
 from cfme.base import Server
 from cfme.base.login import BaseLoggedInPage
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep
-from widgetastic_manageiq import Accordion, ManageIQTree
-from widgetastic_manageiq import ItemsToolBarViewSelector
+from widgetastic_manageiq import Accordion, ItemsToolBarViewSelector, ManageIQTree
 
 
 class ServicesCatalogView(BaseLoggedInPage):
+    title = Text('#explorer_title_text')
 
     @property
     def in_explorer(self):
@@ -19,8 +19,7 @@ class ServicesCatalogView(BaseLoggedInPage):
 
     @property
     def is_displayed(self):
-        return (self.in_explorer and self.toolbar.configuration.is_displayed and
-                not self.catalogs.is_dimmed)
+        return self.in_explorer
 
     @View.nested
     class service_catalogs(Accordion):  # noqa

--- a/cfme/services/service_catalogs/ui.py
+++ b/cfme/services/service_catalogs/ui.py
@@ -60,7 +60,7 @@ class DetailsServiceCatalogView(ServicesCatalogsView):
     @property
     def is_displayed(self):
         return (
-            self.in_explorer and self.service_catalogs.is_opened and
+            self.in_service_catalogs and self.service_catalogs.is_opened and
             self.title.text == 'Service "{}"'.format(self.context['object'].name)
         )
 


### PR DESCRIPTION
Fix service view is_displayed
Part of resolving https://github.com/ManageIQ/integration_tests/issues/7960

{{pytest: cfme/tests/services/test_service_catalogs.py --use-provider vsphere55 --long-running}}