### PR TITLE
[1LP][RFR] updated BZ for templates power control and assertion for template grid

### DIFF
--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -367,9 +367,10 @@ class TestVmDetailsPowerControlPerProvider(object):
 
 
 @pytest.mark.rhv3
-@pytest.mark.meta(blockers=[BZ(1496383, forced_streams=['5.9', '5.10', 'upstream'])])
+@pytest.mark.meta(blockers=[BZ(1634713, forced_streams=['5.9', '5.10', 'upstream'])])
 def test_no_template_power_control(provider, soft_assert):
     """ Ensures that no power button is displayed for templates.
+    See BZ1496383 and BZ1634713
 
     Prerequisities:
         * An infra provider that has some templates.
@@ -391,10 +392,7 @@ def test_no_template_power_control(provider, soft_assert):
     """
     view = navigate_to(provider, 'ProviderTemplates')
     view.toolbar.view_selector.select('Grid View')
-    if provider.appliance.version < '5.10':
-        soft_assert(not view.toolbar.power.is_enabled, "Power enabled in template grid view!")
-    else:
-        soft_assert(not view.toolbar.power.is_displayed, "Power displayed in template grid view!")
+    soft_assert(not view.toolbar.power.is_displayed, "Power displayed in template grid view!")
 
     # Ensure selecting a template doesn't cause power menu to appear
     templates = view.entities.all_entity_names


### PR DESCRIPTION
1. Removed `if` for `5.9` in first assertion as in `5.9.7.0` Power dropdown is not displayed (not just disabled)
2. The test fails at second assertion, that's due to BZ1634713, so I updated the blocker.

I didn't add the PRT as the test is skipped.