### PR TITLE
[RFR]Fixed services orchestration template

### DIFF
--- a/cfme/services/catalogs/orchestration_template.py
+++ b/cfme/services/catalogs/orchestration_template.py
@@ -78,7 +78,6 @@ class CopyTemplateView(CopyTemplateForm):
     @property
     def is_displayed(self):
         return (
-            self.is_displayed and
             self.title.text == "Copying {}".format(self.context['object'].template_name) and
             self.orchestration_templates.is_opened
         )
@@ -178,6 +177,7 @@ class OrchestrationTemplate(BaseEntity, Updateable, Pretty, Taggable):
                    'description': description
                    })
         view.add_button.click()
+        view.wait_displayed('15s')
         view.flash.assert_no_error()
         # TODO - Move assertions to tests
         return self.parent.instantiate(template_group=self.template_group,

--- a/cfme/tests/services/test_orchestration_template.py
+++ b/cfme/tests/services/test_orchestration_template.py
@@ -5,6 +5,7 @@ import re
 
 from cfme import test_requirements
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import BZ
 from cfme.utils.update import update
 
 pytestmark = [
@@ -185,6 +186,9 @@ def test_tag_orchestration_template(tag, created_template):
 
 
 @pytest.mark.parametrize("action", ["copy", "create"], ids=["copy", "create"])
+@pytest.mark.meta(
+    blockers=[BZ(1659947, forced_streams=['5.9', '5.10'],
+                 unblock=lambda action: action != "create")])
 def test_duplicated_content_error_validation(appliance, created_template, template_type,
                                              action):
     """Tests that we are not allowed to have duplicated content in different templates


### PR DESCRIPTION
{{pytest: cfme/tests/services/test_orchestration_template.py -k 'test_duplicated_content_error_validation'   -vvv}}