### PR TITLE
[RFR]Orchestration view is_displayed fix

### DIFF
--- a/cfme/services/catalogs/catalog.py
+++ b/cfme/services/catalogs/catalog.py
@@ -43,7 +43,6 @@ class CatalogsView(ServicesCatalogView):
     def is_displayed(self):
         return (
             self.in_explorer and
-            self.title.text == 'All Catalogs' and
             self.catalogs.is_opened and
             self.catalogs.tree.currently_selected == ["All Catalogs"])
 

--- a/cfme/services/catalogs/catalog_items/__init__.py
+++ b/cfme/services/catalogs/catalog_items/__init__.py
@@ -28,9 +28,9 @@ class BasicInfoForm(ServicesCatalogView):
     name = Input(name='name')
     description = Input(name='description')
     display = Checkbox(name='display')
-    select_provider = BootstrapSelect('manager_id')
     select_orch_template = BootstrapSelect('template_id')
     select_config_template = BootstrapSelect('template_id')
+    select_provider = BootstrapSelect('manager_id')
     subtype = BootstrapSelect('generic_subtype')
     field_entry_point = Input(name='fqname')
     retirement_entry_point = Input(name='retire_fqname')
@@ -355,7 +355,7 @@ class NonCloudInfraCatalogItem(BaseCatalogItem):
             'description': self.description,
             'display': self.display_in,
             'select_catalog': self.catalog_name,
-            'select_dialog': self.dialog,
+            'select_dialog': self.dialog
         }
 
 

--- a/cfme/services/catalogs/orchestration_template.py
+++ b/cfme/services/catalogs/orchestration_template.py
@@ -132,7 +132,7 @@ class AddDialogView(DialogForm):
         return (
             self.orchestration_templates.is_opened and
             self.title.text == 'Adding a new Service Dialog from Orchestration Template "{}"'
-                               .format(self.context['object'].name)
+                               .format(self.context['object'].template_name)
         )
 
 
@@ -177,8 +177,8 @@ class OrchestrationTemplate(BaseEntity, Updateable, Pretty, Taggable):
                    'description': description
                    })
         view.add_button.click()
-        view.flash.assert_success_message('Orchestration Template "{}" was saved'.format(
-            template_name))
+        view.flash.assert_no_error()
+        #TODO - Move assertions to tests
         return self.parent.instantiate(template_group=self.template_group,
                                        description=description,
                                        template_name=template_name,
@@ -189,8 +189,7 @@ class OrchestrationTemplate(BaseEntity, Updateable, Pretty, Taggable):
         view = navigate_to(self, 'AddDialog')
         view.fill({'name': dialog_name})
         view.add_button.click()
-        view.flash.assert_success_message('Service Dialog "{}" was successfully created'.format(
-            dialog_name))
+        view.flash.assert_no_error()
         service_dialog = self.parent.parent.collections.service_dialogs.instantiate(
             label=dialog_name)
         return service_dialog
@@ -222,8 +221,7 @@ class OrchestrationTemplatesCollection(BaseCollection):
         template = self.instantiate(template_group=template_group, description=description,
                                     template_name=template_name, content=content, draft=draft)
         view = self.create_view(DetailsTemplateView)
-        view.flash.assert_success_message('Orchestration Template '
-                                          '"{}" was saved'.format(template_name))
+        view.flash.assert_no_error()
         return template
 
 


### PR DESCRIPTION
1) Removed assertions to be moved to test in following PR
2) Fixed some views
3) Changed order of filling fields as provider dropdown appears once template is selected.

{{ pytest: --use-provider rhos11 cfme/tests/services/test_provision_stack.py::test_provision_stack }}