### PR TITLE
[1LP][RFR ]Added new @pytest.mark to separate regression and RFE tests

### DIFF
--- a/cfme/tests/openstack/cloud/test_provider.py
+++ b/cfme/tests/openstack/cloud/test_provider.py
@@ -16,6 +16,7 @@ CARDS = [("Flavors", "list_flavor"), ("Images", "list_templates"),
          ("Instances", "list_vms"), ("Cloud Volumes", "list_volume")]
 
 
+@pytest.mark.rfe
 @pytest.mark.ignore_stream('5.9')
 @pytest.mark.parametrize('card, api', CARDS)
 def test_cloud_provider_cards(provider, card, api):
@@ -26,6 +27,7 @@ def test_cloud_provider_cards(provider, card, api):
     assert dashboard_card.value == len(attr())
 
 
+@pytest.mark.rfe
 @pytest.mark.ignore_stream('5.9')
 def test_dashboard_card_availability_zones(provider):
     view = navigate_to(provider, 'Details')
@@ -34,6 +36,7 @@ def test_dashboard_card_availability_zones(provider):
     assert dashboard_card.value == len(provider.mgmt.api.availability_zones.list())
 
 
+@pytest.mark.rfe
 @pytest.mark.ignore_stream('5.9')
 def test_dashboard_card_tenants(provider):
     collection = provider.appliance.collections.cloud_tenants
@@ -44,6 +47,7 @@ def test_dashboard_card_tenants(provider):
     assert card_tenants == view.entities.paginator.items_amount
 
 
+@pytest.mark.rfe
 @pytest.mark.ignore_stream('5.9')
 def test_dashboard_card_security_groups(provider):
     view = navigate_to(provider, 'Details')

--- a/cfme/tests/openstack/infrastructure/test_hosts.py
+++ b/cfme/tests/openstack/infrastructure/test_hosts.py
@@ -149,6 +149,7 @@ def test_hypervisor_hostname_views(host_collection, provider, view_type, soft_as
                     "Hypervisor hostname {} is not in Hypervisor list".format(hv_name))
 
 
+@pytest.mark.rfe
 def test_host_networks(provider, host_collection, soft_assert):
     hosts = host_collection.all()
     nodes = provider.mgmt.nodes
@@ -163,6 +164,7 @@ def test_host_networks(provider, host_collection, soft_assert):
                     "Networks associated to host does not match between UI and OSP")
 
 
+@pytest.mark.rfe
 def test_host_subnets(provider, appliance, host_collection, soft_assert):
     hosts = host_collection.all()
     net_collection = appliance.collections.cloud_networks


### PR DESCRIPTION
Update to previous PR: https://github.com/ManageIQ/integration_tests/pull/8023

Added @pytest.mark to separate regression and RFE tests.

Marked all RFE tests with @pytest.mark.rfe, then
in order to run only RFE tests, we invoke the following key during execution:
-m rfe
Marked all Regression tests with @pytest.mark.regression, then
in order to run only Regression tests, we invoke the following key during execution:
-m regression