### PR TITLE
[1LP][RFR] Update Alert docstring and add ability to create alert with only a 'description'

### DIFF
--- a/cfme/control/explorer/alerts.py
+++ b/cfme/control/explorer/alerts.py
@@ -301,15 +301,16 @@ class AlertCollection(BaseCollection):
             Note: Since alerts in CFME require a description, driving_event, and one
             of snmp_trap, emails, timeline_event, or mgmt_event, we set defaults to
             timeline_event=True, and driving_event=<first_item_from_dropdown>
+            We select the first item from the dropdown for efficiency.
 
             This allows creation of an alert only by a description. e.g.
-            >>> alert = appliance.collection.alerts.create('my_alert_description')
+            >>> alert = appliance.collections.alerts.create('my_alert_description')
             >>> alert.delete()
         """
         view = navigate_to(self,"Add")
         if driving_event is None:
-            view.driving_event.select_by_visible_text(partial_match('H'))
-            driving_event = view.driving_event.read()
+            driving_event = view.driving_event.all_options[1].text
+        # instantiate the alert
         alert = self.instantiate(description, severity=severity, active=active, based_on=based_on,
             evaluate=evaluate, driving_event=driving_event,
             notification_frequency=notification_frequency, snmp_trap=snmp_trap, emails=emails,

--- a/cfme/control/explorer/alerts.py
+++ b/cfme/control/explorer/alerts.py
@@ -7,6 +7,7 @@ from copy import copy
 from navmazing import NavigateToAttribute, NavigateToSibling
 
 from widgetastic.widget import Checkbox, Text, View
+from widgetastic.utils import partial_match
 from widgetastic_manageiq import AlertEmail, SNMPForm, SummaryForm
 from widgetastic_patternfly import BootstrapSelect, Button, Input
 
@@ -125,11 +126,14 @@ class AlertDetailsView(ControlExplorerView):
 class Alert(BaseEntity, Updateable, Pretty):
     """Alert representation object.
     Example:
-        >>> alert = Alert("my_alert", timeline_event=True, driving_event="Hourly Timer")
-        >>> alert.create()
+        >>> alert = appliance.collections.alerts.create(
+        >>>    "my_alert",
+        >>>    timeline_event=True,
+        >>>    driving_event="Hourly Timer"
+        >>> )
         >>> alert.delete()
 
-    Args:
+    Attributes:
         description: Name of the Alert.
         based_on: Cluster, Datastore, Host, Provider, ...
         evaluate: Use it as follows:
@@ -291,12 +295,25 @@ class AlertCollection(BaseCollection):
 
     def create(self, description, severity=None, active=None, based_on=None, evaluate=None,
             driving_event=None, notification_frequency=None, snmp_trap=None, emails=None,
-            timeline_event=None, mgmt_event=None):
+            timeline_event=True, mgmt_event=None):
+        """ Create a new alert in the UI.
+
+            Note: Since alerts in CFME require a description, driving_event, and one
+            of snmp_trap, emails, timeline_event, or mgmt_event, we set defaults to
+            timeline_event=True, and driving_event=<first_item_from_dropdown>
+
+            This allows creation of an alert only by a description. e.g.
+            >>> alert = appliance.collection.alerts.create('my_alert_description')
+            >>> alert.delete()
+        """
+        view = navigate_to(self,"Add")
+        if driving_event is None:
+            view.driving_event.select_by_visible_text(partial_match('H'))
+            driving_event = view.driving_event.read()
         alert = self.instantiate(description, severity=severity, active=active, based_on=based_on,
             evaluate=evaluate, driving_event=driving_event,
             notification_frequency=notification_frequency, snmp_trap=snmp_trap, emails=emails,
             timeline_event=timeline_event, mgmt_event=mgmt_event)
-        view = navigate_to(self, "Add")
         alert._fill(view)
         view.add_button.click()
         view = alert.create_view(AlertDetailsView)

--- a/cfme/tests/control/test_basic.py
+++ b/cfme/tests/control/test_basic.py
@@ -540,9 +540,7 @@ def test_modify_condition_expression(condition_for_expressions, fill_type, expre
 def test_alert_crud(alert_collection):
     # CR
     alert = alert_collection.create(
-        fauxfactory.gen_alphanumeric(),
-        timeline_event=True,
-        driving_event="Hourly Timer"
+        fauxfactory.gen_alphanumeric()
     )
     # U
     with update(alert):


### PR DESCRIPTION
Purpose or Intent
=================
__Extending__  the `alert_collection.create()` method to work when only passed a description. The `create()` method now defaults to have `timeline_event=True` and `driving_event='Hourly Timer'`. The latter is selected from the dropdown menu on the `AlertCollection` "Add" page. 

__Updating__ docstring for `Alert` to reflect the proper way to create new alerts; via `alert_collection.create()` method

{{ pytest: --long-running cfme/tests/control/test_basic.py::test_alert_crud }}
