### PR TITLE
[RFR] Fix: Clean automation log before execute button

### DIFF
--- a/cfme/tests/automate/custom_button/__init__.py
+++ b/cfme/tests/automate/custom_button/__init__.py
@@ -19,13 +19,11 @@ def check_log_requests_count(appliance, parse_str=None):
     return int(count.output)
 
 
-def log_request_check(appliance, initial_count, expected_count):
+def log_request_check(appliance, expected_count):
     """ Method for checking expected request count in automation log
 
     Args:
         appliance: an appliance for ssh
-        initial_count: initial request count available in automation log
         expected_count: expected request count in automation log
     """
-    diff = check_log_requests_count(appliance=appliance) - initial_count
-    return diff == expected_count
+    return check_log_requests_count(appliance=appliance) == expected_count

--- a/cfme/tests/automate/custom_button/test_infra_objects.py
+++ b/cfme/tests/automate/custom_button/test_infra_objects.py
@@ -174,18 +174,13 @@ def test_custom_button_automate(appliance, request, submit, setup_obj, button_gr
             except AttributeError:
                 paginator = view.entities.paginator
 
-            if paginator.items_amount > paginator.items_per_page:
-                entity_count = paginator.items_per_page
-            else:
-                entity_count = paginator.items_amount
+            entity_count = min(paginator.items_amount, paginator.items_per_page)
             paginator.check_all()
         else:
             entity_count = 1
 
         # Clear the automation log
-        clean = appliance.ssh_client.run_command('echo -n "" > '
-                                                 '/var/www/miq/vmdb/log/automation.log')
-        assert clean.success
+        assert appliance.ssh_client.run_command('echo -n "" > /var/www/miq/vmdb/log/automation.log')
 
         custom_button_group.item_select(button.text)
         view.flash.assert_message('"{}" was executed'.format(button.text))

--- a/cfme/tests/automate/custom_button/test_infra_objects.py
+++ b/cfme/tests/automate/custom_button/test_infra_objects.py
@@ -7,6 +7,7 @@ from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.tests.automate.custom_button import log_request_check
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 from cfme.utils.wait import TimedOutError, wait_for
 
@@ -112,6 +113,11 @@ def test_custom_button_display(request, display, setup_obj, button_group):
 
 @pytest.mark.parametrize(
     "submit", SUBMIT, ids=["_".join(item.split()) for item in SUBMIT]
+)
+@pytest.mark.meta(
+    blockers=[
+        BZ(1628224, forced_streams=["5.10"], unblock=lambda submit: submit != "Submit all")
+    ]
 )
 def test_custom_button_automate(appliance, request, submit, setup_obj, button_group):
     """ Test custom button for automate and requests count as per submit


### PR DESCRIPTION
# Purpose or Intent
=================
- Some time tests  fails due to parameterization and big automation log request. So better to clean before execution of custom button.
- Also increased wait_for time.

{{pytest: cfme/tests/automate/custom_button/test_infra_objects.py::test_custom_button_automate -v}}

https://github.com/ManageIQ/integration_tests/pull/7964 needs for proper navigations