### PR TITLE
[WIPTEST] Moving up provider field in service catalog items form

### DIFF
--- a/cfme/services/catalogs/catalog_items/__init__.py
+++ b/cfme/services/catalogs/catalog_items/__init__.py
@@ -22,15 +22,16 @@ from cfme.utils.wait import wait_for
 class BasicInfoForm(ServicesCatalogView):
     title = Text('#explorer_title_text')
 
-    # Filling dropdowns first to avoid selenium field reset bug
-    select_catalog = BootstrapSelect('catalog_id')
-    select_dialog = BootstrapSelect('dialog_id')
     name = Input(name='name')
     description = Input(name='description')
     display = Checkbox(name='display')
+
+    select_catalog = BootstrapSelect('catalog_id')
+    select_dialog = BootstrapSelect('dialog_id')
+    select_provider = BootstrapSelect('manager_id')
     select_orch_template = BootstrapSelect('template_id')
     select_config_template = BootstrapSelect('template_id')
-    select_provider = BootstrapSelect('manager_id')
+
     subtype = BootstrapSelect('generic_subtype')
     field_entry_point = Input(name='fqname')
     retirement_entry_point = Input(name='retire_fqname')


### PR DESCRIPTION
{{ pytest: cfme/tests/services/test_config_provider_servicecatalogs.py::test_order_tower_catalog_item -v }}

I'm moving up the provider field in the service catalog items form since the template field shows up only after the provider field is populated for Ansible Tower.

The following Ansible Tower tests were failing prior to this fix:
test_order_tower_catalog_item
test_retire_ansible_service