### PR TITLE
[1LP][RFR][NOTEST] Fix for all method avoiding Ansible Embedded Manager

### DIFF
--- a/cfme/infrastructure/cluster.py
+++ b/cfme/infrastructure/cluster.py
@@ -334,7 +334,7 @@ class ClusterCollection(BaseCollection):
             providers_db = {
                 prov.id: get_crud_by_name(prov.name)
                 for prov in providers
-                if not getattr(prov, "parent_ems_id", False)
+                if not (getattr(prov, "parent_ems_id", False) and ("Manager" in prov.name))
             }
             cluster_obj = [
                 self.instantiate(name=cluster.name, provider=providers_db[cluster.ems_id])

--- a/cfme/infrastructure/datastore.py
+++ b/cfme/infrastructure/datastore.py
@@ -328,13 +328,14 @@ class DatastoreCollection(BaseCollection):
     def all(self):
         "Returning all datastore objects with filtering support as per provider"
         provider = self.filters.get("provider")
-        datastores = self.appliance.rest_api.collections.data_stores
-        datastores = datastores.all_include_attributes(attributes=["hosts"])
-        datastore_db = {ds.name: ds.hosts[0]["ems_id"] for ds in datastores}
+        datastores = self.appliance.rest_api.collections.data_stores.all_include_attributes(
+            attributes=["hosts"]
+        )
+        datastore_db = {ds.name: ds.hosts[0]["ems_id"] for ds in datastores if ds.hosts}
         provider_db = {
             prov.id: get_crud_by_name(prov.name)
             for prov in self.appliance.rest_api.collections.providers.all
-            if not getattr(prov, "parent_ems_id", False)
+            if not (getattr(prov, "parent_ems_id", False) and ("Manager" in prov.name))
         }
         datastores = [
             self.instantiate(name=name, provider=provider_db[prov_id])


### PR DESCRIPTION
Purpose or Intent
=================
```
>       raise NameError("Could not find provider {}".format(provider_name))
E       NameError: Could not find provider Embedded Ansible Automation Manager

cfme/utils/providers.py:340: NameError
NameError
Could not find provider Embedded Ansible Automation Manager
```
```
In [5]: for prov in providers:
   ...:     print prov.name, getattr(prov, "parent_ems_id", False)
   ...:
   ...:
RHOS11 False
RHOS11 Network Manager 3
RHOS11 Cinder Manager 3
RHOS11 Swift Manager 3
Embedded Ansible Automation Manager False
```

I found the check for `parent_ems_id` is not proper in case of `Ansible Embedded Manager`. To deal with Manger better to check in provider name only `"Manager"` is available or not. 


