### PR TITLE
[RFR] removed BZ and fixed fill_tag for test_group_crud_with_tag

### DIFF
--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -76,10 +76,8 @@ def tag_value(appliance, category, tag, request):
         tag_for_create = ([category.display_name, tag.display_name], True)
         tag_for_update = ([category.display_name, tag.display_name], False)
     else:
-        if BZ(1579867, forced_streams=['5.9']).blocks:
-            tag_for_create = 'fill_tag(My Company Tags : Cost Center, Cost Center 001)'
-        else:
-            tag_for_create = 'fill_tag(My Company Tags : {})'.format(category.display_name)
+        tag_for_create = 'fill_tag(My Company Tags : {}, {})'.format(category.display_name,
+                                                                     tag.display_name)
         tag_for_update = 'delete_whole_expression'
     return tag_for_create, tag_for_update
 


### PR DESCRIPTION
{{ pytest: -v cfme/tests/configure/test_access_control.py::test_group_crud_with_tag }}

This PR fixes `test_group_crud_with_tag[tag_expression-virtualcenter]`that didn't work because tag value was not filled

![image](https://user-images.githubusercontent.com/42433123/48895134-ad734680-ee44-11e8-9ece-dd16aaeaa27d.png)
