### PR TITLE
[1LP][RFR] Ensure Nuage AE Class contains auth attributes in AE Schema

### DIFF
--- a/cfme/automate/explorer/__init__.py
+++ b/cfme/automate/explorer/__init__.py
@@ -8,7 +8,7 @@ from cfme.base import Server
 from cfme.base.login import BaseLoggedInPage
 from cfme.base.ui import automate_menu_name
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep
-from widgetastic_manageiq import Accordion, ManageIQTree
+from widgetastic_manageiq import Accordion, ManageIQTree, Splitter
 
 
 class AutomateExplorerView(BaseLoggedInPage):
@@ -26,6 +26,7 @@ class AutomateExplorerView(BaseLoggedInPage):
     @View.nested
     class datastore(Accordion):  # noqa
         tree = ManageIQTree()
+        splitter = Splitter()
 
     configuration = Dropdown('Configuration')
 

--- a/cfme/automate/explorer/klass.py
+++ b/cfme/automate/explorer/klass.py
@@ -329,7 +329,15 @@ class Details(CFMENavigateStep):
     prerequisite = NavigateToAttribute('appliance.server', 'AutomateExplorer')
 
     def step(self):
+        # Because click is performed on the middle of the element and at the middle there is a
+        # chevron button for expanding tree (if there are instances inside class), this navigation
+        # then fails to navigate to details. We make use of the splitter to make explorer
+        # larger, so chevron button is not exactly at the middle
+        self.prerequisite_view.datastore.splitter.pull_right()
         self.prerequisite_view.datastore.tree.click_path(*self.obj.tree_path)
+
+    def resetter(self, *args, **kwargs):
+        self.prerequisite_view.datastore.splitter.reset()
 
 
 @navigator.register(Class)

--- a/cfme/tests/networks/nuage/test_automation.py
+++ b/cfme/tests/networks/nuage/test_automation.py
@@ -1,0 +1,14 @@
+def test_auth_attributes_of_nuage_ae_class(appliance):
+    """
+        Ensure Nuage AE Class contains auth attributes in AE Schema
+    """
+    expected_fields = ['nuage_password', 'nuage_username', 'nuage_enterprise', 'nuage_url',
+                       'nuage_api_version']
+    manageiq_domain = appliance.collections.domains.instantiate(name='ManageIQ')
+    system_namespace = manageiq_domain.namespaces.instantiate(name='System')
+    event_namespace = system_namespace.namespaces.instantiate(name='Event')
+    ems_event_namespace = event_namespace.namespaces.instantiate(name='EmsEvent')
+    nuage_class = ems_event_namespace.classes.instantiate(name='Nuage')
+    schema_fields = nuage_class.schema.schema_field_names
+
+    assert all(expected in schema_fields for expected in expected_fields)


### PR DESCRIPTION
With this commit we are testing nuage automation, more specifically we are testing if variables exist in Nuage class, which is navigated through automate explorer tree (ManageIQ/System/Event/EmsEvent/Nuage).

\cc @miha-plesko 

There was an issue because clicking happens at the middle of an element, and at the middle of an element there was a chevron for expanding tree. This chevron only expanded the tree not actually clicking on it. We made use of the buttons showed on the image to make the explorer larger so chevron is not exactly at the middle of the element.
![automate_explorer](https://user-images.githubusercontent.com/1367334/50147252-f1c3fc00-02b5-11e9-98e9-ccf138c15a15.png)

