### PR TITLE
[1LP][RFR] fixed OneProviderBalancerView

### DIFF
--- a/cfme/networks/views.py
+++ b/cfme/networks/views.py
@@ -675,7 +675,7 @@ class OneProviderBalancerView(BaseLoggedInPage):
 
     @property
     def is_displayed(self):
-        title = '{name} (All Balancers)'.format(name=self.context['object'].name)
+        title = '{name} (All Load Balancers)'.format(name=self.context['object'].name)
         return (super(BaseLoggedInPage, self).is_displayed and
                 self.navigation.currently_selected == ['Networks', 'Providers'] and
                 self.entities.title.text == title)

--- a/cfme/tests/networks/test_sdn_balancers.py
+++ b/cfme/tests/networks/test_sdn_balancers.py
@@ -6,6 +6,7 @@ from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.exceptions import DestinationNotFound
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import BZ
 
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
@@ -56,6 +57,7 @@ def test_sdn_balancers_detail(provider, network_prov_with_load_balancers):
 
 
 # only one provider is needed for that test, used Azure as it has balancers
+@pytest.mark.meta(blockers=[BZ(1648658, forced_streams=["5.9"])])
 @pytest.mark.provider([AzureProvider], scope='module', override=True)
 @pytest.mark.parametrize('visibility', [True, False], ids=['visible', 'notVisible'])
 def test_sdn_balancers_tagvis(check_item_visibility, visibility, network_prov_with_load_balancers):


### PR DESCRIPTION
{{ pytest: -v cfme/tests/networks/test_sdn_balancers.py::test_sdn_balancers_tagvis --use-provider azure }}

For 5.9.6 title is also with `(All Load Balancers)`

juwatts: adding azure provider to pytest statement, tests were uncollected on azure_msdn. 