### PR TITLE
[RFR] Fixed KeyError of customization_template in 5.10z

### DIFF
--- a/cfme/infrastructure/pxe.py
+++ b/cfme/infrastructure/pxe.py
@@ -402,9 +402,9 @@ class PXECustomizationTemplateDetailsView(PXEMainView):
     @property
     def is_displayed(self):
         if getattr(self.context['object'], 'name'):
-            title = 'Customization Template "{name}"'.format(self.context['object'].name)
+            title = 'Customization Template "{name}"'.format(name=self.context['object'].name)
             return (super(PXECustomizationTemplateDetailsView, self).is_displayed and
-                    self.entities.title.text == title)
+                    self.title.text == title)
         else:
             return False
 


### PR DESCRIPTION
{{ pytest: cfme/tests/infrastructure/test_customization_template.py::test_name_max_character_validation -qsvvv }}

Fixed:
```
>           title = 'Customization Template "{name}"'.format(self.context['object'].name)
E           KeyError: 'name'

cfme/infrastructure/pxe.py:405: KeyError
KeyError
'name'
```