### PR TITLE
[RFR] added shortcut for create_view() and wait_displayed()

### DIFF
--- a/cfme/automate/dialogs/dialog_element.py
+++ b/cfme/automate/dialogs/dialog_element.py
@@ -132,8 +132,7 @@ class Element(BaseEntity):
         view.fill(element)
         view.ele_save_button.click()
         view.save_button.click()
-        view = self.create_view(DetailsDialogView)
-        assert view.is_displayed
+        view = self.create_view(DetailsDialogView, wait='10s')
         view.flash.assert_no_error()
 
     def reorder_elements(self, add_element, second_element, element_data):
@@ -158,8 +157,7 @@ class Element(BaseEntity):
         dropped_el = second_element.get('element_information').get("ele_label")
         view.dragndrop.drag_and_drop(self.element_loc(dragged_el), self.element_loc(dropped_el))
         view.save_button.click()
-        view = self.create_view(DetailsDialogView)
-        assert view.is_displayed
+        view = self.create_view(DetailsDialogView, wait='10s')
         view.flash.assert_no_error()
 
 

--- a/cfme/automate/explorer/klass.py
+++ b/cfme/automate/explorer/klass.py
@@ -206,8 +206,7 @@ class Class(BaseEntity, Copiable):
             assert details_page.is_displayed
             details_page.flash.assert_no_error()
         else:
-            result_view = self.create_view(NamespaceDetailsView, self.parent_obj)
-            assert result_view.is_displayed
+            result_view = self.create_view(NamespaceDetailsView, self.parent_obj, wait='10s')
             result_view.flash.assert_no_error()
             result_view.flash.assert_message(
                 'Automate Class "{}": Delete successful'.format(self.description or self.name))
@@ -219,8 +218,7 @@ class Class(BaseEntity, Copiable):
             view.save_button.click()
         else:
             view.cancel_button.click()
-        view = self.create_view(ClassDetailsView, override=updates)
-        assert view.is_displayed
+        view = self.create_view(ClassDetailsView, override=updates, wait='10s')
         view.flash.assert_no_error()
         if changed:
             # When updating, class FQDN is used

--- a/cfme/automate/explorer/method.py
+++ b/cfme/automate/explorer/method.py
@@ -391,9 +391,7 @@ class Method(BaseEntity, Copiable):
             view.save_button.click()
         else:
             view.cancel_button.click()
