### PR TITLE
[1LP][RFR] Add in a view for the Monitor->Alerts->Overview page

### DIFF
--- a/cfme/tests/control/test_bugs.py
+++ b/cfme/tests/control/test_bugs.py
@@ -7,7 +7,6 @@ from widgetastic.widget import Text
 
 from cfme import test_requirements
 from cfme.control.explorer import ControlExplorerView
-from cfme.control.explorer.alerts import AlertDetailsView
 from cfme.control.explorer.conditions import VMCondition
 from cfme.control.explorer.policies import VMCompliancePolicy, VMControlPolicy
 from cfme.exceptions import CFMEExceptionOccured

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -5084,3 +5084,46 @@ class MigrationDashboardStatusCard(AggregateStatusCard):
         ' h2[contains(@class,"card-pf-title")  and contains(.,{@name|quote})]]'
     )
     TITLE_ANCHOR = ".//h2"
+
+
+class MonitorStatusCard(ParametrizedView):
+
+    PARAMETERS = ("name",)
+
+    class MonitorCard(AggregateStatusCard):
+        """ MonitorCard class to overwrite defaults of AggregateStatusCard """
+
+        ROOT = ParametrizedLocator(
+            './/div[contains(@class, "card-pf-aggregate-status") '
+            'and not(contains(@class, "card-pf-aggregate-status-mini")) '
+            "and contains(.//span, {@name|quote})]"
+        )
+        TITLE = './/span[contains(@class, "h2 card-pf-title")]'
+        TITLE_ANCHOR = ".//a"
+
+    _card = MonitorCard(name=Parameter("name"))
+
+    # define all the properties and methods of the AggregateStatusCard
+    @property
+    def count(self):
+        return self._card.count
+
+    @property
+    def icon(self):
+        return self._card.icon
+
+    @property
+    def notifications(self):
+        return self._card.notifications
+
+    def read(self):
+        return self._card.read()
+
+    def click_title(self):
+        return self._card.click_title()
+
+    def click_body_action(self):
+        return self._card.click_body_action()
+
+    def click(self):
+        return self.click_title()


### PR DESCRIPTION
Purpose or Intent
=================

__1)__ __Adding view__ for the "Monitor->Alerts->Overview" page in CFME. This view is registered to the alert collection because they will only have content on them if an alert has fired on an appliance. 

__2)__ __Adding test__ to test basic functionality of this view/page.
This, in combination with PR #8235, provide representation of both of the pages on Monitor->Alerts.  

{{ pytest: --long-running cfme/tests/control/test_basic.py::test_alerts_monitor_overview_page }}
