### PR TITLE
[1LP][RFR] ipv6 handing in sprout

### DIFF
--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -35,7 +35,7 @@ from cfme.utils.blockers import BZ
 from cfme.utils.conf import hidden
 from cfme.utils.datafile import load_data_file
 from cfme.utils.log import logger, create_sublogger, logger_wrap
-from cfme.utils.net import net_check
+from cfme.utils.net import net_check, resolve_hostname
 from cfme.utils.path import data_path, patches_path, scripts_path, conf_path
 from cfme.utils.ssh import SSHTail
 from cfme.utils.version import Version, get_stream, VersionPicker
@@ -2637,7 +2637,8 @@ class Appliance(IPAppliance):
                     else:
                         vm = provider.mgmt.get_vm(vm_name)
                         ip = vm.ip
-                    return ip or False  # get_ip_address might return None
+                    # get_ip_address might return None
+                    return ip if ip and resolve_hostname(ip) else False
                 except (AttributeError, VMInstanceNotFound):
                     return False
             ec, tc = wait_for(is_ip_available,

--- a/cfme/utils/net.py
+++ b/cfme/utils/net.py
@@ -152,3 +152,39 @@ def is_pingable(ip_addr):
     except Exception as e:
         logger.exception(e)
         return False
+
+
+def is_ipv4(ip_addr):
+    """verifies whether address is ipv4.
+
+    Args:
+        ip_addr: ip_address to verify.
+    returns: return True if ip_address is ipv4 else returns False.
+    """
+    try:
+        socket.inet_pton(socket.AF_INET, ip_addr)
+    except AttributeError:
+        try:
+            socket.inet_aton(ip_addr)
+        except socket.error:
+            return False
+        return ip_addr.count('.') == 3
+    except socket.error:
+        return False
+
+    return True
+
+
+def is_ipv6(ip_addr):
+    """verifies whether address is ipv6.
+
+    Args:
+        ip_addr: ip_address to verify.
+    returns: return True if ip_address is ipv6 else returns False.
+    """
+    try:
+        socket.inet_pton(socket.AF_INET6, ip_addr)
+    except socket.error:
+        return False
+
+    return True

--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -320,8 +320,7 @@ Werkzeug==0.14.1
 widgetastic.core==0.30.3
 widgetastic.patternfly==0.0.40
 widgetsnbextension==3.4.2
-#wrapanapi==3.0.34
-git+git://github.com/izapolsk/wrapanapi.git@sprout_methods#wrapanapi
+wrapanapi==3.0.36
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0

--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -320,7 +320,8 @@ Werkzeug==0.14.1
 widgetastic.core==0.30.3
 widgetastic.patternfly==0.0.40
 widgetsnbextension==3.4.2
-wrapanapi==3.0.34
+#wrapanapi==3.0.34
+git+git://github.com/izapolsk/wrapanapi.git@sprout_methods#wrapanapi
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -307,7 +307,8 @@ Werkzeug==0.14.1
 widgetastic.core==0.30.3
 widgetastic.patternfly==0.0.40
 widgetsnbextension==3.4.2
-wrapanapi==3.0.34
+#wrapanapi==3.0.34
+git+git://github.com/izapolsk/wrapanapi.git@sprout_methods#wrapanapi
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -307,8 +307,7 @@ Werkzeug==0.14.1
 widgetastic.core==0.30.3
 widgetastic.patternfly==0.0.40
 widgetsnbextension==3.4.2
-#wrapanapi==3.0.34
-git+git://github.com/izapolsk/wrapanapi.git@sprout_methods#wrapanapi
+wrapanapi==3.0.36
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0

--- a/sprout/appliances/tasks.py
+++ b/sprout/appliances/tasks.py
@@ -1406,12 +1406,15 @@ def refresh_appliances_provider(self, provider_id):
 
     for vm in vms:
         if provider.provider_type == 'openshift':
+            if not provider.api.is_appliance(vm):
+                # there are some service projects in openshift which we need to skip here
+                continue
             try:
-                ocp_vm = FakeVm(ip=None, name=None, uuid=None, state=None)
-                ocp_vm.name = vm
-                ocp_vm.state = provider.api.vm_status(vm)
-                ocp_vm.ip = provider.api.get_appliance_url(vm)
-                vm = ocp_vm
+                vm_data = dict(ip=provider.api.get_appliance_url(vm),
+                               name=vm,
+                               uuid=provider.api.get_appliance_uuid(vm),
+                               state=provider.api.vm_status(vm))
+                vm = FakeVm(**vm_data)
             except Exception as e:
                 self.logger.error("Couldn't refresh vm {} because of {}".format(vm, e.message))
                 continue


### PR DESCRIPTION
REQUIRES: https://github.com/ManageIQ/wrapanapi/pull/350

with updating wrapanapi to 3.0, rhev ip started returning ipv6 until ipv4 was available. This ip isn't accessaible and isn't parsed well in appliance atm.
So, we need to wait for ipv4 and return appliance only then.