### PR TITLE
[1LP][RFR] Auth: add logout after evm restart

### DIFF
--- a/cfme/fixtures/authentication.py
+++ b/cfme/fixtures/authentication.py
@@ -74,3 +74,6 @@ def configure_auth(appliance, auth_mode, auth_provider, user_type, request, fix_
     appliance.server.authentication.auth_settings = original_config
     appliance.evmserverd.restart()
     appliance.wait_for_web_ui()
+    # After evmserverd restart, we need to logout from the appliance in the UI.
+    # Otherwise the UI would be in a bad state and produce errors while testing.
+    appliance.server.logout()


### PR DESCRIPTION
This fixes numerous 'CandidateNotFound' errors for both 5.9 and 5.10.

The error:

> CandidateNotFound
> path: ('Zones', 'Zone: Default Zone (current)', 'Server:  [1] (current)'), message: Could not find the item CFME Region: Region 0 [0]/Zones/Zone: Default Zone (current)/Server:  [1] (current) in Boostrap tree settings_tree, cause: Was not found in Zone: Default Zone (current)

Cause:
During auth testing, evmserverd is restarted; after that, we wait for an UI to appear. What in fact does happen in automation is that the UI never disappears. The browser sits there and seems like the server never restarted. This causes appliance to behave unexpectedly when the automation tries to navigate or perform actions in UI.
The appliance does not logout the user after evmserverd restart. BZ in progress.

Proposed fix:
Added server.logout after the evmserverd restart. This forces automation to log in again and everything works as expected from there.

{{ pytest: -v --long-running cfme/tests/integration/test_cfme_auth.py -k test_login_evm_group --use-provider vsphere67-nested }}