### PR TITLE
[WIPTEST] Fix CloudIntelReportsView TimedOutError: Add resetter

### DIFF
--- a/cfme/intelligence/reports/__init__.py
+++ b/cfme/intelligence/reports/__init__.py
@@ -67,6 +67,8 @@ class CloudIntelReports(CFMENavigateStep):
     def step(self):
         self.view.navigation.select("Cloud Intel", "Reports")
 
+    def resetter(self):
+        self.view.saved_reports.open()
 
 class ReportsMultiBoxSelect(MultiBoxSelect):
     move_into_button = Button(title=Parameter("@move_into"))


### PR DESCRIPTION
This PR fixes `TimedOutError` with `CloudIntelReportsView`. A `resetter` method has been added to the `CloudIntelReports` to reset the page.

{{pytest: cfme/tests/intelligence/reports/test_menus.py::test_shuffle_top_level --use-template-cache -sqvvvv}}