### PR TITLE
[RFR] is_displayed for Search

### DIFF
--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -2527,6 +2527,10 @@ class Search(View):
             self.filter_clear_button.click()
         self.clear_simple_search()
 
+    @property
+    def is_displayed(self):
+        return self.search_input.is_displayed
+
 
 class UpDownSelect(View):
     """Multiselect with two arrows (up/down) next to it. Eg. in AE/Domain priority selection.


### PR DESCRIPTION
Purpose or Intent
=================
- I was just debugging things for container custom button. As container objects using serach while navigation. I stuck on one place and found

Current `Serach` `is_displayed` pointing to `View` `is_displayed`

Example: fallowing condition always `True` as its pointing `view`. 
https://github.com/ManageIQ/integration_tests/blob/master/cfme/containers/pod.py#L111

{{pytest: cfme/tests/automate/custom_button/test_container_objects.py::test_custom_button_display -v --use-provider ocp-39-hawk}}

FIXES #8385 
