### PR TITLE
[WIPTEST] Fixing is_displayed in AddDialogView

### DIFF
--- a/cfme/automate/dialogs/__init__.py
+++ b/cfme/automate/dialogs/__init__.py
@@ -41,10 +41,7 @@ class AddDialogView(DialogForm):
 
     @property
     def is_displayed(self):
-        return (
-            self.in_customization and self.service_dialogs.is_opened and
-            self.create_tab.is_displayed
-        )
+        return self.in_customization and self.create_tab.is_displayed
 
 
 class EditDialogView(DialogForm):


### PR DESCRIPTION
Panel with Service Dialogs is not visible when adding a new dialog.

{{pytest: cfme/tests/services/test_different_dialogs_in_catalogs.py::test_tagdialog_catalog_item -vv}}