### PR TITLE
[1LP][RFR] Add in a CloudIntelTimelines View and automate manual test cases

### DIFF
--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -26,6 +26,7 @@ from cfme.exceptions import BugException
 from cfme.exceptions import ZoneNotFound, DestinationNotFound
 from cfme.intelligence.chargeback import ChargebackView
 from cfme.intelligence.rss import RSSView
+from cfme.intelligence.timelines import CloudIntelTimelinesView
 from cfme.utils import conf
 from cfme.utils.appliance import MiqImplementationContext
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep, ViaUI, navigate_to
@@ -413,6 +414,15 @@ class RSS(CFMENavigateStep):
 
     def step(self):
         self.view.navigation.select('Cloud Intel', 'RSS')
+
+
+@navigator.register(Server)
+class CloudIntelTimelines(CFMENavigateStep):
+    VIEW = CloudIntelTimelinesView
+    prerequisite = NavigateToSibling('LoggedIn')
+
+    def step(self):
+        self.view.navigation.select('Cloud Intel', 'Timelines')
 
 
 @navigator.register(Server)

--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -12,6 +12,7 @@ from widgetastic_manageiq.expression_editor import ExpressionEditor
 from widgetastic_patternfly import Button, Input, BootstrapSelect, CandidateNotFound
 
 from cfme.intelligence.reports.schedules import SchedulesFormCommon
+from cfme.intelligence.timelines import CloudIntelTimelinesView
 from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.utils import ParamClassName
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
@@ -118,6 +119,22 @@ class ReportEditView(CustomReportFormCommon):
             self.report_title.text == 'Editing Report "{}"'.format(self.context["object"].menu_name)
         )
 
+
+class ReportCopyView(ReportAddView):
+    """ Class for copying a report, functionally this is the same as the ReportAddView.
+    The is_displayed function needs to be slightly modified. """
+
+    @property
+    def is_displayed(self):
+        return (
+            self.in_intel_reports and
+            self.reports.is_opened and
+            self.report_title.text == "Adding a new Report" and
+            self.reports.tree.currently_selected == [
+                "All Reports", self.context["object"].type, self.context["object"].subtype,
+                self.context["object"].menu_name
+            ]
+        )
 
 class ReportDetailsView(CloudIntelReportsView):
     title = Text("#explorer_title_text")
@@ -301,8 +318,7 @@ class Report(BaseEntity, Updateable):
             view.save_button.click()
         else:
             view.cancel_button.click()
