### PR TITLE
[1LP][RFR]Adding a new dialog element entry point mandatory test

### DIFF
--- a/cfme/tests/automate/test_service_dialog.py
+++ b/cfme/tests/automate/test_service_dialog.py
@@ -307,3 +307,37 @@ def test_radiobutton_dialog_element(appliance, request):
     }
     dialog, element = create_dialog(appliance, element_data)
     request.addfinalizer(dialog.delete_if_exists)
+
+
+@pytest.mark.ignore_stream('5.9')
+def test_mandatory_entry_point_with_dynamic_element(appliance):
+    """Tests Entry point should be mandatory if element is dynamic
+
+    Testing BZ 1488579
+
+    Polarion:
+        assignee: nansari
+        casecomponent: services
+        caseimportance: high
+        initialEstimate: 1/8h
+    """
+    element_1_data = {
+        'element_information': {
+            'ele_label': "ele_label_{}".format(fauxfactory.gen_alphanumeric()),
+            'ele_name': fauxfactory.gen_alphanumeric(),
+            'ele_desc': fauxfactory.gen_alphanumeric(),
+            'dynamic_chkbox': True,
+            'choose_type': "Text Box",
+        }
+    }
+    service_dialog = appliance.collections.service_dialogs
+    sd = service_dialog.create(label='label_{}'.format(fauxfactory.gen_alphanumeric(),
+                               description="my dialog"))
+    tab = sd.tabs.create(tab_label='tab_{}'.format(fauxfactory.gen_alphanumeric(),
+                         tab_desc="my tab desc"))
+    box = tab.boxes.create(box_label='box_{}'.format(fauxfactory.gen_alphanumeric(),
+                           box_desc="my box desc"))
+    box.elements.create(element_data=[element_1_data])
+    view_cls = navigator.get_class(sd.parent, 'Add').VIEW
+    view = appliance.browser.create_view(view_cls)
+    assert view.save.disabled


### PR DESCRIPTION
{{ pytest: cfme/tests/automate/test_service_dialog.py::test_mandatory_entry_point_with_dynamic_element -v }}