### PR TITLE
[1LP][RFR] Add default alerts smoke test

### DIFF
--- a/cfme/tests/control/test_default_alerts.py
+++ b/cfme/tests/control/test_default_alerts.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+import os
+import pytest
+import yaml
+
+from cfme.utils.path import data_path
+
+@pytest.fixture
+def default_alerts(appliance):
+    file_name = data_path.join('ui/control/default_alerts.yaml').strpath
+    alerts = {}
+    if os.path.exists(file_name):
+        with open(file_name,'r') as f:
+            all_alerts = yaml.load(f)
+            alerts = (
+                all_alerts.get('v5.10') if appliance.version >= '5.10'
+                else all_alerts.get('v5.9')
+            )
+    else:
+        pytest.skip('Could not find {}, skipping test.'.format(file_name))
+
+    # instantiate a list of alerts based on default_alerts.yaml
+    alert_collection = appliance.collections.alerts
+    default_alerts = [
+        alert_collection.instantiate(
+            description=alert.get('Description'),
+            active=alert.get('Active'),
+            based_on=alert.get('Based On'),
+            evaluate=alert.get('What is evaluated'),
+            emails=alert.get('Email'),
+            snmp_trap=alert.get('SNMP'),
+            timeline_event=alert.get('Event on Timeline'),
+            mgmt_event=alert.get('Management Event Raised')
+        )
+        for key,alert in alerts.items()
+    ]
+    return default_alerts
+
+@pytest.mark.smoke
+def test_default_alerts(appliance,default_alerts):
+    """ Tests the default pre-configured alerts on the appliance and
+        ensures that they have not changed between versions.
+    """
+    # get the alerts of the appliance
+    alerts = appliance.collections.alerts.all()
+    # compare sorted lists to deal with unordered dictionary
+    assert sorted(default_alerts) == sorted(alerts)

