### PR TITLE
[1LP][RFR] Fix TimeProfileAddView's is_displayed

### DIFF
--- a/cfme/configure/settings.py
+++ b/cfme/configure/settings.py
@@ -44,7 +44,7 @@ class TimeProfileAddView(TimeProfileView):
 
     @property
     def is_displayed(self):
-        return self.entities.title == 'Time Profile Information'
+        return self.entities.title.text == 'Time Profile Information'
 
 
 class TimeProfileEditView(TimeProfileView):


### PR DESCRIPTION
This PR fixes `TimedOutError` error on time_profile test cases.

{{pytest: cfme/tests/configure/test_timeprofile.py -k "test_time_profile_crud or test_time_profile_name_max_character_validation or test_time_profile_copy" --use-template-cache -sqvvv}}