### PR TITLE
[WIPTEST] Install polarion-docstrings in travis linting stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ jobs:
       env:
       install:
       - pip install pre-commit flake8
+      - pip install polarion-docstrings
       - pre-commit install-hooks
       script:
       - pre-commit run --all-files


### PR DESCRIPTION
polarion-docstrings needs to be installed to have the flake plugin for validating polarion docstring components.

I'll resolve any outstanding issues I find.