### PR TITLE
[1LP][RFR] fixed power_operations for test_service_start (ssui)

### DIFF
--- a/cfme/services/myservice/ssui.py
+++ b/cfme/services/myservice/ssui.py
@@ -11,7 +11,7 @@ from cfme.utils.appliance import MiqImplementationContext
 from cfme.utils.appliance.implementations.ssui import (
     navigator, SSUINavigateStep, navigate_to, ViaSSUI
 )
-from cfme.utils.version import VersionPicker, LATEST
+from cfme.utils.version import VersionPicker, LOWEST
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import (
     Notification,
@@ -57,7 +57,7 @@ class DetailsMyServiceView(MyServicesView):
     notification = Notification()
     policy = SSUIDropdown('Policy')
     power_operations = VersionPicker(
-        {LATEST: SSUIDropdown("Power Operations"), "5.10": Kebab()}
+        {LOWEST: SSUIDropdown("Power Operations"), "5.10": Kebab()}
     )
     access_dropdown = SSUIAppendToBodyDropdown('Access')
     remove_service = Button("Remove Service")


### PR DESCRIPTION
{{ pytest: -v cfme/tests/ssui/test_ssui_myservice.py::test_service_start }}

Should be `LOWEST` as in `5.9` it's the dropdown, not kebab.

Fixes the error 
```
> view.power_operations.item_select(power)
E AttributeError: 'NoneType' object has no attribute 'item_select'
```