### PR TITLE
[RFR] Fix orchestration template flash assertion error

### DIFF
--- a/cfme/services/catalogs/orchestration_template.py
+++ b/cfme/services/catalogs/orchestration_template.py
@@ -177,7 +177,8 @@ class OrchestrationTemplate(BaseEntity, Updateable, Pretty, Taggable):
                    'description': description
                    })
         view.add_button.click()
-        view.wait_displayed('15s')
+        view.wait_displayed()
+        assert view.is_displayed
         view.flash.assert_no_error()
         # TODO - Move assertions to tests
         return self.parent.instantiate(template_group=self.template_group,


### PR DESCRIPTION
{{pytest: cfme/tests/services/test_orchestration_template.py -k 'test_duplicated_content_error_validation' -vvv}}