### PR TITLE
[1LP][RFR] Fix StaleElementReferenceException error for test_schedule_crud

### DIFF
--- a/cfme/intelligence/reports/schedules.py
+++ b/cfme/intelligence/reports/schedules.py
@@ -157,6 +157,7 @@ class Schedule(Updateable, Pretty, BaseEntity):
         else:
             view.cancel_button.click()
         view = self.create_view(ScheduleDetailsView, override=updates)
+        view.wait_displayed()
         assert view.is_displayed
         # TODO Doesn't work due https://bugzilla.redhat.com/show_bug.cgi?id=1441101
         # view.flash.assert_no_error()

--- a/cfme/tests/intelligence/reports/test_crud.py
+++ b/cfme/tests/intelligence/reports/test_crud.py
@@ -76,8 +76,7 @@ def test_custom_report_crud(custom_report_values, appliance):
 @pytest.mark.meta(blockers=[1202412])
 @test_requirements.report
 def test_schedule_crud(schedule_data, appliance):
-    schedules = ScheduleCollection(appliance)
-    schedule = schedules.create(**schedule_data)
+    schedule = appliance.collections.schedules.create(**schedule_data)
     with update(schedule):
         schedule.description = "badger badger badger"
     schedule.queue()

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -2439,6 +2439,7 @@ class AlertEmail(View):
                 self.recipients(value).remove()
             for value in values_to_add:
                 self._add_recipient(value)
+                wait_for(lambda: value in self.all_emails, num_sec=10, delay=3)
             return True
 
     def _values_to_remove(self, values):


### PR DESCRIPTION
This PR fixes `test_schedule_crud` by making following changes:
1) `StaleElementReferenceException` error. A condition has been added to `AlertEmail` in `widgetastic_manageiq/__init__.py` file. 
2) `view_wait_displayed` has been added to `update` method of schedules, which fixes assertion error on asserting `view.is_displayed`.
3) Fix `NameError` for `ScheduleCollection` in `test_schedule_crud`.

{{pytest: cfme/tests/intelligence/reports/test_crud.py::test_schedule_crud --use-template-cache -sqvvv}}