### PR TITLE
[WIPTEST] Update wt.core, debug StopIteration

### DIFF
--- a/cfme/cloud/instance/image.py
+++ b/cfme/cloud/instance/image.py
@@ -85,7 +85,7 @@ class ImageDetailsView(CloudInstanceView):
     @property
     def is_displayed(self):
         accordion = self.sidebar.images_by_provider
-        relationships = self.entities.relationships
+        relationships = self.entities.summary('Relationships')
         return (
             self.in_cloud_instance and
             accordion.is_opened and

--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -305,7 +305,8 @@ wcwidth==0.1.7
 webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
-widgetastic.core==0.30.1
+-e git://github.com/mshriver/widgetastic.core.git@fix-table-StopIteration#egg=widgetastic.core
+#widgetastic.core==0.30.2
 widgetastic.patternfly==0.0.38
 widgetsnbextension==3.2.1
 wrapanapi==3.0.28

--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -305,8 +305,7 @@ wcwidth==0.1.7
 webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
--e git://github.com/mshriver/widgetastic.core.git@fix-table-StopIteration#egg=widgetastic.core
-#widgetastic.core==0.30.2
+widgetastic.core==0.30.2
 widgetastic.patternfly==0.0.38
 widgetsnbextension==3.2.1
 wrapanapi==3.0.28

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -294,7 +294,8 @@ wcwidth==0.1.7
 webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
-widgetastic.core==0.30.1
+-e git://github.com/mshriver/widgetastic.core.git@fix-table-StopIteration#egg=widgetastic.core
+#widgetastic.core==0.30.2
 widgetastic.patternfly==0.0.38
 widgetsnbextension==3.2.1
 wrapanapi==3.0.28

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -294,8 +294,7 @@ wcwidth==0.1.7
 webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
--e git://github.com/mshriver/widgetastic.core.git@fix-table-StopIteration#egg=widgetastic.core
-#widgetastic.core==0.30.2
+widgetastic.core==0.30.2
 widgetastic.patternfly==0.0.38
 widgetsnbextension==3.2.1
 wrapanapi==3.0.28

--- a/requirements/frozen_docs.py2.txt
+++ b/requirements/frozen_docs.py2.txt
@@ -170,8 +170,7 @@ wcwidth==0.1.7
 webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
--e git://github.com/mshriver/widgetastic.core.git@fix-table-StopIteration#egg=widgetastic.core
-#widgetastic.core==0.30.2
+widgetastic.core==0.30.2
 widgetastic.patternfly==0.0.38
 widgetsnbextension==3.2.1
 wrapt==1.10.11

--- a/requirements/frozen_docs.py2.txt
+++ b/requirements/frozen_docs.py2.txt
@@ -170,7 +170,8 @@ wcwidth==0.1.7
 webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
-widgetastic.core==0.30.1
+-e git://github.com/mshriver/widgetastic.core.git@fix-table-StopIteration#egg=widgetastic.core
+#widgetastic.core==0.30.2
 widgetastic.patternfly==0.0.38
 widgetsnbextension==3.2.1
 wrapt==1.10.11

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -161,7 +161,8 @@ wcwidth==0.1.7
 webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
-widgetastic.core==0.30.1
+-e git://github.com/mshriver/widgetastic.core.git@fix-table-StopIteration#egg=widgetastic.core
+#widgetastic.core==0.30.2
 widgetastic.patternfly==0.0.38
 widgetsnbextension==3.2.1
 wrapt==1.10.11

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -161,8 +161,7 @@ wcwidth==0.1.7
 webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
--e git://github.com/mshriver/widgetastic.core.git@fix-table-StopIteration#egg=widgetastic.core
-#widgetastic.core==0.30.2
+widgetastic.core==0.30.2
 widgetastic.patternfly==0.0.38
 widgetsnbextension==3.2.1
 wrapt==1.10.11


### PR DESCRIPTION
for running PRT

Will collect tests here that were hitting StopIteration on dynamictable.row_save, or other index access to table.

Might include some test/framework tweaks as well.  Really just looking to eliminate StopIteration exceptions, but not replace them with RowNotFound. 

{{ pytest: --use-provider complete --long-running -vvv cfme/tests/cloud/test_providers.py cfme/tests/ansible/test_embedded_ansible_tags.py cfme/tests/cloud_infra_common/test_provisioning.py cfme/tests/cloud_infra_common/test_relationships.py cfme/tests/cloud_infra_common/test_tag_objects.py }}