### PR TITLE
[RFR] Test Embedded Ansible integration for Nuage

### DIFF
--- a/cfme/automate/explorer/method.py
+++ b/cfme/automate/explorer/method.py
@@ -243,6 +243,7 @@ class MethodAddView(AutomateExplorerView):
     machine_credential = PlaybookBootstrapSelect('provisioning_machine_credential_id')
     hosts = Input('provisioning_inventory')
     max_ttl = Input('provisioning_execution_ttl')
+    logging_output = PlaybookBootstrapSelect('provisioning_log_output')
     escalate_privilege = BootstrapSwitch('provisioning_become_enabled')
     verbosity = PlaybookBootstrapSelect('provisioning_verbosity')
     playbook_input_parameters = PlaybookInputParameters()
@@ -280,6 +281,7 @@ class MethodEditView(AutomateExplorerView):
     machine_credential = PlaybookBootstrapSelect('provisioning_machine_credential_id')
     hosts = Input('provisioning_inventory')
     max_ttl = Input('provisioning_execution_ttl')
+    logging_output = PlaybookBootstrapSelect('provisioning_log_output')
     escalate_privilege = BootstrapSwitch('provisioning_become_enabled')
     verbosity = PlaybookBootstrapSelect('provisioning_verbosity')
     playbook_input_parameters = PlaybookInputParameters()
@@ -312,7 +314,7 @@ class Method(BaseEntity, Copiable):
 
     def __init__(self, collection, name=None, display_name=None, location='inline', script=None,
                  data=None, repository=None, playbook=None, machine_credential=None, hosts=None,
-                 max_ttl=None, escalate_privilege=None, verbosity=None,
+                 max_ttl=None, logging_output=None, escalate_privilege=None, verbosity=None,
                  playbook_input_parameters=None, cancel=False, validate=True, inputs=None):
         super(Method, self).__init__(collection)
 
@@ -327,6 +329,7 @@ class Method(BaseEntity, Copiable):
         self.machine_credential = machine_credential
         self.hosts = hosts
         self.max_ttl = max_ttl
+        self.logging_output = logging_output
         self.escalate_privilege = escalate_privilege
         self.verbosity = verbosity
         self.playbook_input_parameters = playbook_input_parameters
@@ -433,7 +436,7 @@ class MethodCollection(BaseCollection):
     def create(
             self, name=None, display_name=None, location='inline', script=None, data=None,
             cancel=False, validate=True, repository=None, playbook=None, machine_credential=None,
-            hosts=None, max_ttl=None, escalate_privilege=None, verbosity=None,
+            hosts=None, max_ttl=None, logging_output=None, escalate_privilege=None, verbosity=None,
             playbook_input_parameters=None, inputs=None):
         add_page = navigate_to(self, 'Add')
         add_page.fill({'location': location})
@@ -458,6 +461,7 @@ class MethodCollection(BaseCollection):
                 'machine_credential': machine_credential,
                 'hosts': hosts,
                 'max_ttl': max_ttl,
+                'logging_output': logging_output,
                 'escalate_privilege': escalate_privilege,
                 'verbosity': verbosity,
                 'playbook_input_parameters': playbook_input_parameters
@@ -488,6 +492,7 @@ class MethodCollection(BaseCollection):
                 machine_credential=machine_credential,
                 hosts=hosts,
                 max_ttl=max_ttl,
+                logging_output=logging_output,
                 escalate_privilege=escalate_privilege,
                 verbosity=verbosity,
                 playbook_input_parameters=playbook_input_parameters,

--- a/cfme/fixtures/ansible_fixtures.py
+++ b/cfme/fixtures/ansible_fixtures.py
@@ -18,12 +18,23 @@ def wait_for_ansible(appliance):
 
 
 @pytest.fixture(scope="module")
-def ansible_repository(appliance, wait_for_ansible):
+def ansible_repository(request, appliance, wait_for_ansible):
+    """
+    By default cfme_data.ansible_links.playbook_repositories.embedded_ansible is set for the url,
+    but you can specify it explicitly with @pytest.mark.parametrize decorator on your test function.
+
+    Example:
+    @pytest.mark.parametrize('ansible_repository', ['nuage'], indirect=True)
+    def test_function(ansible_repository):
+        ...
+    """
     repositories = appliance.collections.ansible_repositories
+    playbooks = cfme_data.ansible_links.playbook_repositories
     try:
+        playbook = getattr(request, 'param', 'embedded_ansible')
         repository = repositories.create(
             name=fauxfactory.gen_alpha(),
-            url=cfme_data.ansible_links.playbook_repositories.embedded_ansible,
+            url=getattr(playbooks, playbook),
             description=fauxfactory.gen_alpha())
     except KeyError:
         pytest.skip("Skipping since no such key found in yaml")

