### PR TITLE
[1LP][RFR] Fixed KeyError and AssertionError in inline automate method

### DIFF
--- a/cfme/automate/explorer/method.py
+++ b/cfme/automate/explorer/method.py
@@ -472,8 +472,8 @@ class MethodCollection(BaseCollection):
             validate = False
         if validate and not BZ(1499881, forced_streams=['5.9']).blocks:
             add_page.validate_button.click()
-            add_page.flash.assert_no_error()
             add_page.wait_displayed()
+            add_page.flash.assert_no_error()
             add_page.flash.assert_message('Data validated successfully')
         if cancel:
             add_page.cancel_button.click()

--- a/cfme/automate/explorer/method.py
+++ b/cfme/automate/explorer/method.py
@@ -445,6 +445,7 @@ class MethodCollection(BaseCollection):
         add_page = navigate_to(self, 'Add')
         add_page.fill({'location': location})
         if location == 'inline':
+            add_page.wait_displayed()
             add_page.fill({
                 'inline_name': name,
                 'inline_display_name': display_name,
@@ -472,6 +473,7 @@ class MethodCollection(BaseCollection):
         if validate and not BZ(1499881, forced_streams=['5.9']).blocks:
             add_page.validate_button.click()
             add_page.flash.assert_no_error()
+            add_page.wait_displayed()
             add_page.flash.assert_message('Data validated successfully')
         if cancel:
             add_page.cancel_button.click()

--- a/cfme/tests/automate/test_vmware_methods.py
+++ b/cfme/tests/automate/test_vmware_methods.py
@@ -67,7 +67,7 @@ def testing_group(appliance, request):
 def testing_vm(setup_provider, provider):
     collection = provider.appliance.provider_based_collection(provider)
     try:
-        template_name = provider.data['full_template']['name']
+        template_name = provider.data['templates']['full_template']['name']
     except KeyError:
         pytest.skip('Unable to identify full_template for provider: {}'.format(provider))
 


### PR DESCRIPTION
- This test was skipping because of ```Key Error``` while getting ```small_template``` of vSphere provider.
- Also fixed ```Assertion Error``` which is occurred while asserting flash message of data validation in ```MethodAddView```


{{ pytest: cfme/tests/automate/test_vmware_methods.py -k 'test_vmware_vimapi_hotadd_disk' --long-running --use-provider complete -v }}