### PR TITLE
[1LP][RFR] Fix failing rest test cases and add blockers

### DIFF
--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -43,7 +43,7 @@ def service_catalogs(request, appliance, num=5):
 
 def service_catalog_obj(request, appliance):
     """Return service catalog object."""
-    rest_catalog = service_catalogs(request, appliance.rest_api, num=1)[0]
+    rest_catalog = service_catalogs(request, appliance, num=1)[0]
     return appliance.collections.catalogs.instantiate(name=rest_catalog.name,
                                                       description=rest_catalog.description)
 
@@ -123,7 +123,7 @@ def dialog_rest(request, appliance):
 
 def dialog(request, appliance):
     """Returns service dialog object."""
-    rest_resource = dialog_rest(request, appliance.rest_api)
+    rest_resource = dialog_rest(request, appliance)
     service_dialogs = appliance.collections.service_dialogs
     service_dialog = service_dialogs.instantiate(
         label=rest_resource.label,
@@ -321,7 +321,7 @@ def service_templates_rest(request, appliance, service_dialog=None, service_cata
             }
         })
 
-    return _creating_skeleton(request, appliance.rest_api, "service_templates", data)
+    return _creating_skeleton(request, appliance, "service_templates", data)
 
 
 def service_templates(request, appliance, service_dialog=None, service_catalog=None, num=4):
@@ -473,7 +473,7 @@ def mark_vm_as_template(appliance, provider, vm_name):
     """
         Function marks vm as template via mgmt and returns template Entity
         Usage:
-            mark_vm_as_template(appliance.rest_api, provider, vm_name)
+            mark_vm_as_template(appliance, provider, vm_name)
     """
     t_vm = appliance.rest_api.collections.vms.get(name=vm_name)
     t_vm.action.stop()

--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -582,7 +582,7 @@ def policies(request, appliance, num=2):
             'name': 'test_policy_{}'.format(uniq),
             'description': 'Test Policy {}'.format(uniq),
             'mode': 'compliance',
-            'towhat': 'ManageIQ::Providers::Redhat::InfraManager',
+            'towhat': 'ExtManagementSystem',
             'conditions_ids': [conditions_response[0].id, conditions_response[1].id],
             'policy_contents': [{
                 'event_id': 2,

--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -28,7 +28,7 @@ TEMPLATE_TORSO = """{
 """
 
 
-def service_catalogs(request, rest_api, num=5):
+def service_catalogs(request, appliance, num=5):
     """Create service catalogs using REST API."""
     scls_data = []
     for _ in range(num):
@@ -38,7 +38,7 @@ def service_catalogs(request, rest_api, num=5):
             'service_templates': []
         })
 
-    return _creating_skeleton(request, rest_api, 'service_catalogs', scls_data, col_action='add')
+    return _creating_skeleton(request, appliance, 'service_catalogs', scls_data, col_action='add')
 
 
 def service_catalog_obj(request, appliance):
@@ -48,7 +48,7 @@ def service_catalog_obj(request, appliance):
                                                       description=rest_catalog.description)
 
 
-def categories(request, rest_api, num=1):
+def categories(request, appliance, num=1):
     ctg_data = []
     for _ in range(num):
         uniq = fauxfactory.gen_alphanumeric().lower()
@@ -57,10 +57,10 @@ def categories(request, rest_api, num=1):
             'description': 'test_category_{}'.format(uniq)
         })
 
-    return _creating_skeleton(request, rest_api, 'categories', ctg_data)
+    return _creating_skeleton(request, appliance, 'categories', ctg_data)
 
 
-def tags(request, rest_api, categories):
+def tags(request, appliance, categories):
     # Category id, href or name needs to be specified for creating a new tag resource
     tags = []
     for index, ctg in enumerate(categories):
@@ -72,10 +72,10 @@ def tags(request, rest_api, categories):
             'category': refs[index % 3]
         })
 
-    return _creating_skeleton(request, rest_api, 'tags', tags, substr_search=True)
+    return _creating_skeleton(request, appliance, 'tags', tags, substr_search=True)
 
 
-def dialog_rest(request, rest_api):
+def dialog_rest(request, appliance):
     """Creates service dialog using REST API."""
     uid = fauxfactory.gen_alphanumeric()
     data = {
@@ -117,7 +117,7 @@ def dialog_rest(request, rest_api):
         }]
     }
 
-    service_dialog = _creating_skeleton(request, rest_api, "service_dialogs", [data])
+    service_dialog = _creating_skeleton(request, appliance, "service_dialogs", [data])
     return service_dialog[0]
 
 
