### PR TITLE
[1LP][RFR] new test_tag_mapping_azure_instances

### DIFF
--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -16,7 +16,7 @@ from cfme.utils.log import logger
 from cfme.utils.providers import get_crud_by_name
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import (ManageIQTree, TimelinesView, Accordion, CompareToolBarActionsView,
-    Search)
+                                  Search, SummaryTable)
 
 
 class InstanceDetailsToolbar(View):
@@ -122,6 +122,8 @@ class InstanceProviderAllView(CloudInstanceView):
 
 
 class InstanceDetailsView(CloudInstanceView):
+    tag = SummaryTable(title='Smart Management')
+
     @property
     def is_displayed(self):
         expected_name = self.context['object'].name

--- a/cfme/configure/configuration/region_settings.py
+++ b/cfme/configure/configuration/region_settings.py
@@ -459,7 +459,7 @@ class MapTagsCollection(BaseCollection):
         else:
             view.add_button.click()
 
-        view = self.create_view(navigator.get_class(self.parent, 'All').VIEW)
+        view = self.create_view(navigator.get_class(self, 'All').VIEW)
         assert view.is_displayed
         view.flash.assert_no_error()
 

--- a/cfme/tests/cloud/test_tag_mapping.py
+++ b/cfme/tests/cloud/test_tag_mapping.py
@@ -1,0 +1,69 @@
+import pytest
+
+from cfme.cloud.provider.azure import AzureProvider
+from cfme.exceptions import ItemNotFound
+from cfme.markers.env_markers.provider import ONE_PER_CATEGORY
+from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.wait import wait_for
+
+from widgetastic.utils import partial_match
+
+pytestmark = [
+    pytest.mark.provider([AzureProvider], selector=ONE_PER_CATEGORY, scope='function'),
+    pytest.mark.usefixtures('setup_provider')
+]
+
+
+@pytest.fixture(scope='function')
+def map_tags(appliance, provider, request):
+    tag = appliance.collections.map_tags.create(entity_type=partial_match(provider.name.title()),
+                                                label='test',
+                                                category='Testing')
+    yield tag
+    request.addfinalizer(lambda: tag.delete())
+
+
+@pytest.fixture(scope='function')
+def vm(appliance, provider):
+    # cu-24x7 vm is tagged with test:testing in provider
+    tag_vm = provider.data.cap_and_util.capandu_vm
+    collection = provider.appliance.provider_based_collection(provider)
+    try:
+        return collection.instantiate(tag_vm, provider)
+    except IndexError:
+        raise ItemNotFound('VM for tag mapping not found!')
+
+
+@pytest.fixture(scope='function')
+def refresh_provider(provider):
+    provider.refresh_provider_relationships()
+    wait_for(provider.is_refreshed, func_kwargs={'refresh_delta': 10}, timeout=600)
+    return True
+
+
+def test_tag_mapping_azure_instances(vm, map_tags, refresh_provider):
+    """"
+    1. Find Instance that tagged with test:testing in Azure (cu-24x7)
+    2. Create tag mapping for Azure instances
+    3. Refresh Provider
+    4. Go to Summary of the Instance
+    Expected result: In Smart Management field should be:
+    My Company Tags Testing: testing
+
+    Polarion:
+        assignee: anikifor
+        casecomponent: cloud
+        caseimportance: high
+        initialEstimate: 1/12h
+    """
+    view = navigate_to(vm, 'Details')
+
+    def my_company_tags():
+        return view.tag.get_text_of('My Company Tags') != 'No My Company Tags have been assigned'
+    # sometimes it's not updated immediately after provider refresh
+    wait_for(
+        my_company_tags,
+        timeout=300,
+        fail_func=view.toolbar.reload.click
+    )
+    assert view.tag.get_text_of('My Company Tags')[0] == 'Testing: testing'

--- a/cfme/tests/cloud/test_tag_mapping.py
+++ b/cfme/tests/cloud/test_tag_mapping.py
@@ -1,5 +1,6 @@
 import pytest
 
+from cfme import test_requirements
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.exceptions import ItemNotFound
 from cfme.markers.env_markers.provider import ONE_PER_CATEGORY
@@ -41,20 +42,24 @@ def refresh_provider(provider):
     return True
 
 
+@test_requirements.tag
 def test_tag_mapping_azure_instances(vm, map_tags, refresh_provider):
     """"
-    1. Find Instance that tagged with test:testing in Azure (cu-24x7)
-    2. Create tag mapping for Azure instances
-    3. Refresh Provider
-    4. Go to Summary of the Instance
-    Expected result: In Smart Management field should be:
-    My Company Tags Testing: testing
-
     Polarion:
         assignee: anikifor
         casecomponent: cloud
         caseimportance: high
         initialEstimate: 1/12h
+        testSteps:
+            1. Find Instance that tagged with test:testing in Azure (cu-24x7)
+            2. Create tag mapping for Azure instances
+            3. Refresh Provider
+            4. Go to Summary of the Instance and read Smart Management field
+        expectedResults:
+            1.
+            2.
+            3.
+            4. Field value reads "My Company Tags Testing: testing"
     """
     view = navigate_to(vm, 'Details')
 

--- a/cfme/tests/test_manual.py
+++ b/cfme/tests/test_manual.py
@@ -19382,33 +19382,6 @@ def test_verify_session_timeout_works_fine_for_external_auth():
 
 
 @pytest.mark.manual
-@test_requirements.tag
-@pytest.mark.tier(2)
-def test_tag_mapping_azure_instances():
-    """
-    Requirement: Have an azure provider
-    1) Create an instance and tag it with test:testing
-    2) Go to Configuration -> CFME Region -> Map Tags
-    3) Add a tag:
-    Entity: Instance (Microsoft Azure)
-    Label: test
-    Category: Testing
-    4) Refresh provider
-    5) Go to summary of that instance
-    6) In Smart Management field should be:
-    My Company Tags testing: Testing
-    7) Delete that instance
-
-    Polarion:
-        assignee: anikifor
-        casecomponent: cloud
-        initialEstimate: 1/2h
-        startsin: 5.9
-    """
-    pass
-
-
-@pytest.mark.manual
 @test_requirements.cfme_tenancy
 @pytest.mark.tier(2)
 def test_tenant_visibility_vms_all_childs():


### PR DESCRIPTION
{{ pytest: -v cfme/tests/cloud/test_tag_mapping.py::test_tag_mapping_azure_instances --use-provider=complete }}

Here I automated the manual test `test_tag_mapping_azure_instances`. 
I'm planning to expand the tag mapping testing later.