### PR TITLE
[WIPTEST] Fixed is_displayed issue of edit dashboard view

### DIFF
--- a/cfme/intelligence/reports/dashboards.py
+++ b/cfme/intelligence/reports/dashboards.py
@@ -85,7 +85,7 @@ class EditDefaultDashboardView(EditDashboardView):
     def is_displayed(self):
         return (
             self.in_intel_reports and
-            self.title.text == "Editing Dashboard {}".format(self.context["object"].name) and
+            self.title.text == 'Editing Dashboard "{}"'.format(self.context["object"].name) and
             self.dashboards.is_opened and
             self.dashboards.tree.currently_selected == [
                 "All Dashboards",


### PR DESCRIPTION
This PR fixes:
```
>       assert view.is_displayed
E       AssertionError

cfme/intelligence/reports/widgets/__init__.py:126: AssertionError
AssertionError
```

{{ pytest: cfme/tests/intelligence/reports/test_widgets.py -k 'test_widgets_on_dashboard' -v }}