@@ -182,8 +182,8 @@ def services(request, appliance, provider, service_dialog=None, service_catalog=
     return [provisioned_service]
 
 
-def rates(request, rest_api, num=3):
-    chargeback = rest_api.collections.chargebacks.get(rate_type='Compute')
+def rates(request, appliance, num=3):
+    chargeback = appliance.rest_api.collections.chargebacks.get(rate_type='Compute')
     data = []
     for _ in range(num):
         req = {'description': 'test_rate_{}'.format(fauxfactory.gen_alphanumeric()),
@@ -195,11 +195,11 @@ def rates(request, rest_api, num=3):
                'chargeable_field_id': chargeback.id}
         data.append(req)
 
-    return _creating_skeleton(request, rest_api, 'rates', data)
+    return _creating_skeleton(request, appliance, 'rates', data)
 
 
-def vm(request, provider, rest_api):
-    provider_rest = rest_api.collections.providers.get(name=provider.name)
+def vm(request, provider, appliance):
+    provider_rest = appliance.rest_api.collections.providers.get(name=provider.name)
     vm = deploy_template(
         provider.key,
         'test_rest_vm_{}'.format(fauxfactory.gen_alphanumeric(length=4))
@@ -216,7 +216,7 @@ def vm(request, provider, rest_api):
 
     provider_rest.action.refresh()
     wait_for(
-        lambda: rest_api.collections.vms.find_by(name=vm_name) or False,
+        lambda: appliance.rest_api.collections.vms.find_by(name=vm_name) or False,
         num_sec=600, delay=5)
     return vm_name
 
@@ -369,7 +369,7 @@ def automation_requests_data(vm, requests_collection=False, approve=True, num=4)
     return [data for _ in range(num)]
 
 
-def groups(request, rest_api, role, tenant, num=1):
+def groups(request, appliance, role, tenant, num=1):
     data = []
     for _ in range(num):
         data.append({
@@ -378,25 +378,25 @@ def groups(request, rest_api, role, tenant, num=1):
             "tenant": {"href": tenant.href}
         })
 
-    groups = _creating_skeleton(request, rest_api, "groups", data)
+    groups = _creating_skeleton(request, appliance, "groups", data)
     if num == 1:
         return groups.pop()
     return groups
 
 
-def roles(request, rest_api, num=1):
+def roles(request, appliance, num=1):
     data = []
     for _ in range(num):
         data.append({"name": "role_name_{}".format(fauxfactory.gen_alphanumeric())})
 
-    roles = _creating_skeleton(request, rest_api, "roles", data)
+    roles = _creating_skeleton(request, appliance, "roles", data)
     if num == 1:
         return roles.pop()
     return roles
 
 
-def copy_role(rest_api, orig_name, new_name=None):
-    orig_role = rest_api.collections.roles.get(name=orig_name)
+def copy_role(appliance, orig_name, new_name=None):
+    orig_role = appliance.rest_api.collections.roles.get(name=orig_name)
     orig_features = orig_role._data.get('features')
     orig_settings = orig_role._data.get('settings')
     if not orig_features and hasattr(orig_role, 'features'):
@@ -405,7 +405,7 @@ def copy_role(rest_api, orig_name, new_name=None):
         orig_features = features_subcol._data.get('resources')
     if not orig_features:
         raise NotImplementedError('Role copy is not implemented for this version.')
-    new_role = rest_api.collections.roles.action.create(
+    new_role = appliance.rest_api.collections.roles.action.create(
         name=new_name or 'EvmRole-{}'.format(fauxfactory.gen_alphanumeric()),
         features=orig_features,
         settings=orig_settings
@@ -413,8 +413,8 @@ def copy_role(rest_api, orig_name, new_name=None):
     return new_role[0]
 
 
-def tenants(request, rest_api, num=1):
-    parent = rest_api.collections.tenants.get(name='My Company')
+def tenants(request, appliance, num=1):
+    parent = appliance.rest_api.collections.tenants.get(name='My Company')
     data = []
     for _ in range(num):
         uniq = fauxfactory.gen_alphanumeric()
@@ -426,13 +426,13 @@ def tenants(request, rest_api, num=1):
             'parent': {'href': parent.href}
         })
 
-    tenants = _creating_skeleton(request, rest_api, 'tenants', data)
+    tenants = _creating_skeleton(request, appliance, 'tenants', data)
     if num == 1:
         return tenants.pop()
     return tenants
 
 
-def users(request, rest_api, num=1):
+def users(request, appliance, num=1):
     data = []
     for _ in range(num):
         uniq = fauxfactory.gen_alphanumeric(4).lower()
@@ -444,22 +444,22 @@ def users(request, rest_api, num=1):
             "group": {"description": "EvmGroup-user_self_service"}
         })
 
