### PR TITLE
[1LP][RFR] Use vddk v6_5 for provider vSphere 6.7 (nested) on test_alert_hardware_reconfigured

### DIFF
--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -13,6 +13,7 @@ from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import providers
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import BZ
 from cfme.utils.conf import cfme_data, credentials
 from cfme.utils.log import logger
 from cfme.utils.providers import ProviderFilter
@@ -108,10 +109,14 @@ def vddk_url(provider):
         major = str(provider.version)
         minor = "0"
     vddk_version = "v{}_{}".format(major, minor)
-    try:
-        return cfme_data.get("basic_info").get("vddk_url").get(vddk_version)
-    except AttributeError:
+    # cf. BZ 1651702 vddk_version 6_7 does not currently work with CFME, so use v6_5
+    if BZ(1651702).blocks:
+        vddk_version = "v6_5"
+    url = cfme_data.get("basic_info").get("vddk_url").get(vddk_version)
+    if url is None:
         pytest.skip("There is no vddk url for this VMware provider version")
+    else:
+        return url
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ `cfme/tests/control/test_alerts.py::test_alert_hardware_reconfigured` because it is currently using vddk v5_5 instead of a more recent v6_5. This results in the test failing against the provider "virtualcenter 6.7" because SSA is not able to be completed. In order to fix this, I have modified `vddk_url` to default to `v6_5` is testing against the provider "virtualcenter 6.7"

We do not use vddk `v6_7` because according to [BZ 1651702](https://bugzilla.redhat.com/show_bug.cgi?id=1651702), this version does not work with SSA in CFME. 


{{ pytest: --use-provider vsphere67-nested --long-running cfme/tests/control/test_alerts.py::test_alert_hardware_reconfigured }}