### PR TITLE
[1LP][RFR] Added @pytest.mark to separate Regression and RFE tests

### DIFF
--- a/cfme/tests/openstack/cloud/test_flavors.py
+++ b/cfme/tests/openstack/cloud/test_flavors.py
@@ -70,6 +70,7 @@ def new_instance(provider, zero_disk_flavor):
     instance.cleanup_on_provider()
 
 
+@pytest.mark.rfe
 @pytest.mark.ignore_stream('5.9')
 def test_create_instance_with_zero_disk_flavor(new_instance, soft_assert):
     view = navigate_to(new_instance, 'Details')
@@ -94,6 +95,7 @@ def test_create_instance_with_zero_disk_flavor(new_instance, soft_assert):
         soft_assert(v == prov_data[p[1]])
 
 
+@pytest.mark.regression
 def test_flavor_crud(appliance, provider, request):
     collection = appliance.collections.cloud_flavors
     flavor = collection.create(name=fauxfactory.gen_alpha(),

--- a/cfme/tests/openstack/cloud/test_instances.py
+++ b/cfme/tests/openstack/cloud/test_instances.py
@@ -75,6 +75,7 @@ def volume(appliance, provider):
         volume.delete(wait=False)
 
 
+@pytest.mark.regression
 def test_create_instance(new_instance, soft_assert):
     """Creates an instance and verifies it appears on UI"""
     view = navigate_to(new_instance, 'Details')
@@ -98,6 +99,7 @@ def test_create_instance(new_instance, soft_assert):
         soft_assert(v == prov_data[p[1]])
 
 
+@pytest.mark.regression
 def test_stop_instance(new_instance):
     new_instance.power_control_from_cfme(from_details=True,
                                          option=OpenStackInstance.STOP)
@@ -107,6 +109,7 @@ def test_stop_instance(new_instance):
     assert state == OpenStackInstance.STATE_OFF
 
 
+@pytest.mark.regression
 def test_suspend_instance(new_instance):
     new_instance.power_control_from_cfme(from_details=True,
                                          option=OpenStackInstance.SUSPEND)
@@ -116,6 +119,7 @@ def test_suspend_instance(new_instance):
     assert state == OpenStackInstance.STATE_SUSPENDED
 
 
+@pytest.mark.regression
 def test_pause_instance(new_instance):
     new_instance.power_control_from_cfme(from_details=True,
                                          option=OpenStackInstance.PAUSE)
@@ -125,6 +129,7 @@ def test_pause_instance(new_instance):
     assert state == OpenStackInstance.STATE_PAUSED
 
 
+@pytest.mark.regression
 def test_shelve_instance(new_instance):
     new_instance.power_control_from_cfme(from_details=True,
                                          option=OpenStackInstance.SHELVE)
@@ -138,6 +143,7 @@ def test_shelve_instance(new_instance):
                      OpenStackInstance.STATE_SHELVED)
 
 
+@pytest.mark.regression
 def test_shelve_offload_instance(new_instance):
     new_instance.power_control_from_cfme(from_details=True,
                                          option=OpenStackInstance.SHELVE)
@@ -154,6 +160,7 @@ def test_shelve_offload_instance(new_instance):
     assert state == OpenStackInstance.STATE_SHELVED_OFFLOAD
 
 
+@pytest.mark.regression
 def test_start_instance(new_instance):
     new_instance.mgmt.ensure_state(VmState.STOPPED)
     new_instance.wait_for_instance_state_change(OpenStackInstance.STATE_OFF)
@@ -165,6 +172,7 @@ def test_start_instance(new_instance):
     assert state == OpenStackInstance.STATE_ON
 
 
+@pytest.mark.regression
 def test_soft_reboot_instance(new_instance):
     new_instance.power_control_from_cfme(from_details=True,
                                          option=OpenStackInstance.SOFT_REBOOT)
@@ -176,6 +184,7 @@ def test_soft_reboot_instance(new_instance):
                      OpenStackInstance.STATE_REBOOTING)
 
 
+@pytest.mark.regression
 def test_hard_reboot_instance(new_instance):
     new_instance.power_control_from_cfme(from_details=True,
                                          option=OpenStackInstance.HARD_REBOOT)
@@ -187,6 +196,7 @@ def test_hard_reboot_instance(new_instance):
                      OpenStackInstance.STATE_REBOOTING)
 
 
+@pytest.mark.regression
 def test_delete_instance(new_instance, provider):
     new_instance.power_control_from_cfme(from_details=True,
                                          option=OpenStackInstance.TERMINATE)
