### PR TITLE
[RFR] Fixing test_host_drift_analysis

### DIFF
--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -345,7 +345,7 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Taggable):
         Args:
             drift_section (str): Title text of the row to compare
             section (str): Accordion section where the change happened
-            indexes: Indexes of results to compare starting with 1 for first row (latest result).
+            indexes: Indexes of results to compare starting with 0 for first row (latest result).
                      Compares all available drifts, if left empty (default)
 
         Note:

--- a/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
+++ b/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
@@ -849,8 +849,8 @@ def test_drift_analysis(request, ssa_vm, soft_assert, appliance):
         ssa_vm.equal_drift_results(
             '{} (1)'.format(added_tag.category.display_name),
             'My Company Tags',
-            -2,
-            -1
+            0,
+            1
         ),
         "Drift analysis results are equal when they shouldn't be"
     )

--- a/cfme/tests/infrastructure/test_host_drift_analysis.py
+++ b/cfme/tests/infrastructure/test_host_drift_analysis.py
@@ -116,8 +116,8 @@ def test_host_drift_analysis(appliance, request, a_host, soft_assert, set_host_c
         a_host.equal_drift_results(
             '{} (1)'.format(added_tag.category.display_name),
             'My Company Tags',
-            -2,
-            -1
+            0,
+            1
         ),
         "Drift analysis results are equal when they shouldn't be"
     )


### PR DESCRIPTION
This PR is a reaction to [commit](https://github.com/ManageIQ/integration_tests/commit/93ed7bd51fad54eb50ab87ee0131cba605e687aa) made by @mshriver few days ago. The indexes used there (-2 and -1) actually selected the _oldest_ two SSA runs. Often times, this was not an issue. Especially with VMs that are provided fresh and clean. However, if you had some older SSA runs still present on your hosts, this test failed, because it was not comparing the two most recent SSAs. 

Unfortunately, I cannot properly test test_drift_analysis for VMs in automation since that test case is still blocked by #8152.

{{pytest: cfme/tests/infrastructure/test_host_drift_analysis.py::test_host_drift_analysis --long-running --use-provider rhv41 -vv}}