### PR TITLE
[RFR] Testing Redfish physical server detail page's buttons

### DIFF
--- a/cfme/tests/physical_infrastructure/test_redfish_physical_server_details.py
+++ b/cfme/tests/physical_infrastructure/test_redfish_physical_server_details.py
@@ -2,14 +2,27 @@
 import pytest
 
 from cfme.physical.provider.redfish import RedfishProvider
+from cfme.utils.appliance.implementations.ui import navigate_to
 
 pytestmark = [pytest.mark.provider([RedfishProvider], scope="function")]
 
 
 @pytest.fixture(scope="function")
 def physical_server(appliance, provider, setup_provider_funcscope):
-    # Get and return the first physical server
+    """Get and return the first physical server."""
     yield appliance.collections.redfish_physical_servers.all(provider)[0]
+
+
+def assert_message(physical_server, expected_message):
+    """
+    Assert that the physical server details view displays the requested message.
+
+    Args:
+      physical_server: check the details view of this physical server.
+      expected_message: the message we expect to be displayed in the flash alert
+    """
+    view = navigate_to(physical_server, "Details")
+    view.flash.assert_message(expected_message)
 
 
 def test_redfish_physical_server_details_stats(physical_server):
@@ -20,3 +33,29 @@ def test_redfish_physical_server_details_stats(physical_server):
         initialEstimate: None
     """
     physical_server.validate_stats(ui=True)
+
+
+def test_redfish_power_buttons(physical_server, provider):
+    """
+    Test that pressing of the power buttons for physical server succeeds.
+
+    The test assumes that the buttons can be pressed in any order and that we
+    will get a flash that tells us of success regardless of the state that the
+    physical server is in. Here we only test that the request in the gui
+    succeeds.
+    """
+    power_actions = [
+        ("power_off", lambda: physical_server.power_off()),
+        ("power_on", lambda: physical_server.power_on()),
+        ("power_off_now", lambda: physical_server.power_off_immediately()),
+        ("restart", lambda: physical_server.restart()),
+        ("restart_now", lambda: physical_server.restart_immediately()),
+        ("turn_on_loc_led", lambda: physical_server.turn_on_led()),
+        ("turn_off_loc_led", lambda: physical_server.turn_off_led()),
+        ("blink_loc_led", lambda: physical_server.turn_blink_led()),
+    ]
+
+    for action_name, action in power_actions:
+        action()
+        assert_message(physical_server, "Requested {} of selected item.".format(
+            action_name))


### PR DESCRIPTION
__Adding tests__ for feature Redfish physical infrastructure provider to test that pressing power, LED identification and lifecycle menu buttons of a pysical server details works. This functionality is implemented in Hammer.

Depends on:
  * [#8234](https://github.com/ManageIQ/integration_tests/pull/8234) for the fix of flash message assertion

Related Bugzilla bugs:
  * https://bugzilla.redhat.com/show_bug.cgi?id=1574816
  * https://bugzilla.redhat.com/show_bug.cgi?id=1574817
  * https://bugzilla.redhat.com/show_bug.cgi?id=1574818
  * https://bugzilla.redhat.com/show_bug.cgi?id=1574820
  * https://bugzilla.redhat.com/show_bug.cgi?id=1574821

/cc. @miha-plesko 