### PR TITLE
[RFR] resetter method not able to access prerequisite view

### DIFF
--- a/cfme/automate/explorer/klass.py
+++ b/cfme/automate/explorer/klass.py
@@ -337,7 +337,7 @@ class Details(CFMENavigateStep):
         self.prerequisite_view.datastore.tree.click_path(*self.obj.tree_path)
 
     def resetter(self, *args, **kwargs):
-        self.prerequisite_view.datastore.splitter.reset()
+        self.view.datastore.splitter.reset()
 
 
 @navigator.register(Class)


### PR DESCRIPTION
Purpose or Intent
=================
Total 23 failures due to this issue. 
```
E           AssertionError: Pattern 'Name has already been taken' not found in ''Details' object has no attribute 'prerequisite_view''
```

{{pytest: cfme/tests/automate/test_class.py -sqvv}}