@@ -203,6 +213,7 @@ def test_delete_instance(new_instance, provider):
         pass
 
 
+@pytest.mark.regression
 @pytest.mark.provider([OpenStackProvider],
                       required_fields=[['provisioning', 'image', 'os_distro']],
                       override=True, scope='module')
@@ -213,6 +224,7 @@ def test_instance_operating_system_linux(new_instance):
     assert os == prov_data_os, 'OS type mismatch: expected {} and got {}'.format(prov_data_os, os)
 
 
+@pytest.mark.regression
 def test_instance_attach_volume(new_instance, volume, appliance):
     initial_volume_count = new_instance.volume_count
     new_instance.attach_volume(volume.name)

--- a/cfme/tests/openstack/cloud/test_keypairs.py
+++ b/cfme/tests/openstack/cloud/test_keypairs.py
@@ -21,6 +21,7 @@ def keypair(appliance, provider):
         keypair.delete(wait=False)
 
 
+@pytest.mark.rfe
 @pytest.mark.ignore_stream('5.9')
 def test_download_private_key(keypair):
     assert keypair.exists

--- a/cfme/tests/openstack/cloud/test_networks.py
+++ b/cfme/tests/openstack/cloud/test_networks.py
@@ -110,6 +110,7 @@ def router_with_gw(provider, appliance, ext_subnet):
     delete_entity(router)
 
 
+@pytest.mark.regression
 def test_create_network(network, provider):
     """Creates private cloud network and verifies it's relationships"""
     assert network.exists
@@ -117,6 +118,7 @@ def test_create_network(network, provider):
     assert network.cloud_tenant == provider.data.get('provisioning').get('cloud_tenant')
 
 
+@pytest.mark.regression
 def test_edit_network(network):
     """Edits private cloud network's name"""
     network.edit(name=fauxfactory.gen_alpha())
@@ -126,6 +128,7 @@ def test_edit_network(network):
     assert network.exists
 
 
+@pytest.mark.regression
 def test_delete_network(network):
     """Deletes private cloud network"""
     network.delete()
@@ -134,6 +137,7 @@ def test_delete_network(network):
     assert not network.exists
 
 
+@pytest.mark.regression
 def test_create_subnet(subnet, provider):
     """Creates private subnet and verifies it's relationships"""
     assert subnet.exists
@@ -144,6 +148,7 @@ def test_create_subnet(subnet, provider):
     assert subnet.net_protocol == 'ipv4'
 
 
+@pytest.mark.regression
 def test_edit_subnet(subnet):
     """Edits private subnet's name"""
     subnet.edit(new_name=fauxfactory.gen_alpha())
@@ -152,6 +157,7 @@ def test_edit_subnet(subnet):
     assert subnet.exists
 
 
+@pytest.mark.regression
 def test_delete_subnet(subnet):
     """Deletes private subnet"""
     subnet.delete()
@@ -161,12 +167,14 @@ def test_delete_subnet(subnet):
     assert not subnet.exists
 
 
+@pytest.mark.regression
 def test_create_router(router, provider):
     """Create router without gateway"""
     assert router.exists
     assert router.cloud_tenant == provider.data.get('provisioning').get('cloud_tenant')
 
 
+@pytest.mark.regression
 def test_create_router_with_gateway(router_with_gw, provider):
     """Creates router with gateway (external network)"""
     assert router_with_gw.exists
@@ -174,6 +182,7 @@ def test_create_router_with_gateway(router_with_gw, provider):
     assert router_with_gw.cloud_network == router_with_gw.ext_network
 
 
+@pytest.mark.regression
 def test_edit_router(router):
     """Edits router's name"""
     router.edit(name=fauxfactory.gen_alpha())
@@ -183,6 +192,7 @@ def test_edit_router(router):
     assert router.exists
 
 
+@pytest.mark.regression
 def test_delete_router(router, appliance):
     """Deletes router"""
     router.delete()
@@ -192,6 +202,7 @@ def test_delete_router(router, appliance):
     assert not router.exists
 
 
+@pytest.mark.regression
 def test_clear_router_gateway(router_with_gw):
     """Deletes a gateway from the router"""
     router_with_gw.edit(change_external_gw=False)
@@ -202,6 +213,7 @@ def test_clear_router_gateway(router_with_gw):
     assert 'Cloud Network' not in view.entities.relationships.fields
 
 