-    resources = _creating_skeleton(request, rest_api, "users", data)
+    resources = _creating_skeleton(request, appliance, "users", data)
     return resources, data
 
 
-def _creating_skeleton(request, rest_api, col_name, col_data, col_action='create',
+def _creating_skeleton(request, appliance, col_name, col_data, col_action='create',
         substr_search=False):
 
     entities = create_resource(
-        rest_api, col_name, col_data, col_action=col_action, substr_search=substr_search)
+        appliance.rest_api, col_name, col_data, col_action=col_action, substr_search=substr_search)
 
     # make sure the original list of `entities` is preserved for cleanup
     original_entities = list(entities)
 
     @request.addfinalizer
     def _finished():
-        collection = getattr(rest_api.collections, col_name)
+        collection = getattr(appliance.rest_api.collections, col_name)
         collection.reload()
         ids = [e.id for e in original_entities]
         delete_entities = [e for e in collection if e.id in ids]
@@ -469,25 +469,25 @@ def _creating_skeleton(request, rest_api, col_name, col_data, col_action='create
     return entities
 
 
-def mark_vm_as_template(rest_api, provider, vm_name):
+def mark_vm_as_template(appliance, provider, vm_name):
     """
         Function marks vm as template via mgmt and returns template Entity
         Usage:
-            mark_vm_as_template(rest_api, provider, vm_name)
+            mark_vm_as_template(appliance.rest_api, provider, vm_name)
     """
-    t_vm = rest_api.collections.vms.get(name=vm_name)
+    t_vm = appliance.rest_api.collections.vms.get(name=vm_name)
     t_vm.action.stop()
     vm_mgmt = provider.mgmt.get_vm(vm_name)
     vm_mgmt.ensure_state(VmState.STOPPED, timeout=1000)
     vm_mgmt.mark_as_template()
 
     wait_for(
-        lambda: rest_api.collections.templates.find_by(name=vm_name).subcount != 0,
+        lambda: appliance.rest_api.collections.templates.find_by(name=vm_name).subcount != 0,
         num_sec=700, delay=15)
-    return rest_api.collections.templates.get(name=vm_name)
+    return appliance.rest_api.collections.templates.get(name=vm_name)
 
 
-def arbitration_settings(request, rest_api, num=2):
+def arbitration_settings(request, appliance, num=2):
     data = []
     for _ in range(num):
         uniq = fauxfactory.gen_alphanumeric(5)
@@ -495,10 +495,10 @@ def arbitration_settings(request, rest_api, num=2):
             'name': 'test_settings_{}'.format(uniq),
             'display_name': 'Test Settings {}'.format(uniq)})
 
-    return _creating_skeleton(request, rest_api, 'arbitration_settings', data)
+    return _creating_skeleton(request, appliance, 'arbitration_settings', data)
 
 
-def orchestration_templates(request, rest_api, num=2):
+def orchestration_templates(request, appliance, num=2):
     data = []
     for _ in range(num):
         uniq = fauxfactory.gen_alphanumeric(5)
@@ -510,11 +510,11 @@ def orchestration_templates(request, rest_api, num=2):
             'draft': False,
             'content': TEMPLATE_TORSO.replace('CloudFormation', uniq)})
 
-    return _creating_skeleton(request, rest_api, 'orchestration_templates', data)
+    return _creating_skeleton(request, appliance, 'orchestration_templates', data)
 
 
-def arbitration_profiles(request, rest_api, provider, num=2):
-    r_provider = rest_api.collections.providers.get(name=provider.name)
+def arbitration_profiles(request, appliance, provider, num=2):
+    r_provider = appliance.rest_api.collections.providers.get(name=provider.name)
     data = []
     providers = [{'id': r_provider.id}, {'href': r_provider.href}]
     for index in range(num):
@@ -523,10 +523,10 @@ def arbitration_profiles(request, rest_api, provider, num=2):
             'provider': providers[index % 2]
         })
 
