### PR TITLE
[WIP] Add view for Monitor->Alerts->All page and test coverage for BZ 1637609

### DIFF
--- a/cfme/control/explorer/alerts.py
+++ b/cfme/control/explorer/alerts.py
@@ -9,10 +9,10 @@ from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.exceptions import NoSuchElementException
 from widgetastic.widget import Checkbox, Text, View
 from widgetastic_manageiq import (
-    AllAlertsList, AlertEmail, SNMPForm, SummaryForm, Table
+    AlertItem, AlertEmail, SNMPForm, SummaryForm, Table
 )
 from widgetastic_patternfly import (
-    BootstrapSelect, Button, Input, SelectorDropdown
+    BootstrapSelect, Button, Input, ItemsList, SelectorDropdown
 )
 from . import ControlExplorerView
 from cfme.base.login import BaseLoggedInPage
@@ -131,7 +131,9 @@ class AlertDetailsView(ControlExplorerView):
 class MonitorAlertsAllView(BaseLoggedInPage):
 
     result_header = Text('h5.ng-binding')
-    alerts_list = AllAlertsList(list_class='list-view-pf-view')
+    @View.nested
+    class alerts_list(ItemsList):
+        item_class = AlertItem
     # Used for Ascending/Descending sort
     sort_order = Text(".//button[./span[contains(@class,'sort-direction')]]")
     # Used to select filter_by items like 'Name', 'Severity'
@@ -149,41 +151,6 @@ class MonitorAlertsAllView(BaseLoggedInPage):
     @property
     def is_displayed(self):
         return self.in_monitor_alerts_all
-
-
-class MonitorAlertsOverviewView(BaseLoggedInPage):
-
-    # Used for Ascending/Descending sort
-    sort_order = Text(".//button[./span[contains(@class,'sort-direction')]]")
-    # Used to select filter_by items like 'Name', 'Severity'
-    filter_by_dropdown = SelectorDropdown('uib-tooltip', 'Filter by')
-    # Used to select sort by options like 'Name', 'Number of Associated Plans'
-    sort_by_dropdown = SelectorDropdown('class', 'btn btn-default dropdown-toggle')
-    # Used to set group by
-    group_by = BootstrapSelect(
-        locator=(
-            './/div[contains(@class, "bootstrap-select")] '
-            '/button[normalize-space(@title)="Environment"]/..'
-        )
-    )
-    # Used to set display
-    display = BootstrapSelect(
-        locator=(
-            './/div[contains(@class, "bootstrap-select")] '
-            '/button[normalize-space(@title)="providers"]/..'
-        )
-    )
-
-    @property
-    def in_monitor_alerts_overview(self):
-        return (
-            self.logged_in_as_current_user and
-            self.navigation.currently_selected == ['Monitor', 'Alerts', 'Overview']
-        )
-
-    @property
-    def is_displayed(self):
-        return self.in_monitor_alerts_overview
 
 
 @attr.s
@@ -435,15 +402,6 @@ class MonitorAlertsAll(CFMENavigateStep):
 
     def step(self):
         self.prerequisite_view.navigation.select("Monitor","Alerts","All Alerts")
-
-
-@navigator.register(AlertCollection)
-class MonitorAlertsOverview(CFMENavigateStep):
-    VIEW = MonitorAlertsOverviewView
-    prerequisite = NavigateToAttribute("appliance.server", "LoggedIn")
-
-    def step(self):
-        self.prerequisite_view.navigation.select("Monitor","Alerts","Overview")
 
 
 @navigator.register(Alert, "Edit")

--- a/cfme/tests/control/test_bugs.py
+++ b/cfme/tests/control/test_bugs.py
@@ -396,6 +396,12 @@ def test_alert_nav_from_monitor_goes_to_infra_provider(alert_collection, virtual
     """Test coverage for BZ 1637609, this test tries to navigate to the infra provider page
     from the Monitor->Alerts->All Alerts page. This requires an appliance that has fired alerts
     on it. If the appliance does not have fired alerts on it, then we inject one into the DB.
+
+    Polarion:
+        assignee: jdupuy
+        casecomponent: control
+        caseimportance: medium
+        initialEstimate: 1/12h
     """
     if current_version() < '5.10':
         pytest.skip('The fix for BZ 1637609 is not backported to CFME 5.9, so skipping test.')
@@ -406,8 +412,8 @@ def test_alert_nav_from_monitor_goes_to_infra_provider(alert_collection, virtual
     if BZ(1507011, forced_streams=['5.9','5.10']).blocks:
         wait_for(lambda: view.is_displayed, timeout=10, delay=5.0)
     try:
-        view.alerts_list[description].click_provider()
-    except ItemNotFound:
+        next(view.alerts_list[description]).click_provider()
+    except StopIteration:
         logger.exception(
             'No alerts from provider {} '
             'fired on this appliance.'.format(virtualcenter_provider.name)


### PR DESCRIPTION
Purpose or Intent
=================

__1)__ __Adding views__ for "Monitor->Alerts->All Alerts" in CFME. This view is registered to the alert collection because they will only have content on them if an alert has fired on an appliance. 

__2)__ __Creating__ a widget that will represent the `list-view` on the "Monitor->Alerts->All Alerts" view. Currently this is fairly bare-bones and future PRs will improve on the functionality of this page. 

__3)__ __Adding test__ coverage for [BZ 1637609](https://bugzilla.redhat.com/show_bug.cgi?id=1637609)

{{ pytest: --long-running cfme/tests/control/test_bugs.py::test_alert_nav_from_monitor_goes_to_infra_provider }}