### PR TITLE
[1LP][RFR] Test network port details

### DIFF
--- a/cfme/networks/__init__.py
+++ b/cfme/networks/__init__.py
@@ -1,5 +1,6 @@
 from cfme.modeling.base import BaseCollection
-from cfme.utils.appliance.implementations.ui import navigate_to, navigator
+from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.appliance.implementations.ui import navigator
 
 
 class ValidateStatsMixin(object):

--- a/cfme/networks/__init__.py
+++ b/cfme/networks/__init__.py
@@ -1,4 +1,5 @@
-from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.modeling.base import BaseCollection
+from cfme.utils.appliance.implementations.ui import navigate_to, navigator
 
 
 class ValidateStatsMixin(object):
@@ -6,7 +7,11 @@ class ValidateStatsMixin(object):
     # network module, maybe BaseEntity
 
     def ui_details_value(self, path, property_name):
-        view = navigate_to(self, "Details", use_resetter=False)
+        is_filtered = isinstance(self.parent, BaseCollection) and self.parent.filters
+        if is_filtered and 'DetailsFromParent' in navigator.list_destinations(self):
+            view = navigate_to(self, 'DetailsFromParent', use_resetter=False)
+        else:
+            view = navigate_to(self, 'Details', use_resetter=False)
         return getattr(view.entities, path).get_text_of(property_name)
 
     def validate_stats(self, expected_stats):

--- a/cfme/networks/network_port.py
+++ b/cfme/networks/network_port.py
@@ -2,15 +2,14 @@ import attr
 from navmazing import NavigateToAttribute
 
 from cfme.common import Taggable
-from cfme.exceptions import ItemNotFound
 from cfme.exceptions import DestinationNotFound
+from cfme.exceptions import ItemNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.modeling.base import parent_of_type
+from cfme.networks import ValidateStatsMixin
 from cfme.networks.views import NetworkPortDetailsView
 from cfme.networks.views import NetworkPortView
-from cfme.networks import ValidateStatsMixin
-
 from cfme.utils import version
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigate_to

--- a/cfme/networks/subnet.py
+++ b/cfme/networks/subnet.py
@@ -6,6 +6,7 @@ from widgetastic.exceptions import NoSuchElementException
 from cfme.common import CustomButtonEventsMixin
 from cfme.common import Taggable
 from cfme.exceptions import ItemNotFound
+from cfme.exceptions import DestinationNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.modeling.base import parent_of_type
@@ -14,6 +15,7 @@ from cfme.networks.network_port import NetworkPortCollection
 from cfme.networks.views import SubnetAddView
 from cfme.networks.views import SubnetDetailsView
 from cfme.networks.views import SubnetEditView
+from cfme.networks.views import SubnetNetworkPortView
 from cfme.networks.views import SubnetView
 from cfme.utils import providers
 from cfme.utils import version
@@ -221,3 +223,17 @@ class EditSubnet(CFMENavigateStep):
 
     def step(self, *args, **kwargs):
         self.prerequisite_view.toolbar.configuration.item_select('Edit this Cloud Subnet')
+
+
+@navigator.register(Subnet, 'NetworkPorts')
+class NetworkPorts(CFMENavigateStep):
+    VIEW = SubnetNetworkPortView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        item = 'Network Ports'
+        if not int(self.prerequisite_view.entities.relationships.get_text_of(item)):
+            raise DestinationNotFound(
+                'Cloud Subnet {} has a 0 count for {} relationships'.format(self.obj, item))
+
+        self.prerequisite_view.entities.relationships.click_at(item)

--- a/cfme/networks/subnet.py
+++ b/cfme/networks/subnet.py
@@ -5,8 +5,8 @@ from widgetastic.exceptions import NoSuchElementException
 
 from cfme.common import CustomButtonEventsMixin
 from cfme.common import Taggable
-from cfme.exceptions import ItemNotFound
 from cfme.exceptions import DestinationNotFound
+from cfme.exceptions import ItemNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.modeling.base import parent_of_type

--- a/cfme/networks/views.py
+++ b/cfme/networks/views.py
@@ -362,7 +362,7 @@ class NetworkPortView(BaseLoggedInPage):
 
     @property
     def is_displayed(self):
-        return (super(BaseLoggedInPage, self).is_displayed and
+        return (self.logged_in_as_current_user and
                 self.navigation.currently_selected == ['Networks', 'Network Ports'] and
                 self.entities.title.text == 'Network Ports')
 

--- a/cfme/networks/views.py
+++ b/cfme/networks/views.py
@@ -374,6 +374,18 @@ class NetworkPortView(BaseLoggedInPage):
         tree = ManageIQTree()
 
 
+class SubnetNetworkPortView(NetworkPortView):
+    """ Represents a Subnet network with port view"""
+    title = Text('//div[@id="main-content"]//h1')
+
+    @property
+    def is_displayed(self):
+        return (super(BaseLoggedInPage, self).is_displayed and
+                self.navigation.currently_selected == ['Networks', 'Subnets'] and
+                self.title.text == '{name} (All Network Ports)'.format(
+                    name=self.context['object'].name))
+
+
 class NetworkPortDetailsView(BaseLoggedInPage):
     """ Represents detail view of network provider """
     title = Text('//div[@id="main-content"]//h1')

--- a/cfme/tests/networks/nuage/test_inventory.py
+++ b/cfme/tests/networks/nuage/test_inventory.py
@@ -82,3 +82,101 @@ def test_network_router_details(setup_provider_modscope, provider, with_nuage_sa
         ('relationships', 'Cloud Subnets'): '1',
         ('relationships', 'Security Groups'): '1',
     })
