### PR TITLE
[WIP] Update py2 requirements with wrapanapi updates

### DIFF
--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -3,7 +3,7 @@
 # to upgrade a single package use requirements/freeze_all.py --upgrade-only apackage
 
 
-adal==0.6.0
+adal==1.0.2
 alabaster==0.7.10
 appdirs==1.4.3
 asn1crypto==0.24.0
@@ -162,7 +162,7 @@ jupyter-console==5.2.0
 jupyter-core==4.4.0
 keyring==12.2.1
 keystoneauth1==3.7.0
-kubernetes==3.0.0
+kubernetes==7.0.0
 kwargify==2.2.0
 layered-yaml-attrdict-config==16.1.0
 lxml==4.2.1
@@ -188,7 +188,7 @@ notebook==5.5.0
 ntlm-auth==1.1.0
 oauth2client==4.1.2
 oauthlib==2.1.0
-openshift==0.3.4
+openshift==0.7.2
 openstacksdk==0.13.0
 ordereddict==1.1
 os-client-config==1.31.1
@@ -242,7 +242,7 @@ python-heatclient==1.15.0
 python-ironicclient==2.3.0
 python-jenkins==1.0.0
 python-keystoneclient==3.16.0
-python-novaclient==7.1.2
+python-novaclient==11.1.0
 python-string-utils==0.6.0
 python-swiftclient==3.5.0
 pytz==2018.4
@@ -303,12 +303,13 @@ wait-for==1.0.9
 warlock==1.3.0
 wcwidth==0.1.7
 webencodings==0.5.1
-websocket-client==0.40.0
+websocket-client==0.53.0
 Werkzeug==0.14.1
 widgetastic.core==0.30.2
 widgetastic.patternfly==0.0.38
 widgetsnbextension==3.2.1
-wrapanapi==3.0.30
+-e git://github.com/mshriver/wrapanapi.git@update-requirements#egg=wrapanapi
+#wrapanapi==3.0.30
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0


### PR DESCRIPTION
Testing some package updates, trying to collect tests that use a variety of wrapanapi function calls or direct API access through wrapanapi.

{{ pytest: --long-running --use-provider complete cfme/tests/containers/test_overview_data_integrity.py cfme/tests/cloud_infra_common/test_provisioning.py cfme/tests/infrastructure/test_provisioning_rest.py cfme/tests/infrastructure/test_provisioning_dialog.py }}