### PR TITLE
[1LP][RFR] Fixed KeyError in quadicon for 5.10z

### DIFF
--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -66,7 +66,7 @@ class InstanceEntity(JSBaseEntity):
                 data_dict['no_snapshots'] = data_dict['total_snapshots']
             # openstack instances require this
             except KeyError:
-                data_dict['no_snapshots'] = data_dict['quad']['bottomRight']['tooltip']
+                data_dict['no_snapshots'] = data_dict['quad']['bottomRight']['text']
             data_dict['state'] = data_dict['quad']['topRight']['tooltip']
 
         return data_dict


### PR DESCRIPTION
{{ pytest: cfme/tests/cloud/test_delete_cloud_object.py -k 'test_delete_image_appear_after_refresh' -v }}

Fixed Error:
```
>               data_dict['no_snapshots'] = data_dict['quad']['bottomRight']['tooltip']
E               KeyError: 'tooltip'

cfme/common/vm_views.py:69: KeyError
KeyError
'tooltip'
```