### PR TITLE
[1LP][RFR] upgrade notebook requirement after cve warning

### DIFF
--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -195,7 +195,7 @@ nbconvert==5.4.0
 nbformat==4.4.0
 netaddr==0.7.19
 netifaces==0.10.7
-notebook==5.7.0
+notebook==5.7.2
 ntlm-auth==1.2.0
 oauth2client==4.1.3
 oauthlib==2.1.0

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -189,7 +189,7 @@ nbconvert==5.4.0
 nbformat==4.4.0
 netaddr==0.7.19
 netifaces==0.10.7
-notebook==5.7.0
+notebook==5.7.2
 ntlm-auth==1.2.0
 oauth2client==4.1.3
 oauthlib==2.1.0

--- a/requirements/frozen_docs.py2.txt
+++ b/requirements/frozen_docs.py2.txt
@@ -84,7 +84,7 @@ nbconvert==5.4.0
 nbformat==4.4.0
 netaddr==0.7.19
 netifaces==0.10.7
-notebook==5.7.0
+notebook==5.7.2
 ntlm-auth==1.2.0
 oauthlib==2.1.0
 os-service-types==1.3.0
@@ -172,7 +172,6 @@ Werkzeug==0.14.1
 widgetastic.core==0.30.3
 widgetastic.patternfly==0.0.39
 widgetsnbextension==3.4.2
-wrapanapi==3.0.32
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -78,7 +78,7 @@ nbconvert==5.4.0
 nbformat==4.4.0
 netaddr==0.7.19
 netifaces==0.10.7
-notebook==5.7.0
+notebook==5.7.2
 ntlm-auth==1.2.0
 oauthlib==2.1.0
 os-service-types==1.3.0
@@ -163,7 +163,6 @@ Werkzeug==0.14.1
 widgetastic.core==0.30.3
 widgetastic.patternfly==0.0.39
 widgetsnbextension==3.4.2
-wrapanapi==3.0.32
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0


### PR DESCRIPTION
note: wrapanapi being removed from the `frozen_doc.*.txt` rectifies a version file management mistake