### PR TITLE
[1LP][RFR] Fix generic object test and views

### DIFF
--- a/cfme/generic_objects/definition/__init__.py
+++ b/cfme/generic_objects/definition/__init__.py
@@ -30,6 +30,7 @@ class GenericObjectDefinition(BaseEntity, Updateable, sentaku.modeling.ElementMi
     add_button = sentaku.ContextualMethod()
     add_button_group = sentaku.ContextualMethod()
     generic_objects = sentaku.ContextualProperty()
+    instance_count = sentaku.ContextualProperty()
 
     name = attr.ib()
     description = attr.ib()

--- a/cfme/generic_objects/definition/definition_views.py
+++ b/cfme/generic_objects/definition/definition_views.py
@@ -217,6 +217,7 @@ class GenericObjectEditButtonView(GenericObjectAddEditButtonView):
 
 
 class GenericObjectActionsDetailsView(GenericObjectDefinitionView):
+    title = Text('#explorer_title_text')
     group_table = Table('//h3[contains(text(), "Groups")]/following-sibling::table[1]')
     button_table = Table('//h3[contains(text(), "Buttons")]/following-sibling::table[1]')
     accordion = View.nested(AccordionForm)
@@ -243,7 +244,7 @@ class GenericObjectButtonGroupAddView(GenericObjectDefinitionView):
     @property
     def is_displayed(self):
         return (
-            self.title.text == 'GenericObjectButtonGroupAddView' and
+            self.title.text == "Add a new Custom Button Group" and
             self.name.is_displayed and
             self.in_generic_object_definition
         )

--- a/cfme/generic_objects/definition/ui.py
+++ b/cfme/generic_objects/definition/ui.py
@@ -107,6 +107,12 @@ def generic_objects(self):
     return self.collections.generic_objects
 
 
+@MiqImplementationContext.external_for(GenericObjectDefinition.instance_count.getter, ViaUI)
+def instance_count(self):
+    view = navigate_to(self, "Details")
+    return int(view.summary("Relationships").get_text_of("Instances"))
+
+
 @navigator.register(GenericObjectDefinitionCollection)
 class All(CFMENavigateStep):
     VIEW = GenericObjectDefinitionAllView
@@ -115,6 +121,9 @@ class All(CFMENavigateStep):
 
     def step(self):
         self.prerequisite_view.navigation.select('Automation', 'Automate', 'Generic Objects')
+
+    def resetter(self, *args, **kwargs):
+        self.view.accordion.fill({'classes': {'tree': [u'All Generic Object Classes']}})
 
 
 @navigator.register(GenericObjectDefinitionCollection)

--- a/cfme/generic_objects/instance/ui.py
+++ b/cfme/generic_objects/instance/ui.py
@@ -75,15 +75,13 @@ class MyServiceGenericObjectInstanceView(BaseLoggedInPage):
 
 @MiqImplementationContext.external_for(GenericObjectInstance.exists.getter, ViaUI)
 def exists(self):
-    try:
-        # first need to check if any instances are created
-        view = navigate_to(self.definition, 'Instances')
-        if view.is_displayed:
+    if self.definition.instance_count > 0:
+        try:
             navigate_to(self, 'Details')
             return True
-        else:
+        except CandidateNotFound:
             return False
-    except CandidateNotFound:
+    else:
         return False
 
 

--- a/cfme/services/myservice/ui.py
+++ b/cfme/services/myservice/ui.py
@@ -33,17 +33,19 @@ class MyServicesView(BaseLoggedInPage):
     toolbar = View.nested(MyServiceToolbar)
     search = View.nested(Search)
 
+    @property
     def in_myservices(self):
         return (
             self.logged_in_as_current_user and
-            self.navigation.currently_selected == ['Services', 'MyServices'])
+            self.navigation.currently_selected == ["Services", "My Services"])
 
     @property
     def is_displayed(self):
         return (
             self.in_myservices and
-            self.toolbar.configuration.is_displayed and not
-            self.myservice.is_dimmed)
+            self.toolbar.configuration.is_displayed and
+            not self.myservice.is_dimmed
+        )
 
     @View.nested
     class myservice(Accordion):  # noqa

