### PR TITLE
[1LP][RFR] Fix fill for orchestration catalog item view 

### DIFF
--- a/cfme/services/catalogs/catalog_items/__init__.py
+++ b/cfme/services/catalogs/catalog_items/__init__.py
@@ -123,6 +123,14 @@ class AddCatalogItemView(BasicInfoForm):
     add = Button('Add')
     cancel = Button('Cancel')
 
+    def fill(self, values):
+        provider = values.pop('select_provider', None)
+        changed = super(AddCatalogItemView, self).fill(values)
+        # for orchestration catalog item
+        # where provider appears with some timeout after template has been chosen
+        changed_prov = super(AddCatalogItemView, self).fill({'select_provider': provider})
+        return changed or changed_prov
+
     @property
     def is_displayed(self):
         return (
@@ -180,11 +188,18 @@ class TabbedEditCatalogItemView(ServicesCatalogView):
     reset = Button('Reset')
     cancel = Button('Cancel')
 
+    def fill(self, values):
+        provider = values.pop('select_provider', None)
+        changed = super(TabbedEditCatalogItemView, self).fill(values)
+        # for orchestration catalog item
+        # where provider appears with some timeout after template has been chosen
+        changed_prov = super(TabbedEditCatalogItemView, self).fill({'select_provider': provider})
+        return changed or changed_prov
+
     @View.nested
     class basic_info(WaitTab):  # noqa
         TAB_NAME = 'Basic Info'
         included_form = View.include(BasicInfoForm)
-
 
     class request_info(WaitTab):  # noqa
         TAB_NAME = 'Request Info'

--- a/cfme/services/service_catalogs/ui.py
+++ b/cfme/services/service_catalogs/ui.py
@@ -9,8 +9,6 @@ from cfme.services.requests import RequestsView
 from cfme.services.service_catalogs import ServiceCatalogs, BaseOrderForm
 from cfme.utils.appliance import MiqImplementationContext
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to, ViaUI
-from cfme.utils.blockers import BZ
-from cfme.utils.version import VersionPicker, LOWEST
 
 
 class ServicesCatalogsView(BaseLoggedInPage):
@@ -88,13 +86,10 @@ def order(self):
         view.fill(self.dialog_values)
     if self.ansible_dialog_values:
         view.fill(self.ansible_dialog_values)
-    msg = "Order Request was Submitted"
-    msg_type = "success"
     view.submit_button.click()
     view = self.create_view(RequestsView)
     view.flash.assert_no_error()
-    if not BZ(1605102, forced_streams=['5.10']).blocks:
-        view.flash.assert_message(msg, msg_type)
+    view.flash.assert_success_message("Order Request was Submitted")
     return self.appliance.collections.requests.instantiate(self.name, partial_check=True)
 
 


### PR DESCRIPTION
where provider dropdown appears with some timeout

{{pytest: --long-running --use-template-cache --use-provider=azure -k test_provision_stack cfme/tests/services/test_provision_stack.py}}