### PR TITLE
[1LP][RFR] fixed PlaybookDetailsView

### DIFF
--- a/cfme/ansible/playbooks.py
+++ b/cfme/ansible/playbooks.py
@@ -52,7 +52,7 @@ class PlaybookDetailsView(PlaybookBaseView):
     @property
     def is_displayed(self):
         return (
-            self.in_ansible_repositories and
+            self.in_ansible_playbooks and
             self.title.text == "{} (Summary)".format(self.context["object"].name)
         )
 

--- a/cfme/tests/ansible/test_embedded_ansible_tags.py
+++ b/cfme/tests/ansible/test_embedded_ansible_tags.py
@@ -126,6 +126,7 @@ def test_tagvis_ansible_credential(credential, check_item_visibility, visibility
     check_item_visibility(credential, visibility)
 
 
+@pytest.mark.meta(blockers=[BZ(1648658, forced_streams=["5.9"])])
 @pytest.mark.parametrize('visibility', [True, False], ids=['visible', 'notVisible'])
 def test_tagvis_playbook(playbook, check_item_visibility, visibility):
     """ Test for cloud items tagging action from list and details pages """


### PR DESCRIPTION
{{ pytest: -v cfme/tests/ansible/test_embedded_ansible_tags.py::test_tagvis_playbook }}

This PR fixes
```
test_tagvis_playbook[visible]
test_tagvis_playbook[notVisible]
```
Fixed the error
`AttributeError: 'PlaybookDetailsView' object has no attribute 'in_ansible_repositories'` 