### PR TITLE
[WIP][NOTEST]Cleanup duplicate VMs

### DIFF
--- a/scripts/cleanup_old_vms.py
+++ b/scripts/cleanup_old_vms.py
@@ -132,8 +132,19 @@ def scan_provider(provider_key, matchers, match_queue, scan_failure_queue):
         scan_failure_queue.put(VmReport(provider_key, FAIL, NULL, NULL, NULL))
         logger.exception('%r: Exception listing vms', provider_key)
         return
+    text_matched_vms = {}
+    text_matched_duplicate_vms = []
+    for vm in vm_list:
+        if match(matchers, vm.name):
+            if vm.name not in text_matched_vms:
+                text_matched_vms[vm.name] = vm
+            else:
+                text_matched_duplicate_vms.append(vm)
+    text_matched_vms = [vm for vm in text_matched_vms.values()]
+    for vm in text_matched_duplicate_vms:
+        logger.info("%r: DELETING DUPLICATE VMS: %r", provider_key, vm.name)
+        vm.cleanup()
 
-    text_matched_vms = [vm for vm in vm_list if match(matchers, vm.name)]
     for vm in text_matched_vms:
         match_queue.put(VmProvider(provider_key, vm.name))
 


### PR DESCRIPTION
This PR fixes cleaup_old_vms script failures every time a duplicate vm is encoutered.
Changes introduced:
1. Use a separate list to keep track of duplicate vms.
2. Delete all the duplicate vms before sending each vm for an age checkup.
3. `text_matched_vms` is initially a dictionary with `vm_name` as key. Once all the vms are checked and duplicate vms are caught, `text_matched_vms` will be converted to a list of matched vms, and things will continue as before.