### PR TITLE
[1LP][RFR] Fixes dual NICs MAC comparison failure - 1liner

### DIFF
--- a/cfme/tests/v2v/test_v2v_migrations.py
+++ b/cfme/tests/v2v/test_v2v_migrations.py
@@ -219,7 +219,7 @@ def test_dual_nics_migration(request, appliance, v2v_providers, host_creds, conv
     # validate MAC address matches between source and target VMs
     src_vm = form_data_vm_obj_dual_nics.vm_list.pop()
     migrated_vm = get_migrated_vm_obj(src_vm, v2v_providers.rhv_provider)
-    assert src_vm.mac_address == migrated_vm.mac_address
+    assert set(src_vm.mac_address.split(", ")) == set(migrated_vm.mac_address.split(", "))
 
 
 @pytest.mark.parametrize('form_data_vm_obj_single_datastore', [['nfs', 'nfs', dual_disk_template]],


### PR DESCRIPTION
{{pytest: cfme/tests/v2v/test_v2v_migrations.py --use-provider rhv42 --use-provider vsphere65-nested --provider-limit 2 -k test_dual_nics_migration -vvvv}}

Purpose or Intent
=================
Migration with dual NICs working in 5.10.0.24 and this test compare MAC of both vms on source and target.  As it is reading string from UI tables, sometime MACs become unordered and string just don't match, this will fix that.

For example,
```
E         - 00:50:56:80:20:5d, 00:50:56:80:84:c7
E         + 00:50:56:80:84:c7, 00:50:56:80:20:5d
```

Failure - https://cfmeqe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/kkulkarn-v2v/50/Artifactor_Report/report.html#cfme/tests/v2v/test_v2v_migrations.py/test_dual_nics_migration[virtualcenter-6.5-rhevm-4.2-form_data_vm_obj_dual_nics0]
