### PR TITLE
[WIP] Fixed TemplateNotFound and RowNotFound Error

### DIFF
--- a/cfme/tests/infrastructure/test_quota.py
+++ b/cfme/tests/infrastructure/test_quota.py
@@ -40,7 +40,14 @@ def template_name(provider):
     if provider.one_of(RHEVMProvider):
         return provider.data.templates.get('full_template')['name']
     elif provider.one_of(VMwareProvider):
-        return provider.data.templates.get('big_template')['name']
+        if provider.name == "vSphere 6 (nested)":
+            return provider.data.templates.get('rhel74_template')['name']
+        # Tests running with vsphere 6 (nested) does not have Fedora_24WS template. Thus it is not
+        # found in list of provisioning templates. Which results in Error - 'TemplateNotFound'.
+        # So Automation doesn't able to select template from provisioning template list.
+        # Hence used rhel74_template - 'env-rhel74-tpl'.
+        else:
+            return provider.data.templates.get('big_template')['name']
 
 
 @pytest.fixture

--- a/cfme/tests/infrastructure/test_quota_tagging.py
+++ b/cfme/tests/infrastructure/test_quota_tagging.py
@@ -42,7 +42,14 @@ def template_name(provider):
     if provider.one_of(RHEVMProvider):
         return provider.data.templates.get('full_template')['name']
     elif provider.one_of(VMwareProvider):
-        return provider.data.templates.get('big_template')['name']
+        if provider.name == "vSphere 6 (nested)":
+            return provider.data.templates.get('rhel74_template')['name']
+        # Tests running with vsphere 6 (nested) does not have Fedora_24WS template. Thus it is not
+        # found in list of provisioning templates. Which results in Error - 'TemplateNotFound'.
+        # So Automation does not able to select template from provisioning template list.
+        # Hence used rhel74_template - 'env-rhel74-tpl'.
+        else:
+            return provider.data.templates.get('big_template')['name']
 
 
 @pytest.fixture


