### PR TITLE
[NOTEST] removed BZ1648658 and unused imports

### DIFF
--- a/cfme/tests/ansible/test_embedded_ansible_tags.py
+++ b/cfme/tests/ansible/test_embedded_ansible_tags.py
@@ -155,7 +155,6 @@ def test_tagvis_ansible_credential(credential, check_item_visibility, visibility
     check_item_visibility(credential, visibility)
 
 
-@pytest.mark.meta(blockers=[BZ(1648658, forced_streams=["5.9"])])
 @pytest.mark.parametrize('visibility', [True, False], ids=['visible', 'notVisible'])
 def test_tagvis_playbook(playbook, check_item_visibility, visibility):
     """ Test for cloud items tagging action from list and details pages

--- a/cfme/tests/cloud_infra_common/test_tag_objects.py
+++ b/cfme/tests/cloud_infra_common/test_tag_objects.py
@@ -2,11 +2,9 @@
 """This module tests tagging of objects in different locations."""
 import pytest
 
-from cfme.cloud.keypairs import KeyPair
 from cfme.cloud.provider import CloudProvider
 from cfme.infrastructure.provider import InfraProvider
 from cfme.markers.env_markers.provider import ONE_PER_CATEGORY
-from cfme.utils.blockers import BZ
 
 pytestmark = [
     pytest.mark.tier(2),
@@ -98,7 +96,6 @@ def tagging_check(tag, request):
     return _tagging_check
 
 
-@pytest.mark.meta(blockers=[BZ(1648658, forced_streams=["5.9"])])
 @pytest.mark.provider([CloudProvider], selector=ONE_PER_CATEGORY)
 @pytest.mark.parametrize('tag_place', [True, False], ids=['details', 'list'])
 def test_tag_cloud_objects(tagging_check, cloud_test_item, tag_place):
@@ -132,7 +129,6 @@ def test_tagvis_cloud_object(check_item_visibility, cloud_test_item, visibility,
     request.addfinalizer(lambda: tag_cleanup(cloud_test_item, tag))
 
 
-@pytest.mark.meta(blockers=[BZ(1648658, forced_streams=["5.9"])])
 @pytest.mark.provider([InfraProvider], selector=ONE_PER_CATEGORY)
 @pytest.mark.parametrize('tag_place', [True, False], ids=['details', 'list'])
 def test_tag_infra_objects(tagging_check, infra_test_item, tag_place):

--- a/cfme/tests/cloud_infra_common/test_tag_visibility.py
+++ b/cfme/tests/cloud_infra_common/test_tag_visibility.py
@@ -7,7 +7,6 @@ from cfme.exceptions import VmOrInstanceNotFound
 from cfme.infrastructure.provider import InfraProvider
 from cfme.markers.env_markers.provider import ONE, ONE_PER_TYPE
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.blockers import BZ
 
 pytestmark = [
     test_requirements.tag,
@@ -120,9 +119,6 @@ def check_vm_visibility(user_restricted, appliance):
     return _check_vm_visibility
 
 
-@pytest.mark.uncollectif(lambda appliance: appliance.version < '5.9',
-                         reason="Tag expression starts from 5.9 version")
-@pytest.mark.meta(blockers=[BZ(1648658, forced_streams=["5.9"])])
 @pytest.mark.provider([InfraProvider], override=True, selector=ONE, scope='module')
 def test_tag_expression_and_condition(
     request, vms_for_tagging, location_tag,
@@ -153,9 +149,6 @@ def test_tag_expression_and_condition(
     check_vm_visibility(group, first_vm, True)
 
 
-@pytest.mark.uncollectif(lambda appliance: appliance.version < '5.9',
-                         reason="Tag expression starts from 5.9 version")
-@pytest.mark.meta(blockers=[BZ(1648658, forced_streams=["5.9"])])
 @pytest.mark.provider([InfraProvider], override=True, selector=ONE, scope='module')
 def test_tag_expression_or_condition(
     request, vms_for_tagging, location_tag,
@@ -186,9 +179,6 @@ def test_tag_expression_or_condition(
     check_vm_visibility(group, second_vm, True)
 
 
-@pytest.mark.uncollectif(lambda appliance: appliance.version < '5.9',
-                         reason="Tag expression starts from 5.9 version")
-@pytest.mark.meta(blockers=[BZ(1648658, forced_streams=["5.9"])])
 @pytest.mark.provider([InfraProvider], override=True, selector=ONE, scope='module')
 def test_tag_expression_not_condition(
     request, vms_for_tagging, location_tag,
@@ -215,9 +205,6 @@ def test_tag_expression_not_condition(
     check_vm_visibility(group, second_vm, True)
 
 
-@pytest.mark.uncollectif(lambda appliance: appliance.version < '5.9',
-                         reason="Tag expression starts from 5.9 version")
-@pytest.mark.meta(blockers=[BZ(1648658, forced_streams=["5.9"])])
 @pytest.mark.provider([InfraProvider], override=True, selector=ONE, scope='module')
 def test_tag_expression_not_and_condition(
         request, vms_for_tagging, location_tag,
@@ -255,9 +242,6 @@ def test_tag_expression_not_and_condition(
     check_vm_visibility(group, second_vm, True)
 
 
-@pytest.mark.uncollectif(lambda appliance: appliance.version < '5.9',
-                         reason="Tag expression starts from 5.9 version")
-@pytest.mark.meta(blockers=[BZ(1648658, forced_streams=["5.9"])])
 @pytest.mark.provider([InfraProvider], override=True, selector=ONE, scope='module')
 def test_tag_expression_not_or_condition(
     request, vms_for_tagging, location_tag, service_level_tag, group_with_tag_expression,

--- a/cfme/tests/generic_objects/test_instances.py
+++ b/cfme/tests/generic_objects/test_instances.py
@@ -9,7 +9,6 @@ from cfme.base.login import BaseLoggedInPage
 from cfme.services.myservice import MyService
 from cfme.utils.appliance import ViaREST, ViaUI
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.blockers import BZ
 from cfme.utils.rest import assert_response
 from cfme.utils.update import update
 
@@ -209,7 +208,6 @@ def test_generic_objects_with_buttons_ui(appliance, request, add_generic_object_
             assert view.toolbar.button(generic_button.name).custom_button.is_displayed
 
 
-@pytest.mark.meta(blockers=[BZ(1648658, forced_streams=['5.9'])])
 @pytest.mark.parametrize('tag_place', [True, False], ids=['details', 'collection'])
 def test_generic_objects_tag_ui(appliance, generic_object, tag_place):
     """Tests assigning and unassigning tags using UI.

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -190,7 +190,6 @@ def test_multiple_host_bad_creds(setup_provider, provider):
     edit_view.cancel_button.click()
 
 
-@pytest.mark.meta(blockers=[BZ(1648658, forced_streams=["5.9"])])
 @pytest.mark.provider([InfraProvider], override=True, selector=ONE, scope='module')
 def test_tag_host_after_provider_delete(provider, appliance, setup_provider, request):
     """Test if host can be tagged after delete

--- a/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
+++ b/cfme/tests/infrastructure/test_infra_tag_filters_combination.py
@@ -4,7 +4,6 @@ from cfme import test_requirements
 from cfme.infrastructure.provider import InfraProvider
 from cfme.markers.env_markers.provider import ONE
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.blockers import BZ
 from cfme.utils.update import update
 
 pytestmark = [
@@ -51,7 +50,6 @@ def group_tag_datacenter_combination(group_with_tag, provider):
                                         provider.data['datacenters'][0]], True)
 
 
-@pytest.mark.meta(blockers=[BZ(1648658, forced_streams=["5.9"])])
 @pytest.mark.parametrize('visibility', [True, False], ids=['visible', 'not_visible'])
 def test_tagvis_tag_datacenter_combination(testing_vis_object, group_tag_datacenter_combination,
                                 check_item_visibility, visibility):

--- a/cfme/tests/networks/test_sdn_balancers.py
+++ b/cfme/tests/networks/test_sdn_balancers.py
@@ -6,7 +6,6 @@ from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.exceptions import DestinationNotFound
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.blockers import BZ
 
 pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
@@ -65,7 +64,6 @@ def test_sdn_balancers_detail(provider, network_prov_with_load_balancers):
 
 
 # only one provider is needed for that test, used Azure as it has balancers
-@pytest.mark.meta(blockers=[BZ(1648658, forced_streams=["5.9"])])
 @pytest.mark.provider([AzureProvider], scope='module', override=True)
 @pytest.mark.parametrize('visibility', [True, False], ids=['visible', 'notVisible'])
 def test_sdn_balancers_tagvis(check_item_visibility, visibility, network_prov_with_load_balancers):


### PR DESCRIPTION
blockers-only

1. Removed BZ1648658 (broken tagging)
2. Removed unused imports
3. Removed `uncollectif` for `appliance.version < '5.9'`