-        view = self.create_view(ReportDetailsView, override=updates)
-        assert view.is_displayed
+        view = self.create_view(ReportDetailsView, override=updates, wait='5s')
         view.flash.assert_no_error()
         if changed:
             view.flash.assert_message(
@@ -311,6 +327,20 @@ class Report(BaseEntity, Updateable):
             view.flash.assert_message(
                 'Edit of Report "{}" was cancelled by the user'.format(self.menu_name))
 
+    def copy(self):
+        """ Copy a report via UI and return a copy of a Report object"""
+        menu_name = "Copy of {}".format(self.menu_name)
+
+        view = navigate_to(self, "Copy")
+        view.add_button.click()
+        view = self.create_view(AllReportsView, wait='5s')
+        view.flash.assert_no_error()
+
+        view.flash.assert_message('Report "{}" was added'.format(menu_name))
+        return self.appliance.collections.reports.instantiate(
+            type=self.company_name, subtype="Custom", menu_name=menu_name
+        )
+
     def delete(self, cancel=False):
         view = navigate_to(self, "Details")
         node = view.reports.tree.expand_path("All Reports", self.company_name, "Custom")
@@ -318,14 +348,13 @@ class Report(BaseEntity, Updateable):
         view.configuration.item_select("Delete this Report from the Database",
             handle_alert=not cancel)
         if cancel:
-            assert view.is_displayed
+            view.wait_displayed()
             view.flash.assert_no_error()
         else:
             # This check is needed because after deleting the last custom report,
             # the whole "My Company (All EVM Groups)" branch in the tree will be removed.
             if custom_reports_number > 1:
-                view = self.create_view(AllCustomReportsView)
-                assert view.is_displayed
+                view = self.create_view(AllCustomReportsView, wait='5s')
             view.flash.assert_no_error()
             if not BZ(1561779, forced_streams=['5.9', '5.8']).blocks:
                 view.flash.assert_message(
@@ -419,8 +448,7 @@ class ReportsCollection(BaseCollection):
         view = navigate_to(self, "Add")
         view.fill(values)
         view.add_button.click()
-        view = self.create_view(AllReportsView)
-        assert view.is_displayed
+        view = self.create_view(AllReportsView, wait='5s')
         view.flash.assert_no_error()
         view.flash.assert_message('Report "{}" was added'.format(values["menu_name"]))
         return self.instantiate(**values)
@@ -603,6 +631,28 @@ class ReportEdit(CFMENavigateStep):
 
     def step(self):
         self.prerequisite_view.configuration.item_select("Edit this Report")
+
+
+@navigator.register(Report, "Copy")
+class ReportCopy(CFMENavigateStep):
+    VIEW = ReportCopyView
+    prerequisite = NavigateToSibling("Details")
+
+    def step(self):
+        self.prerequisite_view.configuration.item_select("Copy this Report")
+
+
+@navigator.register(Report, "Timeline")
+class ReportTimeline(CFMENavigateStep):
+    VIEW = CloudIntelTimelinesView
+    prerequisite = NavigateToAttribute("appliance.server", "CloudIntelTimelines")
+
+    def step(self):
+        self.prerequisite_view.timelines.tree.click_path(
+            self.obj.type or self.obj.company_name,
+            self.obj.subtype or "Custom",
+            self.obj.menu_name
+        )
 
 
 @navigator.register(Report, "Details")

--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -318,7 +318,7 @@ class Report(BaseEntity, Updateable):
             view.save_button.click()
         else:
             view.cancel_button.click()
-        view = self.create_view(ReportDetailsView, override=updates, wait='5s')
+        view = self.create_view(ReportDetailsView, override=updates, wait="5s")
         view.flash.assert_no_error()
         if changed:
             view.flash.assert_message(
@@ -333,10 +333,8 @@ class Report(BaseEntity, Updateable):
 
         view = navigate_to(self, "Copy")
         view.add_button.click()
-        view = self.create_view(AllReportsView, wait='5s')
-        view.flash.assert_no_error()
+        view = self.create_view(AllReportsView, wait="5s")
 
-        view.flash.assert_message('Report "{}" was added'.format(menu_name))
         return self.appliance.collections.reports.instantiate(
             type=self.company_name, subtype="Custom", menu_name=menu_name
         )

--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -170,6 +170,18 @@ class ReportDetailsView(CloudIntelReportsView):
         )
 
 
+class ReportTimelineView(CloudIntelTimelinesView):
+    title = Text(".//h1")
+
+    @property
+    def is_displayed(self):
+        return (
+            self.logged_in_as_current_user and
+            self.navigation.currently_selected == ['Cloud Intel', 'Timelines'] and
+            self.title.text == self.context["object"].title
+        )
+
+
 class SavedReportDetailsView(CloudIntelReportsView):
     title = Text("#explorer_title_text")
     table = VanillaTable(".//div[@id='report_html_div']/table")
@@ -333,10 +345,10 @@ class Report(BaseEntity, Updateable):
 
         view = navigate_to(self, "Copy")
         view.add_button.click()
-        view = self.create_view(AllReportsView, wait="5s")
+        self.create_view(AllReportsView, wait="5s")
 
         return self.appliance.collections.reports.instantiate(
-            type=self.company_name, subtype="Custom", menu_name=menu_name
+            type=self.company_name, subtype="Custom", menu_name=menu_name, title=self.title,
         )
 
     def delete(self, cancel=False):
@@ -642,7 +654,7 @@ class ReportCopy(CFMENavigateStep):
 
 @navigator.register(Report, "Timeline")
 class ReportTimeline(CFMENavigateStep):
-    VIEW = CloudIntelTimelinesView
+    VIEW = ReportTimelineView
     prerequisite = NavigateToAttribute("appliance.server", "CloudIntelTimelines")
 
     def step(self):
@@ -681,6 +693,7 @@ class ReportSchedule(CFMENavigateStep):
             self.obj.menu_name
         )
         self.prerequisite_view.configuration.item_select("Add a new Schedule")
+
 
 @navigator.register(SavedReport, "Details")
 class SavedReportDetails(CFMENavigateStep):

--- a/cfme/intelligence/timelines.py
+++ b/cfme/intelligence/timelines.py
@@ -1,0 +1,21 @@
+from widgetastic.widget import View
+from widgetastic_manageiq import ManageIQTree, TimelinesChart
+from widgetastic_patternfly import Accordion
+
+
+from cfme.base.login import BaseLoggedInPage
+
+
+class CloudIntelTimelinesView(BaseLoggedInPage):
+
+    chart = TimelinesChart(locator='//div/*[@class="timeline-pf-chart"]')
+
+    @property
+    def is_displayed(self):
+        return (
+            self.logged_in_as_current_user and
+            self.navigation.currently_selected == ['Cloud Intel', 'Timelines'])
+
+    @View.nested
+    class timelines(Accordion):
+        tree = ManageIQTree()

--- a/cfme/intelligence/timelines.py
+++ b/cfme/intelligence/timelines.py
@@ -2,7 +2,6 @@ from widgetastic.widget import View
 from widgetastic_manageiq import ManageIQTree, TimelinesChart
 from widgetastic_patternfly import Accordion
 
-
 from cfme.base.login import BaseLoggedInPage
 
 
@@ -14,8 +13,9 @@ class CloudIntelTimelinesView(BaseLoggedInPage):
     def is_displayed(self):
         return (
             self.logged_in_as_current_user and
-            self.navigation.currently_selected == ['Cloud Intel', 'Timelines'])
+            self.navigation.currently_selected == ['Cloud Intel', 'Timelines']
+        )
 
     @View.nested
