### PR TITLE
[1LP][RFR] Uncollect Host Provisioning dialog test in 5.10

### DIFF
--- a/cfme/tests/automate/test_provisioning_dialogs.py
+++ b/cfme/tests/automate/test_provisioning_dialogs.py
@@ -60,8 +60,9 @@ for name in ProvisioningDialogsCollection.ALLOWED_TYPES:
 @test_requirements.general_ui
 @pytest.mark.tier(3)
 @pytest.mark.parametrize(("name", "by", "order"), sort_by_params)
-@pytest.mark.meta(
-    blockers=[BZ(1662219, forced_streams=['5.10'], unblock=lambda name: name != "Host Provision")])
+@pytest.mark.uncollectif(
+    lambda appliance, name: appliance.version >= "5.10" and name == "Host Provision",
+    reason='Host Provisioning was deprecated and doesnt exist in 5.10')
 def test_provisioning_dialogs_sorting(appliance, name, by, order):
     """
     Polarion:


### PR DESCRIPTION
{{ pytest: cfme/tests/automate/test_provisioning_dialogs.py::test_provisioning_dialogs_sorting -v }}
https://bugzilla.redhat.com/show_bug.cgi?id=1662219#c2