### PR TITLE
[WIPTEST] Use ensure_page_safe on provisioning form

### DIFF
--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import os
-from time import sleep
 
 from lxml.html import document_fromstring
+from wait_for import wait_for
 from widgetastic.widget import (
     View, TableRow, Text, TextInput, ParametrizedView, Image, ConditionalSwitchableView)
 from widgetastic_patternfly import (
@@ -355,9 +355,7 @@ class ProvisionView(BaseLoggedInPage):
                 self.parent.sidebar.decrease_button.click()
                 self._select_template(template_name, provider_name)
             self.continue_button.click()
-            # TODO timing, wait_displayed is timing out and can't get it to stop in is_displayed
-            sleep(3)
-            self.flush_widget_cache()
+            wait_for(self.browser.plugin.ensure_page_safe, delay=.1, num_sec=10)
 
     is_displayed = displayed_not_implemented
 


### PR DESCRIPTION
Within before_fill, the static sleep was sometimes failing with an activity spinner that took longer than 3 seconds to load the 2nd part of the provisioning form

@jan-zmeskal I'm interested in seeing how this impacts the various provisioning / provisioning dialog tests that are failing to find their elements.

We may need to include some allowance for delay between tab selection and sub-widget access as well.

{{ pytest: cfme/tests/infrastructure/test_provisioning_dialog.py cfme/tests/cloud_infra_common/test_provisioning.py --use-provider default --long-running -vvv }}

FIXES #7965 