-    class timelines(Accordion):
+    class timelines(Accordion): # noqa
         tree = ManageIQTree()

--- a/cfme/tests/intelligence/test_reports_with_timelines.py
+++ b/cfme/tests/intelligence/test_reports_with_timelines.py
@@ -1,15 +1,123 @@
 # -*- coding: utf-8 -*-
+import fauxfactory
 import pytest
 
-timelines_reports = ('hosts', 'vm_operation', 'policy_events', 'policy_events2')
+from cfme.control.explorer import policies
+from cfme.tests.cloud_infra_common.test_events import vm_crud
+from cfme.infrastructure.provider import InfraProvider
+from cfme.utils.appliance.implementations.ui import navigate_to
 
+pytestmark = [
+    pytest.mark.usefixtures('uses_infra_providers'),
+    pytest.mark.tier(2),
+    pytest.mark.provider([InfraProvider], required_fields=['provisioning'], scope='module')
+]
 
-@pytest.mark.manual
-@pytest.mark.tier(2)
-@pytest.mark.parametrize('report', timelines_reports)
-def test_default_reports_with_timelines(report):
+PATHS = [
+        ["Events", "Policy", "Policy Events for Last Week"],
+        ["Events", "Policy", "Policy Events for the Last 7 Days"],
+        ["Configuration Management", "Hosts", "Date brought under Management for Last Week"],
+        ["Events", "Operations", "Operations VMs Powered On/Off for Last Week"],
+    ]
+
+UPDATES = [
+         {'filter':
+             {'primary_filter':"fill_field(Policy Event : Activity Sample - Timestamp (Day/Time), "
+                "IS, This Week)"},
+         },
+         {'report_fields': ["Activity Sample - Timestamp (Day/Time)",
+            "Miq Policy Sets : Date Created", "Miq Policy Sets : Date Updated",
+            "Miq Policy Sets : Description", "Miq Policy Sets : EVM Unique ID (Guid)"
+            ],
+          'filter':
+             {'primary_filter':"fill_field(Policy Event : Activity Sample - Timestamp (Day/Time), "
+                "IS, This Week)"},
+         },
+         {'filter':
+              {'primary_filter':"fill_field(Host / Node : Date Created, IS, This Week)"}
+         },
+         {'filter':
+             {'primary_filter':"fill_field(Event Stream.Host / Node : Total VMs, >, 0)"}
+         },
+
+    ]
+
+@pytest.fixture(scope="function")
+def setup_for_reports():
+    """ wrapper function for _setup_for_reports, so that it runs during test
+
+    Returns:
+        unbound function object for calling during the test
     """
