### PR TITLE
[1LP][RFR] Ensuring page safe after filling VM provisioning form

### DIFF
--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -357,6 +357,9 @@ class ProvisionView(BaseLoggedInPage):
             self.continue_button.click()
             wait_for(self.browser.plugin.ensure_page_safe, delay=.1, num_sec=10)
 
+        def after_fill(self, was_change):
+            wait_for(self.browser.plugin.ensure_page_safe, delay=.1, num_sec=10)
+
     is_displayed = displayed_not_implemented
 
 


### PR DESCRIPTION
Sometimes it happened to me that during filling of VM provision request, in the end, the `Submit` button was not _actually_ clicked but the framework thought it was. Therefore it expected to see a flash message and failed with this:

> TimedOutError: Could not do wait for Flash Success at /home/jan/cfme_tests/integration_tests/cfme/common/vm.py:526 in time

So I added `ensure_page_safe` to `after_fill` for provisioning form. To be completely honest, I don't know if that's what's really needed. But it helps and I am not seeing the aforementioned problem any more.

What do you think, @mshriver?

{{pytest: cfme/tests/infrastructure/test_provisioning_dialog.py::test_tag --long-running -vv}}