### PR TITLE
[WIPTEST] fixed InstanceProviderAllView

### DIFF
--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -104,7 +104,7 @@ class InstanceProviderAllView(CloudInstanceView):
         return (
             self.in_cloud_instance and
             self.entities.title.text == 'Instances under Provider "{}"'
-                               .format(self.context['object'].provider.name) and
+                               .format(self.context['object'].filters.get('provider').name) and
             self.sidebar.instances_by_provider.is_opened)
 
     toolbar = View.nested(VMToolbar)


### PR DESCRIPTION
{{ pytest: -v cfme/tests/cloud_infra_common/test_tag_objects.py::test_tag_cloud_objects }}

This PR fixes at least these two tests:
```
test_tag_cloud_objects[cloud_instances-cloud-details]
test_tag_cloud_objects[cloud_instances-cloud-list]
```
The error `AttributeError: 'InstanceCollection' object has no attribute 'provider'` is seen 16 times in 5.10 run, so I think other tests will be fixed by this PR.