### PR TITLE
[1LP][RFR] Update ViewSelector widgets and selected checks against title

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -222,8 +222,7 @@ class BaseVM(BaseEntity, Pretty, Updateable, PolicyProfileAssignable, Taggable, 
         else:
             view = navigate_to(self, 'AllForProvider', use_resetter=False)
 
-        if 'Grid View' != view.toolbar.view_selector.selected:
-            view.toolbar.view_selector.select('Grid View')
+        view.toolbar.view_selector.select('Grid View')
         try:
             return view.entities.get_entity(name=self.name, surf_pages=True, use_search=use_search)
         except ItemNotFound:

--- a/cfme/infrastructure/datastore.py
+++ b/cfme/infrastructure/datastore.py
@@ -411,9 +411,7 @@ class All(CFMENavigateStep):
         """
         # Reset view and selection
         self.view.sidebar.datastores.tree.click_path('All Datastores')
-        tb = self.view.toolbar
-        if tb.view_selector.is_displayed and 'Grid View' not in tb.view_selector.selected:
-            tb.view_selector.select("Grid View")
+        self.view.toolbar.view_selector.select("Grid View")
         self.view.entities.paginator.reset_selection()
 
 

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -285,9 +285,7 @@ class All(CFMENavigateStep):
     def resetter(self):
         # Reset view and selection
         self.appliance.browser.widgetastic.browser.refresh()
-        tb = self.view.toolbar
-        if 'Grid View' not in tb.view_selector.selected:
-            tb.view_selector.select('Grid View')
+        self.view.toolbar.view_selector.select('Grid View')
         self.view.entities.paginator.reset_selection()
 
 

--- a/cfme/physical/provider/__init__.py
+++ b/cfme/physical/provider/__init__.py
@@ -137,9 +137,7 @@ class Details(CFMENavigateStep):
 
     def resetter(self):
         """Reset view and selection"""
-        view_selector = self.view.toolbar.view_selector
-        if view_selector.selected != 'Summary View':
-            view_selector.select('Summary View')
+        self.view.toolbar.view_selector.select('Summary View')
 
 
 @navigator.register(PhysicalProvider, 'Edit')


### PR DESCRIPTION
Move the title check that's done in-code to the widget, collapse common view selector widget operations into single class.

{{ pytest: cfme/tests/cloud_infra_common/test_relationships.py --long-running --use-provider default -k test_host_relationships }}