### PR TITLE
[RFR] changed the provider to azure for test_tag_tagvis.py

### DIFF
--- a/cfme/networks/floating_ips.py
+++ b/cfme/networks/floating_ips.py
@@ -42,13 +42,13 @@ class FloatingIpCollection(BaseCollection):
     ENTITY = FloatingIp
 
     def all(self):
+        floating_ips = []
         view = navigate_to(self, 'All')
-        all_ips = view.entities.get_all(surf_pages=True)
-        list_floating_ip_obj = []
-        for ip in all_ips:
-            # as for 5.9 floating ip doesn't have name att, will get name as address from data
-            list_floating_ip_obj.append(ip.name if ip.name else ip.data['address'])
-        return [self.instantiate(address=name) for name in list_floating_ip_obj]
+        for _ in view.entities.paginator.pages():
+            ips = view.entities.get_all()
+            for ip in ips:
+                floating_ips.append(self.instantiate(address=ip.data['address']))
+        return floating_ips
 
 
 @navigator.register(FloatingIpCollection, 'All')

--- a/cfme/tests/networks/test_tag_tagvis.py
+++ b/cfme/tests/networks/test_tag_tagvis.py
@@ -1,6 +1,6 @@
 import pytest
 
-from cfme.cloud.provider.openstack import OpenStackProvider
+from cfme.cloud.provider.azure import AzureProvider
 from cfme.markers.env_markers.provider import ONE_PER_CATEGORY
 from cfme.networks.views import (CloudNetworkView, SubnetView, NetworkRouterView, SecurityGroupView,
                                  NetworkPortView, BalancerView, FloatingIpView)
@@ -8,7 +8,7 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
-    pytest.mark.provider([OpenStackProvider], selector=ONE_PER_CATEGORY, scope='module')
+    pytest.mark.provider([AzureProvider], selector=ONE_PER_CATEGORY, scope='module')
 ]
 
 network_collections = [


### PR DESCRIPTION
{{ pytest: -v cfme/tests/networks/test_tag_tagvis.py  --use-provider=complete }}

I changed the provider for these tests from OpenStack to Azure because Azure has load balancers and `test_tagvis_network_provider_children[cloud-Load Balancers]` will not be skipped anymore.
