### PR TITLE
[1LP][RFR] Fix test service/ssui ansible 

### DIFF
--- a/cfme/fixtures/ansible_fixtures.py
+++ b/cfme/fixtures/ansible_fixtures.py
@@ -1,10 +1,10 @@
 import fauxfactory
 import pytest
 
-from cfme.services.catalogs.catalog import Catalog
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.services.myservice import MyService
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import BZ
 from cfme.utils.conf import cfme_data
 from cfme.utils.wait import wait_for
 
@@ -101,7 +101,8 @@ def order_ansible_service_in_ops_ui(appliance, ansible_catalog_item,
     service_request = appliance.collections.requests.instantiate(description=request_descr)
     if service_request.exists():
         service_request.wait_for_request()
-        service_request.remove_request()
+        if not BZ(1646333, forced_streams=['5.10']).blocks:
+            service_request.remove_request()
     yield cat_item_name
     service = MyService(appliance, cat_item_name)
     if service.exists:

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -339,30 +339,6 @@ def appliance_with_providers(appliance_preupdate):
     return appliance_preupdate
 
 
-@pytest.fixture(scope="module")
-def ansible_repository(appliance):
-    repositories = appliance.collections.ansible_repositories
-    try:
-        repository = repositories.create(
-            name=fauxfactory.gen_alpha(),
-            url=cfme_data.ansible_links.playbook_repositories.embedded_ansible,
-            description=fauxfactory.gen_alpha()
-        )
-    except KeyError:
-        pytest.skip("Skipping since no such key found in yaml")
-    view = navigate_to(repository, "Details")
-    refresh = view.toolbar.refresh.click
-    wait_for(
-        lambda: view.entities.summary("Properties").get_text_of("Status") == "successful",
-        timeout=60,
-        fail_func=refresh,
-    )
-    yield repository
-
-    if repository.exists:
-        repository.delete()
-
-
 def provider_app_crud(provider_class, appliance):
     try:
         prov = list_providers_by_class(provider_class)[0]


### PR DESCRIPTION
{{pytest: cfme/tests/ssui/test_ssui_ansible_service.py::test_service_catalog_crud_ui -v --long-running}}

