### PR TITLE
[1LP][RFR] new test for advanced setting for remote servers

### DIFF
--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -495,10 +495,10 @@ class ServerView(ConfigurationView):
             self.context['object'].zone.region.settings_string,
             "Zones",
             "Zone: {} (current)".format(self.context['object'].zone.description),
-            "Server: {} [{}]{}".format(
-                self.context['object'].name,
-                self.context['object'].sid,
-                '' if self.context['object'] in self.context['object'].slave_servers
+            "Server: {name} [{sid}]{current}".format(
+                name=self.context['object'].name,
+                sid=self.context['object'].sid,
+                current='' if self.context['object'] in self.context['object'].slave_servers
                 else ' (current)')]
         return (
             self.in_configuration and
@@ -516,10 +516,10 @@ class Details(CFMENavigateStep):
             self.obj.zone.region.settings_string,
             "Zones",
             "Zone: {} (current)".format(self.obj.appliance.server.zone.description),
-            "Server: {} [{}]{}".format(
-                self.obj.appliance.server.name,
-                self.obj.sid,
-                '' if self.obj in self.obj.slave_servers else ' (current)'))
+            "Server: {name} [{sid}]{current}".format(
+                name=self.obj.appliance.server.name,
+                sid=self.obj.sid,
+                current='' if self.obj in self.obj.slave_servers else ' (current)'))
 
 
 @navigator.register(Server, 'Server')
@@ -769,10 +769,10 @@ class ServerDiagnosticsView(ConfigurationView):
         return self.accordions.diagnostics.tree.currently_selected == [
             self.context['object'].zone.region.settings_string,
             "Zone: {} (current)".format(self.context['object'].zone.description),
-            "Server: {} [{}]{}".format(
-                self.context['object'].name,
-                self.context['object'].sid,
-                '' if self.context['object'] in self.context['object'].slave_servers
+            "Server: {name} [{sid}]{current}".format(
+                name=self.context['object'].name,
+                sid=self.context['object'].sid,
+                current='' if self.context['object'] in self.context['object'].slave_servers
                 else ' (current)')]
 
 
@@ -791,10 +791,10 @@ class Diagnostics(CFMENavigateStep):
         self.prerequisite_view.accordions.diagnostics.tree.click_path(
             self.obj.zone.region.settings_string,
             "Zone: {} (current)".format(self.obj.zone.description),
-            "Server: {} [{}]{}".format(
-                self.obj.appliance.server.name,
-                self.obj.sid,
-                '' if self.obj in self.obj.slave_servers else ' (current)'))
+            "Server: {name} [{sid}]{current}".format(
+                name=self.obj.appliance.server.name,
+                sid=self.obj.sid,
+                current='' if self.obj in self.obj.slave_servers else ' (current)'))
 
 
 @navigator.register(Server)

--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -495,8 +495,11 @@ class ServerView(ConfigurationView):
             self.context['object'].zone.region.settings_string,
             "Zones",
             "Zone: {} (current)".format(self.context['object'].zone.description),
-            "Server: {} [{}] (current)".format(self.context['object'].name,
-                                               self.context['object'].sid)]
+            "Server: {} [{}]{}".format(
+                self.context['object'].name,
+                self.context['object'].sid,
+                '' if self.context['object'] in self.context['object'].slave_servers
+                else ' (current)')]
         return (
             self.in_configuration and
             self.accordions.settings.is_displayed and
@@ -513,8 +516,10 @@ class Details(CFMENavigateStep):
             self.obj.zone.region.settings_string,
             "Zones",
             "Zone: {} (current)".format(self.obj.appliance.server.zone.description),
-            "Server: {} [{}] (current)".format(self.obj.appliance.server.name,
-                self.obj.sid))
+            "Server: {} [{}]{}".format(
+                self.obj.appliance.server.name,
+                self.obj.sid,
+                '' if self.obj in self.obj.slave_servers else ' (current)'))
 
 
 @navigator.register(Server, 'Server')
@@ -764,8 +769,11 @@ class ServerDiagnosticsView(ConfigurationView):
         return self.accordions.diagnostics.tree.currently_selected == [
             self.context['object'].zone.region.settings_string,
             "Zone: {} (current)".format(self.context['object'].zone.description),
-            "Server: {} [{}] (current)".format(
-                self.context['object'].name, self.context['object'].sid)]
+            "Server: {} [{}]{}".format(
+                self.context['object'].name,
+                self.context['object'].sid,
+                '' if self.context['object'] in self.context['object'].slave_servers
+                else ' (current)')]
 
 
 class ServerDiagnosticsCollectLogsView(ServerDiagnosticsView):
