### PR TITLE
[1LP][RFR] Fixed Assertion error in system_image_duplicate_name for 5.10z

### DIFF
--- a/cfme/tests/infrastructure/test_system_image_type.py
+++ b/cfme/tests/infrastructure/test_system_image_type.py
@@ -31,7 +31,12 @@ def test_system_image_duplicate_name_error_validation(appliance):
     sys_image_type = collection.create(
         name=name,
         provision_type=SystemImageType.VM_OR_INSTANCE)
-    with pytest.raises(Exception, match='Name has already been taken'):
+    error_message = (
+        "Name has already been taken"
+        if appliance.version < "5.10"
+        else "Name is not unique within region 0"
+    )
+    with pytest.raises(Exception, match=error_message):
         collection.create(
             name=name,
             provision_type=SystemImageType.VM_OR_INSTANCE)


### PR DESCRIPTION
{{ pytest: cfme/tests/infrastructure/test_system_image_type.py -k 'test_system_image_duplicate_name_error_validation' -v }}

Fixed Error:
```
>               provision_type=SystemImageType.VM_OR_INSTANCE)
E           AssertionError: Pattern 'Name has already been taken' not found in 'assert_no_error: error: Name is not unique within region 0'

cfme/tests/infrastructure/test_system_image_type.py:37: AssertionError
AssertionError
Pattern 'Name has already been taken' not found in 'assert_no_error: error: Name is not unique within region 0'
```