-    return _creating_skeleton(request, rest_api, 'arbitration_profiles', data)
+    return _creating_skeleton(request, appliance, 'arbitration_profiles', data)
 
 
-def arbitration_rules(request, rest_api, num=2):
+def arbitration_rules(request, appliance, num=2):
     data = []
     for _ in range(num):
         data.append({
@@ -535,10 +535,10 @@ def arbitration_rules(request, rest_api, num=2):
             'expression': {'EQUAL': {'field': 'User-userid', 'value': 'admin'}}
         })
 
-    return _creating_skeleton(request, rest_api, 'arbitration_rules', data)
+    return _creating_skeleton(request, appliance, 'arbitration_rules', data)
 
 
-def blueprints(request, rest_api, num=2):
+def blueprints(request, appliance, num=2):
     data = []
     for _ in range(num):
         uniq = fauxfactory.gen_alphanumeric(5)
@@ -553,10 +553,10 @@ def blueprints(request, rest_api, num=2):
             }
         })
 
-    return _creating_skeleton(request, rest_api, 'blueprints', data)
+    return _creating_skeleton(request, appliance, 'blueprints', data)
 
 
-def conditions(appliance, request, num=2):
+def conditions(request, appliance, num=2):
     data = []
     for _ in range(num):
         uniq = fauxfactory.gen_alphanumeric(5)
@@ -570,11 +570,11 @@ def conditions(appliance, request, num=2):
             data_dict["modifier"] = "allow"
         data.append(data_dict)
 
-    return _creating_skeleton(request, appliance.rest_api, 'conditions', data)
+    return _creating_skeleton(request, appliance, 'conditions', data)
 
 
-def policies(appliance, request, num=2):
-    conditions_response = conditions(appliance, request, num=2)
+def policies(request, appliance, num=2):
+    conditions_response = conditions(request, appliance, num=2)
     data = []
     for _ in range(num):
         uniq = fauxfactory.gen_alphanumeric(5)
@@ -590,7 +590,7 @@ def policies(appliance, request, num=2):
             }]
         })
 
-    return _creating_skeleton(request, appliance.rest_api, 'policies', data)
+    return _creating_skeleton(request, appliance, 'policies', data)
 
 
 def get_dialog_service_name(appliance, service_request, *item_names):

--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -556,23 +556,25 @@ def blueprints(request, rest_api, num=2):
     return _creating_skeleton(request, rest_api, 'blueprints', data)
 
 
-def conditions(request, rest_api, num=2):
+def conditions(appliance, request, num=2):
     data = []
     for _ in range(num):
         uniq = fauxfactory.gen_alphanumeric(5)
-        data.append({
+        data_dict = {
             'name': 'test_condition_{}'.format(uniq),
             'description': 'Test Condition {}'.format(uniq),
             'expression': {'=': {'field': 'ContainerImage-architecture', 'value': 'dsa'}},
-            'towhat': 'ExtManagementSystem',
-            'modifier': 'allow'
-        })
+            'towhat': 'ExtManagementSystem'
+        }
+        if appliance.version < '5.10':
+            data_dict["modifier"] = "allow"
+        data.append(data_dict)
 
-    return _creating_skeleton(request, rest_api, 'conditions', data)
+    return _creating_skeleton(request, appliance.rest_api, 'conditions', data)
 
 
-def policies(request, rest_api, num=2):
-    conditions_response = conditions(request, rest_api, num=2)
+def policies(appliance, request, num=2):
+    conditions_response = conditions(appliance, request, num=2)
     data = []
     for _ in range(num):
         uniq = fauxfactory.gen_alphanumeric(5)
@@ -588,7 +590,7 @@ def policies(request, rest_api, num=2):
             }]
         })
 
-    return _creating_skeleton(request, rest_api, 'policies', data)
+    return _creating_skeleton(request, appliance.rest_api, 'policies', data)
 
 
 def get_dialog_service_name(appliance, service_request, *item_names):

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -710,7 +710,7 @@ class TestProvidersRESTAPI(object):
     def arbitration_profiles(self, request, appliance, cloud_provider):
         num_profiles = 2
         response = _arbitration_profiles(
-            request, appliance.rest_api, cloud_provider, num=num_profiles)
+            request, appliance, cloud_provider, num=num_profiles)
         assert_response(appliance)
         assert len(response) == num_profiles
 
@@ -877,7 +877,7 @@ class TestProvidersRESTAPI(object):
                 'expression': {'EQUAL': {'field': 'User-userid', 'value': 'admin'}}
             })
 
