### PR TITLE
[1LP][RFR] Fixed AssertionError while hard_reboot of azure in 5.10z

### DIFF
--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -353,8 +353,12 @@ def test_hard_reboot_unsupported(appliance, testing_instance):
     testing_instance.power_control_from_cfme(option=testing_instance.HARD_REBOOT,
                                              from_details=False)
     # power_control_from_cfme navigated
-    appliance.browser.create_view(BaseLoggedInPage).flash.assert_message(
-        "Reset does not apply to at least one of the selected items")
+    message = (
+        "Reset does not apply to at least one of the selected items"
+        if appliance.version < "5.10"
+        else "Reset action does not apply to selected items"
+    )
+    appliance.browser.create_view(BaseLoggedInPage).flash.assert_message(message)
 
 
 @pytest.mark.uncollectif(lambda provider: not provider.one_of(AzureProvider, OpenStackProvider))


### PR DESCRIPTION
{{ pytest: cfme/tests/cloud/test_instance_power_control.py::test_hard_reboot_unsupported --use-provider azure  --long-running -v }} 

Fixed Error:
```
E           AssertionError: assert  message: Reset does not apply to at least one of the selected items. 
E            Available messages: [u'Reset action does not apply to selected items']

../cfme_venv/lib/python2.7/site-packages/widgetastic_patternfly/__init__.py:258: AssertionError
AssertionError
assert  message: Reset does not apply to at least one of the selected items. 
 Available messages: [u'Reset action does not apply to selected items']
```