+
+
+def test_network_port_vm(setup_provider_modscope, provider, with_nuage_sandbox_modscope):
+    """
+    Ensure vm network port details displays expected info.
+
+    L3 subnets are always connected to routers, hence we navigate to network ports as
+      Tenant > Router > Subnet > Network Port
+    """
+    sandbox = with_nuage_sandbox_modscope
+    tenant_name = sandbox['enterprise'].name
+    subnet_name = sandbox['subnet'].name
+    router_name = sandbox['domain'].name
+    vport_name = sandbox['vm_vport'].name
+    tenant = provider.collections.cloud_tenants.instantiate(name=tenant_name, provider=provider)
+    router = tenant.collections.routers.instantiate(name=router_name)
+    subnet = router.collections.subnets.instantiate(name=subnet_name)
+    network_port = subnet.collections.network_ports.instantiate(name=vport_name)
+
+    network_port.validate_stats({
+        ('properties', 'Name'): vport_name,
+        ('properties', 'Type'): 'ManageIQ/Providers/Nuage/Network Manager/Network Port/Vm',
+        ('relationships', 'Cloud tenant'): tenant_name,
+        ('relationships', 'Cloud subnets'): '1',
+    })
+
+
+def test_network_port_container(setup_provider_modscope, provider, with_nuage_sandbox_modscope):
+    """
+    Ensure container network port details displays expected info.
+
+    L3 subnets are always connected to routers, hence we navigate to network ports as
+      Tenant > Router > Subnet > Network Port
+    """
+    sandbox = with_nuage_sandbox_modscope
+    tenant_name = sandbox['enterprise'].name
+    subnet_name = sandbox['subnet'].name
+    router_name = sandbox['domain'].name
+    vport_name = sandbox['cont_vport'].name
+    tenant = provider.collections.cloud_tenants.instantiate(name=tenant_name, provider=provider)
+    router = tenant.collections.routers.instantiate(name=router_name)
+    subnet = router.collections.subnets.instantiate(name=subnet_name)
+    network_port = subnet.collections.network_ports.instantiate(name=vport_name)
+
+    network_port.validate_stats({
+        ('properties', 'Name'): vport_name,
+        ('properties', 'Type'): 'ManageIQ/Providers/Nuage/Network Manager/Network Port/Container',
+        ('relationships', 'Cloud tenant'): tenant_name,
+        ('relationships', 'Cloud subnets'): '1',
+    })
+
+
+def test_network_port_l2_vm(setup_provider_modscope, provider, with_nuage_sandbox_modscope):
+    """
+    Ensure vm network port details displays expected info.
+
+    L2 subnets act as standalone and are thus not connected to any router.
+    We navigate to network ports as
+      Tenant > Subnet > Network Port
+    """
+    sandbox = with_nuage_sandbox_modscope
+    tenant_name = sandbox['enterprise'].name
+    subnet_name = sandbox['l2_domain'].name
+    vport_name = sandbox['l2_vm_vport'].name
+    tenant = provider.collections.cloud_tenants.instantiate(name=tenant_name, provider=provider)
+    subnet = tenant.collections.subnets.instantiate(name=subnet_name)
+    network_port = subnet.collections.network_ports.instantiate(name=vport_name)
+
+    network_port.validate_stats({
+        ('properties', 'Name'): vport_name,
+        ('properties', 'Type'): 'ManageIQ/Providers/Nuage/Network Manager/Network Port/Vm',
+        ('relationships', 'Cloud tenant'): tenant_name,
+        ('relationships', 'Cloud subnets'): '1',
+    })
+
+
+def test_network_port_l2_container(setup_provider_modscope, provider, with_nuage_sandbox_modscope):
+    """
+    Ensure container network port details displays expected info.
+
+    L2 subnets act as standalone and are thus not connected to any router.
+    We navigate to network ports as
+      Tenant > Subnet > Network Port
+    """
+    sandbox = with_nuage_sandbox_modscope
+    tenant_name = sandbox['enterprise'].name
+    subnet_name = sandbox['l2_domain'].name
+    vport_name = sandbox['l2_cont_vport'].name
+    tenant = provider.collections.cloud_tenants.instantiate(name=tenant_name, provider=provider)
+    subnet = tenant.collections.subnets.instantiate(name=subnet_name)
+    network_port = subnet.collections.network_ports.instantiate(name=vport_name)
+
+    network_port.validate_stats({
+        ('properties', 'Name'): vport_name,
+        ('properties', 'Type'): 'ManageIQ/Providers/Nuage/Network Manager/Network Port/Container',
+        ('relationships', 'Cloud tenant'): tenant_name,
+        ('relationships', 'Cloud subnets'): '1',
+    })


### PR DESCRIPTION
This test creates sandbox with Nuage cloud tenant and its entities. We then navigate to Network port through Nuage network provider, where we compare UI stats of ports with sandbox stats.
We test two different navigations, one navigates through L3 subnet, other one through L2 subnet.

This PR depends on: https://github.com/ManageIQ/integration_tests/pull/8169

Please review 4th commit as the first, second and third one are related to other PRs.

\cc @miha-plesko 