### PR TITLE
[1LP][RFR]New Test to validate emails in schedules and add a new attribute to `Schedule`

### DIFF
--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -336,7 +336,7 @@ class Report(BaseEntity, Updateable):
         return self.collections.saved_reports
 
     def create_schedule(self, name=None, description=None, active=None,
-            timer=None, emails=None, email_options=None):
+            timer=None, from_email=None, emails=None, email_options=None):
 
         view = navigate_to(self, "ScheduleReport")
         view.fill({
@@ -349,6 +349,7 @@ class Report(BaseEntity, Updateable):
             "hour": timer.get("hour"),
             "minute": timer.get("minute"),
             "emails_send": bool(emails),
+            "from_email": from_email,
             "emails": emails,
             "send_if_empty": email_options.get("send_if_empty"),
             "send_txt": email_options.get("send_txt"),

--- a/cfme/intelligence/reports/schedules.py
+++ b/cfme/intelligence/reports/schedules.py
@@ -60,6 +60,7 @@ class SchedulesFormCommon(CloudIntelReportsView):
     minute = BootstrapSelect("start_min")
     # Email
     emails_send = Checkbox("send_email_cb")
+    from_email = TextInput(name="from")
     emails = AlertEmail()
     send_if_empty = Checkbox("send_if_empty")
     send_txt = Checkbox("send_txt")
@@ -135,6 +136,7 @@ class Schedule(Updateable, Pretty, BaseEntity):
     filter = attr.ib()
     active = attr.ib(default=None)
     timer = attr.ib(default=None)
+    from_email = attr.ib(default=None)
     emails = attr.ib(default=None)
     email_options = attr.ib(default=None)
 
@@ -193,7 +195,7 @@ class ScheduleCollection(BaseCollection):
     ENTITY = Schedule
 
     def create(self, name=None, description=None, filter=None, active=None,
-               timer=None, emails=None, email_options=None):
+               timer=None, from_email=None, emails=None, email_options=None):
         schedule = self.instantiate(name, description, filter, active=active, timer=timer,
             emails=emails, email_options=email_options)
         view = navigate_to(self, "Add")
@@ -210,6 +212,7 @@ class ScheduleCollection(BaseCollection):
             "hour": timer.get("hour"),
             "minute": timer.get("minute"),
             "emails_send": bool(emails),
+            "from_email": from_email,
             "emails": emails,
             "send_if_empty": email_options.get("send_if_empty"),
             "send_txt": email_options.get("send_txt"),

--- a/cfme/tests/intelligence/reports/test_crud.py
+++ b/cfme/tests/intelligence/reports/test_crud.py
@@ -4,6 +4,7 @@ import pytest
 import yaml
 
 from cfme import test_requirements
+from cfme.intelligence.reports.schedules import NewScheduleView
 from cfme.intelligence.reports.widgets import AllDashboardWidgetsView
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
@@ -309,3 +310,14 @@ def test_crud_custom_report_schedule(
     custom_report_schedule = appliance.collections.schedules.create(**schedule_data)
     assert custom_report_schedule.exists
     custom_report_schedule.delete(cancel=False)
+
+
+@pytest.mark.uncollectif(lambda appliance: appliance.version < "5.10.0.26")
+def test_report_schedules_invalid_email(appliance, schedule_data):
+    schedule_data["emails"] = (fauxfactory.gen_alpha(), fauxfactory.gen_alpha())
+    schedule_data["from_email"] = fauxfactory.gen_alpha()
+    with pytest.raises(AssertionError):
+        appliance.collections.schedules.create(**schedule_data)
+    view = appliance.collections.schedules.create_view(NewScheduleView)
+    view.flash.assert_message("One of e-mail addresses 'To' is not valid")
+    view.flash.assert_message("E-mail address 'From' is not valid")

--- a/cfme/tests/intelligence/reports/test_crud.py
+++ b/cfme/tests/intelligence/reports/test_crud.py
@@ -312,7 +312,7 @@ def test_crud_custom_report_schedule(
     custom_report_schedule.delete(cancel=False)
 
 
-@pytest.mark.uncollectif(lambda appliance: appliance.version < "5.10.0.26")
+@pytest.mark.ignore_stream('5.9')
 def test_report_schedules_invalid_email(appliance, schedule_data):
     schedule_data["emails"] = (fauxfactory.gen_alpha(), fauxfactory.gen_alpha())
     schedule_data["from_email"] = fauxfactory.gen_alpha()

--- a/data/schedules_crud/basic01.yaml
+++ b/data/schedules_crud/basic01.yaml
@@ -11,8 +11,7 @@ timer:
 emails:
     - test1@example.test
     - test2@example.test
-from_email:
-    - sender@example.test
+from_email: sender@example.test
 email_options:
   send_if_empty: True
   send_txt: True

--- a/data/schedules_crud/basic01.yaml
+++ b/data/schedules_crud/basic01.yaml
@@ -11,6 +11,8 @@ timer:
 emails:
     - test1@example.test
     - test2@example.test
+from_email:
+    - sender@example.test
 email_options:
   send_if_empty: True
   send_txt: True

--- a/data/schedules_report/daily.yaml
+++ b/data/schedules_report/daily.yaml
@@ -11,8 +11,7 @@ timer:
 emails:
     - test1@example.test
     - test2@example.test
-from_email:
-    - sender@example.test
+from_email: sender@example.test
 email_options:
   send_if_empty: True
   send_txt: True

--- a/data/schedules_report/daily.yaml
+++ b/data/schedules_report/daily.yaml
@@ -11,6 +11,8 @@ timer:
 emails:
     - test1@example.test
     - test2@example.test
+from_email:
+    - sender@example.test
 email_options:
   send_if_empty: True
   send_txt: True

--- a/data/schedules_report/hourly.yaml
+++ b/data/schedules_report/hourly.yaml
@@ -11,8 +11,7 @@ timer:
 emails:
     - test1@example.test
     - test2@example.test
-from_email:
-    - sender@example.test
+from_email: sender@example.test
 email_options:
   send_if_empty: True
   send_txt: True

--- a/data/schedules_report/hourly.yaml
+++ b/data/schedules_report/hourly.yaml
@@ -11,6 +11,8 @@ timer:
 emails:
     - test1@example.test
     - test2@example.test
+from_email:
+    - sender@example.test
 email_options:
   send_if_empty: True
   send_txt: True

--- a/data/schedules_report/monthly.yaml
+++ b/data/schedules_report/monthly.yaml
@@ -11,8 +11,7 @@ timer:
 emails:
     - test1@example.test
     - test2@example.test
-from_email:
-    - sender@example.test
+from_email: sender@example.test
 email_options:
   send_if_empty: True
   send_txt: True

--- a/data/schedules_report/monthly.yaml
+++ b/data/schedules_report/monthly.yaml
@@ -11,6 +11,8 @@ timer:
 emails:
     - test1@example.test
     - test2@example.test
+from_email:
+    - sender@example.test
 email_options:
   send_if_empty: True
   send_txt: True

--- a/data/schedules_report/once.yaml
+++ b/data/schedules_report/once.yaml
@@ -10,8 +10,7 @@ timer:
 emails:
     - test1@example.test
     - test2@example.test
-from_email:
-    - sender@example.test
+from_email: sender@example.test
 email_options:
   send_if_empty: True
   send_txt: True

--- a/data/schedules_report/once.yaml
+++ b/data/schedules_report/once.yaml
@@ -10,6 +10,8 @@ timer:
 emails:
     - test1@example.test
     - test2@example.test
+from_email:
+    - sender@example.test
 email_options:
   send_if_empty: True
   send_txt: True

--- a/data/schedules_report/weekly.yaml
+++ b/data/schedules_report/weekly.yaml
@@ -11,8 +11,7 @@ timer:
 emails:
     - test1@example.test
     - test2@example.test
-from_email:
-    - sender@example.test
+from_email: sender@example.test
 email_options:
   send_if_empty: True
   send_txt: True

--- a/data/schedules_report/weekly.yaml
+++ b/data/schedules_report/weekly.yaml
@@ -11,6 +11,8 @@ timer:
 emails:
     - test1@example.test
     - test2@example.test
+from_email:
+    - sender@example.test
 email_options:
   send_if_empty: True
   send_txt: True


### PR DESCRIPTION
This PR brings the following changes:
1. Add a new test `test_report_schedules_invalid_email` to test if invalid emails are checked for sanity while adding a schedule.
2. Add a `from_email` attribute to `Schedule` entity, `from_email` widget to `SchedulesFormCommon` and all the methods where it's required.
3. Add `from_email` to all the YAML files related to schedules.

{{pytest: cfme/tests/intelligence/reports/test_crud.py::test_report_schedules_invalid_email --use-template-cache -sqvvv}}