### PR TITLE
[RFR] Fix is_displayed() for DiagnosticServerWorkersView

### DIFF
--- a/cfme/configure/configuration/diagnostics_settings.py
+++ b/cfme/configure/configuration/diagnostics_settings.py
@@ -34,7 +34,8 @@ class DiagnosticServerWorkersView(ServerDiagnosticsView):
             self.workers.is_displayed and
             self.workers.is_active and
             self.title.text == 'Diagnostics Server "{} [{}]" (current)'.format(
-                self.context['object'].name, self.context['object'].sid)
+                self.context['object'].appliance.server.name,
+                self.context['object'].appliance.server.sid)
         )
 
 


### PR DESCRIPTION
{{ pytest: cfme/tests/containers/test_pause_resume_workers.py --use-provider ocp-36-hawk }}