### PR TITLE
[WIP] Fix is_displayed for genealogy test

### DIFF
--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -475,8 +475,7 @@ class EditView(BaseLoggedInPage):
 
     @property
     def is_displayed(self):
-        # Only name is displayed
-        return False
+        raise NotImplementedError("This view has no unique markers for is_displayed check")
 
 
 class SetOwnershipView(BaseLoggedInPage):


### PR DESCRIPTION
Just added the NotImplementedError to is_displayed that is needed in a view for genealogy testing.

Fixes all genealogy tests that are using edit page.

Part of #7960

{{ pytest: -v cfme/tests/cloud_infra_common/test_genealogy.py --use-provider vsphere65-nested }}