--- a/cfme/fixtures/embedded_ansible.py
+++ b/cfme/fixtures/embedded_ansible.py
@@ -1,0 +1,101 @@
+import pytest
+from wrapanapi.utils.random import random_name
+
+
+def instantiate_namespace(domain_name, namespace_levels):
+    namespace = domain_name
+    for namespace_name in namespace_levels:
+        namespace = namespace.namespaces.instantiate(namespace_name)
+    return namespace
+
+
+def copy_ae_instance(appliance, instance_fqdn, domain_name):
+    """
+    Copy AE Instance into a domain. We split 'instance_fqdn' which is a full string path to existing
+    AE instance. Then based on the values we get from split, proper classes are instantiated.
+    AE Instance is copied to provided domain name, then instantiated and returned under new domain.
+    Example:
+    if 'instance_fqdn' is 'ManageIQ/System/Event/EmsEvent/Nuage/nuage_enterprise_create' we get the
+    following values:
+    source = ['ManageIQ', 'System', 'Event', 'EmsEvent', 'Nuage', 'nuage_enterprise_create']
+    'ManageIQ' as source_domain
+    'nuage_enterprise_create' as source AE instance
+    'Nuage' as source AE class
+    the remaining strings left after 'pop' calls are the AE namespaces which are instantiated
+    through 'instantiate_namespace' function
+    AE instance is then copied to a new domain. We also instantiate all the destination classes so
+    we get proper parent-child structure.
+
+    Args:
+        appliance (Appliance): Instance of :class:`Appliance`
+        instance_fqdn (string): Full path to the existing AE Instance that we want to copy e.g.
+                                   'ManageIQ/System/Event/EmsEvent/Nuage/nuage_enterprise_create'
+        domain_name (string): name of existing AE Domain where we want to copy to e.g. 'TestDomain'
+
+    Returns:
+        Instance: The new AE Instance object under new domain
+    """
+    source = instance_fqdn.split('/')
+    source_domain_name = source.pop(0)
+    source_instance_name = source.pop(-1)
+    source_class_name = source.pop(-1)
+    source_domain = appliance.collections.domains.instantiate(source_domain_name)
+
+    source_namespace = instantiate_namespace(source_domain, source)
+    source_class = source_namespace.classes.instantiate(source_class_name)
+    source_instance = source_class.instances.instantiate(source_instance_name)
+
+    source_instance.copy_to(domain_name)
+
+    destination_domain = appliance.collections.domains.instantiate(domain_name)
+    destination_namespace = instantiate_namespace(destination_domain, source)
+    destination_class = destination_namespace.classes.instantiate(source_class_name)
+    # Instantiate instance under new domain
+    return destination_class.instances.instantiate(source_instance_name)
+
+
+@pytest.fixture
+def custom_ae_domain(request, appliance):
+    """
+    Create a new AE Domain.
+
+    By default, a random name is generated for the Domain, but you can specify it explicitly with
+    @pytest.mark.parametrize decorator on your test function.
+
+    Example:
+    @pytest.mark.parametrize('domain', ['TestDomain'], indirect=True)
+    def test_my_automation(domain):
+      ...
+    """
+    domains_collection = appliance.collections.domains
+    domain = domains_collection.create(
+        name=getattr(request, 'param', random_name()),
+        enabled=True)
+    yield domain
+    domain.delete()
+
+
+@pytest.fixture
+def copy_ae_instance_to_new_domain(request, appliance, custom_ae_domain):
+    """
+    Copy AE Instance to a newly created AE Domain.
+
+    This fixture requires at least Instance fqdn parameter, while newly created domain name
+    can also be customized:
+
+    @pytest.mark.parametrize(
+      'copy_ae_instance_to_new_domain',
+      ['ManageIQ/System/Event/EmsEvent/Nuage/nuage_enterprise_create'],
+      indirect=True
+    )
+    @pytest.mark.parametrize(
+      'custom_ae_domain',
+      ['CustomDomainName'],
+      indirect=True
+    )
+    def test_my_automation(copy_ae_instance_to_domain):
+      ...
+
+    :return: newly created AE Instance
+    """
+    return copy_ae_instance(appliance, request.param, custom_ae_domain.name)