-        response = creating_skeleton(request, appliance.rest_api, 'arbitration_rules', data)
+        response = creating_skeleton(request, appliance, 'arbitration_rules', data)
         assert_response(appliance)
         assert len(response) == num_rules
         for rule in response:
@@ -906,7 +906,7 @@ class TestProvidersRESTAPI(object):
             'expression': {'EQUAL': {'field': 'User-userid', 'value': 'admin'}}
         }]
 
-        response = creating_skeleton(request, appliance.rest_api, 'arbitration_rules', data)
+        response = creating_skeleton(request, appliance, 'arbitration_rules', data)
         # this will fail once BZ 1433477 is fixed - change and expand the test accordingly
         assert_response(appliance)
         for rule in response:

--- a/cfme/tests/configure/test_rest_access_control.py
+++ b/cfme/tests/configure/test_rest_access_control.py
@@ -28,7 +28,7 @@ class TestTenantsViaREST(object):
     @pytest.fixture(scope="function")
     def tenants(self, request, appliance):
         num_tenants = 3
-        response = _tenants(request, appliance.rest_api, num=num_tenants)
+        response = _tenants(request, appliance, num=num_tenants)
         assert_response(appliance)
         assert len(response) == num_tenants
         return response
@@ -137,7 +137,7 @@ class TestRolesViaREST(object):
     @pytest.fixture(scope="function")
     def roles(self, request, appliance):
         num_roles = 3
-        response = _roles(request, appliance.rest_api, num=num_roles)
+        response = _roles(request, appliance, num=num_roles)
         assert_response(appliance)
         assert len(response) == num_roles
         return response
@@ -299,16 +299,16 @@ class TestRolesViaREST(object):
 class TestGroupsViaREST(object):
     @pytest.fixture(scope="function")
     def tenants(self, request, appliance):
-        return _tenants(request, appliance.rest_api, num=1)
+        return _tenants(request, appliance, num=1)
 
     @pytest.fixture(scope="function")
     def roles(self, request, appliance):
-        return _roles(request, appliance.rest_api, num=1)
+        return _roles(request, appliance, num=1)
 
     @pytest.fixture(scope="function")
     def groups(self, request, appliance, roles, tenants):
         num_groups = 3
-        response = _groups(request, appliance.rest_api, roles, tenants, num=num_groups)
+        response = _groups(request, appliance, roles, tenants, num=num_groups)
         assert_response(appliance)
         assert len(response) == num_groups
         return response
@@ -417,7 +417,7 @@ class TestUsersViaREST(object):
     @pytest.fixture(scope="function")
     def users_data(self, request, appliance, num=3):
         num_users = num
-        response, prov_data = _users(request, appliance.rest_api, num=num_users)
+        response, prov_data = _users(request, appliance, num=num_users)
         assert_response(appliance)
         assert len(response) == num
         return response, prov_data
@@ -491,7 +491,7 @@ class TestUsersViaREST(object):
             "group": {"description": "EvmGroup-user_self_service"}
         }
 
-        user = _creating_skeleton(request, appliance.rest_api, 'users', [data])[0]
+        user = _creating_skeleton(request, appliance, 'users', [data])[0]
         assert_response(appliance)
         user_auth = (user.userid, data['password'])
         assert appliance.new_rest_api_instance(auth=user_auth)

--- a/cfme/tests/configure/test_tag.py
+++ b/cfme/tests/configure/test_tag.py
@@ -117,7 +117,7 @@ class TestTagsViaREST(object):
     def service_templates(self, request, appliance):
         return _service_templates(request, appliance)
 
-    @pytest.fixture(scope="module")
+    @pytest.fixture(scope="function")
     def vm(self, request, provider, appliance):
         return _vm(request, provider, appliance)
 

--- a/cfme/tests/configure/test_tag.py
+++ b/cfme/tests/configure/test_tag.py
@@ -91,11 +91,11 @@ class TestTagsViaREST(object):
 
     @pytest.fixture(scope="function")
     def categories(self, request, appliance, num=3):
-        return _categories(request, appliance.rest_api, num)
+        return _categories(request, appliance, num)
 
     @pytest.fixture(scope="function")
     def tags(self, request, appliance, categories):
-        return _tags(request, appliance.rest_api, categories)
+        return _tags(request, appliance, categories)
 
     @pytest.fixture(scope="module")
     def services_mod(self, request, appliance):
@@ -103,15 +103,15 @@ class TestTagsViaREST(object):
 
     @pytest.fixture(scope="module")
     def categories_mod(self, request, appliance, num=3):
