### PR TITLE
[1LP][RFR] visibility and enablement test for container

### DIFF
--- a/cfme/automate/buttons.py
+++ b/cfme/automate/buttons.py
@@ -373,7 +373,7 @@ class ButtonCollection(BaseCollection):
                 tag = "EVM {obj_type}.{tag}".format(
                     obj_type=self.group.type, tag=visibility["tag"]
                 )
-            elif self.group.type == "Tenant":
+            elif self.group.type in ["Tenant", "Container Volume"]:
                 tag = "{obj_type}.Build.{tag}".format(
                     obj_type=self.group.type, tag=visibility["tag"]
                 )
@@ -390,7 +390,7 @@ class ButtonCollection(BaseCollection):
                 tag = "EVM {obj_type}.{tag}".format(
                     obj_type=self.group.type, tag=enablement["tag"]
                 )
-            elif self.group.type == "Tenant":
+            elif self.group.type in ["Tenant", "Container Volume"]:
                 tag = "{obj_type}.Build.{tag}".format(
                     obj_type=self.group.type, tag=enablement["tag"]
                 )


### PR DESCRIPTION
Purpose or Intent
=================
{{pytest: cfme/tests/automate/custom_button/test_container_objects.py::test_custom_button_expression -vv --use-provider ocp-39-hawk}}