### PR TITLE
[RFR] fixed indent for test_tagvis_cloud_object and removed if for appliance.version < 5.8

### DIFF
--- a/cfme/tests/cloud_infra_common/test_tag_objects.py
+++ b/cfme/tests/cloud_infra_common/test_tag_objects.py
@@ -119,11 +119,8 @@ def test_tagvis_cloud_object(check_item_visibility, cloud_test_item, visibility,
         3. As admin remove tag
         4. Login as restricted user, item is not visible for user
     """
-    if isinstance(cloud_test_item, KeyPair) and appliance.version < '5.9':
-        pytest.skip('Keypairs visibility works starting 5.9')
-
-        check_item_visibility(cloud_test_item, visibility)
-        request.addfinalizer(lambda: tag_cleanup(cloud_test_item, tag))
+    check_item_visibility(cloud_test_item, visibility)
+    request.addfinalizer(lambda: tag_cleanup(cloud_test_item, tag))
 
 
 @pytest.mark.meta(blockers=[BZ(1648658, forced_streams=["5.9"])])


### PR DESCRIPTION
{{ pytest: -v  cfme/tests/cloud_infra_common/test_tag_objects.py::test_tagvis_cloud_object --use-provider=complete }}

1. fixed indent for `test_tagvis_cloud_object` so it will be executed 
2. removed the line with `appliance.version < '5.9'` as 5.8 in the separate branch and is not supported in master

PRT will not pass until #8191 is merged