### PR TITLE
[RFR] Fix condition modify by adding a time.sleep(1) to get around BZ's 1664852 and 1664886

### DIFF
--- a/cfme/control/explorer/conditions.py
+++ b/cfme/control/explorer/conditions.py
@@ -8,8 +8,12 @@ from widgetastic_patternfly import Button, Input
 from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.utils import ParamClassName
 from cfme.utils.appliance.implementations.ui import navigator, navigate_to, CFMENavigateStep
+from cfme.utils.log import logger
 from cfme.utils.pretty import Pretty
 from cfme.utils.update import Updateable
+from cfme.utils.wait import TimedOutError
+
+from selenium.common.exceptions import StaleElementReferenceException
 from widgetastic_manageiq.expression_editor import ExpressionEditor
 from . import ControlExplorerView
 
@@ -119,6 +123,7 @@ class EditConditionView(ConditionFormCommon):
     title = Text("#explorer_title_text")
 
     save_button = Button("Save")
+    cancel_button = Button("Cancel")
     reset_button = Button("Reset")
 
     @property
@@ -193,16 +198,22 @@ class BaseCondition(BaseEntity, Updateable, Pretty):
 
         Args:
             updates: Provided by update() context manager.
-            cancel: Whether to cancel the update (default False).
         """
         view = navigate_to(self, "Edit")
-        view.fill(updates)
-        view.wait_displayed()
-        view.save_button.click()
-        view = self.create_view(ConditionDetailsView, override=updates)
-        view.wait_displayed()
-        view.flash.assert_success_message(
+        try:
+            view.fill(updates)
+            view.wait_displayed()
+            view.save_button.click()
+            view = self.create_view(ConditionDetailsView, override=updates)
+            view.wait_displayed()
+            view.flash.assert_success_message(
             'Condition "{}" was saved'.format(updates.get("description", self.description)))
+        except (TimedOutError, StaleElementReferenceException):
+            logger.exception('Updating the condition failed waiting for view, canceling update.')
+            view.cancel_button.click()
+            view = navigate_to(self, "Details")
+            view.wait_displayed()
+
 
     def delete(self, cancel=False):
         """Delete this Condition in UI.

--- a/cfme/control/explorer/conditions.py
+++ b/cfme/control/explorer/conditions.py
@@ -197,6 +197,7 @@ class BaseCondition(BaseEntity, Updateable, Pretty):
         """
         view = navigate_to(self, "Edit")
         view.fill(updates)
+        view.wait_displayed()
         view.save_button.click()
         view = self.create_view(ConditionDetailsView, override=updates)
         view.wait_displayed()

--- a/widgetastic_manageiq/expression_editor.py
+++ b/widgetastic_manageiq/expression_editor.py
@@ -33,12 +33,17 @@ class BootstrapSelect(VanillaBootstrapSelect):
         # should wait until it appears and only then we can fill it.
         self.logger.info("FILLING WIDGET %s", str(self))
         self.wait_displayed()
+        super(BootstrapSelect, self).fill(value)
         # BZ 1649057 documents that a loading screen appears twice when a scope or expression
         # element is selected. Between loads, the page is displayed and we make a selection, which
         # is then overwritten in the next load. This work-around will wait for both loads.
-        if BZ(1649057, forced_streams=["5.9", "5.10"]).blocks:
+        # BZ 1664886 and BZ 1664852 are similar but for different fields in the Expression Editor.
+        if (
+            BZ(1649057, forced_streams=["5.9", "5.10"]).blocks
+            or BZ(1664886, forced_streams=["5.9", "5.10"]).blocks
+            or BZ(1664852, forced_streams=["5.9", "5.10"]).blocks
+        ):
             time.sleep(1)
-        super(BootstrapSelect, self).fill(value)
 
 
 class ExpressionEditor(View, Pretty):

--- a/widgetastic_manageiq/expression_editor.py
+++ b/widgetastic_manageiq/expression_editor.py
@@ -339,6 +339,7 @@ class ExpressionEditor(View, Pretty):
                 cvalue=cvalue,
             )
         )
+        view.wait_displayed()
         self.click_commit()
 
     def fill_field(self, field=None, key=None, value=None):


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ `expression_editor` as a workaround for [BZ 1664852](https://bugzilla.redhat.com/show_bug.cgi?id=1664852) and [BZ 1664886](https://bugzilla.redhat.com/show_bug.cgi?id=1664886). This bug is impacting automation by causing condition creation to fail -- which leaves a browser stuck on that view with no way to get off of it. For that reason, it is impacting many tests. 

Another issue is arising on CFME 5.10.0.31 when an expression is created with the field `Find`. So that this issue does not impact other automation we have allowed for `condition.update()` to click the `cancel` button if we hit a `TimedOutError`. A future PR will address the issue directly. 

{{ pytest: --long-running cfme/tests/control/test_basic.py::test_modify_condition_expression }}