-    Test that a timeline widget is displayed for the default reports.
+    def _setup_for_reports(request, appliance, provider, path, updates, vm_crud, register_event):
+        """ This function makes copies of the default reports so that we can test the timelines
+        on the CloudIntel->Timelines page
+
+        Args:
+            request: py.test funcarg request
+            appliance: IPAppliance object
+            provider: provider object
+            path: path to the report in the tree
+            updates: updates to the default report so that it will display events
+            vm_crud: vm for Policy events
+            register_event: function for registering events
+            args: kwargs for extra_steps
+        """
+        # first perform extra steps for Policy stuff
+        if "Policy" in path:
+            generate_policy_event(request, appliance, provider, vm_crud, register_event)
+        report = appliance.collections.reports.instantiate(
+            type=path[0], subtype=path[1], menu_name=path[2]
+        )
+        # copy the default report
+        copied_report = report.copy()
+        # update the copied report
+        copied_report.update(updates)
+        # delete report at end of test
+        request.addfinalizer(copied_report.delete)
+
+        return copied_report
+
+    return _setup_for_reports
+
+
+def generate_policy_event(request, appliance, provider, vm_crud, register_event):
+    # create necessary objects
+    action = appliance.collections.actions.create(
+        fauxfactory.gen_alpha(),
+        "Tag",
+        dict(tag=("My Company Tags", "Environment", "Development")))
+    request.addfinalizer(action.delete)
+
+    policy = appliance.collections.policies.create(
+        policies.VMControlPolicy,
+        fauxfactory.gen_alpha()
+    )
+    request.addfinalizer(policy.delete)
+
+    policy.assign_events("VM Create Complete")
+    request.addfinalizer(policy.assign_events)
+    policy.assign_actions_to_event("VM Create Complete", action)
+
+    profile = appliance.collections.policy_profiles.create(
+        fauxfactory.gen_alpha(), policies=[policy])
+    request.addfinalizer(profile.delete)
+
+    # assign the policy profile to the provider
+    provider.assign_policy_profiles(profile.description)
+    request.addfinalizer(lambda: provider.unassign_policy_profiles(profile.description))
+
+    register_event(target_type='VmOrTemplate', target_name=vm_crud.name,
+                   event_type='vm_create')
+
+    vm_crud.create_on_provider(find_in_cfme=True)
+
+
+@pytest.mark.parametrize("path, updates", zip(PATHS, UPDATES))
+def test_reports_with_timelines(request, appliance, provider, path, updates, setup_for_reports,
+                                vm_crud, register_event):
+    """
+    Test that a timeline widget is displayed for a reports.
     Note that since the default reports look at last week, to test, we modify the reports
 
     Polarion:
@@ -25,27 +133,9 @@ def test_default_reports_with_timelines(report):
             5. Click on the report you created
             6. Verify that the timeline (with events) is properly displayed
     """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(2)
-@pytest.mark.parametrize('report', timelines_reports)
-def test_custom_reports_with_timelines(report):
-    """
-    Test that a timeline widget is displayed for custom reports.
-
-    Polarion:
-        assignee: jdupuy
-        initialEstimate: 1/5h
-        casecomponent: web_ui
-        caseimportance: medium
-        testSteps:
-            1. Add an infrastructure provider to ensure that an event for each report will occur
-            2. Navigate to Cloud Intel -> Reports
-            3. Create a custom report for each of the parameters
-            4. Navigate to Cloud Intel -> Timelines
-            5. Click on the report you created
-            6. Verify that the timeline (with events) is properly displayed
-    """
-    pass
+    copied_report = setup_for_reports(request, appliance, provider, path, updates,
+                                      vm_crud, register_event)
+    # navigate to timeline for this report
+    view = navigate_to(copied_report, 'Timeline')
+    # assert that at least 1 event is present on the timeline chart
+    assert len(view.chart.get_events()) > 0

--- a/cfme/tests/intelligence/test_reports_with_timelines.py
+++ b/cfme/tests/intelligence/test_reports_with_timelines.py
@@ -2,45 +2,53 @@
 import fauxfactory
 import pytest
 
+from cfme.cloud.provider.gce import GCEProvider
 from cfme.control.explorer import policies
