### PR TITLE
[1LP][RFR] fix teardown of test_instance_attach_volume

### DIFF
--- a/cfme/tests/openstack/cloud/test_instances.py
+++ b/cfme/tests/openstack/cloud/test_instances.py
@@ -252,7 +252,7 @@ def test_instance_operating_system_linux(new_instance):
 
 
 @pytest.mark.regression
-def test_instance_attach_volume(new_instance, volume, appliance):
+def test_instance_attach_volume(volume, new_instance, appliance):
     initial_volume_count = new_instance.volume_count
     new_instance.attach_volume(volume.name)
     view = appliance.browser.create_view(navigator.get_class(new_instance, 'AttachVolume').VIEW)


### PR DESCRIPTION
Purpose or Intent
=================
Changed order of test arguments so instances will be torn down before volume
If volume is deleted first while still attached to instance, deletion will fail

{{ pytest: cfme/tests/openstack/cloud/test_instances.py::test_instance_attach_volume }}