-        view = self.create_view(MethodDetailsView, override=updates)
-        view.wait_displayed()
-        assert view.is_displayed
+        view = self.create_view(MethodDetailsView, override=updates, wait='10s')
         view.flash.assert_no_error()
         if changed:
             view.flash.assert_message(
@@ -409,8 +407,7 @@ class Method(BaseEntity, Copiable):
             assert details_page.is_displayed
             details_page.flash.assert_no_error()
         else:
-            result_view = self.create_view(ClassDetailsView, self.parent_obj)
-            assert result_view.is_displayed
+            result_view = self.create_view(ClassDetailsView, self.parent_obj, wait='10s')
             result_view.flash.assert_no_error()
             result_view.flash.assert_message(
                 'Automate Method "{}": Delete successful'.format(self.name))

--- a/cfme/automate/import_export.py
+++ b/cfme/automate/import_export.py
@@ -80,14 +80,12 @@ class AutomateGitRepository(Navigatable):
         assert imex_page.import_git.fill(self.fill_values_repo_add)
         imex_page.import_git.submit.click()
         imex_page.browser.plugin.ensure_page_safe(timeout='5m')
-        git_select = self.create_view(GitImportSelectorView)
-        assert git_select.is_displayed
+        git_select = self.create_view(GitImportSelectorView, wait='10s')
         git_select.flash.assert_no_error()
         git_select.fill(self.fill_values_branch_select(branch, tag))
         git_select.submit.click()
         git_select.browser.plugin.ensure_page_safe(timeout='5m')
-        imex_page = self.create_view(AutomateImportExportView)
-        assert imex_page.is_displayed
+        imex_page = self.create_view(AutomateImportExportView, wait='10s')
         imex_page.flash.assert_no_error()
         # Now find the domain in database
         namespaces = self.appliance.db.client['miq_ae_namespaces']

--- a/cfme/automate/provisioning_dialogs.py
+++ b/cfme/automate/provisioning_dialogs.py
@@ -203,8 +203,8 @@ class ProvisioningDialogsCollection(BaseCollection):
             flash_msg = 'Dialog "{}" was added'.format(dialog.description)
             btn = view.form.add
         btn.click()
-        view = dialog.create_view(ProvDiagAllView if cancel else ProvDiagDetailsView)
-        assert view.is_displayed
+        view = dialog.create_view(ProvDiagAllView if cancel else ProvDiagDetailsView,
+                                           wait='10s')
         view.flash.assert_success_message(flash_msg)
         return dialog
 

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -546,8 +546,7 @@ class BaseProvider(Taggable, Updateable, Navigatable, BaseEntity):
         if not cancel:
             msg = ('Delete initiated for 1 {} Provider from '
                    'the {} Database'.format(self.string_name, self.appliance.product_name))
-            main_view = self.create_view(navigator.get_class(self, 'All').VIEW)
-            main_view.wait_displayed(timeout='10s')
+            main_view = self.create_view(navigator.get_class(self, 'All').VIEW, wait='10s')
             main_view.flash.assert_success_message(msg)
 
     def delete_rest(self):

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -925,8 +925,7 @@ class VM(BaseVM):
             view.form.cancel.click()
             msg = 'Set/remove retirement date was cancelled by the user'
         if self.DETAILS_VIEW_CLASS is not None:
-            view = self.create_view(self.DETAILS_VIEW_CLASS)
-            assert view.is_displayed
+            view = self.create_view(self.DETAILS_VIEW_CLASS, wait='5s')
         view.flash.assert_success_message(msg)
 
     def equal_drift_results(self, drift_section, section, *indexes):
@@ -952,8 +951,7 @@ class VM(BaseVM):
         # mark by indexes or mark all
         details_view = navigate_to(self, "Details")
         details_view.entities.summary("Relationships").click_at("Drift History")
-        drift_history_view = self.create_view(DriftHistory)
-        assert drift_history_view.is_displayed
+        drift_history_view = self.create_view(DriftHistory, wait='10s')
         if indexes:
             _select_rows(indexes)
         else:
@@ -965,8 +963,7 @@ class VM(BaseVM):
             else:
                 _select_rows(range(rows_number))
         drift_history_view.analyze_button.click()
-        drift_analysis_view = self.create_view(DriftAnalysis)
-        assert drift_analysis_view.is_displayed
+        drift_analysis_view = self.create_view(DriftAnalysis, wait='10s')
         drift_analysis_view.drift_sections.check_node(section)
         drift_analysis_view.apply_button.click()
         if not drift_analysis_view.toolbar.all_attributes.active:

--- a/cfme/configure/access_control/__init__.py
+++ b/cfme/configure/access_control/__init__.py
@@ -877,7 +877,7 @@ class GroupCollection(BaseCollection):
         else:
             view.add_button.click()
             flash_message = 'Group "{}" was saved'.format(group.description)
-        view = self.create_view(AllGroupView)
+        view = self.create_view(AllGroupView, wait='10s')
 
         try:
             view.flash.assert_message(flash_blocked_msg)
@@ -885,9 +885,7 @@ class GroupCollection(BaseCollection):
         except AssertionError:
             pass
 
-        view.wait_displayed()
         view.flash.assert_success_message(flash_message)
-        assert view.is_displayed
 
         # To ensure that the group list is updated
         view.browser.refresh()

--- a/cfme/control/explorer/actions.py
+++ b/cfme/control/explorer/actions.py
@@ -176,8 +176,7 @@ class Action(BaseEntity, Updateable, Pretty):
             view.save_button.click()
         else:
             view.cancel_button.click()
-        view = self.create_view(ActionDetailsView, override=updates)
-        view.wait_displayed('15s')
+        view = self.create_view(ActionDetailsView, override=updates, wait='15s')
         view.flash.assert_no_error()
         if changed:
             view.flash.assert_message(
@@ -252,8 +251,7 @@ class ActionCollection(BaseCollection):
         self.browser.plugin.ensure_page_safe()
         view.add_button.click()
         action = self.instantiate(description, action_type, action_values=action_values)
-        view = action.create_view(ActionDetailsView)
-        view.wait_displayed()
+        view = action.create_view(ActionDetailsView, wait='10s')
         view.flash.assert_success_message('Action "{}" was added'.format(action.description))
         return action
 

--- a/cfme/control/explorer/alerts.py
+++ b/cfme/control/explorer/alerts.py
@@ -240,8 +240,7 @@ class Alert(BaseEntity, Updateable, Pretty):
             view.save_button.click()
         else:
             view.cancel_button.click()
-        view = self.create_view(AlertDetailsView, override=updates)
-        view.wait_displayed()
+        view = self.create_view(AlertDetailsView, override=updates, wait='10s')
         view.flash.assert_no_error()
         if changed:
             view.flash.assert_message(
@@ -282,8 +281,7 @@ class Alert(BaseEntity, Updateable, Pretty):
             view.cancel_button.click()
         for attrib, value in updates.items():
             setattr(new_alert, attrib, value)
-        view = new_alert.create_view(AlertDetailsView)
-        view.wait_displayed()
+        view = new_alert.create_view(AlertDetailsView, wait='10s')
         view.flash.assert_no_error()
         if changed:
             view.flash.assert_message(
@@ -370,8 +368,7 @@ class AlertCollection(BaseCollection):
             timeline_event=timeline_event, mgmt_event=mgmt_event)
         alert._fill(view)
         view.add_button.click()
-        view = alert.create_view(AlertDetailsView)
-        view.wait_displayed()
+        view = alert.create_view(AlertDetailsView, wait='10s')
         view.flash.assert_success_message('Alert "{}" was added'.format(alert.description))
         return alert
 

--- a/cfme/control/explorer/conditions.py
+++ b/cfme/control/explorer/conditions.py
@@ -204,15 +204,13 @@ class BaseCondition(BaseEntity, Updateable, Pretty):
             view.fill(updates)
             view.wait_displayed()
             view.save_button.click()
-            view = self.create_view(ConditionDetailsView, override=updates)
-            view.wait_displayed()
+            view = self.create_view(ConditionDetailsView, override=updates, wait='10s')
             view.flash.assert_success_message(
             'Condition "{}" was saved'.format(updates.get("description", self.description)))
         except (TimedOutError, StaleElementReferenceException):
             logger.exception('Updating the condition failed waiting for view, canceling update.')
             view.cancel_button.click()
             view = navigate_to(self, "Details")
-            view.wait_displayed()
 
 
     def delete(self, cancel=False):
@@ -228,8 +226,7 @@ class BaseCondition(BaseEntity, Updateable, Pretty):
             assert view.is_displayed
             view.flash.assert_no_error()
         else:
-            view = self.create_view(ConditionClassAllView)
-            view.wait_displayed()
+            view = self.create_view(ConditionClassAllView, wait='10s')
             view.flash.assert_success_message('Condition "{}": Delete successful'.format(
                 self.description))
 

--- a/cfme/control/explorer/policies.py
+++ b/cfme/control/explorer/policies.py
@@ -603,8 +603,7 @@ class PolicyCollection(BaseCollection):
         })
         view.add_button.click()
 
-        view = policy.create_view(PolicyDetailsView, o=policy)
-        view.wait_displayed()
+        view = policy.create_view(PolicyDetailsView, o=policy, wait='10s')
         view.flash.assert_success_message('Policy "{}" was added'.format(policy.description))
         return policy
 

--- a/cfme/control/explorer/policy_profiles.py
+++ b/cfme/control/explorer/policy_profiles.py
@@ -95,8 +95,7 @@ class PolicyProfile(BaseEntity, Updateable, Pretty):
             view.save_button.click()
         else:
             view.cancel_button.click()
-        view = self.create_view(PolicyProfileDetailsView, override=updates)
-        view.wait_displayed()
+        view = self.create_view(PolicyProfileDetailsView, override=updates, wait='10s')
         view.flash.assert_no_error()
         if changed:
             view.flash.assert_message(

--- a/cfme/generic_objects/definition/ui.py
+++ b/cfme/generic_objects/definition/ui.py
@@ -88,8 +88,7 @@ def delete(self):
 
     view.configuration.item_select(
         'Remove this Generic Object Classes from Inventory', handle_alert=True)
-    view = self.create_view(GenericObjectDefinitionAllView)
-    view.wait_displayed('15s')
+    view = self.create_view(GenericObjectDefinitionAllView, wait='15s')
     view.flash.assert_no_error()
 
 

--- a/cfme/intelligence/reports/schedules.py
+++ b/cfme/intelligence/reports/schedules.py
@@ -153,9 +153,7 @@ class Schedule(Updateable, Pretty, BaseEntity):
             view.save_button.click()
         else:
             view.cancel_button.click()
-        view = self.create_view(ScheduleDetailsView, override=updates)
-        view.wait_displayed()
-        assert view.is_displayed
+        view = self.create_view(ScheduleDetailsView, override=updates, wait='10s')
         view.flash.assert_no_error()
         if changed:
             view.flash.assert_message(

--- a/cfme/services/catalogs/catalog.py
+++ b/cfme/services/catalogs/catalog.py
@@ -98,8 +98,7 @@ class Catalog(BaseEntity, Updateable, Pretty, Taggable):
             view.save_button.click()
         else:
             view.cancel_button.click()
-        view = self.create_view(DetailsCatalogView, override=updates)
-        assert view.wait_displayed()
+        view = self.create_view(DetailsCatalogView, override=updates, wait='10s')
         view.flash.assert_no_error()
         if changed:
             view.flash.assert_message(
@@ -111,8 +110,7 @@ class Catalog(BaseEntity, Updateable, Pretty, Taggable):
     def delete(self):
         view = navigate_to(self, "Details")
         view.configuration.item_select('Remove Catalog', handle_alert=True)
-        view = self.create_view(CatalogsView)
-        assert view.is_displayed
+        view = self.create_view(CatalogsView, wait='10s')
         view.flash.assert_no_error()
         view.flash.assert_success_message(
             'Catalog "{}": Delete successful'.format(self.description or self.name))

--- a/cfme/services/catalogs/catalog_items/__init__.py
+++ b/cfme/services/catalogs/catalog_items/__init__.py
@@ -254,9 +254,7 @@ class BaseCatalogItem(BaseEntity, Updateable, Pretty, Taggable):
             view.save.click()
         else:
             view.cancel.click()
-        view = self.create_view(DetailsCatalogItemView, override=updates)
-        view.wait_displayed()
-        assert view.is_displayed
+        view = self.create_view(DetailsCatalogItemView, override=updates, wait='10s')
         view.flash.assert_no_error()
         # TODO move these assertions to tests
         # if changed:
@@ -503,12 +501,10 @@ class CatalogItemsCollection(BaseCollection):
         view = navigate_to(cat_item, 'Add')
         view.fill(cat_item.fill_dict)
         view.add.click()
-        view = self.create_view(AllCatalogItemView)
+        view = self.create_view(AllCatalogItemView, wait='10s')
         # TODO move this assertion to tests
         # view.flash.assert_success_message('Catalog Item "{}" was added'.format(
         #     cat_item.name), partial=True)
-        view.wait_displayed()
-        assert view.is_displayed
         view.flash.assert_no_error()
         return cat_item
 

--- a/cfme/services/catalogs/catalog_items/catalog_bundles.py
+++ b/cfme/services/catalogs/catalog_items/catalog_bundles.py
@@ -70,8 +70,7 @@ class CatalogBundle(NonCloudInfraCatalogItem):
         else:
             view.flash.assert_success_message(
                 'Edit of Catalog Bundle"{}" was cancelled by the user'.format(self.name))
-        view = self.create_view(DetailsCatalogItemView, override=updates)
-        assert view.is_displayed
+        view = self.create_view(DetailsCatalogItemView, override=updates, wait='10s')
         view.flash.assert_no_error()
 
 
@@ -106,8 +105,7 @@ class CatalogBundlesCollection(BaseCollection):
             view.resources.fill({'select_resource': cat_item})
         view.add_button.click()
         view.flash.assert_success_message('Catalog Bundle "{}" was added'.format(name))
-        view = self.create_view(AllCatalogItemView)
-        assert view.is_displayed
+        view = self.create_view(AllCatalogItemView, wait='10s')
         view.flash.assert_no_error()
         return self.instantiate(name, catalog_items=catalog_items, catalog=catalog,
                                 description=description, display_in=display_in, dialog=dialog,

--- a/cfme/services/catalogs/orchestration_template.py
+++ b/cfme/services/catalogs/orchestration_template.py
@@ -178,7 +178,6 @@ class OrchestrationTemplate(BaseEntity, Updateable, Pretty, Taggable):
                    })
         view.add_button.click()
         view.wait_displayed()
-        assert view.is_displayed
         view.flash.assert_no_error()
         # TODO - Move assertions to tests
         return self.parent.instantiate(template_group=self.template_group,

--- a/cfme/services/dashboard/ssui.py
+++ b/cfme/services/dashboard/ssui.py
@@ -82,12 +82,8 @@ def total_services(self):
     total_service = view.dashboard_card.get_count('Total Services')
     view = navigate_to(self, 'TotalServices')
     view.flash.assert_no_error()
-    view = self.create_view(MyServicesView)
-    wait_for(
-        lambda: view.is_displayed, delay=15, num_sec=300,
-        message="waiting for view to be displayed"
-    )
-    assert view.is_displayed
+    self.create_view(MyServicesView, wait=300)
+
     return total_service
 
 
@@ -143,12 +139,7 @@ def retiring_soon(self):
     retiring_services = view.aggregate_card.get_count('Retiring Soon')
     view = navigate_to(self, 'RetiringSoon')
     view.flash.assert_no_error()
-    view = self.create_view(MyServicesView)
-    wait_for(
-        lambda: view.is_displayed, delay=15, num_sec=300,
-        message="waiting for view to be displayed"
-    )
-    assert view.is_displayed
+    self.create_view(MyServicesView, wait=300)
     return retiring_services
 
 
@@ -160,12 +151,7 @@ def current_services(self):
     current_service = view.aggregate_card.get_count('Current Services')
     view = navigate_to(self, 'CurrentServices')
     view.flash.assert_no_error()
-    view = self.create_view(MyServicesView)
-    wait_for(
-        lambda: view.is_displayed, delay=15, num_sec=300,
-        message="waiting for view to be displayed"
-    )
-    assert view.is_displayed
+    self.create_view(MyServicesView, wait=300)
     return current_service
 
 
@@ -177,12 +163,7 @@ def retired_services(self):
     retired_service = view.aggregate_card.get_count('Retired Services')
     view = navigate_to(self, 'RetiredServices')
     view.flash.assert_no_error()
-    view = self.create_view(MyServicesView)
-    wait_for(
-        lambda: view.is_displayed, delay=15, num_sec=300,
-        message="waiting for view to be displayed"
-    )
-    assert view.is_displayed
+    self.create_view(MyServicesView, wait=300)
     return retired_service
 
 

--- a/cfme/services/myservice/ssui.py
+++ b/cfme/services/myservice/ssui.py
@@ -219,12 +219,7 @@ def delete(self):
         view.remove_service.click()
     view = self.create_view(RemoveServiceView)
     view.remove.click()
-    view = self.create_view(MyServicesView)
-    wait_for(
-        lambda: view.is_displayed, delay=15, num_sec=300,
-        message="waiting for view to be displayed"
-    )
-    assert view.is_displayed
+    view = self.create_view(MyServicesView, wait=300)
     # TODO - remove sleep when BZ 1518954 is fixed
     time.sleep(10)
     assert view.notification.assert_message("{} was removed.".format(self.name))
@@ -252,13 +247,10 @@ def retire(self):
     view = navigate_to(self, 'Retire')
     view.retire.click()
     if self.appliance.version < "5.10":
-        view = self.create_view(MyServicesView)
-    else:
-        view = self.create_view(DetailsMyServiceView)
-    view.wait_displayed('20s')
-    if self.appliance.version < "5.10":
+        view = self.create_view(MyServicesView, wait='20s')
         assert view.notification.assert_message("{} was retired.".format(self.name))
     else:
+        view = self.create_view(DetailsMyServiceView, wait='20s')
         assert view.notification.assert_message("Service Retire - Request Created")
 
 

--- a/cfme/services/myservice/ui.py
+++ b/cfme/services/myservice/ui.py
@@ -260,8 +260,7 @@ def update(self, updates):
         view.flash.assert_success_message(
             'Edit of Service "{}" was cancelled by the user'.format(
                 updates.get('description', self.description)))
-    view = self.create_view(MyServiceDetailView, override=updates)
-    view.wait_displayed(timeout='5s')
+    self.create_view(MyServiceDetailView, override=updates, wait='5s')
 
 
 @MiqImplementationContext.external_for(MyService.exists.getter, ViaUI)
@@ -281,9 +280,8 @@ def delete(self):
     else:
         remove_str = 'Remove Service from Inventory'
     view.toolbar.configuration.item_select(remove_str, handle_alert=True)
-    view = self.create_view(MyServicesView)
+    view = self.create_view(MyServicesView, wait='5s')
     view.flash.assert_no_error()
-    view.wait_displayed(timeout='5s')
     view.flash.assert_success_message(
         'Service "{}": Delete successful'.format(self.name))
 
@@ -294,8 +292,7 @@ def set_ownership(self, owner, group):
     view.fill({'select_owner': owner,
                'select_group': group})
     view.save_button.click()
-    view = self.create_view(MyServiceDetailView)
-    view.wait_displayed(timeout='5s')
+    view = self.create_view(MyServiceDetailView, wait='5s')
     view.flash.assert_no_error()
     view.flash.assert_success_message('Ownership saved for selected Service')
 
@@ -306,8 +303,7 @@ def edit_tags(self, tag, value):
     view.fill({'select_tag': tag,
                'select_value': value})
     view.save_button.click()
-    view = self.create_view(MyServiceDetailView)
-    view.wait_displayed(timeout='5s')
+    view = self.create_view(MyServiceDetailView, wait='5s')
     view.flash.assert_no_error()
     view.flash.assert_success_message('Tag edits were successfully saved')
 
@@ -332,8 +328,7 @@ def reconfigure_service(self):
     view = navigate_to(self, 'Reconfigure')
     view.submit_button.click()
     view.flash.assert_no_error()
-    view = self.create_view(MyServiceDetailView)
-    view.wait_displayed(timeout='5s')
+    self.create_view(MyServiceDetailView, wait='5s')
 
 
 @navigator.register(MyService, 'All')

--- a/cfme/tests/ansible/test_embedded_ansible_services.py
+++ b/cfme/tests/ansible/test_embedded_ansible_services.py
@@ -426,7 +426,6 @@ def test_service_ansible_playbook_order_credentials(ansible_catalog_item, ansibl
             "machine_credential": ansible_credential.name
         }
     view = navigate_to(service_catalog, "Order")
-    view.wait_displayed()
     options = [o.text for o in (view.fields('credential')).visible_widget.all_options]
     assert ansible_credential.name in set(options)
 

--- a/cfme/tests/automate/custom_button/test_buttons.py
+++ b/cfme/tests/automate/custom_button/test_buttons.py
@@ -322,8 +322,7 @@ def test_custom_button_quotes(appliance, provider, setup_provider, dialog, reque
     assert custom_button_group.has_item(button.text)
     custom_button_group.item_select(button.text)
 
-    dialog_view = view.browser.create_view(TextInputDialogView)
-    dialog_view.wait_displayed("60s")
+    dialog_view = view.browser.create_view(TextInputDialogView, wait='60s')
     dialog_view.service_name.fill("Custom Button Execute")
 
     dialog_view.submit.click()

--- a/cfme/tests/automate/custom_button/test_cloud_objects.py
+++ b/cfme/tests/automate/custom_button/test_cloud_objects.py
@@ -187,8 +187,7 @@ def test_custom_button_dialog(appliance, dialog, request, setup_objs, button_gro
         assert custom_button_group.has_item(button.text)
         custom_button_group.item_select(button.text)
 
-        dialog_view = view.browser.create_view(TextInputDialogView)
-        dialog_view.wait_displayed()
+        dialog_view = view.browser.create_view(TextInputDialogView, wait='10s')
         dialog_view.service_name.fill("Custom Button Execute")
 
         # Clear the automation log

--- a/cfme/tests/automate/custom_button/test_container_objects.py
+++ b/cfme/tests/automate/custom_button/test_container_objects.py
@@ -158,8 +158,7 @@ def test_custom_button_dialog(appliance, dialog, request, setup_obj, button_grou
     assert custom_button_group.has_item(button.text)
     custom_button_group.item_select(button.text)
 
-    dialog_view = view.browser.create_view(TextInputDialogView)
-    dialog_view.wait_displayed()
+    dialog_view = view.browser.create_view(TextInputDialogView, wait='10s')
     assert dialog_view.service_name.fill("Custom Button Execute")
 
     # Clear the automation log

--- a/cfme/tests/automate/custom_button/test_generic_objects.py
+++ b/cfme/tests/automate/custom_button/test_generic_objects.py
@@ -223,8 +223,7 @@ def test_custom_button_dialog(appliance, dialog, request, setup_obj, button_grou
     assert custom_button_group.has_item(button.text)
     custom_button_group.item_select(button.text)
 
-    dialog_view = view.browser.create_view(TextInputDialogView)
-    dialog_view.wait_displayed()
+    dialog_view = view.browser.create_view(TextInputDialogView, wait='10s')
     assert dialog_view.service_name.fill("Custom Button Execute")
 
     # Clear the automation log

--- a/cfme/tests/automate/custom_button/test_infra_objects.py
+++ b/cfme/tests/automate/custom_button/test_infra_objects.py
@@ -299,8 +299,7 @@ def test_custom_button_dialog(appliance, dialog, request, setup_obj, button_grou
     assert custom_button_group.has_item(button.text)
     custom_button_group.item_select(button.text)
 
-    dialog_view = view.browser.create_view(TextInputDialogView)
-    dialog_view.wait_displayed()
+    dialog_view = view.browser.create_view(TextInputDialogView, wait='10s')
     assert dialog_view.service_name.fill("Custom Button Execute")
 
     # Clear the automation log

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -1371,7 +1371,7 @@ def test_copied_user_password_inheritance(appliance, group_collection, request):
     request.addfinalizer(user.delete)
     view = navigate_to(user, 'Details')
     view.toolbar.configuration.item_select('Copy this User to a new User')
-    view = user.create_view(AddUserView)
+    view = user.create_view(AddUserView, wait='10s')
     assert view.password_txt.value == '' and view.password_verify_txt.value == ''
     view.cancel_button.click()
 

--- a/cfme/tests/configure/test_analysis_profiles.py
+++ b/cfme/tests/configure/test_analysis_profiles.py
@@ -171,9 +171,8 @@ def test_vmanalysis_profile_description_validation(analysis_profile_collection):
 
     # Should still be on the form page after create method raises exception
     view = analysis_profile_collection.create_view(
-        navigator.get_class(analysis_profile_collection, 'AddVmProfile').VIEW
+        navigator.get_class(analysis_profile_collection, 'AddVmProfile').VIEW, wait='10s'
     )
-    assert view.is_displayed
     view.flash.assert_message("Description can't be blank")
     view.cancel.click()
 
@@ -204,9 +203,8 @@ def test_analysis_profile_duplicate_name(analysis_profile_collection):
 
     # Should still be on the form page after create method raises exception
     view = analysis_profile_collection.create_view(
-        navigator.get_class(analysis_profile_collection, 'AddVmProfile').VIEW
+        navigator.get_class(analysis_profile_collection, 'AddVmProfile').VIEW, wait='10s'
     )
-    assert view.is_displayed
     view.flash.assert_message("Name has already been taken")
     view.cancel.click()
 
@@ -280,9 +278,8 @@ def test_analysis_profile_item_validation(analysis_profile_collection):
 
     # Should still be on the form page after create method raises exception
     view = analysis_profile_collection.create_view(
-        navigator.get_class(analysis_profile_collection, 'AddHostProfile').VIEW
+        navigator.get_class(analysis_profile_collection, 'AddHostProfile').VIEW, wait='10s'
     )
-    assert view.is_displayed
     view.flash.assert_message("At least one item must be entered to create Analysis Profile")
     view.cancel.click()
 
@@ -307,9 +304,8 @@ def test_analysis_profile_name_validation(analysis_profile_collection):
 
     # Should still be on the form page after create method raises exception
     view = analysis_profile_collection.create_view(
-        navigator.get_class(analysis_profile_collection, 'AddHostProfile').VIEW
+        navigator.get_class(analysis_profile_collection, 'AddHostProfile').VIEW, wait='10s'
     )
-    assert view.is_displayed
     view.flash.assert_message("Name can't be blank")
     view.cancel.click()
 
@@ -333,8 +329,7 @@ def test_analysis_profile_description_validation(analysis_profile_collection):
 
     # Should still be on the form page after create method raises exception
     view = analysis_profile_collection.create_view(
-        navigator.get_class(analysis_profile_collection, 'AddHostProfile').VIEW
+        navigator.get_class(analysis_profile_collection, 'AddHostProfile').VIEW, wait='10s'
     )
-    assert view.is_displayed
     view.flash.assert_message("Description can't be blank")
     view.cancel.click()

--- a/cfme/tests/configure/test_visual_cloud.py
+++ b/cfme/tests/configure/test_visual_cloud.py
@@ -192,8 +192,7 @@ def test_cloud_start_page(request, appliance, start_page):
     appliance.user.my_settings.visual.login_page = start_page
     appliance.server.logout()
     appliance.server.login_admin()
-    landing_view = appliance.browser.create_view(landing_pages[start_page])
-    assert landing_view.is_displayed
+    appliance.browser.create_view(landing_pages[start_page], wait='10s')
 
 
 def test_cloudprovider_noquads(request, set_cloud_provider_quad):

--- a/cfme/tests/intelligence/test_chargeback.py
+++ b/cfme/tests/intelligence/test_chargeback.py
@@ -88,8 +88,7 @@ def test_compute_chargeback_duplicate_disallowed(request):
     # cancel form, check all redirect
     view.cancel_button.click()
     view = cb_rate.create_view(
-        navigator.get_class(cb_rate, 'All').VIEW)
-    assert view.is_displayed
+        navigator.get_class(cb_rate, 'All').VIEW, wait='10s')
     view.flash.assert_success_message('Add of new Chargeback Rate was cancelled by the user')
 
 

--- a/cfme/tests/services/test_catalog_item.py
+++ b/cfme/tests/services/test_catalog_item.py
@@ -165,8 +165,7 @@ def test_catalog_item_duplicate_name(appliance, dialog, catalog):
         catalog=catalog,
         dialog=dialog
     )
-    view = cat_item.create_view(AllCatalogItemView)
-    view.wait_displayed()
+    view = cat_item.create_view(AllCatalogItemView, wait='10s')
     view.flash.assert_success_message('Service Catalog Item "{}" was added'.format(cat_item.name))
     with pytest.raises(AssertionError):
         appliance.collections.catalog_items.create(
@@ -177,8 +176,7 @@ def test_catalog_item_duplicate_name(appliance, dialog, catalog):
             catalog=catalog,
             dialog=dialog
         )
-    view = cat_item.create_view(AddCatalogItemView)
-    view.wait_displayed()
+    view = cat_item.create_view(AddCatalogItemView, wait='10s')
     view.flash.assert_message('Name has already been taken')
 
 

--- a/cfme/tests/storage/test_volume_snapshot.py
+++ b/cfme/tests/storage/test_volume_snapshot.py
@@ -83,8 +83,7 @@ def test_storage_snapshot_create_cancelled_validation(volume):
 
     snapshot_name = fauxfactory.gen_alpha()
     volume.create_snapshot(snapshot_name, cancel=True)
-    view = volume.create_view(VolumeDetailsView)
-    view.wait_displayed(timeout='10s')
+    view = volume.create_view(VolumeDetailsView, wait='10s')
     view.flash.assert_message(
         'Snapshot of Cloud Volume "{}" was cancelled by the user'.format(volume.name))
 
@@ -133,8 +132,7 @@ def test_storage_volume_snapshot_crud(volume):
     initial_snapshot_count = volume.snapshots_count
     snapshot_name = fauxfactory.gen_alpha()
     snapshot = volume.create_snapshot(snapshot_name)
-    view = volume.create_view(VolumeDetailsView)
-    view.wait_displayed(timeout='10s')
+    view = volume.create_view(VolumeDetailsView, wait='10s')
     view.flash.assert_success_message(
         'Snapshot for Cloud Volume "{}" created'.format(volume.name))
 

--- a/cfme/tests/v2v/test_v2v_cancel_migrations.py
+++ b/cfme/tests/v2v/test_v2v_cancel_migrations.py
@@ -62,8 +62,7 @@ def test_dual_vm_migration_cancel_migration(request, appliance, v2v_providers, h
         handle_exception=True)
     view.progress_card.select_plan(migration_plan.name)
     view = appliance.browser.create_view(navigator.get_class(migration_plan_collection,
-                                                             'Details').VIEW)
-    view.wait_displayed()
+                                                             'Details').VIEW, wait='10s')
     request_details_list = view.migration_request_details_list
     vms = request_details_list.read()
 

--- a/cfme/tests/v2v/test_v2v_migrations.py
+++ b/cfme/tests/v2v/test_v2v_migrations.py
@@ -126,8 +126,7 @@ def test_single_network_single_vm_migration(request, appliance, v2v_providers, h
         handle_exception=True)
     view.progress_card.select_plan(migration_plan.name)
     view = appliance.browser.create_view(navigator.get_class(migration_plan_collection,
-                                                             'Details').VIEW)
-    view.wait_displayed()
+                                                             'Details').VIEW, wait='10s')
     request_details_list = view.migration_request_details_list
     vms = request_details_list.read()
     # ideally this will always pass as request details list shows VMs in migration plan
@@ -182,8 +181,7 @@ def test_dual_datastore_dual_vm_migration(request, appliance, v2v_providers, hos
         handle_exception=True)
     view.progress_card.select_plan(migration_plan.name)
     view = appliance.browser.create_view(navigator.get_class(migration_plan_collection,
-                                                             'Details').VIEW)
-    view.wait_displayed()
+                                                             'Details').VIEW, wait='10s')
     request_details_list = view.migration_request_details_list
     vms = request_details_list.read()
 
@@ -343,8 +341,7 @@ def test_migrations_different_os_templates(request, appliance, v2v_providers, ho
         handle_exception=True)
     view.progress_card.select_plan(migration_plan.name)
     view = appliance.browser.create_view(navigator.get_class(migration_plan_collection,
-                                                             'Details').VIEW)
-    view.wait_displayed()
+                                                             'Details').VIEW, wait='10s')
     request_details_list = view.migration_request_details_list
     view.items_on_page.item_select('15')
     vms = request_details_list.read()
