### PR TITLE
[1LP][RFR] adding teardown to rbac tests

### DIFF
--- a/cfme/configure/access_control/__init__.py
+++ b/cfme/configure/access_control/__init__.py
@@ -1156,6 +1156,13 @@ class Role(Updateable, Pretty, BaseEntity):
         else:
             return False
 
+    @property
+    def exists(self):
+        try:
+            navigate_to(self, 'Details')
+            return True
+        except CandidateNotFound:
+            return False
 
 @attr.s
 class RoleCollection(BaseCollection):


### PR DESCRIPTION
{{pytest: --use-template-cache --use-provider=complete --long-running cfme/tests/services/test_service_rbac.py cfme/tests/webui/test_advanced_search.py}}
adding teardown steps to rbac tests because those screw up many other tests