### PR TITLE
[1LP][RFR] whitelist test_v2v in xunit_tools

### DIFF
--- a/cfme/fixtures/xunit_tools.py
+++ b/cfme/fixtures/xunit_tools.py
@@ -15,6 +15,7 @@ from cfme.utils.pytest_shortcuts import extract_fixtures_values
 whitelist = [
     r'cfme/tests/infrastructure/test_quota_tagging.py::test_.*\[.*rhe?v',
     r'test_tenant_quota.py',
+    r'cfme/tests/v2v/.*',
 ]
 compiled_whitelist = re.compile('(' + ')|('.join(whitelist) + ')')
 

--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -318,7 +318,7 @@ Werkzeug==0.14.1
 widgetastic.core==0.30.3
 widgetastic.patternfly==0.0.39
 widgetsnbextension==3.4.2
-wrapanapi==3.0.31
+wrapanapi==3.0.32
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -305,7 +305,7 @@ Werkzeug==0.14.1
 widgetastic.core==0.30.3
 widgetastic.patternfly==0.0.39
 widgetsnbextension==3.4.2
-wrapanapi==3.0.31
+wrapanapi==3.0.32
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0

--- a/requirements/frozen_docs.py2.txt
+++ b/requirements/frozen_docs.py2.txt
@@ -172,7 +172,7 @@ Werkzeug==0.14.1
 widgetastic.core==0.30.3
 widgetastic.patternfly==0.0.39
 widgetsnbextension==3.4.2
-wrapanapi==3.0.31
+wrapanapi==3.0.32
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -163,7 +163,7 @@ Werkzeug==0.14.1
 widgetastic.core==0.30.3
 widgetastic.patternfly==0.0.39
 widgetsnbextension==3.4.2
-wrapanapi==3.0.31
+wrapanapi==3.0.32
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0


### PR DESCRIPTION
This is effectively temporary, as #7690 will replace this use.