### PR TITLE
[RFR] Remove manual cases that are already automated and add Polarion data

### DIFF
--- a/cfme/tests/cloud/test_cloud_events.py
+++ b/cfme/tests/cloud/test_cloud_events.py
@@ -22,8 +22,9 @@ def test_manage_nsg_group(appliance, provider, register_event):
         test_flag: events
 
     Polarion:
-        assignee: anikifor
+        assignee: jdupuy
         initialEstimate: 1/8h
+        casecomponent: control
         caseimportance: medium
     """
 
@@ -75,8 +76,9 @@ def test_vm_capture(appliance, request, provider, register_event):
         test_flag: events, provision
 
     Polarion:
-        assignee: anikifor
+        assignee: jdupuy
         initialEstimate: 1/8h
+        casecomponent: control
         caseimportance: medium
     """
 

--- a/cfme/tests/test_manual.py
+++ b/cfme/tests/test_manual.py
@@ -702,21 +702,6 @@ def test_copy_provisioning_dialog():
 
 
 @pytest.mark.manual
-@pytest.mark.tier(3)
-def test_capture_vm_event_azure():
-    """
-    capture vm event[azure]
-
-    Polarion:
-        assignee: None
-        caseimportance: low
-        initialEstimate: 1/4h
-        title: capture vm event[azure]
-    """
-    pass
-
-
-@pytest.mark.manual
 @test_requirements.quota
 @pytest.mark.tier(1)
 def test_user_cloud_storage_quota_by_services():
@@ -26603,21 +26588,6 @@ def test_regions_gov_azure():
         initialEstimate: 1/8h
         setup: Check the region list when adding a Azure Provider.
         startsin: 5.7
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(3)
-def test_create_remove_network_security_groups_events_azure():
-    """
-    create/remove network security groups events[azure]
-
-    Polarion:
-        assignee: None
-        caseimportance: low
-        initialEstimate: 1/4h
-        title: create/remove network security groups events[azure]
     """
     pass
 


### PR DESCRIPTION
Removing manual test cases: 

`test_capture_vm_event_azure`, this is replaced by automated case: `test_vm_capture`
`test_create_remove_security_groups_azure`, this is replaced by automated case: `test_manage_nsg_group`

Also updating assignments and `casecomponents`