### PR TITLE
[1LP][RFR] Test network router details

### DIFF
--- a/cfme/networks/network_router.py
+++ b/cfme/networks/network_router.py
@@ -5,6 +5,7 @@ from widgetastic.exceptions import NoSuchElementException
 from cfme.common import Taggable
 from cfme.exceptions import ItemNotFound, DestinationNotFound
 from cfme.modeling.base import BaseCollection, BaseEntity, parent_of_type
+from cfme.networks import ValidateStatsMixin
 from cfme.networks.subnet import SubnetCollection
 from cfme.networks.views import (NetworkRouterDetailsView, NetworkRouterView, NetworkRouterAddView,
                                  NetworkRouterEditView, NetworkRouterAddInterfaceView,
@@ -15,7 +16,7 @@ from cfme.utils.wait import wait_for
 
 
 @attr.s
-class NetworkRouter(Taggable, BaseEntity):
+class NetworkRouter(Taggable, BaseEntity, ValidateStatsMixin):
     """ Class representing network ports in sdn"""
     in_version = ('5.8', version.LATEST)
     category = 'networks'

--- a/cfme/tests/networks/nuage/test_inventory.py
+++ b/cfme/tests/networks/nuage/test_inventory.py
@@ -67,3 +67,18 @@ def test_l2_subnet_details(setup_provider_modscope, provider, with_nuage_sandbox
         ('relationships', 'Network Ports'): '2',
         ('relationships', 'Security Groups'): '1',
     })
+
+
+def test_network_router_details(setup_provider_modscope, provider, with_nuage_sandbox_modscope):
+    sandbox = with_nuage_sandbox_modscope
+    tenant_name = sandbox['enterprise'].name
+    router_name = sandbox['domain'].name
+    tenant = provider.collections.cloud_tenants.instantiate(name=tenant_name, provider=provider)
+    router = tenant.collections.routers.instantiate(name=router_name)
+
+    router.validate_stats({
+        ('properties', 'Name'): router_name,
+        ('properties', 'Type'): 'ManageIQ/Providers/Nuage/Network Manager/Network Router',
+        ('relationships', 'Cloud Subnets'): '1',
+        ('relationships', 'Security Groups'): '1',
+    })


### PR DESCRIPTION
This test creates sandbox with Nuage cloud tenant and its entities. We then navigate to Cloud tenant's network routers through provider, where we compare UI stats with sandbox stats.

This PR depends on: https://github.com/ManageIQ/integration_tests/pull/8150

Please review 3rd commit as the first and the second one are related to other PRs.

\cc @miha-plesko 