### PR TITLE
[1LP][RFR] Fix services catalog view

### DIFF
--- a/cfme/automate/explorer/domain.py
+++ b/cfme/automate/explorer/domain.py
@@ -13,6 +13,7 @@ from cfme.exceptions import ItemNotFound
 from cfme.utils import clear_property_cache
 from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
+from cfme.utils.wait import TimedOutError
 
 from . import AutomateExplorerView
 
@@ -269,7 +270,7 @@ class Domain(BaseEntity, Fillable):
         try:
             navigate_to(self, 'Details')
             return True
-        except (CandidateNotFound, ItemNotFound):
+        except (CandidateNotFound, ItemNotFound, TimedOutError):
             return False
 
     def delete_if_exists(self):

--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -17,7 +17,9 @@ from cfme.base.credential import Credential
 from cfme.base.login import BaseLoggedInPage
 from cfme.configure.about import AboutView
 from cfme.configure.configuration.server_settings import (
-    ServerInformationView, ServerAuthenticationView)
+    ServerInformationView,
+    ServerAuthenticationView
+)
 from cfme.configure.documentation import DocView
 from cfme.configure.tasks import TasksView
 from cfme.dashboard import DashboardView

--- a/cfme/services/catalogs/catalog_items/__init__.py
+++ b/cfme/services/catalogs/catalog_items/__init__.py
@@ -141,7 +141,6 @@ class TabbedAddCatalogItemView(ServicesCatalogView):
         TAB_NAME = 'Basic Info'
         included_form = View.include(BasicInfoForm)
 
-
     class request_info(Tab):  # noqa
         TAB_NAME = 'Request Info'
         provisioning = View.nested(BasicProvisionFormView)
@@ -525,11 +524,6 @@ class CatalogItemAddStep(CFMENavigateStep):
             return TabbedAddCatalogItemView
         else:
             return AddCatalogItemView
-
-    def am_i_here(self):
-        # Going to an Add page should always be done from first principles incase a previous Add
-        # failed
-        return False
 
     def step(self):
         self.prerequisite_view.select_item_type.select_by_visible_text(self.obj.item_type)

--- a/cfme/services/catalogs/catalog_items/ansible_catalog_items.py
+++ b/cfme/services/catalogs/catalog_items/ansible_catalog_items.py
@@ -260,9 +260,6 @@ class Add(CFMENavigateStep):
     VIEW = AddAnsibleCatalogItemView
     prerequisite = NavigateToAttribute("parent", "Choose Type")
 
-    def am_i_here(self):
-        return False
-
     def step(self):
         self.prerequisite_view.select_item_type.select_by_visible_text(self.obj.item_type)
 

--- a/cfme/services/catalogs/orchestration_template.py
+++ b/cfme/services/catalogs/orchestration_template.py
@@ -237,9 +237,6 @@ class All(CFMENavigateStep):
         self.prerequisite_view.navigation.select('Services', 'Catalogs')
         self.view.orchestration_templates.tree.click_path("All Orchestration Templates")
 
-    def am_i_here(self, *args, **kwargs):
-        return self.view.is_displayed
-
 
 @navigator.register(OrchestrationTemplate)
 class Details(CFMENavigateStep):
@@ -251,9 +248,6 @@ class Details(CFMENavigateStep):
         self.view.orchestration_templates.tree.click_path("All Orchestration Templates",
                                                           self.obj.template_group,
                                                           self.obj.template_name)
-
-    def am_i_here(self, *args, **kwargs):
-        return self.view.is_displayed
 
 
 @navigator.register(OrchestrationTemplatesCollection)


### PR DESCRIPTION
Related to #7960

PRT run 27593 shows the tests that were hitting view timeouts when navigating to ServiceCatalog are passing.  Without #8007 content, will likely fail PRT in 27595

{{ pytest: cfme/tests/cloud/test_quota_tagging.py -k test_quota_tagging_cloud_via_services --use-provider rhos11 -vvvv --long-running }}