-from cfme.tests.cloud_infra_common.test_events import vm_crud
 from cfme.infrastructure.provider import InfraProvider
 from cfme.utils.appliance.implementations.ui import navigate_to
 
 pytestmark = [
-    pytest.mark.usefixtures('uses_infra_providers'),
+    pytest.mark.usefixtures("uses_infra_providers"),
     pytest.mark.tier(2),
-    pytest.mark.provider([InfraProvider], required_fields=['provisioning'], scope='module')
+    pytest.mark.provider([InfraProvider], required_fields=["provisioning"], scope="function"),
 ]
 
 PATHS = [
-        ["Events", "Policy", "Policy Events for Last Week"],
-        ["Events", "Policy", "Policy Events for the Last 7 Days"],
-        ["Configuration Management", "Hosts", "Date brought under Management for Last Week"],
-        ["Events", "Operations", "Operations VMs Powered On/Off for Last Week"],
-    ]
+    ["Events", "Policy", "Policy Events for Last Week"],
+    ["Events", "Policy", "Policy Events for the Last 7 Days"],
+    ["Configuration Management", "Hosts", "Date brought under Management for Last Week"],
+    ["Events", "Operations", "Operations VMs Powered On/Off for Last Week"],
+]
 
 UPDATES = [
-         {'filter':
-             {'primary_filter':"fill_field(Policy Event : Activity Sample - Timestamp (Day/Time), "
-                "IS, This Week)"},
-         },
-         {'report_fields': ["Activity Sample - Timestamp (Day/Time)",
-            "Miq Policy Sets : Date Created", "Miq Policy Sets : Date Updated",
-            "Miq Policy Sets : Description", "Miq Policy Sets : EVM Unique ID (Guid)"
-            ],
-          'filter':
-             {'primary_filter':"fill_field(Policy Event : Activity Sample - Timestamp (Day/Time), "
-                "IS, This Week)"},
-         },
-         {'filter':
-              {'primary_filter':"fill_field(Host / Node : Date Created, IS, This Week)"}
-         },
-         {'filter':
-             {'primary_filter':"fill_field(Event Stream.Host / Node : Total VMs, >, 0)"}
-         },
+    {
+        "filter": {
+            "primary_filter": "fill_field(Policy Event : Activity Sample - Timestamp ("
+            "Day/Time), "
+            "IS, This Week)"
+        }
+    },
+    {
+        "report_fields": [
+            "Activity Sample - Timestamp (Day/Time)",
+            "Miq Policy Sets : Date " "Created",
+            "Miq Policy Sets : Date Updated",
+            "Miq Policy Sets : Description",
+            "Miq Policy Sets : EVM Unique ID (Guid)",
+        ],
+        "filter": {
+            "primary_filter": "fill_field(Policy Event : Activity Sample - Timestamp (Day/Time), "
+            "IS, This Week)"
+        },
+    },
+    {"filter": {"primary_filter": "fill_field(Host / Node : Date Created, IS, This Week)"}},
+    {
+        "filter": {
+            "primary_filter": "fill_field(Event Stream.VM and Instance : Date Created, IS, Today)"
+        }
+    },
+]
 
-    ]
 
 @pytest.fixture(scope="function")
 def setup_for_reports():
@@ -49,6 +57,7 @@ def setup_for_reports():
     Returns:
         unbound function object for calling during the test
     """
+
     def _setup_for_reports(request, appliance, provider, path, updates, vm_crud, register_event):
         """ This function makes copies of the default reports so that we can test the timelines
         on the CloudIntel->Timelines page
@@ -61,7 +70,6 @@ def setup_for_reports():
             updates: updates to the default report so that it will display events
             vm_crud: vm for Policy events
             register_event: function for registering events
