### PR TITLE
[1LP][WIP] Fix is_displayed for snapshot create

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -366,7 +366,8 @@ class InfraVmSnapshotAddView(InfraVmView):
     @property
     def is_displayed(self):
         """Is this view being displayed"""
-        return False
+        expected_title = "Adding a new Snapshot"
+        return self.in_infra_vms and self.title.text == expected_title
 
 
 class InfraVmGenealogyToolbar(View):


### PR DESCRIPTION
Note: Snapshot tests require PR #7681 to work.

This fixes is_displayed for snapshot create. Fixes all snapshot failures.

Part of  #7960

{{ pytest: -v --long-running cfme/tests/infrastructure/test_snapshot.py -k test_delete_all_snapshots --use-provider vsphere65-nested }}