### PR TITLE
[1LP][RFR] fixed finalizer cleanup for test_tagvis_infra_object

### DIFF
--- a/cfme/fixtures/tag.py
+++ b/cfme/fixtures/tag.py
@@ -2,6 +2,7 @@ import fauxfactory
 import pytest
 
 from cfme.base.credential import Credential
+from cfme.infrastructure.host import Host
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
@@ -119,6 +120,10 @@ def check_item_visibility(tag, user_restricted):
                 vis_object.remove_tag(tag=tag)
         with user_restricted:
             try:
+                if isinstance(vis_object, Host):
+                    # need to remove the link to the provider from the host,
+                    # so the navigation goes Compute -> Infrastructure -> Hosts, not Providers
+                    vis_object.parent.filters.update({'provider': None})
                 navigate_to(vis_object, 'Details')
                 actual_visibility = True
             except Exception:

--- a/cfme/tests/cloud_infra_common/test_tag_objects.py
+++ b/cfme/tests/cloud_infra_common/test_tag_objects.py
@@ -147,4 +147,4 @@ def test_tagvis_infra_object(infra_test_item, check_item_visibility, visibility,
         4. Login as restricted user, iten is not visible for user
     """
     check_item_visibility(infra_test_item, visibility)
-    request.addfinalizer(lambda: tag_cleanup(cloud_test_item, tag))
+    request.addfinalizer(lambda: tag_cleanup(infra_test_item, tag))


### PR DESCRIPTION
{{ pytest: -v cfme/tests/cloud_infra_common/test_tag_objects.py::test_tagvis_infra_object }}

1. fixed finalizer cleanup for test_tagvis_infra_object
2. fixed checking visibility for hosts