### PR TITLE
[RFR][1LP] Fix `object has no attribute 'app'`.

### DIFF
--- a/cfme/tests/test_db_migrate.py
+++ b/cfme/tests/test_db_migrate.py
@@ -35,7 +35,7 @@ def temp_appliance_extended_db(temp_appliance_preconfig):
     app = temp_appliance_preconfig
     app.evmserverd.stop()
     app.db.extend_partition()
-    app.app.evmserverd.start()
+    app.evmserverd.start()
     return app
 
 
@@ -45,7 +45,7 @@ def temp_appliance_remote(temp_appliance_preconfig_funcscope):
     app = temp_appliance_preconfig_funcscope
     app.evmserverd.stop()
     app.db.extend_partition()
-    app.app.evmserverd.start()
+    app.evmserverd.start()
     return app
 
 


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ object has no attribute 'app'. Probably a "typo".

{ pytest: -v cfme/tests/test_db_migrate.py -k 'test_db_migrate_replication' }