### PR TITLE
[1LP][RFR] Fixed AttributeError in DomainEditView for 5.10z

### DIFF
--- a/cfme/automate/explorer/domain.py
+++ b/cfme/automate/explorer/domain.py
@@ -82,7 +82,7 @@ class DomainEditView(DomainForm):
     def is_displayed(self):
         return (
             self.in_explorer and
-            self.title.text == 'Editing Automate Domain "{}"'.format(self.obj.name))
+            self.title.text == 'Editing Automate Domain "{}"'.format(self.context['object'].name))
 
 
 class Domain(BaseEntity, Fillable):


### PR DESCRIPTION
{{ pytest: cfme/tests/automate/test_domain.py -k 'test_domain_edit_enabled or test_domain_crud' -v }}

Fixed Attribute Error:
```
>           self.title.text == 'Editing Automate Domain "{}"'.format(self.obj.name))
E       AttributeError: 'DomainEditView' object has no attribute 'obj'

cfme/automate/explorer/domain.py:85: AttributeError
AttributeError
'DomainEditView' object has no attribute 'obj'
```
Affected tests:
1. cfme/tests/automate/test_domain.py/test_domain_crud[disabled]
2. cfme/tests/automate/test_domain.py/test_domain_crud[enabled]
3. cfme/tests/automate/test_domain.py/test_domain_edit_enabled