### PR TITLE
[1LP][RFR] Fix alert_timeline_cpu by making change for TimelinesChart class

### DIFF
--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -2573,14 +2573,19 @@ class TimelinesChart(View):
         node = document_fromstring(evt)
         # lxml doesn't replace <br> with \n in this case. so this has to be done by us
         for br in node.xpath("*//br"):
-            br.tail = "\n" + br.tail if br.tail else "\n"
+            br.tail = "\n" + br.tail.rstrip() if br.tail and br.tail.rstrip() else "\n"
 
         # parsing event and preparing its attributes
         event = self.TimelinesEvent()
         for line in node.text_content().split("\n"):
-            attr_name, attr_val = re.search(r"^(.*?):(.*)$", line).groups()
-            attr_name = attr_name.strip().lower().replace(" ", "_")
-            setattr(event, attr_name, attr_val.strip())
+            try:
+                attr_name, attr_val = re.search(r"^(.*?):(.*)$", line).groups()
+                attr_name = attr_name.strip().lower().replace(" ", "_")
+                setattr(event, attr_name, attr_val.strip())
+            except AttributeError:
+                self.logger.exception(
+                    "Regex search failed for line: {} in TimelinesChart Cell".format(line)
+                )
         event.category = category
         return event
 


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ test_alert_timeline_cpu because currently it is failing in the `_prepare_event()` method of `TimelinesChart` class. The fix is to remove whitespace from `br.tail` and to add a `try` `except` clause around the `get_groups()` method.

{{ pytest: --long-running cfme/tests/control/test_alerts.py::test_alert_timeline_cpu }}