### PR TITLE
[RFR] Fixed is_displayed for PolicyProfileDetailsView

### DIFF
--- a/cfme/control/explorer/policy_profiles.py
+++ b/cfme/control/explorer/policy_profiles.py
@@ -96,7 +96,7 @@ class PolicyProfile(BaseEntity, Updateable, Pretty):
         else:
             view.cancel_button.click()
         view = self.create_view(PolicyProfileDetailsView, override=updates)
-        assert view.is_displayed
+        view.wait_displayed()
         view.flash.assert_no_error()
         if changed:
             view.flash.assert_message(


### PR DESCRIPTION
Fixed error:
```
>       assert view.is_displayed
E       AssertionError

cfme/control/explorer/policy_profiles.py:99: AssertionError
AssertionError
```

{{ pytest: cfme/tests/control/test_basic.py -k 'test_policy_profile_crud' --long-running }}
