### PR TITLE
[RFR][NOTEST] added BZ1659340 and removed BZ1632782

### DIFF
--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -420,7 +420,8 @@ def test_no_template_power_control(provider, soft_assert):
 @pytest.mark.rhv3
 @pytest.mark.meta(blockers=[BZ(1520489, forced_streams=['5.9'],
                                unblock=lambda provider: not provider.one_of(SCVMMProvider)),
-                            BZ(1633727, forced_streams=['5.10'])])
+                            BZ(1659340, forced_streams=['5.9', '5.10'],
+                               unblock=lambda provider: not provider.one_of(RHEVMProvider))])
 def test_no_power_controls_on_archived_vm(appliance, testing_vm, archived_vm, soft_assert):
     """ Ensures that no power button is displayed from details view of archived vm
 

--- a/cfme/tests/infrastructure/test_vm_reconfigure.py
+++ b/cfme/tests/infrastructure/test_vm_reconfigure.py
@@ -84,7 +84,6 @@ def ensure_vm_running(small_vm):
 
 @pytest.mark.rhel_testing
 @pytest.mark.rhv1
-@pytest.mark.meta(blockers=[BZ(1632782, forced_streams=['5.10'])])
 @pytest.mark.parametrize('change_type', ['cores_per_socket', 'sockets', 'memory'])
 def test_vm_reconfig_add_remove_hw_cold(provider, small_vm, ensure_vm_stopped, change_type):
     """


### PR DESCRIPTION
1. `test_no_power_controls_on_archived_vm` fails due to BZ1659340 and it's true for both 5.9 and 5.10
2. BZ1632782 and 1633727 are verified, so I removed it