-            args: kwargs for extra_steps
         """
         # first perform extra steps for Policy stuff
         if "Policy" in path:
@@ -81,17 +89,28 @@ def setup_for_reports():
     return _setup_for_reports
 
 
+@pytest.fixture(scope="function")
+def vm_crud(provider, setup_provider, small_template):
+    template = small_template
+    # GCE providers require the '-' instead of '_' to work properly with cleanup
+    base_name = "test-events-{}" if provider.one_of(GCEProvider) else "test_events_{}"
+    vm_name = base_name.format(fauxfactory.gen_alpha(length=8).lower())
+
+    collection = provider.appliance.provider_based_collection(provider)
+    vm = collection.instantiate(vm_name, provider, template_name=template.name)
+    yield vm
+    vm.cleanup_on_provider()
+
+
 def generate_policy_event(request, appliance, provider, vm_crud, register_event):
     # create necessary objects
     action = appliance.collections.actions.create(
-        fauxfactory.gen_alpha(),
-        "Tag",
-        dict(tag=("My Company Tags", "Environment", "Development")))
+        fauxfactory.gen_alpha(), "Tag", dict(tag=("My Company Tags", "Environment", "Development"))
+    )
     request.addfinalizer(action.delete)
 
     policy = appliance.collections.policies.create(
-        policies.VMControlPolicy,
-        fauxfactory.gen_alpha()
+        policies.VMControlPolicy, fauxfactory.gen_alpha()
     )
     request.addfinalizer(policy.delete)
 
@@ -100,22 +119,23 @@ def generate_policy_event(request, appliance, provider, vm_crud, register_event)
     policy.assign_actions_to_event("VM Create Complete", action)
 
     profile = appliance.collections.policy_profiles.create(
-        fauxfactory.gen_alpha(), policies=[policy])
+        fauxfactory.gen_alpha(), policies=[policy]
+    )
     request.addfinalizer(profile.delete)
 
     # assign the policy profile to the provider
     provider.assign_policy_profiles(profile.description)
     request.addfinalizer(lambda: provider.unassign_policy_profiles(profile.description))
 
-    register_event(target_type='VmOrTemplate', target_name=vm_crud.name,
-                   event_type='vm_create')
+    register_event(target_type="VmOrTemplate", target_name=vm_crud.name, event_type="vm_create")
 
     vm_crud.create_on_provider(find_in_cfme=True)
 
 
 @pytest.mark.parametrize("path, updates", zip(PATHS, UPDATES))
-def test_reports_with_timelines(request, appliance, provider, path, updates, setup_for_reports,
-                                vm_crud, register_event):
+def test_reports_with_timelines(
+    request, appliance, provider, path, updates, setup_for_reports, vm_crud, register_event
+):
     """
     Test that a timeline widget is displayed for a reports.
     Note that since the default reports look at last week, to test, we modify the reports
@@ -133,9 +153,10 @@ def test_reports_with_timelines(request, appliance, provider, path, updates, set
             5. Click on the report you created
             6. Verify that the timeline (with events) is properly displayed
     """
-    copied_report = setup_for_reports(request, appliance, provider, path, updates,
-                                      vm_crud, register_event)
+    copied_report = setup_for_reports(
+        request, appliance, provider, path, updates, vm_crud, register_event
+    )
     # navigate to timeline for this report
-    view = navigate_to(copied_report, 'Timeline')
+    view = navigate_to(copied_report, "Timeline")
     # assert that at least 1 event is present on the timeline chart
     assert len(view.chart.get_events()) > 0

--- a/cfme/tests/test_modules_importable.py
+++ b/cfme/tests/test_modules_importable.py
@@ -13,6 +13,7 @@ KNOWN_FAILURES = set(ROOT.dirpath().join(x) for x in[
     'cfme/utils/dockerbot/check_prs.py',  # unprotected script
     'cfme/utils/conf.py',  # config object that replaces the module
     'cfme/intelligence/rss.py',  # import loops
+    'cfme/intelligence/timelines.py',
     'cfme/intelligence/chargeback/rates.py',
     'cfme/intelligence/chargeback/assignments.py',
     'cfme/intelligence/chargeback/__init__.py',


### PR DESCRIPTION
Purpose or Intent
=================

__Automating__ manual test cases `test_reports_with_timelines` for `cfme.tests.intelligence`

This requires two things: 

__1)__ Adding a new view for the `Cloud Intel -> Timelines` page, and registering this view both against the server in `cfme.base.ui`, and since the timeline will appear if a Custom report is made, against a report in `cfme.intelligence.reports`

__2)__ Since the default reports are quite long, I have added functionality to copy pre-defined reports in CFME. This is a new method in the `Report` object. 

{{ pytest: --long-running --use-provider vsphere6-nested cfme/tests/intelligence/test_reports_with_timelines.py }}

