### PR TITLE
[RFR] Update polarion docstrings, flaking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,15 @@ repos:
   - id: flake8
     language_version: python3.6
     <<: *exclude
+# separately flake via system for polarion docstrings plugins
+- repo: local
+  hooks:
+    - id: system-flake8
+      name: flake8-plugins
+      description: flake8 integration_tests plugins
+      entry: python -m flake8.__main__ --select P --ignore P665
+      files: \.py$
+      language: system
 - repo: https://github.com/asottile/pyupgrade
   rev: v1.10.1
   hooks:

--- a/cfme/tests/automate/custom_button/test_buttons.py
+++ b/cfme/tests/automate/custom_button/test_buttons.py
@@ -188,7 +188,7 @@ def test_button_required(appliance, field):
 
     Polarion:
         assignee: ndhandre
-        caseimportance: mediun
+        caseimportance: medium
         initialEstimate: 1/6h
     """
     unassigned_gp = appliance.collections.button_groups.instantiate(

--- a/cfme/tests/automate/test_smoke.py
+++ b/cfme/tests/automate/test_smoke.py
@@ -30,7 +30,7 @@ def test_domain_present(domain_name, soft_assert, appliance):
         casecomponent: automate
         caseimportance: critical
         initialEstimate: 1/60h
-        testtype: sanity
+        testtype: functional
     """
     dc = DomainCollection(appliance)
     domain = dc.instantiate(name=domain_name)

--- a/cfme/tests/cli/test_evmserverd.py
+++ b/cfme/tests/cli/test_evmserverd.py
@@ -33,7 +33,7 @@ def test_evmserverd_stop(appliance, request):
             stopping the service are present.
 
     Polarion:
-        assignee: amavinag
+        assignee: mshriver
         caseimportance: medium
         initialEstimate: 1/4h
     """

--- a/cfme/tests/intelligence/reports/test_crud.py
+++ b/cfme/tests/intelligence/reports/test_crud.py
@@ -372,9 +372,7 @@ def test_reports_crud_schedule_for_base_report_once(appliance, request):
     assert not schedule.exists
 
 
-def test_crud_custom_report_schedule(
-    appliance, request, get_custom_report, schedule_data
-):
+def test_crud_custom_report_schedule(appliance, request, get_custom_report, schedule_data):
     """This test case creates a schedule for custom reports and tests if it was created
     successfully.
 
