### PR TITLE
[1LP][WIPTEST] Add test for validation of Nuage Cloud Tenant inventory

### DIFF
--- a/cfme/networks/__init__.py
+++ b/cfme/networks/__init__.py
@@ -1,0 +1,29 @@
+from cfme.utils.appliance.implementations.ui import navigate_to
+
+
+class ValidateStatsMixin(object):
+    # TODO: Move this class to a higher level, where could be useful for thing beyond this
+    # network module, maybe BaseEntity
+
+    def ui_details_value(self, path, property_name):
+        view = navigate_to(self, "Details", use_resetter=False)
+        return getattr(view.entities, path).get_text_of(property_name)
+
+    def validate_stats(self, expected_stats):
+        """ Validates that the details page matches the expected stats.
+
+        Args:
+            expected_stats: dictionary of values to be compered to UI values
+
+        This method is given expected stats as an argument and those are then matched
+        against the UI. An AssertionError exception will be raised if the stats retrieved
+        from the UI do not match those from expected stats.
+
+        IMPORTANT: Please make sure inherited classes implements `ui_details_value` which fetches
+        the value of a stat
+        """
+
+        cfme_stats = {
+            (path, stat): self.ui_details_value(path, stat) for path, stat in expected_stats
+        }
+        assert cfme_stats == expected_stats

--- a/cfme/networks/provider/__init__.py
+++ b/cfme/networks/provider/__init__.py
@@ -2,6 +2,7 @@ import attr
 from cached_property import cached_property
 from navmazing import NavigateToSibling, NavigateToAttribute
 
+from cfme.cloud.tenant import ProviderTenantAllView
 from cfme.common import Taggable
 from cfme.common.provider import BaseProvider, prepare_endpoints
 from cfme.exceptions import DestinationNotFound
@@ -364,6 +365,20 @@ class Edit(CFMENavigateStep):
     def step(self):
         self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True).check()
         self.prerequisite_view.toolbar.configuration.item_select('Edit Selected Network Provider')
+
+
+@navigator.register(NetworkProvider, 'CloudTenants')
+class OpenCloudTenants(CFMENavigateStep):
+    prerequisite = NavigateToSibling('Details')
+    VIEW = ProviderTenantAllView
+
+    def step(self):
+        item = 'Cloud Tenants'
+        item_amt = int(self.prerequisite_view.entities.relationships.get_text_of(item))
+        if item_amt > 0:
+            self.prerequisite_view.entities.relationships.click_at(item)
+        else:
+            raise DestinationNotFound("This provider doesn't have {item}".format(item=item))
 
 
 @navigator.register(NetworkProvider, 'CloudSubnets')

--- a/cfme/networks/provider/nuage.py
+++ b/cfme/networks/provider/nuage.py
@@ -1,7 +1,10 @@
 import attr
 import copy
+
 from widgetastic.widget import View
 from widgetastic_patternfly import BootstrapSelect, Input, Button
+
+from cfme.cloud.tenant import TenantCollection
 from wrapanapi.systems import NuageSystem
 
 from cfme.common.provider import DefaultEndpoint, DefaultEndpointForm, EventsEndpoint
@@ -68,6 +71,7 @@ class NuageProvider(NetworkProvider):
 
     _collections = {
         'security_groups': SecurityGroupCollection,
+        'cloud_tenants': TenantCollection
     }
 
     key = attr.ib(default=None)

--- a/cfme/tests/networks/nuage/test_inventory.py
+++ b/cfme/tests/networks/nuage/test_inventory.py
@@ -1,0 +1,20 @@
+import pytest
+
+from cfme.networks.provider.nuage import NuageProvider
+
+pytestmark = [
+    pytest.mark.provider([NuageProvider], scope='module')
+]
+
+
+def test_tenant_details(setup_provider_modscope, provider, with_nuage_sandbox_modscope):
+    sandbox = with_nuage_sandbox_modscope
+    tenant_name = sandbox['enterprise'].name
+    tenant = provider.collections.cloud_tenants.instantiate(name=tenant_name, provider=provider)
+
+    tenant.validate_stats({
+        ('relationships', 'Cloud Subnets'): '2',
+        ('relationships', 'Network Routers'): '1',
+        ('relationships', 'Security Groups'): '2',
+        ('relationships', 'Network Ports'): '4'
+    })


### PR DESCRIPTION
This test creates sandbox with Nuage cloud tenant and its entities. We then navigate to Cloud tenant (which we created in previous step) through provider, where we compare UI stats with sandbox stats.
We also extended fixture for nuage sandbox and made it 'module' scoped which will help us with the future inventory tests.

\cc @miha-plesko 