+@pytest.mark.regression
 def test_add_gateway_to_router(router, ext_subnet):
     """Adds gateway to the router"""
     router.edit(change_external_gw=True, ext_network=ext_subnet.network,
@@ -212,6 +224,7 @@ def test_add_gateway_to_router(router, ext_subnet):
     assert router.cloud_network == ext_subnet.network
 
 
+@pytest.mark.regression
 def test_add_interface_to_router(router, subnet):
     """Adds interface (subnet) to router"""
     router.add_interface(subnet.name)
@@ -224,6 +237,7 @@ def test_add_interface_to_router(router, subnet):
     assert subnets_count == 1  # Compare to '1' because clean router was used initially
 
 
+@pytest.mark.regression
 def test_list_networks(provider, appliance):
     networks = [n.label for n in provider.mgmt.api.networks.list()]
     displayed_networks = [n.name for n in appliance.collections.cloud_networks.all()]

--- a/cfme/tests/openstack/cloud/test_volume_backup.py
+++ b/cfme/tests/openstack/cloud/test_volume_backup.py
@@ -98,16 +98,19 @@ def attached_volume(appliance, provider, volume_backup, new_instance):
         return new_instance.volume_count == initial_volume_count
 
 
+@pytest.mark.rfe
 def test_create_volume_backup(volume_backup):
     assert volume_backup.exists
     assert volume_backup.size == VOLUME_SIZE
 
 
+@pytest.mark.rfe
 def test_create_volume_incremental_backup(incremental_backup):
     assert incremental_backup.exists
     assert incremental_backup.size == VOLUME_SIZE
 
 
+@pytest.mark.rfe
 def test_incr_backup_of_attached_volume_crud(appliance, provider, request, attached_volume):
     backup_name = fauxfactory.gen_alpha()
     collection = appliance.collections.volume_backups.filter({'provider': provider})

--- a/cfme/tests/openstack/cloud/test_volumes.py
+++ b/cfme/tests/openstack/cloud/test_volumes.py
@@ -36,12 +36,14 @@ def volume(appliance, provider):
         logger.warning('Exception during volume deletion - skipping..')
 
 
+@pytest.mark.regression
 def test_create_volume(volume, provider):
     assert volume.exists
     assert volume.size == '{} GB'.format(VOLUME_SIZE)
     assert volume.tenant == provider.data['provisioning']['cloud_tenant']
 
 
+@pytest.mark.regression
 def test_edit_volume(volume, appliance):
     new_name = fauxfactory.gen_alpha()
     with update(volume):
@@ -50,6 +52,7 @@ def test_edit_volume(volume, appliance):
     assert view.entities.get_entity(name=new_name, surf_pages=True)
 
 
+@pytest.mark.regression
 def test_delete_volume(volume):
     volume.delete()
     assert not volume.exists

--- a/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
+++ b/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
@@ -36,6 +36,7 @@ def has_mistral_service(provider):
         pytest.skip('Skipping because no Mistral service found on OSPD deployment')
 
 
+@pytest.mark.regression
 def test_scale_provider_down(provider, host, has_mistral_service):
     """Scale down Openstack Infrastructure provider
     Metadata:
@@ -70,6 +71,7 @@ def test_scale_provider_down(provider, host, has_mistral_service):
     assert prov_state == 'available'
 
 
+@pytest.mark.regression
 def test_delete_host(appliance, host, provider, has_mistral_service):
     """Remove host from appliance and Ironic service
     Metadata:
@@ -85,6 +87,7 @@ def test_delete_host(appliance, host, provider, has_mistral_service):
     assert host.name not in host_collection.all(provider)
 
 
+@pytest.mark.regression
 def test_register_host(provider, host, has_mistral_service):
     """Register new host by uploading instackenv.json file
     Metadata:
@@ -108,6 +111,7 @@ def test_register_host(provider, host, has_mistral_service):
     assert host.exists
 
 
+@pytest.mark.regression
 def test_introspect_host(host, provider, has_mistral_service):
     """Introspect host
     Metadata:
@@ -125,6 +129,7 @@ def test_introspect_host(host, provider, has_mistral_service):
     assert view.entities.summary('Openstack Hardware').get_text_of('Introspected') == 'true'
 
 
+@pytest.mark.regression
 def test_provide_host(host, provider, has_mistral_service):
     """Provide host
     Metadata:
@@ -139,6 +144,7 @@ def test_provide_host(host, provider, has_mistral_service):
     assert prov_state == 'available'
 
 
+@pytest.mark.regression
 def test_scale_provider_out(host, provider, has_mistral_service):
     """Scale out Infra provider
     Metadata:

--- a/cfme/tests/openstack/infrastructure/test_host_power_control.py
+++ b/cfme/tests/openstack/infrastructure/test_host_power_control.py
@@ -42,6 +42,7 @@ def host_off(host_collection, provider):
     return my_host_off
 
 
+@pytest.mark.regression
 def test_host_power_off(host_on):
     host_on.power_off()
     host_on.refresh()
@@ -49,6 +50,7 @@ def test_host_power_off(host_on):
     assert result
 
 
+@pytest.mark.regression
 def test_host_power_on(host_off):
     host_off.power_on()
     host_off.refresh()

--- a/cfme/tests/openstack/infrastructure/test_hosts.py
+++ b/cfme/tests/openstack/infrastructure/test_hosts.py
@@ -17,6 +17,7 @@ def host_collection(appliance):
     return appliance.collections.hosts
 
 
+@pytest.mark.regression
 def test_host_configuration(host_collection, provider, soft_assert, appliance):
     hosts = host_collection.all()
     assert hosts
@@ -32,6 +33,7 @@ def test_host_configuration(host_collection, provider, soft_assert, appliance):
             soft_assert(value > 0, 'Nodes number of {} is 0'.format(field))
 
 
+@pytest.mark.regression
 def test_host_cpu_resources(host_collection, provider, soft_assert):
     hosts = host_collection.all()
     assert hosts
@@ -44,6 +46,7 @@ def test_host_cpu_resources(host_collection, provider, soft_assert):
             soft_assert(value > 0, "Aggregate Node {} is 0".format(field))
 
 
+@pytest.mark.regression
 def test_host_auth(host_collection, provider, soft_assert):
     hosts = host_collection.all()
     assert hosts
@@ -55,6 +58,7 @@ def test_host_auth(host_collection, provider, soft_assert):
                     'Incorrect SSH authentication status {}'.format(auth_status))
 
 
