### PR TITLE
[1LP][RFR]Add blocker to tests provisioning vsphere65 VM via REST

### DIFF
--- a/cfme/tests/cloud_infra_common/test_provisioning.py
+++ b/cfme/tests/cloud_infra_common/test_provisioning.py
@@ -14,6 +14,7 @@ from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.infrastructure.provider import InfraProvider
+from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import providers
 from cfme.utils import normalize_text
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -255,6 +256,16 @@ def test_provision_approval(appliance, provider, vm_name, smtp_test, request,
     wait_for(verify, message="email receive check", delay=5)
 
 
+@pytest.mark.meta(
+    blockers=[
+        BZ(
+            1662638,
+            forced_streams=["5.9", "5.10", "upstream"],
+            unblock=lambda provider: provider.one_of(VMwareProvider)
+            and provider.version == "6.5",
+        )
+    ]
+)
 @pytest.mark.parametrize('auto', [True, False], ids=["Auto", "Manual"])
 def test_provision_from_template_using_rest(appliance, request, provider, vm_name, auto):
     """ Tests provisioning from a template using the REST API.

--- a/cfme/tests/infrastructure/test_provisioning_rest.py
+++ b/cfme/tests/infrastructure/test_provisioning_rest.py
@@ -84,6 +84,16 @@ def clean_vm(appliance, provider, vm_name):
     appliance.collections.infra_vms.instantiate(vm_name, provider).cleanup_on_provider()
 
 
+@pytest.mark.meta(
+    blockers=[
+        BZ(
+            1662638,
+            forced_streams=["5.9", "5.10", "upstream"],
+            unblock=lambda provider: provider.one_of(VMwareProvider)
+            and provider.version == "6.5",
+        )
+    ]
+)
 @pytest.mark.rhv2
 # Here also available the ability to create multiple provision request, but used the save
 # href and method, so it doesn't make any sense actually
@@ -174,6 +184,16 @@ def test_provision_vlan(request, appliance, provision_data, vnic_profile, provid
             format(profile_via_provider.name, profile_name)
 
 
+@pytest.mark.meta(
+    blockers=[
+        BZ(
+            1662638,
+            forced_streams=["5.9", "5.10", "upstream"],
+            unblock=lambda provider: provider.one_of(VMwareProvider)
+            and provider.version == "6.5",
+        )
+    ]
+)
 @pytest.mark.rhv3
 @pytest.mark.meta(server_roles="+notifier")
 def test_provision_emails(request, provision_data, provider, appliance, smtp_test):


### PR DESCRIPTION
This PR brings the following changes:
1. Add a blocker to `test_provision` and `test_provision_emails` that tests/requires VM provisioning via REST. Issue is related to vsphere65-nested provider.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1662638

{{pytest: cfme/tests/infrastructure/test_provisioning_rest.py::test_provision cfme/tests/infrastructure/test_provisioning_rest.py::test_provision_emails cfme/tests/cloud_infra_common/test_provisioning.py::test_provision_from_template_using_rest --use-provider=vsphere65-nested --use-template-cache -sqvvvv }}