### PR TITLE
[1LP][RFR]Fix ScopeMismatch Error

### DIFF
--- a/cfme/tests/infrastructure/test_vm_ownership.py
+++ b/cfme/tests/infrastructure/test_vm_ownership.py
@@ -20,7 +20,7 @@ pytestmark = [
 
 
 class TestVmOwnershipRESTAPI(object):
-    @pytest.fixture(scope="module")
+    @pytest.fixture(scope="function")
     def vm(self, request, provider, appliance):
         return _vm(request, provider, appliance.rest_api)
 


### PR DESCRIPTION
This PR fixes `ScopeMismatch` error in `test_vm_ownership.py`.
Error: 
`ScopeMismatch: You tried to access the 'function' scoped fixture 'provider' with a 'module' scoped request object, involved factories
cfme/tests/infrastructure/test_vm_ownership.py:22:  def vm(request, provider, appliance)`

{{pytest: cfme/tests/infrastructure/test_vm_ownership.py::TestVmOwnershipRESTAPI --use-template-cache -sqvvv}}