### PR TITLE
[1LP][RFR] Fixed is_displayed of MethodEditView

### DIFF
--- a/cfme/automate/explorer/__init__.py
+++ b/cfme/automate/explorer/__init__.py
@@ -41,6 +41,10 @@ class AutomateExplorer(CFMENavigateStep):
 
 
 def check_tree_path(actual, desired, partial=False):
+    # keyword argument - 'partial'  is introduced here because of unexpected behaviour of automate
+    # tree accordions. In this case, actual and desired trees will not be same which creates problem
+    # For more details please refer:
+    # https://github.com/ManageIQ/integration_tests/pull/8358#discussion_r247770688
     if len(actual) != len(desired) and not partial:
         return False
     # We don't care about icons because we also match titles, which give the type away

--- a/cfme/automate/explorer/__init__.py
+++ b/cfme/automate/explorer/__init__.py
@@ -40,8 +40,8 @@ class AutomateExplorer(CFMENavigateStep):
         self.view.navigation.select(*automate_menu_name(self.obj.appliance) + ['Explorer'])
 
 
-def check_tree_path(actual, desired):
-    if len(actual) != len(desired):
+def check_tree_path(actual, desired, partial=False):
+    if len(actual) != len(desired) and not partial:
         return False
     # We don't care about icons because we also match titles, which give the type away
     for actual_item, desired_item in zip(actual, without_icons(desired)):

--- a/cfme/automate/explorer/domain.py
+++ b/cfme/automate/explorer/domain.py
@@ -299,12 +299,9 @@ class DomainCollection(BaseCollection):
         else:
             add_page.add_button.click()
             add_page.flash.assert_no_error()
-            if self.appliance.version >= '5.8.2':
-                add_page.flash.assert_message(
-                    'Automate Domain "{}" was added'.format(description or name))
-            else:
-                add_page.flash.assert_message(
-                    'Automate Domain "{}" was added'.format(name))
+            add_page.flash.assert_message(
+                'Automate Domain "{}" was added'.format(description or name))
+
             if enabled is None:
                 # Assume
                 enabled = False

--- a/cfme/automate/explorer/method.py
+++ b/cfme/automate/explorer/method.py
@@ -75,7 +75,7 @@ class Inputs(View, ClickableMixin):
 
     add_field = Text(VersionPicker({
         Version.lowest(): '//img[@alt="Equal green"]',
-        '5.10': '//div[@id="class_fields_div"]//i[contains(@class, "fa-plus")]'
+        '5.10': '//*[@id="inputs_div"]//i[contains(@class, "fa-plus")]'
     }))
     name = Input(locator='.//td/input[contains(@id, "field_name")]')
     data_type = Select(locator='.//td/select[contains(@id, "field_datatype")]')
@@ -101,6 +101,7 @@ class Inputs(View, ClickableMixin):
             if key not in present:
                 new_value = value.pop(key)
                 new_value['name'] = key
+                self.add_field.wait_displayed()
                 self.add_field.click()
                 super(Inputs, self).fill(new_value)
                 self.finish_add_field.click()
@@ -301,8 +302,8 @@ class MethodEditView(AutomateExplorerView):
         return (
             self.in_explorer and
             self.datastore.is_opened and
-            'Automate Method [{}'.format(self.context['object'].name) in self.title.text and
-            check_tree_path(
+            'Editing Automate Method "{}"'.format(self.context['object'].name) in self.title.text
+            and check_tree_path(
                 self.datastore.tree.currently_selected,
                 self.context['object'].tree_path))
 

--- a/cfme/automate/explorer/method.py
+++ b/cfme/automate/explorer/method.py
@@ -305,7 +305,7 @@ class MethodEditView(AutomateExplorerView):
             'Editing Automate Method "{}"'.format(self.context['object'].name) in self.title.text
             and check_tree_path(
                 self.datastore.tree.currently_selected,
-                self.context['object'].tree_path))
+                self.context['object'].tree_path, partial=True))
 
 
 class Method(BaseEntity, Copiable):
@@ -393,13 +393,8 @@ class Method(BaseEntity, Copiable):
         else:
             view.cancel_button.click()
         view = self.create_view(MethodDetailsView, override=updates, wait='10s')
+        view.wait_displayed()
         view.flash.assert_no_error()
-        if changed:
-            view.flash.assert_message(
-                'Automate Method "{}" was saved'.format(updates.get('name', self.name)))
-        else:
-            view.flash.assert_message(
-                'Edit of Automate Method "{}" was cancelled by the user'.format(self.name))
 
     def delete(self, cancel=False):
         details_page = navigate_to(self, 'Details')

--- a/cfme/tests/automate/test_domain.py
+++ b/cfme/tests/automate/test_domain.py
@@ -120,6 +120,7 @@ def test_duplicate_domain_disallowed(request, appliance):
     Polarion:
         assignee: ghubale
         casecomponent: Automate
+        caseimportance: medium
         caseposneg: negative
         initialEstimate: 1/60h
         tags: automate
