### PR TITLE
[WIPTEST] fixed ImageProviderAllView

### DIFF
--- a/cfme/cloud/instance/image.py
+++ b/cfme/cloud/instance/image.py
@@ -66,12 +66,16 @@ class ImageProviderAllView(CloudInstanceView):
 
     @property
     def is_displayed(self):
-        expected_title = 'Images under Provider "{}"'.format(self.context['object'].provider.name)
+        try:
+            provider = self.context['object'].provider.name
+        except AttributeError:
+            provider = self.context['object'].filters['provider'].name
+        expected_title = 'Images under Provider "{}"'.format(provider)
         accordion = self.sidebar.images_by_provider
         return (
             self.in_cloud_instance and
             accordion.is_opened and
-            accordion.tree.selected_item.text == self.context['object'].provider.name and
+            accordion.tree.selected_item.text == provider and
             self.entities.title.text == expected_title)
 
 

--- a/cfme/tests/cloud_infra_common/test_tag_objects.py
+++ b/cfme/tests/cloud_infra_common/test_tag_objects.py
@@ -7,6 +7,7 @@ from cfme.cloud.provider import CloudProvider
 from cfme.infrastructure.provider import InfraProvider
 from cfme.markers.env_markers.provider import ONE_PER_CATEGORY
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import BZ
 
 pytestmark = [
     pytest.mark.tier(2),
@@ -99,6 +100,7 @@ def tagging_check(tag, request):
     return _tagging_check
 
 
+@pytest.mark.meta(blockers=[BZ(1648658, forced_streams=["5.9"])])
 @pytest.mark.provider([CloudProvider], selector=ONE_PER_CATEGORY)
 @pytest.mark.parametrize('tag_place', [True, False], ids=['details', 'list'])
 def test_tag_cloud_objects(tagging_check, cloud_test_item, tag_place):


### PR DESCRIPTION
{{ pytest: -v cfme/tests/cloud_infra_common/test_tag_objects.py::test_tag_cloud_objects }}

This PR fixes
```
test_tag_cloud_objects[cloud_images-cloud-list] 
test_tag_cloud_objects[cloud_images-cloud-details]
```
Fixed `AttributeError: 'ImageCollection' object has no attribute 'provider'` 