--- a/cfme/test_framework/pytest_plugin.py
+++ b/cfme/test_framework/pytest_plugin.py
@@ -53,6 +53,7 @@ pytest_plugins = (
     'cfme.fixtures.prov_filter',
 
     'cfme.fixtures.appliance',
+    'cfme.fixtures.embedded_ansible',
     'cfme.fixtures.single_appliance_sprout',
     'cfme.fixtures.dev_branch',
     'cfme.fixtures.events',

--- a/cfme/tests/networks/nuage/test_automation.py
+++ b/cfme/tests/networks/nuage/test_automation.py
@@ -1,3 +1,12 @@
+import pytest
+from _pytest.outcomes import Failed
+from wrapanapi.utils.random import random_name
+
+from cfme.utils.log_validator import LogValidator
+from cfme.utils.update import update
+from cfme.utils.wait import wait_for
+
+
 def test_auth_attributes_of_nuage_ae_class(appliance):
     """
         Ensure Nuage AE Class contains auth attributes in AE Schema
@@ -12,3 +21,71 @@ def test_auth_attributes_of_nuage_ae_class(appliance):
     schema_fields = nuage_class.schema.schema_field_names
 
     assert all(expected in schema_fields for expected in expected_fields)
+
+
+@pytest.mark.parametrize(
+    'copy_ae_instance_to_new_domain',
+    ['ManageIQ/System/Event/EmsEvent/Nuage/nuage_enterprise_create'],
+    indirect=True)
+@pytest.mark.parametrize('ansible_repository', ['nuage'], indirect=True)
+def test_embedded_ansible_executed_with_data_upon_event(request,
+                                                        ansible_repository,
+                                                        copy_ae_instance_to_new_domain,
+                                                        networks_provider):
+    """
+    Test that Nuage events trigger Embedded Ansible automation and that playbook has access to
+    authentication attributes and event data.
+
+    Specifically, we copy AE Instance 'ManageIQ/System/Event/EmsEvent/Nuage/nuage_enterprise_create'
+    from default domain into our own domain and customize it's 'meth5' attribute to invoke
+    Embedded Ansible playbook which prints authentication attributes and event data into evm.log.
+    This test then triggers a 'nuage_enterprise_create' event and waits for appropriate line
+    to appear in evm.log.
+
+    Prerequisites:
+    Following content needs to be present in cfme_data.yaml in order to fetch correct
+    Ansible repository:
+
+    ansible_links:
+      playbook_repositories:
+        embedded_ansible: https://github.com/xlab-si/integration-tests-nuage-automation.git
+    """
+    ae_instance = copy_ae_instance_to_new_domain
+    ae_class = ae_instance.klass
+    ae_method = ae_class.methods.create(
+        name='printout',
+        location='playbook',
+        repository=ansible_repository.name,
+        playbook='printout.yaml',
+        machine_credential='CFME Default Credential',
+        logging_output='Always')
+
+    username = random_name()
+    with update(ae_instance):
+        ae_instance.fields = {
+            'nuage_username': {'value': username},
+            'nuage_enterprise': {'value': 'csp'},
+            'nuage_url': {'value': 'https://nuage:8443'},
+            'nuage_api_version': {'value': 'v5_0'},
+            'meth5': {'value': ae_method.name}
+        }
+
+    enterprise = networks_provider.mgmt.create_enterprise()
+    request.addfinalizer(lambda: networks_provider.mgmt.delete_enterprise(enterprise))
+    catch_string = '.*I confirm that username is {} and event is raised for {}.*' \
+        .format(username, enterprise.id)
+    evm_tail = LogValidator('/var/www/miq/vmdb/log/evm.log', matched_patterns=[catch_string])
+    evm_tail.fix_before_start()
+
+    # LogValidator.validate_logs throws `Failed` exception which inherits `BaseException`.
+    # wait_for function checks for `Exception` which inherits `BaseException` when
+    # 'handle_exception' parameter is used. We can't make use of this functionality because
+    # `Failed` exception is not caught with `Exception` class, hence the helper function.
+    def validate_logs():
+        try:
+            evm_tail.validate_logs()
+            return True
+        except Failed:
+            return False
+
+    wait_for(validate_logs, timeout=300, delay=10, fail_condition=False)

--- a/cfme/tests/networks/nuage/test_automation.py
+++ b/cfme/tests/networks/nuage/test_automation.py
@@ -72,9 +72,13 @@ def test_embedded_ansible_executed_with_data_upon_event(request,
 
     enterprise = networks_provider.mgmt.create_enterprise()
     request.addfinalizer(lambda: networks_provider.mgmt.delete_enterprise(enterprise))
-    catch_string = '.*I confirm that username is {} and event is raised for {}.*' \
-        .format(username, enterprise.id)
-    evm_tail = LogValidator('/var/www/miq/vmdb/log/evm.log', matched_patterns=[catch_string])
+    evm_tail = LogValidator(
+        '/var/www/miq/vmdb/log/evm.log',
+        matched_patterns=[
+            r'.*I confirm that username is {} and event is raised for {}.*'.format(username,
+                                                                                   enterprise.id)
+        ]
+    )
     evm_tail.fix_before_start()
 
     # LogValidator.validate_logs throws `Failed` exception which inherits `BaseException`.


### PR DESCRIPTION
Test that Nuage events trigger Embedded Ansible automation and that playbook has access to authentication attributes and event data.

Specifically, we copy AE Instance 'ManageIQ/System/Event/EmsEvent/Nuage/nuage_enterprise_create' from default domain into our own domain and customize it's 'meth5' attribute to invoke Embedded Ansible playbook which prints authentication attributes and event data into evm.log. This test then triggers a 'nuage_enterprise_create' event and waits for appropriate line to appear in evm.log.

Prerequisites:
Following content needs to be present in cfme_data.yaml in order to fetch correct Ansible repository:

```yaml
# cfme_data.yaml
ansible_links:
  playbook_repositories:
    embedded_ansible: https://github.com/xlab-si/integration-tests-nuage-automation.git
```

Video explaining what the test is doing: 
https://drive.google.com/file/d/1weHHLjQ_0t1OrXECaDDxoGjzjYwwJ18R/view

\cc @miha-plesko 