+@pytest.mark.regression
 def test_host_devices(host_collection, provider):
     hosts = host_collection.all()
     assert hosts
@@ -64,6 +68,7 @@ def test_host_devices(host_collection, provider):
         assert result > 0
 
 
+@pytest.mark.regression
 def test_host_hostname(host_collection, provider, soft_assert):
     hosts = host_collection.all()
     assert hosts
@@ -73,6 +78,7 @@ def test_host_hostname(host_collection, provider, soft_assert):
         soft_assert(result, "Missing hostname in: " + str(result))
 
 
+@pytest.mark.regression
 def test_host_memory(host_collection, provider):
     hosts = host_collection.all()
     assert hosts
@@ -82,6 +88,7 @@ def test_host_memory(host_collection, provider):
         assert result > 0
 
 
+@pytest.mark.regression
 def test_host_security(host_collection, provider, soft_assert):
     hosts = host_collection.all()
     assert hosts
@@ -96,6 +103,7 @@ def test_host_security(host_collection, provider, soft_assert):
             'Nodes number of Groups is 0')
 
 
+@pytest.mark.regression
 def test_host_smbios_data(host_collection, provider, soft_assert):
     """Checks that Manufacturer/Model values are shown for each infra node"""
     hosts = host_collection.all()
@@ -107,6 +115,7 @@ def test_host_smbios_data(host_collection, provider, soft_assert):
         soft_assert(res != 'N/A')
 
 
+@pytest.mark.regression
 def test_host_zones_assigned(host_collection, provider):
     hosts = host_collection.all()
     assert hosts
@@ -116,6 +125,7 @@ def test_host_zones_assigned(host_collection, provider):
         assert result, "Availability zone doesn't specified"
 
 
+@pytest.mark.rfe
 def test_hypervisor_hostname(host_collection, provider, soft_assert):
     hvisors = provider.mgmt.list_hosts()
     hosts = host_collection.all()
@@ -126,6 +136,7 @@ def test_hypervisor_hostname(host_collection, provider, soft_assert):
             "Hypervisor hostname {} is not in Hypervisor list".format(hv_name))
 
 
+@pytest.mark.rfe
 @pytest.mark.parametrize("view_type", VIEWS)
 def test_hypervisor_hostname_views(host_collection, provider, view_type, soft_assert):
     hvisors = provider.mgmt.list_hosts()

--- a/cfme/tests/openstack/infrastructure/test_provider.py
+++ b/cfme/tests/openstack/infrastructure/test_provider.py
@@ -12,6 +12,7 @@ pytestmark = [
 ]
 
 
