### PR TITLE
[RFR] Add in manual test cases and update docstrings with polarion info via mkoura's polarion2docstring script

### DIFF
--- a/cfme/tests/ansible/test_embedded_ansible_actions.py
+++ b/cfme/tests/ansible/test_embedded_ansible_actions.py
@@ -153,6 +153,10 @@ def test_action_run_ansible_playbook_localhost(request, ansible_catalog_item, an
         policy_for_testing, full_template_vm_modscope, ansible_credential, service_request,
         service):
     """Tests a policy with ansible playbook action against localhost.
+
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/6h
     """
     with update(ansible_action):
         ansible_action.run_ansible_playbook = {"inventory": {"localhost": True}}
@@ -169,7 +173,12 @@ def test_action_run_ansible_playbook_localhost(request, ansible_catalog_item, an
 def test_action_run_ansible_playbook_manual_address(request, ansible_catalog_item, ansible_action,
         policy_for_testing, full_template_vm_modscope, ansible_credential, service_request,
         service):
-    """Tests a policy with ansible playbook action against manual address."""
+    """Tests a policy with ansible playbook action against manual address.
+
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/6h
+    """
     vm = full_template_vm_modscope
     with update(ansible_catalog_item):
         ansible_catalog_item.provisioning = {"machine_credential": ansible_credential.name}
@@ -193,7 +202,12 @@ def test_action_run_ansible_playbook_manual_address(request, ansible_catalog_ite
 def test_action_run_ansible_playbook_target_machine(request, ansible_catalog_item, ansible_action,
         policy_for_testing, full_template_vm_modscope, ansible_credential, service_request,
         service):
-    """Tests a policy with ansible playbook action against target machine."""
+    """Tests a policy with ansible playbook action against target machine.
+
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/6h
+    """
     vm = full_template_vm_modscope
     with update(ansible_action):
         ansible_action.run_ansible_playbook = {"inventory": {"target_machine": True}}
@@ -210,7 +224,12 @@ def test_action_run_ansible_playbook_target_machine(request, ansible_catalog_ite
 def test_action_run_ansible_playbook_unavailable_address(request, ansible_catalog_item,
         full_template_vm_modscope, ansible_action, policy_for_testing, ansible_credential,
         service_request, service):
-    """Tests a policy with ansible playbook action against unavailable address."""
+    """Tests a policy with ansible playbook action against unavailable address.
+
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/6h
+    """
     vm = full_template_vm_modscope
     with update(ansible_catalog_item):
         ansible_catalog_item.provisioning = {"machine_credential": ansible_credential.name}
@@ -233,7 +252,12 @@ def test_action_run_ansible_playbook_unavailable_address(request, ansible_catalo
 @pytest.mark.tier(3)
 def test_control_action_run_ansible_playbook_in_requests(request,
         full_template_vm_modscope, policy_for_testing, service_request):
-    """Checks if execution of the Action result in a Task/Request being created."""
+    """Checks if execution of the Action result in a Task/Request being created.
+
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/6h
+    """
     vm = full_template_vm_modscope
     added_tag = vm.add_tag()
     request.addfinalizer(lambda: vm.remove_tag(added_tag))

--- a/cfme/tests/ansible/test_embedded_ansible_automate.py
+++ b/cfme/tests/ansible/test_embedded_ansible_automate.py
@@ -245,7 +245,14 @@ def alert_profile(appliance, alert, full_template_vm_modscope):
 
 def test_automate_ansible_playbook_method_type_crud(appliance, ansible_repository, domain,
         namespace, klass):
-    """CRUD test for ansible playbook method."""
+    """CRUD test for ansible playbook method.
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
     method = klass.methods.create(
         name=fauxfactory.gen_alphanumeric(),
         location="playbook",
@@ -262,7 +269,14 @@ def test_automate_ansible_playbook_method_type_crud(appliance, ansible_repositor
 
 def test_automate_ansible_playbook_method_type(request, appliance, domain, namespace, klass,
         instance, method):
-    """Tests execution an ansible playbook via ansible playbook method using Simulation."""
+    """Tests execution an ansible playbook via ansible playbook method using Simulation.
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
     simulate(
         appliance=appliance,
         request="Call_Instance",
@@ -278,6 +292,13 @@ def test_automate_ansible_playbook_method_type(request, appliance, domain, names
 
 
 def test_ansible_playbook_button_crud(ansible_catalog_item, appliance, request):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     buttongroup = appliance.collections.button_groups.create(
         text=fauxfactory.gen_alphanumeric(),
         hover=fauxfactory.gen_alphanumeric(),
@@ -307,6 +328,11 @@ def test_ansible_playbook_button_crud(ansible_catalog_item, appliance, request):
 
 def test_embedded_ansible_custom_button_localhost(full_template_vm_modscope, custom_vm_button,
         appliance, service_request, service, ansible_catalog_item):
+    """
+    Polarion:
+        assignee: mmojzis
+        initialEstimate: None
+    """
     with update(custom_vm_button):
         custom_vm_button.inventory = "Localhost"
     view = navigate_to(full_template_vm_modscope, "Details")
@@ -325,6 +351,11 @@ def test_embedded_ansible_custom_button_localhost(full_template_vm_modscope, cus
 
 def test_embedded_ansible_custom_button_target_machine(full_template_vm_modscope, custom_vm_button,
         ansible_credential, appliance, service_request, service):
+    """
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: None
+    """
     with update(custom_vm_button):
         custom_vm_button.inventory = "Target Machine"
     view = navigate_to(full_template_vm_modscope, "Details")
@@ -343,6 +374,11 @@ def test_embedded_ansible_custom_button_target_machine(full_template_vm_modscope
 
 def test_embedded_ansible_custom_button_specific_hosts(full_template_vm_modscope, custom_vm_button,
         ansible_credential, appliance, service_request, service):
+    """
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: None
+    """
     with update(custom_vm_button):
         custom_vm_button.inventory = "Specific Hosts"
         custom_vm_button.hosts = full_template_vm_modscope.ip_address
@@ -363,6 +399,11 @@ def test_embedded_ansible_custom_button_specific_hosts(full_template_vm_modscope
 def test_alert_run_ansible_playbook(full_template_vm_modscope, alert_profile, request, appliance):
     """Tests execution of an ansible playbook method by triggering a management event from an
     alert.
+
+    Polarion:
+        assignee: jdupuy
+        casecomponent: control
+        initialEstimate: 1/6h
     """
     added_tag = full_template_vm_modscope.add_tag()
     full_template_vm_modscope.remove_tag(added_tag)

--- a/cfme/tests/ansible/test_embedded_ansible_basic.py
+++ b/cfme/tests/ansible/test_embedded_ansible_basic.py
@@ -180,6 +180,12 @@ def catalog_item(appliance, ansible_repository):
 @pytest.mark.rhel_testing
 @pytest.mark.tier(1)
 def test_embedded_ansible_repository_crud(ansible_repository, wait_for_ansible):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: ansible
+        initialEstimate: 1/12h
+    """
     updated_description = "edited_{}".format(fauxfactory.gen_alpha())
     with update(ansible_repository):
         ansible_repository.description = updated_description
@@ -196,6 +202,12 @@ def test_embedded_ansible_repository_crud(ansible_repository, wait_for_ansible):
                          credential_type == "Red Hat Virtualization")
 def test_embedded_ansible_credential_crud(credentials_collection, wait_for_ansible, credential_type,
         credentials, appliance):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: ansible
+        initialEstimate: 1/6h
+    """
     credential = credentials_collection.create(
         "{}_credential_{}".format(credential_type, fauxfactory.gen_alpha()),
         credential_type,
@@ -234,6 +246,12 @@ def test_embedded_ansible_credential_crud(credentials_collection, wait_for_ansib
 @pytest.mark.meta(blockers=[1437108])
 @pytest.mark.tier(2)
 def test_embed_tower_playbooks_list_changed(appliance, wait_for_ansible):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: ansible
+        initialEstimate: 1/6h
+    """
     "Tests if playbooks list changed after playbooks repo removing"
     playbooks = []
     repositories_collection = appliance.collections.ansible_repositories
@@ -250,6 +268,12 @@ def test_embed_tower_playbooks_list_changed(appliance, wait_for_ansible):
 
 @pytest.mark.tier(2)
 def test_control_crud_ansible_playbook_action(request, catalog_item, action_collection):
+    """
+    Polarion:
+        assignee: mmojzis
+        casecomponent: control
+        initialEstimate: 1/12h
+    """
     action = action_collection.create(
         fauxfactory.gen_alphanumeric(),
         action_type="Run Ansible Playbook",
@@ -283,6 +307,12 @@ def test_control_crud_ansible_playbook_action(request, catalog_item, action_coll
 @pytest.mark.tier(2)
 def test_control_add_ansible_playbook_action_invalid_address(request, catalog_item,
         action_collection):
+    """
+    Polarion:
+        assignee: mmojzis
+        casecomponent: control
+        initialEstimate: 1/12h
+    """
     action = action_collection.create(
         fauxfactory.gen_alphanumeric(),
         action_type="Run Ansible Playbook",
@@ -310,6 +340,12 @@ def test_embedded_ansible_credential_with_private_key(request, wait_for_ansible,
 
     Adding new ssh credentials via Automation/Ansible/Credentials, add new credentials does not
     actually create new credentials with ssh keys.
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
     credential = credentials_collection.create(
         fauxfactory.gen_alpha(),

--- a/cfme/tests/ansible/test_embedded_ansible_crud.py
+++ b/cfme/tests/ansible/test_embedded_ansible_crud.py
@@ -22,8 +22,16 @@ def enabled_embedded_appliance(appliance):
     appliance.disable_embedded_ansible_role()
 
 
+@pytest.mark.tier(3)
 def test_embedded_ansible_enable(enabled_embedded_appliance):
-    """Tests whether the embedded ansible role and all workers have started correctly"""
+    """Tests whether the embedded ansible role and all workers have started correctly
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: critical
+        initialEstimate: 1/6h
+    """
     assert wait_for(func=lambda: enabled_embedded_appliance.is_embedded_ansible_running, num_sec=30)
     assert wait_for(func=lambda: enabled_embedded_appliance.is_rabbitmq_running, num_sec=30)
     assert wait_for(func=lambda: enabled_embedded_appliance.is_nginx_running, num_sec=30)
@@ -33,8 +41,16 @@ def test_embedded_ansible_enable(enabled_embedded_appliance):
         container=enabled_embedded_appliance._ansible_pod_name)
 
 
+@pytest.mark.tier(3)
 def test_embedded_ansible_disable(enabled_embedded_appliance):
-    """Tests whether the embedded ansible role and all workers have stopped correctly"""
+    """Tests whether the embedded ansible role and all workers have stopped correctly
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: critical
+        initialEstimate: 1/6h
+    """
     assert wait_for(func=lambda: enabled_embedded_appliance.is_rabbitmq_running, num_sec=30)
     assert wait_for(func=lambda: enabled_embedded_appliance.is_nginx_running, num_sec=30)
     enabled_embedded_appliance.disable_embedded_ansible_role()

--- a/cfme/tests/ansible/test_embedded_ansible_rest.py
+++ b/cfme/tests/ansible/test_embedded_ansible_rest.py
@@ -72,6 +72,11 @@ class TestReposRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: medium
+            initialEstimate: 1/4h
         """
         new_description = "Test Repository {}".format(fauxfactory.gen_alphanumeric(5))
 
@@ -102,6 +107,11 @@ class TestReposRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: medium
+            initialEstimate: 1/4h
         """
         del_action = getattr(repository.action.delete, method.upper())
         del_action()
@@ -122,6 +132,11 @@ class TestReposRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: medium
+            initialEstimate: 1/4h
         """
         delete_resources_from_collection([repository], not_found=False, num_sec=300, delay=5)
 
@@ -132,6 +147,10 @@ class TestPayloadsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         collection = appliance.rest_api.collections.configuration_script_payloads
         collection.reload()
@@ -144,6 +163,10 @@ class TestPayloadsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         script_payloads = appliance.rest_api.collections.configuration_script_payloads
         script_payloads.reload()
@@ -154,6 +177,10 @@ class TestPayloadsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         script_sources = appliance.rest_api.collections.configuration_script_sources
         script_sources.reload()

--- a/cfme/tests/ansible/test_embedded_ansible_services.py
+++ b/cfme/tests/ansible/test_embedded_ansible_services.py
@@ -179,6 +179,12 @@ def custom_service_button(appliance, ansible_catalog_item):
 @pytest.mark.tier(1)
 @pytest.mark.meta(blockers=[BZ(1515841, forced_streams=['5.9'])])
 def test_service_ansible_playbook_available(appliance):
+    """
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1/6h
+    """
     view = navigate_to(appliance.collections.catalog_items, "Choose Type")
     assert "Ansible Playbook" in [option.text for option in view.select_item_type.all_options]
 
@@ -186,6 +192,12 @@ def test_service_ansible_playbook_available(appliance):
 @pytest.mark.tier(1)
 @pytest.mark.meta(blockers=[BZ(1515841, forced_streams=['5.9'])])
 def test_service_ansible_playbook_crud(appliance, ansible_repository):
+    """
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1/6h
+    """
     cat_item = appliance.collections.catalog_items.create(
         appliance.collections.catalog_items.ANSIBLE_PLAYBOOK,
         fauxfactory.gen_alphanumeric(),
@@ -221,6 +233,11 @@ def test_service_ansible_playbook_tagging(ansible_catalog_item):
         2. Add tag for ansible_playbook
         3. Check added tag
         4. Remove the given tag
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1/2h
     """
     added_tag = ansible_catalog_item.add_tag()
     assert any(tag.category.display_name == added_tag.category.display_name and
@@ -234,6 +251,13 @@ def test_service_ansible_playbook_tagging(ansible_catalog_item):
 @pytest.mark.tier(2)
 @pytest.mark.meta(blockers=[BZ(1515841, forced_streams=['5.9'])])
 def test_service_ansible_playbook_negative(appliance):
+    """
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseposneg: negative
+        initialEstimate: 1/6h
+    """
     collection = appliance.collections.catalog_items
     cat_item = collection.instantiate(collection.ANSIBLE_PLAYBOOK, "", "", {})
     view = navigate_to(cat_item, "Add")
@@ -247,7 +271,15 @@ def test_service_ansible_playbook_negative(appliance):
 @pytest.mark.tier(2)
 @pytest.mark.meta(blockers=[BZ(1515841, forced_streams=['5.9'])])
 def test_service_ansible_playbook_bundle(appliance, ansible_catalog_item):
-    """Ansible playbooks are not designed to be part of a cloudforms service bundle."""
+    """Ansible playbooks are not designed to be part of a cloudforms service bundle.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/6h
+    """
     view = navigate_to(appliance.collections.catalog_bundles, "Add")
     options = view.resources.select_resource.all_options
     assert ansible_catalog_item.name not in [o.text for o in options]
@@ -260,7 +292,14 @@ def test_service_ansible_playbook_bundle(appliance, ansible_catalog_item):
 ])
 def test_service_ansible_playbook_provision_in_requests(appliance, ansible_catalog_item,
                                                         service_catalog, request):
-    """Tests if ansible playbook service provisioning is shown in service requests."""
+    """Tests if ansible playbook service provisioning is shown in service requests.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     service_catalog.order()
     cat_item_name = ansible_catalog_item.name
     request_descr = "Provisioning Service [{0}] from [{0}]".format(cat_item_name)
@@ -283,6 +322,12 @@ def test_service_ansible_playbook_provision_in_requests(appliance, ansible_catal
 def test_service_ansible_playbook_confirm(appliance, soft_assert):
     """Tests after selecting playbook additional widgets appear and are pre-populated where
     possible.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
     collection = appliance.collections.catalog_items
     cat_item = collection.instantiate(collection.ANSIBLE_PLAYBOOK, "", "", {})
@@ -326,6 +371,10 @@ def test_service_ansible_playbook_order_retire(appliance, ansible_catalog_item, 
         service_request, service, host_type, order_value, result, action):
     """Test ordering and retiring ansible playbook service against default host, blank field and
     unavailable host.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     service_catalog.ansible_dialog_values = {"hosts": order_value}
     service_catalog.order()
@@ -337,9 +386,17 @@ def test_service_ansible_playbook_order_retire(appliance, ansible_catalog_item, 
 
 
 @pytest.mark.meta(blockers=[BZ(1519275, forced_streams=['5.9'])])
+@pytest.mark.tier(3)
 def test_service_ansible_playbook_plays_table(service_catalog, service_request, service,
         soft_assert):
-    """Plays table in provisioned and retired service should contain at least one row."""
+    """Plays table in provisioned and retired service should contain at least one row.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: low
+        initialEstimate: 1/6h
+    """
     service_catalog.order()
     service_request.wait_for_request()
     view = navigate_to(service, "Details")
@@ -353,6 +410,12 @@ def test_service_ansible_playbook_order_credentials(ansible_catalog_item, ansibl
         service_catalog, appliance):
     """Test if credentials avaialable in the dropdown in ordering ansible playbook service
     screen.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
     with update(ansible_catalog_item):
         ansible_catalog_item.provisioning = {
@@ -370,7 +433,12 @@ def test_service_ansible_playbook_order_credentials(ansible_catalog_item, ansibl
 def test_service_ansible_playbook_pass_extra_vars(service_catalog, service_request, service,
         action):
     """Test if extra vars passed into ansible during ansible playbook service provision and
-    retirement."""
+    retirement.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     service_catalog.order()
     service_request.wait_for_request()
     if action == "retirement":
@@ -395,6 +463,12 @@ def test_service_ansible_execution_ttl(request, service_catalog, ansible_catalog
     """Test if long running processes allowed to finish. There is a code that guarantees to have 100
     retries with a minimum of 1 minute per retry. So we need to run ansible playbook service more
     than 100 minutes and set max ttl greater than ansible playbook running time.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 2h
     """
     with update(ansible_catalog_item):
         ansible_catalog_item.provisioning = {
@@ -426,6 +500,12 @@ def test_custom_button_ansible_credential_list(custom_service_button, service_ca
     """Test if credential list matches when the Ansible Playbook Service Dialog is invoked from a
     Button versus a Service Order Screen.
     https://bugzilla.redhat.com/show_bug.cgi?id=1448918
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/3h
     """
     service_catalog.order()
     service_request.wait_for_request()
@@ -441,10 +521,17 @@ def test_custom_button_ansible_credential_list(custom_service_button, service_ca
     assert ["<Default>", "CFME Default Credential"] == all_options
 
 
+@pytest.mark.tier(3)
 def test_ansible_group_id_in_payload(service_catalog, service_request, service):
     """Test if group id is presented in manageiq payload.
     https://bugzilla.redhat.com/show_bug.cgi?id=1480019
     In order to get manageiq payload the service's standard output should be parsed.
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
     service_catalog.order()
     service_request.wait_for_request()
@@ -464,6 +551,11 @@ def test_ansible_group_id_in_payload(service_catalog, service_request, service):
 @pytest.mark.provider([EC2Provider], scope="function")
 def test_embed_tower_exec_play_against_amazon(request, provider, setup_provider,
         ansible_catalog_item, service, ansible_amazon_credential, service_catalog):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     with update(ansible_catalog_item):
         ansible_catalog_item.provisioning = {
             "playbook": "list_ec2_instances.yml",

--- a/cfme/tests/ansible/test_embedded_ansible_tags.py
+++ b/cfme/tests/ansible/test_embedded_ansible_tags.py
@@ -98,36 +98,66 @@ def check_tag_place(soft_assert):
 
 @pytest.mark.parametrize('tag_place', [True, False], ids=['details', 'list'])
 def test_tag_ansible_repository(repository, tag_place, check_tag_place):
-    """ Test for cloud items tagging action from list and details pages """
+    """ Test for cloud items tagging action from list and details pages
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
+    """
     check_tag_place(repository, tag_place)
 
 
 @pytest.mark.parametrize('tag_place', [True, False], ids=['details', 'list'])
 def test_tag_ansible_credential(credential, tag_place, check_tag_place):
-    """ Test for cloud items tagging action from list and details pages """
+    """ Test for cloud items tagging action from list and details pages
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
+    """
     check_tag_place(credential, tag_place)
 
 
 @pytest.mark.parametrize('tag_place', [True, False], ids=['details', 'list'])
 def test_tag_ansible_playbook(playbook, tag_place, check_tag_place):
-    """ Test for cloud items tagging action from list and details pages """
+    """ Test for cloud items tagging action from list and details pages
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
+    """
     check_tag_place(playbook, tag_place)
 
 
 @pytest.mark.parametrize('visibility', [True, False], ids=['visible', 'notVisible'])
 def test_tagvis_ansible_repository(repository, check_item_visibility, visibility):
-    """ Test for cloud items tagging action from list and details pages """
+    """ Test for cloud items tagging action from list and details pages
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
+    """
     check_item_visibility(repository, visibility)
 
 
 @pytest.mark.parametrize('visibility', [True, False], ids=['visible', 'notVisible'])
 def test_tagvis_ansible_credential(credential, check_item_visibility, visibility):
-    """ Test for cloud items tagging action from list and details pages """
+    """ Test for cloud items tagging action from list and details pages
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
+    """
     check_item_visibility(credential, visibility)
 
 
 @pytest.mark.meta(blockers=[BZ(1648658, forced_streams=["5.9"])])
 @pytest.mark.parametrize('visibility', [True, False], ids=['visible', 'notVisible'])
 def test_tagvis_playbook(playbook, check_item_visibility, visibility):
-    """ Test for cloud items tagging action from list and details pages """
+    """ Test for cloud items tagging action from list and details pages
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
+    """
     check_item_visibility(playbook, visibility)

--- a/cfme/tests/automate/custom_button/test_buttons.py
+++ b/cfme/tests/automate/custom_button/test_buttons.py
@@ -93,6 +93,11 @@ def test_button_group_crud(request, appliance, obj_type):
         * Change the hover text, ensure the text is changed on details page
         * Delete the button group
         * Assert that the button group no longer exists.
+
+    Polarion:
+        assignee: ndhandre
+        caseimportance: critical
+        initialEstimate: 1/6h
     """
     # 1) Create it
     collection = appliance.collections.button_groups
@@ -152,6 +157,11 @@ def test_button_crud(appliance, dialog, request, buttongroup, obj_type):
 
     Bugzillas:
         * 1143019, 1205235
+
+    Polarion:
+        assignee: ndhandre
+        caseimportance: critical
+        initialEstimate: 1/6h
     """
     button_gp = buttongroup(obj_type)
     button = button_gp.buttons.create(
@@ -183,6 +193,11 @@ def test_button_avp_displayed(appliance, dialog, request):
     Steps:
         * Open a dialog to create a button.
         * Locate the section with attribute/value pairs.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: automate
+        initialEstimate: 1/12h
     """
     # This is optional, our nav tree does not have unassigned button
     buttongroup = appliance.collections.button_groups.create(
@@ -210,6 +225,10 @@ def test_button_required(appliance, field):
     Steps:
         * Try to add custom button without icon/request
         * Assert flash message.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     unassigned_gp = appliance.collections.button_groups.instantiate(
         text="[Unassigned Buttons]", hover="Unassigned Buttons", type="Provider"
@@ -252,6 +271,10 @@ def test_open_url_availability(appliance):
     Steps:
         * Create a Button with other than Single display options
         * Assert flash message.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     unassigned_gp = appliance.collections.button_groups.instantiate(

--- a/cfme/tests/automate/custom_button/test_cloud_objects.py
+++ b/cfme/tests/automate/custom_button/test_cloud_objects.py
@@ -129,6 +129,11 @@ def test_custom_button_display(appliance, request, display, setup_objs, button_g
         * List: All page of the entity
         * Single and list: Both All and Details page of the entity
         * Check for button group and button
+
+    Polarion:
+        assignee: ndhandre
+        caseimportance: critical
+        initialEstimate: 1/4h
     """
 
     group, obj_type = button_group
@@ -172,6 +177,10 @@ def test_custom_button_dialog(appliance, dialog, request, setup_objs, button_gro
 
     Bugzillas:
         * 1635797, 1555331, 1574403, 1640592
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     group, obj_type = button_group
@@ -240,6 +249,10 @@ def test_custom_button_automate(appliance, request, submit, setup_objs, button_g
 
     Bugzillas:
         * 1628224, 1642147
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     group, obj_type = button_group
@@ -324,6 +337,10 @@ def test_custom_button_expression(appliance, request, setup_objs, button_group, 
         * Navigate to object Detail page
         * Check: button should not enable/visible without tag
         * Check: button should enable/visible with tag
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     group, obj_type = button_group

--- a/cfme/tests/automate/custom_button/test_container_objects.py
+++ b/cfme/tests/automate/custom_button/test_container_objects.py
@@ -90,6 +90,11 @@ def test_custom_button_display(request, display, setup_obj, button_group):
         * List: All page of the entity
         * Single and list: Both All and Details page of the entity
         * Check for button group and button
+
+    Polarion:
+        assignee: ndhandre
+        caseimportance: critical
+        initialEstimate: 1/4h
     """
 
     group, obj_type = button_group
@@ -131,6 +136,10 @@ def test_custom_button_dialog(appliance, dialog, request, setup_obj, button_grou
         * Fill dialog and submit
         * Check for the proper flash message related to button execution
         * Check request in automation log
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     group, obj_type = button_group
@@ -191,6 +200,10 @@ def test_custom_button_expression(appliance, request, setup_obj, button_group, e
         * Navigate to object Detail page
         * Check: button should not enable/visible without tag
         * Check: button should enable/visible with tag
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     group, obj_type = button_group

--- a/cfme/tests/automate/custom_button/test_generic_objects.py
+++ b/cfme/tests/automate/custom_button/test_generic_objects.py
@@ -70,6 +70,11 @@ def test_custom_button_display(request, display, setup_obj, button_group):
         * List: All page of the entity
         * Single and list: Both All and Details page of the entity
         * Check for button group and button
+
+    Polarion:
+        assignee: ndhandre
+        caseimportance: critical
+        initialEstimate: 1/4h
     """
 
     group, obj_type = button_group
@@ -120,6 +125,10 @@ def test_custom_button_automate(appliance, request, submit, setup_obj, button_gr
 
     Bugzillas:
         * 1628224, 1642939
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     group, obj_type = button_group
@@ -189,6 +198,10 @@ def test_custom_button_dialog(appliance, dialog, request, setup_obj, button_grou
         * Fill dialog and submit
         * Check for the proper flash message related to button execution
         * Check request in automation log
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     group, obj_type = button_group
@@ -250,6 +263,10 @@ def test_custom_button_expression(appliance, request, setup_obj, button_group, e
         * Navigate to object Detail page
         * Check: button should not enable/visible without tag
         * Check: button should enable/visible with tag
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     group, obj_type = button_group

--- a/cfme/tests/automate/custom_button/test_import_export.py
+++ b/cfme/tests/automate/custom_button/test_import_export.py
@@ -95,6 +95,10 @@ def test_custom_button_import_export(appliance, setup_groups_buttons):
             `rake evm:import:custom_buttons -- --source /tmp/custom_buttons`
         * Check for custom buttons and groups which was exported comes back to UI or not
         * Check for custom buttons in respective implementation location
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     # Check all buttons, groups and respective display at respective locations

--- a/cfme/tests/automate/custom_button/test_infra_objects.py
+++ b/cfme/tests/automate/custom_button/test_infra_objects.py
@@ -82,6 +82,11 @@ def test_custom_button_display(request, display, setup_obj, button_group):
         * List: All page of the entity
         * Single and list: Both All and Details page of the entity
         * Check for button group and button
+
+    Polarion:
+        assignee: ndhandre
+        caseimportance: critical
+        initialEstimate: 1/4h
     """
 
     group, obj_type = button_group
@@ -134,6 +139,10 @@ def test_custom_button_automate(appliance, request, submit, setup_obj, button_gr
 
     Bugzillas:
         * 1628224
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     group, obj_type = button_group
@@ -218,6 +227,10 @@ def test_custom_button_dialog(appliance, dialog, request, setup_obj, button_grou
 
     Bugzillas:
         * 1635797, 1555331, 1574403, 1640592
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     group, obj_type = button_group
@@ -278,6 +291,10 @@ def test_custom_button_expression(appliance, request, setup_obj, button_group, e
         * Navigate to object Detail page
         * Check: button should not enable/visible without tag
         * Check: button should enable/visible with tag
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     group, obj_type = button_group

--- a/cfme/tests/automate/custom_button/test_service_objects.py
+++ b/cfme/tests/automate/custom_button/test_service_objects.py
@@ -125,6 +125,11 @@ def test_custom_button_display(request, appliance, context, display, objects, bu
 
     Bugzilla:
         * 1650066
+
+    Polarion:
+        assignee: ndhandre
+        caseimportance: critical
+        initialEstimate: 1/4h
     """
 
     group, obj_type = button_group

--- a/cfme/tests/automate/test_class.py
+++ b/cfme/tests/automate/test_class.py
@@ -41,6 +41,13 @@ def namespace(request, domain):
 @pytest.mark.sauce
 @pytest.mark.tier(2)
 def test_class_crud(namespace):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: critical
+        initialEstimate: 1/30h
+    """
     a_class = namespace.classes.create(
         name=fauxfactory.gen_alphanumeric(),
         display_name=fauxfactory.gen_alphanumeric(),
@@ -59,6 +66,13 @@ def test_class_crud(namespace):
 @pytest.mark.tier(2)
 @pytest.mark.meta(blockers=[1404788])
 def test_schema_crud(request, namespace):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: critical
+        initialEstimate: 1/20h
+    """
     a_class = namespace.classes.create(
         name=fauxfactory.gen_alphanumeric(),
         display_name=fauxfactory.gen_alphanumeric(),
@@ -79,6 +93,13 @@ def test_schema_crud(request, namespace):
 @pytest.mark.tier(2)
 @pytest.mark.meta(blockers=[1404788])
 def test_schema_duplicate_field_disallowed(request, domain):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/16h
+    """
     ns = domain.namespaces.create(
         name=fauxfactory.gen_alpha(),
         description=fauxfactory.gen_alpha()
@@ -97,6 +118,13 @@ def test_schema_duplicate_field_disallowed(request, domain):
 @pytest.mark.tier(2)
 @pytest.mark.meta(blockers=[BZ(1428424, forced_streams=['5.8', 'upstream'])])
 def test_duplicate_class_disallowed(namespace):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseposneg: negative
+        initialEstimate: 1/30h
+    """
     name = fauxfactory.gen_alphanumeric()
     namespace.classes.create(name=name)
     with pytest.raises(Exception, match="Name has already been taken"):
@@ -105,6 +133,12 @@ def test_duplicate_class_disallowed(namespace):
 
 @pytest.mark.tier(2)
 def test_same_class_name_different_namespace(request, domain):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        initialEstimate: 1/16h
+    """
     ns1 = domain.namespaces.create(
         name=fauxfactory.gen_alpha(),
         description=fauxfactory.gen_alpha()
@@ -136,6 +170,12 @@ def test_same_class_name_different_namespace(request, domain):
 @pytest.mark.tier(3)
 @pytest.mark.polarion('RHCF3-3455')
 def test_class_display_name_unset_from_ui(request, namespace):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        initialEstimate: 1/30h
+    """
     a_class = namespace.classes.create(
         name=fauxfactory.gen_alphanumeric(),
         display_name=fauxfactory.gen_alphanumeric(),

--- a/cfme/tests/automate/test_common_methods.py
+++ b/cfme/tests/automate/test_common_methods.py
@@ -67,6 +67,10 @@ def test_vm_retire_extend(appliance, request, testing_vm, soft_assert):
 
     Metadata:
         test_flag: retire, provision
+
+    Polarion:
+        assignee: tpapaioa
+        initialEstimate: 1/3h
     """
     num_days = 5
     soft_assert(testing_vm.retirement_date == 'Never', "The retirement date is not 'Never'!")

--- a/cfme/tests/automate/test_customization_paginator.py
+++ b/cfme/tests/automate/test_customization_paginator.py
@@ -60,6 +60,10 @@ def test_paginator(some_dialogs, soft_assert, appliance):
             dialogs must contain all idalogs you created before.
         * During the cycling, assert the numbers displayed in the paginator make sense
         * During the cycling, assert the paginator does not get stuck.
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
     """
     service_dialog = appliance.collections.service_dialogs
     view = navigate_to(service_dialog, 'All')

--- a/cfme/tests/automate/test_domain.py
+++ b/cfme/tests/automate/test_domain.py
@@ -14,6 +14,13 @@ pytestmark = [test_requirements.automate]
 @pytest.mark.tier(1)
 @pytest.mark.parametrize('enabled', [True, False], ids=['enabled', 'disabled'])
 def test_domain_crud(request, enabled, appliance):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: critical
+        initialEstimate: 1/30h
+    """
     domain = appliance.collections.domains.create(
         name=fauxfactory.gen_alpha(),
         description=fauxfactory.gen_alpha(),
@@ -39,6 +46,12 @@ def test_domain_crud(request, enabled, appliance):
 
 @pytest.mark.tier(1)
 def test_domain_edit_enabled(request, appliance):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        initialEstimate: 1/16h
+    """
     domain = appliance.collections.domains.create(
         name=fauxfactory.gen_alpha(),
         description=fauxfactory.gen_alpha(),
@@ -55,6 +68,13 @@ def test_domain_edit_enabled(request, appliance):
 
 @pytest.mark.tier(2)
 def test_domain_lock_disabled(request, appliance):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/16h
+    """
     domain = appliance.collections.domains.create(
         name=fauxfactory.gen_alpha(),
         description=fauxfactory.gen_alpha(),
@@ -68,6 +88,13 @@ def test_domain_lock_disabled(request, appliance):
 
 @pytest.mark.tier(1)
 def test_domain_delete_from_table(request, appliance):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: low
+        initialEstimate: 1/30h
+    """
     generated = []
     for _ in range(3):
         domain = appliance.collections.domains.create(
@@ -84,6 +111,13 @@ def test_domain_delete_from_table(request, appliance):
 
 @pytest.mark.tier(2)
 def test_duplicate_domain_disallowed(request, appliance):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseposneg: negative
+        initialEstimate: 1/60h
+    """
     domain = appliance.collections.domains.create(
         name=fauxfactory.gen_alpha(),
         description=fauxfactory.gen_alpha(),
@@ -99,6 +133,14 @@ def test_duplicate_domain_disallowed(request, appliance):
 @pytest.mark.tier(2)
 @pytest.mark.polarion('RHCF3-11228')
 def test_domain_cannot_delete_builtin(appliance):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: critical
+        caseposneg: negative
+        initialEstimate: 1/16h
+    """
     manageiq_domain = appliance.collections.domains.instantiate(name='ManageIQ')
     details_view = navigate_to(manageiq_domain, 'Details')
     if appliance.version < '5.7':
@@ -111,6 +153,14 @@ def test_domain_cannot_delete_builtin(appliance):
 @pytest.mark.tier(2)
 @pytest.mark.polarion('RHCF3-11227')
 def test_domain_cannot_edit_builtin(appliance):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: critical
+        caseposneg: negative
+        initialEstimate: 1/16h
+    """
     manageiq_domain = appliance.collections.domains.instantiate(name='ManageIQ')
     details_view = navigate_to(manageiq_domain, 'Details')
     if appliance.version < '5.7':
@@ -122,12 +172,26 @@ def test_domain_cannot_edit_builtin(appliance):
 
 @pytest.mark.tier(2)
 def test_domain_name_wrong(appliance):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/60h
+    """
     with pytest.raises(Exception, match='Name may contain only'):
         appliance.collections.domains.create(name='with space')
 
 
 @pytest.mark.tier(2)
 def test_domain_lock_unlock(request, appliance):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        initialEstimate: 1/16h
+    """
     domain = appliance.collections.domains.create(
         name=fauxfactory.gen_alpha(),
         description=fauxfactory.gen_alpha(),
@@ -188,8 +252,15 @@ def test_domain_lock_unlock(request, appliance):
         ('https://github.com/RedHatQE/ManageIQ-automate-git.git', 'tag', '0.1', False)
     ])
 @pytest.mark.meta(server_roles=['+git_owner'])
+@pytest.mark.tier(1)
 def test_domain_import_git(request, appliance, url, param_type, param_value, verify_ssl):
-    """Verifies that a domain can be imported from git."""
+    """Verifies that a domain can be imported from git.
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        initialEstimate: 1/20h
+    """
     repo = AutomateGitRepository(url=url, verify_ssl=verify_ssl, appliance=appliance)
     domain = repo.import_domain_from(**{param_type: param_value})
     request.addfinalizer(domain.delete_if_exists)

--- a/cfme/tests/automate/test_domain_priority.py
+++ b/cfme/tests/automate/test_domain_priority.py
@@ -118,6 +118,11 @@ def test_priority(
         * Then pick the domain order so the original domain is first.
         * Run the same simulation again.
         * The contents of the file should be the same as in the first case.
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        initialEstimate: 1/4h
     """
     ssh_client = appliance.ssh_client
     ssh_client.run_command("rm -f {}".format(FILE_LOCATION))

--- a/cfme/tests/automate/test_git_import.py
+++ b/cfme/tests/automate/test_git_import.py
@@ -32,19 +32,33 @@ def imported_domain(appliance, branch):
     domain.delete_if_exists()
 
 
+@pytest.mark.tier(1)
 def test_automate_git_domain_removed_from_disk(appliance, imported_domain):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
     imported_domain.delete()
     repo_path = urlparse(GIT_REPO_URL).path
     assert appliance.ssh_client.run_command(
         '[ ! -d "/var/www/vmdb/data/git_repos{}" ]'.format(repo_path)).success
 
 
+@pytest.mark.tier(2)
 def test_automate_git_domain_displayed_in_service(appliance, imported_domain, branch):
     """Tests if a domain is displayed in a service.
 
     Checks if the domain imported from git is displayed and usable in the pop-up tree in the
     dialog for creating services.
 
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        initialEstimate: 1/20h
     """
     collection = appliance.collections.catalog_items
     cat_item = collection.instantiate(collection.GENERIC, "test")

--- a/cfme/tests/automate/test_instance.py
+++ b/cfme/tests/automate/test_instance.py
@@ -42,6 +42,13 @@ def klass(request, namespace):
 @pytest.mark.tier(2)
 @pytest.mark.polarion('RHCF3-3922')
 def test_instance_crud(klass):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: critical
+        initialEstimate: 1/16h
+    """
     instance = klass.instances.create(
         name=fauxfactory.gen_alphanumeric(),
         display_name=fauxfactory.gen_alphanumeric(),
@@ -59,6 +66,13 @@ def test_instance_crud(klass):
 @pytest.mark.tier(2)
 @pytest.mark.polarion('RHCF3-20871')
 def test_duplicate_instance_disallowed(request, klass):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseposneg: negative
+        initialEstimate: 1/60h
+    """
     name = fauxfactory.gen_alphanumeric()
     klass.instances.create(name=name)
     with pytest.raises(Exception, match="Name has already been taken"):
@@ -69,6 +83,12 @@ def test_duplicate_instance_disallowed(request, klass):
 @pytest.mark.tier(3)
 @pytest.mark.polarion('RHCF3-20872')
 def test_instance_display_name_unset_from_ui(request, klass):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        initialEstimate: 1/30h
+    """
     instance = klass.instances.create(
         name=fauxfactory.gen_alphanumeric(),
         display_name=fauxfactory.gen_alphanumeric())
@@ -80,11 +100,17 @@ def test_instance_display_name_unset_from_ui(request, klass):
     assert instance.exists
 
 
+@pytest.mark.tier(1)
 def test_automate_instance_missing(domain, klass, namespace, appliance):
     """If an instance called in class does not exist, a .missing instance is processed if it exists.
 
     A _missing_instance attribute (which contains the name of the instance that was supposed to be
     called) is then set on $evm.object so it then can be used eg. to resolve methods dynamically.
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        initialEstimate: 1/10h
     """
     catch_string = fauxfactory.gen_alphanumeric()
     method = klass.methods.create(

--- a/cfme/tests/automate/test_method.py
+++ b/cfme/tests/automate/test_method.py
@@ -41,6 +41,13 @@ def klass(request, namespace):
 @pytest.mark.sauce
 @pytest.mark.tier(2)
 def test_method_crud(klass):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: critical
+        initialEstimate: 1/16h
+    """
     method = klass.methods.create(
         name=fauxfactory.gen_alphanumeric(),
         display_name=fauxfactory.gen_alphanumeric(),
@@ -63,6 +70,12 @@ def test_method_crud(klass):
 @pytest.mark.sauce
 @pytest.mark.tier(2)
 def test_automate_method_inputs_crud(klass):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        initialEstimate: 1/8h
+    """
     method = klass.methods.create(
         name=fauxfactory.gen_alphanumeric(),
         display_name=fauxfactory.gen_alphanumeric(),
@@ -95,6 +108,13 @@ def test_automate_method_inputs_crud(klass):
 
 @pytest.mark.tier(2)
 def test_duplicate_method_disallowed(request, klass):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseposneg: negative
+        initialEstimate: 1/10h
+    """
     name = fauxfactory.gen_alpha()
     klass.methods.create(
         name=name,

--- a/cfme/tests/automate/test_namespace.py
+++ b/cfme/tests/automate/test_namespace.py
@@ -33,6 +33,13 @@ def parent_namespace(request, domain):
 @pytest.mark.sauce
 @pytest.mark.tier(1)
 def test_namespace_crud(request, parent_namespace):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: critical
+        initialEstimate: 1/16h
+    """
     ns = parent_namespace.namespaces.create(
         name=fauxfactory.gen_alpha(),
         description=fauxfactory.gen_alpha())
@@ -49,6 +56,13 @@ def test_namespace_crud(request, parent_namespace):
 
 @pytest.mark.tier(1)
 def test_namespace_delete_from_table(request, parent_namespace):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/30h
+    """
     generated = []
     for _ in range(3):
         namespace = parent_namespace.namespaces.create(
@@ -63,6 +77,13 @@ def test_namespace_delete_from_table(request, parent_namespace):
 
 @pytest.mark.tier(2)
 def test_duplicate_namespace_disallowed(request, parent_namespace):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseposneg: negative
+        initialEstimate: 1/16h
+    """
     ns = parent_namespace.namespaces.create(
         name=fauxfactory.gen_alpha(),
         description=fauxfactory.gen_alpha())

--- a/cfme/tests/automate/test_provisioning_dialogs.py
+++ b/cfme/tests/automate/test_provisioning_dialogs.py
@@ -13,6 +13,12 @@ from cfme.utils.update import update
 @test_requirements.automate
 @pytest.mark.tier(3)
 def test_provisioning_dialog_crud(appliance):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        initialEstimate: 1/10h
+    """
     # CREATE
     collection = appliance.collections.provisioning_dialogs
     dialog = collection.create(
@@ -54,6 +60,13 @@ for name in ProvisioningDialogsCollection.ALLOWED_TYPES:
 @pytest.mark.tier(3)
 @pytest.mark.parametrize(("name", "by", "order"), sort_by_params)
 def test_provisioning_dialogs_sorting(appliance, name, by, order):
+    """
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/30h
+    """
     view = navigate_to(appliance.collections.provisioning_dialogs, 'All')
     view.sidebar.provisioning_dialogs.tree.click_path("All Dialogs", name)
     view.entities.table.sort_by(by, order)

--- a/cfme/tests/automate/test_rest.py
+++ b/cfme/tests/automate/test_rest.py
@@ -7,6 +7,12 @@ pytestmark = [test_requirements.rest]
 
 
 def test_rest_search_automate(appliance):
+    """
+    Polarion:
+        assignee: mkourim
+        caseimportance: low
+        initialEstimate: 1/3h
+    """
     rest_api = appliance.rest_api
 
     def _do_query(**kwargs):

--- a/cfme/tests/automate/test_service_dialog.py
+++ b/cfme/tests/automate/test_service_dialog.py
@@ -28,6 +28,12 @@ def create_dialog(appliance, element_data, label=None):
 
 @pytest.mark.sauce
 def test_crud_service_dialog(appliance):
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        initialEstimate: 1/4h
+    """
     element_data = {
         'element_information': {
             'ele_label': "ele_" + fauxfactory.gen_alphanumeric(),
@@ -51,6 +57,13 @@ def test_crud_service_dialog(appliance):
 
 
 def test_service_dialog_duplicate_name(appliance, request):
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: low
+        initialEstimate: 1/8h
+    """
     element_data = {
         'element_information': {
             'ele_label': "ele_" + fauxfactory.gen_alphanumeric(),
@@ -77,6 +90,13 @@ def test_service_dialog_duplicate_name(appliance, request):
 
 
 def test_checkbox_dialog_element(appliance, request):
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: low
+        initialEstimate: 1/8h
+    """
     element_data = {
         'element_information': {
             'ele_label': "ele_" + fauxfactory.gen_alphanumeric(),
@@ -94,6 +114,13 @@ def test_checkbox_dialog_element(appliance, request):
 
 
 def test_datecontrol_dialog_element(appliance, request):
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
     if appliance.version >= "5.9":
         choose_type = "Datepicker"
     else:
@@ -114,6 +141,13 @@ def test_datecontrol_dialog_element(appliance, request):
 
 
 def test_tagcontrol_dialog_element(appliance, request):
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
     element_data = {
         'element_information': {
             'ele_label': "ele_" + fauxfactory.gen_alphanumeric(),
@@ -131,6 +165,13 @@ def test_tagcontrol_dialog_element(appliance, request):
 
 
 def test_textareabox_dialog_element(appliance, request):
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
     if appliance.version >= "5.9":
         choose_type = "Text Area"
     else:
@@ -151,6 +192,12 @@ def test_textareabox_dialog_element(appliance, request):
 
 
 def test_reorder_elements(appliance, request):
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        initialEstimate: 1/8h
+    """
     element_1_data = {
         'element_information': {
             'ele_label': "ele_label_" + fauxfactory.gen_alphanumeric(),
@@ -181,6 +228,13 @@ def test_reorder_elements(appliance, request):
 
 
 def test_reorder_unsaved_elements(appliance, request):
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: low
+        initialEstimate: 1/16h
+    """
     # Automate BZ - https://bugzilla.redhat.com/show_bug.cgi?id=1238721
     box_label = 'box_' + fauxfactory.gen_alphanumeric()
     element_1_data = {
@@ -212,6 +266,13 @@ def test_reorder_unsaved_elements(appliance, request):
 
 
 def test_dropdownlist_dialog_element(appliance, request):
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: low
+        initialEstimate: 1/4h
+    """
     if appliance.version >= "5.9":
         choose_type = "Dropdown"
     else:
@@ -229,6 +290,13 @@ def test_dropdownlist_dialog_element(appliance, request):
 
 
 def test_radiobutton_dialog_element(appliance, request):
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: low
+        initialEstimate: 1/4h
+    """
     element_data = {
         'element_information': {
             'ele_label': "ele_" + fauxfactory.gen_alphanumeric(),

--- a/cfme/tests/automate/test_smoke.py
+++ b/cfme/tests/automate/test_smoke.py
@@ -24,6 +24,13 @@ def test_domain_present(domain_name, soft_assert, appliance):
     Steps:
         * Open the Automate Explorer.
         * Verify that all of the required domains are present.
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: critical
+        initialEstimate: 1/60h
+        testtype: sanity
     """
     dc = DomainCollection(appliance)
     domain = dc.instantiate(name=domain_name)

--- a/cfme/tests/automate/test_vmware_methods.py
+++ b/cfme/tests/automate/test_vmware_methods.py
@@ -99,6 +99,10 @@ def test_vmware_vimapi_hotadd_disk(
 
     Metadata:
         test_flag: hotdisk, provision
+
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/8h
     """
     meth = cls.methods.create(
         name='load_value_{}'.format(fauxfactory.gen_alpha()),

--- a/cfme/tests/candu/test_azone_graph.py
+++ b/cfme/tests/candu/test_azone_graph.py
@@ -49,6 +49,11 @@ def test_graph_screen(provider, azone, graph_type, interval, enable_candu):
         * Select interval Hourly
         * Zoom graph to get Table
         * Compare table and graph data
+
+    Polarion:
+        assignee: nachandr
+        caseimportance: medium
+        initialEstimate: None
     """
     azone.wait_candu_data_available(timeout=1200)
 

--- a/cfme/tests/candu/test_cluster_graph.py
+++ b/cfme/tests/candu/test_cluster_graph.py
@@ -68,6 +68,11 @@ def test_graph_screen(provider, cluster, host, graph_type, interval, enable_cand
         * Select interval Hourly/Daily
         * Zoom graph to get Table
         * Compare table and graph data
+
+    Polarion:
+        assignee: nachandr
+        caseimportance: medium
+        initialEstimate: None
     """
     host.capture_historical_data()
     cluster.wait_candu_data_available(timeout=1200)

--- a/cfme/tests/candu/test_datastore_graph.py
+++ b/cfme/tests/candu/test_datastore_graph.py
@@ -40,6 +40,11 @@ def test_graph_screen(provider, interval, graph_type, enable_candu):
         * Select interval Hourly
         * Zoom graph to get Table
         * Compare table and graph data
+
+    Polarion:
+        assignee: nachandr
+        caseimportance: medium
+        initialEstimate: None
     """
     vm_collection = provider.appliance.provider_based_collection(provider)
     vm = vm_collection.instantiate("cu-24x7", provider)

--- a/cfme/tests/candu/test_gap_collection.py
+++ b/cfme/tests/candu/test_gap_collection.py
@@ -49,6 +49,12 @@ def test_gap_collection(appliance, provider, element, graph_type, order_data):
         * Navigate to VM or Host Utilization page
         * Check for Hourly data
         * Check for Daily data
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: None
     """
     if element == 'host':
         collection = appliance.collections.hosts

--- a/cfme/tests/candu/test_host_graph.py
+++ b/cfme/tests/candu/test_host_graph.py
@@ -63,6 +63,10 @@ def test_host_most_recent_hour_graph_screen(graph_type, provider, host, enable_c
         * Check graph displayed or not
         * Check legends hide and display properly or not
         * Check data for legends collected or not
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     host.wait_candu_data_available(timeout=1200)
@@ -117,6 +121,11 @@ def test_graph_screen(provider, interval, graph_type, host, enable_candu):
         * Select interval(Hourly or Daily)
         * Zoom graph to get Table
         * Compare table and graph data
+
+    Polarion:
+        assignee: nachandr
+        caseimportance: medium
+        initialEstimate: None
     """
     wait_for(
         host.capture_historical_data,
@@ -192,6 +201,10 @@ def test_tagwise(provider, interval, graph_type, gp_by, candu_tag_vm, enable_can
 
     Bugzillas:
         * 1367560
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     # Capture historical data for cu-24x7 and its host
     candu_tag_vm.capture_historical_data()

--- a/cfme/tests/candu/test_utilization_metrics.py
+++ b/cfme/tests/candu/test_utilization_metrics.py
@@ -118,6 +118,11 @@ def query_metric_db(appliance, provider, metric, vm_name=None, host_name=None):
     unblock=lambda provider: not provider.one_of(GCEProvider))]
 )
 def test_raw_metric_vm_cpu(metrics_collection, appliance, provider):
+    """
+    Polarion:
+        assignee: nachandr
+        initialEstimate: 1/12h
+    """
     vm_name = provider.data['cap_and_util']['capandu_vm']
     if provider.category == "infra":
         query = query_metric_db(appliance, provider, 'cpu_usagemhz_rate_average',
@@ -138,6 +143,12 @@ def test_raw_metric_vm_cpu(metrics_collection, appliance, provider):
 @pytest.mark.uncollectif(
     lambda provider: provider.one_of(EC2Provider) or provider.one_of(GCEProvider))
 def test_raw_metric_vm_memory(metrics_collection, appliance, provider):
+    """
+    Polarion:
+        assignee: nachandr
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
     vm_name = provider.data['cap_and_util']['capandu_vm']
 
     if provider.type == 'azure':
@@ -165,6 +176,11 @@ def test_raw_metric_vm_memory(metrics_collection, appliance, provider):
     unblock=lambda provider: not provider.one_of(GCEProvider))]
 )
 def test_raw_metric_vm_network(metrics_collection, appliance, provider):
+    """
+    Polarion:
+        assignee: nachandr
+        initialEstimate: 1/12h
+    """
     vm_name = provider.data['cap_and_util']['capandu_vm']
     query = query_metric_db(appliance, provider, 'net_usage_rate_average',
         vm_name)
@@ -183,6 +199,12 @@ def test_raw_metric_vm_network(metrics_collection, appliance, provider):
     unblock=lambda provider: not provider.one_of(GCEProvider))]
 )
 def test_raw_metric_vm_disk(metrics_collection, appliance, provider):
+    """
+    Polarion:
+        assignee: nachandr
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
     vm_name = provider.data['cap_and_util']['capandu_vm']
     query = query_metric_db(appliance, provider, 'disk_usage_rate_average',
         vm_name)
@@ -197,6 +219,11 @@ def test_raw_metric_vm_disk(metrics_collection, appliance, provider):
 @pytest.mark.uncollectif(
     lambda provider: provider.one_of(CloudProvider))
 def test_raw_metric_host_cpu(metrics_collection, appliance, provider):
+    """
+    Polarion:
+        assignee: nachandr
+        initialEstimate: 1/12h
+    """
     host_name = get_host_name(provider)
     query = query_metric_db(appliance, provider, 'cpu_usagemhz_rate_average',
         host_name)
@@ -211,6 +238,12 @@ def test_raw_metric_host_cpu(metrics_collection, appliance, provider):
 @pytest.mark.uncollectif(
     lambda provider: provider.one_of(CloudProvider))
 def test_raw_metric_host_memory(metrics_collection, appliance, provider):
+    """
+    Polarion:
+        assignee: nachandr
+        caseimportance: low
+        initialEstimate: 1/12h
+    """
     host_name = get_host_name(provider)
     query = query_metric_db(appliance, provider, 'derived_memory_used',
         host_name)
@@ -225,6 +258,11 @@ def test_raw_metric_host_memory(metrics_collection, appliance, provider):
 @pytest.mark.uncollectif(
     lambda provider: provider.one_of(CloudProvider))
 def test_raw_metric_host_network(metrics_collection, appliance, provider):
+    """
+    Polarion:
+        assignee: nachandr
+        initialEstimate: 1/12h
+    """
     host_name = get_host_name(provider)
     query = query_metric_db(appliance, provider, 'net_usage_rate_average',
         host_name)
@@ -243,6 +281,12 @@ def test_raw_metric_host_network(metrics_collection, appliance, provider):
     unblock=lambda provider: not provider.one_of(RHEVMProvider))]
 )
 def test_raw_metric_host_disk(metrics_collection, appliance, provider):
+    """
+    Polarion:
+        assignee: nachandr
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
     host_name = get_host_name(provider)
     query = query_metric_db(appliance, provider, 'disk_usage_rate_average',
         host_name)

--- a/cfme/tests/candu/test_vm_graph.py
+++ b/cfme/tests/candu/test_vm_graph.py
@@ -47,6 +47,11 @@ def test_vm_most_recent_hour_graph_screen(graph_type, provider, enable_candu):
         * Check graph displayed or not
         * Check legends hide and display properly or not
         * Check data for legends collected or not
+
+    Polarion:
+        assignee: nachandr
+        caseimportance: medium
+        initialEstimate: None
     """
     collection = provider.appliance.provider_based_collection(provider)
     vm = collection.instantiate('cu-24x7', provider)
@@ -105,6 +110,11 @@ def test_graph_screen(provider, interval, graph_type, enable_candu):
         * Check graph displayed or not
         * Zoom graph
         * Compare data of Table and Graph
+
+    Polarion:
+        assignee: nachandr
+        caseimportance: medium
+        initialEstimate: None
     """
     collection = provider.appliance.provider_based_collection(provider)
     vm = collection.instantiate('cu-24x7', provider)

--- a/cfme/tests/cli/test_appliance_cli.py
+++ b/cfme/tests/cli/test_appliance_cli.py
@@ -30,8 +30,16 @@ requires_59 = pytest.mark.uncollectif(
 
 
 @requires_59
+@pytest.mark.tier(1)
 def test_appliance_console_cli_datetime(temp_appliance_preconfig_funcscope):
-    """Grab fresh appliance and set time and date through appliance_console_cli and check result"""
+    """Grab fresh appliance and set time and date through appliance_console_cli and check result
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     app = temp_appliance_preconfig_funcscope
     app.ssh_client.run_command("appliance_console_cli --datetime 2020-10-20T09:59:00")
 
@@ -43,15 +51,29 @@ def test_appliance_console_cli_datetime(temp_appliance_preconfig_funcscope):
 @pytest.mark.rhel_testing
 @requires_59
 @pytest.mark.parametrize('timezone', tzs, ids=[tz[0] for tz in tzs])
+@pytest.mark.tier(2)
 def test_appliance_console_cli_timezone(timezone, temp_appliance_preconfig_modscope):
-    """Set and check timezones are set correctly through appliance conosle cli"""
+    """Set and check timezones are set correctly through appliance conosle cli
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        initialEstimate: 1/12h
+    """
     app = temp_appliance_preconfig_modscope
     app.ssh_client.run_command("appliance_console_cli --timezone {}".format(timezone))
     app.appliance_console.timezone_check(timezone)
 
 
 @pytest.mark.meta(blockers=[BZ(1598427, forced_streams=['5.9', '5.10'])])
+@pytest.mark.tier(2)
 def test_appliance_console_cli_set_hostname(configured_appliance):
+    """
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        initialEstimate: 1/12h
+    """
     hostname = 'test.example.com'
     configured_appliance.appliance_console_cli.set_hostname(hostname)
     result = configured_appliance.ssh_client.run_command("hostname -f")
@@ -60,7 +82,15 @@ def test_appliance_console_cli_set_hostname(configured_appliance):
 
 
 @pytest.mark.rhel_testing
+@pytest.mark.tier(2)
 def test_appliance_console_cli_internal_fetch_key(app_creds, unconfigured_appliance, appliance):
+    """
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+    """
     fetch_key_ip = appliance.hostname
     unconfigured_appliance.appliance_console_cli.configure_appliance_internal_fetch_key(
         0, 'localhost', app_creds['username'], app_creds['password'], 'vmdb_production',
@@ -70,8 +100,16 @@ def test_appliance_console_cli_internal_fetch_key(app_creds, unconfigured_applia
     unconfigured_appliance.wait_for_web_ui()
 
 
+@pytest.mark.tier(2)
 def test_appliance_console_cli_external_join(app_creds, appliance,
                                              temp_appliance_unconfig_funcscope):
+    """
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
     appliance_ip = appliance.hostname
     temp_appliance_unconfig_funcscope.appliance_console_cli.configure_appliance_external_join(
         appliance_ip, app_creds['username'], app_creds['password'], 'vmdb_production', appliance_ip,
@@ -81,8 +119,15 @@ def test_appliance_console_cli_external_join(app_creds, appliance,
 
 
 @pytest.mark.rhel_testing
+@pytest.mark.tier(2)
 def test_appliance_console_cli_external_create(app_creds, dedicated_db_appliance,
                                                unconfigured_appliance_secondary):
+    """
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        initialEstimate: 1/3h
+    """
     hostname = dedicated_db_appliance.hostname
     unconfigured_appliance_secondary.appliance_console_cli.configure_appliance_external_create(5,
         hostname, app_creds['username'], app_creds['password'], 'vmdb_production', hostname,
@@ -94,6 +139,11 @@ def test_appliance_console_cli_external_create(app_creds, dedicated_db_appliance
 @pytest.mark.parametrize('auth_type', ['sso_enabled', 'saml_enabled', 'local_login_disabled'],
     ids=['sso', 'saml', 'local_login'])
 def test_appliance_console_cli_external_auth(auth_type, ipa_crud, app_creds, configured_appliance):
+    """
+    Polarion:
+        assignee: mpusater
+        initialEstimate: None
+    """
     evm_tail = LogValidator('/var/www/miq/vmdb/log/evm.log',
                             matched_patterns=['.*{} to true.*'.format(auth_type)],
                             hostname=configured_appliance.hostname,
@@ -124,6 +174,11 @@ def no_ipa_config(configured_appliance):
 
 @pytest.mark.rhel_testing
 def test_appliance_console_cli_ipa(ipa_crud, configured_appliance, no_ipa_config):
+    """
+    Polarion:
+        assignee: mpusater
+        initialEstimate: None
+    """
     ipa_args = ipa_crud.as_external_value()
     configured_appliance.appliance_console_cli.configure_ipa(**ipa_args)
     assert wait_for(lambda: configured_appliance.sssd.running)
@@ -132,7 +187,14 @@ def test_appliance_console_cli_ipa(ipa_crud, configured_appliance, no_ipa_config
 
 
 @requires_59
+@pytest.mark.tier(1)
 def test_appliance_console_cli_extend_storage(unconfigured_appliance):
+    """
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        initialEstimate: 1/6h
+    """
     unconfigured_appliance.ssh_client.run_command('appliance_console_cli -t auto')
 
     def is_storage_extended():
@@ -141,7 +203,15 @@ def test_appliance_console_cli_extend_storage(unconfigured_appliance):
 
 
 @requires_59
+@pytest.mark.tier(1)
 def test_appliance_console_cli_extend_log_storage(unconfigured_appliance):
+    """
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     unconfigured_appliance.ssh_client.run_command('appliance_console_cli -l auto')
 
     def is_storage_extended():
@@ -151,7 +221,14 @@ def test_appliance_console_cli_extend_log_storage(unconfigured_appliance):
 
 @pytest.mark.rhel_testing
 @requires_59
+@pytest.mark.tier(1)
 def test_appliance_console_cli_configure_dedicated_db(unconfigured_appliance, app_creds):
+    """
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        initialEstimate: 1/6h
+    """
     unconfigured_appliance.appliance_console_cli.configure_appliance_dedicated_db(
         app_creds['username'], app_creds['password'], 'vmdb_production',
         unconfigured_appliance.unpartitioned_disks[0]
@@ -160,8 +237,15 @@ def test_appliance_console_cli_configure_dedicated_db(unconfigured_appliance, ap
 
 
 @pytest.mark.meta(blockers=[BZ(1544854, forced_streams=['5.9', '5.10'])])
+@pytest.mark.tier(2)
 def test_appliance_console_cli_ha_crud(unconfigured_appliances, app_creds):
-    """Tests the configuration of HA with three appliances including failover to standby node"""
+    """Tests the configuration of HA with three appliances including failover to standby node
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        initialEstimate: 1h
+    """
     apps = unconfigured_appliances
     app0_ip = apps[0].hostname
     app1_ip = apps[1].hostname

--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -42,8 +42,16 @@ ext_auth_options = [
 @pytest.mark.rhel_testing
 @pytest.mark.uncollectif(lambda appliance: appliance.is_pod)
 @pytest.mark.smoke
+@pytest.mark.tier(2)
 def test_appliance_console(appliance):
-    """'ap | tee /tmp/opt.txt)' saves stdout to file, 'ap' launch appliance_console."""
+    """'ap | tee /tmp/opt.txt)' saves stdout to file, 'ap' launch appliance_console.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: critical
+        initialEstimate: 1/12h
+    """
     command_set = ('ap | tee -a /tmp/opt.txt', 'ap')
     appliance.appliance_console.run_commands(command_set)
     assert appliance.ssh_client.run_command("cat /tmp/opt.txt | grep '{} Virtual Appliance'"
@@ -55,13 +63,21 @@ def test_appliance_console(appliance):
 
 
 @pytest.mark.rhel_testing
+@pytest.mark.tier(2)
 def test_appliance_console_set_hostname(configured_appliance):
     """ Commands:
     1. 'ap' launch appliance_console,
     2. '' clear info screen,
     3. '1' loads network settings,
     4. '5' gives access to set hostname,
-    5. 'hostname' sets new hostname."""
+    5. 'hostname' sets new hostname.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
 
     hostname = 'test.example.com'
     command_set = ('ap', '', '1', '5', hostname,)
@@ -78,6 +94,7 @@ def test_appliance_console_set_hostname(configured_appliance):
 
 @pytest.mark.rhel_testing
 @pytest.mark.parametrize('timezone', tzs, ids=[tz.name for tz in tzs])
+@pytest.mark.tier(2)
 def test_appliance_console_set_timezone(timezone, temp_appliance_preconfig_modscope):
     """ Commands:
     1. 'ap' launch appliance_console,
@@ -86,7 +103,13 @@ def test_appliance_console_set_timezone(timezone, temp_appliance_preconfig_modsc
     4. 'opt' select region,
     5. 'timezone' selects zone,
     6. 'y' confirm slection,
-    7. '' finish."""
+    7. '' finish.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        initialEstimate: 1/6h
+    """
     command_set = ('ap', '', '2') + timezone[1] + ('y', '')
     temp_appliance_preconfig_modscope.appliance_console.run_commands(command_set)
 
@@ -94,8 +117,15 @@ def test_appliance_console_set_timezone(timezone, temp_appliance_preconfig_modsc
 
 
 @pytest.mark.rhel_testing
+@pytest.mark.tier(1)
 def test_appliance_console_datetime(temp_appliance_preconfig_funcscope):
-    """Grab fresh appliance and set time and date through appliance_console and check result"""
+    """Grab fresh appliance and set time and date through appliance_console and check result
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        initialEstimate: 1/6h
+    """
     app = temp_appliance_preconfig_funcscope
     command_set = ('ap', '', '3', 'y', '2020-10-20', '09:58:00', 'y', '')
     app.appliance_console.run_commands(command_set)
@@ -106,6 +136,7 @@ def test_appliance_console_datetime(temp_appliance_preconfig_funcscope):
 
 
 @pytest.mark.rhel_testing
+@pytest.mark.tier(2)
 def test_appliance_console_internal_db(app_creds, unconfigured_appliance):
     """ Commands:
     1. 'ap' launch appliance_console,
@@ -119,7 +150,14 @@ def test_appliance_console_internal_db(app_creds, unconfigured_appliance):
     9. '0' db region number,
     10. 'pwd' db password,
     11. 'pwd' confirm db password + wait 360 secs
-    12. '' finish."""
+    12. '' finish.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: critical
+        initialEstimate: 1/4h
+    """
 
     pwd = app_creds['password']
     command_set = ('ap', '', '5', '1', '1', 'y', '1', 'n', '0', pwd, TimedCommand(pwd, 360), '')
@@ -128,6 +166,7 @@ def test_appliance_console_internal_db(app_creds, unconfigured_appliance):
     unconfigured_appliance.wait_for_web_ui()
 
 
+@pytest.mark.tier(2)
 def test_appliance_console_internal_db_reset(temp_appliance_preconfig_funcscope):
     """ Commands:
     1. 'ap' launch appliance_console,
@@ -136,7 +175,14 @@ def test_appliance_console_internal_db_reset(temp_appliance_preconfig_funcscope)
     4. '4' reset db,
     5. 'y' confirm db reset,
     6. '1' db region number + wait 360 secs,
-    7. '' continue"""
+    7. '' continue
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
 
     temp_appliance_preconfig_funcscope.ssh_client.run_command('systemctl stop evmserverd')
     command_set = ('ap', '', '5', '4', 'y', TimedCommand('1', 360), '')
@@ -146,6 +192,7 @@ def test_appliance_console_internal_db_reset(temp_appliance_preconfig_funcscope)
     temp_appliance_preconfig_funcscope.wait_for_web_ui()
 
 
+@pytest.mark.tier(2)
 def test_appliance_console_dedicated_db(unconfigured_appliance, app_creds):
     """ Commands:
     1. 'ap' launch appliance_console,
@@ -158,7 +205,14 @@ def test_appliance_console_dedicated_db(unconfigured_appliance, app_creds):
     8. 'y' create dedicated db,
     9. 'pwd' db password,
     10. 'pwd' confirm db password + wait 360 secs
-    11. '' finish."""
+    11. '' finish.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        initialEstimate: 1/3h
+        testtype: structural
+    """
 
     pwd = app_creds['password']
     command_set = ('ap', '', '5', '1', '1', 'y', '1', 'y', pwd, TimedCommand(pwd, 360), '')
@@ -166,6 +220,7 @@ def test_appliance_console_dedicated_db(unconfigured_appliance, app_creds):
     wait_for(lambda: unconfigured_appliance.db.is_dedicated_active)
 
 
+@pytest.mark.tier(2)
 def test_appliance_console_ha_crud(unconfigured_appliances, app_creds):
     """Testing HA configuration with 3 appliances.
 
@@ -200,6 +255,12 @@ def test_appliance_console_ha_crud(unconfigured_appliances, app_creds):
     Appliance one, stop APPLIANCE_PG_SERVICE and check that the standby node takes over correctly
     and evm starts up again pointing at the new primary database.
 
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        initialEstimate: 1h
+        testtype: structural
     """
     apps = unconfigured_appliances
     app0_ip = apps[0].hostname
@@ -247,6 +308,7 @@ def test_appliance_console_ha_crud(unconfigured_appliances, app_creds):
     apps[2].wait_for_web_ui()
 
 
+@pytest.mark.tier(2)
 def test_appliance_console_external_db(temp_appliance_unconfig_funcscope, app_creds, appliance):
     """ Commands:
     1. 'ap' launch appliance_console,
@@ -263,7 +325,15 @@ def test_appliance_console_external_db(temp_appliance_unconfig_funcscope, app_cr
     12. '' default username,
     13. 'pwd' db password,
     14. 'pwd' confirm db password + wait 360 secs
-    15. '' finish."""
+    15. '' finish.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: critical
+        initialEstimate: 1/2h
+        testtype: structural
+    """
 
     ip = appliance.hostname
     pwd = app_creds['password']
@@ -274,6 +344,7 @@ def test_appliance_console_external_db(temp_appliance_unconfig_funcscope, app_cr
     temp_appliance_unconfig_funcscope.wait_for_web_ui()
 
 
+@pytest.mark.tier(2)
 def test_appliance_console_external_db_create(
         app_creds, dedicated_db_appliance, unconfigured_appliance_secondary):
     """
@@ -291,7 +362,13 @@ def test_appliance_console_external_db_create(
     12. '' default username,
     13. 'pwd' db  password,
     14. 'pwd' confirm db password + wait 360 secs,
-    15. '' finish."""
+    15. '' finish.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        initialEstimate: 1/3h
+    """
 
     ip = dedicated_db_appliance.hostname
     pwd = app_creds['password']
@@ -302,6 +379,7 @@ def test_appliance_console_external_db_create(
     unconfigured_appliance_secondary.wait_for_web_ui()
 
 
+@pytest.mark.tier(2)
 def test_appliance_console_extend_storage(unconfigured_appliance):
     """ Commands:
     1. 'ap' launches appliance_console,
@@ -309,7 +387,14 @@ def test_appliance_console_extend_storage(unconfigured_appliance):
     3. '9' extend storage,
     4. '1' select disk,
     5. 'y' confirm configuration,
-    6. '' complete."""
+    6. '' complete.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: critical
+        initialEstimate: 1/4h
+    """
     command_set = ('ap', '', '9', '1', 'y', '')
     unconfigured_appliance.appliance_console.run_commands(command_set)
 
@@ -324,7 +409,12 @@ def test_appliance_console_ipa(ipa_crud, configured_appliance):
     1. 'ap' launches appliance_console,
     2. '' clears info screen,
     3. '10' setup IPA, + wait 40 secs,
-    4. '' finish."""
+    4. '' finish.
+
+    Polarion:
+        assignee: mpusater
+        initialEstimate: None
+    """
 
     command_set = ('ap', RETURN, '10',
                    ipa_crud.host1,
@@ -352,7 +442,12 @@ def test_appliance_console_external_auth(auth_type, app_creds, ipa_crud, configu
     2. '' clears info screen,
     3. '11' change ext auth options,
     4. 'auth_type' auth type to change,
-    5. '4' apply changes."""
+    5. '4' apply changes.
+
+    Polarion:
+        assignee: mpusater
+        initialEstimate: None
+    """
     # TODO this depends on the auth_type options being disabled when the test is run
     # TODO it assumes that first switch is to true, then false.
 
@@ -384,7 +479,12 @@ def test_appliance_console_external_auth_all(app_creds, ipa_crud, configured_app
     2. '' clears info screen,
     3. '12/15' change ext auth options,
     4. 'auth_type' auth type to change,
-    5. '4' apply changes."""
+    5. '4' apply changes.
+
+    Polarion:
+        assignee: mpusater
+        initialEstimate: None
+    """
 
     evm_tail = LogValidator('/var/www/miq/vmdb/log/evm.log',
                             matched_patterns=['.*sso_enabled to true.*',
@@ -413,12 +513,20 @@ def test_appliance_console_external_auth_all(app_creds, ipa_crud, configured_app
 
 
 @pytest.mark.rhel_testing
+@pytest.mark.tier(2)
 def test_appliance_console_scap(temp_appliance_preconfig, soft_assert):
     """ Commands:
     1. 'ap' launches appliance_console,
     2. '' clears info screen,
     3. '13' Hardens appliance using SCAP configuration,
-    4. '' complete."""
+    4. '' complete.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: critical
+        initialEstimate: 1/3h
+    """
 
     command_set = ('ap', '', '13', '')
     temp_appliance_preconfig.appliance_console.run_commands(command_set)
@@ -461,6 +569,7 @@ def test_appliance_console_scap(temp_appliance_preconfig, soft_assert):
             logger.info("{}: rule not found".format(rule))
 
 
+@pytest.mark.tier(1)
 def test_appliance_console_dhcp(unconfigured_appliance, soft_assert):
     """ Commands:
     1. 'ap' launches appliance_console,
@@ -468,7 +577,14 @@ def test_appliance_console_dhcp(unconfigured_appliance, soft_assert):
     3. '1' configure network,
     4. '1' configure DHCP,
     5. 'y' confirm IPv4 configuration,
-    6. 'y' IPv6 configuration."""
+    6. 'y' IPv6 configuration.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: critical
+        initialEstimate: 1/6h
+    """
     command_set = ('ap', '', '1', '1', 'y', 'y')
     unconfigured_appliance.appliance_console.run_commands(command_set)
 
@@ -482,6 +598,7 @@ def test_appliance_console_dhcp(unconfigured_appliance, soft_assert):
         ("ip a show dev eth0 | grep 'inet6\s.*dynamic'"))
 
 
+@pytest.mark.tier(1)
 def test_appliance_console_static_ipv4(unconfigured_appliance, soft_assert):
     """ Commands:
     1. 'ap' launches appliance_console,
@@ -495,6 +612,12 @@ def test_appliance_console_static_ipv4(unconfigured_appliance, soft_assert):
     9. '' confirm default secondary DNS,
     10. '' confirm default search order,
     11. 'y' apply static configuration.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: critical
+        initialEstimate: 1/6h
     """
     command_set = ('ap', '', '1', '2', '', '', '', '', '', '', 'y')
     unconfigured_appliance.appliance_console.run_commands(command_set)
@@ -522,6 +645,10 @@ def test_appliance_console_static_ipv6(unconfigured_appliance, soft_assert):
     9. '' confirm default secondary DNS,
     10. '' confirm default search order,
     11. 'y' apply static configuration.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     command_set = ('ap', '', '1', '3', '1::1', '', '1::f', '', '', '', 'y')
     unconfigured_appliance.appliance_console.run_commands(command_set)

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -232,6 +232,12 @@ def setup_nfs_samba_backup(appl1):
 def test_appliance_console_restore_db_local(request, get_appliances_with_providers):
     """ Test single appliance backup and restore, configures appliance with providers,
     backs up database, restores it to fresh appliance and checks for matching providers.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: critical
+        initialEstimate: 1/2h
     """
     appl1, appl2 = get_appliances_with_providers
     # Transfer v2_key and db backup from first appliance to second appliance
@@ -259,6 +265,13 @@ def test_appliance_console_restore_db_local(request, get_appliances_with_provide
 @pytest.mark.uncollectif(lambda appliance: not appliance.is_downstream or appliance.version < '5.9',
                          reason='Test not supported below 5.9')
 def test_appliance_console_restore_pg_basebackup_ansible(get_appliance_with_ansible):
+    """
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: critical
+        initialEstimate: 1/2h
+    """
     appl1 = get_appliance_with_ansible
     # Restore DB on the second appliance
     appl1.evmserverd.stop()
@@ -290,6 +303,14 @@ def test_appliance_console_restore_pg_basebackup_ansible(get_appliance_with_ansi
                          reason='Test only for downstream version of product')
 def test_appliance_console_restore_pg_basebackup_replicated(
         request, get_replicated_appliances_with_providers):
+    """
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: critical
+        initialEstimate: 1/2h
+        upstream: no
+    """
     appl1, appl2 = get_replicated_appliances_with_providers
     providers_before_restore = set(appl1.managed_provider_names)
     # Restore DB on the second appliance
@@ -328,6 +349,12 @@ def test_appliance_console_restore_pg_basebackup_replicated(
 def test_appliance_console_restore_db_external(request, get_ext_appliances_with_providers):
     """Configure ext environment with providers, run backup/restore on configuration,
     Confirm that providers still exist after restore and provisioning works.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: critical
+        initialEstimate: 1h
     """
     appl1, appl2 = get_ext_appliances_with_providers
     # Restore DB on the second appliance
@@ -364,6 +391,12 @@ def test_appliance_console_restore_db_external(request, get_ext_appliances_with_
                          reason='Test only for downstream version of product')
 def test_appliance_console_restore_db_replicated(
         request, get_replicated_appliances_with_providers):
+    """
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        initialEstimate: 1h
+    """
     appl1, appl2 = get_replicated_appliances_with_providers
     providers_before_restore = set(appl1.managed_provider_names)
     # Restore DB on the second appliance
@@ -406,6 +439,11 @@ def test_appliance_console_restore_db_replicated(
 def test_appliance_console_restore_db_ha(request, get_ha_appliances_with_providers):
     """Configure HA environment with providers, run backup/restore on configuration,
     Confirm that ha failover continues to work correctly and providers still exist.
+
+    Polarion:
+        assignee: lcouzens
+        casecomponent: appl
+        initialEstimate: None
     """
     appl1, appl2, appl3 = get_ha_appliances_with_providers
     providers_before_restore = set(appl3.managed_provider_names)
@@ -452,6 +490,12 @@ def test_appliance_console_restore_db_ha(request, get_ha_appliances_with_provide
 def test_appliance_console_restore_db_nfs(request, get_appliances_with_providers):
     """ Test single appliance backup and restore through nfs, configures appliance with providers,
         backs up database, restores it to fresh appliance and checks for matching providers.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: critical
+        initialEstimate: 1h
     """
     appl1, appl2 = get_appliances_with_providers
     host = cfme_data['network_share']['hostname']
@@ -484,6 +528,12 @@ def test_appliance_console_restore_db_nfs(request, get_appliances_with_providers
 def test_appliance_console_restore_db_samba(request, get_appliances_with_providers):
     """ Test single appliance backup and restore through smb, configures appliance with providers,
         backs up database, restores it to fresh appliance and checks for matching providers.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: critical
+        initialEstimate: 1h
     """
     appl1, appl2 = get_appliances_with_providers
     host = cfme_data['network_share']['hostname']

--- a/cfme/tests/cli/test_appliance_update.py
+++ b/cfme/tests/cli/test_appliance_update.py
@@ -90,7 +90,12 @@ def appliance_preupdate(old_version, appliance):
 
 @pytest.mark.rhel_testing
 def test_update_yum(appliance_preupdate, appliance):
-    """Tests appliance update between versions"""
+    """Tests appliance update between versions
+
+    Polarion:
+        assignee: lcouzens
+        initialEstimate: 1/4h
+    """
     appliance_preupdate.evmserverd.stop()
     with appliance_preupdate.ssh_client as ssh:
         result = ssh.run_command('yum update -y', timeout=3600)
@@ -104,7 +109,12 @@ def test_update_yum(appliance_preupdate, appliance):
 @pytest.mark.ignore_stream("upstream")
 def test_update_webui(appliance_with_providers, appliance, request, old_version):
     """ Tests updating an appliance with providers, also confirms that the
-        provisioning continues to function correctly after the update has completed"""
+        provisioning continues to function correctly after the update has completed
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     update_appliance(appliance_with_providers)
 
     wait_for(do_appliance_versions_match, func_args=(appliance, appliance_with_providers),
@@ -119,7 +129,12 @@ def test_update_webui(appliance_with_providers, appliance, request, old_version)
 @pytest.mark.ignore_stream("upstream")
 def test_update_scap_webui(appliance_with_providers, appliance, request, old_version):
     """ Tests updating an appliance with providers and scap hardened, also confirms that the
-        provisioning continues to function correctly after the update has completed"""
+        provisioning continues to function correctly after the update has completed
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     appliance_with_providers.appliance_console.scap_harden_appliance()
     rules_failures = appliance_with_providers.appliance_console.scap_check_rules()
     assert not rules_failures, "Some rules have failed, check log"
@@ -140,7 +155,12 @@ def test_update_scap_webui(appliance_with_providers, appliance, request, old_ver
 @pytest.mark.ignore_stream("upstream")
 def test_update_embedded_ansible_webui(enabled_embedded_appliance, appliance, old_version):
     """ Tests updating an appliance which has embedded ansible role enabled, also confirms that the
-        role continues to function correctly after the update has completed"""
+        role continues to function correctly after the update has completed
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     update_appliance(enabled_embedded_appliance)
     wait_for(do_appliance_versions_match, func_args=(appliance, enabled_embedded_appliance),
              num_sec=900, delay=20, handle_exception=True,
@@ -168,7 +188,12 @@ def test_update_embedded_ansible_webui(enabled_embedded_appliance, appliance, ol
 def test_update_distributed_webui(ext_appliances_with_providers, appliance, request, old_version,
                                   soft_assert):
     """ Tests updating an appliance with providers, also confirms that the
-            provisioning continues to function correctly after the update has completed"""
+            provisioning continues to function correctly after the update has completed
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     update_appliance(ext_appliances_with_providers[0])
     wait_for(do_appliance_versions_match, func_args=(appliance, ext_appliances_with_providers[0]),
              num_sec=900, delay=20, handle_exception=True,
@@ -189,7 +214,12 @@ def test_update_distributed_webui(ext_appliances_with_providers, appliance, requ
 def test_update_replicated_webui(replicated_appliances_with_providers, appliance, request,
                                  old_version, soft_assert):
     """ Tests updating an appliance with providers, also confirms that the
-            provisioning continues to function correctly after the update has completed"""
+            provisioning continues to function correctly after the update has completed
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     providers_before_upgrade = set(replicated_appliances_with_providers[0].managed_provider_names)
     update_appliance(replicated_appliances_with_providers[0])
     update_appliance(replicated_appliances_with_providers[1])
@@ -217,7 +247,12 @@ def test_update_replicated_webui(replicated_appliances_with_providers, appliance
 @pytest.mark.ignore_stream("upstream")
 def test_update_ha_webui(ha_appliances_with_providers, appliance, request, old_version):
     """ Tests updating an appliance with providers, also confirms that the
-            provisioning continues to function correctly after the update has completed"""
+            provisioning continues to function correctly after the update has completed
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     update_appliance(ha_appliances_with_providers[2])
     wait_for(do_appliance_versions_match, func_args=(appliance, ha_appliances_with_providers[2]),
              num_sec=900, delay=20, handle_exception=True,

--- a/cfme/tests/cli/test_evmserverd.py
+++ b/cfme/tests/cli/test_evmserverd.py
@@ -31,6 +31,11 @@ def test_evmserverd_stop(appliance, request):
         * Periodically check output of ``service evmserverd status`` that all servers are stopped.
         * For 5.5+: Really call ``service evmserverd status`` and check that the mentions of
             stopping the service are present.
+
+    Polarion:
+        assignee: amavinag
+        caseimportance: medium
+        initialEstimate: 1/4h
     """
 
     server_name_key = 'Server'

--- a/cfme/tests/cli/test_rake_evm_automate-53.py
+++ b/cfme/tests/cli/test_rake_evm_automate-53.py
@@ -48,6 +48,10 @@ def test_evm_automate_import_export_works_upstream(appliance, rake, soft_assert)
         * Use ``evm:automate:import`` rake task to import the testing file.
         * Use ``evm:automate:export`` rake task to export the data to another file.
         * Verify the file exists.
+
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/3h
     """
     appliance.ssh_client.put_file(
         cli_path.join("QECliTesting.yaml").strpath, "/root/QECliTesting.yaml")
@@ -74,6 +78,11 @@ def test_evm_automate_simulate_upstream(rake, qe_ae_data, appliance):
             INSTANCE=touch`` rake task
         * Verify the file ``/var/www/miq/vmdb/check_file`` exists and it contains string
             ``check content``
+
+    Polarion:
+        assignee: dmisharo
+        caseimportance: low
+        initialEstimate: 1/4h
     """
     appliance.ssh_client.run_command("rm -f /var/www/miq/vmdb/check_file")
     result = rake(
@@ -98,6 +107,10 @@ def test_evm_automate_convert(request, rake, appliance):
         * Import the ZIP file using ``evm:automate_import`` rake task.
         * Use ``evm:automate:extract_methods FOLDER=/some_folder`` and verify that a file named
             ``relay_events.rb`` is present in the directory hierarchy.
+
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/6h
     """
     appliance.ssh_client.put_file(
         data_path.join("qe_event_handler.xml").strpath, "/root/convert_test.xml")

--- a/cfme/tests/cloud/test_cloud_events.py
+++ b/cfme/tests/cloud/test_cloud_events.py
@@ -20,6 +20,10 @@ def test_manage_nsg_group(appliance, provider, register_event):
 
     Metadata:
         test_flag: events
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     nsg_name = random_vm_name(context='nsg')
@@ -68,6 +72,10 @@ def test_vm_capture(appliance, request, provider, register_event):
 
     Metadata:
         test_flag: events, provision
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     vm = appliance.collections.cloud_instances.instantiate(

--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -254,6 +254,10 @@ def test_cloud_timeline_create_event(new_instance, soft_assert, azone):
     """
     Metadata:
         test_flag: timelines, events
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     targets = (new_instance, new_instance.provider, azone)
     event = 'create'
@@ -268,6 +272,10 @@ def test_cloud_timeline_policy_event(new_instance, control_policy, soft_assert):
     """
     Metadata:
         test_flag: timelines, events
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     event = 'policy'
     targets = (new_instance, new_instance.provider)
@@ -281,6 +289,10 @@ def test_cloud_timeline_stop_event(new_instance, soft_assert, azone):
     """
     Metadata:
         test_flag: timelines, events
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     targets = (new_instance, new_instance.provider, azone)
     event = 'stop'
@@ -294,6 +306,10 @@ def test_cloud_timeline_start_event(new_instance, soft_assert, azone):
     """
     Metadata:
         test_flag: timelines, events
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     targets = (new_instance, new_instance.provider, azone)
     event = 'start'
@@ -308,6 +324,10 @@ def test_cloud_timeline_diagnostic(new_instance, mark_vm_as_appliance, soft_asse
 
     Metadata:
         test_flag: timelines, events
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     event = 'create'
     targets = (new_instance.appliance.server,)
@@ -322,6 +342,10 @@ def test_cloud_timeline_rename_event(new_instance, soft_assert, azone):
     """
     Metadata:
         test_flag: timelines, events
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     event = 'rename'
     targets = (new_instance, new_instance.provider, azone)
@@ -337,6 +361,10 @@ def test_cloud_timeline_delete_event(new_instance, soft_assert, azone):
     """
     Metadata:
         test_flag: timelines, events
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     event = 'delete'
     targets = (new_instance, new_instance.provider, azone)

--- a/cfme/tests/cloud/test_delete_cloud_object.py
+++ b/cfme/tests/cloud/test_delete_cloud_object.py
@@ -28,6 +28,10 @@ def test_delete_instance_appear_after_refresh(appliance, provider):
 
     Metadata:
         test_flag: delete_object
+
+    Polarion:
+        assignee: mmojzis
+        initialEstimate: None
     """
     instance_name = provider.data['remove_test']['instance']
     test_instance = appliance.collections.cloud_instances.instantiate(instance_name, provider)
@@ -42,6 +46,12 @@ def test_delete_image_appear_after_refresh(appliance, provider, set_grid, reques
 
     Metadata:
         test_flag: delete_object
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
     """
     image_name = provider.data['remove_test']['image']
     test_image = appliance.collections.cloud_images.instantiate(image_name, provider)
@@ -57,6 +67,10 @@ def test_delete_stack_appear_after_refresh(appliance, provider, provisioning,
 
     Metadata:
         test_flag: delete_object
+
+    Polarion:
+        assignee: mmojzis
+        initialEstimate: None
     """
 
     stack = appliance.collections.cloud_stacks.instantiate(name=provisioning['stacks'][0],

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -197,6 +197,10 @@ def test_quadicon_terminate_cancel(provider, testing_instance, ensure_vm_running
 
     Metadata:
         test_flag: power_control, provision
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/4h
     """
     testing_instance.power_control_from_cfme(option=testing_instance.TERMINATE,
                                              cancel=True,
@@ -209,6 +213,10 @@ def test_quadicon_terminate(appliance, provider, testing_instance, ensure_vm_run
 
     Metadata:
         test_flag: power_control, provision
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/4h
     """
     testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_ON)
     testing_instance.power_control_from_cfme(option=testing_instance.TERMINATE, from_details=False)
@@ -230,6 +238,10 @@ def test_stop(appliance, provider, testing_instance, ensure_vm_running, soft_ass
 
     Metadata:
         test_flag: power_control, provision
+
+    Polarion:
+        assignee: bsquizza
+        initialEstimate: 1/4h
     """
     testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_ON)
     testing_instance.power_control_from_cfme(option=testing_instance.STOP)
@@ -246,6 +258,10 @@ def test_start(appliance, provider, testing_instance, ensure_vm_stopped, soft_as
 
     Metadata:
         test_flag: power_control, provision
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/4h
     """
     testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_OFF,
                                                     timeout=900)
@@ -264,6 +280,10 @@ def test_soft_reboot(appliance, provider, testing_instance, ensure_vm_running, s
 
     Metadata:
         test_flag: power_control, provision
+
+    Polarion:
+        assignee: bsquizza
+        initialEstimate: 1/4h
     """
     testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_ON)
     view = navigate_to(testing_instance, 'Details')
@@ -293,6 +313,10 @@ def test_power_on_or_off_multiple(provider, testing_instance, testing_instance2,
 
     Metadata:
         test_flag: power_control, provision
+
+    Polarion:
+        assignee: bsquizza
+        initialEstimate: 1/8h
     """
     # The instances *should* be on after provisioning... but we'll make sure here...
     testing_instance.mgmt.ensure_state(VmState.RUNNING)
@@ -329,6 +353,10 @@ def test_hard_reboot(appliance, provider, testing_instance, ensure_vm_running, s
 
     Metadata:
         test_flag: power_control, provision
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_ON)
     view = navigate_to(testing_instance, 'Details')
@@ -349,6 +377,10 @@ def test_hard_reboot_unsupported(appliance, testing_instance):
 
     Metadata:
         test_flag: power_control, provision
+
+    Polarion:
+        assignee: bsquizza
+        initialEstimate: 1/8h
     """
     testing_instance.power_control_from_cfme(option=testing_instance.HARD_REBOOT,
                                              from_details=False)
@@ -367,6 +399,10 @@ def test_suspend(appliance, provider, testing_instance, ensure_vm_running, soft_
 
     Metadata:
         test_flag: power_control, provision
+
+    Polarion:
+        assignee: bsquizza
+        initialEstimate: 1/4h
     """
     testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_ON)
     testing_instance.power_control_from_cfme(option=testing_instance.SUSPEND)
@@ -385,6 +421,10 @@ def test_unpause(appliance, provider, testing_instance, ensure_vm_paused, soft_a
 
     Metadata:
         test_flag: power_control, provision
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_PAUSED)
     testing_instance.power_control_from_cfme(option=testing_instance.START)
@@ -401,6 +441,10 @@ def test_resume(appliance, provider, testing_instance, ensure_vm_suspended, soft
 
     Metadata:
         test_flag: power_control, provision
+
+    Polarion:
+        assignee: bsquizza
+        initialEstimate: 1/4h
     """
     testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_SUSPENDED)
     testing_instance.power_control_from_cfme(option=testing_instance.START)
@@ -416,6 +460,10 @@ def test_terminate(provider, testing_instance, ensure_vm_running, soft_assert, a
 
     Metadata:
         test_flag: power_control, provision
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/4h
     """
     testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_ON)
     testing_instance.power_control_from_cfme(option=testing_instance.TERMINATE)
@@ -432,6 +480,11 @@ def test_instance_power_options_from_on(provider, testing_instance, ensure_vm_ru
 
     Metadata:
         test_flag: power_control
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: cloud
+        initialEstimate: 1/10h
     """
     testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_ON)
     check_power_options(soft_assert, testing_instance, 'on')
@@ -443,6 +496,11 @@ def test_instance_power_options_from_off(provider, testing_instance,
 
     Metadata:
         test_flag: power_control
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: cloud
+        initialEstimate: 1/10h
     """
     testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_OFF,
                                                     timeout=1200)
@@ -475,6 +533,10 @@ class TestInstanceRESTAPI(object):
 
         Metadata:
             test_flag: power_control, provision, rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_ON)
         vm = testing_instance.get_vm_via_rest()
@@ -492,6 +554,10 @@ class TestInstanceRESTAPI(object):
 
         Metadata:
             test_flag: power_control, provision, rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         testing_instance.wait_for_instance_state_change(
             desired_state=testing_instance.STATE_OFF, timeout=1200)
@@ -510,6 +576,10 @@ class TestInstanceRESTAPI(object):
 
         Metadata:
             test_flag: power_control, provision, rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_ON)
         vm = testing_instance.get_vm_via_rest()
@@ -538,6 +608,10 @@ class TestInstanceRESTAPI(object):
 
         Metadata:
             test_flag: power_control, provision, rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_ON)
         vm = testing_instance.get_vm_via_rest()
@@ -558,6 +632,10 @@ class TestInstanceRESTAPI(object):
 
         Metadata:
             test_flag: power_control, provision, rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_ON)
         vm = testing_instance.get_vm_via_rest()
@@ -584,6 +662,10 @@ class TestInstanceRESTAPI(object):
 
         Metadata:
             test_flag: power_control, provision, rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_ON)
         vm = testing_instance.get_vm_via_rest()
@@ -609,6 +691,10 @@ class TestInstanceRESTAPI(object):
 
         Metadata:
             test_flag: power_control, provision, rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_ON)
         vm = testing_instance.get_vm_via_rest()

--- a/cfme/tests/cloud/test_keypairs.py
+++ b/cfme/tests/cloud/test_keypairs.py
@@ -19,6 +19,10 @@ def test_keypair_crud(appliance, provider):
         * Provide Keypair name.
         * Select Cloud Provider.
         * Also delete it.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     try:
         keypair = appliance.collections.cloud_keypairs.create(name=fauxfactory.gen_alphanumeric(),
@@ -42,6 +46,10 @@ def test_keypair_crud_with_key(openstack_provider, appliance):
         * Provide Keypair name.
         * Select Cloud Provider.
         * Also delete it.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     key = RSA.generate(1024)
     public_key = key.publickey().exportKey('OpenSSH')
@@ -68,6 +76,10 @@ def test_keypair_create_cancel(openstack_provider, appliance):
         * Provide Keypair name.
         * Select Cloud Provider.
         * Also delete it.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     keypair = appliance.collections.cloud_keypairs.create(name="",
                                                           provider=openstack_provider,
@@ -86,6 +98,10 @@ def test_keypair_add_and_remove_tag(openstack_provider, appliance):
         * Add tag to Keypair.
         * Remove tag from Keypair
         * Also delete it.
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
     """
     try:
         keypair = appliance.collections.cloud_keypairs.create(name=fauxfactory.gen_alphanumeric(),

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -45,7 +45,12 @@ def enable_regions(provider):
 @pytest.mark.uncollectif(lambda: store.current_appliance.version >= '5.9',
                          reason='no more support for cloud provider discovery')
 def test_empty_discovery_form_validation_cloud(appliance):
-    """ Tests that the flash message is correct when discovery form is empty."""
+    """ Tests that the flash message is correct when discovery form is empty.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     collection = appliance.collections.cloud_providers
 
     collection.discover(None, AzureProvider)
@@ -59,7 +64,12 @@ def test_empty_discovery_form_validation_cloud(appliance):
 @pytest.mark.uncollectif(lambda: store.current_appliance.version >= '5.9',
                          reason='no more support for cloud provider discovery')
 def test_discovery_cancelled_validation_cloud(appliance):
-    """ Tests that the flash message is correct when discovery is cancelled."""
+    """ Tests that the flash message is correct when discovery is cancelled.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     collection = appliance.collections.cloud_providers
     collection.discover(None, AzureProvider, cancel=True)
     view = appliance.browser.create_view(CloudProvidersView)
@@ -69,7 +79,12 @@ def test_discovery_cancelled_validation_cloud(appliance):
 @pytest.mark.tier(3)
 @test_requirements.discovery
 def test_add_cancelled_validation_cloud(request, appliance):
-    """Tests that the flash message is correct when add is cancelled."""
+    """Tests that the flash message is correct when add is cancelled.
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/16h
+    """
     collection = appliance.collections.cloud_providers
     prov = collection.instantiate(prov_class=EC2Provider)
     request.addfinalizer(prov.delete_if_exists)
@@ -86,6 +101,11 @@ def test_add_cancelled_validation_cloud(request, appliance):
 @pytest.mark.uncollectif(lambda: store.current_appliance.version >= '5.9',
                          reason='no more support for cloud provider discovery')
 def test_discovery_password_mismatch_validation_cloud(appliance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     cred = Credential(
         principal=fauxfactory.gen_alphanumeric(5),
         secret=fauxfactory.gen_alphanumeric(5),
@@ -111,6 +131,10 @@ def test_discovery_error_azure_cloud(appliance):
         * Start Discovery
         * Even with wrong data discovery will start with the proper flash message assert it
         * Check for provider should not discover
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     cred = Credential(
         principal=fauxfactory.gen_alphanumeric(5),
@@ -138,6 +162,11 @@ def test_discovery_error_azure_cloud(appliance):
 @pytest.mark.usefixtures('has_no_cloud_providers')
 @test_requirements.discovery
 def test_providers_discovery_amazon(appliance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     # This test was being uncollected anyway, and needs to be parametrized and not directory call
     # out to specific credential keys
     # amazon_creds = get_credentials_from_config('cloudqe_amazon')
@@ -159,6 +188,10 @@ def test_providers_discovery(request, appliance, provider):
 
     Metadata:
         test_flag: crud
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/8h
     """
     if provider.one_of(AzureProvider):
         cred = Credential(
@@ -190,6 +223,10 @@ def test_cloud_provider_add_with_bad_credentials(provider, enable_regions):
 
     Metadata:
         test_flag: crud
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: None
     """
     default_credentials = provider.default_endpoint.credentials
 
@@ -227,6 +264,10 @@ def test_cloud_provider_crud(provider, enable_regions):
 
     Metadata:
         test_flag: crud
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: None
     """
     provider.create()
     provider.validate_stats(ui=True)
@@ -245,7 +286,12 @@ def test_cloud_provider_crud(provider, enable_regions):
 @pytest.mark.tier(3)
 @test_requirements.discovery
 def test_type_required_validation_cloud(request, appliance):
-    """Test to validate type while adding a provider"""
+    """Test to validate type while adding a provider
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/10h
+    """
     collection = appliance.collections.cloud_providers
     view = navigate_to(collection, 'Add')
     view.fill({'name': 'foo'})
@@ -255,7 +301,12 @@ def test_type_required_validation_cloud(request, appliance):
 @pytest.mark.tier(3)
 @test_requirements.discovery
 def test_name_required_validation_cloud(request, appliance):
-    """Tests to validate the name while adding a provider"""
+    """Tests to validate the name while adding a provider
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/15h
+    """
     collection = appliance.collections.cloud_providers
     prov = collection.instantiate(prov_class=EC2Provider,
                                   name=None,
@@ -270,7 +321,13 @@ def test_name_required_validation_cloud(request, appliance):
 
 @pytest.mark.tier(3)
 def test_region_required_validation(request, soft_assert, appliance):
-    """Tests to validate the region while adding a provider"""
+    """Tests to validate the region while adding a provider
+
+    Polarion:
+        assignee: anikifor
+        caseimportance: low
+        initialEstimate: 1/6h
+    """
     collection = appliance.collections.cloud_providers
     prov = collection.instantiate(prov_class=EC2Provider, name=fauxfactory.gen_alphanumeric(5),
                                   region=None)
@@ -285,7 +342,12 @@ def test_region_required_validation(request, soft_assert, appliance):
 @pytest.mark.tier(3)
 @test_requirements.discovery
 def test_host_name_required_validation_cloud(request, appliance):
-    """Test to validate the hostname while adding a provider"""
+    """Test to validate the hostname while adding a provider
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/15h
+    """
     endpoint = RHOSEndpoint(hostname=None,
                             ip_address=fauxfactory.gen_ipaddr(prefix=[10]),
                             security_protocol=None)
@@ -304,7 +366,13 @@ def test_host_name_required_validation_cloud(request, appliance):
 
 @pytest.mark.tier(3)
 def test_api_port_blank_validation(request, appliance):
-    """Test to validate blank api port while adding a provider"""
+    """Test to validate blank api port while adding a provider
+
+    Polarion:
+        assignee: anikifor
+        caseimportance: low
+        initialEstimate: 1/6h
+    """
     endpoint = RHOSEndpoint(hostname=fauxfactory.gen_alphanumeric(5),
                             ip_address=fauxfactory.gen_ipaddr(prefix=[10]),
                             api_port='',
@@ -326,6 +394,11 @@ def test_api_port_blank_validation(request, appliance):
 @pytest.mark.uncollectif(lambda: store.current_appliance.version >= '5.9',
                          reason='EC2 option not available')
 def test_user_id_max_character_validation(appliance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     cred = Credential(principal=fauxfactory.gen_alphanumeric(51), secret='')
     collection = appliance.collections.cloud_providers
     collection.discover(cred, EC2Provider)
@@ -335,6 +408,11 @@ def test_user_id_max_character_validation(appliance):
 @pytest.mark.uncollectif(lambda: store.current_appliance.version >= '5.9',
                          reason='EC2 option not available')
 def test_password_max_character_validation(appliance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     password = fauxfactory.gen_alphanumeric(51)
     cred = Credential(
         principal=fauxfactory.gen_alphanumeric(5),
@@ -347,7 +425,12 @@ def test_password_max_character_validation(appliance):
 @pytest.mark.tier(3)
 @test_requirements.discovery
 def test_name_max_character_validation_cloud(request, cloud_provider):
-    """Test to validate that provider can have up to 255 characters in name"""
+    """Test to validate that provider can have up to 255 characters in name
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/15h
+    """
     request.addfinalizer(lambda: cloud_provider.delete_if_exists(cancel=False))
     name = fauxfactory.gen_alphanumeric(255)
     with update(cloud_provider):
@@ -357,7 +440,12 @@ def test_name_max_character_validation_cloud(request, cloud_provider):
 
 @pytest.mark.tier(3)
 def test_hostname_max_character_validation_cloud(appliance):
-    """Test to validate max character for hostname field"""
+    """Test to validate max character for hostname field
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/15h
+    """
     endpoint = RHOSEndpoint(hostname=fauxfactory.gen_alphanumeric(256),
                             api_port=None,
                             security_protocol=None)
@@ -378,7 +466,13 @@ def test_hostname_max_character_validation_cloud(appliance):
 @pytest.mark.tier(3)
 @test_requirements.discovery
 def test_api_port_max_character_validation_cloud(appliance):
-    """Test to validate max character for api port field"""
+    """Test to validate max character for api port field
+
+    Polarion:
+        assignee: pvala
+        casecomponent: cloud
+        initialEstimate: 1/15h
+    """
     endpoint = RHOSEndpoint(hostname=fauxfactory.gen_alphanumeric(5),
                             api_port=fauxfactory.gen_alphanumeric(16),
                             security_protocol='Non-SSL')
@@ -402,6 +496,10 @@ def test_azure_subscription_required(request, provider):
 
     Metadata:
         test_flag: crud
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     provider.subscription_id = ''
     request.addfinalizer(provider.delete_if_exists)
@@ -423,6 +521,10 @@ def test_azure_multiple_subscription(appliance, request, soft_assert):
 
     Metadata:
         test_flag: crud
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     pf = ProviderFilter(classes=[AzureProvider], required_flags=['crud'])
     providers = list_providers([pf])
@@ -447,7 +549,12 @@ def test_azure_multiple_subscription(appliance, request, soft_assert):
 
 @pytest.mark.tier(3)
 def test_openstack_provider_has_api_version(appliance):
-    """Check whether the Keystone API version field is present for Openstack."""
+    """Check whether the Keystone API version field is present for Openstack.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(appliance.collections.cloud_providers, 'Add')
     view.fill({"prov_type": "OpenStack"})
     assert view.api_version.is_displayed, "API version select is not visible"
@@ -455,7 +562,12 @@ def test_openstack_provider_has_api_version(appliance):
 
 @pytest.mark.ignore_stream('5.9')
 def test_openstack_provider_has_dashboard(appliance, openstack_provider):
-    """Check whether dashboard view is available for Openstack provider"""
+    """Check whether dashboard view is available for Openstack provider
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(openstack_provider, 'Details', use_resetter=False)
     view.toolbar.view_selector.select('Dashboard View')
     assert view.is_displayed
@@ -475,6 +587,10 @@ def test_select_key_pair_none_while_provisioning(appliance, request, has_no_clou
         3. Go to Properties
         4. Select None in Guest Access Key Pair
         5. None should be selected
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     if 'govcloud' in provider.data.tags:
         pytest.skip("providers with such tag aren't supported for some reason")
@@ -508,6 +624,10 @@ def test_azure_instance_password_requirements(appliance, request,
             * have 3 of the following - one lowercase character, one uppercase character,
               one number and one special character
         5. Error message should be displayed.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     view = navigate_to(appliance.collections.cloud_instances, 'Provision')
     view.image_table[0].click()
@@ -541,6 +661,11 @@ def test_cloud_names_grid_floating_ips(appliance, ec2_provider, soft_assert):
         Go to Network -> Floating IPs
         Change view to grid
         Test if names are displayed
+
+    Polarion:
+        assignee: anikifor
+        caseimportance: medium
+        initialEstimate: 1/30h
     """
     floating_ips_collection = appliance.collections.network_floating_ips
     view = navigate_to(floating_ips_collection, "All")
@@ -562,6 +687,12 @@ def test_display_network_topology(appliance, openstack_provider):
         2. Make sure it has no floating IPs
         3. Go to Networks -> Topology
         4. Topology should be shown without errors.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: prov
+        caseimportance: medium
+        initialEstimate: 1/8h
     """
     floating_ips_collection = appliance.collections.network_floating_ips
     view = navigate_to(floating_ips_collection, "All")
@@ -592,6 +723,11 @@ class TestProvidersRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/3h
         """
         if from_detail:
             networks = appliance.rest_api.collections.providers.get(
@@ -616,6 +752,11 @@ class TestProvidersRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         network = appliance.rest_api.collections.providers.get(
             name=cloud_provider.name).cloud_networks[0]
@@ -635,6 +776,10 @@ class TestProvidersRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         for profile in arbitration_profiles:
             record = appliance.rest_api.collections.arbitration_profiles.get(id=profile.id)
@@ -651,6 +796,10 @@ class TestProvidersRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         delete_resources_from_detail(arbitration_profiles, method=method)
 
@@ -662,6 +811,10 @@ class TestProvidersRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         delete_resources_from_collection(arbitration_profiles)
 
@@ -674,6 +827,10 @@ class TestProvidersRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         response_len = len(arbitration_profiles)
         zone = appliance.rest_api.collections.availability_zones[-1]
@@ -703,6 +860,10 @@ class TestProvidersRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         num_rules = 2
         profile = arbitration_profiles[0]
@@ -733,6 +894,10 @@ class TestProvidersRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         data = [{
             'description': 'test admin rule {}'.format(fauxfactory.gen_alphanumeric(5)),
@@ -751,7 +916,12 @@ class TestProvidersRESTAPI(object):
 @pytest.mark.provider([CloudProvider], override=True, selector=ONE)
 def test_tagvis_provision_fields(setup_provider, request, appliance, user_restricted, tag,
                                  soft_assert):
-    """Test for network environment fields for restricted user"""
+    """Test for network environment fields for restricted user
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     image = appliance.collections.cloud_images.all()[0]
     image.add_tag(tag)
     request.addfinalizer(lambda: image.remove_tag(tag))
@@ -782,6 +952,10 @@ def test_domain_id_validation(request, provider):
         * Navigate add Cloud provider and select OpenStack
         * Select Keystone V3 as API Version
         * Validate without Domain ID
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     prov = provider
     prov.api_version = 'Keystone v3'

--- a/cfme/tests/cloud/test_quota_tagging.py
+++ b/cfme/tests/cloud/test_quota_tagging.py
@@ -53,6 +53,11 @@ def prov_data(provider, vm_name, template_name):
 
 @pytest.fixture(scope='module')
 def test_domain(appliance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     domain = appliance.collections.domains.create('test_{}'.format(fauxfactory.gen_alphanumeric()),
                                                   'description_{}'.format(
                                                       fauxfactory.gen_alphanumeric()),
@@ -152,7 +157,13 @@ def set_entity_quota_tag(request, entities, appliance):
 )
 def test_quota_tagging_cloud_via_lifecycle(request, appliance, provider, prov_data, setup_provider,
                                            set_entity_quota_tag, template_name, vm_name):
-    """Test Group and User Quota in UI using tagging"""
+    """Test Group and User Quota in UI using tagging
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: cloud
+        initialEstimate: 1/6h
+    """
     recursive_update(prov_data, {
         'request': {'email': 'test_{}@example.com'.format(fauxfactory.gen_alphanumeric())}})
     prov_data.update({'template_name': template_name})
@@ -178,7 +189,13 @@ def test_quota_tagging_cloud_via_lifecycle(request, appliance, provider, prov_da
 )
 def test_quota_tagging_cloud_via_services(appliance, request, provider, setup_provider, context,
                                           admin_email, set_entity_quota_tag, catalog_item):
-    """Test Group and User Quota in UI and SSUI using tagging"""
+    """Test Group and User Quota in UI and SSUI using tagging
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: cloud
+        initialEstimate: 1/6h
+    """
     with appliance.context.use(context):
         service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
         if context is ViaSSUI:
@@ -204,6 +221,10 @@ def test_cloud_quota_by_lifecycle(request, appliance, provider, setup_provider,
     4. Provision instance via lifecycle
     5. Make sure that provisioned 'template' is having more than assigned quota
     6. Check whether instance provision 'Denied' with reason 'Quota Exceeded'
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     recursive_update(prov_data, {
         'request': {'email': 'test_{}@example.com'.format(fauxfactory.gen_alphanumeric())}})
@@ -230,6 +251,10 @@ def test_quota_cloud_via_services(appliance, request, setup_provider, admin_emai
            4. Test quota by provisioning instances over quota limit via UI or
               SSUI for user and group
            5. Check whether quota is exceeded or not
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     with appliance.context.use(context):
         service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)

--- a/cfme/tests/cloud/test_security_groups.py
+++ b/cfme/tests/cloud/test_security_groups.py
@@ -34,6 +34,10 @@ def test_security_group_crud(sec_group):
         * Provide Security groups Description.
         * Select Cloud Tenant.
         * Also delete it.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     # TODO: Update need to be done in future.
     assert sec_group.exists
@@ -51,6 +55,10 @@ def test_security_group_create_cancel(appliance, provider):
         * Provide Security groups Description.
         * Select Cloud Tenant.
         * Cancel it.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     security_group = appliance.collections.security_groups
     sec_group = security_group.create(name=fauxfactory.gen_alphanumeric(),

--- a/cfme/tests/cloud/test_stack.py
+++ b/cfme/tests/cloud/test_stack.py
@@ -28,6 +28,11 @@ def stack(setup_provider_modscope, provider, appliance):
 
 @pytest.mark.tier(3)
 def test_security_group_link(stack):
+    """
+    Polarion:
+        assignee: nansari
+        initialEstimate: 1/4h
+    """
     try:
         view = navigate_to(stack, 'RelationshipSecurityGroups')
     except CandidateNotFound:
@@ -42,6 +47,11 @@ def test_security_group_link(stack):
 
 @pytest.mark.tier(3)
 def test_parameters_link(stack):
+    """
+    Polarion:
+        assignee: nansari
+        initialEstimate: 1/8h
+    """
     try:
         view = navigate_to(stack, 'RelationshipParameters')
     except CandidateNotFound:
@@ -56,6 +66,11 @@ def test_parameters_link(stack):
 
 @pytest.mark.tier(3)
 def test_outputs_link(stack):
+    """
+    Polarion:
+        assignee: nansari
+        initialEstimate: None
+    """
     try:
         view = navigate_to(stack, 'RelationshipOutputs')
     except CandidateNotFound:
@@ -69,6 +84,11 @@ def test_outputs_link(stack):
 
 @pytest.mark.tier(3)
 def test_outputs_link_url(appliance, stack):
+    """
+    Polarion:
+        assignee: nansari
+        initialEstimate: None
+    """
     try:
         view = navigate_to(stack, 'RelationshipOutputs')
     except CandidateNotFound:
@@ -85,6 +105,11 @@ def test_outputs_link_url(appliance, stack):
 
 @pytest.mark.tier(3)
 def test_resources_link(stack):
+    """
+    Polarion:
+        assignee: nansari
+        initialEstimate: 1/4h
+    """
     try:
         view = navigate_to(stack, 'RelationshipResources')
     except CandidateNotFound:
@@ -99,12 +124,24 @@ def test_resources_link(stack):
 @pytest.mark.tier(3)
 @test_requirements.tag
 def test_edit_tags(request, stack):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/8h
+    """
     added_tag = stack.add_tag()
     request.addfinalizer(lambda: stack.remove_tag(added_tag))
 
 
 @pytest.mark.tier(3)
 def test_delete_stack(stack, provider, request):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     stack.delete()
     assert not stack.exists
     request.addfinalizer(provider.refresh_provider_relationships)
@@ -112,6 +149,11 @@ def test_delete_stack(stack, provider, request):
 
 @pytest.mark.tier(3)
 def test_collection_delete(provider, setup_provider_modscope, appliance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     collection = appliance.collections.cloud_stacks
 
     stack1 = collection.instantiate(provider.data['provisioning']['stacks'][0], provider=provider)

--- a/cfme/tests/cloud/test_tenant.py
+++ b/cfme/tests/cloud/test_tenant.py
@@ -31,6 +31,10 @@ def test_tenant_crud(tenant):
 
     Metadata:
         test_flag: tenant
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     with update(tenant):

--- a/cfme/tests/cloud/test_tenant_quota.py
+++ b/cfme/tests/cloud/test_tenant_quota.py
@@ -89,7 +89,13 @@ def catalog_item(appliance, provider, provisioning, template_name, dialog, catal
 def test_tenant_quota_enforce_via_lifecycle_cloud(request, appliance, provider, setup_provider,
                                             set_roottenant_quota, extra_msg, custom_prov_data,
                                             approve, prov_data, vm_name, template_name):
-    """Test Tenant Quota in UI"""
+    """Test Tenant Quota in UI
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: cloud
+        initialEstimate: 1/10h
+    """
     prov_data.update(custom_prov_data)
     prov_data['catalog']['vm_name'] = vm_name
     prov_data.update({
@@ -127,7 +133,13 @@ def test_tenant_quota_enforce_via_lifecycle_cloud(request, appliance, provider, 
 def test_tenant_quota_enforce_via_service_cloud(request, appliance, provider, setup_provider,
                                                 context, set_roottenant_quota, custom_prov_data,
                                                 extra_msg, template_name, catalog_item):
-    """Test Tenant Quota in UI and SSUI"""
+    """Test Tenant Quota in UI and SSUI
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: cloud
+        initialEstimate: 1/10h
+    """
     with appliance.context.use(context):
         service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
         if context is ViaSSUI:

--- a/cfme/tests/cloud_infra_common/test_cloud_init_provisioning.py
+++ b/cfme/tests/cloud_infra_common/test_cloud_init_provisioning.py
@@ -72,6 +72,10 @@ def test_provision_cloud_init(appliance, request, setup_provider, provider, prov
 
     Metadata:
         test_flag: cloud_init, provision
+
+    Polarion:
+        assignee: jhenner
+        initialEstimate: 1/4h
     """
     image = provisioning.get('ci-image') or provisioning['image']['name']
     note = ('Testing provisioning from image {} to vm {} on provider {}'.format(
@@ -129,6 +133,10 @@ def test_provision_cloud_init_payload(appliance, request, setup_provider, provid
 
     Metadata:
         test_flag: cloud_init, provision
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     image = provisioning.get('ci-image', None)
     if not image:

--- a/cfme/tests/cloud_infra_common/test_cockpit_server.py
+++ b/cfme/tests/cloud_infra_common/test_cockpit_server.py
@@ -33,6 +33,11 @@ def test_cockpit_server_role(appliance, provider, setup_provider, new_vm, enable
 
     Metadata:
         test_flag: inventory
+
+    Polarion:
+        assignee: nansari
+        caseimportance: medium
+        initialEstimate: None
     """
 
     if enable:

--- a/cfme/tests/cloud_infra_common/test_custom_attributes_rest.py
+++ b/cfme/tests/cloud_infra_common/test_custom_attributes_rest.py
@@ -139,6 +139,10 @@ class TestCustomAttributesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         resource = get_resource[collection_name]()
         attributes = add_custom_attributes(request, resource)
@@ -156,6 +160,10 @@ class TestCustomAttributesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         attributes = add_custom_attributes(request, get_resource[collection_name]())
         delete_resources_from_detail(attributes, method='POST')
@@ -170,6 +178,10 @@ class TestCustomAttributesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         attributes = add_custom_attributes(request, get_resource[collection_name]())
         delete_resources_from_detail(attributes, method='DELETE')
@@ -183,6 +195,10 @@ class TestCustomAttributesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         resource = get_resource[collection_name]()
         attributes = add_custom_attributes(request, resource)
@@ -198,6 +214,10 @@ class TestCustomAttributesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         resource = get_resource[collection_name]()
         attributes = add_custom_attributes(request, resource)
@@ -215,6 +235,10 @@ class TestCustomAttributesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: None
         """
         resource = get_resource[collection_name]()
         attributes = add_custom_attributes(request, resource)
@@ -262,6 +286,10 @@ class TestCustomAttributesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         resource = get_resource[collection_name]()
         attributes = add_custom_attributes(request, resource)
@@ -298,6 +326,10 @@ class TestCustomAttributesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         resource = get_resource[collection_name]()
         add_custom_attributes(request, resource)
@@ -324,6 +356,10 @@ class TestCustomAttributesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: None
         """
         resource = get_resource[collection_name]()
         orig_attribute, = add_custom_attributes(request, resource, num=1)

--- a/cfme/tests/cloud_infra_common/test_discovery.py
+++ b/cfme/tests/cloud_infra_common/test_discovery.py
@@ -70,6 +70,11 @@ def test_vm_discovery(request, setup_provider, provider, vm_crud):
 
     Metadata:
         test_flag: discovery
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: infra
+        initialEstimate: 1/4h
     """
 
     @request.addfinalizer

--- a/cfme/tests/cloud_infra_common/test_events.py
+++ b/cfme/tests/cloud_infra_common/test_events.py
@@ -51,6 +51,10 @@ def test_vm_create(request, appliance, vm_crud, provider, register_event):
 
     Metadata:
         test_flag: provision, events
+
+    Polarion:
+        assignee: izapolsk
+        initialEstimate: 1/8h
     """
     action = appliance.collections.actions.create(
         fauxfactory.gen_alpha(),

--- a/cfme/tests/cloud_infra_common/test_genealogy.py
+++ b/cfme/tests/cloud_infra_common/test_genealogy.py
@@ -58,6 +58,12 @@ def test_vm_genealogy_detected(
 
     Metadata:
         test_flag: genealogy, provision
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/4h
     """
     vm_crud.create_on_provider(find_in_cfme=True, allow_skip="default")
 

--- a/cfme/tests/cloud_infra_common/test_html5_vm_console.py
+++ b/cfme/tests/cloud_infra_common/test_html5_vm_console.py
@@ -69,6 +69,10 @@ def test_html5_vm_console(appliance, provider, configure_websocket, vm_obj,
         - A command that creates a file will be sent through the console.
         - Using ssh we will check that the command worked (i.e. that the file
           was created.
+
+    Polarion:
+        assignee: apagac
+        initialEstimate: None
     """
     console_vm_username = credentials[provider.data.templates.get('console_template')
                             ['creds']].get('username')

--- a/cfme/tests/cloud_infra_common/test_power_control_rest.py
+++ b/cfme/tests/cloud_infra_common/test_power_control_rest.py
@@ -85,6 +85,10 @@ def test_stop_vm_rest(appliance, vm_obj, ensure_vm_running, soft_assert, from_de
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     rest_api = appliance.rest_api
     vm_obj.wait_for_vm_state_change(desired_state=vm_obj.STATE_ON)
@@ -116,6 +120,10 @@ def test_start_vm_rest(appliance, vm_obj, ensure_vm_stopped, soft_assert, from_d
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     rest_api = appliance.rest_api
     vm_obj.wait_for_vm_state_change(desired_state=vm_obj.STATE_OFF, timeout=1200)
@@ -147,6 +155,10 @@ def test_suspend_vm_rest(appliance, vm_obj, ensure_vm_running, soft_assert, from
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     rest_api = appliance.rest_api
     vm_obj.wait_for_vm_state_change(desired_state=vm_obj.STATE_ON)
@@ -185,6 +197,10 @@ def test_reset_vm_rest(vm_obj, ensure_vm_running, from_detail, appliance):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     rest_api = appliance.rest_api
     vm_obj.wait_for_vm_state_change(desired_state=vm_obj.STATE_ON)

--- a/cfme/tests/cloud_infra_common/test_provisioning.py
+++ b/cfme/tests/cloud_infra_common/test_provisioning.py
@@ -92,6 +92,10 @@ def test_provision_from_template(provider, provisioned_instance):
 
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     assert provisioned_instance.exists_on_provider, "Instance wasn't provisioned successfully"
 
@@ -100,6 +104,11 @@ def test_provision_from_template(provider, provisioned_instance):
                       override=True)
 @pytest.mark.usefixtures('setup_provider')
 def test_gce_preemptible_provision(appliance, provider, instance_args, soft_assert):
+    """
+    Polarion:
+        assignee: jhenner
+        initialEstimate: 1/6h
+    """
     vm_name, inst_args = instance_args
     inst_args['properties']['is_preemptible'] = True
     instance = appliance.collections.cloud_instances.create(vm_name,
@@ -139,6 +148,10 @@ def test_provision_approval(appliance, provider, vm_name, smtp_test, request,
     Metadata:
         test_flag: provision
         suite: infra_provisioning
+
+    Polarion:
+        assignee: jhenner
+        initialEstimate: 1/8h
     """
     # generate_tests makes sure these have values
     # template, host, datastore = map(provisioning.get, ('template', 'host', 'datastore'))
@@ -245,6 +258,10 @@ def test_provision_from_template_using_rest(appliance, request, provider, vm_nam
 
     Metadata:
         test_flag: provision, rest
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     if auto:
         form_values = {"vm_fields": {"placement_auto": True}}
@@ -318,6 +335,10 @@ def test_cloud_provision_from_template_with_attached_disks(
 
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     vm_name, inst_args = instance_args
     # Modify availiability_zone for Azure provider
@@ -366,6 +387,10 @@ def test_provision_with_boot_volume(request, instance_args, provider, soft_asser
 
     Metadata:
         test_flag: provision, volumes
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     vm_name, inst_args = instance_args
 
@@ -430,6 +455,10 @@ def test_provision_with_additional_volume(request, instance_args, provider, smal
 
     Metadata:
         test_flag: provision, volumes
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     vm_name, inst_args = instance_args
 
@@ -506,6 +535,10 @@ def test_provision_with_tag(appliance, vm_name, tag, provider, request):
         * Visit instance page, it should display the selected tags
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
     """
 
     inst_args = {'purpose': {

--- a/cfme/tests/cloud_infra_common/test_quota_with_multiple_providers.py
+++ b/cfme/tests/cloud_infra_common/test_quota_with_multiple_providers.py
@@ -28,6 +28,10 @@ def test_show_quota_used_on_tenant_screen(request, appliance, v2v_providers):
         3. Navigate to 'Details' page of 'My Company' tenant.
         4. Go to tenant quota table.
         5. Check whether number of VMs are equal to number of VMs in 'in use' column.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     v2v_providers.vmware_provider.refresh_provider_relationships
     v2v_providers.rhv_provider.refresh_provider_relationships

--- a/cfme/tests/cloud_infra_common/test_relationships.py
+++ b/cfme/tests/cloud_infra_common/test_relationships.py
@@ -148,6 +148,12 @@ def test_host_relationships(appliance, provider, setup_provider, host, relations
 
     Metadata:
         test_flag: inventory
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/12h
     """
     host_view = navigate_to(host, "Details")
     if host_view.entities.summary("Relationships").get_text_of(relationship) == "0":
@@ -167,6 +173,12 @@ def test_infra_provider_relationships(appliance, provider, setup_provider, relat
 
     Metadata:
         test_flag: inventory
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/10h
     """
     provider_view = navigate_to(provider, "Details")  # resetter selects summary view
     if provider_view.entities.summary("Relationships").get_text_of(relationship) == "0":
@@ -180,7 +192,14 @@ def test_infra_provider_relationships(appliance, provider, setup_provider, relat
     ids=[rel[0] for rel in CLOUD_PROVIDER_RELATIONSHIPS])
 @pytest.mark.provider([CloudProvider], selector=ONE_PER_TYPE)
 def test_cloud_provider_relationships(appliance, provider, setup_provider, relationship, view):
-    """Tests relationship navigation for a cloud provider"""
+    """Tests relationship navigation for a cloud provider
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
     # Version dependent strings
     relationship = _fix_item(appliance, relationship)
     provider_view = navigate_to(provider, "Details")  # resetter selects summary view
@@ -243,6 +262,10 @@ def test_tagvis_infra_provider_children(prov_child_visibility, setup_provider, r
     Steps:
         1. As admin add tag to provider
         2. Login as restricted user, providers child not visible for user
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
     """
     prov_child_visibility(relationship, visibility=False)
 
@@ -258,17 +281,27 @@ def test_tagvis_cloud_provider_children(prov_child_visibility, setup_provider, r
     Steps:
         1. As admin add tag to provider
         2. Login as restricted user, providers child not visible for user
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: 1/8h
     """
     prov_child_visibility(relationship, visibility=False)
 
 
 @pytest.mark.rhv1
 @pytest.mark.provider([CloudProvider, InfraProvider])
+@pytest.mark.tier(1)
 def test_provider_refresh_relationship(provider, setup_provider):
     """Tests provider refresh
 
     Metadata:
         test_flag: inventory
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: infra
+        initialEstimate: 1/8h
     """
     provider.refresh_provider_relationships(method='ui')
     wait_for_relationship_refresh(provider)

--- a/cfme/tests/cloud_infra_common/test_rest_providers.py
+++ b/cfme/tests/cloud_infra_common/test_rest_providers.py
@@ -53,6 +53,10 @@ def test_query_provider_attributes(provider, provider_rest, soft_assert):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: None
     """
     outcome = query_resource_attributes(provider_rest)
     for failure in outcome.failed:
@@ -82,6 +86,10 @@ def test_provider_options(appliance):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     options = appliance.rest_api.options(appliance.rest_api.collections.providers._href)
     assert 'provider_settings' in options['data']
@@ -93,6 +101,10 @@ def test_create_provider(provider_rest):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     assert "ManageIQ::Providers::" in provider_rest.type
 
@@ -103,6 +115,10 @@ def test_provider_refresh(provider_rest, appliance):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     # initiate refresh
     def _refresh_success():
@@ -134,6 +150,10 @@ def test_provider_edit(request, provider_rest, appliance):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     new_name = fauxfactory.gen_alphanumeric()
     old_name = provider_rest.name
@@ -153,6 +173,10 @@ def test_provider_delete_from_detail(provider_rest, method):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     delete_resources_from_detail([provider_rest], method=method, num_sec=50)
 
@@ -165,5 +189,9 @@ def test_provider_delete_from_collection(provider_rest):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     delete_resources_from_collection([provider_rest], num_sec=50)

--- a/cfme/tests/cloud_infra_common/test_retirement.py
+++ b/cfme/tests/cloud_infra_common/test_retirement.py
@@ -146,6 +146,10 @@ def generate_retirement_date_now():
 @pytest.mark.rhv1
 def test_retirement_now(retire_vm):
     """Tests on-demand retirement of an instance/vm
+
+    Polarion:
+        assignee: tpapaioa
+        initialEstimate: 1/6h
     """
     # For 5.7 capture two times to assert the retire time is within a window.
     # Too finicky to get it down to minute precision, nor is it really needed here
@@ -164,6 +168,10 @@ def test_retirement_now_ec2_instance_backed(retire_ec2_s3_vm, tagged, appliance)
     """Tests on-demand retirement of an instance/vm
 
     S3 (instance-backed) EC2 instances that aren't lifecycle tagged won't get shut down
+
+    Polarion:
+        assignee: tpapaioa
+        initialEstimate: 1/6h
     """
     # Tag the VM with lifecycle for full retirement based on parameter
     if tagged:
@@ -199,6 +207,10 @@ def test_set_retirement_date(retire_vm, warn):
     """Tests setting retirement date and verifies configured date is reflected in UI
 
     Note we cannot control the retirement time, just day, so we cannot wait for the VM to retire
+
+    Polarion:
+        assignee: tpapaioa
+        initialEstimate: 1/6h
     """
     # TODO retirement supports datetime (no tz) in gaprindashvili/59z, update accordingly
     num_days = 2
@@ -216,6 +228,10 @@ def test_set_retirement_offset(retire_vm, warn):
     """Tests setting the retirement by offset
 
     Minimum is 1 hour, just testing that it is set like test_set_retirement_date
+
+    Polarion:
+        assignee: tpapaioa
+        initialEstimate: 1/15h
     """
     num_hours = 3
     num_days = 1
@@ -238,6 +254,10 @@ def test_set_retirement_offset(retire_vm, warn):
 @pytest.mark.meta(blockers=[BZ(1627758, forced_streams=['5.9', '5.10'])])
 def test_unset_retirement_date(retire_vm):
     """Tests cancelling a scheduled retirement by removing the set date
+
+    Polarion:
+        assignee: tpapaioa
+        initialEstimate: 1/6h
     """
     num_days = 3
     retire_date = generate_retirement_date(delta=num_days)
@@ -259,6 +279,10 @@ def test_resume_retired_instance(retire_vm, provider, remove_date):
     Two methods to resume:
     1. Set a retirement date in the future
     2. Remove the set retirement date
+
+    Polarion:
+        assignee: tpapaioa
+        initialEstimate: 1/2h
     """
     num_days = 5
 

--- a/cfme/tests/cloud_infra_common/test_snapshots_rest.py
+++ b/cfme/tests/cloud_infra_common/test_snapshots_rest.py
@@ -102,6 +102,10 @@ class TestRESTSnapshots(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         vm, snapshot = vm_snapshot
         vm.snapshots.get(description=snapshot.description)
@@ -115,6 +119,10 @@ class TestRESTSnapshots(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         __, snapshot = vm_snapshot
         delete_resources_from_detail([snapshot], method=method, num_sec=300, delay=5)
@@ -125,6 +133,10 @@ class TestRESTSnapshots(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         vm, snapshot = vm_snapshot
         delete_resources_from_collection(
@@ -144,6 +156,10 @@ class TestRESTSnapshots(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         # create and delete snapshot #1
         __, snap1 = vm_snapshot(request, appliance, collection, vm)
@@ -168,6 +184,10 @@ class TestRESTSnapshots(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         __, snapshot = vm_snapshot
 

--- a/cfme/tests/cloud_infra_common/test_tag_objects.py
+++ b/cfme/tests/cloud_infra_common/test_tag_objects.py
@@ -102,7 +102,12 @@ def tagging_check(tag, request):
 @pytest.mark.provider([CloudProvider], selector=ONE_PER_CATEGORY)
 @pytest.mark.parametrize('tag_place', [True, False], ids=['details', 'list'])
 def test_tag_cloud_objects(tagging_check, cloud_test_item, tag_place):
-    """ Test for cloud items tagging action from list and details pages """
+    """ Test for cloud items tagging action from list and details pages
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: 1/12h
+    """
     tagging_check(cloud_test_item, tag_place)
 
 
@@ -118,6 +123,10 @@ def test_tagvis_cloud_object(check_item_visibility, cloud_test_item, visibility,
         2. Login as restricted user, item is visible for user
         3. As admin remove tag
         4. Login as restricted user, item is not visible for user
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
     """
     check_item_visibility(cloud_test_item, visibility)
     request.addfinalizer(lambda: tag_cleanup(cloud_test_item, tag))
@@ -127,7 +136,12 @@ def test_tagvis_cloud_object(check_item_visibility, cloud_test_item, visibility,
 @pytest.mark.provider([InfraProvider], selector=ONE_PER_CATEGORY)
 @pytest.mark.parametrize('tag_place', [True, False], ids=['details', 'list'])
 def test_tag_infra_objects(tagging_check, infra_test_item, tag_place):
-    """ Test for infrastructure items tagging action from list and details pages """
+    """ Test for infrastructure items tagging action from list and details pages
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: 1/12h
+    """
     tagging_check(infra_test_item, tag_place)
 
 
@@ -142,6 +156,10 @@ def test_tagvis_infra_object(infra_test_item, check_item_visibility, visibility,
         2. Login as restricted user, item is visible for user
         3. As admin remove tag
         4. Login as restricted user, iten is not visible for user
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: 1/12h
     """
     check_item_visibility(infra_test_item, visibility)
     request.addfinalizer(lambda: tag_cleanup(infra_test_item, tag))

--- a/cfme/tests/cloud_infra_common/test_tag_visibility.py
+++ b/cfme/tests/cloud_infra_common/test_tag_visibility.py
@@ -32,6 +32,11 @@ def tagged_vm(tag, provider):
 
 @pytest.mark.rhv3
 def test_tag_vis_vm(tagged_vm, user_restricted):
+    """
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
+    """
     with user_restricted:
         assert tagged_vm.exists, "vm not found"
 
@@ -128,6 +133,10 @@ def test_tag_expression_and_condition(
         1. Create group with expression tag1 AND tag2
         2. Assign tag1 to vm1 -> vm should not be visible to restricted user
         3. Assign tag2 to vm1 -> vm should be visible to restricted user
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
     """
     first_vm, _ = vms_for_tagging
     group = group_with_tag_expression(';select_first_expression;click_and;'.join(
@@ -157,6 +166,10 @@ def test_tag_expression_or_condition(
         1. Create group with expression tag1 OR tag2
         2. Assign tag1 to vm1 -> vm should be visible to restricted user
         3. Assign tag2 to vm2 -> vm should be visible to restricted user
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
     """
     first_vm, second_vm = vms_for_tagging
     group = group_with_tag_expression(';select_first_expression;click_or;'.join(
@@ -186,6 +199,10 @@ def test_tag_expression_not_condition(
         1. Create group with expression NOT tag1
         2. Assign tag1 to vm1 -> vm should not be visible to restricted user
         3. vm2 should be visible to restricted user
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
     """
     first_vm, second_vm = vms_for_tagging
     group = group_with_tag_expression('{};select_first_expression;click_not;'.format(
@@ -213,6 +230,10 @@ def test_tag_expression_not_and_condition(
         2. Assign tag1 to vm1 -> vm should not be visible to restricted user
         3. Assign tag2 to vm1 -> vm should not be visible to restricted user
         4. Assign tag2 to vm2 -> vm should be visible to restricted user
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
     """
     first_vm, second_vm = vms_for_tagging
     group = group_with_tag_expression(
@@ -247,6 +268,10 @@ def test_tag_expression_not_or_condition(
         1. Create group with expression NOT tag1 OR tag2
         2. Assign tag1 to vm1 -> vm should not be visible to restricted user
         3. Assign tag2 to vm1 -> vm should be visible to restricted user
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
     """
     first_vm, _ = vms_for_tagging
     group = group_with_tag_expression(

--- a/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
+++ b/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
@@ -524,6 +524,11 @@ def test_ssa_template(local_setup_provider, provider, soft_assert, vm_analysis_p
 
     Metadata:
         test_flag: vm_analysis
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
     """
     template_name = vm_analysis_provisioning_data['image']
     template_collection = appliance.provider_based_collection(provider=provider,
@@ -564,6 +569,11 @@ def test_ssa_compliance(local_setup_provider, ssa_compliance_profile, ssa_vm,
 
     Metadata:
         test_flag: vm_analysis
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
     """
     ssa_vm.smartstate_scan(wait_for_task_result=True)
     task = appliance.collections.tasks.instantiate(
@@ -599,6 +609,12 @@ def test_ssa_schedule(ssa_vm, schedule_ssa, soft_assert, vm_system_type):
 
     Metadata:
         test_flag: vm_analysis
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: critical
+        initialEstimate: 1/2h
     """
     # Check release and quadicon
     quadicon_os_icon = ssa_vm.find_quadicon().data['os']
@@ -631,6 +647,11 @@ def test_ssa_vm(ssa_vm, soft_assert, vm_system_type):
 
     Metadata:
         test_flag: vm_analysis
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
     """
     ssa_vm.smartstate_scan(wait_for_task_result=True)
     # Check release and quadricon
@@ -662,6 +683,12 @@ def test_ssa_users(ssa_vm):
 
     Metadata:
         test_flag: vm_analysis
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        testtype: integration
     """
 
     username = fauxfactory.gen_alphanumeric()
@@ -701,6 +728,11 @@ def test_ssa_groups(ssa_vm):
 
     Metadata:
         test_flag: vm_analysis
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
     """
 
     group = fauxfactory.gen_alphanumeric()
@@ -739,6 +771,11 @@ def test_ssa_packages(ssa_vm):
 
     Metadata:
         test_flag: vm_analysis
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
     """
 
     if ssa_vm.system_type == WINDOWS:
@@ -779,7 +816,13 @@ def test_ssa_packages(ssa_vm):
     unblock=lambda provider: not provider.one_of(RHEVMProvider))])
 @pytest.mark.long_running
 def test_ssa_files(ssa_vm):
-    """Tests that instances can be scanned for specific file."""
+    """Tests that instances can be scanned for specific file.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
+    """
 
     if ssa_vm.system_type == WINDOWS:
         pytest.skip("We cannot verify Windows files yet")
@@ -808,6 +851,11 @@ def test_drift_analysis(request, ssa_vm, soft_assert, appliance):
 
     Metadata:
         test_flag: vm_analysis
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
     """
 
     ssa_vm.load_details()
@@ -883,6 +931,11 @@ def test_ssa_multiple_vms(ssa_multiple_vms, soft_assert, appliance, compare_linu
 
     Metadata:
         test_flag: vm_analysis
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
     """
 
     view = navigate_to(ssa_multiple_vms[0], 'AllForProvider')

--- a/cfme/tests/cloud_infra_common/test_vm_ownership.py
+++ b/cfme/tests/cloud_infra_common/test_vm_ownership.py
@@ -144,6 +144,11 @@ def test_form_button_validation(request, user1, setup_provider, provider, vm_cru
 
     Metadata:
         test_flag: rbac
+
+    Polarion:
+        assignee: apagac
+        caseimportance: medium
+        initialEstimate: None
     """
     # Reset button test
     vm_crud.set_ownership(user=user1, click_reset=True)
@@ -161,6 +166,11 @@ def test_user_ownership_crud(request, user1, setup_provider, provider, vm_crud):
 
     Metadata:
         test_flag: rbac
+
+    Polarion:
+        assignee: apagac
+        caseimportance: medium
+        initialEstimate: None
     """
     # Set the ownership and checking it
     vm_crud.set_ownership(user=user1)
@@ -177,6 +187,11 @@ def test_group_ownership_on_user_only_role(request, user2, setup_provider, provi
 
     Metadata:
         test_flag: rbac
+
+    Polarion:
+        assignee: apagac
+        caseimportance: medium
+        initialEstimate: None
     """
 
     # user is only a member of a single group so it will always be the current group
@@ -195,6 +210,11 @@ def test_group_ownership_on_user_or_group_role(
 
     Metadata:
         test_flag: rbac
+
+    Polarion:
+        assignee: apagac
+        caseimportance: medium
+        initialEstimate: None
     """
     # user is only a member of a single group so it will always be the current group
     vm_crud.set_ownership(group=user3.groups[0])
@@ -214,6 +234,12 @@ def test_template_set_ownership(appliance, request, provider, setup_provider, vm
     then sets it back and in the end removes the template.
     VM is removed via fixture.
     Tests BZ 1446801 in RHCF3-14353
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
 
     # setup the test

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -86,6 +86,12 @@ def tag_value(appliance, category, tag, request):
 @pytest.mark.sauce
 @pytest.mark.tier(2)
 def test_user_crud(appliance, group_collection):
+    """
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
+    """
     group_name = 'EvmGroup-user'
     group = group_collection.instantiate(description=group_name)
 
@@ -106,6 +112,11 @@ def test_user_assign_multiple_groups(appliance, request, group_collection):
         * Create a user and assign them to multiple groups
         * Login as the user
         * Confirm that the user has each group visible in the Settings menu
+
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
     """
     group_names = [
         'EvmGroup-user', 'EvmGroup-administrator', 'EvmGroup-user_self_service', 'EvmGroup-desktop']
@@ -129,6 +140,10 @@ def test_user_assign_multiple_groups(appliance, request, group_collection):
 @pytest.mark.uncollectif(lambda appliance: appliance.version < '5.9')
 def test_user_change_groups(appliance, group_collection):
     """Assign a user to multiple groups and confirm that the user can successfully change groups
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     group_names = [
         'EvmGroup-super_administrator', 'EvmGroup-administrator', 'EvmGroup-approver',
@@ -157,6 +172,12 @@ def test_user_change_groups(appliance, group_collection):
 # @pytest.mark.meta(blockers=[1035399]) # work around instead of skip
 @pytest.mark.tier(2)
 def test_user_login(appliance, group_collection):
+    """
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
+    """
     group_name = 'EvmGroup-user'
     group = group_collection.instantiate(description=group_name)
 
@@ -176,6 +197,11 @@ def test_user_duplicate_username(appliance, group_collection):
         * Generate some credential
         * Create a user with this credential
         * Create another user with same credential
+
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
     """
     group_name = 'EvmGroup-user'
     group = group_collection.instantiate(description=group_name)
@@ -199,6 +225,11 @@ def test_user_allow_duplicate_name(appliance, group_collection):
         * Generate full name
         * Create a user with this full name
         * Create another user with same full name
+
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
     """
     group_name = 'EvmGroup-user'
     group = group_collection.instantiate(description=group_name)
@@ -215,6 +246,12 @@ def test_user_allow_duplicate_name(appliance, group_collection):
 
 @pytest.mark.tier(3)
 def test_username_required_error_validation(appliance, group_collection):
+    """
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
+    """
     group_name = 'EvmGroup-user'
     group = group_collection.instantiate(description=group_name)
 
@@ -229,6 +266,12 @@ def test_username_required_error_validation(appliance, group_collection):
 
 @pytest.mark.tier(3)
 def test_userid_required_error_validation(appliance, group_collection):
+    """
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
+    """
     group_name = 'EvmGroup-user'
     group = group_collection.instantiate(description=group_name)
 
@@ -246,6 +289,12 @@ def test_userid_required_error_validation(appliance, group_collection):
 
 @pytest.mark.tier(3)
 def test_user_password_required_error_validation(appliance, group_collection):
+    """
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
+    """
     group_name = 'EvmGroup-user'
     group = group_collection.instantiate(description=group_name)
 
@@ -265,6 +314,12 @@ def test_user_password_required_error_validation(appliance, group_collection):
 
 @pytest.mark.tier(3)
 def test_user_group_error_validation(appliance):
+    """
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
+    """
     with pytest.raises(Exception, match="A User must be assigned to a Group"):
         appliance.collections.users.create(
             name='user{}'.format(fauxfactory.gen_alphanumeric()),
@@ -275,6 +330,12 @@ def test_user_group_error_validation(appliance):
 
 @pytest.mark.tier(3)
 def test_user_email_error_validation(appliance, group_collection):
+    """
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
+    """
     group = group_collection.instantiate(description='EvmGroup-user')
 
     with pytest.raises(Exception, match="Email must be a valid email address"):
@@ -287,6 +348,11 @@ def test_user_email_error_validation(appliance, group_collection):
 
 @pytest.mark.tier(2)
 def test_user_edit_tag(appliance, group_collection, tag):
+    """
+    Polarion:
+        assignee: anikifor
+        initialEstimate: 1/8h
+    """
     group_name = 'EvmGroup-user'
     group = group_collection.instantiate(description=group_name)
 
@@ -302,6 +368,11 @@ def test_user_edit_tag(appliance, group_collection, tag):
 
 @pytest.mark.tier(3)
 def test_user_remove_tag(appliance, group_collection):
+    """
+    Polarion:
+        assignee: anikifor
+        initialEstimate: 1/8h
+    """
     group_name = 'EvmGroup-user'
     group = group_collection.instantiate(description=group_name)
 
@@ -324,6 +395,11 @@ def test_delete_default_user(appliance):
     Steps:
         * Login as Administrator user
         * Try deleting the user
+
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
     """
     user = appliance.collections.users.instantiate(name='Administrator')
     with pytest.raises(RBACOperationBlocked):
@@ -341,6 +417,11 @@ def test_current_user_login_delete(appliance, request):
         * Create a new user
         * Login with the new user
         * Try deleting the user
+
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
     """
     group_name = "EvmGroup-super_administrator"
     group = group_collection(appliance).instantiate(description=group_name)
@@ -364,6 +445,10 @@ def test_tagvis_user(user_restricted, check_item_visibility):
         2. Login as restricted user, group is visible for user
         3. As admin remove tag from group
         4. Login as restricted user, group is not visible for user
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: 1/8h
     """
     check_item_visibility(user_restricted, user_restricted)
 
@@ -372,6 +457,12 @@ def test_tagvis_user(user_restricted, check_item_visibility):
 @pytest.mark.tier(2)
 # Group test cases
 def test_group_crud(group_collection):
+    """
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
+    """
     role = 'EvmRole-administrator'
     group = group_collection.create(
         description='grp{}'.format(fauxfactory.gen_alphanumeric()), role=role)
@@ -394,6 +485,10 @@ def test_group_crud_with_tag(provider, tag_value, group_collection):
         * Fill all fields
         * Set tag
         * Save group
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: 1/8h
     """
     tag_for_create, tag_for_update = tag_value
 
@@ -417,7 +512,13 @@ def test_group_crud_with_tag(provider, tag_value, group_collection):
 
 @pytest.mark.tier(3)
 def test_group_duplicate_name(group_collection):
-    """ Verify that two groups can't have the same name """
+    """ Verify that two groups can't have the same name
+
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
+    """
     role = 'EvmRole-approver'
     group_description = 'grp{}'.format(fauxfactory.gen_alphanumeric())
     group = group_collection.create(description=group_description, role=role)
@@ -433,6 +534,11 @@ def test_group_duplicate_name(group_collection):
 
 @pytest.mark.tier(2)
 def test_group_edit_tag(group_collection):
+    """
+    Polarion:
+        assignee: anikifor
+        initialEstimate: 1/8h
+    """
     role = 'EvmRole-approver'
     group_description = 'grp{}'.format(fauxfactory.gen_alphanumeric())
     group = group_collection.create(description=group_description, role=role)
@@ -448,6 +554,11 @@ def test_group_edit_tag(group_collection):
 
 @pytest.mark.tier(2)
 def test_group_remove_tag(group_collection):
+    """
+    Polarion:
+        assignee: anikifor
+        initialEstimate: 1/8h
+    """
     role = 'EvmRole-approver'
     group_description = 'grp{}'.format(fauxfactory.gen_alphanumeric())
     group = group_collection.create(description=group_description, role=role)
@@ -465,6 +576,12 @@ def test_group_remove_tag(group_collection):
 
 @pytest.mark.tier(3)
 def test_group_description_required_error_validation(group_collection):
+    """
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
+    """
     error_text = "Description can't be blank"
 
     with pytest.raises(Exception, match=error_text):
@@ -482,6 +599,11 @@ def test_delete_default_group(group_collection):
     Steps:
         * Login as Administrator user
         * Try deleting the group EvmGroup-adminstrator
+
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
     """
     group = group_collection.instantiate(description='EvmGroup-administrator')
 
@@ -492,6 +614,11 @@ def test_delete_default_group(group_collection):
 @pytest.mark.tier(3)
 def test_delete_group_with_assigned_user(appliance, group_collection):
     """Test that CFME prevents deletion of a group that has users assigned
+
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
     """
     role = 'EvmRole-approver'
     group_description = 'grp{}'.format(fauxfactory.gen_alphanumeric())
@@ -508,6 +635,11 @@ def test_edit_default_group(group_collection):
     Steps:
         * Login as Administrator user
         * Try editing the group EvmGroup-adminstrator
+
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
     """
     group = group_collection.instantiate(description='EvmGroup-approver')
 
@@ -525,6 +657,11 @@ def test_edit_sequence_usergroups(request, group_collection):
         * create a new group
         * Edit the sequence of the new group
         * Verify the changed sequence
+
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
     """
     role_name = 'EvmRole-approver'
     group_description = 'grp{}'.format(fauxfactory.gen_alphanumeric())
@@ -545,6 +682,10 @@ def test_tagvis_group(user_restricted, group_with_tag, check_item_visibility):
         2. Login as restricted user, group is visible for user
         3. As admin remove tag from group
         4. Login as restricted user, group is not visible for user
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: 1/8h
     """
     check_item_visibility(group_with_tag, user_restricted)
 
@@ -553,6 +694,12 @@ def test_tagvis_group(user_restricted, group_with_tag, check_item_visibility):
 @pytest.mark.sauce
 @pytest.mark.tier(2)
 def test_role_crud(appliance):
+    """
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
+    """
     role = new_role(appliance)
     with update(role):
         role.name = "{}edited".format(role.name)
@@ -563,6 +710,12 @@ def test_role_crud(appliance):
 
 @pytest.mark.tier(3)
 def test_rolename_required_error_validation(appliance):
+    """
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
+    """
     # When trying to create a role with no name, the Add button is disabled.
     # We are waiting for an Exception saying that there are no success
     # or fail messages, because the Add button cannot be clicked.
@@ -575,6 +728,12 @@ def test_rolename_required_error_validation(appliance):
 
 @pytest.mark.tier(3)
 def test_rolename_duplicate_validation(appliance):
+    """
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
+    """
     name = 'rol{}'.format(fauxfactory.gen_alphanumeric())
     role = new_role(appliance, name=name)
     with pytest.raises(RBACOperationBlocked):
@@ -594,6 +753,11 @@ def test_delete_default_roles(appliance):
         * Login as Administrator user
         * Navigate to Configuration -> Role
         * Try editing the group EvmRole-approver
+
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
     """
     role = appliance.collections.roles.instantiate(name='EvmRole-approver')
     with pytest.raises(RBACOperationBlocked):
@@ -609,6 +773,11 @@ def test_edit_default_roles(appliance):
         * Login as Administrator user
         * Navigate to Configuration -> Role
         * Try editing the group EvmRole-auditor
+
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
     """
     role = appliance.collections.roles.instantiate(name='EvmRole-auditor')
     newrole_name = "{}-{}".format(role.name, fauxfactory.gen_alphanumeric())
@@ -620,6 +789,12 @@ def test_edit_default_roles(appliance):
 
 @pytest.mark.tier(3)
 def test_delete_roles_with_assigned_group(appliance, group_collection):
+    """
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
+    """
     role = new_role(appliance)
     group_description = 'grp{}'.format(fauxfactory.gen_alphanumeric())
     group_collection.create(description=group_description, role=role.name)
@@ -630,6 +805,12 @@ def test_delete_roles_with_assigned_group(appliance, group_collection):
 
 @pytest.mark.tier(3)
 def test_assign_user_to_new_group(appliance, group_collection):
+    """
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
+    """
     role = new_role(appliance)  # call function to get role
 
     group_description = 'grp{}'.format(fauxfactory.gen_alphanumeric())
@@ -676,6 +857,12 @@ def test_permission_edit(appliance, request, product_features):
         request: pytest request fixture
         product_features: product features to set for test role
         action: reference to a function to execute under the test user context
+
+    Polarion:
+        assignee: apagac
+        caseimportance: medium
+        initialEstimate: 1h
+        tags: rbac
     """
     role_name = fauxfactory.gen_alphanumeric()
     role = appliance.collections.roles.create(name=role_name,
@@ -779,6 +966,12 @@ def test_permissions(appliance, product_features, allowed_actions, disallowed_ac
 
         *_actions are a list of actions with each item consisting of a dictionary
             object: [ { "Action Name": function_reference_action }, ...]
+
+    Polarion:
+        assignee: apagac
+        caseimportance: medium
+        initialEstimate: 1h
+        tags: rbac
     """
     # create a user and role
     role = _mk_role(appliance, product_features=product_features)
@@ -826,6 +1019,12 @@ def single_task_permission_test(appliance, product_features, actions):
 
 @pytest.mark.tier(3)
 def test_permissions_role_crud(appliance):
+    """
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/5h
+        tags: rbac
+    """
     single_task_permission_test(appliance,
                                 [['Everything', 'Settings', 'Configuration'],
                                  ['Everything', 'Services', 'Catalogs Explorer']],
@@ -834,6 +1033,13 @@ def test_permissions_role_crud(appliance):
 
 @pytest.mark.tier(3)
 def test_permissions_vm_provisioning(appliance, provider):
+    """
+    Polarion:
+        assignee: apagac
+        caseimportance: medium
+        initialEstimate: 1/5h
+        tags: rbac
+    """
     features = [
         ['Everything', 'Compute', 'Infrastructure', 'Virtual Machines', 'Accordions'],
         ['Everything', 'Access Rules for all Virtual Machines', 'VM Access Rules', 'Modify',
@@ -883,6 +1089,12 @@ def test_permissions_vm_provisioning(appliance, provider):
 
 @pytest.mark.tier(2)
 def test_user_change_password(appliance, request):
+    """
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/8h
+        tags: rbac
+    """
     group_name = 'EvmGroup-user'
     group = group_collection(appliance).instantiate(description=group_name)
 
@@ -921,6 +1133,11 @@ def test_superadmin_tenant_crud(request, appliance):
         * Update description of tenant
         * Update name of tenant
         * Delete tenant
+
+    Polarion:
+        assignee: mnadeem
+        caseimportance: low
+        initialEstimate: 1/4h
     """
     tenant_collection = appliance.collections.tenants
     tenant = tenant_collection.create(
@@ -955,6 +1172,12 @@ def test_superadmin_tenant_project_crud(request, appliance):
         * Update name of project
         * Delete project
         * Delete tenant
+
+    Polarion:
+        assignee: mnadeem
+        casecomponent: config
+        initialEstimate: 1/4h
+        tags: obsolete20180808
     """
     tenant_collection = appliance.collections.tenants
     project_collection = appliance.collections.projects
@@ -995,6 +1218,11 @@ def test_superadmin_child_tenant_crud(request, appliance, number_of_childrens):
         * Update description of tenant(N-1)_* in the tree
         * Update name of tenant(N-1)_*
         * Delete all created tenants in reversed order
+
+    Polarion:
+        assignee: mnadeem
+        casecomponent: config
+        initialEstimate: 1h
     """
     tenant_collection = appliance.collections.tenants
     tenant_list = []
@@ -1067,17 +1295,35 @@ def tenant_unique_tenant_project_name_on_parent_level(request, appliance, object
 
 @pytest.mark.tier(3)
 def test_unique_tenant_name_on_parent_level(request, appliance):
+    """
+    Polarion:
+        assignee: ghubale
+        casecomponent: infra
+        initialEstimate: 1/20h
+    """
     tenant_unique_tenant_project_name_on_parent_level(request, appliance,
                                                       appliance.collections.tenants)
 
 
 @pytest.mark.tier(3)
 def test_unique_project_name_on_parent_level(request, appliance):
+    """
+    Polarion:
+        assignee: ghubale
+        casecomponent: infra
+        initialEstimate: 1/20h
+    """
     tenant_unique_tenant_project_name_on_parent_level(request, appliance,
                                                       appliance.collections.projects)
 
 
 def test_tenant_quota_input_validate(appliance):
+    """
+    Polarion:
+        assignee: ghubale
+        casecomponent: infra
+        initialEstimate: 1/8h
+    """
     roottenant = appliance.collections.tenants.get_root_tenant()
     fields = [('cpu', 2.5), ('storage', '1.x'), ('memory', '2.x'), ('vm', 1.5)]
 
@@ -1096,6 +1342,11 @@ def test_delete_default_tenant(appliance):
     3. Select default tenant('My Company') from tenants table
     4. Delete using 'configuration > Delete selected items'
     5. Check whether default tenant is deleted or not
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: infra
+        initialEstimate: 1/20h
     """
     view = navigate_to(appliance.collections.tenants, "All")
     roottenant = appliance.collections.tenants.get_root_tenant()
@@ -1109,6 +1360,10 @@ def test_delete_default_tenant(appliance):
 def test_copied_user_password_inheritance(appliance, group_collection, request):
     """Test to verify that dialog for copied user should appear and password field should be
     empty
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: 1/15h
     """
     group_name = 'EvmGroup-user'
     group = group_collection.instantiate(description=group_name)

--- a/cfme/tests/configure/test_analysis_profiles.py
+++ b/cfme/tests/configure/test_analysis_profiles.py
@@ -49,7 +49,14 @@ def analysis_profile_collection(appliance):
 @pytest.mark.sauce
 @pytest.mark.tier(2)
 def test_vm_analysis_profile_crud(appliance, soft_assert, analysis_profile_collection):
-    """CRUD for VM analysis profiles."""
+    """CRUD for VM analysis profiles.
+
+    Polarion:
+        assignee: anikifor
+        caseimportance: medium
+        initialEstimate: 1/2h
+        testtype: integration
+    """
     vm_profile = analysis_profile_collection.create(
         name=fauxfactory.gen_alphanumeric(),
         description=fauxfactory.gen_alphanumeric(),
@@ -99,7 +106,14 @@ def test_vm_analysis_profile_crud(appliance, soft_assert, analysis_profile_colle
 @pytest.mark.sauce
 @pytest.mark.tier(2)
 def test_host_analysis_profile_crud(appliance, soft_assert, analysis_profile_collection):
-    """CRUD for Host analysis profiles."""
+    """CRUD for Host analysis profiles.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/12h
+    """
     host_profile = analysis_profile_collection.create(
         name=fauxfactory.gen_alphanumeric(),
         description=fauxfactory.gen_alphanumeric(),
@@ -139,7 +153,14 @@ def test_host_analysis_profile_crud(appliance, soft_assert, analysis_profile_col
 # TODO Combine and parametrize VM + Host validation tests
 # Parametrize VM/Host, and (name/description/no item + flash) message as namedtuple
 def test_vmanalysis_profile_description_validation(analysis_profile_collection):
-    """ Test to validate description in vm profiles"""
+    """ Test to validate description in vm profiles
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/20h
+    """
     with pytest.raises(AssertionError):
         analysis_profile_collection.create(
             name=fauxfactory.gen_alphanumeric(),
@@ -158,7 +179,14 @@ def test_vmanalysis_profile_description_validation(analysis_profile_collection):
 
 
 def test_analysis_profile_duplicate_name(analysis_profile_collection):
-    """ Test to validate duplicate profiles name."""
+    """ Test to validate duplicate profiles name.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/15h
+    """
     profile = analysis_profile_collection.create(
         name=fauxfactory.gen_alphanumeric(),
         description=fauxfactory.gen_alphanumeric(),
@@ -184,7 +212,14 @@ def test_analysis_profile_duplicate_name(analysis_profile_collection):
 
 
 def test_delete_default_analysis_profile(default_host_profile, appliance):
-    """ Test to validate delete default profiles."""
+    """ Test to validate delete default profiles.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/15h
+    """
     # Option disabled from details
     view = navigate_to(default_host_profile, 'Details')
     assert not view.toolbar.configuration.item_enabled('Delete this Analysis Profile')
@@ -202,7 +237,14 @@ def test_delete_default_analysis_profile(default_host_profile, appliance):
 
 
 def test_edit_default_analysis_profile(default_host_profile, appliance):
-    """ Test to validate edit default profiles."""
+    """ Test to validate edit default profiles.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/10h
+    """
     # Option disabled from details
     view = navigate_to(default_host_profile, 'Details')
     assert not view.toolbar.configuration.item_enabled('Edit this Analysis Profile')
@@ -219,7 +261,14 @@ def test_edit_default_analysis_profile(default_host_profile, appliance):
 
 
 def test_analysis_profile_item_validation(analysis_profile_collection):
-    """ Test to validate analysis profile items."""
+    """ Test to validate analysis profile items.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/15h
+    """
     profile_name = fauxfactory.gen_alphanumeric()
 
     with pytest.raises(AssertionError):
@@ -239,7 +288,14 @@ def test_analysis_profile_item_validation(analysis_profile_collection):
 
 
 def test_analysis_profile_name_validation(analysis_profile_collection):
-    """ Test to validate profile name."""
+    """ Test to validate profile name.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/20h
+    """
 
     with pytest.raises(AssertionError):
         analysis_profile_collection.create(
@@ -261,7 +317,12 @@ def test_analysis_profile_name_validation(analysis_profile_collection):
 @pytest.mark.uncollectif(lambda appliance: appliance.version > '5.9',
                          reason='Description is not required started from 5.10')
 def test_analysis_profile_description_validation(analysis_profile_collection):
-    """ Test to validate profile description."""
+    """ Test to validate profile description.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     with pytest.raises(AssertionError):
         analysis_profile_collection.create(
             name=fauxfactory.gen_alphanumeric(),

--- a/cfme/tests/configure/test_database_ui.py
+++ b/cfme/tests/configure/test_database_ui.py
@@ -13,6 +13,12 @@ def test_configure_vmdb_last_start_time(appliance):
         Go to Settings -> Configure -> Database
         Compare Vmdb Last Start Time with output of command
         "journalctl -u rh-postgresql{}-postgresql.service  --boot=0 | sed '4!d'"
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/12h
     """
 
     view = navigate_to(appliance.server, 'DatabaseSummary')
@@ -38,6 +44,12 @@ def test_configuration_database_garbage_collection(appliance):
     """
         Navigate to Settings -> Configuration -> Diagnostics -> CFME Region -> Database
         Submit Run database Garbage Collection Now a check UI/logs for errors.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/12h
     """
     evm_tail = LogValidator('/var/www/miq/vmdb/log/evm.log',
                             matched_patterns=[

--- a/cfme/tests/configure/test_db_backup_schedule.py
+++ b/cfme/tests/configure/test_db_backup_schedule.py
@@ -160,6 +160,10 @@ def get_full_path_to_file(path_on_host, schedule_name):
 @pytest.mark.tier(3)
 def test_db_backup_schedule(request, db_backup_data, db_depot_machine_ip, appliance):
     """ Test scheduled one-type backup on given machines using smb/nfs
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     # ---- Create new db backup schedule set to run in the next 6 min

--- a/cfme/tests/configure/test_default_filters.py
+++ b/cfme/tests/configure/test_default_filters.py
@@ -11,6 +11,12 @@ pytestmark = [pytest.mark.tier(3),
 
 
 def test_default_filters_reset(appliance):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: config
+        initialEstimate: None
+    """
     tree_path = ['Cloud', 'Instances', 'Images', 'Platform / Openstack']
     view = navigate_to(appliance.user.my_settings, "DefaultFilters")
     node = view.tabs.default_filters.tree.CheckNode(tree_path)
@@ -20,6 +26,13 @@ def test_default_filters_reset(appliance):
 
 
 def test_cloudimage_defaultfilters(appliance):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     filters = [['Cloud', 'Instances', 'Images', 'Platform / Amazon']]
     tree_path = ['All Images', 'Global Filters', 'Platform / Amazon']
     appliance.user.my_settings.default_filters.update({'filters': [(k, True) for k in filters]})
@@ -28,6 +41,11 @@ def test_cloudimage_defaultfilters(appliance):
 
 
 def test_cloudinstance_defaultfilters(appliance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     filters = [['Cloud', 'Instances', 'Instances', 'Platform / Openstack']]
     tree_path = ['All Instances', 'Global Filters', 'Platform / Openstack']
     appliance.user.my_settings.default_filters.update({'filters': [(k, True) for k in filters]})
@@ -36,6 +54,13 @@ def test_cloudinstance_defaultfilters(appliance):
 
 
 def test_infrastructurehost_defaultfilters(appliance):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     filters = [['Infrastructure', 'Hosts', 'Platform / HyperV']]
     appliance.user.my_settings.default_filters.update({'filters': [(k, True) for k in filters]})
     host_collecton = appliance.collections.hosts
@@ -44,6 +69,13 @@ def test_infrastructurehost_defaultfilters(appliance):
 
 
 def test_infrastructurevms_defaultfilters(appliance):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     filters = [['Infrastructure', 'Virtual Machines', 'VMs', 'Platform / VMware']]
     tree_path = ['All VMs', 'Global Filters', 'Platform / VMware']
     appliance.user.my_settings.default_filters.update({'filters': [(k, True) for k in filters]})
@@ -52,6 +84,13 @@ def test_infrastructurevms_defaultfilters(appliance):
 
 
 def test_infrastructuretemplates_defaultfilters(appliance):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     filters = [['Infrastructure', 'Virtual Machines', 'Templates', 'Platform / Redhat']]
     tree_path = ['All Templates', 'Global Filters', 'Platform / Redhat']
     appliance.user.my_settings.default_filters.update({'filters': [(k, True) for k in filters]})
@@ -60,6 +99,13 @@ def test_infrastructuretemplates_defaultfilters(appliance):
 
 
 def test_servicetemplateandimages_defaultfilters(appliance, request):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     filters = [['Services', 'Workloads', 'Templates & Images', 'Platform / Microsoft']]
     tree_path = ['All Templates & Images', 'Global Filters', 'Platform / Microsoft']
     appliance.user.my_settings.default_filters.update({'filters': [(k, True) for k in filters]})
@@ -71,6 +117,13 @@ def test_servicetemplateandimages_defaultfilters(appliance, request):
 
 
 def test_servicevmsandinstances_defaultfilters(appliance, request):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     filters = [['Services', 'Workloads', 'VMs & Instances', 'Platform / Openstack']]
     tree_path = ['All VMs & Instances', 'Global Filters', 'Platform / Openstack']
     appliance.user.my_settings.default_filters.update({'filters': [(k, True) for k in filters]})

--- a/cfme/tests/configure/test_default_views_cloud.py
+++ b/cfme/tests/configure/test_default_views_cloud.py
@@ -31,6 +31,10 @@ def test_default_view_cloud_reset(appliance):
         * Check Reset Button is disabled
         * Select 'availability_zones' button from cloud region and change it's default mode
         * Check Reset Button is enabled
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     view = navigate_to(appliance.user.my_settings, "DefaultViews")
     assert view.tabs.default_views.reset.disabled
@@ -44,7 +48,12 @@ def test_default_view_cloud_reset(appliance):
 @pytest.mark.parametrize('group_name', gtl_params.keys())
 @pytest.mark.parametrize('expected_view', ['List View', 'Tile View', 'Grid View'])
 def test_cloud_default_view(appliance, group_name, expected_view):
-    """This test case changes the default view of a cloud related page and asserts the change."""
+    """This test case changes the default view of a cloud related page and asserts the change.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     page = gtl_params[group_name]
     default_views = appliance.user.my_settings.default_views
     old_default = default_views.get_default_view(group_name, fieldset='Clouds')
@@ -60,7 +69,12 @@ def test_cloud_default_view(appliance, group_name, expected_view):
                          ['Expanded View', 'Compressed View', 'Details Mode', 'Exists Mode'])
 def test_cloud_compare_view(appliance, expected_view):
     """This test changes the default view/mode for comparison between cloud provider instances
-    and asserts the change."""
+    and asserts the change.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
 
     if expected_view in ['Expanded View', 'Compressed View']:
         group_name, selector_type = 'Compare', 'views_selector'

--- a/cfme/tests/configure/test_default_views_infra.py
+++ b/cfme/tests/configure/test_default_views_infra.py
@@ -70,6 +70,10 @@ def test_default_view_infra_reset(appliance):
         * Select 'infrastructure_providers' button from infrastructure region
         * Change it's default mode
         * Check Reset Button is enabled
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     view = navigate_to(appliance.user.my_settings, "DefaultViews")
     assert view.tabs.default_views.reset.disabled
@@ -83,7 +87,12 @@ def test_default_view_infra_reset(appliance):
 @pytest.mark.parametrize('group_name', gtl_params.keys(), scope="module")
 @pytest.mark.parametrize('view', ['List View', 'Tile View', 'Grid View'])
 def test_infra_default_view(appliance, group_name, view):
-    """This test case changes the default view of an infra related page and asserts the change."""
+    """This test case changes the default view of an infra related page and asserts the change.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     page = _get_page(gtl_params[group_name], appliance)
     default_views = appliance.user.my_settings.default_views
     old_default = default_views.get_default_view(group_name)
@@ -100,7 +109,12 @@ def test_infra_default_view(appliance, group_name, view):
                          ['Expanded View', 'Compressed View', 'Details Mode', 'Exists Mode'])
 def test_infra_compare_view(appliance, expected_view):
     """This test changes the default view/mode for comparison between infra provider instances
-    and asserts the change."""
+    and asserts the change.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     if expected_view in ['Expanded View', 'Compressed View']:
         group_name, selector_type = 'Compare', 'views_selector'
     else:
@@ -117,10 +131,24 @@ def test_infra_compare_view(appliance, expected_view):
 
 
 def test_vm_visibility_off(appliance):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     appliance.user.my_settings.default_views.set_default_view_switch_off()
     assert not check_vm_visibility(appliance)
 
 
 def test_vm_visibility_on(appliance):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/5h
+    """
     appliance.user.my_settings.default_views.set_default_view_switch_on()
     assert check_vm_visibility(appliance, check=True)

--- a/cfme/tests/configure/test_diagnostic_timelines.py
+++ b/cfme/tests/configure/test_diagnostic_timelines.py
@@ -4,4 +4,9 @@ import pytest
 
 @pytest.mark.manual
 def test_diagnostic_timelines():
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     pass

--- a/cfme/tests/configure/test_display_settings.py
+++ b/cfme/tests/configure/test_display_settings.py
@@ -36,6 +36,12 @@ def test_timezone_setting(appliance, set_timezone):
 
     Metadata:
         test_flag: visuals
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/30h
     """
     view = navigate_to(appliance.server, 'DiagnosticsDetails')
     assert test_timezone.machine in view.summary.started_on.text, 'Timezone settings Failed'

--- a/cfme/tests/configure/test_docs.py
+++ b/cfme/tests/configure/test_docs.py
@@ -44,7 +44,14 @@ def pdf_get_text(file_obj, page_nums):
 @pytest.mark.ignore_stream("upstream")
 @pytest.mark.sauce
 def test_links(appliance):
-    """Test whether the PDF documents are present."""
+    """Test whether the PDF documents are present.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: low
+        initialEstimate: 1/20h
+    """
     view = navigate_to(appliance.server, 'Documentation')
     for link_widget in view.links.sub_widgets:
         # link_widget is nested view, we care about 'link' widget here
@@ -67,7 +74,14 @@ def test_links(appliance):
 @pytest.mark.tier(3)
 @pytest.mark.ignore_stream("upstream")
 def test_contents(appliance, soft_assert):
-    """Test title of each document."""
+    """Test title of each document.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: low
+        initialEstimate: 1/10h
+    """
     view = navigate_to(appliance.server, 'Documentation')
     cur_ver = appliance.version
     for doc_type, title in doc_titles.items():
@@ -106,7 +120,12 @@ def test_info(appliance, soft_assert):
     Test the alt/title and href attributes.
     Each doc link is an anchor with image child element, and then the link text anchor
     Verify anchor title matches alt in anchor image
-    Verify image anchor href matches link text href"""
+    Verify image anchor href matches link text href
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(appliance.server, 'Documentation')
     for link_widget in view.links.sub_widgets:
         if not (hasattr(link_widget, 'img_anchor') or hasattr(link_widget, 'img')):
@@ -131,6 +150,12 @@ def test_all_docs_present(appliance):
     """
     Check that all the documents that we expect to be in the UI are present
     Use the doc_titles dict keys to query widget is_displayed
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: low
+        initialEstimate: 1/10h
     """
     view = navigate_to(appliance.server, 'Documentation')
     for doc_type, title in doc_titles.items():

--- a/cfme/tests/configure/test_email.py
+++ b/cfme/tests/configure/test_email.py
@@ -5,7 +5,14 @@ import pytest
 
 @pytest.mark.tier(3)
 def test_send_test_email(smtp_test, random_string, appliance):
-    """ This test checks whether the mail sent for testing really arrives. """
+    """ This test checks whether the mail sent for testing really arrives.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: critical
+        initialEstimate: 1/10h
+    """
     e_mail = random_string + "@email.test"
     appliance.server.settings.send_test_email(email=e_mail)
     wait_for(lambda: len(smtp_test.get_emails(to_address=e_mail)) > 0, num_sec=60)

--- a/cfme/tests/configure/test_landing_page.py
+++ b/cfme/tests/configure/test_landing_page.py
@@ -145,6 +145,12 @@ def test_landing_page_admin(start_page, appliance, my_settings, request):
             This test checks the functioning of the landing page; 'Start at Login'
             option on 'Visual' tab of setting page for administrator. This test case doesn't
             check the exact page but verifies that all the landing page options works properly.
+
+    Polarion:
+        assignee: pvala
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
     """
     request.addfinalizer(lambda: set_to_default('Cloud Intel / Dashboard', my_settings))
     assert set_landing_page(start_page, appliance, my_settings)

--- a/cfme/tests/configure/test_log_depot_operation.py
+++ b/cfme/tests/configure/test_log_depot_operation.py
@@ -287,6 +287,11 @@ def test_collect_log_depot(log_depot, appliance, service_request, configured_dep
     """ Boilerplate test to verify functionality of this concept
 
     Will be extended and improved.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        initialEstimate: 1/4h
     """
     # Wipe the FTP contents in the end
     @request.addfinalizer
@@ -351,6 +356,12 @@ def test_collect_log_depot(log_depot, appliance, service_request, configured_dep
 def test_collect_unconfigured(appliance):
     """ Test checking is collect button enable and disable after log depot was configured
 
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/4h
     """
     server_log_depot = appliance.server.collect_logs
     with update(server_log_depot):
@@ -374,6 +385,12 @@ def test_collect_multiple_servers(log_depot, temp_appliance_preconfig, depot_mac
                                   configured_external_appliance, zone_collect, collect_type,
                                   from_slave):
 
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        initialEstimate: 1/4h
+    """
     appliance = temp_appliance_preconfig
     log_depot.machine_ip = depot_machine_ip
     collect_logs = (
@@ -425,6 +442,12 @@ def test_collect_multiple_servers(log_depot, temp_appliance_preconfig, depot_mac
 @pytest.mark.tier(3)
 def test_collect_single_servers(log_depot, appliance, depot_machine_ip, request, zone_collect,
                                 collect_type):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        initialEstimate: 1/4h
+    """
     log_depot.machine_ip = depot_machine_ip
 
     @request.addfinalizer

--- a/cfme/tests/configure/test_logs.py
+++ b/cfme/tests/configure/test_logs.py
@@ -35,6 +35,10 @@ def test_provider_log_exists(log_exists):
 
     Metadata:
         test_flag: log
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
     """
     assert log_exists
 
@@ -49,6 +53,10 @@ def test_provider_log_rotate(appliance, provider, log_exists):
 
     Metadata:
         test_flag: log
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     assert log_exists, "Log file {}.log doesn't exist".format(provider.log_name)
     appliance.ssh_client.run_command("logrotate -f /etc/logrotate.d/miq_logs.conf")
@@ -74,6 +82,10 @@ def test_provider_log_updated(appliance, provider, log_exists):
 
     Metadata:
         test_flag: log
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     assert log_exists, "Log file {}.log doesn't exist".format(provider.log_name)
     log_before = appliance.ssh_client.run_command(
@@ -111,6 +123,10 @@ def test_provider_log_level(appliance, provider, log_exists):
 
     Metadata:
         test_flag: log
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     assert log_exists, "Log file {}.log doesn't exist".format(provider.log_name)
     log_level = appliance.server.advanced_settings['log']['level_{}'.format(provider.log_name)]

--- a/cfme/tests/configure/test_ntp_server.py
+++ b/cfme/tests/configure/test_ntp_server.py
@@ -44,6 +44,13 @@ def clear_ntp_settings(appliance, empty_ntp_dict):
 
 @pytest.mark.tier(2)
 def test_ntp_crud(request, appliance, empty_ntp_dict, ntp_servers_keys):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/12h
+    """
     # Adding finalizer
     request.addfinalizer(lambda: appliance.server.settings.update_ntp_servers(empty_ntp_dict))
     """ Insert, Update and Delete the NTP servers """
@@ -59,6 +66,13 @@ def test_ntp_crud(request, appliance, empty_ntp_dict, ntp_servers_keys):
 
 @pytest.mark.tier(3)
 def test_ntp_server_max_character(request, appliance, ntp_servers_keys, empty_ntp_dict):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/8h
+    """
     request.addfinalizer(partial(clear_ntp_settings, appliance, empty_ntp_dict))
     ntp_file_date_stamp = appliance.ssh_client.run_command(
         "stat --format '%y' /etc/chrony.conf").output
@@ -71,6 +85,11 @@ def test_ntp_server_max_character(request, appliance, ntp_servers_keys, empty_nt
 @pytest.mark.tier(3)
 def test_ntp_conf_file_update_check(request, appliance, empty_ntp_dict, ntp_servers_keys):
 
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     request.addfinalizer(lambda: appliance.server.settings.update_ntp_servers(empty_ntp_dict))
     ntp_file_date_stamp = appliance.ssh_client.run_command(
         "stat --format '%y' /etc/chrony.conf").output
@@ -98,6 +117,11 @@ def test_ntp_conf_file_update_check(request, appliance, empty_ntp_dict, ntp_serv
 
 @pytest.mark.tier(3)
 def test_ntp_server_check(request, appliance, ntp_servers_keys, empty_ntp_dict):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     request.addfinalizer(lambda: appliance.server.settings.update_ntp_servers(empty_ntp_dict))
     orig_date = appliance_date(appliance)
     past_date = orig_date - timedelta(days=10)
@@ -132,4 +156,11 @@ def test_ntp_server_check(request, appliance, ntp_servers_keys, empty_ntp_dict):
 
 @pytest.mark.tier(3)
 def test_clear_ntp_settings(request, appliance, empty_ntp_dict):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/30h
+    """
     request.addfinalizer(lambda: appliance.server.settings.update_ntp_servers(empty_ntp_dict))

--- a/cfme/tests/configure/test_paginator.py
+++ b/cfme/tests/configure/test_paginator.py
@@ -103,6 +103,10 @@ def schedule(appliance):
 def test_paginator(appliance, place_info):
     """
         Check paginator is visible for config pages
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
     """
     place_name, place_class, place_navigation, paginator_expected_result = place_info
     if place_class:
@@ -125,6 +129,12 @@ def test_paginator(appliance, place_info):
 def test_paginator_details_page(appliance, place_info, schedule):
     """
         Check paginator is visible for access control pages + schedules
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
     """
     place_name, place_class, place_navigation, paginator_expected_result = place_info
     if place_name == 'tag':

--- a/cfme/tests/configure/test_proxy.py
+++ b/cfme/tests/configure/test_proxy.py
@@ -111,7 +111,12 @@ def test_proxy_valid(appliance, proxy_machine, proxy_ssh, prepare_proxy_default,
      * Configure appliance to use proxy for default provider.
      * Configure appliance to use not use proxy for specific provider.
      * Chceck whether the provider is accessed trough proxy by chceking the
-       proxy logs."""
+       proxy logs.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     provider.refresh_provider_relationships()
     validate_proxy_logs(provider, proxy_ssh, appliance.hostname)
     wait_for(
@@ -135,6 +140,10 @@ def test_proxy_override(appliance, proxy_ssh, prepare_proxy_specific, provider):
      * Configure specific proxy to valid entry.
      * Check whether the provider is accessed trough proxy by checking the proxy logs.
      * Wait for the provider refresh to complete to check the settings worked.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     provider.refresh_provider_relationships()
     validate_proxy_logs(provider, proxy_ssh, appliance.hostname)
@@ -156,6 +165,10 @@ def test_proxy_invalid(appliance, prepare_proxy_invalid, provider):
      * Configure default proxy to invalid entry.
      * Configure specific proxy to invalid entry.
      * Wait for the provider refresh to complete to check the settings causes error.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     provider.refresh_provider_relationships()
 

--- a/cfme/tests/configure/test_region.py
+++ b/cfme/tests/configure/test_region.py
@@ -5,7 +5,12 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 
 
 def test_empty_region_description(appliance):
-    """Test changing region description to empty field"""
+    """Test changing region description to empty field
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(appliance.server.zone.region, 'ChangeRegionName')
     view.region_description.fill("")
     view.save.click()
@@ -14,7 +19,12 @@ def test_empty_region_description(appliance):
 
 
 def test_description_change(appliance, request):
-    """Test changing region description"""
+    """Test changing region description
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(appliance.server.zone.region, 'ChangeRegionName')
 
     def _reset_region_description(description, view):

--- a/cfme/tests/configure/test_register_appliance.py
+++ b/cfme/tests/configure/test_register_appliance.py
@@ -88,7 +88,12 @@ def appliance_preupdate(temp_appliance_preconfig_funcscope, appliance):
 @pytest.mark.rhel_testing
 @pytest.mark.ignore_stream("upstream")
 def test_rh_creds_validation(reg_method, reg_data, proxy_url, proxy_creds):
-    """ Tests whether credentials are validated correctly for RHSM and SAT6 """
+    """ Tests whether credentials are validated correctly for RHSM and SAT6
+
+    Polarion:
+        assignee: lcouzens
+        initialEstimate: 1/12h
+    """
     repo = reg_data.get('enable_repo')
     if not repo:
         set_default_repo = True
@@ -123,7 +128,12 @@ def test_rh_creds_validation(reg_method, reg_data, proxy_url, proxy_creds):
 @pytest.mark.rhel_testing
 @pytest.mark.ignore_stream("upstream")
 def test_rh_registration(appliance, request, reg_method, reg_data, proxy_url, proxy_creds):
-    """ Tests whether an appliance can be registered against RHSM and SAT6 """
+    """ Tests whether an appliance can be registered against RHSM and SAT6
+
+    Polarion:
+        assignee: lcouzens
+        initialEstimate: 1/12h
+    """
     repo = reg_data.get('enable_repo')
     if not repo:
         set_default_repo = True
@@ -180,7 +190,12 @@ def test_rh_registration(appliance, request, reg_method, reg_data, proxy_url, pr
 @pytest.mark.rhel_testing
 def test_rhsm_registration_check_repo_names(
         temp_appliance_preconfig_funcscope, soft_assert, appliance):
-    """ Checks default rpm repos on a fresh appliance """
+    """ Checks default rpm repos on a fresh appliance
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     ver = temp_appliance_preconfig_funcscope.version.series()
     repos = cfme_data.redhat_updates.repos
 
@@ -204,7 +219,12 @@ def test_rhsm_registration_check_repo_names(
 @pytest.mark.rhel_testing
 @pytest.mark.meta(blockers=[BZ(1500878, forced_streams=['5.9', 'upstream'])])
 def test_rh_updates(appliance_preupdate, appliance):
-    """ Tests whether the update button in the webui functions correctly """
+    """ Tests whether the update button in the webui functions correctly
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
 
     set_default_repo = True
 

--- a/cfme/tests/configure/test_remote_server_tabs.py
+++ b/cfme/tests/configure/test_remote_server_tabs.py
@@ -24,6 +24,10 @@ def test_remote_server_advanced_config(temp_appliance_preconfig, request,
     """
     Test that starting in 5.10 it is possible to modify advanced settings for remote servers
     BZ1536524
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     appliance = temp_appliance_preconfig
     remote_server = appliance.server.slave_servers[0]

--- a/cfme/tests/configure/test_rest_access_control.py
+++ b/cfme/tests/configure/test_rest_access_control.py
@@ -39,6 +39,10 @@ class TestTenantsViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         query_resource_attributes(tenants[0], soft_assert=soft_assert)
 
@@ -48,6 +52,11 @@ class TestTenantsViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         for tenant in tenants:
             record = appliance.rest_api.collections.tenants.get(id=tenant.id)
@@ -61,6 +70,11 @@ class TestTenantsViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/3h
         """
         collection = appliance.rest_api.collections.tenants
         tenants_len = len(tenants)
@@ -96,6 +110,11 @@ class TestTenantsViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         delete_resources_from_detail(tenants, method=method)
 
@@ -105,6 +124,11 @@ class TestTenantsViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         delete_resources_from_collection(tenants)
 
@@ -124,6 +148,10 @@ class TestRolesViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         query_resource_attributes(roles[0], soft_assert=soft_assert)
 
@@ -133,6 +161,11 @@ class TestRolesViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         for role in roles:
             record = appliance.rest_api.collections.roles.get(id=role.id)
@@ -146,6 +179,11 @@ class TestRolesViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/3h
         """
         collection = appliance.rest_api.collections.roles
         roles_len = len(roles)
@@ -181,6 +219,11 @@ class TestRolesViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         delete_resources_from_detail(roles, method=method)
 
@@ -190,6 +233,11 @@ class TestRolesViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         delete_resources_from_collection(roles)
 
@@ -199,6 +247,11 @@ class TestRolesViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/3h
         """
         role_data = {"name": "role_name_{}".format(fauxfactory.gen_alphanumeric())}
         role = appliance.rest_api.collections.roles.action.add(role_data)[0]
@@ -223,6 +276,11 @@ class TestRolesViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/3h
         """
         feature = appliance.rest_api.collections.features.get(name="Everything")
         role = roles[0]
@@ -261,6 +319,10 @@ class TestGroupsViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         query_resource_attributes(groups[0], soft_assert=soft_assert)
 
@@ -270,6 +332,11 @@ class TestGroupsViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         for group in groups:
             record = appliance.rest_api.collections.groups.get(id=group.id)
@@ -283,6 +350,11 @@ class TestGroupsViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/3h
         """
         collection = appliance.rest_api.collections.groups
         groups_len = len(groups)
@@ -318,6 +390,11 @@ class TestGroupsViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         delete_resources_from_detail(groups, method=method)
 
@@ -327,6 +404,11 @@ class TestGroupsViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         delete_resources_from_collection(groups, not_found=True)
 
@@ -356,6 +438,10 @@ class TestUsersViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         query_resource_attributes(users[0], soft_assert=soft_assert)
 
@@ -365,6 +451,11 @@ class TestUsersViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         users, prov_data = users_data
         for index, user in enumerate(users):
@@ -386,6 +477,10 @@ class TestUsersViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         uniq = fauxfactory.gen_alphanumeric(4).upper()
         data = {
@@ -407,6 +502,11 @@ class TestUsersViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/3h
         """
         user = users[0]
         new_password = fauxfactory.gen_alphanumeric()
@@ -422,6 +522,11 @@ class TestUsersViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/3h
         """
         collection = appliance.rest_api.collections.users
         users_len = len(users)
@@ -463,6 +568,10 @@ class TestUsersViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         group_descriptions = ['EvmGroup-user_limited_self_service', 'EvmGroup-approver']
         groups = [appliance.rest_api.collections.groups.get(description=desc)
@@ -485,6 +594,10 @@ class TestUsersViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         group_descriptions = ['EvmGroup-user_limited_self_service', 'EvmGroup-approver']
         groups = [appliance.rest_api.collections.groups.get(description=desc)
@@ -537,6 +650,10 @@ class TestUsersViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: None
         """
         group_descriptions = ['EvmGroup-user_limited_self_service', 'EvmGroup-approver']
         groups = [appliance.rest_api.collections.groups.get(description=desc)
@@ -564,6 +681,10 @@ class TestUsersViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: None
         """
         group_descriptions = ['EvmGroup-user_limited_self_service', 'EvmGroup-approver']
         groups = [appliance.rest_api.collections.groups.get(description=desc)
@@ -589,6 +710,10 @@ class TestUsersViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         group_descriptions = ['EvmGroup-user_limited_self_service', 'EvmGroup-approver']
         groups = [appliance.rest_api.collections.groups.get(description=desc)
@@ -615,6 +740,10 @@ class TestUsersViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         group_descriptions = ['EvmGroup-user_limited_self_service', 'EvmGroup-approver']
         groups = [appliance.rest_api.collections.groups.get(description=desc)
@@ -637,6 +766,10 @@ class TestUsersViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         new_password = fauxfactory.gen_alphanumeric()
         new_user_auth = (user_auth[0], new_password)
@@ -658,6 +791,10 @@ class TestUsersViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         new_email = 'new@example.com'
 
@@ -676,6 +813,11 @@ class TestUsersViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         delete_resources_from_detail(users, method=method)
 
@@ -685,5 +827,10 @@ class TestUsersViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         delete_resources_from_collection(users)

--- a/cfme/tests/configure/test_schedule_operations.py
+++ b/cfme/tests/configure/test_schedule_operations.py
@@ -52,6 +52,12 @@ def round_min(value, base=5):
 
 
 def test_schedule_crud(appliance, current_server_time):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        initialEstimate: 1/16h
+    """
     current_time, _ = current_server_time
     start_date = current_time + relativedelta.relativedelta(days=2)
     schedule = appliance.collections.system_schedules.create(
@@ -83,6 +89,11 @@ def test_schedule_crud(appliance, current_server_time):
 
 
 def test_schedule_analysis_in_the_past(appliance, current_server_time, request):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     current_time, _ = current_server_time
     past_time = current_time - relativedelta.relativedelta(minutes=5)
     if round_min(past_time.minute) == 0:
@@ -105,6 +116,11 @@ def test_schedule_analysis_in_the_past(appliance, current_server_time, request):
 
 
 def test_create_multiple_schedules_in_one_timezone(appliance, request):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     schedule_list = []
     request.addfinalizer(lambda: map(lambda item: item.delete(), schedule_list))
 
@@ -120,6 +136,11 @@ def test_create_multiple_schedules_in_one_timezone(appliance, request):
 
 
 def test_inactive_schedule(appliance, current_server_time):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     current_time, _ = current_server_time
     start_date = current_time + relativedelta.relativedelta(minutes=5)
 
@@ -139,6 +160,11 @@ def test_inactive_schedule(appliance, current_server_time):
 @pytest.mark.parametrize('run_types', run_types, ids=[type[0] for type in run_types])
 def test_schedule_timer(appliance, run_types, host_with_credentials, request, current_server_time):
 
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     run_time, time_diff, time_num = run_types
     current_time, tz_num = current_server_time
     start_date = current_time + relativedelta.relativedelta(minutes=5)

--- a/cfme/tests/configure/test_server_name.py
+++ b/cfme/tests/configure/test_server_name.py
@@ -8,7 +8,14 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 @pytest.mark.tier(3)
 @pytest.mark.sauce
 def test_server_name(request, appliance):
-    """Tests that changing the server name updates the about page"""
+    """Tests that changing the server name updates the about page
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/15h
+    """
 
     view = navigate_to(appliance.server, 'Details')
     old_server_name = view.server.basic_information.appliance_name.read()

--- a/cfme/tests/configure/test_server_roles.py
+++ b/cfme/tests/configure/test_server_roles.py
@@ -44,6 +44,12 @@ def test_server_roles_changing(request, roles, appliance):
       TODO:
       - Use for parametrization on more roles set?
       - Change the yaml role list to dict.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/15h
     """
     server_settings = appliance.server.settings
     original_roles = server_settings.server_roles_db

--- a/cfme/tests/configure/test_session_timeout.py
+++ b/cfme/tests/configure/test_session_timeout.py
@@ -11,7 +11,14 @@ from cfme.utils.wait import wait_for
 @pytest.mark.tier(3)
 @pytest.mark.sauce
 def test_session_timeout(request, appliance):
-    """Sets the timeout to shortest possible time and waits if it really times out."""
+    """Sets the timeout to shortest possible time and waits if it really times out.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/8h
+    """
 
     auth_settings = appliance.server.authentication
 
@@ -46,6 +53,10 @@ def test_bind_timeout_rest(appliance, request):
 
     Notes:
         Written for BZ 1553394
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: None
     """
     old_bind = appliance.advanced_settings.get('authentication', {}).get('bind_timeout')
     if not old_bind:

--- a/cfme/tests/configure/test_tag.py
+++ b/cfme/tests/configure/test_tag.py
@@ -40,6 +40,11 @@ def category(appliance):
 @pytest.mark.sauce
 @pytest.mark.tier(2)
 def test_tag_crud(category):
+    """
+    Polarion:
+        assignee: anikifor
+        initialEstimate: 1/8h
+    """
     tag = category.collections.tags.create(
         name=fauxfactory.gen_alphanumeric(8).lower(),
         display_name=fauxfactory.gen_alphanumeric(32).lower()
@@ -122,6 +127,10 @@ class TestTagsViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: None
         """
         collection = appliance.rest_api.collections.tags
         tags_len = len(tags)
@@ -147,6 +156,10 @@ class TestTagsViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         edited = []
         new_names = []
@@ -170,6 +183,10 @@ class TestTagsViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         delete_resources_from_detail(tags, method=method)
 
@@ -179,6 +196,10 @@ class TestTagsViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         delete_resources_from_collection(tags, not_found=True)
 
@@ -188,6 +209,10 @@ class TestTagsViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         data = {
             "name": "test_tag_{}".format(fauxfactory.gen_alphanumeric().lower()),
@@ -216,6 +241,10 @@ class TestTagsViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         collection = getattr(appliance.rest_api.collections, collection_name)
         collection.reload()
@@ -241,6 +270,10 @@ class TestTagsViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         collection = getattr(appliance.rest_api.collections, collection_name)
         collection.reload()
@@ -290,6 +323,10 @@ class TestTagsViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         collection = getattr(appliance.rest_api.collections, collection_name)
         collection.reload()
@@ -322,6 +359,10 @@ class TestTagsViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         collection = appliance.rest_api.collections.services
         collection.reload()

--- a/cfme/tests/configure/test_tag_category.py
+++ b/cfme/tests/configure/test_tag_category.py
@@ -16,6 +16,13 @@ from cfme.utils.wait import wait_for
 @pytest.mark.tier(2)
 @pytest.mark.sauce
 def test_category_crud(appliance, soft_assert):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/15h
+    """
     cg = appliance.collections.categories.create(
         name=fauxfactory.gen_alphanumeric(8).lower(),
         description=fauxfactory.gen_alphanumeric(32),
@@ -44,6 +51,11 @@ class TestCategoriesViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         for ctg in categories:
             record = appliance.rest_api.collections.categories.get(id=ctg.id)
@@ -59,6 +71,11 @@ class TestCategoriesViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/3h
         """
         collection = appliance.rest_api.collections.categories
         categories_len = len(categories)
@@ -93,6 +110,11 @@ class TestCategoriesViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         delete_resources_from_detail(categories, method=method)
 
@@ -102,5 +124,10 @@ class TestCategoriesViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         delete_resources_from_collection(categories, not_found=True)

--- a/cfme/tests/configure/test_timeprofile.py
+++ b/cfme/tests/configure/test_timeprofile.py
@@ -15,6 +15,11 @@ pytestmark = [pytest.mark.tier(3),
 def test_time_profile_crud(appliance):
     """
         This test case performs the CRUD operation.
+
+    Polarion:
+        assignee: pvala
+        casecomponent: config
+        initialEstimate: 1/8h
     """
     collection = appliance.collections.time_profiles
     time_profile = collection.create(
@@ -31,6 +36,12 @@ def test_time_profile_crud(appliance):
 def test_time_profile_name_max_character_validation(appliance):
     """
     This test case performs the check for max character validation.
+
+    Polarion:
+        assignee: pvala
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
     """
     collection = appliance.collections.time_profiles
     time_profile = collection.create(
@@ -45,6 +56,12 @@ def test_time_profile_name_max_character_validation(appliance):
 def test_days_required_error_validation(appliance, soft_assert):
     """
     This test case performs the error validation of days field.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/15h
     """
     collection = appliance.collections.time_profiles
     time_profile = collection.instantiate(description='UTC', scope='Current User',
@@ -61,6 +78,12 @@ def test_days_required_error_validation(appliance, soft_assert):
 def test_hours_required_error_validation(appliance, soft_assert):
     """
     This test case performs the error validation of hours field.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/30h
     """
     collection = appliance.collections.time_profiles
     time_profile = collection.instantiate(description='UTC', scope='Current User',
@@ -77,6 +100,12 @@ def test_hours_required_error_validation(appliance, soft_assert):
 def test_time_profile_description_required_error_validation(appliance, soft_assert):
     """
     This test case performs the error validation of description field.
+
+    Polarion:
+        assignee: pvala
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
     """
     collection = appliance.collections.time_profiles
     time_profile = collection.instantiate(description='UTC', scope='Current User',
@@ -93,6 +122,12 @@ def test_time_profile_description_required_error_validation(appliance, soft_asse
 def test_time_profile_copy(appliance):
     """
     This test case checks the copy operation of the time_profile.
+
+    Polarion:
+        assignee: pvala
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
     """
     collection = appliance.collections.time_profiles
     time_profile = collection.create(

--- a/cfme/tests/configure/test_version.py
+++ b/cfme/tests/configure/test_version.py
@@ -13,6 +13,10 @@ def test_appliance_version(appliance):
     Version in the UI is always: 1.2.3.4.20140505xyzblabla
 
     So we check whether the UI version starts with SSH version
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     ssh_version = str(appliance.version)
     ui_version = about.get_detail(about.VERSION, server=appliance.server)

--- a/cfme/tests/configure/test_visual_cloud.py
+++ b/cfme/tests/configure/test_visual_cloud.py
@@ -88,6 +88,12 @@ def test_cloud_grid_page_per_item(appliance, request, page, value, set_grid):
 
     Metadata:
         test_flag: visuals
+
+    Polarion:
+        assignee: pvala
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/10h
     """
     if isinstance(page, six.string_types):
         page = getattr(appliance.collections, page)
@@ -109,6 +115,12 @@ def test_cloud_tile_page_per_item(appliance, request, page, value, set_tile):
 
     Metadata:
         test_flag: visuals
+
+    Polarion:
+        assignee: pvala
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/10h
     """
     if isinstance(page, six.string_types):
         page = getattr(appliance.collections, page)
@@ -130,6 +142,12 @@ def test_cloud_list_page_per_item(appliance, request, page, value, set_list):
 
     Metadata:
         test_flag: visuals
+
+    Polarion:
+        assignee: pvala
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/10h
     """
     if isinstance(page, six.string_types):
         page = getattr(appliance.collections, page)
@@ -152,6 +170,11 @@ def test_cloud_start_page(request, appliance, start_page):
 
     Metadata:
         test_flag: visuals
+
+    Polarion:
+        assignee: pvala
+        casecomponent: config
+        initialEstimate: 1/6h
     """
     request.addfinalizer(lambda: set_default_page(appliance))
     appliance.user.my_settings.visual.login_page = start_page
@@ -162,6 +185,11 @@ def test_cloud_start_page(request, appliance, start_page):
 
 
 def test_cloudprovider_noquads(request, set_cloud_provider_quad):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(CloudProvider, 'All')
     view.toolbar.view_selector.select('Grid View')
     # Here data property will return an empty dict when the Quadrants option is deactivated.

--- a/cfme/tests/configure/test_visual_infra.py
+++ b/cfme/tests/configure/test_visual_infra.py
@@ -137,6 +137,12 @@ def test_infra_grid_page_per_item(appliance, request, page, value, set_grid):
 
     Metadata:
         test_flag: visuals
+
+    Polarion:
+        assignee: pvala
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/12h
     """
     if isinstance(page, six.string_types):
         page = getattr(appliance.collections, page)
@@ -159,6 +165,12 @@ def test_infra_tile_page_per_item(appliance, request, page, value, set_tile):
 
     Metadata:
         test_flag: visuals
+
+    Polarion:
+        assignee: pvala
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/10h
     """
     if isinstance(page, six.string_types):
         page = getattr(appliance.collections, page)
@@ -181,6 +193,12 @@ def test_infra_list_page_per_item(appliance, request, page, value, set_list):
 
     Metadata:
         test_flag: visuals
+
+    Polarion:
+        assignee: pvala
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/10h
     """
     if isinstance(page, six.string_types):
         page = getattr(appliance.collections, page)
@@ -203,6 +221,12 @@ def test_infra_report_page_per_item(appliance, value, set_report, get_report):
 
     Metadata:
         test_flag: visuals
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/10h
     """
     appliance.user.my_settings.visual.report_view_limit = value
     limit = appliance.user.my_settings.visual.report_view_limit
@@ -228,6 +252,10 @@ def test_infra_start_page(visual, request, appliance, start_page):
 
     Metadata:
         test_flag: visuals
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     request.addfinalizer(set_default_page)
     if appliance.user.my_settings.visual.login_page != start_page:
@@ -247,6 +275,10 @@ def test_infraprovider_noquads(request, set_infra_provider_quad):
     """
         This test checks that Infraprovider Quadrant when switched off from Mysetting page under
         Visual Tab under "Show Infrastructure Provider Quadrants" option works properly.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     view = navigate_to(InfraProvider, 'All')
     view.toolbar.view_selector.select('Grid View')
@@ -258,6 +290,10 @@ def test_host_noquads(appliance, request, set_host_quad):
     """
         This test checks that Host Quadrant when switched off from Mysetting page under
         Visual Tab under "Show Host Quadrants" option works properly.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     host_collection = appliance.collections.hosts
     view = navigate_to(host_collection, 'All')
@@ -270,6 +306,10 @@ def test_datastore_noquads(request, set_datastore_quad, appliance):
     """
         This test checks that Host Quadrant when switched off from Mysetting page under
         Visual Tab under "Show Datastores Quadrants" option works properly.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     dc = DatastoreCollection(appliance)
     view = navigate_to(dc, 'All')
@@ -282,6 +322,10 @@ def test_vm_noquads(appliance, request, set_vm_quad):
     """
         This test checks that VM Quadrant when switched off from Mysetting page under
         Visual Tab under "Show VM Quadrants" option works properly.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     view = navigate_to(appliance.collections.infra_vms, 'VMsOnly')
     view.toolbar.view_selector.select('Grid View')
@@ -294,6 +338,10 @@ def test_template_noquads(appliance, set_template_quad):
     """
         This test checks that Template Quadrant when switched off from Mysetting page under
         Visual Tab under "Show Template Quadrants" option works properly.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     view = navigate_to(appliance.collections.infra_templates, 'TemplatesOnly')
     view.toolbar.view_selector.select('Grid View')

--- a/cfme/tests/configure/test_vmware_console_settings.py
+++ b/cfme/tests/configure/test_vmware_console_settings.py
@@ -8,7 +8,13 @@ from cfme.utils.version import current_version
 @pytest.mark.sauce
 @pytest.mark.uncollectif(lambda: current_version() < '5.8')
 def test_vmware_console_support(request, appliance):
-    """Tests that the VMware Console Support setting may be changed."""
+    """Tests that the VMware Console Support setting may be changed.
+
+    Polarion:
+        assignee: apagac
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
     old_vm_console_type = appliance.server.settings.vmware_console_values['console_type']
     # Set back to original console type
     request.addfinalizer(

--- a/cfme/tests/configure/test_workers.py
+++ b/cfme/tests/configure/test_workers.py
@@ -11,6 +11,12 @@ from cfme.utils.wait import wait_for
 @pytest.mark.nondestructive
 @pytest.mark.meta(blockers=[BZ(1531524, forced_streams=["5.9", "upstream"])])
 def test_restart_workers(appliance):
+    """
+    Polarion:
+        assignee: mmojzis
+        caseimportance: low
+        initialEstimate: None
+    """
     worker = appliance.collections.diagnostic_workers.instantiate(name="Generic Worker")
     pids = worker.reload_worker()
     # Wait for all original workers to be gone

--- a/cfme/tests/configure/test_zones.py
+++ b/cfme/tests/configure/test_zones.py
@@ -11,6 +11,12 @@ from cfme.utils.update import update
 @pytest.mark.sauce
 @pytest.mark.meta(blockers=[1216224])
 def test_zone_crud(soft_assert):
+    """
+    Polarion:
+        assignee: anikifor
+        caseimportance: low
+        initialEstimate: 1/15h
+    """
     zc = current_appliance.collections.zones
     # CREATE
     zone = zc.create(
@@ -37,6 +43,13 @@ def test_zone_crud(soft_assert):
 @pytest.mark.tier(3)
 @pytest.mark.sauce
 def test_zone_add_cancel_validation():
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/20h
+    """
     zc = current_appliance.collections.zones
     # CREATE
     zc.create(
@@ -50,7 +63,14 @@ def test_zone_add_cancel_validation():
 @pytest.mark.sauce
 @pytest.mark.meta(blockers=[1216224])
 def test_zone_change_appliance_zone(request, appliance):
-    """ Tests that an appliance can be changed to another Zone """
+    """ Tests that an appliance can be changed to another Zone
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/15h
+    """
     zc = current_appliance.collections.zones
     # CREATE
     zone = zc.create(
@@ -69,6 +89,12 @@ def test_zone_change_appliance_zone(request, appliance):
 @pytest.mark.tier(2)
 @pytest.mark.sauce
 def test_zone_add_dupe(appliance, request):
+    """
+    Polarion:
+        assignee: anikifor
+        caseimportance: low
+        initialEstimate: None
+    """
     zc = current_appliance.collections.zones
     name = fauxfactory.gen_alphanumeric(5)
     description = fauxfactory.gen_alphanumeric(8)
@@ -91,6 +117,12 @@ def test_zone_add_dupe(appliance, request):
 @pytest.mark.tier(3)
 @pytest.mark.sauce
 def test_zone_add_maxlength(request, soft_assert):
+    """
+    Polarion:
+        assignee: anikifor
+        caseimportance: low
+        initialEstimate: None
+    """
     zc = current_appliance.collections.zones
     zone = zc.create(
         name=fauxfactory.gen_alphanumeric(50),
@@ -105,6 +137,14 @@ def test_zone_add_maxlength(request, soft_assert):
 @pytest.mark.tier(3)
 @pytest.mark.sauce
 def test_zone_add_blank_name():
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/8h
+    """
     zc = current_appliance.collections.zones
     with pytest.raises(Exception, match="Name can't be blank"):
         zc.create(
@@ -116,6 +156,14 @@ def test_zone_add_blank_name():
 @pytest.mark.tier(3)
 @pytest.mark.sauce
 def test_zone_add_blank_description():
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/8h
+    """
     zc = current_appliance.collections.zones
     with pytest.raises(Exception, match="Description can't be blank"):
         zc.create(
@@ -129,6 +177,10 @@ def test_zone_add_blank_description():
 def test_add_zone_windows_domain_credentials(request):
     """
     Testing Windows Domain credentials add
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     zc = current_appliance.collections.zones.all()
     values = {'username': 'userid',
@@ -153,6 +205,10 @@ def test_add_zone_windows_domain_credentials(request):
 def test_remove_zone_windows_domain_credentials():
     """
     Testing Windows Domain credentials removal
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     zc = current_appliance.collections.zones.all()
     values = {'username': 'userid',

--- a/cfme/tests/containers/test_ad_hoc_metrics.py
+++ b/cfme/tests/containers/test_ad_hoc_metrics.py
@@ -42,12 +42,24 @@ def is_ad_hoc_greyed(provider_object):
 
 def test_ad_hoc_metrics_overview(provider, metrics_up_and_running):
 
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     assert is_ad_hoc_greyed(provider), (
         "Monitoring --> Ad hoc Metrics not activated despite provider was set")
 
 
 def test_ad_hoc_metrics_select_filter(provider, metrics_up_and_running):
 
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     view = navigate_to(provider, 'AdHoc')
     view.wait_for_filter_option_to_load()
     view.set_filter(view.get_random_filter())

--- a/cfme/tests/containers/test_alerts.py
+++ b/cfme/tests/containers/test_alerts.py
@@ -18,4 +18,9 @@ pytestmark = [
 
 
 def test_add_alerts_provider(provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     provider.setup()

--- a/cfme/tests/containers/test_basic_metrics.py
+++ b/cfme/tests/containers/test_basic_metrics.py
@@ -63,7 +63,12 @@ def test_basic_metrics(provider):
     """ Basic Metrics availability test
         This test checks that the Metrics service is up
         Curls the hawkular status page and checks if it's up
-        """
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     try:
         router = [router for router in provider.mgmt.list_route()
                   if router.metadata.name == 'hawkular-metrics' or
@@ -81,6 +86,12 @@ def test_basic_metrics(provider):
 def test_validate_metrics_collection_db(provider,
                                         enable_capacity_and_utilization,
                                         reduce_metrics_collection_threshold):
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     assert provider.wait_for_collected_metrics(
         timeout=WAIT_FOR_METRICS_CAPTURE_THRESHOLD_IN_MINUTES)
 
@@ -90,6 +101,12 @@ def test_validate_metrics_collection_provider_gui(appliance, provider,
                                                   reduce_metrics_collection_threshold,
                                                   wait_for_metrics_rollup, soft_assert):
 
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     view = navigate_to(provider, "Details")
     # Wait for the Utilization drop down to become enabled
     wait_for(lambda: view.toolbar.monitoring.item_enabled('Utilization'),
@@ -104,6 +121,12 @@ def test_validate_metrics_collection_provider_gui(appliance, provider,
 
 
 def test_flash_msg_not_contains_html_tags(provider):
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     edit_view = navigate_to(provider, 'Edit')
     metrics_view = getattr(provider.endpoints_form(edit_view), "metrics")
     metrics_view.validate.click()
@@ -125,6 +148,11 @@ def test_flash_msg_not_contains_html_tags(provider):
 def test_typo_in_metrics_endpoint_type(provider):
     """
     This test based on bz1538948
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
 
     view = navigate_to(provider, "Details")

--- a/cfme/tests/containers/test_breadcrumbs.py
+++ b/cfme/tests/containers/test_breadcrumbs.py
@@ -44,6 +44,12 @@ def clear_search(view):
 
 def test_breadcrumbs(provider, appliance, soft_assert):
 
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     for data_set in TESTED_OBJECTS:
 
         instances = ([provider] if data_set.collection_obj == 'containers_providers'

--- a/cfme/tests/containers/test_chargeback.py
+++ b/cfme/tests/containers/test_chargeback.py
@@ -270,6 +270,12 @@ def abstract_test_chargeback_cost(
 @pytest.mark.uncollectif(lambda rate_type: rate_type == 'variable')
 def test_chargeback_rate_fixed_1(
         rate_type, obj_type, interval, chargeback_report_data, compute_rate, soft_assert):
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     abstract_test_chargeback_cost(
         'Fixed1', obj_type, interval, chargeback_report_data, compute_rate, soft_assert)
 
@@ -277,18 +283,36 @@ def test_chargeback_rate_fixed_1(
 @pytest.mark.uncollectif(lambda rate_type: rate_type == 'variable')
 def test_chargeback_rate_fixed_2(
         rate_type, obj_type, interval, chargeback_report_data, compute_rate, soft_assert):
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     abstract_test_chargeback_cost(
         'Fixed2', obj_type, interval, chargeback_report_data, compute_rate, soft_assert)
 
 
 def test_chargeback_rate_cpu_cores(
         rate_type, obj_type, interval, chargeback_report_data, compute_rate, soft_assert):
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     abstract_test_chargeback_cost(
         'CpuCores', obj_type, interval, chargeback_report_data, compute_rate, soft_assert)
 
 
 def test_chargeback_rate_memory_used(
         rate_type, obj_type, interval, chargeback_report_data, compute_rate, soft_assert):
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     abstract_test_chargeback_cost(
         'Memory', obj_type, interval, chargeback_report_data, compute_rate, soft_assert)
 
@@ -298,5 +322,11 @@ def test_chargeback_rate_memory_used(
 @pytest.mark.uncollectif(lambda rate_type: rate_type == 'variable')
 def test_chargeback_rate_network_io(
         rate_type, obj_type, interval, chargeback_report_data, compute_rate, soft_assert):
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     abstract_test_chargeback_cost(
         'Network', obj_type, interval, chargeback_report_data, compute_rate, soft_assert)

--- a/cfme/tests/containers/test_cockpit.py
+++ b/cfme/tests/containers/test_cockpit.py
@@ -22,6 +22,11 @@ pytestmark = [
 def test_cockpit_button_access(appliance, provider, cockpit, request):
     """ The test verifies the existence of cockpit "Web Console"
         button on each node, click the button if enabled, verify no errors are displayed.
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
 
     request.addfinalizer(lambda: appliance.server.settings.disable_server_roles('cockpit_ws'))

--- a/cfme/tests/containers/test_configurable_menus.py
+++ b/cfme/tests/containers/test_configurable_menus.py
@@ -27,6 +27,11 @@ def is_monitoring_menu_visible(appliance):
 
 
 def test_datawarehouse_invisible(is_datawarehouse_menu_visible):
+    """
+    Polarion:
+        assignee: rhcf3_machine
+        initialEstimate: None
+    """
     # This should be the default state
     # Verifies BZ#1421175
     assert not is_datawarehouse_menu_visible
@@ -34,6 +39,11 @@ def test_datawarehouse_invisible(is_datawarehouse_menu_visible):
 
 @pytest.mark.uncollectif(lambda: current_version() > "5.8")
 def test_monitoring_invisible(is_monitoring_menu_visible):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     # This should be the default state
     # Verifies BZ#1421173
     assert not is_monitoring_menu_visible

--- a/cfme/tests/containers/test_containers_smartstate_analysis.py
+++ b/cfme/tests/containers/test_containers_smartstate_analysis.py
@@ -56,11 +56,23 @@ def random_image_instance(appliance):
 
 @pytest.mark.polarion('10030')
 def test_manage_policies_navigation(random_image_instance):
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     random_image_instance.assign_policy_profiles('OpenSCAP profile')
 
 
 @pytest.mark.polarion('10031')
 def test_check_compliance(random_image_instance):
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     random_image_instance.assign_policy_profiles('OpenSCAP profile')
     random_image_instance.check_compliance()
 
@@ -79,6 +91,12 @@ def test_containers_smartstate_analysis(provider, test_item, soft_assert,
                                         delete_all_container_tasks,
                                         random_image_instance):
 
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     if test_item.is_openscap:
         random_image_instance.assign_policy_profiles('OpenSCAP profile')
     else:
@@ -118,6 +136,11 @@ def test_containers_smartstate_analysis_api(provider, test_item, soft_assert,
        entity class.
 
        RFE: BZ 1486362
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
 
     if test_item.is_openscap:

--- a/cfme/tests/containers/test_containers_smartstate_analysis_multiple_images.py
+++ b/cfme/tests/containers/test_containers_smartstate_analysis_multiple_images.py
@@ -58,6 +58,12 @@ def random_image_instances(appliance):
 @pytest.mark.polarion('10031')
 def test_check_compliance(provider, random_image_instances, appliance):
 
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     collection = appliance.collections.container_images
     # create conditions list that will match the images that we want to check
     conditions = []
@@ -85,6 +91,12 @@ def test_containers_smartstate_analysis(provider, test_item,
                                         delete_all_container_tasks, soft_assert,
                                         random_image_instances, appliance):
 
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     collection = appliance.collections.container_images
     # create conditions list that will match the images that we want to check
     conditions = []

--- a/cfme/tests/containers/test_containers_summary.py
+++ b/cfme/tests/containers/test_containers_summary.py
@@ -31,7 +31,12 @@ def test_containers_summary_objects(provider, soft_assert):
            * Checks how many objects are shown in the selected widget
            * Goes to Containers summary page and checks how many objects are shown there.
            * Checks the amount is equal
-       """
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     view = navigate_to(ContainersOverview, 'All')
     # Collecting status boxes values from overview page cards
     status_box_values = {obj: view.status_cards(obj.PLURAL.split(' ')[-1]).value

--- a/cfme/tests/containers/test_labels.py
+++ b/cfme/tests/containers/test_labels.py
@@ -78,6 +78,12 @@ def random_labels(provider, appliance):
 @pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:7687')])
 def test_labels_create(provider, soft_assert, random_labels):
 
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     provider.refresh_provider_relationships()
     # Verify that the labels appear in the UI:
     for instance, label_name, label_value, status_code, json_content in random_labels:
@@ -97,6 +103,12 @@ def test_labels_create(provider, soft_assert, random_labels):
 
 @pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:7687')])
 def test_labels_remove(provider, soft_assert, random_labels):
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     # Removing the labels
     for instance, label_name, label_value, status_code, _ in random_labels:
         if status_code:

--- a/cfme/tests/containers/test_logging.py
+++ b/cfme/tests/containers/test_logging.py
@@ -70,6 +70,12 @@ def kibana_logging_url(provider):
                          ids=[ContainersTestItem.get_pretty_id(ti) for ti in TEST_ITEMS])
 def test_external_logging_activated(provider, appliance, test_item, kibana_logging_url):
 
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     test_collection = ([provider] if test_item.obj is ContainersProvider
                        else test_item.collection_obj(appliance).all())
 

--- a/cfme/tests/containers/test_manageiq_ansible_custom_attributes.py
+++ b/cfme/tests/containers/test_manageiq_ansible_custom_attributes.py
@@ -53,7 +53,12 @@ def test_manageiq_ansible_add_custom_attributes(ansible_custom_attributes, provi
         2. Test navigates  to Providers page and verifies the Custom Attributes
          were added under Providers menu
 
-        """
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     setup_ansible_script(provider, script='add_custom_attributes',
                          values_to_update=custom_attributes_to_add,
                          script_type='custom_attributes')
@@ -75,7 +80,12 @@ def test_manageiq_ansible_edit_custom_attributes(ansible_custom_attributes, prov
         2. Test navigates to Providers page and verifies the Custom Attributes
          were edited under Providers menu
 
-        """
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     setup_ansible_script(provider, script='add_custom_attributes',
                          values_to_update=custom_attributes_to_edit,
                          script_type='custom_attributes')
@@ -98,7 +108,12 @@ def test_manageiq_ansible_add_custom_attributes_same_name(ansible_custom_attribu
         2. Test navigates to Providers page and verifies the Custom Attributes
          weren't added under Providers menu
 
-        """
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     setup_ansible_script(provider, script='add_custom_attributes',
                          values_to_update=custom_attributes_to_edit,
                          script_type='custom_attributes')
@@ -123,7 +138,12 @@ def test_manageiq_ansible_add_custom_attributes_bad_user(ansible_custom_attribut
         3. Test navigates to Providers page and verifies the Custom Attributes
          weren't added under Providers menu
 
-        """
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     setup_ansible_script(provider, script='add_custom_attributes_bad_user',
                          values_to_update=custom_attributes_to_edit,
                          script_type='custom_attributes')
@@ -142,7 +162,12 @@ def test_manageiq_ansible_remove_custom_attributes(ansible_custom_attributes, pr
         2. Test navigates to Providers page and verifies the Custom Attributes
          were removed under Providers menu
 
-        """
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     setup_ansible_script(provider, script='add_custom_attributes',
                          values_to_update=custom_attributes_to_add,
                          script_type='custom_attributes')

--- a/cfme/tests/containers/test_node.py
+++ b/cfme/tests/containers/test_node.py
@@ -15,6 +15,12 @@ TEST_DEST = ('All', 'Details')
 @pytest.mark.provider([ContainersProvider])
 def test_nodes_navigate(soft_assert, appliance):
 
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     for dest in TEST_DEST:
 
         if dest == 'All':

--- a/cfme/tests/containers/test_overview_data_integrity.py
+++ b/cfme/tests/containers/test_overview_data_integrity.py
@@ -63,6 +63,11 @@ def test_containers_overview_data_integrity(appliance, soft_assert):
             # of nodes
             # of providers
             # ...
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
     view = navigate_to(ContainersOverview, 'All')
     api_values = get_api_object_counts(appliance)

--- a/cfme/tests/containers/test_pause_resume_workers.py
+++ b/cfme/tests/containers/test_pause_resume_workers.py
@@ -37,6 +37,11 @@ def test_pause_and_resume_provider_workers(appliance, provider):
         6. Resume the provider
         7. navigate to : User -> Configuration -> Diagnostics ->  Workers
         8. Validate the ems_ workers are started
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
     view = navigate_to(provider, "Details")
     # pause the provider
@@ -60,6 +65,11 @@ def test_pause_and_resume_single_provider_api(appliance, provider, from_collecti
     collection and entity classes.
 
     RFE: BZ 1507812
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
     evm_tail_disable = LogValidator('/var/www/miq/vmdb/log/evm.log',
                                     matched_patterns=['.*Disabling EMS \[{}\] id \[{}\].*'

--- a/cfme/tests/containers/test_projects_dashboard.py
+++ b/cfme/tests/containers/test_projects_dashboard.py
@@ -77,6 +77,11 @@ def test_projects_dashboard_pods(provider, soft_assert, container_project_instan
         * Go to Projects / Dashboard View
         * Compare the data in the Pods status box to API data for
         Pods names
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
     api_pod_names = get_api_pods_names(provider)
     view = navigate_to(container_project_instance, 'Dashboard')
@@ -96,6 +101,11 @@ def test_projects_dashboard_icons(provider, appliance, soft_assert, container_pr
         * Go to Projects / Dashboard View
         * Compare the data in the status boxes to API data forz
         Containers/Images/Services numbers
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
     api_values = get_api_object_counts(appliance, PROJECT_NAME, provider)
     view = navigate_to(container_project_instance, 'Dashboard')
@@ -120,6 +130,11 @@ def test_project_has_provider(appliance, soft_assert, provider):
       * navigate to all project page
       * get through all the project to ensure that the provider column isn't
         empty on each on each of the projects
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
     projects_collection = appliance.collections.container_projects
 

--- a/cfme/tests/containers/test_properties.py
+++ b/cfme/tests/containers/test_properties.py
@@ -88,6 +88,12 @@ TEST_ITEMS = [
                          ids=[ContainersTestItem.get_pretty_id(ti) for ti in TEST_ITEMS])
 def test_properties(provider, appliance, test_item, soft_assert):
 
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     instances = test_item.collection_object(appliance).all()
     for inst in instances:
         if inst.exists:
@@ -110,6 +116,12 @@ def test_properties(provider, appliance, test_item, soft_assert):
 
 def test_pods_conditions(provider, appliance, soft_assert):
 
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     selected_pods_cfme = appliance.collections.container_pods.all()
 
     pods_per_ready_status = provider.pods_per_ready_status()

--- a/cfme/tests/containers/test_provider_configuration_menu.py
+++ b/cfme/tests/containers/test_provider_configuration_menu.py
@@ -26,6 +26,12 @@ def check_buttons_status(view, pause_option, resume_option):
 
 
 def test_edit_selected_containers_provider(provider):
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     '''Testing Configuration -> Edit... button functionality
     Step:
         In Providers summary page - click configuration
@@ -44,6 +50,11 @@ def test_ocp_operator_out_of_the_box(appliance):
      1. Navigate to  Administration | EVM (on the right upper corner)--> Configuration
      2. In the new page on the left menu select Access Control --> roles
      3. Search for container operator role
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
 
     # Navigate to all roles page
@@ -72,6 +83,11 @@ def test_pause_and_resume_provider(provider):
         7. Validate button status
         8. Validate the provider marked as running
     The test based on BZ1516292
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
 
     view = navigate_to(provider, "Details")

--- a/cfme/tests/containers/test_provider_openscap_policy_attached.py
+++ b/cfme/tests/containers/test_provider_openscap_policy_attached.py
@@ -64,6 +64,12 @@ def get_table_attr(instance, table_name, attr):
 def test_check_compliance_provider_policy(provider, soft_assert, delete_all_container_tasks,
                                           openscap_assigned_rand_image):
 
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     # Perform SSA Scan then check compliance with last know configuration
     openscap_assigned_rand_image.perform_smartstate_analysis(wait_for_finish=True, timeout='20M')
 

--- a/cfme/tests/containers/test_relationships.py
+++ b/cfme/tests/containers/test_relationships.py
@@ -45,6 +45,11 @@ def test_relationships_tables(soft_assert, provider, has_persistent_volume, appl
     in the Relationships table also appears in the Properties table,
     or to the page where the number of rows is equal to the number
     that is displayed in the Relationships table.
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
     instances = ([provider] if test_item.obj is ContainersProvider
                  else test_item.collection_obj(appliance).all())
@@ -83,6 +88,10 @@ def test_container_status_relationships_data_integrity(provider, appliance, soft
     """ This test verifies that the sum of running, waiting and terminated containers
         in the status summary table
         is the same number that appears in the Relationships table containers field
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     pod_instances = PodCollection(appliance).all()

--- a/cfme/tests/containers/test_reload_button_provider.py
+++ b/cfme/tests/containers/test_reload_button_provider.py
@@ -14,6 +14,11 @@ def test_reload_button_provider(provider):
     """ This test verifies the data integrity of the fields in
         the Relationships table after clicking the "reload"
         button.
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
 
     provider.validate_stats(ui=True)

--- a/cfme/tests/containers/test_reports.py
+++ b/cfme/tests/containers/test_reports.py
@@ -61,7 +61,13 @@ def get_report(appliance, menu_name, candu=False):
 
 def test_container_reports_base_on_options(soft_assert, appliance):
     """This test verifies that all containers options are available in the report 'based on'
-    Dropdown in the report creation"""
+    Dropdown in the report creation
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     view = navigate_to(appliance.collections.reports, 'Add')
     if appliance.version < '5.9':
         chargeback_for_images = 'Chargeback Container Images'
@@ -84,7 +90,13 @@ def test_container_reports_base_on_options(soft_assert, appliance):
 
 
 def test_report_pods_per_ready_status(appliance, soft_assert, provider):
-    """Testing 'Pods per Ready Status' report, see polarion case for more info"""
+    """Testing 'Pods per Ready Status' report, see polarion case for more info
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     pods_per_ready_status = provider.pods_per_ready_status()
     report = get_report(appliance, 'Pods per Ready Status')
     for row in report.data.rows:
@@ -100,7 +112,13 @@ def test_report_pods_per_ready_status(appliance, soft_assert, provider):
 
 
 def test_report_nodes_by_capacity(appliance, soft_assert, node_hardwares_db_data):
-    """Testing 'Nodes By Capacity' report, see polarion case for more info"""
+    """Testing 'Nodes By Capacity' report, see polarion case for more info
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     report = get_report(appliance, 'Nodes By Capacity')
     for row in report.data.rows:
 
@@ -128,7 +146,13 @@ def test_report_nodes_by_capacity(appliance, soft_assert, node_hardwares_db_data
 
 
 def test_report_nodes_by_cpu_usage(appliance, soft_assert, vporizer):
-    """Testing 'Nodes By CPU Usage' report, see polarion case for more info"""
+    """Testing 'Nodes By CPU Usage' report, see polarion case for more info
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     report = get_report(appliance, 'Nodes By CPU Usage')
     for row in report.data.rows:
 
@@ -142,7 +166,13 @@ def test_report_nodes_by_cpu_usage(appliance, soft_assert, vporizer):
 
 
 def test_report_nodes_by_memory_usage(appliance, soft_assert, vporizer):
-    """Testing 'Nodes By Memory Usage' report, see polarion case for more info"""
+    """Testing 'Nodes By Memory Usage' report, see polarion case for more info
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     report = get_report(appliance, 'Nodes By Memory Usage')
     for row in report.data.rows:
 
@@ -156,7 +186,13 @@ def test_report_nodes_by_memory_usage(appliance, soft_assert, vporizer):
 
 
 def test_report_number_of_nodes_per_cpu_cores(appliance, soft_assert, node_hardwares_db_data):
-    """Testing 'Number of Nodes per CPU Cores' report, see polarion case for more info"""
+    """Testing 'Number of Nodes per CPU Cores' report, see polarion case for more info
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     report = get_report(appliance, 'Nodes by Number of CPU Cores')
     for row in report.data.rows:
 
@@ -169,7 +205,13 @@ def test_report_number_of_nodes_per_cpu_cores(appliance, soft_assert, node_hardw
 
 def test_report_projects_by_number_of_pods(appliance, soft_assert):
 
-    """Testing 'Projects by Number of Pods' report, see polarion case for more info"""
+    """Testing 'Projects by Number of Pods' report, see polarion case for more info
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
 
     container_projects = appliance.db.client['container_projects']
     container_pods = appliance.db.client['container_groups']
@@ -189,7 +231,13 @@ def test_report_projects_by_number_of_pods(appliance, soft_assert):
 
 @pytest.mark.meta(blockers=[BZ(1539378, forced_streams=["5.9"])])
 def test_report_projects_by_cpu_usage(appliance, soft_assert, vporizer):
-    """Testing 'Projects By CPU Usage' report, see polarion case for more info"""
+    """Testing 'Projects By CPU Usage' report, see polarion case for more info
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     report = get_report(appliance, 'Projects By CPU Usage')
     for row in report.data.rows:
 
@@ -204,7 +252,13 @@ def test_report_projects_by_cpu_usage(appliance, soft_assert, vporizer):
 
 @pytest.mark.meta(blockers=[BZ(1539378, forced_streams=["5.9"])])
 def test_report_projects_by_memory_usage(appliance, soft_assert, vporizer):
-    """Testing 'Projects By Memory Usage' report, see polarion case for more info"""
+    """Testing 'Projects By Memory Usage' report, see polarion case for more info
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     report = get_report(appliance, 'Projects By Memory Usage')
     for row in report.data.rows:
 
@@ -219,7 +273,13 @@ def test_report_projects_by_memory_usage(appliance, soft_assert, vporizer):
 
 def test_report_pod_counts_for_container_images_by_project(appliance, provider, soft_assert):
     """Testing 'Pod counts For Container Images by Project' report,\
-    see polarion case for more info"""
+    see polarion case for more info
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     report = get_report(appliance, 'Pod counts For Container Images by Project', candu=True)
 
     pods_api = provider.mgmt.list_pods()
@@ -247,7 +307,13 @@ def test_report_pod_counts_for_container_images_by_project(appliance, provider, 
 
 @pytest.mark.meta(blockers=[1529963], forced_stream=['5.8', '5.9'])
 def test_report_recently_discovered_pods(appliance, provider, soft_assert):
-    """Testing 'Recently Discovered Pods' report, see polarion case for more info"""
+    """Testing 'Recently Discovered Pods' report, see polarion case for more info
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     report = get_report(appliance, 'Recently Discovered Pods')
     pods_in_report = [row['Name'] for row in report.data.rows]
     pods_per_ready_status = provider.pods_per_ready_status()
@@ -258,7 +324,13 @@ def test_report_recently_discovered_pods(appliance, provider, soft_assert):
 
 
 def test_report_number_of_images_per_node(appliance, provider, soft_assert):
-    """Testing 'Number of Images per Node' report, see polarion case for more info"""
+    """Testing 'Number of Images per Node' report, see polarion case for more info
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     pods_api = provider.mgmt.list_pods()
     report = get_report(appliance, 'Number of Images per Node', candu=True)
     report_data = list(report.data.rows)
@@ -277,7 +349,13 @@ def test_report_number_of_images_per_node(appliance, provider, soft_assert):
 
 
 def test_report_projects_by_number_of_containers(appliance, provider, soft_assert):
-    """Testing 'Projects by Number of Containers' report, see polarion case for more info"""
+    """Testing 'Projects by Number of Containers' report, see polarion case for more info
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     report = get_report(appliance, 'Projects by Number of Containers')
     pods_api = provider.mgmt.list_pods()
 

--- a/cfme/tests/containers/test_search_bar.py
+++ b/cfme/tests/containers/test_search_bar.py
@@ -29,6 +29,11 @@ def test_search_bar(provider, appliance, soft_assert):
         * Goes to <object> page
         * Inserts: Irregular symbol, '*' character, full search string, partial search string
         * Verify proper results
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
     for collection_name in COLLECTION_NAMES:
         view = navigate_to(getattr(appliance.collections, collection_name), 'All')

--- a/cfme/tests/containers/test_ssa_set_cve_image_inspector_per_provider.py
+++ b/cfme/tests/containers/test_ssa_set_cve_image_inspector_per_provider.py
@@ -151,6 +151,11 @@ def test_cve_location_update_value(provider, soft_assert, delete_all_container_t
     """This test checks RFE BZ 1459189, Allow to specify per Provider the location of
      OpenSCAP CVEs.
      In order to verify the above setup, run a smart state analysis on container image.
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
     # Perform SSA Scan then check compliance with last know configuration
     openscap_assigned_rand_image.perform_smartstate_analysis(wait_for_finish=True, timeout='20M')
@@ -166,6 +171,11 @@ def test_image_inspector_registry_update_value(provider, soft_assert, delete_all
     """This test checks RFE BZ 1459189, Allow to specify per Provider
      The image inspector registry url.
      In order to verify the above setup, run a smart state analysis on container image.
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
     # Perform SSA Scan then check compliance with last know configuration
     openscap_assigned_rand_image.perform_smartstate_analysis(wait_for_finish=True, timeout='20M')

--- a/cfme/tests/containers/test_ssl_providers.py
+++ b/cfme/tests/containers/test_ssl_providers.py
@@ -53,6 +53,11 @@ def test_add_provider_naming_conventions(provider, appliance, soft_assert, sync_
             - Long Alphanumeric name
             - Integer name
         * Assert that provider was added successfully with each of those
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
     for provider_name in provider_names:
         new_provider = copy(provider)
@@ -81,7 +86,12 @@ def test_add_provider_ssl(provider, default_sec_protocol, soft_assert, sync_ssl_
         * Try to add a Container Provider with each of the following security options:
             Default Endpoint = SSL trusting custom CA/SSL without validation/SSL
         * Assert that provider was added successfully
-        """
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     new_provider = copy(provider)
     endpoints = {'default': new_provider.endpoints['default']}
     endpoints['default'].sec_protocol = default_sec_protocol
@@ -116,7 +126,12 @@ def test_add_mertics_provider_ssl(provider, appliance, test_item,
             Default Endpoint = SSL trusting custom CA/SSL without validation/SSL
             Hawkular Endpoint = SSL trusting custom CA/SSL without validation/SSL
         * Assert that provider was added successfully
-        """
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     if not provider.endpoints.get('metrics', False):
         pytest.skip("This test requires the metrics endpoint to be configured")
     new_provider = copy(provider)
@@ -147,6 +162,11 @@ def test_setup_with_wrong_port(provider, sec_protocol, sync_ssl_certificate):
     """
     Negative test: set a provider with wrong api port
     based on BZ1443520
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
     new_provider = copy(provider)
     new_provider.endpoints["default"].api_port = "1234"

--- a/cfme/tests/containers/test_start_page.py
+++ b/cfme/tests/containers/test_start_page.py
@@ -44,6 +44,12 @@ data_sets = (
 
 def test_start_page(appliance, soft_assert):
 
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     for data_set in data_sets:
         appliance.user.my_settings.visual.login_page = data_set.page_name
         login_page = navigate_to(appliance.server, 'LoginScreen')

--- a/cfme/tests/containers/test_static_custom_attributes.py
+++ b/cfme/tests/containers/test_static_custom_attributes.py
@@ -54,6 +54,11 @@ def test_add_static_custom_attributes(add_delete_custom_attributes, provider):
         * Go to provider summary page
     Expected results:
         * The attributes was successfully added
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
 
     view = refresh_and_navigate(provider, 'Details')
@@ -72,6 +77,11 @@ def test_edit_static_custom_attributes(provider):
         * Go to provider summary page
     Expected results:
         * The attributes was successfully updated to the new values
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
 
     provider.add_custom_attributes(*ATTRIBUTES_DATASET)
@@ -95,6 +105,11 @@ def test_delete_static_custom_attributes(add_delete_custom_attributes, request, 
     Expected results:
         * The attributes was successfully deleted
         (you should not see a custom attributes table)
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
 
     provider.delete_custom_attributes(*ATTRIBUTES_DATASET)
@@ -132,6 +147,11 @@ def test_add_attribute_with_empty_name(provider):
     Expected results:
         * You should get an error
         * You should not see this attribute in the custom  attributes table
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
     with pytest.raises(APIException):
         provider.add_custom_attributes(
@@ -145,7 +165,13 @@ def test_add_attribute_with_empty_name(provider):
 
 
 def test_add_date_attr_with_wrong_value(provider):
-    """Trying to add attribute of type date with non-date value"""
+    """Trying to add attribute of type date with non-date value
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     ca = CustomAttribute('nondate', "koko", 'Date')
     with pytest.raises(APIException):
         provider.add_custom_attributes(ca)
@@ -158,7 +184,13 @@ def test_add_date_attr_with_wrong_value(provider):
 
 
 def test_edit_non_exist_attribute(provider):
-    """Trying to edit non-exist attribute"""
+    """Trying to edit non-exist attribute
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     ca = choice(ATTRIBUTES_DATASET)
     # Note: we need to implement it inside the test instead of using
     #       the API (provider.edit_custom_attributes) in order to
@@ -180,6 +212,12 @@ def test_edit_non_exist_attribute(provider):
 
 def test_delete_non_exist_attribute(provider):
 
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     ca = choice(ATTRIBUTES_DATASET)
     with pytest.raises(APIException):
         provider.delete_custom_attributes(ca)
@@ -190,6 +228,12 @@ def test_delete_non_exist_attribute(provider):
 
 @pytest.mark.meta(blockers=[BZ(1544800, forced_streams=["5.8", "5.9"])])
 def test_add_already_exist_attribute(provider):
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     ca = choice(ATTRIBUTES_DATASET)
     provider.add_custom_attributes(ca)
     try:
@@ -203,6 +247,12 @@ def test_add_already_exist_attribute(provider):
 
 
 def test_very_long_name_with_special_characters(request, provider):
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     ca = CustomAttribute(get_random_string(1000), 'very_long_name', None)
     request.addfinalizer(lambda: provider.delete_custom_attributes(ca))
     provider.add_custom_attributes(ca)
@@ -212,6 +262,12 @@ def test_very_long_name_with_special_characters(request, provider):
 
 # BZ 540647 was closed as no fix. Code was added that strips underscores from attribute names.
 def test_very_long_value_with_special_characters(request, provider):
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     ca = CustomAttribute('very long value', get_random_string(1000), None)
     request.addfinalizer(lambda: provider.delete_custom_attributes(ca))
     provider.add_custom_attributes(ca)

--- a/cfme/tests/containers/test_table_views.py
+++ b/cfme/tests/containers/test_table_views.py
@@ -50,6 +50,12 @@ def random_default_views(appliance):
 
 
 def test_default_views(appliance, random_default_views):
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     for collection_name in objects_mapping.keys():
         obj = (ContainersProvider if collection_name is ContainersProvider
                else getattr(appliance.collections, collection_name))
@@ -62,6 +68,12 @@ def test_default_views(appliance, random_default_views):
 
 
 def test_table_views(appliance):
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     for collection_name in objects_mapping.keys():
         obj = (ContainersProvider if collection_name is ContainersProvider
                else getattr(appliance.collections, collection_name))

--- a/cfme/tests/containers/test_tables_fields.py
+++ b/cfme/tests/containers/test_tables_fields.py
@@ -70,6 +70,12 @@ TEST_ITEMS = [
                          ids=[ti.pretty_id() for ti in TEST_ITEMS])
 def test_tables_fields(provider, test_item, soft_assert, appliance):
 
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     view = navigate_to((test_item.obj if test_item.obj is ContainersProvider
                         else getattr(appliance.collections, test_item.collection_name)), 'All')
     view.toolbar.view_selector.select('List View')
@@ -94,6 +100,11 @@ def test_containers_details_view_title(appliance):
     The word summery has to apper as part of the container title
     In this test the detail container view is tested
     Test based on BZ1338801
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
     random_container = appliance.collections.containers.all().pop()
     view = navigate_to(random_container, "Details")

--- a/cfme/tests/containers/test_tables_sort.py
+++ b/cfme/tests/containers/test_tables_sort.py
@@ -30,6 +30,12 @@ TEST_ITEMS = [
                          ids=[ti.pretty_id() for ti in TEST_ITEMS])
 def test_tables_sort(test_item, soft_assert, appliance):
 
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     view = navigate_to((test_item.obj if test_item.obj is ContainersProvider
         else getattr(appliance.collections, test_item.collection_name)), 'All')
     view.toolbar.view_selector.select('List View')

--- a/cfme/tests/containers/test_tags.py
+++ b/cfme/tests/containers/test_tags.py
@@ -49,7 +49,13 @@ def get_collection_entity(appliance, collection_name, provider):
 @pytest.mark.parametrize('tag_place', [True, False], ids=['details', 'list'])
 def test_tag_container_objects(soft_assert, test_param, appliance, provider, request, tag,
                                tag_place):
-    """ Test for container items tagging action from list and details pages """
+    """ Test for container items tagging action from list and details pages
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
 
     obj_under_test = get_collection_entity(appliance=appliance, collection_name=test_param,
                                            provider=provider)

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -310,6 +310,10 @@ def test_action_start_virtual_machine_after_stopping(request, vm, vm_on, policy_
 
     Metadata:
         test_flag: actions, provision
+
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/6h
     """
     # Set up the policy and prepare finalizer
     policy_for_testing.assign_actions_to_event("VM Power Off", ["Start Virtual Machine"])
@@ -336,6 +340,10 @@ def test_action_stop_virtual_machine_after_starting(request, vm, vm_off, policy_
 
     Metadata:
         test_flag: actions, provision
+
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/6h
     """
     # Set up the policy and prepare finalizer
     policy_for_testing.assign_actions_to_event("VM Power On", ["Stop Virtual Machine"])
@@ -361,6 +369,10 @@ def test_action_suspend_virtual_machine_after_starting(request, vm, vm_off, poli
 
     Metadata:
         test_flag: actions, provision
+
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/6h
     """
     # Set up the policy and prepare finalizer
     policy_for_testing.assign_actions_to_event("VM Power On", ["Suspend Virtual Machine"])
@@ -386,6 +398,10 @@ def test_action_prevent_event(request, vm, vm_off, policy_for_testing):
 
     Metadata:
         test_flag: actions, provision
+
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/6h
     """
     # Set up the policy and prepare finalizer
     policy_for_testing.assign_actions_to_event("VM Power On Request",
@@ -411,6 +427,10 @@ def test_action_prevent_vm_retire(request, vm, vm_on, policy_for_testing):
 
     Metadata:
         test_flag: actions, provision
+
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/6h
     """
     policy_for_testing.assign_actions_to_event("VM Retire Request",
         ["Prevent current event from proceeding"])
@@ -434,6 +454,10 @@ def test_action_prevent_ssa(request, appliance, configure_fleecing, vm, vm_on, p
 
     Metadata:
         test_flag: actions, provision
+
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/4h
     """
     policy_for_testing.assign_actions_to_event("VM Analysis Request",
         ["Prevent current event from proceeding"])
@@ -460,6 +484,10 @@ def test_action_prevent_host_ssa(request, appliance, host, host_policy):
 
     Metadata:
         test_flag: actions, provision
+
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/4h
     """
     host_policy.assign_actions_to_event("Host Analysis Request",
         ["Prevent current event from proceeding"])
@@ -500,6 +528,10 @@ def test_action_power_on_logged(request, vm, vm_off, appliance, policy_for_testi
 
     Metadata:
         test_flag: actions, provision
+
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/6h
     """
     # Set up the policy and prepare finalizer
     policy_for_testing.assign_actions_to_event("VM Power On", ["Generate log message"])
@@ -539,6 +571,10 @@ def test_action_power_on_audit(request, vm, vm_off, appliance, policy_for_testin
 
     Metadata:
         test_flag: actions, provision
+
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/6h
     """
     # Set up the policy and prepare finalizer
     policy_for_testing.assign_actions_to_event("VM Power On", ["Generate Audit Event"])
@@ -584,6 +620,10 @@ def test_action_create_snapshot_and_delete_last(
 
     Metadata:
         test_flag: actions, provision
+
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/6h
     """
     # Set up the policy and prepare finalizer
     snapshot_name = fauxfactory.gen_alphanumeric()
@@ -628,6 +668,10 @@ def test_action_create_snapshots_and_delete_them(request, appliance, vm, vm_on,
 
     Metadata:
         test_flag: actions, provision
+
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/6h
     """
     # Set up the policy and prepare finalizer
     snapshot_name = fauxfactory.gen_alphanumeric()
@@ -679,6 +723,10 @@ def test_action_initiate_smartstate_analysis(request, configure_fleecing, vm, vm
 
     Metadata:
         test_flag: actions, provision
+
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/6h
     """
     # Set up the policy and prepare finalizer
     policy_for_testing.assign_actions_to_event("VM Power On",
@@ -739,6 +787,10 @@ def test_action_tag(request, vm, vm_off, policy_for_testing, appliance):
 
     Metadata:
         test_flag: actions, provision
+
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/6h
     """
     if any(tag.category.display_name == "Service Level" and tag.display_name == "Gold"
            for tag in vm.crud.get_tags()):
@@ -777,6 +829,10 @@ def test_action_untag(request, vm, vm_off, policy_for_testing, appliance, tag):
 
     Metadata:
         test_flag: actions, provision
+
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/6h
     """
     if not any(vm_tag.category.display_name == tag.category.display_name and
                vm_tag.display_name == tag.display_name
@@ -823,6 +879,10 @@ def test_action_cancel_clone(appliance, request, provider, vm_name, vm_big, poli
     """This test checks if 'Cancel vCenter task' action works.
     For this test we need big template otherwise CFME won't have enough time
     to cancel the task https://bugzilla.redhat.com/show_bug.cgi?id=1383372#c9
+
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/4h
     """
     with update(policy_for_testing):
         policy_for_testing.scope = (
@@ -867,6 +927,10 @@ def test_action_check_compliance(request, provider, vm, vm_name, policy_for_test
 
     Metadata:
         test_flag: policy
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     compliance_policy.assign_conditions(compliance_condition)
     if any(vm_tag.category.display_name == tag.category.display_name and

--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -244,6 +244,11 @@ def test_alert_vm_turned_on_more_than_twice_in_past_15_minutes(request, provider
 
     Metadata:
         test_flag: alerts, provision
+
+    Polarion:
+        assignee: jdupuy
+        casecomponent: control
+        initialEstimate: None
     """
     vm = full_template_vm
     alert = alert_collection.instantiate("VM Power On > 2 in last 15 min")
@@ -275,6 +280,11 @@ def test_alert_rtp(request, full_template_vm, smtp_test, provider, setup_candu, 
 
     Metadata:
         test_flag: alerts, provision, metrics_collection
+
+    Polarion:
+        assignee: jdupuy
+        casecomponent: control
+        initialEstimate: 1/6h
     """
     email = fauxfactory.gen_email()
     alert = alert_collection.create(
@@ -308,6 +318,11 @@ def test_alert_timeline_cpu(request, full_template_vm, set_performance_capture_t
 
     Metadata:
         test_flag: alerts, provision, metrics_collection
+
+    Polarion:
+        assignee: jdupuy
+        casecomponent: control
+        initialEstimate: 1/6h
     """
     alert = alert_collection.create(
         "TL event by CPU {}".format(fauxfactory.gen_alpha(length=4)),
@@ -354,6 +369,11 @@ def test_alert_snmp(request, appliance, provider, setup_snmp, setup_candu, full_
 
     Metadata:
         test_flag: alerts, provision, metrics_collection
+
+    Polarion:
+        assignee: jdupuy
+        casecomponent: control
+        initialEstimate: 1/6h
     """
     match_string = fauxfactory.gen_alpha(length=8)
     alert = alert_collection.create(
@@ -409,6 +429,11 @@ def test_alert_hardware_reconfigured(request, configure_fleecing, alert_collecti
     Then the alert for CPU count change should be triggered. It is either CPU increased or decreased
     depending on what has been done in your step 2, not the result of step 4. Step 4 is just to
     trigger the event.
+
+    Polarion:
+        assignee: jdupuy
+        casecomponent: control
+        initialEstimate: 1/4h
     """
     vm = full_template_vm
     email = fauxfactory.gen_email()

--- a/cfme/tests/control/test_basic.py
+++ b/cfme/tests/control/test_basic.py
@@ -410,6 +410,13 @@ def policy_and_condition(request, policy_collection, condition_collection, appli
 @pytest.mark.sauce
 @pytest.mark.tier(2)
 def test_condition_crud(condition_collection, condition_prerequisites):
+    """
+    Polarion:
+        assignee: mmojzis
+        casecomponent: control
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
     # CR
     condition_class, scope, expression = condition_prerequisites
     condition = condition_collection.create(
@@ -427,6 +434,13 @@ def test_condition_crud(condition_collection, condition_prerequisites):
 @pytest.mark.sauce
 @pytest.mark.tier(2)
 def test_action_crud(action_collection):
+    """
+    Polarion:
+        assignee: mmojzis
+        casecomponent: control
+        caseimportance: critical
+        initialEstimate: 1/12h
+    """
     # CR
     action = action_collection.create(
         fauxfactory.gen_alphanumeric(),
@@ -445,6 +459,12 @@ def test_action_crud(action_collection):
 @pytest.mark.uncollectif(lambda appliance, policy_class: (
     policy_class in PHYS_POLICIES and appliance.version < "5.9"))
 def test_policy_crud(policy_collection, policy_class):
+    """
+    Polarion:
+        assignee: mmojzis
+        casecomponent: control
+        initialEstimate: None
+    """
     # CR
     policy = policy_collection.create(policy_class, fauxfactory.gen_alphanumeric())
     # U
@@ -458,6 +478,13 @@ def test_policy_crud(policy_collection, policy_class):
 @pytest.mark.uncollectif(lambda appliance, policy_class: (
     policy_class in PHYS_POLICIES and appliance.version < "5.9"))
 def test_policy_copy(policy_class, policy):
+    """
+    Polarion:
+        assignee: mmojzis
+        casecomponent: control
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
     random_policy_copy = policy.copy()
     assert random_policy_copy.exists
     random_policy_copy.delete()
@@ -469,6 +496,12 @@ def test_policy_copy(policy_class, policy):
     appliance.version < "5.9"))
 def test_assign_two_random_events_to_control_policy(control_policy, control_policy_class,
                                                     soft_assert):
+    """
+    Polarion:
+        assignee: mmojzis
+        casecomponent: control
+        initialEstimate: None
+    """
     random_events = random.sample(EVENTS, 2)
     control_policy.assign_events(*random_events)
     soft_assert(control_policy.is_event_assigned(random_events[0]))
@@ -481,6 +514,13 @@ def test_assign_two_random_events_to_control_policy(control_policy, control_poli
 @pytest.mark.meta(blockers=[BZ(1565576, forced_streams=["5.9"],
                   unblock=lambda policy_class: policy_class is not PHYS_POLICIES[0])])
 def test_control_assign_actions_to_event(request, policy_class, policy, action):
+    """
+    Polarion:
+        assignee: mmojzis
+        casecomponent: control
+        caseimportance: critical
+        initialEstimate: 1/12h
+    """
     if type(policy) in CONTROL_POLICIES:
         event = random.choice(EVENTS)
         policy.assign_events(event)
@@ -501,6 +541,12 @@ def test_assign_condition_to_control_policy(request, policy_and_condition, condi
     Steps:
         * Create a control policy.
         * Assign a condition to the created policy.
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: control
+        caseimportance: medium
+        initialEstimate: 1/12h
     """
     policy, condition = policy_and_condition
     policy.assign_conditions(condition)
@@ -511,6 +557,13 @@ def test_assign_condition_to_control_policy(request, policy_and_condition, condi
 @pytest.mark.sauce
 @pytest.mark.tier(2)
 def test_policy_profile_crud(policy_profile_collection, two_random_policies):
+    """
+    Polarion:
+        assignee: mmojzis
+        casecomponent: control
+        caseimportance: critical
+        initialEstimate: 1/12h
+    """
     profile = policy_profile_collection.create(
         fauxfactory.gen_alphanumeric(),
         policies=two_random_policies
@@ -528,6 +581,13 @@ def test_policy_profile_crud(policy_profile_collection, two_random_policies):
     unblock=lambda fill_type: fill_type != "Find")]
 )
 def test_modify_condition_expression(condition_for_expressions, fill_type, expression, verify):
+    """
+    Polarion:
+        assignee: mmojzis
+        casecomponent: control
+        caseimportance: low
+        initialEstimate: 1/12h
+    """
     with update(condition_for_expressions):
         condition_for_expressions.expression = expression.format(
             condition_for_expressions.FIELD_VALUE)
@@ -538,6 +598,12 @@ def test_modify_condition_expression(condition_for_expressions, fill_type, expre
 @pytest.mark.sauce
 @pytest.mark.tier(2)
 def test_alert_crud(alert_collection):
+    """
+    Polarion:
+        assignee: jdupuy
+        casecomponent: control
+        initialEstimate: 1/12h
+    """
     # CR
     alert = alert_collection.create(
         fauxfactory.gen_alphanumeric()
@@ -552,6 +618,13 @@ def test_alert_crud(alert_collection):
 @pytest.mark.tier(3)
 @pytest.mark.meta(blockers=[1303645], automates=[1303645])
 def test_control_alert_copy(alert):
+    """
+    Polarion:
+        assignee: mmojzis
+        casecomponent: control
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
     alert_copy = alert.copy(description=fauxfactory.gen_alphanumeric())
     assert alert_copy.exists
     alert_copy.delete()
@@ -561,6 +634,13 @@ def test_control_alert_copy(alert):
 @pytest.mark.tier(2)
 def test_alert_profile_crud(request, alert_profile_class, alert_collection,
         alert_profile_collection):
+    """
+    Polarion:
+        assignee: jdupuy
+        casecomponent: control
+        caseimportance: critical
+        initialEstimate: 1/12h
+    """
     alert = alert_collection.create(
         fauxfactory.gen_alphanumeric(),
         based_on=alert_profile_class.TYPE,
@@ -580,6 +660,12 @@ def test_alert_profile_crud(request, alert_profile_class, alert_collection,
 
 @pytest.mark.tier(2)
 def test_alert_profile_assigning(alert_profile, appliance):
+    """
+    Polarion:
+        assignee: jdupuy
+        casecomponent: control
+        initialEstimate: 1/12h
+    """
     view = appliance.browser.create_view(AlertProfileDetailsView)
     if isinstance(alert_profile, alert_profiles.ServerAlertProfile):
         options = dict(assign='Selected Servers', selections=['Servers', 'EVM'])
@@ -600,5 +686,11 @@ def test_alert_profile_assigning(alert_profile, appliance):
 
 @pytest.mark.tier(2)
 def test_control_is_ansible_playbook_available_in_actions_dropdown(action_collection):
+    """
+    Polarion:
+        assignee: mmojzis
+        casecomponent: control
+        initialEstimate: 1/12h
+    """
     view = navigate_to(action_collection, "Add")
     assert "Run Ansible Playbook" in [option.text for option in view.action_type.all_options]

--- a/cfme/tests/control/test_bugs.py
+++ b/cfme/tests/control/test_bugs.py
@@ -151,7 +151,14 @@ def hardware_reconfigured_alert(alert_collection):
 @pytest.mark.meta(blockers=[1155284])
 def test_scope_windows_registry_stuck(request, appliance, infra_provider, policy_collection,
         policy_profile_collection):
-    """If you provide Scope checking windows registry, it messes CFME up. Recoverable."""
+    """If you provide Scope checking windows registry, it messes CFME up. Recoverable.
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: control
+        caseimportance: low
+        initialEstimate: 1/6h
+    """
     policy = policy_collection.create(
         VMCompliancePolicy,
         "Windows registry scope glitch testing Compliance Policy",
@@ -183,6 +190,12 @@ def test_invoke_custom_automation(request, action_collection):
     Steps:
         * Go create new action, select Invoke Custom Automation
         * The form with additional fields should appear
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: control
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
     # The action is to have all possible fields filled, that way we can ensure it is good
     action = action_collection.create(
@@ -221,6 +234,10 @@ def test_check_compliance_history(request, virtualcenter_provider, vmware_vm, po
 
     Result:
         Compliance history screen with last 10 checks should be opened
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     policy = policy_collection.create(
         VMCompliancePolicy,
@@ -254,6 +271,13 @@ def test_delete_all_actions_from_compliance_policy(request, policy_collection):
 
     Result:
         The policy shouldn't be saved.
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: control
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/12h
     """
     policy = policy_collection.create(VMCompliancePolicy, fauxfactory.gen_alphanumeric())
     request.addfinalizer(lambda: policy.delete() if policy.exists else None)
@@ -272,6 +296,12 @@ def test_control_identical_descriptions(request, create_function, collections, a
 
     Result:
         The item shouldn't be created.
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: control
+        caseimportance: low
+        initialEstimate: 1/12h
     """
     args, kwargs = create_function.fn(request, collections[create_function.name])
     flash = appliance.browser.create_view(ControlExplorerView).flash
@@ -289,6 +319,12 @@ def test_vmware_alarm_selection_does_not_fail(request, alert_collection):
 
     Metadata:
         test_flag: alerts
+
+    Polarion:
+        assignee: jdupuy
+        casecomponent: control
+        caseimportance: low
+        initialEstimate: 1/12h
     """
     try:
         alert = alert_collection.create(
@@ -306,6 +342,12 @@ def test_vmware_alarm_selection_does_not_fail(request, alert_collection):
 def test_alert_ram_reconfigured(hardware_reconfigured_alert):
     """Tests the bug when it was not possible to save an alert with RAM option in hardware
     attributes.
+
+    Polarion:
+        assignee: jdupuy
+        casecomponent: control
+        caseimportance: medium
+        initialEstimate: 1/12h
     """
     view = navigate_to(hardware_reconfigured_alert, "Details")
     attr = view.hardware_reconfigured_parameters.get_text_of("Hardware Attribute")

--- a/cfme/tests/control/test_compliance.py
+++ b/cfme/tests/control/test_compliance.py
@@ -134,7 +134,12 @@ def analysis_profile(appliance):
 def test_check_package_presence(request, compliance_vm, analysis_profile, policy_collection,
         policy_profile_collection, condition_collection):
     """This test checks compliance by presence of a certain "kernel" package which is expected
-    to be present on the full_template."""
+    to be present on the full_template.
+
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/4h
+    """
     condition = condition_collection.create(
         VMCondition,
         "Compliance testing condition {}".format(fauxfactory.gen_alphanumeric(8)),
@@ -164,6 +169,10 @@ def test_check_files(request, compliance_vm, analysis_profile, condition_collect
         policy_collection, policy_profile_collection):
     """This test checks presence and contents of a certain file. Due to caching, an existing file
     is checked.
+
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/4h
     """
     check_file_name = "/etc/hosts"
     check_file_contents = "127.0.0.1"
@@ -198,6 +207,11 @@ def test_check_files(request, compliance_vm, analysis_profile, condition_collect
 
 
 def test_compliance_with_unconditional_policy(host, assign_policy_for_testing):
+    """
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/6h
+    """
     assign_policy_for_testing.assign_actions_to_event(
         "Host Compliance Check",
         {"Mark as Non-Compliant": True}

--- a/cfme/tests/control/test_default_alerts.py
+++ b/cfme/tests/control/test_default_alerts.py
@@ -41,6 +41,10 @@ def default_alerts(appliance):
 def test_default_alerts(appliance,default_alerts):
     """ Tests the default pre-configured alerts on the appliance and
         ensures that they have not changed between versions.
+
+    Polarion:
+        assignee: jdupuy
+        initialEstimate: None
     """
     # get the alerts of the appliance
     alerts = appliance.collections.alerts.all()

--- a/cfme/tests/control/test_export_policies.py
+++ b/cfme/tests/control/test_export_policies.py
@@ -39,5 +39,11 @@ def test_policy_profiles_listed(appliance, policy_profile):
         * Go to the Control / Import/Export page
         * Select ``Policy Profiles`` from the ``Export:`` dropdown.
         * Assert that the policy profile is displayed in the selector.
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: control
+        caseimportance: low
+        initialEstimate: 1/12h
     """
     is_imported(appliance, policy_profile)

--- a/cfme/tests/control/test_import_policies.py
+++ b/cfme/tests/control/test_import_policies.py
@@ -28,16 +28,39 @@ def policy_profile_collection(appliance):
 
 @pytest.mark.meta(blockers=[1106456, 1198111], automates=[1198111])
 def test_import_policies(appliance, import_policy_file):
+    """
+    Polarion:
+        assignee: mmojzis
+        casecomponent: control
+        caseimportance: low
+        initialEstimate: 1/12h
+    """
     import_export.import_file(appliance, import_policy_file)
 
 
 def test_control_import_invalid_yaml_file(appliance, import_invalid_yaml_file):
+    """
+    Polarion:
+        assignee: mmojzis
+        casecomponent: control
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/60h
+    """
     error_message = "Error during 'Policy Import': Invalid YAML file"
     with pytest.raises(Exception, match=error_message):
         import_export.import_file(appliance, import_invalid_yaml_file)
 
 
 def test_control_import_existing_policies(appliance, import_policy_file, policy_profile_collection):
+    """
+    Polarion:
+        assignee: mmojzis
+        casecomponent: control
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/12h
+    """
     import_export.import_file(appliance, import_policy_file)
     first_import = policy_profile_collection.all_policy_profile_names
     import_export.import_file(appliance, import_policy_file)

--- a/cfme/tests/control/test_rest_control.py
+++ b/cfme/tests/control/test_rest_control.py
@@ -34,6 +34,10 @@ class TestConditionsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         query_resource_attributes(conditions[0], soft_assert=soft_assert)
 
@@ -42,6 +46,11 @@ class TestConditionsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         for condition in conditions:
             record = appliance.rest_api.collections.conditions.get(id=condition.id)
@@ -53,6 +62,11 @@ class TestConditionsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         delete_resources_from_detail(conditions, method=method, num_sec=100, delay=5)
 
@@ -61,6 +75,11 @@ class TestConditionsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         delete_resources_from_collection(conditions, num_sec=100, delay=5)
 
@@ -72,6 +91,11 @@ class TestConditionsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         num_conditions = len(conditions)
         uniq = [fauxfactory.gen_alphanumeric(5) for _ in range(num_conditions)]
@@ -113,6 +137,10 @@ class TestPoliciesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         query_resource_attributes(policies[0], soft_assert=soft_assert)
 
@@ -121,6 +149,11 @@ class TestPoliciesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         for policy in policies:
             record = appliance.rest_api.collections.policies.get(id=policy.id)
@@ -131,6 +164,11 @@ class TestPoliciesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         delete_resources_from_detail(policies, method='POST', num_sec=100, delay=5)
 
@@ -142,6 +180,11 @@ class TestPoliciesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         delete_resources_from_detail(policies, method='DELETE', num_sec=100, delay=5)
 
@@ -150,6 +193,11 @@ class TestPoliciesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         delete_resources_from_collection(policies, num_sec=100, delay=5)
 
@@ -163,6 +211,11 @@ class TestPoliciesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         num_policies = len(policies)
         uniq = [fauxfactory.gen_alphanumeric(5) for _ in range(num_policies)]

--- a/cfme/tests/control/test_smoke_control.py
+++ b/cfme/tests/control/test_smoke_control.py
@@ -40,6 +40,11 @@ def test_control_navigation(destination, appliance):
 
     Steps:
         * Open each destination of Control tab.
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: web_ui
+        initialEstimate: 1/60h
     """
     # some of views like Control -> Log incredibly long first time
     view = navigate_to(appliance.server, destination, wait_for_view=60)
@@ -52,6 +57,11 @@ def test_control_explorer_tree(control_explorer_view, destination, appliance):
 
     Steps:
         * Open each accordion tab and click on top node of the tree.
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: web_ui
+        initialEstimate: 1/60h
     """
     navigate_to(appliance.server, 'ControlExplorer', wait_for_view=30)
     accordion_name = destination.lower().replace(" ", "_")

--- a/cfme/tests/distributed/test_appliance_file_permissions.py
+++ b/cfme/tests/distributed/test_appliance_file_permissions.py
@@ -9,7 +9,13 @@ pytestmark = [test_requirements.distributed]
 @pytest.mark.uncollectif(lambda appliance: appliance.is_pod,
                          reason="it isn't applicable to pod appliance")
 def test_v2_key_permissions(appliance):
-    """Verifies that the v2_key has proper permissions"""
+    """Verifies that the v2_key has proper permissions
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: config
+        initialEstimate: 1/60h
+    """
     stdout = appliance.ssh_client.run_command(
         "stat --format '%a' /var/www/miq/vmdb/certs/v2_key").output
     assert int(stdout) == 400

--- a/cfme/tests/distributed/test_appliance_replication.py
+++ b/cfme/tests/distributed/test_appliance_replication.py
@@ -85,7 +85,12 @@ def configure_db_replication(db_address, appliance):
 
 @pytest.fixture(scope="module")
 def test_vm(virtualcenter_provider):
-    """Fixture to provision appliance to the provider being tested if necessary"""
+    """Fixture to provision appliance to the provider being tested if necessary
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     vm_name = random_vm_name('distpwr')
     collection = virtualcenter_provider.appliance.provider_based_collection(virtualcenter_provider)
     vm = collection.instantiate(vm_name, virtualcenter_provider)
@@ -107,6 +112,10 @@ def test_appliance_replicate_between_regions(request, virtualcenter_provider):
 
     Metadata:
         test_flag: replication
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     appl1, appl2 = get_replication_appliances()
 
@@ -134,6 +143,10 @@ def test_external_database_appliance(request, virtualcenter_provider, appliance)
 
     Metadata:
         test_flag: replication
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     appl1, appl2 = get_distributed_appliances(appliance)
 
@@ -159,6 +172,10 @@ def test_appliance_replicate_sync_role_change(request, virtualcenter_provider, a
 
     Metadata:
         test_flag: replication
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     appl1, appl2 = get_replication_appliances()
     replication_conf = appliance.server.zone.region.replication
@@ -197,6 +214,10 @@ def test_appliance_replicate_sync_role_change_with_backlog(request, virtualcente
 
     Metadata:
         test_flag: replication
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     appl1, appl2 = get_replication_appliances()
     replication_conf = appliance.server.zone.region.replication
@@ -233,6 +254,10 @@ def test_appliance_replicate_database_disconnection(request, virtualcenter_provi
 
     Metadata:
         test_flag: replication
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     appl1, appl2 = get_replication_appliances()
     replication_conf = appliance.server.zone.region.replication
@@ -268,6 +293,10 @@ def test_appliance_replicate_database_disconnection_with_backlog(request, virtua
 
     Metadata:
         test_flag: replication
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     appl1, appl2 = get_replication_appliances()
     replication_conf = appliance.server.zone.region.replication
@@ -305,6 +334,10 @@ def test_distributed_vm_power_control(request, test_vm, virtualcenter_provider, 
 
     Metadata:
         test_flag: replication
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     appl1, appl2 = get_replication_appliances()
 

--- a/cfme/tests/generic_objects/test_definitions.py
+++ b/cfme/tests/generic_objects/test_definitions.py
@@ -16,6 +16,12 @@ pytestmark = [test_requirements.generic_objects]
 @pytest.mark.sauce
 @pytest.mark.parametrize('context', [ViaREST, ViaUI])
 def test_generic_object_definition_crud(appliance, context, soft_assert):
+    """
+    Polarion:
+        assignee: dmisharo
+        initialEstimate: 1/30h
+        tags: 5.9
+    """
     with appliance.context.use(context):
         definition = appliance.collections.generic_object_definitions.create(
             name="{}_generic_class{}".format(context.name.lower(), fauxfactory.gen_alphanumeric()),

--- a/cfme/tests/generic_objects/test_instances.py
+++ b/cfme/tests/generic_objects/test_instances.py
@@ -127,6 +127,12 @@ def generic_object_button(appliance, generic_object_button_group, definition):
 @pytest.mark.sauce
 @pytest.mark.parametrize('context', [ViaREST, ViaUI])
 def test_generic_objects_crud(appliance, context, request):
+    """
+    Polarion:
+        assignee: mkourim
+        initialEstimate: 1/4h
+        tags: 5.9
+    """
     with appliance.context.use(context):
         definition = appliance.collections.generic_object_definitions.create(
             name='rest_generic_class{}'.format(fauxfactory.gen_alphanumeric()),
@@ -185,6 +191,10 @@ def test_generic_objects_with_buttons_ui(appliance, request, add_generic_object_
 
         Metadata:
             test_flag: ui
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     instance = add_generic_object_to_service
     generic_button = generic_object_button(button_group)
@@ -206,7 +216,11 @@ def test_generic_objects_tag_ui(appliance, generic_object, tag_place):
 
         Metadata:
             test_flag: ui
-        """
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
+    """
     with appliance.context.use(ViaUI):
         assigned_tag = generic_object.add_tag(details=tag_place)
         # TODO uncomment when tags aria added to details
@@ -226,6 +240,10 @@ def test_generic_objects_tag_rest(appliance, generic_object, tags):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
     """
     tag = tags[0]
     with appliance.context.use(ViaREST):

--- a/cfme/tests/infrastructure/test_advanced_search_host.py
+++ b/cfme/tests/infrastructure/test_advanced_search_host.py
@@ -60,11 +60,25 @@ def hosts_advanced_search(host_collection):
 
 
 def test_can_open_host_advanced_search(hosts_advanced_search):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     hosts_advanced_search.entities.search.open_advanced_search()
 
 
 def test_host_filter_without_user_input(host_collection, hosts, hosts_with_vm_count,
                                    host_with_median_vm, infra_provider, hosts_advanced_search):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     median_host, median_vm_count = host_with_median_vm
     # Counting hosts with more than median VMs
     more_than_median_hosts = len([hostname for hostname, vmcount in hosts_with_vm_count
@@ -81,6 +95,13 @@ def test_host_filter_without_user_input(host_collection, hosts, hosts_with_vm_co
 
 def test_host_filter_with_user_input(host_collection, hosts, hosts_with_vm_count,
                                      host_with_median_vm, infra_provider, hosts_advanced_search):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     median_host, median_vm_count = host_with_median_vm
     # Counting hosts with more than median VMs
     more_than_median_hosts = len([hostname for hostname, vmcount in hosts_with_vm_count
@@ -97,6 +118,13 @@ def test_host_filter_with_user_input(host_collection, hosts, hosts_with_vm_count
 
 def test_host_filter_with_user_input_and_cancellation(host_collection, hosts, hosts_with_vm_count,
                                                       host_with_median_vm, hosts_advanced_search):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     median_host, median_vm_count = host_with_median_vm
 
     # Set up the filter
@@ -110,6 +138,13 @@ def test_host_filter_with_user_input_and_cancellation(host_collection, hosts, ho
 
 def test_host_filter_save_cancel(hosts_advanced_search,
                                  hosts, hosts_with_vm_count, host_with_median_vm):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     median_host, median_vm_count = host_with_median_vm
     filter_name = fauxfactory.gen_alphanumeric()
     # Try save filter
@@ -123,6 +158,13 @@ def test_host_filter_save_cancel(hosts_advanced_search,
 
 def test_host_filter_save_and_load(host_collection, request, hosts, hosts_with_vm_count,
                                    host_with_median_vm, infra_provider, hosts_advanced_search):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     median_host, median_vm_count = host_with_median_vm
     # We will filter out hosts with less than median VMs
     more_than_median_hosts = list(dropwhile(lambda h: h[1] <= median_vm_count, hosts_with_vm_count))
@@ -142,6 +184,13 @@ def test_host_filter_save_and_load(host_collection, request, hosts, hosts_with_v
 
 def test_host_filter_save_and_cancel_load(host_collection, request, hosts, hosts_with_vm_count,
                                      host_with_median_vm, hosts_advanced_search):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     median_host, median_vm_count = host_with_median_vm
 
     filter_name = fauxfactory.gen_alphanumeric()
@@ -163,6 +212,13 @@ def test_host_filter_save_and_cancel_load(host_collection, request, hosts, hosts
 def test_host_filter_save_and_load_cancel(
         hosts_advanced_search, request, hosts,
         hosts_with_vm_count, host_with_median_vm):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     median_host, median_vm_count = host_with_median_vm
 
     filter_name = fauxfactory.gen_alphanumeric()
@@ -188,6 +244,13 @@ def test_host_filter_save_and_load_cancel(
 
 def test_quick_search_without_host_filter(host_collection, request, hosts, hosts_with_vm_count,
                                           host_with_median_vm, infra_provider):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     view = navigate_to(host_collection, 'All')
     view.entities.search.remove_search_filters()
     view.flash.assert_no_error()
@@ -203,6 +266,13 @@ def test_quick_search_without_host_filter(host_collection, request, hosts, hosts
 
 def test_quick_search_with_host_filter(host_collection, request, hosts, hosts_with_vm_count,
                                        host_with_median_vm, infra_provider):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     view = navigate_to(host_collection, 'All')
     median_host, median_vm_count = host_with_median_vm
     view.entities.search.advanced_search(get_expression(False, ">=").format(median_vm_count))
@@ -218,6 +288,13 @@ def test_quick_search_with_host_filter(host_collection, request, hosts, hosts_wi
 
 
 def test_can_delete_host_filter(host_collection, hosts_advanced_search):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     filter_name = fauxfactory.gen_alphanumeric()
     hosts_advanced_search.entities.search.save_filter(get_expression(False).format(0), filter_name)
     hosts_advanced_search.flash.assert_no_error()
@@ -232,7 +309,14 @@ def test_can_delete_host_filter(host_collection, hosts_advanced_search):
 
 def test_delete_button_should_appear_after_save_host(host_collection,
                                                      hosts_advanced_search, request):
-    """Delete button appears only after load, not after save"""
+    """Delete button appears only after load, not after save
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     filter_name = fauxfactory.gen_alphanumeric()
     hosts_advanced_search.entities.search.save_filter(get_expression(False).format(0), filter_name)
 
@@ -246,7 +330,14 @@ def test_delete_button_should_appear_after_save_host(host_collection,
 
 
 def test_cannot_delete_host_filter_more_than_once(host_collection, hosts_advanced_search):
-    """When Delete button appars, it does not want to go away"""
+    """When Delete button appars, it does not want to go away
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     filter_name = fauxfactory.gen_alphanumeric()
     hosts_advanced_search.entities.search.save_filter(get_expression(False).format(0), filter_name)
     # circumvent the thing happening in previous test

--- a/cfme/tests/infrastructure/test_advanced_search_providers.py
+++ b/cfme/tests/infrastructure/test_advanced_search_providers.py
@@ -44,10 +44,24 @@ def advanced_search_view():
 
 
 def test_can_open_provider_advanced_search(advanced_search_view):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     advanced_search_view.entities.search.open_advanced_search()
 
 
 def test_provider_filter_without_user_input(advanced_search_view):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     # Set up the filter
     advanced_search_view.entities.search.advanced_search(
         "fill_count(Infrastructure Provider.VMs, >=, 0)")
@@ -55,6 +69,13 @@ def test_provider_filter_without_user_input(advanced_search_view):
 
 
 def test_provider_filter_with_user_input(advanced_search_view):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     # Set up the filter
     logger.debug('DEBUG: test_with_user_input: fill and apply')
     advanced_search_view.entities.search.advanced_search(
@@ -63,6 +84,13 @@ def test_provider_filter_with_user_input(advanced_search_view):
 
 
 def test_provider_filter_with_user_input_and_cancellation(advanced_search_view):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     # Set up the filtergit
     advanced_search_view.entities.search.advanced_search(
         "fill_count(Infrastructure Provider.VMs, >=)", {"COUNT": 0}, True
@@ -71,6 +99,13 @@ def test_provider_filter_with_user_input_and_cancellation(advanced_search_view):
 
 
 def test_provider_filter_save_cancel(rails_delete_filter, advanced_search_view):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     # bind filter_name to the function for fixture cleanup
     test_provider_filter_save_cancel.filter_name = fauxfactory.gen_alphanumeric()
     logger.debug('Set filter_name to: {}'.format(test_provider_filter_save_cancel.filter_name))
@@ -89,6 +124,13 @@ def test_provider_filter_save_cancel(rails_delete_filter, advanced_search_view):
 
 
 def test_provider_filter_save_and_load(rails_delete_filter, advanced_search_view):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     # bind filter_name to the function for fixture cleanup
     test_provider_filter_save_and_load.filter_name = fauxfactory.gen_alphanumeric()
     logger.debug('Set filter_name to: {}'.format(test_provider_filter_save_and_load.filter_name))
@@ -110,6 +152,13 @@ def test_provider_filter_save_and_load(rails_delete_filter, advanced_search_view
 
 
 def test_provider_filter_save_and_cancel_load(rails_delete_filter, advanced_search_view):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     # bind filter_name to the function for fixture cleanup
     test_provider_filter_save_and_cancel_load.filter_name = fauxfactory.gen_alphanumeric()
     logger.debug('Set filter_name to: {}'.format(
@@ -132,6 +181,13 @@ def test_provider_filter_save_and_cancel_load(rails_delete_filter, advanced_sear
 
 def test_provider_filter_save_and_cancel_load_with_user_input(
         rails_delete_filter, advanced_search_view):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     # bind filter_name to the function for fixture cleanup
     test_provider_filter_save_and_cancel_load_with_user_input.filter_name = \
         fauxfactory.gen_alphanumeric()
@@ -155,6 +211,13 @@ def test_provider_filter_save_and_cancel_load_with_user_input(
 
 
 def test_quick_search_without_provider_filter(request):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     view = navigate_to(InfraProvider, 'All')
     # Make sure that we empty the regular view.entities.search field after the test
     request.addfinalizer(view.entities.search.clear_simple_search)
@@ -164,6 +227,13 @@ def test_quick_search_without_provider_filter(request):
 
 
 def test_quick_search_with_provider_filter(request):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     view = navigate_to(InfraProvider, 'All')
     view.entities.search.advanced_search(
         "fill_count(Infrastructure Provider.VMs, >=, 0)")
@@ -176,6 +246,13 @@ def test_quick_search_with_provider_filter(request):
 
 
 def test_can_delete_provider_filter(advanced_search_view):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     filter_name = fauxfactory.gen_alphanumeric()
     logger.debug('Set filter_name to: {}'.format(filter_name))
     assert advanced_search_view.entities.search.save_filter(
@@ -191,7 +268,14 @@ def test_can_delete_provider_filter(advanced_search_view):
 
 
 def test_delete_button_should_appear_after_save_provider(rails_delete_filter, advanced_search_view):
-    """Delete button appears only after load, not after save"""
+    """Delete button appears only after load, not after save
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     # bind filter_name to the function for fixture cleanup
     test_delete_button_should_appear_after_save_provider.filter_name = \
         fauxfactory.gen_alphanumeric()
@@ -205,7 +289,14 @@ def test_delete_button_should_appear_after_save_provider(rails_delete_filter, ad
 
 
 def test_cannot_delete_provider_filter_more_than_once(advanced_search_view):
-    """When Delete button appars, it does not want to go away"""
+    """When Delete button appars, it does not want to go away
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     filter_name = fauxfactory.gen_alphanumeric()
     assert advanced_search_view.entities.search.save_filter(
         "fill_count(Infrastructure Provider.VMs, >, 0)", filter_name)

--- a/cfme/tests/infrastructure/test_advanced_search_vms.py
+++ b/cfme/tests/infrastructure/test_advanced_search_vms.py
@@ -50,11 +50,25 @@ def vm_view(appliance):
 
 
 def test_can_open_vm_advanced_search(vm_view):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     vm_view.entities.search.open_advanced_search()
 
 
 def test_vm_filter_without_user_input(appliance, vm_view, vms, subset_of_vms,
                                       expression_for_vms_subset):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     # Set up the filter
     vm_view.entities.search.advanced_search(expression_for_vms_subset)
     vm_view.flash.assert_no_error()
@@ -66,6 +80,13 @@ def test_vm_filter_without_user_input(appliance, vm_view, vms, subset_of_vms,
 @pytest.mark.meta(blockers=["GH#ManageIQ/manageiq:2322"])
 def test_vm_filter_with_user_input(
         appliance, vm_view, vms, subset_of_vms, expression_for_vms_subset):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     vm = sample(subset_of_vms, 1)[0]
     # Set up the filter
     vm_view.entities.search.advanced_search(
@@ -78,6 +99,13 @@ def test_vm_filter_with_user_input(
 @pytest.mark.meta(blockers=["GH#ManageIQ/manageiq:2322"])
 def test_vm_filter_with_user_input_and_cancellation(vm_view, vms, subset_of_vms,
                                                     expression_for_vms_subset):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     vm = sample(subset_of_vms, 1)[0]
     # Set up the filter
     vm_view.entities.search.advanced_search(
@@ -89,6 +117,13 @@ def test_vm_filter_with_user_input_and_cancellation(vm_view, vms, subset_of_vms,
 
 
 def test_vm_filter_save_cancel(vm_view, vms, subset_of_vms, expression_for_vms_subset):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     filter_name = fauxfactory.gen_alphanumeric()
     # Set up the filter
     vm_view.entities.search.save_filter(
@@ -103,6 +138,13 @@ def test_vm_filter_save_cancel(vm_view, vms, subset_of_vms, expression_for_vms_s
 
 def test_vm_filter_save_and_load(appliance, request, vm_view, vms, subset_of_vms,
                                  expression_for_vms_subset):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     filter_name = fauxfactory.gen_alphanumeric()
     vm = sample(subset_of_vms, 1)[0]
     # Set up the filter
@@ -125,6 +167,13 @@ def test_vm_filter_save_and_load(appliance, request, vm_view, vms, subset_of_vms
 
 
 def test_vm_filter_save_and_cancel_load(request, vm_view):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     filter_name = fauxfactory.gen_alphanumeric()
     # Set up the filter
     vm_view.entities.search.save_filter(
@@ -143,6 +192,13 @@ def test_vm_filter_save_and_cancel_load(request, vm_view):
 
 
 def test_vm_filter_save_and_load_cancel(request, vms, subset_of_vms, vm_view):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     filter_name = fauxfactory.gen_alphanumeric()
     vm = sample(subset_of_vms, 1)[0]
     # Set up the filter
@@ -167,6 +223,13 @@ def test_vm_filter_save_and_load_cancel(request, vms, subset_of_vms, vm_view):
 
 
 def test_quick_search_without_vm_filter(appliance, request, vms, subset_of_vms):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     view = navigate_to(appliance.collections.infra_vms, 'VMsOnly')
     view.flash.assert_no_error()
     vm = sample(subset_of_vms, 1)[0]
@@ -182,6 +245,13 @@ def test_quick_search_without_vm_filter(appliance, request, vms, subset_of_vms):
 
 def test_quick_search_with_vm_filter(
         vm_view, vms, subset_of_vms, appliance, expression_for_vms_subset):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     vm_view.entities.search.advanced_search(expression_for_vms_subset)
     vm_view.flash.assert_no_error()
     # Filter this host only
@@ -194,6 +264,13 @@ def test_quick_search_with_vm_filter(
 
 
 def test_can_delete_vm_filter(vm_view):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     filter_name = fauxfactory.gen_alphanumeric()
     vm_view.entities.search.save_filter(
         "fill_count(Virtual Machine.Files, >, 0)", filter_name)
@@ -208,7 +285,12 @@ def test_can_delete_vm_filter(vm_view):
 
 
 def test_delete_button_should_appear_after_save_vm(request, vm_view):
-    """Delete button appears only after load, not after save"""
+    """Delete button appears only after load, not after save
+
+    Polarion:
+        assignee: mmojzis
+        initialEstimate: 1/10h
+    """
     filter_name = fauxfactory.gen_alphanumeric()
     vm_view.entities.search.save_filter(
         "fill_count(Virtual Machine.Files, >, 0)", filter_name)
@@ -223,7 +305,14 @@ def test_delete_button_should_appear_after_save_vm(request, vm_view):
 
 
 def test_cannot_delete_vm_filter_more_than_once(vm_view):
-    """When Delete button appars, it does not want to go away"""
+    """When Delete button appars, it does not want to go away
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
     filter_name = fauxfactory.gen_alphanumeric()
     vm_view.entities.search.save_filter(
         "fill_count(Virtual Machine.Files, >, 0)", filter_name)

--- a/cfme/tests/infrastructure/test_child_tenant.py
+++ b/cfme/tests/infrastructure/test_child_tenant.py
@@ -127,6 +127,11 @@ def test_child_tenant_quota_enforce_via_lifecycle_infra(appliance, provider, set
 
     Metadata:
         test_flag: quota
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: infra
+        initialEstimate: 1/6h
     """
     with new_user:
         recursive_update(prov_data, custom_prov_data)

--- a/cfme/tests/infrastructure/test_cluster_analysis.py
+++ b/cfme/tests/infrastructure/test_cluster_analysis.py
@@ -21,6 +21,11 @@ def test_run_cluster_analysis(appliance, provider):
 
     Metadata:
         test_flag: cluster_analysis
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
     """
     cluster_coll = appliance.collections.clusters.filter({'provider': provider})
     test_cluster = cluster_coll.all()[0]

--- a/cfme/tests/infrastructure/test_config_management.py
+++ b/cfme/tests/infrastructure/test_config_management.py
@@ -46,17 +46,33 @@ def tag(category):
 
 @pytest.mark.tier(3)
 def test_config_manager_detail_config_btn(request, config_manager):
+    """
+    Polarion:
+        assignee: nachandr
+        initialEstimate: 1/2h
+    """
     config_manager.refresh_relationships()
 
 
 @pytest.mark.tier(2)
 def test_config_manager_add(request, config_manager_obj):
+    """
+    Polarion:
+        assignee: nachandr
+        casecomponent: prov
+        initialEstimate: 1/4h
+    """
     request.addfinalizer(config_manager_obj.delete)
     config_manager_obj.create()
 
 
 @pytest.mark.tier(3)
 def test_config_manager_add_invalid_url(request, config_manager_obj):
+    """
+    Polarion:
+        assignee: nachandr
+        initialEstimate: 1/15h
+    """
     request.addfinalizer(config_manager_obj.delete)
     config_manager_obj.url = 'https://invalid_url'
     error_message = 'getaddrinfo: Name or service not known'
@@ -66,6 +82,12 @@ def test_config_manager_add_invalid_url(request, config_manager_obj):
 
 @pytest.mark.tier(3)
 def test_config_manager_add_invalid_creds(request, config_manager_obj):
+    """
+    Polarion:
+        assignee: nachandr
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
     request.addfinalizer(config_manager_obj.delete)
     config_manager_obj.credentials.principal = 'invalid_user'
     if config_manager_obj.type == "Ansible Tower":
@@ -79,6 +101,11 @@ def test_config_manager_add_invalid_creds(request, config_manager_obj):
 
 @pytest.mark.tier(3)
 def test_config_manager_edit(request, config_manager):
+    """
+    Polarion:
+        assignee: nachandr
+        initialEstimate: 1/15h
+    """
     new_name = fauxfactory.gen_alpha(8)
     old_name = config_manager.name
     with update(config_manager):
@@ -90,6 +117,11 @@ def test_config_manager_edit(request, config_manager):
 
 @pytest.mark.tier(3)
 def test_config_manager_remove(config_manager):
+    """
+    Polarion:
+        assignee: nachandr
+        initialEstimate: 1/15h
+    """
     config_manager.delete()
 
 
@@ -97,6 +129,11 @@ def test_config_manager_remove(config_manager):
 @pytest.mark.tier(3)
 @pytest.mark.uncollectif(lambda config_manager_obj: config_manager_obj.type == "Ansible Tower")
 def test_config_system_tag(request, config_system, tag):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     config_system.add_tag(tag=tag, details=False)
     tags = config_system.get_tags()
     assert '{}: {}'.format(tag.category.display_name, tag.display_name) in \

--- a/cfme/tests/infrastructure/test_config_management_rest.py
+++ b/cfme/tests/infrastructure/test_config_management_rest.py
@@ -84,6 +84,10 @@ class TestAuthenticationsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: None
         """
         query_resource_attributes(authentications[0], soft_assert=soft_assert)
 
@@ -92,6 +96,10 @@ class TestAuthenticationsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         new_names = []
         responses = []
@@ -108,6 +116,10 @@ class TestAuthenticationsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         new_names = []
         auths_data_edited = []
@@ -129,6 +141,10 @@ class TestAuthenticationsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         for auth in authentications:
             auth.action.delete.POST()
@@ -146,6 +162,10 @@ class TestAuthenticationsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         for auth in authentications:
             auth.action.delete.DELETE()
@@ -163,6 +183,10 @@ class TestAuthenticationsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         appliance.rest_api.collections.authentications.action.delete.POST(*authentications)
         assert_response(appliance)
@@ -178,6 +202,11 @@ class TestAuthenticationsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            caseimportance: medium
+            initialEstimate: 1/4h
         """
         collection = appliance.rest_api.collections.authentications
         assert 'credential_types' in collection.options()['data']

--- a/cfme/tests/infrastructure/test_customization_template.py
+++ b/cfme/tests/infrastructure/test_customization_template.py
@@ -27,7 +27,13 @@ def image_type(appliance):
 @pytest.mark.parametrize("script_type", ["Kickstart", "Sysprep", "CloudInit"],
                          ids=["kickstart", "sysprep", "cloudinit"])
 def test_customization_template_crud(collection, script_type, image_type):
-    """Basic CRUD test for customization templates."""
+    """Basic CRUD test for customization templates.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: prov
+        initialEstimate: 1/15h
+    """
 
     template_crud = collection.create(name="{}_{}".format(script_type,
                                                           fauxfactory.gen_alphanumeric(4)),
@@ -41,7 +47,12 @@ def test_customization_template_crud(collection, script_type, image_type):
 
 
 def test_name_required_error_validation_cust_template(collection):
-    """Test to validate name in customization templates."""
+    """Test to validate name in customization templates.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
 
     with pytest.raises(Exception, match='Name is required'):
         collection.create(
@@ -53,7 +64,12 @@ def test_name_required_error_validation_cust_template(collection):
 
 
 def test_type_required_error_validation(collection):
-    """Test to validate type in customization templates."""
+    """Test to validate type in customization templates.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
 
     with pytest.raises(Exception, match='Type is required'):
         collection.create(
@@ -65,7 +81,15 @@ def test_type_required_error_validation(collection):
 
 
 def test_pxe_image_type_required_error_validation(collection):
-    """Test to validate pxe image type in customization templates."""
+    """Test to validate pxe image type in customization templates.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: prov
+        caseimportance: medium
+        initialEstimate: 1/6h
+        upstream: yes
+    """
 
     with pytest.raises(Exception, match="Pxe_image_type can't be blank"):
         collection.create(
@@ -78,7 +102,12 @@ def test_pxe_image_type_required_error_validation(collection):
 
 @pytest.mark.meta(blockers=[BZ(1449116, forced_streams=['5.7', '5.8'])])
 def test_cust_template_duplicate_name_error_validation(collection):
-    """Test to validate duplication in customization templates."""
+    """Test to validate duplication in customization templates.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
 
     name = fauxfactory.gen_alphanumeric(8)
     description = fauxfactory.gen_alphanumeric(16)
@@ -103,6 +132,10 @@ def test_name_max_character_validation(collection):
     """Test to validate name with maximum characters in customization templates.
        Max length is controlled by UI elements - we are not allowed to input more than we should
        Opens template details to verify that extra symbols were cut
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     template_name = collection.create(
         name=fauxfactory.gen_alphanumeric(256),
@@ -119,6 +152,12 @@ def test_name_max_character_validation(collection):
 def test_customization_template_copy(collection):
     """
     Test to check the copy operation of customization templates.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: prov
+        caseimportance: medium
+        initialEstimate: 1/15h
     """
     template_crud = collection.create(name=fauxfactory.gen_alphanumeric(8),
                                       description=fauxfactory.gen_alphanumeric(16),

--- a/cfme/tests/infrastructure/test_datastore_analysis.py
+++ b/cfme/tests/infrastructure/test_datastore_analysis.py
@@ -83,6 +83,12 @@ def test_run_datastore_analysis(setup_provider, datastore, soft_assert, datastor
 
     Metadata:
         test_flag: datastore_analysis
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: critical
+        initialEstimate: 1/3h
     """
     # Initiate analysis
     try:

--- a/cfme/tests/infrastructure/test_delete_infra_object.py
+++ b/cfme/tests/infrastructure/test_delete_infra_object.py
@@ -20,6 +20,11 @@ def test_delete_cluster_appear_after_refresh(provider, appliance):
 
     Metadata:
         test_flag: delete_object
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: infra
+        initialEstimate: 1/10h
     """
     cluster_col = appliance.collections.clusters.filter({'provider': provider})
     test_cluster = cluster_col.all()[0]
@@ -33,6 +38,10 @@ def test_delete_host_appear_after_refresh(appliance, provider):
 
     Metadata:
         test_flag: delete_object
+
+    Polarion:
+        assignee: mkourim
+        initialEstimate: None
     """
     host_collection = appliance.collections.hosts
     host_name = provider.data['remove_test']['host']
@@ -48,6 +57,10 @@ def test_delete_vm_appear_after_refresh(provider):
 
     Metadata:
         test_flag: delete_object
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     vm = provider.data['remove_test']['vm']
     test_vm = provider.appliance.collections.infra_vms.instantiate(vm, provider)
@@ -62,6 +75,10 @@ def test_delete_template_appear_after_refresh(provider):
 
     Metadata:
         test_flag: delete_object
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     template = provider.data['remove_test']['template']
     test_template = provider.appliance.collections.infra_templates.instantiate(template, provider)
@@ -76,6 +93,10 @@ def test_delete_resource_pool_appear_after_refresh(provider, appliance):
 
     Metadata:
         test_flag: delete_object
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     resourcepool_name = provider.data['remove_test']['resource_pool']
     test_resourcepool = appliance.collections.resource_pools.instantiate(
@@ -92,6 +113,10 @@ def test_delete_datastore_appear_after_refresh(provider, appliance):
 
     Metadata:
         test_flag: delete_object
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     datastore_collection = appliance.collections.datastores
     data_store = provider.data['remove_test']['datastore']
@@ -122,6 +147,10 @@ def test_delete_cluster_from_table(provider, appliance):
 
     Metadata:
         test_flag: delete_object
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: None
     """
     cluster_col = appliance.collections.clusters.filter({"provider": provider})
     cluster1 = cluster_col.all()[0]

--- a/cfme/tests/infrastructure/test_esx_direct_host.py
+++ b/cfme/tests/infrastructure/test_esx_direct_host.py
@@ -99,6 +99,10 @@ def test_validate(host_provider):
             set up a VMware provider.
         * Refresh the provider
         * The provider should refresh without problems.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     host_provider.create()
     host_provider.refresh_provider_relationships()

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -83,7 +83,12 @@ def navigate_and_select_quads(provider):
 
 @pytest.mark.uncollectif(lambda provider: not provider.one_of(VMwareProvider))
 def test_discover_host(request, provider, appliance, host_ips):
-    """Tests hosts discovery."""
+    """Tests hosts discovery.
+
+    Polarion:
+        assignee: mkourim
+        initialEstimate: None
+    """
     if provider.delete_if_exists(cancel=False):
         provider.wait_for_delete()
 
@@ -122,6 +127,11 @@ def test_discover_host(request, provider, appliance, host_ips):
     reason="Not relevant for RHEVM Provider."
 )
 def test_multiple_host_good_creds(setup_provider, provider, creds):
+    """
+    Polarion:
+        assignee: mkourim
+        initialEstimate: None
+    """
     if len(provider.data.get('hosts', {})) < 2:
         pytest.skip('not enough hosts to run test')
     """  Tests multiple host credentialing  with good credentials """
@@ -150,7 +160,13 @@ def test_multiple_host_good_creds(setup_provider, provider, creds):
 @pytest.mark.meta(blockers=[BZ(1619626, forced_streams=['5.9', '5.10'],
                                unblock=lambda provider: not provider.one_of(RHEVMProvider))])
 def test_multiple_host_bad_creds(setup_provider, provider):
-    """    Tests multiple host credentialing with bad credentials """
+    """    Tests multiple host credentialing with bad credentials
+
+    Polarion:
+        assignee: nachandr
+        caseimportance: medium
+        initialEstimate: 1/15h
+    """
     if len(provider.data.get('hosts', {})) < 2:
         pytest.skip('not enough hosts to run test')
 
@@ -177,7 +193,12 @@ def test_multiple_host_bad_creds(setup_provider, provider):
 @pytest.mark.meta(blockers=[BZ(1648658, forced_streams=["5.9"])])
 @pytest.mark.provider([InfraProvider], override=True, selector=ONE, scope='module')
 def test_tag_host_after_provider_delete(provider, appliance, setup_provider, request):
-    """Test if host can be tagged after delete"""
+    """Test if host can be tagged after delete
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: 1/8h
+    """
     host_on_provider = provider.hosts.all()[0]
     provider.delete(cancel=False)
     provider.wait_for_delete()
@@ -199,6 +220,10 @@ def test_tag_host_after_provider_delete(provider, appliance, setup_provider, req
 def test_250_vmware_hosts_loading(appliance, create_250_hosts, view_type):
     """
     Test to automate BZ1580569
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
     """
     # Without the patch, this will cause the process to consume roughly 10+ Gigs of RAM
     # due to a poorly optimized database query

--- a/cfme/tests/infrastructure/test_host_analysis.py
+++ b/cfme/tests/infrastructure/test_host_analysis.py
@@ -72,6 +72,11 @@ def test_run_host_analysis(setup_provider_modscope, provider, host_type, host_na
 
     Metadata:
         test_flag: host_analysis
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
     """
     register_event(target_type='Host', target_name=host_name, event_type='request_host_scan')
     register_event(target_type='Host', target_name=host_name, event_type='host_scan_complete')

--- a/cfme/tests/infrastructure/test_host_drift_analysis.py
+++ b/cfme/tests/infrastructure/test_host_drift_analysis.py
@@ -64,6 +64,11 @@ def test_host_drift_analysis(appliance, request, a_host, soft_assert, set_host_c
 
     Metadata:
         test_flag: host_drift_analysis
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
     """
 
     # tabs changed, hack until configure.tasks is refactored for collections and versioned widgets

--- a/cfme/tests/infrastructure/test_host_provisioning.py
+++ b/cfme/tests/infrastructure/test_host_provisioning.py
@@ -96,6 +96,10 @@ def test_host_provisioning(appliance, setup_provider, cfme_data, host_provisioni
 
     Metadata:
         test_flag: host_provision
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     # Add host before provisioning

--- a/cfme/tests/infrastructure/test_individual_host_creds.py
+++ b/cfme/tests/infrastructure/test_individual_host_creds.py
@@ -72,6 +72,10 @@ def test_host_good_creds(appliance, request, setup_provider, provider, creds):
 
     Metadata:
         test_flag: inventory
+
+    Polarion:
+        assignee: nachandr
+        initialEstimate: 1/12h
     """
     test_host = random.choice(provider.data["hosts"])
     host_data = get_host_data_by_name(provider.key, test_host.name)
@@ -132,6 +136,11 @@ def test_host_bad_creds(appliance, request, setup_provider, provider, creds):
 
     Metadata:
         test_flag: inventory
+
+    Polarion:
+        assignee: nachandr
+        caseimportance: medium
+        initialEstimate: 1/15h
     """
     test_host = random.choice(provider.data["hosts"])
     host_data = get_host_data_by_name(provider.key, test_host.name)

--- a/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
+++ b/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
@@ -66,5 +66,9 @@ def test_tagvis_tag_datacenter_combination(testing_vis_object, group_tag_datacen
             2. Login as restricted user, item is visible for user
             3. As admin remove tag
             4. Login as restricted user, iten is not visible for user
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: 1/8h
     """
     check_item_visibility(testing_vis_object, visibility)

--- a/cfme/tests/infrastructure/test_iso_datastore.py
+++ b/cfme/tests/infrastructure/test_iso_datastore.py
@@ -28,6 +28,10 @@ def test_iso_datastore_crud(setup_provider, no_iso_dss, provider):
 
     Metadata:
         test_flag: iso
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     template_crud = pxe.ISODatastore(provider.name)
     template_crud.create()

--- a/cfme/tests/infrastructure/test_iso_provisioning.py
+++ b/cfme/tests/infrastructure/test_iso_provisioning.py
@@ -87,6 +87,10 @@ def test_iso_provision_from_template(appliance, provider, vm_name, datastore_ini
     Metadata:
         test_flag: iso, provision
         suite: infra_provisioning
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     # generate_tests makes sure these have values
     iso_template, host, datastore, iso_file, iso_kickstart,\

--- a/cfme/tests/infrastructure/test_kubevirt.py
+++ b/cfme/tests/infrastructure/test_kubevirt.py
@@ -41,6 +41,11 @@ def temp_vm(appliance, provider, provisioning):
 
 def test_k6t_provider_crud(provider):
 
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     with update(provider):
         provider.name = fauxfactory.gen_alphanumeric() + '_updated'
 
@@ -52,6 +57,11 @@ def test_k6t_provider_crud(provider):
                          [{}, {'hardware': {'cpu_cores': '8', 'memory': '8192'}}],
                          ids=['via_lifecycle', 'override_template_values'])
 def test_k6t_vm_crud(request, appliance, provider, provisioning, custom_prov_data):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     vm_name = random_vm_name('k6tvm')
     prov_data = {'catalog': {'vm_name': vm_name}}
     provider.refresh_provider_relationships()
@@ -72,6 +82,11 @@ def test_k6t_vm_crud(request, appliance, provider, provisioning, custom_prov_dat
                          ids=['PowerOn', 'PowerOff'])
 def test_vm_power_management(request, appliance, provider, temp_vm,
                              from_details, power_option, vm_state):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     # TODO: use wrapanapi to check power state before applying it
     temp_vm.power_control_from_cfme(from_details=from_details, option=power_option)
     provider.refresh_provider_relationships()

--- a/cfme/tests/infrastructure/test_project_quota.py
+++ b/cfme/tests/infrastructure/test_project_quota.py
@@ -116,6 +116,11 @@ def test_project_quota_enforce_via_lifecycle_infra(appliance, provider, setup_pr
 
     Metadata:
         test_flag: quota
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        initialEstimate: 1/4h
     """
     with new_user:
         recursive_update(prov_data, custom_prov_data)

--- a/cfme/tests/infrastructure/test_provider_discovery.py
+++ b/cfme/tests/infrastructure/test_provider_discovery.py
@@ -89,6 +89,14 @@ def delete_providers_after_test():
 @pytest.mark.tier(2)
 @pytest.mark.usefixtures('has_no_infra_providers', 'delete_providers_after_test')
 def test_discover_infra(appliance, providers_for_discover, start_ip, max_range):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/16h
+        upstream: yes
+    """
     collection = appliance.collections.infra_providers
     for provider in providers_for_discover:
         collection.discover(provider, False, start_ip, max_range)

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -45,7 +45,12 @@ discovery_ips = [
 
 @pytest.mark.sauce
 def test_empty_discovery_form_validation_infra(appliance):
-    """ Tests that the flash message is correct when discovery form is empty."""
+    """ Tests that the flash message is correct when discovery form is empty.
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/15h
+    """
     collection = appliance.collections.infra_providers
     collection.discover(None)
     view = appliance.browser.create_view(InfraProvidersDiscoverView)
@@ -54,7 +59,13 @@ def test_empty_discovery_form_validation_infra(appliance):
 
 @pytest.mark.sauce
 def test_discovery_cancelled_validation_infra(appliance):
-    """ Tests that the flash message is correct when discovery is cancelled."""
+    """ Tests that the flash message is correct when discovery is cancelled.
+
+    Polarion:
+        assignee: pvala
+        caseimportance: low
+        initialEstimate: 1/15h
+    """
     collection = appliance.collections.infra_providers
     collection.discover(None, cancel=True)
     view = appliance.browser.create_view(InfraProvidersView)
@@ -64,7 +75,12 @@ def test_discovery_cancelled_validation_infra(appliance):
 
 @pytest.mark.sauce
 def test_add_cancelled_validation_infra(appliance):
-    """Tests that the flash message is correct when add is cancelled."""
+    """Tests that the flash message is correct when add is cancelled.
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/15h
+    """
     appliance.collections.infra_providers.create(prov_class=VMwareProvider, cancel=True)
     view = appliance.browser.create_view(InfraProvidersView)
     view.flash.assert_success_message('Add of Infrastructure Provider was cancelled by the user')
@@ -72,7 +88,12 @@ def test_add_cancelled_validation_infra(appliance):
 
 @pytest.mark.sauce
 def test_type_required_validation_infra(appliance):
-    """Test to validate type while adding a provider"""
+    """Test to validate type while adding a provider
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/15h
+    """
     with pytest.raises(AssertionError):
         appliance.collections.infra_providers.create(prov_class=VMwareProvider)
     view = appliance.browser.create_view(InfraProviderAddView)
@@ -80,7 +101,12 @@ def test_type_required_validation_infra(appliance):
 
 
 def test_name_required_validation_infra(appliance):
-    """Tests to validate the name while adding a provider"""
+    """Tests to validate the name while adding a provider
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/15h
+    """
     collections = appliance.collections.infra_providers
     endpoint = VirtualCenterEndpoint(hostname=fauxfactory.gen_alphanumeric(5))
 
@@ -93,7 +119,12 @@ def test_name_required_validation_infra(appliance):
 
 
 def test_host_name_required_validation_infra(appliance):
-    """Test to validate the hostname while adding a provider"""
+    """Test to validate the hostname while adding a provider
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/15h
+    """
     endpoint = VirtualCenterEndpoint(hostname=None)
     collections = appliance.collections.infra_providers
     prov = collections.instantiate(prov_class=VMwareProvider, name=fauxfactory.gen_alphanumeric(5),
@@ -109,7 +140,12 @@ def test_host_name_required_validation_infra(appliance):
 
 
 def test_name_max_character_validation_infra(request, infra_provider):
-    """Test to validate max character for name field"""
+    """Test to validate max character for name field
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/15h
+    """
     request.addfinalizer(lambda: infra_provider.delete_if_exists(cancel=False))
     name = fauxfactory.gen_alphanumeric(255)
     with update(infra_provider):
@@ -118,7 +154,12 @@ def test_name_max_character_validation_infra(request, infra_provider):
 
 
 def test_host_name_max_character_validation_infra(appliance):
-    """Test to validate max character for host name field"""
+    """Test to validate max character for host name field
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: None
+    """
     endpoint = VirtualCenterEndpoint(hostname=fauxfactory.gen_alphanumeric(256))
     collections = appliance.collections.infra_providers
     prov = collections.instantiate(prov_class=VMwareProvider,
@@ -132,7 +173,12 @@ def test_host_name_max_character_validation_infra(appliance):
 
 
 def test_api_port_max_character_validation_infra(appliance):
-    """Test to validate max character for api port field"""
+    """Test to validate max character for api port field
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/15h
+    """
     collections = appliance.collections.infra_providers
     endpoint = RHEVMEndpoint(hostname=fauxfactory.gen_alphanumeric(5),
                              api_port=fauxfactory.gen_alphanumeric(16),
@@ -159,6 +205,10 @@ def test_providers_discovery(request, appliance, provider):
 
     Metadata:
         test_flag: crud
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/8h
     """
     appliance.collections.infra_providers.discover(provider, cancel=False,
                                                    start_ip=provider.start_ip,
@@ -177,6 +227,10 @@ def test_infra_provider_add_with_bad_credentials(provider):
 
     Metadata:
         test_flag: crud
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: None
     """
     provider.default_endpoint.credentials = Credential(
         principal='bad',
@@ -199,6 +253,10 @@ def test_infra_provider_crud(provider):
 
     Metadata:
         test_flag: crud
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: None
     """
     provider.create()
     # Fails on upstream, all provider types - BZ1087476
@@ -225,6 +283,10 @@ def test_provider_rhv_create_delete_tls(request, provider, verify_tls):
 
     Metadata:
        test_flag: crud
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     if not provider.endpoints.get('default').__dict__.get('verify_tls'):
@@ -249,7 +311,14 @@ def test_provider_rhv_create_delete_tls(request, provider, verify_tls):
 
 
 def test_infrastructure_add_provider_trailing_whitespaces(appliance):
-    """Test to validate the hostname and username should be without whitespaces"""
+    """Test to validate the hostname and username should be without whitespaces
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: infra
+        caseimportance: low
+        initialEstimate: 1/8h
+    """
     collections = appliance.collections.infra_providers
     credentials = Credential(principal="test test", secret=fauxfactory.gen_alphanumeric(5))
     endpoint = VirtualCenterEndpoint(hostname="test test", credentials=credentials)
@@ -266,6 +335,12 @@ def test_infrastructure_add_provider_trailing_whitespaces(appliance):
 
 
 def test_infra_discovery_screen(appliance):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: infra
+        initialEstimate: None
+    """
     collections = appliance.collections.infra_providers
     view = navigate_to(collections, 'Discover')
     assert view.is_displayed

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -128,6 +128,10 @@ def test_change_cpu_ram(provisioner, soft_assert, provider, prov_data, vm_name):
 
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: jhenner
+        initialEstimate: 1/6h
     """
     prov_data['catalog']["vm_name"] = vm_name
     prov_data['hardware']["num_sockets"] = "4"
@@ -180,6 +184,10 @@ def test_disk_format_select(provisioner, disk_format, provider, prov_data, vm_na
 
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: jhenner
+        initialEstimate: 1/6h
     """
 
     if provider.key == "vsphere55" and disk_format == "Thick":
@@ -220,6 +228,10 @@ def test_power_on_or_off_after_provision(provisioner, prov_data, provider, start
 
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: jhenner
+        initialEstimate: 1/4h
     """
     prov_data['catalog']['vm_name'] = vm_name
     prov_data['schedule']["power_on"] = started
@@ -250,6 +262,10 @@ def test_tag(provisioner, prov_data, provider, vm_name):
 
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: 1/8h
     """
     prov_data['catalog']['vm_name'] = vm_name
     prov_data['purpose']["apply_tags"] = CbTree.CheckNode(path=("Service Level *", "Gold"))
@@ -279,6 +295,10 @@ def test_provisioning_schedule(provisioner, provider, prov_data, vm_name):
 
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: jhenner
+        initialEstimate: 1/4h
     """
     now = datetime.utcnow()
     prov_data['catalog']['vm_name'] = vm_name
@@ -322,6 +342,10 @@ def test_provisioning_vnic_profiles(provisioner, provider, prov_data, vm_name, v
 
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     prov_data['catalog']['vm_name'] = vm_name
     prov_data['network'] = {'vlan': vnic_profile}
@@ -363,6 +387,10 @@ def test_provision_vm_with_2_nics(provisioner, provisioning, prov_data, vm_name)
 
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     template_name = provisioning.get('template_2_nics', None)
     prov_data['catalog']['vm_name'] = vm_name
@@ -387,6 +415,10 @@ def test_vmware_default_placement(provisioner, prov_data, provider, setup_provid
         * The VM should be placed in the Datacenter root folder (that's two levels up in API).
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     template_name = provider.data['provisioning']['template']
     prov_data['catalog']['vm_name'] = vm_name

--- a/cfme/tests/infrastructure/test_provisioning_rest.py
+++ b/cfme/tests/infrastructure/test_provisioning_rest.py
@@ -97,6 +97,10 @@ def test_provision(request, appliance, provider, provision_data):
         * Query the request by its id until the state turns to ``finished`` or ``provisioned``.
     Metadata:
         test_flag: rest, provision
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/3h
     """
     vm_name = provision_data['vm_fields']['vm_name']
     request.addfinalizer(lambda: clean_vm(appliance, provider, vm_name))
@@ -129,6 +133,10 @@ def test_provision_vlan(request, appliance, provision_data, vnic_profile, provid
         * Check the VM's vNic profile is as expected.
     Metadata:
         test_flag: rest, provision
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     vm_name = provision_data['vm_fields']['vm_name']
     profile_name = provider.data["provisioning"]["vlan"]
@@ -175,6 +183,10 @@ def test_provision_emails(request, provision_data, provider, appliance, smtp_tes
 
     Metadata:
         test_flag: rest, provision
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     def check_one_approval_mail_received():
         return len(smtp_test.get_emails(subject_like=VersionPicker({
@@ -211,6 +223,10 @@ def test_create_pending_provision_requests(request, appliance, provider, small_t
 
     Metadata:
         test_flag: rest, provision
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     provision_data = get_provision_data(
         appliance.rest_api, provider, small_template.name, auto_approve=False)
@@ -245,6 +261,10 @@ def test_provision_attributes(appliance, provider, small_template, soft_assert):
 
     Metadata:
         test_flag: rest, provision
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     provision_data = get_provision_data(
         appliance.rest_api, provider, small_template.name, auto_approve=False)

--- a/cfme/tests/infrastructure/test_publish_vm_to_template.py
+++ b/cfme/tests/infrastructure/test_publish_vm_to_template.py
@@ -43,6 +43,10 @@ def test_publish_vm_to_template(request, setup_provider, vm_crud):
         2) Publish the VM to a template
         3) Check that the template exists
 
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     vm_crud.mgmt.ensure_state(VmState.STOPPED)
     vm_crud.refresh_relationships()

--- a/cfme/tests/infrastructure/test_pxe.py
+++ b/cfme/tests/infrastructure/test_pxe.py
@@ -18,6 +18,13 @@ def has_no_pxe_servers():
 def test_pxe_server_crud(pxe_name, pxe_server_crud):
     """
     Basic Add test for PXE server including refresh.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: prov
+        caseimportance: medium
+        initialEstimate: 1/6h
+        upstream: yes
     """
     pxe_server_crud.create(refresh_timeout=300)
     with update(pxe_server_crud):

--- a/cfme/tests/infrastructure/test_pxe_provisioning.py
+++ b/cfme/tests/infrastructure/test_pxe_provisioning.py
@@ -102,6 +102,13 @@ def test_pxe_provision_from_template(appliance, provider, vm_name, setup_provide
     Metadata:
         test_flag: pxe, provision
         suite: infra_provisioning
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: prov
+        initialEstimate: 1/6h
+        testtype: integration
+        upstream: yes
     """
 
     # generate_tests makes sure these have values

--- a/cfme/tests/infrastructure/test_quota.py
+++ b/cfme/tests/infrastructure/test_quota.py
@@ -53,6 +53,11 @@ def prov_data(vm_name):
 
 @pytest.fixture(scope='module')
 def test_domain(appliance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     domain = appliance.collections.domains.create('test_{}'.format(fauxfactory.gen_alphanumeric()),
                                                   'description_{}'.format(
                                                       fauxfactory.gen_alphanumeric()),
@@ -193,7 +198,13 @@ def custom_prov_data(request, prov_data, vm_name, template_name):
 )
 def test_quota(appliance, provider, setup_provider, custom_prov_data, vm_name, admin_email,
                entities, template_name, prov_data):
-    """This test case checks quota limit using the automate's predefine method 'quota source'"""
+    """This test case checks quota limit using the automate's predefine method 'quota source'
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: infra
+        initialEstimate: 1/6h
+    """
     recursive_update(prov_data, custom_prov_data)
     do_vm_provisioning(appliance, template_name=template_name, provider=provider, vm_name=vm_name,
                        provisioning_data=prov_data, wait=False, request=None)
@@ -224,6 +235,10 @@ def test_user_quota_diff_groups(request, appliance, provider, setup_provider, ne
     steps:
 
     1. Provision VM with more than assigned quota
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     with new_user:
         recursive_update(prov_data, custom_prov_data)

--- a/cfme/tests/infrastructure/test_quota_tagging.py
+++ b/cfme/tests/infrastructure/test_quota_tagging.py
@@ -62,6 +62,11 @@ def prov_data(provider, vm_name, template_name):
 
 @pytest.fixture(scope='module')
 def test_domain(appliance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     domain = appliance.collections.domains.create('test_{}'.format(fauxfactory.gen_alphanumeric()),
                                                   'description_{}'.format(
                                                       fauxfactory.gen_alphanumeric()),
@@ -168,6 +173,12 @@ def set_entity_quota_tag(request, entities, appliance):
 def test_quota_tagging_infra_via_lifecycle(request, appliance, provider, setup_provider,
                                            set_entity_quota_tag, custom_prov_data,
                                            vm_name, template_name, prov_data):
+    """
+    Polarion:
+        assignee: ghubale
+        casecomponent: infra
+        initialEstimate: 1/6h
+    """
     recursive_update(prov_data, custom_prov_data)
     do_vm_provisioning(appliance, template_name=template_name, provider=provider, vm_name=vm_name,
                        provisioning_data=prov_data, wait=False, request=None)
@@ -199,7 +210,13 @@ def test_quota_tagging_infra_via_lifecycle(request, appliance, provider, setup_p
 def test_quota_tagging_infra_via_services(request, appliance, provider, setup_provider, admin_email,
                                           context, set_entity_quota_tag, custom_prov_data,
                                           prov_data, catalog_item):
-    """This test case verifies the quota tagging is working correctly for the infra providers."""
+    """This test case verifies the quota tagging is working correctly for the infra providers.
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: infra
+        initialEstimate: 1/6h
+    """
 
     prov_data.update(custom_prov_data)
     with appliance.context.use(context):
@@ -270,6 +287,10 @@ def test_quota_vm_reconfigure(
         1. Assign Quota to group and user individually
         2. Reconfigure the VM above the assigned Quota
         3. Check whether VM  reconfiguration 'Denied' with Exceeded Quota or not
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     original_config = small_vm.configuration.copy()
     new_config = small_vm.configuration.copy()
@@ -319,6 +340,10 @@ def test_quota_infra(request, appliance, provider, setup_provider, admin_email, 
         3. Change 'quota_source_type' to 'user' or 'group'
         4. Test quota by provisioning VMs over quota limit via UI or SSUI for user and group
         5. Check whether quota is exceeded or not
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     prov_data.update(custom_prov_data)
     with appliance.context.use(context):
@@ -365,6 +390,10 @@ def test_quota_catalog_bundle_infra(request, appliance, provider, setup_provider
            SSUI for user and group
         5. Add more than one catalog to catalog bundle and order catalog bundle
         6. Check whether quota is exceeded or not
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     prov_data.update(custom_prov_data)
     with appliance.context.use(context):

--- a/cfme/tests/infrastructure/test_rest_automation_request.py
+++ b/cfme/tests/infrastructure/test_rest_automation_request.py
@@ -158,6 +158,10 @@ class TestAutomationRequestsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: None
         """
         query_resource_attributes(requests_pending[0], soft_assert=soft_assert)
 
@@ -170,6 +174,10 @@ class TestAutomationRequestsRESTAPI(object):
 
         Metadata:
             test_flag: rest, requests
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         create_requests(collection, appliance.rest_api, automation_requests_data, multiple)
 
@@ -179,6 +187,10 @@ class TestAutomationRequestsRESTAPI(object):
 
         Metadata:
             test_flag: rest, requests
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         create_pending_requests(collection, appliance.rest_api, requests_pending)
 
@@ -191,6 +203,10 @@ class TestAutomationRequestsRESTAPI(object):
 
         Metadata:
             test_flag: rest, requests
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         approve_requests(collection, appliance.rest_api, requests_pending, from_detail)
 
@@ -203,6 +219,10 @@ class TestAutomationRequestsRESTAPI(object):
 
         Metadata:
             test_flag: rest, requests
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         deny_requests(collection, appliance.rest_api, requests_pending, from_detail)
 
@@ -218,6 +238,10 @@ class TestAutomationRequestsRESTAPI(object):
 
         Metadata:
             test_flag: rest, requests
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         # testing BZ 1418338
         edit_requests(collection, appliance.rest_api, requests_pending, from_detail)
@@ -245,6 +269,10 @@ class TestAutomationRequestsCommonRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: None
         """
         query_resource_attributes(requests_pending[0], soft_assert=soft_assert)
 
@@ -257,6 +285,10 @@ class TestAutomationRequestsCommonRESTAPI(object):
 
         Metadata:
             test_flag: rest, requests
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         create_requests(collection, appliance.rest_api, automation_requests_data, multiple)
 
@@ -266,6 +298,10 @@ class TestAutomationRequestsCommonRESTAPI(object):
 
         Metadata:
             test_flag: rest, requests
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         create_pending_requests(collection, appliance.rest_api, requests_pending)
 
@@ -278,6 +314,10 @@ class TestAutomationRequestsCommonRESTAPI(object):
 
         Metadata:
             test_flag: rest, requests
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         approve_requests(collection, appliance.rest_api, requests_pending, from_detail)
 
@@ -290,6 +330,10 @@ class TestAutomationRequestsCommonRESTAPI(object):
 
         Metadata:
             test_flag: rest, requests
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         deny_requests(collection, appliance.rest_api, requests_pending, from_detail)
 
@@ -302,6 +346,10 @@ class TestAutomationRequestsCommonRESTAPI(object):
 
         Metadata:
             test_flag: rest, requests
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         edit_requests(collection, appliance.rest_api, requests_pending, from_detail)
 
@@ -310,6 +358,10 @@ class TestAutomationRequestsCommonRESTAPI(object):
 
         Metadata:
             test_flag: rest, requests
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         output = mp.Queue()
         entry_point = appliance.rest_api._entry_point

--- a/cfme/tests/infrastructure/test_rest_templates.py
+++ b/cfme/tests/infrastructure/test_rest_templates.py
@@ -44,6 +44,10 @@ def test_query_template_attributes(request, appliance, provider, soft_assert):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     templates = appliance.rest_api.collections.templates.all
     if templates:
@@ -68,6 +72,10 @@ def test_set_ownership(appliance, template, from_detail):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: nansari
+        initialEstimate: 1/8h
     """
     if "set_ownership" not in appliance.rest_api.collections.templates.action.all:
         pytest.skip("set_ownership action for templates is not implemented in this version")
@@ -98,6 +106,10 @@ def test_delete_template_from_detail_post(template):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     delete_resources_from_detail([template], method='POST')
 
@@ -108,6 +120,10 @@ def test_delete_template_from_detail_delete(template):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     delete_resources_from_detail([template], method='DELETE')
 
@@ -118,5 +134,9 @@ def test_delete_template_from_collection(template):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     delete_resources_from_collection([template])

--- a/cfme/tests/infrastructure/test_scvmm_specific.py
+++ b/cfme/tests/infrastructure/test_scvmm_specific.py
@@ -19,5 +19,10 @@ def testing_vm_without_dvd(provider, small_template):
 @pytest.mark.meta(blockers=[1178961])
 @pytest.mark.provider([SCVMMProvider], scope="module")
 def test_no_dvd_ruins_refresh(provider, testing_vm_without_dvd):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     provider.refresh_provider_relationships()
     testing_vm_without_dvd.wait_to_appear()

--- a/cfme/tests/infrastructure/test_set_default_filter.py
+++ b/cfme/tests/infrastructure/test_set_default_filter.py
@@ -9,7 +9,14 @@ pytestmark = [pytest.mark.tier(3), pytest.mark.usefixtures("virtualcenter_provid
 
 
 def test_set_default_host_filter(request, appliance):
-    """ Test for setting default filter for hosts."""
+    """ Test for setting default filter for hosts.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: low
+        initialEstimate: 1/12h
+    """
     host_collection = appliance.collections.hosts
 
     # Add cleanup finalizer
@@ -29,7 +36,14 @@ def test_set_default_host_filter(request, appliance):
 
 
 def test_clear_host_filter_results(appliance):
-    """ Test for clearing filter results for hosts."""
+    """ Test for clearing filter results for hosts.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: low
+        initialEstimate: 1/30h
+    """
     host_collection = appliance.collections.hosts
 
     # TODO many parts of this test and others in this file need to be replaced with WT calls
@@ -41,7 +55,14 @@ def test_clear_host_filter_results(appliance):
 
 
 def test_clear_datastore_filter_results(appliance):
-    """ Test for clearing filter results for datastores."""
+    """ Test for clearing filter results for datastores.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: low
+        initialEstimate: 1/12h
+    """
     dc = DatastoreCollection(appliance)
     view = navigate_to(dc, 'All')
     view.sidebar.datastores.tree.click_path('All Datastores', 'Global Filters',

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -82,6 +82,12 @@ def test_memory_checkbox(small_test_vm, provider, soft_assert):
 
     Metadata:
         test_flag: power_control
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
     """
     # Make sure the VM is powered on
     small_test_vm.power_control_from_cfme(option=small_test_vm.POWER_ON, cancel=False)
@@ -110,6 +116,11 @@ def test_snapshot_crud(small_test_vm, provider):
 
     Metadata:
         test_flag: snapshot, provision
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        initialEstimate: 1/6h
     """
     # has_name is false if testing RHEVMProvider
     snapshot = new_snapshot(small_test_vm, has_name=(not provider.one_of(RHEVMProvider)))
@@ -126,6 +137,10 @@ def test_create_without_description(small_test_vm):
 
     Metadata:
         test_flag: snapshot, provision
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     snapshot = new_snapshot(small_test_vm, has_name=False, create_description=False)
     with pytest.raises(AssertionError):
@@ -141,6 +156,12 @@ def test_delete_all_snapshots(small_test_vm, provider):
 
     Metadata:
         test_flag: snapshot, provision
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/4h
     """
     snapshot1 = new_snapshot(small_test_vm)
     snapshot1.create()
@@ -232,6 +253,11 @@ def test_verify_revert_snapshot(full_test_vm, provider, soft_assert, register_ev
 
     Metadata:
         test_flag: snapshot, provision
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        initialEstimate: 1/4h
     """
     verify_revert_snapshot(full_test_vm, provider, soft_assert, register_event, request)
 
@@ -243,6 +269,12 @@ def test_revert_active_snapshot(full_test_vm, provider, soft_assert, register_ev
 
     Metadata:
         test_flag: snapshot, provision
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
     """
     verify_revert_snapshot(full_test_vm, provider, soft_assert, register_event, request,
                            active_snapshot=True)
@@ -257,6 +289,10 @@ def test_revert_on_running_vm(small_test_vm):
 
     Metadata:
         test_flag: snapshot, provision
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     snapshot = new_snapshot(small_test_vm, has_name=False)
     snapshot.create()
@@ -292,6 +328,12 @@ def test_verify_vm_state_revert_snapshot(provider, parent_vm, small_test_vm):
      - powered on
      - powered off
      - powered off
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
     """
     power = small_test_vm.POWER_ON if parent_vm.startswith('on') else small_test_vm.POWER_OFF
     memory = 'with_memory' in parent_vm
@@ -309,6 +351,11 @@ def test_operations_suspended_vm(small_test_vm, soft_assert):
 
     Metadata:
         test_flag: snapshot, provision
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        initialEstimate: 1/2h
     """
     # Create first snapshot when VM is running
     snapshot1 = new_snapshot(small_test_vm)
@@ -344,6 +391,12 @@ def test_operations_suspended_vm(small_test_vm, soft_assert):
 @pytest.mark.uncollectif(lambda provider: not provider.one_of(VMwareProvider),
                          'Not VMware provider')
 def test_operations_powered_off_vm(small_test_vm):
+    """
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        initialEstimate: 1/2h
+    """
     # Make sure the VM is off
     small_test_vm.power_control_from_cfme(option=small_test_vm.POWER_OFF, cancel=False)
     small_test_vm.wait_for_vm_state_change(desired_state=small_test_vm.STATE_OFF)
@@ -372,6 +425,12 @@ def test_snapshot_history_btn(small_test_vm, provider):
     """Tests snapshot history button
     Metadata:
         test_flag: snapshot
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/6h
     """
     snapshot = new_snapshot(small_test_vm, has_name=(not provider.one_of(RHEVMProvider)))
     snapshot.create()
@@ -399,6 +458,12 @@ def test_create_snapshot_via_ae(appliance, request, domain, small_test_vm):
         * Run the simulation of the method against the VM, preferably setting
             ``snap_name`` to something that can be checked
         * Wait until snapshot with such name appears.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
     """
     # PREPARE
     file = data_path.join("ui").join("automate").join("test_create_snapshot_via_ae.rb")

--- a/cfme/tests/infrastructure/test_ssa_vddk.py
+++ b/cfme/tests/infrastructure/test_ssa_vddk.py
@@ -87,6 +87,11 @@ def vm(request, provider, small_template, ssa_analysis_profile):
 def test_ssa_vddk(vm, configure_vddk):
     """Check if different version of vddk works with provider
 
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
     """
     vm.smartstate_scan(wait_for_task_result=True)
     view = navigate_to(vm, 'Details')

--- a/cfme/tests/infrastructure/test_system_image_type.py
+++ b/cfme/tests/infrastructure/test_system_image_type.py
@@ -12,6 +12,12 @@ pytestmark = [pytest.mark.tier(3)]
 def test_system_image_type_crud(appliance):
     """
     Tests a System Image Type using CRUD operations.
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: low
+        initialEstimate: 1/10h
     """
     collection = appliance.collections.system_image_types
     sys_image_type = collection.create(
@@ -25,6 +31,10 @@ def test_system_image_type_crud(appliance):
 def test_system_image_duplicate_name_error_validation(appliance):
     """
     Tests a System Image for duplicate name.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     collection = appliance.collections.system_image_types
     name = fauxfactory.gen_alphanumeric(8)
@@ -46,6 +56,10 @@ def test_system_image_duplicate_name_error_validation(appliance):
 def test_name_required_error_validation_system_image(appliance):
     """
     Tests a System Image with no name.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     collection = appliance.collections.system_image_types
     with pytest.raises(Exception, match='Name is required'):
@@ -70,6 +84,10 @@ def test_name_required_error_validation_system_image(appliance):
 def test_system_image_type_selective_delete(appliance):
     """
     Tests System Image Type for delete operation using select option on All page.
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/12h
     """
     collection = appliance.collections.system_image_types
     sys_image_type1 = collection.create(

--- a/cfme/tests/infrastructure/test_tenant_quota.py
+++ b/cfme/tests/infrastructure/test_tenant_quota.py
@@ -139,6 +139,11 @@ def test_tenant_quota_enforce_via_lifecycle_infra(appliance, provider, setup_pro
 
     Metadata:
         test_flag: quota
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: infra
+        initialEstimate: 1/8h
     """
     prov_data.update(custom_prov_data)
     prov_data['catalog']['vm_name'] = vm_name
@@ -180,6 +185,11 @@ def test_tenant_quota_enforce_via_service_infra(request, appliance, provider, se
 
     Metadata:
         test_flag: quota
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: infra
+        initialEstimate: 1/8h
     """
     with appliance.context.use(context):
         service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
@@ -220,6 +230,11 @@ def test_tenant_quota_vm_reconfigure(appliance, provider, setup_provider, set_ro
 
     Metadata:
         test_flag: quota
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: infra
+        initialEstimate: 1/6h
     """
     original_config = small_vm.configuration.copy()
     new_config = small_vm.configuration.copy()
@@ -241,6 +256,12 @@ def test_tenant_quota_vm_reconfigure(appliance, provider, setup_provider, set_ro
 )
 def test_setting_child_quota_more_than_parent(appliance, tenants_setup, parent_quota, child_quota,
                                               flash_text):
+    """
+    Polarion:
+        assignee: ghubale
+        casecomponent: prov
+        initialEstimate: 1/12h
+    """
     test_parent, test_child = tenants_setup
     view = navigate_to(test_parent, 'ManageQuotas')
     view.form.fill({'{}_cb'.format(parent_quota[0]): True,
@@ -286,6 +307,11 @@ def test_vm_migration_after_assigning_tenant_quota(appliance, setup_provider, sm
     3. Migrate VM
     4. Check whether migration is successfully done
 
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: infra
+        initialEstimate: 1/6h
     """
 
     migrate_to = check_hosts(small_vm, provider)

--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -278,6 +278,10 @@ class VMEvent(object):
 def test_infra_timeline_create_event(new_vm, soft_assert):
     """Test that the event create is visible on the management event timeline of the Vm,
     Vm's cluster,  VM's host, VM's provider.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     event = 'create'
     vm_event = VMEvent(new_vm, event)
@@ -292,6 +296,10 @@ def test_infra_timeline_policy_event(new_vm, control_policy, soft_assert):
     """Test that the category Policy Event is properly working on the Timeline of the Vm,
     Vm's cluster,  VM's host, VM's provider. For this purpose, there is need to create a policy
     profile, assign it to the VM and stopping it which triggers the policy.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     event = 'policy'
@@ -305,6 +313,10 @@ def test_infra_timeline_policy_event(new_vm, control_policy, soft_assert):
 def test_infra_timeline_stop_event(new_vm, soft_assert):
     """Test that the event Stop is visible on the  management event timeline of the Vm,
     Vm's cluster,  VM's host, VM's provider.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     event = 'stop'
     targets = (new_vm, new_vm.cluster, new_vm.host, new_vm.provider)
@@ -317,6 +329,10 @@ def test_infra_timeline_stop_event(new_vm, soft_assert):
 def test_infra_timeline_start_event(new_vm, soft_assert):
     """Test that the event start is visible on the  management event timeline of the Vm,
     Vm's cluster,  VM's host, VM's provider.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     event = 'start'
     targets = (new_vm, new_vm.host, new_vm.cluster, new_vm.provider)
@@ -329,6 +345,10 @@ def test_infra_timeline_start_event(new_vm, soft_assert):
 def test_infra_timeline_suspend_event(new_vm, soft_assert):
     """Test that the event suspend is visible on the  management event timeline of the Vm,
     Vm's cluster,  VM's host, VM's provider. The VM needs to be set before as management engine.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     event = 'suspend'
     targets = (new_vm, new_vm.cluster, new_vm.host, new_vm.provider)
@@ -341,6 +361,10 @@ def test_infra_timeline_suspend_event(new_vm, soft_assert):
 def test_infra_timeline_diagnostic(new_vm, soft_assert, mark_vm_as_appliance):
     """Test that the event create is visible on the appliance timeline ( EVM/configuration/Server/
     diagnostic/Timelines.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     event = 'create'
     targets = (new_vm.appliance.server,)
@@ -352,6 +376,10 @@ def test_infra_timeline_diagnostic(new_vm, soft_assert, mark_vm_as_appliance):
 def test_infra_timeline_clone_event(new_vm, soft_assert):
     """Test that the event clone is visible on the  management event timeline of the Vm,
     Vm's cluster,  VM's host, VM's provider.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     event = 'clone'
     vm_event = VMEvent(new_vm, event)
@@ -364,6 +392,10 @@ def test_infra_timeline_clone_event(new_vm, soft_assert):
 def test_infra_timeline_migrate_event(new_vm, soft_assert):
     """Test that the event migrate is visible on the  management event timeline of the Vm,
     Vm's cluster,  VM's host, VM's provider.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     event = 'migrate'
     vm_event = VMEvent(new_vm, event)
@@ -378,6 +410,10 @@ def test_infra_timeline_rename_event(new_vm, soft_assert):
     """Test that the event rename is visible on the  management event timeline of the Vm,
     Vm's cluster,  VM's host, VM's provider.
     Action "rename" does not exist on RHV, thats why it is excluded.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     event = 'rename'
     vm_event = VMEvent(new_vm, event)
@@ -392,6 +428,10 @@ def test_infra_timeline_rename_event(new_vm, soft_assert):
 def test_infra_timeline_delete_event(new_vm, soft_assert):
     """Test that the event delete is visible on the  management event timeline of the Vm,
     Vm's cluster,  VM's host, VM's provider.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     event = 'delete'
     vm_event = VMEvent(new_vm, event)

--- a/cfme/tests/infrastructure/test_vm_clone.py
+++ b/cfme/tests/infrastructure/test_vm_clone.py
@@ -41,6 +41,11 @@ def create_vm(appliance, provider, request):
 
 @pytest.mark.uncollectif(lambda provider: not provider.one_of(VMwareProvider))
 def test_vm_clone(appliance, provider, clone_vm_name, create_vm):
+    """
+    Polarion:
+        assignee: jhenner
+        initialEstimate: 1/6h
+    """
     provision_type = 'VMware'
     create_vm.clone_vm("email@xyz.com", "first", "last", clone_vm_name, provision_type)
     request_description = clone_vm_name
@@ -54,7 +59,12 @@ def test_vm_clone(appliance, provider, clone_vm_name, create_vm):
 @pytest.mark.rhv3
 @pytest.mark.uncollectif(lambda provider: provider.one_of(VMwareProvider))
 def test_vm_clone_neg(provider, clone_vm_name, create_vm):
-    """Tests that we can't clone non-VMware VM"""
+    """Tests that we can't clone non-VMware VM
+
+    Polarion:
+        assignee: jhenner
+        initialEstimate: 1/6h
+    """
     provision_type = 'VMware'
     with pytest.raises(DropdownItemNotFound):
             create_vm.clone_vm("email@xyz.com", "first", "last", clone_vm_name, provision_type)

--- a/cfme/tests/infrastructure/test_vm_migrate.py
+++ b/cfme/tests/infrastructure/test_vm_migrate.py
@@ -43,6 +43,10 @@ def test_vm_migrate(appliance, new_vm, provider):
 
     Metadata:
         test_flag: migrate, provision
+
+    Polarion:
+        assignee: rpfannsc
+        initialEstimate: 1/4h
     """
     # auto_test_services should exist to test migrate VM
     view = navigate_to(new_vm, 'Details')

--- a/cfme/tests/infrastructure/test_vm_ownership.py
+++ b/cfme/tests/infrastructure/test_vm_ownership.py
@@ -30,6 +30,10 @@ class TestVmOwnershipRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/3h
         """
         if "set_ownership" not in appliance.rest_api.collections.services.action.all:
             pytest.skip("Set owner action for service is not implemented in this version")
@@ -50,6 +54,10 @@ class TestVmOwnershipRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/3h
         """
         rest_vm = appliance.rest_api.collections.vms.get(name=vm)
         group = appliance.rest_api.collections.groups.get(
@@ -79,6 +87,10 @@ class TestVmOwnershipRESTAPI(object):
             * Assert it has the attribute ``evm_owner`` as we set it.
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/3h
         """
         rest_vm = appliance.rest_api.collections.vms.get(name=vm)
         if from_detail:
@@ -118,6 +130,10 @@ def test_rename_vm(small_vm):
     4. Click on Configuration > Rename this VM > Enter new name
     5. Click on submit
     6. Check whether VM is renamed or not
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     view = navigate_to(small_vm, 'Details')
     vm_name = small_vm.name

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -155,6 +155,10 @@ class TestControlOnQuadicons(object):
 
         Metadata:
             test_flag: power_control, provision
+
+        Polarion:
+            assignee: bsquizza
+            initialEstimate: 1/10h
         """
         testing_vm.wait_for_vm_state_change(desired_state=testing_vm.STATE_ON, timeout=720)
         testing_vm.power_control_from_cfme(option=testing_vm.POWER_OFF, cancel=True)
@@ -172,6 +176,10 @@ class TestControlOnQuadicons(object):
 
         Metadata:
             test_flag: power_control, provision
+
+        Polarion:
+            assignee: ghubale
+            initialEstimate: 1/6h
         """
         testing_vm.wait_for_vm_state_change(desired_state=testing_vm.STATE_ON, timeout=720)
         testing_vm.power_control_from_cfme(option=testing_vm.POWER_OFF, cancel=False)
@@ -191,6 +199,10 @@ class TestControlOnQuadicons(object):
 
         Metadata:
             test_flag: power_control, provision
+
+        Polarion:
+            assignee: ghubale
+            initialEstimate: 1/4h
         """
         testing_vm.wait_for_vm_state_change(desired_state=testing_vm.STATE_OFF, timeout=720)
         testing_vm.power_control_from_cfme(option=testing_vm.POWER_ON, cancel=True)
@@ -207,6 +219,10 @@ class TestControlOnQuadicons(object):
 
         Metadata:
             test_flag: power_control, provision
+
+        Polarion:
+            assignee: ghubale
+            initialEstimate: 1/6h
         """
         testing_vm.wait_for_vm_state_change(desired_state=testing_vm.STATE_OFF, timeout=720)
         testing_vm.power_control_from_cfme(option=testing_vm.POWER_ON, cancel=False)
@@ -229,6 +245,10 @@ class TestVmDetailsPowerControlPerProvider(object):
 
         Metadata:
             test_flag: power_control, provision
+
+        Polarion:
+            assignee: ghubale
+            initialEstimate: 1/6h
         """
         testing_vm.wait_for_vm_state_change(
             desired_state=testing_vm.STATE_ON, timeout=720, from_details=True)
@@ -256,6 +276,10 @@ class TestVmDetailsPowerControlPerProvider(object):
 
         Metadata:
             test_flag: power_control, provision
+
+        Polarion:
+            assignee: ghubale
+            initialEstimate: 1/6h
         """
         testing_vm.wait_for_vm_state_change(
             desired_state=testing_vm.STATE_OFF, timeout=720, from_details=True)
@@ -276,6 +300,10 @@ class TestVmDetailsPowerControlPerProvider(object):
 
         Metadata:
             test_flag: power_control, provision
+
+        Polarion:
+            assignee: ghubale
+            initialEstimate: 1/6h
         """
         testing_vm.wait_for_vm_state_change(
             desired_state=testing_vm.STATE_ON, timeout=720, from_details=True)
@@ -310,6 +338,10 @@ class TestVmDetailsPowerControlPerProvider(object):
 
         Metadata:
             test_flag: power_control, provision
+
+        Polarion:
+            assignee: ghubale
+            initialEstimate: 1/6h
         """
         try:
             testing_vm.provider.refresh_provider_relationships()
@@ -352,6 +384,10 @@ def test_no_template_power_control(provider, soft_assert):
 
     Metadata:
         test_flag: power_control
+
+    Polarion:
+        assignee: bsquizza
+        initialEstimate: 1/10h
     """
     view = navigate_to(provider, 'ProviderTemplates')
     view.toolbar.view_selector.select('Grid View')
@@ -395,6 +431,10 @@ def test_no_power_controls_on_archived_vm(testing_vm, archived_vm, soft_assert):
         * Verify the Power toolbar button is not visible
     Metadata:
         test_flag: power_control
+
+    Polarion:
+        assignee: bsquizza
+        initialEstimate: 1/10h
     """
     view = navigate_to(testing_vm, 'AnyProviderDetails', use_resetter=False)
     soft_assert(not view.toolbar.power.is_displayed, "Power displayed in archived VM's details!")
@@ -410,6 +450,10 @@ def test_archived_vm_status(testing_vm, archived_vm):
 
     Metadata:
         test_flag: inventory
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/10h
     """
     vm_state = testing_vm.find_quadicon(from_any_provider=True).data['state']
     assert (vm_state == 'archived')
@@ -421,6 +465,10 @@ def test_orphaned_vm_status(testing_vm, orphaned_vm):
 
     Metadata:
         test_flag: inventory
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/10h
     """
     vm_state = testing_vm.find_quadicon(from_any_provider=True).data['state']
     assert (vm_state == 'orphaned')
@@ -432,6 +480,10 @@ def test_vm_power_options_from_on(provider, soft_assert, testing_vm, ensure_vm_r
 
     Metadata:
         test_flag: power_control
+
+    Polarion:
+        assignee: bsquizza
+        initialEstimate: None
     """
     testing_vm.wait_for_vm_state_change(
         desired_state=testing_vm.STATE_ON, timeout=720, from_details=True)
@@ -444,6 +496,10 @@ def test_vm_power_options_from_off(provider, soft_assert, testing_vm, ensure_vm_
 
     Metadata:
         test_flag: power_control
+
+    Polarion:
+        assignee: bsquizza
+        initialEstimate: None
     """
     testing_vm.wait_for_vm_state_change(
         desired_state=testing_vm.STATE_OFF, timeout=720, from_details=True)
@@ -458,6 +514,10 @@ def test_guest_os_reset(appliance, testing_vm_tools, ensure_vm_running, soft_ass
 
     Metadata:
         test_flag: power_control
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/6h
     """
     wait_for_vm_tools(testing_vm_tools)
     view = navigate_to(testing_vm_tools, "Details")
@@ -484,6 +544,10 @@ def test_guest_os_shutdown(appliance, testing_vm_tools, ensure_vm_running, soft_
 
     Metadata:
         test_flag: power_control
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/6h
     """
     testing_vm_tools.wait_for_vm_state_change(
         desired_state=testing_vm_tools.STATE_ON, timeout=720, from_details=True)

--- a/cfme/tests/infrastructure/test_vm_reconfigure.py
+++ b/cfme/tests/infrastructure/test_vm_reconfigure.py
@@ -87,6 +87,12 @@ def ensure_vm_running(small_vm):
 @pytest.mark.meta(blockers=[BZ(1632782, forced_streams=['5.10'])])
 @pytest.mark.parametrize('change_type', ['cores_per_socket', 'sockets', 'memory'])
 def test_vm_reconfig_add_remove_hw_cold(provider, small_vm, ensure_vm_stopped, change_type):
+    """
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: 1/3h
+    """
     orig_config = small_vm.configuration.copy()
     new_config = prepare_new_config(orig_config, change_type)
 
@@ -109,6 +115,12 @@ def test_vm_reconfig_add_remove_hw_cold(provider, small_vm, ensure_vm_stopped, c
 def test_vm_reconfig_add_remove_disk_cold(
         provider, small_vm, ensure_vm_stopped, disk_type, disk_mode):
 
+    """
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: 1/3h
+    """
     orig_config = small_vm.configuration.copy()
     new_config = orig_config.copy()
     new_config.add_disk(
@@ -141,7 +153,13 @@ def test_vm_reconfig_add_remove_disk_cold(
 @pytest.mark.rhv3
 @pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:6996')])
 def test_reconfig_vm_negative_cancel(provider, small_vm, ensure_vm_stopped):
-    """ Cancel reconfiguration changes """
+    """ Cancel reconfiguration changes
+
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: None
+    """
     config_vm = small_vm.configuration.copy()
 
     # Some changes in vm reconfigure before cancel
@@ -161,7 +179,12 @@ def test_reconfig_vm_negative_cancel(provider, small_vm, ensure_vm_stopped):
 @pytest.mark.meta(blockers=[BZ(1632782, forced_streams=['5.10'])])
 def test_vm_reconfig_add_remove_hw_hot(provider, small_vm, ensure_vm_running, change_type):
     """Change number of CPU sockets and amount of memory while VM is runnng.
-        Chaning number of cores per socket on running VM is not supported by RHV."""
+        Chaning number of cores per socket on running VM is not supported by RHV.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     orig_config = small_vm.configuration.copy()
     new_config = prepare_new_config(orig_config, change_type)
 

--- a/cfme/tests/infrastructure/test_vm_rest.py
+++ b/cfme/tests/infrastructure/test_vm_rest.py
@@ -34,6 +34,10 @@ def test_query_vm_attributes(vm, soft_assert):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     outcome = query_resource_attributes(vm)
     for failure in outcome.failed:
@@ -54,6 +58,10 @@ def test_vm_scan(appliance, vm, from_detail):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/3h
     """
     if from_detail:
         response = vm.action.scan()
@@ -80,6 +88,10 @@ def test_edit_vm(request, vm, appliance, from_detail):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     request.addfinalizer(vm.action.delete)
     new_description = 'Test REST VM {}'.format(fauxfactory.gen_alphanumeric(5))
@@ -106,9 +118,19 @@ def test_edit_vm(request, vm, appliance, from_detail):
 @pytest.mark.tier(3)
 @pytest.mark.parametrize('method', ['post', 'delete'], ids=['POST', 'DELETE'])
 def test_delete_vm_from_detail(vm, method):
+    """
+    Polarion:
+        assignee: mkourim
+        initialEstimate: 1/4h
+    """
     delete_resources_from_detail([vm], method=method, num_sec=300, delay=10)
 
 
 @pytest.mark.tier(3)
 def test_delete_vm_from_collection(vm):
+    """
+    Polarion:
+        assignee: mkourim
+        initialEstimate: 1/4h
+    """
     delete_resources_from_collection([vm], not_found=True, num_sec=300, delay=10)

--- a/cfme/tests/infrastructure/test_vm_retirement_rest.py
+++ b/cfme/tests/infrastructure/test_vm_retirement_rest.py
@@ -42,6 +42,10 @@ def test_retire_vm_now(appliance, vm, from_collection):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/3h
     """
     retire_vm = appliance.rest_api.collections.vms.get(name=vm)
     if from_collection:
@@ -83,6 +87,10 @@ def test_retire_vm_future(appliance, vm, from_collection):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/3h
     """
     retire_vm = appliance.rest_api.collections.vms.get(name=vm)
     date = (datetime.datetime.now() + datetime.timedelta(days=5)).strftime("%Y/%m/%d")

--- a/cfme/tests/infrastructure/test_webmks_console.py
+++ b/cfme/tests/infrastructure/test_webmks_console.py
@@ -64,6 +64,12 @@ def test_webmks_vm_console(request, appliance, provider, vm_obj, configure_webso
         - A command that creates a file will be sent through the console.
         - Using ssh we will check that the command worked (i.e. that the file
           was created.)
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/4h
     """
     console_vm_username = credentials[provider.data.templates.get('console_template')
                             ['creds']].get('username')

--- a/cfme/tests/integration/test_aws_iam_auth_and_roles.py
+++ b/cfme/tests/integration/test_aws_iam_auth_and_roles.py
@@ -53,6 +53,12 @@ def test_group_roles(appliance, setup_aws_auth_provider, group_name, role_access
     AWS IAM groups
 
     NOTE: Only tests vertical navigation tree at the moment, not accordions within the page
+
+    Polarion:
+        assignee: apagac
+        caseimportance: medium
+        initialEstimate: 1/4h
+        tags: rbac
     """
     group_access = role_access[group_name]
 

--- a/cfme/tests/integration/test_cfme_auth.py
+++ b/cfme/tests/integration/test_cfme_auth.py
@@ -121,6 +121,10 @@ def test_login_evm_group(appliance, auth_user, user_obj, soft_assert):
             * ``auth_data.yaml`` file
             * auth provider configured with user as a member of a group matching default EVM group
         Test will configure auth and login
+
+    Polarion:
+        assignee: mpusater
+        initialEstimate: None
     """
     # get a list of groups for the user that match evm default group names
     # Replace spaces with dashes in UPN type usernames for login compatibility
@@ -181,6 +185,10 @@ def test_login_retrieve_group(appliance, request, auth_mode, auth_provider, soft
         Steps:
             * Make sure corresponding auth_modes data is updated to ``auth_data.yaml``
             * this test fetches the auth_modes from yaml and generates tests per auth_mode.
+
+    Polarion:
+        assignee: mpusater
+        initialEstimate: None
     """
     # get a list of (user_obj, groupname) tuples, creating the user object inline
     # filtering on those that do NOT evmgroup in groupname
@@ -257,6 +265,10 @@ def test_login_local_group(appliance, local_user, local_group, soft_assert):
     Test remote authentication with a locally created group.
     Group is NOT retrieved from or matched to those on authentication provider
 
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     # modify auth settings to not get groups
     appliance.server.authentication.auth_settings = {'auth_settings': {'get_groups': False}}
@@ -279,7 +291,12 @@ def test_login_local_group(appliance, local_user, local_group, soft_assert):
                          reason='User does not have multiple groups')
 def test_user_group_switching(appliance, auth_user, auth_mode, auth_provider, soft_assert, request,
                               user_obj):
-    """Test switching groups on a single user, between retreived group and built-in group"""
+    """Test switching groups on a single user, between retreived group and built-in group
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     retrieved_groups = []
     for group in auth_user.groups:
         # pick non-evm group when there are multiple groups for the user

--- a/cfme/tests/integration/test_ldap_auth_and_roles.py
+++ b/cfme/tests/integration/test_ldap_auth_and_roles.py
@@ -16,6 +16,12 @@ def test_group_roles(
     Validates expected menu and submenu names are present for default
     LDAP group roles
 
+
+    Polarion:
+        assignee: apagac
+        caseimportance: medium
+        initialEstimate: 1/4h
+        tags: rbac
     """
     request.addfinalizer(appliance.server.login_admin)
 

--- a/cfme/tests/intelligence/chargeback/test_chargeback_long_term_rates.py
+++ b/cfme/tests/intelligence/chargeback/test_chargeback_long_term_rates.py
@@ -387,6 +387,10 @@ def test_validate_cpu_usage_cost(chargeback_costs_custom, chargeback_report_cust
     """Test to validate CPU usage cost reported in chargeback reports.
     The cost reported in the Chargeback report should be approximately equal to the
     cost estimated in the chargeback_costs_custom fixture.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     if not chargeback_report_custom[0]["CPU Used Cost"]:
         pytest.skip('missing column in report')
@@ -405,6 +409,10 @@ def test_validate_memory_usage_cost(chargeback_costs_custom, chargeback_report_c
     """Test to validate memory usage cost reported in chargeback reports.
     The cost reported in the Chargeback report should be approximately equal to the
     cost estimated in the chargeback_costs_custom fixture.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     if not chargeback_report_custom[0]["Memory Used Cost"]:
         pytest.skip('missing column in report')
@@ -423,6 +431,10 @@ def test_validate_network_usage_cost(chargeback_costs_custom, chargeback_report_
     """Test to validate network usage cost reported in chargeback reports.
     The cost reported in the Chargeback report should be approximately equal to the
     cost estimated in the chargeback_costs_custom fixture.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     if not chargeback_report_custom[0]["Network I/O Used Cost"]:
         pytest.skip('missing column in report')
@@ -441,6 +453,10 @@ def test_validate_disk_usage_cost(chargeback_costs_custom, chargeback_report_cus
     """Test to validate disk usage cost reported in chargeback reports.
     The cost reported in the Chargeback report should be approximately equal to the
     cost estimated in the chargeback_costs_custom fixture.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     if not chargeback_report_custom[0]["Disk I/O Used Cost"]:
         pytest.skip('missing column in report')
@@ -458,6 +474,10 @@ def test_validate_storage_usage_cost(chargeback_costs_custom, chargeback_report_
     """Test to validate storage usage cost reported in chargeback reports.
     The cost reported in the Chargeback report should be approximately equal to the
     cost estimated in the chargeback_costs_custom fixture.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     if not chargeback_report_custom[0]["Storage Used Cost"]:
         pytest.skip('missing column in report')

--- a/cfme/tests/intelligence/chargeback/test_resource_allocation.py
+++ b/cfme/tests/intelligence/chargeback/test_resource_allocation.py
@@ -439,39 +439,69 @@ def generic_test_resource_alloc(resource_alloc, chargeback_report_custom, column
 
 
 def test_verify_alloc_memory(resource_alloc, chargeback_report_custom, soft_assert):
-    """Test to verify memory allocation"""
+    """Test to verify memory allocation
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     generic_test_resource_alloc(resource_alloc, chargeback_report_custom,
         'Memory Allocated over Time Period', 'memory_alloc', soft_assert)
 
 
 def test_verify_alloc_cpu(resource_alloc, chargeback_report_custom, soft_assert):
-    """Test to verify cpu allocation"""
+    """Test to verify cpu allocation
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     generic_test_resource_alloc(resource_alloc, chargeback_report_custom,
         'vCPUs Allocated over Time Period', 'vcpu_alloc', soft_assert)
 
 
 def test_verify_alloc_storage(resource_alloc, chargeback_report_custom, soft_assert):
-    """Test to verify storage allocation"""
+    """Test to verify storage allocation
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     generic_test_resource_alloc(resource_alloc, chargeback_report_custom,
         'Storage Allocated', 'storage_alloc', soft_assert)
 
 
 def test_validate_alloc_memory_cost(chargeback_costs_custom, chargeback_report_custom,
         soft_assert):
-    """Test to validate cost for memory allocation"""
+    """Test to validate cost for memory allocation
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     generic_test_chargeback_cost(chargeback_costs_custom, chargeback_report_custom,
         'Memory Allocated Cost', 'memory_alloc_cost', soft_assert)
 
 
 def test_validate_alloc_vcpu_cost(chargeback_costs_custom, chargeback_report_custom,
         soft_assert):
-    """Test to validate cost for vCPU allocation"""
+    """Test to validate cost for vCPU allocation
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     generic_test_chargeback_cost(chargeback_costs_custom, chargeback_report_custom,
         'vCPUs Allocated Cost', 'vcpu_alloc_cost', soft_assert)
 
 
 def test_validate_alloc_storage_cost(chargeback_costs_custom, chargeback_report_custom,
         soft_assert):
-    """Test to validate cost for storage allocation"""
+    """Test to validate cost for storage allocation
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     generic_test_chargeback_cost(chargeback_costs_custom, chargeback_report_custom,
         'Storage Allocated Cost', 'storage_alloc_cost', soft_assert)

--- a/cfme/tests/intelligence/reports/test_canned_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_canned_corresponds.py
@@ -33,6 +33,11 @@ def test_providers_summary(appliance, soft_assert):
 
     Metadata:
         test_flag: inventory
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        initialEstimate: 1/6h
     """
     report = appliance.collections.reports.instantiate(
         type="Configuration Management",
@@ -69,6 +74,11 @@ def test_cluster_relationships(appliance, soft_assert):
 
     Metadata:
         test_flag: inventory
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        initialEstimate: 1/6h
     """
 
     report = appliance.collections.reports.instantiate(
@@ -126,6 +136,11 @@ def test_operations_vm_on(soft_assert, appliance, request):
 
     Metadata:
         test_flag: report
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        initialEstimate: 1/6h
     """
 
     adb = appliance.db.client
@@ -178,6 +193,11 @@ def test_datastores_summary(soft_assert, appliance, request):
 
     Metadata:
         test_flag: inventory
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        initialEstimate: 1/6h
     """
     adb = appliance.db.client
     storages = adb['storages']

--- a/cfme/tests/intelligence/reports/test_crud.py
+++ b/cfme/tests/intelligence/reports/test_crud.py
@@ -63,6 +63,12 @@ def get_custom_report(appliance, custom_report_values):
 @pytest.mark.meta(blockers=[BZ(1531600, forced_streams=["5.9"])])
 @test_requirements.report
 def test_custom_report_crud(custom_report_values, appliance):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        initialEstimate: 1/16h
+    """
     custom_report = appliance.collections.reports.create(**custom_report_values)
     with update(custom_report):
         custom_report.title += fauxfactory.gen_alphanumeric()
@@ -77,6 +83,12 @@ def test_custom_report_crud(custom_report_values, appliance):
 @pytest.mark.meta(blockers=[1202412])
 @test_requirements.report
 def test_schedule_crud(schedule_data, appliance):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        initialEstimate: 1/16h
+    """
     schedule = appliance.collections.schedules.create(**schedule_data)
     with update(schedule):
         schedule.description = "badger badger badger"
@@ -89,6 +101,12 @@ def test_schedule_crud(schedule_data, appliance):
 @pytest.mark.tier(3)
 @test_requirements.report
 def test_reports_disable_enable_schedule(schedule_data, appliance):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        initialEstimate: None
+    """
     schedules = appliance.collections.schedules
     schedule = schedules.create(**schedule_data)
     schedules.disable_schedules(schedule)
@@ -101,6 +119,12 @@ def test_reports_disable_enable_schedule(schedule_data, appliance):
 @pytest.mark.sauce
 @pytest.mark.tier(3)
 def test_menuwidget_crud(appliance):
+    """
+    Polarion:
+        assignee: jhenner
+        casecomponent: report
+        initialEstimate: 1/12h
+    """
     w = appliance.collections.dashboard_report_widgets.create(
         appliance.collections.dashboard_report_widgets.MENU,
         fauxfactory.gen_alphanumeric(),
@@ -122,6 +146,12 @@ def test_menuwidget_crud(appliance):
 @pytest.mark.sauce
 @pytest.mark.tier(3)
 def test_reportwidget_crud(appliance):
+    """
+    Polarion:
+        assignee: jhenner
+        casecomponent: report
+        initialEstimate: 1/12h
+    """
     w = appliance.collections.dashboard_report_widgets.create(
         appliance.collections.dashboard_report_widgets.REPORT,
         fauxfactory.gen_alphanumeric(),
@@ -143,6 +173,12 @@ def test_reportwidget_crud(appliance):
 @pytest.mark.sauce
 @pytest.mark.tier(3)
 def test_chartwidget_crud(appliance):
+    """
+    Polarion:
+        assignee: jhenner
+        casecomponent: report
+        initialEstimate: 1/12h
+    """
     w = appliance.collections.dashboard_report_widgets.create(
         appliance.collections.dashboard_report_widgets.CHART,
         fauxfactory.gen_alphanumeric(),
@@ -162,6 +198,12 @@ def test_chartwidget_crud(appliance):
 @pytest.mark.sauce
 @pytest.mark.tier(3)
 def test_rssfeedwidget_crud(appliance):
+    """
+    Polarion:
+        assignee: jhenner
+        casecomponent: report
+        initialEstimate: 1/12h
+    """
     w = appliance.collections.dashboard_report_widgets.create(
         appliance.collections.dashboard_report_widgets.RSS,
         fauxfactory.gen_alphanumeric(),
@@ -192,6 +234,12 @@ def test_rssfeedwidget_crud(appliance):
 @pytest.mark.sauce
 @pytest.mark.tier(3)
 def test_dashboard_crud(appliance):
+    """
+    Polarion:
+        assignee: jhenner
+        casecomponent: report
+        initialEstimate: 1/12h
+    """
     d = appliance.collections.report_dashboards.create(
         fauxfactory.gen_alphanumeric(),
         "EvmGroup-administrator",
@@ -211,6 +259,13 @@ def test_dashboard_crud(appliance):
 @pytest.mark.tier(2)
 @test_requirements.report
 def test_run_report(appliance):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/16h
+    """
     report = appliance.rest_api.collections.reports.get(name='VM Disk Usage')
     response = report.action.run()
     assert_response(appliance)
@@ -229,6 +284,13 @@ def test_run_report(appliance):
 @pytest.mark.tier(3)
 @test_requirements.report
 def test_import_report(appliance):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/16h
+    """
     menu_name = 'test_report_{}'.format(fauxfactory.gen_alphanumeric())
     data = {
         'report': {
@@ -257,6 +319,11 @@ def test_import_report(appliance):
 @pytest.mark.tier(3)
 def test_reports_delete_saved_report(appliance, request):
     """The test case selects reports from the Saved Reports list and deletes them.
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        initialEstimate: 1/16h
     """
     report = appliance.collections.reports.instantiate(
         type="Configuration Management",
@@ -273,7 +340,14 @@ def test_reports_delete_saved_report(appliance, request):
     assert not report.exists
 
 
+@pytest.mark.tier(1)
 def test_reports_crud_schedule_for_base_report_once(appliance, request):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        initialEstimate: None
+    """
     report = appliance.collections.reports.instantiate(
         type="Configuration Management",
         subtype="Virtual Machines",
@@ -301,6 +375,10 @@ def test_crud_custom_report_schedule(
 ):
     """This test case creates a schedule for custom reports and tests if it was created
     successfully.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     schedule_data["filter"] = (
         "My Company (All Groups)",

--- a/cfme/tests/intelligence/reports/test_generate_report.py
+++ b/cfme/tests/intelligence/reports/test_generate_report.py
@@ -44,6 +44,11 @@ def test_reports_generate_report(request, path, appliance):
     Steps:
         *Run one default report
         *Delete this Saved Report from the Database
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        initialEstimate: 1/16h
     """
     report = appliance.collections.reports.instantiate(
         type=path[0],

--- a/cfme/tests/intelligence/reports/test_menus.py
+++ b/cfme/tests/intelligence/reports/test_menus.py
@@ -53,6 +53,12 @@ def custom_report_values(request):
 @pytest.mark.meta(blockers=[BZ(1541324, forced_streams=["5.9"])])
 @pytest.mark.parametrize("group", GROUPS)
 def test_shuffle_top_level(appliance, group, report_menus):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        initialEstimate: 1/6h
+    """
     # Shuffle the order
     with report_menus.manage_folder(group) as folder:
         order = shuffle(folder.fields)
@@ -70,6 +76,13 @@ def test_shuffle_top_level(appliance, group, report_menus):
 @pytest.mark.meta(blockers=[BZ(1541324, forced_streams=["5.9"])])
 @pytest.mark.parametrize("group", GROUPS)
 def test_shuffle_first_level(appliance, group, report_menus):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/3h
+    """
     # Find a folder
     view = navigate_to(appliance.collections.reports, "All")
     tree = view.reports.tree.read_contents()[1]
@@ -95,7 +108,13 @@ def test_shuffle_first_level(appliance, group, report_menus):
 @test_requirements.report
 def test_add_reports_to_available_reports_menu(appliance, request, group,
                                                report_menus, custom_report_values):
-    """This test case moves custom menu to existing menus"""
+    """This test case moves custom menu to existing menus
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        initialEstimate: None
+    """
 
     custom_report = appliance.collections.reports.create(**custom_report_values)
     request.addfinalizer(custom_report.delete)

--- a/cfme/tests/intelligence/reports/test_metering_report.py
+++ b/cfme/tests/intelligence/reports/test_metering_report.py
@@ -277,7 +277,13 @@ def metering_report(appliance, vm_ownership, provider):
 # usage estimated in the resource_usage fixture, therefore a small deviation is fine.
 @pytest.mark.uncollectif(lambda provider: provider.one_of(CloudProvider))
 def test_validate_cpu_usage(resource_usage, metering_report):
-    """Test to validate CPU usage.This metric is not collected for cloud providers."""
+    """Test to validate CPU usage.This metric is not collected for cloud providers.
+
+    Polarion:
+        assignee: nachandr
+        caseimportance: medium
+        initialEstimate: None
+    """
     for groups in metering_report:
         if groups["CPU Used"]:
             estimated_cpu_usage = resource_usage['cpu_used']
@@ -293,7 +299,12 @@ def test_validate_cpu_usage(resource_usage, metering_report):
 @pytest.mark.uncollectif(
     lambda provider: provider.one_of(EC2Provider, GCEProvider))
 def test_validate_memory_usage(resource_usage, metering_report):
-    """Test to validate memory usage.This metric is not collected for GCE, EC2."""
+    """Test to validate memory usage.This metric is not collected for GCE, EC2.
+
+    Polarion:
+        assignee: tpapaioa
+        initialEstimate: None
+    """
     for groups in metering_report:
         if groups["Memory Used"]:
             estimated_memory_usage = resource_usage['memory_used']
@@ -307,7 +318,13 @@ def test_validate_memory_usage(resource_usage, metering_report):
 
 
 def test_validate_network_usage(resource_usage, metering_report):
-    """Test to validate network usage."""
+    """Test to validate network usage.
+
+    Polarion:
+        assignee: nachandr
+        caseimportance: medium
+        initialEstimate: None
+    """
     for groups in metering_report:
         if groups["Network I/O Used"]:
             estimated_network_usage = resource_usage['network_io']
@@ -320,7 +337,12 @@ def test_validate_network_usage(resource_usage, metering_report):
 
 
 def test_validate_disk_usage(resource_usage, metering_report):
-    """Test to validate disk usage."""
+    """Test to validate disk usage.
+
+    Polarion:
+        assignee: tpapaioa
+        initialEstimate: None
+    """
     for groups in metering_report:
         if groups["Disk I/O Used"]:
             estimated_disk_usage = resource_usage['disk_io_used']
@@ -332,7 +354,12 @@ def test_validate_disk_usage(resource_usage, metering_report):
 
 
 def test_validate_storage_usage(resource_usage, metering_report):
-    """Test to validate storage usage."""
+    """Test to validate storage usage.
+
+    Polarion:
+        assignee: tpapaioa
+        initialEstimate: None
+    """
     for groups in metering_report:
         if groups["Storage Used"]:
             estimated_storage_usage = resource_usage['storage_used']

--- a/cfme/tests/intelligence/reports/test_report_chargeback.py
+++ b/cfme/tests/intelligence/reports/test_report_chargeback.py
@@ -26,6 +26,12 @@ def _cleanup_report(report):
 def test_charge_report_filter_owner(appliance, infra_provider, request):
     """Tests creation of chargeback report that is filtered by owner
 
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: low
+        initialEstimate: 1/12h
     """
 
     report = appliance.collections.reports.create(
@@ -58,6 +64,12 @@ def test_charge_report_filter_owner(appliance, infra_provider, request):
 def test_charge_report_filter_tag(appliance, infra_provider, request):
     """Tests creation of chargeback report that is filtered by tag
 
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: low
+        initialEstimate: 1/12h
     """
 
     report = appliance.collections.reports.create(

--- a/cfme/tests/intelligence/reports/test_report_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_report_corresponds.py
@@ -37,6 +37,13 @@ def report_vms(appliance, infra_provider):
 @pytest.mark.meta(blockers=[BZ(1531600, forced_streams=['5.9'])])
 @test_requirements.report
 def test_custom_vm_report(soft_assert, report_vms):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: low
+        initialEstimate: 1/16h
+    """
     cluster = "Cluster / Deployment Role Name"
     host = "Host / Node Name"
     for row in report_vms:

--- a/cfme/tests/intelligence/reports/test_reports_schedules.py
+++ b/cfme/tests/intelligence/reports/test_reports_schedules.py
@@ -38,7 +38,13 @@ def schedule(schedule_data, appliance):
 @pytest.mark.tier(3)
 @test_requirements.report
 def test_schedule_queue(schedule, appliance):
-    """ To test scheduling of report using options: Once, Hourly, Daily, Weekly, Monthly """
+    """ To test scheduling of report using options: Once, Hourly, Daily, Weekly, Monthly
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        initialEstimate: None
+    """
 
     schedule.queue()
     view = schedule.create_view(ScheduleDetailsView)

--- a/cfme/tests/intelligence/reports/test_tenant_quota_reports.py
+++ b/cfme/tests/intelligence/reports/test_tenant_quota_reports.py
@@ -47,6 +47,10 @@ def set_and_get_tenant_quota(appliance):
 def test_queue_tenant_quota_reports(appliance, request, set_and_get_tenant_quota):
     """This test case sets the tenant quota, generates a 'Tenant Quota' report
         and compares both the data.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     tenant_report = appliance.collections.reports.instantiate(
         type="Tenants", subtype="Tenant Quotas", menu_name="Tenant Quotas"

--- a/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
+++ b/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
@@ -496,6 +496,11 @@ def new_compute_rate():
 def test_validate_default_rate_cpu_usage_cost(chargeback_costs_default, chargeback_report_default):
     """Test to validate CPU usage cost.
        Calculation is based on default Chargeback rate.
+
+    Polarion:
+        assignee: tpapaioa
+        caseimportance: medium
+        initialEstimate: 1/12h
     """
     for groups in chargeback_report_default:
         if groups["CPU Used Cost"]:
@@ -515,6 +520,11 @@ def test_validate_default_rate_memory_usage_cost(chargeback_costs_default,
     """Test to validate memory usage cost.
        Calculation is based on default Chargeback rate.
 
+
+    Polarion:
+        assignee: tpapaioa
+        caseimportance: medium
+        initialEstimate: 1/12h
     """
     for groups in chargeback_report_default:
         if groups["Memory Used Cost"]:
@@ -533,6 +543,11 @@ def test_validate_default_rate_network_usage_cost(chargeback_costs_default,
     """Test to validate network usage cost.
        Calculation is based on default Chargeback rate.
 
+
+    Polarion:
+        assignee: tpapaioa
+        caseimportance: medium
+        initialEstimate: 1/12h
     """
     for groups in chargeback_report_default:
         if groups["Network I/O Used Cost"]:
@@ -550,6 +565,10 @@ def test_validate_default_rate_disk_usage_cost(chargeback_costs_default, chargeb
     """Test to validate disk usage cost.
        Calculation is based on default Chargeback rate.
 
+
+    Polarion:
+        assignee: tpapaioa
+        initialEstimate: 1/12h
     """
     for groups in chargeback_report_default:
         if groups["Disk I/O Used Cost"]:
@@ -567,6 +586,10 @@ def test_validate_default_rate_storage_usage_cost(chargeback_costs_default,
         chargeback_report_default):
     """Test to validate stoarge usage cost.
        Calculation is based on default Chargeback rate.
+
+    Polarion:
+        assignee: tpapaioa
+        initialEstimate: 1/12h
     """
     for groups in chargeback_report_default:
         if groups["Storage Used Cost"]:
@@ -585,6 +608,11 @@ def test_validate_custom_rate_cpu_usage_cost(chargeback_costs_custom, chargeback
     """Test to validate CPU usage cost.
        Calculation is based on custom Chargeback rate.
 
+
+    Polarion:
+        assignee: nachandr
+        caseimportance: medium
+        initialEstimate: 1/12h
     """
     for groups in chargeback_report_custom:
         if groups["CPU Used Cost"]:
@@ -603,6 +631,10 @@ def test_validate_custom_rate_memory_usage_cost(chargeback_costs_custom, chargeb
     """Test to validate memory usage cost.
        Calculation is based on custom Chargeback rate.
 
+
+    Polarion:
+        assignee: tpapaioa
+        initialEstimate: 1/12h
     """
     for groups in chargeback_report_custom:
         if groups["Memory Used Cost"]:
@@ -620,6 +652,10 @@ def test_validate_custom_rate_network_usage_cost(chargeback_costs_custom, charge
     """Test to validate network usage cost.
        Calculation is based on custom Chargeback rate.
 
+
+    Polarion:
+        assignee: tpapaioa
+        initialEstimate: 1/12h
     """
     for groups in chargeback_report_custom:
         if groups["Network I/O Used Cost"]:
@@ -637,6 +673,10 @@ def test_validate_custom_rate_disk_usage_cost(chargeback_costs_custom, chargebac
     """Test to validate disk usage cost.
        Calculation is based on custom Chargeback rate.
 
+
+    Polarion:
+        assignee: tpapaioa
+        initialEstimate: None
     """
     for groups in chargeback_report_custom:
         if groups["Disk I/O Used Cost"]:
@@ -653,6 +693,11 @@ def test_validate_custom_rate_disk_usage_cost(chargeback_costs_custom, chargebac
 def test_validate_custom_rate_storage_usage_cost(chargeback_costs_custom, chargeback_report_custom):
     """Test to validate stoarge usage cost.
        Calculation is based on custom Chargeback rate.
+
+    Polarion:
+        assignee: tpapaioa
+        caseimportance: medium
+        initialEstimate: 1/12h
     """
     for groups in chargeback_report_custom:
         if groups["Storage Used Cost"]:

--- a/cfme/tests/intelligence/reports/test_views.py
+++ b/cfme/tests/intelligence/reports/test_views.py
@@ -39,6 +39,11 @@ def test_report_view(report, view_mode):
 
     Metadata:
         test_flag: report
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        initialEstimate: 1/6h
     """
     view = navigate_to(report, 'Details')
     view.view_selector.select(view_mode)

--- a/cfme/tests/intelligence/reports/test_widgets.py
+++ b/cfme/tests/intelligence/reports/test_widgets.py
@@ -69,6 +69,13 @@ def custom_widgets(appliance):
 @pytest.mark.tier(3)
 def test_widgets_on_dashboard(appliance, request, dashboard, default_widgets,
                               custom_widgets, soft_assert):
+    """
+    Polarion:
+        assignee: jhenner
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
     with update(dashboard):
         dashboard.widgets = map(lambda w: w.title, custom_widgets)
 
@@ -89,7 +96,14 @@ def test_widgets_on_dashboard(appliance, request, dashboard, default_widgets,
 @test_requirements.dashboard
 @pytest.mark.tier(3)
 def test_widgets_reorder_in_reports(request, dashboard):
-    """Tests drag and drop widgets in Cloud Intel/Reports/Dashboards"""
+    """Tests drag and drop widgets in Cloud Intel/Reports/Dashboards
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
     view = navigate_to(dashboard, "Edit")
     previous_names = view.widget_picker.all_dashboard_widgets
     first_widget = previous_names[0]

--- a/cfme/tests/intelligence/test_chargeback.py
+++ b/cfme/tests/intelligence/test_chargeback.py
@@ -68,6 +68,13 @@ def chargeback_rate(rate_resource, rate_type, rate_action, request):
 
 
 def test_compute_chargeback_duplicate_disallowed(request):
+    """
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: low
+        initialEstimate: 1/12h
+    """
     cb_rate = chargeback_rate('compute', 'fixed', 'add', request)
 
     cb_rate.create()
@@ -90,6 +97,11 @@ def test_compute_chargeback_duplicate_disallowed(request):
 @pytest.mark.parametrize('rate_type', ['fixed', 'variable'])
 @pytest.mark.parametrize('rate_action', ['add', 'delete', 'edit'])
 def test_chargeback_rate(rate_resource, rate_type, rate_action, request):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     cb_rate = chargeback_rate(rate_resource, rate_type, rate_action, request)
     cb_rate.create()
 
@@ -140,6 +152,12 @@ class TestRatesViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nachandr
+            casecomponent: candu
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         for rate in rates:
             record = appliance.rest_api.collections.rates.get(id=rate.id)
@@ -155,6 +173,12 @@ class TestRatesViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nachandr
+            casecomponent: candu
+            caseimportance: low
+            initialEstimate: 1/3h
         """
         new_descriptions = []
         if multiple:
@@ -194,6 +218,12 @@ class TestRatesViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nachandr
+            casecomponent: candu
+            caseimportance: medium
+            initialEstimate: 1/20h
         """
         delete_resources_from_detail(rates, method=method)
 
@@ -203,5 +233,11 @@ class TestRatesViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nachandr
+            casecomponent: candu
+            caseimportance: low
+            initialEstimate: 1/4h
         """
         delete_resources_from_collection(rates)

--- a/cfme/tests/intelligence/test_chargeback_assignments.py
+++ b/cfme/tests/intelligence/test_chargeback_assignments.py
@@ -15,6 +15,11 @@ pytestmark = [
 
 @pytest.mark.meta(blockers=[1273654])
 def test_assign_compute_enterprise(appliance, virtualcenter_provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(appliance.server, 'Chargeback')
 
     enterprise = cb.ComputeAssign(
@@ -32,6 +37,11 @@ def test_assign_compute_enterprise(appliance, virtualcenter_provider):
 
 
 def test_assign_compute_provider(appliance, virtualcenter_provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(appliance.server, 'Chargeback')
 
     compute_provider = cb.ComputeAssign(
@@ -48,6 +58,13 @@ def test_assign_compute_provider(appliance, virtualcenter_provider):
 
 
 def test_assign_compute_cluster(appliance, virtualcenter_provider):
+    """
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
     view = navigate_to(appliance.server, 'Chargeback')
 
     cluster_name = "{}/{}".format(virtualcenter_provider.name,
@@ -68,6 +85,13 @@ def test_assign_compute_cluster(appliance, virtualcenter_provider):
 
 
 def test_assign_compute_taggedvm(appliance, virtualcenter_provider):
+    """
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
     view = navigate_to(appliance.server, 'Chargeback')
 
     tagged_vm = cb.ComputeAssign(
@@ -86,6 +110,13 @@ def test_assign_compute_taggedvm(appliance, virtualcenter_provider):
 
 @pytest.mark.meta(blockers=[1273654])
 def test_assign_storage_enterprise(appliance, virtualcenter_provider):
+    """
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
     view = navigate_to(appliance.server, 'Chargeback')
 
     enterprise = cb.StorageAssign(
@@ -103,6 +134,11 @@ def test_assign_storage_enterprise(appliance, virtualcenter_provider):
 
 
 def test_assign_storage_datastores(appliance, virtualcenter_provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(appliance.server, 'Chargeback')
 
     datastore = random.choice(virtualcenter_provider.data["datastores"])["name"]
@@ -121,6 +157,13 @@ def test_assign_storage_datastores(appliance, virtualcenter_provider):
 
 
 def test_assign_storage_tagged_datastores(appliance, virtualcenter_provider):
+    """
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
     view = navigate_to(appliance.server, 'Chargeback')
 
     tagged_datastore = cb.StorageAssign(

--- a/cfme/tests/intelligence/test_dashboard.py
+++ b/cfme/tests/intelligence/test_dashboard.py
@@ -33,6 +33,13 @@ def widgets(dashboards):
 
 @pytest.mark.meta(blockers=[BZ(1533792, forced_streams=['5.9'])])
 def test_widgets_operation(dashboards, widgets, soft_assert, infra_provider):
+    """
+    Polarion:
+        assignee: jhenner
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
     # We need to make sure the widgets have some data.
     wait_for(
         lambda: all(not widget.blank for widget in widgets),
@@ -60,7 +67,14 @@ def test_widgets_operation(dashboards, widgets, soft_assert, infra_provider):
 @pytest.mark.rhel_testing
 @pytest.mark.parametrize("number_dashboards", range(1, 4))
 def test_custom_dashboards(request, soft_assert, number_dashboards, dashboards, appliance):
-    """Create some custom dashboards and check their presence. Then check their contents."""
+    """Create some custom dashboards and check their presence. Then check their contents.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
     # Very useful construct. List is mutable, so we can prepare the generic delete finalizer.
     # Then we add everything that succeeded with creation. Simple as that :)
     dashboards_to_delete = []
@@ -99,6 +113,10 @@ def test_verify_rss_links_from_dashboards(dashboards):
         * Loop through all RSS widgets
         * Loop through all the links in a widget
         * Try making a request on the provided URLs, should make sense
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     wait_for(
         lambda: not any(widget.blank for widget in dashboards.default.collections.widgets.all()),
@@ -124,6 +142,12 @@ def test_widgets_reorder(dashboards, soft_assert, request):
         * Go to the Dashboard
         * Reorder first two widgets in the first column using drag&drop
         * Assert that the widgets order is changed
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/12h
     """
     request.addfinalizer(dashboards.default.collections.widgets.reset)
     previous_state = dashboards.default.collections.widgets.all()

--- a/cfme/tests/intelligence/test_download_report.py
+++ b/cfme/tests/intelligence/test_download_report.py
@@ -15,5 +15,10 @@ def report(appliance):
 
 @pytest.mark.parametrize("filetype", ["txt", "csv", "pdf"])
 def test_download_report(infra_provider, report, filetype):
-    """Download the report as a file."""
+    """Download the report as a file.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     report.download(filetype)

--- a/cfme/tests/intelligence/test_reports_with_timelines.py
+++ b/cfme/tests/intelligence/test_reports_with_timelines.py
@@ -7,10 +7,20 @@ timelines_reports = ('hosts', 'vm_operation', 'policy_events', 'policy_events2')
 @pytest.mark.manual
 @pytest.mark.parametrize('report', timelines_reports)
 def test_default_reports_with_timelines(report):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     pass
 
 
 @pytest.mark.manual
 @pytest.mark.parametrize('report', timelines_reports)
 def test_custom_reports_with_timelines(report):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     pass

--- a/cfme/tests/intelligence/test_rss.py
+++ b/cfme/tests/intelligence/test_rss.py
@@ -7,6 +7,11 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 
 @pytest.mark.tier(3)
 def test_verify_rss_links(appliance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(appliance.server, 'RSS')
     for row in view.table.rows():
         url = row[3].text

--- a/cfme/tests/networks/nuage/test_events_are_triggered.py
+++ b/cfme/tests/networks/nuage/test_events_are_triggered.py
@@ -24,6 +24,10 @@ def test_creating_entities_emits_events(register_event, with_nuage_sandbox):
 
     Important: register_event fixture must be listed before with_nuage_sandbox fixture because we
         need to start collecting events before we actually create the entities.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     listener = register_event
     sandbox = with_nuage_sandbox
@@ -60,6 +64,10 @@ def test_creating_entities_triggers_targeted_refresh(targeted_refresh, with_nuag
 
     Important: targeted_refresh fixture must be listed before with_nuage_sandbox
     fixture because we have to start tracking evm.log before we create the entites
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     sandbox = with_nuage_sandbox
     with targeted_refresh.timeout():

--- a/cfme/tests/networks/test_network_providers.py
+++ b/cfme/tests/networks/test_network_providers.py
@@ -19,7 +19,12 @@ pytestmark = [
 
 @pytest.mark.rhel_testing
 def test_add_cancelled_validation(request, appliance):
-    """Tests that the flash message is correct when add is cancelled."""
+    """Tests that the flash message is correct when add is cancelled.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     collection = appliance.collections.network_providers
     try:
         prov = collection.create(prov_class=NuageProvider, name=None, cancel=True,
@@ -38,6 +43,10 @@ def test_network_provider_add_with_bad_credentials(provider):
 
     Metadata:
         test_flag: crud
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     default_credentials = provider.default_endpoint.credentials
 
@@ -56,6 +65,10 @@ def test_network_provider_crud(provider, has_no_networks_providers):
 
     Metadata:
         test_flag: crud
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     provider.create()
     provider.validate_stats(ui=True)

--- a/cfme/tests/networks/test_provision_to_virtual_network.py
+++ b/cfme/tests/networks/test_provision_to_virtual_network.py
@@ -51,6 +51,10 @@ def test_provision_vm_to_virtual_network(appliance, setup_provider, provider,
 
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     vm_name = random_vm_name('provd')
 

--- a/cfme/tests/networks/test_sdn_balancers.py
+++ b/cfme/tests/networks/test_sdn_balancers.py
@@ -37,6 +37,10 @@ def test_sdn_prov_balancers_number(network_prov_with_load_balancers):
 
     Metadata:
         test_flag: sdn
+
+    Polarion:
+        assignee: mmojzis
+        initialEstimate: None
     """
     for prov, sum_all in network_prov_with_load_balancers:
         view = navigate_to(prov, 'Details')
@@ -49,6 +53,10 @@ def test_sdn_balancers_detail(provider, network_prov_with_load_balancers):
 
     Metadata:
         test_flag: sdn
+
+    Polarion:
+        assignee: mmojzis
+        initialEstimate: None
     """
     for prov, _ in network_prov_with_load_balancers:
         for balancer in prov.balancers.all():
@@ -73,6 +81,10 @@ def test_sdn_balancers_tagvis(check_item_visibility, visibility, network_prov_wi
 
     Metadata:
         test_flag: tag, sdn
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
     """
     network_prov = random.choice(network_prov_with_load_balancers)[0]
     balancers_for_provider = network_prov.balancers.all()

--- a/cfme/tests/networks/test_sdn_crud.py
+++ b/cfme/tests/networks/test_sdn_crud.py
@@ -22,6 +22,10 @@ def test_sdn_crud(provider, appliance):
 
     Metadata:
         test_flag: sdn
+
+    Polarion:
+        assignee: mmojzis
+        initialEstimate: 1/2h
     """
     collection = appliance.collections.network_providers.filter({'provider': provider})
     network_provider = collection.all()[0]

--- a/cfme/tests/networks/test_sdn_downloads.py
+++ b/cfme/tests/networks/test_sdn_downloads.py
@@ -52,6 +52,10 @@ def test_download_lists_base(filetype, collection_type, appliance):
 
     Metadata:
         test_flag: sdn
+
+    Polarion:
+        assignee: jhenner
+        initialEstimate: 1/10h
     """
     collection = getattr(appliance.collections, collection_type)
     download(appliance, collection, filetype)
@@ -66,6 +70,10 @@ def test_download_pdf_summary(appliance, collection_type, provider):
 
     Metadata:
         test_flag: sdn
+
+    Polarion:
+        assignee: jhenner
+        initialEstimate: 1/10h
     """
     collection = getattr(appliance.collections, collection_type)
     all_entities = collection.all()

--- a/cfme/tests/networks/test_sdn_inventory_collection.py
+++ b/cfme/tests/networks/test_sdn_inventory_collection.py
@@ -21,6 +21,10 @@ def test_sdn_api_inventory_networks(provider, appliance):
 
     Metadata:
         test_flag: sdn, inventory
+
+    Polarion:
+        assignee: mmojzis
+        initialEstimate: 1/10h
     """
     prov_networks = sorted(provider.mgmt.list_network())
     cfme_networks = sorted([nt.name for nt in appliance.collections.cloud_networks.all()])
@@ -46,6 +50,10 @@ def test_sdn_api_inventory_routers(provider, appliance):
 
     Metadata:
         test_flag: sdn, inventory
+
+    Polarion:
+        assignee: mmojzis
+        initialEstimate: 1/10h
     """
     prov_routers = sorted(provider.mgmt.list_router())
     cfme_routers = sorted([rt.name for rt in appliance.collections.network_routers.all()])
@@ -60,6 +68,10 @@ def test_sdn_api_inventory_subnets(provider, appliance):
 
     Metadata:
         test_flag: sdn, inventory
+
+    Polarion:
+        assignee: mmojzis
+        initialEstimate: 1/10h
     """
     prov_subnets = []
     cfme_subnets = [sb.name for sb in appliance.collections.network_subnets.all()]
@@ -82,6 +94,10 @@ def test_sdn_api_inventory_security_groups(provider, appliance):
 
     Metadata:
         test_flag: sdn, inventory
+
+    Polarion:
+        assignee: mmojzis
+        initialEstimate: 1/10h
     """
     prov_sec_gp = sorted(provider.mgmt.list_security_group())
     cfme_sec_gp = sorted([sec.name for sec in appliance.collections.network_security_groups.all()])
@@ -97,6 +113,10 @@ def test_sdn_api_inventory_loadbalancers(provider, appliance):
 
     Metadata:
         test_flag: sdn, inventory
+
+    Polarion:
+        assignee: mmojzis
+        initialEstimate: 1/10h
     """
     prov_load_balancers = sorted(provider.mgmt.list_load_balancer())
     cfme_load_balancers = sorted([lb.name for lb in appliance.collections.balancers.all()])
@@ -126,6 +146,10 @@ def test_sdn_nsg_firewall_rules(provider, appliance, secgroup_with_rule):
 
     Metadata:
         test_flag: sdn, inventory
+
+    Polarion:
+        assignee: mmojzis
+        initialEstimate: None
     """
 
     # Navigate to network provider.

--- a/cfme/tests/networks/test_sdn_navigation.py
+++ b/cfme/tests/networks/test_sdn_navigation.py
@@ -19,6 +19,10 @@ def test_sdn_provider_relationships_navigation(provider, tested_part, appliance)
     """
     Metadata:
         test_flag: sdn, relationship
+
+    Polarion:
+        assignee: mmojzis
+        initialEstimate: None
     """
     collection = appliance.collections.network_providers.filter({'provider': provider})
     network_provider = collection.all()[0]
@@ -33,6 +37,10 @@ def test_provider_topology_navigation(provider, appliance):
     """
     Metadata:
         test_flag: relationship
+
+    Polarion:
+        assignee: jhenner
+        initialEstimate: 1/10h
     """
     collection = appliance.collections.network_providers.filter({'provider': provider})
     network_provider = collection.all()[0]

--- a/cfme/tests/networks/test_sdn_ports.py
+++ b/cfme/tests/networks/test_sdn_ports.py
@@ -22,6 +22,10 @@ def test_sdn_port_detail_name(provider, appliance):
 
     Metadata:
         test_flag: sdn
+
+    Polarion:
+        assignee: mmojzis
+        initialEstimate: None
     """
     port_collection = NetworkPortCollection(appliance)
     ports = port_collection.all()
@@ -41,6 +45,10 @@ def test_sdn_port_net_prov(provider, appliance):
 
     Metadata:
         test_flag: sdn
+
+    Polarion:
+        assignee: mmojzis
+        initialEstimate: None
     """
     prov_collection = NetworkProviderCollection(appliance)
 

--- a/cfme/tests/networks/test_sdn_topology.py
+++ b/cfme/tests/networks/test_sdn_topology.py
@@ -26,6 +26,10 @@ def test_topology_search(request, elements_collection):
 
     Metadata:
         test_flag: sdn
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
     """
     elements = elements_collection.all()
     logger.info(str(elements))
@@ -52,6 +56,10 @@ def test_topology_toggle_display(elements_collection):
 
     Metadata:
         test_flag: sdn
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     vis_terms = {True: 'Visible', False: 'Hidden'}
     for state in (True, False):

--- a/cfme/tests/networks/test_tag_tagvis.py
+++ b/cfme/tests/networks/test_tag_tagvis.py
@@ -54,6 +54,11 @@ def child_visibility(appliance, network_provider, relationship, view):
                          ids=[rel[0] for rel in network_test_items])
 def test_tagvis_network_provider_children(provider, appliance, request, relationship, view,
                                           tag, user_restricted):
+    """
+    Polarion:
+        assignee: anikifor
+        initialEstimate: 1/8h
+    """
     collection = appliance.collections.network_providers.filter({'provider': provider})
     network_provider = collection.all()[0]
 
@@ -70,6 +75,11 @@ def test_tagvis_network_provider_children(provider, appliance, request, relation
 
 @pytest.fixture(params=network_collections, scope='module')
 def test_entity(request, appliance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     collection_name = request.param
     item_collection = getattr(appliance.collections, collection_name)
     items = item_collection.all()
@@ -90,5 +100,9 @@ def test_network_tagvis(check_item_visibility, test_entity, visibility):
         2. Login as restricted user, item is visible for user
         3. As admin remove tag
         4. Login as restricted user, iten is not visible for user
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
     """
     check_item_visibility(test_entity, visibility)

--- a/cfme/tests/openstack/cloud/test_flavors.py
+++ b/cfme/tests/openstack/cloud/test_flavors.py
@@ -98,6 +98,11 @@ def new_instance(provider, zero_disk_flavor):
 @pytest.mark.rfe
 @pytest.mark.ignore_stream('5.9')
 def test_create_instance_with_zero_disk_flavor(new_instance, soft_assert):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(new_instance, 'Details')
     prov_data = new_instance.provider.data['provisioning']
     power_state = view.entities.summary('Power Management').get_text_of('Power State')
@@ -122,6 +127,11 @@ def test_create_instance_with_zero_disk_flavor(new_instance, soft_assert):
 
 @pytest.mark.regression
 def test_flavor_crud(appliance, provider, request):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     collection = appliance.collections.cloud_flavors
     flavor = collection.create(name=fauxfactory.gen_alpha(),
                                provider=provider,
@@ -155,6 +165,11 @@ def test_flavor_crud(appliance, provider, request):
 @pytest.mark.rfe
 @pytest.mark.ignore_stream('5.9')
 def test_flavors_details_from_list_view(appliance, soft_assert, private_flavor):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     collection = appliance.collections.cloud_flavors
     view = navigate_to(collection, 'All')
     item = view.entities.get_entity(name=private_flavor.name, surf_pages=True)
@@ -168,6 +183,11 @@ def test_flavors_details_from_list_view(appliance, soft_assert, private_flavor):
 @pytest.mark.rfe
 @pytest.mark.ignore_stream('5.9')
 def test_flavor_details(appliance, soft_assert, private_flavor):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(private_flavor, 'Details')
     soft_assert(view.entities.properties.get_text_of('CPUs') == str(private_flavor.vcpus))
 

--- a/cfme/tests/openstack/cloud/test_instances.py
+++ b/cfme/tests/openstack/cloud/test_instances.py
@@ -104,7 +104,12 @@ def volume_with_type(appliance, provider):
 
 @pytest.mark.regression
 def test_create_instance(new_instance, soft_assert):
-    """Creates an instance and verifies it appears on UI"""
+    """Creates an instance and verifies it appears on UI
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(new_instance, 'Details')
     prov_data = new_instance.provider.data['provisioning']
     power_state = view.entities.summary('Power Management').get_text_of('Power State')
@@ -128,6 +133,11 @@ def test_create_instance(new_instance, soft_assert):
 
 @pytest.mark.regression
 def test_stop_instance(new_instance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     new_instance.power_control_from_cfme(from_details=True,
                                          option=OpenStackInstance.STOP)
     new_instance.wait_for_instance_state_change(OpenStackInstance.STATE_OFF)
@@ -138,6 +148,11 @@ def test_stop_instance(new_instance):
 
 @pytest.mark.regression
 def test_suspend_instance(new_instance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     new_instance.power_control_from_cfme(from_details=True,
                                          option=OpenStackInstance.SUSPEND)
     new_instance.wait_for_instance_state_change(OpenStackInstance.STATE_SUSPENDED)
@@ -148,6 +163,11 @@ def test_suspend_instance(new_instance):
 
 @pytest.mark.regression
 def test_pause_instance(new_instance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     new_instance.power_control_from_cfme(from_details=True,
                                          option=OpenStackInstance.PAUSE)
     new_instance.wait_for_instance_state_change(OpenStackInstance.STATE_PAUSED)
@@ -158,6 +178,11 @@ def test_pause_instance(new_instance):
 
 @pytest.mark.regression
 def test_shelve_instance(new_instance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     new_instance.power_control_from_cfme(from_details=True,
                                          option=OpenStackInstance.SHELVE)
     try:
@@ -172,6 +197,11 @@ def test_shelve_instance(new_instance):
 
 @pytest.mark.regression
 def test_shelve_offload_instance(new_instance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     new_instance.power_control_from_cfme(from_details=True,
                                          option=OpenStackInstance.SHELVE)
     new_instance.wait_for_instance_state_change(OpenStackInstance.STATE_SHELVED)
@@ -189,6 +219,11 @@ def test_shelve_offload_instance(new_instance):
 
 @pytest.mark.regression
 def test_start_instance(new_instance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     new_instance.mgmt.ensure_state(VmState.STOPPED)
     new_instance.wait_for_instance_state_change(OpenStackInstance.STATE_OFF)
     new_instance.power_control_from_cfme(from_details=True,
@@ -201,6 +236,11 @@ def test_start_instance(new_instance):
 
 @pytest.mark.regression
 def test_soft_reboot_instance(new_instance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     new_instance.power_control_from_cfme(from_details=True,
                                          option=OpenStackInstance.SOFT_REBOOT)
     new_instance.wait_for_instance_state_change(OpenStackInstance.STATE_REBOOTING)
@@ -213,6 +253,11 @@ def test_soft_reboot_instance(new_instance):
 
 @pytest.mark.regression
 def test_hard_reboot_instance(new_instance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     new_instance.power_control_from_cfme(from_details=True,
                                          option=OpenStackInstance.HARD_REBOOT)
     new_instance.wait_for_instance_state_change(OpenStackInstance.STATE_REBOOTING)
@@ -225,6 +270,11 @@ def test_hard_reboot_instance(new_instance):
 
 @pytest.mark.regression
 def test_delete_instance(new_instance, provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     new_instance.power_control_from_cfme(from_details=True,
                                          option=OpenStackInstance.TERMINATE)
     new_instance.wait_for_instance_state_change(OpenStackInstance.STATE_UNKNOWN)
@@ -245,6 +295,11 @@ def test_delete_instance(new_instance, provider):
                       required_fields=[['provisioning', 'image', 'os_distro']],
                       override=True, scope='module')
 def test_instance_operating_system_linux(new_instance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(new_instance, 'Details')
     os = view.entities.summary('Properties').get_text_of("Operating System")
     prov_data_os = new_instance.provider.data['provisioning']['image']['os_distro']
@@ -253,6 +308,11 @@ def test_instance_operating_system_linux(new_instance):
 
 @pytest.mark.regression
 def test_instance_attach_volume(volume, new_instance, appliance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     initial_volume_count = new_instance.volume_count
     new_instance.attach_volume(volume.name)
     view = appliance.browser.create_view(navigator.get_class(new_instance, 'AttachVolume').VIEW)
@@ -268,6 +328,11 @@ def test_instance_attach_volume(volume, new_instance, appliance):
 @pytest.mark.rfe
 @pytest.mark.ignore_stream('5.9')
 def test_instance_attach_detach_volume_with_type(volume_with_type, new_instance, appliance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     initial_volume_count = new_instance.volume_count
     new_instance.attach_volume(volume_with_type.name)
     view = appliance.browser.create_view(navigator.get_class(new_instance, 'Details').VIEW)

--- a/cfme/tests/openstack/cloud/test_keypairs.py
+++ b/cfme/tests/openstack/cloud/test_keypairs.py
@@ -24,5 +24,10 @@ def keypair(appliance, provider):
 @pytest.mark.rfe
 @pytest.mark.ignore_stream('5.9')
 def test_download_private_key(keypair):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     assert keypair.exists
     keypair.download_private_key()

--- a/cfme/tests/openstack/cloud/test_networks.py
+++ b/cfme/tests/openstack/cloud/test_networks.py
@@ -112,7 +112,12 @@ def router_with_gw(provider, appliance, ext_subnet):
 
 @pytest.mark.regression
 def test_create_network(network, provider):
-    """Creates private cloud network and verifies it's relationships"""
+    """Creates private cloud network and verifies it's relationships
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     assert network.exists
     assert network.parent_provider.name == provider.name
     assert network.cloud_tenant == provider.data.get('provisioning').get('cloud_tenant')
@@ -120,7 +125,12 @@ def test_create_network(network, provider):
 
 @pytest.mark.regression
 def test_edit_network(network):
-    """Edits private cloud network's name"""
+    """Edits private cloud network's name
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     network.edit(name=fauxfactory.gen_alpha())
     wait_for(network.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
              delay=10)
@@ -131,7 +141,12 @@ def test_edit_network(network):
 
 @pytest.mark.regression
 def test_delete_network(network):
-    """Deletes private cloud network"""
+    """Deletes private cloud network
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     network.delete()
     wait_for(network.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
              delay=10)
@@ -142,7 +157,12 @@ def test_delete_network(network):
 
 @pytest.mark.regression
 def test_create_subnet(subnet, provider):
-    """Creates private subnet and verifies it's relationships"""
+    """Creates private subnet and verifies it's relationships
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     assert subnet.exists
     assert subnet.parent_provider.name == provider.name
     assert subnet.cloud_tenant == provider.data.get('provisioning').get('cloud_tenant')
@@ -153,7 +173,12 @@ def test_create_subnet(subnet, provider):
 
 @pytest.mark.regression
 def test_edit_subnet(subnet):
-    """Edits private subnet's name"""
+    """Edits private subnet's name
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     subnet.edit(new_name=fauxfactory.gen_alpha())
     wait_for(subnet.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
              delay=10)
@@ -163,7 +188,12 @@ def test_edit_subnet(subnet):
 
 @pytest.mark.regression
 def test_delete_subnet(subnet):
-    """Deletes private subnet"""
+    """Deletes private subnet
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     subnet.delete()
     wait_for(subnet.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=800,
              delay=30)
@@ -174,14 +204,24 @@ def test_delete_subnet(subnet):
 
 @pytest.mark.regression
 def test_create_router(router, provider):
-    """Create router without gateway"""
+    """Create router without gateway
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     assert router.exists
     assert router.cloud_tenant == provider.data.get('provisioning').get('cloud_tenant')
 
 
 @pytest.mark.regression
 def test_create_router_with_gateway(router_with_gw, provider):
-    """Creates router with gateway (external network)"""
+    """Creates router with gateway (external network)
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     assert router_with_gw.exists
     assert router_with_gw.cloud_tenant == provider.data.get('provisioning').get('cloud_tenant')
     assert router_with_gw.cloud_network == router_with_gw.ext_network
@@ -189,7 +229,12 @@ def test_create_router_with_gateway(router_with_gw, provider):
 
 @pytest.mark.regression
 def test_edit_router(router):
-    """Edits router's name"""
+    """Edits router's name
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     router.edit(name=fauxfactory.gen_alpha())
     wait_for(router.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
              delay=10)
@@ -200,7 +245,12 @@ def test_edit_router(router):
 
 @pytest.mark.regression
 def test_delete_router(router, appliance):
-    """Deletes router"""
+    """Deletes router
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     router.delete()
     wait_for(router.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=20), timeout=800,
              delay=30)
@@ -212,7 +262,12 @@ def test_delete_router(router, appliance):
 
 @pytest.mark.regression
 def test_clear_router_gateway(router_with_gw):
-    """Deletes a gateway from the router"""
+    """Deletes a gateway from the router
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     router_with_gw.edit(change_external_gw=False)
     wait_for(router_with_gw.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10),
              timeout=600, delay=10)
@@ -225,7 +280,12 @@ def test_clear_router_gateway(router_with_gw):
 
 @pytest.mark.regression
 def test_add_gateway_to_router(router, ext_subnet):
-    """Adds gateway to the router"""
+    """Adds gateway to the router
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     router.edit(change_external_gw=True, ext_network=ext_subnet.network,
                 ext_network_subnet=ext_subnet.name)
     wait_for(router.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
@@ -237,7 +297,12 @@ def test_add_gateway_to_router(router, ext_subnet):
 
 @pytest.mark.regression
 def test_add_interface_to_router(router, subnet):
-    """Adds interface (subnet) to router"""
+    """Adds interface (subnet) to router
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(router, 'Details')
     subnets_count_before_adding = int(view.entities.relationships.get_text_of('Cloud Subnets'))
     router.add_interface(subnet.name)
@@ -254,6 +319,11 @@ def test_add_interface_to_router(router, subnet):
 
 @pytest.mark.regression
 def test_list_networks(provider, appliance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     networks = [n.label for n in provider.mgmt.api.networks.list()]
     displayed_networks = [n.name for n in appliance.collections.cloud_networks.all()]
     for n in networks:

--- a/cfme/tests/openstack/cloud/test_provider.py
+++ b/cfme/tests/openstack/cloud/test_provider.py
@@ -20,6 +20,11 @@ CARDS = [("Flavors", "list_flavor"), ("Images", "list_templates"),
 @pytest.mark.ignore_stream('5.9')
 @pytest.mark.parametrize('card, api', CARDS)
 def test_cloud_provider_cards(provider, card, api):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(provider, 'Details')
     view.toolbar.view_selector.select('Dashboard View')
     dashboard_card = view.entities.cards(card)
@@ -30,6 +35,11 @@ def test_cloud_provider_cards(provider, card, api):
 @pytest.mark.rfe
 @pytest.mark.ignore_stream('5.9')
 def test_dashboard_card_availability_zones(provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(provider, 'Details')
     view.toolbar.view_selector.select('Dashboard View')
     dashboard_card = view.entities.cards("Availability Zones")
@@ -39,6 +49,11 @@ def test_dashboard_card_availability_zones(provider):
 @pytest.mark.rfe
 @pytest.mark.ignore_stream('5.9')
 def test_dashboard_card_tenants(provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     collection = provider.appliance.collections.cloud_tenants
     view = navigate_to(provider, 'Details')
     view.toolbar.view_selector.select('Dashboard View')
@@ -50,6 +65,11 @@ def test_dashboard_card_tenants(provider):
 @pytest.mark.rfe
 @pytest.mark.ignore_stream('5.9')
 def test_dashboard_card_security_groups(provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(provider, 'Details')
     sec_groups = view.entities.summary('Relationships').get_text_of('Security Groups')
     view.toolbar.view_selector.select('Dashboard View')

--- a/cfme/tests/openstack/cloud/test_volume_backup.py
+++ b/cfme/tests/openstack/cloud/test_volume_backup.py
@@ -147,18 +147,33 @@ def attached_volume(appliance, provider, volume_backup, new_instance):
 
 @pytest.mark.rfe
 def test_create_volume_backup(volume_backup):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     assert volume_backup.exists
     assert volume_backup.size == VOLUME_SIZE
 
 
 @pytest.mark.rfe
 def test_create_volume_incremental_backup(incremental_backup):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     assert incremental_backup.exists
     assert incremental_backup.size == VOLUME_SIZE
 
 
 @pytest.mark.rfe
 def test_incr_backup_of_attached_volume_crud(appliance, provider, request, attached_volume):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     backup_name = fauxfactory.gen_alpha()
     collection = appliance.collections.volume_backups.filter({'provider': provider})
     attached_volume.create_backup(backup_name, incremental=True, force=True)
@@ -187,12 +202,22 @@ def test_incr_backup_of_attached_volume_crud(appliance, provider, request, attac
 @pytest.mark.rfe
 @pytest.mark.ignore_stream('5.9')
 def test_create_backup_of_volume_with_type(volume_backup_with_type):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     assert volume_backup_with_type.exists
     assert volume_backup_with_type.size == VOLUME_SIZE
 
 
 @pytest.mark.rfe
 def test_restore_volume_backup(volume_backup):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     if volume_backup.status == 'available':
         volume_backup.restore(volume_backup.volume)
     else:
@@ -201,6 +226,11 @@ def test_restore_volume_backup(volume_backup):
 
 @pytest.mark.rfe
 def test_restore_incremental_backup(incremental_backup):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     if incremental_backup.status == 'available':
         incremental_backup.restore(incremental_backup.volume)
     else:

--- a/cfme/tests/openstack/cloud/test_volumes.py
+++ b/cfme/tests/openstack/cloud/test_volumes.py
@@ -67,6 +67,11 @@ def volume_with_type(appliance, provider):
 
 @pytest.mark.regression
 def test_create_volume(volume, provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     assert volume.exists
     assert volume.size == '{} GB'.format(VOLUME_SIZE)
     assert volume.tenant == provider.data['provisioning']['cloud_tenant']
@@ -74,6 +79,11 @@ def test_create_volume(volume, provider):
 
 @pytest.mark.regression
 def test_edit_volume(volume, appliance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     new_name = fauxfactory.gen_alpha()
     with update(volume):
         volume.name = new_name
@@ -83,6 +93,11 @@ def test_edit_volume(volume, appliance):
 
 @pytest.mark.regression
 def test_delete_volume(volume):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     volume.delete()
     assert not volume.exists
 
@@ -90,6 +105,11 @@ def test_delete_volume(volume):
 @pytest.mark.rfe
 @pytest.mark.ignore_stream('5.9')
 def test_create_volume_with_type(volume_with_type, provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     assert volume_with_type.exists
     assert volume_with_type.size == '{} GB'.format(VOLUME_SIZE)
     assert volume_with_type.tenant == provider.data['provisioning']['cloud_tenant']
@@ -98,6 +118,11 @@ def test_create_volume_with_type(volume_with_type, provider):
 @pytest.mark.rfe
 @pytest.mark.ignore_stream('5.9')
 def test_edit_volume_with_type(volume_with_type, appliance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     new_name = fauxfactory.gen_alpha()
     with update(volume_with_type):
         volume_with_type.name = new_name
@@ -108,5 +133,10 @@ def test_edit_volume_with_type(volume_with_type, appliance):
 @pytest.mark.rfe
 @pytest.mark.ignore_stream('5.9')
 def test_delete_volume_with_type(volume_with_type):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     volume_with_type.delete()
     assert not volume_with_type.exists

--- a/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
+++ b/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
@@ -40,7 +40,12 @@ def has_mistral_service(provider):
 def test_scale_provider_down(provider, host, has_mistral_service):
     """Scale down Openstack Infrastructure provider
     Metadata:
-        test_flag: openstack_scale"""
+        test_flag: openstack_scale
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     host.toggle_maintenance_mode()
     host_uuid = host.name.split()[0]  # cut off deployment role part from host's name
     wait_for(lambda: provider.mgmt.iapi.node.get(host_uuid).maintenance, timeout=600, delay=5)
@@ -75,7 +80,12 @@ def test_scale_provider_down(provider, host, has_mistral_service):
 def test_delete_host(appliance, host, provider, has_mistral_service):
     """Remove host from appliance and Ironic service
     Metadata:
-        test_flag: openstack_scale"""
+        test_flag: openstack_scale
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     def is_host_disappeared():
         return host.name not in [h.uuid for h in provider.mgmt.iapi.node.list()]
 
@@ -91,7 +101,12 @@ def test_delete_host(appliance, host, provider, has_mistral_service):
 def test_register_host(provider, host, has_mistral_service):
     """Register new host by uploading instackenv.json file
     Metadata:
-        test_flag: openstack_scale"""
+        test_flag: openstack_scale
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     hosts_before = [h.uuid for h in provider.mgmt.iapi.node.list()]
     provider.register(provider.data['instackenv_file_path'])
     # Wait for a new host to appear
@@ -115,7 +130,12 @@ def test_register_host(provider, host, has_mistral_service):
 def test_introspect_host(host, provider, has_mistral_service):
     """Introspect host
     Metadata:
-        test_flag: openstack_scale"""
+        test_flag: openstack_scale
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     host.run_introspection()
     wait_for(lambda: provider.mgmt.iapi.node.get(host.name).inspection_finished_at, delay=15,
              timeout=600)
@@ -133,7 +153,12 @@ def test_introspect_host(host, provider, has_mistral_service):
 def test_provide_host(host, provider, has_mistral_service):
     """Provide host
     Metadata:
-        test_flag: openstack_scale"""
+        test_flag: openstack_scale
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     host.provide_node()
     wait_for(lambda: provider.mgmt.iapi.node.get(host.name).provision_state == 'available', delay=5,
              timeout=300)
@@ -148,7 +173,12 @@ def test_provide_host(host, provider, has_mistral_service):
 def test_scale_provider_out(host, provider, has_mistral_service):
     """Scale out Infra provider
     Metadata:
-        test_flag: openstack_scale"""
+        test_flag: openstack_scale
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     # Host has to be given a profile role before the scale out
     params = [{'path': '/properties/capabilities', 'value': 'profile:compute,boot_option:local',
                'op': 'replace'}]

--- a/cfme/tests/openstack/infrastructure/test_host_power_control.py
+++ b/cfme/tests/openstack/infrastructure/test_host_power_control.py
@@ -44,6 +44,11 @@ def host_off(host_collection, provider):
 
 @pytest.mark.regression
 def test_host_power_off(host_on):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     host_on.power_off()
     host_on.refresh()
     result = host_on.wait_for_host_state_change('off', 1000)
@@ -52,6 +57,11 @@ def test_host_power_off(host_on):
 
 @pytest.mark.regression
 def test_host_power_on(host_off):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     host_off.power_on()
     host_off.refresh()
     result = host_off.wait_for_host_state_change('on', 1000)

--- a/cfme/tests/openstack/infrastructure/test_hosts.py
+++ b/cfme/tests/openstack/infrastructure/test_hosts.py
@@ -19,6 +19,11 @@ def host_collection(appliance):
 
 @pytest.mark.regression
 def test_host_configuration(host_collection, provider, soft_assert, appliance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     hosts = host_collection.all()
     assert hosts
     for host in hosts:
@@ -35,6 +40,11 @@ def test_host_configuration(host_collection, provider, soft_assert, appliance):
 
 @pytest.mark.regression
 def test_host_cpu_resources(host_collection, provider, soft_assert):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     hosts = host_collection.all()
     assert hosts
     for host in hosts:
@@ -48,6 +58,11 @@ def test_host_cpu_resources(host_collection, provider, soft_assert):
 
 @pytest.mark.regression
 def test_host_auth(host_collection, provider, soft_assert):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     hosts = host_collection.all()
     assert hosts
     for host in hosts:
@@ -60,6 +75,11 @@ def test_host_auth(host_collection, provider, soft_assert):
 
 @pytest.mark.regression
 def test_host_devices(host_collection, provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     hosts = host_collection.all()
     assert hosts
     for host in hosts:
@@ -70,6 +90,11 @@ def test_host_devices(host_collection, provider):
 
 @pytest.mark.regression
 def test_host_hostname(host_collection, provider, soft_assert):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     hosts = host_collection.all()
     assert hosts
     for host in hosts:
@@ -80,6 +105,11 @@ def test_host_hostname(host_collection, provider, soft_assert):
 
 @pytest.mark.regression
 def test_host_memory(host_collection, provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     hosts = host_collection.all()
     assert hosts
     for host in hosts:
@@ -90,6 +120,11 @@ def test_host_memory(host_collection, provider):
 
 @pytest.mark.regression
 def test_host_security(host_collection, provider, soft_assert):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     hosts = host_collection.all()
     assert hosts
     for host in hosts:
@@ -105,7 +140,12 @@ def test_host_security(host_collection, provider, soft_assert):
 
 @pytest.mark.regression
 def test_host_smbios_data(host_collection, provider, soft_assert):
-    """Checks that Manufacturer/Model values are shown for each infra node"""
+    """Checks that Manufacturer/Model values are shown for each infra node
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     hosts = host_collection.all()
     assert hosts
     for host in hosts:
@@ -117,6 +157,11 @@ def test_host_smbios_data(host_collection, provider, soft_assert):
 
 @pytest.mark.regression
 def test_host_zones_assigned(host_collection, provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     hosts = host_collection.all()
     assert hosts
     for host in hosts:
@@ -127,6 +172,11 @@ def test_host_zones_assigned(host_collection, provider):
 
 @pytest.mark.rfe
 def test_hypervisor_hostname(host_collection, provider, soft_assert):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     hvisors = provider.mgmt.list_hosts()
     hosts = host_collection.all()
     for host in hosts:
@@ -139,6 +189,11 @@ def test_hypervisor_hostname(host_collection, provider, soft_assert):
 @pytest.mark.rfe
 @pytest.mark.parametrize("view_type", VIEWS)
 def test_hypervisor_hostname_views(host_collection, provider, view_type, soft_assert):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     hvisors = provider.mgmt.list_hosts()
     view = navigate_to(host_collection, 'All')
     view.toolbar.view_selector.select(view_type)
@@ -151,6 +206,11 @@ def test_hypervisor_hostname_views(host_collection, provider, view_type, soft_as
 
 @pytest.mark.rfe
 def test_host_networks(provider, host_collection, soft_assert):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     hosts = host_collection.all()
     nodes = provider.mgmt.nodes
     networks = {node.name: provider.mgmt.api.servers.ips(server=node) for node in nodes}
@@ -166,6 +226,11 @@ def test_host_networks(provider, host_collection, soft_assert):
 
 @pytest.mark.rfe
 def test_host_subnets(provider, appliance, host_collection, soft_assert):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     hosts = host_collection.all()
     net_collection = appliance.collections.cloud_networks
 

--- a/cfme/tests/openstack/infrastructure/test_provider.py
+++ b/cfme/tests/openstack/infrastructure/test_provider.py
@@ -14,6 +14,11 @@ pytestmark = [
 
 @pytest.mark.regression
 def test_api_port(provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view_details = navigate_to(provider, 'Details')
     port = provider.data['endpoints']['default']['api_port']
     api_port = int(view_details.entities.summary('Properties').get_text_of('API Port'))
@@ -22,6 +27,11 @@ def test_api_port(provider):
 
 @pytest.mark.regression
 def test_credentials_quads(provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(provider, 'All')
     prov_item = view.entities.get_entity(name=provider.name, surf_pages=True)
     valid_message = 'Authentication credentials are valid'
@@ -33,6 +43,11 @@ def test_credentials_quads(provider):
 
 @pytest.mark.regression
 def test_delete_provider(provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     provider.delete(cancel=False)
     provider.wait_for_delete()
     view = navigate_to(provider, 'All')

--- a/cfme/tests/openstack/infrastructure/test_relationships.py
+++ b/cfme/tests/openstack/infrastructure/test_relationships.py
@@ -18,6 +18,11 @@ pytestmark = [
 
 @pytest.mark.regression
 def test_assigned_roles(provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(provider, 'Details')
     try:
         res = view.entities.summary('Relationships').get_text_of('Deployment Roles')
@@ -28,6 +33,11 @@ def test_assigned_roles(provider):
 
 @pytest.mark.regression
 def test_nodes(provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(provider, 'Details')
     nodes = len(provider.mgmt.iapi.node.list())
 
@@ -36,6 +46,11 @@ def test_nodes(provider):
 
 @pytest.mark.regression
 def test_templates(provider, soft_assert):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(provider, 'Details')
     images = [i.name for i in provider.mgmt.images]
 
@@ -51,6 +66,11 @@ def test_templates(provider, soft_assert):
 
 @pytest.mark.regression
 def test_stacks(provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(provider, 'Details')
     """
     todo get the list of tenants from external resource and compare

--- a/cfme/tests/openstack/infrastructure/test_resources.py
+++ b/cfme/tests/openstack/infrastructure/test_resources.py
@@ -13,6 +13,11 @@ pytestmark = [
 
 @pytest.mark.regression
 def test_number_of_cpu(provider, soft_assert):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view_details = navigate_to(provider, 'Details')
     v = view_details.entities.summary('Properties').get_text_of('Aggregate Node CPU Resources')
     soft_assert(float(v.split()[0]) > 0, "Aggregate Node CPU Resources is 0")
@@ -24,6 +29,11 @@ def test_number_of_cpu(provider, soft_assert):
 
 @pytest.mark.regression
 def test_node_memory(provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view_details = navigate_to(provider, 'Details')
     node_memory = view_details.entities.summary('Properties').get_text_of('Aggregate Node Memory')
     assert float(node_memory.split()[0]) > 0

--- a/cfme/tests/openstack/infrastructure/test_roles.py
+++ b/cfme/tests/openstack/infrastructure/test_roles.py
@@ -26,6 +26,11 @@ def roles(appliance, provider):
 
 @pytest.mark.regression
 def test_host_role_association(appliance, provider, soft_assert):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     host_collection = appliance.collections.hosts
     hosts = host_collection.all()
     assert len(hosts) > 0
@@ -49,6 +54,11 @@ def test_host_role_association(appliance, provider, soft_assert):
 
 @pytest.mark.regression
 def test_roles_name(roles):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     for role in roles:
         role_name = role.name.split('-')[1]
         assert role_name in ROLES
@@ -56,6 +66,11 @@ def test_roles_name(roles):
 
 @pytest.mark.regression
 def test_roles_summary(roles, soft_assert):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     err_ptrn = '{} are shown incorrectly'
 
     for role in roles:
@@ -81,6 +96,11 @@ def test_roles_summary(roles, soft_assert):
 
 @pytest.mark.regression
 def test_role_delete(roles):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     role = choice(roles)
     role.delete()
     view = navigate_to(role, 'AllForProvider')

--- a/cfme/tests/optimize/test_bottlenecks.py
+++ b/cfme/tests/optimize/test_bottlenecks.py
@@ -61,7 +61,12 @@ def db_restore(temp_appliance_extended_db):
 @pytest.mark.rhel_testing
 @pytest.mark.tier(2)
 def test_bottlenecks_report_event_groups(temp_appliance_extended_db, db_restore, db_tbl, db_events):
-    """ Checks event_groups selectbox in report tab. It should filter events by type """
+    """ Checks event_groups selectbox in report tab. It should filter events by type
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     col = temp_appliance_extended_db.collections.bottlenecks
     view = navigate_to(col, 'All')
     # Enabling this option to show all possible values
@@ -77,7 +82,12 @@ def test_bottlenecks_report_event_groups(temp_appliance_extended_db, db_restore,
 
 @pytest.mark.tier(2)
 def test_bottlenecks_report_show_host_events(temp_appliance_extended_db, db_restore, db_events):
-    """ Checks host_events checkbox in report tab. It should show or not host events """
+    """ Checks host_events checkbox in report tab. It should show or not host events
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     col = temp_appliance_extended_db.collections.bottlenecks
     view = navigate_to(col, 'All')
     view.report.show_host_events.fill(False)
@@ -92,7 +102,12 @@ def test_bottlenecks_report_show_host_events(temp_appliance_extended_db, db_rest
 
 @pytest.mark.tier(2)
 def test_bottlenecks_report_time_zone(temp_appliance_extended_db, db_restore, db_tbl, db_events):
-    """ Checks time zone selectbox in report tab. It should change time zone of events in table """
+    """ Checks time zone selectbox in report tab. It should change time zone of events in table
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     col = temp_appliance_extended_db.collections.bottlenecks
     view = navigate_to(col, 'All')
     row = view.report.event_details[0]
@@ -110,7 +125,12 @@ def test_bottlenecks_report_time_zone(temp_appliance_extended_db, db_restore, db
 @pytest.mark.tier(2)
 def test_bottlenecks_summary_event_groups(temp_appliance_extended_db, db_restore, db_tbl,
                                           db_events):
-    """ Checks event_groups selectbox in summary tab. It should filter events by type """
+    """ Checks event_groups selectbox in summary tab. It should filter events by type
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     col = temp_appliance_extended_db.collections.bottlenecks
     view = navigate_to(col, 'All')
     # Enabling this option to show all possible values
@@ -126,7 +146,12 @@ def test_bottlenecks_summary_event_groups(temp_appliance_extended_db, db_restore
 
 @pytest.mark.tier(2)
 def test_bottlenecks_summary_show_host_events(temp_appliance_extended_db, db_restore, db_events):
-    """ Checks host_events checkbox in summary tab. It should show or not host events """
+    """ Checks host_events checkbox in summary tab. It should show or not host events
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     col = temp_appliance_extended_db.collections.bottlenecks
     view = navigate_to(col, 'All')
     view.summary.show_host_events.fill(False)
@@ -141,7 +166,12 @@ def test_bottlenecks_summary_show_host_events(temp_appliance_extended_db, db_res
 
 @pytest.mark.tier(2)
 def test_bottlenecks_summary_time_zone(temp_appliance_extended_db, db_restore, db_tbl, db_events):
-    """ Checks time zone selectbox in summary tab. It should change time zone of events in chart """
+    """ Checks time zone selectbox in summary tab. It should change time zone of events in chart
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     col = temp_appliance_extended_db.collections.bottlenecks
     view = navigate_to(col, 'All')
     events = view.summary.chart.get_events()

--- a/cfme/tests/perf/workloads/test_capacity_and_utilization.py
+++ b/cfme/tests/perf/workloads/test_capacity_and_utilization.py
@@ -19,7 +19,12 @@ roles_cap_and_util = ['automate', 'database_operations', 'ems_inventory', 'ems_m
 @pytest.mark.parametrize('scenario', get_capacity_and_utilization_scenarios())
 def test_workload_capacity_and_utilization(request, scenario, appliance):
     """Runs through provider based scenarios enabling C&U and running for a set period of time.
-    Memory Monitor creates graphs and summary at the end of each scenario."""
+    Memory Monitor creates graphs and summary at the end of each scenario.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     from_ts = int(time.time() * 1000)
     logger.debug('Scenario: {}'.format(scenario['name']))
 

--- a/cfme/tests/perf/workloads/test_capacity_and_utilization_replication.py
+++ b/cfme/tests/perf/workloads/test_capacity_and_utilization_replication.py
@@ -20,7 +20,12 @@ roles_cap_and_util_rep = ['automate', 'database_operations', 'database_synchroni
 @pytest.mark.parametrize('scenario', get_capacity_and_utilization_replication_scenarios())
 def test_workload_capacity_and_utilization_rep(appliance, request, scenario, setup_perf_provider):
     """Runs through provider based scenarios enabling C&U and replication, run for a set period of
-    time. Memory Monitor creates graphs and summary at the end of each scenario."""
+    time. Memory Monitor creates graphs and summary at the end of each scenario.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     from_ts = int(time.time() * 1000)
     ssh_client = appliance.ssh_client()
 

--- a/cfme/tests/perf/workloads/test_idle.py
+++ b/cfme/tests/perf/workloads/test_idle.py
@@ -17,7 +17,12 @@ def pytest_generate_tests(metafunc):
 @pytest.mark.usefixtures('generate_version_files')
 def test_idle(appliance, request, scenario):
     """Runs an appliance at idle with specific roles turned on for specific amount of time. Memory
-    Monitor creates graphs and summary at the end of the scenario."""
+    Monitor creates graphs and summary at the end of the scenario.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     from_ts = int(time.time() * 1000)
     logger.debug('Scenario: {}'.format(scenario['name']))
 

--- a/cfme/tests/perf/workloads/test_memory_leak.py
+++ b/cfme/tests/perf/workloads/test_memory_leak.py
@@ -52,7 +52,12 @@ def prepare_workers(appliance):
 @pytest.mark.parametrize('scenario', get_memory_leak_scenarios())
 def test_workload_memory_leak(request, scenario, appliance, provider):
     """Runs through provider based scenarios setting one worker instance and maximum threshold and
-    running for a set period of time. Memory Monitor creates graphs and summary info."""
+    running for a set period of time. Memory Monitor creates graphs and summary info.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     from_ts = int(time.time() * 1000)
     logger.debug('Scenario: {}'.format(scenario['name']))
 

--- a/cfme/tests/perf/workloads/test_provisioning.py
+++ b/cfme/tests/perf/workloads/test_provisioning.py
@@ -74,7 +74,12 @@ def get_provision_data(rest_api, provider, template_name, auto_approve=True):
 def test_provisioning(appliance, request, scenario):
     """Runs through provisioning scenarios using the REST API to
     continously provision a VM for a specified period of time.
-    Memory Monitor creates graphs and summary at the end of each scenario."""
+    Memory Monitor creates graphs and summary at the end of each scenario.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
 
     from_ts = int(time.time() * 1000)
     logger.debug('Scenario: {}'.format(scenario['name']))

--- a/cfme/tests/perf/workloads/test_refresh_providers.py
+++ b/cfme/tests/perf/workloads/test_refresh_providers.py
@@ -20,6 +20,10 @@ def test_refresh_providers(appliance, request, scenario):
     """
     Refreshes providers then waits for a specific amount of time.
     Memory Monitor creates graphs and summary at the end of the scenario.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     from_ts = int(time.time() * 1000)
     logger.debug('Scenario: {}'.format(scenario['name']))

--- a/cfme/tests/perf/workloads/test_refresh_vms.py
+++ b/cfme/tests/perf/workloads/test_refresh_vms.py
@@ -20,7 +20,12 @@ roles_refresh_vms = ['automate', 'database_operations', 'ems_inventory', 'ems_op
 @pytest.mark.parametrize('scenario', get_refresh_vms_scenarios())
 def test_refresh_vms(appliance, request, scenario):
     """Refreshes all vm's then waits for a specific amount of time. Memory Monitor creates
-    graphs and summary at the end of the scenario."""
+    graphs and summary at the end of the scenario.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     from_ts = int(time.time() * 1000)
     logger.debug('Scenario: {}'.format(scenario['name']))
 

--- a/cfme/tests/perf/workloads/test_smartstate_analysis.py
+++ b/cfme/tests/perf/workloads/test_smartstate_analysis.py
@@ -27,7 +27,12 @@ def get_host_data_by_name(provider, host_name):
 @pytest.mark.parametrize('scenario', get_smartstate_analysis_scenarios())
 def test_workload_smartstate_analysis(appliance, request, scenario):
     """Runs through provider based scenarios initiating smart state analysis against VMs, Hosts,
-    and Datastores"""
+    and Datastores
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     from_ts = int(time.time() * 1000)
     logger.debug('Scenario: {}'.format(scenario['name']))
     appliance.install_vddk()

--- a/cfme/tests/physical_infrastructure/api/test_physical_server_api.py
+++ b/cfme/tests/physical_infrastructure/api/test_physical_server_api.py
@@ -32,12 +32,22 @@ def get_server_attr(attr_name, provider, physical_server):
 
 
 def test_get_physical_server(physical_server, appliance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     existent_server = appliance.rest_api.get_entity('physical_servers', physical_server.id)
     existent_server.reload()
     assert_response(appliance)
 
 
 def test_get_nonexistent_physical_server(appliance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     nonexistent = appliance.rest_api.get_entity('physical_servers', 999999)
     with pytest.raises(Exception, match='ActiveRecord::RecordNotFound'):
         nonexistent.reload()
@@ -45,6 +55,11 @@ def test_get_nonexistent_physical_server(appliance):
 
 
 def test_invalid_action(physical_server, appliance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     payload = {
         "action": "invalid_action"
     }
@@ -53,6 +68,11 @@ def test_invalid_action(physical_server, appliance):
 
 
 def test_refresh_physical_server(appliance, physical_server):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     assert getattr(physical_server.action, "refresh")()
     assert_response(appliance)
 
@@ -81,6 +101,10 @@ def test_server_actions(physical_server, appliance, provider, action,
         * desired_state:     the value of the attribute after the action execution
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     def condition():

--- a/cfme/tests/physical_infrastructure/api/test_physical_server_events_api.py
+++ b/cfme/tests/physical_infrastructure/api/test_physical_server_events_api.py
@@ -44,6 +44,11 @@ def enumerate_events_and_refresh_physical_infra_provider(appliance, provider):
 
 
 def test_get_physical_infra_provider_power_event(appliance, physical_server, provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     previous_num_events = enumerate_physical_infra_provider_events(appliance)
     physical_server.action.restart_now()
     assert_response(appliance)

--- a/cfme/tests/physical_infrastructure/api/test_physical_server_inventory_api.py
+++ b/cfme/tests/physical_infrastructure/api/test_physical_server_inventory_api.py
@@ -17,6 +17,11 @@ def physical_server(setup_provider_modscope, appliance):
 
 
 def test_get_hardware(appliance, physical_server):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_server.reload(attributes=['hardware'])
     assert_response(appliance)
     assert physical_server.hardware is not None
@@ -24,6 +29,11 @@ def test_get_hardware(appliance, physical_server):
 
 @pytest.mark.parametrize('attribute', ['firmwares', 'nics', 'ports'])
 def test_get_hardware_attributes(appliance, physical_server, attribute):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     expanded_attribute = 'hardware.{}'.format(attribute)
     physical_server.reload(attributes=[expanded_attribute])
     assert_response(appliance)
@@ -31,6 +41,11 @@ def test_get_hardware_attributes(appliance, physical_server, attribute):
 
 
 def test_get_asset_detail(appliance, physical_server):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_server.reload(attributes=['asset_detail'])
     assert_response(appliance)
     assert physical_server.asset_detail is not None

--- a/cfme/tests/physical_infrastructure/api/test_physical_switch_api.py
+++ b/cfme/tests/physical_infrastructure/api/test_physical_switch_api.py
@@ -11,12 +11,22 @@ pytestmark = [
 
 
 def test_get_switch(physical_switch, appliance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     existent_switch = appliance.rest_api.get_entity('switches', physical_switch.id)
     existent_switch.reload()
     assert_response(appliance)
 
 
 def test_get_nonexistent_physical_switch(appliance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     nonexistent = appliance.rest_api.get_entity('switches', 999999)
     with pytest.raises(Exception, match='ActiveRecord::RecordNotFound'):
         nonexistent.reload()
@@ -24,6 +34,11 @@ def test_get_nonexistent_physical_switch(appliance):
 
 
 def test_invalid_action(physical_switch, appliance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     payload = {
         "action": "invalid_action"
     }
@@ -32,5 +47,10 @@ def test_invalid_action(physical_switch, appliance):
 
 
 def test_refresh_physical_switch(appliance, physical_switch):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     assert getattr(physical_switch.action, "refresh")()
     assert_response(appliance)

--- a/cfme/tests/physical_infrastructure/api/test_physical_switch_inventory_api.py
+++ b/cfme/tests/physical_infrastructure/api/test_physical_switch_inventory_api.py
@@ -11,6 +11,11 @@ pytestmark = [
 
 
 def test_get_hardware(appliance, physical_switch):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_switch.reload(attributes=['hardware'])
     assert_response(appliance)
     assert physical_switch.hardware is not None
@@ -18,6 +23,11 @@ def test_get_hardware(appliance, physical_switch):
 
 @pytest.mark.parametrize('attribute', ['firmwares', 'nics', 'ports'])
 def test_get_hardware_attributes(appliance, physical_switch, attribute):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     expanded_attribute = 'hardware.{}'.format(attribute)
     physical_switch.reload(attributes=[expanded_attribute])
     assert_response(appliance)
@@ -25,6 +35,11 @@ def test_get_hardware_attributes(appliance, physical_switch, attribute):
 
 
 def test_get_asset_detail(appliance, physical_switch):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_switch.reload(attributes=['asset_detail'])
     assert_response(appliance)
     assert physical_switch.asset_detail is not None

--- a/cfme/tests/physical_infrastructure/test_physical_rack.py
+++ b/cfme/tests/physical_infrastructure/test_physical_rack.py
@@ -18,7 +18,12 @@ def physical_rack(appliance, provider, setup_provider):
 
 
 def test_physical_rack_details_dropdowns(physical_rack):
-    """Navigate to the physical rack details page and verify the refresh button"""
+    """Navigate to the physical rack details page and verify the refresh button
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_rack.refresh()
 
 
@@ -28,7 +33,12 @@ def physical_rack_collection(appliance, provider, setup_provider_modscope):
 
 
 def test_physical_racks_view_dropdowns(physical_rack_collection):
-    """Navigate to the physical racks page and verify that the dropdown menus are present"""
+    """Navigate to the physical racks page and verify that the dropdown menus are present
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_racks_view = navigate_to(physical_rack_collection, 'All')
 
     configuration_items = physical_racks_view.toolbar.configuration.items

--- a/cfme/tests/physical_infrastructure/test_providers.py
+++ b/cfme/tests/physical_infrastructure/test_providers.py
@@ -21,6 +21,10 @@ def test_physical_infra_provider_crud(provider, has_no_providers):
 
     Metadata:
         test_flag: crud
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     provider.create()
 

--- a/cfme/tests/physical_infrastructure/test_redfish_physical_server_details.py
+++ b/cfme/tests/physical_infrastructure/test_redfish_physical_server_details.py
@@ -13,5 +13,10 @@ def physical_server(appliance, provider, setup_provider_funcscope):
 
 
 def test_redfish_physical_server_details_stats(physical_server):
-    """Navigate to the physical server details page and verify that the stats match"""
+    """Navigate to the physical server details page and verify that the stats match
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_server.validate_stats(ui=True)

--- a/cfme/tests/physical_infrastructure/test_redfish_providers.py
+++ b/cfme/tests/physical_infrastructure/test_redfish_providers.py
@@ -12,7 +12,12 @@ pytestmark = [
 
 
 def test_redfish_provider_crud(provider, has_no_physical_providers):
-    """Tests provider add with good credentials"""
+    """Tests provider add with good credentials
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     provider.create()
 
     provider.validate_stats(ui=True)

--- a/cfme/tests/physical_infrastructure/ui/test_physical_overview.py
+++ b/cfme/tests/physical_infrastructure/ui/test_physical_overview.py
@@ -8,12 +8,22 @@ pytestmark = [pytest.mark.tier(3),
 
 
 def test_physical_overview_page(appliance, setup_provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     providers = appliance.collections.physical_providers
     view = navigate_to(providers, 'Overview')
     assert view.is_displayed
 
 
 def test_physical_overview_servers_number(appliance, provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     providers = appliance.collections.physical_providers
     servers = provider.mgmt.list_servers()
     view = navigate_to(providers, 'Overview')
@@ -21,6 +31,11 @@ def test_physical_overview_servers_number(appliance, provider):
 
 
 def test_physical_overview_switches_number(appliance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     providers = appliance.collections.physical_providers
     switches = appliance.collections.physical_switches.all()
     view = navigate_to(providers, 'Overview')

--- a/cfme/tests/physical_infrastructure/ui/test_physical_server_details.py
+++ b/cfme/tests/physical_infrastructure/ui/test_physical_server_details.py
@@ -15,13 +15,23 @@ def physical_server(appliance, provider, setup_provider_modscope):
 
 
 def test_physical_server_details(physical_server):
-    """Navigate to the physical server details page and verify that the page is displayed"""
+    """Navigate to the physical server details page and verify that the page is displayed
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_server_view = navigate_to(physical_server, 'Details')
     assert physical_server_view.is_displayed
 
 
 def test_physical_server_details_dropdowns(physical_server):
-    """Navigate to the physical server details page and verify that the menus are present"""
+    """Navigate to the physical server details page and verify that the menus are present
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_server_view = navigate_to(physical_server, 'Details')
 
     configuration_items = physical_server_view.toolbar.configuration.items
@@ -53,7 +63,12 @@ def test_physical_server_details_dropdowns(physical_server):
 
 
 def test_network_devices(physical_server):
-    """Navigate to the Network Devices page and verify that the page is displayed"""
+    """Navigate to the Network Devices page and verify that the page is displayed
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
 
     num_network_devices = physical_server.num_network_devices()
     network_device_view = navigate_to(physical_server, 'NetworkDevices')
@@ -63,7 +78,12 @@ def test_network_devices(physical_server):
 
 
 def test_storage_devices(physical_server):
-    """Navigate to the Storage Devices page and verify that the page is displayed"""
+    """Navigate to the Storage Devices page and verify that the page is displayed
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
 
     num_storage_devices = physical_server.num_storage_devices()
     storage_device_view = navigate_to(physical_server, 'StorageDevices')
@@ -73,5 +93,10 @@ def test_storage_devices(physical_server):
 
 
 def test_physical_server_details_stats(physical_server):
-    """Navigate to the physical server details page and verify that the stats match"""
+    """Navigate to the physical server details page and verify that the stats match
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_server.validate_stats(ui=True)

--- a/cfme/tests/physical_infrastructure/ui/test_physical_server_details_buttons.py
+++ b/cfme/tests/physical_infrastructure/ui/test_physical_server_details_buttons.py
@@ -18,6 +18,11 @@ def physical_server(appliance, provider):
 
 # Configuration Button
 def test_refresh_relationships(physical_server, provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     last_refresh = provider.last_refresh_date()
     physical_server.refresh(provider, handle_alert=True)
     assert last_refresh != provider.last_refresh_date()
@@ -25,30 +30,55 @@ def test_refresh_relationships(physical_server, provider):
 
 # Power Button
 def test_power_off(physical_server, provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_server.power_off()
     view = provider.create_view(PhysicalServerDetailsView, physical_server)
     view.flash.assert_message('Requested Server power_off for the selected server')
 
 
 def test_power_on(physical_server, provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_server.power_on()
     view = provider.create_view(PhysicalServerDetailsView, physical_server)
     view.flash.assert_message('Requested Server power_on for the selected server')
 
 
 def test_power_off_immediately(physical_server, provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_server.power_off_immediately()
     view = provider.create_view(PhysicalServerDetailsView, physical_server)
     view.flash.assert_message('Requested Server power_off_now for the selected server')
 
 
 def test_restart(physical_server, provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_server.restart()
     view = provider.create_view(PhysicalServerDetailsView, physical_server)
     view.flash.assert_message('Requested Server restart for the selected server')
 
 
 def test_restart_immediately(physical_server, provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_server.restart_immediately()
     view = provider.create_view(PhysicalServerDetailsView, physical_server)
     view.flash.assert_message('Requested Server restart_now for the selected server')
@@ -56,18 +86,33 @@ def test_restart_immediately(physical_server, provider):
 
 # Identify Button
 def test_turn_on_led(physical_server, provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_server.turn_on_led()
     view = provider.create_view(PhysicalServerDetailsView, physical_server)
     view.flash.assert_message('Requested Server turn_on_loc_led for the selected server')
 
 
 def test_turn_off_led(physical_server, provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_server.turn_off_led()
     view = provider.create_view(PhysicalServerDetailsView, physical_server)
     view.flash.assert_message('Requested Server turn_off_loc_led for the selected server')
 
 
 def test_turn_blink_led(physical_server, provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_server.turn_blink_led()
     view = provider.create_view(PhysicalServerDetailsView, physical_server)
     view.flash.assert_message('Requested Server blink_loc_led for the selected server')
@@ -75,11 +120,21 @@ def test_turn_blink_led(physical_server, provider):
 
 # Lifecycle Button
 def test_lifecycle_provision(physical_server):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(physical_server, "Provision")
     assert view.is_displayed
 
 
 # Monitoring Button
 def test_monitoring_button(physical_server):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(physical_server, "Timelines")
     assert view.is_displayed

--- a/cfme/tests/physical_infrastructure/ui/test_physical_server_list.py
+++ b/cfme/tests/physical_infrastructure/ui/test_physical_server_list.py
@@ -14,13 +14,23 @@ def physical_server_collection(appliance, provider, setup_provider_modscope):
 
 
 def test_physical_servers_view_displayed(physical_server_collection):
-    """Navigate to the physical servers page and verify that servers are displayed"""
+    """Navigate to the physical servers page and verify that servers are displayed
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_servers_view = navigate_to(physical_server_collection, 'All')
     assert physical_servers_view.is_displayed
 
 
 def test_physical_servers_view_dropdowns(physical_server_collection):
-    """Navigate to the physical servers page and verify that the dropdown menus are present"""
+    """Navigate to the physical servers page and verify that the dropdown menus are present
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_servers_view = navigate_to(physical_server_collection, 'All')
 
     toolbar = physical_servers_view.toolbar

--- a/cfme/tests/physical_infrastructure/ui/test_physical_server_list_buttons.py
+++ b/cfme/tests/physical_infrastructure/ui/test_physical_server_list_buttons.py
@@ -24,6 +24,11 @@ def physical_servers_collection(appliance):
 
 # Configuration Button
 def test_refresh_relationships(physical_servers_collection, physical_servers, provider):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(physical_servers_collection, "All")
     last_refresh = provider.last_refresh_date()
     item = "Refresh Relationships and Power States"
@@ -67,6 +72,10 @@ def test_server_actions(physical_servers_collection, physical_servers, provider,
         current method on the manageIQ.
     Metadata:
         test_flag: crud
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     view = provider.create_view(PhysicalServersView)
 
@@ -91,12 +100,22 @@ def test_server_actions(physical_servers_collection, physical_servers, provider,
 
 # Policy Button
 def test_manage_button(physical_servers_collection, physical_servers):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_servers_collection.select_entity_rows(physical_servers)
     view = navigate_to(physical_servers_collection, "ManagePoliciesCollection")
     assert view.is_displayed
 
 
 def test_edit_tag(physical_servers_collection, physical_servers):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_servers_collection.select_entity_rows(physical_servers)
     view = navigate_to(physical_servers_collection, "EditTagsCollection")
     assert view.is_displayed
@@ -104,6 +123,11 @@ def test_edit_tag(physical_servers_collection, physical_servers):
 
 # Lifecycle Button
 def test_lifecycle_provision(physical_servers_collection, physical_servers):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_servers_collection.select_entity_rows(physical_servers)
     view = navigate_to(physical_servers_collection, "ProvisionCollection")
     assert view.is_displayed

--- a/cfme/tests/physical_infrastructure/ui/test_physical_switch_details.py
+++ b/cfme/tests/physical_infrastructure/ui/test_physical_switch_details.py
@@ -15,13 +15,23 @@ def physical_switch(appliance, setup_provider_modscope):
 
 
 def test_physical_switch_details(physical_switch):
-    """Navigate to the physical switch details page and verify that the page is displayed"""
+    """Navigate to the physical switch details page and verify that the page is displayed
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_switch_view = navigate_to(physical_switch, 'Details')
     assert physical_switch_view.is_displayed
 
 
 def test_physical_switch_details_dropdowns(physical_switch):
-    """Navigate to the physical switch details page and verify that the menus are present"""
+    """Navigate to the physical switch details page and verify that the menus are present
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_switch_view = navigate_to(physical_switch, 'Details')
 
     configuration_items = physical_switch_view.toolbar.configuration.items

--- a/cfme/tests/physical_infrastructure/ui/test_physical_switch_list.py
+++ b/cfme/tests/physical_infrastructure/ui/test_physical_switch_list.py
@@ -8,13 +8,23 @@ pytestmark = [pytest.mark.tier(3), pytest.mark.provider([LenovoProvider], scope=
 
 
 def test_physical_switches_view_displayed(appliance):
-    """Navigate to the physical switches page and verify that switches are displayed"""
+    """Navigate to the physical switches page and verify that switches are displayed
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_switches_view = navigate_to(appliance.collections.physical_switches, 'All')
     assert physical_switches_view.is_displayed
 
 
 def test_physical_switches_view_dropdowns(appliance):
-    """Navigate to the physical switches page and verify that the dropdown menus are present"""
+    """Navigate to the physical switches page and verify that the dropdown menus are present
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     physical_switches_view = navigate_to(appliance.collections.physical_switches, 'All')
 
     toolbar = physical_switches_view.toolbar

--- a/cfme/tests/platform/test_advanced_config.py
+++ b/cfme/tests/platform/test_advanced_config.py
@@ -27,7 +27,12 @@ def reset_nonleaf(config):
 @pytest.mark.ignore_stream("5.9")
 def test_advanced_config_reset_pzed(appliance, vmdb_config, configurer):
     """Check whether we can use "<<reset>>" string to reset the leaf element
-    of the advanced config."""
+    of the advanced config.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
 
     vmdb_config['http_proxy']['default'] = {'host': 'bar'}
     appliance.update_advanced_settings(vmdb_config)

--- a/cfme/tests/pod/test_appliance_crud.py
+++ b/cfme/tests/pod/test_appliance_crud.py
@@ -185,6 +185,10 @@ def test_crud_pod_appliance(temp_pod_appliance, provider, setup_provider):
 
     Metadata:
         test_flag: podtesting
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     appliance = temp_pod_appliance
     collection = appliance.collections.container_projects
@@ -201,6 +205,10 @@ def test_crud_pod_appliance_ansible_deployment(temp_pod_ansible_appliance, provi
 
     Metadata
        test_flag: podtesting
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     appliance = temp_pod_ansible_appliance
     collection = appliance.collections.container_projects
@@ -214,6 +222,10 @@ def test_crud_pod_appliance_ext_db():
     deploys pod appliance
     checks that it is alive
     deletes pod appliance
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     # add ext db templates to provider in template deployment
     # make sprout deploy ext db appliances ? or wrapanapi enhancement ?
@@ -226,6 +238,10 @@ def test_crud_pod_appliance_custom_config():
     overriding default values in template and deploys pod appliance
     checks that it is alive
     deletes pod appliance
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     # custom deployment
     pass
@@ -235,6 +251,10 @@ def test_crud_pod_appliance_custom_config():
 def test_pod_appliance_config_upgrade():
     """
     appliance config update should cause appliance re-deployment
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     pass
 
@@ -243,6 +263,10 @@ def test_pod_appliance_config_upgrade():
 def test_pod_appliance_image_upgrade():
     """
     one of appliance images has been changed. it should cause pod re-deployment
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     pass
 
@@ -251,6 +275,10 @@ def test_pod_appliance_image_upgrade():
 def test_pod_appliance_db_upgrade():
     """
     db scheme/version has been changed
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     pass
 
@@ -261,6 +289,10 @@ def test_pod_appliance_start_stop(temp_pod_appliance, provider, setup_provider):
 
         Metadata:
         test_flag: podtesting
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     appliance = temp_pod_appliance
     assert provider.mgmt.is_vm_running(appliance.project)
@@ -274,6 +306,10 @@ def test_pod_appliance_start_stop(temp_pod_appliance, provider, setup_provider):
 def test_pod_appliance_scale():
     """
     appliance should work correctly after scale up/down
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     pass
 
@@ -282,5 +318,9 @@ def test_pod_appliance_scale():
 def test_aws_smartstate_pod():
     """
     deploy aws smartstate pod and that it works
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     pass

--- a/cfme/tests/pod/test_db_backup_restore.py
+++ b/cfme/tests/pod/test_db_backup_restore.py
@@ -5,5 +5,9 @@ import pytest
 def test_pod_appliance_db_backup_restore():
     """
     database has been saved and recovered
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     pass

--- a/cfme/tests/pod/test_ext_auth.py
+++ b/cfme/tests/pod/test_ext_auth.py
@@ -5,5 +5,9 @@ import pytest
 def test_pod_appliance_basic_ipa_auth():
     """
     auth from ipa server should work
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     pass

--- a/cfme/tests/services/test_add_remove_vm_to_service.py
+++ b/cfme/tests/services/test_add_remove_vm_to_service.py
@@ -75,6 +75,10 @@ def test_add_vm_to_service(myservice, request, copy_domain, new_vm, appliance):
 
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: nansari
+        initialEstimate: 1/4h
     """
     method_torso = """
     def add_to_service

--- a/cfme/tests/services/test_catalog.py
+++ b/cfme/tests/services/test_catalog.py
@@ -14,6 +14,12 @@ pytestmark = [test_requirements.service, pytest.mark.tier(2)]
 @pytest.mark.rhel_testing
 @pytest.mark.sauce
 def test_catalog_crud(appliance):
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        initialEstimate: 1/8h
+    """
     catalog_name = fauxfactory.gen_alphanumeric()
     cat = appliance.collections.catalogs.create(name=catalog_name, description='my catalog')
 
@@ -28,6 +34,13 @@ def test_catalog_crud(appliance):
 
 @pytest.mark.sauce
 def test_catalog_duplicate_name(appliance):
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
     catalog_name = fauxfactory.gen_alphanumeric()
     cat = appliance.collections.catalogs.create(name=catalog_name, description='my catalog')
     with pytest.raises(AssertionError):
@@ -38,7 +51,14 @@ def test_catalog_duplicate_name(appliance):
 
 @pytest.mark.sauce
 def test_permissions_catalog_add(appliance, request):
-    """ Tests that a catalog can be added only with the right permissions"""
+    """ Tests that a catalog can be added only with the right permissions
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
 
     def _create_catalog(appliance):
         cat = appliance.collections.catalogs.create(name=fauxfactory.gen_alphanumeric(),

--- a/cfme/tests/services/test_catalog_item.py
+++ b/cfme/tests/services/test_catalog_item.py
@@ -72,15 +72,36 @@ def check_catalog_visibility(user_restricted, tag):
 
 @pytest.mark.skip('Catalog items are converted to collections. Refactoring is required')
 def test_create_catalog_item(catalog_item):
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
     catalog_item.create()
 
 
 def test_update_catalog_item(catalog_item):
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
     with update(catalog_item):
         catalog_item.description = "my edited item description"
 
 
 def test_add_button_group(catalog_item, appliance):
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
     button_name = catalog_item.add_button_group()
     view = appliance.browser.create_view(BaseLoggedInPage)
     if appliance.version.is_in_series('5.8'):
@@ -91,6 +112,11 @@ def test_add_button_group(catalog_item, appliance):
 
 
 def test_add_button(catalog_item, appliance):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     button_name = catalog_item.add_button()
     view = appliance.browser.create_view(BaseLoggedInPage)
     if appliance.version.is_in_series('5.8'):
@@ -101,6 +127,13 @@ def test_add_button(catalog_item, appliance):
 
 
 def test_edit_tags(catalog_item):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/8h
+    """
     tag = catalog_item.add_tag()
     catalog_item.remove_tag(tag)
 
@@ -108,6 +141,13 @@ def test_edit_tags(catalog_item):
 @pytest.mark.skip('Catalog items are converted to collections. Refactoring is required')
 @pytest.mark.meta(blockers=[BZ(1531512, forced_streams=["5.8", "5.9", "upstream"])])
 def test_catalog_item_duplicate_name(catalog_item):
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
     catalog_item.create()
     with pytest.raises(Exception, match="Name has already been taken"):
         catalog_item.create()
@@ -116,7 +156,14 @@ def test_catalog_item_duplicate_name(catalog_item):
 @pytest.mark.skip('Catalog items are converted to collections. Refactoring is required')
 @pytest.mark.meta(blockers=[BZ(1460891, forced_streams=["5.8", "upstream"])])
 def test_permissions_catalog_item_add(catalog_item):
-    """Test that a catalog can be added only with the right permissions."""
+    """Test that a catalog can be added only with the right permissions.
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: low
+        initialEstimate: 1/8h
+    """
     tac.single_task_permission_test([['Everything', 'Services', 'Catalogs Explorer',
                                       'Catalog Items']],
                                     {'Add Catalog Item': catalog_item.create})
@@ -132,6 +179,11 @@ def test_tagvis_catalog_items(check_catalog_visibility, catalog_item):
         2. Login as restricted user, catalog item is visible for user
         3. As admin remove tag
         4. Login as restricted user, catalog item is not visible for user
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        initialEstimate: 1/8h
     """
     check_catalog_visibility(catalog_item)
 
@@ -146,7 +198,12 @@ def test_tagvis_catalog_bundle(check_catalog_visibility, catalog_bundle):
             2. Login as restricted user, catalog bundle is visible for user
             3. As admin remove tag
             4. Login as restricted user, catalog bundle is not visible for user
-        """
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        initialEstimate: 1/8h
+    """
     check_catalog_visibility(catalog_bundle)
 
 
@@ -154,7 +211,12 @@ def test_tagvis_catalog_bundle(check_catalog_visibility, catalog_bundle):
                          reason='Catalog item restriction was not added to 5.8')
 def test_restricted_catalog_items_select_for_catalog_bundle(appliance, request, catalog_item,
                                                             user_restricted, tag, soft_assert):
-    """Test catalog item restriction while bundle creation"""
+    """Test catalog item restriction while bundle creation
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     catalog_bundles = appliance.collections.catalog_bundles
     with user_restricted:
         view = navigate_to(catalog_bundles, 'Add')

--- a/cfme/tests/services/test_cloud_service_catalogs.py
+++ b/cfme/tests/services/test_cloud_service_catalogs.py
@@ -38,6 +38,10 @@ def test_cloud_catalog_item(appliance, vm_name, setup_provider, provider, dialog
 
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: nansari
+        initialEstimate: 1/4h
     """
     wait_for(provider.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600)
     vm = appliance.collections.cloud_instances.instantiate("{}0001".format(vm_name), provider)

--- a/cfme/tests/services/test_config_provider_servicecatalogs.py
+++ b/cfme/tests/services/test_config_provider_servicecatalogs.py
@@ -69,6 +69,10 @@ def test_order_tower_catalog_item(appliance, catalog_item, request):
     """Tests order catalog item
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
     service_catalogs.order()
@@ -88,6 +92,12 @@ def test_retire_ansible_service(appliance, catalog_item, request):
     """Tests order catalog item
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: low
+        initialEstimate: 1/4h
     """
     service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
     service_catalogs.order()

--- a/cfme/tests/services/test_dialog_element_in_catalog.py
+++ b/cfme/tests/services/test_dialog_element_in_catalog.py
@@ -55,6 +55,10 @@ def test_dropdownlist_required_dialog_element(appliance, catalog_item):
     """Tests service dropdownlist dialog required element.
 
     Testing BZ 1512398.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
     view = navigate_to(service_catalogs, 'Order')

--- a/cfme/tests/services/test_different_dialogs_in_catalogs.py
+++ b/cfme/tests/services/test_different_dialogs_in_catalogs.py
@@ -95,6 +95,10 @@ def test_tagdialog_catalog_item(appliance, provider, catalog_item, request):
     """Tests tag dialog catalog item
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     vm_name = catalog_item.prov_data['catalog']["vm_name"]
     request.addfinalizer(

--- a/cfme/tests/services/test_dynamicdd_dialogelement.py
+++ b/cfme/tests/services/test_dynamicdd_dialogelement.py
@@ -102,6 +102,13 @@ def copy_instance(request, copy_domain, appliance):
 @pytest.mark.tier(3)
 @pytest.mark.meta(blockers=[BZ(1514584, forced_streams=["5.7", "5.8", "5.9"])])
 def test_dynamicdropdown_dialog(appliance, dialog, catalog):
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
     item_name = fauxfactory.gen_alphanumeric()
     catalog_item = appliance.collections.catalog_items.create(
         appliance.collections.catalog_items.GENERIC, name=item_name,

--- a/cfme/tests/services/test_generic_service_catalogs.py
+++ b/cfme/tests/services/test_generic_service_catalogs.py
@@ -36,6 +36,13 @@ def catalog_item(appliance, dialog, catalog):
 
 
 def test_delete_catalog_deletes_service(appliance, dialog, catalog):
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
     item_name = fauxfactory.gen_alphanumeric()
     catalog_item = appliance.collections.catalog_items.create(
         appliance.collections.catalog_items.GENERIC,
@@ -49,6 +56,13 @@ def test_delete_catalog_deletes_service(appliance, dialog, catalog):
 
 
 def test_delete_catalog_item_deletes_service(appliance, catalog_item):
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
     catalog_item.delete()
     service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
     with pytest.raises(CandidateNotFound):
@@ -56,6 +70,13 @@ def test_delete_catalog_item_deletes_service(appliance, catalog_item):
 
 
 def test_service_circular_reference(appliance, catalog_item):
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
     bundle_name = "first_" + fauxfactory.gen_alphanumeric()
     catalog_bundle = appliance.collections.catalog_bundles.create(
         bundle_name, description="catalog_bundle",
@@ -73,6 +94,13 @@ def test_service_circular_reference(appliance, catalog_item):
 
 
 def test_service_generic_catalog_bundle(appliance, catalog_item):
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
     bundle_name = "generic_" + fauxfactory.gen_alphanumeric()
     appliance.collections.catalog_bundles.create(
         bundle_name, description="catalog_bundle",
@@ -90,6 +118,13 @@ def test_service_generic_catalog_bundle(appliance, catalog_item):
 
 
 def test_bundles_in_bundle(appliance, catalog_item):
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: low
+        initialEstimate: 1/8h
+    """
     bundle_name = "first_" + fauxfactory.gen_alphanumeric()
     appliance.collections.catalog_bundles.create(
         bundle_name, description="catalog_bundle",
@@ -117,6 +152,13 @@ def test_bundles_in_bundle(appliance, catalog_item):
 
 
 def test_delete_dialog_before_parent_item(appliance, catalog_item):
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: low
+        initialEstimate: 1/8h
+    """
     service_dialog = appliance.collections.service_dialogs
     dialog = service_dialog.instantiate(label=catalog_item.dialog.label)
     error_message = ('Dialog \"{}\": Error during delete: Dialog cannot be'
@@ -136,6 +178,11 @@ class TestServiceCatalogViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: sshveta
+            caseimportance: low
+            initialEstimate: 1/3h
         """
         delete_resources_from_detail(service_catalogs, method=method)
 
@@ -144,6 +191,11 @@ class TestServiceCatalogViaREST(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: sshveta
+            caseimportance: low
+            initialEstimate: 1/3h
         """
         delete_resources_from_collection(service_catalogs)
 
@@ -156,6 +208,11 @@ class TestServiceCatalogViaREST(object):
             * Check if the service_catalog with ``new_name`` exists
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: sshveta
+            caseimportance: low
+            initialEstimate: 1/3h
         """
         for ctl in service_catalogs:
             new_name = fauxfactory.gen_alphanumeric()
@@ -175,6 +232,11 @@ class TestServiceCatalogViaREST(object):
             * Check if the service_catalogs with ``new_name`` each exist
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: sshveta
+            caseimportance: low
+            initialEstimate: 1/3h
         """
 
         new_names = []

--- a/cfme/tests/services/test_iso_service_catalogs.py
+++ b/cfme/tests/services/test_iso_service_catalogs.py
@@ -87,6 +87,10 @@ def test_rhev_iso_servicecatalog(appliance, provider, setup_provider, setup_iso_
 
     Metadata:
         test_flag: iso, provision
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     vm_name = catalog_item.prov_data['catalog']["vm_name"]
     request.addfinalizer(

--- a/cfme/tests/services/test_myservice.py
+++ b/cfme/tests/services/test_myservice.py
@@ -66,6 +66,10 @@ def test_retire_service_ui(appliance, context, myservice):
 
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: sshveta
+        initialEstimate: None
     """
     service_name, vm_name = myservice
     with appliance.context.use(context):
@@ -79,6 +83,10 @@ def test_retire_service_on_date(appliance, context, myservice):
 
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: sshveta
+        initialEstimate: 1/4h
     """
     service_name, vm_name = myservice
     with appliance.context.use(context):
@@ -93,6 +101,10 @@ def test_crud_set_ownership_and_edit_tags(appliance, context, myservice):
 
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: sshveta
+        initialEstimate: 1/4h
     """
 
     service_name, vm_name = myservice
@@ -114,6 +126,10 @@ def test_download_file(appliance, context, needs_firefox, myservice, filetype):
 
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: nansari
+        initialEstimate: 1/16h
     """
     service_name, vm_name = myservice
     with appliance.context.use(context):
@@ -123,7 +139,12 @@ def test_download_file(appliance, context, needs_firefox, myservice, filetype):
 
 @pytest.mark.parametrize('context', [ViaUI])
 def test_service_link(appliance, context, myservice):
-    """Tests service link from VM details page(BZ1443772)"""
+    """Tests service link from VM details page(BZ1443772)
+
+    Polarion:
+        assignee: sshveta
+        initialEstimate: 1/4h
+    """
     service_name, vm_name = myservice
     with appliance.context.use(context):
         myservice = MyService(appliance, name=service_name, vm_name=vm_name)

--- a/cfme/tests/services/test_operations.py
+++ b/cfme/tests/services/test_operations.py
@@ -97,7 +97,12 @@ def generated_request(appliance, provider, provisioning, template_name, vm_name)
 
 @pytest.mark.tier(3)
 def test_services_request_direct_url(appliance, generated_request):
-    """Go to the request page, save the url and try to access it directly."""
+    """Go to the request page, save the url and try to access it directly.
+
+    Polarion:
+        assignee: nansari
+        initialEstimate: 1/8h
+    """
     widgetastic = appliance.browser.widgetastic
     selenium = widgetastic.selenium
     assert navigate_to(generated_request, 'Details'), "could not find the request!"
@@ -114,7 +119,12 @@ def test_services_request_direct_url(appliance, generated_request):
 
 @pytest.mark.tier(3)
 def test_copy_request(request, generated_request, vm_name, template_name):
-    """Check if request gets properly copied."""
+    """Check if request gets properly copied.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     modifications = {'catalog': {'vm_name': vm_name}}
     new_request = generated_request.copy_request(values=modifications)
     request.addfinalizer(new_request.remove_request)

--- a/cfme/tests/services/test_orchestration_template.py
+++ b/cfme/tests/services/test_orchestration_template.py
@@ -77,6 +77,11 @@ def created_template(appliance, template_type):
 
 
 def test_orchestration_template_crud(appliance, template_type):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     method = METHOD_TORSO.replace('CloudFormation', fauxfactory.gen_alphanumeric())
     collection = appliance.collections.orchestration_templates
     template = collection.create(template_group=templates.get(template_type)[1],
@@ -92,7 +97,12 @@ def test_orchestration_template_crud(appliance, template_type):
 
 
 def test_copy_template(created_template):
-    """Tests Orchestration template copy"""
+    """Tests Orchestration template copy
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     copied_method = METHOD_TORSO_copied.replace('CloudFormation', fauxfactory.gen_alphanumeric())
     template = created_template
     template_copy = template.copy_template("{}_copied".format(template.template_name),
@@ -102,7 +112,12 @@ def test_copy_template(created_template):
 
 
 def test_name_required_error_validation_orch_template(appliance, template_type):
-    """Tests error validation if Name wasn't specified during template creation"""
+    """Tests error validation if Name wasn't specified during template creation
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     flash_msg = \
         "Error during 'Orchestration Template creation': Validation failed: Name can't be blank"
     copied_method = METHOD_TORSO_copied.replace('CloudFormation', fauxfactory.gen_alphanumeric())
@@ -116,7 +131,12 @@ def test_name_required_error_validation_orch_template(appliance, template_type):
 
 
 def test_empty_all_fields_error_validation(appliance, template_type):
-    """Tests error validation if we try to create template with all empty fields"""
+    """Tests error validation if we try to create template with all empty fields
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     flash_msg = \
         "Error during Orchestration Template creation: new template content cannot be empty"
     collection = appliance.collections.orchestration_templates
@@ -129,7 +149,12 @@ def test_empty_all_fields_error_validation(appliance, template_type):
 
 
 def test_empty_content_error_validation(appliance, template_type):
-    """Tests error validation if content wasn't added during template creation"""
+    """Tests error validation if content wasn't added during template creation
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     flash_msg = \
         "Error during Orchestration Template creation: new template content cannot be empty"
     collection = appliance.collections.orchestration_templates
@@ -144,6 +169,12 @@ def test_empty_content_error_validation(appliance, template_type):
 def test_tag_orchestration_template(tag, created_template):
     """Tests template tagging. Verifies that tag was added, confirms in template details,
     removes tag
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/15h
     """
     navigate_to(created_template, 'Details')
     created_template.add_tag(tag=tag)
@@ -156,7 +187,12 @@ def test_tag_orchestration_template(tag, created_template):
 @pytest.mark.parametrize("action", ["copy", "create"], ids=["copy", "create"])
 def test_duplicated_content_error_validation(appliance, created_template, template_type,
                                              action):
-    """Tests that we are not allowed to have duplicated content in different templates"""
+    """Tests that we are not allowed to have duplicated content in different templates
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     collection = appliance.collections.orchestration_templates
     if action == "copy":
         copy_name = "{}_copied".format(created_template.template_name)
@@ -179,7 +215,12 @@ def test_duplicated_content_error_validation(appliance, created_template, templa
 @pytest.mark.uncollectif(lambda template_type: template_type == "vApp" or template_type == "VNF",
                          reason="vApp requires valid vCloud provider and template for this test")
 def test_service_dialog_creation_from_customization_template(request, created_template):
-    """Tests Service Dialog creation  from customization template """
+    """Tests Service Dialog creation  from customization template
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     dialog_name = created_template.template_name
     service_dialog = created_template.create_service_dialog_from_template(dialog_name)
     request.addfinalizer(service_dialog.delete_if_exists)

--- a/cfme/tests/services/test_provision_stack.py
+++ b/cfme/tests/services/test_provision_stack.py
@@ -171,6 +171,10 @@ def test_provision_stack(order_stack):
 
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: jhenner
+        initialEstimate: 1/3h
     """
     provision_request, stack = order_stack
     assert provision_request.is_succeeded()
@@ -182,6 +186,10 @@ def test_reconfigure_service(appliance, service_catalogs, request):
 
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: sshveta
+        initialEstimate: 1/4h
     """
     provision_request = service_catalogs.order()
     provision_request.wait_for_request(method='ui')
@@ -205,6 +213,10 @@ def test_remove_non_read_only_orch_template(appliance, provider, template, servi
 
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     provision_request = service_catalogs.order()
     request.addfinalizer(lambda: _cleanup(appliance, provision_request))
@@ -230,6 +242,10 @@ def test_remove_read_only_orch_template_neg(appliance, provider, template, servi
 
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     provision_request = service_catalogs.order()
     request.addfinalizer(lambda: _cleanup(appliance, provision_request))
@@ -248,6 +264,10 @@ def test_retire_stack(order_stack):
 
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     _, stack = order_stack
     stack.retire_stack()

--- a/cfme/tests/services/test_pxe_service_catalogs.py
+++ b/cfme/tests/services/test_pxe_service_catalogs.py
@@ -126,6 +126,10 @@ def test_pxe_servicecatalog(appliance, setup_provider, provider, catalog_item, r
 
     Metadata:
         test_flag: pxe, provision
+
+    Polarion:
+        assignee: nansari
+        initialEstimate: 1/4h
     """
     vm_name = catalog_item.prov_data['catalog']["vm_name"]
     request.addfinalizer(

--- a/cfme/tests/services/test_request.py
+++ b/cfme/tests/services/test_request.py
@@ -17,7 +17,12 @@ pytestmark = [
 
 
 def test_copy_request_bz1194479(appliance, provider, catalog_item, request):
-    """Automate BZ 1194479"""
+    """Automate BZ 1194479
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     vm_name = catalog_item.prov_data["catalog"]["vm_name"]
     request.addfinalizer(
         lambda: appliance.collections.infra_vms.instantiate(

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -227,6 +227,10 @@ class TestServiceRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: None
         """
         outcome = query_resource_attributes(services[0])
         for failure in outcome.failed:
@@ -248,6 +252,10 @@ class TestServiceRESTAPI(object):
             * Check if the service with ``new_name`` exists
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/3h
         """
         for service in services:
             new_name = fauxfactory.gen_alphanumeric()
@@ -266,6 +274,10 @@ class TestServiceRESTAPI(object):
             * Check if the services with ``new_name`` each exists
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/3h
         """
         new_names = []
         services_data_edited = []
@@ -290,6 +302,10 @@ class TestServiceRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: sshveta
+            initialEstimate: 1/4h
         """
         delete_resources_from_detail(services, method='POST')
 
@@ -298,6 +314,10 @@ class TestServiceRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: sshveta
+            initialEstimate: 1/4h
         """
         delete_resources_from_detail(services, method='DELETE')
 
@@ -306,6 +326,10 @@ class TestServiceRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: sshveta
+            initialEstimate: 1/3h
         """
         delete_resources_from_collection(services)
 
@@ -317,6 +341,10 @@ class TestServiceRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: sshveta
+            initialEstimate: 1/4h
         """
         collection = appliance.rest_api.collections.services
         vm = get_vms_in_service(vm_service).pop()
@@ -339,6 +367,10 @@ class TestServiceRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: sshveta
+            initialEstimate: 1/3h
         """
         date = (datetime.datetime.now() + datetime.timedelta(days=5)).strftime("%Y/%m/%d")
         future = {
@@ -370,6 +402,10 @@ class TestServiceRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: sshveta
+            initialEstimate: 1/4h
         """
         user = appliance.rest_api.collections.users.get(userid="admin")
         data = {
@@ -387,6 +423,10 @@ class TestServiceRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: sshveta
+            initialEstimate: 1/4h
         """
         user = appliance.rest_api.collections.users.get(userid="admin")
         requests = [{
@@ -411,6 +451,10 @@ class TestServiceRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: sshveta
+            initialEstimate: 1/4h
         """
         collection = appliance.rest_api.collections.services
         vm = get_vms_in_service(vm_service).pop()
@@ -434,6 +478,10 @@ class TestServiceRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: sshveta
+            initialEstimate: 1/4h
         """
         vm = get_vms_in_service(vm_service).pop()
         assert vm_service.vms[0].id == vm.id
@@ -443,6 +491,10 @@ class TestServiceRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: sshveta
+            initialEstimate: 1/4h
         """
         service = services(request, appliance, num=1).pop()
         rest_vm = appliance.rest_api.collections.vms.get(name=vm)
@@ -457,6 +509,10 @@ class TestServiceRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: sshveta
+            initialEstimate: 1/4h
         """
         vm = get_vms_in_service(vm_service).pop()
         request.addfinalizer(vm.action.delete)
@@ -472,6 +528,10 @@ class TestServiceRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: sshveta
+            initialEstimate: 1/4h
         """
         vm_assigned = get_vms_in_service(vm_service).pop()
         vm_added = appliance.rest_api.collections.vms.get(name=vm)
@@ -492,6 +552,10 @@ class TestServiceRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: sshveta
+            initialEstimate: 1/4h
         """
         collection = appliance.rest_api.collections.services
         service = collection.action.create(service_body())[0]
@@ -510,6 +574,10 @@ class TestServiceRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: sshveta
+            initialEstimate: 1/4h
         """
         collection = appliance.rest_api.collections.services
         grandparent = collection.action.create(service_body())[0]
@@ -533,6 +601,10 @@ class TestServiceRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: sshveta
+            initialEstimate: 1/4h
         """
         collection = appliance.rest_api.collections.services
         parent = collection.action.create(service_body())[0]
@@ -550,6 +622,10 @@ class TestServiceRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: sshveta
+            initialEstimate: 1/4h
         """
         collection = appliance.rest_api.collections.services
         parent = collection.action.create(service_body())[0]
@@ -571,6 +647,10 @@ class TestServiceRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: sshveta
+            initialEstimate: 1/4h
         """
         collection = appliance.rest_api.collections.services
         service = collection.action.create(service_body())[0]
@@ -597,6 +677,10 @@ class TestServiceRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: sshveta
+            initialEstimate: 1/4h
         """
         collection = appliance.rest_api.collections.services
         parent = collection.action.create(service_body())[0]
@@ -633,6 +717,10 @@ class TestServiceDialogsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         query_resource_attributes(service_dialogs[0], soft_assert=soft_assert)
 
@@ -641,6 +729,10 @@ class TestServiceDialogsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: sshveta
+            initialEstimate: 1/4h
         """
         _dialog_rest(request, appliance.rest_api)
         assert_response(appliance)
@@ -652,6 +744,10 @@ class TestServiceDialogsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: sshveta
+            initialEstimate: 1/4h
         """
         new_descriptions = []
         if from_detail:
@@ -694,6 +790,10 @@ class TestServiceDialogsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: sshveta
+            initialEstimate: 1/4h
         """
         delete_resources_from_detail(service_dialogs, method=method)
 
@@ -702,6 +802,10 @@ class TestServiceDialogsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/4h
         """
         delete_resources_from_collection(service_dialogs)
 
@@ -712,6 +816,10 @@ class TestServiceTemplateRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         query_resource_attributes(service_templates[0], soft_assert=soft_assert)
 
@@ -720,6 +828,10 @@ class TestServiceTemplateRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/4h
         """
         for service_template in service_templates:
             record = appliance.rest_api.collections.service_templates.get(id=service_template.id)
@@ -735,6 +847,10 @@ class TestServiceTemplateRESTAPI(object):
             * Check if the service_template with ``new_name`` exists
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/3h
         """
         for service_template in service_templates:
             new_name = fauxfactory.gen_alphanumeric()
@@ -749,6 +865,10 @@ class TestServiceTemplateRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/3h
         """
         delete_resources_from_collection(service_templates)
 
@@ -758,6 +878,10 @@ class TestServiceTemplateRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/4h
         """
         delete_resources_from_detail(service_templates, method='POST')
 
@@ -766,6 +890,10 @@ class TestServiceTemplateRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/4h
         """
         delete_resources_from_detail(service_templates, method='DELETE')
 
@@ -783,6 +911,10 @@ class TestServiceTemplateRESTAPI(object):
             * Check if the service_templates were unassigned to the service catalog
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/3h
         """
 
         stpl = service_templates[0]
@@ -816,6 +948,10 @@ class TestServiceTemplateRESTAPI(object):
             * Check if the service_templates with ``new_name`` each exists
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/3h
         """
         new_names = []
         service_tpls_data_edited = []
@@ -842,6 +978,10 @@ class TestServiceCatalogsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         outcome = query_resource_attributes(service_catalogs[0])
         for failure in outcome.failed:
@@ -857,6 +997,10 @@ class TestServiceCatalogsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/4h
         """
         new_descriptions = []
         if from_detail:
@@ -896,6 +1040,10 @@ class TestServiceCatalogsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/4h
         """
         catalog = service_catalogs[0]
         unassign_templates(service_templates)
@@ -938,6 +1086,10 @@ class TestServiceCatalogsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/4h
         """
         catalog = service_catalogs[0]
         unassign_templates(service_templates)
@@ -993,6 +1145,10 @@ class TestServiceCatalogsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/4h
         """
         # this doesn't return resource in the "service_requests" collection
         # using workaround with `response.json()`
@@ -1032,6 +1188,10 @@ class TestServiceCatalogsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/4h
         """
         delete_resources_from_detail(service_catalogs, method=method, num_sec=100, delay=5)
 
@@ -1040,6 +1200,10 @@ class TestServiceCatalogsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/4h
         """
         delete_resources_from_collection(service_catalogs, num_sec=300, delay=5)
 
@@ -1119,6 +1283,10 @@ class TestPendingRequestsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         query_resource_attributes(pending_request, soft_assert=soft_assert)
 
@@ -1127,6 +1295,10 @@ class TestPendingRequestsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         # Wait a bit to check that it will not get auto-approved
         # This `wait_for` is expected to fail.
@@ -1144,6 +1316,10 @@ class TestPendingRequestsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         delete_resources_from_detail([pending_request], method=method)
 
@@ -1152,6 +1328,10 @@ class TestPendingRequestsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         delete_resources_from_collection([pending_request])
 
@@ -1160,6 +1340,10 @@ class TestPendingRequestsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         pending_request.action.approve(reason='I said so.')
         assert_response(appliance)
@@ -1184,6 +1368,10 @@ class TestPendingRequestsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         pending_request.action.deny(reason='I said so.')
         assert_response(appliance)
@@ -1236,6 +1424,10 @@ class TestServiceRequests(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/4h
         """
         new_template = _service_templates(request, appliance, num=1)
         new_template = new_template[0]
@@ -1287,6 +1479,10 @@ class TestBlueprintsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         outcome = query_resource_attributes(blueprints[0])
         for failure in outcome.failed:
@@ -1302,6 +1498,10 @@ class TestBlueprintsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         for blueprint in blueprints:
             record = appliance.rest_api.collections.blueprints.get(id=blueprint.id)
@@ -1316,6 +1516,10 @@ class TestBlueprintsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         delete_resources_from_detail(blueprints, method=method)
 
@@ -1325,6 +1529,10 @@ class TestBlueprintsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         delete_resources_from_collection(blueprints)
 
@@ -1337,6 +1545,10 @@ class TestBlueprintsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         response_len = len(blueprints)
         new = [{
@@ -1375,6 +1587,10 @@ class TestOrchestrationTemplatesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         query_resource_attributes(orchestration_templates[0], soft_assert=soft_assert)
 
@@ -1384,6 +1600,10 @@ class TestOrchestrationTemplatesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         for template in orchestration_templates:
             record = appliance.rest_api.collections.orchestration_templates.get(id=template.id)
@@ -1397,6 +1617,10 @@ class TestOrchestrationTemplatesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         delete_resources_from_collection(orchestration_templates, not_found=True)
 
@@ -1407,6 +1631,10 @@ class TestOrchestrationTemplatesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         delete_resources_from_detail(orchestration_templates, method='POST')
 
@@ -1416,6 +1644,10 @@ class TestOrchestrationTemplatesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         delete_resources_from_detail(orchestration_templates, method='DELETE')
 
@@ -1428,6 +1660,10 @@ class TestOrchestrationTemplatesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         response_len = len(orchestration_templates)
         new = [{
@@ -1459,6 +1695,10 @@ class TestOrchestrationTemplatesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         num_orch_templates = len(orchestration_templates)
         new = []
@@ -1502,6 +1742,10 @@ class TestOrchestrationTemplatesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         num_orch_templates = len(orchestration_templates)
         new = []
@@ -1529,6 +1773,10 @@ class TestOrchestrationTemplatesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         uniq = fauxfactory.gen_alphanumeric(5)
         payload = {
@@ -1562,6 +1810,10 @@ class TestServiceOrderCart(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         query_resource_attributes(cart, soft_assert=soft_assert)
 
@@ -1571,6 +1823,10 @@ class TestServiceOrderCart(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/4h
         """
         assert cart.state == 'cart'
         cart_dict = appliance.rest_api.get('{}/cart'.format(cart.collection._href))
@@ -1582,6 +1838,10 @@ class TestServiceOrderCart(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/4h
         """
         # This will fail somehow once BZ 1493788 is fixed.
         # There can be one and only one shopping cart for the authenticated user.
@@ -1598,6 +1858,10 @@ class TestServiceOrderCart(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/4h
         """
         requests = [{'service_template_href': tmplt.href} for tmplt in service_templates]
         body = {'service_requests': requests}
@@ -1620,6 +1884,10 @@ class TestServiceOrderCart(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/4h
         """
         assert cart.service_requests.subcount == 0
         self.add_requests(cart, service_templates_class)
@@ -1634,6 +1902,10 @@ class TestServiceOrderCart(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/4h
         """
         self.add_requests(cart, service_templates_class)
         cart_req_ids = {req.id for req in cart.service_requests}
@@ -1653,6 +1925,10 @@ class TestServiceOrderCart(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/4h
         """
         self.add_requests(cart, service_templates_class)
         cart_req_ids = {req.id for req in cart.service_requests}
@@ -1672,6 +1948,10 @@ class TestServiceOrderCart(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/4h
         """
         self.add_requests(cart, service_templates_class)
         cart_req_ids = {req.id for req in cart.service_requests}
@@ -1689,6 +1969,10 @@ class TestServiceOrderCart(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/4h
         """
         with pytest.raises(Exception, match='Cannot copy a service order in the cart state'):
             cart.action.copy(name='new_cart')
@@ -1700,6 +1984,10 @@ class TestServiceOrderCart(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/4h
         """
         selected_templates = service_templates_class[:2]
         self.add_requests(cart, selected_templates)
@@ -1742,6 +2030,10 @@ class TestServiceOrderCart(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/4h
         """
         delete_resources_from_detail([cart], method=method)
 
@@ -1751,5 +2043,9 @@ class TestServiceOrderCart(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: nansari
+            initialEstimate: 1/4h
         """
         delete_resources_from_collection([cart])

--- a/cfme/tests/services/test_service_catalogs.py
+++ b/cfme/tests/services/test_service_catalogs.py
@@ -34,6 +34,10 @@ def test_order_catalog_item(appliance, provider, catalog_item, request,
     """Tests order catalog item
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: sshveta
+        initialEstimate: 1/4h
     """
     vm_name = catalog_item.prov_data['catalog']["vm_name"]
     request.addfinalizer(
@@ -62,6 +66,10 @@ def test_order_catalog_item_via_rest(
     """Same as :py:func:`test_order_catalog_item`, but using REST.
     Metadata:
         test_flag: provision, rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/3h
     """
     vm_name = catalog_item.prov_data['catalog']["vm_name"]
     request.addfinalizer(
@@ -92,6 +100,10 @@ def test_order_catalog_bundle(appliance, provider, catalog_item, request):
     """Tests ordering a catalog bundle
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: sshveta
+        initialEstimate: 1/4h
     """
 
     vm_name = catalog_item.prov_data['catalog']["vm_name"]
@@ -124,6 +136,10 @@ def test_no_template_catalog_item(provider, provisioning, dialog, catalog, appli
     """Tests no template catalog item
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: nansari
+        initialEstimate: 1/8h
     """
     item_name = fauxfactory.gen_alphanumeric()
     catalog_item = appliance.collections.catalogs.instantiate(
@@ -140,6 +156,10 @@ def test_request_with_orphaned_template(appliance, provider, catalog_item):
     """Tests edit catalog item after deleting provider
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: sshveta
+        initialEstimate: 1/4h
     """
     service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
     service_catalogs.order()
@@ -160,6 +180,10 @@ def test_advanced_search_registry_element(request, appliance):
         Go to Services -> Workloads
         Advanced Search -> Registry element
         Element types select bar shouldn't disappear.
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
     """
     view = navigate_to(VmsInstances(appliance=appliance), 'All')
     view.search.open_advanced_search()

--- a/cfme/tests/services/test_service_manual_approval.py
+++ b/cfme/tests/services/test_service_manual_approval.py
@@ -65,6 +65,10 @@ def test_service_manual_approval(appliance, provider, modify_instance,
     """Tests order catalog item
     Metadata:
         test_flag: provision
+
+    Polarion:
+        assignee: sshveta
+        initialEstimate: 1/4h
     """
     vm_name = catalog_item.prov_data['catalog']["vm_name"]
     request.addfinalizer(

--- a/cfme/tests/services/test_service_rbac.py
+++ b/cfme/tests/services/test_service_rbac.py
@@ -42,7 +42,12 @@ def role_user_group(appliance, new_credential):
 
 
 def test_service_rbac_no_permission(appliance, role_user_group):
-    """ Test service rbac without user permission"""
+    """ Test service rbac without user permission
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     role, user = role_user_group
     error_message = ("The user's role is not authorized for any access, "
                      "please contact the administrator!")
@@ -51,7 +56,12 @@ def test_service_rbac_no_permission(appliance, role_user_group):
 
 
 def test_service_rbac_catalog(role_user_group, catalog):
-    """ Test service rbac with catalog"""
+    """ Test service rbac with catalog
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     role, user = role_user_group
     product_features = [(['Everything'], True), (['Everything'], False)]
     product_features.extend([(['Everything', 'Services', 'Catalogs Explorer', k], True)
@@ -62,7 +72,12 @@ def test_service_rbac_catalog(role_user_group, catalog):
 
 
 def test_service_rbac_service_catalog(appliance, role_user_group, catalog, catalog_item):
-    """ Test service rbac with service catalog"""
+    """ Test service rbac with service catalog
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     role, user = role_user_group
     product_features = [
         (['Everything'], True), (['Everything'], False),
@@ -84,7 +99,12 @@ def test_service_rbac_service_catalog(appliance, role_user_group, catalog, catal
 
 
 def test_service_rbac_catalog_item(role_user_group, catalog_item):
-    """ Test service rbac with catalog item"""
+    """ Test service rbac with catalog item
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     role, user = role_user_group
     product_features = [(['Everything'], True), (['Everything'], False)]
     product_features.extend([(['Everything', 'Services', 'Catalogs Explorer', k], True)
@@ -95,7 +115,12 @@ def test_service_rbac_catalog_item(role_user_group, catalog_item):
 
 
 def test_service_rbac_orchestration(appliance, role_user_group):
-    """ Test service rbac with orchestration"""
+    """ Test service rbac with orchestration
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     role, user = role_user_group
     product_features = [(['Everything'], True), (['Everything'], False)]
     product_features.extend([(['Everything', 'Services', 'Catalogs Explorer', k], True)
@@ -114,7 +139,12 @@ def test_service_rbac_orchestration(appliance, role_user_group):
 
 
 def test_service_rbac_request(appliance, role_user_group, catalog_item):
-    """ Test service rbac with only request module permissions"""
+    """ Test service rbac with only request module permissions
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     role, user = role_user_group
     product_features = [
         (['Everything'], True), (['Everything'], False),

--- a/cfme/tests/ssui/test_ssui_ansible_service.py
+++ b/cfme/tests/ssui/test_ssui_ansible_service.py
@@ -17,7 +17,12 @@ pytestmark = [
 @pytest.mark.rhel_testing
 @pytest.mark.parametrize('context', [ViaSSUI])
 def test_service_catalog_crud_ui(appliance, context, order_ansible_service_in_ops_ui, request):
-    """Tests Ansible Service Catalog in SSUI."""
+    """Tests Ansible Service Catalog in SSUI.
+
+    Polarion:
+        assignee: sshveta
+        initialEstimate: None
+    """
 
     service_name = order_ansible_service_in_ops_ui
     with appliance.context.use(context):

--- a/cfme/tests/ssui/test_ssui_dashboard.py
+++ b/cfme/tests/ssui/test_ssui_dashboard.py
@@ -130,7 +130,12 @@ def run_service_chargeback_report(provider, appliance, assign_chargeback_rate,
 @pytest.mark.rhel_testing
 @pytest.mark.parametrize('context', [ViaSSUI])
 def test_total_services(appliance, setup_provider, context, order_service):
-    """Tests total services count displayed on dashboard."""
+    """Tests total services count displayed on dashboard.
+
+    Polarion:
+        assignee: sshveta
+        initialEstimate: 1/4h
+    """
 
     with appliance.context.use(context):
         dashboard = Dashboard(appliance)
@@ -139,7 +144,13 @@ def test_total_services(appliance, setup_provider, context, order_service):
 
 @pytest.mark.parametrize('context', [ViaSSUI])
 def test_current_service(appliance, context):
-    """Tests current services count displayed on dashboard."""
+    """Tests current services count displayed on dashboard.
+
+    Polarion:
+        assignee: nansari
+        casecomponent: ssui
+        initialEstimate: 1/4h
+    """
 
     with appliance.context.use(context):
         dashboard = Dashboard(appliance)
@@ -148,7 +159,13 @@ def test_current_service(appliance, context):
 
 @pytest.mark.parametrize('context', [ViaSSUI])
 def test_retiring_soon(appliance, context):
-    """Tests retiring soon(int displayed) service count on dashboard."""
+    """Tests retiring soon(int displayed) service count on dashboard.
+
+    Polarion:
+        assignee: nansari
+        casecomponent: ssui
+        initialEstimate: 1/4h
+    """
 
     with appliance.context.use(context):
         dashboard = Dashboard(appliance)
@@ -157,7 +174,13 @@ def test_retiring_soon(appliance, context):
 
 @pytest.mark.parametrize('context', [ViaSSUI])
 def test_retired_service(appliance, context):
-    """Tests count of retired services(int) displayed on dashboard."""
+    """Tests count of retired services(int) displayed on dashboard.
+
+    Polarion:
+        assignee: nansari
+        casecomponent: ssui
+        initialEstimate: 1/4h
+    """
 
     with appliance.context.use(context):
         dashboard = Dashboard(appliance)
@@ -168,7 +191,12 @@ def test_retired_service(appliance, context):
 @pytest.mark.parametrize('context', [ViaSSUI])
 def test_monthly_charges(appliance, has_no_providers_modscope, setup_provider, context,
         order_service, run_service_chargeback_report):
-    """Tests chargeback data"""
+    """Tests chargeback data
+
+    Polarion:
+        assignee: nachandr
+        initialEstimate: 1/4h
+    """
     with appliance.context.use(context):
         dashboard = Dashboard(appliance)
         monthly_charges = dashboard.monthly_charges()
@@ -178,7 +206,13 @@ def test_monthly_charges(appliance, has_no_providers_modscope, setup_provider, c
 
 @pytest.mark.parametrize('context', [ViaSSUI])
 def test_total_requests(appliance, context):
-    """Tests total requests displayed."""
+    """Tests total requests displayed.
+
+    Polarion:
+        assignee: nansari
+        casecomponent: ssui
+        initialEstimate: 1/4h
+    """
 
     with appliance.context.use(context):
         dashboard = Dashboard(appliance)
@@ -187,7 +221,13 @@ def test_total_requests(appliance, context):
 
 @pytest.mark.parametrize('context', [ViaSSUI])
 def test_pending_requests(appliance, context):
-    """Tests pending requests displayed on dashboard."""
+    """Tests pending requests displayed on dashboard.
+
+    Polarion:
+        assignee: nansari
+        casecomponent: ssui
+        initialEstimate: 1/4h
+    """
 
     with appliance.context.use(context):
         dashboard = Dashboard(appliance)
@@ -196,7 +236,13 @@ def test_pending_requests(appliance, context):
 
 @pytest.mark.parametrize('context', [ViaSSUI])
 def test_approved_requests(appliance, context):
-    """Tests approved requests displayed on dashboard."""
+    """Tests approved requests displayed on dashboard.
+
+    Polarion:
+        assignee: nansari
+        casecomponent: ssui
+        initialEstimate: 1/4h
+    """
 
     with appliance.context.use(context):
         dashboard = Dashboard(appliance)
@@ -205,7 +251,13 @@ def test_approved_requests(appliance, context):
 
 @pytest.mark.parametrize('context', [ViaSSUI])
 def test_denied_requests(appliance, context):
-    """Tests denied requests displayed on dashboard."""
+    """Tests denied requests displayed on dashboard.
+
+    Polarion:
+        assignee: nansari
+        casecomponent: ssui
+        initialEstimate: 1/4h
+    """
 
     with appliance.context.use(context):
         dashboard = Dashboard(appliance)

--- a/cfme/tests/ssui/test_ssui_myservice.py
+++ b/cfme/tests/ssui/test_ssui_myservice.py
@@ -39,6 +39,10 @@ def test_myservice_crud(appliance, setup_provider, context, order_service):
 
     Metadata:
         test_flag: ssui, services
+
+    Polarion:
+        assignee: sshveta
+        initialEstimate: 1/4h
     """
     catalog_item = order_service
     with appliance.context.use(context):
@@ -56,6 +60,10 @@ def test_retire_service_ssui(appliance, setup_provider,
 
     Metadata:
         test_flag: ssui, services
+
+    Polarion:
+        assignee: sshveta
+        initialEstimate: None
     """
     catalog_item = order_service
     with appliance.context.use(context):
@@ -75,6 +83,10 @@ def test_service_start(appliance, setup_provider, context,
 
     Metadata:
         test_flag: ssui, services
+
+    Polarion:
+        assignee: sshveta
+        initialEstimate: None
     """
     catalog_item = order_service
     with appliance.context.use(context):
@@ -112,6 +124,12 @@ def test_vm_console(request, appliance, setup_provider, context, configure_webso
 
     Metadata:
         test_flag: ssui
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/2h
     """
     if (provider.one_of(VMwareProvider) and provider.version >= 6.5 or
             'html5_console' in provider.data.get('excluded_test_flags', [])):

--- a/cfme/tests/ssui/test_ssui_service_catalogs.py
+++ b/cfme/tests/ssui/test_ssui_service_catalogs.py
@@ -32,6 +32,10 @@ def test_service_catalog_crud_ssui(appliance, setup_provider,
 
     Metadata:
         test_flag: ssui
+
+    Polarion:
+        assignee: sshveta
+        initialEstimate: None
     """
 
     catalog_item = order_service

--- a/cfme/tests/storage/test_manager.py
+++ b/cfme/tests/storage/test_manager.py
@@ -37,6 +37,11 @@ def manager(request, openstack_provider, appliance):
 
 
 def test_manager_navigation(manager):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     view = navigate_to(manager.parent, 'All')
     assert view.is_displayed
 
@@ -56,6 +61,10 @@ def test_storage_manager_edit_tag(manager):
     Steps:
         * Add tag and check
         * Remove tag and check
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     # add tag with category Department and tag communication
@@ -80,6 +89,10 @@ def test_storage_manager_delete(manager, provider_cleanup):
         * Delete storage manager from inventory
         * Assert flash message
         * Check storage manager exists or not
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     manager.delete()
     view = manager.create_view(StorageManagerDetailsView)

--- a/cfme/tests/storage/test_object_store_container.py
+++ b/cfme/tests/storage/test_object_store_container.py
@@ -22,6 +22,11 @@ def containers(appliance, provider):
 
 @pytest.mark.meta(blockers=[BZ(1648243, forced_streams=["5.9"])])
 def test_add_remove_tag(containers):
+    """
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
+    """
     container = random.choice(containers)
 
     # add tag with category Department and tag communication

--- a/cfme/tests/storage/test_object_store_object.py
+++ b/cfme/tests/storage/test_object_store_object.py
@@ -14,6 +14,11 @@ pytestmark = [
 
 @pytest.mark.meta(blockers=[BZ(1648243, forced_streams=["5.9"])])
 def test_object_add_remove_tag(appliance, provider):
+    """
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
+    """
     collection = appliance.collections.object_store_objects.filter({'provider': provider})
     all_objects = collection.all()
     if all_objects is None:

--- a/cfme/tests/storage/test_volume.py
+++ b/cfme/tests/storage/test_volume.py
@@ -52,6 +52,10 @@ def test_storage_volume_create_cancelled_validation(appliance, provider):
         * Navigate to storage add volume page
         * Click Cancel button
         * Assert flash message
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     volume_collection = appliance.collections.volumes
     manager_name = '{} Cinder Manager'.format(provider.name)
@@ -76,6 +80,10 @@ def test_storage_volume_crud(appliance, provider):
     Steps:
         * Crate new volume
         * Delete volume
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     # create volume
     volume_collection = appliance.collections.volumes
@@ -111,6 +119,10 @@ def test_storage_volume_edit_tag(volume):
     Steps:
         * Add tag and check
         * Remove tag and check
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     # add tag with category Department and tag communication
@@ -127,7 +139,12 @@ def test_storage_volume_edit_tag(volume):
 
 @pytest.mark.meta(blockers=[BZ(1648243, forced_streams=["5.9"])])
 def test_multiple_cloud_volumes_tag_edit(appliance, soft_assert):
-    """Test tag can be added to multiple volumes at once"""
+    """Test tag can be added to multiple volumes at once
+
+    Polarion:
+        assignee: anikifor
+        initialEstimate: 1/12h
+    """
     all_volumes = appliance.collections.volumes.all()
     volumes = all_volumes[:3] if len(all_volumes) > 4 else all_volumes
     assigned_tag = appliance.collections.volumes.add_tag(volumes)

--- a/cfme/tests/storage/test_volume_backup.py
+++ b/cfme/tests/storage/test_volume_backup.py
@@ -47,6 +47,11 @@ def backup(appliance, provider):
 
 @pytest.mark.tier(3)
 def test_storage_volume_backup_create(backup):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     assert backup.exists
     assert backup.size == STORAGE_SIZE
 
@@ -54,6 +59,11 @@ def test_storage_volume_backup_create(backup):
 @pytest.mark.meta(blockers=[BZ(1648243, forced_streams=["5.9"])])
 @pytest.mark.tier(3)
 def test_storage_volume_backup_edit_tag_from_detail(backup):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     # add tag with category Department and tag communication
     added_tag = backup.add_tag()
     tag_available = backup.get_tags()
@@ -69,7 +79,12 @@ def test_storage_volume_backup_edit_tag_from_detail(backup):
 @pytest.mark.tier(3)
 @pytest.mark.uncollectif(lambda appliance: appliance.version < '5.9')
 def test_storage_volume_backup_delete(backup):
-    """ Volume backup deletion method not support by 5.8 """
+    """ Volume backup deletion method not support by 5.8
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
 
     backup.parent.delete(backup)
     assert not backup.exists

--- a/cfme/tests/storage/test_volume_snapshot.py
+++ b/cfme/tests/storage/test_volume_snapshot.py
@@ -75,6 +75,10 @@ def test_storage_snapshot_create_cancelled_validation(volume):
         * Fill snapshot name
         * Click Cancel button
         * Assert flash message
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     snapshot_name = fauxfactory.gen_alpha()
@@ -97,6 +101,10 @@ def test_storage_snapshot_create_reset_validation(volume):
         * Fill snapshot name
         * Click Reset button
         * Assert flash message
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     snapshot_name = fauxfactory.gen_alpha()
@@ -115,6 +123,10 @@ def test_storage_volume_snapshot_crud(volume):
     Steps:
         * Create a snapshot
         * Delete a snapshot
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     # create new snapshot
@@ -161,6 +173,10 @@ def test_storage_volume_snapshot_edit_tag_from_detail(snapshot, tag):
         * Navigate to Snapshot Detail page
         * Add new Tag
         * Remove Tag
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
 
     # add tag with category Department and tag communication

--- a/cfme/tests/test_appliance.py
+++ b/cfme/tests/test_appliance.py
@@ -23,7 +23,13 @@ pytestmark = [pytest.mark.smoke, pytest.mark.tier(1)]
 ])
 @pytest.mark.uncollectif(lambda appliance: appliance.is_pod)
 def test_rpms_present(appliance, package):
-    """Verifies nfs-util rpms are in place needed for pxe & nfs operations"""
+    """Verifies nfs-util rpms are in place needed for pxe & nfs operations
+
+    Polarion:
+        assignee: amavinag
+        initialEstimate: 1/4h
+        testtype: sanity
+    """
     result = appliance.ssh_client.run_command('rpm -q {}'.format(package))
     assert 'is not installed' not in result.output
     assert result.success
@@ -31,21 +37,39 @@ def test_rpms_present(appliance, package):
 
 @pytest.mark.uncollectif(lambda appliance: appliance.is_pod)
 def test_selinux_enabled(appliance):
-    """Verifies selinux is enabled"""
+    """Verifies selinux is enabled
+
+    Polarion:
+        assignee: amavinag
+        initialEstimate: 1/11h
+        testtype: sanity
+    """
     result = appliance.ssh_client.run_command('getenforce').output
     assert 'Enforcing' in result
 
 
 @pytest.mark.uncollectif(lambda appliance: appliance.is_pod)
 def test_firewalld_running(appliance):
-    """Verifies iptables service is running on the appliance"""
+    """Verifies iptables service is running on the appliance
+
+    Polarion:
+        assignee: amavinag
+        initialEstimate: 1/4h
+    """
     result = appliance.ssh_client.run_command('systemctl status firewalld').output
     assert 'active (running)' in result
 
 
 @pytest.mark.uncollectif(lambda appliance: appliance.is_pod)
 def test_evm_running(appliance):
-    """Verifies overall evm service is running on the appliance"""
+    """Verifies overall evm service is running on the appliance
+
+    Polarion:
+        assignee: amavinag
+        caseimportance: critical
+        initialEstimate: 1/4h
+        testtype: sanity
+    """
     result = appliance.ssh_client.run_command('systemctl status evmserverd').output
     assert 'active (running)' in result
 
@@ -59,7 +83,14 @@ def test_evm_running(appliance):
 @pytest.mark.uncollectif(
     lambda appliance: appliance.is_pod)
 def test_service_enabled(appliance, service):
-    """Verifies if key services are configured to start on boot up"""
+    """Verifies if key services are configured to start on boot up
+
+    Polarion:
+        assignee: amavinag
+        caseimportance: critical
+        initialEstimate: 1/6h
+        testtype: sanity
+    """
     if service == 'postgresql':
         service = '{}-postgresql'.format(appliance.db.postgres_version)
     if appliance.os_version >= '7':
@@ -78,7 +109,14 @@ def test_service_enabled(appliance, service):
     ('tcp', 443),
 ])
 def test_iptables_rules(appliance, proto, port):
-    """Verifies key iptable rules are in place"""
+    """Verifies key iptable rules are in place
+
+    Polarion:
+        assignee: amavinag
+        initialEstimate: 1/4h
+        testtype: sanity
+        upstream: no
+    """
     # get the current iptables state, nicely formatted for us by iptables-save
     result = appliance.ssh_client.run_command('iptables-save')
     # get everything from the input chain
@@ -99,7 +137,13 @@ def test_iptables_rules(appliance, proto, port):
 
 # this is based on expected changes tracked in github/ManageIQ/cfme_build repo
 def test_memory_total(appliance):
-    """Verifies that the total memory on the box is >= 6GB"""
+    """Verifies that the total memory on the box is >= 6GB
+
+    Polarion:
+        assignee: amavinag
+        initialEstimate: 1/4h
+        testtype: sanity
+    """
     result = appliance.ssh_client.run_command(
         'free -g | grep Mem: | awk \'{ print $2 }\'').output
     assert int(result) >= 6
@@ -107,7 +151,13 @@ def test_memory_total(appliance):
 
 # this is based on expected changes tracked in github/ManageIQ/cfme_build repo
 def test_cpu_total(appliance):
-    """Verifies that the total number of cpus is >= 4"""
+    """Verifies that the total number of cpus is >= 4
+
+    Polarion:
+        assignee: amavinag
+        initialEstimate: 1/4h
+        testtype: sanity
+    """
     result = appliance.ssh_client.run_command(
         'lscpu | grep ^CPU\(s\): | awk \'{ print $2 }\'').output
     assert int(result) >= 4
@@ -115,7 +165,14 @@ def test_cpu_total(appliance):
 
 @pytest.mark.ignore_stream("upstream")
 def test_certificates_present(appliance, soft_assert):
-    """Test whether the required product certificates are present."""
+    """Test whether the required product certificates are present.
+
+    Polarion:
+        assignee: amavinag
+        initialEstimate: 1/4h
+        testtype: sanity
+        upstream: no
+    """
 
     rhsm_ca_cert = '/etc/rhsm/ca/redhat-uep.pem'
     rhsm_url = 'https://subscription.rhn.redhat.com/'
@@ -146,6 +203,12 @@ def test_html5_ssl_files_present(appliance, soft_assert):
        IPAppliance object.   Note, these files are installed by
        the cfme RPM, so we use rpm verify to make sure they do not verify
        and hence were replaced.
+
+    Polarion:
+        assignee: joden
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: None
     """
     cert = conf.cfme_data['vm_console']['cert']
     cert_file = os.path.join(cert.install_dir, 'server.cer')
@@ -163,18 +226,36 @@ def test_db_connection(appliance):
 
     This looks for a row in the miq_databases table, which should always exist
     on an appliance with a working database and UI
+
+    Polarion:
+        assignee: amavinag
+        initialEstimate: 1/4h
+        testtype: sanity
     """
     databases = appliance.db.client.session.query(appliance.db.client['miq_databases']).all()
     assert len(databases) > 0
 
 
 def test_asset_precompiled(appliance):
+    """
+    Polarion:
+        assignee: amavinag
+        initialEstimate: 1/4h
+        testtype: sanity
+    """
     assert appliance.ssh_client.run_command("test -d /var/www/miq/vmdb/public/assets").success, (
         "Assets not precompiled")
 
 
 @pytest.mark.ignore_stream("upstream")
 def test_keys_included(appliance, soft_assert):
+    """
+    Polarion:
+        assignee: amavinag
+        initialEstimate: 1/4h
+        testtype: sanity
+        upstream: no
+    """
     keys = ['v0_key', 'v1_key', 'v2_key']
     for k in keys:
         soft_assert(appliance.ssh_client.run_command(
@@ -184,5 +265,10 @@ def test_keys_included(appliance, soft_assert):
 
 @pytest.mark.ignore_stream("5.9")
 def test_appliance_console_packages(appliance):
-    """Test that we have no scl packages installed."""
+    """Test that we have no scl packages installed.
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     assert appliance.ssh_client.run_command('scl --list | grep -v rh-ruby').success

--- a/cfme/tests/test_csrf.py
+++ b/cfme/tests/test_csrf.py
@@ -12,6 +12,10 @@ def test_csrf_post(appliance):
     POST requests use the CSRF token to validate requests, so setting the token
     to something invalid should set off the CSRF detector and reject the request
 
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     dashboard = navigate_to(appliance.server, 'Dashboard')
     dashboard.csrf_token = "Bogus!"

--- a/cfme/tests/test_db_migrate.py
+++ b/cfme/tests/test_db_migrate.py
@@ -77,6 +77,11 @@ def appliance_preupdate(temp_appliance_preconfig_funcscope_upgrade, appliance):
 @pytest.mark.meta(
     blockers=[BZ(1354466, unblock=lambda db_url: 'ldap' not in db_url)])
 def test_db_migrate(temp_appliance_extended_db, db_url, db_version, db_desc):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     app = temp_appliance_extended_db
     # Download the database
     logger.info("Downloading database: {}".format(db_desc))
@@ -127,6 +132,11 @@ def test_db_migrate(temp_appliance_extended_db, db_url, db_version, db_desc):
 @pytest.mark.parametrize('dbversion', ['ec2_5540', 'azure_5620', 'rhev_57', 'scvmm_58'],
         ids=['55', '56', '57', '58'])
 def test_db_migrate_replication(temp_appliance_remote, dbversion, temp_appliance_global_region):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     app = temp_appliance_remote
     app2 = temp_appliance_global_region
     # Download the database
@@ -180,9 +190,18 @@ def test_db_migrate_replication(temp_appliance_remote, dbversion, temp_appliance
     wait_for(is_provider_replicated, func_args=[app, app2], timeout=30)
 
 
+@pytest.mark.tier(2)
 @pytest.mark.meta(blockers=[BZ(1655143, forced_streams=[5.9])])
 def test_upgrade_single_inplace(appliance_preupdate, appliance):
-    """Tests appliance upgrade between streams"""
+    """Tests appliance upgrade between streams
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        caseimportance: critical
+        initialEstimate: 1/3h
+        testtype: upgrade
+    """
     appliance_preupdate.evmserverd.stop()
     result = appliance_preupdate.ssh_client.run_command('yum update -y', timeout=3600)
     assert result.success, "update failed {}".format(result.output)

--- a/cfme/tests/test_login.py
+++ b/cfme/tests/test_login.py
@@ -25,7 +25,14 @@ pytestmark = pytest.mark.usefixtures('browser')
 @pytest.mark.uncollectif(lambda context, appliance: context == ViaSSUI and
                          appliance.version == UPSTREAM)
 def test_login(context, method, appliance):
-    """ Tests that the appliance can be logged into and shows dashboard page. """
+    """ Tests that the appliance can be logged into and shows dashboard page.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        initialEstimate: 1/8h
+        tags: rbac
+    """
 
     with appliance.context.use(context):
         logged_in_page = appliance.server.login()
@@ -44,7 +51,14 @@ def test_login(context, method, appliance):
 # BZ 1632718 is only relevant for Chrome browser
 @pytest.mark.meta(blockers=[BZ(1632718, forced_streams=['5.10'])])
 def test_bad_password(context, request, appliance):
-    """ Tests logging in with a bad password. """
+    """ Tests logging in with a bad password.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: web_ui
+        initialEstimate: 1/8h
+        tags: rbac
+    """
 
     username = conf.credentials['default']['username']
     password = "badpassword@#$"
@@ -67,7 +81,13 @@ def test_bad_password(context, request, appliance):
 @pytest.mark.parametrize('context', [ViaUI])
 @pytest.mark.meta(blockers=[BZ(1632718, forced_streams=['5.10'])])
 def test_update_password(context, request, appliance):
-    """ Test updating password from the login screen. """
+    """ Test updating password from the login screen.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        initialEstimate: 1/6h
+    """
 
     # First, create a temporary new user
     username = 'user_temp_{}'.format(fauxfactory.gen_alphanumeric(4).lower())

--- a/cfme/tests/test_manual.py
+++ b/cfme/tests/test_manual.py
@@ -6,6 +6,8 @@ import pytest
 
 from cfme import test_requirements
 
+pytestmark = [pytest.mark.ignore_stream('5.9', '5.10', 'upstream')]
+
 
 @pytest.mark.manual
 @pytest.mark.tier(3)

--- a/cfme/tests/test_manual.py
+++ b/cfme/tests/test_manual.py
@@ -1,0 +1,32669 @@
+# -*- coding: utf-8 -*-
+# pylint: skip-file
+"""Manual tests"""
+
+import pytest
+
+from cfme import test_requirements
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_git_domain_import_top_level_directory():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1389823 Importing domain
+    from git should work with or without the top level domain directory.
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+@pytest.mark.tier(1)
+def test_reports_generate_custom_storage_fields():
+    """
+    Steps to Reproduce:
+    1. Add cloud provider (Openstack) -> Go to Compute-> Clouds->
+    Configuration-> Add new cloud provider.
+    2. Generate Report -> Go to cloud intel -> Reports-> Configuration->
+    Add new report.
+    3. Report filters -> Configure Report Columns:
+    Base the report on: Cloud Volumes
+    Selected Fields:
+    -- Cloud Tenant: Name
+    --  VMs: Name
+    --  VMs: Used Storage
+    --  VMs  RAM Size
+    --  Vms: Disk 1
+    https://bugzilla.redhat.com/show_bug.cgi?id=1499553
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.3
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.log_depot
+@pytest.mark.tier(1)
+def test_log_multiple_servers_uncofigured():
+    """
+    Verify that buttons unclickable( grayed) when log collection
+    unconfigured in all servers under one zone
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/4h
+        testSteps:
+            1.Configure two appliances to work under one zone
+              (distribution mode, one master, another slave)
+            2. Open appliance"s WebUi -> Settings -> Configuration
+            3. Go to Diagnostics tab -> Collect logs
+            4. Select second server (slave) and press "collect" select bar
+        expectedResults:
+            1.
+            2.
+            3.
+            4. "Collect current logs" and "Collect all logs" grayed and
+               became clickable only after configuration log collection
+               settings under current server
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_appliance_chrony_conf():
+    """
+    check that iburst exists within /etc/chrony.conf.
+    https://bugzilla.redhat.com/show_bug.cgi?id=1308606
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware65_test_vm_migration_with_rhel_75_last_time_74():
+    """
+    OSP: vmware65-Test VM migration with RHEL 7.5 (last time 7.4)
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware65-Test VM migration with RHEL 7.5 (last time 7.4)
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.upgrade
+@pytest.mark.tier(2)
+def test_rh_rhsm_sat6_cred_save_crud():
+    """
+    Switch between rhsm and sat6 setup
+    https://bugzilla.redhat.com/show_bug.cgi?id=1463389
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/12h
+        setup: Provision appliance
+               navigate to Configuration-settings-region-redhat updates
+               Click edit subscription
+               Setup rhsm subscription
+               Save (validate and save if fails)
+               edit subscription
+               setup sat6
+               click save
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_ec2_refresh_with_stack_without_parameters():
+    """
+    1) Add cloudformation stack without parameters(https://s3-us-
+    west-2.amazonaws.com/cloudformation-templates-us-
+    west-2/Managed_EC2_Batch_Environment.template  )
+    2) Add ec2 provider with cloudformation stack without parameters
+    3) Wait for refresh - it should be refreshed successfully without
+    errors
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: cloud
+        initialEstimate: 1/5h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.right_size
+@pytest.mark.tier(1)
+def test_nor_cpu_values_correct_vsphere6():
+    """
+    NOR cpu values are correct.
+    Compute > Infrastructure > Virtual Machines > select a VM running on a
+    vSphere 6 provider
+    Normal Operating Ranges widget displays correct values for CPU and CPU
+    Usage max, high, average, and low, if at least one days" worth of
+    metrics have been captured:
+    The Average reflects the most common value obtained during the past 30
+    days" worth of captured metrics.
+    The High and Low reflect the range of values obtained ~85% of the time
+    within the past 30 days.
+    The Max reflects the maximum value obtained within the past 30 days.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.right_size
+@pytest.mark.tier(1)
+def test_nor_cpu_values_correct_rhv41():
+    """
+    NOR CPU values are correct.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rbac
+def test_status_of_a_task_via_api_with_evmrole_administrator():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1535962
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/4h
+        tags: rbac
+        title: Test status of a task via API with EvmRole_administrator
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+def test_calculating_the_sum_of_a_value_in_a_consolidated_report():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1298298
+    Steps to Reproduce:
+    1. create a new report on vms & templates
+    2. select os name, number of cpus, disk space and other nuerical
+    values
+    3. consolidate the report by os name and calculate the total of all
+    the other value
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.5
+        title: Calculating the sum of a value in a consolidated report
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+def test_embed_tower_exec_play_against_vmware():
+    """
+    User/Admin is able to execute playbook without creating Job Temaplate
+    and can execute it against vmware with vmware credentials
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.upgrade
+@pytest.mark.tier(2)
+def test_upgrade_single_inplace_postgres():
+    """
+    Upgrading a single appliance and upgrade postgres to 9.5
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        caseimportance: critical
+        endsin: 5.8
+        initialEstimate: 1/2h
+        setup: Run inplace upgrade and postgres upgrade
+               Migration docs at (https://mojo.redhat.com/docs/DOC-1058772)
+               Check new postgress is running correctly
+        startsin: 5.7
+        testtype: upgrade
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_check_service_link_from_vm_detail_page():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1443772
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Check service link from VM detail page
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_dashboard():
+    """
+    Check dashboard view has been added to existing Tower provider screens
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_dialogs_should_only_run_once():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1595776
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Dialogs should only run once
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_schedule_for_all_clusters_vms():
+    """
+    Navigate to add new schedule page(Configuration->Region->Schedules)
+    Fill all required fields
+    Select all vms for clusters in filter
+    Set timer
+    Save changes
+    Result: Task run successfully for selected filter
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(1)
+def test_error_message_azure():
+    """
+    Starting with 5.8, error messages generated by azure when provisioning
+    from orchestration template will be included in the Last Message
+    field.  Users will no longer have to drill down to Stack/Resources to
+    figure out the error.
+    This is currently working correctly as of 5.8.0.12
+    https://bugzilla.redhat.com/show_bug.cgi?id=1410794
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/4h
+        setup: Easiest way to do this is provision an azure vm from orchestration
+               catalog item and just add a short password like "test".  This will
+               fail on the azure side and the error will be displayed in the request
+               details.
+        startsin: 5.8
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_crud_pod_appliance_custom_config():
+    """
+    overriding default values in template and deploys pod appliance
+    checks that it is alive
+    deletes pod appliance
+
+    Polarion:
+        assignee: izapolsk
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_rbac_assigning_multiple_tags_from_same_category_to_catalog_item():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1339382
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: low
+        initialEstimate: 1/8h
+        startsin: 5.5
+        title: RBAC : Assigning multiple tags from same category to catalog Item
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(3)
+def test_crosshair_op_cluster_vsphere6():
+    """
+    test_crosshair_op_cluster[vsphere6]
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: low
+        initialEstimate: 1/12h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(3)
+def test_crosshair_op_cluster_vsphere65():
+    """
+    Requires:
+    C&U enabled Vsphere-65 appliance.
+    Steps:
+    1. Navigate to Clusters [Compute > infrastructure>Clusters]
+    2. Select any available cluster
+    3. Go for utilization graphs [Monitoring > Utilization]
+    4. Check data point on graphs ["CPU", "VM CPU state", "Memory", "Disk
+    I/O", "N/w I/O", "Host", "VMs"] using drilling operation on the data
+    points.
+    5.  check "chart", "timeline" and "display" options working properly
+    or not.
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_dialog_dropdown_elements_should_honour_defaults():
+    """
+    desc
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        initialEstimate: 1/4h
+        startsin: 5.8
+        title: Dialog dropdown elements should honour defaults
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+def test_embed_tower_retire_service_with_instances_ec2():
+    """
+    Retire Service+instances which were deployed by playbook from CFME UI.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+def test_create_simple_aggregated_custom_report():
+    """
+    Create aggregate custom report.
+    Eg: consolidate and aggregate data points into maximum, minimum,
+    average, and total.
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Create simple aggregated custom report
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_distributed_field_zone_description_special():
+    """
+    Special Chars in description
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/30h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_tagvis_config_manager_provider():
+    """
+    Add Configuration Manager Provider
+    Add tag
+    Check item as restricted user
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+def test_embed_tower_playbook_links():
+    """
+    There are links to repo"s within the playbook table. Clicking in this
+    cell will navigate to the details of the Repo.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_appliance_console_evm_start():
+    """
+    test starting the evm server process
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_childtenant_cloud_memory_quota_by_enforce():
+    """
+    test memory quota for child tenant for cloud instance by enforcement
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        initialEstimate: 1/4h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_ldap_password_being_logged_in_plain_text_in_evm_log():
+    """
+    LDAP password being logged in plain text in evm log
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/3h
+        title: LDAP password being logged in plain text in evm log
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_datastore_files():
+    """
+    Check datastore files are fetched correctly
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/2h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_proxy_remove_default():
+    """
+    With 5.7 there is a new feature that allows users to specific a
+    specific set of proxy settings for each cloud provider.  The way you
+    enable this is to go to Configuration/Advanced Settings and scroll
+    down to the default proxy settings.  For this test you want to create
+    an default proxy, verified it worked, and then remove the proxy and
+    verify it didn"t use a proxy
+    Here are the proxy instructions:
+    https://mojo.redhat.com/docs/DOC-1103999
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/8h
+        setup: I think the best way to do this one is start with a bad proxy value,
+               get the connection error, and then remove the proxy values and make
+               sure it starts connecting again.  I"ll have to see if there is a log
+               value we can look at.  Otherwise, you need to shutdown the proxy
+               server to be absolutely sure.
+        startsin: 5.7
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_proxy_remove_ec2():
+    """
+    With 5.7 there is a new feature that allows users to specific a
+    specific set of proxy settings for each cloud provider.  The way you
+    enable this is to go to Configuration/Advanced Settings and scroll
+    down to the ec2 proxy settings.  For this test you want to create an
+    default proxy, verified it worked, and then remove the proxy and
+    verify it didn"t use a proxy
+    Here are the proxy instructions:
+    https://mojo.redhat.com/docs/DOC-1103999
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/8h
+        setup: I think the best way to do this one is start with a bad proxy value,
+               get the connection error, and then remove the proxy values and make
+               sure it starts connecting again.  I"ll have to see if there is a log
+               value we can look at.  Otherwise, you need to shutdown the proxy
+               server to be absolutely sure.
+        startsin: 5.7
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_proxy_remove_gce():
+    """
+    With 5.7 there is a new feature that allows users to specific a
+    specific set of proxy settings for each cloud provider.  The way you
+    enable this is to go to Configuration/Advanced Settings and scroll
+    down to the ec2 proxy settings.  For this test you want to create an
+    default proxy, verified it worked, and then remove the proxy and
+    verify it didn"t use a proxy
+    Here are the proxy instructions:
+    https://mojo.redhat.com/docs/DOC-1103999
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/8h
+        setup: I think the best way to do this one is start with a bad proxy value,
+               get the connection error, and then remove the proxy values and make
+               sure it starts connecting again.  I"ll have to see if there is a log
+               value we can look at.  Otherwise, you need to shutdown the proxy
+               server to be absolutely sure.
+               You can also remove by setting host to false
+        startsin: 5.7
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_proxy_remove_azure():
+    """
+    With 5.7 there is a new feature that allows users to specific a
+    specific set of proxy settings for each cloud provider.  The way you
+    enable this is to go to Configuration/Advanced Settings and scroll
+    down to the azure proxy settings.  For this test you want to create an
+    azure proxy, verified it worked, and then remove the proxy and verify
+    it used the default which may or may not be blank.
+    Here are the proxy instructions:
+    https://mojo.redhat.com/docs/DOC-1103999
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/8h
+        setup: I think the best way to do this one is start with a bad proxy value,
+               get the connection error, and then remove the proxy values and make
+               sure it starts connecting again.  I"ll have to see if there is a log
+               value we can look at.  Otherwise, you need to shutdown the proxy
+               server to be absolutely sure.
+        startsin: 5.7
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_verify_httpd_only_running_when_roles_require_it():
+    """
+    Provision preconfigured appliance A.
+    Provision non-preconfigured appliance B.
+    On appliance A, stop server processes:
+    # appliance_console
+    > Stop EVM Server Processes > Y
+    On appliance B, join to appliance A:
+    # appliance_console
+    > Configure Database > Fetch key from remote machine
+    > enter IP address of appliance A
+    > root > smartvm
+    > /var/www/miq/vmdb/certs/v2_key
+    > Join Region in External Database
+    > enter IP address of appliance A
+    > 5432 > vmdb_production > root > smartvm
+    On appliance A, restart server processes:
+    > Start EVM Server Processes > Y
+    Log in the web UI on appliance A, and disable roles on appliance B
+    that require httpd:
+    Administrator > Configuration
+    > click on appliance B in accordion menu"s list of servers
+    > under Server Control, disable all server roles > Save
+    On appliance B, verify that the httpd service stops:
+    # systemctl status httpd
+    ● httpd.service - The Apache HTTP Server
+    Loaded: loaded (/usr/lib/systemd/system/httpd.service; disabled;
+    vendor preset: disabled)
+    Active: inactive (dead) since Fri 2018-01-12 10:57:29 EST; 22s ago
+    [...]
+    Enable one of the following roles, and verify that httpd restarts:
+    Cockpit, Embedded Ansible, User Interface, Web Services, Websocket
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Verify httpd only running when roles require it
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(2)
+def test_sui_monitor_ansible_playbook_std_output():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1437210
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: ssui
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: SUI : Monitor Ansible playbook Std output
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(3)
+def test_change_the_domain_sequence_in_sssd_and_verify_user_groups_retrieval():
+    """
+    create user1 in test.com
+    create group1 in test.com
+    assign user1 to group1
+    verify for the group retrived for user1
+    Only group1 should be displayed in the group list in
+    Note:  user should be authenticated with FQDN user1@test.com : group1
+    test.com
+    user1@qetest.com: qegroup1 qetest.com
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/2h
+        title: Change the domain sequence in sssd, and verify user groups retrieval.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+def test_embed_tower_exec_play_against_machine_multi_appliance():
+    """
+    User/Admin is able to execute playbook without creating Job Temaplate
+    and can execute it against machine with machine credentials. Deploy 2
+    appliances, second one as unconfigured, through appliance_console join
+    the
+    region of first appliance. Enable embedded ansible on 2nd appliance.
+    From first appliance, add scm, credentials, new catalog, catalog item
+    of AnsiblePlaybook type. Select playbook e.g. dump_all_vars and order
+    it. When asked what machine to run it against, pick any rhel7 machine.
+    Playbook should be executed successfully.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_black_console_ipa_ntp_negative():
+    """
+    Try to setup IPA on appliance when NTP daemon is stopped on server.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/4h
+        setup: -Provision configured appliance
+               -ssh into IPA server stop NTP daemon
+               -ssh into new appliance
+               -try setting up IPA (https://mojo.redhat.com/docs/DOC-1058778)
+               -after testing remember to start NTP daemon again
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_appliance_terminates_unresponsive_worker_process():
+    """
+    If a queue message consumes significant memory and takes longer than
+    the 10 minute queue timeout, the appliance will kill the worker after
+    the stopping_timeout.
+    Steps to test:
+    https://bugzilla.redhat.com/show_bug.cgi?id=1395736#c30
+    https://bugzilla.redhat.com/show_bug.cgi?id=1395736#c31
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/2h
+        startsin: 5.8
+        title: Appliance terminates unresponsive worker process
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+def test_replication_powertoggle():
+    """
+    power toggle from global to remote
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: infra
+        caseimportance: critical
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_childtenant_cloud_vm_quota_by_enforce():
+    """
+    test no of vms quota for child tenant for cloud instance by
+    enforcement
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        initialEstimate: 1/4h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_cockpit_connected():
+    """
+    Prerequisitiies:
+    Appliance connected to provider
+    Installed Cockpit on VM present on connected provider
+    VM running
+    Cockpit accesible on vm_ip:9090
+    Navigate to Compute > Infrastructure > Virtual Machines
+    Find VM with Cockpit running and accessible and go to its detail
+    Navigate to Access > Web console
+    # Web Console is active
+    Select Web Console
+    # browser is redirected to Cockpit web page on VM
+    Go to VM and disable Cockpit daemon
+    Go to appliance, find VM with Cockpit running and accessible and go to
+    its detail
+    Navigate to Access > Web console
+    # Web Console is disabled
+    Go to VM and enable Cockpit daemon
+    Go to appliance, find VM with Cockpit running and accessible and go to
+    its detail
+    Navigate to Access > Web console
+    # Web Console is enabled
+
+    Polarion:
+        assignee: nansari
+        casecomponent: prov
+        caseimportance: medium
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_copy_provisioning_dialog():
+    """
+    Automate - customization - provisioning dialog
+    Create a new dialog. Save
+    Configuration - Copy this dialog .
+
+    Polarion:
+        assignee: None
+        casecomponent: prov
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.5
+        title: Copy provisioning dialog
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_capture_vm_event_azure():
+    """
+    capture vm event[azure]
+
+    Polarion:
+        assignee: None
+        caseimportance: low
+        initialEstimate: 1/4h
+        title: capture vm event[azure]
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_user_cloud_storage_quota_by_services():
+    """
+    test user storage quota for cloud instance provision by ordering
+    services
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_export_all_existing_dialogs_almost_100_dialogs():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1570298
+    Steps to Reproduce:
+    1. Go to Automation -> Automate -> Customization -> Select Import
+    Export
+    2. Select all existing dialogs (almost 100 dialogs)
+    3. Press the button "Export"
+    4. After some time, the error 502 appears.
+    5. Individual or sometimes a group of dialogs can be exported
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Export all existing dialogs (almost 100 dialogs
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.upgrade
+@pytest.mark.tier(2)
+def test_upgrade_dedicated_db_migration_local():
+    """
+    Test that you can locally migrate a dedicated database after upgrade.
+    Previously it was missing the database.yml during setup with would
+    case the rake task to fail.
+    https://bugzilla.redhat.com/show_bug.cgi?id=1478986
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/3h
+        startsin: 5.8
+        testSteps:
+            1. Upgrade appliances
+            2. Check failover
+        expectedResults:
+            1. Confirm upgrade completes successfully
+            2. Confirm failover continues to work
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_saving_migration_plan_after_creation():
+    """
+    OSP: Test saving migration plan after creation
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test saving migration plan after creation
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+def test_embed_tower_playbooks():
+    """
+    playbooks included under ansible shown in a table view (automation-
+    ansible-playbooks)
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_cmqe_delete_existing_resource_quota():
+    """
+    Delete existing Resource Quota
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1h
+        title: CMQE - Delete Existing Resource Quota
+        testSteps:
+            1. &nbsp;Delete the&nbsp;existing Resource Quota that was added in&nbsp;&nbsp;
+            2. Refresh the CFME appliance
+            3. Check the containers_quota_items table in the database
+            4. Navigate to the namespace in the CFME GUI.
+        expectedResults:
+            1. Verify the Resource Quota was deleted successfully
+            2. Appliance refreshed successfully.
+            3. Verify the deleted Resource Quotas should still exist, with
+               `deleted_on` field set.
+            4. Verify the GUI displays no data referencing Resource Quota.
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_appliance_console_haproxy():
+    """
+    Test HA setup with HAproxy load balancing.
+    https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.5/h
+    tml/high_availability_guide/configuring_haproxy
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/2h
+        setup: setup HA following https://mojo.redhat.com/docs/DOC-1097888
+               setup HAProxy using keepalived and haproxy packages (waiting on
+               official documentation)
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware60_test_vm_migration_with_really_long_name_upto_64_chars_worked_not_65_char():
+    """
+    OSP: vmware60-Test VM migration with really long name(Upto 64 chars
+    worked, not 65 chars)
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware60-Test VM migration with really long name(Upto
+               64 chars worked, not 65 chars)
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware60_test_vm_migration_with_rhel_69():
+    """
+    OSP: vmware60-Test VM migration with RHEL 6.9
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware60-Test VM migration with RHEL 6.9
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_datastore_allocation_summary_before_and_after_migration_disk_memory():
+    """
+    OSP: Test Datastore Allocation Summary before and after migration
+    (Disk, Memory)
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: critical
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test Datastore Allocation Summary before and after migration (Disk, Memory)
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware67_test_vm_migration_with_windows_2016_server():
+    """
+    OSP: vmware67-Test VM migration with Windows 2016 server
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware67-Test VM migration with Windows 2016 server
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_public_ip_without_nic_azure():
+    """
+    Relates to https://bugzilla.redhat.com/show_bug.cgi?id=1531099  -
+    Update testcase after BZ gets resolved
+    Update: we are not filtering PIPs but we can use PIPs which are not
+    associated to any NIC
+    1. Have a Puplic IP on Azure which is not assigned to any Network
+    Interface - such Public IPs should be reused property
+    2. Provision Azure Instance - select public IP from 1.
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.snapshot
+@pytest.mark.tier(1)
+def test_rhos_test_notification_for_snapshot_delete_failure():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1581793
+    Test if cfme can report failure when deleting snapshot from RHOS.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: RHOS: test notification for snapshot delete failure
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_users():
+    """
+    Check users are fetched correctly for analysed VM
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/2h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_rhi_appliance():
+    """
+    Red Hat Insights:
+    Register an Appliance to RHSM or Satellite.
+    Perform SmartState Analysis on appliance.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+def test_replication_central_admin_vm_retirement():
+    """
+    retire a vm via CA
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: infra
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_datastore_files_unicode():
+    """
+    Make sure https://bugzilla.redhat.com/show_bug.cgi?id=1221149 is fixed
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/2h
+        startsin: 5.3
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_external_database_appliance():
+    """
+    Configure appliance to use external DB
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: config
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_distributed_zone_failover_cu_data_processor():
+    """
+    C & U Data Processor (multiple appliances can have this role)
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(3)
+def test_sui_stack_service_vm_detail_page_should_show_correct_data():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1467569
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: ssui
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: SUI : Stack Service VM detail page should show correct data
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.snapshot
+@pytest.mark.tier(1)
+def test_notification_for_snapshot_actions_on_openstack():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1429313
+    Test task notification for snapshot tasks: success and failure of
+    create and delete snapshot.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1h
+        title: Test notification for snapshot actions on OpenStack
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_groups_scvmm2k12_windows2012r2_ntfs():
+    """
+    Add SCVMM-2012 provider.
+    Perform SSA on Windows 2012 server R2 VM having NTFS filesystem.
+    Check whether it retrieves Groups.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_groups_azure_ubuntu():
+    """
+    1. Add Azure provider
+    2. Perform SSA on Ubuntu instance.
+    3. Check Groups are retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_groups_scvmm2k12_centos_xfs():
+    """
+    Add SCVMM-2012 provider.
+    Perform SSA on CentOS VM.
+    Check whether Groups retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_groups_azure_rhel():
+    """
+    1. Add Azure provider
+    2. Perform SSA on RHEL instance.
+    3. Check Groups  are retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_groups_scvmm2k12_rhel74():
+    """
+    Add SCVMM-2012 provider.
+    Perform SSA on RHEL 7.4 VM.
+    Check whether Groups retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_groups_azure_windows2012r2_ntfs():
+    """
+    1. Add Azure provider
+    2. Perform SSA on Windows server 2012 R2.
+    3. Check Groups are retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_groups_rhos7_ga_fedora_22_ext4():
+    """
+    test_ssa_groups[rhos7-ga-fedora-22-ext4]
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/2h
+        startsin: 5.3
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_groups_scvmm2k16_centos_xfs():
+    """
+    Add SCVMM-2016 provider.
+    Perform SSA on CentOS VM.
+    Check whether Groups retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_groups_scvmm2k16_rhel74():
+    """
+    Add SCVMM-2016 provider.
+    Perform SSA on RHEL 7.4 VM.
+    Check whether Groups retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_groups_scvmm2k16_windows2012r2_ntfs():
+    """
+    Add SCVMM-2016 provider.
+    Perform SSA on Windows 2012 server R2 VM having NTFS filesystem.
+    Check whether it retrieves Groups.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_groups_azure_windows2016_ntfs():
+    """
+    1. Add Azure provider
+    2. Perform SSA on Windows2016 server.
+    3. Check Groups are retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_groups_ec2_rhel():
+    """
+    Add EC-2 provider.
+    Perform SSA on RHEL instance.
+    Check whether it retrieves Groups.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_groups_ec2_ubuntu():
+    """
+    Add EC-2 provider.
+    Perform SSA on Ubuntu instance.
+    Check whether it retrieves Groups.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_groups_ec2_windows2012r2_ntfs():
+    """
+    Add EC-2 provider.
+    Perform SSA on Windows 2012 server R2 VM having NTFS filesystem.
+    Check whether it retrieves Groups.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_groups_scvmm2k16_windows2016_ntfs():
+    """
+    Add SCVMM-2016 provider.
+    Perform SSA on Windows 2016 server VM having NTFS filesystem.
+    Check whether it retrieves Groups.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_groups_scvmm2k12_windows2016_ntfs():
+    """
+    Add SCVMM-2012 provider.
+    Perform SSA on Windows 2016 server VM having NTFS filesystem.
+    Check whether it retrieves Groups.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_groups_ec2_fedora():
+    """
+    Add EC-2 provider.
+    Perform SSA on Fedora instance.
+    Check whether it retrieves Groups.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_appliance_console_check_default_ip():
+    """
+    test ip settings, checking all the defaults are what is expected.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.retirement
+@pytest.mark.tier(2)
+def test_retire_infra_vms_folder():
+    """
+    test the retire funtion of vm on infra providers, at least two vm,
+    retire now button vms page
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: prov
+        caseimportance: medium
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_email_should_be_sent_when_service_approval_is_set_to_manual():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1380197
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Email should be sent when service approval is set to manual
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_group_infra_storage_quota_by_services():
+    """
+    test group storage for infra vm provision by ordering services
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_infrastructure_hosts_icons_states():
+    """
+    Requirement: Added a RHEVM provider
+    Then do in console:
+    su - postgres
+    psql
+    \c vmdb_production
+    UPDATE hosts SET power_state = "preparing_for_maintenance" WHERE
+    name="NAME OF THE TESTED HOST";
+    UPDATE hosts SET power_state = "maintenance" WHERE name="NAME OF THE
+    TESTED HOST";
+    UPDATE hosts SET power_state = "unknown" WHERE name="NAME OF THE
+    TESTED HOST";
+    UPDATE hosts SET power_state = "on" WHERE name="NAME OF THE TESTED
+    HOST";
+    UPDATE hosts SET power_state = "off" WHERE name="NAME OF THE TESTED
+    HOST";
+    Between every update check state icon in Compute -> Infrastructure ->
+    Hosts -> Host quadicon and Compute -> Infrastructure -> Hosts ->
+    Summary of the host
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: infra
+        caseimportance: low
+        initialEstimate: 1/3h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(3)
+def test_sui_should_allow_selecting_multiple_items_in_a_service_dialog_element_with_multiselec():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1539862
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: ssui
+        initialEstimate: 1/16h
+        title: SUI should allow selecting multiple items in a Service
+               Dialog element with Multiselect enabled
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(1)
+def test_provision_more_than_15_vms_for_gce():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1337646
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: low
+        initialEstimate: 1/2h
+        startsin: 5.5
+        title: provision more than 15 VM's  for GCE
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_ec2_public_images():
+    """
+    1) Set
+    :ems_refresh:
+    :ec2:
+    :get_public_images: true
+    2) Add an ec2 provider
+    3) Wait for its refresh(It can take more than 30 minutes)
+    4) Refresh should be successful and there should be more than 100k ec2
+    images
+
+    Polarion:
+        assignee: mmojzis
+        caseimportance: critical
+        initialEstimate: 2/3h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_init_processes():
+    """
+    Check init services are fetched correctly for analysed VM
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/2h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_black_console_ipa_negative():
+    """
+    test setting up authentication with invalid host settings
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_packages():
+    """
+    Check packages are fetched correctly for analysed VM
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/2h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(2)
+def test_sui_create_snapshot_from_vm_details_page_snapshot_page_and_service_details_page():
+    """
+    Snapshot can be created from VM details page , service details page
+    and snapshot page .
+    Check all pages and the snapshot count displayed on vm details page .
+
+    Polarion:
+        assignee: apagac
+        casecomponent: ssui
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.9
+        title: SUI : Create snapshot from vm details page, snapshot page
+               and service details page
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_group_cloud_storage_quota_by_lifecycle():
+    """
+    test group storage quota for cloud instance provision by Automate
+    model
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: cloud
+        caseimportance: low
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_validate_chargeback_cost_weekly_rate_network_cost():
+    """
+    Validate network I/O used cost in a daily Chargeback report by
+    assigning weekly rate
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+@pytest.mark.tier(2)
+def test_validate_chargeback_cost_tiered_rate_fixedvariable_network_cost():
+    """
+    Validate network I/O used cost  for a tiered rate with fixed and
+    variable components
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_validate_chargeback_cost_monthly_rate_disk_cost():
+    """
+    Validate disk I/O used cost in a daily Chargeback report by assigning
+    monthly rate
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_chargeback_cost_monthlyreport_hourly_rate_network_cost():
+    """
+    Validate network I/O used cost in a monthly Chargeback report
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_chargeback_cost_weeklyreport_hourly_rate_disk_cost():
+    """
+    Validate disk I/O used cost in a weekly Chargeback report
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_validate_chargeback_cost_monthly_rate_network_cost():
+    """
+    Validate network I/O used cost in a daily Chargeback report by
+    assigning monthly rate
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_validate_chargeback_cost_weekly_rate_disk_cost():
+    """
+    Validate disk I/O used cost in a dailyy Chargeback report by assigning
+    weekly rate
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+@pytest.mark.tier(2)
+def test_validate_chargeback_cost_resource_allocation_cpu_allocated():
+    """
+    Validate CPU allocated cost in a Chargeback report based on resource
+    allocation. C&U data is not considered for these reports.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_chargeback_cost_weekly_rate_cpu_cost():
+    """
+    Validate CPU usage cost in a daily Chargeback report by assigning
+    weekly rate
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+@pytest.mark.tier(2)
+def test_validate_chargeback_cost_tiered_rate_fixedvariable_cpu_cost():
+    """
+    Validate CPU usage cost for a tiered rate with fixed and variable
+    components
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+@pytest.mark.tier(2)
+def test_validate_chargeback_cost_resource_allocation_storage_allocated():
+    """
+    Validate storage allocated cost in a Chargeback report based on
+    resource allocation. C&U data is not considered for these reports.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_chargeback_cost_monthlyreport_hourly_rate_disk_cost():
+    """
+    Validate disk I/O used cost in a monthly Chargeback report
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_chargeback_cost_weeklyreport_hourly_rate_cpu_cost():
+    """
+    Validate CPU usage cost in a weekly Chargeback report
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_chargeback_cost_monthlyreport_hourly_rate_memory_cost():
+    """
+    Validate memory usage cost in a monthly Chargeback report
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_validate_chargeback_cost_monthly_rate_cpu_cost():
+    """
+    Validate CPU usage cost in a daily Chargeback report by assigning
+    monthly rate
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_chargeback_cost_weekly_rate_memory_cost():
+    """
+    Validate memory usage cost in a daily Chargeback report by assigning
+    weekly rate
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_chargeback_cost_weeklyreport_hourly_rate_memory_cost():
+    """
+    Validate memory usage cost in a weekly Chargeback report
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_chargeback_cost_weeklyreport_hourly_rate_network_cost():
+    """
+    Validate network I/O used cost in a weekly Chargeback report
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+@pytest.mark.tier(2)
+def test_validate_chargeback_cost_tiered_rate_fixedvariable_disk_cost():
+    """
+    Validate disk I/O used cost for a tiered rate with fixed and variable
+    components
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+@pytest.mark.tier(2)
+def test_validate_chargeback_cost_resource_allocation_memory_allocated():
+    """
+    Validate memory allocated cost in a Chargeback report based on
+    resource allocation. C&U data is not considered for these reports.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_chargeback_cost_monthlyreport_hourly_rate_cpu_cost():
+    """
+    Validate CPU usage cost in a monthly Chargeback report
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+@pytest.mark.tier(2)
+def test_validate_chargeback_cost_tiered_rate_fixedvariable_memory_cost():
+    """
+    Validate memory usage cost  for a tiered rate with fixed and variable
+    components
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_validate_chargeback_cost_monthly_rate_memory_cost():
+    """
+    Validate memory usage cost in a daily Chargeback report by assigning
+    monthly rate
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.log_depot
+@pytest.mark.tier(2)
+def test_log_scvmm_settings_scvmm():
+    """
+    In configuration\server\advanced you can set the log level for the
+    azure specific scvmm.log file.  Need to changes the values and verify
+    that the correct info is recording.  For this test, at least set it to
+    DEBUG.
+    tail -f scvmm.log | grep --line-buffered ERROR or WARN or something.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.5
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(2)
+def test_quota_with_invalid_service_request():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1531914 Test quotas with
+    various regions and invalid service requests
+    This bug contains the steps to follow:
+    https://bugzilla.redhat.com/show_bug.cgi?id=1534589
+    To reproduce this issue: (You"ll need to have the RedHat Automate
+    domain)
+    1. Setup multiple zones.(You can use a single appliance and just add a
+    "test" zone)
+    2. Add VMWare provider and configure it to the "test" zone.
+    3. Create a VMWare Service Item.
+    4. Order the Service.
+    5. Delete the Service Template used in the Service creation in step 3.
+    6. Modify the VMWare provider to use the default zone. (This should
+    leave the existing Service request(s) in the queue for the "test" zone
+    and the service_template will be invalid)
+    7. Provision a VMWare VM.
+    You should see the following error in the log:
+    "[----] E, [2018-01-06T11:11:20.073924 #13027:e0ffc4] ERROR -- :
+    Q-task_id([miq_provision_787]) MiqAeServiceModelBase.ar_method raised:
+    <NoMethodError>: <undefined method `service_resources" for
+    nil:NilClass>
+    [----] E, [2018-01-06T11:11:20.074019 #13027:e0ffc4] ERROR -- :
+    Q-task_id([miq_provision_787]) "
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: control
+        initialEstimate: 1/4h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware_67_test_vm_name_with_punycode_characters():
+    """
+    OSP: vmware 67- Test VM name with Punycode characters
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware 67- Test VM name with Punycode characters
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_template_info_scvmm2016():
+    """
+    The purpose of this test is to verify that the same number of
+    templates in scvmm are in cfme.  Take the time to spot check a random
+    template and check that the details correspond to SCVMM details.
+
+    Polarion:
+        assignee: None
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_reconfigure_vm_vmware_cores_multiple():
+    """
+    Test changing the cpu cores of multiple vms at the same time.
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/6h
+        setup: -get new configured appliance
+               -add vmware provider
+               -provision 2 new vms
+               -power off 1 vm
+               -select both vms
+               -configure-->reconfigure vm
+               -increase/decrease counts
+               -power on vm
+               -check changes
+        startsin: 5.6
+        testSteps:
+            1. Hot increase
+            2. Hot Decrease
+            3. Cold Increase
+            4. Cold Decrease
+            5. Hot + Cold Increase
+            6. Hot + Cold Decrease
+        expectedResults:
+            1. Action should fail
+            2. Action should fail
+            3. Action should succeed
+            4. Action should succeed
+            5. Action should fail
+            6. Action should Error
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_group_cloud_memory_quota_by_services():
+    """
+    test group memory quota for cloud instance provision by ordering
+    services
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        initialEstimate: 1/4h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.config_management
+@pytest.mark.tier(1)
+def test_config_manager_prov_from_service_survey_ansible_tower_310():
+    """
+    1) Navigate to Configuration -> Configuration management -> Ansible
+    Tower job templates.
+    - click on job template -> Configuration -> Create service dialog from
+    this job template -> give it name
+    (Job template with preconfigured Survey must be used!!!)
+    2) Create new catalog Item
+    - Catalog Item type: AnsibleTower
+    - name your catalog item
+    - Display in catalog: checked
+    - catalog: pick your catalog
+    - Dialog: Tower_dialog
+    - Provider: Ansible Tower .....
+    3) Order service and fill in service details
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: prov
+        initialEstimate: 1h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_executing_previously_created_migration_plan():
+    """
+    OSP: Test executing previously created migration plan
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test executing previously created migration plan
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.cfme_tenancy
+def test_tenant_unique_catalog():
+    """
+    Catalog name is unique per tenant. Every tenant can have catalog with
+    name "catalog" defined.
+
+    Polarion:
+        assignee: mnadeem
+        casecomponent: config
+        caseposneg: negative
+        initialEstimate: 1/2h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_pdf_summary_infra_provider():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1651194
+    1. Add an Infrastructure Provider (tested with VMware)
+    2. Open the summary page of the provider
+    3. In the toolbar click "Print or export summary"
+    = Quadicon is shown correctly, exactly as in the UI
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        initialEstimate: 1/8h
+        startsin: 5.10
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(3)
+def test_service_ansible_retirement_remove_resources():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1501143
+    Description of problem:
+    It"s not possible to have "Remove resources?" field with "No" value in
+    Ansible Playbook catalog item
+    Steps to Reproduce:
+    1. Open creation screen of Ansible Playbook catalog item.
+    2. Fill required fields.
+    3. Open Retirement tab.
+    4. Fill "Remove resources?" field with "No" value.
+    5. Press "Save" button.
+    Actual results:
+    In details screen of the catalog item "Remove resources?" has "Yes".
+    Expected results:
+    "Remove resources" should have correct value.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1/4h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_user_quota_vm_reconfigure():
+    """
+    Create User quota
+    assign some quota limitations
+    recongifure VM over limit.
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        initialEstimate: 1/4h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_configure_external_auth_for_ldaps_with_sssdconf_for_single_ldaps_domain():
+    """
+    Look for the steps/instructions at
+    https://mojo.redhat.com/docs/DOC-1085797
+    Verify appliance_console is updated with “External Auth: “ correctly
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/2h
+        title: Configure External auth for ldaps with sssd.conf for single ldaps domain
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+@pytest.mark.tier(2)
+def test_chargeback_report_weekly():
+    """
+    Verify that 1)weekly chargeback reports can be generated and 2)that
+    the report contains relevant data for the relevant period.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_immediately_migration_after_migration_plan_creation():
+    """
+    OSP: Test immediately migration after migration plan creation
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test immediately migration after migration plan creation
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+@pytest.mark.tier(1)
+def test_reports_should_generate_with_no_errors_in_logs():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1592480#c21
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        initialEstimate: 1/2h
+        startsin: 5.9
+        title: Reports should generate with no errors in logs
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_provision_bad_password():
+    """
+    This test verifies that an acceptable password is entered when
+    provisioning an Azure VM from an Azure image.  "test" won"t work.
+    Dog8Code8Dog will work.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(3)
+def test_verify_change_update_in_ldap_server_takes_effect_in_the_cfme_authentication():
+    """
+    Change user/groups attribute in  ldap domain server.
+    E.g change user display name
+    Verify authentication fails for old display name
+    Verify authentication for new display name for the user.
+    Verify changing cache_credentials = True
+    entry_cache_timeout = 600
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/2h
+        title: Verify change/update in ldap server takes effect in the CFME authentication.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+def test_distributed_add_provider_to_remote_zone():
+    """
+    Adding a provider from the global region to a remote zone.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_role_configured_with_the_option_only_user_or_group_owned_should_allow_to_access_to_se():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1554775
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.9
+        title: Role configured with the option "only user or group owned"
+               should allow to access to service catalogs and items
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_group_cloud_cpu_quota_by_services():
+    """
+    test group cpu quota for cloud instance provision by ordering services
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(2)
+def test_that_non_admin_users_can_view_catalog_items_in_ssui():
+    """
+    Verify user with a non-administrator role can login to the SSUI and
+    view catalog items that are tagged for them to see
+    See https://bugzilla.redhat.com/show_bug.cgi?id=1465642
+    Note: in order for this to work, all ownership limitations must be
+    removed.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: ssui
+        initialEstimate: 1/2h
+        setup: Create a user account with a non-admin role w/ any necessary tags,
+               "View Catalog Items" permissions and SSUI access
+               Create a catalog item that is visible to the user
+        title: Test that non-admin users can view catalog items in SSUI
+        testSteps:
+            1. Login to the SSUI as a non-admin user
+            2. Attempt to view all catalog items the user has access to
+        expectedResults:
+            1. SSUI login
+            2.
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_kill_the_v2v_process_in_the_middle_restart_evmserverd_should_resume_migration_pos():
+    """
+    OSP: kill the v2v process in the middle(restart evmserverd) - should
+    resume migration post restart
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: kill the v2v process in the middle(restart evmserverd)
+               - should resume migration post restart
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_shutdown_guest_scvmm():
+    """
+    This test performs the Shutdown Guest from the LifeCycle menu which
+    invokes the Hyper-V Guest Services Integration command.  This
+    gracefully exits the Windows OS rather than just powering off.
+    From collections page, select the VM and click "Shut down guest"
+    On SCVMM powershell, use "$vm = Get-VM -name "name_of_vm"; Find-SCJob
+    -objectId $vm.id -recent" to verify VM history shows "Shut down
+    virtual machine" instead of "power off"
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.4
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_button_display_ssui_single():
+    """
+    Test custom button display for single/detail page for SSUI
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: automate
+        initialEstimate: 1/8h
+        startsin: 5.9
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_storage_ebs_volume_crud():
+    """
+    Requires:
+    test_storage_ebs_added
+    Steps to test:
+    Create:
+    1. Go to Storage -> Block Storage -> Volumes
+    2. Add a new cloud volume
+    3.Form to fill:
+    ec2 EBS Storage Manager
+    us-east-1
+    volume_test
+    Magnetic
+    6
+    Encryption off
+    4. Add
+    Read:
+    1. Select "volume_test" and go to its summary
+    Edit:
+    1. Configuration -> Edit this Cloud Volume
+    2. Change volume name from "volume_test" to "volume_edited_test"
+    3. Select "volume_edited_test" in Block Volume list and go to its
+    summary
+    Delete:
+    1. Configuration -> Delete this Cloud Volume
+    2. Check whether volume was deleted
+
+    Polarion:
+        assignee: mmojzis
+        initialEstimate: 1/4h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_failover():
+    """
+    Check that ansible fails over to new region correctly
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_add_scm_credentials():
+    """
+    Add SCM credentials for private GIT repo.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1/4h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_regions_disable_azure():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1412355
+    CloudForms should be able to enable/disable unusable regions in Azure,
+    like the Government one for example.
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/10h
+        setup: You will need to go into advanced settings and add or remove items
+               from the following section.
+               :ems_azure:
+               :disabled_regions:
+               - usgovarizona
+               - usgoviowa
+               - usgovtexas
+               - usgovvirginia
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(3)
+def test_generic_objects_class_accordion_should_display_when_locale_is_french():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1594480
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.10
+        title: Generic objects class accordion should display when locale is french
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.general_ui
+@pytest.mark.tier(1)
+def test_ui_pinning_after_relog():
+    """
+    Go to Automate -> Explorer
+    Pin this menu
+    Logout
+    Log in
+    No menu should be pinned
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_triggered_refresh_shouldnt_occurs_for_dialog_after_changing_type_to_static():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1614436
+
+    Polarion:
+        assignee: None
+        casecomponent: services
+        initialEstimate: None
+        title: Triggered Refresh shouldn't Occurs for Dialog After Changing Type to Static
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_childtenant_cloud_storage_quota_by_enforce():
+    """
+    test storage quota for child tenant for cloud instance by enforcement
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        initialEstimate: 1/4h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_notification_banner_vm_provisioning_notification_and_service_request_should_be_in_syn():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1389312
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Notification Banner - VM Provisioning Notification and
+               Service Request should be in  Sync
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_retirement_now_scvmm():
+    """
+    Verify that a VM can be retired immediately.  This should work whether
+    the VM is running or not, so repeat this test with a vm that is
+    running and a vm that is off.  Note that the VM is no longer removed
+    with later versions
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.4
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_patches_azure_windows2012r2_ntfs():
+    """
+    1. Add Azure provider
+    2. Perform SSA on Windows server 2012 R2.
+    3. Check Patches are retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_patches_ec2_windows2012r2_ntfs():
+    """
+    Add EC-2 provider.
+    Perform SSA on Windows 2012 R2 server VM.
+    Check whether Patches are retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_patches_azure_windows2016_ntfs():
+    """
+    1. Add Azure provider
+    2. Perform SSA on Windows2016 server.
+    3. Check Patches are retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_ec2_deploy_cfme_image():
+    """
+    BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1413835
+    Requirement: CFME image imported as AMI in EC2 environment - should be
+    imported automatically with every build
+    1) Deploy appliance:
+    c4.xlarge instance type
+    default vpc network
+    Two disks: one default 41GB, one additional 10GB
+    Security group with open port 22 & 443 to world
+    select appropriate private key
+    2) Associate instance with Elastic IP
+    3) Configure database using appliance_console
+    4) Start evmserverd
+    5) CFME appliance should work
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: appl
+        caseimportance: critical
+        initialEstimate: 4h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware67_test_vm_migration_with_really_long_name_upto_64_chars_worked_not_65_char():
+    """
+    OSP: vmware67-Test VM migration with really long name(Upto 64 chars
+    worked, not 65 chars)
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware67-Test VM migration with really long name(Upto
+               64 chars worked, not 65 chars)
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+@pytest.mark.tier(1)
+def test_reports_generate_persistent_volumes():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1563861
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_migrating_a_vm_using_migration_plan_with_name_which_has_all_special_characte():
+    """
+    OSP: Test migrating a VM using migration plan with name which has all
+    special characters
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test migrating a VM using migration plan with name
+               which has all special characters
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_timepicker_should_show_date_when_chosen_once():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1638079
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: None
+        title: Timepicker should show date when chosen once
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_distributed_field_zone_description_long():
+    """
+    When creating a new zone, the description can be up to 50 characters
+    long, and displays correctly after saving.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/30h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_flavors_can_be_selected_creating_migration_plan():
+    """
+    OSP: Test flavors can be selected creating migration plan
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test flavors can be selected creating migration plan
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.dashboard
+@pytest.mark.tier(3)
+def test_dashboard_layouts_match():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1518766
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_cmqe_modify_existing_resource_quota():
+    """
+    Modify Existing Quota
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1h
+        title: CMQE - Modify Existing Resource Quota
+        testSteps:
+            1. Modify the existing Resource Quota that was added in &nbsp;
+            2. Refresh the CFME appliance
+            3. Check the containers_quota_items table in the database
+            4. Navigate to the namespace in the CFME GUI.
+            5. Modify the existing Resource Quota again
+            6. Refresh the CFME appliance
+            7. Check the containers_quota_items table in the database
+            8. Navigate to the namespace in the CFME GUI.
+        expectedResults:
+            1. Verify the update was successful
+            2. Appliance refreshed successfully.
+            3. Verify the modified values (eg. increased cpu) should appear
+               as multiple rows — old value with `deleted_on` field set,
+               and new value with approximately same `created_at`.
+            4. Verify the GUI displays the correct data and the fractional
+               values are formatted properly.
+            5. Verify the update was successful
+            6. Appliance refreshed successfully.
+            7. Verify multiple values with both (created_at, deleted_on)
+               set and only last one with deleted_on=null.
+            8. Verify the GUI displays the correct data and the fractional
+               values are formatted properly.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_user_cloud_memory_quota_by_lifecycle():
+    """
+    test user memory quota for cloud instance provision by Automate model
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_appliance_executing_script():
+    """
+    check that a script from /var/www/miq/vmdb/tools/ runs correctly as
+    expected.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_reconfigure_add_disk_cold():
+    """
+    Test adding 16th disk to test how a new scsi controller is handled.
+    https://bugzilla.redhat.com/show_bug.cgi?id=1337310
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_migration_plan_filtering_for_plans_table_list_on_overview_and_details_page():
+    """
+    OSP: Test Migration Plan Filtering for plans table/list on overview
+    and details page
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test Migration Plan Filtering for plans table/list on
+               overview and details page
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.retirement
+def test_retirement_date_uses_correct_time_zone():
+    """
+    Bug 1565128 - Wrong timezone when selecting retirement time
+    https://bugzilla.redhat.com/show_bug.cgi?id=1565128
+    After saving VM retirement date/time (using both "Specific Date and
+    Time" and "Time Delay from Now" options), the displayed Retirement
+    Date has the correct date and time-zone appropriate time.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/15h
+        startsin: 5.9
+        title: Retirement date uses correct time zone
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_monitor_resources():
+    """
+    Check there is a method for monitoring embedded ansibles resource
+    usage.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/10h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_check_default_value_setting_for_all_options_in_dialog():
+    """
+    Cannot set default option for static dropdown list in Service Dialog -
+    https://bugzilla.redhat.com/show_bug.cgi?id=1471964
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        initialEstimate: 1/4h
+        title: Check default value setting for all options in Dialog
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+def test_distributed_zone_add_provider_to_nondefault_zone():
+    """
+    Can a new provider be added the first time to a non default zone.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: infra
+        caseimportance: critical
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.general_ui
+@pytest.mark.tier(1)
+def test_automate_buttons_requests():
+    """
+    Navigate to Automate -> Requests
+    Check whether these buttons are displayed:
+    Reload
+    Apply
+    Reset
+    Default
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: automate
+        caseimportance: low
+        initialEstimate: 1/18h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(3)
+def test_saml_verify_user_login_with_and_without_correct_groups_added_to_saml_server():
+    """
+    Create cfme default groups in saml server.
+    Assign user to the default groups. e.g.  EvmGroup-administrator
+    Configure cfme for ldaps external auth as in TC#1
+    Authentication for ldap user is expected to be successful as cfme
+    default groups are already assigned for user in saml server.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/2h
+        title: saml: verify user login with and without correct groups added to SAML server.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(2)
+def test_azone_cpu_usage_gce():
+    """
+    Utilization Test
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        initialEstimate: 1/12h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(1)
+def test_azone_cpu_usage_azure():
+    """
+    Utilization Test
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        initialEstimate: 1/12h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_orchestration_link_mismatch():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1601523
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: stack
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: orchestration link mismatch
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.control
+@pytest.mark.tier(3)
+def test_control_import_with_incorrect_schema():
+    """
+    Test importing yaml with incorrect schema.
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: control
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.log_depot
+@pytest.mark.tier(2)
+def test_log_azure_settings_azure():
+    """
+    In configuration\server\advanced you can set the log level for the
+    azure specific azure.log file.  Need to changes the values and verify
+    that the correct info is recording.  For this test, at least set it to
+    DEBUG.
+    tail -f azure.log | grep --line-buffered ERROR or WARN or something.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/8h
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.log_depot
+@pytest.mark.tier(1)
+def test_log_collect_all_zone_unconfigured():
+    """
+    check collect all logs under zone when both levels are unconfigured.
+    Expected result - all buttons are disabled
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.upgrade
+@pytest.mark.tier(2)
+def test_upgrade_rubyrep_to_pglogical():
+    """
+    Test upgrading appliances in ruby replication and change it over to
+    pglogical
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        endsin: 5.9
+        initialEstimate: 1h
+        setup: provision 2 appliances
+               setup rubyrep between them
+               test replication is working
+               stop replication
+               upgrade appliances following version dependent docs found here
+               https://mojo.redhat.com/docs/DOC-1058772
+               configure pglogical replication
+               confirm replication is working correctly
+        startsin: 5.6
+        testtype: upgrade
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rest
+def test_cloud_volume_types():
+    """
+    Test CloudVolumeType endpoint. Add a cloud provider and check if it
+    gives correct response for the GET request.
+    GET /api/cloud_volume_types
+    GET /api/cloud_volume_types/:id
+    PR: https://github.com/ManageIQ/manageiq-api/pull/465
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: None
+        startsin: 5.10
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_tagvis_storage_provider_children():
+    """
+    1. Tag provider
+    2. Login as restricted user
+    3. Check Providers children visibility
+    Expected result: Providers children should not be visible for
+    restricted user
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+@pytest.mark.tier(2)
+def test_service_chargeback_multiple_vms():
+    """
+    Validate Chargeback costs for a service with multiple VMs
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_vm_mac_scvmm():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1514461
+    Test case covers this BZ - we can"t get MAC ID of VM at the moment
+
+    Polarion:
+        assignee: None
+        casecomponent: infra
+        caseimportance: low
+        initialEstimate: 1/20h
+        setup: https://bugzilla.redhat.com/show_bug.cgi?id=1514461
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_provision_market_place_image_azure():
+    """
+    1.Enable Marketplace images in Advanced settings
+    2.Provision a VM using one
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.9
+        tags: provision
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware67_test_vm_migration_with_windows_7():
+    """
+    OSP: vmware67-Test VM migration with Windows 7
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware67-Test VM migration with Windows 7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+@pytest.mark.tier(1)
+def test_reports_import_invalid_file():
+    """
+    import invalid file like txt, pdf.
+    Import yaml file with wrong data.
+    Flash message should display if we import wrong file.
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/16h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_navigation_with_18000_tags():
+    """
+    create > 18000 tags, Make navigation to services
+    No error should occur
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(2)
+def test_crosshair_op_azone_azure():
+    """
+    Utilization Test
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(2)
+def test_crosshair_op_azone_gce():
+    """
+    Utilization Test
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(2)
+def test_crosshair_op_azone_ec2():
+    """
+    test_crosshair_op_azone[ec2]
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/12h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_button_state_hidden():
+    """
+    If the expression of visibility is true then the button will be in
+    enabled(unhidden) state but if it is false then it will be in the
+    hidden state.
+    Steps:
+    1. Add provider
+    2. Create service dialog
+    3. Create custom button group in service accordion option
+    5. Add button to the group. In "Advanced" tab of button, put valid
+    expression for Visibility (Make sure to select dialog created at
+    step2)
+    6. Create catalog from Services
+    7. Create catalog item and assign dialog & catalog created in step2 &
+    6 respectively.
+    8. Navigate to self-service UI and Order created catalog item
+    9. Click service you have ordered and you will notice button will
+    disappear.
+    (Better practice will be carried test_custom_button_state_enabled
+    first and then try out this)
+    Expression used while test: COUNT OF Service.User.VMs < -1
+    Additional info:
+    This enhancement feature is related to https://github.com/ManageIQ
+    /manageiq-ui-service/pull/1012.
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: ssui
+        caseimportance: low
+        initialEstimate: None
+        startsin: 5.9
+        upstream: no
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rest
+def test_edit_provider_request_task():
+    """
+    In this test we will try to edit a provider request using POST
+    request.
+    Note: Only Option field can be edited
+
+    Polarion:
+        assignee: mkourim
+        caseimportance: medium
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_button_access_ssui():
+    """
+    Test custom button for role access of SSUI
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_distributed_zone_delete_occupied():
+    """
+    Delete Zone that has appliances in it.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_quota_source_user():
+    """
+    When copying and modifying
+    /System/CommonMethods/QuotaStateMachine/quota to user the user as the
+    quota source and when the user is tagged, the quotas are in effect.
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rbac
+def test_can_add_child_tenant_to_tenant():
+    """
+    BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1387088
+    1. Go to Configuration -> Access Control
+    2. Select a Tenant
+    3. Use "Configuration" Toolbar to navigate to "Add child Tenant to
+    this Tenant"
+    4. Fill the form in:
+    Name: "test_tenant"
+    Description: "test_tenant"
+    Then select "Add"
+    Child tenant should be displayed under Parent Tenant
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        initialEstimate: 1/10h
+        tags: rbac
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_regions_all_azure():
+    """
+    Need to validate the list of regions we show in the UI compared with
+    regions.rb  Recent additions include UK South
+    These really don"t change much, but you can use this test case id
+    inside bugzilla to set qe_test flag.
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/12h
+        startsin: 5.6
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_credentials_login_password_with_special_characters():
+    """
+    Alphanumeric password with special characters
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/8h
+        tags: rbac
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_vm_reconfig_attach_iso_vsphere67_nested():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1533728
+
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: 1/6h
+        startsin: 5.10
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.provision
+@pytest.mark.tier(2)
+def test_azure_instance_password_requirements_azure():
+    """
+    Create provision request with password which doesn"t meet requirements
+    - warning message should appear in UI
+    Additional details are in
+    https://bugzilla.redhat.com/show_bug.cgi?id=1454812
+    The supplied password must be between 8-123 characters long and must
+    satisfy at least 3 of password complexity requirements from the
+    following:
+    1) Contains an uppercase character
+    2) Contains a lowercase character
+    3) Contains a numeric digit
+    4) Contains a special character.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: prov
+        caseposneg: negative
+        initialEstimate: 1/10h
+        testtype: nonfunctional
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_in_progress_migrations_can_be_cancelled():
+    """
+    OSP: Test in-progress Migrations can be cancelled
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseposneg: negative
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test in-progress Migrations can be cancelled
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(3)
+def test_host_tagged_crosshair_op_vsphere65():
+    """
+    Required C&U enabled application:1. Navigate to host C&U graphs
+    2. select Group by option with suitable VM tag
+    3. try to drill graph for VM
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(3)
+def test_host_tagged_crosshair_op_vsphere6():
+    """
+    Required C&U enabled application:1. Navigate to host C&U graphs
+    2. select Group by option with suitable VM tag
+    3. try to drill graph for VM
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(3)
+def test_host_tagged_crosshair_op_vsphere55():
+    """
+    Required C&U enabled application:1. Navigate to host C&U graphs
+    2. select Group by option with suitable VM tag
+    3. try to drill graph for VM
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_vm_reconfig_add_remove_network_adapters_vsphere67_nested_vmkernel():
+    """
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: 1/16h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rbac
+def test_verify_only_groups_with_ssui_access_can_access_the_ssui_when_switching_groups():
+    """
+    When a user is a member of two or more groups and one of the groups
+    does not have access to the SSUI, verify that the group w/o SSUI does
+    not stay logged in after switching groups.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: ssui
+        caseimportance: critical
+        initialEstimate: 1/6h
+        setup: Create a user that is a member of two more groups with one group
+               having SSUI access and the other group having SSUI access disabled.
+        startsin: 5.9
+        tags: rbac
+        title: Verify only groups with SSUI access can access the SSUI when switching groups
+        testSteps:
+            1. Login to the SSUI
+            2. Switch to the group that doesn"t have SSUI access
+        expectedResults:
+            1. Login successful
+            2. Automatically logged out of the SSUI
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.log_depot
+@pytest.mark.tier(1)
+def test_log_collect_all_server_server_setup():
+    """
+    using any type of depot check collect all log function under applince
+    (settings under applince should be configured, under zone should not
+    be configured)
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_replication_central_admin_service_provisioning():
+    """
+    Polarion:
+        assignee: tpapaioa
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_edit_migration_plan_before_and_after_deletion_soon_in_510():
+    """
+    OSP: Edit migration plan before and after deletion (soon in 5.10)
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Edit migration plan before and after deletion (soon in 5.10)
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_edge_vsphere67_win10():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_ie11_vsphere65_win7():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_firefox_vsphere67_win10():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        initialEstimate: 1/2h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_chrome_vsphere65_rhel7x():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: critical
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_chrome_vsphere65_fedora27():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_firefox_vsphere65_fedora27():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/2h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_passwordwithspecialchars():
+    """
+    VMware WebMKS Remote Console Test based on
+    https://bugzilla.redhat.com/show_bug.cgi?id=1545927
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: critical
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_chrome_vsphere65_win7():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_chrome_vsphere6_win2012():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_chrome_vsphere65_fedora26():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_firefox_vsphere6_win10():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_chrome_vsphere67_fedora26():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_chrome_vsphere67_rhel7x():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: critical
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_firefox_vsphere6_fedora27():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/2h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_chrome_vsphere6_win7():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_chrome_vsphere67_fedora28():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_chrome_vsphere6_rhel7x():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        initialEstimate: 1/2h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_chrome_vsphere65_fedora28():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_firefox_vsphere67_rhel7x():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: critical
+        initialEstimate: 1/2h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_chrome_vsphere65_win10():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_firefox_vsphere67_fedora26():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/2h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_chrome_vsphere6_fedora26():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_chrome_vsphere67_win10():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_edge_vsphere65_win10():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_chrome_vsphere67_win7():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_firefox_vsphere65_rhel7x():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: critical
+        initialEstimate: 1/2h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_ie11_vsphere65_win2012():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_edge_vsphere6_win10():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_firefox_vsphere67_fedora28():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        initialEstimate: 1/2h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_firefox_vsphere6_win7():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_chrome_vsphere6_win10():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_ie11_vsphere67_win2012():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_firefox_vsphere65_fedora26():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/2h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_firefox_vsphere65_fedora28():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        initialEstimate: 1/2h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_chrome_vsphere6_fedora28():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_chrome_vsphere65_win2012():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_chrome_vsphere67_fedora27():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_firefox_vsphere6_fedora26():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/2h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_firefox_vsphere65_win2012():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/2h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_firefox_vsphere6_win2012():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_ie11_vsphere67_win7():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_firefox_vsphere6_fedora28():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        initialEstimate: 1/2h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_ie11_vsphere6_win2012():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_firefox_vsphere6_rhel7x():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        initialEstimate: 1/2h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_chrome_vsphere67_win2012():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_firefox_vsphere67_win7():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/2h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_firefox_vsphere67_fedora27():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/2h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_chrome_vsphere6_fedora27():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_firefox_vsphere65_win7():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/2h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_firefox_vsphere65_win10():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        initialEstimate: 1/2h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_firefox_vsphere67_win2012():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/2h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_webmks_console_ie11_vsphere6_win7():
+    """
+    VMware WebMKS Remote Console Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VMware WebMKS".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using VMware WebMKS Console and not
+               to use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware60_test_vm_migration_with_windows_7():
+    """
+    OSP: vmware60-Test VM migration with Windows 7
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware60-Test VM migration with Windows 7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.storage
+def test_storage_volume_backup_restore_openstack():
+    """
+    Requires:
+    test_storage_volume_backup[openstack]
+    1 . Go back to the summary page of the respective volume.
+    2 . Restore Volume [configuration > Restore from backup of this cloud
+    volume > select cloud volume backup]
+    3. check in Task whether restored or not.
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/5h
+        startsin: 5.7
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware60_test_vm_migration_with_windows_2012_server():
+    """
+    OSP: vmware60-Test VM migration with Windows 2012 server
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware60-Test VM migration with Windows 2012 server
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_group_infra_memory_quota_by_lifecycle():
+    """
+    test group memory quota for infra vm provision by Automate model
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: cloud
+        caseimportance: low
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_default_dialog_entries_should_localized_when_ordering_catalog_item_in_french():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1592573
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/16h
+        title: Default dialog entries should localized when ordering catalog item in French
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_ec2_targeted_refresh_instance():
+    """
+    Instance CREATE
+    Instance RUNNING
+    Instance STOPPED
+    Instance UPDATE
+    Instance DELETE \ Instance Terminate
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: cloud
+        initialEstimate: 1 1/6h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rbac
+def test_verify_that_changing_groups_while_in_ssui_updates_dashboard_items():
+    """
+    Verify that switching Groups in SSUI changes the dashboard items to
+    match the new groups permissions
+
+    Polarion:
+        assignee: apagac
+        casecomponent: ssui
+        initialEstimate: 1/4h
+        setup: Create a user with two or more groups with access to the SSUI. The
+               groups should have role permissions that grant access to different
+               features so you can easily see that the dashboard is updated
+               appropriately.
+        startsin: 5.9
+        tags: rbac
+        title: Verify that changing groups while in SSUI updates dashboard items
+        testSteps:
+            1. Login to the SSUI
+            2. Switch to another group
+            3. Check that dashboard items are updated appropriately
+        expectedResults:
+            1. Login successful
+            2. Group switch successful
+            3. Dashboard items are updated from to reflect that access of the new group
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+@pytest.mark.tier(1)
+def test_create_and_run_custom_report_using_rbac():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1526058
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.configuration
+def test_configure_diagnostics_pages_cfme_region():
+    """
+    Go to Settings -> Configuration -> Diagnostics -> CFME Region
+    and check whether all sub pages are showing.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/15h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+def test_embed_tower_exec_play_stdout():
+    """
+    User/Admin is able to execute playbook and see stdout of it once
+    completed.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.upgrade
+@pytest.mark.tier(2)
+def test_upgrade_multi_ext_inplace():
+    """
+    test_upgrade_multi_ext_inplace
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1h
+        setup: 2 appliances:
+               - Appliance A: internal DB, region 0
+               - Appliance B: external DB, pointed at A, region 0
+               - Setup LDAP on one of the appliances
+               - Login as LDAP user A
+               - Setup a provider
+               - Provision a VM
+        testtype: upgrade
+        testSteps:
+            1. Run upgrade according to the migration guide (version-dependent)
+            2. Start the appliances back up
+            3. Login as LDAP user B
+            4. Add another provider
+            5. Provision another VM using the new provider
+            6. Visit provider/host/vm summary pages
+        expectedResults:
+            1. Upgrade is successful, so is migration and related tasks (fix_auth)
+            2. Appliances are running
+            3. Login is successful
+            4. Provider added
+            5. VM provisioned
+            6. Summary pages can be loaded and show correct information
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware_65_test_vm_name_with_punycode_characters():
+    """
+    OSP: vmware 65- Test VM name with Punycode characters
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware 65- Test VM name with Punycode characters
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.config_management
+def test_config_manager_accordion_tree():
+    """
+    Make sure there is accordion tree, once Tower is added to the UI.
+    https://bugzilla.redhat.com/show_bug.cgi?id=1560552
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: web_ui
+        caseimportance: low
+        initialEstimate: None
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_service_chargeback_bundled_service():
+    """
+    Validate Chargeback costs for a bundled service
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.bottleneck
+@pytest.mark.tier(2)
+def test_bottleneck_datastore():
+    """
+    Verify bottleneck events from host
+
+    Polarion:
+        assignee: None
+        casecomponent: optimize
+        caseimportance: medium
+        initialEstimate: 3/4h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_ec2_api_filter_limit():
+    """
+    BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1612086
+    The easiest way to simulate AWS API Limit for > 200 items is to enable
+    and disable public images:
+    Requirement: Have an ec2 provider
+    1) Enable public images for ec2 in Advanced Settings
+    2) Wait for public images to be refreshed
+    3) Disable public images for ec2 in Advanced Settings
+    4) Wait for public images to be refreshed (cleared)
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        initialEstimate: 1 1/3h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_reconfigure_add_disk_cold_controller_sas():
+    """
+    Steps to Reproduce:
+    1. Add 15 disks to an existing VM with Controller type set to SAS
+    2. look at the 16th Disk Controller Type
+    Expected results: Should be SAS like exiting Controller
+    https://bugzilla.redhat.com/show_bug.cgi?id=1445874
+
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
+        startsin: 5.3
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_host_credentials_web():
+    """
+    Validate that web connections to the host can be created.
+
+    Polarion:
+        assignee: None
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/4h
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware67_test_vm_migration_from_nfs_storage_in_vmware_to_nfs_on_osp():
+    """
+    OSP: vmware67-Test VM migration from NFS Storage in VMware to NFS on
+    OSP
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware67-Test VM migration from NFS Storage in VMware to NFS on OSP
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_automate_simulate_retry():
+    """
+    PR Link
+    Automate simulation now supports simulating the state machines.
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/4h
+        setup: Create a state machine that contains a couple of states from which one
+               of them retries at least once.
+        startsin: 5.6
+        testSteps:
+            1. Use automate simulation UI to call the state machine (Call_Instance)
+        expectedResults:
+            1. A Retry button appears.
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_appliance_log_rotate_postgres():
+    """
+    [root@host-192-168-55-133 ~]# cd /var/opt/rh/rh-
+    postgresql95/lib/pgsql/data/pg_log
+    [root@host-192-168-55-133 pg_log]# ll
+    total 204
+    -rw-------. 1 postgres postgres 108218 Nov 10 14:39 postgresql.log
+    -rw-------. 1 postgres postgres  10776 Nov  3 03:34
+    postgresql.log-20161103.gz
+    -rw-------. 1 postgres postgres   8095 Nov  4 03:26
+    postgresql.log-20161104.gz
+    -rw-------. 1 postgres postgres   7544 Nov  5 03:20
+    postgresql.log-20161105.gz
+    -rw-------. 1 postgres postgres   8385 Nov  6 03:22
+    postgresql.log-20161106.gz
+    -rw-------. 1 postgres postgres   7637 Nov  7 03:26
+    postgresql.log-20161107.gz
+    -rw-------. 1 postgres postgres   8621 Nov  8 03:09
+    postgresql.log-20161108.gz
+    -rw-------. 1 postgres postgres  13083 Nov  9 03:28
+    postgresql.log-20161109.gz
+    -rw-------. 1 postgres postgres  14880 Nov 10 03:05
+    postgresql.log-20161110.gz
+    # are the log files being compressed and archived each day ( like
+    appliance_console.log-20161109.gz )
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        initialEstimate: 1/12h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_appliance_log_rotate_evm():
+    """
+    [root@host-192-168-55-133 pg_log]# vmdb
+    [root@host-192-168-55-133 vmdb]# cd log
+    # are the log files being compressed and archived each day ( like
+    appliance_console.log-20161109.gz )
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        initialEstimate: 1/12h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_diagnostic_timelines():
+    """
+    None
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_group_quota_via_ssui():
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_black_console_ext_auth_options():
+    """
+    Test enabling ext_auth options through appliance_console
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/6h
+        setup: -ssh to appliance
+               -run appliance_console
+               -select option "Update External Authentication Options"
+               -select each option to enable it
+               -select option
+               1) Enable Single Sign-On
+               2) Enable SAML
+               3) Enable Local Login
+               -select "Apply updates"
+               -check changes have been made
+        startsin: 5.6
+        testSteps:
+            1. Enable Single Sign-On
+            2. Enable SAML
+            3. Enable Local Login
+        expectedResults:
+            1. check changes in ui
+            2. check changes in ui
+            3. check changes in ui
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(2)
+def test_embed_ansible_next_gen():
+    """
+    Follow BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1511126
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1/2h
+        startsin: 5.10
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(3)
+def test_cluster_graph_by_vm_tag_vsphere65():
+    """
+    test_cluster_graph_by_vm_tag[vsphere65]
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(3)
+def test_cluster_graph_by_vm_tag_vsphere6():
+    """
+    test_cluster_graph_by_vm_tag[vsphere6]
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: low
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_group_cloud_storage_quota_by_services():
+    """
+    test group storage quota for cloud instance provision by ordering
+    services
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.tag
+@pytest.mark.tier(2)
+def test_tagvis_vm_and_template():
+    """
+    Enable one or multiple VM's and Template's in the group and check for
+    the visibility
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.general_ui
+def test_ui_notification_icon():
+    """
+    BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1489798
+    1) Go to rails console and type:
+    Notification.create(:type => :automate_user_error, :initiator =>
+    User.first, :options => { :message => "test" })
+    2) Check in UI whether notification icon was displayed
+    3) Go to rails console and type:
+    Notification.create(:type => :automate_global_error, :initiator =>
+    User.first, :options => { :message => "test" })
+    4) Check in UI whether notification icon was displayed
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: low
+        initialEstimate: 1/6h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rbac
+def test_can_add_project_to_tenant():
+    """
+    BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1387088
+    1. Go to Configuration -> Access Control
+    2. Select a Tenant
+    3. Use "Configuration" Toolbar to navigate to "Add Project to this
+    Tenant"
+    4. Fill the form in:
+    Name: "test_project"
+    Description: "test_project"
+    Then select "Add"
+    Project should be displayed under Parent Tenant
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        initialEstimate: 1/10h
+        tags: rbac
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+def test_service_bundle_provsioning_with_quota_enabled():
+    """
+    test_service_bundle_provsioning_with_quota_enabled
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: prov
+        initialEstimate: 1/4h
+        setup: 1.create a catalog item of type vmware
+               2.create a catalog bundle by adding the above resource.
+               3.make sure CloudForms quotas are enabled
+               4.provision the bundle
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_if_non_csv_files_can_be_imported():
+    """
+    OSP: Test if non-csv files can be imported
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test if non-csv files can be imported
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.config_management
+def test_no_rbac_warnings_in_logs_when_viewing_satellite_provider():
+    """
+    RBAC-related warnings logged when viewing Satellite provider in web UI
+    https://bugzilla.redhat.com/show_bug.cgi?id=1565266
+    1.) Add Satellite provider.
+    2.) Click on items under Providers accordion.
+    3.) View evm.log. No WARN-level messages should be logged.
+    [----] W, [2018-04-09T14:09:19.654859 #13384:84e658]  WARN -- :
+    MIQ(Rbac::Filterer#lookup_method_for_descendant_class) could not find
+    method name for ConfiguredSystem::ConfiguredSystem
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: prov
+        caseimportance: medium
+        initialEstimate: 1/15h
+        title: No RBAC warnings in logs when viewing Satellite provider
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_ec2_create_sns_topic():
+    """
+    Requires: No SNS topic for tested region
+    1) Add an ec2 provider with tested region
+    2) Wait 3 minutes
+    3) Check SNS topic for this region in AWS Console
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: cloud
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.bottleneck
+@pytest.mark.tier(2)
+def test_bottleneck_provider():
+    """
+    Verify bottleneck events from providers
+
+    Polarion:
+        assignee: None
+        casecomponent: optimize
+        caseimportance: medium
+        initialEstimate: 3/4h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_multi_host_migration_execution_if_more_than_one_host_present_migration_of_mu():
+    """
+    OSP: Test Multi-host migration execution, if more than one host
+    present, migration of muliple VMs should be spread across all
+    available hosts
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: critical
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test Multi-host migration execution, if more than one
+               host present, migration of muliple VMs should be spread
+               across all available hosts
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.config_management
+@pytest.mark.tier(1)
+def test_config_manager_prov_from_service_limit_ansible_tower_310():
+    """
+    1) Navigate to Configuration -> Configuration management -> Ansible
+    Tower job templates.
+    - click on job template -> Configuration -> Create service dialog from
+    this job template -> give it name
+    2) Create new catalog Item
+    - Catalog Item type: AnsibleTower
+    - name your catalog item
+    - Display in catalog: checked
+    - catalog: pick your catalog
+    - Dialog: Tower_dialog
+    - Provider: Ansible Tower .....
+    3) Order service with limit
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: prov
+        initialEstimate: 1h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_creating_multiple_migration_plans_with_same_name():
+    """
+    OSP: Test flavors can be selected creating migration plan
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test creating multiple migration plans with same name
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_database_wildcard_should_work_and_be_included_in_the_query():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1581853
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: None
+        startsin: 5.10
+        title: Database wildcard should work and be included in the query
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_user_should_be_able_to_see_requests_irrespective_of_tags_assigned():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1641012
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        initialEstimate: 1/4h
+        startsin: 5.9
+        title: User should be able to see requests irrespective of tags assigned
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.cfme_tenancy
+@pytest.mark.tier(2)
+def test_tenant_visibility_service_template_catalogs_all_parents():
+    """
+    Members of child tenants can see service templates which are visible
+    in parent tenants.
+
+    Polarion:
+        assignee: mnadeem
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/2h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_schedule_for_all_host_vms():
+    """
+    Navigate to add new schedule page(Configuration->Region->Schedules)
+    Fill all required fields
+    Select all vms for host in filter
+    Set timer
+    Save changes
+    Result: Task run successfully for selected filter
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(2)
+def test_ssui_myservice_myrequests_and_service_catalog_filter_links():
+    """
+    Filter Links of all pages
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        endsin: 5.6
+        initialEstimate: 1/8h
+        startsin: 5.5
+        title: SSUI : MyService, MyRequests and Service Catalog - Filter Links
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_appliance_console_restart():
+    """
+    test restarting the appliance
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_refresh_ssui_page():
+    """
+    Upon logging into the SSUI, Hit F5, the page should refresh, but
+    previously this action logged the user out.
+
+    Polarion:
+        assignee: nansari
+        casecomponent: ssui
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_tagvis_tag_host_vm_combination():
+    """
+    Combine My Company tag tab restriction, with Clusters&Host tab and
+    VM&templates
+    User should be restricted to see tagged host and vm, template
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.cfme_tenancy
+@pytest.mark.tier(2)
+def test_tenant_visibility_services_all_childs():
+    """
+    Members of parent tenant can see services of all child tenants.
+
+    Polarion:
+        assignee: mnadeem
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_create_generic_class():
+    """
+    Automation - automate - Generic Object - create new generic class .
+    test Generic class with different associations , attributes and
+    methods .
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: create generic class
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+def test_embed_tower_exec_play_against_rhos():
+    """
+    User/Admin is able to execute playbook without creating Job Temaplate
+    and can execute it against RHOS with RHOS credentials.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.tag
+@pytest.mark.tier(2)
+def test_tagvis_cluster_change():
+    """
+    Enable / Disable a Cluster in the group and check its visibility
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+def test_simultaneous_tenant_quota():
+    """
+    Test multiple tenant quotas simultaneously
+    https://bugzilla.redhat.com/show_bug.cgi?id=1456819
+    https://bugzilla.redhat.com/show_bug.cgi?id=1401251
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: prov
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(3)
+def test_distributed_migrate_embedded_ansible_role():
+    """
+    Ansible role failsover/migrates when active service fails
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: infra
+        caseimportance: critical
+        initialEstimate: 1/4h
+        setup: 1. Configure a 2 server installation (same region + zone)
+               2. Assign the embedded ansible role to both servers
+               5. Find the server the role is active on (for me it was Server 1 and I
+               used the diagnostics tab Zone view)
+               6. run `systemctl stop evmserverd` on Server 1
+               7. Observe that the role is started on Server 2
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_if_vm_name_with_special_characters_can_be_imported_it_should_allow_such_impo():
+    """
+    OSP: Test if VM name with special characters can be imported (It
+    should allow such imports)
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: low
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test if VM name with special characters can be imported
+               (It should allow such imports)
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.tag
+@pytest.mark.tier(2)
+def test_tagvis_vm_and_template_modified():
+    """
+    Enable / Disable a VM's and Template's in the group and check its
+    visibility
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_cost_weekly_usage_memory():
+    """
+    Validate cost for memory usage for a VM in a weekly chargeback report
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_cost_weekly_allocation_storage():
+    """
+    Validate cost for VM storage allocation in a weekly report
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_cost_weekly_usage_disk():
+    """
+    Validate cost for disk io for a VM in a weekly chargeback report
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_cost_weekly_usage_storage():
+    """
+    Validate cost for storage usage for a VM in a weekly report
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_cost_weekly_usage_cpu():
+    """
+    Validate cost for CPU usage for a VM in a weekly chargeback report
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_cost_weekly_allocation_memory():
+    """
+    Validate cost for VM memory allocation in a weekly report
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_cost_weekly_usage_network():
+    """
+    Validate cost for network io for a VM  in a weekly chargeback report
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_cost_weekly_allocation_cpu():
+    """
+    Validate cost for VM CPU allocation in a weekly report
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_ec2_targeted_refresh_floating_ip():
+    """
+    #AWS naming is Elastic IP
+    Classic Floating IP Allocate
+    VPC Floating IP Allocate
+    Classic Floating IP Allocate to Instance (Check both IP and Instance)
+    Classic Floating IP Allocate to Network Port (Check both IP and Port)
+    VPC Floating IP Allocate to Instance (Check both IP and Instance)
+    VPC Floating IP Allocate to Network Port (Check both IP and Port)
+    Floating IP UPDATE
+    Floating IP DELETE
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.upgrade
+@pytest.mark.tier(2)
+def test_upgrade_single_inplace_ipv6():
+    """
+    Upgrading a single appliance on ipv6 only env
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: provision appliance
+               add provider
+               add repo file to /etc/yum.repos.d/
+               run "yum update"
+               run "rake db:migrate"
+               run "rake evm:automate:reset"
+               run "systemctl start evmserverd"
+               check webui is available
+               add additional provider/provision vms
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_reports_custom_tags():
+    """
+    Add custom tags to report
+    1)add custom tags to appliance using black console
+    ssh to appliance, vmdb; rails c
+    use following commands
+    cat = Classification.create_category!(name: "rocat1", description:
+    "read_only cat 1", read_only: true)
+    cat.add_entry(name: "roent1", description: "read_only entry
+    1")2)Create new or Edit existing report and look for the tag category
+    in list of columns.
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_in_dynamic_dropdown_list_the_default_value_should_not_contain_all_the_values_of_the_l():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1568440
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: In dynamic dropdown list, the default value should not
+               contain ALL the values of the list
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(3)
+def test_sui_snapshots_for_vm_create_edit_delete():
+    """
+    desc
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: ssui
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.8
+        title: SUI : Snapshots for VM (Create/Edit/delete)
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.cfme_tenancy
+def test_tenant_osp_mapping_refresh():
+    """
+    There is new feature in 5.7, mapping of Openstack tenants to CFME
+    tenants.
+    1) switch"Tenant Mapping Enabled" checkbox to Yes when adding RHOS
+    cloud provider
+    2) create new test tenant in RHOS
+    2) perform refresh of RHOS provider in CFME UI
+    3) new tenants are created automatically
+
+    Polarion:
+        assignee: mnadeem
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_submit_or_cancelation_buttons_in_dynamic_dialogs_tied_to_a_service_button_should_be_v():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1611527
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        initialEstimate: 1/6h
+        title: Submit or cancelation buttons in dynamic dialogs tied to a
+               Service button should be visble
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.snapshot
+@pytest.mark.tier(1)
+def test_notification_for_snapshot_delete_failure():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1449243
+    Requires ec2 access via web-ui.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: prov
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: test notification for snapshot delete failure
+        testSteps:
+            1. Create a snapshot on EC2 provider
+            2. Try to delete snapshot via CFME UI
+        expectedResults:
+            1. Snapshot created
+            2. Snapshot not deleted and notification displayed
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_authentication_user_created_after_success_login():
+    """
+    Configure CFME for LDAP authentication and add group. Authenticate
+    with LDAP user and check if user exists in Configuration - Access
+    Control - Users.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(2)
+def test_host_graph_by_vm_tag_vsphere6():
+    """
+    test_host_graph_by_vm_tag[vsphere6]
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: low
+        initialEstimate: 1/12h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(2)
+def test_host_graph_by_vm_tag_vsphere65():
+    """
+    Requires:
+    C&U enabled Vsphere-65 appliance.
+    Steps:
+    1. Navigate to Host [Compute > infrastructure>Hosts]
+    2. Select any available host
+    3. Go for utilization graphs [Monitoring > Utilization]
+    4. For hourly "Group by"  select VM tag
+    5. For Daily "Group by" select VM tag
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_ssh_creds_can_be_added_while_adding_osp_provider():
+    """
+    OSP: Test SSH Creds can be added while adding OSP provider
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test SSH Creds can be added while adding OSP provider
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_change_provider_template_in_catalog_item():
+    """
+    test_change_provider_template_in_catalog_item
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.5
+        testSteps:
+            1. Create a catalog item and select template for a provider in catalog tab
+            2. Select datastore etc in environment tab
+            3. In catalog tab change template from one provider to another
+        expectedResults:
+            1.
+            2.
+            3. Validation message should be shown
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_button_crud_via_rest():
+    """
+    In this Test case we verify the functionality of custom button using
+    rest api
+    Steps
+    1) POST method to create the custom button
+    2) POST method to edit the custom button
+    3) Delete method to delete the custom button
+
+    Polarion:
+        assignee: ndhandre
+        initialEstimate: None
+        startsin: 5.9
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_ec2_targeted_refresh_network():
+    """
+    #AWS naming is VPC
+    Network CREATE
+    Network UPDATE
+    Network DELETE
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 2/3h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+@pytest.mark.tier(1)
+def test_reports_generate_custom_conditional_filter_report():
+    """
+    Steps to Reproduce: ===================
+    1. Create a service with one of the above naming conventions (vm-test
+    ,My-Test)
+    2. Have at least one VM in the service so the reporting will parse it
+    3. Create a report with a conditional filter in it, such as:
+    conditions: !ruby/object:MiqExpression exp: and: - IS NOT NULL: field:
+    Vm.service-name - IS NOT NULL: field: Vm-ems_cluster_name 3. Run the
+    report
+    https://bugzilla.redhat.com/show_bug.cgi?id=1521167
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(3)
+def test_candu_graphs_vm_compare_host_vsphere6():
+    """
+    test_candu_graphs_vm_compare_host[vsphere6]
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: low
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(3)
+def test_candu_graphs_vm_compare_host_vsphere65():
+    """
+    test_candu_graphs_vm_compare_host[vsphere65]
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_log_collection_via_ftp_over_ipv6():
+    """
+    Bug 1452224 - Log Collection fails via IPv6
+    https://bugzilla.redhat.com/show_bug.cgi?id=1452224
+    An IPv6 FTP server can be validated for log collection, and log
+    collection succeeds.
+    # subscription-manager register
+    # subscription-manager attach --pool 8a85f98159d214030159d24651155286
+    # yum install vsftpd
+    # vim /etc/vsftpd/vsftpd.conf
+    anon_upload_enable=YES
+    anon_mkdir_write_enable=YES
+    # ip6tables -F
+    # setenforce 0
+    # systemctl start vsftpd
+    # mkdir /var/ftp/pub/anon
+    # chmod 777 /var/ftp/pub/anon
+    Administrator > Configuration > Diagnostics > Collect Logs > Edit
+    Type        Anonymous FTP
+    Depot Name    tpapaioa
+    URI        ftp://localhost6/pub/anon
+    > Save
+    Collect > Collect current logs
+    Refresh after a couple minutes
+    Basic Info
+    Log Depot URI        ftp://localhost6/pub/anon
+    Last Log Collection    2018-01-10 20:29:31 UTC
+    Last Message        Log files were successfully collected
+
+    Polarion:
+        assignee: None
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Log collection via FTP over IPv6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+def test_embed_tower_crud_repo():
+    """
+    CRUD repo.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: critical
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_sdn_nsg_firewall_rules_azure():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1520196
+    1. Add Network Security group on Azure with coma separated port ranges
+    `1023,1025` rule inbound/outbound ( ATM this feature is not allowed in
+    East US region of Azure - try West/Central)
+    2. Add such Azure Region into CFME
+    3. Refresh provider
+    4. Open such NSG in CFME and check that ports from 1) do present in
+    the UI as Firewall rules
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rest
+def test_provider_specific_vm():
+    """
+    Steps:
+    1) Add multiple provider
+    2) Check for the vms specific to a provider
+    2) Repeat it for all the providers
+
+    Polarion:
+        assignee: mkourim
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.provision
+@pytest.mark.tier(2)
+def test_provision_request_approved_msg():
+    """
+    Test the flash message content on denial; should contain "approved"
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_new_dialog_editor_all_element_types_ui_and_validations():
+    """
+    Check all element types for the new dialog editor
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        initialEstimate: 1/4h
+        startsin: 5.9
+        title: New dialog editor - All element types UI and validations
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(3)
+def test_embed_tower_refresh_provider_repo_list():
+    """
+    Test if ansible playbooks list is updated in the UI when "Refresh
+    Selected Ansible Repositories" clicked in the repository list.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: critical
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(3)
+def test_embed_tower_refresh_provider_repo_details():
+    """
+    Test if ansible playbooks list is updated in the UI when "Refresh this
+    Repository" clicked in the repository details view.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: critical
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(1)
+def test_utilization_utilization_graphs():
+    """
+    Polarion:
+        assignee: None
+        casecomponent: optimize
+        initialEstimate: 1/4h
+        testSteps:
+            1. Enable C&U
+            2. Wait until data will be collected
+            3. Go to Optimize/Utilization
+        expectedResults:
+            1.
+            2.
+            3. Verify that all graphs shows correctly
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_distributed_field_zone_name_special():
+    """
+    When creating a new zone, special characters can be used in the name,
+    including leading and trailing characters, and the name displays
+    correctly in the web UI after saving.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/30h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.cfme_tenancy
+@pytest.mark.tier(2)
+def test_tenant_visibility_providers_all_parents():
+    """
+    Child tenants can see providers which were defined in parent tenants.
+
+    Polarion:
+        assignee: mnadeem
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_delete_orchestration_template_in_use():
+    """
+    Delete orchestration template in use
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: low
+        initialEstimate: 1/16h
+        setup: Create a orchestration template and provision a stack from it .
+               Delete the template
+        startsin: 5.5
+        title: Delete orchestration template in use
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(2)
+def test_embed_tower_invisible():
+    """
+    Embedded Ansible Tower provider won"t be visible in the CFME UI (Tower
+    should be headless, its UI should not be enabled.) p1
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/12h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_cmqe_add_new_resource_quota():
+    """
+    Add new resource quota
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        initialEstimate: 1h
+        title: CMQE - Add New Resource Quota
+        testSteps:
+            1. On the Openshift provider, create different namespaces and
+               assign them Resource Quotas. Assign different fractional
+               values to the CPU quotas like  `1.152` or `0.087` or `87m`.
+            2. Refresh the CFME appliance
+            3. Check the containers_quota_items table in the database
+            4. Navigate to the namespace in the CFME GUI.
+            5. Refresh the CFME appliance
+            6. Check the containers_quota_items table in the database
+        expectedResults:
+            1. Resource Quota assigned successfully.
+            2. Appliance refreshed successfully.
+            3. Database in `container_quota_items` table should contain
+               both old and current values.            Newly added quotas
+               should have `created_at` field set.
+            4. Verify the GUI displays the correct data and the fractional
+               values are formatted properly.
+            5. Appliance refreshed successfully.
+            6. Verify duplicate records were not added to the table
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_service_chargeback_retired_service():
+    """
+    Validate Chargeback costs for a retired service
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: report
+        caseimportance: low
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_ec2_targeted_refresh_network_router():
+    """
+    #AWS naming is Route Table
+    Network Router CREATE
+    Network Router DELETE
+    Network Router UPDATE
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 2/3h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.storage
+def test_storage_object_store_object_remove():
+    """
+    Requirs:
+    OpenstackProvider
+    1) Navigate to Object Store Object [Storage > Object Storage > Object
+    Store Objects]
+    2) Select objects for removal
+    3) Remove [Configuration > Remove Object Storage Objects from
+    Inventory]
+    4) Verify object removed or not
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(3)
+def test_sui_order_and_request_should_be_sorted_by_time():
+    """
+    desc
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: ssui
+        caseimportance: low
+        initialEstimate: 1/8h
+        startsin: 5.8
+        title: SUI : Order and Request should be sorted by time
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.upgrade
+@pytest.mark.tier(2)
+def test_update_custom_widgets():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1375313
+    Upgrade appliance with custom widgets added
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: provision appliance
+               add custom widgets
+               add repo file to /etc/yum.repos.d/
+               add RHSM details
+               check for updates
+               update using webui
+               check webui is available
+               check widgets still work correctly
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(2)
+def test_replication_appliance_add_single_subscription():
+    """
+    Add one remote subscription to global region
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: critical
+        initialEstimate: 1/12h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(2)
+def test_notification_show_notification_when_tenant_quota_is_reached():
+    """
+    when quota is soon to be reached,CFME should notify affected users
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.8
+        title: Notification : Show notification when tenant quota is reached
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_tagvis_tag_and_cluster_combination():
+    """
+    Combine My Company tag tab restriction, with Clusters&Host tab
+    Visible cluster should match both tab restrictions
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(2)
+def test_in_the_self_service_portal_reconfigure_service_should_shows_available_provisioning_di():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1633453
+
+    Polarion:
+        assignee: nansari
+        casecomponent: ssui
+        initialEstimate: 1/2h
+        title: In the self service portal, reconfigure service should shows
+               available Provisioning Dialog
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_networking_before_and_after_migration_mac_address():
+    """
+    OSP: Test networking before and after migration (MAC Address)
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: critical
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test networking before and after migration (MAC Address)
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_service_infra_tenant_quota_storage_default_entry_point():
+    """
+    tenant service storage quota validation for infra provider using
+    default entry point
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        initialEstimate: 1/4h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_groups():
+    """
+    Check groups are fetched correctly for analysed VM
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/2h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_service_cloud_tenant_quota_memory_default_entry_point():
+    """
+    tenant service memory quota validation for cloud provider using
+    default entry point
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        initialEstimate: 1/4h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_puma_server():
+    """
+    From a bugPuma, by default is a threaded web server, which means each
+    http(s) request will be handled in a new thread. Since Rails" database
+    connection pool reserves connections to threads, it"s possible to
+    exhaust the connection pool with enough web requests spinning up new
+    puma threads. Thin, by contrast, still processes each request in a
+    single thread by default. While this is usually slower, you don"t have
+    the issues of multiple threads in flight at the same time.We should
+    make puma the default web server but have an easy option to switch to
+    thin in case there are thread issues with puma.To change the web
+    server, change puma to thin in the advanced configuration:
+    :server:
+    :rails_server: pumaNote: Testers/users, the proctitle for
+    UI/Webservice and web socket workers will
+    look different in ps, top, etc. if you use thin instead of puma. Puma
+    configures
+    it"s own proctitle and we configure the parts that we can. Thin does
+    not, so it
+    will look like all the other workers.
+    For example:
+    thin:
+    43177 ttys002 0:08.20 MIQ: MiqUiWorker id: 158, uri:
+    http://0.0.0.0:3000
+    puma:
+    43871 ttys004 0:00.68 puma 3.3.0 (tcp://0.0.0.0:3000) [MIQ: Web Server
+    Worker]
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: web_ui
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_saving_a_service_dialog_with_a_multi_select_drop_down_populated_by_expression_method_():
+    """
+    Saving a service dialog with a multi-select drop-down populated by
+    expression method gives a 500 internal server error
+    https://bugzilla.redhat.com/show_bug.cgi?id=1559030
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        initialEstimate: 1/4h
+        title: Saving a service dialog with a multi-select drop-down
+               populated by expression method should not error
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(2)
+def test_sui_reconfigure_service_from_sui():
+    """
+    desc
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: ssui
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.8
+        title: SUI : Reconfigure service from SUI
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_azure_windows2016_ntfs():
+    """
+    1. Add Azure provider
+    2. Perform SSA on Windows2016 server.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_scvmm2k16_centos_xfs():
+    """
+    Add SCVMM-2016 provider.
+    Perform SSA on CentOS VM.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_azure_multiple_vms():
+    """
+    Perform SSA on multiple VMs.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: critical
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_scvmm2k16_windows2016_disk_fileshare():
+    """
+    Add SCVMM-2016 provider.
+    Perform SSA on Windows 2016 server R2 VM having disk located on
+    Fileshare.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_scvmm2k12_windows2016_ntfs():
+    """
+    Add SCVMM-2012 provider.
+    Perform SSA on Windows 2016 server VM having NTFS filesystem.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_scvmm2k12_windows2016_refs():
+    """
+    Add SCVMM-2012 provider.
+    Perform SSA on Windows 2016 server R2 VM having ReFS filesystem.
+    It should fail-->  Unable to mount filesystem. Reason:[ReFS is Not
+    Supported]
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_azure_windows2012r2_ntfs():
+    """
+    1. Add Azure provider
+    2. Perform SSA on Windows2012 R2 server Instance.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_scvmm2k16_windows2012r2_refs():
+    """
+    Add SCVMM-2016 provider.
+    Perform SSA on Windows 2012 server R2 VM having ReFS filesystem.
+    It should fail-->  Unable to mount filesystem. Reason:[ReFS is Not
+    Supported]
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_ec2_customer_scenario():
+    """
+    This test case should be checked after each CFME release.(which
+    supports EC2 SSA)
+    Add EC-2 provider.
+    Perform SSA on instance.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_rhos7_ga_fedora_22_ext4():
+    """
+    test_ssa_vm[rhos7-ga-fedora-22-ext4]
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/2h
+        startsin: 5.3
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_scvmm2k16_schedule():
+    """
+    Trigger SmartState Analysis via schedule on VM.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: critical
+        initialEstimate: 1/4h
+        startsin: 5.3
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_scvmm2k12_second_disk_refs():
+    """
+    Add SCVMM-2012 provider.
+    Perform SSA on Windows 2012 server R2 VM having
+    NTFS as Primary Disk filesystem and secondary disk ReFS filesystem.
+    It should pass without any error.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm():
+    """
+    Make sure SSA can be started on a VM for configured provider
+    (parametrized)
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/2h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_ec2_fedora():
+    """
+    Add EC-2 provider.
+    Perform SSA on Fedora instance.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_azure_compliance_policy():
+    """
+    Checks compliance condition on VM/Instance which triggers Smartstate
+    Analysis on VM/Instance.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: critical
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_vsphere6_nested_wimdows7_xfs_ssui():
+    """
+    1. Provision service with Windows 7 VM
+    2. Perform SSA on it.
+    3. Check data populated on Provisioned Service in SSUI Dashboard.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/3h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_scvmm2k12_compliance_policy():
+    """
+    Checks compliance condition on VM/Instance which triggers Smartstate
+    Analysis on VM/Instance.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: critical
+        initialEstimate: 1/4h
+        startsin: 5.3
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_scvmm2k16_multiple_vms():
+    """
+    Perform SSA on multiple VMs.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: critical
+        initialEstimate: 1/4h
+        startsin: 5.3
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_azure_schedule():
+    """
+    Trigger SmartState Analysis via schedule on VM.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: critical
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_scvmm2k16_windows2012r2_ntfs():
+    """
+    Add SCVMM-2016 provider.
+    Perform SSA on Windows 2012 server R2 VM having NTFS filesystem.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_azure_managed_disk():
+    """
+    Perform SSA on Managed disk on Azure provider.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_ec2_windows2012_ssui():
+    """
+    1. Provision service with Windows 2012 VM
+    2. Perform SSA on it.
+    3. Check data populated on Provisioned Service in SSUI Dashboard.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/3h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_ec2_windows2012r2_ntfs():
+    """
+    Add EC-2 provider.
+    Perform SSA on Windows 2012 server R2 VM having NTFS filesystem.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_azure_rhel():
+    """
+    Create or Use existing RHEL VM/Instance present in Azure.
+    Perform SSA on RHEL VM/Instance when
+    VM/Instance is Powered ON
+    VM/Instance is Powered OFF
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.6
+        upstream: no
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_azure_wimdows2016_ssui():
+    """
+    1. Provision service with Windows 2016 VM
+    2. Perform SSA on it.
+    3. Check data populated on Provisioned Service in SSUI Dashboard.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/3h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_azure_windows2016_refs():
+    """
+    This test is to verify that you get an error when trying to perform
+    SSA on a Windows2016 VM that has a ReFS formatted disk attached.  Here
+    is the before and after.
+    05/26/17 18:13:36 UTC
+    05/26/17 18:10:56 UTC
+    05/26/17 18:10:46 UTC
+    finished
+    Unable to mount filesystem. Reason:[ReFS is Not Supported]
+    Scan from Vm ReFS16on16a
+    admin
+    EVM
+    Scanning completed.
+    05/26/17 16:12:45 UTC
+    05/26/17 16:08:30 UTC
+    05/26/17 16:08:26 UTC
+    finished
+    Process completed successfully
+    Scan from Vm ReFS16on16a
+    admin
+    EVM
+    Synchronization complete
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/4h
+        setup: Need to create a windows 2016 instance and save it onto the ReFS disks
+               on Azure.
+               Add a second disk to the VM config.  Open VM, initialize disk and
+               format it as ReFS
+               Refresh you CFME appliance
+               Perform SSA on that VM.
+               Best to just use existing ReFS vms.
+        startsin: 5.6
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_scvmm2k12_multiple_vms():
+    """
+    Perform SSA on multiple VMs.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: critical
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_scvmm2k12_centos_xfs():
+    """
+    Add SCVMM-2012 provider.
+    Perform SSA on CentOS VM.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_azure_region():
+    """
+    1. Add an Azure Instance in one region and assign it to a Resource
+    Group from another region.
+    BZ link: https://bugzilla.redhat.com/show_bug.cgi?id=1503295
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_scvmm2k16_windows2016_ntfs():
+    """
+    Add SCVMM-2016 provider.
+    Perform SSA on Windows 2016 server VM having NTFS filesystem.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_scvmm2k16_windows2016_refs():
+    """
+    Add SCVMM-2016 provider.
+    Perform SSA on Windows 2016 server R2 VM having ReFS filesystem.
+    It should fail-->  Unable to mount filesystem. Reason:[ReFS is Not
+    Supported]
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_ec2_ubuntu_ssui():
+    """
+    1. Provision service with Ubuntu VM
+    2. Perform SSA on it.
+    3. Check data populated on Provisioned Service in SSUI Dashboard.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/3h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_azure_wimdows2012_ssui():
+    """
+    1. Provision service with Windows 2012 VM
+    2. Perform SSA on it.
+    3. Check data populated on Provisioned Service in SSUI Dashboard.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/3h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_ec2_rhel():
+    """
+    Add EC-2 provider.
+    Perform SSA on RHEL instance.
+    Cross-check whether smartstate instance created from AMI mentioned in
+    production.yml.
+    BZ:https://bugzilla.redhat.com/show_bug.cgi?id=1547228
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_ec2_agent_tracker():
+    """
+    BZ link:  https://bugzilla.redhat.com/show_bug.cgi?id=1557452
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_azure_windows2012r2_refs():
+    """
+    This test is to verify that you get an error when trying to perform
+    SSA on a Windows2012 r2 instance that has a ReFS formatted disk
+    attached.  Here is the before and after.
+    05/26/17 18:13:36 UTC
+    05/26/17 18:10:56 UTC
+    05/26/17 18:10:46 UTC
+    finished
+    Unable to mount filesystem. Reason:[ReFS is Not Supported]
+    Scan from Vm ReFS16on16a
+    admin
+    EVM
+    Scanning completed.
+    05/26/17 16:12:45 UTC
+    05/26/17 16:08:30 UTC
+    05/26/17 16:08:26 UTC
+    finished
+    Process completed successfully
+    Scan from Vm ReFS16on16a
+    admin
+    EVM
+    Synchronization complete
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseposneg: negative
+        initialEstimate: 1/2h
+        setup: Need to create a windows 2012r2 instance and save it onto the ReFS
+               disks on Azure.
+               Add a second disk to the VM config.  Open VM, initialize disk and
+               format it as ReFS
+               Refresh you CFME appliance
+               Perform SSA on that VM.
+               Best to just use existing ReFS vms.
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_ec2_ubuntu():
+    """
+    Add EC-2 provider.
+    Perform SSA on Ubuntu instance.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_vsphere6_nested_centos_xfs_ssui():
+    """
+    1. Provision service with CentOS VM
+    2. Perform SSA on it.
+    3. Check data populated on Provisioned Service in SSUI Dashboard.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/3h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_azure_ubuntu():
+    """
+    Perform SSA on Ubuntu VM
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_scvmm2k12_windows2012r2_refs():
+    """
+    Add SCVMM-2012 provider.
+    Perform SSA on Windows 2012 server R2 VM having ReFS filesystem.
+    It should fail-->  Unable to mount filesystem. Reason:[ReFS is Not
+    Supported]
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_scvmm2k12_windows2012r2_ntfs():
+    """
+    Add SCVMM-2012 provider.
+    Perform SSA on Windows 2012 server R2 VM having NTFS filesystem.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_azure_non_managed_disk():
+    """
+    Perform SSA on non-managed (blod) disk on Azure provider.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_scvmm2k12_windows2016_disk_fileshare():
+    """
+    Add SCVMM-2012 provider.
+    Perform SSA on Windows 2016 server R2 VM having disk located on
+    Fileshare..
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_scvmm2k16_rhel74():
+    """
+    Add SCVMM-2016 provider.
+    Perform SSA on RHEL 7.4 VM.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_azure_ubuntu_ssui():
+    """
+    1. Provision service with Ubuntu VM
+    2. Perform SSA on it.
+    3. Check data populated on Provisioned Service in SSUI Dashboard.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/3h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_scvmm2k16_second_disk_refs():
+    """
+    Add SCVMM-2012 provider.
+    Perform SSA on Windows 2016 server R2 VM having
+    NTFS as Primary Disk filesystem and secondary disk ReFS filesystem.
+    It should pass without any error.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_scvmm2k12_schedule():
+    """
+    Trigger SmartState Analysis via schedule on VM.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: critical
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_ec2_windows2016_ssui():
+    """
+    1. Provision service with Windows 2016 VM
+    2. Perform SSA on it.
+    3. Check data populated on Provisioned Service in SSUI Dashboard.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/3h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_disk_usage():
+    """
+    1. Add a VMware provider
+    2. Run SSA for the VM and the data store (might not be necessary, but
+    wanted to make sure all data collection is executed)
+    3. Navigate to a VM
+    4. Click on "number of disks"
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.3
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_cancel_task():
+    """
+    Start SSA on VM and wait snapshot to create.
+    Cancel the task immediately.
+    BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1538347
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_scvmm2k12_rhel74():
+    """
+    Add SCVMM-2012 provider.
+    Perform SSA on RHEL 7.4 VM.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_scvmm2k16_compliance_policy():
+    """
+    Checks compliance condition on VM/Instance which triggers Smartstate
+    Analysis on VM/Instance.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: critical
+        initialEstimate: 1/4h
+        startsin: 5.3
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_azure():
+    """
+    Perform SSA on Instance on States:
+    1. Power ON
+    2. Power OFF.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_ec2_vpc():
+    """
+    1. Create a VPC;
+    2. Do not attach any gateway to it;
+    3. Turn on "DNS resolution", "DNS hostname" to "yes";
+    4. Deploy an agent on this VPC;
+    5. Run SSA job;
+    BZ link: https://bugzilla.redhat.com/show_bug.cgi?id=1557377
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_vm_collect_running_processes_neg():
+    """
+    Same as 9570, only Verify that you CANNOT extract the running
+    processes from a VM with a Linux Guest OS that is running and has an
+    IP Address.
+    The Extract Running Processes menu item should be grey when a Linux VM
+    is selected.
+
+    Polarion:
+        assignee: None
+        casecomponent: infra
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_ui_requests_notifications_negative():
+    """
+    After all processes are running make sure websockets are enabled then
+    add a repo with the same name as a current repo and check the
+    notifications display correctly. With a Red banner to show it was
+    unsuccessful.
+    https://bugzilla.redhat.com/show_bug.cgi?id=1471868
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_openstack_provider_has_dashboard():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1487142
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: cloud
+        initialEstimate: 1/4h
+        startsin: 5.10
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(3)
+def test_automate_ansible_playbook_method_type_verbosity():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1542665
+    Check if ansible playbook method  can work with different verbosity
+    levels.
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.cfme_tenancy
+@pytest.mark.tier(2)
+def test_tenant_visibility_miq_requests_all_childs():
+    """
+    Tenant members can see MIQ requests of this tenant and its children.
+
+    Polarion:
+        assignee: mnadeem
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/2h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_session_purging_occurs_only_when_session_store_is_sql():
+    """
+    If Settings > server > session_store is set to "sql", then evm.log
+    shows that the Session.check_session_timeout worker gets regularly
+    queued (at a regular interval of Settings > workers > worker_base >
+    schedule_worker > session_timeout_interval). If session_store is not
+    set to "sql", then the worker does not get scheduled.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/10h
+        title: Session purging occurs only when session_store is sql
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_actions():
+    """
+    Check SSA can be a part of action for VM
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/2h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_drop_down_dialog_should_honor_the_order_of_values_as_they_are_inputted():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1593874
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        initialEstimate: 1/16h
+        startsin: 5.9
+        title: Drop Down Dialog should Honor the Order of Values as they are Inputted
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.cfme_tenancy
+def test_tenant_osp_mapping_delete():
+    """
+    Tenants created by tenant mapping cannot be deleted.
+    1) Add rhos which has at least one tenant enabled and perform refresh
+    2) Navigate to Configuration -> Access Control -> tenants
+    3) Try to delete any of the tenants created by tenant mapping process
+    4) This is not possible until RHOS provider is removed from VMDB
+    5) try this again after provider is removed
+
+    Polarion:
+        assignee: mnadeem
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_customize_request_security_group():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1335989
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_authentication_ldap_switch_groups():
+    """
+    Test whether user who is member of more LDAP groups is able to switch
+    between them
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_host_credentials_default():
+    """
+    Verified that the Host Default credential can be set in order to allow
+    Collect Running Processes to get the processes from a VM>
+
+    Polarion:
+        assignee: None
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/4h
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_aws_smartstate_pod():
+    """
+    deploy aws smartstate pod and that it works
+
+    Polarion:
+        assignee: izapolsk
+        caseimportance: medium
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+def test_embed_tower_repo_tag():
+    """
+    RBAC - tag Ansible repo and allow new user see only this repo.
+    https://bugzilla.redhat.com/show_bug.cgi?id=1526217
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1/2h
+        startsin: 5.10
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_custom_button_openurl_vm():
+    """
+    Refer custom button mojo FAQ for more detail.
+    Additional info - https://bugzilla.redhat.com/show_bug.cgi?id=1602023
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: automate
+        initialEstimate: 1/8h
+        startsin: 5.10
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_create_appliance_on_scvmm_using_the_vhd_image():
+    """
+    Log into qeblade33 and download the VHD appliance image.  Create a new
+    VM, attach the VHD disk, and boot system.
+
+    Polarion:
+        assignee: None
+        casecomponent: appl
+        initialEstimate: 1/4h
+        subtype1: usability
+        title: Create Appliance on SCVMM using the VHD image.
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.config_management
+def test_satellite_host_groups_show_up_as_configuration_profiles_satellite_62():
+    """
+    For the Satellite provider satellite_62, both the centos and fedora-
+    cloud configuration profiles show up in Configuration > Manage, in the
+    accordion menu under All Configuration Manager Providers > Red Hat
+    Satellite Providers > satellite_62 Configuration Manager.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/15h
+        title: Satellite host groups show up as Configuration Profiles [satellite_62]
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(3)
+def test_service_ansible_playbook_with_already_existing_catalog_item_name():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1509809
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_appliance_console_ha_setup_dc():
+    """
+    Test configuring a high availability setup over multiple data centers.
+    Primary + standby in DC1 and standby in DC2
+    In order for the slave in DC2 to be promoted to primary, it would need
+    to have visibility to > 50% of the nodes. In this
+    case, that slave node has visibility to only 1 node, itself, because
+    of the network outage. It would need visibility to at
+    least 2 nodes in order to be eligible to be promoted. Therefore, it
+    cannot be promoted so, it would just be cut off
+    from the primary until network connectivity is restored. This is
+    specifically the reason for having the extra node on the
+    segment with the primary, to ensure that node always has the voting
+    majority.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        initialEstimate: 1/2h
+        setup: provision 3 appliances
+               setup HA following https://mojo.redhat.com/docs/DOC-1097888
+               (https://mojo.redhat.com/docs/DOC-1168738)
+               check setup is working be accessing webui
+        startsin: 5.8
+        testSteps:
+            1. Setup HA
+        expectedResults:
+            1. Confirm primary database server, application server is
+               running and it can access the webui
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_verify_external_auth_details_updated_in_appliance_console_ipa_():
+    """
+    Run appliance_console and verify external_auth details are correctly
+    updated for IPA
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Verify external_auth details updated in appliance_console[IPA].
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_dynamic_dropdowns_should_show_value_only_once():
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Dynamic dropdowns should show value only once
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(2)
+def test_snapshot_timeline_group_actions():
+    """
+    Test the SUI snapshot timeline.
+    Test grouping of actions in a timeline. Try to create a couple of
+    snapshots in a rapid succession, check how it looks in the timeline.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: low
+        initialEstimate: 1/3h
+        testSteps:
+            1. create a new vm
+            2. create multiple snapshots in fast succession (two should be enough)
+            3. go to the VM details page, then Monitoring -> Timelines
+            4. select "Management Events" and "Snapshot Activity" and click Apply
+            5. click on the group of events in timeline
+        expectedResults:
+            1. vm created
+            2. snapshots created
+            3. timelines page displayed
+            4. group of events displayed in the timeline
+            5. details of events displayed, correct number of events
+               displayed, time/date seems correct
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_dynamic_dropdown_multiselect_default_element_is_shouldnt_be_blank_when_loaded_by_anot():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1645555
+    https://bugzilla.redhat.com/show_bug.cgi?id=1645555
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        initialEstimate: 1/16h
+        title: Dynamic Dropdown Multiselect: Default element is shouldn't
+               be blank when loaded by another element
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_expression_method_definitions_should_not_fail_with_script_error_in_a_dialog():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1558926
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        initialEstimate: 1/6h
+        startsin: 5.10
+        title: Expression method definitions should not fail with "" in a dialog
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_if_no_password_is_exposed_in_logs_during_migration():
+    """
+    OSP: Test if no password is exposed in logs during migration
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test if no password is exposed in logs during migration
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_appliance_console_screen():
+    """
+    Test new screen package added to appliances. Should be able to run a
+    task and switch terminal/screen within ssh to run other tasks
+    simultaneously.
+    Just type "screen" after logging in to ssh to start using it. Once you
+    have screen running, "ctrl-a" intiates screen command "c" creates new
+    screen, "n" switch to next screen., "p" for previous screen, "d"
+    detach from screens (this takes you back to standard terminal) and run
+    screen -r to resume using screen.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/12h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.upgrade
+@pytest.mark.tier(2)
+def test_rh_registration_rhsm_proxy_on_ipv6():
+    """
+    Test RHSM registration with IPV6 proxy settings
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/12h
+        setup: Provision appliace
+               Connect to webui
+               Nav to Configuration-Settings-Region-Red Hat Updates
+               Edit Registration
+               The following settings that work for internal testing
+               can be found here https://mojo.redhat.com/docs/DOC-1123648
+               Save settings
+               Select appliance and click register
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(3)
+def test_sui_test_all_language_translations():
+    """
+    desc
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: SUI : Test all Language translations
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(3)
+def test_service_ansible_verbosity():
+    """
+    BZ 1460788
+    Check if the different Verbosity levels can be applied to service and
+    monitor the std out
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.dashboard
+@pytest.mark.tier(3)
+def test_dashboard_widgets_fullscreen():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1518901
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: web_ui
+        caseimportance: low
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_update_yum_bad_version_59017():
+    """
+    Tests appliance update between versions
+    Test Source
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rbac
+def test_vm_request_approval_by_user_in_different_group():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1545395
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
+        title: Test VM request approval by user in different group
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.bottleneck
+@pytest.mark.tier(2)
+def test_bottleneck_host():
+    """
+    Verify bottleneck events from host
+
+    Polarion:
+        assignee: None
+        casecomponent: optimize
+        caseimportance: medium
+        initialEstimate: 3/4h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.discovery
+@pytest.mark.tier(1)
+def test_domain_id_required_validation():
+    """
+    Steps:1. Try to add OpenStack provider
+    2. Select Keystone V3 as for it only we need to set domain id
+    3. don"t fill domain id
+    4. Verify
+    5. check for flash
+    https://bugzilla.redhat.com/show_bug.cgi?id=1545520
+
+    Polarion:
+        assignee: pvala
+        casecomponent: infra
+        caseimportance: low
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+def test_the_columns_for_the_custom_attribute_should_have_their_values_in_report():
+    """
+    Steps to Reproduce:
+    1. set a custom attribute on a VM with a space in the name
+    2. set a custom attribute on a VM with a colon in the name
+    3. Create a report with the VM name and the two custom attributes
+    4. run the report
+    https://bugzilla.redhat.com/show_bug.cgi?id=1553750
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: The columns for the custom attribute should have their values in report
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_vmware_provider_filters():
+    """
+    N-3 filters for esx provider.
+    Example: ESXi 6.5 is the current new release.
+    So filters for 6.5 (n), 6.0 (n-1), 5.5 (n-2) at minimum.
+
+    Polarion:
+        assignee: None
+        casecomponent: prov
+        caseimportance: low
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_verify_saml_sso_works_fine_check_both_enable_disable_options():
+    """
+    Configure external auth as in TC#1 and enable SSO option.
+    Verify SSO option works fine.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/4h
+        title: Verify SAML SSO works fine, check both enable/disable options.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_dialog_text_box_triggers_fields_shouldnt_refresh_too_soon_often():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1614321
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        initialEstimate: None
+        startsin: 5.10
+        title: Dialog text box triggers fields shouldn't refresh too soon / often
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_distributed_zone_mixed_appliance_ip_versions():
+    """
+    IPv6 and IPv4 appliances
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_appliance_scsi_control_vmware():
+    """
+    Appliance cfme-vsphere-paravirtual-*.ova has SCSI controller as Para
+    Virtual
+
+    Polarion:
+        assignee: None
+        casecomponent: appl
+        caseimportance: critical
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_dynamic_check_box_does_not_update_in_classic_ui():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1570152
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        caseimportance: critical
+        initialEstimate: 1/4h
+        startsin: 5.8
+        title: Dynamic check box does not update in Classic UI
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_ec2_targeted_refresh_network_port():
+    """
+    #AWS naming is Network Interface
+    Network port CREATE
+    Network port UPDATE
+    Assign private IP
+    Unassign private IP
+    Network port DELETE
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 2/3h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_service_provision_azure():
+    """
+    Azure service provsioning
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: cloud
+        initialEstimate: 1/8h
+        startsin: 5.6
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_git_import_multiple_domains():
+    """
+    Import of multiple domains from a single git repo is not allowed
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/12h
+        startsin: 5.10
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_cui_should_check_dialog_field_associations():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1559382
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/6h
+        title: CUI Should check dialog field associations
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_verify_ldap_group_lookup_fails_with_correct_error_message_for_invalid_user_details():
+    """
+    verify ldap group lookup fails with correct error message for invalid
+    config details.
+    1. configure ldap.
+    2. specify wrong user details while group look up, verify group lookup
+    fails with correct error message.
+    refer the BZ:
+    https://bugzilla.redhat.com/show_bug.cgi?id=1378213
+
+    Polarion:
+        assignee: apagac
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/4h
+        title: verify ldap group lookup fails with correct error message
+               for invalid user details
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(2)
+def test_snapshot_timeline_new_vm():
+    """
+    Test the SUI snapshot timeline.
+    See if there"s no timeline when there"s no snapshot.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: low
+        initialEstimate: 1/6h
+        testSteps:
+            1. create a new vm
+            2. go to the VM details page, then Monitoring -> Timelines
+            3. select "Management Events" and "Snapshot Activity" and click Apply
+        expectedResults:
+            1. vm created
+            2. timelines page displayed
+            3. no timeline visible, warning "No records found for this timeline" displayed
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_schedule_for_all_providers_vms():
+    """
+    Navigate to add new schedule page(Configuration->Region->Schedules)
+    Fill all required fields
+    Select all vms for provider in filter
+    Set timer
+    Save changes
+    Result: Task run successfully for selected filter
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+def test_embed_tower_repo_links():
+    """
+    test clicking #of playbooks cell will navigate to the Playbooks area,
+    filtered by the associated repo name.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware60_test_vm_migration_from_ubuntu():
+    """
+    OSP: vmware60-Test VM migration from ubuntu
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware60-Test VM migration from ubuntu
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_changing_action_order_in_catalog_bundle_should_not_removes_resource():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1615853
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        initialEstimate: 1/16h
+        title: Changing action order in catalog bundle should not removes resource
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_rhn_mirror_role_packages():
+    """
+    Test the RHN mirror role by adding a repo and checking if the contents
+    necessary for product update got downloaded to the appliance
+
+    Polarion:
+        assignee: jkrocil
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 3/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware65_test_vm_migration_from_nfs_storage_in_vmware_to_osp():
+    """
+    OSP: vmware65-Test VM migration from NFS Storage in VMware to iSCSI on
+    OSP
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware65-Test VM migration from NFS Storage in VMware to OSP
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_delete_infra_mapping():
+    """
+    OSP: Test delete infra mapping
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test delete infra mapping
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_none_public_ip_provision_azure():
+    """
+    Testing provision w/o public IP - to cover -
+    https://bugzilla.redhat.com/show_bug.cgi?id=1497202
+    1.Provision VM
+    2.Verify we don"t have public IP
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: prov
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/6h
+        startsin: 5.9
+        tags: provision
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_sdn_nsg_arrays_refresh_azure():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1520196
+    1. Add Network Security group on Azure with coma separated port ranges
+    `1023,1025` rule inbound/outbound ( ATM this feature is not allowed in
+    East US region of Azure - try West/Central)
+    2. Add such Azure Region into CFME
+    3. Refresh provider
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(3)
+def test_sui_duplicate_order_does_not_provision_service():
+    """
+    desc
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: ssui
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.8
+        title: SUI : Duplicate order does not provision service
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_provider_flavors_azure():
+    """
+    Verify that the vm flavors in Azure are of the correct sizes and that
+    the size display in CFME is accurate.  This test checks a regression
+    of https://bugzilla.redhat.com/show_bug.cgi?id=1357086
+    Low priority as it is unlikely to change once set.  Will want to check
+    when azure adds new sizes.  Only need to spot check a few values.
+    For current size values, you can check here:
+    https://azure.microsoft.com/en-us/documentation/articles/virtual-
+    machines-windows-sizes/
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: low
+        initialEstimate: 1/8h
+        startsin: 5.6
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+def test_embed_tower_exec_play_against_amazon():
+    """
+    User/Admin is able to execute playbook without creating Job Temaplate
+    and can execute it against Amazon EC2 with EC2 credentials
+    enable Embedded Ansible
+    wait until it is enabled and add repository with playbooks
+    add AWS EC2 credentials
+    create new catalog
+    add new catalog item with EC2 playbook
+    order the service and wait for it"s execution
+    check if service was finished OK
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.general_ui
+@pytest.mark.tier(1)
+def test_control_icons_simulation():
+    """
+    Requirements: Have an infrastructure provider
+    Go to Control -> Simulation
+    Select:
+    Type: Datastore Operation
+    Event: Datastore Analysis Complete
+    VM Selection: By Clusters, Default
+    Submit
+    Check for all icons in this page
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: control
+        caseimportance: medium
+        initialEstimate: 1/15h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_show_quota_used_on_tenant_quota_screen_even_when_no_quotas_are_set():
+    """
+    BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1415792
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: infra
+        initialEstimate: 1/6h
+        startsin: 5.9
+        title: Test show quota used on tenant quota screen even when no quotas are set
+        testSteps:
+            1. Add multiple providers and check the tenant quota screen
+               and check in use quota
+        expectedResults:
+            1. quota  in "In use" column should reflect the correct count
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_market_place_images_azure():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1491330
+    1.Enable market place images
+    2.Verify the list of images
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_storage_ebs_snapshot_create():
+    """
+    Requires: An ec2 provider
+    1) Create a block storage volume
+    2) Go to its summary
+    3) Select Configuration in toolbar and click on Create a Snapshot of
+    this Cloud Volume
+    4) Go to Storage -> Block Storage -> Snapshots
+    5) Check whether newly created snapshot appears
+
+    Polarion:
+        assignee: mmojzis
+        caseimportance: medium
+        initialEstimate: 1/5h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+def test_embed_tower_add_branch_repo():
+    """
+    Ability to add repo with branch (without SCM credentials).
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: critical
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.cfme_tenancy
+def test_tenant_ssui_users_can_see_their_services():
+    """
+    Self Service UI - users can see their services
+    1) Configure LDAP authentication on CFME
+    1) Create 2 different parent parent-tenants
+    - marketing
+    - finance
+    2) Create groups marketing and finance (these are defined in LDAP) and
+    group names in LDAP and CFME must match
+    Assign these groups to corresponding tenants and assign them EvmRole-
+    SuperAdministrator roles
+    3) In LDAP we have 3 users:
+    - bill -> member of marketing group
+    - jim -> member of finance group
+    - mike -> is member of both groups
+    4) add rhos/amazon providers and refresh them
+    - BUG: if provider with the same IP is added to CFME already it is not
+    seen in Cloud - Providers and it cannot be added again.
+    Therefore you have to add 2 different providers as a workaround.
+    Providers must be added under corresponding tenants!!!
+    5) login as bill and create new catalog with  - finance_catalog and
+    catalog item
+    - catalog items cannot contain fields which requires input from users?
+    -known limitation based on information from Brad"s presentation - this
+    is for froms that have dynamic dialogs items
+    6) login as jim and create new catalog with EC2 item
+    7) login as jim or bill, you should see catalog items of parent-
+    tenants and  for tenant they are in, mike user should see items from
+    marketing or finance catalog based on which group is active in Classic
+    UI
+    - this does not work well - in SSUI - My Services and My requests does
+    not show any items (correct) but number of services/requests is
+    calculated also from services not relevant to actual tenant - this is
+    fixed in next RC
+
+    Polarion:
+        assignee: mnadeem
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(3)
+def test_distributed_delete_offline_worker_appliance():
+    """
+    Steps to Reproduce:
+    have 3 servers .
+    Shutdown one server. This become inactive.
+    go to WebUI > Configuration > Diagnostics > Select "Zone: Default
+    zone" > Select worker > Configuration > Delete
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(3)
+def test_replication_delete_remote_from_global():
+    """
+    Delete remote subscription from global region
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: infra
+        caseimportance: critical
+        initialEstimate: 1/5h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_playbook_with_already_existing_dialogs_name():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1449345
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Test Playbook with already existing dialog's name
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_notification_banner_service_event_should_be_shown_in_notification_bell():
+    """
+    1) OPS UI  and SSUI service requests should create an event in
+    notification bell
+    2) Also check , Clear All and "MArk as read" in notification bell
+    3) Number of events shown in notification bell
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        initialEstimate: 1/4h
+        title: Notification Banner : Service event should be shown in notification bell
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_appliance_console_ha_dc_re_establish():
+    """
+    Test that upon re-connection of networks the repmgr process continues
+    to replicate correctly to the disconnected node within DC2
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        initialEstimate: 1/2h
+        setup: Restore network connectivity between DC1 and DC2
+        startsin: 5.8
+        testSteps:
+            1. Restore network connectivity between DC1 and DC2
+        expectedResults:
+            1. Confirm replication is working correctly
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.retirement
+@pytest.mark.tier(2)
+def test_retire_cloud_vms_date_folder():
+    """
+    test the retire funtion of vm on cloud providers, at leat two vm, set
+    retirement date button from vms page(without notification)
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: prov
+        caseimportance: medium
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_create_generic_instance():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1577395
+
+    Polarion:
+        assignee: nansari
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Create generic Instance
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(2)
+def test_utilization_provider():
+    """
+    Verify гutilication data from providers
+
+    Polarion:
+        assignee: None
+        casecomponent: optimize
+        caseimportance: medium
+        initialEstimate: 1/8h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_pg_stat_activity_view_in_postgres_should_show_worker_information():
+    """
+    pg_stat_activity view in postgres should show worker information.
+    Bug 1445928 - It is impossible to identify the source
+    process/appliance for each connection in pg_stat_activity
+    https://bugzilla.redhat.com/show_bug.cgi?id=1445928
+    # su - postgres
+    # psql vmdb_production
+    vmdb_production=# select pid, application_name from pg_stat_activity;
+    pid  |                        application_name
+    -------+--------------------------------------------------------------
+    ---
+    17109 | MIQ 16946 Server[2], default[2]
+    17274 | MIQ 17236 Generic[49], s[2], default[2]
+    17264 | MIQ 17227 Generic[48], s[2], default[2]
+    17286 | MIQ 17266 Schedule[52], s[2], default[2]
+    17277 | MIQ 17245 Priority[50], s[2], default[2]
+    17280 | MIQ 17254 Priority[51], s[2], default[2]
+    17320 | MIQ 17298 Redhat::InfraManager::MetricsCollector[53], s[2],
+    d..
+    17329 | MIQ 17307 Redhat::InfraManager::MetricsCollector[54], s[2],
+    d..
+    [...]
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/10h
+        startsin: 5.7
+        title: pg_stat_activity view in postgres should show worker information
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_replication_low_bandwidth():
+    """
+    ~5MB/s up/down
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: infra
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_black_console_ext_auth_options_disable():
+    """
+    Test disabling ext_auth options through appliance_console
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/6h
+        setup: -ssh to appliance
+               -run appliance_console
+               -select option "Update External Authentication Options"
+               -select each option to enable it
+               -select option
+               1) Disable Single Sign-On
+               2) Disable SAML
+               3) Disable Local Login
+               -select "Apply updates"
+               -check changes have been made
+        startsin: 5.6
+        testSteps:
+            1. Disable Single Sign-On
+            2. Disable SAML
+            3. Disable Local Login
+        expectedResults:
+            1. check changes in ui
+            2. check changes in ui
+            3. check changes in ui
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_reconfigure_service_fields_empty_after_deploying_service():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1580987
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Reconfigure service fields empty after deploying service
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_distributed_zone_failover_reporting():
+    """
+    Reporting (multiple)
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rest
+def test_edit_request_task():
+    """
+    In this test we will try to edit a request using POST request.
+    Note: Only Option field can be edited
+
+    Polarion:
+        assignee: mkourim
+        caseimportance: medium
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.general_ui
+@pytest.mark.tier(3)
+def test_cloud_tenant_link():
+    """
+    verify clicking cloud Tenant field in cloud image summary page
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: appl
+        caseimportance: low
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_automate_relationship_trailing_spaces():
+    """
+    PR Link (Merged 2016-04-01)
+    Handle trailing whitespaces in automate instance relationships.
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/10h
+        setup: A fresh appliance.
+        startsin: 5.6
+        testSteps:
+            1. Create a class and its instance, also create second one,
+               that has a relationship field. Create an instance with the
+               relationship field pointing to the first class" instance but
+               add a couple of whitespaces after it.
+            2. Execute the AE model, eg. using Simulate.
+        expectedResults:
+            1.
+            2. Logs contain no resolution errors
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.upgrade
+@pytest.mark.tier(2)
+def test_rh_registration_ui_proxy():
+    """
+    Check proxy settings are show in the list of info after saving
+    subscription using proxy settings (RFE)
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/12h
+        setup: Provision appliance
+               navigate to Configuration-settings-region-redhat updates
+               Click edit subscription
+               Setup subscription with proxy
+               validate and save
+               check proxy settings areshown in ui
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_vm_reconfig_add_remove_network_adapters_vsphere67_nested_dportgroup():
+    """
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: 1/16h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_vm_reconfig_add_remove_network_adapters_vsphere67_nested_mgmtnetwork():
+    """
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: 1/16h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_vm_reconfig_add_remove_network_adapters_vsphere67_nested_vmnetwork():
+    """
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: 1/16h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_reports_with_timelines_policy_events2():
+    """
+    None
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_reports_with_timelines_vm_operation():
+    """
+    None
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.timelines
+@pytest.mark.tier(2)
+def test_custom_reports_with_timelines():
+    """
+    Cloud Intel->Reports allows to copy existing reports with timelines or
+    create new ones from scratch.
+    Such custom reports appear in Cloud Intel -> Timelines after creation.
+
+    Polarion:
+        assignee: None
+        casecomponent: report
+        caseimportance: low
+        initialEstimate: 1/3h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_reports_with_timelines_hosts():
+    """
+    None
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_reports_with_timelines_policy_events():
+    """
+    None
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_migration_plan_can_be_unscheduled():
+    """
+    OSP: Test migration plan can be unscheduled
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test migration plan can be unscheduled
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_crud_pod_appliance_ansible_deployment():
+    """
+    deploys pod appliance
+    checks that it is alive
+    deletes pod appliance
+
+    Polarion:
+        assignee: izapolsk
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(3)
+def test_ssui_dynamic_dropdown_values_are_not_loaded_in_dropdown_unless_refresh_button_is_pres():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1322594
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.5
+        title: SSUI : Dynamic dropdown values are not loaded in dropdown
+               unless refresh button is pressed
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.control
+@pytest.mark.tier(3)
+def test_control_policy_simulation_displayed():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1550503
+    Test if policy simulation is displayed
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: control
+        caseimportance: low
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_verify_look_up_ldap_groups_option_works_fine():
+    """
+    verify Look Up LDAP Groups option works fine.
+    1. configure external auth
+    2. navigate to "configuration -> Access Control -> Groups -> Add new
+    group"
+    3. Check the option "Look Up LDAP Groups" and verify retrieve groups
+    works fine.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        initialEstimate: 1/4h
+        title: verify Look Up LDAP Groups option works fine.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.access
+@pytest.mark.tier(1)
+def test_switching_user_group_without_disconnecting():
+    """
+    Switching user"s group while user is online
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: Open two private/anonymous windows in Firefox/Chrome/etc.
+               Identify or create EvmRole-super_administrator level user admin
+               Identify or create EvmRole-user level user testusr
+               Identify or create EvmRole-user level group testGrp
+        tags: rbac
+        title: Switching user group without disconnecting
+        testSteps:
+            1. Sign up toa ppliance in browser1 as admin
+            2. Sign up to appliance in browser2 as testusr
+            3. Browser2: Navigate to Settings > About
+            4.
+            5. //About
+            6. Browser1: Navigate to Settings > Configuration > Access Control
+            7. Locate and select testusr
+            8. Locate and select Configuration
+            9. Select Edit
+            10. Change group to EvmGroup-security
+            11. Save user
+            12. Browser2: Navigate to Settings > About
+            13.
+            14.
+            15. Browser1: Navigate to Settings > Configuration > Access Control
+            16. Locate and select testusr
+            17. Locate and select Configuration
+            18. Select Edit
+            19. Change group to EvmGroup-user
+            20. Save user
+            21. Browser2: Navigate to Settings > About
+            22.
+            23.
+            24. Browser1: Navigate to Settings > Configuration > Access Control
+            25. Locate and select testusr
+            26. Locate and select Configuration
+            27. Select Edit
+            28. Change group to testGrp
+            29. Save user
+            30. Browser2: Navigate to Settings > About
+            31.
+            32.
+            33. Sign out both users
+        expectedResults:
+            1.
+            2.
+            3. Verify that user was not disconnected.
+            4. Verify that testusr"s group is EvmGroup-user
+            5. Verify that testusr"s role is EvmRole-user
+            6.
+            7.
+            8.
+            9. Verify you"ve been redirected to Editing User
+            10.
+            11.
+            12. Verify that user was not disconnected.
+            13. Verify that testusr"s group is EvmGroup-security
+            14. Verify that testusr"s role is EvmRole-security
+            15.
+            16.
+            17.
+            18. Verify you"ve been redirected to Editing User
+            19.
+            20.
+            21. Verify that user was not disconnected.
+            22. Verify that testusr"s group is EvmGroup-user
+            23. Verify that testusr"s role is EvmRole-user
+            24.
+            25.
+            26.
+            27. Verify you"ve been redirected to Editing User
+            28.
+            29.
+            30. Verify that user was not disconnected.
+            31. Verify that testusr"s group is testGrp
+            32. Verify that testusr"s role is EvmRole-user
+            33.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+@pytest.mark.tier(1)
+def test_report_import_export_widgets():
+    """
+    Import and  Export widgets
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        initialEstimate: 1/16h
+        startsin: 5.3
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_button_automate_ssui():
+    """
+    Test custom button with automation request method
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: automate
+        initialEstimate: 1/8h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_distributed_zone_failover_cu_data_collector():
+    """
+    C & U Data Collector (multiple appliances can have this role)
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_dialog_value_type_integer_string_check_in_dropdown_elements():
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        initialEstimate: 1/4h
+        title: Dialog : value type(Integer/string) check in dropdown elements
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_group_cloud_memory_quota_by_lifecycle():
+    """
+    test group memory quota for cloud instance provision by Automate model
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_rhi_inventory():
+    """
+    Verify various tabs by applying filters on one or more systems
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+def test_single_custom_button_disable():
+    """
+    Steps 1.Create a custom button (Unassigned Button) for services
+    2.Provide an Enablement expression for disabling the custom button.
+    (e.g: COUNT OF Service.VMs > 5000 )
+    3.Add "Disabled Button Text"
+    4.Click on save
+    5.Login on to SSUI page
+    6.Goto Service and check the button is disabled
+    7.Hover over button to check the disable text.
+    Additional Information:
+    https://bugzilla.redhat.com/show_bug.cgi?id=%201502304 Use the above
+    BZ link for understand the [RFE]
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_project_cloud_storage_quota_by_enforce():
+    """
+    test storage quota for project for cloud instance by enforcement
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        initialEstimate: 1/4h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_automate_generic_object_service_associations():
+    """
+    Use the attached domain to test this bug:
+    1) Import end enable the domain
+    2) Have at least one service created (Generic is enough)
+    3) Run rails console and create the object definition:
+    GenericObjectDefinition.create(
+    :name => "LoadBalancer",
+    :properties => {
+    :attributes   => {:location => "string"},
+    :associations => {:vms => "Vm", :services => "Service"},
+    }
+    )
+    4) Run tail -fn0 log/automation.log | egrep "ERROR|XYZ"
+    5) Simulate Request/GOTest with method execution
+    In the tail"ed log:
+    There should be no ERROR lines related to the execution.
+    There should be these two lines:
+    <AEMethod gotest> XYZ go object: #<MiqAeServiceGenericObject
+    ....something...>
+    <AEMethod gotest> XYZ load balancer got service:
+    #<MiqAeServiceService:....something....>
+    If there is "XYZ load balancer got service: nil", then this bug was
+    reproduced.
+    thx @lfu
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_button_in_sui():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1450473
+    https://bugzilla.redhat.com/show_bug.cgi?id=1454910
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: ssui
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Test Custom button in SUI
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_automate_git_domain_displayed_in_dialog():
+    """
+    Check that the domain imported from git is displayed and usable in the
+    pop-up tree in the dialog editor.
+    You can use eg. https://github.com/ramrexx/CloudForms_Essentials.git
+    for that
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        initialEstimate: 1/15h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_verify_user_validation_works_fine_but_authentication_fails_if_no_group_is_assigned_fo():
+    """
+    Create user in ldap domain server.
+    Do not assign any group to the user.
+    Configure cfme for ldaps external auth as in TC#1
+    Validation for ldap user is expected to be successful but the
+    authentication should fail as there is no group for the user.
+    Check audit.log and evm.log for “unable to match user"s group
+    membership to an EVM role” message.
+    Verify this scenario by "Get User Groups from External Authentication
+    (httpd)" option ENABLED and DISABLED.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: verify user validation works fine but authentication fails
+               if no group is assigned for user.
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_multiple_sources_to_single_target_mapping_for_clusters_ds_network():
+    """
+    OSP: Test multiple sources to single target mapping (For Clusters, DS,
+    Network)
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test multiple sources to single target mapping (For Clusters, DS, Network)
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_multiple_sources_to_single_target_mapping_for_clusters_ds_network():
+    """
+    OSP: Test multiple sources to single target mapping (For Clusters, DS,
+    Network)
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test multiple sources to single target mapping (For Clusters, DS, Network)
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(3)
+def test_service_ansible_playbook_cloud_credentials():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1444092When the service is
+    viewed in my services it should also show that the cloud credentials
+    were attached to the service.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: low
+        initialEstimate: 1/4h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_rhi_unregister():
+    """
+    Verify Unregisteration of system by selecting one or more systems from
+    list
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_repo_list():
+    """
+    After all processes are running add a few repo"s for playbooks. Check
+    that all these repos appear in the repo list section in the ui, With
+    the correct status and the correct quantity of playbooks.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_disabled_domains_in_domain_priority():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1331017 When the admin
+    clicks on a instance that has duplicate entries in two different
+    domains. If one domain is disabled it is still displayed in the UI for
+    the domain priority.
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.storage
+def test_storage_volume_in_use_delete_openstack():
+    """
+    Requires:
+    RHCF3-21779 - test_storage_volume_attach[openstack]
+    Steps to test:
+    1. Check after attached status of volume in-used or not
+    2. Now try to delete volume from Detail page
+    3. check for flash message " Cloud Volume "Volume_name" cannot be
+    removed because it is attached to one or more Instances "
+    4. Navigate on All page
+    5. try to delete volume from All page
+    6. check for flash message " Cloud Volume "Volume_name" cannot be
+    removed because it is attached to one or more Instances "
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/16h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_automate_engine_database_connection():
+    """
+    All steps in: https://bugzilla.redhat.com/show_bug.cgi?id=1334909
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.configuration
+def test_configuration_region_description_change():
+    """
+    BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1350808 Go to Settings
+    -> Configure -> Settings
+    Details -> Region
+    Change region description
+    Check whether description was changed
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/20h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+@pytest.mark.tier(3)
+def test_import_duplicate_report():
+    """
+    This case tests appliance behaviour when a duplicate report is
+    imported.
+    Steps:
+    1) Create a custom report.
+    2) Go to Import/Export accordion and click on `Custom Reports`.
+    3) Export the available report(newly created custom report from step
+    1).
+    4) Import the same exported yaml file.
+    Expected Result:
+    A flash message should appear: `Skipping Report (already in DB):
+    [report_name]`
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_ec2_add_delete_add_provider():
+    """
+    Polarion:
+        assignee: mmojzis
+        casecomponent: cloud
+        initialEstimate: 1h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware67_test_vm_migration_with_rhel_7x():
+    """
+    OSP: vmware67-Test VM migration with RHEL 7.x
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware67-Test VM migration with RHEL 7.x
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_pod_appliance_start_stop():
+    """
+    appliance should start w/o issues
+
+    Polarion:
+        assignee: izapolsk
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_credentials_change_password_trailing_whitespace():
+    """
+    Password with trailing whitespace
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/8h
+        tags: rbac
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_event_catcher_collect():
+    """
+    EventCatcher process collects all activity from api/acitivity_streamis
+    and is writing data into PG DB
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1/4h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.log_depot
+@pytest.mark.tier(1)
+def test_log_collect_current_zone_all_unconfigured():
+    """
+    check collect logs under zone when both levels are unconfigured.
+    Expected result - all buttons are disabled
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.upgrade
+@pytest.mark.tier(2)
+def test_update_webui_custom_css():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1553841
+    Test css customization"s function correctly after webui update.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/6h
+        setup: provision appliance
+               add custom css file
+               add repo file to /etc/yum.repos.d/
+               add RHSM settings
+               update through webui
+               check webui is available
+               check customization"s still work
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rest
+@pytest.mark.tier(3)
+def test_api_edit_user_no_groups():
+    """
+    Verify that the CFME REST API does not allow you to edit a user and
+    remove it from all assigned groups
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.9
+        tags: rbac
+        testSteps:
+            1. Create a user and assign it to one or more groups
+            2. Using the REST API, edit the user and attempt to assign it to no groups
+        expectedResults:
+            1. PASS
+            2. FAIL
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(3)
+def test_generic_object_should_be_visible_in_service_view():
+    """
+    Generic object should be visible in service view
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        initialEstimate: 1/4h
+        setup: https://bugzilla.redhat.com/show_bug.cgi?id=1515945
+        startsin: 5.9
+        title: Generic object should be visible in service view
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_custom_service_dialog_quota_flavors():
+    """
+    Test quota with instance_type in custom dialog
+    https://bugzilla.redhat.com/show_bug.cgi?id=1499193
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        initialEstimate: 1/4h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_custom_button_on_resource_detail_ssui():
+    """
+    Steps:
+    1. Add custom button under service option (from automation > automate
+    > customization > service accordion)
+    2. In normal UI - OPS, Provision test service using any infra provider
+    (nvc55 recommended)
+    3. In SSUI, Check custom button on VM resource details page
+    Additional info: https://bugzilla.redhat.com/show_bug.cgi?id=1427430
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: ssui
+        initialEstimate: None
+        startsin: 5.9
+        tags: ssui
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(3)
+def test_service_ansible_playbook_order_credentials_usecredsfromservicedialog():
+    """
+    Test if creds from Service Dialog are picked up for execution of
+    playbook or the default are used(that were set at the time of dialog
+    creation)
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.tag
+@pytest.mark.tier(2)
+def test_tagvis_ldap_group_host():
+    """
+    Add LDAP group, assign a host permission and check for the visibility
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_attribute_override():
+    """
+    Steps to Reproduce:
+    1. create a custom button to request the call_instance_with_message
+    2. set the message to create
+    3. set the attributes instance, class, namespace to "whatever"
+    4. set the attribute message to "my_message"
+    5. save it
+    Reference BZ:
+    https://bugzilla.redhat.com/show_bug.cgi?id=1651099
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_pod_appliance_config_upgrade():
+    """
+    appliance config update should cause appliance re-deployment
+
+    Polarion:
+        assignee: izapolsk
+        caseimportance: medium
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_appliance_console_evm_stop():
+    """
+    test stopping the evm server process
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.storage
+def test_storage_object_store_container_edit_tag_openstack():
+    """
+    Requirs:
+    OpenstackProvider
+    1) Add Object Store Container
+    2) go to summery pages
+    2) add tag : [Policy > Edit Tags]
+    3) Verify the tag is assigned
+    4) remove tag: [Policy > Edit Tags]
+    5) Verify the tag is removed
+
+    Polarion:
+        assignee: None
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_storage_ebs_volume_detach():
+    """
+    Requires:
+    test_storage_ebs_volume_attach
+    Steps to test:
+    1. Go to Storage -> Block Storage -> Volumes
+    2. Select volume from test_storage_ebs_volume_attach
+    3. Configuration -> Detach this Cloud Volume
+    4. Select instance from test_storage_ebs_volume_attach and Save
+    5. Check whether volume was detached from that instance
+
+    Polarion:
+        assignee: mmojzis
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.provision
+@pytest.mark.tier(2)
+def test_template_list_of_provider():
+    """
+    test case to cover BZ 1427477 - check list of templates available
+    during provision from particular provider view
+    expected result: only provider specific templates should be available
+    Bug 1427477 - [RFE] In UI, VM provision, in scope of specific
+    provider, should not suggest all the providers templates.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: prov
+        caseimportance: low
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_in_dynamic_multi_select_dialog_elements_the_first_element_shouldnt_be_selected_when_n():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1576288
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        initialEstimate: 1/6h
+        title: In Dynamic multi select dialog elements the first element
+               shouldn't be selected when nil default is specified
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(3)
+def test_service_ansible_playbook_machine_credentials_service_details_opsui():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1515561  When the service
+    is viewed in my services it should also show that the cloud and
+    machine credentials were attached to the service.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(3)
+def test_service_ansible_playbook_machine_credentials_service_details_sui():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1540689  When the service
+    is viewed in my services it should also show that the cloud and
+    machine credentials were attached to the service.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_associated_tags_before_and_after_migration_department_accounting_kind():
+    """
+    OSP: Test associated tags before and after migration
+    (Department:Accounting kind)
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test associated tags before and after migration
+               (Department:Accounting kind)
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.provision
+@pytest.mark.tier(2)
+def test_vmware_default_placement_vmware():
+    """
+    Test host autoplacement provisioning on VMware. now we are able to get
+    DRS property of the Cluster from VC and specify if selected Cluster
+    requires pre-selected Host Name or not
+    CFME: Cluster properties -  DRS = True
+    VC: Cluster / Manage / Settings / vSphere DRS
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: prov
+        initialEstimate: 1/6h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_default_view_settings_should_apply_for_service_catalogs():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1553337
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.9
+        title: Default view settings should apply for service catalogs
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.upgrade
+@pytest.mark.tier(2)
+def test_upgrade_single_negative_v2_key_fix_auth():
+    """
+    test migration without fetching v2_key also requires fix_auth
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/3h
+        setup: restore a backup without using its v2_key
+               run "fix_auth --invalid <password>"
+               this will allow evm to start without credential errors
+        testtype: upgrade
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_default_reports_with_timelines_policy_events():
+    """
+    None
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_default_reports_with_timelines_vm_operation():
+    """
+    None
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.timelines
+@pytest.mark.tier(2)
+def test_default_reports_with_timelines_vm_power_on_off_events_for_last_week():
+    """
+    Verify timeline events are rendered on Cloud Intelligence->Timelines
+
+    Polarion:
+        assignee: None
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/5h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.timelines
+@pytest.mark.tier(2)
+def test_default_reports_with_timelines_date_brought_under_management_for_last_week():
+    """
+    Verify timeline events are rendered on Cloud Intelligence->Timelines
+
+    Polarion:
+        assignee: None
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/5h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.timelines
+@pytest.mark.tier(2)
+def test_default_reports_with_timelines_policy_events_for_the_last_7_days():
+    """
+    Verify timeline events are rendered on Cloud Intelligence->Timelines
+
+    Polarion:
+        assignee: None
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/5h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.timelines
+@pytest.mark.tier(2)
+def test_default_reports_with_timelines_policy_events_for_last_week():
+    """
+    Verify timeline events are rendered on Cloud Intelligence->Timelines
+
+    Polarion:
+        assignee: None
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/5h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_default_reports_with_timelines_hosts():
+    """
+    None
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_default_reports_with_timelines_policy_events2():
+    """
+    None
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_appliance_ssl():
+    """
+    Test ssl connections to postgres database from other appliances.
+    https://bugzilla.redhat.com/show_bug.cgi?id=1482697
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/3h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_user_cloud_cpu_quota_by_services():
+    """
+    test user cpu quota for cloud instance provision by ordering services
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.log_depot
+@pytest.mark.tier(1)
+def test_log_collect_current_zone_multiple_servers_server_setup():
+    """
+    using any type of depot check collect current log function under zone.
+    Zone should have multiplie servers under it. Zone should not be setup,
+    servers should
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_ec2_targeted_refresh_stack():
+    """
+    Stack CREATE
+    Stack DELETE
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_button_dialog_ssui():
+    """
+    Test custom button dialog runner via SSUI
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.9
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_button_dialog_service_archived():
+    """
+    From Service OPS check if archive vms"s dialog invocation via custom
+    button
+    https://bugzilla.redhat.com/show_bug.cgi?id=1439883
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: automate
+        caseimportance: low
+        initialEstimate: 1/8h
+        startsin: 5.9
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_running_processes():
+    """
+    Check running processes are fetched correctly for analysed VM
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/2h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+def test_embed_tower_repos_available():
+    """
+    Repositories are included under Ansible, Check Empty State pattern is
+    displayed when none exist.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: critical
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(3)
+def test_quota_for_simultaneous_service_catalog_request_with_different_users():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1456819
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: prov
+        initialEstimate: 1/4h
+        startsin: 5.8
+        title: test quota for simultaneous service catalog request with different users
+        testSteps:
+            1.Create a service catalog with vm_name, instance_type &
+              number_of_vms as fields. Set quotas threshold values for
+              number_of_vms to 5. 2.Create two users from same group try
+              to provision service catalog from different web-sessions
+        expectedResults:
+            1. Quota exceeded message should be displayed
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(3)
+def test_replication_re_add_deleted_remote():
+    """
+    Re-add deleted remote region
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: infra
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.snapshot
+@pytest.mark.tier(2)
+def test_ssui_test_snapshot_vm_memory_checkbox_when_creating_snapshot_for_powered_off_vm():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1600043
+
+    Polarion:
+        assignee: apagac
+        casecomponent: prov
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: [SSUI] Test "snapshot vm memory" checkbox when creating
+               snapshot for powered off vm.
+        testSteps:
+            1. test creating snapshot for powered off vm"s
+        expectedResults:
+            1. "snapshot vm memory" checkbox should not be displayed.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_heat_stacks_in_non_admin_tenants_shall_also_be_collected():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1290005
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.5
+        title: Heat stacks in non-admin tenants shall also be  collected
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_automate_schedule_crud():
+    """
+    Create the automate task schedule and make sure all the values are the
+    same after creation.
+    Bug 1479570 - Internal Server Error when creating schedule for
+    automate task
+    https://bugzilla.redhat.com/show_bug.cgi?id=1479570
+    1.) Create a schedule, selecting Automation Tasks under Action.
+    2.) Select a value from the dropdown list under Object Attribute Type.
+    3.) Undo the selection by selecting "<Choose>" from the dropdown.
+    4.) No pop-up window with Internal Server Error.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: automate
+        initialEstimate: 1/15h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_add_vmware_credentials():
+    """
+    Allow user/admin to create/import credentials for machines which will
+    be managed (may need to be split into multiple tests to cover
+    -Machine, Network, Amazon Web Services, Rackspace, VMware vCenter, Red
+    Hat Satellite 6, Red Hat CloudForms, Google Compute Engine, Microsoft
+    Azure Classic, Microsoft Azure Resource Manager, OpenStack)
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(3)
+def test_add_to_shopping_cart_button_should_enable_after_refresh_on_some_dialog_fields_in_sui():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1539871
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: ssui
+        initialEstimate: 1/6h
+        startsin: 5.10
+        title: "Add to shopping cart" button should enable after refresh on
+               some dialog fields in SUI.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+def test_embed_tower_repo_details():
+    """
+    test clicking on a repo name should show details of the repository.
+    (Automation-Ansible-repositories table view showing added repos)
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: critical
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_distributed_zone_failover_web_services():
+    """
+    Web Services (multiple)
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_validate_lookup_button_provsioning():
+    """
+    configure ldap and validate for lookup button in provisioning form
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_verify_role_configuration_work_as_expected_for_new_ldap_groups():
+    """
+    Retrieve ldap user groups, assign roles to the group.
+    Login to cfme webui as ldap user and verify user role is working as
+    expected.
+    NOTE: execute rbac test cases.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1h
+        title: verify role configuration work as expected for new ldap groups
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(3)
+def test_crosshair_op_vm_vsphere65():
+    """
+    Requires:
+    C&U enabled Vsphere-65 appliance.
+    Steps:
+    1. Navigate to Datastores [Compute > infrastructure>VMs]
+    2. Select any available VM (cu24x7)
+    3. Go for utilization graphs [Monitoring > Utilization]
+    4. Check data point on graphs ["CPU", "VM CPU state", "Memory", "Disk
+    I/O", "N/w I/O"] using drilling operation on the data points.
+    5.  check "chart" and "timeline" options working properly or not.
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(3)
+def test_crosshair_op_vm_vsphere6():
+    """
+    test_crosshair_op_vm[vsphere6]
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: low
+        initialEstimate: 1/12h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.right_size
+@pytest.mark.tier(1)
+def test_rightsize_memory_values_correct_vsphere6():
+    """
+    Right-size memory values are correct.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.right_size
+@pytest.mark.tier(1)
+def test_rightsize_memory_values_correct_rhv41():
+    """
+    Right-size memory values are correct.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_dialog_fields_should_update_after_hitting_save_in_dialog_editor():
+    """
+    de
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        initialEstimate: 1/4h
+        title: Dialog fields should update after hitting save in dialog editor
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_tag_expression_and_with_or_with_not():
+    """
+    Combine tags with AND and NOT and OR conditions
+    Check item visibility
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_vpc_env_selection():
+    """
+    Test selection of components in environment page of cloud instances
+    with and without selected virtual private cloud
+    Related to BZ 1315945
+
+    Polarion:
+        assignee: None
+        casecomponent: web_ui
+        initialEstimate: 1d
+        testSteps:
+            1. Provision an Azure Instance from an Image.
+            2. At the environment page, try to select components without vpc
+            3. At the environment page, try to select components without vpc with vpc
+        expectedResults:
+            1. Instance provisioned and added successfully
+            2. Items are selected successfully
+            3. Items are selected successfully
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+@pytest.mark.tier(1)
+def test_reports_create_schedule_for_base_report_one_time_a_day():
+    """
+    Create schedule that runs report daily. Check it was ran successfully
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/16h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_verify_passwords_are_not_registered_in_plain_text_in_auth_logs():
+    """
+    verify passwords are not registered in plain text in auth logs.
+    1. Configure LDAP/External Auth/Database Auth.
+    2. Verify username and passwords are not registered in plain text to
+    audit.log and evm.log
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: verify passwords are not registered in plain text in auth logs.
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_set_retirement_date_scvmm():
+    """
+    Verify that the retirement of a vm can be set in the future and that
+    it actually gets retired.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.4
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_add_provider_without_subscription_azure():
+    """
+    1.Add Azure Provider w/0 subscription
+    2.Validate
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseposneg: negative
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+@pytest.mark.tier(2)
+def test_saved_chargeback_report():
+    """
+    Verify that saved Chargeback reports are saved in the "Saved
+    Chargeback Reports" folder on the Cloud Intelligence->Chargeback->
+    Report page.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_appliance_console_restore_ha_standby_node():
+    """
+    Test backup and restore with a HA setup
+    So this should work if you stop the repmgrd service on each of the
+    standby nodes before doing the restore and start it after.
+    Should be just `systemctl stop rh-postgresql95-repmgr` then `systemctl
+    start rh-postgresql95-repmgr` after the restore is finished.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/2h
+        setup: provision 3 appliances
+               setup HA following https://mojo.redhat.com/docs/DOC-1097888
+               backup database server
+               make changes to database
+               stop database
+               restore backup
+               check changes are restored and HA continues to work correctly
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_create_migration_plan_create_and_read():
+    """
+    OSP: Test create migration plan - Create and Read
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test create migration plan - Create and Read
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+def test_report_menus_moving_reports():
+    """
+    Go to Cloud Intel -> Reports -> Edit reports menuSelect EvmGroup
+    Administrator -> Configuration Management -> Virtual MachinesSelect
+    Virtual Machines folder
+    Select 5 Reports and move them to the left.
+    All 5 reports should be moved.
+    Then reset it and select all reports and move them to the left.
+    All reports should be moved.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: report
+        caseimportance: low
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_appliance_console_cancel():
+    """
+    Test option to navigate back from all submenus in appliance_console
+    https://bugzilla.redhat.com/show_bug.cgi?id=1438844
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_it_should_add_new_service_catalog_item_when_display_in_catalog_selected_and_no_catalo():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1630385
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        initialEstimate: None
+        startsin: 5.9
+        title: It should add new Service Catalog Item when "Display in
+               Catalog" selected and no Catalog chosen
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_warnings_after_bad_failed_imports():
+    """
+    OSP: Test warnings after bad/failed imports
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseposneg: negative
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test warnings after bad/failed imports
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_proxy_override_gce():
+    """
+    With 5.7 there is a new feature that allows users to specific a
+    specific set of proxy settings for each cloud provider.  The way you
+    enable this is to go to Configuration/Advanced Settings and scroll
+    down to the ec2 proxy settings.  For this test you want to create a
+    bogus setting for the default entry and a correct entry for ec2 so
+    that you can make sure it is switching to ec2 correctly.
+    Here are the proxy instructions:
+    https://mojo.redhat.com/docs/DOC-1103999
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/8h
+        setup: Make sure you create a bad proxy for default and a correct proxy for
+               ec2 so that you are certain we grab the right entry.
+        startsin: 5.7
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_proxy_override_ec2():
+    """
+    With 5.7 there is a new feature that allows users to specific a
+    specific set of proxy settings for each cloud provider.  The way you
+    enable this is to go to Configuration/Advanced Settings and scroll
+    down to the ec2 proxy settings.  For this test you want to create a
+    bogus setting for the default entry and a correct entry for ec2 so
+    that you can make sure it is switching to ec2 correctly.
+    Here are the proxy instructions:
+    https://mojo.redhat.com/docs/DOC-1103999
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/8h
+        setup: Make sure you create a bad proxy for default and a correct proxy for
+               ec2 so that you are certain we grab the right entry.
+        startsin: 5.7
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_proxy_override_azure():
+    """
+    With 5.7 there is a new feature that allows users to specific a
+    specific set of proxy settings for each cloud provider.  The way you
+    enable this is to go to Configuration/Advanced Settings and scroll
+    down to the azure proxy settings.  For this test you want to create a
+    bogus setting for the default entry and a correct entry for azure so
+    that you can make sure it is switch to azure correctly.
+    Here are the proxy instructions:
+    https://mojo.redhat.com/docs/DOC-1103999
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/4h
+        setup: Setup the azure proxy correct and the default proxy incorrectly and
+               make sure azure uses the correct entry.
+        startsin: 5.7
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_rbac_user_with_no_permissions_should_not_be_able_to_create_catalog_item():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1460891
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: RBAC : User with no permissions should not be able to create catalog item
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_zone_credentials_windows():
+    """
+    This test verified that the Windows credential can be set and that
+    these credentials allow CFME to connect to a Windows VM.  Used for
+    Collect Running Processes.
+
+    Polarion:
+        assignee: None
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/4h
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.storage
+def test_storage_object_store_object_edit_tag_openstack():
+    """
+    Requirs:
+    OpenstackProvider
+    1) Navigate to Object Store Object [Storage > Object Storage > Object
+    Store Objects]
+    2) go to summery pages of any object
+    2) add tag : [Policy > Edit Tags]
+    3) Verify the tag is assigned
+    4) remove tag: [Policy > Edit Tags]
+    5) Verify the tag is removed
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_appliance_console_network_conf():
+    """
+    test network configuration
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_able_to_add_long_description_for_playbook_catalog_items():
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Able to add long description for playbook catalog items
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.general_ui
+@pytest.mark.tier(1)
+def test_containers_topology_display_names():
+    """
+    Navigate to Compute -> Containers -> Topology.Check whether the
+    "Display Name" box is displayed correctly.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: low
+        initialEstimate: 1/30h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(2)
+def test_utilization_cluster():
+    """
+    Verify гutilication data from cluster
+
+    Polarion:
+        assignee: None
+        casecomponent: optimize
+        caseimportance: medium
+        initialEstimate: 1/8h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(1)
+def test_ldap_user_login():
+    """
+    Verify the user login with valid credentials, based on role configured
+    for the user.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        initialEstimate: 1/4h
+        testSteps:
+            1. login with the valid ldap user configured with CFME
+            2. Verify the logged in user details in login page
+            3. verify the feature access for the user based on the role
+               configured/assigned to the user.
+            4. verify the login with invalid credentials for the user login
+        expectedResults:
+            1. Login is expected to be successful for the valid user and credentials.
+            2. username and group name needs be displayed.
+            3. the user is expected to get full access to the features defined for his role.
+            4. Login is expected to fail with invalid credentials.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.cfme_tenancy
+def test_tenant_unique_automation_domain_name_on_parent_level():
+    """
+    Automation domain name is unique across parent tenants and cannot be
+    used twice.
+
+    Polarion:
+        assignee: mnadeem
+        casecomponent: config
+        caseposneg: negative
+        initialEstimate: 1/2h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_ec2_deploy_instance_with_ssh_addition_template():
+    """
+    Requirement: EC2 provider
+    1) Provision an instance
+    2) Select Choose Automatically in Environment -> Placement
+    3) Select SSH key addition template in Customize -> Customize Template
+    4) Instance should be provisioned without any errors
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_add_cloud_key_pair():
+    """
+    Add Cloud key pair
+    Add Ec2 provider, Clouds - Key pair, Give any name , select provider.
+    Click on Add .
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/16h
+        startsin: 5.5
+        title: Add Cloud Key pair
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_textbox_value_should_update_with_automate_method():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1613443
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: TextBox value should update with automate method
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_replication_central_admin_ansible_playbook_service_from_global():
+    """
+    Playbook service is ordered from the master region catalog.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/3h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware65_test_vm_with_multiple_nics_with_single_ip_ipv6_to_first_nic_and_ipv4_to_():
+    """
+    OSP: vmware65-Test VM with multiple NICs with single IP (IPv6 to first
+    NIC and IPv4 to second)
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware65-Test VM with multiple NICs with single IP
+               (IPv6 to first NIC and IPv4 to second)
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(3)
+def test_custom_button_order_ansible_playbook_service():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1449361 An Ansible Service
+    Playbook can be ordered from a Custom Button
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/3h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_vmware_vds_deploy_target():
+    """
+    Target vDS for deployment
+
+    Polarion:
+        assignee: None
+        casecomponent: infra
+        initialEstimate: 1/12h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.bottleneck
+@pytest.mark.tier(2)
+def test_bottleneck_cluster():
+    """
+    Verify bottleneck events from cluster
+
+    Polarion:
+        assignee: None
+        casecomponent: optimize
+        caseimportance: medium
+        initialEstimate: 3/4h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+@pytest.mark.tier(1)
+def test_copy_generate_report_provisioning_activity():
+    """
+    1.Copied the report "Provisioning Activity - by Requester" to
+    "Provisioning Activity - by Requester-2"
+    2.Executing the copied report, one can se the vaule "Administrator"
+    for the field "Provision.Request : Approved By".
+    If one later configures the Styling to:
+    Style: if: Red Background = Administrador Light Background Starts With
+    A
+    https://bugzilla.redhat.com/show_bug.cgi?id=1402547
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/16h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_verify_purging_of_old_records():
+    """
+    Verify that DriftState, MiqReportResult, EventStream, PolicyEvent,
+    VmdbMetric, Metric, and Container-related records are purged
+    regularly.
+    Bug 1348625 - We might not be purging all tables that we should be
+    https://bugzilla.redhat.com/show_bug.cgi?id=1348625
+    [----] I, [2017-05-19T07:48:23.994536 #63471:985134]  INFO -- :
+    MIQ(DriftState.purge_by_date) Purging Drift states older than
+    [2016-11-20 11:48:20 UTC]...Complete - Deleted 0 records"
+    [----] I, [2017-09-21T06:09:57.911327 #1775:a53138]  INFO -- :
+    MIQ(MiqReportResult.atStartup) Purging adhoc report results...
+    complete
+    [----] I, [2017-09-21T06:15:31.118400 #2181:a53138]  INFO -- :
+    MIQ(EventStream.purge) Purging all events older than [2017-03-25
+    10:15:27 UTC]...Complete - Deleted 0 records
+    [----] I, [2017-09-21T06:15:31.284846 #2181:a53138]  INFO -- :
+    MIQ(PolicyEvent.purge_by_date) Purging Policy events older than
+    [2017-03-25 10:15:31 UTC]...Complete - Deleted 0 records
+    [----] I, [2017-09-21T06:50:25.643198 #2116:a53138]  INFO -- :
+    MIQ(VmdbMetric.purge_by_date) Purging hourly metrics older than
+    [2017-03-25 10:50:19 UTC]...Complete - Deleted 0 records
+    [----] I, [2017-09-21T06:50:25.674445 #2116:a53138]  INFO -- :
+    MIQ(VmdbMetric.purge_by_date) Purging daily metrics older than
+    [2017-03-25 10:50:19 UTC]...Complete - Deleted 0 records
+    [----] I, [2017-09-21T11:04:18.496532 #32143:a53138]  INFO -- :
+    MIQ(Metric::Purging.purge) Purging all realtime metrics older than
+    [2017-09-21 11:04:13 UTC]...Complete - Deleted 135 records and 0
+    associated tag values - Timings: {:purge_metrics=>0.23389387130737305,
+    :total_time=>0.23413729667663574}
+    [----] I, [2017-09-27T15:37:42.206807 #6336:39d140]  INFO -- :
+    MIQ(Container.purge_by_date) Purging Containers older than [2017-03-31
+    19:37:38 UTC]...Complete - Deleted 0 records
+    [----] I, [2017-09-27T15:37:42.264940 #6326:39d140]  INFO -- :
+    MIQ(ContainerGroup.purge_by_date) Purging Container groups older than
+    [2017-03-31 19:37:38 UTC]...Complete - Deleted 0 records
+    [----] I, [2017-09-27T15:37:42.281474 #6336:39d140]  INFO -- :
+    MIQ(ContainerImage.purge_by_date) Purging Container images older than
+    [2017-03-31 19:37:38 UTC]...Complete - Deleted 0 records
+    [----] I, [2017-09-27T15:37:42.340960 #6336:39d140]  INFO -- :
+    MIQ(ContainerDefinition.purge_by_date) Purging Container definitions
+    older than [2017-03-31 19:37:38 UTC]...Complete - Deleted 0 records
+    [----] I, [2017-09-27T15:37:42.392486 #6326:39d140]  INFO -- :
+    MIQ(ContainerProject.purge_by_date) Purging Container projects older
+    than [2017-03-31 19:37:38 UTC]...Complete - Deleted 0 records
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        initialEstimate: 1/4h
+        startsin: 5.8
+        title: Verify purging of old records
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_tagvis_tag_and_configuration_management_ansible_tower_job_templates():
+    """
+    Combination of My Company tag and ansible tower job template
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.configuration
+@pytest.mark.tier(1)
+def test_configuration_icons_trusted_forest_settings():
+    """
+    Go to Configuration -> Authentication
+    Select Mode LDAP
+    Check Get User Groups from LDAP
+    Now there should be green plus icon in Trusted Forest Settings
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/20h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_vm_collect_running_processes():
+    """
+    Verify that you can extract the running processes from a VM with a
+    Windows Guest OS that is running and has an IP Address.
+
+    Polarion:
+        assignee: None
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.5
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.config_management
+@pytest.mark.tier(1)
+def test_config_manager_prov_from_service_ansible_tower_310():
+    """
+    1) Navigate to Configuration -> Configuration management -> Ansible
+    Tower job templates.
+    - click on job template -> Configuration -> Create service dialog from
+    this job template -> give it name
+    2) Create new catalog Item
+    - Catalog Item type: AnsibleTower
+    - name your catalog item
+    - Display in catalog: checked
+    - catalog: pick your catalog
+    - Dialog: Tower_dialog
+    - Provider: Ansible Tower .....
+    3) Order service
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: prov
+        initialEstimate: 1h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_add_gce_credentials():
+    """
+    Add GCE credentials.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_when_clicking_refresh_for_text_field_2_only_text_field_2_should_refreshed_of_service_():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1559999
+    Steps to Reproduce:
+    1. create a dialog with two text fields with no refresh relation
+    between them, showing their refresh buttons.
+    2. associate each to a different method that just logs "Refreshing X"
+    3. associating the dialog to a catalog item
+    4. tail -f log/automation.log | grep "Refreshing"
+    5. load the dialog
+    6. click "refresh" for field 2
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        initialEstimate: 1/4h
+        title: When clicking refresh for text field 2 only text field 2
+               should refreshed of service dialog
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_verify_disable_local_login_option_works_fine_verify_enable_disable_option():
+    """
+    Configure external auth as in TC#1 and enable “disable local login.”
+    Verify the default “admin” user for cfme no longer allowed to login to
+    CFME
+    ‘"disable local login". can be reset with an administratively
+    privileged user and using the appliance_console "Update Ext Auth"
+    option.
+    Verify “admin” login works fine upon “disable local login” is
+    disabled.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/2h
+        title: Verify disable local login option works fine. Verify enable/disable option
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.right_size
+@pytest.mark.tier(2)
+def test_nor_cpu_vsphere6():
+    """
+    Test Normal Operating Range for CPU usage
+    Compute > Infrastructure > Virtual Machines > select a VM running on a
+    vSphere 6 provider
+    Normal Operating Ranges widget displays values for CPU and CPU Usage
+    max, high, average, and low, if at least one days" worth of metrics
+    have been captured.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.right_size
+@pytest.mark.tier(1)
+def test_nor_cpu_rhv41():
+    """
+    Normal Operating Ranges for CPU display correctly for RHV 4.1 VM.
+    Compute > Infrastructure > Virtual Machines > select a VM running on a
+    RHV 4.1 provider
+    Normal Operating Ranges widget displays values for CPU and CPU Usage
+    max, high, average, and low, if at least one days" worth of metrics
+    have been captured.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.right_size
+@pytest.mark.tier(2)
+def test_nor_cpu_vsphere55():
+    """
+    Test Normal Operating Range for CPU usage
+    Compute > Infrastructure > Virtual Machines > select a VM running on a
+    vSphere 5.5 provider
+    Normal Operating Ranges widget displays values for CPU and CPU Usage
+    max, high, average, and low, if at least one days" worth of metrics
+    have been captured.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_dialogs_including_a_tag_control_element_should_submit_the_dialog():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1569470
+    1. create a dialog with a tag control element
+    2. configure the tag control element to be required
+    3. associated the dialog with a service
+    4. log into self-service to load the dialog
+    5. Submit the dialog
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        initialEstimate: 1/4h
+        title: Dialogs including a tag control element should submit the dialog
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.retirement
+@pytest.mark.tier(2)
+def test_retire_infra_vms_notification_folder():
+    """
+    test the retire funtion of vm on infra providers, select at least two
+    vms and press retirement date button from vms main page and specify
+    retirement warning period (1week, 2weeks, 1 months).
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: prov
+        caseimportance: medium
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware65_test_vm_migration_from_iscsi_storage_in_vmware_osp():
+    """
+    OSP: vmware65-Test VM migration from iSCSI Storage in VMware to NFS on
+    OSP
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware65-Test VM migration from iSCSI Storage in VMware OSP
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_retry_plan():
+    """
+    OSP: Test retry plan
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test retry plan
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.storage
+def test_storage_volume_detach_openstack():
+    """
+    Requires:
+    test_storage_volume_attach[openstack]
+    Steps to test:
+    1. Go to Storage -> Block Storage -> Volumes
+    2. Select volume from test_storage_openstack_volume_attach
+    3. Configuration -> Detach this Cloud Volume from an instance
+    4. Select instance from test_storage_openstack_volume_attach and Save
+    5. Check whether volume was detached from that instance
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        initialEstimate: 1/8h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rbac
+@pytest.mark.tier(2)
+def test_verify_that_users_can_access_help_documentation():
+    """
+    Verify that admin and user"s with access to Documentation can view the
+    PDF documents
+    Relevant BZ:
+    https://bugzilla.redhat.com/show_bug.cgi?id=1563241
+
+    Polarion:
+        assignee: apagac
+        casecomponent: control
+        caseimportance: medium
+        initialEstimate: 1/8h
+        tags: rbac
+        title: Verify that users can access Help Documentation
+        testSteps:
+            1. Login as admin
+            2. Verify that admin can access Help->Documentation and view
+               the supporting documents
+            3. Create a user with product feature Help->Documentation enabled
+            4. Verify that admin can access Help->Documentation and view
+               the supporting documents
+        expectedResults:
+            1. Login successful
+            2. Help documents are visible
+            3. User created
+            4. Help document are visible
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_reconfigure_service_for_dialogs_with_timeout_values():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1442920
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: low
+        initialEstimate: 1/4h
+        title: Test reconfigure service for dialogs with timeout values
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.provision
+@pytest.mark.tier(2)
+def test_provision_with_storage_profile_vsphere():
+    """
+    Starting from vc 55 we may use Storage Profiles(Policies) in CFME
+    Prerequisite - VC with configured Storage Policies/VM with assigned
+    St.Policy
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: prov
+        initialEstimate: 1/6h
+        startsin: 5.7
+        tags: provision, vmware
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_appliance_log_crond():
+    """
+    check that CROND service does not get stopped after appliance has been
+    running.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.cfme_tenancy
+def test_tenantadmin_user_crud():
+    """
+    As a Tenant Admin I want to be able to create users in my tenant
+    1. Login as super admin and create new tenant
+    2. Create new role by copying EvmRole-tenant_administrator
+    3. Create new group and choose role created in previous step and your
+    tenant
+    4. Create new tenant admin user and assign him into group created in
+    previous step
+    5. login as tenant admin
+    6. Perform crud operations
+    Note: BZ 1278484 - tenant admin role has no permissions to create new
+    roles - Workaround is to add modify permissions to
+    tenant_administrator role or Roles must be created by
+    superadministrator
+    5.5.0.13 - after giving additional permissions to tenant_admin - able
+    to create new roles
+
+    Polarion:
+        assignee: mnadeem
+        casecomponent: config
+        initialEstimate: 1/4h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_user_can_download_post_migration_ansible_playbook_log():
+    """
+    OSP: Test user can download post migration ansible playbook log
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test user can download post migration ansible playbook log
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_replication_remote_to_global_by_ip_pglogical():
+    """
+    Test replication from remote region to global using any data type
+    (provider,event,etc)
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: infra
+        caseimportance: critical
+        initialEstimate: 1/4h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.upgrade
+@pytest.mark.tier(2)
+def test_rh_registration_proxy_crud():
+    """
+    Check proxy settings get added and removed from /etc/rhsm/rhsm.conf
+    https://bugzilla.redhat.com/show_bug.cgi?id=1463289
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/12h
+        setup: Provision appliance
+               navigate to Configuration-settings-region-redhat updates
+               Click edit subscription
+               Setup subscription with proxy
+               validate and save
+               check proxy settings are added to rhsm.conf
+               edit subscription again
+               remove proxy settings
+               validate and save
+               check proxy settings are removed from rhsm.conf
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rbac
+def test_requests_in_ui_and_api():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1608554
+    1. Login with user with Services > My Services > Requests > Operate
+    enabled
+    2. View Services > Requests
+    3. Query API on service_requests
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/4h
+        tags: rbac
+        title: Test requests in UI and API
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_childtenant_cloud_cpu_quota_by_enforce():
+    """
+    test cpu quota for child tenant for cloud instance by enforcement
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        initialEstimate: 1/4h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_crud_pod_appliance_ext_db():
+    """
+    deploys pod appliance
+    checks that it is alive
+    deletes pod appliance
+
+    Polarion:
+        assignee: izapolsk
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_add_ec2_provider_with_instance_without_name():
+    """
+    1) Add an ec2 provider with instance without name
+    2) Wait for refresh
+    3) Refresh should complete without errors
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: cloud
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_check_quota_regression():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1554989
+    Update from 5.8.2 to 5.8.3 has broken custom automate method.  Error
+    is thrown for the check_quota instance method for an undefined method
+    provisioned_storage.
+    You"ll need to create an invalid VM provisioning request to reproduce
+    this issue.
+    The starting point is an appliance with a provider configured, that
+    can successfully provision a VM using lifecycle provisioning.
+    1. Add a second provider to use for VM lifecycle provisioning.
+    2. Add a 2nd zone called "test_zone". (Don"t add a second appliance
+    for this zone)
+    3. Set the zone of the second provider to be "test_zone".
+    4. Provision a VM for the second provider, using VM lifecycle
+    provisioning. (The provisioning request should remain in
+    pending/active status and should not get processed because there is no
+    appliance/workers for the "test_zone".)
+    5. Delete the template used in step 4.(Through the UI when you
+    navigate to virtual machines, templates is on the left nav bar, select
+    the template used in step 4 and select: "Remove from Inventory"
+    6. Provisioning a VM for the first provider, using VM lifecycle
+    provisioning should produce the reported error.
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_pod_appliance_db_upgrade():
+    """
+    db scheme/version has been changed
+
+    Polarion:
+        assignee: izapolsk
+        caseimportance: medium
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+def test_embed_tower_exec_play_against_openstack():
+    """
+    Execute playbook against Openstack provider.
+    Workaround must be applied:
+    https://bugzilla.redhat.com/show_bug.cgi?id=1511017
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+@pytest.mark.tier(3)
+def test_chargeback_report_compute_provider():
+    """
+    Assign compute rates to provider;Generate chargeback report and verify
+    that rates are applied to selected providers only
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+@pytest.mark.tier(3)
+def test_chargeback_report_storage_tenants():
+    """
+    Assign storage rates to tenants;Generate chargeback report and verify
+    that rates are applied to the tenant.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+@pytest.mark.tier(3)
+def test_chargeback_report_compute_tenants():
+    """
+    Assign compute rates to tenants;Generate chargeback report and verify
+    that rates are applied to the tenant.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+@pytest.mark.tier(2)
+def test_chargeback_report_storage_tagged_datastore():
+    """
+    Assign storage rates to tagged datastore;Generate chargeback report
+    and verify that rates are applied to selected datastores only
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+@pytest.mark.tier(2)
+def test_chargeback_report_storage_enterprise():
+    """
+    Assign storage rates to Enterprise;Generate chargeback report and
+    verify that rates are applied to Enterprise
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+@pytest.mark.tier(2)
+def test_chargeback_report_compute_cluster():
+    """
+    Assign compute rates to cluster;Generate chargeback report and verify
+    that rates are applied to selected clusters only
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+@pytest.mark.tier(2)
+def test_chargeback_report_compute_enterprise():
+    """
+    Assign compute rates to Enterprise;Generate chargeback report and
+    verify that rates are applied to Enterprise
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+@pytest.mark.tier(3)
+def test_chargeback_report_compute_tagged_vm():
+    """
+    Assign compute rates to tagged Vms;Generate chargeback report and
+    verify that rates are applied to tagged VMs only
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+@pytest.mark.tier(3)
+def test_chargeback_report_storage_datastore():
+    """
+    Assign storage rates to datastore;Generate chargeback report and
+    verify that rates are applied to selected datastores only
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rbac
+@pytest.mark.tier(2)
+def test_authorized_users_can_login():
+    """
+    Verify that authorized users can login successfully with a valid
+    password
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: critical
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_users_azure_windows2016_ntfs():
+    """
+    1. Add Azure provider
+    2. Perform SSA on Windows2016 server.
+    3. Check Users are retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_users_azure_rhel():
+    """
+    1. Add Azure provider
+    2. Perform SSA on RHEL instance.
+    3. Check Users  are retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_users_scvmm2k16_centos_xfs():
+    """
+    Add SCVMM-2016 provider.
+    Perform SSA on CentOS VM.
+    Check whether Users retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_users_scvmm2k12_windows2016_ntfs():
+    """
+    Add SCVMM-2012 provider.
+    Perform SSA on Windows 2016 server VM having NTFS filesystem.
+    Check whether it retrieves Users.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_users_scvmm2k16_windows2016_ntfs():
+    """
+    Add SCVMM-2016 provider.
+    Perform SSA on Windows 2016 server VM having NTFS filesystem.
+    Check whether it retrieves Users.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_users_scvmm2k12_centos_xfs():
+    """
+    Add SCVMM-2012 provider.
+    Perform SSA on CentOS VM.
+    Check whether Users retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_users_ec2_ubuntu():
+    """
+    Add EC-2 provider.
+    Perform SSA on Ubuntu instance.
+    Check whether it retrieves Users.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_users_scvmm2k12_rhel74():
+    """
+    Add SCVMM-2012 provider.
+    Perform SSA on RHEL 7.4 VM.
+    Check whether Users retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_users_azure_ubuntu():
+    """
+    1. Add Azure provider
+    2. Perform SSA on Ubuntu Instance.
+    3. Check Users are retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_users_ec2_fedora():
+    """
+    Add EC-2 provider.
+    Perform SSA on Fedora instance.
+    Check whether it retrieves Users.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_users_scvmm2k16_rhel74():
+    """
+    Add SCVMM-2016 provider.
+    Perform SSA on RHEL 7.4 VM.
+    Check whether Users retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_users_rhos7_ga_fedora_22_ext4():
+    """
+    test_ssa_users[rhos7-ga-fedora-22-ext4]
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/2h
+        startsin: 5.3
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_users_scvmm2k16_windows2012r2_ntfs():
+    """
+    Add SCVMM-2016 provider.
+    Perform SSA on Windows 2012 server R2 VM having NTFS filesystem.
+    Check whether it retrieves Users.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_users_scvmm2k12_windows2012r2_ntfs():
+    """
+    Add SCVMM-2012 provider.
+    Perform SSA on Windows 2012 server R2 VM having NTFS filesystem.
+    Check whether it retrieves Users.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_users_ec2_rhel():
+    """
+    Add EC-2 provider.
+    Perform SSA on RHEL instance.
+    Check whether it retrieves Users.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_users_azure_windows2012r2_ntfs():
+    """
+    1. Add Azure provider
+    2. Perform SSA on Windows server 2012 R2.
+    3. Check Users are retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_users_ec2_windows2012r2_ntfs():
+    """
+    Add EC-2 provider.
+    Perform SSA on Windows 2012 server R2 VM having NTFS filesystem.
+    Check whether it retrieves Users.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_cloud_icons_instances():
+    """
+    Requirement: Have a cloud provider added.Navigate to Compute -> Cloud
+    -> Instances
+    Mark off any instance.
+    Go through all select bars and everything on this page and check for
+    missing icons.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/20h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.upgrade
+@pytest.mark.tier(2)
+def test_rh_unregistration_ui():
+    """
+    Check that you can unregister an appliance from subscriptions through
+    the ui.
+    https://bugzilla.redhat.com/show_bug.cgi?id=1464387
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/12h
+        setup: Provision appliance
+               navigate to Configuration-settings-region-redhat updates
+               Click edit subscription
+               Setup subscription
+               validate and save
+               Register appliance
+               Try to unregister
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.config_management
+@pytest.mark.tier(1)
+def test_config_manager_remove_objects_ansible_tower_310():
+    """
+    1) Add Configuration manager
+    2) Perform refresh and wait until it is successfully refreshed
+    3) Remove provider
+    4) Click through accordion and double check that no objects (e.g.
+    tower job templates) were left in the UI
+
+    Polarion:
+        assignee: nachandr
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_set_ownership_back_to_default():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1483512
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Set Ownership back to default
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.provision
+@pytest.mark.tier(2)
+def test_vm_placement_with_duplicated_folder_name_vmware():
+    """
+    This testcase is related to -
+    https://bugzilla.redhat.com/show_bug.cgi?id=1414136
+    Description of problem:
+    Duplicate folder names between host & vm/templates causes placement
+    issues
+    Hosts & Clusters shared a common folder name with a folder that also
+    resides in vm & templates inside of VMWare which will cause CloudForms
+    to attempt to place a vm inside of the Host & Clusters folder.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: prov
+        caseimportance: low
+        initialEstimate: 1/4h
+        startsin: 5.7
+        testtype: nonfunctional
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+def test_after_setting_certain_types_of_filters_filter_tab_should_be_accessible_and_editable():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1519809
+    Steps to Reproduce:
+    1.configure a report using a filter based on "EVM Custom Attributes:
+    Name" and "EVM Custom Attributes: Value"
+    2.
+    3.
+    Actual results:
+    after saving changes, trying to edit the filter will result in the
+    user looping and being unable to access the page. Attempts to access
+    the report will also cause puma to consume all cpu on at least one
+    thread
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: After setting certain types of filters filter tab should be
+               accessible and editable
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.configuration
+def test_can_only_select_this_regions_zones_when_changing_server_zone():
+    """
+    Bug 1470283 - zones of sub region show up as zones appliances of a
+    central region can move to
+    https://bugzilla.redhat.com/show_bug.cgi?id=1470283
+    Configure 1 appliance for use as a reporting db server, with region
+    99. Create zones zone-99-a and zone-99-b.
+    Configure a 2nd appliance as a remote appliance, with region 0. Create
+    zones zone-0-a and zone-0-b.
+    In the web UI of the 1st appliance, change the zone of the appliance.
+    Verify that only the zones for this appliance"s region (i.e.,
+    zone-99-a and zone-99-b) appear in the drop-down list.
+    1.) Set up first appliance:
+    a.) Request appliance that isn"t pre-configured.
+    b.) ssh to appliance and run appliance_console.
+    c.) Choose:
+    > Configure Database
+    > Create key
+    > Create Internal Database
+    Should this appliance run as a standalone database server?    ? (Y/N):
+    |N|
+    Enter the database region number: 99
+    Enter the database password on 127.0.0.1: smartvm
+    d.) Log in to the web UI and enable only the following Server Roles:
+    Reporting
+    Scheduler
+    User Interface
+    Web Services
+    e.) Create two more zones: tpapaioa-99-a and tpapaioa-99-b
+    2.) set up second appliance:
+    a.) request appliance that is pre-configured.
+    b.) Log in to the web UI and enable replication:
+    Administrator > Configuration > Settings > Region 0 > Replication >
+    Type: Remote > Save
+    3.) on the first appliance:
+    a.) set up replication for the second appliance:
+    Administrator > Configuration > Settings > Region 99 > Replication >
+    Type: Global > Add Subscription >
+    Database    vmdb_production
+    Host        <ip address of 2nd appliance>
+    Username    root
+    Password    smartvm
+    Port        5432
+    > Accept > Save
+    4.) on the second appliance, create two more zones: tpapaioa-0-a and
+    tpapaioa-0-b.
+    5.) on the first appliance, click on the appliance"s Zone drop-down
+    menu, and verify that only tpapaioa-99-a and tpapaioa-99-b are
+    visible:
+    Administrator > Configuration > Server > Zone
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Can only select this region's zones when changing server zone
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware65_test_vm_migration_with_windows_7():
+    """
+    OSP: vmware65-Test VM migration with Windows 7
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware65-Test VM migration with Windows 7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(3)
+def test_service_ansible_overridden_extra_vars():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1444107Once a Ansible
+    Playbook Service Dialog is built, it has default parameters, which can
+    be overridden at "ordering" time. Check if the overridden parameters
+    are passed.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+def test_embed_tower_add_public_repo():
+    """
+    Ability to add public repo (without SCM credentials).
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: critical
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(2)
+def test_disable_toast_notifications_by_role_in_sui():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1496233
+
+    Polarion:
+        assignee: nansari
+        casecomponent: ssui
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.9
+        title: Disable toast notifications by role in SUI
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_ec2_flavor_list_up_to_date():
+    """
+    Requirement: EC2 Provider
+    1) Go to Compute -> Cloud -> Instances
+    2) Try to provision an HVM instance
+    3) Go to Properties and compare hvm instance types with HVM instance
+    types in AWS console.
+    4) AWS console instance types list should be equal to instance types
+    in CFME
+    5) Try to provision an paravirtual instance
+    6) Go to Properties and compare paravirtual instance types with
+    paravirtual instance types in AWS console.
+    7) AWS console instance types list should be equal to instance types
+    in CFME
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: cloud
+        initialEstimate: 1/3h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(3)
+def test_verify_ldap_user_login_when_email_has_an_apostrophe_character():
+    """
+    refer the BZ:
+    https://bugzilla.redhat.com/show_bug.cgi?id=1379420
+
+    Polarion:
+        assignee: apagac
+        caseimportance: low
+        initialEstimate: 1/3h
+        title: verify ldap user login when email has an apostrophe character
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_user_quota_via_ssui():
+    """
+    Create user quota
+    assign some quota limitations
+    try to provision over limit via ssui
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        initialEstimate: 1/4h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.cfme_tenancy
+def test_tenant_automation_domains():
+    """
+    Tenants can see Automation domains owned by tenant or parent tenants
+    1) Configure LDAP authentication on CFME
+    2) Create 2 different parent parent-tenants
+    - marketing
+    - finance
+    2) Create groups marketing and finance (these are defined in LDAP) and
+    group names in LDAP and CFME must match
+    Assign these groups to corresponding tenants and assign them EvmRole-
+    SuperAdministrator roles
+    3) In LDAP we have 3 users:
+    - bill -> member of marketing group
+    - jim -> member of finance group
+    - mike -> is member of both groups
+    4) In each tenant create new Automation domain and copy
+    ManageIQ/System/Request/InspectMe instance and
+    ManageIQ/System/Request/new_method method to new domain
+    5) User can see only domains (locked) from his parent tenants and can
+    create his own which are visible only to his tenant
+
+    Polarion:
+        assignee: mnadeem
+        casecomponent: config
+        initialEstimate: 1/4h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware67_test_vm_migration_with_windows_10():
+    """
+    OSP: vmware67-Test VM migration with Windows 10
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: critical
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware67-Test VM migration with Windows 10
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(3)
+def test_candu_graphs_vm_compare_cluster_vsphere6():
+    """
+    test_candu_graphs_vm_compare_cluster[vsphere6]
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: low
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(3)
+def test_candu_graphs_vm_compare_cluster_vsphere65():
+    """
+    test_candu_graphs_vm_compare_cluster[vsphere65]
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_git_domain_import_with_no_connection():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1391208
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+@pytest.mark.tier(1)
+def test_reports_create_schedule_send_report():
+    """
+    Create schedule
+    Send an E-mail" and add more than five users in the mailing list.
+    Un-check "Send if Report is Empty" option and select the type of
+    attachmentQueue up this Schedule
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.cloud_init
+@pytest.mark.tier(1)
+def test_cloud_init_cfme():
+    """
+    test adding cloud init payload to cfme appliance (infra-PXE clod init)
+
+    Polarion:
+        assignee: None
+        casecomponent: appl
+        endsin: 5.4
+        initialEstimate: 1/2h
+        startsin: 5.4
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_schema_field_without_type():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1365442
+    It shouldn"t be possible to add a field without specifying a type.
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_packages_ec2_ubuntu():
+    """
+    Add EC-2 provider.
+    Perform SSA on Ubuntu instance.
+    Check whether it retrieves Packages.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_packages_scvmm2k12_rhel74():
+    """
+    Add SCVMM-2012 provider.
+    Perform SSA on RHEL 7.4 VM.
+    Check whether Packages retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_packages_rhos7_ga_fedora_22_ext4():
+    """
+    test_ssa_packages[rhos7-ga-fedora-22-ext4]
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/2h
+        startsin: 5.3
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_packages_ec2_fedora():
+    """
+    Add EC-2 provider.
+    Perform SSA on Fedora instance.
+    Check whether it retrieves Packages.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_packages_scvmm2k16_centos_xfs():
+    """
+    Add SCVMM-2016 provider.
+    Perform SSA on CentOS VM.
+    Check whether Packages retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_packages_ec2_rhel():
+    """
+    Add EC-2 provider.
+    Perform SSA on RHEL instance.
+    Check whether it retrieves Packages.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_packages_scvmm2k12_windows2016_ntfs():
+    """
+    Add SCVMM-2012 provider.
+    Perform SSA on Windows 2016 server VM having NTFS filesystem.
+    Check whether it retrieves Applications.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_packages_azure_ubuntu():
+    """
+    1. Add Azure provider
+    2. Perform SSA on Ubuntu Instance.
+    3. Check Packages are retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_packages_azure_windows2016_ntfs():
+    """
+    1. Add Azure provider
+    2. Perform SSA on Windows2016 server.
+    3. Check Applications are retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_packages_scvmm2k12_windows2012r2_ntfs():
+    """
+    Add SCVMM-2012 provider.
+    Perform SSA on Windows 2012 server R2 VM having NTFS filesystem.
+    Check whether it retrieves Applications.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_packages_scvmm2k16_rhel74():
+    """
+    Add SCVMM-2016 provider.
+    Perform SSA on RHEL 7.4 VM.
+    Check whether Packages retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_packages_scvmm2k16_windows2012r2_ntfs():
+    """
+    Add SCVMM-2016 provider.
+    Perform SSA on Windows 2012 server R2 VM having NTFS filesystem.
+    Check whether it retrieves Applications.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_packages_ec2_windows2012r2_ntfs():
+    """
+    Add EC-2 provider.
+    Perform SSA on Windows 2012 server R2 VM having NTFS filesystem.
+    Check whether it retrieves Applications.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_packages_scvmm2k16_windows2016_ntfs():
+    """
+    Add SCVMM-2016 provider.
+    Perform SSA on Windows 2016 server VM having NTFS filesystem.
+    Check whether it retrieves Applications.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_packages_azure_rhel():
+    """
+    1. Add Azure provider
+    2. Perform SSA on RHEL instance.
+    3. Check Packages are retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_packages_azure_windows2012r2_ntfs():
+    """
+    1. Add Azure provider
+    2. Perform SSA on Windows server 2012 R2.
+    3. Check Packages are retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_packages_scvmm2k12_centos_xfs():
+    """
+    Add SCVMM-2012 provider.
+    Perform SSA on CentOS VM.
+    Check whether Packages retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_verify_ldap_authentication_works_without_groups_from_ldap_by_uncheck_the_get_user_gro():
+    """
+    verify LDAP authentication works without groups from LDAP
+    refer this bz: https://bugzilla.redhat.com/show_bug.cgi?id=1302345
+    Steps:
+    1.In Configuration->Authentication, set the auth mode to LDAP.
+    LDAP Hostname: "cfme-openldap-rhel7.cfme.lab.eng.rdu2.redhat.com"
+    LDAP Port: 389
+    UserType: Distinguished Name (UID=<user>)
+    User Suffix: UID=<user> :  ou=people,ou=prod,dc=psavrocks,dc=com
+    2. uncheck the "Get User Groups from LDAP"
+    3. In Access Control -> Users, created new user
+    "uid=test,ou=people,ou=prod,dc=psavrocks,dc=com" and set Group to
+    EvmGroup-administrator
+    ("uid=test,ou=people,ou=prod,dc=psavrocks,dc=com" user is already
+    created in LDAP Server)
+    4. Logout and tried Login with username: test and password: test,
+    Login failed.
+    Expected results:
+    Base DN should always be visible and should be part of the LDAP
+    Settings, when it is always needed.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/4h
+        title: verify LDAP authentication works without groups from LDAP by
+               uncheck the "Get User Groups from LDAP"
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_tagvis_ansible_tower_tag_configured_system():
+    """
+    "Setup: Create group with tag, use this group for user creation
+    1. Add tag(used in group) for Ansible Tower configured_system via
+    detail page
+    2. Remove tag for Ansible Tower configured_system via detail page
+    3. Add tag for Ansible Tower configured_system via list
+    4. Check Ansible Tower configured_system is visible for restricted
+    user
+    5. Remove tag for Ansible Tower configured_system via list
+    6 . Check ansible tower configured_system isn"t visible for restricted
+    user"
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_vmware_vds_ui_display():
+    """
+    Virtual Distributed Switch port groups are displayed for VMs assigned
+    to vds port groups.
+    Compute > Infrastructure > Host > [Select host] > Properties > Network
+
+    Polarion:
+        assignee: None
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/12h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(3)
+def test_verify_login_fails_for_user_in_cfme_after_changing_the_password_in_saml_for_the_user():
+    """
+    Configure SAML for cfme.
+    Create user and assign group in saml.
+    Create groups in cfme, and login and SAML user.
+    Logout
+    Change user credentials in SAML server.
+    Verify user login  to CFME using old credential fails.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/4h
+        title: Verify login fails for user in CFME after changing the
+               Password in SAML for the user.
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_automate_retry_onexit_increases():
+    """
+    To reproduce:
+    1) Import the attached file, it will create a domain called
+    OnExitRetry
+    2) Enable the domain
+    3) Go to Automate / Simulation
+    4) Simulate Request with instance OnExitRetry, execute methods
+    5) Click submit, open the tree on right and expand ae_state_retries
+    It should be 1 by now and subsequent clicks on Retry should raise the
+    number if it works properly.
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_proxy_invalid_azure():
+    """
+    With 5.7 there is a new feature that allows users to specific a
+    specific set of proxy settings for each cloud provider.  The way you
+    enable this is to go to Configuration/Advanced Settings and scroll
+    down to the azure proxy settings.  You just need to fill in the
+    appropriate information, only screw up a few of the values to make
+    sure it reports a connection error.
+    Here are the proxy instructions:
+    https://mojo.redhat.com/docs/DOC-1103999
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/2h
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_proxy_invalid_gce():
+    """
+    With 5.7 there is a new feature that allows users to specific a
+    specific set of proxy settings for each cloud provider.  The way you
+    enable this is to go to Configuration/Advanced Settings and scroll
+    down to the azure proxy settings.  You just need to fill in the
+    appropriate information, only screw up a few of the values to make
+    sure it reports a connection error.
+    Here are the proxy instructions:
+    https://mojo.redhat.com/docs/DOC-1103999
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/8h
+        setup: The only thing different you need to do for this is enter some wrong
+               information and Refresh Relationships.  Wait two minutes and refresh
+               the page.  You"ll definitely get an error if any of the values are
+               wrong.
+        startsin: 5.7
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_proxy_invalid_default():
+    """
+    With 5.7 there is a new feature that allows users to specify a
+    specific set of proxy settings for each cloud provider.  The way you
+    enable this is to go to Configuration/Advanced Settings and scroll
+    down to the default proxy settings.  You just need to fill in the
+    appropriate information, only screw up a few of the values to make
+    sure it reports a connection error.
+    Here are the proxy instructions:
+    https://mojo.redhat.com/docs/DOC-1103999
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/2h
+        setup: The mojo page has all the information you will need.
+        startsin: 5.7
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_proxy_invalid_ec2():
+    """
+    With 5.7 there is a new feature that allows users to specify a
+    specific set of proxy settings for each cloud provider.  The way you
+    enable this is to go to Configuration/Advanced Settings and scroll
+    down to the ec2 proxy settings.  You just need to fill in the
+    appropriate information, only screw up a few of the values to make
+    sure it reports a connection error.
+    Here are the proxy instructions:
+    https://mojo.redhat.com/docs/DOC-1103999
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/4h
+        setup: Follow the instructions in the mojo document.
+        startsin: 5.7
+        teardown: You should probably reset or delete the changes.
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_tagvis_tag_and_host_combination():
+    """
+    Combine My Company tag tab restriction, with Clusters&Host tab
+    Visible host should match both tab restrictions
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.log_depot
+@pytest.mark.tier(1)
+def test_log_collect_current_server_zone_setup():
+    """
+    using any type of depot check collect current log function under
+    appliance (settings under server should not be configured, under zone
+    should be configured)
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(2)
+def test_crosshair_op_instance_gce():
+    """
+    Utilization Test
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(2)
+def test_crosshair_op_instance_azure():
+    """
+    Utilization Test
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(2)
+def test_crosshair_op_instance_ec2():
+    """
+    Verify that the following cross-hair operations can be performed on
+    each of the C&U graphs for an instance:
+    1.Chart
+    1.1 Hourly for this day and then back to daily
+    2.Timeline
+    2.1 Daily events on this VM
+    2.2 Hourly events for this VM
+
+    Polarion:
+        assignee: mshriver
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/12h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.log_depot
+@pytest.mark.tier(1)
+def test_log_collect_current_server_server_setup():
+    """
+    using any type of depot check collect current log function under
+    appliance (settings under applince should be configured, under zone
+    should not be configured)
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_edit_migration_plan():
+    """
+    OSP: Test edit migration plan
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test edit migration plan
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_proxy_valid_gce():
+    """
+    With 5.7.1 there is a new feature that allows users to specific a
+    specific set of proxy settings for each cloud provider.  The way you
+    enable this is to go to Configuration/Advanced Settings and scroll
+    down to the azure proxy settings.  You just need to fill in the
+    appropriate information
+    Here are the proxy instructions:
+    https://mojo.redhat.com/docs/DOC-1103999
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/4h
+        setup: Configure advanced settings for GCE proxy.
+               Add gce provider
+               Probably need to check the packets to make sure they are vectoring
+               through the proxy server, or just check the proxy server log.
+        startsin: 5.7
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_proxy_valid_default():
+    """
+    With 5.7 there is a new feature that allows users to specific a
+    specific set of proxy settings for each cloud provider.  The way you
+    enable this is to go to Configuration/Advanced Settings and scroll
+    down to the azure proxy settings.  You just need to fill in the
+    appropriate information
+    Here are the proxy instructions:
+    https://mojo.redhat.com/docs/DOC-1103999
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/2h
+        setup: Follow the instructions in the mojo doc above.
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_proxy_valid_azure():
+    """
+    With 5.7 there is a new feature that allows users to specific a
+    specific set of proxy settings for each cloud provider.  The way you
+    enable this is to go to Configuration/Advanced Settings and scroll
+    down to the azure proxy settings.  You just need to fill in the
+    appropriate information
+    Here are the proxy instructions:
+    https://mojo.redhat.com/docs/DOC-1103999
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/2h
+        setup: Configure advanced settings for Azure proxy.
+               Add azure provider
+               Probably need to check the packets to make sure they are vectoring
+               through the proxy server, or just check the proxy server log.
+        startsin: 5.7
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_proxy_valid_ec2():
+    """
+    With 5.7 there is a new feature that allows users to specify a
+    specific set of proxy settings for each cloud provider.  The way you
+    enable this is to go to Configuration/Advanced Settings and scroll
+    down to the ec2 proxy settings.  You just need to fill in the
+    appropriate information
+    Here are the proxy instructions:
+    https://mojo.redhat.com/docs/DOC-1103999
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/2h
+        setup: Follow the instructions in the mojo doc above as it is easier to
+               change in one place.
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_simulation_result_has_hash_data():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1445089
+    The UI should display the result objects if the Simulation Result has
+    hash data.
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_verify_two_factor_authentication_works_with_user_password_and_otp():
+    """
+    Verifies two factor auth using external_authentication:
+    Steps:
+    1. configure CFME for external auth (IPA, SAML etc..)
+    2. configure user for OTP in authentication server.
+    3. verify two factor authentication for CFME works with user password
+    and otp.
+
+    Polarion:
+        assignee: apagac
+        initialEstimate: 1/3h
+        title: verify two factor authentication works with user password and otp.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_add_amazon_credentials():
+    """
+    Add Amazon credentials.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_timepicker_should_pass_correct_timing_on_service_order():
+    """
+    Timepicker doesn"t pass correct timing on service order
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Timepicker should pass correct timing on service order
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(2)
+def test_candu_graphs_cluster_hourly_vsphere55():
+    """
+    test_candu_graphs_cluster_hourly[vsphere55]
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: low
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_should_be_able_to_see_requests_if_our_users_are_in_groups_with_managed_tags():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1596738
+    rootTenant
+    |
+    subTenant
+    /           |               \
+    sub2Tenant sub2Tenant2 sub2Tenant3
+    usiness_group, can be: team1, team2, team3
+    business_unit, can be: fr, de, uk
+    We have 3 user groups:
+    groupA, attached to rootTenant and no filter, custom role full access
+    groupB, attached to rootTenant and filter business_unit=fr, custom
+    role access to catalog, services and machines
+    groupC, attached to sub2Tenant and filter business_unit=fr &
+    business_group=teamC, custom role access to catalog, services and
+    machines (same as for groupB)
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        initialEstimate: 1/4h
+        title: Should be able to see requests if our users are in groups with managed tags
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+@pytest.mark.tier(2)
+def test_chargeback_resource_allocation_cpu_allocated():
+    """
+    Verify CPU allocation in a Chargeback report based on resource
+    allocation. C&U data is not considered for these reports.
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+@pytest.mark.tier(2)
+def test_chargeback_resource_allocation_memory_allocated():
+    """
+    Verify memory allocation in a Chargeback report based on resource
+    allocation.C&U data is not considered for these reports.
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+@pytest.mark.tier(2)
+def test_chargeback_resource_allocation_storage_allocated():
+    """
+    Verify storage allocation in a Chargeback report based on resource
+    allocation. C&U data is not considered for these reports.
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_ldap_user_group():
+    """
+    verifies the ldap user group by loggin with different users across
+    groups.
+    setup/pre-requisite: configure the ldap with multiple groups and users
+    defined in each group
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        initialEstimate: 1/4h
+        testSteps:
+            1.configure CFME appliance with ldap authentication mode.
+            2. configure Access Control for multiple groups/users defined in the ldap
+            3. login with users in different groups, with valid credentials
+            4. verify the user logged in has no access to the user
+               details/data defined in other groups
+        expectedResults:
+            1. ldap configuration should be successful.
+            2. CFME configuration for multiple users/groups should work without any error.
+            3. login should be successful upon valid credentials input.
+            4. user should have access to only the data defined by him/group
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_replication_appliance_set_type_global_ui():
+    """
+    Set appliance replication type to "Global" and add subscription in the
+    UI
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: infra
+        caseimportance: critical
+        initialEstimate: 1/6h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_git_import_without_master():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1508881
+    Git repository doesn"t have to have master branch
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_edit_catalog_item_after_remove_resource_pool():
+    """
+    Create catalog item with a resource pool , Remove resource pool from
+    the provider and then edit catalog item.
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: low
+        initialEstimate: 1/8h
+        startsin: 5.5
+        testSteps:
+            1. Create a catalog item
+            2. Select cluster and resource pool and Save
+            3. Remove resource pool from provider
+            4. Edit catalog
+        expectedResults:
+            1.
+            2.
+            3.
+            4. Validation message should be shown
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_optimize_memory_usage_by_making_object_in_hash():
+    """
+    The object in the hash reference should be as small as possible,
+    so we don"t need to store that many data in memory.
+
+    Polarion:
+        assignee: None
+        casecomponent: appl
+        initialEstimate: 1h
+        title: Optimize memory usage by making object in hash
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.general_ui
+@pytest.mark.tier(1)
+def test_key_pairs_quadicon():
+    """
+    BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1352914
+    Requirement: Have a cloud provider with at least one key pair
+    1. Go to Compute -> Cloud -> Key Pairs
+    2. Set View to Grid
+    3. Cloud with two keys icon should be displayed(auth_key_pair.png)
+    4. Same in Key Pairs summary.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: cloud
+        caseimportance: low
+        initialEstimate: 1/20h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_default_views_can_save_or_reset():
+    """
+    BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1389225
+    1) Go to My Settings -> Default views
+    2) Change something and try to reset configuration
+    3) Change something and try to save it
+
+    Polarion:
+        assignee: pvala
+        casecomponent: config
+        initialEstimate: 1/20h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_schedule_global_filters():
+    """
+    Navigate to add new schedule page(Configuration->Region->Schedules)
+    Fill all required fields
+    Select some global filter
+    Set timer
+    Save changes
+    Result: Task run successfully for selected filter
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_disabling_dashboard_under_service_ui_for_a_role_shall_disable_the_dashboard():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1589409
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Disabling "Dashboard" under service UI for a role shall disable the dashboard
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_ec2_targeted_refresh_volume():
+    """
+    #AWS naming is EBS
+    Volume CREATE
+    Volume UPDATE
+    Volume DELETE
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: cloud
+        initialEstimate: 2/3h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_appliance_console_network_conf_negative():
+    """
+    test network configuration error with invalid settings
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.upgrade
+@pytest.mark.tier(2)
+def test_upgrade_multi_replication_inplace():
+    """
+    test_upgrade_multi_replication_inplace
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1h
+        setup: 2 appliances:
+               - Appliance A: internal DB, region 0
+               - Appliance B: external DB, pointed at A, region 0
+               - Setup LDAP on one of the appliances
+               - Login as LDAP user A
+               - Setup a provider
+               - Provision a VM
+        testtype: upgrade
+        testSteps:
+            1. Run upgrade according to the migration guide (version-dependent)
+            2. Start the appliances back up
+            3. Login as LDAP user B
+            4. Add another provider
+            5. Provision another VM using the new provider
+            6. Visit provider/host/vm summary pages
+        expectedResults:
+            1. Upgrade is successful, so is migration and related tasks (fix_auth)
+            2. Appliances are running
+            3. Login is successful
+            4. Provider added
+            5. VM provisioned
+            6. Summary pages can be loaded and show correct information
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware67_test_vm_migration_from_nfs_storage_in_vmware_to_iscsi_on_osp():
+    """
+    OSP: vmware67-Test VM migration from NFS Storage in VMware to iSCSI on
+    OSP
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware67-Test VM migration from NFS Storage in VMware to iSCSI on OSP
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rbac
+def test_view_quotas_without_manage_quota_permisson():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1535556
+    1. disable "manage quota" from the role of a user
+    2. try to view quotas as that user
+    copy the EVMRole-tenant_quota_administrator role, disable Settings ->
+    Configuration -> Access Control -> Tenants -> Modify -> Manage Quotas
+    and still view quotas when the "Manage Quotas" button was no longer
+    available.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: None
+        tags: rbac
+        title: Test view quotas without manage quota permisson
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_ec2_proxy():
+    """
+    1) Go to Configuration -> Advanced Settings
+    2) Find:
+    :http_proxy:
+    :ec2:
+    :host:
+    :password:
+    :port:
+    :user:
+    and fill in squid proxy credentials
+    3) Add an ec2 provider
+    4) Check whether traffic goes through squid proxy
+    5) Check whether ec2 provider was refreshed successfully
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: cloud
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(3)
+def test_crosshair_op_datastore_vsphere65():
+    """
+    Requires:
+    C&U enabled Vsphere-65 appliance.
+    Steps:
+    1. Navigate to Datastores [Compute > infrastructure>Datastores]
+    2. Select any available datastore
+    3. Go for utilization graphs [Monitoring > Utilization]
+    4. Check data point on graphs ["Used Disk Space", "Hosts", "VMs"]
+    using drilling operation on the data points.
+    5.  check "chart" and "display" option working properly or not.
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.drift
+@pytest.mark.tier(1)
+def test_drift_analysis_vpshere6_rhel():
+    """
+    1. Go to Compute-> Infrastructure-> Virtual Machines -> Select any vm
+    for SSA
+    2. Perform SSA on VM
+    3. Next, Reconfigure the VM with change in memory and CPU etc.
+    4. Again perform SSA on VM
+    5. Next, compare drift history
+    6. Check the drift comparison
+    Validate that updated values get displayed.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
+        startsin: 5.3
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_bundle_stack_deployment():
+    """
+    bundle stack provisioning for entry point catalog items
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_appliance_console_vmdb_httpd():
+    """
+    check that httpd starts after restarting vmdb
+    https://bugzilla.redhat.com/show_bug.cgi?id=1337525
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_project_cloud_memory_quota_by_enforce():
+    """
+    test memory quota for project for cloud instance by enforcement
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        initialEstimate: 1/4h
+        setup: Prerequisities:
+               * A provider set up, supporting provisioning in CFME
+        startsin: 5.5
+        testSteps:
+            1. Set the project tenant quota for cpu by UI enforcement
+            2. Open the provisioning dialog.
+            3. Apart from the usual provisioning settings, set memory
+               greater then tenant quota memory
+            4. Submit the provisioning request and wait for it to finish.
+            5. Visit the requests page. The last message should state quota validation message
+        expectedResults:
+            1.
+            2.
+            3.
+            4.
+            5.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rbac
+def test_provider_refresh_via_api():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1602413
+    1. set up a new user with a new group based on vm_user plus api access
+    and refresh access to cloud and infrastructure providers
+    2. issue a refresh using the classic ui with that user
+    3. issue a refresh of the same provider using the api
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/4h
+        tags: rbac
+        title: Test provider refresh via API
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rest
+def test_tenant_parent_name_rest():
+    """
+    When you change the main parent tenant"s name that change is not
+    reflected in api calls
+
+    Polarion:
+        assignee: mkourim
+        caseimportance: medium
+        initialEstimate: None
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.discovery
+@pytest.mark.tier(1)
+def test_infrastructure_providers_rhevm_edit_provider_no_default_port():
+    """
+    1) Add a rhevm provider
+    2) Edit it and try to change it to another rhevm provider
+    3) There shouldn"t be any default API port and API port should be
+    blank
+
+    Polarion:
+        assignee: pvala
+        casecomponent: infra
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(2)
+def test_utilization_host():
+    """
+    Verify гutilication data from host
+
+    Polarion:
+        assignee: None
+        casecomponent: optimize
+        caseimportance: medium
+        initialEstimate: 1/8h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_state_machine_variable():
+    """
+    Test whether storing the state machine variable works and the vaule is
+    available in another state.
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rbac
+@pytest.mark.tier(2)
+def test_credentials_login_password_blank():
+    """
+    No password
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/8h
+        tags: rbac
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_value_input_into_service_dialog_element():
+    """
+    A value input into a service dialog element is not always visible to
+    another dynamic element that is set to auto refresh
+    https://bugzilla.redhat.com/show_bug.cgi?id=1364407
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/16h
+        startsin: 5.5
+        title: test value input into service dialog element
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_vm_owner_before_and_after_migration_remains_same():
+    """
+    OSP: Test VM owner before and after migration remains same
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test VM owner before and after migration remains same
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_multiple_vm_provision_with_public_ip_azure():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1531275
+    Wait for BZ to get resolved first. Design solution still wasn"t made
+    "This isn"t a dup of the other ticket, as the distinction is single vs
+    multiple VM"s. So, what we need to do is alter the UI to allow two
+    options when provisioning multiple VM"s - public or private."
+    1.Provision multiple VMs w/ or w/o Public IP
+    Currently we are not able to select any Public IP option when we
+    provision multiple VMs - all VMs will get new Public IP
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_ui_requests_notifications():
+    """
+    After all processes are running and websockets role is enabled, add a
+    new repo to embedded tower and check the notifications display
+    correctly. With a Green banner to show it was successful.
+    https://bugzilla.redhat.com/show_bug.cgi?id=1471868
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.right_size
+@pytest.mark.tier(1)
+def test_nor_memory_values_correct_vsphere6():
+    """
+    Compute > Infrastructure > Virtual Machines > select a VM running on a
+    vSphere 6 provider
+    Normal Operating Ranges widget displays correct values for Memory and
+    Memory Usage max, high, average, and low, if at least one days" worth
+    of metrics have been captured:
+    The Average reflects the most common value obtained during the past 30
+    days" worth of captured metrics.
+    The High and Low reflect the range of values obtained ~85% of the time
+    within the past 30 days.
+    The Max reflects the maximum value obtained within the past 30 days.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.right_size
+@pytest.mark.tier(1)
+def test_nor_memory_values_correct_rhv41():
+    """
+    NOR memory values are correct.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(2)
+def test_gap_collection_vsphere6():
+    """
+    Draft
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_vm_reconfig_add_remove_hw_hot_vsphere67_nested_cores_per_socket():
+    """
+    test changing vm"s cpu cores
+
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: 1/6h
+        setup: -get new configured appliance
+               -add vmware provider
+               -provision new vm
+               -select vm
+               -configure-->reconfigure vm
+               -increase/decrease the cpu cores
+               -check changes
+        startsin: 5.5
+        testSteps:
+            1. Increase vm cpu cores
+            2. Decrease vm cpu cores
+        expectedResults:
+            1. Changes shouldn"t succeed
+            2. Changes shouldn"t succeed
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_vm_reconfig_add_remove_hw_hot_vsphere67_nested_sockets():
+    """
+    test change vm"s cpu sockets
+
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: 1/6h
+        setup: -get new configured appliance
+               -add vmware provider
+               -provision new vm
+               -select vm
+               -configure-->reconfigure vm
+               -increase/decreasing cpu sockets
+               -check changes
+        startsin: 5.5
+        testSteps:
+            1. Increase sockets of vm
+            2. Decrease sockets of vm
+        expectedResults:
+            1. Changes should succeed
+            2. Changes shouldn"t succeed
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_vm_reconfig_add_remove_hw_hot_vsphere67_nested_memory():
+    """
+    test changing the memory of a vm
+
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: 1/6h
+        setup: -get new configured appliance
+               -add vmware provider
+               -provision new vm
+               -select vm
+               -configure-->reconfigure vm
+               -increase/decrease the memory and submit
+               -check changes
+        startsin: 5.5
+        testSteps:
+            1. Increase memory of selected VM
+            2. Decrease memory of select vm
+        expectedResults:
+            1. Changes should succeed
+            2. Changes should fail (you can"t hot decrease memory) [Error:
+               The operation is not supported on the object.]
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_vmware_manual_placemant_cluster_only():
+    """
+    VMware MANUAL Placement to Support ONLY Clusters
+
+    Polarion:
+        assignee: None
+        casecomponent: infra
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_api_auth():
+    """
+    The Tower API should not be wide open, authentication is required.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: critical
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_service_retirement_requests_shall_be_run_by_the_user():
+    """
+    Create a request from non-admin user. Request shall be run by user.
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.5
+        title: service retirement requests shall be run by the user
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.settings
+@pytest.mark.tier(3)
+def test_validate_landing_pages_for_rbac():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1450012
+
+    Polarion:
+        assignee: pvala
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/5h
+        title: test validate landing pages for rbac
+        testSteps:
+            1.create a new role by selecting few product features.
+              2.create a group base on the above role and the create a new
+              user with this group 3.Login with the new user and navigate
+              to my settings->visuals and check the start page entries in
+              show at login drop down list
+        expectedResults:
+            1. Display landing pages for which the user has access to
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.discovery
+def test_add_infra_provider_screen():
+    """
+    Manually add provider using Add screen
+    Provider Add:
+    -test form validation using incorrect format for each field
+    -test wrong ip
+    -test wrong credentials
+    -test verify cretentials
+    -test verify wrong credentials
+    -test wrong security protocol
+    -test wrong provider type
+
+    Polarion:
+        assignee: pvala
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_tagvis_tag_and_vm_combination():
+    """
+    Combine My Company tag restriction tab with VM&Tepmlates restriction
+    tab
+    Vm , template should match both tab restrictions
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_migrating_a_vm_which_has_encrypted_disk():
+    """
+    OSP: Test migrating a VM which has encrypted disk
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test migrating a VM which has encrypted disk
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+def test_embed_tower_exec_play_against_gce():
+    """
+    User/Admin is able to execute playbook without creating Job Temaplate
+    and can execute it against Google Compute Engine Cloud with GCE
+    credentials.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.log_depot
+@pytest.mark.tier(1)
+def test_log_collect_all_zone_zone_multiple_servers_server_setup():
+    """
+    using any type of depot check collect all log function under zone.
+    Zone should have multiplie servers under it. Zone should not be setup,
+    servers should
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_new_dialog_editor_entry_point_should_be_mandatory_for_dynamic_elements():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1488579
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        initialEstimate: 1/4h
+        startsin: 5.9
+        title: New dialog editor : Entry point should be mandatory for dynamic elements
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(3)
+def test_group_by_tag_azone_azure():
+    """
+    Utilization Test
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: low
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(3)
+def test_group_by_tag_azone_gce():
+    """
+    Utilization Test
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: low
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_template_info_scvmm():
+    """
+    The purpose of this test is to verify that the same number of
+    templates in scvmm are in cfme.  Take the time to spot check a random
+    template and check that the details correspond to SCVMM details.
+
+    Polarion:
+        assignee: None
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.4
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.snapshot
+@pytest.mark.tier(1)
+def test_snapshot_tree_view_functionality():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1398239
+    Just test the snapshot tree view. Create a bunch of snapshots and see
+    if the snapshot tree seems right. Check if the last created snapshot
+    is active. Revert to some snapshot, then create another bunch of
+    snapshots and check if the tree is correct.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: prov
+        caseimportance: medium
+        initialEstimate: 1/4h
+        setup: https://bugzilla.redhat.com/show_bug.cgi?id=1398239
+        title: Test snapshot tree view functionality
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.cfme_tenancy
+def test_superadmin_child_tenant_delete_parent_catalog():
+    """
+    Child superadmin tenant should able to delete catalog belonging to
+    superadmin in parent tenant. This is by design tenancy has not been
+    split any further and at this point is not expected to be changed
+    Note: As per below BZ#1375713,  Child superadmin tenant should not
+    delete catalog belonging to superadmin in parent tenant. However as
+    per the current code base this is by design: "ServiceTemplate"
+    => :ancestor_ids,
+    https://github.com/ManageIQ/manageiq/blob/2a66cb59e26816c7296896620b5b
+    7731b350943d/lib/rbac/filterer.rb#L114
+    You"re able to see Catalog items of parent and ancestor tenants.  If
+    your role has permission to modify catalog items / delete them, and
+    you can to see ones from ancestor tenants, then you can delete them.
+    https://bugzilla.redhat.com/show_bug.cgi?id=1375713
+
+    Polarion:
+        assignee: mnadeem
+        casecomponent: config
+        initialEstimate: 1/2h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+@pytest.mark.tier(3)
+def test_report_fullscreen_enabled():
+    """
+    Navigate to Intelligence > Reports
+    (queue same report twice)
+    1)Sucesful report generting [populated]
+    Select Generating Report
+    -check Configuration > Show Fullscreen Report is disabled
+    Wait ~1minute and Select sucesfully generated report
+    -check Configuration > Show Fullscreen Report is enabled
+    Select Show Fullscreen Report
+    -check report was shown in fullscreen
+    2)Select report with no data for reporting, queue the report [blank]
+    (queue same report twice)
+    Select Generating Report
+    -check Configuration > Show Fullscreen Report is disabled
+    Wait ~1minute and Select sucesfully generated report
+    -check Configuration > Show Fullscreen Report is disabled
+    Navigate to Intelligence > Saved Reports
+    3)Select group of [populated] reports
+    In table, select one of reports
+    -check Configuration > Show Fullscreen Report is enabled
+    Select Show Fullscreen Report
+    -check report was shown in fullscreen
+    Select both of reports
+    -check Configuration > Show Fullscreen Report is disabled
+    4)Select group of [blank] reports
+    In table, select one of reports
+    -check Configuration > Show Fullscreen Report is disabled
+    Select both of reports
+    -check Configuration > Show Fullscreen Report is disabled
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: low
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_provider_summary_scvmm2016():
+    """
+    The purpose of this test is to verify that the information on the
+    provider summary is substantially the same as what is on SCVMM.
+    Since SCVMM-2016 only has a short sequence of test cases, you must use
+    this test case as the catch all to go in and spend 15-30 minutes and
+    check as many links from this page and verify both the navigation and
+    the content.
+
+    Polarion:
+        assignee: None
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_provider_summary_scvmm():
+    """
+    The purpose of this test is to verify that the information on the
+    provider summary is substantially the same as what is on SCVMM.
+    Since SCVMM-SP1 only has a short sequence of test cases, you must use
+    this test case as the catch all to go in and spend 15-30 minutes and
+    check as many links from this page and verify both the navigation and
+    the content.
+
+    Polarion:
+        assignee: None
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/2h
+        startsin: 5.4
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.tag
+@pytest.mark.tier(2)
+def test_tagvis_host_change():
+    """
+    Enable / Disable a host in the group and check its visibility
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_vm_relationship_datastore_fileshare_scvmm():
+    """
+    Valid for SCVMM with Host which have Fileshare storage
+    1.Provision Vm into fileshare linked to the host
+    2.Check VM"s relationships - Datastore
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.7
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.cfme_tenancy
+@pytest.mark.tier(1)
+def test_verify_groups_for_tenant_user():
+    """
+    verify if only 1 group displayed when login as tenant user ()that one
+    where user belongs to)
+
+    Polarion:
+        assignee: mnadeem
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.tag
+@pytest.mark.tier(2)
+def test_tagvis_provision_fields():
+    """
+    1. Create restricted user
+    2. Check items restrictions for provision fields
+    3. Check items restriction for fields while service order
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: prov
+        caseimportance: medium
+        initialEstimate: 1/3h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_appliance_console_shutdown():
+    """
+    test shutting down the appliance
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_ec2_tags_mapping():
+    """
+    Requirement: Have an ec2 provider
+    1) Create an instance and tag it with test:testing
+    2) Go to Configuration -> CFME Region -> Map Tags
+    3) Add a tag:
+    Entity: Instance (Amazon)
+    Label: test
+    Category: Testing
+    4) Refresh provider
+    5) Go to summary of that instance
+    6) In Smart Management field should be:
+    My Company Tags testing: Testing
+    7) Delete that instance
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/5h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(2)
+def test_instance_quota_reconfigure_with_flavors():
+    """
+    Test reconfiguration of instance using flavors after setting quota
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: cloud
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_appliance_console_static_ip_negative():
+    """
+    test error on invalid static ip
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(3)
+def test_distributed_zone_create_new():
+    """
+    Create new zone in local region
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: config
+        caseimportance: critical
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware60_test_vm_migration_with_rhel_74_5():
+    """
+    OSP: vmware60-Test VM migration with RHEL 7.4/5
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware60-Test VM migration with RHEL 7.4/5
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_project_cloud_vm_quota_by_enforce():
+    """
+    test no of vms quota for project for cloud instance by enforcement
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        initialEstimate: 1/4h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_service_dialog_default_values_should_be_rendered_in_dialog_fields():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1385898
+    Create a dialog .set default value
+    Use the dialog in a catalog .
+    Order catalog.
+    Default values should be shown
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        initialEstimate: 1/8h
+        title: Service Dialog : Default values should be rendered in dialog fields
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_service_dialog_elements_with_regex_validation_should_be_validated():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1518971
+    Steps to Reproduce:
+    1. Create a Service Dialog
+    2. Add an element such as a text box and add a validation regex
+    3. Create a Catalog Item using the previously created Service Dialog
+    4. Order the Catalog Item
+    5. Enter data that fails to validate against the regex
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        initialEstimate: 1/4h
+        title: Service Dialog Elements with regex validation should be validated
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(2)
+def test_replication_appliance_add_multi_subscription():
+    """
+    add two or more subscriptions to global
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        initialEstimate: 1/4h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_verify_smart_mgmt_orchest_template():
+    """
+    Verify Smart Management section in Orchestration template summary
+    page.
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: low
+        initialEstimate: 1/4h
+        startsin: 5.5
+        testtype: structural
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware60_test_vm_with_multiple_disks():
+    """
+    OSP: vmware60-Test VM with multiple Disks
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware60-Test VM with multiple Disks
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_child_dialog_should_update_with_new_options_based_on_option_of_parent_dialog_upon_ref():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1580535
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        initialEstimate: 1/4h
+        title: Child dialog should update with new options based on option
+               of parent dialog upon refreshing
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.general_ui
+def test_notification_window_events_show_in_timestamp_order():
+    """
+    Bug 1469534 - The notification events are out of order
+    https://bugzilla.redhat.com/show_bug.cgi?id=1469534
+    If multiple event notifications are created near-simultaneously (e.g.,
+    several VM"s are provisioned), then clicking on the bell icon in the
+    top right of the web UI displays the event notifications in timestamp
+    order.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.9
+        title: Notification window events show in timestamp order
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_migration_plan_can_be_scheduled_to_run_at_later_date_time():
+    """
+    OSP: Test migration plan can be scheduled to run at later date/time
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test migration plan can be scheduled to run at later date/time
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_dynamic_dropdown_values_should_load_correctly():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1581996
+    Steps to Reproduce:
+    1. Import the dialog and domain attached .
+    2. Select Contract A . Contract B gets selected .
+    3. In Location no values are loaded .
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        initialEstimate: 1/4h
+        title: Dynamic dropdown Values should load correctly
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.right_size
+@pytest.mark.tier(2)
+def test_rightsize_cpu_vsphere55():
+    """
+    Test Right size recommendation for cpu
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.right_size
+@pytest.mark.tier(2)
+def test_rightsize_cpu_vsphere6():
+    """
+    Test Right size recommendation for cpu
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.right_size
+@pytest.mark.tier(1)
+def test_rightsize_cpu_rhv41():
+    """
+    For a RHV 4.1 provider with C & U metrics collection configured and
+    running for >1 day, a VM that has been up and running for >1 day shows
+    values in all cells of the tables displayed on the Right-Size
+    Recommendations page:
+    Compute > Infrastructure > Virtual Machines > click on VM name >
+    Configuration > Right-Size Recommendations
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(2)
+def test_ssa_with_snapshot_scvmm2():
+    """
+    Needed to verify this bug -
+    https://bugzilla.redhat.com/show_bug.cgi?id=1376172
+    There is a vm called LocalSSATest33 that is preconfigured for this
+    test.
+    I"ll do these one off tests for a while.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1h
+        startsin: 5.6.1
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_group_quota_vm_reconfigure():
+    """
+    Steps:
+    1)Copy Automation-->Automate-->Explorer-->ManageIQ-->system-->CommonMe
+    thods-->QuotaStateMachine-->quota
+    as Automation-->Automate-->Explorer-->quota_test-->system-->CommonMeth
+    ods-->QuotaStateMachine-->quota
+    2) Create a Vm with in the limits of quota defined
+    3) Try to reconfigure the Vm with values above quota set in Automation
+    -->Automate-->Explorer-->quota_test-->system-->CommonMethods-->QuotaSt
+    ateMachine-->quota
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: infra
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rbac
+@pytest.mark.tier(2)
+def test_verify_orchestration_catalog_items_can_only_use_providers_that_are_visible_to_the_use():
+    """
+    When creating a new catalog item of type "Orchestration", the
+    available providers should be restricted to providers that are visible
+    to the user
+
+    Polarion:
+        assignee: apagac
+        casecomponent: control
+        caseimportance: medium
+        initialEstimate: 1/4h
+        setup: On CFME appliance, add a Microsoft Azure provider with no restrictions
+        title: Verify orchestration catalog items can only use providers
+               that are visible to the user
+        testSteps:
+            1. As admin: Create an administrator group that restricts
+               access to objects with a certain tag.
+            2. As admin: Create a user that is assigned to the restricted group
+            3. Restricted user: Verfiy that the Azure provider is not visible
+            4. Create a new catalog item with type "Orchestration" and
+               Orchestration Template of type azure
+            5. When the provider option is visible, verify that any
+               providers listed are visible providers
+            6. As admin: Change the tag for the azure provider to match
+               tags that are accessible by the restricted user
+            7. As the restricted user: Verify that the cloud provider is now visible
+            8. Attempt to create a new catalog item of type
+               "Orchestration", Orchestration Template for azure and
+               confirm that the azure provider is an available option
+        expectedResults:
+            1.
+            2.
+            3.
+            4.
+            5.
+            6.
+            7.
+            8.
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_osp_test_osp_volumes_are_cleaned_up_if_migration_fails_to_create_instance():
+    """
+    V2V Test for https://bugzilla.redhat.com/show_bug.cgi?id=1651352
+    https://bugzilla.redhat.com/show_bug.cgi?id=1653412
+
+    Polarion:
+        assignee: kkulkarn
+        casecomponent: V2V
+        caseimportance: medium
+        initialEstimate: None
+        title: OSP: Test OSP Volumes are cleaned up if migration fails to create instance
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_consistent_capitalization_of_cpu_when_creating_compute_chargeback_rate():
+    """
+    Consistent capitalization of "CPU":
+    1.) When adding a Compute Chargeback Rate, the "CPU" group should not
+    change to "Cpu" when you click the "Add" button to add a second
+    tier/row.
+    2.) The "CPU Cores" group should not display as "Cpu Cores".
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/15h
+        title: Consistent capitalization of 'CPU' when creating compute chargeback rate
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_show_tag_info_for_playbook_services():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1449020
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Show tag info for playbook services
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_replication_appliance_set_type_remote_ui():
+    """
+    Can the appliance be set to the "remote" type in the ui
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: infra
+        caseimportance: critical
+        initialEstimate: 1/12h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_vm_reconfig_resize_disk_hot_vsphere67_nested_independent_persistent_thin():
+    """
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: 1/6h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_vm_reconfig_resize_disk_hot_vsphere67_nested_independent_persistent_thick():
+    """
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: 1/6h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_vm_reconfig_resize_disk_hot_vsphere67_nested_persistent_thin():
+    """
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: 1/6h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_vmware_storage_profile_vm_summary():
+    """
+    Correctly display the name of the storage profile
+
+    Polarion:
+        assignee: None
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_tagvis_tag_cluster_vm_combination():
+    """
+    Combine My Company tag, Cluster and VM/Template
+    All restriction should be applied for vm and template
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.snapshot
+@pytest.mark.tier(1)
+def test_snapshot_link_in_vm_summary_page_after_deleting_snapshot():
+    """
+    test snapshot link in vm summary page after deleting snapshot
+    Have a vm, create couple of snapshots. Delete one snapshot. From the
+    vm summary page use the history button and try to go back to
+    snapshots. Go to the vm summary page again and try to click snapshots
+    link, it should work.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: prov
+        caseimportance: medium
+        initialEstimate: 1/6h
+        setup: https://bugzilla.redhat.com/show_bug.cgi?id=1395116
+        title: test snapshot link in vm summary page after deleting snapshot
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_distributed_zone_failover_cu_coordinator_singleton():
+    """
+    C & U Coordinator (singleton role)
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_stack_parent():
+    """
+    This test is where you need to verify that the VM Instance created by
+    an Orchestration Stack has, or can have, it"s parent relationship set.
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: low
+        initialEstimate: 1/8h
+        setup: This test is pretty straight forward.  Spin up a VM using and
+               orchestration template.  Go to the instance details. Select Edit this
+               Instance
+        testSteps:
+            1. Set Parent for VM Instance
+        expectedResults:
+            1. The possible parents are listed and can be saved
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(3)
+def test_sui_rbac_see_catalogs_and_orders_as_user_with_permissions():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1438922
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: ssui
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: SUI : RBAC : see catalogs and orders as user with permissions
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_pod_appliance_db_backup_restore():
+    """
+    database has been saved and recovered
+
+    Polarion:
+        assignee: izapolsk
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_dialog_dropdown_ui_values_in_the_dropdown_should_be_visible_in_edit_mode():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1557508
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/16h
+        title: Dialog dropdown UI values in the dropdown should be visible in edit mode
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(3)
+def test_embed_tower_credentials():
+    """
+    Credentials included under ansible shown in a table view (automation-
+    ansible-credentials)
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: critical
+        initialEstimate: 1/12h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_cockpit_after_uninstalling():
+    """
+    Test if cockpit is working after uninstalling from the VM (negative
+    test)
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: infra
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/12h
+        title: Test Cockpit after uninstalling
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_vmware_topology_status():
+    """
+    Polarion:
+        assignee: None
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_appliance_console_ha_dc_failover():
+    """
+    Test failing over from DC1 primary to DC1 standby then drop the
+    connection between DC1/2. This should create a split brain scenario,
+    upon re-establishing connections we need to manually kill/shutdown DC1
+    current primary.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        initialEstimate: 1/2h
+        setup: Failover to DC1 standby node, drop connections between DC"s, restore
+               network connectivity between DC1 and DC2 manually kill DC1 current
+               primary if its in a split brain scenario.
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_replication_network_dropped_packets():
+    """
+    10% dropped packets
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: infra
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware65_test_vm_migration_with_windows_2012_server():
+    """
+    OSP: vmware65-Test VM migration with Windows 2012 server
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware65-Test VM migration with Windows 2012 server
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_automate_method_copy():
+    """
+    Should copy selected automate method/Instance without going into edit
+    mode.
+    Steps:
+    1. Add new domain (In enabled/unlock mode)
+    2. Add namespace in that domain
+    3. Add class in that namespace
+    4. Unlock ManageIQ domain now
+    5. Select Instance/Method from any class in ManageIQ
+    6. From configuration toolbar, select `Copy this method/Instance`
+    Additional info: https://bugzilla.redhat.com/show_bug.cgi?id=1500956
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.9
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_appliance_console_logfile():
+    """
+    Test configuring new log file disk volume.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/6h
+        setup: -provision new appliance with additional disk
+               -ssh to appliance
+               -run appliance_console
+               -select option "Logfile Configuration"
+               -configure disk
+               -confirm new logfile disk is configured correctly
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_ec2_targeted_refresh_subnet():
+    """
+    Subnet CREATE
+    Subnet UPDATE
+    Subnet DELETE
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 2/3h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_cost_monthly_usage_storage():
+    """
+    Validate cost for storage usage for a VM in a monthly chargeback
+    report
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_cost_monthly_usage_disk():
+    """
+    Validate cost for disk io for a VM in a monthly chargeback report
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_cost_monthly_allocation_cpu():
+    """
+    Validate cost for VM cpu allocation in a monthly report
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_cost_monthly_allocation_storage():
+    """
+    Validate cost for VM storage allocation in a monthly report
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_cost_monthly_usage_cpu():
+    """
+    Validate cost for CPU usage for a VM in a monthly chargeback report
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_cost_monthly_allocation_memory():
+    """
+    Validate cost for VM memory allocation in a monthly report
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_cost_monthly_usage_memory():
+    """
+    Validate cost for memory usage for a VM in a monthly chargeback report
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_cost_monthly_usage_network():
+    """
+    Validate cost for network io for a VM in a monthly chargeback report
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+def test_embed_tower_enhanced_playbook_debug():
+    """
+    Enable Embedded Ansible and add repo with playbooks. Try to create new
+    service dialog and try to order the service. In the dialog, there
+    should be option to enable debugging of the playbook (I believe the
+    playbook is executed with -vvv option).
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1h
+        startsin: 5.8
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.tag
+@pytest.mark.tier(2)
+def test_tagvis_cluster_and_vm_combination():
+    """
+    Combine Host&Cluster with VM&Templates
+    Check restricted user can see Cluster and only VMs and Templates from
+    this cluster
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_creds_details():
+    """
+    Clicking on a cred name should show details of the Credentials.
+    (Automation-Ansible-Credentials Table view showing provider creds
+    added)
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_vm_tempate_ownership_nogroup():
+    """
+    test assigning no groups ownership for vm and templates
+    https://bugzilla.redhat.com/show_bug.cgi?id=1330022
+    https://bugzilla.redhat.com/show_bug.cgi?id=1456681
+    UPDATE: There was no movement on BZ 1456681 for a long time. If this
+    BZ is not resolved, we don"t know how exactly the ownership should
+    behave in certain situations and this testcase will always fail.
+    Assigning no group ownership should work fine.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_appliance_console_restore_db_network_negative():
+    """
+    test restoring database with invalid connection settings
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/3h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_should_be_able_to_access_services_requests_as_user():
+    """
+    Unexpected Error when accessing SERVICE -> REQUESTS (undefined method
+    find_tags_by_grouping)
+    https://bugzilla.redhat.com/show_bug.cgi?id=1576129
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Should be able to access services - requests as user
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_drop_down_list_dialog_does_should_keep_default_value_for_integer_type_in_dialogs():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1554780
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        initialEstimate: 1/4h
+        startsin: 5.9
+        title: Drop Down List Dialog does should keep default value for Integer type in dialogs
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware67_test_vm_with_multiple_disks():
+    """
+    OSP: vmware67-Test VM with multiple Disks
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: critical
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware67-Test VM with multiple Disks
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_dynamic_drop_down_dialog_should_work_with_automate_expression_method():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1583694
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        initialEstimate: 1/6h
+        title: Dynamic Drop Down Dialog should work with Automate Expression Method
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.log_depot
+@pytest.mark.tier(1)
+def test_log_collect_all_server_unconfigured():
+    """
+    check collect all logs under server when both levels are unconfigured.
+    Expected result - all buttons are disabled
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_retire_ansible_stack():
+    """
+    Retire Ansible stack
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+        setup: 1. Add Ansible Tower provider (name: tower) and perform refresh
+               2. Navigate to Ansible Tower Job templates, click on configured job ->
+               Configuration -> Create service dialog from this template (name it:
+               first_job_template_dialog)
+               3. Go to Services -> Catalog and create new catalog_tower
+               4. Create new catalog item under your new catalog
+               5. Catalog item parameters:
+               Catalog Item Type: AnsibleTower
+               Name: tower
+               Display in catalog: checked
+               Catalog: catalog_tower
+               Dialog: first_job_template_dialog
+               Provider: tower
+               Ansible Tower Job Template: first_job_template
+               6. Click on Add button and order this service
+               7. Monitor that job has been executed correctly on Ansible Tower side
+               and that in CFME is completed successfully
+               8. Navigate to Compute -> Clouds -> Stacks
+               9. Select first_job_template stack -> Lifecycle -> Retire selected
+               stacks
+        startsin: 5.5
+        title: Retire Ansible stack
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_replication_global_region_dashboard():
+    """
+    Global dashboard show remote data
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(3)
+def test_azone_group_by_tag_ec2():
+    """
+    test_azone_group_by_tag[ec2]
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: low
+        initialEstimate: 1/12h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_tag_expression_and_with_or():
+    """
+    Combine tags with AND and OR conditions
+    Check item visibility
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_automated_locale_switching():
+    """
+    Having the automatic locale selection selected, the appliance"s locale
+    changes accordingly with user"s preferred locale in the browser.
+
+    Polarion:
+        assignee: None
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_user_cloud_cpu_quota_by_lifecycle():
+    """
+    test user cpu quota for cloud instance provision by Automate model
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_stack_template_azure():
+    """
+    There was a new field added to Orchestration stacks to show which
+    image was used to create it.  You need to verify the end points of
+    this image are displayed correctly.
+    This just needs to be checked every once in a while.  Perhaps once per
+    build.  Should be able to automate it by comparing the yaml entries to
+    the value.
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: low
+        initialEstimate: 1/8h
+        setup: Create a stack based on a cloud image.  Go to stack details and check
+               the
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_verify_the_authentication_mode_is_displayed_correctly_for_new_trusted_forest_table_en():
+    """
+    verify the authentication mode is displayed correctly for new trusted
+    forest table entry.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/6h
+        title: verify the authentication mode is displayed correctly for
+               new trusted forest table entry.
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_custom_button_disable():
+    """
+    Check if the button is disable or not (i.e. visible but blurry)
+    Steps
+    1)Add Button Group
+    2)Add a button to the newly created button group
+    3)Add an expression for disabling button (can use simple {"tag":
+    {"department":"Support"}} expression)
+    4)Add the Button group to a page
+    5)Check that button is enabled; if enabled pass else fail.
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/12h
+        startsin: 5.9
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_tagvis_cloud_host_aggregates():
+    """
+    Setup: Create group with tag, use this group for user creation
+    1. Add tag(used in group) for cloud host aggregate via detail page
+    2. Remove tag for cloud host aggregate via detail page
+    3. Add tag for cloud host aggregate via list
+    4. Check cloud host aggregate is visible for restricted user
+    5. Remove tag for cloud host aggregate via list
+    6 . Check cloud host aggregate isn"t visible for restricted user
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.log_depot
+@pytest.mark.tier(1)
+def test_log_collect_current_zone_multiple_servers_zone_setup():
+    """
+    using any type of depot check collect current log function under zone.
+    Zone should have multiplie servers under it. Zone should be setup,
+    servers should not
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.cfme_tenancy
+@pytest.mark.tier(2)
+def test_tenant_visibility_service_template_items_all_parents():
+    """
+    Child tenants can see all service template items defined in parent
+    tenants.
+
+    Polarion:
+        assignee: mnadeem
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/2h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_host_info_scvmm():
+    """
+    The purpose of this test is to verify that SCVMM-SP1 hosts are not
+    only added, but that the host information details are correct.  Take
+    the time to spot check at least one host.
+
+    Polarion:
+        assignee: None
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.4
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_policy_to_prevent_source_vm_from_starting_if_migration_is_comaplete():
+    """
+    OSP: Test policy to prevent source VM from starting if migration is
+    comAplete
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test policy to prevent source VM from starting if migration is comAplete
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(1)
+def test_configure_ldap_authentication():
+    """
+    Verifies the ldap authentication mode configuration/setup on CFME
+    appliance.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        initialEstimate: 1/4h
+        testSteps:
+            1. specify the authentication mode to LDAP.
+            2. specify the valid credentials
+            3. specify the port number, hostname and other details to
+               configure the ldap authentication for CFME appliance.
+        expectedResults:
+            1. No Error is expected to occur by specifying the LDAP authentication mode.
+            2. validation is expected to be successful with valid credentials
+            3. the ldap authentication mode is expected to be successful
+               after specifying the valid details.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_quota_for_ansible_service():
+    """
+    test quota for ansible service
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/4h
+        setup: Quota check causes errors for service provisioning when using Ansible
+               Tower service types
+               https://bugzilla.redhat.com/show_bug.cgi?id=1363901
+        startsin: 5.5
+        title: test quota for ansible service
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rbac
+def test_verify_that_when_modifying_rbac_roles_existing_enabled_disabled_product_features_dont():
+    """
+    When modifying RBAC Roles, all existing enabled/disabled product
+    features should retain their state when modifying other product
+    features.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/4h
+        tags: rbac
+        title: Verify that when modifying RBAC Roles, existing
+               enabled/disabled product features don't change state when
+               modifying other features
+        testSteps:
+            1. Navigate to access control and create a new role with all
+               product features enabled
+            2. Edit the role, disable 1 or more product features and save the changes
+            3. Create a new role with only one sub product feature enabled and save it
+            4. Modify the previous role and enable an additional product
+               feature. Save the modifications.
+        expectedResults:
+            1. New role created successfully
+            2. Only the user modified feature(s) should be changes
+            3. Only the single product feature should be enabled
+            4. Only the specified product features should be enabled
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_check_all_availability_zones_for_amazon_provider():
+    """
+    Check if all availability zones can be selected while creating catalog
+    item.
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.5
+        title: Check all availability zones for amazon provider
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(2)
+def test_sui_timeline_should_display_snapshots_at_the_time_of_creation():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1490510
+
+    Polarion:
+        assignee: apagac
+        casecomponent: ssui
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.9
+        title: SUI : Timeline should display snapshots at the time of creation
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware67_test_vm_with_mutliple_nics_with_single_ip_ipv6_to_first_nic_and_ipv4_to_():
+    """
+    vmware67-Test VM with mutliple NICs with single IP (IPv6 to first NIC
+    and IPv4 to second
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware67-Test VM with mutliple NICs with single IP
+               (IPv6 to first NIC and IPv4 to second)
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_replication_global_to_remote_new_vm_from_template():
+    """
+    Create a new VM from template in remote region from global region
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: prov
+        caseimportance: critical
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_git_import_deleted_tag():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1394194
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/12h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+def test_check_my_company_all_evm_groups_filter_from_reports_schedule():
+    """
+    Steps to Reproduce:
+    1.Navigate to Cloud Intel → Reports.
+    2.Click the Schedules accordion
+    3.Add a New Schedule
+    4.Under Report Selection →
+    Try to select custom report In Filter drop downs that you want to
+    schedule
+    https://bugzilla.redhat.com/show_bug.cgi?id=1559323
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        initialEstimate: 1/16h
+        startsin: 5.9
+        title: Check My Company(All EVM Groups) filter from reports schedule
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.upgrade
+@pytest.mark.tier(2)
+def test_update_webui_ipv6():
+    """
+    Test updating the appliance to release version from prior version.
+    (i.e 5.5.x to 5.5.x+) IPV6 only env
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: -Provision configured appliance
+               -Register it with RHSM using web UI
+               -Create /etc/yum.repos.d/update.repo
+               -populate file with repos from
+               https://mojo.redhat.com/docs/DOC-1058772
+               -check for update in web UI
+               -apply update
+               -appliance should shutdown update and start back up
+               -confirm you can login afterwards
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_ec2_targeted_refresh_load_balancer():
+    """
+    #AWS naming is ELB
+    Apply Security group
+    Floating IP CREATE
+    Floating IP UPDATE
+    Floating IP DELETE
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 2/3h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.power
+@pytest.mark.tier(2)
+def test_suspend_scvmm2016_from_collection():
+    """
+    Test the a VM can be Suspended, or Saved, from the Collection Page
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_automate_service_quota_runs_only_once():
+    """
+    Steps described here:
+    https://bugzilla.redhat.com/show_bug.cgi?id=1317698
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.config_management
+@pytest.mark.tier(1)
+def test_config_manager_change_zone():
+    """
+    Add Ansible Tower in multi appliance, add it to appliance with UI. Try
+    to change to zone where worker is enabled.
+    https://bugzilla.redhat.com/show_bug.cgi?id=1353015
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: prov
+        caseimportance: medium
+        initialEstimate: 1h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(3)
+def test_service_ansible_linked_vms_opsui_sui():
+    """
+    Associated with BZhttps://bugzilla.redhat.com/show_bug.cgi?id=1510797
+    Please follow the steps below to recreate the scenario: 1. Enable
+    Embedded Ansible role.
+    2. Wait until it will be enabled.
+    3. Navigate to Automate/Ansible.
+    4. Add ansible repository https://github.com/mkanoor/playbook.
+    5. Navigate to Services->Catalogs.
+    6. Expand "Catalog Items" accordion.
+    7. Create "Ansible Playbook" Catalog Item.
+    8. Pick "add_single_vm_to_service.yml" playbook.
+    9. Navigate to Control->Explorer.
+    10. Expand Actions accordion.
+    11. Click Configuration->Add a new Action.
+    12. In action type choose "Run Ansible Playbook".
+    13. In Playbook Catalog Item choose just created catalog item.
+    14. In inventory choose "Target machine" or provide a specific host.
+    15. Assign this action to some event in a host or vm control policy.
+    16. Assign policy profile which contains that policy to some host or
+    vm.
+    17. Trigger the event which assigned to the policy.
+    18. Wait until the service will be provisioned.
+    19. Navigate tot Services/My Services.
+    20. Open details of the provisioned service, open "Provisioning" tab.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_request_filter_on_request_page():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1498237
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: low
+        initialEstimate: 1/4h
+        title: Test Request filter on Request page
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(2)
+def test_sui_test_snapshot_count():
+    """
+    create few snapshots and check if the count displayed on service
+    details page is same as the number of snapshots created
+    and last snapshot created is displayed on service detail page .
+    Also click on the snapshot link should navigate to snapshot page .
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rbac
+def test_verify_that_a_user_with_a_custom_tag_can_view_vms_with_the_same_tag():
+    """
+    When a user is assigned a custom tag restricting visible items, verify
+    that the user can only see VMs with the same tag.
+    See: https://access.redhat.com/articles/421423 and
+    https://cloudformsblog.redhat.com/2016/10/13/using-tags-for-access-
+    control
+
+    Polarion:
+        assignee: apagac
+        casecomponent: prov
+        initialEstimate: 1/3h
+        setup: Add a provider with two VMs available for tagging
+        tags: rbac
+        title: Verify that a user with a custom tag can view VMs with the same tag
+        testSteps:
+            1. Create a custom Category and tag
+            2. Tag a VM with the custom tag and tag another VM with a different tag
+            3. Create a new group with the custom tag
+            4. Create a new user and assign it to the new group
+            5. Login as the new user and attempt to view the VM with the custom tag
+        expectedResults:
+            1. Category & tag created successfully
+            2. VMs tagged successfully
+            3. Group created successfully
+            4. User created successfully
+            5. User can see the VM with the custom tag and not the VM with a different tag
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_storage_ebs_snapshot_delete():
+    """
+    Requires: test_storage_ebs_snapshot_create
+    1) Delete previously created EBS snapshot from volume
+    2) Check whether snapshot is not displayed anymore
+
+    Polarion:
+        assignee: mmojzis
+        caseimportance: medium
+        initialEstimate: 1/15h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_tagvis_ssui_catalog_items():
+    """
+    Steps:
+    1.Create groups with tag
+    2. Create user and assign it to group
+    3. As admin create service catalog and catalog item
+    4. Log in as user to ssui
+    5. Check catalog item list -> User should not see any items
+    6. As admin set tag to catalog item
+    7. As user, check visibility -> User should see tagged catalog item
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: ssui
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_embedded_ansible_update_bad_version_59017():
+    """
+    Tests updating an appliance which has embedded ansible role enabled,
+    also confirms that the
+    role continues to function correctly after the update has completed
+    Test Source
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.cfme_tenancy
+def test_tenantadmin_group_crud():
+    """
+    As a Tenant Admin I want to be able to create groups related to the
+    roles in my tenant and assign roles
+    1) Login as tenant admin
+    2) Navigate to Configure - Configuration - Access Control - Groups
+    3) Configuration - Add a new group
+    4) Assign Group name, role and Project/tenant and click Add
+
+    Polarion:
+        assignee: mnadeem
+        casecomponent: config
+        initialEstimate: 1/4h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_sui_should_show_custom_button_dialog():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1574774
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: SUI should show custom button dialog
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(2)
+def test_candu_graphs_datastore_vsphere6():
+    """
+    test_candu_graphs_datastore[vsphere6]
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: low
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_ldap_invalid_user_login():
+    """
+    Verifies scenario"s associated with the invalid user login(negative
+    test case).
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/4h
+        testSteps:
+            1. login with the invalid user.
+            2. configure the ldap with userA in groupA, configure CFME
+               for userA and groupA. Login with userA
+            3. delete the userA in the ldap. try Login with userA to CFME appliance
+        expectedResults:
+            1. login should fail for invalid credentials.
+            2. login should be successful
+            3. login should fail
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware67_test_vm_migration_from_iscsi_storage_in_vmware_to_nfs_on_osp():
+    """
+    OSP: vmware67-Test VM migration from iSCSI Storage in VMware to NFS on
+    OSP
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware67-Test VM migration from iSCSI Storage in VMware to NFS on OSP
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(3)
+def test_sui_create_snapshot_when_no_provider_is_connected():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1440966
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: ssui
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: SUI : Create snapshot when no provider is connected
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_tagvis_storage_managers():
+    """
+    Setup: Create group with tag, use this group for user creation
+    1. Add tag(used in group) for storage manager via detail page
+    2. Remove tag for storage manager via detail page
+    3. Add tag for storage manager via list
+    4. Check storage manager is visible for restricted user
+    5. Remove tag for storage manager via list
+    6 . Check storage manager isn"t visible for restricted user
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware65_test_vm_with_multiple_disks():
+    """
+    OSP: vmware65-Test VM with multiple Disks
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: critical
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware65-Test VM with multiple Disks
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(3)
+def test_remove_display_name_for_user_in_ldap_and_verify_auth():
+    """
+    1. Remove display name for user in ldap and verify auth.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/2h
+        title: Remove display name for user in ldap and verify auth.
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_ec2_security_group_record_values():
+    """
+    BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1540283
+
+    Polarion:
+        assignee: mmojzis
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_template_rhos7_ga_fedora_22_ext4():
+    """
+    test_ssa_template[rhos7-ga-fedora-22-ext4]
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/2h
+        startsin: 5.3
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware60_test_vm_migration_from_iscsi_storage_vmware_to_osp():
+    """
+    OSP: vmware60-Test VM migration from iSCSI Storage VMware to iSCSI in
+    OSP
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware60-Test VM migration from iSCSI Storage VMware to OSP
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_rhi_rules():
+    """
+    Verify all sub-tabs in rules and whether filter is working properly
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(3)
+def test_change_the_search_base_for_user_and_groups_lookup_at_domain_component_():
+    """
+    Change the search base for user and groups lookup at domain component
+    . e.g. change the search level from
+    "ou=Groups,ou=prod,dc=qetest,dc=com "
+    To "dc=qetest,dc=com"
+    Change the ‘ldap_group_search_base’ and ‘ldap_user_search_base’ in
+    /etc/sssd/sssd.conf for specific domain.
+    Make sure domain_suffix is updated correctly for your ldap domain
+    under test.
+    Restart sssd service (service sssd restart)
+    Verify configuration with dbus commands (refer MOJO)
+    Verify user/group retrieval in CFME webui.
+    user/group created at any hierarchy level under the tree
+    dc=qetest,dc=com is expected to be retrieved.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/2h
+        title: Change the search base for user and groups lookup at domain component .
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_automation_executed_on_field_refresh_are_called_twice_in_self_service_dialogs():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1576873
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: automation executed on field refresh are called twice in self service dialogs
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_appliance_console_packages():
+    """
+    Check that we no long use scl packages in cfme. We should not have an
+    rh-ruby packages.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        initialEstimate: 1/12h
+        startsin: 5.10
+        testtype: structural
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_distributed_zone_failover_smartstate_analysis():
+    """
+    SmartState Analysis (multiple)
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware_60_test_vm_name_with_punycode_characters():
+    """
+    OSP: vmware 60- Test VM name with Punycode characters
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware 60- Test VM name with Punycode characters
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_user_cloud_storage_quota_by_lifecycle():
+    """
+    test user storage quota for cloud instance provision by Automate model
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_multiple_stack_deployment():
+    """
+    Create bundle of stack and provision
+
+    Polarion:
+        assignee: None
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.5
+        title: Multiple Stack deployment
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.dashboard
+@pytest.mark.tier(3)
+def test_identical_dashboard_widgets():
+    """
+    test_identical_dashboard_widgets
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: report
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_group_infra_memory_quota_by_services():
+    """
+    test group memory for infra vm provision by ordering services
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.storage
+def test_storage_volume_attach_openstack():
+    """
+    Requires:
+    An Openstack Cloud Provider
+    Step to test:
+    1. Create an Openstack instance
+    2 . Go to Storage -> Block Storage -> Volumes
+    3. Create an Openstack Volume
+    4. Select created volume
+    5. Configuration -> Attach this Cloud Volume
+    Fill in form:
+    Created instance
+    /dev/sdf
+    6. Check whether volume was attached to that instance
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        initialEstimate: 1/4h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_distributed_field_zone_name_whitespace():
+    """
+    When creating a new zone, the name can have whitespace, including
+    leading and trailing characters. After saving, any leading or trailing
+    whitespace is not displayed in the web UI.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/30h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(2)
+def test_snapshot_timeline_crud():
+    """
+    Test the SUI snapshot timeline.
+    See if the data in the timeline are corresponding to the snapshot
+    actions. Try to create snapshots, revert to snapshot and delete
+    snapshot and see if the timeline reflects this correctly
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: low
+        initialEstimate: 1/2h
+        testSteps:
+            1. create a new vm
+            2. create two snapshots for the VM
+            3. revert to the first snapshot
+            4. delete all snapshots
+            5. go to the VM details page, then Monitoring -> Timelines
+            6. select "Management Events" and "Snapshot Activity" and click Apply
+        expectedResults:
+            1. vm created
+            2. snapshots created
+            3. revert successful
+            4. delete successful
+            5. timelines page displayed
+            6. snapshot timeline appears, all actions are in the timeline
+               and visible, the time/date appears correct
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_distributed_zone_create_duplicate():
+    """
+    Create Zone with name that is already in use.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.log_depot
+@pytest.mark.tier(1)
+def test_log_collect_all_server_zone_setup():
+    """
+    using any type of depot check collect all log function under applince
+    (settings under server should not be configured, under zone should be
+    configured)
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.genealogy
+@pytest.mark.tier(2)
+def test_edit_vm():
+    """
+    Edit infra vm and cloud instance
+    https://bugzilla.redhat.com/show_bug.cgi?id=1399141
+    https://bugzilla.redhat.com/show_bug.cgi?id=1399144
+    When editing cloud instance, genealogy should be present on the edit
+    page.
+    When you have two providers - one infra and one cloud - added, there
+    should be no cloud vms displayed when setting genealogy for infra vm
+    and vice-versa.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+def test_project_cloud_cpu_quota_by_enforce():
+    """
+    test cpu quota for project for cloud instance by enforcement
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        initialEstimate: 1/4h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_group_cloud_cpu_quota_by_lifecycle():
+    """
+    test group cpu quota for cloud instance provision by Automate model
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: cloud
+        caseimportance: low
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware60_test_vm_migration_from_nfs_storage_in_vmware_to_osp():
+    """
+    OSP: vmware60-Test VM migration from NFS Storage in VMware to iSCSI on
+    OSP
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware60-Test VM migration from NFS Storage in VMware to OSP
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_remove_catalog_items_from_catalog_bundle_resource_list():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1639557
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        initialEstimate: None
+        title: remove catalog items from Catalog Bundle resource list
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.dashboard
+@pytest.mark.tier(3)
+def test_dashboard_chart_widgets_size_in_modal():
+    """
+    Test whether dashboard chart widgets have correct size in modal
+    window.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: report
+        caseimportance: low
+        initialEstimate: 1/6h
+        testtype: nonfunctional
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_automate_state_method():
+    """
+    PR link (merged 2016-03-24)
+    You can pass methods as states compared to the old method of passing
+    instances which had to be located in different classes. You use the
+    METHOD:: prefix
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/4h
+        setup: A fresh appliance.
+        startsin: 5.6
+        testSteps:
+            1. Create an automate class that has one state.
+            2. Create a method in the class, make the method output
+               something recognizable in the logs
+            3. Create an instance inside the class, and as a Value for the
+               state use: METHOD::method_name where method_name is the name
+               of the method you created
+            4. Run a simulation, use Request / Call_Instance to call your
+               state machine instance
+        expectedResults:
+            1. Class created
+            2. Method created
+            3. Instance created
+            4. The method got called, detectable by grepping logs
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware60_test_vm_migration_with_windows_2016_server():
+    """
+    OSP: vmware60-Test VM migration with Windows 2016 server
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware60-Test VM migration with Windows 2016 server
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.right_size
+@pytest.mark.tier(1)
+def test_rightsize_cpu_values_correct_rhv41():
+    """
+    For a RHV 4.1 provider with C & U metrics collection configured and
+    running for >1 day, a VM that has been up and running for >1 day shows
+    correct recommended CPU values on the Right-Size Recommendations page:
+    Compute > Infrastructure > Virtual Machines > click on VM name >
+    Configuration > Right-Size Recommendations
+    The correct Max, High, Average, and Low CPU and CPU Usage values in
+    the Normal Operating Ranges table should be determined by the maximum,
+    ~85th percentile, ~50th percentile, and ~15th percentile CPU (MHz) and
+    CPU Usage (%) realtime metric values from the past 30 days for this
+    VM.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.right_size
+@pytest.mark.tier(1)
+def test_rightsize_cpu_values_correct_vsphere6():
+    """
+    Right-size recommended cpu values are correct.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_button_can_trigger_events():
+    """
+    In the button creation dialog there must be MiqEvent available for
+    System/Process entry.
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/60h
+        startsin: 5.6.1
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_host_os_info():
+    """
+    Checks the host's OS name and version
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/2h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_external_auth_configuration_with_ipa():
+    """
+    Set hostname for the appliance with FQDN
+    Update /etc/hosts with IPA server ip and FQDN
+    Update appliance FQDN to IPA server /etc/hosts
+    Make sure, both the machine can communicate using FQDN.
+    Run appliance_console and follow the steps in https://mojo.redhat.com/
+    docs/DOC-1088176/edit?ID=1088176&draftID=1981816  Configuring CFME
+    with external auth for IPA
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        initialEstimate: 1/4h
+        title: External Auth configuration with IPA
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(3)
+def test_sui_auto_refresh_of_pages_of_sui_request_and_service_explorer_and_myorders():
+    """
+    https://www.pivotaltracker.com/story/show/134430901
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: SUI : Auto-refresh of pages of SUI (Request and Service Explorer and MyOrders)
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_requests_tab_exposed():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1508490
+    Need to expose Automate => Requests tab from the Web UI without
+    exposing any other Automate tabs (i.e. Explorer, Customization,
+    Import/Export, Logs). The only way to expose this in the Web UI, is to
+    enable Services => Requests, and at least one tab from the Automate
+    section (i.e. Explorer, Customization, etc).
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/12h
+        startsin: 5.10
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_button_state_disabled():
+    """
+    Custom button by default will be in the enabled state. For example:
+    (enabled only if VM > 0) In this case, button get enabled if condition
+    true and disabled if it is false.
+    Steps:
+    1. Add provider
+    2. Create service dialog
+    3. Create custom button group in service accordion option
+    5. Add button to the group. In "Advanced" tab of a button, put valid
+    expression for Enablement such that condition should fail. (Make sure
+    to select dialog created at step2)
+    6. Create catalog from Services
+    7. Create catalog item and assign dialog & catalog created in step2 &
+    6 respectively.
+    8. Navigate to self-service UI and Order created catalog item
+    9. Click service you have ordered and check enabled custom button
+    there
+    Additional info:
+    This enhancement feature is related to https://github.com/ManageIQ
+    /manageiq-ui-service/pull/1012.
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: ssui
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: None
+        startsin: 5.9
+        upstream: no
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.provision
+@pytest.mark.tier(2)
+def test_provision_request_info():
+    """
+    1)Create provisioning request
+    2)Open Request info
+    3)Check if Request Info is filled (mainly Environment tab etc)
+    all - preselected options should be mentioned here
+
+    Polarion:
+        assignee: jhenner
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_distributed_field_zone_name_long():
+    """
+    When creating a new zone, the name can be up to 50 characters long,
+    and displays correctly after saving.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/30h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_appliance_console_cli_rh_registration():
+    """
+    Test RHSM registration through cli and check if changes are made
+    within the ui
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/12h
+        setup: Provision appliace
+               ssh to it and run "subscription-manager register"
+               check changes within the ui
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(1)
+def test_verify_retrieve_ldaps_groups_works_fine_for_ldap_user_from_cfme_webui():
+    """
+    Configure external auth as in TC#1
+    Retrieve user groups in Access Control->groups->configuration->New
+    group
+    Monitor the audit.log and evm.log for no errors.
+    validate the data comparing with ldap server data.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        initialEstimate: 1/4h
+        title: verify retrieve ldaps groups works fine for ldap user from CFME webui.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+def test_retire_ansible_service_bundle():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1363897
+    Retirement state machine does not handle Ansible Tower services when
+    part of a bundle
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.5
+        title: test retire ansible service bundle
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_quota_calculation_using_service_dialog_overrides():
+    """
+    Bz- https://bugzilla.redhat.com/show_bug.cgi?id=1492158
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: infra
+        initialEstimate: 1/6h
+        startsin: 5.8
+        title: Test Quota calculation using service dialog overrides.
+        testSteps:
+            1. create a new domain quota_test
+            2.Using the Automate Explorer, copy the
+              ManageIQ/System/CommonMethods/QuotaMethods/requested method
+              to the quota_test domain.
+            3. Import the attached dialog . create catalog and catalog
+               item using this dialog
+            4. create a child tenant and set quota. create new group and
+               user for this tenant.
+            5. login with this user and provision by overidding values
+            6. Also test the same for user and group quota source type
+        expectedResults:
+            1.
+            2. quota should be denied
+            3.
+            4.
+            5.
+            6.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.retirement
+@pytest.mark.tier(2)
+def test_retire_infra_vms_date_folder():
+    """
+    test the retire funtion of vm on infra providers, at least two vm, set
+    retirement date button from vms page(without notification)
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: prov
+        caseimportance: medium
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_generic_object_details_displayed_from_a_service_do_not_include_associations_of_that_g():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1576828
+
+    Polarion:
+        assignee: nansari
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Generic object details displayed from a service do not
+               include associations of that generic object
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware60_test_vm_migration_with_windows_10():
+    """
+    OSP: vmware60-Test VM migration with Windows 10
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: critical
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware60-Test VM migration with Windows 10
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+def test_distributed_zone_in_different_networks():
+    """
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: infra
+        initialEstimate: 1h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_verify_that_errored_out_queue_messages_are_removed():
+    """
+    Verify that errored-out queue messages are removed.
+    Bug 1460263 - shutdown_and_exit messages get marked as error and never
+    removed from miq_queue table
+    https://bugzilla.redhat.com/show_bug.cgi?id=1460263
+    # appliance_console
+    -> Stop EVM Server Processes
+    -> Start EVM Server Processes
+    # cd /var/www/miq/vmdb/
+    # bin/rails c
+    irb(main):001:0> MiqQueue.where(:state => "error")
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/15h
+        title: Verify that errored-out queue messages are removed
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.filter
+def test_search_is_displayed_myservices():
+    """
+    1) Go to Services -> My Services
+    2) Check whether Search Bar and Advanced Search button are displayed
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/30h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.config_management
+def test_satellite_credential_validation_times_out_with_error_message():
+    """
+    Bug 1564601 - Satellite credential validation times out with no error
+    message
+    https://bugzilla.redhat.com/show_bug.cgi?id=1564601
+    When adding a new Satellite configuration provider, if the URL cannot
+    be accessed because of a firewall dropping packets, then credential
+    validation should time out after 2 minutes with a flash message.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: prov
+        caseimportance: medium
+        initialEstimate: 1/6h
+        title: Satellite credential validation times out with error message
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_azure_provisioning_service_owner():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1352903
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/16h
+        startsin: 5.5
+        title: Test azure provisioning service owner
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_verify_session_timeout_works_fine_for_external_auth():
+    """
+    As admin change the session timeout in cfme webui.
+    Login as ldap user and verify session times out after the specified
+    timeout value.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/6h
+        title: Verify session timeout works fine for external auth.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.tag
+@pytest.mark.tier(2)
+def test_tag_mapping_azure_instances():
+    """
+    Requirement: Have an azure provider
+    1) Create an instance and tag it with test:testing
+    2) Go to Configuration -> CFME Region -> Map Tags
+    3) Add a tag:
+    Entity: Instance (Microsoft Azure)
+    Label: test
+    Category: Testing
+    4) Refresh provider
+    5) Go to summary of that instance
+    6) In Smart Management field should be:
+    My Company Tags testing: Testing
+    7) Delete that instance
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: cloud
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.cfme_tenancy
+@pytest.mark.tier(2)
+def test_tenant_visibility_vms_all_childs():
+    """
+    Members of parent tenant can see all VMs/instances created by users in
+    child tenants.
+
+    Polarion:
+        assignee: mnadeem
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_button_groups_created_on_orchestration_type_heat_service_catalog_items_are_not_seen_o():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1496190
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: low
+        initialEstimate: 1/4h
+        title: Button groups created on orchestration type (heat) service
+               catalog items are not seen on services
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(1)
+def test_default_value_on_dropdown_inside_dialog():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1516721
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Test default value on Dropdown inside Dialog
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.snapshot
+@pytest.mark.tier(1)
+def test_check_disk_allocation_size_scvmm():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1490440
+    Steps to Reproduce:
+    1.Provision VM and check it"s "Total Datastore Used Space"
+    2.go to VMM and create Vm"s Checkpoint
+    3.open VM Details check - "Total Datastore Used Space"
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/2h
+        title: Check disk allocation size [SCVMM]
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_appliance_console_extend_storage_negative():
+    """
+    test extending storage with no additional partition
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.cfme_tenancy
+def test_tenant_ldap_group_switch_between_tenants():
+    """
+    User who is member of 2 or more LDAP groups can switch between tenants
+    1) Configure LDAP authentication on CFME
+    2) Create 2 different parent parent-tenants
+    - marketing
+    - finance
+    2) Create groups marketing and finance (these are defined in LDAP) and
+    group names in LDAP and CFME must match
+    Assign these groups to corresponding tenants and assign them EvmRole-
+    SuperAdministrator roles
+    3) In LDAP we have 3 users:
+    - bill -> member of marketing group
+    - jim -> member of finance group
+    - mike -> is member of both groups
+    4) Login as mike user who is member of 2 different tenants
+    5) User is able switch between groups - switching is done in a way
+    that current current group which is chosen is writtent into DB as
+    active group. Therefore user who is assigned to more groups must login
+    to Classic UI and switch to desired group. Afterthat he is able login
+    via Self Service UI to desired tenant
+
+    Polarion:
+        assignee: mnadeem
+        casecomponent: config
+        initialEstimate: 1/4h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_imports_with_non_existing_vm_name_should_give_error():
+    """
+    OSP: Test imports with non-existing VM name (Should give error)
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test imports with non-existing VM name (Should give error)
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_verify_user_groups_can_be_retrieved_from_trusted_forest():
+    """
+    verify user groups can be retrieved from "trusted forest", when the
+    "import roles from home forest" is unchecked.configuration:
+    1. Create the user "ldaptest" and group "engineering" in ldap:"cfme-
+    qe-ldap", and add "ldaptest" user to "engineering" group.
+    2. Create the user "ldaptest" and group "cfme" in ldap:"cfme-qe-ipa"
+    and add "ldaptest" user to "cfme" group.
+    Steps :
+    1. Login as "admin" and navigate to
+    configure->configuration->authentication
+    2. change the authentication mode to "ldap"
+    3. specify the hostname for the "cfme-qe-ipa", as the primary ldap.
+    4. in the "Role Settings" check "Get User Groups from LDAP", observe
+    that "Trusted Forest Settings" table displayed below. specify "Base
+    DN" and "Bind DN"
+    5. click on "+" to add "Trusted Forest Settings", specify HostName as
+    "cfme-qe-ldap",enter valid Base DN, Bind DN and "Bind Password" click
+    add the trusted forest and click "Save"
+    6. navigate to "access control"-> "groups"->"add new group", check
+    (Look Up LDAP Groups), specify the user "ldaptest", click retrieve.
+    Observe that only the groups(cfme) from Primary ldap (cfme-qe-ipa) are
+    retrieved. no group(engineering) from "cfme-qe-ldap" is reqtrieved.
+    7. manually add the group "engineering", logout and login as
+    "ldaptest". Observe that login fails for the user "ldaptest"
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/2h
+        title: verify user groups can be retrieved from "trusted forest"
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_catalog_item_changing_the_provider_template_after_filling_all_tabs():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1240443
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.5
+        title: Catalog Item : Changing the provider(template) after filling all tabs
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_ha():
+    """
+    Tower should be highly available. p2
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_distributed_zone_failover_scheduler_singleton():
+    """
+    Scheduler (singleton)
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_add_azure_credentials():
+    """
+    Add Azure credentials.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_create_azure_vm_from_azure_image():
+    """
+    This step takes a while.  You need to run a long powershell script
+    against the image uploaded in Test Case RHCF3-11273
+    Make the VM
+    Config SSH support
+    Config DNS is desired.
+    SSH into new VM with Azure Public IP address and verify it has booted
+    correctly.
+    Optionally - Use HTTP to DNS into the appliance web ui and make sure
+    you can log in.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: cloud
+        initialEstimate: 1/2h
+        setup: # Virtual Machine Name - as it appears in Azure
+               $VMName = "myVmName"
+               $ResourceGroupName = "CFMEQE-Main"
+               Break
+               # Existing Azure Deployment Values - Video with instructions
+               forthcoming.
+               $AvailabilitySetName = "cfmeqe-as-free"
+               $AzureLocation = "East US"
+               $VMDeploymentSize= "Standard_A1"
+               $StorageAccountName = "cfmeqestore"
+               $BlobContainerName = "templates"
+               $VHDName = "cfme-azure-56013.vhd"
+               $VirtualNetworkName = "cfmeqe"
+               $NetworkSecurityGroupName = "cfmeqe-nsg"
+               $VirtualNetworkSubnetName = "default"
+               $VirtualNetworkAddressPrefix = "10.0.0.0/16"
+               $VirtualNetworkSubnetAddressPrefix = "10.0.0.0/24"
+               # Create VM Components
+               $StorageAccount = Get-AzureRmStorageAccount -ResourceGroupName
+               $ResourceGroupName -Name $StorageAccountName
+               $InterfaceName = $VMName
+               $NetworkSecurityGroupID = Get-AzureRmNetworkSecurityGroup -Name
+               $NetworkSecurityGroupName -ResourceGroupName $ResourceGroupName
+               $PIp = New-AzureRmPublicIpAddress -Name $InterfaceName
+               -ResourceGroupName $ResourceGroupName -Location $AzureLocation
+               -AllocationMethod Dynamic -Force
+               $SubnetConfig = New-AzureRmVirtualNetworkSubnetConfig -Name
+               $VirtualNetworkSubnetName -AddressPrefix
+               $VirtualNetworkSubnetAddressPrefix
+               $VNet = New-AzureRmVirtualNetwork -Name $VirtualNetworkName
+               -ResourceGroupName $ResourceGroupName -Location $AzureLocation
+               -AddressPrefix $VirtualNetworkAddressPrefix -Subnet $SubnetConfig
+               -Force
+               $Interface = New-AzureRmNetworkInterface -Name $InterfaceName
+               -ResourceGroupName $ResourceGroupName -Location $AzureLocation
+               -SubnetId $VNet.Subnets[0].Id -PublicIpAddressId $PIp.Id -Force
+               $AvailabilitySet = Get-AzureRmAvailabilitySet -ResourceGroupName
+               $ResourceGroupName -Name $AvailabilitySetName
+               $VirtualMachine = New-AzureRmVMConfig -VMName $VMName -VMSize
+               $VMDeploymentSize -AvailabilitySetID $AvailabilitySet.Id
+               $VirtualMachine = Add-AzureRmVMNetworkInterface -VM $VirtualMachine
+               -Id $Interface.Id
+               $OSDiskUri = $StorageAccount.PrimaryEndpoints.Blob.ToString() +
+               $BlobContainerName + "/" + $VHDName
+               $VirtualMachine = Set-AzureRmVMOSDisk -VM $VirtualMachine -Name
+               $VMName -VhdUri $OSDiskUri -CreateOption attach -Linux
+               # Create the Virtual Machine
+               New-AzureRmVM -ResourceGroupName $ResourceGroupName -Location
+               $AzureLocation -VM $VirtualMachine
+        startsin: 5.6
+        teardown: When you"re done, delete everything.  Make sure at a minimum that the
+                  VM is completely Stopped in Azure.
+        title: Create Azure VM from Azure image
+        upstream: no
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(1)
+def test_service_dialog_import():
+    """
+    Steps:
+    1. Navigate to Automation > Automate > Customization
+    2. In `Import/Export` accordion, try to upload sample service dialog
+    How to check dialog uploaded successful?
+    Recheck it from `Export` table on same page or from `Service Dialogs`
+    accordion
+    Note:
+    CFME don"t support export from a version N to a version N-1
+    Additional info:
+    https://bugzilla.redhat.com/show_bug.cgi?id=1535419
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_verify_the_trusted_forest_settings_table_display_in_authentication_page():
+    """
+    verify the trusted forest settings table display in authentication
+    page. switch between the authentication modes and check the trusted
+    forest settings table does not disappear.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/6h
+        title: verify the trusted forest settings table display in authentication page.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+def test_date_should_be_change_in_editing_reports_scheduled():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1446052
+    Steps to Reproduce:
+    1. Edit schedule report
+    2. Under "Timer" Select "monthly"  every "month"
+    3. Try to change "Starting Date"
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/16h
+        startsin: 5.3
+        title: Date should be change In editing reports scheduled
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware65_test_vm_migration_with_windows_2016_server():
+    """
+    OSP: vmware65-Test VM migration with Windows 2016 server
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware65-Test VM migration with Windows 2016 server
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(3)
+def test_sui_session_timeout():
+    """
+    Set the session timeout to 5 mins. Check if session times out.
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: ssui
+        initialEstimate: 1/4h
+        startsin: 5.8
+        title: SUI : Session Timeout
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rest
+def test_rest_metric_rollups():
+    """
+    This test checks that the we get a correct reply for our query.
+
+    Polarion:
+        assignee: pvala
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_provider_discover_error_azure():
+    """
+    Same as discover provider, only we want to make sure to enter an
+    incorrect value for all fields and make sure it doesn"t accept the
+    entry as valid. (Provider will not discover)
+
+    Polarion:
+        assignee: pvala
+        casecomponent: cloud
+        caseimportance: medium
+        caseposneg: negative
+        endsin: 5.8
+        initialEstimate: 1/8h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_provision_image_managed_azure():
+    """
+    Azure as of this test case date allows for provisioning from Managed
+    Images.
+    See RFE - https://bugzilla.redhat.com/show_bug.cgi?id=1452227
+    See Create Manage Image - https://docs.microsoft.com/en-us/azure
+    /virtual-machines/windows/capture-image-resource Section 1
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: cloud
+        initialEstimate: 1/4h
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_verify_switch_groups_works_fine_for_user_with_multiple_groups_assigned():
+    """
+    Assign ldap user to multiple default groups.
+    Login as user and verify switch groups works fine.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Verify switch groups works fine for user with multiple groups assigned.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_credentials_change_password_greater_than_16_chars():
+    """
+    Password > 16 char
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/8h
+        tags: rbac
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.bottleneck
+@pytest.mark.tier(1)
+def test_bottleneck_summary_graph():
+    """
+    test_bottleneck_summary_graph
+
+    Polarion:
+        assignee: None
+        casecomponent: optimize
+        initialEstimate: 1/4h
+        testSteps:
+            1. setup c&u for provider and wait for bottleneck events
+        expectedResults:
+            1. summary graph is present and clickeble
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_custom_button_language():
+    """
+    There was bug with usecase before.
+    Additional info - https://bugzilla.redhat.com/show_bug.cgi?id=1568417
+    Steps:
+    1. set the language to french
+    2. go to automation-> automate -> customization
+    Expected:
+    The custom buttons tree should not empty from automation-> automate ->
+    customization
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: automate
+        caseimportance: low
+        customerscenario: true
+        initialEstimate: 1/8h
+        startsin: 5.9
+        testtype: nonfunctional
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_pod_appliance_basic_ipa_auth():
+    """
+    auth from ipa server should work
+
+    Polarion:
+        assignee: izapolsk
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+def test_embed_tower_exec_play_against_machine():
+    """
+    User/Admin is able to execute playbook without creating Job Temaplate
+    and can execute it against machine with machine credentials
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_files_scvmm2k12_centos_xfs():
+    """
+    Add SCVMM-2012 provider.
+    Perform SSA on CentOS VM.
+    Check whether Files retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_files_azure_windows2016_ntfs():
+    """
+    1. Add Azure provider
+    2. Perform SSA on Windows2016 server.
+    3. Check Files are retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_files_scvmm2k12_windows2016_ntfs():
+    """
+    Add SCVMM-2012 provider.
+    Perform SSA on Windows 2016 server VM having NTFS filesystem.
+    Check whether it retrieves Files.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_files_rhos7_ga_fedora_22_ext4():
+    """
+    test_ssa_files[rhos7-ga-fedora-22-ext4]
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/2h
+        startsin: 5.3
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_files_azure_ubuntu():
+    """
+    1. Add Azure provider
+    2. Perform SSA on Ubuntu instance.
+    3. Check Files are retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_files_ec2_rhel():
+    """
+    Add EC-2 provider.
+    Perform SSA on RHEL instance.
+    Check whether it retrieves Files.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_files_ec2_fedora():
+    """
+    Add EC-2 provider.
+    Perform SSA on Fedora instance.
+    Check whether it retrieves Files.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_files_scvmm2k12_rhel74():
+    """
+    Add SCVMM-2012 provider.
+    Perform SSA on RHEL 7.4 VM.
+    Check whether Files retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_files_scvmm2k16_centos_xfs():
+    """
+    Add SCVMM-2016 provider.
+    Perform SSA on CentOS VM.
+    Check whether Files retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_files_scvmm2k16_rhel74():
+    """
+    Add SCVMM-2016 provider.
+    Perform SSA on RHEL 7.4 VM.
+    Check whether Files retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_files_scvmm2k16_windows2012r2_ntfs():
+    """
+    Add SCVMM-2016 provider.
+    Perform SSA on Windows 2012 server R2 VM having NTFS filesystem.
+    Check whether it retrieves Files.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_files_scvmm2k12_windows2012r2_ntfs():
+    """
+    Add SCVMM-2012 provider.
+    Perform SSA on Windows 2012 server R2 VM having NTFS filesystem.
+    Check whether it retrieves Files.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_files_ec2_ubuntu():
+    """
+    Add EC-2 provider.
+    Perform SSA on Ubuntu instance.
+    Check whether it retrieves Files.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_files_scvmm2k16_windows2016_ntfs():
+    """
+    Add SCVMM-2016 provider.
+    Perform SSA on Windows 2016 server VM having NTFS filesystem.
+    Check whether it retrieves Files.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_files_azure_windows2012r2_ntfs():
+    """
+    1. Add Azure provider
+    2. Perform SSA on Windows server 2012 R2.
+    3. Check Files are retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_files_ec2_windows2012r2_ntfs():
+    """
+    Add EC-2 provider.
+    Perform SSA on Windows 2012 server R2 VM having NTFS filesystem.
+    Check whether it retrieves Files.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_files_azure_rhel():
+    """
+    1. Add Azure provider
+    2. Perform SSA on RHEL instance.
+    3. Check Files are retrieved.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/3h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_upload_azure_image_to_azure():
+    """
+    Upload image copied from RHCF3-11271 to azure using powershell
+    similiar the script in the setup section.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/2h
+        setup: # Video Demo Script - Upload VHD to Azure
+               # You have to log in via Login-AzureRmAccount
+               Get-AzureRmSubscription -SubscriptionId "9ee63d8e-aee7-4121-861c-
+               d67a5b8d231e" -TenantId "2e64678d-2fa8-40ed-8922-c9b8e2c3f100" |
+               Select-AzureRmSubscription
+               $ResourceGroupName = "CFMEQE-Main"
+               $BlobLocation = "https://cfmeqestore.blob.core.windows.net/"
+               $BlobContainer = "templates"
+               $BlobName = "tmpl-osDisk.vhd"
+               $BlobDestination = $BlobLocation + $BlobContainer + "/" + $BlobName
+               $LocalFilePath = "C:\tmp\"
+               $LocalFileName = "cfme-azure-5.6.0.13-1.x86_64.vhd"
+               $LocalFile = $LocalFilePath + $LocalFileName
+               Add-AzureRmVhd -ResourceGroupName $ResourceGroupName -Destination
+               $BlobDestination -LocalFilePath $LocalFile -NumberOfUploaderThreads 8
+        startsin: 5.6
+        title: Upload Azure image to Azure
+        upstream: no
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_add_network_credentials():
+    """
+    Add Network credentials.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+@pytest.mark.tier(2)
+def test_chargeback_report_filter_owner():
+    """
+    Verify that chargeback reports can be generated by filtering on
+    owners.Make sure to include the "owner" column in the report.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+@pytest.mark.tier(3)
+def test_chargeback_report_filter_tag():
+    """
+    Verify that chargeback reports can be generated by filtering on tags
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_inventory_refresh_westindia_azure():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1473619
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_misclicking_checkbox_vms():
+    """
+    BZ1627387
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: infra
+        caseimportance: low
+        initialEstimate: 1/8h
+        setup: https://bugzilla.redhat.com/show_bug.cgi?id=1627387
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.upgrade
+@pytest.mark.tier(2)
+def test_upgrade_check_repo_names():
+    """
+    Checks default rpm repos on a upgraded appliance
+    https://bugzilla.redhat.com/show_bug.cgi?id=1411890
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/12h
+        setup: Provision appliance
+               navigate to Configuration-settings-region-redhat updates
+               Click edit subscription
+               Check repo name
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_sui_while_ordering_service_catalog_the_dynamic_drop_down_dialogs_fields_should_auto_r():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1568342
+    SUI - While ordering service catalog, the dynamic drop-down dialogs
+    fields do not auto-refreshed
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: SUI - While ordering service catalog, the dynamic drop-down
+               dialogs fields should auto-refresh
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_storage_ebs_volume_attach():
+    """
+    Requires:
+    An ec2 provider
+    Step to test:
+    1. Create an ec2 instance in region us-east-1
+    2. Create an ebs volume in region us-east-1
+    3. Go to Storage -> Block Storage -> Volumes
+    4. Select created volume
+    5. Configuration -> Attach this Cloud Volume
+    Fill in form:
+    Created instance
+    /dev/sdf
+    6. Check whether volume was attached to that instance
+
+    Polarion:
+        assignee: mmojzis
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_git_credentials_changed():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1552274
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_set_hostname_from_appliance_console_and_configure_external_auth():
+    """
+    set hostname from appliance_console and configure external_auth.
+    Steps:
+    1. ssh to appliance, and run appliance_console command
+    2. change the appliance hostname with valid FQDN
+    3. Verify External auth configuration does not fail.
+    https://bugzilla.redhat.com/show_bug.cgi?id=1360928
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/3h
+        title: set hostname from appliance_console and configure external_auth
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_group_infra_cpu_quota_by_lifecycle():
+    """
+    test group cpu quota for infra vm provision by Automate model
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: cloud
+        caseimportance: low
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.tag
+@pytest.mark.tier(2)
+def test_restricted_user_rbac_for_access_control():
+    """
+    Related to BZ#1311399
+    Navigate to Configure ==> Configuration ==> Access Control.
+    Create a new role with "VM & Template Access Restriction" as "Only
+    User or Group Owned" or "Only User Owned".  Make sure all the module
+    access is given in "Product Features (Editing)" i.e., Everything is
+    checked.
+    Create a new group with the above role.
+    Create a new user with the above group.
+    Login with the newly created user and navigate to Configure ==>
+    Configuration ==> Access Control.
+    Click on Users or Groups.
+
+    Polarion:
+        assignee: None
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_files_unicode():
+    """
+    Make sure https://bugzilla.redhat.com/show_bug.cgi?id=1221149 is fixed
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/2h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_upgrade_appliance_console_scap():
+    """
+    "ap" launches appliance_console, "" clears info screen, "14/17"
+    Hardens appliance using SCAP configuration, "" complete.
+    apply scap rules upgrade appliance and re-apply scap rules
+    Test Source
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/3h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_appliance_exec_scripts():
+    """
+    check that scripts in /var/www/miq/vmdb/tools have the executable
+    section added to the files.
+    #!/usr/bin/env ruby # finds ruby
+    require File.expand_path("../config/environment", __dir__) # loads
+    rails, only needed if the script needs it
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.log_depot
+@pytest.mark.tier(2)
+def test_log_scvmm_rollover_scvmm():
+    """
+    Need to verify that the scvmm.log rolls over at the end of each day
+    and is zipped up.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.5
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_verify_ldap_group_retrieval_works_fine_for_groups_with_descriptions_which_are_base64_():
+    """
+    verify ldap group retrieval works fine for groups with descriptions
+    which are base64 decoded , one random sample having an "é"
+    Refer the BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1367600
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/4h
+        title: verify ldap group retrieval works fine for groups with
+               descriptions which are base64 decoded
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware65_test_vm_migration_with_really_long_name_upto_64_chars_worked_not_65_char():
+    """
+    OSP: vmware65-Test VM migration with really long name(Upto 64 chars
+    worked, not 65 chars)
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware65-Test VM migration with really long name(Upto
+               64 chars worked, not 65 chars)
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.retirement
+def test_vms_retirement_state_field_is_capitalized_correctly():
+    """
+    Bug 1518926 - Inconsistent capitalization for Retirement State field
+    https://bugzilla.redhat.com/show_bug.cgi?id=1518926
+    When a VM is retiring or retired, the VM should show a "Retirement
+    State" field, not "Retirement state".
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/15h
+        title: VM's Retirement State field is capitalized correctly
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_catalog_item_for_ansible_playbook():
+    """
+    desc
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: critical
+        initialEstimate: 1/4h
+        startsin: 5.8
+        title: Catalog Item for Ansible Playbook
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_ansible_catalog_items():
+    """
+    test adding new playbook catalogs and items to remote and global
+    region
+    https://bugzilla.redhat.com/show_bug.cgi?id=1449696
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: config
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_add_rhos_credentials():
+    """
+    Add RHOS credentials.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1/2h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_user_can_run_post_migration_ansible_playbook():
+    """
+    OSP: Test user can run post migration ansible playbook
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test user can run post migration ansible playbook
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_user_can_download_pre_migration_ansible_playbook_log():
+    """
+    OSP: Test user can download pre migration ansible playbook log
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test user can download pre migration ansible playbook log
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_public_ip_reuse_azure():
+    """
+    Testing Public Ip reuse
+    prerequirements:
+    Free Public IP associated with Network interface but not assigned to
+    any VM
+    Select PubIP on Environment tab during provisioning
+
+    Polarion:
+        assignee: None
+        casecomponent: prov
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.7
+        tags: provision
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_service_infra_tenant_quota_cpu_default_entry_point():
+    """
+    tenant service cpu quota validation for infra provider using default
+    entry point
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        initialEstimate: 1/4h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(3)
+def test_service_ui_should_not_time_outs_after_10_mins_even_if_you_are_interacting_with_it():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1591436
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        initialEstimate: 1/16h
+        startsin: 5.8
+        title: Service UI should not time-outs after 10 mins even if you
+               are interacting with it
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_disabled_vsphere65_opsui_ssui():
+    """
+    For all versions of CFME 5.7 onward, VNC console should be Disabled
+    for vsphere65 in OPSUI and SSUI
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseposneg: negative
+        initialEstimate: 1h
+        startsin: 5.7
+        testSteps:
+            1. Select VMware Console Support to VNC in CFME and Try to
+               Access VM Console in OPS UI
+            2. Create a Service to provision VM on vSphere65, open SUI,
+               provision service, select provisioned service, On details
+               page, try to access VM Console
+        expectedResults:
+            1. VM Console button is disabled
+            2. VM Console is disabled
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware67_test_vm_migration_from_ubuntu():
+    """
+    OSP: vmware67-Test VM migration from ubuntu
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware67-Test VM migration from ubuntu
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_distributed_field_zone_description_leading_whitespace():
+    """
+    Leading whitespace in description
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/30h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_chargeback_report_monthly():
+    """
+    Verify that 1)monthly chargeback reports can be generated and 2)that
+    the report contains relevant data for the relevant period.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_edit_catalog_bundle():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1631040
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        initialEstimate: 1/4h
+        title: Edit catalog bundle
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_appliance_console_db_maintenance_periodic_unconfigure():
+    """
+    Test unconfiguring full vacums
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        endsin: 5.8
+        initialEstimate: 1/6h
+        setup: -ssh to appliance
+               -run appliance_console
+               -select option "configure database maintenance"
+               -say yes to "unconfigure Periodic Database Maintance"
+               -wait for the set time
+               -check that full vacums have stopped by checking log in
+               "vmdb/log/hourly.........log" (all timescales are stored in the hourly
+               log file)
+        startsin: 5.7
+        testSteps:
+            1. unconfigure periodic maintenance
+        expectedResults:
+            1. full vacuums stop running
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+def test_schedules_send_multiple_recipients():
+    """
+    Using scripts/smtp_collectior.py
+    Pre-requirements:
+    Set CFME Notifier role ON
+    CFME set up to use external SMTP using your local pc ip (port 1025)
+    Allow 1025 on local machine (firewall-cmd --add-port 1025/tcp)
+    Turn on smtp_collector in cfme_tests env
+    Set up schedule to send to 10 contacts.
+    1)Send schedule mail using default From address
+    2)Change From address and resend schedule mail
+    Check http://localhost:1026/messages.html for both sets of mail
+    present.
+
+    Polarion:
+        assignee: None
+        caseimportance: medium
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_duplicate_groups_when_setting_ownership_to_multiple_items():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1589009
+    1. Navigate to Infrastructure -> Provider -> Vmware
+    2. select multiple vms and go to Configuration -> Set ownership
+    3. Under group list, duplicate group names listed.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/6h
+        title: Test duplicate groups when setting ownership to multiple items
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_service_cloud_tenant_quota_storage_default_entry_point():
+    """
+    tenant service storage quota validation for cloud provider using
+    default entry point
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        initialEstimate: 1/4h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+def test_replication_central_admin_vm_reconfigure():
+    """
+    reconfigure a VM via CA
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: infra
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+def test_orphaned_vms_get_excluded_from_used_quota_counts():
+    """
+    Test that used Quota gets recounted and reduced, when a VM is
+    orphaned.
+    https://bugzilla.redhat.com/show_bug.cgi?id=1515979
+
+    Polarion:
+        assignee: mkourim
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/6h
+        title: Test orphaned VMs get excluded from used quota counts
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+@pytest.mark.tier(3)
+def test_saved_chargeback_report_show_full_screen():
+    """
+    Verify that saved chargeback reports can be viewed
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: low
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_button_state_enabled():
+    """
+    Custom button by default will be in the enabled state, but it can be
+    also used by putting positive expressions. For example: (enabled only
+    if VM > 0) In this case, button get enabled if the condition is true
+    and disabled if it is false.
+    Steps:
+    1. Add provider
+    2. Create service dialog
+    3. Create custom button group in service accordion option
+    5. Add button to the button group. In "Advanced" tab of button, put
+    valid expression for visibility (Make sure to select dialog created at
+    step2)
+    6. Create catalog from Services
+    7. Create catalog item and assign dialog & catalog created in step2 &
+    6 respectively.
+    8. Navigate to self-service UI and Order catalog item
+    9. Check enabled custom button by clicking service you have ordered
+    Expression used while test:  COUNT OF Service.User.VMs > -1
+    Additional info:
+    [1]This enhancement feature is related to https://github.com/ManageIQ
+    /manageiq-ui-service/pull/1012.
+    [2]Screenshot attached
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: ssui
+        caseimportance: low
+        initialEstimate: None
+        startsin: 5.9
+        upstream: no
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(3)
+def test_service_ansible_playbook_standard_output_non_ascii_hostname():
+    """
+    Look for Standard ouptut
+    https://bugzilla.redhat.com/show_bug.cgi?id=1534039
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+def test_embed_tower_add_private_repo():
+    """
+    Ability to add private repo with SCM credentials.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: critical
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+@pytest.mark.tier(1)
+def test_report_export_import_run_custom_report():
+    """
+    Steps:1. generate a report from an affected custom report
+    2. export the custom report
+    3. import the custom report
+    4. generate a new report of that custom reportall rows behave
+    consistently
+    https://bugzilla.redhat.com/show_bug.cgi?id=1498471
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.3
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(3)
+def test_service_ansible_service_name():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1505929
+    After creating the service using ansible playbook type add a new text
+    field to service dialog named "service_name" and then use that service
+    to order the service which will have a different name than the service
+    catalog item.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_authentication_user_not_in_ldap_but_in_db():
+    """
+    User is not able to authenticate if he has account in CFME DB but not
+    in LDAP.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.upgrade
+@pytest.mark.tier(2)
+def test_upgrade_multi_ha_inplace():
+    """
+    Test upgrading HA setup to latest build and confirm it continues to
+    work as expected.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1h
+        startsin: 5.8
+        testSteps:
+            1. Upgrade appliances
+            2. Check failover
+        expectedResults:
+            1. Confirm upgrade completes successfully
+            2. Confirm failover continues to work
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_service_ui_should_take_user_default_language():
+    """
+    Polarion:
+        assignee: sshveta
+        casecomponent: ssui
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.9
+        title: Service UI should take 'user default' language
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.general_ui
+def test_timeout():
+    """
+    Set timeout to 5 minutes.
+    Wait 6 minutes.
+    Click on anything.
+    There should be redirection to login view.
+    Log in.
+    There should be redirection to dashboard view.
+
+    Polarion:
+        assignee: anikifor
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_provision_from_private_image_azure():
+    """
+    1.Provision a VM using one private images
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: prov
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.9
+        tags: provision
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware67_test_vm_migration_with_rhel_69():
+    """
+    OSP: vmware67-Test VM migration with RHEL 6.9
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: critical
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware67-Test VM migration with RHEL 6.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.upgrade
+@pytest.mark.tier(2)
+def test_upgrade_multi_replication_inplace_55():
+    """
+    test upgrading replicated appliances to latest version
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        endsin: 5.9
+        initialEstimate: 1h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.upgrade
+@pytest.mark.tier(2)
+def test_upgrade_multi_replication_inplace_56():
+    """
+    test upgrading replicated appliances to latest version
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        endsin: 5.10
+        initialEstimate: 1h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_distributed_change_appliance_zone():
+    """
+    Move an appliance from one zone to another.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_creating_multiple_mappings_with_same_name():
+    """
+    OSP: Test creating multiple mappings with same name
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test creating multiple mappings with same name
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_ec2_tags_images():
+    """
+    Requirement: Have an ec2 provider
+    1) Select an AMI in AWS console and tag it with test:testing
+    2) Refresh provider
+    3) Go to summary of this image  and check whether there is
+    test:testing in Labels field
+    4) Delete that tag
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_migrations_with_multi_zonal_setup():
+    """
+    OSP: Test migrations with multi-zonal setup
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test migrations with multi-zonal setup
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_migration_using_vddk_connection_type_for_vmware():
+    """
+    OSP: Test Migration using VDDK (Connection type for VMware)
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: critical
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test Migration using VDDK (Connection type for VMware)
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_cloud_key_pair_validation():
+    """
+    Cloud - Key pair - without filling data , click on add
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/16h
+        startsin: 5.5
+        title: Cloud Key pair validation
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_provider_log_level():
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: infra
+        initialEstimate: 1/4h
+        setup: Tests that log level in advanced settings affects log files
+               Steps:
+               1. Change log level to debug
+               2. Refresh provider
+               3. Check logs contain debug level
+               4. Reset level back
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_mapping_can_be_created_with_name_including_international_chars():
+    """
+    OSP: Test mapping can be created with name including international
+    chars
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test mapping can be created with name including international chars
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_cluster_and_project_availablity_in_source_and_target():
+    """
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: RHV
+        title: Test cluster and project availablity in source and target
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_repo_url_validation():
+    """
+    After all processes are running fill out a new repo with resolvable
+    /un-resolvable url, use the validation button to check its correct.
+    https://bugzilla.redhat.com/show_bug.cgi?id=1478958
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.power
+@pytest.mark.tier(2)
+def test_restart_guest_scvmm2016():
+    """
+    This test performs the Restart Guest from the LifeCycle menu which
+    invokes the Hyper-V Guest Services Integration command.  This
+    gracefully exits and restarts the Windows OS rather than just powering
+    off and back on.
+    From collections page, select the VM and click "Restart Guest"
+    On SCVMM powershell, use "$vm = Get-VM -name "name_of_vm"; Find-SCJob
+    -objectId $vm.id -recent" to verify VM history shows "Shut down
+    virtual machine" instead of "power off"
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_restart_guest_scvmm():
+    """
+    This test performs the Restart Guest from the LifeCycle menu which
+    invokes the Hyper-V Guest Services Integration command.  This
+    gracefully exits and restarts the Windows OS rather than just powering
+    off and back on.
+    From collections page, select the VM and click "Restart Guest"
+    On SCVMM powershell, use "$vm = Get-VM -name "name_of_vm"; Find-SCJob
+    -objectId $vm.id -recent" to verify VM history shows "Shut down
+    virtual machine" instead of "power off"
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.4
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+@pytest.mark.tier(1)
+def test_reports_create_schedule_for_base_report_hourly():
+    """
+    Create schedule that runs report hourly during the day. Check it was
+    ran successfully
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/16h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(3)
+def test_crosshair_op_host_vsphere65():
+    """
+    Requires:
+    C&U enabled Vsphere-65 appliance.
+    Steps:
+    1. Navigate to Hosts [Compute > infrastructure>Hosts]
+    2. Select any available host
+    3. Go for utilization graphs [Monitoring > Utilization]
+    4. Check data point on graphs ["CPU", "VM CPU state", "Memory", "Disk
+    I/O", "N/w I/O", VMs] using drilling operation on the data points.
+    5.  check "chart", "timeline" and "display" option working properly or
+    not.
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(3)
+def test_crosshair_op_host_vsphere6():
+    """
+    test_crosshair_op_host[vsphere6]
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: low
+        initialEstimate: 1/12h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_automate_git_import_case_insensitive():
+    """
+    bin/rake evm:automate:import PREVIEW=false
+    GIT_URL=https://github.com/mkanoor/SimpleDomain REF=test2branch
+    This should not cause an error (the actual name of the branch is
+    Test2Branch).
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_custom_button_enable():
+    """
+    Check if the button is enabled or not
+    Steps
+    1)Add Button Group
+    2)Add a button to the newly created button group
+    3)Add an expression for enabling button
+    4)Add the Button group to a page
+    5)Check that button is enabled; if enabled pass else fail.
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/12h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(3)
+def test_service_ansible_playbook_retire_non_ascii():
+    """
+    Retire ansible playbook service with non_ascii host
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_verify_database_user_login_fails_with_external_auth_configured():
+    """
+    Login with user registered to cfme internal database.
+    Authentication expected to fail, check audit.log and evm.log for
+    correct log messages.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Verify DataBase user login fails with External auth configured.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_appliance_replicate_database_disconnection_with_backlog():
+    """
+    Test replication re-connect with backlog
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_verify_invalid_user_login_fails():
+    """
+    Login with invalid user
+    Authentication expected to fail, check audit.log and evm.log for
+    correct log messages.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/4h
+        title: Verify invalid user login fails
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_assert_failed_substitution():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1335669
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_subscription_multiple_azure():
+    """
+    Azure cloud providers are added to an appliance, not only by region
+    like other cloud providers, but by subscription as well.  This allows
+    customer to further refine access permissions.
+    For CFME-QE, we have two official subscriptions.  Dajo"s MSDN account
+    9ee63d8e-aee7-4121-861c-d67a5b8d231e and our PayGo account c9e72ccc-
+    b20e-48bd-a0c8-879c6dbcbfbb
+    Need to add one provider for the same account and region for each of
+    the above subscriptions.  The rest of the data is in the yamls  The
+    test passes when each "provider" contains only the relevant data.  You
+    can verify this inside of Azure.
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/8h
+        setup: Create an appliance
+        startsin: 5.7
+        upstream: yes
+        testSteps:
+            1. Add a provider with subscription 1
+            2. Add a provider with subscription 2
+        expectedResults:
+            1. Correct subscription VMs and data appear
+            2. Correct subscription VMs and data appear.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.right_size
+@pytest.mark.tier(1)
+def test_rightsize_memory_rhv41():
+    """
+    For a RHV 4.1 provider with C & U metrics collection configured and
+    running for >1 day, a VM that has been up and running for >1 day shows
+    values in all cells of the tables displayed on the Right-Size
+    Recommendations page:
+    Compute > Infrastructure > Virtual Machines > click on VM name >
+    Configuration > Right-Size Recommendations
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.right_size
+@pytest.mark.tier(2)
+def test_rightsize_memory_vsphere55():
+    """
+    Test Right size recommendation for memory
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.right_size
+@pytest.mark.tier(2)
+def test_rightsize_memory_vsphere6():
+    """
+    Test Right size recommendation for memory
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(3)
+def test_service_ansible_playbook_order_non_ascii():
+    """
+    test ordering ansible playbook service with non ascii characters in
+    the host
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_entries_shouldnt_be_mislabeled_for_dropdown_element_in_dialog_editor():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1597802
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        initialEstimate: 1/16h
+        startsin: 5.10
+        title: Entries Shouldn't be Mislabeled for Dropdown element in Dialog Editor
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.configuration
+@pytest.mark.tier(1)
+def test_my_settings_default_views_alignment():
+    """
+    Go to My Settings -> Default Views
+    See that all icons are aligned correctly
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/20h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_credentials_change_password_leading_whitespace():
+    """
+    Password with leading whitespace
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/8h
+        tags: rbac
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.retirement
+@pytest.mark.tier(2)
+def test_retire_cloud_vms_folder():
+    """
+    test the retire funtion of vm on cloud providers, at leat two vm,
+    retire now button vms page
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: prov
+        caseimportance: medium
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rest
+def test_automation_request_task():
+    """
+    In this test we will try to edit a automation request using POST
+    request.
+    Note: Only Option field can be edited
+
+    Polarion:
+        assignee: mkourim
+        caseimportance: medium
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.configuration
+def test_configure_icons_roles_by_server():
+    """
+    Go to Settings -> Configuration and enable all Server Roles.
+    Navigate to Settings -> Configuration -> Diagnostics -> CFME Region ->
+    Roles by Servers.
+    Click through all Roles and look for missing icons.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/15h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_service_chargeback_vm_poweredoff():
+    """
+    Validate Chargeback costs for a service with a VM that has been
+    powered off
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: report
+        caseimportance: low
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_scheduled_retirement_remains_same_in_migrated_vm():
+    """
+    OSP: Test scheduled retirement remains same in migrated VM
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test scheduled retirement remains same in migrated VM
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware65_test_vm_migration_with_rhel_69():
+    """
+    OSP: vmware65-Test VM migration with RHEL 6.9
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: critical
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware65-Test VM migration with RHEL 6.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(3)
+def test_opening_ssui_and_regular_ui_tab_in_same_browser_and_then_edit_catalog():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1321655
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: ssui
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.5
+        title: Opening SSUI and regular UI tab in same browser and then edit catalog
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_refresh_azure_provider_with_empty_ipv6_config_on_vm():
+    """
+    test case to cover -
+    https://bugzilla.redhat.com/show_bug.cgi?id=1468700
+    1) prepare azure  with https://mojo.redhat.com/docs/DOC-1145084
+    2) refresh provider - check logs
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_appliance_replicate_sync_role_change_with_backlog():
+    """
+    Replicate role change w/ a replication backlog
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        endsin: 5.6
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_active_tasks_get_timed_out_when_they_run_too_long():
+    """
+    active tasks get timed out when they run too long
+    Bug 1397600 - After killing reporting worker, report status still says
+    Running
+    https://bugzilla.redhat.com/show_bug.cgi?id=1397600
+    ****
+    1.) Set task timeout check frequency and timeout values:
+    :task_timeout_check_frequency: 600
+    :active_task_timeout: 10.minutes
+    2.) Queue a bunch of reports.
+    3.) Kill the MiqReportingWorker pid(s).
+    4.) Repeat #2 and #3 a couple times, until one of the reports gets
+    stuck with a Running status.
+    5.) After ~10 minutes, see entries like the following in evm.log, and
+    verify that the reports show a status of Error in the web UI.
+    [----] I, [2017-06-12T16:05:14.491076 #18861:3bd134]  INFO -- :
+    MIQ(MiqTask#update_status) Task: [213] [Finished] [Error] [Task [213]
+    timed out - not active for more than 600 seconds]
+    ****
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/2h
+        startsin: 5.7
+        title: active tasks get timed out when they run too long
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(2)
+def test_reconfigure_existing_duplicate_orders():
+    """
+    decs
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.log_depot
+@pytest.mark.tier(1)
+def test_log_collect_current_zone():
+    """
+    using any type of depot check collect current log function under zone
+    (using structure one server under zone, zone and server should be
+    configured)
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.power
+@pytest.mark.tier(2)
+def test_power_controls_on_archived_vm():
+    """
+    1)add any Cloud provider
+    2)provision VM
+    3)delete it (we need Archived VM)
+    4)open Archived Vms/or All Vms and find your VM
+    5)select it"s Quadicon and/or open it"s Details
+    6)power menu should be Disabled
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: cloud
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/10h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_replication_central_admin_adhoc_provision_template():
+    """
+    Polarion:
+        assignee: tpapaioa
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+def test_report_secondary_display_filter_should_be_editable():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1565171
+    Steps to Reproduce:
+    1.Create report based on container images
+    2. Select some fields for the report
+    3. ON the filter tab add primary filter
+    4. Add secondary filter
+    5. try to edit the secondary filter.
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/6h
+        title: Report secondary (display) filter should be editable
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_playbooks_tag():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1526218
+    RBAC - tag playbooks and allow user to see just this taged playbook.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1/2h
+        startsin: 5.10
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rbac
+def test_ordering_service_by_non_admin_user():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1546944
+    1. Go to Access Control, Create a role named "service_role" with below
+    roles should be enabled i.e. Compute and Services.
+    2. Create a user i.e. "service_user" based on this "service_role"
+    3. Login with service_user and while ordering the catalog, it is
+    throwing 403 Forbidden exception.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Test ordering service by non-admin user
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(3)
+def test_gap_collection_hourly_graph_vsphere6():
+    """
+    Draft
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_appliance_replicate_database_disconnection():
+    """
+    test replication re-connection w/ no backlog
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_distributed_zone_failover_provider_inventory_singleton():
+    """
+    Provider Inventory (singleton)
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_vm_reconfig_resize_disk_cold_vsphere67_nested_independent_persistent_thick():
+    """
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: 1/6h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_vm_reconfig_resize_disk_cold_vsphere67_nested_persistent_thin():
+    """
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: 1/6h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_vm_reconfig_resize_disk_cold_vsphere67_nested_independent_persistent_thin():
+    """
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: 1/6h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_vm_reconfig_resize_disk_cold_vsphere67_nested_independent_nonpersistent_thin():
+    """
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: 1/6h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_vm_reconfig_resize_disk_cold_vsphere67_nested_independent_nonpersistent_thick():
+    """
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: 1/6h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_deployment_multiple_instances():
+    """
+    Deployment of mutiple instances in same stack
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_distributed_zone_failover_provider_operations():
+    """
+    Provider Operations (multiple appliances can have this role)
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_archive_completed_migration_plan():
+    """
+    OSP: Test Archive completed migration plan
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test Archive completed migration plan
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_migration_logs_from_conversion_host_can_be_retrieved_from_miq_appliance():
+    """
+    OSP: Test migration logs from conversion host can be retrieved from
+    miq appliance
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: critical
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test migration logs from conversion host can be
+               retrieved from miq appliance
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_vm_volume_specchar1_scvmm():
+    """
+    Special Test to verify that VMs that have Volumes with no drive letter
+    assigned don"t cause systemic SCVMM provider errors.  This is a low
+    priority test.
+    https://bugzilla.redhat.com/show_bug.cgi?id=1353285
+
+    Polarion:
+        assignee: None
+        casecomponent: infra
+        caseimportance: low
+        initialEstimate: 1/4h
+        startsin: 5.6.1
+        upstream: no
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_appliance_console_static_dns():
+    """
+    test setting secondary dns and check it"s saved as the new default
+    https://bugzilla.redhat.com/show_bug.cgi?id=1439348
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_evmgroup_self_service_user_can_access_the_self_service_ui():
+    """
+    Verify that a user in the assigned to the EVMRole-self_service and
+    EVMRole-self_service can login to the SSUI
+
+    Polarion:
+        assignee: apagac
+        casecomponent: ssui
+        caseimportance: critical
+        initialEstimate: 1/4h
+        startsin: 5.8
+        title: EVMGroup-self_service user can access the Self Service UI
+        testSteps:
+            1. Create a user assigned to the default role of EVMRole-self_service
+            2. Login to the SSUI with the user
+        expectedResults:
+            1. User created successfully
+            2. SSUI access granted
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(2)
+def test_notifications_should_appear_in_sui_after_enableing_embedded_ansible_role():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1637512
+
+    Polarion:
+        assignee: nansari
+        casecomponent: ssui
+        caseimportance: medium
+        initialEstimate: 1/16h
+        title: Notifications should appear in SUI after Enableing Embedded Ansible Role
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(3)
+def test_able_to_access_openstack_instance_console_from_self_service_portal():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1624573
+
+    Polarion:
+        assignee: nansari
+        casecomponent: ssui
+        initialEstimate: 1/2h
+        startsin: 5.9
+        title: Able to access Openstack instance console from self service portal
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_service_provision_managed_image_azure():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1470491
+    1. Provision Service using azure managed disk/image
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: cloud
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.provision
+@pytest.mark.tier(2)
+def test_admin_username_azure():
+    """
+    Create provision request with username = "admin" - UI warning should
+    appear
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: infra
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/10h
+        testtype: nonfunctional
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_user_can_run_pre_migration_ansible_playbook():
+    """
+    OSP: Test user can run pre migration ansible playbook
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test user can run pre migration ansible playbook
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_vm_terminate_deletedisk_azure():
+    """
+    New for 5.6.1, when terminating a VM in Azure, we need to go to the
+    storage account and make sure the disk has also been removed.  You can
+    check the VM details for the exact disk location prior to deleting.
+    Note that Azure itself does not delete the disk when a VM is deleted,
+    so this may initially cause some confusion.
+    https://bugzilla.redhat.com/show_bug.cgi?id=1353306
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.6.1
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_import_namespace_attributes_updated():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1440226 1. Export an
+    Automate model
+    2. Change the display name and description in the exported namespace
+    yaml file
+    3. Run an import with the updated data
+    4. Check if the namespace attributes get updated.Display name and
+    description attributes should get updated
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: low
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_appliance_console_apache_reload_log_rotate():
+    """
+    Check that apache is not reloaded twice after log rotations.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        initialEstimate: 1/12h
+        startsin: 5.10
+        testtype: structural
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.upgrade
+@pytest.mark.tier(2)
+def test_update_webui_ha():
+    """
+    Test webui update from minor versions with HA active
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/2h
+        setup: provision 3 appliances
+               setup HA following https://mojo.redhat.com/docs/DOC-1097888
+               check setup is working by accessing webui
+               add repos for new build
+               login to RHSM
+               check for updates
+               update appliances
+               confirm HA continues to work as expected after update
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_tagvis_configuration_management_configured_system():
+    """
+    Tag a configuration management's configured system and check for its
+    visibility
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+@pytest.mark.tier(1)
+def test_edit_chargeback_for_projects_report():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1485006
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/16h
+        startsin: 5.3
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_service_infra_tenant_quota_memory_default_entry_point():
+    """
+    tenant service memory quota validation for infra provider using
+    default entry point
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        initialEstimate: 1/4h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.power
+@pytest.mark.tier(2)
+def test_power_contols_on_vm_in_stack_cloud():
+    """
+    1.Provision a VM via Service (Orchestration template - azure/ec2/rhos)
+    2.Navigate to cloud->stacks->select a stack
+    3.click on the instance in relationship section of stack summary page
+    4.check power controls
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/3h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.tag
+@pytest.mark.tier(2)
+def test_tenant_template_visibility():
+    """
+    Create group with role "user owned only"
+    As admin navigate to templates and set ownership for user
+    Log in as user, check template is visible for user(only this template)
+
+    Polarion:
+        assignee: None
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_vncstartportnegative_endportnegative():
+    """
+    Should fail to open console
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+def test_html5_console_firefox_ssui_rhel():
+    """
+    1.Login to ssui
+    2.provision service
+    3.Navigate to the my services and click on "Open a HTML5 console for
+    this vm" icon of that service.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 2/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Automation-> Automate -> Customization and from
+               accordion menu on the left, select Service Dialogs and
+               Create a service dialog
+            3. Go to Services-> Catalogs, click on Catalog items in
+               accordion menu and create a new catalog item using the
+               service dialog that you just created
+            4. Click on Catalogs in the Accordion menu and create a new
+               catalog to hold catalog item created in the previous step
+            5. login to self service portal of CFME and order the service catalog
+            6. Once service is up and running, you should see a VM running
+               for that service, kindly click on Access-> VM Console for
+               that VM
+            7. Repeat previous 2 steps in Firefox version latest, latest-1, latest-2
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Service dialog should get created and appear in the
+               accordion menu under service dialogs
+            3. catalog item should be created
+            4. new catalog should be created
+            5. service request should get created and completed successfully in few mins
+            6. VM Console should open and you should be able to interact
+               with it with mouse and keyboard
+            7. All should behave the same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_ie11_vsphere6_win7():
+    """
+    HTML5 Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on IE
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+def test_html5_console_edge_ssui_win10():
+    """
+    1.Login to ssui
+    2.provision service
+    3.Navigate to the my services and click on "Open a HTML5 console for
+    this vm" icon of that service.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 2/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on IE
+            2. Go to Automation-> Automate -> Customization and from
+               accordion menu on the left, select Service Dialogs and
+               Create a service dialog
+            3. Go to Services-> Catalogs, click on Catalog items in
+               accordion menu and create a new catalog item using the
+               service dialog that you just created
+            4. Click on Catalogs in the Accordion menu and create a new
+               catalog to hold catalog item created in the previous step
+            5. login to self service portal of CFME and order the service catalog
+            6. Once service is up and running, you should see a VM running
+               for that service, kindly click on Access-> VM Console for
+               that VM
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Service dialog should get created and appear in the
+               accordion menu under service dialogs
+            3. catalog item should be created
+            4. new catalog should be created
+            5. service request should get created and completed successfully in few mins
+            6. VM Console should open and you should be able to interact
+               with it with mouse and keyboard
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_firefox_vsphere55_win7():
+    """
+    HTML5 Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat the steps for the Firefox versions Latest, Latest-1, Latest-2
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+            5. All should behave same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_vncstartport5955_endportblank():
+    """
+    Should open connections for VNC port starting 5955 and keep opening
+    until ports exhausted.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+def test_html5_console_chrome_vsphere6_fedora28():
+    """
+    HTML5 test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+def test_html5_console_chrome_ssui_fedora():
+    """
+    1.Login to ssui
+    2.provision service
+    3.Navigate to the my services and click on "Open a HTML5 console for
+    this vm" icon of that service.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Automation-> Automate -> Customization and from
+               accordion menu on the left, select Service Dialogs and
+               Create a service dialog
+            3. Go to Services-> Catalogs, click on Catalog items in
+               accordion menu and create a new catalog item using the
+               service dialog that you just created
+            4. Click on Catalogs in the Accordion menu and create a new
+               catalog to hold catalog item created in the previous step
+            5. login to self service portal of CFME and order the service catalog
+            6. Once service is up and running, you should see a VM running
+               for that service, kindly click on Access-> VM Console for
+               that VM
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Service dialog should get created and appear in the
+               accordion menu under service dialogs
+            3. catalog item should be created
+            4. new catalog should be created
+            5. service request should get created and completed successfully in few mins
+            6. VM Console should open and you should be able to interact
+               with it with mouse and keyboard
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+def test_html5_console_chrome_vsphere55_fedora28():
+    """
+    HTML5 test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+def test_html5_console_firefox_vsphere55_fedora28():
+    """
+    HTML5 test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 2/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat the steps for the Firefox versions Latest, Latest-1, Latest-2
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+            5. All should behave same
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_html5_console_inaddproviderhoststartvncportpresent():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1514594
+    Check to see if the Add provider screen has the Host VNC Start Port
+    and Host VNC End port.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/4h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+def test_html5_console_chrome_ssui_rhel():
+    """
+    1.Login to ssui
+    2.provision service
+    3.Navigate to the my services and click on "Open a HTML5 console for
+    this vm" icon of that service.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 2/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Automation-> Automate -> Customization and from
+               accordion menu on the left, select Service Dialogs and
+               Create a service dialog
+            3. Go to Services-> Catalogs, click on Catalog items in
+               accordion menu and create a new catalog item using the
+               service dialog that you just created
+            4. Click on Catalogs in the Accordion menu and create a new
+               catalog to hold catalog item created in the previous step
+            5. login to self service portal of CFME and order the service catalog
+            6. Once service is up and running, you should see a VM running
+               for that service, kindly click on Access-> VM Console for
+               that VM
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Service dialog should get created and appear in the
+               accordion menu under service dialogs
+            3. catalog item should be created
+            4. new catalog should be created
+            5. service request should get created and completed successfully in few mins
+            6. VM Console should open and you should be able to interact
+               with it with mouse and keyboard
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_firefox_vsphere6_win2012():
+    """
+    HTML5 Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat the steps for the Firefox versions Latest, Latest-1, Latest-2
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+            5. All should behave same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_firefox_vsphere6_win10():
+    """
+    HTML5 Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 2/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat the steps for the Firefox versions Latest, Latest-1, Latest-2
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+            5. All should behave same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_vncstartportblank_endport5901():
+    """
+    Should open connections for VNC port starting 5900 and end at 5901
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_firefox_vsphere6_rhel6x():
+    """
+    HTML5 Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat the steps for the Firefox versions Latest, Latest-1, Latest-2
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+            5. All should behave same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+def test_html5_console_firefox_vsphere55_fedora26():
+    """
+    HTML5 test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat the steps for the Firefox versions Latest, Latest-1, Latest-2
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+            5. All should behave same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+def test_html5_console_chrome_vsphere6_fedora26():
+    """
+    HTML5 test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_html5_console_edge_rhevm41_win10_vnc():
+    """
+    HTML5 test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/3h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_html5_console_firefox_rhevm41_fedora28_vnc():
+    """
+    HTML5 test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/3h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_firefox_vsphere55_rhel7x():
+    """
+    HTML5 Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 2/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testtype: integration
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat the steps for the Firefox versions Latest, Latest-1, Latest-2
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+            5. All should behave same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_chrome_vsphere55_win10():
+    """
+    HTML5 Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_html5_console_firefox_rhevm41_fedora28_spice():
+    """
+    HTML5 test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/3h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_ie11_vsphere55_win2012():
+    """
+    HTML5 Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on IE
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+def test_html5_console_firefox_vsphere6_fedora26():
+    """
+    HTML5 test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat the steps for Firefox Version Latest, Latest-1, Latest-2
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+            5. All should behave same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_vsphere6_ssui():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1597393VMware VNC Remote
+    Console does not work in SSUI with following error:
+    There was an error opening the console. undefined
+    Steps to Reproduce:
+    1.Add VMware 6.0 or less provider to CFME
+    2.Create a Catalog item to provision a VM on VMware
+    3.Order the catalog
+    4.Login to SUI and open service details page
+    5.Click Access -> VM Console (Make sure in OPS UI Configuration VMware
+    Console Support is set to VNC)
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_chrome_vsphere55_rhel7x():
+    """
+    HTML5 Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+def test_html5_console_chrome_vsphere55_fedora27():
+    """
+    HTML5 test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_chrome_vsphere55_win7():
+    """
+    HTML5 Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_vncstartport5900_endport5902():
+    """
+    HTML5 tests have Host VNC start and End port settings now in Add
+    VMware provider section, specifying the port range limits number of
+    Consoles that can be opened simultaneously.We need to check that
+    End port - Start Port + 1 = Number of Connections(console) that can be
+    opened
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_ie11_vsphere55_win7():
+    """
+    HTML5 Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testtype: integration
+        testSteps:
+            1. Launch CFME Appliance on IE
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+def test_html5_console_firefox_vsphere6_fedora28():
+    """
+    HTML5 test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 2/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat the steps for Firefox Version Latest, Latest-1, Latest-2
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+            5. All should behave same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_firefox_vsphere55_win2012():
+    """
+    HTML5 Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat all steps for Firefox version Latest, Latest-1, Latest-2
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+            5. All should behave same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_rhv():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1573739
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_firefox_vsphere55_win10():
+    """
+    HTML5 Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 2/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat the steps for the Firefox versions Latest, Latest-1, Latest-2
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+            5. All should behave same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_edge_vsphere6_win10():
+    """
+    HTML5 Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on IE
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_vncstartport5955_endport5956():
+    """
+    HTML5 tests have Host VNC start and End port settings now in Add
+    VMware provider section, specifying the port range limits number of
+    Consoles that can be opened simultaneously.We need to check that
+    End port - Start Port + 1 = Number of Connections(console) that can be
+    opened
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_vncstartportblank_endportblank():
+    """
+    Both Start and End ports are blank. So Console will start opening with
+    port 5900 and you can open consoles until ports are exhausted.
+    UPDATE: I think console is going to be opened on
+    port_that_was_last_used + 1. This means it won"t always be 5900.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+def test_html5_console_edge_rhevm41_win10_spice():
+    """
+    HTML5 test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/3h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+def test_html5_console_chrome_ssui_win7():
+    """
+    1.Login to ssui
+    2.provision service
+    3.Navigate to the my services and click on "Open a HTML5 console for
+    this vm" icon of that service.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Automation-> Automate -> Customization and from
+               accordion menu on the left, select Service Dialogs and
+               Create a service dialog
+            3. Go to Services-> Catalogs, click on Catalog items in
+               accordion menu and create a new catalog item using the
+               service dialog that you just created
+            4. Click on Catalogs in the Accordion menu and create a new
+               catalog to hold catalog item created in the previous step
+            5. login to self service portal of CFME and order the service catalog
+            6. Once service is up and running, you should see a VM running
+               for that service, kindly click on Access-> VM Console for
+               that VM
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Service dialog should get created and appear in the
+               accordion menu under service dialogs
+            3. catalog item should be created
+            4. new catalog should be created
+            5. service request should get created and completed successfully in few mins
+            6. VM Console should open and you should be able to interact
+               with it with mouse and keyboard
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_html5_console_check_consistency_of_behavior():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1525692
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 3/4h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+def test_html5_console_firefox_ssui_win7():
+    """
+    1.Login to ssui
+    2.provision service
+    3.Navigate to the my services and click on "Open a HTML5 console for
+    this vm" icon of that service.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Automation-> Automate -> Customization and from
+               accordion menu on the left, select Service Dialogs and
+               Create a service dialog
+            3. Go to Services-> Catalogs, click on Catalog items in
+               accordion menu and create a new catalog item using the
+               service dialog that you just created
+            4. Click on Catalogs in the Accordion menu and create a new
+               catalog to hold catalog item created in the previous step
+            5. login to self service portal of CFME and order the service catalog
+            6. Once service is up and running, you should see a VM running
+               for that service, kindly click on Access-> VM Console for
+               that VM
+            7. Repeat previous 2 steps in Firefox version latest, latest-1, latest-2
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Service dialog should get created and appear in the
+               accordion menu under service dialogs
+            3. catalog item should be created
+            4. new catalog should be created
+            5. service request should get created and completed successfully in few mins
+            6. VM Console should open and you should be able to interact
+               with it with mouse and keyboard
+            7. All should behave the same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+def test_html5_console_firefox_vsphere55_fedora27():
+    """
+    HTML5 test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat the steps for the Firefox versions Latest, Latest-1, Latest-2
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+            5. All should behave same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+def test_html5_console_firefox_ssui_fedora():
+    """
+    1.Login to ssui
+    2.provision service
+    3.Navigate to the my services and click on "Open a HTML5 console for
+    this vm" icon of that service.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Automation-> Automate -> Customization and from
+               accordion menu on the left, select Service Dialogs and
+               Create a service dialog
+            3. Go to Services-> Catalogs, click on Catalog items in
+               accordion menu and create a new catalog item using the
+               service dialog that you just created
+            4. Click on Catalogs in the Accordion menu and create a new
+               catalog to hold catalog item created in the previous step
+            5. login to self service portal of CFME and order the service catalog
+            6. Once service is up and running, you should see a VM running
+               for that service, kindly click on Access-> VM Console for
+               that VM
+            7. Repeat previous 2 steps in Firefox version latest, latest-1, latest-2
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Service dialog should get created and appear in the
+               accordion menu under service dialogs
+            3. catalog item should be created
+            4. new catalog should be created
+            5. service request should get created and completed successfully in few mins
+            6. VM Console should open and you should be able to interact
+               with it with mouse and keyboard
+            7. All should behave the same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_chrome_vsphere6_win7():
+    """
+    HTML5 Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_chrome_vsphere6_rhel7x():
+    """
+    HTML5 Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: critical
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_edge_vsphere55_win10():
+    """
+    HTML5 Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on IE
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+def test_html5_console_firefox_ssui_win10():
+    """
+    1.Login to ssui
+    2.provision service
+    3.Navigate to the my services and click on "Open a HTML5 console for
+    this vm" icon of that service.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 2/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Automation-> Automate -> Customization and from
+               accordion menu on the left, select Service Dialogs and
+               Create a service dialog
+            3. Go to Services-> Catalogs, click on Catalog items in
+               accordion menu and create a new catalog item using the
+               service dialog that you just created
+            4. Click on Catalogs in the Accordion menu and create a new
+               catalog to hold catalog item created in the previous step
+            5. login to self service portal of CFME and order the service catalog
+            6. Once service is up and running, you should see a VM running
+               for that service, kindly click on Access-> VM Console for
+               that VM
+            7. Repeat previous 2 steps in Firefox version latest, latest-1, latest-2
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Service dialog should get created and appear in the
+               accordion menu under service dialogs
+            3. catalog item should be created
+            4. new catalog should be created
+            5. service request should get created and completed successfully in few mins
+            6. VM Console should open and you should be able to interact
+               with it with mouse and keyboard
+            7. All should behave the same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+def test_html5_console_chrome_vsphere55_fedora26():
+    """
+    HTML5 test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_html5_console_chrome_rhevm41_fedora28_spice():
+    """
+    HTML5 test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/3h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_firefox_vsphere55_rhel6x():
+    """
+    HTML5 Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat the steps for the Firefox versions Latest, Latest-1, Latest-2
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+            5. All should behave same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_chrome_vsphere6_win10():
+    """
+    HTML5 Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_chrome_vsphere55_win2012():
+    """
+    HTML5 Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+def test_html5_console_chrome_vsphere6_fedora27():
+    """
+    HTML5 test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+def test_html5_console_firefox_vsphere6_fedora27():
+    """
+    HTML5 test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat the steps for Firefox Version Latest, Latest-1, Latest-2
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+            5. All should behave same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_chrome_vsphere6_win2012():
+    """
+    HTML5 Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+def test_html5_console_ie11_ssui_win7():
+    """
+    1.Login to ssui
+    2.provision service
+    3.Navigate to the my services and click on "Open a HTML5 console for
+    this vm" icon of that service.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on IE
+            2. Go to Automation-> Automate -> Customization and from
+               accordion menu on the left, select Service Dialogs and
+               Create a service dialog
+            3. Go to Services-> Catalogs, click on Catalog items in
+               accordion menu and create a new catalog item using the
+               service dialog that you just created
+            4. Click on Catalogs in the Accordion menu and create a new
+               catalog to hold catalog item created in the previous step
+            5. login to self service portal of CFME and order the service catalog
+            6. Once service is up and running, you should see a VM running
+               for that service, kindly click on Access-> VM Console for
+               that VM
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Service dialog should get created and appear in the
+               accordion menu under service dialogs
+            3. catalog item should be created
+            4. new catalog should be created
+            5. service request should get created and completed successfully in few mins
+            6. VM Console should open and you should be able to interact
+               with it with mouse and keyboard
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_ie11_vsphere6_win2012():
+    """
+    HTML5 Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on IE
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_firefox_vsphere6_win7():
+    """
+    HTML5 Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat the steps for the Firefox versions Latest, Latest-1, Latest-2
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+            5. All should behave same
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_html5_console_chrome_rhevm41_fedora28_vnc():
+    """
+    HTML5 test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/3h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.html5
+@pytest.mark.tier(2)
+def test_html5_console_firefox_vsphere6_rhel7x():
+    """
+    HTML5 Test
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: critical
+        initialEstimate: 2/3h
+        setup: On CFME Appliance do the following:
+               1) Login to CFME Appliance as admin.
+               2) On top right click Administrator|EVM -> Configuration.
+               3) Under VMware Console Support section and click on Dropdown in front
+               of "Use" and select "VNC".
+               4) Click save at the bottom of the page.
+               This will setup your appliance for using HTML5 VNC Console and not to
+               use VMRC Plug in which is Default when you setup appliance.
+               Note: [XX-YY-ZZ] stands for ->
+               XX: Browser
+               YY: Platform or SSUI-Self Service UI
+               ZZ: OS
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat the steps for the Firefox versions Latest, Latest-1, Latest-2
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs console should render in the
+               HTML5 canvas element and should be able to interact with it
+               using mouse & keyboard.
+            5. All should behave same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.log_depot
+@pytest.mark.tier(1)
+def test_log_collect_current_zone_multiple_servers():
+    """
+    using any type of depot check collect current log function under zone,
+    zone has multiplie servers under it. Zone and all servers should have
+    theire own settings
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware65_test_vm_with_multiple_nics_each_of_those_two_nic_can_have_only_2_ip_addr():
+    """
+    OSP: vmware65-Test VM with multiple NICs with single IP (IPv6 to first
+    NIC and IPv4 to second)
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware65-Test VM with multiple NICs (Each of those two
+               NIC can have only 2 IP addresses, 1 IPv4 and 1 IPv6)
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.config_management
+@pytest.mark.tier(1)
+def test_config_manager_override_extra_vars_dialog_vsphere():
+    """
+    1. add tower 2.4.3 provider and perform refresh
+    2. Go to job templates
+    3. Create service dialog from third_job_template
+    - this template is bound to vsphere55 inventory
+    - simple_play_4_dockers.yaml playbook is part of this template
+    - this playbook will touch /var/tmp/touch_from_play.txt
+    - into /var/tmp/touch_from_play_dumped_vars.txt all variables
+    available during play run will be dumped
+    - this includes also variables passed from Tower or CFME
+    - this project is linked with Tower and Vsphere55 credentials
+    - Vsphere55 credentials are used when inventory is retrieved
+    - Tower credentials are the creds used to login into VM which will be
+    deployed
+    - Vsphere template used for VM deployment must have ssh key "baked" in
+    -
+    Prompt for Extra variables must be enabled.
+    4. Add Vsphere55 provider into CFME and perform refresh
+    5. Create new Catalog
+    6. Add new catalog item for Vsphere vcentre - VMWare
+    7. give it name, display in catalog, catalog,
+    8 Provisioning entry point:
+    /Service/Provisioning/StateMachines/ServiceProvision_Template/CatalogI
+    temInitialization
+    Request info tab:
+    Name of template: template_Fedora-Cloud-Base-23-vm-tools_v4 (this
+    template has ssh key which matches with Tower creentials)
+    VM Name: test_tower_pakotvan_1234 (it must start with test_tower_ -
+    inventory script on Tower 2.4.3 was modified to look only for such VMs
+    in order to speed up provisioning)
+    Envirnment tab:
+    - select where VM will be placed and datastore
+    Hardware: Select at least 1GB ram for our template
+    Network:
+    vLAN: VM Network
+    9. Automate -> Explorer
+    10. Add new Domain
+    11. Copy instance Infrastructure->Vm->Provisioning->StateMachines->VMP
+    rovision_VM->Provision_VM
+    from Template into your domain
+    12. Edit this instance
+    13. look for PostProvision in the first field/column
+    14. Into Value column add:
+    /ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job/def
+    ault?job_template_name=third_job_template
+    15. Automate -> Customization -> Service dialogs -> tower_dialog ->
+    Edit this dialog
+    Extra variables:
+    - make elements in extra variables writable (uncheck readonly).
+    - add new element add 1 extra variable - variables must start with
+    param_prefix, otherwised will be ignored!!!
+    16. Order service
+    Into limit field put exact name of your VM:  test_tower_pakotvan_1234
+    17. Login into provision VM and `cat
+    /var/tmp/touch_from_play_dumped_vars.txt` and grep for variables which
+    were passed from CFME UI.
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1d
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(2)
+def test_azone_disk_io_gce():
+    """
+    Utilization Test
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        initialEstimate: 1/12h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(1)
+def test_azone_disk_io_azure():
+    """
+    Utilization Test
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        initialEstimate: 1/12h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(2)
+def test_monitor_ansible_playbook_std_output():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1444853
+
+    Polarion:
+        assignee: apagac
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Monitor Ansible playbook std output
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.discovery
+def test_add_cloud_provider_screen():
+    """
+    Add cloud provider using Add Provider screen:
+    Open Stack:
+    -test Name
+    -test incorrect format of Name
+    (all combinations of following)
+    -test Hostname
+    -test incorrect format of Hostname
+    -test incorrect Hostname
+    -test Security Protocol
+    -test incorrect Security Protocol
+    -test Username
+    -test incorrect format of Username
+    -test incorrect Username
+    -test Password
+    -test incorrect format of Password
+    -test incorrect Password
+    -test Validate
+    -test switching Security Protocol
+    Events > AMQP
+    (all combinations of following)
+    -test Hostname
+    -test incorrect format of Hostname
+    -test incorrect Hostname
+    -test API Port
+    -test incorrect format of API Port
+    -test incorrect API Port
+    -test Security Protocol
+    -test incorrect Security Protocol
+    -test Username
+    -test incorrect format of Username
+    -test incorrect Username
+    -test Password
+    -test incorrect format of Password
+    -test incorrect Password
+    -test Validate
+    -test switching Security Protocol
+    Amazon EC2:
+    -test Name
+    -test incorrect format of Name
+    (all combinations of following)
+    -test Region
+    -test incorrect Region
+    -test Access Key ID
+    -test incorrect format of Access Key ID
+    -test incorrect Access Key ID
+    -test Secret Access Key
+    -test incorrect format of Secret Access Key
+    -test incorrect Secret Access Key
+    -test Confirm Secret Access Key
+    -test incorrect format of Confirm Secret Access Key
+    -test incorrect Confirm Secret Access Key
+    -test Validate
+    Azure:
+    -test Name
+    -test incorrect format of Name
+    (all combinations of following)
+    -test Region
+    -test incorrect Region
+    -test Tenant ID
+    -test incorrect format of Tenant ID
+    -test incorrect Tenant ID
+    -test Subscription ID
+    -test incorrect format of Subscription ID
+    -test incorrect Subscription ID
+    (all combinations of following)
+    -test Client ID
+    -test incorrect format of Client ID
+    -test incorrect Client ID
+    -test Client Key
+    -test incorrect format of Client Key
+    -test incorrect Client Key
+    -test Confirm Client Key
+    -test incorrect format of Confirm Client Key
+    -test incorrect Confirm Client Key
+    -test Validate
+    Google Compute Engine
+    -test Name
+    -test incorrect format of Name
+    (all combinations of following)
+    -test Region
+    -test incorrect Region
+    -test Project
+    -test incorrect format of Project
+    -test incorrect Project
+    -test Service Account JSON
+    -test incorrect format of Service Account JSON
+    -test incorrect Service Account JSON
+    -test Validate
+
+    Polarion:
+        assignee: pvala
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 3h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_appliance_log_error():
+    """
+    check logs for errors such as
+    https://bugzilla.redhat.com/show_bug.cgi?id=1392087
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_user_has_groups():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1411424
+    This method should work:  groups = $evm.vmdb(:user).first.miq_groups
+    $evm.log(:info, "Displaying the user"s groups: #{groups.inspect}")
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/12h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_automate_methods_from_dynamic_dialog_should_run_as_per_designed():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1571000
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        initialEstimate: 1/16h
+        startsin: 5.9
+        title: Automate Methods from Dynamic Dialog should Run as per Designed
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_button_enabled_ssui_false():
+    """
+    Steps to Reproduce:
+    1. Create a button, eg. for Service in this case. Set the visibility
+    and enablement expression to eg. some tags.
+    2. Create a service
+    3. Go to the Self Service UI, select the service and look for the
+    button and its status
+    4. Repeat 3 with setting and unsetting the appropriate tags and also
+    removing either or both of the expressions
+    If button disable then PASS
+    Additional info:
+    https://bugzilla.redhat.com/show_bug.cgi?id=1509959
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: automate
+        caseposneg: negative
+        initialEstimate: 1/8h
+        startsin: 5.9
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_button_enabled_ssui_true():
+    """
+    Steps to Reproduce:
+    1. Create a button, eg. for Service in this case. Set the visibility
+    and enablement expression to eg. some tags.
+    2. Create a service
+    3. Go to the Self Service UI, select the service and look for the
+    button and its status
+    4. Repeat 3 with setting and unsetting the appropriate tags and also
+    removing either or both of the expressions
+    If button enabled then PASS
+    Additional info:
+    https://bugzilla.redhat.com/show_bug.cgi?id=1509959
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: automate
+        initialEstimate: 1/8h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_vmware_storage_profile_provision():
+    """
+    The VM provisioning page includes drop-down listing storage_profiles
+    applicable to the ems.
+    if selected vm template has storage_profile attached, that
+    storage_profile is pre-selected
+    datastore listing is filtered by both existing filter and the selected
+    storage_profile
+
+    Polarion:
+        assignee: None
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/6h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_host_credentials_remote():
+    """
+    Validate that the host can be configured to allow remote connections,
+    usually WMI.  Used for Collect Running Processes
+
+    Polarion:
+        assignee: None
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/4h
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_cpu_cores_and_sockets_pre_vs_post_migration():
+    """
+    OSP: Test CPU Cores and Sockets Pre vs Post migration
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test CPU Cores and Sockets Pre vs Post migration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+@pytest.mark.tier(1)
+def test_import_export_report():
+    """
+    Import and export report
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/2h
+        setup: Create or Identify appliance
+               (no prerequisite or provider needed for this test)
+        title: Import/Export report
+        testSteps:
+            1. Sign up to appliance
+            2. Navigate to Cloud Intelligence > Reports
+            3. Select any report and create its copy
+            4. Locate newly created report in My Company > Custom
+            5. Navigate to Import / Export
+            6. Select Custom reports
+            7. Select newly copied report and select Export
+            8. Download the yaml file
+            9. Locate exported report in My Company > Custom
+            10. Delete exported report
+            11. Navigate back to Import / Export
+            12. Select Choose file
+            13. Locate and select previously downloaded yaml file
+            14. Select Upload
+            15. Locate import report in My Company > Custom
+            16. Sign out
+        expectedResults:
+            1.
+            2.
+            3.
+            4. Verify that canned report was copied under new name
+            5.
+            6. Verify you"ve been redirected to Import / Export screen
+            7. Verify that yaml file download was initiated
+            8.
+            9.
+            10.
+            11.
+            12. Verify File upload screen was open
+            13.
+            14. Verify Imported report is now again available for Export
+            15. Verify report is present
+            16.
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_button_on_catalog_item():
+    """
+    Steps:
+    1. Add catalog_item
+    2. Goto catalog detail page and select `add button` from toolbar
+    3. Fill info and save button
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(3)
+def test_service_template_provisioning_quota_for_number_of_vms_using_custom_dialog():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1455844
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: prov
+        initialEstimate: 1/4h
+        startsin: 5.8
+        title: test service template provisioning quota for number of vm's using custom dialog
+        testSteps:
+            1. Create a service catalog with vm_name, instance_type &
+               number_of_vms as fields. Set quotas threshold values for
+               number_of_vms to 5 and provision service catalog with vm
+               count as 10.
+        expectedResults:
+            1. should get quota exceeded message
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(3)
+def test_verify_external_authentication_with_openldap_proxy_to_3_different_domains():
+    """
+    verify external authentication with OpenLDAP proxy to 3 different
+    domains
+    refer the bz: https://bugzilla.redhat.com/show_bug.cgi?id=1306436
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/2h
+        title: verify external authentication with OpenLDAP proxy to 3 different domains
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+@pytest.mark.tier(1)
+def test_distributed_zone_failover_notifier_singleton():
+    """
+    Notifier (singleton)
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_appliance_console_db_maintenance_hourly_unconfigure():
+    """
+    Test unconfiguring db maintenance for Hourly re-indexing of tables
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        endsin: 5.8
+        initialEstimate: 1/6h
+        setup: -ssh to appliance
+               -run appliance_console
+               -select option "configure database maintenance"
+               -say yes to unconfigure hourly database maintenance (requires hourly
+               db maintenance to already be configured)
+               -wait 1 hour
+               -check that maintenance is has stopped correctly by checking log in
+               "vmdb/log/hourly.........log"
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_button_visible_ssui_false():
+    """
+    Steps to Reproduce:
+    1. Create a button, eg. for Service in this case. Set the visibility
+    and enablement expression to eg. some tags.
+    2. Create a service
+    3. Go to the Self Service UI, select the service and look for the
+    button and its status
+    4. Repeat 3 with setting and unsetting the appropriate tags and also
+    removing either or both of the expressions
+    If button hidden then PASS
+    Additional info:
+    https://bugzilla.redhat.com/show_bug.cgi?id=1509959
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: automate
+        caseposneg: negative
+        initialEstimate: 1/8h
+        startsin: 5.9
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_button_visible_ssui_true():
+    """
+    Steps to Reproduce:
+    1. Create a button, eg. for Service in this case. Set the visibility
+    and enablement expression to eg. some tags.
+    2. Create a service
+    3. Go to the Self Service UI, select the service and look for the
+    button and its status
+    4. Repeat 3 with setting and unsetting the appropriate tags and also
+    removing either or both of the expressions
+    If button visible then PASS
+    Additional info:
+    https://bugzilla.redhat.com/show_bug.cgi?id=1509959
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: automate
+        initialEstimate: 1/8h
+        startsin: 5.9
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.cfme_tenancy
+def test_superadmin_tenant_admin_crud():
+    """
+    Super admin is able to create new tenant administrator
+    1) Create new role by copying EvmRole-tenant_administrator
+    2) Create new group and choose role created in previous step and your
+    tenant
+    3) Create new tenant admin user and assign him into group created in
+    previous step
+    4) Update the user details and delete the user.
+
+    Polarion:
+        assignee: mnadeem
+        casecomponent: config
+        initialEstimate: 1/4h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(3)
+def test_self_service_ui_should_honor_some_service_dialog_settings():
+    """
+    SSUI should honor dialog settings.
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: ssui
+        initialEstimate: 1/4h
+        setup: https://bugzilla.redhat.com/show_bug.cgi?id=1518017
+               Steps to Reproduce:
+               1. Create service dialog with at least one dynamic drop down, click
+               the "Show Refresh Button" option
+               2. De-select "Load Values on Init" to disable this option for the
+               dynamic drop
+               3. Crete a catalog item that uses this service dialog
+               4. Navigate using the normal UI to and order the catalog item.  Notice
+               the dynamic drop down does not run and load values, which is as
+               expected.
+               5. Now, open the Self Service ui and order this same catalog item.
+               Notice that the dynamic drop down will run and load values, ignoring
+               the "load values on init" option.
+        title: Self Service UI should honor some service dialog settings
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.upgrade
+@pytest.mark.tier(2)
+def test_upgrade_custom_css():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1553841
+    Test css customization"s function correctly after upgrades.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/6h
+        setup: provision appliance
+               add custom css file
+               add repo file to /etc/yum.repos.d/
+               run "yum update"
+               run "rake db:migrate"
+               run "rake evm:automate:reset"
+               run "systemctl start evmserverd"
+               check webui is available
+               check customization"s still work
+        startsin: 5.10
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(3)
+def test_sui_service_explorer_will_also_show_child_services():
+    """
+    Login in SSUI
+    Service explorer should show child services if any.
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: SUI : Service Explorer will also show child services
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(1)
+def test_dialog_items_default_values_on_different_screens():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1540273
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
+        title: Test dialog items default values on different screens
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(1)
+def test_verify_user_authentication_works_fine_if_default_evm_groups_are_already_created_and_a():
+    """
+    Create cfme default groups in ldaps domain server.
+    Assign user to the default groups. e.g.  EvmGroup-administrator
+    Configure cfme for ldaps external auth as in TC#1
+    Authentication for ldap user is expected to be successful as cfme
+    default groups are already assigned for user in ldap server.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        initialEstimate: 1/4h
+        title: verify user authentication works fine if default evm groups
+               are already created and assigned for user in ldaps
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_crud_pod_appliance():
+    """
+    deploys pod appliance
+    checks that it is alive
+    deletes pod appliance
+
+    Polarion:
+        assignee: izapolsk
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.cfme_tenancy
+@pytest.mark.tier(2)
+def test_tenant_visibility_miq_ae_namespaces_all_parents():
+    """
+    Child tenants can see MIQ AE namespaces of parent tenants.
+
+    Polarion:
+        assignee: mnadeem
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_multi_host_migration_execution_if_more_than_one_host_present_migration_of_mu():
+    """
+    OSP: Test Multi-host migration execution, if more than one host
+    present, migration of multiple VMs should be spread across all
+    available host
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test Multi-host migration execution, if more than one
+               host present, migration of multiple VMs should be spread
+               across all available hosts
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(3)
+def test_quota_enforcement_for_cloud_volumes():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1455349
+    test quota enforcement for cloud volumes
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: prov
+        initialEstimate: 1/4h
+        startsin: 5.8
+        title: test quota enforcement for cloud volumes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_api_on_url():
+    """
+    The API should be present on https://<ip>/ansibleapi.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: critical
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.snapshot
+def test_creating_second_snapshot_on_suspended_vm():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1419872
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
+        title: test creating second snapshot on suspended vm
+        testSteps:
+            1.Navigate to  compute->infrastructure->virtual machines
+              2.Select a vm with suspended state 3.Take a first snapshot.
+              snapshot successful 4.Take a second snapshot
+        expectedResults:
+            1. Flash message Snapshot not taken since the state of the
+               virtual machine has not changed since the last snapshot
+               operation should be displayed in UI
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_appliance_console_datetime_negative():
+    """
+    test setting invalid date/time
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_security_group_can_be_selected_while_creating_migration_plan():
+    """
+    OSP: Test security group can be selected while creating migration plan
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test security group can be selected while creating migration plan
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_provision_fileshare_scvmm():
+    """
+    With 5.7.3 and 5.8.1 you can deploy templates onto scvmm registered
+    File Shares.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.7
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.upgrade
+@pytest.mark.tier(2)
+def test_rh_rhsm_reregistering():
+    """
+    Switch between rhsm and sat6 registration
+    https://bugzilla.redhat.com/show_bug.cgi?id=1461716
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/12h
+        setup: Provision appliance
+               navigate to Configuration-settings-region-redhat updates
+               Click edit subscription
+               Setup sat6 subscription
+               validate and save
+               register
+               unregister (requires ssh commands)
+               edit subscription
+               setup rhsm
+               validate and save
+               register
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_generic_objects_class_crud():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1650137
+    1.Create Generic Objects Class
+    2.Add button group
+    3.Go to Generic Objects Class details page
+    4.Delete the Generic Objects Class
+
+    Polarion:
+        assignee: nansari
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/16h
+        title: Generic Objects Class Crud
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_service_cloud_tenant_quota_cpu_default_entry_point():
+    """
+    tenant service cpu quota validation for cloud provider using default
+    entry point
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        initialEstimate: 1/4h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_service_dialog_saving_elements_when_switching_elements():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1454428
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Test service dialog saving elements when switching elements
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_quota_units():
+    """
+    Steps described here:
+    https://bugzilla.redhat.com/show_bug.cgi?id=1334318
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: low
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_verify_saml_configuration_works_fine_for_cfme():
+    """
+    Look for the steps/instructions at http://file.rdu.redhat.com/abellott
+    /manageiq_docs/master/auth/saml.html
+    Verify appliance_console is updated with “External Auth: “ correctly
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        initialEstimate: 1/2h
+        title: Verify SAML configuration works fine for CFME
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_grid_tile_list_view_pages_on_instance():
+    """
+    Add a cloud provider..Click on the provider , go to Instances, Click
+    on Grid/ Tile or list view
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/16h
+        startsin: 5.5
+        title: Grid/Tile/List View pages on Instance
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_tagvis_group_filter_network_provider():
+    """
+    Setup:
+    Add cloud provider
+    1. Create group and select cloud network provider in "Cluster&Hosts"
+    filter
+    2. Create user assigned to group from step 1
+    3. As restricted user, login and navigate to Network Provider
+    Result: User should see network provider + all its children
+    Note: Repeat this case with tag filter
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.power
+@pytest.mark.tier(2)
+def test_power_operations_from_global_region():
+    """
+    This test case is to check power operations from Global region
+    Setup is 2 or more appliances(DB should be configured manually). One
+    is Global region, others are Remote
+    To get this working on 5.6.4 you need to specify the :webservices =>
+    :remote_miq_api user (username) and password values in the global
+    region"s advanced settings for the server with the user interface
+    role.
+    Or Enable Central Admin for 5.7 or later
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: control
+        caseimportance: medium
+        initialEstimate: 1/2h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rbac
+@pytest.mark.tier(2)
+def test_credentials_change_password_with_special_characters():
+    """
+    Password with only special characters
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/8h
+        tags: rbac
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_default_selection_of_dropdown_list_is_should_display_properly():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1579405
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        initialEstimate: 1/6h
+        title: Default selection of dropdown list is should display properly
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+def test_distributed_diagnostics_servers_view():
+    """
+    The above should all be shown as different regions 1-4
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_replication_subscription_revalidation_pglogical():
+    """
+    Subscription validation passes for replication subscriptions which
+    have been validated and successfully saved.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/12h
+        testSteps:
+            1. Attempt to validate the subscription
+        expectedResults:
+            1. Validation succeeds as this subscription was successfully
+               saved and is currently replicating
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_create_provisioning_dialog_without_dialog_type():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1344080
+    Create provision dialog without selecting dialog type
+    Automate - Customization - Provisioning dialog
+    Configuration - Add a new dialog
+    Provide name and description.
+    Save
+    Error should appear
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: prov
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/4h
+        startsin: 5.5
+        title: create provisioning dialog without dialog type
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.log_depot
+@pytest.mark.tier(1)
+def test_log_collect_current_zone_zone_setup():
+    """
+    using any type of depot check collect current log function under zone
+    (settings under server should not be configured, under zone should be
+    configured)
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_user_cloud_memory_quota_by_services():
+    """
+    test user memory quota for cloud instance provision by ordering
+    services
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(3)
+def test_crosshair_op_datastore_vsphere6():
+    """
+    Requires:
+    C&U enabled Vsphere-6 appliance.
+    Steps:
+    1. Navigate to Datastores [Compute > infrastructure>Datastores]
+    2. Select any available datastore
+    3. Go for utilization graphs [Monitoring > Utilization]
+    4. Check data point on graphs ["Used Disk Space", "Hosts", "VMs"]
+    using drilling operation on the data points
+    5.  check "chart" and "display" options working properly or not
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_vm_reconfig_add_remove_disk_hot_vsphere67_nested_independent_nonpersistent_thick():
+    """
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: 1/3h
+        startsin: 5.7
+        title: test_vm_reconfig_add_remove_disk_hot[vsphere67-nested-
+               independent_nonpersistent-thick]
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_vm_reconfig_add_remove_disk_hot_vsphere67_nested_independent_persistent_thick():
+    """
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: 1/3h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_vm_reconfig_add_remove_disk_hot_vsphere67_nested_independent_nonpersistent_thin():
+    """
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: 1/3h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_vm_reconfig_add_remove_disk_hot_vsphere67_nested_independent_persistent_thin():
+    """
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: 1/3h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_vm_reconfig_add_remove_disk_hot_vsphere67_nested_persistent_thin():
+    """
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: 1/3h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_vm_reconfig_add_remove_disk_hot_vsphere67_nested_persistent_thick():
+    """
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: 1/3h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_migration_plan_delete():
+    """
+    OSP: Test migration plan delete
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test migration plan delete
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.provision
+@pytest.mark.tier(2)
+def test_auto_placement_provision_to_dvswitch_vlan_vmware():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1467399
+    Description of problem: issue appeared after 1458363
+    Auto_placement provision into DVS vlan fails with Error "Destination
+    placement_ds_name not provided]" if provider Network with the same
+    name exists
+    Version-Release number of selected component (if applicable):5.8.1
+    Virtualcenter: 6.5
+    How reproducible:100%
+    Steps to Reproduce:
+    1.Configure environment networks (check attachment)
+    2.Provision VM with auto_placement
+    3.Select DVS vlan
+    Actual results:Provision fails
+    Expected results: Provision should succeed and VM should be in
+    selected vlan
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: prov
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_custom_image_on_item_bundle_crud():
+    """
+    test_custom_image_on_item_bundle_crud
+    Upload image and test if the uploaded icon/image shows up in the table
+    .
+    https://bugzilla.redhat.com/show_bug.cgi?id=1487056
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.5
+        testSteps:
+            1. Create a catalog item
+            2. Upload custom image
+            3. remove custom image
+            4. Create a catalog  bundle
+            5. Upload a custom image
+            6. Change custom image
+        expectedResults:
+            1.
+            2. No error seen
+            3.
+            4.
+            5. No error seen
+            6.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_group_infra_storage_quota_by_lifecycle():
+    """
+    test group storage quota for infra vm provision by Automate model
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: infra
+        caseimportance: low
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_event_catcher_process():
+    """
+    EventCatcher process is started after Ansible role is enabled (rails
+    evm:status)
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1/4h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_storage_ebs_added_in_ec2_provider():
+    """
+    Requires:
+    test_storage_ebs_added
+    Steps to test:
+    1. Add an EC2 provider
+    2. Wait for refresh
+    3. Go to EC2 provider summary
+    4. Check whether ebs storage manager is paired with EC2 provider
+
+    Polarion:
+        assignee: mmojzis
+        initialEstimate: 1/10h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.general_ui
+@pytest.mark.tier(1)
+def test_copying_customization_dialog():
+    """
+    BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1342260
+    1. Automate -> Customization -> Check checkbox for at least one dialog
+    2. Select another dialog by clicking on it
+    3. Select in Toolbar Configuration -> Copy this dialog
+    4. Selected dialog should be copied and not the first checked dialog
+    in alphanumerical sort
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_pod_appliance_scale():
+    """
+    appliance should work correctly after scale up/down
+
+    Polarion:
+        assignee: izapolsk
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_ds_and_volume_availiblity_in_source_and_target():
+    """
+    OSP: Test DS and Volume availiblity in source and target
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test DS and Volume availiblity in source and target
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.general_ui
+def test_notification_window_can_be_closed_by_clicking_x():
+    """
+    Bug 1427484 - Add "X" option to enable closing the Notification window
+    by it.
+    https://bugzilla.redhat.com/show_bug.cgi?id=1427484
+    After clicking the bell icon in the top right of the web UI, the "x"
+    in the top right corner of the notification window can be clicked to
+    close it.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/15h
+        startsin: 5.9
+        title: Notification window can be closed by clicking 'x'
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+@pytest.mark.tier(1)
+def test_reports_generate_report_custom_with_tag():
+    """
+    steps:
+    1 Assign tag to VM, for example, departament tag,we have used
+    "Discipline".
+    2 Asign tag to Tenant, for example, departament tag, we have used
+    "Discipline".
+    3 Create report with base report "VMs and Instances" and the next
+    fields: Name Departament tag.
+    4 Create report with base report "Cloud Tenant" and the next fields:
+    Name Departament tag.
+    5 Generate the two reports.
+    https://bugzilla.redhat.com/show_bug.cgi?id=1504086
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_storage_ebs_volume_crud_from_manager_list():
+    """
+    BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1449293
+    Requires:
+    test_storage_ebs_added
+    Steps to test:
+    Create:
+    1. Go to Storage -> Block Storage -> Block Storage Manager -> Volumes
+    Relationship
+    2. Add a new cloud volume
+    3.Form to fill:
+    ec2 EBS Storage Manager
+    us-east-1
+    volume_test
+    Magnetic
+    6
+    Encryption off
+    4. Add
+    Read:
+    1. Select "volume_test" and go to its summary
+    Edit:
+    1. Configuration -> Edit this Cloud Volume
+    2. Change volume name from "volume_test" to "volume_edited_test"
+    3. Select "volume_edited_test" in Block Volume list and go to its
+    summary
+    Delete:
+    1. Configuration -> Delete this Cloud Volume
+    2. Check whether volume was deleted
+
+    Polarion:
+        assignee: mmojzis
+        initialEstimate: 1/4h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_earlier_infra_mapping_can_be_viewed_in_migration_plan_wizard():
+    """
+    OSP: Test earlier infra mapping can be viewed in migration plan wizard
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test earlier infra mapping can be viewed in migration plan wizard
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_tagvis_ansible_tower_job():
+    """
+    "Setup: Create group with tag, use this group for user creation
+    1. Add tag(used in group) for Ansible Tower job via detail page
+    2. Remove tag for Ansible Tower job via detail page
+    3. Add tag for Ansible Tower job via list
+    4. Check Ansible Tower job is visible for restricted user
+    5. Remove tag for Ansible Tower job via list
+    6 . Check ansible tower job isn"t visible for restricted user"
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_dialog_dynamic_entry_point_should_show_full_path():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1553846
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        initialEstimate: 1/4h
+        startsin: 5.10
+        title: Dialog : dynamic entry point should show full path
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(1)
+def test_verify_ldap_authentication_for_the_cfme_default_groups():
+    """
+    verify ldap authentication for the cfme default groups.
+    1. define the user in ldap, and create the group in ldap with the same
+    name as in cfme
+    2. register the user to ldap group.
+    3. verify login, monitor evm.log, aurdit.log for no errors.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        initialEstimate: 1/4h
+        title: verify ldap authentication for the cfme default groups.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(3)
+def test_cluster_graph_by_host_tag_vsphere6():
+    """
+    test_cluster_graph_by_host_tag[vsphere6]
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: low
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(3)
+def test_cluster_graph_by_host_tag_vsphere65():
+    """
+    test_cluster_graph_by_host_tag[vsphere65]
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_group_infra_cpu_quota_by_services():
+    """
+    test group cpu quota for infra vm provision by ordering services
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(1)
+def test_azone_memory_usage_azure():
+    """
+    Utilization Test
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        initialEstimate: 1/12h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+def test_embed_tower_add_repo_invalid_url():
+    """
+    Try to add GIT/HTPPs url which does not exist. User should be notified
+    about invalid URL.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: critical
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+def test_schedule_add_from_report():
+    """
+    Add schedule from report queue
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.3
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_save_and_cancel_retirement_form_for_orchestration_stack_in_g_t_l_view():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1360417https://bugzilla.re
+    dhat.com/show_bug.cgi?id=1359150
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: stack
+        caseimportance: medium
+        initialEstimate: 1/16h
+        startsin: 5.5
+        title: test Save and cancel retirement form for orchestration stack in G/T/L View
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.retirement
+@pytest.mark.tier(2)
+def test_retire_cloud_vms_notification_folder():
+    """
+    test the retire funtion of vm on cloud providers, one vm, set
+    retirement date button from vm summary page with notification for two
+    vms for one of the period (1week, 2weeks, 1 months)
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: prov
+        caseimportance: medium
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_request_check_provisioned_vm_link_on_request_page():
+    """
+    Provision a VM and click on the Provisioned VM Link on request page.
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/16h
+        startsin: 5.5
+        title: Request : Check Provisioned VM link on Request page
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_ec2_targeted_refresh_security_group():
+    """
+    Security group CREATE
+    Security group UPDATE
+    Security group DELETE
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 2/3h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_group_on_catalog_item():
+    """
+    Steps:
+    1. Add catalog_item
+    2. Goto catalog detail page and select `add group` from toolbar
+    3. Fill info and save button
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.9
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_provision_host_maintenancemode_scvmm():
+    """
+    In scvmm, set qeblade26 into maintenance mode
+    Refresh provider
+    Attempt to provision to that host using auto placement.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.7
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_verify_page_landing_cloud_subnets():
+    """
+    1. Login To CloudForms Operational Portal
+    2. Navigate to compute-> cloud -> instance -> click on any instance ->
+    Click on Cloud Networks (under relationships)
+    3. Check properly land on page or not.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: cloud
+        caseimportance: low
+        initialEstimate: 1/10h
+        startsin: 5.6
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_files_windows_utf_8_files():
+    """
+    Configure SSA to include c:\windows\debug\* and verify its content
+
+    Polarion:
+        assignee: sbulage
+        caseimportance: medium
+        initialEstimate: 1/2h
+        setup: 1. Configure SSA profile to include c:\windows\debug\*
+               2. Run SSA
+               3. View the content of all the files (i.e., mrt.log, passwd.log,
+               sammui.log, wlms.log, etc...)
+        startsin: 5.3
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.provision
+@pytest.mark.tier(2)
+def test_add_multiple_iso_datastore():
+    """
+    Add two RHEV providers.
+    Under Infrastructure- PXE -ISO datastore - add ISO datastore for first
+    provider
+    Add new datastore button should not be disabled once the datastore was
+    added and second datastore can be added.
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: services
+        initialEstimate: 1/8h
+        startsin: 5.5
+        title: Add multiple ISO datastore
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(2)
+def test_monitor_ansible_playbook_logging_output():
+    """
+    bugzilla.redhat.com/1518952
+    https://bugzilla.redhat.com/show_bug.cgi?id=1518952
+
+    Polarion:
+        assignee: apagac
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 2/3h
+        startsin: 5.8
+        title: Monitor Ansible playbook Logging output
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_black_console_ext_auth_options_skip():
+    """
+    Test skip update of ext_auth options through appliance_console
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/6h
+        setup: -ssh to appliance
+               -run appliance_console
+               -select option "Update External Authentication Options"
+               -select each option to enable it
+               -select option
+               1) Enable/Disable Single Sign-On
+               2) Enable/Disable SAML
+               3) Enable/Disable Local Login
+               -select "Skip updates"
+               -check changes have not been made
+        startsin: 5.6
+        testSteps:
+            1. Enable Single Sign-On, SAML, Local Login then select skip updates
+            2. Disable Single Sign-On, SAML, Local Login then select skip updates
+            3. Enable Single Sign-On then select skip updates
+            4. Disable Single Sign-On then select skip updates
+            5. Enable SAML then select skip updates
+            6. Disable SAML then select skip updates
+            7. Enable Local Login then select skip updates
+            8. Disable Local Login then select skip updates
+        expectedResults:
+            1. check changes in ui
+            2. check changes in ui
+            3. check changes in ui
+            4. check changes in ui
+            5. check changes in ui
+            6. check changes in ui
+            7. check changes in ui
+            8. check changes in ui
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_appliance_console_key_fetch_negative():
+    """
+    test fetching key from fake remote host
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_vm_reconfig_resize_disk_hot_vsphere65_nested_persistent_thick():
+    """
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: 1/6h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_candu_collection_tab():
+    """
+    Test case to cover -
+    https://bugzilla.redhat.com/show_bug.cgi?id=1393675
+    from BZ comments:
+    "for QE testing you can only replicate that in the UI by running a
+    refresh and immediately destroying the provider and hope that it runs
+    into this race conditions."
+
+    Polarion:
+        assignee: nachandr
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(3)
+def test_sui_self_service_ui_should_show_pending_requests():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1321352
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: ssui
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.5
+        title: SUI : Self Service Ui should show pending requests
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_migration_request_details_page_shows_vms_for_not_started_plans():
+    """
+    OSP: Test migration request details page shows VMs for not started
+    plans
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test migration request details page shows VMs for not started plans
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.log_depot
+@pytest.mark.tier(1)
+def test_log_collect_current_server_all_unconfigured():
+    """
+    check collect logs under server when both levels are unconfigured.
+    Expected result - all buttons are disabled
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_add_machine_credentials_vault():
+    """
+    Add vault password and test in the playbook that encrypted yml can be
+    decrypted.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_add_machine_credentials_escalate_perm_sudo():
+    """
+    Allow user/admin to create/import credentials for machines which will
+    be managed (may need to be split into multiple tests to cover
+    -Machine, Network, Amazon Web Services, Rackspace, VMware vCenter, Red
+    Hat Satellite 6, Red Hat CloudForms, Google Compute Engine, Microsoft
+    Azure Classic, Microsoft Azure Resource Manager, OpenStack)
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_add_machine_credentials_machine_root_pass():
+    """
+    Allow user/admin to create/import credentials for machines which will
+    be managed (may need to be split into multiple tests to cover
+    -Machine, Network, Amazon Web Services, Rackspace, VMware vCenter, Red
+    Hat Satellite 6, Red Hat CloudForms, Google Compute Engine, Microsoft
+    Azure Classic, Microsoft Azure Resource Manager, OpenStack)
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_add_machine_credentials_machine_ssh_key():
+    """
+    Allow user/admin to create/import credentials for machines which will
+    be managed (may need to be split into multiple tests to cover
+    -Machine, Network, Amazon Web Services, Rackspace, VMware vCenter, Red
+    Hat Satellite 6, Red Hat CloudForms, Google Compute Engine, Microsoft
+    Azure Classic, Microsoft Azure Resource Manager, OpenStack)
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+@pytest.mark.tier(2)
+def test_chargeback_preview():
+    """
+    Verify that Chargeback Preview is generated for VMs
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_verify_multi_domain_configuration_for_external_auth_ldaps():
+    """
+    Look for the steps/instructions at
+    https://mojo.redhat.com/docs/DOC-1085797
+    Verify appliance_console is updated with “External Auth: “ correctly.
+    Verify appliance_console displays all the domains configured. Now it
+    displays only one. There will be BZ.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/2h
+        title: verify multi domain configuration for external auth ldaps
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_storage_ebs_added():
+    """
+    Steps to test:
+    1. Add an ec2 provider
+    2. Go to Storage -> Block Storage -> Managers
+    3. Check whether ebs storage manager was added automatically
+
+    Polarion:
+        assignee: mmojzis
+        caseimportance: critical
+        initialEstimate: 1/10h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(2)
+def test_azone_network_io_gce():
+    """
+    Utilization Test
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        initialEstimate: 1/12h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(1)
+def test_azone_network_io_azure():
+    """
+    Utilization Test
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        initialEstimate: 1/12h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_saml_verify_get_user_groups_from_external_authentication_httpd__option():
+    """
+    Enable “Get User Groups from External Authentication (httpd)” option.
+    Verify “user groups from SAML server are updated correctly and user
+    with correct groups can login. (retrieve groups option is not valid in
+    case of SAML)
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        initialEstimate: 1/2h
+        title: saml: Verify “Get User Groups from External Authentication (httpd)” option.
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_rhi_overview():
+    """
+    Verify testing whehter issues related to systems are categorised or
+    not
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        initialEstimate: 1/2h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rep
+def test_distributed_zone_mixed_infra():
+    """
+    Azure,AWS, and local infra
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_creds_tag():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1526219
+    RBAC - tag credentials and allow new user see just this credential.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1/2h
+        startsin: 5.10
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.config_management
+@pytest.mark.tier(1)
+def test_config_manager_add_multiple_times_ansible_tower_243():
+    """
+    Try to add same Tower manager twice (use the same IP/hostname). It
+    should fail and flash message should be displayed.
+
+    Polarion:
+        assignee: nachandr
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/4h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_verify_external_auth_configuration_for_ldap_can_be_un_configured_using_appliance_cons():
+    """
+    Run command “appliance_console”
+    Select option for “configure external authentication”
+    Verify “IPA Client already configured on this Appliance, Un-Configure
+    first?” is displayed
+    Answer yes to continue with unconfigure process.
+    Verify Database user login works fine upon external auth un configured
+    and auth mode set to ‘Database’.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/3h
+        title: Verify external auth configuration for ldap can be un
+               configured using appliance_console
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(2)
+def test_embed_tower_order_service_extra_vars():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1444831
+    Execute playbook with extra variables which will be passed to Tower.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1/4h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_infrastructure_provider_left_panel_titles():
+    """
+    Requirement: Added and infrastructure provider
+    Navigate to Compute -> Infrastructure -> Providers
+    Select Properties on the panel and check all items, whether they do
+    have their titles.
+    Select Relationships on the panel and check all items, whether they do
+    have their titles.
+
+    Polarion:
+        assignee: mmojzis
+        casecomponent: infra
+        caseimportance: low
+        initialEstimate: 1/18h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(2)
+def test_candu_graphs_host_hourly_vsphere55():
+    """
+    test_candu_graphs_host_hourly[vsphere55]
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: low
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.cfme_tenancy
+@pytest.mark.tier(1)
+def test_cloud_tenant_crud_rhos():
+    """
+    1. Add RHOS provider and perform refresh
+    2. Navigate to Compute -> Clouds -> Providers
+    3. Click on RHOS provider which was added
+    4. In the Relationships table click on Cloud Tenants
+    5. Configuration ->Create Cloud tenant6. Edit created tenant
+    7. Try to delete it
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+@pytest.mark.tier(1)
+def test_reports_manage_report_menu_accordion_with_users():
+    """
+    Steps:
+    1. Create a new report called report01
+    2. Create a new user under EvmGroup-super_administrator called
+    testuser
+    3. "Edit Report Menus" and add the report01 under EvmGroup-
+    super_administrator"s Provisioning -> Activities
+    4. Login using testuser and navigate to Reports
+    5. No report01 is under Provisioning -> Activities
+    BZ: 1535023
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(3)
+def test_cluster_tagged_crosshair_op_vsphere65():
+    """
+    Required C&U enabled application:1. Navigate to cluster C&U graphs
+    2. select Group by option with suitable VM/Host tag
+    3. try to drill graph for VM/Host
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(3)
+def test_cluster_tagged_crosshair_op_vsphere6():
+    """
+    Required C&U enabled application:1. Navigate to cluster C&U graphs
+    2. select Group by option with suitable VM/Host tag
+    3. try to drill graph for VM/Host
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.c_and_u
+@pytest.mark.tier(3)
+def test_cluster_tagged_crosshair_op_vsphere55():
+    """
+    Required C&U enabled application:1. Navigate to cluster C&U graphs
+    2. select Group by option with suitable VM/Host tag
+    3. try to drill graph for VM/Host
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_refresh_with_empty_iot_hub_azure():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1495318
+    "For QE, if it helps - to reproduce reliably create an IoT Hub in
+    Azure (using free tier pricing is good enough):
+    $ az iot hub create --name rmanes-iothub --resource-group iot_rg"
+    1.Prepare env ^^
+    2.Refresh provider
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: low
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_reconfigure_vm_vmware_sockets_multiple():
+    """
+    Test changing the cpu sockets of multiple vms at the same time.
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/6h
+        setup: -get new configured appliance
+               -add vmware provider
+               -provision 2 new vms
+               -power off 1 vm
+               -select both vms
+               -configure-->reconfigure vm
+               -increase/decrease counts
+               -power on vm
+               -check changes
+        startsin: 5.6
+        testSteps:
+            1. Hot increase
+            2. Hot Decrease
+            3. Cold Increase
+            4. Cold Decrease
+            5. Hot + Cold Increase
+            6. Hot + Cold Decrease
+        expectedResults:
+            1. Action should succeed
+            2. Action should fail
+            3. Action should succeed
+            4. Action should succeed
+            5. Action should succeed
+            6. Action should Error
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware65_test_vm_migration_from_ubuntu():
+    """
+    OSP: vmware65-Test VM migration from ubuntu
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware65-Test VM migration from ubuntu
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware65_test_vm_migration_with_windows_10():
+    """
+    OSP: vmware65-Test VM migration with Windows 10
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: critical
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware65-Test VM migration with Windows 10
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_ec2_tags_instances():
+    """
+    Requirement: Have an ec2 provider
+    1) Create an instance with tag test:testing
+    2) Refresh provider
+    3) Go to summary of this instance and check whether there is
+    test:testing in Labels field
+    4) Delete that instance
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+@pytest.mark.tier(1)
+def test_embed_tower_logs():
+    """
+    Separate log files should be generated for Ansible to aid debugging.
+    p1 (/var/log/tower)
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        initialEstimate: 1/4h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_pod_appliance_image_upgrade():
+    """
+    one of appliance images has been changed. it should cause pod re-
+    deployment
+
+    Polarion:
+        assignee: izapolsk
+        caseimportance: medium
+        initialEstimate: None
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.log_depot
+@pytest.mark.tier(1)
+def test_log_collect_all_zone_multiple_servers_zone_setup():
+    """
+    using any type of depot check collect all log function under zone.
+    Zone should have multiplie servers under it. Zone should be setup,
+    servers should not
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.log_depot
+@pytest.mark.tier(1)
+def test_log_collection_usercase_multiple_servers_dropbox():
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        initialEstimate: 1/4h
+        setup: Set servers into distributed mode t
+        testSteps:
+            1. Go to Configure/Configuration/Diagnostics
+            2. With the cfme server selected go to Collect Logs and click on Edit
+            3. Select Red Hat Dropbox for type and click Save in the bottom right hand corner.
+            4. Go back to Configure/Configuration/Diagnostics/Collect Logs
+               and collect all or current log
+            5. Provide the support case number in the dialog that pops up.
+        expectedResults:
+            1.
+            2.
+            3.
+            4.
+            5. Log file created with case number in the beginning
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_in_progress_migrations_can_be_canceled():
+    """
+    OSP: Test in-progress Migrations can be canceled
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test in-progress Migrations can be canceled
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_button_edit_via_rest_put():
+    """
+    Steps:
+    1) Create custom button
+    2) Use Put method to edit the custom button
+    3) Delete custom button
+
+    Polarion:
+        assignee: ndhandre
+        initialEstimate: None
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_button_edit_via_rest_patch():
+    """
+    Steps:
+    1) Create Custom button
+    2) Edit custom button using Patch method
+    3) Delete custom button
+
+    Polarion:
+        assignee: ndhandre
+        initialEstimate: None
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.upgrade
+@pytest.mark.tier(2)
+def test_update_webui_replication():
+    """
+    Test webui update with replicated env
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1h
+        setup: Provision two appliances of the previous minor build
+               setup replication between the two
+               add update.repo file to /etc/yum.repos.d/
+               populate file with correct repos from
+               https://mojo.redhat.com/docs/DOC-1058772
+               register with RHSM in webui
+               check for updates
+               apply update
+               check replication/providers/vms
+        testtype: upgrade
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_tagvis_infra_networking_switch():
+    """
+    Setup: Create group with tag, use this group for user creation
+    1. Add tag(used in group) for infra networking switch via detail page
+    2. Remove tag for infra networking switch via detail page
+    3. Add tag for infra networking switch via list
+    4. Check infra networking switch is visible for restricted user
+    5. Remove tag for infra networking switch via list
+    6 . Check infra networking switch isn"t visible for restricted user
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: infra
+        caseimportance: low
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.config_management
+def test_config_manager_job_template_refresh():
+    """
+    After first Tower refresh, go to Tower UI and change name of 1 job
+    template. Go back to CFME UI, perform refresh and check if job
+    template name was changed.
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: ansible
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+@pytest.mark.tier(1)
+def test_generate_reports_after_upgrade():
+    """
+    Test generate reports after updating the appliance to release version
+    from prior version.
+    BZ LInk: 1464154
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        caseimportance: medium
+        initialEstimate: 1/2h
+        startsin: 5.3
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_button_submit_ssui_all():
+    """
+    Test custom button all submit via SSUI
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.9
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_button_submit_ssui_sequence():
+    """
+    Test custom button submit sequence via SSUI
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.9
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_button_submit_ssui_both():
+    """
+    Test custom button display for detail and list page of SSUI
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.9
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_button_submit_ssui_list():
+    """
+    Test custom button display for list page for SSUI
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.9
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_test_networking_before_and_after_migration_ip_address():
+    """
+    OSP: Test networking before and after migration (IP Address)
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        caseimportance: critical
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: Test networking before and after migration (IP Address)
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(1)
+def test_service_reconfigure_in_distributed_environment():
+    """
+    Create master and child appliance.
+    raise provisioning request in master and reconfigure in child.
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Service Reconfigure in distributed environment
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_kill_the_v2v_process_in_the_middle_by_rebooting_miq_cfme_appliance_should_resume_():
+    """
+    OSP: kill the v2v process in the middle- by rebooting miq/cfme
+    appliance- should resume migration post restart
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: kill the v2v process in the middle- by rebooting
+               miq/cfme appliance- should resume migration post restart
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(2)
+def test_snapshot_timeline_verify_data():
+    """
+    Test the SUI snapshot timeline.
+    See if data on the popup correspond to data shown below the timeline.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: infra
+        caseimportance: low
+        initialEstimate: 1/3h
+        testSteps:
+            1. create a new vm
+            2. create a snapshot
+            3. go to the VM details page, then Monitoring -> Timelines
+            4. select "Management Events" and "Snapshot Activity" and click Apply
+            5. click on the event, compare data from the popup with data
+               shown below the timeline
+        expectedResults:
+            1. vm created
+            2. snapshot created
+            3. timelines page displayed
+            4. event displayed on timeline
+            5. data should be identical
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_custom_button_simulation():
+    """
+    Test whether custom button works with simulation option
+    (Additional info: https://bugzilla.redhat.com/show_bug.cgi?id=1535215)
+
+    Polarion:
+        assignee: ndhandre
+        casecomponent: automate
+        caseimportance: low
+        initialEstimate: 1/8h
+        startsin: 5.8
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(3)
+def test_cfme_features_with_ldap():
+    """
+    verifies the cfme features with authentication mode configured to
+    ldap.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1h
+        testSteps:
+            1. login with ldap user
+            2. verify the CFME features after login with ldap user.
+        expectedResults:
+            1. login should be successful
+            2. All the CFME features should work properly with ldap authentication.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_firefox_vsphere67_rhel6x():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Firefox (versions : latest to latest-2)
+    vSphere: 65
+    OS: RHEL 6.x
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create RHEL 6.x VM on vSphere55
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Get Firefox browser tar balls from the following URL:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Untar each and launch firefox from respective directories. (Technical
+               Gotcha: Start with latest browser, so it will not auto-update before
+               you change its update settings)
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "I understand Risks" then click "Add exception" and
+               click "Confirm")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere67_win10():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Chrome
+    vSphere: 6.5
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere5.5
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome Browser latest version
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_firefox_vsphere65_win7():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Firefox (52,51,50) - Always take latest to latest-2 versions.
+    vSphere: 6.5
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere5.5
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               All Firefox versions can be found at following address:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. repeat above steps for other versions of firefox
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. results should be the same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+def test_vmrc_console_firefox_vsphere6_fedora28():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: firefox
+    vSphere: 6
+    OS: Fedora 28
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create Fedora 28 VM on vSphere6
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               All Firefox versions can be found at following address:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat above steps for other 2 versions of firefox
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. results should be same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_firefox_vsphere6_win10():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Firefox (52,51,50) - Always take latest to latest-2 versions.
+    vSphere: 6
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere6
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               All Firefox versions can be found at following address:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat above steps for each version of Firefox
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. You should see same result across all versions
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere65_rhel7x():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Chrome
+    vSphere: 6.5
+    OS: RHEL 7.x
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: critical
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create RHEL 7.x VM on vSphere5.5
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome Browser latest version
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_edge_vsphere6_win10():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Edge
+    vSphere: 6
+    OS: Windows 10
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/4h
+        setup: Steps:
+               Create Windows 7 VM on vSphere6
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on IE11
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere55_win10():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Chrome
+    vSphere: 5.5
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere5.5
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome Browser latest version
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere65_fedora26():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: chrome-latest
+    vSphere: 6.5
+    OS: fedora26
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Fedora 26 VM on vSphere5.5
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere67_fedora26():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: chrome-latest
+    vSphere: 6.5
+    OS: fedora26
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Fedora 26 VM on vSphere5.5
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_firefox_vsphere67_rhel7x():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Firefox (versions : latest to latest-2)
+    vSphere: 65
+    OS: RHEL 7.x
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create RHEL 7.x VM on vSphere65
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Get Firefox browser tar balls from the following URL:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Untar each and launch firefox from respective directories. (Technical
+               Gotcha: Start with latest browser, so it will not auto-update before
+               you change its update settings)
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat above steps for all the firefox versions
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "I understand Risks" then click "Add exception" and
+               click "Confirm")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. you should see same results
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere55_fedora26():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: chrome-latest
+    vSphere: 5.5
+    OS: fedora26
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Fedora 26 VM on vSphere5.5
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere55_win7():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Chrome
+    vSphere: 5.5
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere5.5
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome Browser latest version
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_ie11_vsphere6_win2012():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: IE11
+    vSphere: 5.5
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere 5.5
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on IE11
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_novmrccredsinprovider():
+    """
+    Leave the VMRC Creds blank in the provider add/edit dialog and observe
+    behavior trying to launch console. It should fail. Also observe the
+    message in VMRC Console Creds tab about what will happen if creds left
+    blank. https://bugzilla.redhat.com/show_bug.cgi?id=1550612
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: critical
+        caseposneg: negative
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere55_fedora28():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: chrome-latest
+    vSphere: 5.5
+    OS: fedora28
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Fedora 28 VM on vSphere5.5
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+def test_vmrc_console_firefox_vsphere65_fedora26():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: firefox
+    vSphere: 6.5
+    OS: Fedora 26
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create Fedora 26 VM on vSphere6.5
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               All Firefox versions can be found at following address:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat above steps for other 2 versions of firefox
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. results should be same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_firefox_vsphere65_rhel7x():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Firefox (versions : latest to latest-2)
+    vSphere: 65
+    OS: RHEL 7.x
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create RHEL 7.x VM on vSphere65
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Get Firefox browser tar balls from the following URL:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Untar each and launch firefox from respective directories. (Technical
+               Gotcha: Start with latest browser, so it will not auto-update before
+               you change its update settings)
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat above steps for all the firefox versions
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "I understand Risks" then click "Add exception" and
+               click "Confirm")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. you should see same results
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_ie11_vsphere65_win7():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: IE11
+    vSphere: 6.5
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere 5.5
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on IE11
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere67_rhel7x():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Chrome
+    vSphere: 6.5
+    OS: RHEL 7.x
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: critical
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create RHEL 7.x VM on vSphere5.5
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome Browser latest version
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+def test_vmrc_console_firefox_vsphere65_fedora28():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: firefox
+    vSphere: 6.5
+    OS: Fedora 28
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create Fedora 28 VM on vSphere6.5
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               All Firefox versions can be found at following address:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat above steps for other 2 versions of firefox
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. results should be same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_firefox_vsphere65_rhel6x():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Firefox (versions : latest to latest-2)
+    vSphere: 65
+    OS: RHEL 6.x
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create RHEL 6.x VM on vSphere55
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Get Firefox browser tar balls from the following URL:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Untar each and launch firefox from respective directories. (Technical
+               Gotcha: Start with latest browser, so it will not auto-update before
+               you change its update settings)
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "I understand Risks" then click "Add exception" and
+               click "Confirm")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_firefox_vsphere6_win7():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Firefox (52,51,50) - Always take latest to latest-2 versions.
+    vSphere: 6
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere6
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               All Firefox versions can be found at following address:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat above steps for each version of Firefox
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. You should see same result across all versions
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere65_win10():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Chrome
+    vSphere: 6.5
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere5.5
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome Browser latest version
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+def test_vmrc_console_firefox_vsphere67_fedora28():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: firefox
+    vSphere: 6.5
+    OS: Fedora 26
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create Fedora 26 VM on vSphere6.5
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               All Firefox versions can be found at following address:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat above steps for other 2 versions of firefox
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. results should be same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere67_win7():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Chrome
+    vSphere: 6.5
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere5.5
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome Browser latest version
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere6_fedora27():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: chrome-latest
+    vSphere: 6
+    OS: fedora27
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Fedora 27 VM on vSphere6
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_ie11_vsphere6_win7():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: IE11
+    vSphere: 6
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere6
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on IE11
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_firefox_vsphere67_win10():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Firefox (52,51,50) - Always take latest to latest-2 versions.
+    vSphere: 6.5
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere5.5
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               All Firefox versions can be found at following address:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. repeat above steps for other versions of firefox
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. results should be the same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere67_fedora28():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: chrome-latest
+    vSphere: 6.5
+    OS: fedora26
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Fedora 26 VM on vSphere5.5
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_ie11_vsphere65_win2012():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: IE11
+    vSphere: 5.5
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere 5.5
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on IE11
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere65_fedora28():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: chrome-latest
+    vSphere: 6.5
+    OS: fedora28
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Fedora 28 VM on vSphere6.5
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_firefox_vsphere55_win7():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Firefox (52,51,50) - Always take latest to latest-2 versions.
+    vSphere: 5.5
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere5.5
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               All Firefox versions can be found at following address:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. repeat above steps for other versions of firefox
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. results should be the same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_edge_vsphere67_win10():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Edge
+    vSphere: 65
+    OS: Windows 10
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/4h
+        setup: Steps:
+               Create Windows 7 VM on vSphere6
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on IE11
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_edge_vsphere65_win10():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Edge
+    vSphere: 65
+    OS: Windows 10
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/4h
+        setup: Steps:
+               Create Windows 7 VM on vSphere6
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on IE11
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere55_rhel7x():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Chrome
+    vSphere: 5.5
+    OS: RHEL 7.x
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create RHEL 7.x VM on vSphere5.5
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome Browser latest version
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere55_fedora27():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: chrome-latest
+    vSphere: 5.5
+    OS: fedora27
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Fedora 27 VM on vSphere5.5
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+def test_vmrc_console_firefox_vsphere67_fedora26():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: firefox
+    vSphere: 6.5
+    OS: Fedora 26
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create Fedora 26 VM on vSphere6.5
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               All Firefox versions can be found at following address:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat above steps for other 2 versions of firefox
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. results should be same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_firefox_vsphere67_win2012():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Firefox (52,51,50) - Always take latest to latest-2 versions.
+    vSphere: 6.5
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere5.5
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               All Firefox versions can be found at following address:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. repeat above steps for other versions of firefox
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. results should be the same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_firefox_vsphere65_win2012():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Firefox (52,51,50) - Always take latest to latest-2 versions.
+    vSphere: 6.5
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere5.5
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               All Firefox versions can be found at following address:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. repeat above steps for other versions of firefox
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. results should be the same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_firefox_vsphere67_win7():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Firefox (52,51,50) - Always take latest to latest-2 versions.
+    vSphere: 6.5
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere5.5
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               All Firefox versions can be found at following address:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. repeat above steps for other versions of firefox
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. results should be the same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+def test_vmrc_console_firefox_vsphere6_fedora27():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: firefox
+    vSphere: 6
+    OS: Fedora 27
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create Fedora 27 VM on vSphere6
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               All Firefox versions can be found at following address:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat above steps for other 2 versions of firefox
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. results should be same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_ie11_vsphere67_win7():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: IE11
+    vSphere: 6.5
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere 5.5
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on IE11
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere65_win2012():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Chrome
+    vSphere: 6.5
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere5.5
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome Browser latest version
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere67_win2012():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Chrome
+    vSphere: 6.5
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere5.5
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome Browser latest version
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_ie11_vsphere67_win2012():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: IE11
+    vSphere: 5.5
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere 5.5
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on IE11
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_addremovevmwarecreds():
+    """
+    Add VMware VMRC Console Credentials to a VMware Provider and then
+    Remove it. As per BZ:
+    https://bugzilla.redhat.com/show_bug.cgi?id=1559957
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/4h
+        startsin: 5.8
+        testSteps:
+            1. Compute->Infrastructure->Provider, Add VMware Provider with VMRC Console Creds
+            2. Edit provider, remove VMware VMRC Console Creds and Save
+        expectedResults:
+            1. Provider added
+            2. Provider can be Saved without VMRC Console Creds
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere65_fedora27():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: chrome-latest
+    vSphere: 6.5
+    OS: fedora27
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Fedora 27 VM on vSphere5.5
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_firefox_vsphere55_win10():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Firefox (52,51,50) - Always take latest to latest-2 versions.
+    vSphere: 5.5
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere5.5
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               All Firefox versions can be found at following address:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. repeat above steps for other versions of firefox
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. results should be the same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+def test_vmrc_console_firefox_vsphere55_fedora26():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: firefox
+    vSphere: 5.5
+    OS: Fedora 26
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create Fedora 26 VM on vSphere5.5
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               All Firefox versions can be found at following address:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat above steps for other 2 versions of firefox
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. results should be same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere67_fedora27():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: chrome-latest
+    vSphere: 6.5
+    OS: fedora26
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Fedora 26 VM on vSphere5.5
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+def test_vmrc_console_firefox_vsphere55_fedora27():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: firefox
+    vSphere: 5.5
+    OS: Fedora 27
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create Fedora 27 VM on vSphere5.5
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               All Firefox versions can be found at following address:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat above steps for other 2 versions of firefox
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. results should be same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_firefox_vsphere55_win2012():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Firefox (52,51,50) - Always take latest to latest-2 versions.
+    vSphere: 5.5
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere5.5
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               All Firefox versions can be found at following address:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. repeat above steps for other versions of firefox
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. results should be the same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere6_win2012():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Chrome
+    vSphere: 6
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere6
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome Browser latest version
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere65_win7():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Chrome
+    vSphere: 6.5
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere5.5
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome Browser latest version
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+def test_vmrc_console_firefox_vsphere65_fedora27():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: firefox
+    vSphere: 6.5
+    OS: Fedora 25
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create Fedora 25 VM on vSphere6.5
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               All Firefox versions can be found at following address:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat above steps for other 2 versions of firefox
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. results should be same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_firefox_vsphere6_rhel6x():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Firefox
+    vSphere: 6
+    OS: RHEL 6.x
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create RHEL 6.x VM on vSphere6
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Get Firefox browser tar balls from the following URL:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Untar each and launch firefox from respective directories. (Technical
+               Gotcha: Start with latest browser, so it will not auto-update before
+               you change its update settings)
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat above steps for all the firefox versions
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "I understand Risks" then click "Add exception" and
+               click "Confirm")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. you should see same results
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere6_win7():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Chrome
+    vSphere: 6
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere6
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome Browser latest version
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere6_rhel7x():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Chrome
+    vSphere: 6
+    OS: RHEL 7.x
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: critical
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create RHEL 7.x VM on vSphere6
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome Browser latest version
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_firefox_vsphere65_win10():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Firefox (52,51,50) - Always take latest to latest-2 versions.
+    vSphere: 6.5
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere5.5
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               All Firefox versions can be found at following address:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. repeat above steps for other versions of firefox
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. results should be the same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_firefox_vsphere55_rhel7x():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Firefox (versions : latest to latest-2)
+    vSphere: 55
+    OS: RHEL 7.x
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create RHEL 7.x VM on vSphere55
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Get Firefox browser tar balls from the following URL:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Untar each and launch firefox from respective directories. (Technical
+               Gotcha: Start with latest browser, so it will not auto-update before
+               you change its update settings)
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat above steps for all the firefox versions
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "I understand Risks" then click "Add exception" and
+               click "Confirm")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. you should see same results
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere6_fedora26():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: chrome-latest
+    vSphere: 6
+    OS: fedora26
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Fedora 26 VM on vSphere6
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere6_win10():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Chrome
+    vSphere: 6
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere6
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome Browser latest version
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_firefox_vsphere6_rhel7x():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Firefox (versions : latest to latest-2)
+    vSphere: 6
+    OS: RHEL 7.x
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: critical
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create RHEL 7.x VM on vSphere6
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Get Firefox browser tar balls from the following URL:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Untar each and launch firefox from respective directories. (Technical
+               Gotcha: Start with latest browser, so it will not auto-update before
+               you change its update settings)
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat above steps for all the firefox versions
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "I understand Risks" then click "Add exception" and
+               click "Confirm")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. you should see same results
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_edge_vsphere55_win10():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Edge
+    vSphere: 6
+    OS: Windows 10
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/4h
+        setup: Steps:
+               Create Windows 7 VM on vSphere6
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on IE11
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+def test_vmrc_console_firefox_vsphere55_fedora28():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: firefox
+    vSphere: 5.5
+    OS: Fedora 27
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create Fedora 27 VM on vSphere5.5
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               All Firefox versions can be found at following address:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat above steps for other 2 versions of firefox
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. results should be same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_firefox_vsphere6_win2012():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Firefox (52,51,50) - Always take latest to latest-2 versions.
+    vSphere: 6
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere6
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               All Firefox versions can be found at following address:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat above steps for each version of Firefox
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. You should see same result across all versions
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+def test_vmrc_console_firefox_vsphere67_fedora27():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: firefox
+    vSphere: 6.5
+    OS: Fedora 26
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create Fedora 26 VM on vSphere6.5
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               All Firefox versions can be found at following address:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat above steps for other 2 versions of firefox
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. results should be same
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_ie11_vsphere55_win7():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: IE11
+    vSphere: 5.5
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere 5.5
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on IE11
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_usecredwithlimitedvmrcaccess():
+    """
+    Add Provider in VMware now has a new VMRC Console Tab for adding
+    credentials which will be used to initiate VMRC Connections and these
+    credentials could be less privileged as compared to Admin user but
+    needs to have Console Access.
+    In current VMware env we have "user_interact@vsphere.local" for this
+    purpose. It is setup on vSphere65(NVC) and has no permissions to add
+    network device, suspend vm, install vmware tools or reconfigure
+    floppy. So if you can see your VMRC Console can"t do these operations
+    with user_interact, mark this test as passed. As the sole purpose of
+    this test is to validate correct user and permissions are being used.
+    https://bugzilla.redhat.com/show_bug.cgi?id=1479840
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: critical
+        initialEstimate: 1/2h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_firefox_vsphere55_rhel6x():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Firefox (versions : latest to latest-2)
+    vSphere: 55
+    OS: RHEL 6.x
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create RHEL 6.x VM on vSphere55
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Get Firefox browser tar balls from the following URL:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Untar each and launch firefox from respective directories. (Technical
+               Gotcha: Start with latest browser, so it will not auto-update before
+               you change its update settings)
+               Make sure the browser auto updates are also disabled
+        testtype: integration
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "I understand Risks" then click "Add exception" and
+               click "Confirm")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere55_win2012():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: Chrome
+    vSphere: 5.5
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere5.5
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome Browser latest version
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_ie11_vsphere55_win2012():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: IE11
+    vSphere: 5.5
+    OS: Windows 7
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Windows 7 VM on vSphere 5.5
+               Disable Automatic updates for OS
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on IE11
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+@pytest.mark.tier(2)
+def test_vmrc_console_chrome_vsphere6_fedora28():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: chrome-latest
+    vSphere: 6
+    OS: fedora28
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        initialEstimate: 1/3h
+        setup: Steps:
+               Create Fedora 28 VM on vSphere6
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               Install Chrome
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Chrome
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Advanced" and then click "Proceed to
+               <CFME_URL>(unsafe)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.vmrc
+def test_vmrc_console_firefox_vsphere6_fedora26():
+    """
+    VMRC Console Testing in following Environment:
+    Browser: firefox
+    vSphere: 6
+    OS: Fedora 26
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 2/3h
+        setup: Steps:
+               Create Fedora 25 VM on vSphere6
+               Install VMRC Plugin (Ask mpusater on IRC for the setup file)
+               All Firefox versions can be found at following address:
+               https://ftp.mozilla.org/pub/firefox/releases/
+               Make sure the browser auto updates are also disabled
+        testSteps:
+            1. Launch CFME Appliance on Firefox
+            2. Go to Compute->Infrastructure->Virtual Machines
+            3. Click on any of the running/powered on VMs
+            4. On top of details, Click on Access->Select VM Console from Dropdown
+            5. Repeat above steps for other 2 versions of firefox
+        expectedResults:
+            1. CFME Appliance Login page should be displayed (Might warn
+               you about certificate/trust please proceed by accepting
+               (Click "Continue to this website (not Recommended)")
+            2. Should see list of Available VMs by all providers
+            3. Should see a details page containing detailed info about that VM
+            4. You should see a Pop-up being Blocked, Please allow it to
+               open (always allow pop-ups for this site) and then a new tab
+               will open and then in few secs, you will see a prompt asking
+               you if you would like to open VMRC, click Yes. Once done,
+               VMRC Window will open(apart from browser) and it will ask
+               you if you would like to View Certificate or Connect anyway
+               or Cancel, please click Connect Anyway. Finally, you should
+               see VM in this window and should be able to interact with it
+               using mouse/keyboard.
+            5. results should be same
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_black_console_ext_auth_options_all():
+    """
+    Test enabling/disabling all ext_auth options through appliance_console
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/6h
+        setup: -ssh to appliance
+               -run appliance_console
+               -select option "Update External Authentication Options"
+               -select each option to enable it
+               -select option
+               1) Enable/Disable Single Sign-On
+               2) Enable/Disable SAML
+               3) Enable/Disable Local Login
+               -select "Apply updates"
+               -check changes have been made
+        startsin: 5.6
+        testSteps:
+            1. Enable Single Sign-On, SAML, Local Login
+            2. Disable Single Sign-On, SAML, Local Login
+        expectedResults:
+            1. check changes in ui
+            2. check changes in ui
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware67_test_vm_migration_with_windows_2012_server():
+    """
+    OSP: vmware67-Test VM migration with Windows 2012 server
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware67-Test VM migration with Windows 2012 server
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_second_dialog_dynamic_element_should_be_able_to_read_the_previous_textbox_element():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1576107 Steps to
+    Reproduce:
+    1. import example automate domain
+    2. import example service dialog
+    3. create a generic catalog item with the dialog service dialog
+    provided
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        initialEstimate: 1/4h
+        title: Second dialog dynamic element should be able to read the
+               previous textbox element
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.general_ui
+def test_configuration_displayed_navigation_pane():
+    """
+    Go to Configuration -> Settings
+    1) CFME Region - no navigation pane
+    1a) C & U Collection - no navigation pane
+    1b) Tags -> My Company Categories/My Company Tags/ Import Tags/Import
+    Variables/Map Tags - no navigation pane
+    1c) Red Hat Updates - no navigation pane
+    1d) Help Menu - no navigation pane
+    2) Analysis Profiles - pagination pane
+    2a) sample analysis profile - no pagination pane
+    3) Zones - no navigation pane
+    3a) Default zone -> Zone/SmartProxy Affinity - no pagination pane
+    4) Server - no navigation pane
+    4a) Authentication - no navigation pane
+    4b) Workers - no navigation pane
+    4c) Custom Logos - no navigation pane
+    4d) Advanced - no navigation pane
+    5) Schedules - navigation pane
+    5a) Create a schedule -> Schedules - navigation pane
+    5b) Single schedule - no navigation pane
+    Go to Configuration -> Access Control
+    1) CFME Region - no navigation pane
+    1a) Users - navigation pane
+    2b) Single user - no navigation pane
+    2c) Groups - navigation pane
+    2d) Single group - no navigation pane
+    2e) Roles - navigation pane
+    2f) Single role - no navigation pane
+    2g) Tenant - navigation pane
+    2h) Single tenant - no navigation pane
+    Go to Configuration -> Diagnostics
+    1) CFME Region - no navigation pane
+    1a) Roles by Servers - no navigation pane
+    1b) Servers by Roles - no navigation pane
+    1c) Servers - no navigation pane
+    1d) Database - no navigation pane
+    1e) Orphaned data - no navigation pane
+    2) Zone - no navigation pane
+    2a) Servers by Roles - no navigation pane
+    2b) Servers - no navigation pane
+    2c) Collect logs - no navigation pane
+    2d) C & U Gap Collection - no navigation pane
+    3) Server - no navigation pane
+    3a) Workers - no navigation pane
+    3b) Collect Logs - no navigation pane
+    3c) CFME Log - no navigation pane
+    3d) Audit Log - no navigation pane
+    3e) Production Log - no navigation pane
+    3f) Utilization - no navigation pane
+    3g) Timelines - no navigation pane
+    4) Go to Configuration -> Database - no pagination pane
+    4a) Tables - pagination pane
+    4b) Indexes - pagination pane
+    4c) Settings - pagination pane
+    4d) Client Connections - pagination pane
+    4e) Utilization - no pagination pane
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_username_fields_error_azure():
+    """
+    1.Provision Azure Instance
+    2.Use "admin" as username / "password" as password
+    3.Verify that we have Error Flash messages for both fields
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/10h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_cockpit_button_disabled_on_windows_vms():
+    """
+    Cockpit is a Linux only solution.  Talked with UI team and they wanted
+    a bug to make sure Access\Web Console is disabled for Windows VMs
+    https://bugzilla.redhat.com/show_bug.cgi?id=1447100
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: web_ui
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/4h
+        setup: You need to select a Windows VM that is both running and has an IP
+               address assigned to it.  When fixed, the Access \ Web Console menu
+               item should be deleted.
+        startsin: 5.8
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_verify_benchmark_timings_are_correct():
+    """
+    Bug 1424716 - Benchmark timings are incorrect for all workers in
+    evm.log
+    https://bugzilla.redhat.com/show_bug.cgi?id=1424716
+    Timings logged in evm.log are/seem to be reasonable values:
+    [----] I, [2017-09-21T14:53:01.220711 #23936:ded140]  INFO -- :
+    MIQ(ManageIQ::Providers::Vmware::InfraManager::Refresher#refresh) EMS:
+    [vsphere6], id: [2]
+    Refreshing targets for EMS...Complete - Timings
+    {:get_ems_data=>0.11566829681396484,
+    :get_vc_data=>0.7215437889099121,
+    :get_vc_data_ems_customization_specs=>0.014485597610473633,
+    :filter_vc_data=>0.0004775524139404297,
+    :get_vc_data_host_scsi=>0.5094377994537354,
+    :collect_inventory_for_targets=>1.363351821899414,
+    :parse_vc_data=>0.10647010803222656,
+    :parse_targeted_inventory=>0.10663747787475586,
+    :db_save_inventory=>9.141719341278076,
+    :save_inventory=>9.141741275787354,
+    :ems_refresh=>10.612204551696777}
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.8
+        title: Verify benchmark timings are correct
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_retire_on_date_for_multiple_service():
+    """
+    Retire on date for multiple service
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.5
+        title: Retire on date for multiple service
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_order_service_after_deleting_provider():
+    """
+    Order service
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: Order service after deleting provider
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.rbac
+def test_verify_that_changing_groups_in_the_webui_updates_dashboard_items():
+    """
+    Verify that switching groups the webui changes the dashboard items to
+    match the new groups permissions
+
+    Polarion:
+        assignee: apagac
+        casecomponent: web_ui
+        initialEstimate: 1/4h
+        setup: Create a user with two or more groups. The groups should have role
+               permissions that grant access to different features so you can easily
+               see that the dashboard is updated appropriately.
+        startsin: 5.9
+        tags: rbac
+        title: Verify that changing groups in the webui updates dashboard items
+        testSteps:
+            1. Login to the OPS webui
+            2. Switch to another group
+            3. Check that dashboard items are updated appropriately
+        expectedResults:
+            1. Login successful
+            2. Group switch successful
+            3. Dashboard items are updated from to reflect that access of the new group
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.general_ui
+def test_configuration_start_page_menu_category():
+    """
+    Navigate to Settings -> My Settings
+    List through Start Page - Show at Login select menu and check whether
+    Items have right menu category.
+    Like Cloud Intel / Dashboard means that Dashboard page is in Cloud
+    Intel menu.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.smartstate
+@pytest.mark.tier(1)
+def test_ssa_vm_files():
+    """
+    Check file list is fetched correctly for analysed VM
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: smartst
+        caseimportance: medium
+        initialEstimate: 1/2h
+        testtype: integration
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_restrict_domain_crud():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1365493
+    When you create a role that can only view automate domains, it can
+    view automate domains, it cannot manipulate the domains themselves,
+    but can CRUD on namespaces, classes, instances ....
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_vm_migrate_should_create_notifications_when_migrations_fail():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1478462
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        title: VM Migrate should create notifications  when migrations fail.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.cloud_init
+@pytest.mark.tier(1)
+def test_cloud_init_with_cfme():
+    """
+    test cloud init payload with latest cfme image
+
+    Polarion:
+        assignee: None
+        casecomponent: appl
+        endsin: 5.4
+        initialEstimate: 1/2h
+        startsin: 5.4
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_remote_server_advanced_config():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1536524
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        initialEstimate: 1/4h
+        startsin: 5.10
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_notification_notification_about_new_cfme_appliance_update_to_the_admin():
+    """
+    desc
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: low
+        initialEstimate: 1/4h
+        title: Notification : Notification about new cfme-appliance update to the admin
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_regions_gov_azure():
+    """
+    This test verifies that Azure Government regions are not included in
+    the default region list as most users will receive errors if they try
+    to use them.
+    https://bugzilla.redhat.com/show_bug.cgi?id=1412363
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/8h
+        setup: Check the region list when adding a Azure Provider.
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_tagvis_performance_reports():
+    """
+    1. Create role with group and user restriction
+    2. Create groups with tag
+    3. Create user with selected group
+    4. Set the group ownership and tag for one of VMs
+    5. Generate performance report
+    6. As user add widget to dashboard
+    7. Check widget content -> User should see only one vm with set
+    ownership and tag
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/3h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_create_remove_network_security_groups_events_azure():
+    """
+    create/remove network security groups events[azure]
+
+    Polarion:
+        assignee: None
+        caseimportance: low
+        initialEstimate: 1/4h
+        title: create/remove network security groups events[azure]
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.log_depot
+@pytest.mark.tier(1)
+def test_log_collect_all_zone_multiple_servers():
+    """
+    using any type of depot check collect all log function under zone.
+    Zone should have multiplie servers under it. Zone and all servers
+    should have their own settings
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.report
+@pytest.mark.tier(1)
+def test_queue_tenant_quotas_report():
+    """
+    Test multiple possible Tenant Quota Report configurations
+
+    Polarion:
+        assignee: pvala
+        casecomponent: report
+        initialEstimate: 1/4h
+        setup: Create or Identify appliance with one or more synced providers
+        title: Queue Tenant Quotas Report
+        testSteps:
+            1. Sign in to appliance
+            2. Navigate to Settings > Access control > Tenants > My Tenant > Manage quotas
+            3. Turn on Allocated Virtual CPUs and set it up to 10
+            4. Save new quota configuration
+            5. Navigate to Cloud Intel > Reports > Reports > Tentant Quotas
+            6. Queue Tenant Quotas report
+            7. //Wait ~1 minute
+            8.
+            9.
+            10. Navigate to Settings > Access control > Tenants > My Tenant > Manage quotas
+            11. Turn off Allocated Virtual CPUs, turn on Allocated Memory in
+                GB and set it up to 100
+            12. Save new quota configuration
+            13. Navigate to Cloud Intel > Reports > Reports > Tentant Quotas
+            14. Queue Tenant Quotas report
+            15. //Wait ~1 minute
+            16.
+            17.
+            18. Navigate to Settings > Access control > Tenants > My Tenant > Manage quotas
+            19. Turn on Allocated Virtual CPUs and set it up to 10, turn on
+                Allocated Memory in GB and set it up to 100
+            20. Save new quota configuration
+            21. Navigate to Cloud Intel > Reports > Reports > Tentant Quotas
+            22. Queue Tenant Quotas report
+            23. //Wait ~1 minute
+            24.
+            25.
+            26. Navigate to Settings > Access control > Tenants > My Tenant > Manage quotas
+            27. Turn on all quotas and set them up adequate numbers
+            28. Save new quota configuration
+            29. Navigate to Cloud Intel > Reports > Reports > Tentant Quotas
+            30. Queue Tenant Quotas report
+            31. //Wait ~1 minute
+            32.
+            33.
+            34. Sign out
+        expectedResults:
+            1.
+            2.
+            3.
+            4. Verify that flash message "Quotas for Tenant were saved" is shown
+            5.
+            6.
+            7. Verify that only Allocated Virtual CPUs row is present in report
+            8. Verify that Count is unit in the report
+            9. Verify that following columns are shown in report:
+               Tenant Name         Quota Name         Total Quota
+               In Use         Allocated         Available
+            10.
+            11.
+            12. Verify that flash message "Quotas for Tenant were saved" is shown
+            13.
+            14.
+            15. Verify that only Allocated Memory in GB row is present in report
+            16. Verify that GB is unit in the report
+            17. Verify that following columns are shown in report:
+                Tenant Name         Quota Name         Total Quota
+                In Use         Allocated         Available
+            18.
+            19.
+            20. Verify that flash message "Quotas for Tenant were saved" is shown
+            21.
+            22.
+            23. Verify that Allocated Virtual CPUs and Allocated Memory in
+                GB rows are present in report
+            24. Verify that both Count and GB units are used in the report
+            25. Verify that following columns are shown in report:
+                Tenant Name         Quota Name         Total Quota
+                In Use         Allocated         Available
+            26.
+            27.
+            28. Verify that flash message "Quotas for Tenant were saved" is shown
+            29.
+            30.
+            31. Verify that all quotas are present in report
+            32. Verify that both Count and GB units are used in the report
+            33. Verify that following columns are shown in report:
+                Tenant Name         Quota Name         Total Quota
+                In Use         Allocated         Available
+            34.
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_chargeback_cost_resource_average_cpu():
+    """
+    Validate cost for allocated CPU with "Average" method for allocated
+    metrics.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_chargeback_cost_resource_average_memory():
+    """
+    Validate cost for allocated memory with "Average" method for allocated
+    metrics
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_chargeback_cost_resource_maximum_cpu():
+    """
+    Validate cost for allocated CPU with "Maximum" method for allocated
+    metrics
+    1))Let VM run for a few hours(3- 24 hours)
+    2)Sometime during that interval(3-24 hours),reconfigure VM to have
+    different resources from when it was created(add/remove
+    vCPU,memory,disk)
+    3)Validate that chargeback costs are appropriate for vCPU allocated
+    when method for allocated metrics is "Maximum".
+    Also, see RHCF3-34343, RHCF3-34344, RHCF3-34345, RHCF3-34346,
+    RHCF3-34347 .
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_chargeback_cost_resource_maximum_storage():
+    """
+    Validate cost for allocated storage with "Maximum" method for
+    allocated metrics
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_chargeback_cost_resource_average_stoarge():
+    """
+    Validate cost for allocated storage with "Average" method for
+    allocated metrics
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.chargeback
+def test_validate_chargeback_cost_resource_maximum_memory():
+    """
+    Validate cost for allocated memory with "Maximum" method for allocated
+    metrics
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_vm_reconfig_resize_disk_cold_vsphere67_nested_persistent_thick():
+    """
+    Polarion:
+        assignee: nansari
+        casecomponent: infra
+        initialEstimate: 1/6h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.log_depot
+@pytest.mark.tier(1)
+def test_edit_log_collection_spinner_present():
+    """
+    Check that spinner present in "edit log depot" page.
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_schedule_compliance_check():
+    """
+    Navigate to add new schedule page(Configuration->Region->Schedules)
+    Fill all required fields
+    Select compliance check in filter
+    Set timer
+    Save changes
+    Result: Task run successfully
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_appliance_console_negative():
+    """
+    test launching appliance_console without a network attached
+    https://bugzilla.redhat.com/show_bug.cgi?id=1439345
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(3)
+def test_configure_ldaps_for_customized_port_eg_10636_10389_and_validate_cfme_auth():
+    """
+    Configure ldap/ldaps domain server with customized port.
+    Configure cfme for customized domain ports. Check mojo page for
+    details.
+    Verify ldap user/group authentication.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: low
+        initialEstimate: 1/2h
+        title: Configure  ldaps for customized port e.g 10636, 10389 and validate CFME auth
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(3)
+def test_sui_request_explorer_will_show_all_status_of_requests():
+    """
+    desc
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.8
+        title: SUI: Request explorer will show all status of requests
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(2)
+def test_user_should_be_able_to_change_the_order_of_values_of_the_drop_down_list():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1594301
+
+    Polarion:
+        assignee: nansari
+        initialEstimate: 1/16h
+        startsin: 5.10
+        title: User should be able to change the order of values of the drop down list
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.log_depot
+@pytest.mark.tier(1)
+def test_log_collect_all_zone_zone_setup():
+    """
+    using any type of depot check collect all log function under zone
+    (settings under server should not be configured, under zone should be
+    configured)
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/2h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.reconfigure
+@pytest.mark.tier(1)
+def test_reconfigure_vm_vmware_mem_multiple():
+    """
+    Test changing the memory of multiple vms at the same time.
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/6h
+        setup: -get new configured appliance
+               -add vmware provider
+               -provision 2 new vms
+               -power off 1 vm
+               -select both vms
+               -configure-->reconfigure vm
+               -increase/decrease counts
+               -power on vm
+               -check changes
+        startsin: 5.6
+        testSteps:
+            1. Hot increase
+            2. Hot Decrease
+            3. Cold Increase
+            4. Cold Decrease
+            5. Hot + Cold Increase
+            6. Hot + Cold Decrease
+        expectedResults:
+            1. Action should succeed
+            2. Action should fail
+            3. Action should succeed
+            4. Action should succeed
+            5. Action should succeed
+            6. Action should Error
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.ansible
+def test_embed_tower_exec_play_against_ipv6_machine():
+    """
+    User/Admin is able to execute playbook without creating Job Temaplate
+    and can execute it against machine which has ipv6 address.
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: ansible
+        caseimportance: medium
+        initialEstimate: 1h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.right_size
+@pytest.mark.tier(2)
+def test_nor_memory_vsphere55():
+    """
+    Test Normal Operating Range for memory usage
+    Compute > Infrastructure > Virtual Machines > select a VM running on a
+    vSphere 5.5 provider
+    Normal Operating Ranges widget displays values for Memory and Memory
+    Usage max, high, average, and low, if at least one days" worth of
+    metrics have been captured.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.right_size
+@pytest.mark.tier(1)
+def test_nor_memory_rhv41():
+    """
+    Normal Operating Ranges for memory display correctly for RHV 4.1 VM.
+    Compute > Infrastructure > Virtual Machines > select a VM running on a
+    RHV 4.1 provider
+    Normal Operating Ranges widget displays values for Memory and Memory
+    Usage max, high, average, and low, if at least one days" worth of
+    metrics have been captured.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.right_size
+@pytest.mark.tier(2)
+def test_nor_memory_vsphere6():
+    """
+    Test Normal Operating Range for memory usage
+    Compute > Infrastructure > Virtual Machines > select a VM running on a
+    vSphere 6 provider
+    Normal Operating Ranges widget displays values for Memory and Memory
+    Usage max, high, average, and low, if at least one days" worth of
+    metrics have been captured.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: candu
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_check_required_button_on_all_dialog_elements():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1512398
+    Steps to Reproduce:
+    1. Create a dialog with some entries and "required" button turned ON.
+    2. Create a catalog item that uses this dialog.
+    3. When we order that catalog item the order is submitted without
+    selecting any item in the dropdown.
+
+    Polarion:
+        assignee: sshveta
+        casecomponent: services
+        initialEstimate: 1/4h
+        title: Check "Required" button on all dialog elements
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_osp_vmware67_test_vm_migration_from_iscsi_storage_in_vmware_to_iscsi_on_osp():
+    """
+    OSP: vmware67-Test VM migration from iSCSI Storage in VMware to iSCSI
+    on OSP
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        initialEstimate: 1/8h
+        startsin: 5.10
+        subcomponent: OSP
+        title: OSP: vmware67-Test VM migration from iSCSI Storage in VMware to iSCSI on OSP
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_custom_button_visibility():
+    """
+    This test is required to test the visibility option in the customize
+    button.
+    Steps
+    1)Create Button Group
+    2)Create a Button for the button group
+    3)Add the Button group to a page
+    4)Make write a positive visibility expression
+    5)If button is visible and clickable then pass else fail
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/12h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(3)
+def test_saml_verify_multiple_appliances_can_be_added_to_the_same_realm():
+    """
+    Verify configuring more than one appliance to SAML authentication as
+    mentioned in Step#1 works fine.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/2h
+        title: saml: Verify multiple appliances can be added to the same REALM.
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_embedded_method():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1523379
+    For a "new" method when adding Embedded Methods the UI hangs in the
+    tree view when the method is selected
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.storage
+def test_storage_volume_backup_restore_from_backup_page_openstack():
+    """
+    Requires:
+    test_storage_volume_backup[openstack]
+    1) Navigate to Volume Backups [Storage > Block Storage > Volume
+    Backups]
+    2) Select respective Volume backups
+    3) Restore Volume [configuration > Restore backup to cloud volume
+    4) Select Proper Volume to restore
+    5) check in Task whether restored or not.
+
+    Polarion:
+        assignee: None
+        casecomponent: cloud
+        caseimportance: medium
+        initialEstimate: 1/5h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_verify_cfme_login_page_redirects_to_saml_login_page_upon_successful_configuration():
+    """
+    click on login to corporate account if local login is enabled,
+    redirects to SAML REALM page for which user is appliance is configured
+    to.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: config
+        initialEstimate: 1/4h
+        title: Verify CFME login page redirects to SAML login page upon
+               successful configuration
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_search_field_at_the_top_of_a_dynamic_drop_down_dialog_element_should_display():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1553347
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        initialEstimate: 1/4h
+        startsin: 5.9
+        title: search field at the top of a dynamic drop-down dialog element should display
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.upgrade
+@pytest.mark.tier(2)
+def test_upgrade_custom_widgets():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1375313
+    Upgrade appliance with custom widgets added
+
+    Polarion:
+        assignee: jhenner
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/3h
+        setup: provision appliance
+               add custom widgets
+               add repo file to /etc/yum.repos.d/
+               run "yum update"
+               run "rake db:migrate"
+               run "rake evm:automate:reset"
+               run "systemctl start evmserverd"
+               check webui is available
+               check widgets still work correctly
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_git_verify_ssl():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1470738
+
+    Polarion:
+        assignee: dmisharo
+        casecomponent: automate
+        caseimportance: low
+        initialEstimate: 1/12h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.auth
+@pytest.mark.tier(2)
+def test_credentials_login_password_leading_whitespace():
+    """
+    Password with leading whitespace
+
+    Polarion:
+        assignee: apagac
+        casecomponent: appl
+        caseimportance: medium
+        initialEstimate: 1/8h
+        tags: rbac
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_host_info_scvmm2016():
+    """
+    The purpose of this test is to verify that SCVMM-2016 hosts are not
+    only added, but that the host information details are correct.  Take
+    the time to spot check at least one host.
+
+    Polarion:
+        assignee: None
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/12h
+        startsin: 5.7
+    """
+    pass

--- a/cfme/tests/test_modules_importable.py
+++ b/cfme/tests/test_modules_importable.py
@@ -25,6 +25,11 @@ KNOWN_FAILURES = set(ROOT.dirpath().join(x) for x in[
 @pytest.mark.parametrize('module_path', MODULES, ids=ROOT.dirpath().bestrelpath)
 @pytest.mark.long_running
 def test_import_own_module(module_path):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     if module_path in KNOWN_FAILURES:
         pytest.skip("{} is a known failed path".format(ROOT.dirpath().bestrelpath(module_path)))
     subprocess.check_call(

--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -198,6 +198,10 @@ def test_query_simple_collections(appliance, collection_name):
         * GET /api/<collection_name>
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/3h
     """
     collection = getattr(appliance.rest_api.collections, collection_name)
     assert_response(appliance)
@@ -222,6 +226,10 @@ def test_collections_actions(appliance, collection_name):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     collection_href = '{}/{}'.format(appliance.rest_api._entry_point, collection_name)
     response = appliance.rest_api.get(collection_href)
@@ -247,6 +255,10 @@ def test_query_with_api_version(api_version, collection_name):
         * GET /api/<version>/<collection_name>
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     collection = getattr(api_version.collections, collection_name)
     assert_response(api_version)
@@ -271,6 +283,10 @@ def test_select_attributes(appliance, collection_name):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/8h
     """
     if collection_name in COLLECTIONS_BUGGY_ATTRS and appliance.version < '5.9':
         pytest.skip("Affected by BZ 1437201, cannot test.")
@@ -291,6 +307,10 @@ def test_http_options(appliance):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/3h
     """
     assert 'boot_time' in appliance.rest_api.collections.vms.options()['attributes']
     assert_response(appliance)
@@ -302,6 +322,10 @@ def test_http_options_node_types(appliance, collection_name):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     collection = getattr(appliance.rest_api.collections, collection_name)
     assert 'node_types' in collection.options()['data']
@@ -313,6 +337,10 @@ def test_http_options_subcollections(appliance):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     assert 'tags' in appliance.rest_api.collections.vms.options()['subcollections']
     assert_response(appliance)
@@ -323,6 +351,10 @@ def test_server_info(appliance):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/3h
     """
     assert all(item in appliance.rest_api.server_info for item in ('appliance', 'build', 'version'))
 
@@ -332,6 +364,10 @@ def test_server_info_href(appliance):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     items = ('server_href', 'zone_href', 'region_href')
     for item in items:
@@ -344,6 +380,10 @@ def test_default_region(appliance):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     reg = appliance.rest_api.collections.regions[0]
     assert hasattr(reg, 'guid')
@@ -355,6 +395,10 @@ def test_product_info(appliance):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/3h
     """
     assert all(item in appliance.rest_api.product_info for item in
                ('copyright', 'name', 'name_full', 'support_website', 'support_website_text'))
@@ -365,6 +409,10 @@ def test_settings_collection(appliance):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     # the "settings" collection is untypical as it doesn't have "resources" and
     # for this reason can't be reloaded (bug in api client)
@@ -377,6 +425,10 @@ def test_identity(appliance):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/3h
     """
     assert all(item in appliance.rest_api.identity for item in
                ('userid', 'name', 'group', 'role', 'tenant', 'groups'))
@@ -387,6 +439,10 @@ def test_user_settings(appliance):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/3h
     """
     assert isinstance(appliance.rest_api.settings, dict)
 
@@ -396,6 +452,10 @@ def test_datetime_filtering(appliance, provider):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     collection = appliance.rest_api.collections.vms
     url_string = '{}{}'.format(
@@ -432,6 +492,10 @@ def test_date_filtering(appliance, provider):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     collection = appliance.rest_api.collections.vms
     url_string = '{}{}'.format(
@@ -464,6 +528,10 @@ def test_resources_hiding(appliance):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/8h
     """
     roles = appliance.rest_api.collections.roles
     resources_visible = appliance.rest_api.get(roles._href + '?filter[]=read_only=true')
@@ -481,6 +549,10 @@ def test_sorting_by_attributes(appliance):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     url_string = '{}{}'.format(
         appliance.rest_api.collections.groups._href,
@@ -519,6 +591,10 @@ def test_rest_paging(appliance, paging):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     limit, offset = paging
     url_string = '{}{}'.format(
@@ -590,6 +666,10 @@ def test_attributes_present(appliance, collection_name):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: None
     """
     attrs = 'href,id,href_slug'
     collection = getattr(appliance.rest_api.collections, collection_name)
@@ -611,6 +691,10 @@ def test_collection_class_valid(appliance, provider, vendor):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     collection = appliance.rest_api.collections.vms
     collection.reload()
@@ -634,6 +718,10 @@ def test_collection_class_invalid(appliance, provider):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     with pytest.raises(Exception, match='Invalid collection_class'):
         appliance.rest_api.collections.vms.query_string(
@@ -650,6 +738,10 @@ def test_bulk_delete(request, appliance):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     collection = appliance.rest_api.collections.services
     data = [{'name': fauxfactory.gen_alphanumeric()} for __ in range(2)]
@@ -675,6 +767,10 @@ def test_rest_ping(appliance):
 
     Metadata:
         test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        initialEstimate: 1/4h
     """
     ping_addr = '{}/ping'.format(appliance.rest_api._entry_point)
     assert appliance.rest_api._session.get(ping_addr).text == 'pong'
@@ -694,6 +790,10 @@ class TestPicturesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         picture = self.create_picture(appliance)
         outcome = query_resource_attributes(picture)
@@ -710,6 +810,10 @@ class TestPicturesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         collection = appliance.rest_api.collections.pictures
         collection.reload()
@@ -724,6 +828,10 @@ class TestPicturesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         collection = appliance.rest_api.collections.pictures
         count = collection.count
@@ -741,6 +849,10 @@ class TestPicturesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         collection = appliance.rest_api.collections.pictures
         count = collection.count
@@ -759,6 +871,10 @@ class TestBulkQueryRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         collection = appliance.rest_api.collections.events
         data0, data1, data2 = collection[0]._data, collection[1]._data, collection[2]._data
@@ -775,6 +891,10 @@ class TestBulkQueryRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         data = appliance.rest_api.collections.users[0]._data
         response = appliance.rest_api.collections.users.action.query(
@@ -788,6 +908,10 @@ class TestBulkQueryRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         collection = appliance.rest_api.collections.roles
         data0, data1 = collection[0]._data, collection[1]._data
@@ -802,6 +926,10 @@ class TestBulkQueryRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         collection = appliance.rest_api.collections.groups
         data0, data1 = collection[0]._data, collection[1]._data
@@ -828,6 +956,10 @@ class TestArbitrationSettingsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         query_resource_attributes(arbitration_settings[0], soft_assert=soft_assert)
 
@@ -836,6 +968,10 @@ class TestArbitrationSettingsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         for setting in arbitration_settings:
             record = appliance.rest_api.collections.arbitration_settings.get(id=setting.id)
@@ -847,6 +983,10 @@ class TestArbitrationSettingsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         delete_resources_from_detail(arbitration_settings, method=method)
 
@@ -855,6 +995,10 @@ class TestArbitrationSettingsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         delete_resources_from_collection(arbitration_settings)
 
@@ -866,6 +1010,10 @@ class TestArbitrationSettingsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         num_settings = len(arbitration_settings)
         uniq = [fauxfactory.gen_alphanumeric(5) for _ in range(num_settings)]
@@ -903,6 +1051,10 @@ class TestArbitrationRulesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         query_resource_attributes(arbitration_rules[0], soft_assert=soft_assert)
 
@@ -911,6 +1063,10 @@ class TestArbitrationRulesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         for rule in arbitration_rules:
             record = appliance.rest_api.collections.arbitration_rules.get(id=rule.id)
@@ -922,6 +1078,10 @@ class TestArbitrationRulesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         delete_resources_from_detail(arbitration_rules, method='POST')
 
@@ -930,6 +1090,10 @@ class TestArbitrationRulesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         delete_resources_from_collection(arbitration_rules)
 
@@ -941,6 +1105,10 @@ class TestArbitrationRulesRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: None
+            initialEstimate: None
         """
         num_rules = len(arbitration_rules)
         uniq = [fauxfactory.gen_alphanumeric(5) for _ in range(num_rules)]
@@ -974,6 +1142,10 @@ class TestNotificationsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         collection = appliance.rest_api.collections.notifications
         collection.reload()
@@ -987,6 +1159,10 @@ class TestNotificationsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         unseen = appliance.rest_api.collections.notifications.find_by(seen=False)
         notifications = [unseen[-i] for i in range(1, 3)]
@@ -1011,6 +1187,10 @@ class TestNotificationsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         # BZ 1420872 was fixed for >= 5.9 only
         if method == 'delete' and appliance.version < '5.9':
@@ -1024,6 +1204,10 @@ class TestNotificationsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         notifications = appliance.rest_api.collections.notifications.all[-3:]
         delete_resources_from_collection(notifications)
@@ -1047,6 +1231,10 @@ class TestEventStreamsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         collection = appliance.rest_api.collections.event_streams
         collection.reload()
@@ -1058,6 +1246,10 @@ class TestEventStreamsRESTAPI(object):
 
         Metadata:
             test_flag: rest
+
+        Polarion:
+            assignee: pvala
+            initialEstimate: 1/4h
         """
         vm_name = vm_obj
         collections = appliance.rest_api.collections

--- a/cfme/tests/test_ui.py
+++ b/cfme/tests/test_ui.py
@@ -17,6 +17,11 @@ def traverse(dic, paths, path=None):
 
 
 def test_each_page(appliance):
+    """
+    Polarion:
+        assignee: anikifor
+        initialEstimate: None
+    """
     view = navigate_to(appliance.server, 'Dashboard')
     tree = view.navigation.nav_item_tree()
     paths = []

--- a/cfme/tests/test_utilization.py
+++ b/cfme/tests/test_utilization.py
@@ -55,6 +55,10 @@ def test_metrics_collection(clean_setup_provider, provider, enable_candu):
 
     Metadata:
         test_flag: metrics_collection
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
     """
     metrics_tbl = store.current_appliance.db.client['metrics']
     mgmt_systems_tbl = store.current_appliance.db.client['ext_management_systems']

--- a/cfme/tests/v2v/test_csv_import.py
+++ b/cfme/tests/v2v/test_csv_import.py
@@ -108,26 +108,54 @@ def archived_vm(appliance, second_provider):
 
 
 def test_non_csv(appliance, infra_map):
-    """Test non-csv file import"""
+    """Test non-csv file import
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        customerscenario: true
+        initialEstimate: 1/8h
+        subcomponent: RHV
+        upstream: yes
+    """
     error_msg = "Invalid file extension. Only .csv files are accepted."
     assert import_and_check(appliance, infra_map, error_msg, filetype='txt', alert=True)
 
 
 def test_blank_csv(appliance, infra_map):
-    """Test csv with blank file"""
+    """Test csv with blank file
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        customerscenario: true
+        initialEstimate: 1/8h
+        subcomponent: RHV
+        upstream: yes
+    """
     error_msg = "Error: Possibly a blank .CSV file"
     assert import_and_check(appliance, infra_map, error_msg)
 
 
 def test_column_headers(appliance, infra_map):
-    """Test csv with unsupported column header"""
+    """Test csv with unsupported column header
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     content = fauxfactory.gen_alpha(10)
     error_msg = "Error: Required column 'Name' does not exist in the .CSV file"
     assert import_and_check(appliance, infra_map, error_msg, content=content)
 
 
 def test_inconsistent_columns(appliance, infra_map):
-    """Test csv with extra inconsistent column value"""
+    """Test csv with extra inconsistent column value
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     content = "Name\n{}, {}".format(fauxfactory.gen_alpha(10), fauxfactory.gen_alpha(10))
     error_msg = "Error: Number of columns is inconsistent on line 2"
     assert import_and_check(appliance, infra_map, error_msg, content=content)
@@ -135,7 +163,16 @@ def test_inconsistent_columns(appliance, infra_map):
 
 @pytest.mark.meta(blockers=[BZ(1639239, forced_streams=["5.10"])])
 def test_csv_empty_vm(appliance, infra_map):
-    """Test csv with empty column value"""
+    """Test csv with empty column value
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        customerscenario: true
+        initialEstimate: 1/8h
+        subcomponent: RHV
+        upstream: yes
+    """
     content = "Name\n\n"
     error_msg = "Empty name specified"
     assert import_and_check(appliance, infra_map, error_msg, content=content, table_hover=True)
@@ -143,21 +180,48 @@ def test_csv_empty_vm(appliance, infra_map):
 
 @pytest.mark.meta(blockers=[BZ(1639239, forced_streams=["5.10"])])
 def test_csv_invalid_vm(appliance, infra_map):
-    """Test csv with invalid vm name"""
+    """Test csv with invalid vm name
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        customerscenario: true
+        initialEstimate: 1/8h
+        subcomponent: RHV
+        upstream: yes
+    """
     content = "Name\n{}".format(fauxfactory.gen_alpha(10))
     error_msg = "VM does not exist"
     assert import_and_check(appliance, infra_map, error_msg, content=content, table_hover=True)
 
 
 def test_csv_valid_vm(appliance, infra_map, valid_vm):
-    """Test csv with valid vm name"""
+    """Test csv with valid vm name
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        customerscenario: true
+        initialEstimate: 1/8h
+        subcomponent: RHV
+        upstream: yes
+    """
     content = "Name\n{}".format(valid_vm)
     error_msg = "VM available for migration"
     assert import_and_check(appliance, infra_map, error_msg, content=content, table_hover=True)
 
 
 def test_csv_duplicate_vm(appliance, infra_map, valid_vm):
-    """Test csv with duplicate vm name"""
+    """Test csv with duplicate vm name
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        customerscenario: true
+        initialEstimate: 1/8h
+        subcomponent: RHV
+        upstream: yes
+    """
     content = "Name\n{}\n{}".format(valid_vm, valid_vm)
     error_msg = "Duplicate VM"
     assert import_and_check(appliance, infra_map, error_msg, content=content,
@@ -166,7 +230,16 @@ def test_csv_duplicate_vm(appliance, infra_map, valid_vm):
 
 @pytest.mark.meta(blockers=[BZ(1639239, forced_streams=["5.10"])])
 def test_csv_archived_vm(appliance, infra_map, archived_vm):
-    """Test csv with archived vm name"""
+    """Test csv with archived vm name
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        customerscenario: true
+        initialEstimate: 1/8h
+        subcomponent: RHV
+        upstream: yes
+    """
     content = "Name\n{}".format(archived_vm)
     error_msg = "VM is inactive"
     assert import_and_check(appliance, infra_map, error_msg, content=content, table_hover=True)

--- a/cfme/tests/v2v/test_post_migrations.py
+++ b/cfme/tests/v2v/test_post_migrations.py
@@ -38,7 +38,12 @@ def get_migrated_vm_obj(src_vm_obj, target_provider):
 )
 def test_migration_policy_tag(request, appliance, v2v_providers, host_creds, conversion_tags,
                               form_data_vm_obj_single_datastore, soft_assert):
-    """Test policy to prevent source VM from starting if migration is complete"""
+    """Test policy to prevent source VM from starting if migration is complete
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     infrastructure_mapping_collection = appliance.collections.v2v_mappings
     mapping = infrastructure_mapping_collection.create(form_data_vm_obj_single_datastore.form_data)
 

--- a/cfme/tests/v2v/test_v2v_cancel_migrations.py
+++ b/cfme/tests/v2v/test_v2v_cancel_migrations.py
@@ -34,6 +34,11 @@ def test_dual_vm_migration_cancel_migration(request, appliance, v2v_providers, h
                                         conversion_tags,
                                         form_data_multiple_vm_obj_single_datastore, soft_assert,
                                         cancel_migration_after_percent):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     # TODO: Improve this test to cover cancel operation at various stages in migration.
     # This test will make use of migration request details page to track status of migration
     infrastructure_mapping_collection = appliance.collections.v2v_mappings

--- a/cfme/tests/v2v/test_v2v_migrations.py
+++ b/cfme/tests/v2v/test_v2v_migrations.py
@@ -44,6 +44,14 @@ def get_migrated_vm_obj(src_vm_obj, target_provider):
 def test_single_datastore_single_vm_migration(request, appliance, v2v_providers, host_creds,
                                             conversion_tags,
                                             form_data_vm_obj_single_datastore):
+    """
+    Polarion:
+        assignee: kkulkarn
+        casecomponent: V2V
+        initialEstimate: None
+        subcomponent: RHV
+        upstream: yes
+    """
     infrastructure_mapping_collection = appliance.collections.v2v_mappings
     mapping = infrastructure_mapping_collection.create(form_data_vm_obj_single_datastore.form_data)
 
@@ -89,6 +97,14 @@ def test_single_datastore_single_vm_migration(request, appliance, v2v_providers,
 def test_single_network_single_vm_migration(request, appliance, v2v_providers, host_creds,
                                             conversion_tags,
                                             form_data_vm_obj_single_network):
+    """
+    Polarion:
+        assignee: kkulkarn
+        casecomponent: V2V
+        initialEstimate: None
+        subcomponent: RHV
+        upstream: yes
+    """
     # This test will make use of migration request details page to track status of migration
     infrastructure_mapping_collection = appliance.collections.v2v_mappings
     mapping = infrastructure_mapping_collection.create(form_data_vm_obj_single_network.form_data)
@@ -136,6 +152,14 @@ def test_single_network_single_vm_migration(request, appliance, v2v_providers, h
 def test_dual_datastore_dual_vm_migration(request, appliance, v2v_providers, host_creds,
                                         conversion_tags,
                                         form_data_dual_vm_obj_dual_datastore, soft_assert):
+    """
+    Polarion:
+        assignee: kkulkarn
+        casecomponent: V2V
+        initialEstimate: None
+        subcomponent: RHV
+        upstream: yes
+    """
     # This test will make use of migration request details page to track status of migration
     infrastructure_mapping_collection = appliance.collections.v2v_mappings
     mapping = infrastructure_mapping_collection.create(form_data_dual_vm_obj_dual_datastore.
@@ -184,6 +208,14 @@ def test_dual_datastore_dual_vm_migration(request, appliance, v2v_providers, hos
 )
 def test_dual_nics_migration(request, appliance, v2v_providers, host_creds, conversion_tags,
          form_data_vm_obj_dual_nics):
+    """
+    Polarion:
+        assignee: kkulkarn
+        casecomponent: V2V
+        initialEstimate: None
+        subcomponent: RHV
+        upstream: yes
+    """
     infrastructure_mapping_collection = appliance.collections.v2v_mappings
     mapping = infrastructure_mapping_collection.create(form_data_vm_obj_dual_nics.form_data)
 
@@ -228,6 +260,14 @@ def test_dual_nics_migration(request, appliance, v2v_providers, host_creds, conv
                         indirect=True)
 def test_dual_disk_vm_migration(request, appliance, v2v_providers, host_creds, conversion_tags,
                                 form_data_vm_obj_single_datastore):
+    """
+    Polarion:
+        assignee: kkulkarn
+        casecomponent: V2V
+        initialEstimate: None
+        subcomponent: RHV
+        upstream: yes
+    """
     infrastructure_mapping_collection = appliance.collections.v2v_mappings
     mapping = infrastructure_mapping_collection.create(form_data_vm_obj_single_datastore.form_data)
 
@@ -274,6 +314,14 @@ def test_migrations_different_os_templates(request, appliance, v2v_providers, ho
                                     conversion_tags,
                                     form_data_multiple_vm_obj_single_datastore,
                                     soft_assert):
+    """
+    Polarion:
+        assignee: kkulkarn
+        casecomponent: V2V
+        initialEstimate: None
+        subcomponent: RHV
+        upstream: yes
+    """
     infrastructure_mapping_collection = appliance.collections.v2v_mappings
     mapping = infrastructure_mapping_collection.create(
         form_data_multiple_vm_obj_single_datastore.form_data)
@@ -320,6 +368,13 @@ def test_conversion_host_tags(appliance, v2v_providers):
 
     1)Test Attribute in UI indicating host has/has not been configured as conversion host like Tags
     2)Test converstion host tags
+
+    Polarion:
+        assignee: kkulkarn
+        casecomponent: V2V
+        initialEstimate: None
+        subcomponent: RHV
+        upstream: yes
     """
     tag1 = (appliance.collections.categories.instantiate(
             display_name='V2V - Transformation Host *')
@@ -350,6 +405,14 @@ def test_conversion_host_tags(appliance, v2v_providers):
 def test_single_vm_migration_with_ssh(request, appliance, v2v_providers, host_creds,
                                     conversion_tags,
                                     form_data_vm_obj_single_datastore):
+    """
+    Polarion:
+        assignee: kkulkarn
+        casecomponent: V2V
+        initialEstimate: None
+        subcomponent: RHV
+        upstream: yes
+    """
     infrastructure_mapping_collection = appliance.collections.v2v_mappings
     mapping = infrastructure_mapping_collection.create(form_data_vm_obj_single_datastore.form_data)
 
@@ -396,6 +459,14 @@ def test_single_vm_migration_power_state_tags_retirement(request, appliance, v2v
                                     host_creds, conversion_tags,
                                     form_data_vm_obj_single_datastore,
                                     power_state):
+    """
+    Polarion:
+        assignee: kkulkarn
+        casecomponent: V2V
+        initialEstimate: None
+        subcomponent: RHV
+        upstream: yes
+    """
     # Test VM migration power state and tags are preserved
     # as this is single_vm_migration it only has one vm_obj, which we extract on next line
     src_vm = form_data_vm_obj_single_datastore.vm_list[0]
@@ -463,6 +534,14 @@ def test_single_vm_migration_power_state_tags_retirement(request, appliance, v2v
 def test_multi_host_multi_vm_migration(request, appliance, v2v_providers, host_creds,
                                     conversion_tags, soft_assert,
                                     form_data_multiple_vm_obj_single_datastore):
+    """
+    Polarion:
+        assignee: kkulkarn
+        casecomponent: V2V
+        initialEstimate: None
+        subcomponent: RHV
+        upstream: yes
+    """
     infrastructure_mapping_collection = appliance.collections.v2v_mappings
     mapping = infrastructure_mapping_collection.create(
         form_data_multiple_vm_obj_single_datastore.form_data)
@@ -525,7 +604,15 @@ def test_multi_host_multi_vm_migration(request, appliance, v2v_providers, host_c
 def test_migration_special_char_name(request, appliance, v2v_providers, host_creds, conversion_tags,
                                     form_data_vm_obj_single_datastore):
     """Tests migration where name of migration plan is comprised of special non-alphanumeric
-       characters, such as '@#$(&#@('."""
+       characters, such as '@#$(&#@('.
+
+    Polarion:
+        assignee: kkulkarn
+        casecomponent: V2V
+        initialEstimate: None
+        subcomponent: RHV
+        upstream: yes
+    """
     infrastructure_mapping_collection = appliance.collections.v2v_mappings
     mapping = infrastructure_mapping_collection.create(form_data_vm_obj_single_datastore.form_data)
 
@@ -567,7 +654,12 @@ def test_migration_special_char_name(request, appliance, v2v_providers, host_cre
 
 
 def test_migration_long_name(request, appliance, v2v_providers, host_creds, conversion_tags):
-    """Test to check VM name with 64 character should work"""
+    """Test to check VM name with 64 character should work
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     source_datastores_list = v2v_providers.vmware_provider.data.get("datastores", [])
     source_datastore = [d.name for d in source_datastores_list if d.type == "nfs"][0]
     collection = appliance.provider_based_collection(v2v_providers.vmware_provider)

--- a/cfme/tests/v2v/test_v2v_migrations_ui.py
+++ b/cfme/tests/v2v/test_v2v_migrations_ui.py
@@ -34,6 +34,14 @@ pytestmark = [
 @pytest.mark.parametrize('form_data_single_datastore', [['nfs', 'nfs']], indirect=True)
 def test_infra_mapping_ui_assertions(appliance, v2v_providers, form_data_single_datastore,
                                     host_creds, conversion_tags, soft_assert):
+    """
+    Polarion:
+        assignee: kkulkarn
+        casecomponent: V2V
+        initialEstimate: None
+        subcomponent: RHV
+        upstream: yes
+    """
     # TODO: This test case does not support update
     # as update is not a supported feature for mapping.
     infrastructure_mapping_collection = appliance.collections.v2v_mappings
@@ -78,7 +86,15 @@ def test_infra_mapping_ui_assertions(appliance, v2v_providers, form_data_single_
 
 @pytest.mark.parametrize('form_data_single_datastore', [['nfs', 'nfs']], indirect=True)
 def test_v2v_ui_set1(appliance, v2v_providers, form_data_single_datastore, soft_assert):
-    """Perform UI Validations on Infra_Mappings Wizard."""
+    """Perform UI Validations on Infra_Mappings Wizard.
+
+    Polarion:
+        assignee: kkulkarn
+        casecomponent: V2V
+        initialEstimate: None
+        subcomponent: RHV
+        upstream: yes
+    """
     infrastructure_mapping_collection = appliance.collections.v2v_mappings
 
     view = navigate_to(infrastructure_mapping_collection, 'Add')
@@ -161,6 +177,14 @@ def test_v2v_ui_set1(appliance, v2v_providers, form_data_single_datastore, soft_
 
 
 def test_v2v_ui_no_providers(appliance, v2v_providers, soft_assert):
+    """
+    Polarion:
+        assignee: kkulkarn
+        casecomponent: V2V
+        initialEstimate: None
+        subcomponent: RHV
+        upstream: yes
+    """
     infrastructure_mapping_collection = appliance.collections.v2v_mappings
     view = navigate_to(infrastructure_mapping_collection, 'All')
     soft_assert(view.create_infrastructure_mapping.is_displayed)
@@ -182,6 +206,14 @@ def test_v2v_ui_no_providers(appliance, v2v_providers, soft_assert):
 @pytest.mark.parametrize('form_data_single_datastore', [['nfs', 'nfs']], indirect=True)
 def test_v2v_mapping_with_special_chars(appliance, v2v_providers, form_data_single_datastore,
                                         soft_assert):
+    """
+    Polarion:
+        assignee: kkulkarn
+        casecomponent: V2V
+        initialEstimate: None
+        subcomponent: RHV
+        upstream: yes
+    """
     # Test mapping can be created with non-alphanumeric name e.g '!@#$%^&*()_+)=-,./,''[][]]':
     infrastructure_mapping_collection = appliance.collections.v2v_mappings
     form_data_single_datastore['general']['name'] = fauxfactory.gen_special(length=10)
@@ -201,6 +233,14 @@ def test_v2v_mapping_with_special_chars(appliance, v2v_providers, form_data_sing
 
 @pytest.mark.parametrize('form_data_single_datastore', [['nfs', 'nfs']], indirect=True)
 def test_v2v_ui_set2(request, appliance, v2v_providers, form_data_single_datastore, soft_assert):
+    """
+    Polarion:
+        assignee: kkulkarn
+        casecomponent: V2V
+        initialEstimate: None
+        subcomponent: RHV
+        upstream: yes
+    """
     # Test migration plan name 24 chars and description 128 chars max length
     # Test earlier infra mapping can be viewed in migration plan wizard
     infrastructure_mapping_collection = appliance.collections.v2v_mappings
@@ -278,6 +318,11 @@ def test_v2v_ui_set2(request, appliance, v2v_providers, form_data_single_datasto
     [small_template, small_template]]], indirect=True)
 def test_v2v_ui_migration_plan_sorting(appliance, v2v_providers, host_creds, conversion_tags,
         form_data_multiple_vm_obj_single_datastore, soft_assert):
+    """
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     infrastructure_mapping_collection = appliance.collections.v2v_mappings
     migration_plan_collection = appliance.collections.v2v_plans
 
@@ -347,7 +392,16 @@ def test_v2v_ui_migration_plan_sorting(appliance, v2v_providers, host_creds, con
 
 
 def test_migration_rbac(appliance, new_credential, v2v_providers):
-    """Test migration with role-based access control"""
+    """Test migration with role-based access control
+
+    Polarion:
+        assignee: ytale
+        casecomponent: V2V
+        customerscenario: true
+        initialEstimate: 1/8h
+        subcomponent: RHV
+        upstream: yes
+    """
     role = new_role(appliance=appliance,
                     product_features=[(['Everything'], True)])
     group = new_group(appliance=appliance, role=role.name)

--- a/cfme/tests/v2v/test_v2v_schedule_migrations.py
+++ b/cfme/tests/v2v/test_v2v_schedule_migrations.py
@@ -30,6 +30,14 @@ pytestmark = [
 def test_single_vm_scheduled_migration(request, appliance, v2v_providers, host_creds,
                                     conversion_tags, soft_assert,
                                     form_data_vm_obj_single_datastore):
+    """
+    Polarion:
+        assignee: kkulkarn
+        casecomponent: V2V
+        initialEstimate: None
+        subcomponent: RHV
+        upstream: yes
+    """
     infrastructure_mapping_collection = appliance.collections.v2v_mappings
     mapping = infrastructure_mapping_collection.create(
         form_data_vm_obj_single_datastore.form_data)

--- a/cfme/tests/webui/test_advanced_search.py
+++ b/cfme/tests/webui/test_advanced_search.py
@@ -96,6 +96,13 @@ def _navigation(params, appliance):
 
 
 def test_advanced_search_button_displayed(params, appliance):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/30h
+    """
     view = _navigation(params, appliance)
     if not view.search.is_advanced_search_possible:
         pytest.fail(
@@ -105,6 +112,13 @@ def test_advanced_search_button_displayed(params, appliance):
 
 
 def test_can_open_advanced_search(params, appliance):
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: web_ui
+        caseimportance: medium
+        initialEstimate: 1/30h
+    """
     view = _navigation(params, appliance)
     view.search.open_advanced_search()
     if not view.search.is_advanced_search_opened:

--- a/cfme/tests/webui/test_general_ui.py
+++ b/cfme/tests/webui/test_general_ui.py
@@ -90,7 +90,12 @@ def create_20k_vms(appliance):
 
 @pytest.mark.provider([VMwareProvider], selector=ONE_PER_TYPE)
 def test_add_provider_trailing_whitespaces(provider, soft_assert):
-    """Test to validate the hostname and username should be without whitespaces """
+    """Test to validate the hostname and username should be without whitespaces
+
+    Polarion:
+        assignee: None
+        initialEstimate: None
+    """
     provider.endpoints['default'].credentials.principal = '{}  '.format(
         provider.endpoints['default'].credentials.principal)
     provider.endpoints['default'].hostname = '{}  '.format(
@@ -108,7 +113,15 @@ def test_add_provider_trailing_whitespaces(provider, soft_assert):
 
 @pytest.mark.long_running
 def test_configuration_large_number_of_tags(appliance, import_tags, soft_assert):
-    """Test page should be loaded within a minute with large number of tags"""
+    """Test page should be loaded within a minute with large number of tags
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/3h
+    """
     group = appliance.collections.groups.instantiate(description='EvmGroup-administrator')
     view = navigate_to(group, 'Details')
     for category, tags in import_tags.items():
@@ -127,6 +140,12 @@ def test_configuration_help_menu(appliance, set_help_menu_options, soft_assert):
         2) Click on the "Help Menu" tab
         3) Fill the fields
         4) Check if the changes are reflected or not
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: config
+        caseimportance: medium
+        initialEstimate: 1/4h
     """
     view = navigate_to(appliance.server, 'Dashboard')
     for option in set_help_menu_options:
@@ -144,6 +163,12 @@ def test_automate_can_edit_copied_method(appliance, request):
     5) Select it and try to edit it in the new Datastore
     6) Save it
     It should be saved successfully
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/10h
     """
 
     domain = appliance.collections.domains.create(
@@ -182,6 +207,12 @@ def test_infrastructure_filter_20k_vms(appliance, create_20k_vms):
         2) In the UI go to Compute -> Infrastructure -> Virtual Machines -> VMs
         3) Create filter Field -> Virtual Machine: Vendor = "vmware"
         4) There should be filtered 20k vms
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: infra
+        caseimportance: medium
+        initialEstimate: 1/3h
     """
     view = navigate_to(appliance.collections.infra_vms, 'VMsOnly')
     view.entities.search.save_filter(

--- a/cfme/tests/webui/test_splitter.py
+++ b/cfme/tests/webui/test_splitter.py
@@ -50,6 +50,12 @@ pytestmark = [
 @pytest.mark.requirement('general_ui')
 @pytest.mark.tier(3)
 def test_pull_splitter_persistence(request, appliance, model_object, destination):
+    """
+    Polarion:
+        assignee: mmojzis
+        caseimportance: low
+        initialEstimate: 1/20h
+    """
     splitter = Splitter(parent=appliance.browser.widgetastic)
 
     request.addfinalizer(splitter.reset)


### PR DESCRIPTION
Purpose or Intent
=================
This PR brings in all the changes from mkoura's `polarion2docstring` script. It does 3 things:
1) updates the docstrings of numerous tests to reflect polarion information
2) updates the metadata of numerous tests to mark the tier of the test
3) adds a file `cfme/tests/test_manual.py` that defines all the manual test cases from polarion as functions in `integrations_tests`

All credit goes to @mkoura for the additions to the code base in this PR. 
