### PR TITLE
[WIPTEST] Fixed template not found error of EC2 provider

### DIFF
--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -335,10 +335,9 @@ class ProvisionView(BaseLoggedInPage):
 
         def _select_template(self, template_name, provider_name):
             try:
-                self.parent.paginator.find_row_on_pages(self.parent.image_table,
-                                                        name=template_name,
-                                                        provider=provider_name).click()
-            # image was not found, therefore raise an exception
+                self.parent.paginator.set_items_per_page(1000)
+                row = self.parent.image_table.row(name=template_name, provider=provider_name)
+                row.click()
             except IndexError:
                 raise TemplateNotFound('Cannot find template "{}" for provider "{}"'
                                        .format(template_name, provider_name))


### PR DESCRIPTION
This PR fixes:
```
>                                  .format(template_name, provider_name))
E           TemplateNotFound: Cannot find template "rhel-63-with-shutdown" for provider "ec2-west"

cfme/common/vm_views.py:341: TemplateNotFound
TemplateNotFound
Cannot find template "rhel-63-with-shutdown" for provider "ec2-west"
```

{{ pytest: cfme/tests/cloud_infra_common/test_provisioning.py -k 'test_provision_approval' --use-provider=ec2west -v }}