### PR TITLE
[RFR] Add blocker to test_service_query_attributes

### DIFF
--- a/cfme/tests/infrastructure/test_vm_rest.py
+++ b/cfme/tests/infrastructure/test_vm_rest.py
@@ -44,9 +44,6 @@ def test_query_vm_attributes(vm, soft_assert):
         if failure.type == 'attribute' and failure.name == 'policy_events' and BZ(
                 1546995, forced_streams=['5.8', '5.9', 'upstream']).blocks:
             continue
-        # this one is expected because additional arguments are needed
-        if failure.type == 'subcollection' and failure.name == 'metric_rollups':
-            continue
         soft_assert(False, '{0} "{1}": status: {2}, error: `{3}`'.format(
             failure.type, failure.name, failure.response.status_code, failure.error))
 

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -221,7 +221,6 @@ def unassign_templates(templates):
 
 
 class TestServiceRESTAPI(object):
-    # testing BZ1539741
     def test_query_service_attributes(self, services, soft_assert):
         """Tests access to service attributes.
 
@@ -230,15 +229,12 @@ class TestServiceRESTAPI(object):
 
         Polarion:
             assignee: nansari
-            initialEstimate: None
+            initialEstimate: 1/30h
         """
         outcome = query_resource_attributes(services[0])
         for failure in outcome.failed:
-            if failure.name == 'configuration_script' and BZ(
-                    1540250, forced_streams=['5.9', 'upstream']).blocks:
-                continue
-            if failure.name == 'metric_rollups' and BZ(
-                    1540254, forced_streams=['5.9', 'upstream']).blocks:
+            if failure.name == "reconfigure_dialog"and BZ(
+                    1663972, forced_streams=["5.9", "5.10", "upstream"]).blocks:
                 continue
             soft_assert(False, '{0} "{1}": status: {2}, error: `{3}`'.format(
                 failure.type, failure.name, failure.response.status_code, failure.error))

--- a/cfme/utils/rest.py
+++ b/cfme/utils/rest.py
@@ -228,6 +228,13 @@ def query_resource_attributes(resource, soft_assert=None):
 
     for subcol in subcolls_to_check:
         try:
+            if subcol == 'metric_rollups':
+                response = rest_api.get(
+                    "{}/{}?capture_interval=hourly&start_date=2019-01-01".format(
+                        service_href, subcol))
+                assert rest_api.response, "Failed response"
+                continue
+
             subcol_rest = getattr(resource, subcol)
             subcol_rest.reload()
         except Exception as err:


### PR DESCRIPTION
This PR brings the following changes:
1. Add conditions to block certain subcollections in `test_service_query_attributes`.
BZ: [1663972](https://bugzilla.redhat.com/show_bug.cgi?id=1663972) - Internal Server Error when querying services attribute `reconfigure_dialog`


{{ pytest: cfme/tests/services/test_rest_services.py::TestServiceRESTAPI::test_query_service_attributes cfme/tests/infrastructure/test_vm_rest.py::test_query_vm_attributes --use-template-cache -sqvvvv --long-running }}