### PR TITLE
[1LP][WIPTEST] This will fix embedded_ansible_services tests

### DIFF
--- a/cfme/fixtures/ansible_fixtures.py
+++ b/cfme/fixtures/ansible_fixtures.py
@@ -28,10 +28,7 @@ def ansible_repository(appliance, wait_for_ansible):
     except KeyError:
         pytest.skip("Skipping since no such key found in yaml")
     view = navigate_to(repository, "Details")
-    if appliance.version < "5.9":
-        refresh = view.browser.refresh
-    else:
-        refresh = view.toolbar.refresh.click
+    refresh = view.toolbar.refresh.click
     wait_for(
         lambda: view.entities.summary("Properties").get_text_of("Status") == "successful",
         timeout=60,

--- a/cfme/services/catalogs/catalog_items/__init__.py
+++ b/cfme/services/catalogs/catalog_items/__init__.py
@@ -262,7 +262,7 @@ class BaseCatalogItem(BaseEntity, Updateable, Pretty, Taggable):
 
     @property
     def button_icon_name(self):
-        return 'Button Image 1' if self.appliance.version < '5.9' else 'broom'
+        return 'broom'
 
     def update(self, updates):
         view = navigate_to(self, 'Edit')

--- a/cfme/services/catalogs/catalog_items/ansible_catalog_items.py
+++ b/cfme/services/catalogs/catalog_items/ansible_catalog_items.py
@@ -12,7 +12,6 @@ from widgetastic_patternfly import (
 )
 
 from cfme.services.catalogs import ServicesCatalogView
-from cfme.exceptions import displayed_not_implemented
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep, navigator
 from . import BaseCatalogItem
 
@@ -69,10 +68,10 @@ class AnsibleExtraVariables(View):
         self.tab = tab
 
     def _values_to_remove(self, values):
-        return list(set(self.all_vars) - set(values))
+        return map(tuple, set(self.all_vars) - set(values))
 
     def _values_to_add(self, values):
-        return list(set(values) - set(self.all_vars))
+        return map(tuple, set(values) - set(self.all_vars))
 
     def fill(self, values):
         """
@@ -151,7 +150,7 @@ class AnsibleCatalogItemForm(ServicesCatalogView):
         max_ttl = Input("retirement_execution_ttl")
         escalate_privilege = BootstrapSwitch("retirement_become_enabled")
         verbosity = BootstrapSelect("retirement_verbosity")
-        remove_resources = BootstrapSelect("vm.vm.catalogItemModel.retirement_remove_resources")
+        remove_resources = BootstrapSelect("retirement_remove_resources")
         extra_vars = AnsibleExtraVariables(tab="retirement")
 
     cancel = Button("Cancel")
@@ -173,7 +172,13 @@ class EditAnsibleCatalogItemView(AnsibleCatalogItemForm):
     save = Button("Save")
     reset = Button("Reset")
 
-    is_displayed = displayed_not_implemented
+    @property
+    def is_displayed(self):
+        return (
+            self.in_explorer and
+            self.title.text == 'Editing Service Catalog Item "{}"'.format(
+                self.context["object"].name) and self.provisioning.repository.is_displayed
+        )
 
 
 class DetailsEntitiesAnsibleCatalogItemView(View):


### PR DESCRIPTION
PRT run:
{{ pytest: cfme/tests/ansible/test_embedded_ansible_services.py -k 'test_service_ansible_playbook_available or test_service_ansible_playbook_tagging or test_service_ansible_playbook_negative or test_service_ansible_playbook_bundle or test_service_ansible_playbook_provision_in_requests or test_service_ansible_playbook_confirm or test_service_ansible_playbook_order_retire' -qsvvvv --long-running }}