### PR TITLE
[1LP][RFR] This PR blocks the test cases because of BZs

### DIFF
--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -448,7 +448,7 @@ def test_no_power_controls_on_archived_vm(appliance, testing_vm, archived_vm, so
 @pytest.mark.rhv3
 @pytest.mark.meta(blockers=[BZ(1520489, forced_streams=['5.9'],
                                unblock=lambda provider: not provider.one_of(SCVMMProvider)),
-                            BZ(1592430, forced_streams=['5.8', '5.9', '5.10'],
+                            BZ(1659340, forced_streams=['5.9', '5.10'],
                                unblock=lambda provider: not provider.one_of(RHEVMProvider))])
 def test_archived_vm_status(testing_vm, archived_vm):
     """Tests archived vm status
@@ -512,7 +512,7 @@ def test_vm_power_options_from_off(provider, soft_assert, testing_vm, ensure_vm_
 
 
 @pytest.mark.provider([VMwareProvider, RHEVMProvider], override=True, scope='function')
-@pytest.mark.meta(blockers=[BZ(1571830, forced_streams=['5.8', '5.9'],
+@pytest.mark.meta(blockers=[BZ(1571830, forced_streams=['5.8', '5.9', '5.10'],
     unblock=lambda provider: not provider.one_of(RHEVMProvider))])
 def test_guest_os_reset(appliance, testing_vm_tools, ensure_vm_running, soft_assert):
     """Tests vm guest os reset
@@ -541,7 +541,7 @@ def test_guest_os_reset(appliance, testing_vm_tools, ensure_vm_running, soft_ass
     soft_assert(testing_vm_tools.mgmt.is_running, "vm not running")
 
 
-@pytest.mark.meta(blockers=[BZ(1571895, forced_streams=['5.8', '5.9'],
+@pytest.mark.meta(blockers=[BZ(1571895, forced_streams=['5.8', '5.9', '5.10'],
                                unblock=lambda provider: not provider.one_of(RHEVMProvider))])
 @pytest.mark.provider([VMwareProvider, RHEVMProvider], override=True)
 def test_guest_os_shutdown(appliance, testing_vm_tools, ensure_vm_running, soft_assert):

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -512,7 +512,7 @@ def test_vm_power_options_from_off(provider, soft_assert, testing_vm, ensure_vm_
 
 
 @pytest.mark.provider([VMwareProvider, RHEVMProvider], override=True, scope='function')
-@pytest.mark.meta(blockers=[BZ(1571830, forced_streams=['5.8', '5.9', '5.10'],
+@pytest.mark.meta(blockers=[BZ(1571830, forced_streams=['5.9', '5.10'],
     unblock=lambda provider: not provider.one_of(RHEVMProvider))])
 def test_guest_os_reset(appliance, testing_vm_tools, ensure_vm_running, soft_assert):
     """Tests vm guest os reset
@@ -541,7 +541,7 @@ def test_guest_os_reset(appliance, testing_vm_tools, ensure_vm_running, soft_ass
     soft_assert(testing_vm_tools.mgmt.is_running, "vm not running")
 
 
-@pytest.mark.meta(blockers=[BZ(1571895, forced_streams=['5.8', '5.9', '5.10'],
+@pytest.mark.meta(blockers=[BZ(1571895, forced_streams=['5.9', '5.10'],
                                unblock=lambda provider: not provider.one_of(RHEVMProvider))])
 @pytest.mark.provider([VMwareProvider, RHEVMProvider], override=True)
 def test_guest_os_shutdown(appliance, testing_vm_tools, ensure_vm_running, soft_assert):


### PR DESCRIPTION
- BZ - [1592430](https://bugzilla.redhat.com/show_bug.cgi?id=1592430) is already verified. hence removed.
- BZ - [1659340](https://bugzilla.redhat.com/show_bug.cgi?id=1659340) is reproducible on 5.10z and 5.9z. Hence test ```test_archived_vm_status``` is failing for rhv provider.
- BZ -  [1571830](https://bugzilla.redhat.com/show_bug.cgi?id=1571830) is not yet fixed. Also it is now reproducible on 5.10z. hence test ```test_guest_os_reset``` is failing for rhv provider.
- BZ - [1571895](https://bugzilla.redhat.com/show_bug.cgi?id=1571895) not yet fixed. And reproducible on 5.10 as well.

{{ pytest: cfme/tests/infrastructure/test_vm_power_control.py -k 'test_guest_os_reset or test_archived_vm_status or test_guest_os_shutdown' --long-running -v }}