### PR TITLE
[1LP][RFR] Fixed power option button is_displayed on archived vms details page

### DIFF
--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -385,7 +385,7 @@ def test_no_template_power_control(provider, soft_assert):
 @pytest.mark.meta(blockers=[BZ(1520489, forced_streams=['5.9'],
                                unblock=lambda provider: not provider.one_of(SCVMMProvider)),
                             BZ(1633727, forced_streams=['5.10'])])
-def test_no_power_controls_on_archived_vm(testing_vm, archived_vm, soft_assert):
+def test_no_power_controls_on_archived_vm(appliance, testing_vm, archived_vm, soft_assert):
     """ Ensures that no power button is displayed from details view of archived vm
 
     Prerequisities:
@@ -397,7 +397,12 @@ def test_no_power_controls_on_archived_vm(testing_vm, archived_vm, soft_assert):
         test_flag: power_control
     """
     view = navigate_to(testing_vm, 'AnyProviderDetails', use_resetter=False)
-    soft_assert(not view.toolbar.power.is_displayed, "Power displayed in archived VM's details!")
+    status = (
+        getattr(view.toolbar.power, "is_displayed")
+        if appliance.version < "5.10"
+        else getattr(view.toolbar.power, "is_enabled")
+    )
+    soft_assert(not status, "Power displayed in archived VM's details!")
 
 
 @pytest.mark.rhv3

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -397,12 +397,12 @@ def test_no_power_controls_on_archived_vm(appliance, testing_vm, archived_vm, so
         test_flag: power_control
     """
     view = navigate_to(testing_vm, 'AnyProviderDetails', use_resetter=False)
-    status = (
-        getattr(view.toolbar.power, "is_displayed")
-        if appliance.version < "5.10"
-        else getattr(view.toolbar.power, "is_enabled")
-    )
-    soft_assert(not status, "Power displayed in archived VM's details!")
+    if appliance.version < "5.10":
+        status = getattr(view.toolbar.power, "is_displayed")
+    else:
+        status = getattr(view.toolbar.power, "is_enabled")
+
+    assert not status, "Power displayed in archived VM's details!"
 
 
 @pytest.mark.rhv3


### PR DESCRIPTION
- This PR fixes the **power** drop-down button issue on archived vm's details page.
- Observations:
    - 5.9 - The power button option on archived VM's detail page is not present.
    - 5.10 - The power button option on VM's detail page is present, but it's disabled. 

{{ pytest: cfme/tests/infrastructure/test_vm_power_control.py::test_no_power_controls_on_archived_vm --use-provider vsphere67-nested --long-running }}