### PR TITLE
[1LP][RFR] fixed ProviderTemplatesView and removed BZ blocker

### DIFF
--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from lxml.html import document_fromstring
+from widgetastic.utils import Version
 
 from widgetastic_patternfly import BreadCrumb, Dropdown, BootstrapSelect
 from widgetastic.exceptions import NoSuchElementException
@@ -7,6 +8,7 @@ from widgetastic.widget import View, Text, ConditionalSwitchableView
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.common.host_views import HostEntitiesView
+from cfme.utils.version import VersionPicker
 from widgetastic_manageiq import (
     ParametrizedSummaryTable,
     Button,
@@ -249,14 +251,14 @@ class ProviderTemplatesView(ProviderVmsTemplatesView):
 
     @property
     def is_displayed(self):
-        if self.browser.product_version < '5.10':
-            title = '{name} (All VM Templates)'.format(name=self.context['object'].name)
-        else:
-            title = '{name} (All VM Templates and Images)'.format(name=self.context['object'].name)
-
+        title = VersionPicker({
+            Version.lowest(): '{name} (All VM Templates)'.format(name=self.context['object'].name),
+            '5.10': '{name} (All VM Templates and Images)'.format(name=self.context['object'].name),
+        }).pick(self.extra.appliance.version)
         return (self.logged_in_as_current_user and
                 self.navigation.currently_selected == ['Compute', 'Infrastructure', 'Providers'] and
                 self.title.text == title)
+
 
 class ProviderVmsView(ProviderVmsTemplatesView):
 

--- a/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
+++ b/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
@@ -51,7 +51,7 @@ def group_tag_datacenter_combination(group_with_tag, provider):
                                         provider.data['datacenters'][0]], True)
 
 
-@pytest.mark.meta(blockers=[BZ(1533391, forced_streams=["5.9", "upstream"])])
+@pytest.mark.meta(blockers=[BZ(1648658, forced_streams=["5.9"])])
 @pytest.mark.parametrize('visibility', [True, False], ids=['visible', 'not_visible'])
 def test_tagvis_tag_datacenter_combination(testing_vis_object, group_tag_datacenter_combination,
                                 check_item_visibility, visibility):


### PR DESCRIPTION
{{ pytest: -v cfme/tests/infrastructure/test_infra_tag_filters_combination.py::test_tagvis_tag_datacenter_combination }}

This PR fixes ProviderTemplatesView that affected 2 tests:
```
test_tagvis_tag_datacenter_combination[infra_templates-infra-not_visible]
test_tagvis_tag_datacenter_combination[infra_templates-infra-visible]
```

Also removed the BZ blocker.

