### PR TITLE
[RFR] Fix sprout orphans

### DIFF
--- a/sprout/appliances/admin.py
+++ b/sprout/appliances/admin.py
@@ -165,12 +165,27 @@ class GroupAdmin(Admin):
 @register_for(Provider)
 class ProviderAdmin(Admin):
     readonly_fields = [
-        "remaining_provisioning_slots", "provisioning_load", "show_ip_address", "appliance_load",
-        'total_memory', 'memory_limit', 'used_memory',
-        'total_cpu', 'cpu_limit', 'used_cpu']
+        "remaining_provisioning_slots",
+        "provisioning_load",
+        "show_ip_address",
+        "appliance_load",
+        'total_memory',
+        'memory_limit',
+        'used_memory',
+        'total_cpu',
+        'cpu_limit',
+        'used_cpu'
+    ]
     list_display = [
-        "id", "working", "num_simultaneous_provisioning", "remaining_provisioning_slots",
-        "provisioning_load", "show_ip_address", "appliance_load"]
+        "id",
+        "disabled",
+        "working",
+        "num_simultaneous_provisioning",
+        "remaining_provisioning_slots",
+        "provisioning_load",
+        "show_ip_address",
+        "appliance_load"
+    ]
 
     def remaining_provisioning_slots(self, instance):
         return str(instance.remaining_provisioning_slots)

--- a/sprout/appliances/tasks.py
+++ b/sprout/appliances/tasks.py
@@ -1993,7 +1993,10 @@ def synchronize_untracked_vms_in_provider(self, provider_id):
         # This provider does not have VMs
         return
     for vm in sorted(provider_api.list_vms()):
-        if Appliance.objects.filter(name=vm.name, template__provider=provider).count() != 0:
+        if (
+            Appliance.objects.filter(name=getattr(vm, 'name', vm),
+                                     template__provider=provider).count() != 0
+        ):
             continue
         # We have an untracked VM. Let's investigate
         try:


### PR DESCRIPTION
Exception when this is run by celery-beat against cm-pod1/2 since their `list_vms` mgmt function returns a list of names instead of objects.

Continuing to debug orphan behavior, just small change to consider on its own.

```
2018-10-31 17:13:37,547 [ERROR] 'str' object has no attribute 'name'
Traceback (most recent call last):
  File "/opt/sprout/integration_tests/sprout/appliances/tasks.py", line 125, in wrapped_task
    return task(self, *args, **kwargs)
  File "/opt/sprout/integration_tests/sprout/appliances/tasks.py", line 1985, in synchronize_untracked_vms_in_provider
    if Appliance.objects.filter(name=vm.name, template__provider=provider).count() != 0:
AttributeError: 'str' object has no attribute 'name'
```