### PR TITLE
[1LP][RFR]Fix CloudIntelReportsView TimedOutError and other test failure

### DIFF
--- a/cfme/intelligence/reports/__init__.py
+++ b/cfme/intelligence/reports/__init__.py
@@ -67,6 +67,8 @@ class CloudIntelReports(CFMENavigateStep):
     def step(self):
         self.view.navigation.select("Cloud Intel", "Reports")
 
+    def resetter(self):
+        self.view.saved_reports.open()
 
 class ReportsMultiBoxSelect(MultiBoxSelect):
     move_into_button = Button(title=Parameter("@move_into"))

--- a/cfme/intelligence/reports/menus.py
+++ b/cfme/intelligence/reports/menus.py
@@ -67,7 +67,9 @@ class ReportMenu(BaseEntity):
         """
         view = self.go_to_group(group)
         view.reports_tree.click_path("Top Level")
-        return view.manager.fields
+        fields = view.manager.fields
+        view.discard_button.click()
+        return fields
 
     def get_subfolders(self, group, folder):
         """Returns list of sub-folders for given user group and folder.
@@ -78,7 +80,9 @@ class ReportMenu(BaseEntity):
         """
         view = self.go_to_group(group)
         view.reports_tree.click_path("Top Level", folder)
-        return view.manager.fields
+        fields = view.manager.fields
+        view.discard_button.click()
+        return fields
 
     def add_folder(self, group, folder):
         """Adds a folder under top-level.


### PR DESCRIPTION
This PR fixes TimedOutError with CloudIntelReportsView  and `test_add_reports_to_available_reports_menu` test which failed due to UI change in 5.10
Changes:
1) A resetter method has been added to the CloudIntelReports to reset the page.
2) To fix UI error, `get_folders` and `get_subfolders` methods have been updated.

{{pytest: cfme/tests/intelligence/reports/test_menus.py --use-template-cache -sqvvv}}

Related to #7960 