--- a/cfme/tests/generic_objects/test_instances.py
+++ b/cfme/tests/generic_objects/test_instances.py
@@ -9,6 +9,7 @@ from cfme.base.login import BaseLoggedInPage
 from cfme.services.myservice import MyService
 from cfme.utils.appliance import ViaREST, ViaUI
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import BZ
 from cfme.utils.rest import assert_response
 from cfme.utils.update import update
 
@@ -202,6 +203,7 @@ def test_generic_objects_with_buttons_ui(appliance, request, add_generic_object_
             assert view.toolbar.button(generic_button.name).custom_button.is_displayed
 
 
+@pytest.mark.meta(blockers=[BZ(1648243, forced_streams=['5.9'])])
 @pytest.mark.parametrize('tag_place', [True, False], ids=['details', 'collection'])
 def test_generic_objects_tag_ui(appliance, generic_object, tag_place):
     """Tests assigning and unassigning tags using UI.

--- a/cfme/tests/generic_objects/test_instances.py
+++ b/cfme/tests/generic_objects/test_instances.py
@@ -20,7 +20,7 @@ pytestmark = [
 ]
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def definition(appliance):
     with appliance.context.use(ViaREST):
         definition = appliance.collections.generic_object_definitions.create(
@@ -35,7 +35,7 @@ def definition(appliance):
             definition.delete()
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def service(appliance):
     service_name = 'rest_service_{}'.format(fauxfactory.gen_alphanumeric())
     rest_service = appliance.rest_api.collections.services.action.create(
@@ -47,7 +47,7 @@ def service(appliance):
     rest_service.action.delete()
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def generic_object(definition, service, appliance):
     myservice = MyService(appliance, name=service.name)
     with appliance.context.use(ViaREST):
@@ -57,12 +57,13 @@ def generic_object(definition, service, appliance):
             attributes={'addr01': 'Test Address'},
             associations={'services': [myservice]}
         )
+        instance.my_service = myservice
         yield instance
         if instance.exists:
             instance.delete()
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def add_generic_object_to_service(appliance, service, generic_object):
     with appliance.context.use(ViaREST):
         service.action.add_resource(
@@ -70,6 +71,7 @@ def add_generic_object_to_service(appliance, service, generic_object):
                 name=generic_object.name)[0]._ref_repr()
         )
         assert_response(appliance)
+    return generic_object
 
 
 @pytest.fixture(scope="module")
@@ -82,17 +84,18 @@ def tags(request, appliance, categories):
     return rest_gen_data.tags(request, appliance.rest_api, categories)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def generic_object_button_group(appliance, definition):
 
     def _generic_object_button_group(create_action=True):
         if create_action:
             with appliance.context.use(ViaUI):
                 group_name = 'button_group_{}'.format(fauxfactory.gen_alphanumeric())
+                group_desc = 'Group_button_description_{}'.format(fauxfactory.gen_alphanumeric())
                 generic_object_button_group = definition.collections.generic_object_groups_buttons\
                     .create(
                         name=group_name,
-                        description='Group_button_description',
+                        description=group_desc,
                         image='fa-user'
                     )
                 view = appliance.browser.create_view(BaseLoggedInPage)
@@ -102,7 +105,7 @@ def generic_object_button_group(appliance, definition):
     return _generic_object_button_group
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def generic_object_button(appliance, generic_object_button_group, definition):
 
     def _generic_object_button(button_group):
@@ -111,9 +114,10 @@ def generic_object_button(appliance, generic_object_button_group, definition):
                 generic_object_button_group(button_group) if button_group else definition
             )
             button_name = 'button_{}'.format(fauxfactory.gen_alphanumeric())
+            button_desc = 'Button_description_{}'.format(fauxfactory.gen_alphanumeric())
             generic_object_button = button_parent.collections.generic_object_buttons.create(
                 name=button_name,
-                description='Button_description',
+                description=button_desc,
                 image='fa-home',
                 request=fauxfactory.gen_alphanumeric()
             )
@@ -177,7 +181,7 @@ def test_generic_objects_crud(appliance, context, request):
 
 @pytest.mark.parametrize('button_group', [True, False],
                          ids=['button_group_with_button', 'single_button'])
-def test_generic_objects_with_buttons_ui(appliance, request, definition, service,
+def test_generic_objects_with_buttons_ui(appliance, request, add_generic_object_to_service,
                                          button_group, generic_object_button):
     """
         Tests buttons ui visibility assigned to generic object
@@ -185,24 +189,10 @@ def test_generic_objects_with_buttons_ui(appliance, request, definition, service
         Metadata:
             test_flag: ui
     """
-    myservice = MyService(appliance, name=service.name)
+    instance = add_generic_object_to_service
     generic_button = generic_object_button(button_group)
     generic_button_group = generic_button.parent.parent
 
-    with appliance.context.use(ViaREST):
-        instance = appliance.collections.generic_objects.create(
-            name='rest_generic_instance{}'.format(fauxfactory.gen_alphanumeric()),
-            definition=definition,
-            attributes={'addr01': 'Test Address'},
-            associations={'services': [myservice]}
-        )
-        request.addfinalizer(instance.delete)
-        service.action.add_resource(
-            resource=appliance.rest_api.collections.generic_objects.find_by(
-                name=instance.name)[0]._ref_repr()
-        )
-        assert_response(appliance)
-        instance.my_service = myservice
     with appliance.context.use(ViaUI):
         view = navigate_to(instance, 'MyServiceDetails')
         if button_group:

--- a/cfme/tests/generic_objects/test_instances.py
+++ b/cfme/tests/generic_objects/test_instances.py
@@ -87,18 +87,15 @@ def tags(request, appliance, categories):
 
 @pytest.fixture(scope="module")
 def generic_object_button_group(appliance, definition):
-
     def _generic_object_button_group(create_action=True):
         if create_action:
             with appliance.context.use(ViaUI):
-                group_name = 'button_group_{}'.format(fauxfactory.gen_alphanumeric())
-                group_desc = 'Group_button_description_{}'.format(fauxfactory.gen_alphanumeric())
-                generic_object_button_group = definition.collections.generic_object_groups_buttons\
-                    .create(
-                        name=group_name,
-                        description=group_desc,
-                        image='fa-user'
-                    )
+                group_name = "button_group_{}".format(fauxfactory.gen_alphanumeric())
+                group_desc = "Group_button_description_{}".format(fauxfactory.gen_alphanumeric())
+                groups_buttons = definition.collections.generic_object_groups_buttons
+                generic_object_button_group = groups_buttons.create(
+                    name=group_name, description=group_desc, image="fa-user"
+                )
                 view = appliance.browser.create_view(BaseLoggedInPage)
                 view.flash.assert_no_error()
             return generic_object_button_group
@@ -108,7 +105,6 @@ def generic_object_button_group(appliance, definition):
 
 @pytest.fixture(scope="module")
 def generic_object_button(appliance, generic_object_button_group, definition):
-
     def _generic_object_button(button_group):
         with appliance.context.use(ViaUI):
             button_parent = (
@@ -203,7 +199,7 @@ def test_generic_objects_with_buttons_ui(appliance, request, add_generic_object_
             assert view.toolbar.button(generic_button.name).custom_button.is_displayed
 
 
-@pytest.mark.meta(blockers=[BZ(1648243, forced_streams=['5.9'])])
+@pytest.mark.meta(blockers=[BZ(1648658, forced_streams=['5.9'])])
 @pytest.mark.parametrize('tag_place', [True, False], ids=['details', 'collection'])
 def test_generic_objects_tag_ui(appliance, generic_object, tag_place):
     """Tests assigning and unassigning tags using UI.


### PR DESCRIPTION
Purpose or Intent
=================
- Fix `MyServicesView` `is_displayed`
- Fix `GenericObjectActionsDetailsView`
- Added `resetter` after `All` call so, It will maintain All view every time... When we try to navigate second time. It will on a detail page due to previous actions.
- Added sentaku propery for `instance` count. So if count is 0; it will not try to click on `Instance` from relationship table.

Let's add complete generic object tests against changes. 

{{pytest: cfme/tests/generic_objects/ -vv}}
