### PR TITLE
[RFR] Fixed is_displayed for ActionDetailsView

### DIFF
--- a/cfme/control/explorer/actions.py
+++ b/cfme/control/explorer/actions.py
@@ -177,6 +177,7 @@ class Action(BaseEntity, Updateable, Pretty):
         else:
             view.cancel_button.click()
         view = self.create_view(ActionDetailsView, override=updates)
+        view.wait_displayed('15s')
         assert view.is_displayed
         view.flash.assert_no_error()
         if changed:

--- a/cfme/control/explorer/actions.py
+++ b/cfme/control/explorer/actions.py
@@ -178,7 +178,6 @@ class Action(BaseEntity, Updateable, Pretty):
             view.cancel_button.click()
         view = self.create_view(ActionDetailsView, override=updates)
         view.wait_displayed('15s')
-        assert view.is_displayed
         view.flash.assert_no_error()
         if changed:
             view.flash.assert_message(


### PR DESCRIPTION
Fixed error:
```
>       assert view.is_displayed
E       AssertionError

cfme/control/explorer/actions.py:180: AssertionError
AssertionError
```

{{ pytest: cfme/tests/control/test_basic.py -k 'test_action_crud' --long-running }}