### PR TITLE
[RFR] removing keep_alive = False workaround

### DIFF
--- a/cfme/utils/browser.py
+++ b/cfme/utils/browser.py
@@ -143,14 +143,6 @@ class BrowserFactory(object):
 
     def processed_browser_args(self):
         self._add_missing_options()
-
-        if 'keep_alive' in self.browser_kwargs:
-            warnings.warn(
-                "forcing browser keep_alive to False due to selenium bugs\n"
-                "we are aware of the performance cost and hope to redeem",
-                category=RuntimeWarning,
-            )
-            return dict(self.browser_kwargs, keep_alive=False)
         return self.browser_kwargs
 
     def create(self, url_key):


### PR DESCRIPTION
it seems keepalive works right. So, this workaround should be removed if extended testing proves no errors

REQUIRES: 
https://github.com/RedHatQE/cfme_dockerfiles/pull/8
https://github.com/RedHatQE/cfme_dockerfiles/pull/9