-        return _categories(request, appliance.rest_api, num)
+        return _categories(request, appliance, num)
 
     @pytest.fixture(scope="module")
     def tags_mod(self, request, appliance, categories_mod):
-        return _tags(request, appliance.rest_api, categories_mod)
+        return _tags(request, appliance, categories_mod)
 
     @pytest.fixture(scope="module")
     def tenants(self, request, appliance):
-        return _tenants(request, appliance.rest_api, num=1)
+        return _tenants(request, appliance, num=1)
 
     @pytest.fixture(scope="module")
     def service_templates(self, request, appliance):
@@ -119,7 +119,7 @@ class TestTagsViaREST(object):
 
     @pytest.fixture(scope="module")
     def vm(self, request, provider, appliance):
-        return _vm(request, provider, appliance.rest_api)
+        return _vm(request, provider, appliance)
 
     @pytest.mark.tier(2)
     def test_edit_tags_rest(self, appliance, tags):

--- a/cfme/tests/configure/test_tag_category.py
+++ b/cfme/tests/configure/test_tag_category.py
@@ -40,7 +40,7 @@ def test_category_crud(appliance, soft_assert):
 class TestCategoriesViaREST(object):
     @pytest.fixture(scope="function")
     def categories(self, request, appliance):
-        response = _categories(request, appliance.rest_api, num=5)
+        response = _categories(request, appliance, num=5)
         assert_response(appliance)
         assert len(response) == 5
         return response

--- a/cfme/tests/control/test_rest_control.py
+++ b/cfme/tests/control/test_rest_control.py
@@ -6,6 +6,7 @@ import fauxfactory
 from cfme import test_requirements
 from cfme.rest.gen_data import conditions as _conditions
 from cfme.rest.gen_data import policies as _policies
