### PR TITLE
[1LP][RFR] Fixed assertion error in region for 5.10z

### DIFF
--- a/cfme/tests/configure/test_region.py
+++ b/cfme/tests/configure/test_region.py
@@ -28,5 +28,9 @@ def test_description_change(appliance, request):
     view.save.click()
     view.flash.assert_message('Region "{}" was saved'.format(region_description))
     view.redhat_updates.click()
-    assert view.title.text == 'Settings Region "{} [{}]"'.format(
-        region_description, appliance.server.zone.region.number)
+    if appliance.version < "5.10":
+        assert view.title.text == 'Settings Region "{} [{}]"'.format(
+            region_description, appliance.server.zone.region.number)
+    else:
+        assert view.title.text == 'CFME Region "{} [{}]"'.format(
+            region_description, appliance.server.zone.region.number)

--- a/cfme/tests/configure/test_region.py
+++ b/cfme/tests/configure/test_region.py
@@ -28,9 +28,8 @@ def test_description_change(appliance, request):
     view.save.click()
     view.flash.assert_message('Region "{}" was saved'.format(region_description))
     view.redhat_updates.click()
-    if appliance.version < "5.10":
-        assert view.title.text == 'Settings Region "{} [{}]"'.format(
-            region_description, appliance.server.zone.region.number)
-    else:
-        assert view.title.text == 'CFME Region "{} [{}]"'.format(
-            region_description, appliance.server.zone.region.number)
+    reg = "Settings Region" if appliance.version < "5.10" else "CFME Region"
+    expected_title = '{reg} "{des} [{num}]"'.format(
+        reg=reg, des=region_description, num=appliance.server.zone.region.number
+    )
+    assert view.title.text == expected_title


### PR DESCRIPTION
{{ pytest: cfme/tests/configure/test_region.py -k 'test_description_change' -v }}

Fixed error:
```
E         + Settings Region "y7VlL [0]"
E         ? ^^^^^^^^

cfme/tests/configure/test_region.py:31: AssertionError
AssertionError
assert 'CFME Region "y7VlL [0]"' == 'Settings Region "y7VlL [0]"'
  - CFME Region "y7VlL [0]"
  ? ^^^^
  + Settings Region "y7VlL [0]"
  ? ^^^^^^^^
```