### PR DESCRIPTION
- This PR fixes **TemplateNotFound** and **RowNotFound** Error of ```vsphere 6 (netsed)``` type of provider. 
- All the other types of virtual-center providers (vsphere65-nested, vsphere67-netsed etc.) have ```Fedora_24WS``` except **vsphere 6 (nested)**.
- So if tests are running for **vsphere 6 (nested)** then ```Fedora_24WS``` template is not found in list of provisioning templates. Because of this, automation does not able to select template. 
- Hence used **rhel74_template** for **vsphere 6 (nested)** which is **env-rhel74-tpl**  and it is available in the list of provisioning templates.
- Fixed Error:
```
>                                  .format(template_name, provider_name))
E           TemplateNotFound: Cannot find template "Fedora_24WS" for provider "vSphere 6 (nested)"

cfme/common/vm_views.py:341: TemplateNotFound
TemplateNotFound
Cannot find template "Fedora_24WS" for provider "vSphere 6 (nested)"
==============================================================================
>               'Row not found when using filters {!r}/{!r}'.format(extra_filters, filters))
E           RowNotFound: Row not found when using filters ()/{'name': 'Fedora_24WS'}

../cfme_venv/lib/python2.7/site-packages/widgetastic/widget/table.py:469: RowNotFound
RowNotFound
Row not found when using filters ()/{'name': 'Fedora_24WS'}
```
- Affected Tests:
```
 <Function 'test_quota_tagging_infra_via_lifecycle[group-virtualcenter-max_memory]'>
  <Function 'test_quota_tagging_infra_via_services[group-virtualcenter-max_memory-ViaSSUI]'>
  <Function 'test_quota_infra[group-virtualcenter-max_memory-ViaSSUI]'>
  <Function 'test_quota_tagging_infra_via_lifecycle[group-virtualcenter-max_storage]'>
  <Function 'test_quota_tagging_infra_via_services[group-virtualcenter-max_memory-ViaUI]'>
  <Function 'test_quota_infra[group-virtualcenter-max_memory-ViaUI]'>
  <Function 'test_quota_tagging_infra_via_lifecycle[group-virtualcenter-max_cpu]'>
  <Function 'test_quota_tagging_infra_via_services[group-virtualcenter-max_storage-ViaSSUI]'>
  <Function 'test_quota_infra[group-virtualcenter-max_storage-ViaSSUI]'>
  <Function 'test_quota_tagging_infra_via_services[group-virtualcenter-max_storage-ViaUI]'>
  <Function 'test_quota_infra[group-virtualcenter-max_storage-ViaUI]'>
  <Function 'test_quota_tagging_infra_via_lifecycle[user-virtualcenter-max_memory]'>
  <Function 'test_quota_tagging_infra_via_lifecycle[user-virtualcenter-max_storage]'>
  <Function 'test_quota_tagging_infra_via_services[group-virtualcenter-max_cpu-ViaSSUI]'>
  <Function 'test_quota_infra[group-virtualcenter-max_vm-ViaSSUI]'>
  <Function 'test_quota_tagging_infra_via_lifecycle[user-virtualcenter-max_cpu]'>
  <Function 'test_quota_tagging_infra_via_services[group-virtualcenter-max_cpu-ViaUI]'>
  <Function 'test_quota_infra[group-virtualcenter-max_vm-ViaUI]'>
  <Function 'test_quota_tagging_infra_via_services[user-virtualcenter-max_memory-ViaSSUI]'>
  <Function 'test_quota_infra[group-virtualcenter-max_cpu-ViaSSUI]'>
  <Function 'test_quota_tagging_infra_via_services[user-virtualcenter-max_memory-ViaUI]'>
  <Function 'test_quota_infra[group-virtualcenter-max_cpu-ViaUI]'>
  <Function 'test_quota_tagging_infra_via_services[user-virtualcenter-max_storage-ViaSSUI]'>
  <Function 'test_quota_infra[user-virtualcenter-max_memory-ViaSSUI]'>
  <Function 'test_quota_tagging_infra_via_services[user-virtualcenter-max_storage-ViaUI]'>
  <Function 'test_quota_infra[user-virtualcenter-max_memory-ViaUI]'>
  <Function 'test_quota_tagging_infra_via_services[user-virtualcenter-max_cpu-ViaSSUI]'>
  <Function 'test_quota_infra[user-virtualcenter-max_storage-ViaSSUI]'>
  <Function 'test_quota_tagging_infra_via_services[user-virtualcenter-max_cpu-ViaUI]'>
  <Function 'test_quota_infra[user-virtualcenter-max_storage-ViaUI]'>
  <Function 'test_quota_infra[user-virtualcenter-max_vm-ViaSSUI]'>
  <Function 'test_quota_infra[user-virtualcenter-max_vm-ViaUI]'>
  <Function 'test_quota_infra[user-virtualcenter-max_cpu-ViaSSUI]'>
  <Function 'test_quota_infra[user-virtualcenter-max_cpu-ViaUI]'>
  <Function 'test_quota[group-virtualcenter-max_memory]'>
  <Function 'test_quota[group-virtualcenter-max_storage]'>
  <Function 'test_user_quota_diff_groups[virtualcenter-max_storage]'>
  <Function 'test_quota[group-virtualcenter-max_vm]'>
  <Function 'test_user_quota_diff_groups[virtualcenter-max_memory]'>
  <Function 'test_quota[group-virtualcenter-max_cpu]'>
  <Function 'test_user_quota_diff_groups[virtualcenter-max_vms]'>
  <Function 'test_user_quota_diff_groups[virtualcenter-max_cpu]'>
  <Function 'test_quota[user-virtualcenter-max_memory]'>
  <Function 'test_quota[user-virtualcenter-max_storage]'>
  <Function 'test_quota[user-virtualcenter-max_vm]'>
  <Function 'test_quota[user-virtualcenter-max_cpu]'>

```
 {{ pytest: cfme/tests/infrastructure/test_quota_tagging.py::test_quota_tagging_infra_via_lifecycle --use-provider vsphere6-nested -v}}