### PR TITLE
[1LP][RFR] Fix Myservice Details view tables implementation. 

### DIFF
--- a/cfme/services/myservice/ui.py
+++ b/cfme/services/myservice/ui.py
@@ -14,7 +14,7 @@ from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep,
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import (Accordion, ManageIQTree, Calendar, SummaryTable,
                                   BaseNonInteractiveEntitiesView, ItemsToolBarViewSelector,
-                                  BaseEntitiesView, Search, WaitTab)
+                                  BaseEntitiesView, Search)
 
 
 class MyServiceToolbar(View):
@@ -92,7 +92,7 @@ class MyServiceDetailView(MyServicesView):
     entities = View.nested(BaseNonInteractiveEntitiesView)
 
     @View.nested
-    class details(WaitTab):  # noqa
+    class details(View):  # noqa
         properties = SummaryTable(title='Properties')
         lifecycle = SummaryTable(title='Lifecycle')
         relationships = SummaryTable(title='Relationships')
@@ -101,7 +101,7 @@ class MyServiceDetailView(MyServicesView):
         generic_objects = SummaryTable(title='Generic Objects')
 
     @View.nested
-    class provisioning(WaitTab):  # noqa
+    class provisioning(View):  # noqa
         results = SummaryTable(title='Results')
         plays = Table('.//table[./thead/tr/th[contains(@align, "left") and '
                       'normalize-space(.)="Plays"]]')
@@ -110,7 +110,7 @@ class MyServiceDetailView(MyServicesView):
         standart_output = Text('.//div[@id="provisioning"]//pre')
 
     @View.nested
-    class retirement(WaitTab):  # noqa
+    class retirement(View):  # noqa
         results = SummaryTable(title='Results')
         plays = Table('.//table[./thead/tr/th[contains(@align, "left") and '
                       'normalize-space(.)="Plays"]]')


### PR DESCRIPTION
Purpose or Intent
=================
- Fix test
- As PR-https://github.com/ManageIQ/integration_tests/pull/8194 merged this wrong implementation fails. No need  of  `WaitTab`
```
>               view = navigate_to(obj, dest_name)
test_service_objects.py:147: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../../../../cfme_venv/lib/python2.7/site-packages/navmazing/__init__.py:123: in navigate
    return nav(cls_or_obj, self, self.logger).go(0, *args, **kwargs)
../../../utils/appliance/implementations/ui.py:544: in go
    self.check_for_badness(self.step, _tries, nav_args, *args, **kwargs)
../../../utils/appliance/implementations/ui.py:387: in check_for_badness
    return fn(*args, **kwargs)
../../../services/myservice/ui.py:427: in step
    self.prerequisite_view.details.generic_objects.click_at('Instances')
../../../../../cfme_venv/lib/python2.7/site-packages/widgetastic/widget/base.py:128: in __get__
    obj.child_widget_accessed(widget)
../../../../../cfme_venv/lib/python2.7/site-packages/widgetastic/widget/base.py:66: in wrapped
    return method(self, *new_args, **new_kwargs)
../../../../widgetastic_manageiq/__init__.py:3701: in child_widget_accessed
    self.wait_displayed(timeout="5s")
../../../../../cfme_venv/lib/python2.7/site-packages/widgetastic/widget/base.py:66: in wrapped
    return method(self, *new_args, **new_kwargs)
../../../../../cfme_venv/lib/python2.7/site-packages/widgetastic/log.py:117: in wrapped
    result = f(self, *args, **kwargs)
../../../../../cfme_venv/lib/python2.7/site-packages/widgetastic/widget/base.py:493: in wait_displayed
    ret, _ = wait_for(lambda: self.is_displayed, timeout=timeout, delay=delay)
```

{{pytest: cfme/tests/automate/custom_button/test_service_objects.py -vvv}}