+@pytest.mark.regression
 def test_api_port(provider):
     view_details = navigate_to(provider, 'Details')
     port = provider.data['endpoints']['default']['api_port']
@@ -19,6 +20,7 @@ def test_api_port(provider):
     assert api_port == port, 'Invalid API Port'
 
 
+@pytest.mark.regression
 def test_credentials_quads(provider):
     view = navigate_to(provider, 'All')
     prov_item = view.entities.get_entity(name=provider.name, surf_pages=True)
@@ -29,6 +31,7 @@ def test_credentials_quads(provider):
         assert prov_item.data.get('creds') and 'checkmark' in prov_item.data['creds']
 
 
+@pytest.mark.regression
 def test_delete_provider(provider):
     provider.delete(cancel=False)
     provider.wait_for_delete()

--- a/cfme/tests/openstack/infrastructure/test_relationships.py
+++ b/cfme/tests/openstack/infrastructure/test_relationships.py
@@ -16,6 +16,7 @@ pytestmark = [
 ]
 
 
+@pytest.mark.regression
 def test_assigned_roles(provider):
     view = navigate_to(provider, 'Details')
     try:
@@ -25,6 +26,7 @@ def test_assigned_roles(provider):
     assert int(res) > 0
 
 
+@pytest.mark.regression
 def test_nodes(provider):
     view = navigate_to(provider, 'Details')
     nodes = len(provider.mgmt.iapi.node.list())
@@ -32,6 +34,7 @@ def test_nodes(provider):
     assert int(view.entities.summary('Relationships').get_text_of('Nodes')) == nodes
 
 
+@pytest.mark.regression
 def test_templates(provider, soft_assert):
     view = navigate_to(provider, 'Details')
     images = [i.name for i in provider.mgmt.images]
@@ -46,6 +49,7 @@ def test_templates(provider, soft_assert):
         soft_assert(image in template_names, 'Missing template: {}'.format(image))
 
 
+@pytest.mark.regression
 def test_stacks(provider):
     view = navigate_to(provider, 'Details')
     """

--- a/cfme/tests/openstack/infrastructure/test_resources.py
+++ b/cfme/tests/openstack/infrastructure/test_resources.py
@@ -11,6 +11,7 @@ pytestmark = [
 ]
 
 
+@pytest.mark.regression
 def test_number_of_cpu(provider, soft_assert):
     view_details = navigate_to(provider, 'Details')
     v = view_details.entities.summary('Properties').get_text_of('Aggregate Node CPU Resources')
@@ -21,6 +22,7 @@ def test_number_of_cpu(provider, soft_assert):
     assert int(v) > 0, "Aggregate Node CPU Cores is 0"
 
 
+@pytest.mark.regression
 def test_node_memory(provider):
     view_details = navigate_to(provider, 'Details')
     node_memory = view_details.entities.summary('Properties').get_text_of('Aggregate Node Memory')

--- a/cfme/tests/openstack/infrastructure/test_roles.py
+++ b/cfme/tests/openstack/infrastructure/test_roles.py
@@ -24,6 +24,7 @@ def roles(appliance, provider):
     yield roles if roles else pytest.skip("No Roles Available")
 
 
+@pytest.mark.regression
 def test_host_role_association(appliance, provider, soft_assert):
     host_collection = appliance.collections.hosts
     hosts = host_collection.all()
@@ -46,12 +47,14 @@ def test_host_role_association(appliance, provider, soft_assert):
         soft_assert(role_name in role_assoc, 'Deployment roles misconfigured')
 
 
+@pytest.mark.regression
 def test_roles_name(roles):
     for role in roles:
         role_name = role.name.split('-')[1]
         assert role_name in ROLES
 
 
+@pytest.mark.regression
 def test_roles_summary(roles, soft_assert):
     err_ptrn = '{} are shown incorrectly'
 
@@ -76,6 +79,7 @@ def test_roles_summary(roles, soft_assert):
             soft_assert(res, err_ptrn.format(v))
 
 
+@pytest.mark.regression
 def test_role_delete(roles):
     role = choice(roles)
     role.delete()


### PR DESCRIPTION
Added `@pytest.mark` to separate regression and RFE tests.

Marked all RFE tests with `@pytest.mark.rfe`, then
in order to run only RFE tests, we invoke the following key during execution:
`-m rfe`
Marked all Regression tests with `@pytest.mark.regression`, then
in order to run only Regression tests, we invoke the following key during execution:
`-m regression`
