### PR TITLE
[1LP][RFR] added all method for keypairs, tenant and flavor collections

### DIFF
--- a/cfme/cloud/keypairs.py
+++ b/cfme/cloud/keypairs.py
@@ -120,7 +120,7 @@ class KeyPair(BaseEntity, Taggable):
     _param_name = "KeyPair"
 
     name = attr.ib()
-    provider = attr.ib()
+    provider = attr.ib(default=None)
     public_key = attr.ib(default="")
 
     def delete(self, cancel=False, wait=False):
@@ -207,6 +207,10 @@ class KeyPairCollection(BaseCollection):
         assert view.is_displayed
         view.flash.assert_success_message(flash_message)
         return self.instantiate(name, provider, public_key=public_key)
+
+    def all(self):
+        view = navigate_to(self, 'All')
+        return [self.instantiate(name) for name in view.entities.all_entity_names]
 
 
 @navigator.register(KeyPairCollection, 'All')


### PR DESCRIPTION
{{ pytest: -v cfme/tests/cloud_infra_common/test_tag_objects.py::test_tag_cloud_objects }}

fixed 
```
AttributeError: 'KeyPairCollection' object has no attribute 'all'
AttributeError: 'TenantCollection' object has no attribute 'all'
AttributeError: 'FlavorCollection' object has no attribute 'all'
```
that I introduced by fixing `test_tag_infra_objects tests` in #8144