@@ -562,8 +559,7 @@ def test_multi_host_multi_vm_migration(request, appliance, v2v_providers, host_c
         handle_exception=True)
     view.progress_card.select_plan(migration_plan.name)
     view = appliance.browser.create_view(navigator.get_class(migration_plan_collection,
-                                                             'Details').VIEW)
-    view.wait_displayed()
+                                                             'Details').VIEW, wait='10s')
     request_details_list = view.migration_request_details_list
     vms = request_details_list.read()
     view.items_on_page.item_select('15')

--- a/cfme/tests/v2v/test_v2v_migrations_ui.py
+++ b/cfme/tests/v2v/test_v2v_migrations_ui.py
@@ -284,7 +284,6 @@ def test_v2v_ui_set2(request, appliance, v2v_providers, form_data_single_datasto
         view.migration_plans_not_started_list.migrate_plan(plan_name)
 
     view = navigate_to(migration_plan_collection, 'All')
-    view.wait_displayed()
     soft_assert(plan_name in view.migration_plans_not_started_list.read())
     soft_assert(view.migration_plans_not_started_list.get_plan_description(plan_name) ==
      plan_description)
@@ -292,8 +291,7 @@ def test_v2v_ui_set2(request, appliance, v2v_providers, form_data_single_datasto
     soft_assert(str(len(vm_selected)) in view.migration_plans_not_started_list.
         get_vm_count_in_plan(plan_name))
     view.migration_plans_not_started_list.select_plan(plan_name)
-    view = appliance.browser.create_view(MigrationPlanRequestDetailsView)
-    view.wait_displayed()
+    view = appliance.browser.create_view(MigrationPlanRequestDetailsView, wait='10s')
     view.items_on_page.item_select('15')
     soft_assert(set(view.migration_request_details_list.read()) == set(vm_selected))
     # Test plan has unique name
@@ -308,7 +306,6 @@ def test_v2v_ui_set2(request, appliance, v2v_providers, form_data_single_datasto
     view.cancel_btn.click()
 
     view = navigate_to(infrastructure_mapping_collection, 'All')
-    view.wait_displayed()
     soft_assert(view.infra_mapping_list.get_associated_plans_count(mapping.name) ==
      '1 Associated Plan')
     soft_assert(view.infra_mapping_list.get_associated_plans(mapping.name) == plan_name)

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -3177,15 +3177,19 @@ class NavigatableMixin(object):
     def browser(self):
         return self.appliance.browser.widgetastic
 
-    def create_view(self, view_class, o=None, override=None):
+    def create_view(self, view_class, o=None, override=None, wait=None):
         o = o or self
         if override is not None:
             new_obj = copy(o)
             new_obj.__dict__.update(override)
         else:
             new_obj = o
-        return self.appliance.browser.create_view(
-            view_class, additional_context={'object': new_obj})
+
+        view = self.appliance.browser.create_view(view_class,
+                                                  additional_context={'object': new_obj})
+        if wait:
+            view.wait_displayed(timeout=wait)
+        return view
 
     def list_destinations(self):
         """This function returns a list of all valid destinations for a particular object

--- a/cfme/utils/appliance/implementations/__init__.py
+++ b/cfme/utils/appliance/implementations/__init__.py
@@ -34,7 +34,7 @@ class Implementation(object):
         except AttributeError:
             pass
 
-    def create_view(self, view_class, additional_context=None):
+    def create_view(self, view_class, additional_context=None, wait=None):
         """Method that is used to instantiate a Widgetastic View.
 
         Views may define ``LOCATION`` on them, that implies a :py:meth:`force_navigate` call with
@@ -45,7 +45,7 @@ class Implementation(object):
             additional_context: Additional informations passed to the view (user name, VM name, ...)
                 which is also passed to the :py:meth:`force_navigate` in case when navigation is
                 requested.
-
+            wait: time to wait for view to show up
         Returns:
             An instance of the ``view_class``
         """
@@ -54,5 +54,6 @@ class Implementation(object):
             self.widgetastic,
             additional_context=additional_context,
             logger=logger)
-
+        if wait:
+            view.wait_displayed(timeout=wait)
         return view

--- a/cfme/utils/appliance/implementations/ssui.py
+++ b/cfme/utils/appliance/implementations/ssui.py
@@ -41,7 +41,11 @@ class MiqSSUIBrowser(Browser):
         return self.extra_objects['appliance']
 
     def create_view(self, *args, **kwargs):
-        return self.appliance.ssui.create_view(*args, **kwargs)
+        timeout = kwargs.pop('wait', None)
+        view = self.appliance.ssui.create_view(*args, **kwargs)
+        if timeout:
+            view.wait_displayed(timeout=timeout)
+        return view
 
     @property
     def product_version(self):

--- a/cfme/utils/appliance/implementations/ui.py
+++ b/cfme/utils/appliance/implementations/ui.py
@@ -244,7 +244,11 @@ class MiqBrowser(Browser):
         return self.extra_objects['appliance']
 
     def create_view(self, *args, **kwargs):
-        return self.appliance.browser.create_view(*args, **kwargs)
+        timeout = kwargs.pop('wait', None)
+        view = self.appliance.browser.create_view(*args, **kwargs)
+        if timeout:
+            view.wait_displayed(timeout=timeout)
+        return view
 
     @property
     def product_version(self):


### PR DESCRIPTION
There are many places where we use 
```
view = create_view()
view.wait_displayed()
```
or 
```
view = create_view()
assert view.is_displayed
```
This change is going to replace all such calls with
```
view = create_view(wait='10s')
```
what will call wait_displayed after view creation