### PR TITLE
[RFR] fix all method

### DIFF
--- a/cfme/infrastructure/cluster.py
+++ b/cfme/infrastructure/cluster.py
@@ -334,7 +334,7 @@ class ClusterCollection(BaseCollection):
             providers_db = {
                 prov.id: get_crud_by_name(prov.name)
                 for prov in providers
-                if not (getattr(prov, "parent_ems_id", False) and ("Manager" in prov.name))
+                if not (getattr(prov, "parent_ems_id", False) or ("Manager" in prov.name))
             }
             cluster_obj = [
                 self.instantiate(name=cluster.name, provider=providers_db[cluster.ems_id])

--- a/cfme/infrastructure/datastore.py
+++ b/cfme/infrastructure/datastore.py
@@ -331,11 +331,18 @@ class DatastoreCollection(BaseCollection):
         datastores = self.appliance.rest_api.collections.data_stores.all_include_attributes(
             attributes=["hosts"]
         )
-        datastore_db = {ds.name: ds.hosts[0]["ems_id"] for ds in datastores if ds.hosts}
+        datastore_db = {}
+
+        for ds in datastores:
+            for host in ds.hosts:
+                if host.get("ems_id"):
+                    datastore_db.update({ds.name: host.get("ems_id")})
+                    break
+
         provider_db = {
             prov.id: get_crud_by_name(prov.name)
             for prov in self.appliance.rest_api.collections.providers.all
-            if not (getattr(prov, "parent_ems_id", False) and ("Manager" in prov.name))
+            if not (getattr(prov, "parent_ems_id", False) or ("Manager" in prov.name))
         }
         datastores = [
             self.instantiate(name=name, provider=provider_db[prov_id])


### PR DESCRIPTION
Purpose or Intent
=================
- Fix my bad; replece `and`  by `or` :D. 
- I dont understand, why sometime we are not  getting `ems_id` for `host`? Adding workaround  for it by itteration  over available `hosts` attached to `datastore`.
```
>   datastore_db = {ds.name: ds.hosts[0]["ems_id"] for ds in datastores if ds.hosts}
E   KeyError: 'ems_id'
```
{{pytest: cfme/tests/automate/custom_button/test_infra_objects.py::test_custom_button_display[Datastore-virtualcenter-Single_entity]}}