### PR TITLE
[1LP][RFR] Move all yaml.load calls to yaml.safe_load

### DIFF
--- a/cfme/fixtures/events.py
+++ b/cfme/fixtures/events.py
@@ -18,7 +18,7 @@ more complex example:
 .. code-block:: python
 
     def add_cmp(_, y):
-        data = yaml.load(y)
+        data = yaml.safe_load(y)
         return data['resourceId'].endswith(nsg_name) and data['status']['value'] == 'Accepted' and \
             data['subStatus']['value'] == 'Created'
 
@@ -30,7 +30,7 @@ more complex example:
                    event_type='networkSecurityGroups_write_EndRequest')
 
     def rm_cmp(_, y):
-        data = yaml.load(y)
+        data = yaml.safe_load(y)
         return data['resourceId'].endswith(nsg_name) and data['status']['value'] == 'Succeeded' \
             and len(data['subStatus']['value']) == 0
 

--- a/cfme/fixtures/nelson.py
+++ b/cfme/fixtures/nelson.py
@@ -116,7 +116,7 @@ class GoogleDocstring(docstring.GoogleDocstring):
     def _parse_metadata_section(self, section):
         lines = self._consume_metadata_section()
         if lines:
-            self.metadata = yaml.load("\n".join(lines))
+            self.metadata = yaml.safe_load("\n".join(lines))
         return ['']
 
 

--- a/cfme/fixtures/ui_coverage.py
+++ b/cfme/fixtures/ui_coverage.py
@@ -336,7 +336,7 @@ class UiCoveragePlugin(object):
 # so I'm commenting it out instead of outright deleting it :)
 #         try:
 #             global ui_coverage_percent
-#             last_run = json.load(log_path.join('coverage', 'merged', '.last_run.json').open())
+#             last_run = json.safe_load(log_path.join('coverage', 'merged', '.last_run.json').open())
 #             ui_coverage_percent = last_run['result']['covered_percent']
 #             style = {'bold': True}
 #             if ui_coverage_percent > 40:

--- a/cfme/scripting/sprout.py
+++ b/cfme/scripting/sprout.py
@@ -104,7 +104,7 @@ def populate_config_from_appliances(appliance_data):
     file_name = conf_path.join('env.local.yaml').strpath
     if os.path.exists(file_name):
         with open(file_name) as f:
-            y_data = yaml.load(f)
+            y_data = yaml.safe_load(f)
         if not y_data:
             y_data = {}
     else:

--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -558,7 +558,7 @@ def test_appliance_console_scap(temp_appliance_preconfig, soft_assert):
         '{rules}'.format(rules=rules), '/tmp/scap_rules.yml')    # Get the scap rules
 
     with open('/tmp/scap_rules.yml') as f:
-        yml = yaml.load(f.read())
+        yml = yaml.safe_load(f.read())
         rules = yml['rules']
 
     tree = lxml.etree.parse('/tmp/scap-results.xccdf.xml')

--- a/cfme/tests/cloud/test_cloud_events.py
+++ b/cfme/tests/cloud/test_cloud_events.py
@@ -34,7 +34,7 @@ def test_manage_nsg_group(appliance, provider, register_event):
 
     def add_cmp(_, y):
         # In 5.9 version `y` is a dict, not a yaml stream.
