### PR TITLE
[RFR] [NOTEST] Added unzipping of manageiq templates for ec2 and gce

### DIFF
--- a/cfme/utils/template/gce.py
+++ b/cfme/utils/template/gce.py
@@ -66,10 +66,17 @@ class GoogleCloudTemplateUpload(ProviderTemplateUpload):
         return True
 
     def run(self):
-        self.download_image()
-        self.create_bucket()
-        self.upload_image()
-        self.create_template()
+        if not self.download_image():
+            return False
+
+        if not self.create_bucket():
+            return False
+
+        if not self.upload_image():
+            return False
+
+        if not self.create_template():
+            return False
 
     @log_wrap("cleanup")
     def teardown(self):


### PR DESCRIPTION
Added unzipping of manageiq images, which are for some reason zipped for scvmm, gce, hyperv and azure.
It also changes image_name to unzipped image and then removes zipped archived from system.
It works for EC2. Can't test on GCE.