### PR TITLE
[1LP][RFR] added properties table for vmdb summary

### DIFF
--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -8,7 +8,7 @@ from selenium.webdriver.common.keys import Keys
 from widgetastic.utils import Version, VersionPick
 from widgetastic.widget import View, Table, Text, Image, FileInput
 from widgetastic_manageiq import (ManageIQTree, Checkbox, AttributeValueForm, TimelinesView,
-                                  SummaryFormItem, WaitTab)
+                                  SummaryFormItem, SummaryTable, WaitTab)
 from widgetastic_patternfly import (Accordion, Input, Button, Dropdown, DatePicker,
                                     FlashMessages, BootstrapSelect, CheckableBootstrapTreeview)
 
@@ -625,6 +625,7 @@ class ServerDatabaseView(ConfigurationView):
 
 
 class DatabaseSummaryView(ServerDatabaseView):
+    properties = SummaryTable(title='Properties')
 
     @property
     def is_displayed(self):

--- a/cfme/tests/configure/test_database_ui.py
+++ b/cfme/tests/configure/test_database_ui.py
@@ -7,7 +7,6 @@ from cfme.utils.log_validator import LogValidator
 
 
 @pytest.mark.tier(2)
-@pytest.mark.uncollectif(lambda appliance: appliance.version < '5.9')
 def test_configure_vmdb_last_start_time(appliance):
     """
         Go to Settings -> Configure -> Database
@@ -23,12 +22,13 @@ def test_configure_vmdb_last_start_time(appliance):
 
     view = navigate_to(appliance.server, 'DatabaseSummary')
 
-    for item in view.summary('Properties').get_text_of('Data Directory').split('/'):
+    for item in view.properties.get_text_of('Data Directory').split('/'):
         if 'rh-postgresql' in item:
             logs_last_start_time = appliance.ssh_client.run_command(
                 "journalctl -u {}-postgresql.service  --boot=0 | sed '4!d'".format(item))
+            break
 
-    ui_last_start_time = parser.parse(view.summary('Properties').get_text_of('Last Start Time'))
+    ui_last_start_time = parser.parse(view.properties.get_text_of('Last Start Time'))
     # timedatectl is used here as we will get full timezone name, like 'US/Eastern',
     #  which is easier and safer(to omit UnknownTimeZoneError) to use later
     tz = pytz.timezone(appliance.ssh_client.run_command("timedatectl | grep 'Time zone'")


### PR DESCRIPTION
{{ pytest: -v cfme/tests/configure/test_database_ui.py::test_configure_vmdb_last_start_time }}

1. added properties table, it fixed `test_configure_vmdb_last_start_time`
2. removed `uncollectif` as 5.8 tests are in separate branch