### PR TITLE
pin to python3.6 for more pre-commit hooks to ensure stable result data

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,11 +9,13 @@ repos:
   hooks:
   - id: seed-isort-config
     args: [--exclude, "^data/.*|^sprout/"]
+    language_version: python3.6
 - repo: https://github.com/pre-commit/mirrors-isort
   rev: v4.3.4
   hooks:
   - id: isort
     exclude: ^(cfme|scripts)
+    language_version: python3.6
 - repo: https://github.com/ambv/black
   rev: 18.6b4
   hooks:
@@ -30,9 +32,11 @@ repos:
   - id: debug-statements
     exclude: ^(sprout|scripts|cfme/fixtures/rdb.py)
   - id: flake8
+    language_version: python3.6
     <<: *exclude
 - repo: https://github.com/asottile/pyupgrade
   rev: v1.6.0
   hooks:
   - id: pyupgrade
+    language_version: python3.6
     <<: *exclude


### PR DESCRIPTION
ref: https://github.com/asottile/seed-isort-config/issues/22

