### PR TITLE
[1LP][RFR] Fix ClassAddView.is_displayed

### DIFF
--- a/cfme/automate/explorer/instance.py
+++ b/cfme/automate/explorer/instance.py
@@ -94,7 +94,6 @@ class InstanceAddView(AutomateExplorerView):
     def is_displayed(self):
         return (
             self.in_explorer and
-            self.title.text == 'Datastore' and
             self.datastore.is_opened and
             self.title.text == 'Adding a new Automate Instance')
 

--- a/cfme/automate/explorer/klass.py
+++ b/cfme/automate/explorer/klass.py
@@ -101,9 +101,15 @@ class ClassEditView(ClassForm):
 
     @property
     def is_displayed(self):
+        expected_title = VersionPicker(
+            {
+                LOWEST: 'Editing Class "{}"',
+                '5.10': 'Editing Automate Class "{}"'
+            }
+        ).pick(self.browser.product_version)
         return (
             self.in_explorer and
-            self.title.text == 'Editing Class "{}"'.format(self.context['object'].name))
+            self.title.text == expected_title.format(self.context['object'].name))
 
 
 class Class(BaseEntity, Copiable):

--- a/cfme/automate/explorer/klass.py
+++ b/cfme/automate/explorer/klass.py
@@ -353,7 +353,7 @@ class Copy(CFMENavigateStep):
 # schema
 class ClassSchemaEditView(ClassDetailsView):
     class schema(WaitTab):  # noqa
-        schema_title = Text('//div[@id="form_div"]/h3')
+        schema_title = Text('//div[@class="form_div"]/h3')
 
         @ParametrizedView.nested
         class fields(ParametrizedView):  # noqa

--- a/cfme/automate/explorer/klass.py
+++ b/cfme/automate/explorer/klass.py
@@ -16,7 +16,7 @@ from cfme.utils.appliance import Navigatable
 from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
 from cfme.utils.blockers import BZ
-from cfme.utils.version import Version, VersionPicker
+from cfme.utils.version import Version, VersionPicker, LOWEST
 
 from . import AutomateExplorerView, check_tree_path
 from .common import Copiable, CopyViewBase
@@ -83,11 +83,17 @@ class ClassAddView(ClassForm):
 
     @property
     def is_displayed(self):
+        expected_title = VersionPicker(
+            {
+                LOWEST: 'Adding a new Class',
+                '5.10': 'Adding a new Automate Class'
+            }
+        ).pick(self.browser.product_version)
         return (
             self.in_explorer and
-            self.title.text == 'Datastore' and
             self.datastore.is_opened and
-            self.title.text == 'Adding a new Class')
+            self.title.text == expected_title
+        )
 
 
 class ClassEditView(ClassForm):


### PR DESCRIPTION
This tiny fix should resolve at least one navigation failure in about 20 automate tests using automate classes.

I've included test_instance module as well since a few of those tests were failing from this as well.

I'll be on PTO tomorrow, planning a very small scope for this, PRT may not be totally clean for these modules, but I'm looking for no timeout failures from adding a class, because of the view's is_displayed method.

{{ pytest: cfme/tests/automate/test_class.py cfme/tests/automate/test_instance.py --long-running -vv }}