### PR TITLE
[1LP][RFR] Quota test for Infra: Testing tenant quota via UI and SSUI 

### DIFF
--- a/cfme/services/requests.py
+++ b/cfme/services/requests.py
@@ -191,7 +191,7 @@ class Request(BaseEntity):
             cancel: Whether to cancel the deletion.
         """
         view = navigate_to(self, 'Details')
-        view.toolbar.delete.click(handle_alert=True)
+        view.toolbar.delete.click(handle_alert=not cancel)
 
     @variable(alias='rest')
     def is_finished(self):

--- a/cfme/tests/infrastructure/test_tenant_quota.py
+++ b/cfme/tests/infrastructure/test_tenant_quota.py
@@ -18,9 +18,29 @@ pytestmark = [
     test_requirements.quota,
     pytest.mark.meta(server_roles="+automate"),
     test_requirements.vm_migrate,
-    pytest.mark.usefixtures('setup_provider', 'uses_infra_providers'),
+    pytest.mark.usefixtures('setup_provider'),
     pytest.mark.provider([VMwareProvider, RHEVMProvider], scope="module", selector=ONE_PER_TYPE)
 ]
+
+
+@pytest.fixture
+def set_default(provider, request):
+    """This fixture is used to return paths for provisioning_entry_point, reconfigure_entry_point
+       and retirement_entry_point. The value of 'provisioning_entry_point' is required while
+       creating new catalog item in 'test_service_infra_tenant_quota_with_default_entry_point' test.
+       But other tests does not require these values since those tests takes default values hence
+       providing default value. So in this file, this fixture - 'set_default'
+       must be used in all tests of quota which are related to services where catalog item needs to
+       be created with specific values for these entries.
+    """
+    with_prov = (
+        "/ManageIQ (Locked)/{}/VM/Provisioning/StateMachines/ProvisionRequestApproval/Default"
+        .format(provider.string_name)
+    )
+    default = (
+        "/Service/Provisioning/StateMachines/ServiceProvision_Template/CatalogItemInitialization"
+    )
+    return with_prov if request.param else default
 
 
 @pytest.fixture
@@ -80,17 +100,21 @@ def set_roottenant_quota(request, roottenant, appliance):
     roottenant.set_quota(**{'{}_cb'.format(field): False})
 
 
-@pytest.fixture
-def catalog_item(appliance, provider, dialog, catalog, prov_data):
+@pytest.fixture(scope='function')
+def catalog_item(appliance, provider, dialog, catalog, prov_data, set_default):
     collection = appliance.collections.catalog_items
-    yield collection.create(
+    catalog_item = collection.create(
         provider.catalog_item_type,
         name='test_{}'.format(fauxfactory.gen_alphanumeric()),
         description='test catalog',
         display_in=True,
         catalog=catalog,
         dialog=dialog,
-        prov_data=prov_data)
+        prov_data=prov_data,
+        provider=provider,
+        provisioning_entry_point=set_default)
+    yield catalog_item
+    catalog_item.delete()
 
 
 @pytest.fixture(scope='module')
@@ -166,18 +190,19 @@ def test_tenant_quota_enforce_via_lifecycle_infra(appliance, provider, set_roott
 # indirect is the list where we define which fixtures are to be passed values indirectly.
 @pytest.mark.parametrize('context', [ViaSSUI, ViaUI])
 @pytest.mark.parametrize(
-    ['set_roottenant_quota', 'custom_prov_data', 'extra_msg'],
+    ['set_roottenant_quota', 'custom_prov_data', 'extra_msg', 'set_default'],
     [
-        [('cpu', '2'), {'hardware': {'num_sockets': '8'}}, ''],
-        [('storage', '0.01'), {}, ''],
-        [('memory', '2'), {'hardware': {'memory': '4096'}}, ''],
-        [('vm', '1'), {'catalog': {'num_vms': '4'}}, '###'],
+        [('cpu', '2'), {'hardware': {'num_sockets': '8'}}, '', False],
+        [('storage', '0.01'), {}, '', False],
+        [('memory', '2'), {'hardware': {'memory': '4096'}}, '', False],
+        [('vm', '1'), {'catalog': {'num_vms': '4'}}, '###', False],
     ],
-    indirect=['set_roottenant_quota', 'custom_prov_data'],
+    indirect=['set_roottenant_quota', 'custom_prov_data', 'set_default'],
     ids=['max_cpu', 'max_storage', 'max_memory', 'max_vms']
 )
 def test_tenant_quota_enforce_via_service_infra(request, appliance, context, set_roottenant_quota,
-                                                extra_msg, custom_prov_data, catalog_item):
+                                                extra_msg, set_default, custom_prov_data,
+                                                catalog_item):
     """Tests quota enforcement via service infra
 
     Polarion:
