### PR TITLE
[1LP][RFR] added is_displayed for UtilizationView, fixed is_displayed for ServiceCatalogsDefaultView and added TimedOutError to exception for test_pull_splitter_persistence

### DIFF
--- a/cfme/optimize/utilization.py
+++ b/cfme/optimize/utilization.py
@@ -22,6 +22,15 @@ class UtilizationView(BaseLoggedInPage):
             "Utilization",
         ]
 
+    @property
+    def is_displayed(self):
+        # region = CFME Region: Region 0 [0]'
+        region = self.extra.appliance.region()
+        return (
+            self.in_utilization and
+            self.title.text == 'Region "{}" Utilization Trend Summary'.format(region)
+        )
+
 
 @attr.s
 class Utilization(BaseEntity):

--- a/cfme/services/service_catalogs/ui.py
+++ b/cfme/services/service_catalogs/ui.py
@@ -47,7 +47,7 @@ class ServiceCatalogsDefaultView(ServicesCatalogsView):
     @property
     def is_displayed(self):
         return (
-            self.in_explorer and
+            self.in_service_catalogs and
             self.title.text == 'All Services' and
             self.service_catalogs.is_opened)
 

--- a/cfme/tests/webui/test_splitter.py
+++ b/cfme/tests/webui/test_splitter.py
@@ -1,6 +1,7 @@
 from xml.sax.saxutils import quoteattr, unescape
 
 import pytest
+from wait_for import TimedOutError
 
 # from cfme.cloud.instance import Instance
 # from cfme.infrastructure.config_management import ConfigManager
@@ -52,7 +53,7 @@ pytestmark = [
 def test_pull_splitter_persistence(request, appliance, model_object, destination):
     """
     Polarion:
-        assignee: mmojzis
+        assignee: anikifor
         caseimportance: low
         initialEstimate: 1/20h
     """
@@ -72,9 +73,10 @@ def test_pull_splitter_persistence(request, appliance, model_object, destination
     navigate_to(appliance.server, 'Dashboard')
     try:
         navigate_to(model_object, destination)
-    except (TypeError, CannotScrollException):
+    except (TypeError, CannotScrollException, TimedOutError):
         # this exception is expected here since
         # some navigation commands try to use accordion when it is hidden by splitter
+        # and accordion is often part of is_displayed check
         pass
 
     # Then we check hidden position splitter

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2048,6 +2048,9 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
         return "{} Region: Region {} [{}]".format(
             self.product_name, r, r)
 
+    def region(self):
+        return "Region {}".format(self.server.zone.region.number)
+
     @cached_property
     def company_name(self):
         return self.advanced_settings["server"]["company"]


### PR DESCRIPTION
{{ pytest: -v cfme/tests/webui/test_splitter.py::test_pull_splitter_persistence }}

1. missing `is_displayed` for `UtilizationView` led to broken navigation
2. `self.in_service_catalogs` is more specific for the `ServiceCatalogsDefaultView`
3. Added `TimedOutError` as some `is_displayed` checks rely on accordion, that can be hidden during this test