### PR TITLE
[RFR] Update keys in schedules_report/*.yaml, email types

### DIFF
--- a/cfme/intelligence/reports/__init__.py
+++ b/cfme/intelligence/reports/__init__.py
@@ -11,6 +11,8 @@ from widgetastic_manageiq import ManageIQTree, MultiBoxSelect
 
 
 class CloudIntelReportsView(BaseLoggedInPage):
+    mycompany_title = "My Company (All Groups)"
+
     @property
     def in_intel_reports(self):
         return (
@@ -21,14 +23,6 @@ class CloudIntelReportsView(BaseLoggedInPage):
     @property
     def is_displayed(self):
         return self.in_intel_reports and self.configuration.is_displayed
-
-    @property
-    def mycompany_title(self):
-        if self.browser.product_version < "5.9":
-            title = "My Company (All EVM Groups)"
-        else:
-            title = "My Company (All Groups)"
-        return title
 
     @View.nested
     class saved_reports(Accordion):  # noqa

--- a/cfme/intelligence/reports/schedules.py
+++ b/cfme/intelligence/reports/schedules.py
@@ -27,6 +27,18 @@ class SchedulesAllView(CloudIntelReportsView):
         return self.in_intel_reports and self.title.text == "All Schedules"
 
 
+# TODO debug the closing widget behavior
+class BootstrapSelectRetry(BootstrapSelect):
+    """Workaround for schedule filter widget that is closing itself
+
+    Retrys the open action
+    """
+    def open(self):
+        super(BootstrapSelectRetry, self).open()
+        if not self.is_open:
+            super(BootstrapSelectRetry, self).open()
+
+
 class SchedulesFormCommon(CloudIntelReportsView):
     flash = FlashMessages('.//div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
                           'contains(@class, "flash_text_div")] | '
@@ -37,9 +49,9 @@ class SchedulesFormCommon(CloudIntelReportsView):
     description = TextInput(name="description")
     active = Checkbox("enabled")
     # Report Selection
-    filter1 = BootstrapSelect("filter_typ")
-    filter2 = BootstrapSelect("subfilter_typ")
-    filter3 = BootstrapSelect("repfilter_typ")
+    filter1 = BootstrapSelectRetry("filter_typ")
+    filter2 = BootstrapSelectRetry("subfilter_typ")
+    filter3 = BootstrapSelectRetry("repfilter_typ")
     # Timer
     run = BootstrapSelect("timer_typ")
     time_zone = BootstrapSelect("time_zone")

--- a/data/schedules_report/daily.yaml
+++ b/data/schedules_report/daily.yaml
@@ -13,6 +13,6 @@ emails:
     - test2@example.test
 email_options:
   send_if_empty: True
-  txt: True
-  csv: True
-  pdf: True
+  send_txt: True
+  send_csv: True
+  send_pdf: True

--- a/data/schedules_report/hourly.yaml
+++ b/data/schedules_report/hourly.yaml
@@ -13,6 +13,6 @@ emails:
     - test2@example.test
 email_options:
   send_if_empty: True
-  txt: True
-  csv: True
-  pdf: True
+  send_txt: True
+  send_csv: True
+  send_pdf: True

--- a/data/schedules_report/monthly.yaml
+++ b/data/schedules_report/monthly.yaml
@@ -13,6 +13,6 @@ emails:
     - test2@example.test
 email_options:
   send_if_empty: True
-  txt: True
-  csv: True
-  pdf: True
+  send_txt: True
+  send_csv: True
+  send_pdf: True

--- a/data/schedules_report/once.yaml
+++ b/data/schedules_report/once.yaml
@@ -12,6 +12,6 @@ emails:
     - test2@example.test
 email_options:
   send_if_empty: True
-  txt: True
-  csv: True
-  pdf: True
+  send_txt: True
+  send_csv: True
+  send_pdf: True

--- a/data/schedules_report/weekly.yaml
+++ b/data/schedules_report/weekly.yaml
@@ -13,6 +13,6 @@ emails:
     - test2@example.test
 email_options:
   send_if_empty: True
-  txt: True
-  csv: True
-  pdf: True
+  send_txt: True
+  send_csv: True
+  send_pdf: True


### PR DESCRIPTION
move CloudIntelReportsView mycompany_title out of property

Related to #7960

The schedule form is not filling out correctly due to wt.patternfly's `BootstrapSelect' widget not filling correctly.  When it uses click to open, the widget immediately closes, and fails to complete `select_by_visible_text`.  Requires further debugging.

The form uses different keys than were being set by the data yaml, so I updated those keys.

{{ pytest: cfme/tests/intelligence/reports/test_reports_schedules.py -k test_schedule_queue }} 