+from cfme.utils.blockers import BZ
 from cfme.utils.rest import (
     assert_response,
     delete_resources_from_collection,
@@ -24,7 +25,7 @@ class TestConditionsRESTAPI(object):
     @pytest.fixture(scope='function')
     def conditions(self, request, appliance):
         num_conditions = 2
-        response = _conditions(request, appliance.rest_api, num=num_conditions)
+        response = _conditions(appliance, request, num=num_conditions)
         assert_response(appliance)
         assert len(response) == num_conditions
         return response
@@ -123,11 +124,12 @@ class TestConditionsRESTAPI(object):
             assert condition.description == edited[index].description == record[0].description
 
 
+@pytest.mark.meta(blockers=[BZ('1659899', forced_streams=["5.10"])])
 class TestPoliciesRESTAPI(object):
     @pytest.fixture(scope='function')
     def policies(self, request, appliance):
         num_policies = 2
-        response = _policies(request, appliance.rest_api, num=num_policies)
+        response = _policies(appliance, request, num=num_policies)
         assert_response(appliance)
         assert len(response) == num_policies
         return response

--- a/cfme/tests/control/test_rest_control.py
+++ b/cfme/tests/control/test_rest_control.py
@@ -124,7 +124,6 @@ class TestConditionsRESTAPI(object):
             assert condition.description == edited[index].description == record[0].description
 
 
-@pytest.mark.meta(blockers=[BZ('1659899', forced_streams=["5.10"])])
 class TestPoliciesRESTAPI(object):
     @pytest.fixture(scope='function')
     def policies(self, request, appliance):

--- a/cfme/tests/control/test_rest_control.py
+++ b/cfme/tests/control/test_rest_control.py
@@ -25,7 +25,7 @@ class TestConditionsRESTAPI(object):
     @pytest.fixture(scope='function')
     def conditions(self, request, appliance):
         num_conditions = 2
-        response = _conditions(appliance, request, num=num_conditions)
+        response = _conditions(request, appliance, num=num_conditions)
         assert_response(appliance)
         assert len(response) == num_conditions
         return response
@@ -129,7 +129,7 @@ class TestPoliciesRESTAPI(object):
     @pytest.fixture(scope='function')
     def policies(self, request, appliance):
         num_policies = 2
-        response = _policies(appliance, request, num=num_policies)
+        response = _policies(request, appliance, num=num_policies)
         assert_response(appliance)
         assert len(response) == num_policies
         return response

--- a/cfme/tests/infrastructure/test_rest_automation_request.py
+++ b/cfme/tests/infrastructure/test_rest_automation_request.py
@@ -21,7 +21,7 @@ pytestmark = [
 
 @pytest.fixture(scope='function')
 def vm(request, provider, appliance):
-    return _vm(request, provider, appliance.rest_api)
+    return _vm(request, provider, appliance)
 
 
 def wait_for_requests(requests):

--- a/cfme/tests/infrastructure/test_rest_templates.py
+++ b/cfme/tests/infrastructure/test_rest_templates.py
@@ -23,12 +23,12 @@ pytestmark = [
 
 @pytest.fixture(scope="function")
 def vm(request, provider, appliance):
-    return _vm(request, provider, appliance.rest_api)
+    return _vm(request, provider, appliance)
 
 
 @pytest.fixture(scope="function")
 def template(request, appliance, provider, vm):
-    template = mark_vm_as_template(appliance.rest_api, provider=provider, vm_name=vm)
+    template = mark_vm_as_template(appliance, provider=provider, vm_name=vm)
 
     @request.addfinalizer
     def _finished():

--- a/cfme/tests/infrastructure/test_vm_ownership.py
+++ b/cfme/tests/infrastructure/test_vm_ownership.py
@@ -22,7 +22,7 @@ pytestmark = [
 class TestVmOwnershipRESTAPI(object):
     @pytest.fixture(scope="function")
     def vm(self, request, provider, appliance):
-        return _vm(request, provider, appliance.rest_api)
+        return _vm(request, provider, appliance)
 
     @pytest.mark.tier(3)
     def test_vm_set_ownership(self, appliance, vm):

--- a/cfme/tests/infrastructure/test_vm_rest.py
+++ b/cfme/tests/infrastructure/test_vm_rest.py
@@ -24,7 +24,7 @@ pytestmark = [
 
 @pytest.fixture(scope='function')
 def vm(request, provider, appliance):
-    vm_name = _vm(request, provider, appliance.rest_api)
+    vm_name = _vm(request, provider, appliance)
     return appliance.rest_api.collections.vms.get(name=vm_name)
 
 

--- a/cfme/tests/infrastructure/test_vm_retirement_rest.py
+++ b/cfme/tests/infrastructure/test_vm_retirement_rest.py
@@ -19,7 +19,7 @@ pytestmark = [
 
 @pytest.fixture(scope="function")
 def vm(request, provider, appliance):
-    return _vm(request, provider, appliance.rest_api)
+    return _vm(request, provider, appliance)
 
 
 @pytest.mark.tier(3)

--- a/cfme/tests/intelligence/test_chargeback.py
+++ b/cfme/tests/intelligence/test_chargeback.py
@@ -142,7 +142,7 @@ def test_chargeback_rate(rate_resource, rate_type, rate_action, request):
 class TestRatesViaREST(object):
     @pytest.fixture(scope="function")
     def rates(self, request, appliance):
-        response = _rates(request, appliance.rest_api)
+        response = _rates(request, appliance)
         assert_response(appliance)
         return response
 

--- a/cfme/tests/services/test_generic_service_catalogs.py
+++ b/cfme/tests/services/test_generic_service_catalogs.py
@@ -170,7 +170,7 @@ def test_delete_dialog_before_parent_item(appliance, catalog_item):
 class TestServiceCatalogViaREST(object):
     @pytest.fixture(scope="function")
     def service_catalogs(self, request, appliance):
-        return _service_catalogs(request, appliance.rest_api)
+        return _service_catalogs(request, appliance)
 
     @pytest.mark.parametrize("method", ["post", "delete"], ids=["POST", "DELETE"])
     def test_delete_service_catalog(self, service_catalogs, method):

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -100,13 +100,13 @@ def dialog(request, appliance):
 
 @pytest.fixture(scope="function")
 def service_dialogs(request, appliance, num=3):
-    service_dialogs = [_dialog_rest(request, appliance.rest_api) for __ in range(num)]
+    service_dialogs = [_dialog_rest(request, appliance) for __ in range(num)]
     return service_dialogs
 
 
 @pytest.fixture(scope="function")
 def service_catalogs(request, appliance):
-    response = _service_catalogs(request, appliance.rest_api)
+    response = _service_catalogs(request, appliance)
     assert_response(appliance)
     return response
 
@@ -179,7 +179,7 @@ def vm_service(request, appliance, provider):
 
 @pytest.fixture(scope="function")
 def vm(request, provider, appliance):
-    return _vm(request, provider, appliance.rest_api)
+    return _vm(request, provider, appliance)
 
 
 @pytest.fixture(scope="function")
@@ -734,7 +734,7 @@ class TestServiceDialogsRESTAPI(object):
             assignee: sshveta
             initialEstimate: 1/4h
         """
-        _dialog_rest(request, appliance.rest_api)
+        _dialog_rest(request, appliance)
         assert_response(appliance)
         self.check_returned_dialog(appliance)
 
@@ -1389,7 +1389,7 @@ class TestPendingRequestsRESTAPI(object):
 class TestServiceRequests(object):
     @pytest.fixture(scope='class')
     def new_role(self, appliance):
-        role = copy_role(appliance.rest_api, 'EvmRole-user_self_service')
+        role = copy_role(appliance, 'EvmRole-user_self_service')
         # allow role to access all Services, VMs, and Templates
         role.action.edit(settings=None)
         yield role
@@ -1398,7 +1398,7 @@ class TestServiceRequests(object):
     @pytest.fixture(scope='class')
     def new_group(self, request, appliance, new_role):
         tenant = appliance.rest_api.collections.tenants.get(name='My Company')
-        return groups(request, appliance.rest_api, new_role, tenant, num=1)
+        return groups(request, appliance, new_role, tenant, num=1)
 
     @pytest.fixture(scope='class')
     def user_auth(self, request, appliance, new_group):
@@ -1410,7 +1410,7 @@ class TestServiceRequests(object):
             "group": {"id": new_group.id}
         }]
 
-        user = _creating_skeleton(request, appliance.rest_api, 'users', data)
+        user = _creating_skeleton(request, appliance, 'users', data)
         user = user[0]
         return user.userid, password
 
@@ -1469,7 +1469,7 @@ class TestBlueprintsRESTAPI(object):
     @pytest.fixture(scope="function")
     def blueprints(self, request, appliance):
         num = 2
-        response = _blueprints(request, appliance.rest_api, num=num)
+        response = _blueprints(request, appliance, num=num)
         assert_response(appliance)
         assert len(response) == num
         return response
@@ -1577,7 +1577,7 @@ class TestOrchestrationTemplatesRESTAPI(object):
     @pytest.fixture(scope='function')
     def orchestration_templates(self, request, appliance):
         num = 2
-        response = _orchestration_templates(request, appliance.rest_api, num=num)
+        response = _orchestration_templates(request, appliance, num=num)
         assert_response(appliance)
         assert len(response) == num
         return response

--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -38,7 +38,7 @@ def api_version(appliance):
 
 @pytest.fixture(scope="function")
 def vm_obj(request, provider, appliance):
-    return _vm(request, provider, appliance.rest_api)
+    return _vm(request, provider, appliance)
 
 
 def wait_for_requests(requests):
@@ -926,7 +926,7 @@ class TestArbitrationSettingsRESTAPI(object):
     @pytest.fixture(scope='function')
     def arbitration_settings(self, request, appliance):
         num_settings = 2
-        response = _arbitration_settings(request, appliance.rest_api, num=num_settings)
+        response = _arbitration_settings(request, appliance, num=num_settings)
         assert_response(appliance)
         assert len(response) == num_settings
         return response
@@ -1021,7 +1021,7 @@ class TestArbitrationRulesRESTAPI(object):
     @pytest.fixture(scope='function')
     def arbitration_rules(self, request, appliance):
         num_rules = 2
-        response = _arbitration_rules(request, appliance.rest_api, num=num_rules)
+        response = _arbitration_rules(request, appliance, num=num_rules)
         assert_response(appliance)
         assert len(response) == num_rules
         return response


### PR DESCRIPTION
This PR brings the following changes:
1. Fix failing `TestConditionsRESTAPI`. `modifier` attribute is no longer supported in 5.10, so make changes related to that.
2. Fix failing `TestPoliciesRESTAPI` test.
3. Replace all `rest_api` arguments of functions with `appliance` and make corresponding changes to tests.
4. Fix `ScopeMismatchError` in test_tag.py.
 
{{ pytest: cfme/tests -k "test_user_item_order or test_edit_service or test_query_orchestration_templates_attributes or test_cloud_networks_query or test_query_tenant_attributes or test_query_role_attributes or test_query_group_attributes or test_query_user_attributes or test_assign_and_unassign_tag or test_query_condition_attributes or test_query_policy_attributes or test_query_request_attributes or test_create_categories or test_set_ownership or test_vm_set_ownership or test_query_vm_attributes or test_retire_vm_now or test_create_rates or test_delete_service_catalog or test_query_event_attributes" --use-template-cache --long-running -sqvvvv
 }}

