### PR TITLE
[1LP][RFR] _select template for all pages

### DIFF
--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -317,6 +317,7 @@ class ProvisionView(BaseLoggedInPage):
     title = Text('#explorer_title_text')
     breadcrumb = BreadCrumb()
     image_table = Table('//div[@id="pre_prov_div"]//table')
+    paginator = PaginationPane()
 
     @View.nested
     class sidebar(View):  # noqa
@@ -334,8 +335,10 @@ class ProvisionView(BaseLoggedInPage):
 
         def _select_template(self, template_name, provider_name):
             try:
-                row = self.parent.image_table.row(name=template_name, provider=provider_name)
-                row.click()
+                self.parent.paginator.find_row_on_pages(self.parent.image_table,
+                                                        name=template_name,
+                                                        provider=provider_name).click()
+            # image was not found, therefore raise an exception
             except IndexError:
                 raise TemplateNotFound('Cannot find template "{}" for provider "{}"'
                                        .format(template_name, provider_name))


### PR DESCRIPTION
{{ pytest: -v cfme/tests/cloud_infra_common/test_provisioning.py::test_provision_with_tag }}

`test_provision_with_tag[ec2]` was failing because `def _select_template` was looking for the template only on the first page and the template was not there.
There are tons of templates on ec2 provider, so some iteration is needed.