### PR TITLE
[WIPTEST] Fix: Automate Explorer View

### DIFF
--- a/cfme/automate/explorer/__init__.py
+++ b/cfme/automate/explorer/__init__.py
@@ -21,7 +21,7 @@ class AutomateExplorerView(BaseLoggedInPage):
 
     @property
     def is_displayed(self):
-        return self.in_explorer and self.configuration.is_displayed and not self.datastore.is_dimmed
+        return self.in_explorer and not self.datastore.is_dimmed
 
     @View.nested
     class datastore(Accordion):  # noqa


### PR DESCRIPTION
Purpose or Intent
=================
- removed check for `configuration` button each time. which is not a good way to treat a common view. 
- `AutomateExplorerView`  is entry view for Explorer tab so better to check common things like
1. `in_explorer`
2. `Datastore  is not dimmed` as its sidebar
3. Configuration is displayed only  for `Datastore` not for specific subitem of tree like Domain `Redhat` or `MangeIQ`

Error: 
```
TimedOutError: Could not do Waiting for view [AutomateExplorerView] to display at /var/ci/workspace/template-tester-openstack/integration_tests/cfme/utils/appliance/implementations/ui.py:558 in time
```


{{pytest: cfme/tests/automate/test_smoke.py -v}}