### PR TITLE
[1LP][RFR] Update conditions to use wait keyword for create_view

### DIFF
--- a/cfme/control/explorer/conditions.py
+++ b/cfme/control/explorer/conditions.py
@@ -204,7 +204,7 @@ class BaseCondition(BaseEntity, Updateable, Pretty):
             view.fill(updates)
             view.wait_displayed()
             view.save_button.click()
-            view = self.create_view(ConditionDetailsView, override=updates, wait='10s')
+            view = self.create_view(ConditionDetailsView, override=updates, wait="10s")
             view.flash.assert_success_message(
             'Condition "{}" was saved'.format(updates.get("description", self.description)))
         except (TimedOutError, StaleElementReferenceException):
@@ -226,7 +226,7 @@ class BaseCondition(BaseEntity, Updateable, Pretty):
             assert view.is_displayed
             view.flash.assert_no_error()
         else:
-            view = self.create_view(ConditionClassAllView, wait='10s')
+            view = self.create_view(ConditionClassAllView, wait="10s")
             view.flash.assert_success_message('Condition "{}": Delete successful'.format(
                 self.description))
 
@@ -271,8 +271,7 @@ class ConditionCollection(BaseCollection):
         })
         view.wait_displayed()
         view.add_button.click()
-        view = condition.create_view(ConditionDetailsView)
-        assert view.is_displayed
+        view = condition.create_view(ConditionDetailsView, wait="10s")
         view.flash.assert_success_message('Condition "{}" was added'.format(condition.description))
         return condition
 

--- a/cfme/control/explorer/conditions.py
+++ b/cfme/control/explorer/conditions.py
@@ -203,7 +203,8 @@ class BaseCondition(BaseEntity, Updateable, Pretty):
         view.save_button.click()
         view = self.create_view(ConditionDetailsView, override=updates, wait="10s")
         view.flash.assert_success_message(
-        'Condition "{}" was saved'.format(updates.get("description", self.description)))
+            'Condition "{}" was saved'.format(updates.get("description", self.description))
+        )
 
     def delete(self, cancel=False):
         """Delete this Condition in UI.

--- a/cfme/control/explorer/conditions.py
+++ b/cfme/control/explorer/conditions.py
@@ -3,17 +3,15 @@ import attr
 
 from navmazing import NavigateToAttribute, NavigateToSibling
 from widgetastic.widget import Text, TextInput, Widget
+from widgetastic.utils import WaitFillViewStrategy
 from widgetastic_patternfly import Button, Input
 
 from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.utils import ParamClassName
 from cfme.utils.appliance.implementations.ui import navigator, navigate_to, CFMENavigateStep
-from cfme.utils.log import logger
 from cfme.utils.pretty import Pretty
 from cfme.utils.update import Updateable
-from cfme.utils.wait import TimedOutError
 
-from selenium.common.exceptions import StaleElementReferenceException
 from widgetastic_manageiq.expression_editor import ExpressionEditor
 from . import ControlExplorerView
 
@@ -120,6 +118,7 @@ class ConditionClassAllView(ControlExplorerView):
 
 
 class EditConditionView(ConditionFormCommon):
+    fill_strategy = WaitFillViewStrategy()
     title = Text("#explorer_title_text")
 
     save_button = Button("Save")
@@ -200,18 +199,11 @@ class BaseCondition(BaseEntity, Updateable, Pretty):
             updates: Provided by update() context manager.
         """
         view = navigate_to(self, "Edit")
-        try:
-            view.fill(updates)
-            view.wait_displayed()
-            view.save_button.click()
-            view = self.create_view(ConditionDetailsView, override=updates, wait="10s")
-            view.flash.assert_success_message(
-            'Condition "{}" was saved'.format(updates.get("description", self.description)))
-        except (TimedOutError, StaleElementReferenceException):
-            logger.exception('Updating the condition failed waiting for view, canceling update.')
-            view.cancel_button.click()
-            view = navigate_to(self, "Details")
-
+        view.fill(updates)
+        view.save_button.click()
+        view = self.create_view(ConditionDetailsView, override=updates, wait="10s")
+        view.flash.assert_success_message(
+        'Condition "{}" was saved'.format(updates.get("description", self.description)))
 
     def delete(self, cancel=False):
         """Delete this Condition in UI.

--- a/widgetastic_manageiq/expression_editor.py
+++ b/widgetastic_manageiq/expression_editor.py
@@ -85,6 +85,7 @@ class ExpressionEditor(View, Pretty):
 
     @View.nested
     class find_form_view(View):  # noqa
+        fill_strategy = WaitFillViewStrategy()
         type = BootstrapSelect("chosen_typ")
         field = BootstrapSelect("chosen_field")
         skey = BootstrapSelect("chosen_skey")
@@ -171,6 +172,7 @@ class ExpressionEditor(View, Pretty):
         self.browser.click(self.REMOVE)
 
     def click_commit(self):
+        self.COMMIT.wait_displayed()
         self.browser.click(self.COMMIT)
         self.UNDO.wait_displayed()
 

--- a/widgetastic_manageiq/expression_editor.py
+++ b/widgetastic_manageiq/expression_editor.py
@@ -9,7 +9,7 @@ from functools import partial
 import six
 from selenium.common.exceptions import NoSuchElementException
 from widgetastic.utils import Version, VersionPick, WaitFillViewStrategy
-from widgetastic.widget import View
+from widgetastic.widget import Text, View
 from widgetastic_patternfly import BootstrapSelect as VanillaBootstrapSelect
 from widgetastic_patternfly import Button, Input
 
@@ -123,6 +123,8 @@ class ExpressionEditor(View, Pretty):
     })
     # fmt: on
     EXPRESSION_TEXT = "//a[contains(@id,'exp_')]"
+    expression_text_widget = Text(EXPRESSION_TEXT)
+    # TODO: do not refer to these buttons with CAPS
     COMMIT = Button(title="Commit expression element changes")
     DISCARD = Button(title="Discard expression element changes")
     REMOVE = Button(title="Remove this expression element")
@@ -153,6 +155,7 @@ class ExpressionEditor(View, Pretty):
     def __locator__(self):
         return self.ROOT
 
+    # TODO: update these methods to use the button's click method
     def click_undo(self):
         self.browser.click(self.UNDO)
 
@@ -196,7 +199,7 @@ class ExpressionEditor(View, Pretty):
     @property
     def expression_text(self):
         try:
-            return self.browser.text(self.EXPRESSION_TEXT, parent=self._expressions_root)
+            return self.expression_text_widget.text
         except NoSuchElementException:
             return "<new element>"
 
@@ -262,6 +265,13 @@ class ExpressionEditor(View, Pretty):
         prog = create_program(expression, self)
         before = self.expression_text.encode("utf-8").strip()
         prog()
+        wait_for(
+            lambda: self.expression_text != "<new element>" and self.expression_text != before,
+            handle_exception=True,
+            num_sec=10,
+            message="updated expression text to appear",
+            delay=1,
+        )
         after = self.expression_text.encode("utf-8").strip()
         return before != after
 


### PR DESCRIPTION
Making use of #8361 for conditions. The second and third commits to this PR are meant to address a `StaleElementReferenceException` that was occurring after an expression was entered into CFME 5.10. The second commit waits for a button to be displayed before clicking it. The third commit waits for the text to have changed in the expression after the fill is completed. 

__Fixes__ `cfme.tests.control.test_basic::test_modify_condition_expression`

{{ pytest: --long-running cfme/tests/control/test_basic.py::test_modify_condition_expression }}