### PR TITLE
[1LP][RFR] fixed azure vms provisioning in 5.10

### DIFF
--- a/cfme/cloud/instance/azure.py
+++ b/cfme/cloud/instance/azure.py
@@ -49,13 +49,20 @@ class AzureInstance(Instance):
         provisioning = self.provider.data['provisioning']
         vm_user = provisioning.get('customize_username')
         vm_password = provisioning.get('customize_password')
+        if self.appliance.version >= '5.10':
+            instance_type = provisioning.get('instance_type').title()
+        else:
+            instance_type = provisioning.get('instance_type')
         recursive_update(inst_args, {
             'environment': {
                 'public_ip_address': '<None>',
             },
             'customize': {
                 'admin_username': vm_user,
-                'root_password': vm_password}})
+                'root_password': vm_password
+            },
+            'properties': {
+                'instance_type': instance_type}})
         return inst_args
 
     @property


### PR DESCRIPTION
{{ pytest: -v cfme/tests/cloud_infra_common/test_provisioning.py::test_provision_with_tag[azure-common] --use-provider=complete }}

This PR fixes
`SelectItemNotFound: Could not find 'standard_a1' in BootstrapSelect(locator=u'.//div[contains(@class, "bootstrap-select")]/button[normalize-space(@data-id)="hardware__instance_type"]/..')`

In 5.9 instance types are like `standard_a1`, but in 5.10 they are like `Standard_A1`

![image](https://user-images.githubusercontent.com/42433123/48205119-e521bf00-e36b-11e8-910f-18c6285d4287.png)
