### PR TITLE
[RFR]Remove typo

### DIFF
--- a/cfme/intelligence/reports/schedules.py
+++ b/cfme/intelligence/reports/schedules.py
@@ -256,7 +256,7 @@ class ScheduleCollection(BaseCollection):
         """
         view = self._select_schedules(schedules)
         view.configuration.item_select(action)
-        view.flash.assert_no_errors()
+        view.flash.assert_no_error()
 
     def enable_schedules(self, *schedules):
         """Select and enable specified schedules.


### PR DESCRIPTION
This PR fixes a typo in `reports/schedules.py` from one of my previous commits.

{{pytest: cfme/tests/intelligence/reports/test_crud.py::test_reports_disable_enable_schedule --use-template-cache -sqvvv}}