### PR TITLE
[1LP][RFR] Add a new test to create policy with invalid data

### DIFF
--- a/cfme/tests/control/test_rest_control.py
+++ b/cfme/tests/control/test_rest_control.py
@@ -3,6 +3,8 @@
 import pytest
 import fauxfactory
 
+from manageiq_client.api import APIException
+
 from cfme import test_requirements
 from cfme.rest.gen_data import conditions as _conditions
 from cfme.rest.gen_data import policies as _policies
@@ -14,7 +16,6 @@ from cfme.utils.rest import (
 )
 from cfme.utils.version import current_version
 from cfme.utils.wait import wait_for
-from manageiq_client.api import APIException
 
 pytestmark = [
     test_requirements.rest
@@ -253,7 +254,7 @@ class TestPoliciesRESTAPI(object):
 
         Polarion:
             assignee: pvala
-            component: Rest
+            casecomponent: Rest
             caseimportance: High
             initialEstimate: 1/30h
         """

--- a/conf/polarion_tools.yaml
+++ b/conf/polarion_tools.yaml
@@ -103,6 +103,7 @@ docstrings:
             - optimize
             - prov
             - report
+            - Rest
             - services
             - smartst
             - ssui


### PR DESCRIPTION
This PR brings the following change:
1. Add a new test, `test_create_invalid_policy` to check policy creation with invalid data. This test is created to cover BZ: [1435780](https://bugzilla.redhat.com/show_bug.cgi?id=1435780)


{{ pytest: cfme/tests/control/test_rest_control.py::TestPoliciesRESTAPI::test_create_invalid_policies --use-template-cache -sqvvvvv }}