### PR TITLE
[RFR] Fix alert_profile 'Edit' view by adding a check to is_displayed()

### DIFF
--- a/cfme/control/explorer/alert_profiles.py
+++ b/cfme/control/explorer/alert_profiles.py
@@ -52,6 +52,7 @@ class EditAlertProfileView(AlertProfileFormCommon):
                 self.context["object"].description) and
             self.alert_profiles.tree.currently_selected == [
                 "All Alert Profiles",
+                "{} Alert Profiles".format(self.context["object"].TYPE),
                 self.context["object"].description
             ]
         )


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ AlertProfile 'Edit' view because currently the is_displayed() conditions are not met, the third condition has been edited to fix this and reflect the accordion tree info. 

{{ pytest: --long-running cfme/tests/control/test_basic.py::test_alert_profile_crud }}