### PR TITLE
[RFR] replace yaml.dump()->yaml.safe_dump()

### DIFF
--- a/cfme/fixtures/nelson.py
+++ b/cfme/fixtures/nelson.py
@@ -51,7 +51,7 @@ def pytest_collection_modifyitems(items):
         import lya
         from yaml.representer import SafeRepresenter
         yaml.add_representer(lya.lya.AttrDict, SafeRepresenter.represent_dict)
-        yaml.dump(output, f)
+        yaml.safe_dump(output, f)
 
 
 def pytest_pycollect_makeitem(collector, name, obj):

--- a/cfme/fixtures/node_annotate.py
+++ b/cfme/fixtures/node_annotate.py
@@ -131,4 +131,4 @@ def parse(path):
 
 if __name__ == '__main__':
     mapping_file = project_path.join(py.std.sys.argv[1])
-    print(yaml.dump(parse(mapping_file), default_flow_style=False))
+    print(yaml.safe_dump(parse(mapping_file), default_flow_style=False))

--- a/cfme/scripting/sprout.py
+++ b/cfme/scripting/sprout.py
@@ -111,7 +111,7 @@ def populate_config_from_appliances(appliance_data):
         y_data = {}
     if y_data:
         with open(conf_path.join('env.local.backup').strpath, 'w') as f:
-            yaml.dump(y_data, f, default_flow_style=False)
+            yaml.safe_dump(y_data, f, default_flow_style=False)
 
     y_data['appliances'] = []
     for app in appliance_data:

--- a/cfme/utils/ansible.py
+++ b/cfme/utils/ansible.py
@@ -11,7 +11,7 @@ from cfme.utils.appliance import current_appliance
 
 
 from git import Repo
-from yaml import load, dump
+from yaml import load, safe_dump
 
 local_git_repo = "manageiq_ansible_module"
 yml_path = path.join(path.dirname(__file__), local_git_repo)
@@ -141,7 +141,7 @@ def setup_basic_script(provider, script_type):
         elif script_type == 'tags':
             doc[0]['tasks'][0]['manageiq_tag_assignment'][key] = values_dict[key]
         with open(script_path, 'w') as f:
-            f.write(dump(doc))
+            f.write(safe_dump(doc))
 
 
 def open_yml(script, script_type):
@@ -153,7 +153,7 @@ def open_yml(script, script_type):
 
 def write_yml(script, doc):
     with open(path.join(basic_yml_path, script + yml), 'w') as f:
-        f.write(dump(doc))
+        f.write(safe_dump(doc))
 
 
 def setup_ansible_script(provider, script, script_type=None, values_to_update=None):

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2124,7 +2124,7 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
 
             temp_yaml = NamedTemporaryFile()
             dest_yaml = '/tmp/conf.yaml'
-            yaml.dump(data_dict_base, temp_yaml, default_flow_style=False)
+            yaml.safe_dump(data_dict_base, temp_yaml, default_flow_style=False)
             self.ssh_client.put_file(temp_yaml.name, dest_yaml)
             # Build and send ruby script
             dest_ruby = '/tmp/set_conf.rb'

--- a/cfme/utils/smem_memory_monitor.py
+++ b/cfme/utils/smem_memory_monitor.py
@@ -408,7 +408,7 @@ def create_report(scenario_data, appliance_results, process_results, use_slab, g
 
     # Dump scenario Yaml:
     with open(str(scenario_path.join('scenario.yml')), 'w') as scenario_file:
-        yaml.dump(dict(scenario_data['scenario']), scenario_file, default_flow_style=False)
+        yaml.safe_dump(dict(scenario_data['scenario']), scenario_file, default_flow_style=False)
 
     generate_summary_csv(scenario_path.join('{}-summary.csv'.format(ver)), appliance_results,
         process_results, provider_names, ver)
@@ -971,7 +971,7 @@ def add_workload_quantifiers(quantifiers, scenario_data):
 
 def get_scenario_html(scenario_data):
     scenario_dict = create_dict(scenario_data)
-    scenario_yaml = yaml.dump(scenario_dict)
+    scenario_yaml = yaml.safe_dump(scenario_dict)
     scenario_html = scenario_yaml.replace('\n', '<br>\n')
     scenario_html = scenario_html.replace(', ', '<br>\n &nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;')
     scenario_html = scenario_html.replace(' ', '&nbsp;')

--- a/sprout/appliances/models.py
+++ b/sprout/appliances/models.py
@@ -66,7 +66,7 @@ def apply_if_not_none(o, meth, *args, **kwargs):
 class MetadataMixin(models.Model):
     class Meta:
         abstract = True
-    object_meta_data = models.TextField(default=yaml.dump({}))
+    object_meta_data = models.TextField(default=yaml.safe_dump({}))
     created_on = models.DateTimeField(default=timezone.now, editable=False)
     modified_on = models.DateTimeField(default=timezone.now)
 
@@ -99,7 +99,7 @@ class MetadataMixin(models.Model):
     def metadata(self, value):
         if not isinstance(value, dict):
             raise TypeError("You can store only dict in metadata!")
-        self.object_meta_data = yaml.dump(value)
+        self.object_meta_data = yaml.safe_dump(value)
 
     @property
     @contextmanager


### PR DESCRIPTION
yaml.dump() saves data with python extensions which cannot be parsed by safe_load()
