### PR TITLE
[1LP][RFR] WaitTab should wait until it is displayed before accessing child widget

### DIFF
--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -3690,6 +3690,7 @@ class WaitTab(Tab):
     def child_widget_accessed(self, widget):
         _to_try = 2
         _tries = 0
+        self.wait_displayed(timeout="5s")
         while _tries < _to_try:
             _tries += 1
             self.select()


### PR DESCRIPTION
There are views with WaitTab widget like AnsibleCatalogItemView where WaitTab is displayed after some timeout. If other view tries to access child widget of such view right after navigation, it will get exception on wait_tab->child_widget_accessed->select() because wait tab isn't rendered yet.

So, it is necessary to wait for WaitTab to be displayed before attempt to select tab and/or access child widget.