### PR TITLE
[1LP][RFR] Add view.wait_displayed() when updating an alert

### DIFF
--- a/cfme/control/explorer/alerts.py
+++ b/cfme/control/explorer/alerts.py
@@ -185,7 +185,7 @@ class Alert(BaseEntity, Updateable, Pretty):
         else:
             view.cancel_button.click()
         view = self.create_view(AlertDetailsView, override=updates)
-        assert view.is_displayed
+        view.wait_displayed()
         view.flash.assert_no_error()
         if changed:
             view.flash.assert_message(


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ `update` method of `Alert` object by using `view.wait_displayed()`

{{ pytest: --long-running cfme/tests/control/test_basic.py::test_alert_crud }}
