### PR TITLE
[RFR] Fixed is_displayed in HostTemplatesOnlyAllView for 5.10z

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -255,10 +255,10 @@ class HostTemplatesOnlyAllView(TemplatesOnlyAllView):
 
     @property
     def is_displayed(self):
-        if self.browser.product_version < "5.9":
-            title = "{} (All Templates)".format(self.context["object"].name)
-        else:
+        if self.browser.product_version < "5.10":
             title = "{} (All VM Templates)".format(self.context["object"].name)
+        else:
+            title = "{} (All VM Templates and Images)".format(self.context["object"].name)
         return (
             self.logged_in_as_current_user and
             self.navigation.currently_selected == ['Compute', 'Infrastructure', 'Hosts'] and


### PR DESCRIPTION
Fixed following Error:
```
E       assert False
E        +  where False = <cfme.infrastructure.virtual_machines.HostTemplatesOnlyAllView object at 0x7f2e613bcad0>.is_displayed

cfme/tests/cloud_infra_common/test_relationships.py:158: AssertionError
AssertionError
assert False
 +  where False = <cfme.infrastructure.virtual_machines.HostTemplatesOnlyAllView object at 0x7f2e613bcad0>.is_displayed
```


{{ pytest: cfme/tests/cloud_infra_common/test_relationships.py::test_host_relationships[virtualcenter-Templates] -v }}