### PR TITLE
[1LP][RFR] unifying flash message xpaths and fixing issue in hammer

### DIFF
--- a/cfme/automate/explorer/method.py
+++ b/cfme/automate/explorer/method.py
@@ -472,11 +472,12 @@ class MethodCollection(BaseCollection):
         if validate and not BZ(1499881, forced_streams=['5.9']).blocks:
             add_page.validate_button.click()
             add_page.flash.assert_no_error()
-            add_page.flash.assert_message('Data validated successfully')
+            add_page.flash.assert_message('Data validated successfully', wait=3)
         if cancel:
             add_page.cancel_button.click()
             add_page.flash.assert_no_error()
-            add_page.flash.assert_message('Add of new Automate Method was cancelled by the user')
+            add_page.flash.assert_message('Add of new Automate Method was cancelled by the user',
+                                          wait=3)
             return None
         else:
             add_page.add_button.click()

--- a/cfme/base/login.py
+++ b/cfme/base/login.py
@@ -11,11 +11,7 @@ class BaseLoggedInPage(View):
     logged in.
     """
     CSRF_TOKEN = '//meta[@name="csrf-token"]'
-    flash = FlashMessages(
-        './/div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
-        'contains(@class, "flash_text_div")] | '
-        './/div[starts-with(@class, "flash_text_div") or @id="flash_text_div"]'
-    )
+    flash = FlashMessages('.//div[@id="flash_msg_div"]')
     help = NavDropdown('.//li[./a[@id="dropdownMenu1"]]|.//li[./a[@id="help-menu"]]')
     settings = SettingsNavDropdown('.//li[./a[@id="dropdownMenu2"]]')
     navigation = VerticalNavigation('#maintab')

--- a/cfme/base/ssui.py
+++ b/cfme/base/ssui.py
@@ -21,7 +21,7 @@ class SSUIBaseLoggedInPage(View):
     """This page should be subclassed by any page that models any other page that is available as
     logged in.
     """
-    flash = FlashMessages('div#flash_text_div')
+    flash = FlashMessages('.//div[@id="flash_msg_div"]')
     help = NavDropdown('.//li[./a[@id="dropdownMenu1"]]')
     navigation = SSUIVerticalNavigation('//ul[@class="list-group"]')
     domain_switcher = Button(id="domain-switcher")
@@ -82,7 +82,7 @@ class SSUIBaseLoggedInPage(View):
 
 
 class LoginPage(View):
-    flash = FlashMessages('div#flash_text_div')
+    flash = FlashMessages('.//div[@id="flash_msg_div"]')
     username = Input(id='inputUsername')
     password = Input(id='inputPassword')
     login = Button('Log In')

--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -1620,7 +1620,7 @@ class AutomateSimulation(CFMENavigateStep):
 class AutomateImportExportBaseView(BaseLoggedInPage):
     # TODO This is currently overiding the base flash and should be renamed and efforts made
     # to update assocaited tests
-    flash = FlashMessages('.//div[@id="flash_msg_div"]')
+    flash = FlashMessages('div.import-flash-message')
     title = Text('.//div[@id="main-content"]//h1')
 
     @property

--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -41,7 +41,7 @@ def address(self):
 
 
 class LoginPage(View):
-    flash = FlashMessages('//div[@class="flash_text_div" or @id="flash_text_div"]')
+    flash = FlashMessages('.//div[@id="flash_msg_div"]')
 
     class details(View):  # noqa
         region = Text('.//p[normalize-space(text())="Region:"]/span')
@@ -1620,7 +1620,7 @@ class AutomateSimulation(CFMENavigateStep):
 class AutomateImportExportBaseView(BaseLoggedInPage):
     # TODO This is currently overiding the base flash and should be renamed and efforts made
     # to update assocaited tests
-    flash = FlashMessages('div.import-flash-message')
+    flash = FlashMessages('.//div[@id="flash_msg_div"]')
     title = Text('.//div[@id="main-content"]//h1')
 
     @property

--- a/cfme/configure/configuration/server_settings.py
+++ b/cfme/configure/configuration/server_settings.py
@@ -34,9 +34,7 @@ class ServerInformationView(View):
     """ Class represents full Server tab view"""
     title = Text("//div[@id='settings_server']/h3[1]")
     # Local Flash widget for validation since class nested under a class inheriting BaseLoggedInPage
-    flash = FlashMessages('.//div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
-                          'contains(@class, "flash_text_div")] | '
-                          './/div[starts-with(@class, "flash_text_div") or @id="flash_text_div"]')
+    flash = FlashMessages('.//div[@id="flash_msg_div"]')
     save = Button('Save')
     reset = Button('Reset')
 
@@ -555,9 +553,7 @@ class ServerAuthenticationView(View):
     """ Server Authentication View."""
     title = Text("//div[@id='settings_authentication']/h3[1]")
     # Local Flash widget for validation since class nested under a class inheriting BaseLoggedInPage
-    flash = FlashMessages('.//div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
-                          'contains(@class, "flash_text_div")] | '
-                          './/div[starts-with(@class, "flash_text_div") or @id="flash_text_div"]')
+    flash = FlashMessages('.//div[@id="flash_msg_div"]')
     hours_timeout = BootstrapSelect(id='session_timeout_hours')
     minutes_timeout = BootstrapSelect(id='session_timeout_mins')
     # TODO new button widget to handle buttons_on buttons_off divs

--- a/cfme/intelligence/reports/schedules.py
+++ b/cfme/intelligence/reports/schedules.py
@@ -40,9 +40,7 @@ class BootstrapSelectRetry(BootstrapSelect):
 
 
 class SchedulesFormCommon(CloudIntelReportsView):
-    flash = FlashMessages('.//div[@id="flash_msg_div"]/div[@id="flash_text_div" or '
-                          'contains(@class, "flash_text_div")] | '
-                          './/div[starts-with(@class, "flash_text_div") or @id="flash_text_div"]')
+    flash = FlashMessages('.//div[@id="flash_msg_div"]')
     # Basic Information
     title = Text("#explorer_title_text")
     name = TextInput(name="name")

--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -318,7 +318,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
 widgetastic.core==0.30.3
-widgetastic.patternfly==0.0.39
+widgetastic.patternfly==0.0.40
 widgetsnbextension==3.4.2
 wrapanapi==3.0.32
 wrapt==1.10.11

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -305,7 +305,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
 widgetastic.core==0.30.3
-widgetastic.patternfly==0.0.39
+widgetastic.patternfly==0.0.40
 widgetsnbextension==3.4.2
 wrapanapi==3.0.32
 wrapt==1.10.11

--- a/requirements/frozen_docs.py2.txt
+++ b/requirements/frozen_docs.py2.txt
@@ -172,7 +172,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
 widgetastic.core==0.30.3
-widgetastic.patternfly==0.0.39
+widgetastic.patternfly==0.0.40
 widgetsnbextension==3.4.2
 wrapt==1.10.11
 xmltodict==0.11.0

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -163,7 +163,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
 widgetastic.core==0.30.3
-widgetastic.patternfly==0.0.39
+widgetastic.patternfly==0.0.40
 widgetsnbextension==3.4.2
 wrapt==1.10.11
 xmltodict==0.11.0


### PR DESCRIPTION
Many views have their own xpaths for FlashMessages. We need to unify that. 
Besides that there are flash messages stored in their own flash_text_div block in hammer. This also has to be sorted out
REQUIRES: https://github.com/RedHatQE/widgetastic.patternfly/pull/76

{{ pytest: cfme/tests/infrastructure/test_providers.py cfme/tests/automate/test_domain.py --long-running }}