-        data = yaml.load(y) if appliance.version < '5.9' else y
+        data = yaml.safe_load(y) if appliance.version < '5.9' else y
 
         return (data['resourceId'].endswith(nsg_name) and
                 (data['status']['value'] == 'Accepted' and
@@ -50,7 +50,7 @@ def test_manage_nsg_group(appliance, provider, register_event):
 
     def rm_cmp(_, y):
         # In 5.9 version `y` is a dict, not a yaml stream.
-        data = yaml.load(y) if appliance.version < '5.9' else y
+        data = yaml.safe_load(y) if appliance.version < '5.9' else y
 
         return data['resourceId'].endswith(nsg_name) and data['status']['value'] == 'Succeeded'
 
@@ -90,7 +90,7 @@ def test_vm_capture(appliance, request, provider, register_event):
 
     def cmp_function(_, y):
         # In 5.9 version `y` is a dict, not a yaml stream.
-        data = yaml.load(y) if appliance.version < '5.9' else y
+        data = yaml.safe_load(y) if appliance.version < '5.9' else y
 
         return data['resourceId'].endswith(vm.name) and data['status']['value'] == 'Succeeded'
 

--- a/cfme/tests/control/test_default_alerts.py
+++ b/cfme/tests/control/test_default_alerts.py
@@ -12,7 +12,7 @@ def default_alerts(appliance):
     alerts = {}
     if os.path.exists(file_name):
         with open(file_name,'r') as f:
-            all_alerts = yaml.load(f)
+            all_alerts = yaml.safe_load(f)
             alerts = (
                 all_alerts.get('v5.10') if appliance.version >= '5.10'
                 else all_alerts.get('v5.9')

--- a/cfme/tests/intelligence/reports/test_crud.py
+++ b/cfme/tests/intelligence/reports/test_crud.py
@@ -41,13 +41,13 @@ def crud_files_schedules():
 @pytest.fixture(params=crud_files_reports())
 def custom_report_values(request):
     with report_crud_dir.join(request.param).open(mode="r") as rep_yaml:
-        return yaml.load(rep_yaml)
+        return yaml.safe_load(rep_yaml)
 
 
 @pytest.fixture(params=crud_files_schedules())
 def schedule_data(request):
     with schedules_crud_dir.join(request.param).open(mode="r") as rep_yaml:
-        return yaml.load(rep_yaml)
+        return yaml.safe_load(rep_yaml)
 
 
 @pytest.fixture(scope="function")

--- a/cfme/tests/intelligence/reports/test_menus.py
+++ b/cfme/tests/intelligence/reports/test_menus.py
@@ -46,7 +46,7 @@ def crud_files_reports():
 @pytest.fixture(params=crud_files_reports())
 def custom_report_values(request):
     with report_crud_dir.join(request.param).open(mode="r") as rep_yaml:
-        return yaml.load(rep_yaml)
+        return yaml.safe_load(rep_yaml)
 
 
 @pytest.mark.tier(3)

--- a/cfme/tests/intelligence/reports/test_reports_schedules.py
+++ b/cfme/tests/intelligence/reports/test_reports_schedules.py
@@ -22,7 +22,7 @@ def schedule_files():
                 ids=[schedule.split(".")[0] for schedule in schedule_files()])
 def schedule_data(request):
     with schedules_report_dir.join(request.param).open(mode="r") as rep_yaml:
-        return yaml.load(rep_yaml)
+        return yaml.safe_load(rep_yaml)
 
 
 @pytest.fixture(scope='function')

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -164,7 +164,7 @@ class ApplianceConsole(object):
             '{rules}'.format(rules=rules), '/tmp/scap_rules.yml')  # Get the scap rules
 
         with open('/tmp/scap_rules.yml') as f:
-            yml = yaml.load(f.read())
+            yml = yaml.safe_load(f.read())
             rules = yml['rules']
 
         tree = lxml.etree.parse('/tmp/scap-results.xccdf.xml')
@@ -2099,7 +2099,7 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
                 logger.error(base_data.output)
                 raise Exception('Error obtaining config')
             try:
-                return yaml.load(base_data.output)
+                return yaml.safe_load(base_data.output)
             except Exception:
                 logger.debug(base_data.output)
                 raise

--- a/scripts/matrix.py
+++ b/scripts/matrix.py
@@ -49,7 +49,7 @@ with open(os.path.join(data_path.strpath, 'suite.yaml')) as f:
 
 
 with open('doc_data.yaml') as f:
-    doc_data = yaml.load(f)
+    doc_data = yaml.safe_load(f)
 
 tree = ET.parse('junit-report.xml')
 elem = tree.getroot()

--- a/sprout/appliances/migrations/0043_provider_provider_type.py
+++ b/sprout/appliances/migrations/0043_provider_provider_type.py
@@ -11,7 +11,7 @@ def add_type_to_provider(apps, schema_editor):
     Provider = apps.get_model("appliances", "Provider")  # noqa
     for provider in Provider.objects.using(schema_editor.connection.alias).all():
         # Need to replicate the functionality from the model here
-        provider_data = yaml.load(provider.object_meta_data).get('provider_data')
+        provider_data = yaml.safe_load(provider.object_meta_data).get('provider_data')
         if not provider_data:
             provider_data = cfme_data.get("management_systems", {}).get(provider.id, {})
         provider_type = provider_data.get('type', None)

--- a/sprout/appliances/models.py
+++ b/sprout/appliances/models.py
@@ -93,7 +93,7 @@ class MetadataMixin(models.Model):
 
     @property
     def metadata(self):
-        return yaml.load(self.object_meta_data)
+        return yaml.safe_load(self.object_meta_data)
 
     @metadata.setter
     def metadata(self, value):


### PR DESCRIPTION
4.1 release was reverted, 4.2 is not yet available, 3.13 flagged as high severity because of code execution through load calls

Should not have any impact on the modified calls.