### PR TITLE
[RFR] Fixed TypeError of host in 5.10z

### DIFF
--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -90,7 +90,7 @@ def test_discover_host(request, provider, appliance, host_ips):
     collection = appliance.collections.hosts
 
     def _cleanup():
-        all_hosts = collection.all(provider)
+        all_hosts = collection.all()
         if all_hosts:
             collection.delete(*all_hosts)
 


### PR DESCRIPTION
{{ pytest: cfme/tests/infrastructure/test_host.py::test_discover_host  -qsvvvv }}

Fixed:
```
>       all_hosts = collection.all(provider)
E       TypeError: all() takes exactly 1 argument (2 given)

cfme/tests/infrastructure/test_host.py:93: TypeError
TypeError
all() takes exactly 1 argument (2 given)
```