### PR TITLE
Fix: One more check for customization view related to button

### DIFF
--- a/cfme/automate/__init__.py
+++ b/cfme/automate/__init__.py
@@ -21,7 +21,7 @@ class AutomateCustomizationView(BaseLoggedInPage):
 
     @property
     def is_displayed(self):
-        return self.in_customization
+        return self.in_customization and not self.buttons.is_dimmed
 
     @View.nested
     class provisioning_dialogs(Accordion):  # noqa


### PR DESCRIPTION
Purpose or Intent
=================
- Fix : 
```
TimedOutError
Could not do Waiting for view [ButtonGroupObjectTypeView]
```
- Explanation:
Button group add navigation prerequisite is
`prerequisite = NavigateToAttribute('appliance.server', 'AutomateCustomization')`

`AutomateCustomization` view is not proper... even automation stuck in `Add new button page`. this view `is_displayed  satisfy`. so better to check button is dimmed or not. 

{{pytest: cfme/tests/automate/custom_button/test_infra_objects.py::test_custom_button_automate}}