### PR TITLE
[1LP][RFR]Fix ScheduleEditView is_displayed

### DIFF
--- a/cfme/configure/configuration/system_schedules.py
+++ b/cfme/configure/configuration/system_schedules.py
@@ -144,7 +144,7 @@ class ScheduleEditView(ConfigurationView):
         return (
             self.in_configuration and
             self.accordions.settings.tree.currently_selected == expected_tree and
-            self.title.text == 'Edit Schedule "{}"'.format(self.context['object'].name)
+            self.title.text == 'Editing Schedule "{}"'.format(self.context['object'].name)
         )
 
 


### PR DESCRIPTION
This PR fixes `TimedOutError` due to a typo in the `ScheduleEditView`'s is_displayed method.

{{pytest: cfme/tests/configure/test_schedule_operations.py::test_schedule_crud --use-template-cache -sqvvv}}