### PR TITLE
[1LP][RFR] Fixed assertion error while creating  new group

### DIFF
--- a/cfme/configure/access_control/__init__.py
+++ b/cfme/configure/access_control/__init__.py
@@ -836,11 +836,7 @@ class GroupCollection(BaseCollection):
                 not having appropriate permissions OR delete is not allowed
                 for currently selected user
         """
-        if self.appliance.version < "5.8":
-            flash_blocked_msg = ("Description has already been taken")
-        else:
-            flash_blocked_msg = "Description is not unique within region {}".format(
-                self.appliance.server.zone.region.number)
+        flash_blocked_msg = "Description can't be blank"
 
         view = navigate_to(self, 'Add')
 

--- a/cfme/configure/access_control/__init__.py
+++ b/cfme/configure/access_control/__init__.py
@@ -836,7 +836,13 @@ class GroupCollection(BaseCollection):
                 not having appropriate permissions OR delete is not allowed
                 for currently selected user
         """
-        flash_blocked_msg = "Description can't be blank"
+        flash_blocked_msg = (
+            "Description is not unique within region {}".format(
+                self.appliance.server.zone.region.number
+            )
+            if description
+            else "Description can't be blank"
+        )
 
         view = navigate_to(self, 'Add')
 

--- a/cfme/configure/access_control/__init__.py
+++ b/cfme/configure/access_control/__init__.py
@@ -836,13 +836,13 @@ class GroupCollection(BaseCollection):
                 not having appropriate permissions OR delete is not allowed
                 for currently selected user
         """
-        flash_blocked_msg = (
-            "Description is not unique within region {}".format(
-                self.appliance.server.zone.region.number
+        if description:
+            flash_blocked_msg = (
+                "Description is not unique within region {}".format(
+                    self.appliance.server.zone.region.number)
             )
-            if description
-            else "Description can't be blank"
-        )
+        else:
+            flash_blocked_msg = "Description can't be blank"
 
         view = navigate_to(self, 'Add')
 


### PR DESCRIPTION
- This PR fixes the Assertion Error while creating new group with blank description. 

{{ pytest: cfme/tests/configure/test_access_control.py -k 'test_group_description_required_error_validation' -v }}

Fixed Error:
```
>           group_collection.create(description=None, role='EvmRole-approver')
E           AssertionError: Pattern 'Description can't be blank' not found in 'Could not do function <lambda>() at /var/ci/workspace/downstream-510z-rc/cfme_venv/lib/python2.7/site-packages/widgetastic/widget/base.py:493 in time'

cfme/tests/configure/test_access_control.py:471: AssertionError
AssertionError
Pattern 'Description can't be blank' not found in 'Could not do function <lambda>() at /var/ci/workspace/downstream-510z-rc/cfme_venv/lib/python2.7/site-packages/widgetastic/widget/base.py:493 in time'
```