### PR TITLE
[1LP][RFR] fixed is_displayed for BaseEditDashboardWidgetView and added BZ

### DIFF
--- a/cfme/intelligence/reports/widgets/__init__.py
+++ b/cfme/intelligence/reports/widgets/__init__.py
@@ -210,7 +210,7 @@ class BaseEditDashboardWidgetView(DashboardWidgetsView):
     def is_displayed(self):
         return (
             self.in_dashboard_widgets and
-            self.title_text == 'Editing Widget "{}"'.format(self.context["object"]) and
+            self.title.text == 'Editing Widget "{}"'.format(self.context["object"].title) and
             self.dashboard_widgets.tree.currently_selected == [
                 "All Widgets",
                 self.context["object"].TYPE,

--- a/cfme/tests/intelligence/reports/test_crud.py
+++ b/cfme/tests/intelligence/reports/test_crud.py
@@ -121,6 +121,7 @@ def test_menuwidget_crud(appliance):
 
 @pytest.mark.sauce
 @pytest.mark.tier(3)
+@pytest.mark.meta(blockers=[BZ(1656413, forced_streams=['5.10'])])
 def test_reportwidget_crud(appliance):
     w = appliance.collections.dashboard_report_widgets.create(
         appliance.collections.dashboard_report_widgets.REPORT,
@@ -135,8 +136,9 @@ def test_reportwidget_crud(appliance):
     )
     view = w.create_view(AllDashboardWidgetsView)
     view.flash.assert_message('Widget "{}" was saved'.format(w.title))
-    with update(w):
-        w.active = False
+    if not BZ(1653796, forced_streams=['5.9']).blocks:
+        with update(w):
+            w.active = False
     w.delete()
 
 


### PR DESCRIPTION
{{ pytest: -v cfme/tests/intelligence/reports/test_crud.py::test_reportwidget_crud }}

1. fixed title comparison in is_displayed
2. but it fails due to BZ (there's description instead of title) - so `update` part will not be executed for 5.9 until BZ is verified
3. widget description instead of title is shown in the flash message after creation, added BZ for 5.10