### PR TITLE
[1LP][RFR] Fixing Condition CRUD test 

### DIFF
--- a/widgetastic_manageiq/expression_editor.py
+++ b/widgetastic_manageiq/expression_editor.py
@@ -3,6 +3,7 @@
 
 """
 import re
+import time
 from functools import partial
 
 import six
@@ -12,6 +13,7 @@ from widgetastic.widget import View
 from widgetastic_patternfly import BootstrapSelect as VanillaBootstrapSelect
 from widgetastic_patternfly import Button, Input
 
+from cfme.utils.blockers import BZ
 from cfme.utils.pretty import Pretty
 from cfme.utils.wait import TimedOutError, wait_for
 from widgetastic_manageiq import Calendar, Checkbox
@@ -31,6 +33,11 @@ class BootstrapSelect(VanillaBootstrapSelect):
         # should wait until it appears and only then we can fill it.
         self.logger.info("FILLING WIDGET %s", str(self))
         self.wait_displayed()
+        # BZ 1649057 documents that a loading screen appears twice when a scope or expression
+        # element is selected. Between loads, the page is displayed and we make a selection, which
+        # is then overwritten in the next load. This work-around will wait for both loads.
+        if BZ(1649057, forced_streams=["5.9", "5.10"]).blocks:
+            time.sleep(1)
         super(BootstrapSelect, self).fill(value)
 
 


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ the condition CRUD test. This requires: 
__1)__ Updating the `condition_collection.create()` method to use `view.wait_displayed()` and update `ExpressionEditor` to use `show_loc` to select the proper buttons. 
__2)__ Putting in a workaround for [BZ 1649057](https://bugzilla.redhat.com/show_bug.cgi?id=1649057) in `BootstrapSelect` for the expression_editor
__3)__ Fixing `EditConditionView` `is_displayed()` method
__4)__ Adding a view for all the conditions in a condition class, since the appliance redirects the user to this page when a condition is deleted. 

FIXES #8103

{{ pytest: --long-running cfme/tests/control/test_basic.py::test_condition_crud }}

