### PR TITLE
[1LP][RFR] CMQE Fix is_displayed for Container Builds

### DIFF
--- a/cfme/containers/build.py
+++ b/cfme/containers/build.py
@@ -28,7 +28,7 @@ class BuildView(BaseLoggedInPage):
 
 
 class BuildDefaultView(BuildView):
-    title = Text("#explorer_title_text")
+    title = Text(".//div[@id='main-content']//h1")
 
     @property
     def is_displayed(self):


### PR DESCRIPTION
```
In[2]: ocp = providers.get_crud('ocp-36-hawk')
In[3]: coll = appliance.collections.container_builds
In[4]: view = navigate_to(coll, 'All')
In[5]: view.is_displayed
Out[5]: True
In[6]: navigate_to(ocp, 'All')
Out[6]: <cfme.common.provider_views.ContainerProvidersView at 0x7f56d3b04450>
In[7]: view.is_displayed
Out[7]: False
```