### PR TITLE
[1LP][RFR][NOTEST] Adding BZ1639364 to appliance name workaround

### DIFF
--- a/cfme/base/__init__.py
+++ b/cfme/base/__init__.py
@@ -133,7 +133,8 @@ class ServerCollection(BaseCollection, sentaku.modeling.ElementMixin):
             logger.error('The EVM has no name, setting it to EVM')
             if (self.appliance.version == LATEST or
                     self.appliance.is_pod or
-                    BZ(1635178, forced_streams=['5.9', '5.10']).blocks):
+                    BZ(1635178, forced_streams=['5.10']).blocks or
+                    BZ(1639364, forced_streams=['5.9']).blocks):
                 name = 'EVM'
             else:
                 name = server.name


### PR DESCRIPTION
Hi all, I am adding [BZ1639364](https://bugzilla.redhat.com/show_bug.cgi?id=1639364) to appliance name workaround. The original condition looked like this:

`BZ(1635178, forced_streams=['5.9', '5.10']).blocks`

I don't know why, but this resolves as `False`. Even though [BZ1635178](https://bugzilla.redhat.com/show_bug.cgi?id=1635178) has [BZ1639364](https://bugzilla.redhat.com/show_bug.cgi?id=1639364) listed in Blocks field. It might be caused by the fact that [BZ1635178](https://bugzilla.redhat.com/show_bug.cgi?id=1635178) is in ON_QA state. However I still believe `blocks` should resolve to `True` since [BZ1639364](https://bugzilla.redhat.com/show_bug.cgi?id=1639364) is still ON_DEV.

I am not sure which test case to verify this against, since it's pretty hard for me to find a test that does not fail on #7965.