### PR TITLE
[1LP][RFR] Refactor cleanup_old_vms

### DIFF
--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -298,7 +298,7 @@ SQLAlchemy==1.2.12
 stevedore==1.30.0
 subprocess32==3.5.3
 suds==0.4
-tabulate==0.7.7
+tabulate==0.8.2
 taretto==0.5.5
 terminado==0.8.1
 testpath==0.4.2

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -287,7 +287,7 @@ sphinx-rtd-theme==0.4.2
 SQLAlchemy==1.2.12
 stevedore==1.30.0
 suds-jurko==0.6
-tabulate==0.7.7
+tabulate==0.8.2
 taretto==0.5.5
 terminado==0.8.1
 testpath==0.4.2

--- a/requirements/frozen_docs.py2.txt
+++ b/requirements/frozen_docs.py2.txt
@@ -157,7 +157,7 @@ Sphinx==1.3.5
 sphinx-rtd-theme==0.4.2
 SQLAlchemy==1.2.12
 stevedore==1.30.0
-tabulate==0.7.7
+tabulate==0.8.2
 taretto==0.5.5
 terminado==0.8.1
 testpath==0.4.2

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -148,7 +148,7 @@ Sphinx==1.3.5
 sphinx-rtd-theme==0.4.2
 SQLAlchemy==1.2.12
 stevedore==1.30.0
-tabulate==0.7.7
+tabulate==0.8.2
 taretto==0.5.5
 terminado==0.8.1
 testpath==0.4.2


### PR DESCRIPTION
Rework the multiprocess structure in cleanup_old_vms to layer the process/thread use across providers, and to avoid two things:

1. failing to delete vms because of duplicate names
2. skipping deletion of vms with unknown creation dates

I've also removed the prompt, instead opting for a 'dry-run' kind of approach, leaving this as the default via keeping the --force arg.

Unfortunately `Pool.starmap`, is only python 3.