### PR TITLE
[1LP][RFR] New tagging updates

### DIFF
--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -321,19 +321,32 @@ class TaggableCommonBase(object):
 class Taggable(TaggableCommonBase):
     """
     This class can be inherited by any class that honors tagging.
-    Class should have following
+
+    Classes inheriting this class should have following defined:
 
     * 'Details' navigation
     * 'Details' view should have entities.smart_management SummaryTable widget
-    * 'EditTags' navigation
-    * 'EditTags' view should have nested 'form' view with 'tags' table widget
-    * Suggest using class cfme.common.TagPageView as view for 'EditTags' nav
+    * 'EditTagsFromDetails' navigation
+    * 'EditTagsFromDetails' At a minimum, views should include EditTagsFromDetails class. View
+    should have nested 'form' view with 'tags' table widget
+    'In addition, the prerequisite should be NavigateToSibling('Details')
+
+    Optional classes that can be defined:
+
+    'EditTags':
+    * 'All' navigation
+    * Same as EditTagsFromDetails but the prerequisite should be NavigateToSibling('All')
+    'EditTagsFromDashboard':
+    * 'Dashboard' navigation
+    * Same as EditTagsFromDetails but the prerequisite should be NavigateToSibling('Dashboard')
+
+    Suggest using class cfme.common.TagPageView as view for all 'EditTags' nav
 
     This class provides functionality to assign and unassigned tags for page models with
     standardized widgetastic views
     """
 
-    def add_tag(self, tag=None, cancel=False, reset=False, details=True):
+    def add_tag(self, tag=None, cancel=False, reset=False, details=True, dashboard=False):
         """ Add tag to tested item
 
         Args:
@@ -342,8 +355,14 @@ class Taggable(TaggableCommonBase):
             reset: set True to reset already set up tag
             details (bool): set False if tag should be added for list selection,
                             default is details page
+            dashboard (bool): Set to True if tag should be added via the Dashboard view
         """
-        step = 'EditTagsFromDetails' if details else 'EditTags'
+        if details and not dashboard:
+            step = 'EditTagsFromDetails'
+        elif dashboard:
+            step = 'EditTagsFromDashboard'
+        else:
+            step = 'EditTags'
         view = navigate_to(self, step)
         added_tag, updated = self._assign_tag_action(view, tag)
         # In case if field is not updated cancel the edition

--- a/cfme/containers/project.py
+++ b/cfme/containers/project.py
@@ -23,7 +23,7 @@ class ProjectDetailsView(ContainerObjectDetailsBaseView):
     SUMMARY_TEXT = 'Container Projects'
 
 
-class ProjectDashboardView(ContainerObjectDetailsBaseView):
+class ProjectDashboardView(ProjectDetailsView):
 
     @property
     def is_displayed(self):
@@ -111,11 +111,9 @@ class Details(CFMENavigateStep):
         self.prerequisite_view.entities.get_entity(name=self.obj.name,
                                                    surf_pages=not search_visible,
                                                    use_search=search_visible).click()
-        self.view.toolbar.view_selector.select("Summary View")
 
     def resetter(self):
-        if (self.appliance.version.is_in_series('5.9') and
-                self.view.toolbar.view_selector.is_displayed):
+        if self.view.toolbar.view_selector.is_displayed:
             self.view.toolbar.view_selector.select("Summary View")
 
 
@@ -135,10 +133,19 @@ class Dashboard(CFMENavigateStep):
             self.view.toolbar.view_selector.select("Dashboard View")
 
 
-@navigator.register(Project, 'EditTags')
-class EditTags(CFMENavigateStep):
+@navigator.register(Project, 'EditTagsFromDetails')
+class EditTagsFromDetails(CFMENavigateStep):
     VIEW = TagPageView
     prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
+
+
+@navigator.register(Project, 'EditTagsFromDashboard')
+class EditTagsFromDashboard(CFMENavigateStep):
+    VIEW = TagPageView
+    prerequisite = NavigateToSibling('Dashboard')
 
     def step(self):
         self.prerequisite_view.toolbar.policy.item_select('Edit Tags')

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -149,6 +149,15 @@ class ContainerProviderDetailsView(ProviderDetailsView, LoggingableView):
         return self.SUMMARY_TEXT
 
 
+class ContainersProviderDashboardView(ContainerProviderDetailsView):
+
+    @property
+    def is_displayed(self):
+        return (
+            super(ContainerProviderDetailsView, self).is_displayed and
+            'Dashboard' in self.breadcrumb.active_location)
+
+
 @attr.s(hash=False)
 class ContainersProvider(BaseProvider, Pretty, PolicyProfileAssignable):
     PLURAL = 'Providers'
@@ -408,6 +417,14 @@ class Details(CFMENavigateStep):
         self.view.toolbar.view_selector.select("Summary View")
 
 
+@navigator.register(ContainersProvider, 'Dashboard')
+class Dashboard(Details):
+    VIEW = ContainersProviderDashboardView
+
+    def resetter(self):
+        self.view.toolbar.view_selector.select("Dashboard View")
+
+
 @navigator.register(ContainersProvider, 'Edit')
 class Edit(CFMENavigateStep):
     VIEW = ContainerProviderEditViewUpdated
@@ -443,6 +460,15 @@ class EditTags(CFMENavigateStep):
 class EditTagsFromDetails(CFMENavigateStep):
     VIEW = TagPageView
     prerequisite = NavigateToSibling('Details')
+
+    def step(self):
+        self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
+
+
+@navigator.register(ContainersProvider, 'EditTagsFromDashboard')
+class EditTagsFromDashboard(CFMENavigateStep):
+    VIEW = TagPageView
+    prerequisite = NavigateToSibling('Dashboard')
 
     def step(self):
         self.prerequisite_view.toolbar.policy.item_select('Edit Tags')


### PR DESCRIPTION
Added the ability to add tags from the dashboard view. Default functionality has remained the same with this change. 

{{ pytest: cfme/tests/cloud_infra_common/test_tag_objects.py --use-provider complete }}