### PR TITLE
[1LP][RFR]Fix YAML data for scheduling a report

### DIFF
--- a/data/schedules_crud/basic01.yaml
+++ b/data/schedules_crud/basic01.yaml
@@ -13,6 +13,6 @@ emails:
     - test2@example.test
 email_options:
   send_if_empty: True
-  txt: True
-  csv: True
-  pdf: True
+  send_txt: True
+  send_csv: True
+  send_pdf: True


### PR DESCRIPTION
This PR introduces fix to YAML data for scheduling a report. There is a change in the name of `txt`, `csv` and `pdf`. Until this change, `txt`, `csv` and `pdf` were not selected even if they were set to `True` in the data, since they were not configured properly. 

{{ pytest: cfme/tests/intelligence/reports/test_crud.py::test_schedule_crud --use-template-cache -sqvvv }}
