### PR TITLE
[1LP][RFR] Address upstream change of message type to success for flash message …

### DIFF
--- a/cfme/services/service_catalogs/ui.py
+++ b/cfme/services/service_catalogs/ui.py
@@ -89,10 +89,7 @@ def order(self):
     if self.ansible_dialog_values:
         view.fill(self.ansible_dialog_values)
     msg = "Order Request was Submitted"
-    msg_type = VersionPicker({
-        LOWEST: "success",
-        "5.10": "info"
-    }).pick()
+    msg_type = "success"
     view.submit_button.click()
     view = self.create_view(RequestsView)
     view.flash.assert_no_error()


### PR DESCRIPTION
{{pytest: cfme/tests/ssui/test_ssui_dashboard.py -k test_monthly_charges}}

Several tests involving service catalogs were failing with this error in 5.10.0.21 and not older versions.This is because of the change introduced through https://github.com/ManageIQ/manageiq-ui-classic/pull/4700/

> raise AssertionError('assert {} message: {}. \n Available messages: {}'
>                                .format(log_part, e_text, [msg.text for msg in all_messages]))
E           AssertionError: assert  message: info: Order Request was Submitted. 
E            Available messages: [u'Order Request was Submitted']

Note that this issue doesn't impact 59.