@@ -196,19 +221,15 @@ def test_tenant_quota_enforce_via_service_infra(request, appliance, context, set
     request_description = 'Provisioning Service [{0}] from [{0}]'.format(catalog_item.name)
     provision_request = appliance.collections.requests.instantiate(request_description)
     provision_request.wait_for_request(method='ui')
+    request.addfinalizer(provision_request.remove_request)
     assert provision_request.row.reason.text == "Quota Exceeded"
 
-    @request.addfinalizer
-    def delete():
-        provision_request.remove_request()
-        catalog_item.delete()
 
-
+@pytest.mark.rhv2
 # first arg of parametrize is the list of fixtures or parameters,
 # second arg is a list of lists, with each one a test is to be generated
 # sequence is important here
 # indirect is the list where we define which fixtures are to be passed values indirectly.
-@pytest.mark.rhv2
 @pytest.mark.parametrize(
     ['set_roottenant_quota', 'custom_prov_data'],
     [
@@ -316,3 +337,59 @@ def test_vm_migration_after_assigning_tenant_quota(appliance, small_vm, set_root
     migrate_request.wait_for_request(method='ui')
     msg = "Request failed with the message {}".format(migrate_request.row.last_message.text)
     assert migrate_request.is_succeeded(method='ui'), msg
+
+
+# Args of parametrize is the list of navigation parameters to order catalog item.
+# first arg of parametrize is the list of fixtures or parameters,
+# second arg is a list of lists, with each one a test is to be generated
+# sequence is important here
+# indirect is the list where we define which fixtures are to be passed values indirectly.
+@pytest.mark.parametrize('context', [ViaSSUI, ViaUI])
+@pytest.mark.parametrize(
+    ['set_roottenant_quota', 'custom_prov_data', 'extra_msg', 'set_default'],
+    [
+        [('cpu', '2'), {'hardware': {'num_sockets': '8'}}, '', True],
+        [('storage', '0.01'), {}, '', True],
+        [('memory', '2'), {'hardware': {'memory': '4096'}}, '', True],
+        [('vm', '1'), {'catalog': {'num_vms': '4'}}, '###', True],
+    ],
+    indirect=['set_roottenant_quota', 'custom_prov_data', 'set_default'],
+    ids=['max_cpu', 'max_storage', 'max_memory', 'max_vms']
+)
+def test_service_infra_tenant_quota_with_default_entry_point(request, appliance, context,
+                                                             set_roottenant_quota, extra_msg,
+                                                             set_default, custom_prov_data,
+                                                             catalog_item):
+    """Test Tenant Quota in UI and SSUI by selecting field entry points.
+       Quota has to be checked if it is working with field entry points also.
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: Infra
+        caseimportance: medium
+        initialEstimate: 1/12h
+        tags: quota
+        testSteps:
+            1. Add infrastructure provider
+            2. Set quota for root tenant - 'My Company'
+            3. Navigate to services > catalogs
+            4. Create catalog item with selecting following field entry points:
+                a.provisioning_entry_point = /ManageIQ (Locked)/Infrastructure/VM/Provisioning
+                /StateMachines/ProvisionRequestApproval/Default
+                b.retirement_entry_point = /Service/Retirement/StateMachines/ServiceRetirement
+                /Default
+            5. Add other information required in catalog for provisioning VM
+            6. Order the catalog item via UI and SSUI individually
+    """
+    with appliance.context.use(context):
+        service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
+        if context is ViaSSUI:
+            service_catalogs.add_to_shopping_cart()
+        service_catalogs.order()
+    # nav to requests page to check quota validation
+    request_description = 'Provisioning Service [{name}] from [{name}]'.format(
+        name=catalog_item.name)
+    provision_request = appliance.collections.requests.instantiate(request_description)
+    provision_request.wait_for_request(method='ui')
+    request.addfinalizer(provision_request.remove_request)
+    assert provision_request.row.reason.text == "Quota Exceeded"

--- a/cfme/tests/infrastructure/test_tenant_quota.py
+++ b/cfme/tests/infrastructure/test_tenant_quota.py
@@ -114,7 +114,8 @@ def catalog_item(appliance, provider, dialog, catalog, prov_data, set_default):
         provider=provider,
         provisioning_entry_point=set_default)
     yield catalog_item
-    catalog_item.delete()
+    if catalog_item.exists:
+        catalog_item.delete()
 
 
 @pytest.fixture(scope='module')

--- a/cfme/tests/infrastructure/test_tenant_quota.py
+++ b/cfme/tests/infrastructure/test_tenant_quota.py
@@ -370,7 +370,7 @@ def test_service_infra_tenant_quota_with_default_entry_point(request, appliance,
         caseimportance: medium
         initialEstimate: 1/12h
         tags: quota
-        testSteps:
+        setup:
             1. Add infrastructure provider
             2. Set quota for root tenant - 'My Company'
             3. Navigate to services > catalogs
@@ -380,7 +380,11 @@ def test_service_infra_tenant_quota_with_default_entry_point(request, appliance,
                 b.retirement_entry_point = /Service/Retirement/StateMachines/ServiceRetirement
                 /Default
             5. Add other information required in catalog for provisioning VM
-            6. Order the catalog item via UI and SSUI individually
+        testSteps:
+            1. Order the catalog item via UI and SSUI individually
+        expectedResults:
+            1. Request of vm provisioning via service catalog should be denied with reason:
+               "Quota Exceeded"
     """
     with appliance.context.use(context):
         service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)


### PR DESCRIPTION
- To test Tenant Quota in UI and SSUI by selecting field entry points.
- Quota has to be checked if it is working with field entry points also.

{{ pytest: cfme/tests/infrastructure/test_tenant_quota.py -k 'test_service_infra_tenant_quota_with_default_entry_point' --use-provider=rhv42 -v }}

Note:
This test is depend on PR #7903 