### PR TITLE
[RFR] Re-enable server roles for chargeback report validation tests

### DIFF
--- a/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
+++ b/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
@@ -300,15 +300,12 @@ def resource_usage(vm_ownership, appliance, provider):
     # Convert storage used in bytes to GB
     average_storage_used = average_storage_used * math.pow(2, -30)
 
-    return {"average_cpu_used_in_mhz": average_cpu_used_in_mhz,
+    yield {"average_cpu_used_in_mhz": average_cpu_used_in_mhz,
             "average_memory_used_in_mb": average_memory_used_in_mb,
             "average_network_io": average_network_io,
             "average_disk_io": average_disk_io,
             "average_storage_used": average_storage_used,
             "consumed_hours": consumed_hours}
-
-    yield
-
     appliance.server.settings.enable_server_roles(
         'ems_metrics_coordinator', 'ems_metrics_collector')
 

--- a/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
+++ b/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
@@ -307,6 +307,11 @@ def resource_usage(vm_ownership, appliance, provider):
             "average_storage_used": average_storage_used,
             "consumed_hours": consumed_hours}
 
+    yield
+
+    appliance.server.settings.enable_server_roles(
+        'ems_metrics_coordinator', 'ems_metrics_collector')
+
 
 def resource_cost(appliance, provider, metric_description, usage, description, rate_type,
         consumed_hours):


### PR DESCRIPTION
The code changes through this PR re-enable server roles which were disabled as part of the test setup.

{{ pytest: cfme/tests/intelligence/reports/test_validate_chargeback_report.py --use-provider complete --long-running }}