### PR TITLE
[WIPTEST] Fix dashboard displayed

### DIFF
--- a/cfme/intelligence/reports/dashboards.py
+++ b/cfme/intelligence/reports/dashboards.py
@@ -55,7 +55,7 @@ class NewDashboardView(DashboardFormCommon):
             self.dashboards.tree.currently_selected == [
                 "All Dashboards",
                 "All Groups",
-                self.context["object"].group
+                self.context["object"]._group
             ]
         )
 
@@ -68,7 +68,7 @@ class EditDashboardView(DashboardFormCommon):
     def is_displayed(self):
         return (
             self.in_intel_reports and
-            self.title.text == "Editing Dashboard {}".format(self.context["object"].name) and
+            self.title.text == "Editing Dashboard \"{}\"".format(self.context["object"].name) and
             self.dashboards.is_opened and
             self.dashboards.tree.currently_selected == [
                 "All Dashboards",
@@ -163,7 +163,7 @@ class Dashboard(BaseEntity, Updateable, Pretty):
         Args:
             updates: Provided by update() context manager.
         """
-        view = navigate_to(self, "Edit")
+        view = navigate_to(self, "Edit", use_resetter=False)
         if "widgets" in updates:
             updates["widget_picker"] = updates.pop("widgets")
         changed = view.fill(updates)
@@ -172,6 +172,7 @@ class Dashboard(BaseEntity, Updateable, Pretty):
         else:
             view.cancel_button.click()
         view = self.create_view(DashboardDetailsView, override=updates)
+        view.wait_displayed()
         assert view.is_displayed
         view.flash.assert_no_error()
         if self.appliance.version < "5.9":

--- a/cfme/intelligence/reports/widgets/__init__.py
+++ b/cfme/intelligence/reports/widgets/__init__.py
@@ -58,13 +58,14 @@ class BaseDashboardReportWidget(BaseEntity, Updateable, Pretty):
         """
         # In order to update the tree in the side menu we have to refresh a whole page
         self.browser.refresh()
-        view = navigate_to(self, "Edit")
+        view = navigate_to(self, "Edit", use_resetter=False)
         changed = view.fill_with(
             updates,
             on_change=view.save_button.click,
             no_change=view.cancel_button.click
         )
         view = self.create_view(DashboardWidgetDetailsView, override=updates)
+        view.wait_displayed()
         assert view.is_displayed
         view.flash.assert_no_error()
         if changed:


### PR DESCRIPTION
This PR brings the following changes:
1. Add a `view.wait_displayed` to fix `TimedOutError` in widget tests.
2. Fix `is_displayed` method.

{{pytest: cfme/tests/intelligence/reports/test_crud.py -k "test_dashboard_crud or test_menuwidget_crud or test_rssfeedwidget_crud" --use-template-cache -sqvvv}}