@@ -783,8 +791,10 @@ class Diagnostics(CFMENavigateStep):
         self.prerequisite_view.accordions.diagnostics.tree.click_path(
             self.obj.zone.region.settings_string,
             "Zone: {} (current)".format(self.obj.zone.description),
-            "Server: {} [{}] (current)".format(
-                self.obj.name, self.obj.sid))
+            "Server: {} [{}]{}".format(
+                self.obj.appliance.server.name,
+                self.obj.sid,
+                '' if self.obj in self.obj.slave_servers else ' (current)'))
 
 
 @navigator.register(Server)

--- a/cfme/tests/configure/test_remote_server_tabs.py
+++ b/cfme/tests/configure/test_remote_server_tabs.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from cfme.utils.appliance.implementations.ui import navigate_to
+
+
+@pytest.fixture(scope="module")
+def configured_external_appliance(temp_appliance_preconfig, app_creds_modscope,
+                                  temp_appliance_unconfig):
+    hostname = temp_appliance_preconfig.hostname
+    temp_appliance_unconfig.appliance_console_cli.configure_appliance_external_join(hostname,
+        app_creds_modscope['username'], app_creds_modscope['password'], 'vmdb_production',
+        hostname, app_creds_modscope['sshlogin'], app_creds_modscope['sshpass'])
+    temp_appliance_unconfig.evmserverd.start()
+    temp_appliance_unconfig.evmserverd.wait_for_running()
+    temp_appliance_unconfig.wait_for_web_ui()
+    return temp_appliance_unconfig
+
+
+@pytest.mark.uncollectif(lambda appliance: appliance.version < '5.10')
+def test_remote_server_advanced_config(temp_appliance_preconfig, request,
+                                       configured_external_appliance):
+    """
+    Test that starting in 5.10 it is possible to modify advanced settings for remote servers
+    BZ1536524
+    """
+    appliance = temp_appliance_preconfig
+    remote_server = appliance.server.slave_servers[0]
+    #  Advanced tab exists for remote servers
+    navigate_to(remote_server, 'Advanced')
+
+    # change one setting
+    initial_conf = remote_server.advanced_settings['server']['startup_timeout']
+    request.addfinalizer(lambda: appliance.update_advanced_settings(
+        {'server': {'startup_timeout': initial_conf}})
+                         )
+    remote_server.update_advanced_settings({'server': {'startup_timeout': initial_conf * 2}})
+    new_conf = remote_server.advanced_settings['server']['startup_timeout']
+    assert new_conf == initial_conf * 2
+
+
+

--- a/cfme/tests/configure/test_remote_server_tabs.py
+++ b/cfme/tests/configure/test_remote_server_tabs.py
@@ -33,8 +33,7 @@ def test_remote_server_advanced_config(temp_appliance_preconfig, request,
     # change one setting
     initial_conf = remote_server.advanced_settings['server']['startup_timeout']
     request.addfinalizer(lambda: appliance.update_advanced_settings(
-        {'server': {'startup_timeout': initial_conf}})
-                         )
+        {'server': {'startup_timeout': initial_conf}}))
     remote_server.update_advanced_settings({'server': {'startup_timeout': initial_conf * 2}})
     new_conf = remote_server.advanced_settings['server']['startup_timeout']
     assert new_conf == initial_conf * 2

--- a/cfme/tests/configure/test_remote_server_tabs.py
+++ b/cfme/tests/configure/test_remote_server_tabs.py
@@ -18,7 +18,7 @@ def configured_external_appliance(temp_appliance_preconfig, app_creds_modscope,
     return temp_appliance_unconfig
 
 
-@pytest.mark.uncollectif(lambda appliance: appliance.version < '5.10')
+@pytest.mark.ignore_stream('5.9')
 def test_remote_server_advanced_config(temp_appliance_preconfig, request,
                                        configured_external_appliance):
     """

--- a/cfme/tests/configure/test_remote_server_tabs.py
+++ b/cfme/tests/configure/test_remote_server_tabs.py
@@ -38,6 +38,3 @@ def test_remote_server_advanced_config(temp_appliance_preconfig, request,
     remote_server.update_advanced_settings({'server': {'startup_timeout': initial_conf * 2}})
     new_conf = remote_server.advanced_settings['server']['startup_timeout']
     assert new_conf == initial_conf * 2
-
-
-


### PR DESCRIPTION
{{ pytest: -v cfme/tests/configure/test_remote_server_tabs.py }}

new test to address new feature (in 5.10) https://bugzilla.redhat.com/show_bug.cgi?id=1536524

I had to modify is_displayed and navigation for Server as it depends whether the server is remote or not