@@ -150,11 +151,7 @@ def test_domain_cannot_delete_builtin(appliance):
     """
     manageiq_domain = appliance.collections.domains.instantiate(name='ManageIQ')
     details_view = navigate_to(manageiq_domain, 'Details')
-    if appliance.version < '5.7':
-        assert details_view.configuration.is_displayed
-        assert 'Remove this Domain' not in details_view.configuration.items
-    else:
-        assert not details_view.configuration.is_displayed
+    assert not details_view.configuration.is_displayed
 
 
 @pytest.mark.tier(2)
@@ -171,11 +168,7 @@ def test_domain_cannot_edit_builtin(appliance):
     """
     manageiq_domain = appliance.collections.domains.instantiate(name='ManageIQ')
     details_view = navigate_to(manageiq_domain, 'Details')
-    if appliance.version < '5.7':
-        assert details_view.configuration.is_displayed
-        assert not details_view.configuration.item_enabled('Edit this Domain')
-    else:
-        assert not details_view.configuration.is_displayed
+    assert not details_view.configuration.is_displayed
 
 
 @pytest.mark.tier(2)

--- a/cfme/tests/automate/test_domain.py
+++ b/cfme/tests/automate/test_domain.py
@@ -210,9 +210,6 @@ def test_domain_lock_unlock(request, appliance):
     meth = cls.methods.create(name='meth', script='$evm')
     # Lock the domain
     domain.lock()
-    navigate_to(appliance.server, 'Dashboard')
-    # Check that nothing is editable
-    # namespaces
     details = navigate_to(ns1, 'Details')
     assert not details.configuration.is_displayed
     details = navigate_to(ns2, 'Details')

--- a/cfme/tests/automate/test_method.py
+++ b/cfme/tests/automate/test_method.py
@@ -40,7 +40,7 @@ def klass(request, namespace):
 
 @pytest.mark.sauce
 @pytest.mark.tier(2)
-def test_method_crud(klass):
+def test_method_crud(appliance, klass):
     """
     Polarion:
         assignee: ghubale
@@ -61,6 +61,9 @@ def test_method_crud(klass):
         method.name = fauxfactory.gen_alphanumeric(8)
         method.script = "bar"
     assert method.exists
+    navigate_to(appliance.server, 'Dashboard')
+    # Navigation to 'Dashboard' is required to navigate to details page of method.
+    # So that 'Edit this Method' option from configuration will be selected from details page.
     with update(method):
         method.name = origname
     assert method.exists
@@ -70,7 +73,7 @@ def test_method_crud(klass):
 
 @pytest.mark.sauce
 @pytest.mark.tier(2)
-def test_automate_method_inputs_crud(klass):
+def test_automate_method_inputs_crud(appliance, klass):
     """
     Polarion:
         assignee: ghubale
@@ -102,6 +105,9 @@ def test_automate_method_inputs_crud(klass):
     assert view.inputs.read() == {
         'different': {'Data Type': 'string', 'Default Value': 'value'},
     }
+    navigate_to(appliance.server, 'Dashboard')
+    # Navigation to 'Dashboard' is required to navigate on details page of method.
+    # So that 'Edit this Method' option from configuration will be selected from details page.
     with update(method):
         method.inputs = {}
     view = navigate_to(method, 'Details')

--- a/cfme/tests/automate/test_method.py
+++ b/cfme/tests/automate/test_method.py
@@ -41,7 +41,7 @@ def klass(namespace):
 
 @pytest.mark.sauce
 @pytest.mark.tier(2)
-def test_method_crud(appliance, klass):
+def test_method_crud(klass):
     """
     Polarion:
         assignee: ghubale
@@ -56,7 +56,7 @@ def test_method_crud(appliance, klass):
         location='inline',
         script='$evm.log(:info, ":P")',
     )
-    view = appliance.browser.create_view(ClassDetailsView)
+    view = method.create_view(ClassDetailsView)
     view.flash.assert_message('Automate Method "{}" was added'.format(method.name))
     assert method.exists
     origname = method.name


### PR DESCRIPTION
{{ pytest: cfme/tests/automate -k 'test_method_crud or test_domain_lock_unlock or test_domain_cannot_delete_builtin or test_domain_cannot_edit_builtin or test_priority or test_automate_method_inputs_crud' -v }}

Fixed Error:
```
>           raise TimedOutError("Could not do {} at {}:{} in time".format(message, filename, line_no))
E           TimedOutError: Could not do Waiting for view [MethodEditView] to display at /var/ci/workspace/downstream-59z-tests-master/integration_tests/cfme/utils/appliance/implementations/ui.py:562 in time

../cfme_venv/lib/python2.7/site-packages/wait_for/__init__.py:180: TimedOutError
TimedOutError
Could not do Waiting for view [MethodEditView] to display at /var/ci/workspace/downstream-59z-tests-master/integration_tests/cfme/utils/appliance/implementations/ui.py:562 in time
```

This PR fixes:

 - Fixed is_displyed of MethodEditView
 - Removed "< 5.7" dependencies
 - Assigned tests to 'ghubale'
 - Updated xpath of add_field for 5.10