### PR TITLE
[1LP][RFR] Fixed configuration DropdownDisabled issue

### DIFF
--- a/cfme/configure/access_control/__init__.py
+++ b/cfme/configure/access_control/__init__.py
@@ -656,9 +656,15 @@ class Group(BaseEntity, Taggable):
         edit_group_txt = 'Edit this Group'
 
         view = navigate_to(self, 'Details')
-        if not view.toolbar.configuration.item_enabled(edit_group_txt):
-            raise RBACOperationBlocked("Configuration action '{}' is not enabled".format(
-                edit_group_txt))
+        if self.appliance.version < '5.10':
+            if not view.toolbar.configuration.item_enabled(edit_group_txt):
+                raise RBACOperationBlocked("Configuration action '{}' is not enabled".format(
+                    edit_group_txt))
+        else:
+            if not view.toolbar.configuration.is_enabled:
+                raise RBACOperationBlocked("Configuration action '{}' is not enabled".format(
+                    edit_group_txt))
+
         view = navigate_to(self, 'Edit')
 
         changed = view.fill({
@@ -708,9 +714,14 @@ class Group(BaseEntity, Taggable):
 
         view = navigate_to(self, 'Details')
 
-        if not view.toolbar.configuration.item_enabled(delete_group_txt):
-            raise RBACOperationBlocked("Configuration action '{}' is not enabled".format(
-                delete_group_txt))
+        if self.appliance.version < '5.10':
+            if not view.toolbar.configuration.item_enabled(delete_group_txt):
+                raise RBACOperationBlocked("Configuration action '{}' is not enabled".format(
+                    delete_group_txt))
+        else:
+            if not view.toolbar.configuration.is_enabled:
+                raise RBACOperationBlocked("Configuration action '{}' is not enabled".format(
+                    delete_group_txt))
 
         view.toolbar.configuration.item_select(delete_group_txt, handle_alert=cancel)
         for flash_blocked_msg in flash_blocked_msg_list:


### PR DESCRIPTION
{{ pytest: cfme/tests/configure/test_access_control.py -k 'test_delete_default_group or test_edit_default_group' -v }}
- While **deleting** or **editing** default group, configuration drop-down issue.
- Observations:
    - ```Configuration``` drop-down is disabled in 5.10
    -  ```Configuratio``` drop-down is enabled in 5.9 but both options **Edit this group**  and **Delete this group** are disabled.

Fixed Error:
```
>           raise DropdownDisabled('Dropdown "{}" is not enabled'.format(self.text))
E           DropdownDisabled: Dropdown "Configuration" is not enabled

../cfme_venv/lib/python2.7/site-packages/widgetastic_patternfly/__init__.py:1538: DropdownDisabled
DropdownDisabled
Dropdown "Configuration" is not enabled
```