### PR TITLE
[1LP][RFR] Remove smtp_test kwarg from do_vm_provisioning call

### DIFF
--- a/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
+++ b/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
@@ -269,7 +269,7 @@ def ssa_single_vm(request, local_setup_provider, enable_smartproxy_affinity, pro
 
             do_vm_provisioning(vm_name=vm_name, appliance=appliance, provider=provider,
                                provisioning_data=provisioning_data, template_name=template_name,
-                               request=request, smtp_test=False, num_sec=2500)
+                               request=request, num_sec=2500)
         else:
             deploy_template(vm.provider.key, vm_name, template_name, timeout=2500)
             vm.wait_to_appear(timeout=900, load_details=False)


### PR DESCRIPTION
Just looking to resolve TypeError on L272 for test_vm_instance_analysis.

{{ pytest: cfme/tests/cloud_infra_common/test_vm_instance_analysis.py --use-provider complete --long-running -k 'test_ssa_template or test_ssa_schedule or test_ssa_vm or test_ssa_users or test_ssa_groups or test_drift_analysis' }}

FIXES #8099 

