### PR TITLE
[1LP][RFR] Custom button Icon and Request required test

### DIFF
--- a/cfme/automate/buttons.py
+++ b/cfme/automate/buttons.py
@@ -498,12 +498,17 @@ class ButtonGroupDetailView(AutomateCustomizationView):
     @property
     def is_displayed(self):
         return (
-            self.in_customization and
-            self.title.text == 'Button Group "{}"'.format(self.context['object'].text) and
-            self.buttons.is_opened and
-            not self.buttons.is_dimmed and
-            self.buttons.tree.currently_selected == [
-                'Object Types', self.context['object'].type, self.context['object'].text])
+            self.in_customization
+            and self.title.text
+            in [
+                'Button Group "{}"'.format(self.context["object"].text),
+                '{} Button Group "Unassigned Buttons"'.format(self.context["object"].type),
+            ]
+            and self.buttons.is_opened
+            and not self.buttons.is_dimmed
+            and self.buttons.tree.currently_selected
+            == ["Object Types", self.context["object"].type, self.context["object"].text]
+        )
 
 
 class ButtonGroupFormCommon(AutomateCustomizationView):

--- a/cfme/automate/buttons.py
+++ b/cfme/automate/buttons.py
@@ -497,13 +497,16 @@ class ButtonGroupDetailView(AutomateCustomizationView):
 
     @property
     def is_displayed(self):
+        # Unassigned Buttons is default group for each custom button object
+        expected_title = (
+            '{} Button Group "Unassigned Buttons"'.format(self.context["object"].type)
+            if self.context["object"].text == "[Unassigned Buttons]"
+            else 'Button Group "{}"'.format(self.context["object"].text)
+        )
+
         return (
             self.in_customization
-            and self.title.text
-            in [
-                'Button Group "{}"'.format(self.context["object"].text),
-                '{} Button Group "Unassigned Buttons"'.format(self.context["object"].type),
-            ]
+            and self.title.text == expected_title
             and self.buttons.is_opened
             and not self.buttons.is_dimmed
             and self.buttons.tree.currently_selected

--- a/cfme/tests/automate/custom_button/test_buttons.py
+++ b/cfme/tests/automate/custom_button/test_buttons.py
@@ -197,3 +197,46 @@ def test_button_avp_displayed(appliance, dialog, request):
         assert view.advanced.attribute(n).key.is_displayed
         assert view.advanced.attribute(n).value.is_displayed
     view.cancel_button.click()
+
+
+@pytest.mark.tier(3)
+@pytest.mark.parametrize("field", ["icon", "request"])
+def test_button_required(appliance, field):
+    """Test Icon and Request are required field while adding custom button.
+
+    Prerequisities:
+        * Button Group
+
+    Steps:
+        * Try to add custom button without icon/request
+        * Assert flash message.
+    """
+    unassigned_gp = appliance.collections.button_groups.instantiate(
+        text="[Unassigned Buttons]", hover="Unassigned Buttons", type="Provider"
+    )
+    button_coll = appliance.collections.buttons
+    button_coll.group = unassigned_gp  # Need for supporting navigation
+
+    view = navigate_to(button_coll, "Add")
+    view.fill(
+        {
+            "options": {
+                "text": fauxfactory.gen_alphanumeric(),
+                "hover": fauxfactory.gen_alphanumeric(),
+                "open_url": True,
+            },
+            "advanced": {"system": "Request", "request": "InspectMe"},
+        }
+    )
+
+    if field == "icon":
+        msg = "Button Icon must be selected"
+    elif field == "request":
+        view.fill({"options": {"image": "fa-user"}, "advanced": {"request": ""}})
+        msg = "Request is required"
+
+    view.title.click()  # Workaround automation unable to read upside flash message
+
+    view.add_button.click()
+    view.flash.assert_message(msg)
+    view.cancel_button.click()


### PR DESCRIPTION
Purpose or Intent
=================
- Every custom button object have `Unassigned Buttons` Group. The view is common like other group except title.
- Added new non fuctional test for required filed checks like icon and request. 

{{pytest: cfme/tests/automate/custom_button/test_buttons.py::test_button_required -v}}