### PR TITLE
[RFR][NOTEST] Method to get details of all the providers present inside an appli…

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -951,6 +951,22 @@ class BaseProvider(Taggable, Updateable, Navigatable, BaseEntity):
 
         return details
 
+    def get_all_provider_details(self):
+        """
+        Returns a dictionary mapping id of all the providers present in the appliance,
+        to their name and type.
+        """
+        logger.debug(
+            "Retrieving all the provider details for appliance: {}".format(
+                self.appliance.hostname
+            )
+        )
+
+        details = {}
+        for provider in self.appliance.rest_api.collections.providers.all:
+            details[provider.id] = {"name": provider.name, "type": provider.type}
+        return details
+
     def get_vm_details(self, vm_id):
         """
         Returns the name, type, vendor, host_id, and power_state associated with


### PR DESCRIPTION
This PR adds a method to the `BaseProvider` to get details of all the providers present inside an appliance. It returns a dictionary mapping the provider id to their name and type.
Example:
```
rhos = providers.get_crud('rhos11')
vsphere55 = providers.get_crud('vsphere55')

In [1]: rhos.create_rest()
Out[1]: True

In [3]: vsphere55.create_rest()
Out[3]: True

In [4]: rhos.get_all_provider_details()
Out[4]: 
{u'10': {'name': u'vSphere 5.5 (nested)',
  'type': u'ManageIQ::Providers::Vmware::InfraManager'},
 u'6': {'name': u'RHOS11 Cinder Manager',
  'type': u'ManageIQ::Providers::Openstack::StorageManager::CinderManager'},
 u'7': {'name': u'RHOS11 Swift Manager',
  'type': u'ManageIQ::Providers::StorageManager::SwiftManager'},
 u'8': {'name': u'RHOS11',
  'type': u'ManageIQ::Providers::Openstack::CloudManager'},
 u'9': {'name': u'RHOS11 Network Manager',
  'type': u'ManageIQ::Providers::Openstack::NetworkManager'}}

```