@@ -394,6 +392,12 @@ def test_crud_custom_report_schedule(
 
 @pytest.mark.ignore_stream('5.9')
 def test_report_schedules_invalid_email(appliance, schedule_data):
+    """
+        Polarion:
+            assignee: pvala
+            casecomponent: report
+            initialEstimate: 1/12h
+    """
     schedule_data["emails"] = (fauxfactory.gen_alpha(), fauxfactory.gen_alpha())
     schedule_data["from_email"] = fauxfactory.gen_alpha()
     with pytest.raises(AssertionError):

--- a/cfme/tests/test_appliance.py
+++ b/cfme/tests/test_appliance.py
@@ -27,9 +27,9 @@ def test_rpms_present(appliance, package):
     """Verifies nfs-util rpms are in place needed for pxe & nfs operations
 
     Polarion:
-        assignee: amavinag
+        assignee: mshriver
         initialEstimate: 1/4h
-        testtype: sanity
+        testtype: functional
     """
     result = appliance.ssh_client.run_command('rpm -q {}'.format(package))
     assert 'is not installed' not in result.output
@@ -41,9 +41,9 @@ def test_selinux_enabled(appliance):
     """Verifies selinux is enabled
 
     Polarion:
-        assignee: amavinag
+        assignee: mshriver
         initialEstimate: 1/11h
-        testtype: sanity
+        testtype: functional
     """
     result = appliance.ssh_client.run_command('getenforce').output
     assert 'Enforcing' in result
@@ -54,7 +54,7 @@ def test_firewalld_running(appliance):
     """Verifies iptables service is running on the appliance
 
     Polarion:
-        assignee: amavinag
+        assignee: mshriver
         initialEstimate: 1/4h
     """
     result = appliance.ssh_client.run_command('systemctl status firewalld').output
@@ -66,10 +66,10 @@ def test_evm_running(appliance):
     """Verifies overall evm service is running on the appliance
 
     Polarion:
-        assignee: amavinag
+        assignee: mshriver
         caseimportance: critical
         initialEstimate: 1/4h
-        testtype: sanity
+        testtype: functional
     """
     result = appliance.ssh_client.run_command('systemctl status evmserverd').output
     assert 'active (running)' in result
@@ -87,10 +87,10 @@ def test_service_enabled(appliance, service):
     """Verifies if key services are configured to start on boot up
 
     Polarion:
-        assignee: amavinag
+        assignee: mshriver
         caseimportance: critical
         initialEstimate: 1/6h
-        testtype: sanity
+        testtype: functional
     """
     if service == 'postgresql':
         service = '{}-postgresql'.format(appliance.db.postgres_version)
@@ -113,9 +113,9 @@ def test_iptables_rules(appliance, proto, port):
     """Verifies key iptable rules are in place
 
     Polarion:
-        assignee: amavinag
+        assignee: mshriver
         initialEstimate: 1/4h
-        testtype: sanity
+        testtype: functional
         upstream: no
     """
     # get the current iptables state, nicely formatted for us by iptables-save
@@ -141,9 +141,9 @@ def test_memory_total(appliance):
     """Verifies that the total memory on the box is >= 6GB
 
     Polarion:
-        assignee: amavinag
+        assignee: mshriver
         initialEstimate: 1/4h
-        testtype: sanity
+        testtype: functional
     """
     result = appliance.ssh_client.run_command(
         'free -g | grep Mem: | awk \'{ print $2 }\'').output
@@ -155,9 +155,9 @@ def test_cpu_total(appliance):
     """Verifies that the total number of cpus is >= 4
 
     Polarion:
-        assignee: amavinag
+        assignee: mshriver
         initialEstimate: 1/4h
-        testtype: sanity
+        testtype: functional
     """
     result = appliance.ssh_client.run_command(
         'lscpu | grep ^CPU\(s\): | awk \'{ print $2 }\'').output
@@ -169,9 +169,9 @@ def test_certificates_present(appliance, soft_assert):
     """Test whether the required product certificates are present.
 
     Polarion:
-        assignee: amavinag
+        assignee: mshriver
         initialEstimate: 1/4h
-        testtype: sanity
+        testtype: functional
         upstream: no
     """
 
@@ -229,9 +229,9 @@ def test_db_connection(appliance):
     on an appliance with a working database and UI
 
     Polarion:
-        assignee: amavinag
+        assignee: mshriver
         initialEstimate: 1/4h
-        testtype: sanity
+        testtype: functional
     """
     databases = appliance.db.client.session.query(appliance.db.client['miq_databases']).all()
     assert len(databases) > 0
@@ -240,9 +240,9 @@ def test_db_connection(appliance):
 def test_asset_precompiled(appliance):
     """
     Polarion:
-        assignee: amavinag
+        assignee: mshriver
         initialEstimate: 1/4h
-        testtype: sanity
+        testtype: functional
     """
     assert appliance.ssh_client.run_command("test -d /var/www/miq/vmdb/public/assets").success, (
         "Assets not precompiled")
@@ -252,9 +252,9 @@ def test_asset_precompiled(appliance):
 def test_keys_included(appliance, soft_assert):
     """
     Polarion:
-        assignee: amavinag
+        assignee: mshriver
         initialEstimate: 1/4h
-        testtype: sanity
+        testtype: functional
         upstream: no
     """
     keys = ['v0_key', 'v1_key', 'v2_key']


### PR DESCRIPTION
Add system-flake call for polarion plugin checks to pre-commit
Including only 'P' class flake errors, and ignoring P665 which is missing polarion

Don't want to enforce having polarion docblock on everything in integration_tests