### PR TITLE
[1LP][RFR] fixed collect_time for dropbox log collection

### DIFF
--- a/cfme/tests/configure/test_log_depot_operation.py
+++ b/cfme/tests/configure/test_log_depot_operation.py
@@ -7,6 +7,7 @@ Since: 2013-02-20
 """
 from datetime import datetime, timedelta
 from ftplib import FTP
+from pytz import timezone
 from wait_for import TimedOutError
 
 import fauxfactory
@@ -302,7 +303,9 @@ def test_collect_log_depot(log_depot, appliance, service_request, configured_dep
         ftp.recursively_delete()
 
     # Start the collection
-    collect_time = datetime.utcnow() - timedelta(hours=4)  # time on dropbox is UTC-4
+    # set collect_time as time on dropbox and remove TZ for further comparison
+    tz_name = 'America/New_York'
+    collect_time = datetime.now(timezone('UTC')).astimezone(timezone(tz_name)).replace(tzinfo=None)
     configured_depot.collect_all()
     # Check it on FTP
     if log_depot.protocol != 'dropbox':


### PR DESCRIPTION
{{ pytest: -v cfme/tests/configure/test_log_depot_operation.py::test_collect_log_depot }}

Fixed here the error for `test_collect_log_depot[dropbox]`
```
AssertionError
assert datetime.datetime(2018, 11, 21, 22, 55, 58) >= datetime.datetime(2018, 11, 21, 23, 55, 38, 959365)
```
that happened due to incorrect `collect_time` calculation, introduced here #7859

Initially, I didn't take DST (Daylight saving time) into account, so with the use of timezones this test should work correctly all year round :+1: 
