### PR TITLE
[WIPTEST] Fixed AttributeError for VMwareProvider host_views in 5.9z

### DIFF
--- a/cfme/common/host_views.py
+++ b/cfme/common/host_views.py
@@ -277,5 +277,5 @@ class ProviderAllHostsView(HostsView):
         return (
             self.navigation.currently_selected == ["Compute", "Infrastructure", "Providers"] and
             self.title.text == "{} (All Managed Hosts)".format(
-                self.context["object"].filters['parent'].name)
+                self.context["object"].name)
         )


### PR DESCRIPTION

{{ pytest: cfme/tests/cloud_infra_common/test_relationships.py::test_infra_provider_relationships -qsvvv }}

Fixed Errror:
```
        )
E       AttributeError: 'VMwareProvider' object has no attribute 'filters'

cfme/common/host_views.py:280: AttributeError
AttributeError
'VMwareProvider' object has no attribute 'filters'
```
