### PR TITLE
[1LP][RFR] Fix test failures related to view.is_displayed during Alert creation 

### DIFF
--- a/cfme/control/explorer/alerts.py
+++ b/cfme/control/explorer/alerts.py
@@ -300,7 +300,7 @@ class AlertCollection(BaseCollection):
         alert._fill(view)
         view.add_button.click()
         view = alert.create_view(AlertDetailsView)
-        assert view.is_displayed
+        view.wait_displayed()
         view.flash.assert_success_message('Alert "{}" was added'.format(alert.description))
         return alert
 


### PR DESCRIPTION
Purpose or Intent
=================

__Changing__ `assert view.is_displayed` to `view.wait_displayed()` in the `AlertCollection` method `create()` to fix the `test_alert_snmp` test. 

{{ pytest: --long-running cfme/tests/control/test_alerts.py::test_alert_snmp }}