--- a/data/ui/control/default_alerts.yaml
+++ b/data/ui/control/default_alerts.yaml
@@ -1,0 +1,579 @@
+v5.9:
+  '0':
+    0: ''
+    1: ''
+    Active: ''
+    Based On: Cluster / Deployment Role
+    Description: Cluster DRS not enabled
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)
+  '1':
+    0: ''
+    1: ''
+    Active: ''
+    Based On: Cluster / Deployment Role
+    Description: Cluster HA not enabled
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)
+  '10':
+    0: ''
+    1: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM CD Drive or Floppy Connected
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)
+  '11':
+    0: ''
+    1: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM CPU count was decreased
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Hardware Reconfigured
+  '12':
+    0: ''
+    1: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM CPU count was increased
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Hardware Reconfigured
+  '13':
+    0: ''
+    1: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM Environment Tag <> Datastore Environment Tag
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)
+  '14':
+    0: ''
+    1: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM Environment Tag <> Host Environment Tag
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)
+  '15':
+    0: ''
+    1: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: 'VM Guest C: Drive < 10% Free'
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)
+  '16':
+    0: ''
+    1: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM Guest Windows Event Log Error - NtpClient
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Event Log Threshold
+  '17':
+    0: ''
+    1: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM Memory Balloon > 250 in last 10 min
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Real Time Performance
+  '18':
+    0: ''
+    1: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM Memory was decreased
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Hardware Reconfigured
+  '19':
+    0: ''
+    1: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM Memory was increased
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Hardware Reconfigured
+  '2':
+    0: ''
+    1: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: CPU Ready > 4000 ms for more than 10 min
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Real Time Performance
+  '20':
+    0: ''
+    1: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM Migration > 1 in last 30 min
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Event Threshold
+  '21':
+    0: ''
+    1: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM Power On > 2 in last 15 min
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Event Threshold
+  '22':
+    0: ''
+    1: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM Silver and CPU > 1
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)
+  '23':
+    0: ''
+    1: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM Silver and RAM > 2 GB
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)
+  '24':
+    0: ''
+    1: ''
+    Active: ''
+    Based On: Datastore
+    Description: VMs on local storage
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)
+  '25':
+    0: ''
+    1: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM Unregistered
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)
+  '26':
+    0: ''
+    1: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM VMotion > 1 in last 30 min
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Event Threshold
+  '3':
+    0: ''
+    1: ''
+    Active: ''
+    Based On: Datastore
+    Description: Datacenter VMs > 10
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)
+  '4':
+    0: ''
+    1: ''
+    Active: 'True'
+    Based On: Container Node
+    Description: External Prometheus - Nodes
+    Email: 'False'
+    Event on Timeline: 'True'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: External Prometheus Alerts
+  '5':
+    0: ''
+    1: ''
+    Active: 'True'
+    Based On: Provider
+    Description: External Prometheus - Providers
+    Email: 'False'
+    Event on Timeline: 'True'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: External Prometheus Alerts
+  '6':
+    0: ''
+    1: ''
+    Active: ''
+    Based On: Host / Node
+    Description: Host Datastore < 5% of Free Space
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)
+  '7':
+    0: ''
+    1: ''
+    Active: ''
+    Based On: Host / Node
+    Description: Host Event Log Error - Failed to validate VM IP address
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Hostd Log Threshold
+  '8':
+    0: ''
+    1: ''
+    Active: ''
+    Based On: Host / Node
+    Description: Host Event Log Error - Memory Exceed Soft Limit
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Hostd Log Threshold
+  '9':
+    0: ''
+    1: ''
+    Active: ''
+    Based On: Host / Node
+    Description: Host VMs >10
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)
+v5.10:
+  '0':
+    0: ''
+    Active: ''
+    Based On: Cluster / Deployment Role
+    Description: Cluster DRS not enabled
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)
+  '1':
+    0: ''
+    Active: ''
+    Based On: Cluster / Deployment Role
+    Description: Cluster HA not enabled
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)
+  '10':
+    0: ''
+    Active: ''
+    Based On: Physical Server
+    Description: Physical server has critical health state
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)
+  '11':
+    0: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM CD Drive or Floppy Connected
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)
+  '12':
+    0: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM CPU count was decreased
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Hardware Reconfigured
+  '13':
+    0: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM CPU count was increased
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Hardware Reconfigured
+  '14':
+    0: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM Environment Tag <> Datastore Environment Tag
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)
+  '15':
+    0: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM Environment Tag <> Host Environment Tag
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)
+  '16':
+    0: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: 'VM Guest C: Drive < 10% Free'
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)
+  '17':
+    0: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM Guest Windows Event Log Error - NtpClient
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Event Log Threshold
+  '18':
+    0: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM Memory Balloon > 250 in last 10 min
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Real Time Performance
+  '19':
+    0: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM Memory was decreased
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Hardware Reconfigured
+  '2':
+    0: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: CPU Ready > 4000 ms for more than 10 min
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Real Time Performance
+  '20':
+    0: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM Memory was increased
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Hardware Reconfigured
+  '21':
+    0: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM Migration > 1 in last 30 min
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Event Threshold
+  '22':
+    0: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM Power On > 2 in last 15 min
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Event Threshold
+  '23':
+    0: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM Silver and CPU > 1
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)
+  '24':
+    0: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM Silver and RAM > 2 GB
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)
+  '25':
+    0: ''
+    Active: ''
+    Based On: Datastore
+    Description: VMs on local storage
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)
+  '26':
+    0: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM Unregistered
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)
+  '27':
+    0: ''
+    Active: ''
+    Based On: VM and Instance
+    Description: VM VMotion > 1 in last 30 min
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Event Threshold
+  '3':
+    0: ''
+    Active: ''
+    Based On: Datastore
+    Description: Datacenter VMs > 10
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)
+  '4':
+    0: ''
+    Active: 'True'
+    Based On: Container Node
+    Description: External Prometheus - Nodes
+    Email: 'False'
+    Event on Timeline: 'True'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: External Prometheus Alerts
+  '5':
+    0: ''
+    Active: 'True'
+    Based On: Provider
+    Description: External Prometheus - Providers
+    Email: 'False'
+    Event on Timeline: 'True'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: External Prometheus Alerts
+  '6':
+    0: ''
+    Active: ''
+    Based On: Host / Node
+    Description: Host Datastore < 5% of Free Space
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)
+  '7':
+    0: ''
+    Active: ''
+    Based On: Host / Node
+    Description: Host Event Log Error - Failed to validate VM IP address
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Hostd Log Threshold
+  '8':
+    0: ''
+    Active: ''
+    Based On: Host / Node
+    Description: Host Event Log Error - Memory Exceed Soft Limit
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Hostd Log Threshold
+  '9':
+    0: ''
+    Active: ''
+    Based On: Host / Node
+    Description: Host VMs >10
+    Email: 'True'
+    Event on Timeline: 'False'
+    Management Event Raised: 'False'
+    SNMP: 'False'
+    What is evaluated: Expression (Custom)


### PR DESCRIPTION

Purpose or Intent
=================


__Extending__  AlertCollection to have an all() method. The all method will read the table on the "All Alerts" alerts page and create a list of alert objects based on the fields in that table. 

__Adding tests__ smoke test for the default alerts predefined on the appliance. 

__Adding data file__ for the default alerts on CFME 5.9.5.3 and 5.10.0.21

{{ pytest: cfme/tests/control/test_default_alerts.py::test_default_alerts }}



