### PR TITLE
[1LP][RFR]Fixing navigation on host collection via Compute-Infrastructure-Providers

### DIFF
--- a/cfme/common/host_views.py
+++ b/cfme/common/host_views.py
@@ -276,5 +276,6 @@ class ProviderAllHostsView(HostsView):
     def is_displayed(self):
         return (
             self.navigation.currently_selected == ["Compute", "Infrastructure", "Providers"] and
-            self.title.text == "{} (All Managed Hosts)".format(self.context["object"].name)
+            self.title.text == "{} (All Managed Hosts)".format(
+                self.context["object"].filters['parent'].name)
         )

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -19,7 +19,8 @@ from cfme.common.host_views import (
     HostDriftHistory,
     HostEditView,
     HostsView,
-    HostTimelinesView
+    HostTimelinesView,
+    ProviderAllHostsView
 )
 from cfme.exceptions import ItemNotFound
 from cfme.infrastructure.datastore import HostAllDatastoresView
@@ -634,7 +635,14 @@ class HostsCollection(BaseCollection):
 
 @navigator.register(HostsCollection)
 class All(CFMENavigateStep):
-    VIEW = HostsView
+
+    @property
+    def VIEW(self):     # noqa
+        parent = self.obj.filters.get('parent') or self.obj.filters.get('provider')
+        if parent:
+            return ProviderAllHostsView
+        else:
+            return HostsView
 
     def prerequisite(self):
         parent = self.obj.filters.get('parent') or self.obj.filters.get('provider')

--- a/cfme/v2v/migrations.py
+++ b/cfme/v2v/migrations.py
@@ -414,7 +414,8 @@ class AddMigrationPlanView(View):
 
         @property
         def is_displayed(self):
-            return self.filter_by_dropdown.is_displayed
+            return (self.filter_by_dropdown.is_displayed and
+                 (len(self.browser.elements(".//div[contains(@class,'spinner')]")) == 0))
 
         def filter_by_name(self, vm_name):
             try:
@@ -652,9 +653,8 @@ class MigrationPlanCollection(BaseCollection):
             view.vms.hidden_field.fill(temp_file.name)
         else:
             view.next_btn.click()
+        view.vms.wait_displayed()
 
-        wait_for(lambda: view.vms.table.is_displayed, timeout=60, message='Wait for VMs view',
-                 delay=2)
         for vm in vm_list:
             view.vms.filter_by_name(vm.name)
             for row in view.vms.table.rows():


### PR DESCRIPTION

Purpose or Intent
=================

__Fixing__ host collection navigation to use correct view when navigating via Compute->Infrastructure->Providers.

{{pytest: cfme/tests/v2v/test_v2v_migrations.py --use-provider rhv42 --use-provider vsphere65-nested --provider-limit 2 -vvvv --long-running  -k 'test_single_datastore_single_vm_migration'}}