### PR TITLE
[1LP][RFR] Custom Button: Open url non functional test

### DIFF
--- a/cfme/tests/automate/custom_button/test_buttons.py
+++ b/cfme/tests/automate/custom_button/test_buttons.py
@@ -240,3 +240,41 @@ def test_button_required(appliance, field):
     view.add_button.click()
     view.flash.assert_message(msg)
     view.cancel_button.click()
+
+
+@pytest.mark.tier(3)
+def test_open_url_availability(appliance):
+    """Test open URL option should only available for Single display.
+
+    Prerequisities:
+        * Button Group
+
+    Steps:
+        * Create a Button with other than Single display options
+        * Assert flash message.
+    """
+
+    unassigned_gp = appliance.collections.button_groups.instantiate(
+        text="[Unassigned Buttons]", hover="Unassigned buttons", type="Provider"
+    )
+    button_coll = appliance.collections.buttons
+    button_coll.group = unassigned_gp  # Need for supporting navigation
+
+    view = navigate_to(button_coll, "Add")
+    view.fill(
+        {
+            "options": {
+                "text": "test_open_url",
+                "hover": "Open Url Test",
+                "image": "fa-user",
+                "open_url": True,
+            },
+            "advanced": {"system": "Request", "request": "InspectMe"},
+        }
+    )
+
+    for display in ["List", "Single and list"]:
+        view.options.display_for.fill(display)
+        view.add_button.click()
+        view.flash.assert_message("URL can be opened only by buttons for a single entity")
+    view.cancel_button.click()


### PR DESCRIPTION
Purpose or Intent
=================
- OpenUrl facility now only available for `Single` display for option
- It was  bug now fixed by restricting it for `List` or `single and list`

{{pytest: cfme/tests/automate/custom_button/test_buttons.py::test_open_url_availability -v}}

Note: Need https://github.com/ManageIQ/integration_tests/pull/8118 for Unassigned Group functionality 