### PR TITLE
[1LP][RFR]miq-version 0.1.8, fix py3 compat and TypeError

### DIFF
--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -169,7 +169,7 @@ lxml==4.2.1
 manageiq-client==0.4.1
 MarkupSafe==1.0
 mccabe==0.6.1
-miq-version==0.1.7
+miq-version==0.1.8
 mistune==0.8.3
 mock==2.0.0
 monotonic==1.5

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -164,7 +164,7 @@ lxml==4.2.1
 manageiq-client==0.4.1
 MarkupSafe==1.0
 mccabe==0.6.1
-miq-version==0.1.7
+miq-version==0.1.8
 mistune==0.8.3
 mock==2.0.0
 monotonic==1.5

--- a/requirements/frozen_docs.py2.txt
+++ b/requirements/frozen_docs.py2.txt
@@ -72,7 +72,7 @@ lxml==4.2.1
 manageiq-client==0.4.1
 MarkupSafe==1.0
 mccabe==0.6.1
-miq-version==0.1.7
+miq-version==0.1.8
 mistune==0.8.3
 mock==2.0.0
 monotonic==1.5

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -66,7 +66,7 @@ lxml==4.2.1
 manageiq-client==0.4.1
 MarkupSafe==1.0
 mccabe==0.6.1
-miq-version==0.1.7
+miq-version==0.1.8
 mistune==0.8.3
 mock==2.0.0
 monotonic==1.5


### PR DESCRIPTION
sync_template_tracker hitting TypeError when trying to parse templates