### PR TITLE
[1LP][RFR]Service Link test fix

### DIFF
--- a/cfme/services/myservice/ui.py
+++ b/cfme/services/myservice/ui.py
@@ -186,12 +186,7 @@ class ReconfigureServiceView(SetOwnershipForm):
 class ServiceVMDetailsView(VMDetailsEntities):
     @property
     def is_displayed(self):
-        return (
-            self.logged_in_as_current_user and
-            self.navigation.currently_selected == ['Services', 'MyServices'] and
-            self.myservice.is_opened and
-            self.title.text == 'VM and Instance "{}"'.format(self.context['object'].name)
-        )
+        return self.title.text == 'VM and Instance "{}"'.format(self.context['object'].vm_name)
 
 
 class AllGenericObjectInstanceView(BaseLoggedInPage):


### PR DESCRIPTION
{{pytest: cfme/tests/services/test_myservice.py::test_service_link -v --long-running}}

ServiceVMDetailsView inherits VMDetailsEntities
which does not have navigation and other things so removed them and fixed object .