### PR TITLE
[RFR] Fix Test: test_infra_report_page_per_item

### DIFF
--- a/cfme/tests/configure/test_visual_infra.py
+++ b/cfme/tests/configure/test_visual_infra.py
@@ -186,6 +186,7 @@ def test_infra_list_page_per_item(appliance, request, page, value, set_list):
     assert int(max_item) <= int(item_amt)
 
 
+@pytest.mark.uncollectif(lambda appliance: appliance.version < "5.10.0.20")
 def test_infra_report_page_per_item(appliance, value, set_report):
     """ Tests report items per page
 


### PR DESCRIPTION
This PR introduces changes and fixes to the test `test_infra_report_page_per_item`. Due to a BZ: [1616201](https://bugzilla.redhat.com/show_bug.cgi?id=1616201), the test was failing. The BZ has now been fixed on version `5.10.0.20`. The new changes include:
1. Uncollect the test if `appliance.version < 5.10.0.20`.
2. Add a new fixture `get_report` to queue a report as a part of setup and delete it as a part of teardown. The test would fail otherwise.
3. Navigate to correct page and use correct paginator.
4. Assert if the value of `items_per_page` is according to the value set on settings page.

{{pytest: cfme/tests/configure/test_visual_infra.py::test_infra_report_page_per_item --use-template-cache -sqvvv}}