### PR TITLE
[1LP][RFR] Test for Quota with Catalog_bundle: Verifying quota limit by ordering catalog bundle over the assigned quota 

### DIFF
--- a/cfme/services/catalogs/catalog_items/catalog_bundles.py
+++ b/cfme/services/catalogs/catalog_items/catalog_bundles.py
@@ -103,7 +103,7 @@ class CatalogBundlesCollection(BaseCollection):
                 "StateMachines", "ServiceProvision_Template", "CatalogItemInitialization")
             view.apply_button.click()
         for cat_item in catalog_items:
-            view.resources.fill({'select_resource': cat_item.name})
+            view.resources.fill({'select_resource': cat_item})
         view.add_button.click()
         view.flash.assert_success_message('Catalog Bundle "{}" was added'.format(name))
         view = self.create_view(AllCatalogItemView)

--- a/cfme/services/catalogs/catalog_items/catalog_bundles.py
+++ b/cfme/services/catalogs/catalog_items/catalog_bundles.py
@@ -103,7 +103,7 @@ class CatalogBundlesCollection(BaseCollection):
                 "StateMachines", "ServiceProvision_Template", "CatalogItemInitialization")
             view.apply_button.click()
         for cat_item in catalog_items:
-            view.resources.fill({'select_resource': cat_item})
+            view.resources.fill({'select_resource': cat_item.name})
         view.add_button.click()
         view.flash.assert_success_message('Catalog Bundle "{}" was added'.format(name))
         view = self.create_view(AllCatalogItemView)

--- a/cfme/tests/infrastructure/test_quota_tagging.py
+++ b/cfme/tests/infrastructure/test_quota_tagging.py
@@ -89,11 +89,9 @@ def catalog_item(appliance, provider, dialog, catalog, prov_data):
 
 @pytest.fixture
 def catalog_bundle(appliance, dialog, catalog, catalog_item):
-    catalog_item_list = []
-    catalog_item_list.append(catalog_item)
     collection = appliance.collections.catalog_bundles
     catalog_bundle = collection.create(name='test_{}'.format(fauxfactory.gen_alphanumeric()),
-                                       catalog_items=catalog_item_list,
+                                       catalog_items=[catalog_item.name],
                                        description='test catalog bundle',
                                        display_in=True,
                                        catalog=catalog,

--- a/cfme/tests/infrastructure/test_quota_tagging.py
+++ b/cfme/tests/infrastructure/test_quota_tagging.py
@@ -339,7 +339,12 @@ def test_quota_infra(request, appliance, provider, setup_provider, admin_email, 
     ['custom_prov_data'],
     [
         [{'hardware': {'memory': '4096'}}],
-        [{}],
+        [{}],  # This parameterization is for selecting storage while provisioning VM.
+        # But it is not possible to parameterize storage size.
+        # Becuase it is defined in disk formats(Thin, Thick, Default and other types).
+        # Also it varies with providers.
+        # But we don't need to select storage because by default storage is already more than
+        #  assigned storage quota which is 2GB maximum.
         [{'hardware': {'vm_num': '21'}}],
         [{'hardware': {'num_sockets': '8'}}]
     ],


### PR DESCRIPTION
 - This test case verifies the quota assigned by automation method for user and group
   is working correctly for the infra providers by ordering catalog bundle.
- Added new fixture
    - **catalog bundle()**
        - **catalog_item_list** : this is used to add more than one catalog items to list and pass them to catalog bundle.
        - Here in this test, only one catalog item is created and it is passed to add in catalog bundle.
        - catalog_item_list is taken because list of catalog items are accepted by catalog bundle's create method

{{ pytest: cfme/tests/infrastructure/test_quota_tagging.py -k 'test_quota_catalog_bundle_infra' -v }}
