### PR TITLE
[RFR][NOTEST] Distributed manual tests with manual tag

### DIFF
--- a/cfme/tests/automate/test_automate_manual.py
+++ b/cfme/tests/automate/test_automate_manual.py
@@ -2,82 +2,145 @@
 
 import pytest
 
-pytestmark = [pytest.mark.ignore_stream("5.9", "5.10", "upstream")]
+from cfme import test_requirements
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(3)
 def test_automate_git_domain_import_top_level_directory():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1389823 Importing domain
-    from git should work with or without the top level domain directory.
+    Importing domain from git should work with or without the top level domain directory.
 
     Polarion:
         assignee: ghubale
-        casecomponent: automate
-        caseimportance: medium
         initialEstimate: 1/6h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
         startsin: 5.7
+        casecomponent: Automate
+        tags: automate
+        title: Test automate git domain import top level directory
+        testSteps:
+            1. Enable server role: git Repositories Owner
+            2. Navigate to Automation > Automate > Import/Export
+            3. Create a Git Repository with the contents of a domain directory without including
+               the domain directory.
+        expectedResults:
+            1.
+            2.
+            3. Import should work with or without the top level domain directory.
+
+    Bugzilla:
+        1389823
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(2)
 def test_quota_source_user():
     """
     When copying and modifying
-    /System/CommonMethods/QuotaStateMachine/quota to user the user as the
+    /System/CommonMethods/QuotaStateMachine/quota to user; the user as the
     quota source and when the user is tagged, the quotas are in effect.
 
     Polarion:
         assignee: ghubale
-        casecomponent: automate
-        caseimportance: medium
         initialEstimate: 1/8h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.7
+        casecomponent: Automate
+        tags: automate
+        title: Test quota source user
+        testSteps:
+            1. Assign quota to user by automate method
+            2. Also assign quota to user by tagging(more/less than automate quota method limit)
+            3. Provision Vm exceeding assigned quota
+            4. Check last message of request info or notification message
+        expectedResults:
+            1.
+            2.
+            3. Request should be denied with quota exceeded message
+            4. Last message should contain, quota exceeded because of tagging quota limit
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(1)
 def test_automate_simulate_retry():
     """
-    PR Link
     Automate simulation now supports simulating the state machines.
 
     Polarion:
         assignee: ghubale
-        casecomponent: automate
-        caseimportance: medium
         initialEstimate: 1/4h
-        setup: Create a state machine that contains a couple of states from which one
-               of them retries at least once.
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
         startsin: 5.6
+        casecomponent: Automate
+        tags: automate
+        title: Test automate simulate retry
+        setup:
+            1. Create a state machine that contains a couple of states
         testSteps:
-            1. Use automate simulation UI to call the state machine (Call_Instance)
+            1. Create an Automate model that has a State Machine that can end in a retry
+            2. Run a simulation to test the Automate Model from Step 1
+            3. When the Automation ends in a retry, we should be able to resubmit the request
+            4. Use automate simulation UI to call the state machine (Call_Instance)
         expectedResults:
-            1. A Retry button appears.
+            1.
+            2.
+            3.
+            4. A Retry button should appear.
+
+    Bugzilla:
+        1299579
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(1)
 def test_customize_request_security_group():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1335989
-
     Polarion:
         assignee: ghubale
-        casecomponent: automate
-        caseimportance: medium
         initialEstimate: 1/4h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.6
+        casecomponent: Automate
+        tags: automate
+        title: Test customize request security group
+        testSteps:
+            1. Copy the "customize request" method to a writable domain and modify the mapping
+               setting from mapping = 0 to mapping = 1.
+            2. Create a REST API call to provision an Amazon or OpenStack instance and pass the
+               "security_group" value with the name in "additional_values" that you want to apply.
+            3. Check the request that was created and verify that the security group was not applied
+        expectedResults:
+            1.
+            2.
+            3. Specified security group gets set.
+
+    Bugzilla:
+        1335989
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(3)
 def test_automate_git_import_multiple_domains():
     """
@@ -85,81 +148,107 @@ def test_automate_git_import_multiple_domains():
 
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        initialEstimate: 1/12h
         caseimportance: medium
         caseposneg: negative
-        initialEstimate: 1/12h
+        testtype: functional
         startsin: 5.10
+        casecomponent: Automate
+        tags: automate
+        title: Test automate git import multiple domains
+        testSteps:
+            1. Enable server role: git Repositories Owner
+            2. Navigate to Automation > Automate > Import/Export
+            3. Import multiple domains from a single git repository
+        expectedResults:
+            1.
+            2.
+            3. Import of multiple domains from a single git repo is not allowed
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(1)
 def test_automate_relationship_trailing_spaces():
     """
-    PR Link (Merged 2016-04-01)
     Handle trailing whitespaces in automate instance relationships.
 
     Polarion:
         assignee: ghubale
-        casecomponent: automate
-        caseimportance: medium
         initialEstimate: 1/10h
-        setup: A fresh appliance.
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
         startsin: 5.6
+        casecomponent: Automate
+        tags: automate
+        title: Test automate relationship trailing spaces
         testSteps:
             1. Create a class and its instance, also create second one,
-               that has a relationship field. Create an instance with the
-               relationship field pointing to the first class" instance but
-               add a couple of whitespaces after it.
-            2. Execute the AE model, eg. using Simulate.
+               that has a relationship field.
+            2. Create an instance with the relationship field pointing to the first class"
+               instance but add a couple of whitespaces after it.
+            3. Execute the AE model, eg. using Simulate.
         expectedResults:
             1.
-            2. Logs contain no resolution errors
+            2.
+            3. Logs contain no resolution errors.
+
+    PR:
+        https://github.com/ManageIQ/manageiq/pull/7550
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(1)
 def test_automate_generic_object_service_associations():
     """
-    Use the attached domain to test this bug:
-    1) Import end enable the domain
-    2) Have at least one service created (Generic is enough)
-    3) Run rails console and create the object definition:
-    GenericObjectDefinition.create(
-    :name => "LoadBalancer",
-    :properties => {
-    :attributes   => {:location => "string"},
-    :associations => {:vms => "Vm", :services => "Service"},
-    }
-    )
-    4) Run tail -fn0 log/automation.log | egrep "ERROR|XYZ"
-    5) Simulate Request/GOTest with method execution
-    In the tail"ed log:
-    There should be no ERROR lines related to the execution.
-    There should be these two lines:
-    <AEMethod gotest> XYZ go object: #<MiqAeServiceGenericObject
-    ....something...>
-    <AEMethod gotest> XYZ load balancer got service:
-    #<MiqAeServiceService:....something....>
-    If there is "XYZ load balancer got service: nil", then this bug was
-    reproduced.
-    thx @lfu
-
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        initialEstimate: 1/10h
         caseimportance: medium
-        initialEstimate: 1/8h
+        caseposneg: positive
+        testtype: functional
         startsin: 5.7
+        casecomponent: Automate
+        tags: automate
+        title: Test automate generic object service associations
+        testSteps:
+            1. Use the attached domain to test this bug:
+            2. Import end enable the domain
+            3. Have at least one service created (Generic is enough)
+            4. Run rails console and create the object definition:
+               GenericObjectDefinition.create(:name => "LoadBalancer", :properties => {
+               :attributes   => {:location => "string"}, :associations => {:vms => "Vm",
+               :services => "Service"},})
+            5. Run tail -fn0 log/automation.log | egrep "ERROR|XYZ"
+        expectedResults:
+            1.
+            2.
+            3.
+            4.
+            5.
+            6. Simulate Request/GOTest with method execution
+               In the tail"ed log:
+               There should be no ERROR lines related to the execution.
+               There should be these two lines:
+               <AEMethod gotest> XYZ go object: #<MiqAeServiceGenericObject....something...>
+               <AEMethod gotest> XYZ load balancer got service:
+               #<MiqAeServiceService:....something....>
+               If there is "XYZ load balancer got service: nil", then this bug was reproduced.
+
+    Bugzilla:
+        1410920
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(2)
 def test_automate_git_domain_displayed_in_dialog():
     """
@@ -170,14 +259,27 @@ def test_automate_git_domain_displayed_in_dialog():
 
     Polarion:
         assignee: ghubale
-        casecomponent: automate
         initialEstimate: 1/15h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
         startsin: 5.7
+        casecomponent: Automate
+        tags: automate
+        title: Test automate git domain displayed in dialog
+        testSteps:
+            1. Import domain given in step 2
+            2. You can use eg. https://github.com/ramrexx/CloudForms_Essentials.git
+        expectedResults:
+            1.
+            2. Check that the domain imported from git is displayed and usable in the pop-up tree
+               in the dialog editor.
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(3)
 def test_automate_disabled_domains_in_domain_priority():
     """
@@ -188,15 +290,33 @@ def test_automate_disabled_domains_in_domain_priority():
 
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        initialEstimate: 1/12h
         caseimportance: low
         caseposneg: negative
-        initialEstimate: 1/12h
+        testtype: functional
+        startsin: 5.7
+        casecomponent: Automate
+        tags: automate
+        title: Test automate disabled domains in domain priority
+        testSteps:
+            1. create two domains
+            2. attach the same automate code to both domains.
+            3. disable one domain
+            4. click on a instance and see domains displayed.
+        expectedResults:
+            1.
+            2.
+            3.
+            4. CFME should not display disabled domains
+
+    Bugzilla:
+        1331017
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(1)
 def test_automate_engine_database_connection():
     """
@@ -204,251 +324,357 @@ def test_automate_engine_database_connection():
 
     Polarion:
         assignee: ghubale
-        casecomponent: automate
-        caseimportance: medium
         initialEstimate: 1/8h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.7
+        casecomponent: Automate
+        tags: automate
+        title: Test automate engine database connection
+        testSteps:
+            1. Create a 'visibility' tag category, containing a single tag
+            2. Run the attached script via the RESTful API to duplicate the tags in the category
+            3. Observe the error
+        expectedResults:
+            1.
+            2.
+            3. No error
+
+    Bugzilla:
+        1334909
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(3)
 def test_automate_check_quota_regression():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1554989
     Update from 5.8.2 to 5.8.3 has broken custom automate method.  Error
     is thrown for the check_quota instance method for an undefined method
     provisioned_storage.
-    You"ll need to create an invalid VM provisioning request to reproduce
-    this issue.
-    The starting point is an appliance with a provider configured, that
-    can successfully provision a VM using lifecycle provisioning.
-    1. Add a second provider to use for VM lifecycle provisioning.
-    2. Add a 2nd zone called "test_zone". (Don"t add a second appliance
-    for this zone)
-    3. Set the zone of the second provider to be "test_zone".
-    4. Provision a VM for the second provider, using VM lifecycle
-    provisioning. (The provisioning request should remain in
-    pending/active status and should not get processed because there is no
-    appliance/workers for the "test_zone".)
-    5. Delete the template used in step 4.(Through the UI when you
-    navigate to virtual machines, templates is on the left nav bar, select
-    the template used in step 4 and select: "Remove from Inventory"
-    6. Provisioning a VM for the first provider, using VM lifecycle
-    provisioning should produce the reported error.
 
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/6h
+        tags: automate
+        testSteps:
+            1. You"ll need to create an invalid VM provisioning request to reproduce this issue.
+            2. The starting point is an appliance with a provider configured, that can successfully
+               provision a VM using lifecycle provisioning.
+            3. Add a second provider to use for VM lifecycle provisioning.
+            4. Add a 2nd zone called "test_zone". (Don"t add a second appliance for this zone)
+            5. Set the zone of the second provider to be "test_zone".
+            6. Provision a VM for the second provider, using VM lifecycle provisioning.
+               (The provisioning request should remain in pending/active status and should not get
+               processed because there is no appliance/workers for the "test_zone".)
+            7. Delete the template used in step
+            8. Through the UI when you navigate to virtual machines, templates is on the left nav
+               bar, select the template used in step 4 and select: "Remove from Inventory"
+            9.Provisioning a VM for the first provider, using VM lifecycle provisioning should
+               produce the reported error.
+        expectedResults:
+            1.
+            2.
+            3.
+            4.
+            5.
+            6.
+            7.
+            8.
+            9. No error
+
+    Bugzilla:
+        1554989
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(3)
 def test_automate_git_domain_import_with_no_connection():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1391208
 
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/6h
+        tags: automate
         startsin: 5.7
+        testSteps:
+            1. Import a Git Domain into Automate
+            2. Server the connection to the GIT Server from the appliance
+               (Disable VPN or some other trick)
+            3. List all the Automate Domains using Automate-> Explorer
+        expectedResults:
+            1.
+            2.
+            3. The domain should be displayed properly
+
+    Bugzilla:
+        1391208
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(3)
 def test_automate_schema_field_without_type():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1365442
-    It shouldn"t be possible to add a field without specifying a type.
+    It shouldn't be possible to add a field without specifying a type.
 
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        casecomponent: Automate
         caseimportance: medium
         caseposneg: negative
         initialEstimate: 1/12h
+        tags: automate
+        testSteps:
+            1. Create a schema field that does not specify a type
+            2. Save the schema
+        expectedResults:
+            1.
+            2. it is not possible to add a field that does not specify the type
+               (assertion, attribute, relationship, ...)
+
+    Bugzilla:
+        1365442
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(1)
 def test_automate_retry_onexit_increases():
     """
-    To reproduce:
-    1) Import the attached file, it will create a domain called
-    OnExitRetry
-    2) Enable the domain
-    3) Go to Automate / Simulation
-    4) Simulate Request with instance OnExitRetry, execute methods
-    5) Click submit, open the tree on right and expand ae_state_retries
-    It should be 1 by now and subsequent clicks on Retry should raise the
-    number if it works properly.
-
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/8h
+        tags: automate
+        testSteps:
+            1. Import the attached file, it will create a domain called OnExitRetry
+            2. Enable the domain
+            3. Go to Automate / Simulation
+            4. Simulate Request with instance OnExitRetry, execute methods
+            5. Click submit, open the tree on right and expand ae_state_retries
+        expectedResults:
+            1.
+            2.
+            3.
+            4.
+            5. It should be 1 by now and subsequent clicks on Retry should raise the
+               number if it works properly.
+
+    Bugzilla:
+        1365442
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(3)
 def test_automate_simulation_result_has_hash_data():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1445089
     The UI should display the result objects if the Simulation Result has
     hash data.
 
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/6h
+        tags: automate
+        testSteps:
+            1. Create a Instance under /System/Request called ListUser, update it so that it points
+               to a ListUser Method
+            2. Create ListUser Method under /System/Request, paste the Attached Method
+            3. Run Simulation
+        expectedResults:
+            1.
+            2.
+            3. The UI should display the result objects
+
+    Bugzilla:
+        1445089
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(3)
 def test_automate_git_import_without_master():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1508881
-    Git repository doesn"t have to have master branch
+    Git repository doesn't have to have master branch
 
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/12h
+        tags: automate
+        testSteps:
+            1. Create git repository with different default branch than master.
+            2. Add some valid code, for example exported one.
+            3. Navigate to Automation -> Automate -> Import/Export
+            4. Enter credentials and hit the submit button.
+        expectedResults:
+            1.
+            2.
+            3.
+            4. Domain was imported from git
+
+    Bugzilla:
+        1508881
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(1)
 def test_state_machine_variable():
     """
-    Test whether storing the state machine variable works and the vaule is
+    Test whether storing the state machine variable works and the value is
     available in another state.
 
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/4h
+        tags: automate
+        testSteps:
+            1. Test whether storing the state machine variable works and the value is available in
+               another state.
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(2)
 def test_automate_method_copy():
     """
-    Should copy selected automate method/Instance without going into edit
-    mode.
-    Steps:
-    1. Add new domain (In enabled/unlock mode)
-    2. Add namespace in that domain
-    3. Add class in that namespace
-    4. Unlock ManageIQ domain now
-    5. Select Instance/Method from any class in ManageIQ
-    6. From configuration toolbar, select `Copy this method/Instance`
-    Additional info: https://bugzilla.redhat.com/show_bug.cgi?id=1500956
+    Should copy selected automate method/Instance without going into edit mode.
 
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/8h
+        tags: automate
         startsin: 5.9
         upstream: yes
+        testSteps:
+            1. Add new domain (In enabled/unlock mode)
+            2. Add namespace in that domain
+            3. Add class in that namespace
+            4. Unlock ManageIQ domain now
+            5. Select Instance/Method from any class in ManageIQ
+            6. From configuration toolbar, select "Copy this method/Instance"
+        expectedResults:
+            1.
+            2.
+            3.
+            4. Able to copy method with "Copy This Method" toolbar.
+
+    Bugzilla:
+        1500956
     """
     pass
 
 
 @pytest.mark.manual
-@pytest.mark.tier(2)
-def test_custom_button_disable():
-    """
-    Check if the button is disable or not (i.e. visible but blurry)
-    Steps
-    1)Add Button Group
-    2)Add a button to the newly created button group
-    3)Add an expression for disabling button (can use simple {"tag":
-    {"department":"Support"}} expression)
-    4)Add the Button group to a page
-    5)Check that button is enabled; if enabled pass else fail.
-
-    Polarion:
-        assignee: ghubale
-        casecomponent: automate
-        caseimportance: medium
-        initialEstimate: 1/12h
-        startsin: 5.9
-        upstream: yes
-    """
-    pass
-
-
-@pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(3)
 def test_automate_git_import_deleted_tag():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1394194
 
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/12h
+        tags: automate
         startsin: 5.7
+        testSteps:
+            1. Create a github-hosted repository containing a correctly formatted automate domain.
+               This repository should contain two or more tagged commits.
+            2. Import the git-hosted domain into automate. Note that the tags are visible to select
+               from in the import dialog
+            3. Delete the most recent tagged commit and tag from the source github repository
+            4. In automate explorer, click on the domain and click Configuration -> Refresh with a
+               new branch or tag
+            5. Observe the list of available tags to import from
+        expectedResults:
+            1.
+            2.
+            3.
+            4.
+            5. The deleted tag should no longer be visible in the list of tags to refresh from
+
+    Bugzilla:
+        1394194
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(1)
 def test_automate_service_quota_runs_only_once():
     """
-    Steps described here:
-    https://bugzilla.redhat.com/show_bug.cgi?id=1317698
-
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/4h
+        tags: automate
+        testSteps:
+            1. Provision a service.
+            2. Check the automation.log to see both quota checks, one for
+               ServiceTemplateProvisionRequest_created,
+               and ServiceTemplateProvisionRequest_starting.
+        expectedResults:
+            1.
+            2. Quota executed once.
+
+    Bugzilla:
+        1317698
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(1)
 def test_automate_state_method():
     """
-    PR link (merged 2016-03-24)
     You can pass methods as states compared to the old method of passing
     instances which had to be located in different classes. You use the
     METHOD:: prefix
 
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/4h
-        setup: A fresh appliance.
+        tags: automate
         startsin: 5.6
+        setup: A fresh appliance.
         testSteps:
             1. Create an automate class that has one state.
             2. Create a method in the class, make the method output
@@ -468,6 +694,7 @@ def test_automate_state_method():
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(2)
 def test_button_can_trigger_events():
     """
@@ -476,19 +703,37 @@ def test_button_can_trigger_events():
 
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/60h
+        tags: automate
         startsin: 5.6.1
+        testSteps:
+            1. Go to automate and copy the Class /ManageIQ/System/Process to your custom domain
+            2. Create an instance named
+               MiqEvent with a rel5 of : /System/Event/MiqEvent/Policy/${/#event_type}
+            3. On the custom button provide the following details.
+               * System/Process/   MiqEvent
+               * Message    create
+               * Request    vm_retire_warn
+               * Attribute
+               * event_type   vm_retire_warn
+        expectedResults:
+            1.
+            2.
+            3. The MiqEntry is present and triggering an event should work
+
+    Bugzilla:
+        1348605
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(3)
 def test_automate_requests_tab_exposed():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1508490
     Need to expose Automate => Requests tab from the Web UI without
     exposing any other Automate tabs (i.e. Explorer, Customization,
     Import/Export, Logs). The only way to expose this in the Web UI, is to
@@ -497,30 +742,63 @@ def test_automate_requests_tab_exposed():
 
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/12h
+        tags: automate
         startsin: 5.10
+        testSteps:
+            1. Test this with the role EvmRole-support
+            2. By default this role does not have access to the Automation tab in the Web UI.
+            3. Copy this role to AA-EVMRole-support and add all of the Automate role features.
+            4. Did not allow user to see Requests under Automate.
+            5. Enabled all the Service => Request role features.
+            6. This allows user to see the Automate => Requests.
+
+        expectedResults:
+            1.
+            2.
+            3.
+            4.
+            5.
+            6. "Automate/Requests" tab can be exposed for a role without exposing "Service/Requests"
+               tab
+
+    Bugzilla:
+        1508490
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(3)
 def test_automate_git_credentials_changed():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1552274
-
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/6h
+        tags: automate
+        testSteps:
+            1. Customer is using a private enterprise git repo.
+            2. The original username was changed and upon a refresh, the customer noticed
+               it did not update
+            3. There was no message letting the user know there was a validation error
+        expectedResults:
+            1.
+            2.
+            3. There were no FATAL messages in the log if the credentials were changed
+
+    Bugzilla:
+        1552274
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(1)
 def test_automate_git_import_case_insensitive():
     """
@@ -531,73 +809,81 @@ def test_automate_git_import_case_insensitive():
 
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/8h
+        tags: automate
         startsin: 5.7
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(1)
 def test_custom_button_enable():
     """
-    Check if the button is enabled or not
-    Steps
-    1)Add Button Group
-    2)Add a button to the newly created button group
-    3)Add an expression for enabling button
-    4)Add the Button group to a page
-    5)Check that button is enabled; if enabled pass else fail.
-
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/12h
         startsin: 5.9
+        tags: automate
+        testSteps:
+            1. Add Button Group
+            2. Add a button to the newly created button group
+            3. Add an expression for enabling button
+            4. Add the Button group to a page
+            5. Check that button is enabled; if enabled pass else fail.
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(1)
 def test_assert_failed_substitution():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1335669
-
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/4h
+        tags: automate
+
+    Bigzilla:
+        1335669
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(3)
 def test_automate_import_namespace_attributes_updated():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1440226 1. Export an
-    Automate model
-    2. Change the display name and description in the exported namespace
-    yaml file
-    3. Run an import with the updated data
-    4. Check if the namespace attributes get updated.Display name and
-    description attributes should get updated
-
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        casecomponent: Automate
         caseimportance: low
         initialEstimate: 1/12h
+        tags: automate
+        testSteps:
+            1. Export an Automate model
+            2. Change the display name and description in the exported namespace yaml file
+            3. Run an import with the updated data
+            4. Check if the namespace attributes get updated.Display name and description attributes
+               should get updated
+
+    Bugzilla:
+        1440226
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(3)
 def test_automate_user_has_groups():
     """
@@ -607,99 +893,391 @@ def test_automate_user_has_groups():
 
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/12h
+        tags: automate
         startsin: 5.8
+
+    Bugzilla:
+        1411424
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(3)
 def test_automate_quota_units():
     """
-    Steps described here:
-    https://bugzilla.redhat.com/show_bug.cgi?id=1334318
-
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        casecomponent: Automate
         caseimportance: low
         initialEstimate: 1/4h
+        tags: automate
+
+    Bugzilla:
+        1334318
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(3)
 def test_automate_restrict_domain_crud():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1365493
     When you create a role that can only view automate domains, it can
     view automate domains, it cannot manipulate the domains themselves,
     but can CRUD on namespaces, classes, instances ....
 
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/6h
+        tags: automate
+
+    Bugzilla:
+        1365493
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(1)
 def test_custom_button_visibility():
     """
     This test is required to test the visibility option in the customize
     button.
-    Steps
-    1)Create Button Group
-    2)Create a Button for the button group
-    3)Add the Button group to a page
-    4)Make write a positive visibility expression
-    5)If button is visible and clickable then pass else fail
 
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/12h
+        tags: automate
         startsin: 5.9
+        testSteps:
+            1. Create Button Group
+            2. Create a Button for the button group
+            3. Add the Button group to a page
+            4. Make write a positive visibility expression
+            5. If button is visible and clickable then pass else fail
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(3)
 def test_automate_embedded_method():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1523379
     For a "new" method when adding Embedded Methods the UI hangs in the
     tree view when the method is selected
 
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/12h
+        tags: automate
+
+    Bugzilla:
+        1523379
     """
     pass
 
 
 @pytest.mark.manual
+@test_requirements.automate
 @pytest.mark.tier(3)
 def test_automate_git_verify_ssl():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1470738
-
     Polarion:
         assignee: ghubale
-        casecomponent: automate
+        casecomponent: Automate
         caseimportance: low
         initialEstimate: 1/12h
+        tags: automate
         startsin: 5.7
+
+    Bugzilla:
+        1470738
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.general_ui
+@pytest.mark.tier(1)
+def test_automate_buttons_requests():
+    """
+    Polarion:
+        assignee: ghubale
+        casecomponent: Automate
+        caseimportance: low
+        initialEstimate: 1/18h
+        tags: automate
+        testSteps:
+            1. Navigate to Automate -> Requests
+            2. Check whether these buttons are displayed: Reload, Apply , Reset, Default
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.automate
+@pytest.mark.tier(1)
+def test_check_system_request_calls_depr_configurationmanagement():
+    """
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/8h
+        caseimportance: low
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.10
+        casecomponent: Automate
+        tags: automate
+        testSteps:
+            1. Copy /System/Request/ansible_tower_job instance to new domain
+            2. Run that instance using simulation
+            3. See automation log
+
+    Bugzilla:
+        1615444
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.automate
+@pytest.mark.tier(1)
+def test_task_id_for_method_automation_log():
+    """
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/8h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.9
+        casecomponent: Automate
+        tags: automate
+        testSteps:
+            1. Add existing or new automate method to newly created domain
+            2. Run that instance using simulation
+            3. See automation log
+        expectedResults:
+            1.
+            2.
+            3. Task id should be included in automation log for method logs.
+
+    Bugzilla:
+        1592428
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.automate
+@pytest.mark.tier(1)
+def test_refresh_git_current_user():
+    """
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/8h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.9
+        casecomponent: Automate
+        tags: automate
+        testSteps:
+            1. created non-super user 'ganesh' along with default 'admin' user.
+            2. Using admin user imported git repo.:
+               'https://github.com/ramrexx/CloudForms_Essentials.git'
+            3. Logged in with admin and refreshed domain- 'CloudForms_Essentials'.
+               Then checked all tasks.
+            4. Found user name 'admin' next to 'Refresh git repository'.
+            5. Then checked instances in that domain by logging in with user 'ganesh' and 'admin'.
+            6. Logged in with non-super user 'ganesh' and refreshed domain- 'CloudForms_Essentials'.
+               Then checked all tasks.
+            7. Found user name 'ganesh' next to 'Refresh git repository'.
+            8. Then checked instances in that domain by logging in with user 'ganesh' and 'admin'.
+        expectedResults:
+            1.
+            2.
+            3.
+            4.
+            5. It shows that
+               e.g. 'Automate Instance [Provisioning - Updated 2019-01-15 11:41:43 UTC by admin]'
+            6.
+            7.
+            8. It shows that
+               e.g. 'Automate Instance [Provisioning - Updated 2019-01-15 11:44:43 UTC by ganesh]'
+               Hence, correct user that calls refresh automation domain from git branch is shown.
+    Bugzilla:
+        1592428
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.automate
+@pytest.mark.tier(1)
+def test_list_of_diff_vm_storages_via_rails():
+    """
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/8h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.9
+        casecomponent: Automate
+        tags: automate
+        testSteps:
+            1. vmware = $evm.vmdb('ems').find_by_name('vmware 6.5 (nested)') ;
+            2. vm = vmware.vms.select { |v| v.name == 'ghubale-cfme510' }.first ;
+            3. vm.storage
+            4. vm.storages
+        expectedResults:
+            1.
+            2.
+            3. Returns only one storage
+            4. Returns available storages
+
+    Bugzilla:
+        1574444
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.automate
+@pytest.mark.tier(1)
+def test_generate_widget_content_by_automate():
+    """
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/8h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.9
+        casecomponent: Automate
+        tags: automate
+        testSteps:
+            1. create a new widget and add this widget to dashboard
+            2. Create automate method with below content:
+                #
+                # Description: generate widget content by calling shell command
+                #
+                cmd =("/var/www/miq/vmdb/bin/rails r
+                      'MiqWidget.find_by_title(\"Migration Candidates\").queue_generate_content'")
+                system(cmd)
+                exit MIQ_OK
+            3. Execute the automate method(by simulation) and check updated time of that widget
+               on dashboard.
+            4. Updated status changes once we trigger the generation of a widget content from
+               Automate method.
+            5. Or we can check widget status by executing following commands on rails console:
+                >> MiqWidget.find_by_title("widget_name")
+                >> service_miq_widget = MiqAeMethodService::MiqAeServiceMiqWidget.find(widget_id)
+                >> service_miq_widget.queue_generate_content (this will do same what we did with
+                   automate method)
+        expectedResults:
+            1.
+            2.
+            3. Updated time of that widget on dashboard should be changes to current time of update
+               by automate method.
+            4.
+            5. Updated time of that widget on dashboard should be changes to current time of update
+               by rails.
+
+    Bugzilla:
+        1445932
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.automate
+@pytest.mark.tier(1)
+def test_valid_names_of_domain_namespace():
+    """
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/8h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.9
+        casecomponent: Automate
+        tags: automate
+        testSteps:
+            1. Navigate to Automation> Automate> Explorer
+            2. Try to create Domain with name `Dummy Domain` (I put space which is invalid)
+            3. Should give proper flash message
+
+    Bugzilla:
+        1650071
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.automate
+@pytest.mark.tier(1)
+def test_method_for_log_and_notify():
+    """
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/8h
+        caseimportance: high
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.9
+        casecomponent: Automate
+        tags: automate
+        testSteps:
+            1. Create an Automate domain or use an existing writeable Automate domain
+            2. Create a new Automate Method
+            3. In the Automate Method screen embed ManageIQ/System/CommonMethods/Utils/log_object
+               you can pick this
+               method from the UI tree picker
+            4. In your method add a line akin to
+               ManageIQ::Automate::System::CommonMethods::Utils::LogObject.log_and_notify
+               (:info, "Hello Testing Log & Notify", $evm.root['vm'], $evm)
+            5. Check the logs
+            6. In your UI session you should see a notification
+
+    PR:
+        https://github.com/ManageIQ/manageiq-content/pull/423
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.automate
+@pytest.mark.tier(1)
+def test_miq_stop_abort_with_state_machines():
+    """
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/8h
+        caseimportance: high
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.9
+        casecomponent: Automate
+        tags: automate
+
+    Bugzilla:
+        1441353
     """
     pass

--- a/cfme/tests/automate/test_automate_manual.py
+++ b/cfme/tests/automate/test_automate_manual.py
@@ -1,0 +1,705 @@
+"""Manual tests"""
+
+import pytest
+
+pytestmark = [pytest.mark.ignore_stream("5.9", "5.10", "upstream")]
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_git_domain_import_top_level_directory():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1389823 Importing domain
+    from git should work with or without the top level domain directory.
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_quota_source_user():
+    """
+    When copying and modifying
+    /System/CommonMethods/QuotaStateMachine/quota to user the user as the
+    quota source and when the user is tagged, the quotas are in effect.
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_automate_simulate_retry():
+    """
+    PR Link
+    Automate simulation now supports simulating the state machines.
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/4h
+        setup: Create a state machine that contains a couple of states from which one
+               of them retries at least once.
+        startsin: 5.6
+        testSteps:
+            1. Use automate simulation UI to call the state machine (Call_Instance)
+        expectedResults:
+            1. A Retry button appears.
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_customize_request_security_group():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1335989
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_git_import_multiple_domains():
+    """
+    Import of multiple domains from a single git repo is not allowed
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/12h
+        startsin: 5.10
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_automate_relationship_trailing_spaces():
+    """
+    PR Link (Merged 2016-04-01)
+    Handle trailing whitespaces in automate instance relationships.
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/10h
+        setup: A fresh appliance.
+        startsin: 5.6
+        testSteps:
+            1. Create a class and its instance, also create second one,
+               that has a relationship field. Create an instance with the
+               relationship field pointing to the first class" instance but
+               add a couple of whitespaces after it.
+            2. Execute the AE model, eg. using Simulate.
+        expectedResults:
+            1.
+            2. Logs contain no resolution errors
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_automate_generic_object_service_associations():
+    """
+    Use the attached domain to test this bug:
+    1) Import end enable the domain
+    2) Have at least one service created (Generic is enough)
+    3) Run rails console and create the object definition:
+    GenericObjectDefinition.create(
+    :name => "LoadBalancer",
+    :properties => {
+    :attributes   => {:location => "string"},
+    :associations => {:vms => "Vm", :services => "Service"},
+    }
+    )
+    4) Run tail -fn0 log/automation.log | egrep "ERROR|XYZ"
+    5) Simulate Request/GOTest with method execution
+    In the tail"ed log:
+    There should be no ERROR lines related to the execution.
+    There should be these two lines:
+    <AEMethod gotest> XYZ go object: #<MiqAeServiceGenericObject
+    ....something...>
+    <AEMethod gotest> XYZ load balancer got service:
+    #<MiqAeServiceService:....something....>
+    If there is "XYZ load balancer got service: nil", then this bug was
+    reproduced.
+    thx @lfu
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_automate_git_domain_displayed_in_dialog():
+    """
+    Check that the domain imported from git is displayed and usable in the
+    pop-up tree in the dialog editor.
+    You can use eg. https://github.com/ramrexx/CloudForms_Essentials.git
+    for that
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        initialEstimate: 1/15h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_disabled_domains_in_domain_priority():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1331017 When the admin
+    clicks on a instance that has duplicate entries in two different
+    domains. If one domain is disabled it is still displayed in the UI for
+    the domain priority.
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: low
+        caseposneg: negative
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_automate_engine_database_connection():
+    """
+    All steps in: https://bugzilla.redhat.com/show_bug.cgi?id=1334909
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_check_quota_regression():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1554989
+    Update from 5.8.2 to 5.8.3 has broken custom automate method.  Error
+    is thrown for the check_quota instance method for an undefined method
+    provisioned_storage.
+    You"ll need to create an invalid VM provisioning request to reproduce
+    this issue.
+    The starting point is an appliance with a provider configured, that
+    can successfully provision a VM using lifecycle provisioning.
+    1. Add a second provider to use for VM lifecycle provisioning.
+    2. Add a 2nd zone called "test_zone". (Don"t add a second appliance
+    for this zone)
+    3. Set the zone of the second provider to be "test_zone".
+    4. Provision a VM for the second provider, using VM lifecycle
+    provisioning. (The provisioning request should remain in
+    pending/active status and should not get processed because there is no
+    appliance/workers for the "test_zone".)
+    5. Delete the template used in step 4.(Through the UI when you
+    navigate to virtual machines, templates is on the left nav bar, select
+    the template used in step 4 and select: "Remove from Inventory"
+    6. Provisioning a VM for the first provider, using VM lifecycle
+    provisioning should produce the reported error.
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_git_domain_import_with_no_connection():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1391208
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_schema_field_without_type():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1365442
+    It shouldn"t be possible to add a field without specifying a type.
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_automate_retry_onexit_increases():
+    """
+    To reproduce:
+    1) Import the attached file, it will create a domain called
+    OnExitRetry
+    2) Enable the domain
+    3) Go to Automate / Simulation
+    4) Simulate Request with instance OnExitRetry, execute methods
+    5) Click submit, open the tree on right and expand ae_state_retries
+    It should be 1 by now and subsequent clicks on Retry should raise the
+    number if it works properly.
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/8h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_simulation_result_has_hash_data():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1445089
+    The UI should display the result objects if the Simulation Result has
+    hash data.
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_git_import_without_master():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1508881
+    Git repository doesn"t have to have master branch
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_state_machine_variable():
+    """
+    Test whether storing the state machine variable works and the vaule is
+    available in another state.
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_automate_method_copy():
+    """
+    Should copy selected automate method/Instance without going into edit
+    mode.
+    Steps:
+    1. Add new domain (In enabled/unlock mode)
+    2. Add namespace in that domain
+    3. Add class in that namespace
+    4. Unlock ManageIQ domain now
+    5. Select Instance/Method from any class in ManageIQ
+    6. From configuration toolbar, select `Copy this method/Instance`
+    Additional info: https://bugzilla.redhat.com/show_bug.cgi?id=1500956
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.9
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_custom_button_disable():
+    """
+    Check if the button is disable or not (i.e. visible but blurry)
+    Steps
+    1)Add Button Group
+    2)Add a button to the newly created button group
+    3)Add an expression for disabling button (can use simple {"tag":
+    {"department":"Support"}} expression)
+    4)Add the Button group to a page
+    5)Check that button is enabled; if enabled pass else fail.
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/12h
+        startsin: 5.9
+        upstream: yes
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_git_import_deleted_tag():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1394194
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/12h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_automate_service_quota_runs_only_once():
+    """
+    Steps described here:
+    https://bugzilla.redhat.com/show_bug.cgi?id=1317698
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_automate_state_method():
+    """
+    PR link (merged 2016-03-24)
+    You can pass methods as states compared to the old method of passing
+    instances which had to be located in different classes. You use the
+    METHOD:: prefix
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/4h
+        setup: A fresh appliance.
+        startsin: 5.6
+        testSteps:
+            1. Create an automate class that has one state.
+            2. Create a method in the class, make the method output
+               something recognizable in the logs
+            3. Create an instance inside the class, and as a Value for the
+               state use: METHOD::method_name where method_name is the name
+               of the method you created
+            4. Run a simulation, use Request / Call_Instance to call your
+               state machine instance
+        expectedResults:
+            1. Class created
+            2. Method created
+            3. Instance created
+            4. The method got called, detectable by grepping logs
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+def test_button_can_trigger_events():
+    """
+    In the button creation dialog there must be MiqEvent available for
+    System/Process entry.
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/60h
+        startsin: 5.6.1
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_requests_tab_exposed():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1508490
+    Need to expose Automate => Requests tab from the Web UI without
+    exposing any other Automate tabs (i.e. Explorer, Customization,
+    Import/Export, Logs). The only way to expose this in the Web UI, is to
+    enable Services => Requests, and at least one tab from the Automate
+    section (i.e. Explorer, Customization, etc).
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/12h
+        startsin: 5.10
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_git_credentials_changed():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1552274
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_automate_git_import_case_insensitive():
+    """
+    bin/rake evm:automate:import PREVIEW=false
+    GIT_URL=https://github.com/mkanoor/SimpleDomain REF=test2branch
+    This should not cause an error (the actual name of the branch is
+    Test2Branch).
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/8h
+        startsin: 5.7
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_custom_button_enable():
+    """
+    Check if the button is enabled or not
+    Steps
+    1)Add Button Group
+    2)Add a button to the newly created button group
+    3)Add an expression for enabling button
+    4)Add the Button group to a page
+    5)Check that button is enabled; if enabled pass else fail.
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/12h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_assert_failed_substitution():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1335669
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_import_namespace_attributes_updated():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1440226 1. Export an
+    Automate model
+    2. Change the display name and description in the exported namespace
+    yaml file
+    3. Run an import with the updated data
+    4. Check if the namespace attributes get updated.Display name and
+    description attributes should get updated
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: low
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_user_has_groups():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1411424
+    This method should work:  groups = $evm.vmdb(:user).first.miq_groups
+    $evm.log(:info, "Displaying the user"s groups: #{groups.inspect}")
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/12h
+        startsin: 5.8
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_quota_units():
+    """
+    Steps described here:
+    https://bugzilla.redhat.com/show_bug.cgi?id=1334318
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: low
+        initialEstimate: 1/4h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_restrict_domain_crud():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1365493
+    When you create a role that can only view automate domains, it can
+    view automate domains, it cannot manipulate the domains themselves,
+    but can CRUD on namespaces, classes, instances ....
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/6h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_custom_button_visibility():
+    """
+    This test is required to test the visibility option in the customize
+    button.
+    Steps
+    1)Create Button Group
+    2)Create a Button for the button group
+    3)Add the Button group to a page
+    4)Make write a positive visibility expression
+    5)If button is visible and clickable then pass else fail
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/12h
+        startsin: 5.9
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_embedded_method():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1523379
+    For a "new" method when adding Embedded Methods the UI hangs in the
+    tree view when the method is selected
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: medium
+        initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(3)
+def test_automate_git_verify_ssl():
+    """
+    https://bugzilla.redhat.com/show_bug.cgi?id=1470738
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: automate
+        caseimportance: low
+        initialEstimate: 1/12h
+        startsin: 5.7
+    """
+    pass

--- a/cfme/tests/automate/test_class.py
+++ b/cfme/tests/automate/test_class.py
@@ -43,10 +43,11 @@ def namespace(request, domain):
 def test_class_crud(namespace):
     """
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
         caseimportance: critical
         initialEstimate: 1/30h
+        tags: automate
     """
     a_class = namespace.classes.create(
         name=fauxfactory.gen_alphanumeric(),
@@ -68,10 +69,11 @@ def test_class_crud(namespace):
 def test_schema_crud(request, namespace):
     """
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
         caseimportance: critical
         initialEstimate: 1/20h
+        tags: automate
     """
     a_class = namespace.classes.create(
         name=fauxfactory.gen_alphanumeric(),
@@ -95,10 +97,11 @@ def test_schema_crud(request, namespace):
 def test_schema_duplicate_field_disallowed(request, domain):
     """
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/16h
+        tags: automate
     """
     ns = domain.namespaces.create(
         name=fauxfactory.gen_alpha(),
@@ -120,10 +123,11 @@ def test_schema_duplicate_field_disallowed(request, domain):
 def test_duplicate_class_disallowed(namespace):
     """
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
         caseposneg: negative
         initialEstimate: 1/30h
+        tags: automate
     """
     name = fauxfactory.gen_alphanumeric()
     namespace.classes.create(name=name)
@@ -135,9 +139,10 @@ def test_duplicate_class_disallowed(namespace):
 def test_same_class_name_different_namespace(request, domain):
     """
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
         initialEstimate: 1/16h
+        tags: automate
     """
     ns1 = domain.namespaces.create(
         name=fauxfactory.gen_alpha(),
@@ -172,9 +177,10 @@ def test_same_class_name_different_namespace(request, domain):
 def test_class_display_name_unset_from_ui(request, namespace):
     """
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
         initialEstimate: 1/30h
+        tags: automate
     """
     a_class = namespace.classes.create(
         name=fauxfactory.gen_alphanumeric(),

--- a/cfme/tests/automate/test_domain.py
+++ b/cfme/tests/automate/test_domain.py
@@ -16,10 +16,11 @@ pytestmark = [test_requirements.automate]
 def test_domain_crud(request, enabled, appliance):
     """
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
         caseimportance: critical
         initialEstimate: 1/30h
+        tags: automate
     """
     domain = appliance.collections.domains.create(
         name=fauxfactory.gen_alpha(),
@@ -48,9 +49,11 @@ def test_domain_crud(request, enabled, appliance):
 def test_domain_edit_enabled(request, appliance):
     """
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
         initialEstimate: 1/16h
+        caseimportance: high
+        tags: automate
     """
     domain = appliance.collections.domains.create(
         name=fauxfactory.gen_alpha(),
@@ -70,10 +73,11 @@ def test_domain_edit_enabled(request, appliance):
 def test_domain_lock_disabled(request, appliance):
     """
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/16h
+        tags: automate
     """
     domain = appliance.collections.domains.create(
         name=fauxfactory.gen_alpha(),
@@ -90,10 +94,11 @@ def test_domain_lock_disabled(request, appliance):
 def test_domain_delete_from_table(request, appliance):
     """
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
         caseimportance: low
         initialEstimate: 1/30h
+        tags: automate
     """
     generated = []
     for _ in range(3):
@@ -113,10 +118,11 @@ def test_domain_delete_from_table(request, appliance):
 def test_duplicate_domain_disallowed(request, appliance):
     """
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
         caseposneg: negative
         initialEstimate: 1/60h
+        tags: automate
     """
     domain = appliance.collections.domains.create(
         name=fauxfactory.gen_alpha(),
@@ -135,11 +141,12 @@ def test_duplicate_domain_disallowed(request, appliance):
 def test_domain_cannot_delete_builtin(appliance):
     """
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
         caseimportance: critical
         caseposneg: negative
         initialEstimate: 1/16h
+        tags: automate
     """
     manageiq_domain = appliance.collections.domains.instantiate(name='ManageIQ')
     details_view = navigate_to(manageiq_domain, 'Details')
@@ -155,11 +162,12 @@ def test_domain_cannot_delete_builtin(appliance):
 def test_domain_cannot_edit_builtin(appliance):
     """
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
         caseimportance: critical
         caseposneg: negative
         initialEstimate: 1/16h
+        tags: automate
     """
     manageiq_domain = appliance.collections.domains.instantiate(name='ManageIQ')
     details_view = navigate_to(manageiq_domain, 'Details')
@@ -174,11 +182,12 @@ def test_domain_cannot_edit_builtin(appliance):
 def test_domain_name_wrong(appliance):
     """
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
         caseimportance: medium
         caseposneg: negative
         initialEstimate: 1/60h
+        tags: automate
     """
     with pytest.raises(Exception, match='Name may contain only'):
         appliance.collections.domains.create(name='with space')
@@ -188,9 +197,11 @@ def test_domain_name_wrong(appliance):
 def test_domain_lock_unlock(request, appliance):
     """
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
         initialEstimate: 1/16h
+        caseimportance: medium
+        tags: automate
     """
     domain = appliance.collections.domains.create(
         name=fauxfactory.gen_alpha(),
@@ -267,9 +278,11 @@ def test_domain_import_git(request, appliance, url, param_type, param_value, ver
     """Verifies that a domain can be imported from git.
 
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
         initialEstimate: 1/20h
+        caseimportance: medium
+        tags: automate
     """
     repo = AutomateGitRepository(url=url, verify_ssl=verify_ssl, appliance=appliance)
     domain = repo.import_domain_from(**{param_type: param_value})

--- a/cfme/tests/automate/test_domain_priority.py
+++ b/cfme/tests/automate/test_domain_priority.py
@@ -98,31 +98,29 @@ def test_priority(
         original_method_write_data, copy_method_write_data, domain_collection):
     """This test checks whether method overriding works across domains with the aspect of priority.
 
-    Prerequisities:
-        * Pick a random file name.
-
-    Steps:
-        * If the picked file name exists on the appliance, delete it
-        * Create two domains (one for the original method and one for copied method).
-        * Create a method in ``System/Request`` (in original domain) containing the method code as
-            in this testing module, with the file in the method being the file picked and you pick
-            the contents you want to write to the file.
-        * Set the domain order so the original domain is first.
-        * Run the simulation on the ``Request/<method_name>`` with executing.
-        * The file on appliance should contain the data as you selected.
-        * Copy the method to the second (copy) domain.
-        * Change the copied method so it writes different data.
-        * Set the domain order so the copy domain is first.
-        * Run the same simulation again.
-        * Check the file contents, it should be the same as the content you entered last.
-        * Then pick the domain order so the original domain is first.
-        * Run the same simulation again.
-        * The contents of the file should be the same as in the first case.
-
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
+        caseimportance: medium
         initialEstimate: 1/4h
+        tags: automate
+        testSteps:
+            1.If the picked file name exists on the appliance, delete it
+            2.Create two domains (one for the original method and one for copied method).
+            3.Create a method in ``System/Request`` (in original domain) containing the method code
+              as in this testing module, with the file in the method being the file picked and you
+              pick the contents you want to write to the file.
+            4.Set the domain order so the original domain is first.
+            5.Run the simulation on the ``Request/<method_name>`` with executing.
+            6.The file on appliance should contain the data as you selected.
+            7.Copy the method to the second (copy) domain.
+            8.Change the copied method so it writes different data.
+            9.Set the domain order so the copy domain is first.
+            10.Run the same simulation again.
+            11.Check the file contents, it should be the same as the content you entered last.
+            12.Then pick the domain order so the original domain is first.
+            13.Run the same simulation again.
+            14.The contents of the file should be the same as in the first case.
     """
     ssh_client = appliance.ssh_client
     ssh_client.run_command("rm -f {}".format(FILE_LOCATION))

--- a/cfme/tests/automate/test_git_import.py
+++ b/cfme/tests/automate/test_git_import.py
@@ -36,10 +36,11 @@ def imported_domain(appliance, branch):
 def test_automate_git_domain_removed_from_disk(appliance, imported_domain):
     """
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/8h
+        tags: automate
     """
     imported_domain.delete()
     repo_path = urlparse(GIT_REPO_URL).path
@@ -50,15 +51,15 @@ def test_automate_git_domain_removed_from_disk(appliance, imported_domain):
 @pytest.mark.tier(2)
 def test_automate_git_domain_displayed_in_service(appliance, imported_domain, branch):
     """Tests if a domain is displayed in a service.
-
-    Checks if the domain imported from git is displayed and usable in the pop-up tree in the
-    dialog for creating services.
-
+       Checks if the domain imported from git is displayed and usable in the pop-up tree in the
+       dialog for creating services.
 
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
+        caseimportance: medium
         initialEstimate: 1/20h
+        tags: automate
     """
     collection = appliance.collections.catalog_items
     cat_item = collection.instantiate(collection.GENERIC, "test")

--- a/cfme/tests/automate/test_instance.py
+++ b/cfme/tests/automate/test_instance.py
@@ -44,10 +44,11 @@ def klass(request, namespace):
 def test_instance_crud(klass):
     """
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
         caseimportance: critical
         initialEstimate: 1/16h
+        tags: automate
     """
     instance = klass.instances.create(
         name=fauxfactory.gen_alphanumeric(),
@@ -68,10 +69,12 @@ def test_instance_crud(klass):
 def test_duplicate_instance_disallowed(request, klass):
     """
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
+        caseimportance: high
         caseposneg: negative
         initialEstimate: 1/60h
+        tags: automate
     """
     name = fauxfactory.gen_alphanumeric()
     klass.instances.create(name=name)
@@ -79,15 +82,16 @@ def test_duplicate_instance_disallowed(request, klass):
         klass.instances.create(name=name)
 
 
-@pytest.mark.meta(blockers=[1148541])
 @pytest.mark.tier(3)
 @pytest.mark.polarion('RHCF3-20872')
 def test_instance_display_name_unset_from_ui(request, klass):
     """
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
+        caseimportance: high
         initialEstimate: 1/30h
+        tags: automate
     """
     instance = klass.instances.create(
         name=fauxfactory.gen_alphanumeric(),
@@ -103,14 +107,15 @@ def test_instance_display_name_unset_from_ui(request, klass):
 @pytest.mark.tier(1)
 def test_automate_instance_missing(domain, klass, namespace, appliance):
     """If an instance called in class does not exist, a .missing instance is processed if it exists.
-
     A _missing_instance attribute (which contains the name of the instance that was supposed to be
     called) is then set on $evm.object so it then can be used eg. to resolve methods dynamically.
 
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
+        caseimportance: high
         initialEstimate: 1/10h
+        tags: automate
     """
     catch_string = fauxfactory.gen_alphanumeric()
     method = klass.methods.create(

--- a/cfme/tests/automate/test_method.py
+++ b/cfme/tests/automate/test_method.py
@@ -43,10 +43,11 @@ def klass(request, namespace):
 def test_method_crud(klass):
     """
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
         caseimportance: critical
         initialEstimate: 1/16h
+        tags: automate
     """
     method = klass.methods.create(
         name=fauxfactory.gen_alphanumeric(),
@@ -72,9 +73,11 @@ def test_method_crud(klass):
 def test_automate_method_inputs_crud(klass):
     """
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
         initialEstimate: 1/8h
+        caseimportance: critical
+        tags: automate
     """
     method = klass.methods.create(
         name=fauxfactory.gen_alphanumeric(),
@@ -110,10 +113,12 @@ def test_automate_method_inputs_crud(klass):
 def test_duplicate_method_disallowed(request, klass):
     """
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
         caseposneg: negative
         initialEstimate: 1/10h
+        caseimportance: critical
+        tags: automate
     """
     name = fauxfactory.gen_alpha()
     klass.methods.create(

--- a/cfme/tests/automate/test_namespace.py
+++ b/cfme/tests/automate/test_namespace.py
@@ -35,10 +35,11 @@ def parent_namespace(request, domain):
 def test_namespace_crud(request, parent_namespace):
     """
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
         caseimportance: critical
         initialEstimate: 1/16h
+        tags: automate
     """
     ns = parent_namespace.namespaces.create(
         name=fauxfactory.gen_alpha(),
@@ -58,10 +59,11 @@ def test_namespace_crud(request, parent_namespace):
 def test_namespace_delete_from_table(request, parent_namespace):
     """
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/30h
+        tags: automate
     """
     generated = []
     for _ in range(3):
@@ -79,10 +81,11 @@ def test_namespace_delete_from_table(request, parent_namespace):
 def test_duplicate_namespace_disallowed(request, parent_namespace):
     """
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
         caseposneg: negative
         initialEstimate: 1/16h
+        tags: automate
     """
     ns = parent_namespace.namespaces.create(
         name=fauxfactory.gen_alpha(),

--- a/cfme/tests/automate/test_provisioning_dialogs.py
+++ b/cfme/tests/automate/test_provisioning_dialogs.py
@@ -3,7 +3,6 @@ import fauxfactory
 import pytest
 
 from cfme import test_requirements
-from cfme.utils.blockers import BZ
 from cfme.automate.provisioning_dialogs import ProvisioningDialogsCollection
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.update import update
@@ -16,9 +15,11 @@ from cfme.utils.update import update
 def test_provisioning_dialog_crud(appliance):
     """
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
         initialEstimate: 1/10h
+        caseimportance: medium
+        tags: automate
     """
     # CREATE
     collection = appliance.collections.provisioning_dialogs
@@ -70,6 +71,7 @@ def test_provisioning_dialogs_sorting(appliance, name, by, order):
         casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/30h
+        tags: automate
     """
     view = navigate_to(appliance.collections.provisioning_dialogs, 'All')
     view.sidebar.provisioning_dialogs.tree.click_path("All Dialogs", name)

--- a/cfme/tests/automate/test_smoke.py
+++ b/cfme/tests/automate/test_smoke.py
@@ -18,19 +18,17 @@ pytestmark = [
 def test_domain_present(domain_name, soft_assert, appliance):
     """This test verifies presence of domains that are included in the appliance.
 
-    Prerequisities:
-        * Clean appliance.
-
-    Steps:
-        * Open the Automate Explorer.
-        * Verify that all of the required domains are present.
-
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         casecomponent: Automate
         caseimportance: critical
         initialEstimate: 1/60h
         testtype: functional
+        tags: automate
+        testSteps:
+            1. Clean appliance.
+            2. Open the Automate Explorer.
+            3. Verify that all of the required domains are present.
     """
     dc = DomainCollection(appliance)
     domain = dc.instantiate(name=domain_name)

--- a/cfme/tests/automate/test_vmware_methods.py
+++ b/cfme/tests/automate/test_vmware_methods.py
@@ -87,22 +87,20 @@ def testing_vm(setup_provider, provider):
 def test_vmware_vimapi_hotadd_disk(
         appliance, request, testing_group, provider, testing_vm, domain, cls):
     """ Tests hot adding a disk to vmware vm.
-
     This test exercises the ``VMware_HotAdd_Disk`` method, located in ``/Integration/VMware/VimApi``
 
-    Steps:
-        * It creates an instance in ``System/Request`` that can be accessible from eg. a button.
-        * Then it creates a button, that refers to the ``VMware_HotAdd_Disk`` in ``Request``. The
-            button shall belong in the VM and instance button group.
-        * After the button is created, it goes to a VM's summary page, clicks the button.
-        * The test waits until the capacity of disks is raised.
-
-    Metadata:
-        test_flag: hotdisk, provision
-
     Polarion:
-        assignee: dmisharo
+        assignee: ghubale
         initialEstimate: 1/8h
+        casecomponent: Automate
+        caseimportance: critical
+        tags: automate
+        testSteps:
+            1. It creates an instance in ``System/Request`` that can be accessible from eg. button
+            2. Then it creates a button, that refers to the ``VMware_HotAdd_Disk`` in ``Request``.
+               The button shall belong in the VM and instance button group.
+            3. After the button is created, it goes to a VM's summary page, clicks the button.
+            4. The test waits until the capacity of disks is raised.
     """
     meth = cls.methods.create(
         name='load_value_{}'.format(fauxfactory.gen_alpha()),

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -195,12 +195,12 @@ def wait_for_instance_state(soft_assert, instance, state):
 def test_quadicon_terminate_cancel(provider, testing_instance, ensure_vm_running, soft_assert):
     """ Tests terminate cancel
 
-    Metadata:
-        test_flag: power_control, provision
-
     Polarion:
         assignee: ghubale
         initialEstimate: 1/4h
+        casecomponent: Cloud
+        caseimportance: high
+        tags: power
     """
     testing_instance.power_control_from_cfme(option=testing_instance.TERMINATE,
                                              cancel=True,
@@ -211,12 +211,12 @@ def test_quadicon_terminate_cancel(provider, testing_instance, ensure_vm_running
 def test_quadicon_terminate(appliance, provider, testing_instance, ensure_vm_running, soft_assert):
     """ Tests terminate instance
 
-    Metadata:
-        test_flag: power_control, provision
-
     Polarion:
         assignee: ghubale
         initialEstimate: 1/4h
+        casecomponent: Cloud
+        caseimportance: high
+        tags: power
     """
     testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_ON)
     testing_instance.power_control_from_cfme(option=testing_instance.TERMINATE, from_details=False)
@@ -256,12 +256,12 @@ def test_stop(appliance, provider, testing_instance, ensure_vm_running, soft_ass
 def test_start(appliance, provider, testing_instance, ensure_vm_stopped, soft_assert):
     """ Tests instance start
 
-    Metadata:
-        test_flag: power_control, provision
-
     Polarion:
         assignee: ghubale
         initialEstimate: 1/4h
+        casecomponent: Cloud
+        caseimportance: high
+        tags: power
     """
     testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_OFF,
                                                     timeout=900)
@@ -351,12 +351,12 @@ def test_power_on_or_off_multiple(provider, testing_instance, testing_instance2,
 def test_hard_reboot(appliance, provider, testing_instance, ensure_vm_running, soft_assert):
     """ Tests instance hard reboot
 
-    Metadata:
-        test_flag: power_control, provision
-
     Polarion:
         assignee: ghubale
         initialEstimate: 1/4h
+        casecomponent: Cloud
+        caseimportance: high
+        tags: power
     """
     testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_ON)
     view = navigate_to(testing_instance, 'Details')
@@ -375,12 +375,12 @@ def test_hard_reboot_unsupported(appliance, testing_instance):
     """
     Tests that hard reboot throws an 'unsupported' error message on an Azure instance
 
-    Metadata:
-        test_flag: power_control, provision
-
     Polarion:
         assignee: ghubale
         initialEstimate: 1/8h
+        casecomponent: Cloud
+        caseimportance: high
+        tags: power
     """
     testing_instance.power_control_from_cfme(option=testing_instance.HARD_REBOOT,
                                              from_details=False)
@@ -397,12 +397,12 @@ def test_hard_reboot_unsupported(appliance, testing_instance):
 def test_suspend(appliance, provider, testing_instance, ensure_vm_running, soft_assert):
     """ Tests instance suspend
 
-    Metadata:
-        test_flag: power_control, provision
-
     Polarion:
         assignee: ghubale
         initialEstimate: 1/4h
+        casecomponent: Cloud
+        caseimportance: high
+        tags: power
     """
     testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_ON)
     testing_instance.power_control_from_cfme(option=testing_instance.SUSPEND)
@@ -419,12 +419,12 @@ def test_suspend(appliance, provider, testing_instance, ensure_vm_running, soft_
 def test_unpause(appliance, provider, testing_instance, ensure_vm_paused, soft_assert):
     """ Tests instance unpause
 
-    Metadata:
-        test_flag: power_control, provision
-
     Polarion:
         assignee: ghubale
         initialEstimate: 1/4h
+        casecomponent: Cloud
+        caseimportance: high
+        tags: power
     """
     testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_PAUSED)
     testing_instance.power_control_from_cfme(option=testing_instance.START)
@@ -439,12 +439,12 @@ def test_unpause(appliance, provider, testing_instance, ensure_vm_paused, soft_a
 def test_resume(appliance, provider, testing_instance, ensure_vm_suspended, soft_assert):
     """ Tests instance resume
 
-    Metadata:
-        test_flag: power_control, provision
-
     Polarion:
         assignee: ghubale
         initialEstimate: 1/4h
+        casecomponent: Cloud
+        caseimportance: high
+        tags: power
     """
     testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_SUSPENDED)
     testing_instance.power_control_from_cfme(option=testing_instance.START)
@@ -456,14 +456,14 @@ def test_resume(appliance, provider, testing_instance, ensure_vm_suspended, soft
 
 
 def test_terminate(provider, testing_instance, ensure_vm_running, soft_assert, appliance):
-    """ Tests instance terminate
-
-    Metadata:
-        test_flag: power_control, provision
+    """Tests instance terminate
 
     Polarion:
         assignee: ghubale
         initialEstimate: 1/4h
+        casecomponent: Cloud
+        caseimportance: high
+        tags: power
     """
     testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_ON)
     testing_instance.power_control_from_cfme(option=testing_instance.TERMINATE)
@@ -478,13 +478,12 @@ def test_terminate(provider, testing_instance, ensure_vm_running, soft_assert, a
 def test_instance_power_options_from_on(provider, testing_instance, ensure_vm_running, soft_assert):
     """ Tests available power options from ON state
 
-    Metadata:
-        test_flag: power_control
-
     Polarion:
         assignee: ghubale
         casecomponent: Cloud
         initialEstimate: 1/10h
+        caseimportance: high
+        tags: power
     """
     testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_ON)
     check_power_options(soft_assert, testing_instance, 'on')
@@ -492,15 +491,14 @@ def test_instance_power_options_from_on(provider, testing_instance, ensure_vm_ru
 
 def test_instance_power_options_from_off(provider, testing_instance,
                                          ensure_vm_stopped, soft_assert):
-    """ Tests available power options from OFF state
-
-    Metadata:
-        test_flag: power_control
+    """Tests available power options from OFF state
 
     Polarion:
         assignee: ghubale
         casecomponent: Cloud
         initialEstimate: 1/10h
+        caseimportance: high
+        tags: power
     """
     testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_OFF,
                                                     timeout=1200)

--- a/cfme/tests/cloud_infra_common/test_power_control_manual.py
+++ b/cfme/tests/cloud_infra_common/test_power_control_manual.py
@@ -1,0 +1,337 @@
+"""Manual tests"""
+
+import pytest
+
+from cfme import test_requirements
+
+
+@pytest.mark.manual
+@test_requirements.power
+@pytest.mark.tier(2)
+def test_shutdown_guest_scvmm():
+    """
+    This test performs the Shutdown Guest from the LifeCycle menu which
+    invokes the Hyper-V Guest Services Integration command.  This
+    gracefully exits the Windows OS rather than just powering off.
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/4h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.4
+        casecomponent: Infra
+        tags: power
+        title: test shutdown guest scvmm
+        testSteps:
+            1. Add provider scvmm
+            2. From collections page, select the VM
+            3. Click "Shut down guest" On SCVMM powershell
+        expectedResults:
+            1.
+            2.
+            3. Use "$vm = Get-VM -name "name_of_vm"; Find-SCJob-objectId $vm.id -recent"
+               to verify VM history shows "Shut down virtual machine" instead of "power off"
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.power
+@pytest.mark.tier(1)
+def test_vm_relationship_datastore_fileshare_scvmm():
+    """
+    This test case is valid for SCVMM with Host which have Fileshare storage
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/4h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.7
+        casecomponent: Infra
+        tags: power
+        title: test vm relationship datastore fileshare scvmm
+        setup:
+            1. SCVMM provider should have Host which have Fileshare storage
+        testSteps:
+            1. Add provider scvmm
+            2. Provision Vm into fileshare linked to the host
+            3. Check VM's relationships - Datastore
+        expectedResults:
+            1.
+            2.
+            3. Datastore should be 'fileshare'
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.power
+@test_requirements.power
+@pytest.mark.tier(2)
+def test_suspend_scvmm2016_from_collection():
+    """
+    Test the a VM can be Suspended, or Saved, from the Collection Page
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/8h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.7
+        casecomponent: Infra
+        tags: power
+        title: test suspend scvmm2016 from collection
+        testSteps:
+            1. Add provider scvmm2016
+            2. From collections page, select the VM
+            3. Click "suspend" On SCVMM powershell
+        expectedResults:
+            1.
+            2.
+            3. Use "$vm = Get-VM -name "name_of_vm"; Find-SCJob-objectId $vm.id -recent"
+               to verify VM history shows "suspend" instead of "power off"
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.power
+@pytest.mark.tier(2)
+def test_restart_guest_scvmm2016():
+    """
+    This test performs the Restart Guest from the LifeCycle menu which
+    invokes the Hyper-V Guest Services Integration command.  This
+    gracefully exits and restarts the Windows OS rather than just powering
+    off and back on.
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/8h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.7
+        casecomponent: Infra
+        tags: power
+        title: test restart guest scvmm2016
+        testSteps:
+            1. Add provider scvmm2016
+            2. Provision VM
+            3. From collections page, Select the VM
+            4. Click on "Restart Guest" On SCVMM powershell
+        expectedResults:
+            1.
+            2.
+            3.
+            4. Use "$vm = Get-VM -name "name_of_vm"; Find-SCJob-objectId $vm.id -recent"
+               to verify VM history shows "Shut down virtual machine" instead of "power off"
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.power
+@pytest.mark.tier(2)
+def test_restart_guest_scvmm():
+    """
+    This test performs the Restart Guest from the LifeCycle menu which
+    invokes the Hyper-V Guest Services Integration command.  This
+    gracefully exits and restarts the Windows OS rather than just powering
+    off and back on.
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/4h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.4
+        casecomponent: Infra
+        tags: power
+        title: test restart guest scvmm
+        testSteps:
+            1. Add provider scvmm
+            2. Provision VM
+            3. From collections page, Select the VM
+            4. Click on "Restart Guest" On SCVMM powershell
+        expectedResults:
+            1.
+            2.
+            3.
+            4. Use "$vm = Get-VM -name "name_of_vm"; Find-SCJob-objectId $vm.id -recent"
+               to verify VM history shows "Shut down virtual machine" instead of "power off"
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.power
+@pytest.mark.tier(2)
+def test_power_controls_on_archived_vm():
+    """
+    This test case is to check power operations are not working on archived VM.
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/10h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.7
+        casecomponent: Cloud
+        tags: power
+        title: test power controls on archived vm
+        testSteps:
+            1. Add any Cloud provider
+            2. Provision VM
+            3. Delete/Retire this VM (we need Archived VM)
+            4. Open Archived Vms/or All Vms and find your VM
+            5. Select it's Quadicon and/or open it's Details page
+        expectedResults:
+            1.
+            2.
+            3.
+            4.
+            5. Power control options drop-down should be disabled
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.power
+@pytest.mark.tier(2)
+def test_power_controls_on_vm_in_stack_cloud():
+    """
+    This test case is to check power controls on vm in stack cloud.
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/3h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.6
+        casecomponent: Cloud
+        tags: power
+        title: test power controls on vm in stack cloud
+        testSteps:
+            1. Provision a VM via Service (Orchestration template - azure/ec2/rhos)
+            2. Navigate to cloud-> stacks-> select a stack
+            3. Click on the instance in relationship section of stack summary page
+            4. Select it's Quadicon and/or open it's Details page
+            5. Check power controls operations on that instance
+        expectedResults:
+            1.
+            2.
+            3.
+            4.
+            5. Power operations applicable for this instance should be working as expected
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.power
+@pytest.mark.tier(2)
+def test_power_operations_from_global_region():
+    """
+    This test case is to check power operations from Global region
+    Setup is 2 or more appliances(DB should be configured manually). One
+    is Global region, others are Remote. To get this working enable Central Admin.
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/2h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.6
+        casecomponent: Control
+        tags: power
+        title:test power operations from global region
+        testSteps:
+            1. Take two or more appliances
+            2. Configure DB manually
+            3. Make one appliance as Global region and others are Remote
+            4. Add provider to remote region appliance
+            5. Provision VM
+            6. Perform power operations on VM from global region
+        expectedResults:
+            1.
+            2.
+            3.
+            4.
+            5.
+            6. Power operations applicable for this vm should be working as expected
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.power
+@pytest.mark.tier(2)
+def test_power_options_on_archived_orphaned_vms_all_page():
+    """
+    This test case is to check Power option drop-down button is disabled on archived and orphaned
+    VMs all page.
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/2h
+        caseimportance: low
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.9
+        casecomponent: Control
+        tags: power
+        testSteps:
+            1. Add provider infrastructure provider
+            2. Navigate to Archived or orphaned VMs all page
+            3. Select any VM and click on power option drop-down
+        expectedResults:
+            1.
+            2.
+            3. As we don't perform any power operations on archived or orphaned VMs. So power
+               button drop-down should not present there at all.
+
+    Bugzilla:
+        1655477
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.power
+@pytest.mark.tier(2)
+def test_check_compliance_policy_option_on_vm_summery_page():
+    """
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/12h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.9
+        casecomponent: Control
+        tags: power
+        testSteps:
+            1. Go to Compute--> VM Summary screen.
+            2. Select VM with compliance policy
+            3. Click on Policy and Compliance check is greyed out.
+            4. Click on the actually VM to enter next screen, Check compliance is not greyed out
+               and is available.
+        expectedResults:
+            1.
+            2.
+            3.
+            4. Run compliance check button should be available on VM summary screen
+
+    Bugzilla:
+        1560107
+    """
+    pass

--- a/cfme/tests/cloud_infra_common/test_quota_manual.py
+++ b/cfme/tests/cloud_infra_common/test_quota_manual.py
@@ -1,0 +1,503 @@
+"""Manual tests"""
+
+import pytest
+
+from cfme import test_requirements
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+@pytest.mark.ignore_stream('5.9')
+def test_custom_service_dialog_quota_flavors():
+    """
+    Test quota with instance_type in custom dialog
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/4h
+        caseimportance: low
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.8
+        casecomponent: Configuration
+        tags: quota
+        title: Test quota with instance_type in custom dialog
+        testSteps:
+            1. Set tenant quota for storage.
+            2. Create a service dialog with field: option_0_instance_type
+            3. Attach that dialog to catalog item
+            4. Order the service by changing the flavor from the drop-down list.
+
+        expectedResults:
+            1.
+            2.
+            3. Quota exceeded message should be displayed
+
+    Bugzilla:
+        1499193, 1581288, 1657628
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(3)
+def test_quota_for_simultaneous_service_catalog_request_with_different_users():
+    """
+    This test case is to test quota for simultaneous service catalog request with different users.
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/4h
+        caseimportance: low
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.8
+        casecomponent: Provisioning
+        tags: quota
+        title: Test quota for simultaneous service catalog request with different users
+        testSteps:
+            1. Create a service catalog with vm_name, instance_type &
+               number_of_vms as fields.
+            2. Set quotas threshold values for number_of_vms to 5
+            3. Create two users from same group try to provision service catalog from different
+               web-sessions with more that quota limit
+        expectedResults:
+            1.
+            2.
+            3. Quota exceeded message should be displayed
+
+    Bugzilla:
+        1456819
+
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(2)
+@pytest.mark.ignore_stream('5.9', '5.10')
+def test_instance_quota_reconfigure_with_flavors():
+    """
+    Test reconfiguration of instance using flavors after setting quota but this is RFE which is not
+    yet implemented.
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/6h
+        caseimportance: low
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.8
+        casecomponent: Cloud
+        tags: quota
+        title: test quota for ansible service
+        testSteps:
+            1. Add openstack provider
+            2. Set quota
+            3. Provision instance under the quota limit
+            4. Reconfigure this instance and provision it with changing flavors
+        expectedResults:
+            1.
+            2.
+            3. Provision instance successfully
+            4. Provision instance request should be denied
+
+    Bugzilla:
+        1473325
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(3)
+def test_quota_for_ansible_service():
+    """
+    This test case is to test quota for ansible service
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/4h
+        caseimportance: low
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.5
+        casecomponent: Configuration
+        tags: quota
+        title: test quota for ansible service
+        testSteps:
+            1. create a service bundle including an Ansible Tower service type
+            2. make sure CloudForms quotas are enabled
+            3. provision the service
+        expectedResults:
+            1.
+            2.
+            3. No error in service bundle provisioning for Ansible Tower service types when quota
+               is enforce.
+
+    Bugzilla:
+        1363901
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_quota_calculation_using_service_dialog_overrides():
+    """
+    This test case is to check Quota calculation using service dialog overrides.
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/6h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.8
+        casecomponent: Infra
+        tags: quota
+        title: Test Quota calculation using service dialog overrides.
+        testSteps:
+            1. create a new domain quota_test
+            2. Using the Automate Explorer, copy the
+               ManageIQ/System/CommonMethods/QuotaMethods/requested method
+               to the quota_test domain.
+            3. Import the attached dialog. create catalog and catalog
+               item using this dialog
+            4. create a child tenant and set quota. create new group and
+               user for this tenant.
+            5. login with this user and provision by overriding values
+            6. Also test the same for user and group quota source type
+        expectedResults:
+            1.
+            2.
+            3.
+            4.
+            5. Quota should be denied with reason for quota exceeded message
+            6. Quota should be denied with reason for quota exceeded message
+
+    Bugzilla:
+        1492158
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(3)
+def test_service_template_provisioning_quota_for_number_of_vms_using_custom_dialog():
+    """
+    This test case is to test service template provisioning quota for number of vm's using custom
+    dialog.
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/4h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.8
+        casecomponent: Provisioning
+        tags: quota
+        title: test service template provisioning quota for number of vm's using custom dialog
+        testSteps:
+            1. Create a service catalog with vm_name, instance_type &
+               number_of_vms as fields.
+            2. Set quotas threshold values for number_of_vms to 5
+            3. Provision service catalog with vm count as 10.
+        expectedResults:
+            1.
+            2.
+            3. CFME should show quota exceeded message for VMs requested
+
+    Bugzilla:
+        1455844
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(3)
+def test_quota_enforcement_for_cloud_volumes():
+    """
+    This test case is to test quota enforcement for cloud volumes
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/4h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.8
+        casecomponent: Provisioning
+        tags: quota
+        title: test quota enforcement for cloud volumes
+        testSteps:
+            1. Add openstack provider
+            2. Set quota for storage
+            3. While provisioning instance; add cloud volume with values
+            4. Submit the request and see the last message in request info row
+        expectedResults:
+            1.
+            2.
+            3.
+            4. Last message should show requested storage value is equal to
+               instance type's default storage + volume storage value added while provisioning.
+
+    Bugzilla:
+        1455349
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(2)
+def test_quota_with_invalid_service_request():
+    """
+    This test case is to test quotas with various regions and invalid service requests
+    To reproduce this issue: (You"ll need to have the RedHat Automate
+    domain)
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/4h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.9
+        casecomponent: Control
+        tags: quota
+        title: Test multiple tenant quotas simultaneously
+        testSteps:
+            1. Setup multiple zones.(You can use a single appliance and just add a "test" zone)
+            2. Add VMWare provider and configure it to the "test" zone.
+            3. Create a VMWare Service Item.
+            4. Order the Service.
+            5. Delete the Service Template used in the Service creation in step 3.
+            6. Modify the VMWare provider to use the default zone. (This should
+               leave the existing Service request(s) in the queue for the "test" zone
+               and the service_template will be invalid)
+            7. Provision a VMWare VM.
+        expectedResults:
+            1.
+            2.
+            3.
+            4.
+            5.
+            6. You should see the following error in the log:
+               "[----] E, [2018-01-06T11:11:20.073924 #13027:e0ffc4] ERROR -- :
+               Q-task_id([miq_provision_787]) MiqAeServiceModelBase.ar_method raised:
+               <NoMethodError>: <undefined method `service_resources" for
+               nil:NilClass> [----] E, [2018-01-06T11:11:20.074019 #13027:e0ffc4] ERROR -- :
+               Q-task_id([miq_provision_787])"
+
+    Bugzilla:
+        1534589, 1531914
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(2)
+def test_simultaneous_tenant_quota():
+    """
+    Test multiple tenant quotas simultaneously
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/6h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.8
+        casecomponent: Provisioning
+        tags: quota
+        title: Test multiple tenant quotas simultaneously
+        testSteps:
+            1. Create tenant1 and tenant2.
+            2. Create a project under tenant1 or tenant2
+            3. Enable quota for cpu, memory or storage etc
+            4. Create a group and add role super_administrator
+            5. Create a user and add it to the group
+            6. Login with the newly created user in the service portal. Take multiple items which go
+               over the allocated quota
+        expectedResults:
+            1.
+            2.
+            3.
+            4.
+            5.
+            6. CFME should cancel or notify that multiple items which are above assigned quota
+               are cancelled
+
+    Bugzilla:
+        1456819, 1401251
+
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(2)
+def test_notification_show_notification_when_quota_is_exceed():
+    """
+    This test case is to check when quota is exceeded, CFME should notify with reason.
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/4h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.8
+        casecomponent: Services
+        tags: quota
+        title: Notification - Show notification when quota is exceeded
+        testSteps:
+            1. Add provider
+            2. Set quota
+            3. Provision VM via service or life cylce with more than quota assigned
+        expectedResults:
+            1.
+            2.
+            3. CFME should notify with reason why provision VM is denied
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_quota_not_fails_after_vm_reconfigure_disk_remove():
+    """
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/4h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.8
+        casecomponent: Infra
+        tags: quota
+        testSteps:
+            1. Add infra provider and Add disk(s) to a vm instance
+            2. Turn quota on
+            3. Try to remove the disk(s)
+        expectedResults:
+            1.
+            2.
+            3. Request should be successful and size of disk(s) should be included in quota
+               requested.
+
+     Bugzilla:
+        1644351
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_quota_exceed_mail_with_more_info_link():
+    """
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/12h
+        caseimportance: high
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.9
+        casecomponent: Infra
+        tags: quota
+        testSteps:
+            1. Setup smtp for cfme using https://mojo.redhat.com/videos/925032
+            2. See if you are Able to see the expected link address in an email for Quota Exceeded.
+
+    Bugzilla:
+        1579031
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_custome_role_modify_for_dynamic_product_feature():
+    """
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/12h
+        caseimportance: high
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.10
+        casecomponent: Configuration
+        tags: quota
+        testSteps:
+            1. create two tenants
+            2. create new custom role using existing role
+            3. Update newly created custom role by doing uncheck in to options provided under
+               automation > automate > customization > Dialogs > modify > edit/add/copy/delete
+               > uncheck for any tenant
+            4. You will see save button is not enabled but if you changed 'Name' or
+               'Access Restriction for Services, VMs, and Templates' then save button is getting
+               enabled.
+            5. It updates changes only when we checked or unchecked for all of the tenants under
+               edit/add/copy/delete options.
+
+    Bugzilla:
+        1655012
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.quota
+@pytest.mark.tier(1)
+def test_dynamic_product_feature_for_tenant_quota():
+    """
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/12h
+        caseimportance: high
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.10
+        casecomponent: Configuration
+        tags: quota
+        testSteps:
+            1. Add two users > alpha and omega
+            2. Create two tenants > alpha_tenant and it's child - omega_tenant
+            3. Create two custom roles (role_alpha and role_omega) from copying
+               EvmRole-tenant_administrator role
+            4. Create groups alpha_group(for alpha_tenant) and omega_group(for omega_tenant)
+               then assign role_alpha
+               to alpha_group and role_omega to omega_group
+            5. Add alpha_group to alpha user and omega_group to omega user
+            6. Modify role_alpha for manage quota permissions of alpha user as it will manage
+               only quota of omega_tenant
+            7. Modify role_omega for manage quota permissions of omega user as it will not even
+               manage quota of itself or other tenants
+            8. CHECK IF YOU ARE ABLE TO MODIFY THE "MANAGE QUOTA" CHECKS IN ROLE AS YOU WANT
+            9  Then see if you are able to save these two new roles.
+            10. Then login with both users one by one and see if these roles permissions are
+                applied or not.
+            10a. login with alpha and SEE IF ALPHA USER CAN ABLE TO SET QUOTA OF omega_tenant
+                 FOR CPU - 5
+            11b. login with omega and SEE QUOTA GETS CHANGED OR NOT. THEN TRY TO CHANGE QUOTA
+                 IMPOSED BY ALPHA USER.
+            12c. Here as per role_omega permissions, omega must not able change its own quota or
+                 other tenants quota.
+
+    Bugzilla:
+        1655012, 1468795
+    """
+    pass

--- a/cfme/tests/cloud_infra_common/test_quota_with_multiple_providers.py
+++ b/cfme/tests/cloud_infra_common/test_quota_with_multiple_providers.py
@@ -22,16 +22,20 @@ pytestmark = [
 def test_show_quota_used_on_tenant_screen(request, appliance, v2v_providers):
     """Test show quota used on tenant quota screen even when no quotas are set.
 
-    Steps:
-        1. Navigate to provider's 'Details' page.
-        2. Fetch the information of 'number of VMs'.
-        3. Navigate to 'Details' page of 'My Company' tenant.
-        4. Go to tenant quota table.
-        5. Check whether number of VMs are equal to number of VMs in 'in use' column.
-
     Polarion:
         assignee: ghubale
         initialEstimate: 1/4h
+        caseimportance: low
+        caseposneg: positive
+        casecomponent: Infra
+        tags: quota
+        testSteps:
+            1. Add two infra providers
+            2. Navigate to provider's 'Details' page.
+            3. Fetch the information of 'number of VMs'.
+            4. Navigate to 'Details' page of 'My Company' tenant.
+            5. Go to tenant quota table.
+            6. Check whether number of VMs are equal to number of VMs in 'in use' column.
     """
     v2v_providers.vmware_provider.refresh_provider_relationships
     v2v_providers.rhv_provider.refresh_provider_relationships

--- a/cfme/tests/cloud_infra_common/test_relationships.py
+++ b/cfme/tests/cloud_infra_common/test_relationships.py
@@ -154,6 +154,7 @@ def test_host_relationships(appliance, provider, setup_provider, host, relations
         casecomponent: Infra
         caseimportance: medium
         initialEstimate: 1/12h
+        tags: relationship
     """
     host_view = navigate_to(host, "Details")
     if host_view.entities.summary("Relationships").get_text_of(relationship) == "0":
@@ -179,6 +180,7 @@ def test_infra_provider_relationships(appliance, provider, setup_provider, relat
         casecomponent: Infra
         caseimportance: medium
         initialEstimate: 1/10h
+        tags: relationship
     """
     provider_view = navigate_to(provider, "Details")  # resetter selects summary view
     if provider_view.entities.summary("Relationships").get_text_of(relationship) == "0":
@@ -199,6 +201,7 @@ def test_cloud_provider_relationships(appliance, provider, setup_provider, relat
         casecomponent: Cloud
         caseimportance: medium
         initialEstimate: 1/8h
+        tags: relationship
     """
     # Version dependent strings
     relationship = _fix_item(appliance, relationship)
@@ -301,7 +304,9 @@ def test_provider_refresh_relationship(provider, setup_provider):
     Polarion:
         assignee: ghubale
         casecomponent: Infra
+        caseimportance: high
         initialEstimate: 1/8h
+        tags: relationship
     """
     provider.refresh_provider_relationships(method='ui')
     wait_for_relationship_refresh(provider)
@@ -319,6 +324,7 @@ def test_host_refresh_relationships(provider, setup_provider):
         casecomponent: Infra
         caseimportance: high
         initialEstimate: 1/8h
+        tags: relationship
         testSteps:
             1. Go to a host summary page in cfme
             2. From configuration -> select "Refresh Relationships and Power State"
@@ -340,5 +346,27 @@ def test_inventory_refresh_westindia_azure():
         casecomponent: Cloud
         caseimportance: medium
         initialEstimate: 1/12h
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+def test_change_network_security_groups_per_page_items():
+    """
+    Polarion:
+        assignee: ghubale
+        casecomponent: Cloud
+        caseimportance: medium
+        initialEstimate: 1/12h
+        tags: relationship
+        testSteps:
+            1.Open Azure provider details view.
+            2.Open Azure Network Manager
+            3.Select Network Security Groups
+            4.Change items per page
+
+    Bugzilla:
+        1524443
     """
     pass

--- a/cfme/tests/infrastructure/test_child_tenant.py
+++ b/cfme/tests/infrastructure/test_child_tenant.py
@@ -103,7 +103,7 @@ def new_user(appliance, new_group, new_credential):
 @pytest.mark.rhv3
 @pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:7385',
     unblock=lambda provider, appliance_version:
-    not provider.one_of(RHEVMProvider) or appliance_version < '5.9')])
+    not provider.one_of(RHEVMProvider))])
 # first arg of parametrize is the list of fixtures or parameters,
 # second arg is a list of lists, with each one a test is to be generated
 # sequence is important here
@@ -131,7 +131,9 @@ def test_child_tenant_quota_enforce_via_lifecycle_infra(appliance, provider, set
     Polarion:
         assignee: ghubale
         casecomponent: Infra
+        caseimportance: medium
         initialEstimate: 1/6h
+        tags: quota
     """
     with new_user:
         recursive_update(prov_data, custom_prov_data)

--- a/cfme/tests/infrastructure/test_quota.py
+++ b/cfme/tests/infrastructure/test_quota.py
@@ -198,7 +198,9 @@ def test_quota(appliance, provider, setup_provider, custom_prov_data, vm_name, a
     Polarion:
         assignee: ghubale
         casecomponent: Quota
+        caseimportance: medium
         initialEstimate: 1/6h
+        tags: quota
     """
     recursive_update(prov_data, custom_prov_data)
     do_vm_provisioning(appliance, template_name=template_name, provider=provider, vm_name=vm_name,
@@ -227,14 +229,12 @@ def test_user_quota_diff_groups(request, appliance, provider, setup_provider, ne
                                 prov_data, vm_name, template_name):
     """prerequisite: Provider should be added
 
-    steps:
-
-    1. Provision VM with more than assigned quota
-
     Polarion:
         assignee: ghubale
         initialEstimate: 1/4h
         casecomponent: Quota
+        caseimportance: high
+        tags: quota
     """
     with new_user:
         recursive_update(prov_data, custom_prov_data)

--- a/cfme/tests/infrastructure/test_quota_tagging.py
+++ b/cfme/tests/infrastructure/test_quota_tagging.py
@@ -172,10 +172,13 @@ def test_quota_tagging_infra_via_lifecycle(request, appliance, provider, setup_p
                                            set_entity_quota_tag, custom_prov_data,
                                            vm_name, template_name, prov_data):
     """
+
     Polarion:
         assignee: ghubale
         casecomponent: Quota
+        caseimportance: medium
         initialEstimate: 1/6h
+        tags: quota
     """
     recursive_update(prov_data, custom_prov_data)
     do_vm_provisioning(appliance, template_name=template_name, provider=provider, vm_name=vm_name,
@@ -213,7 +216,9 @@ def test_quota_tagging_infra_via_services(request, appliance, provider, setup_pr
     Polarion:
         assignee: ghubale
         casecomponent: Quota
+        caseimportance: medium
         initialEstimate: 1/6h
+        tags: quota
     """
 
     prov_data.update(custom_prov_data)
@@ -281,15 +286,16 @@ def test_quota_vm_reconfigure(
 ):
     """Tests quota with vm reconfigure
 
-    Steps:
-        1. Assign Quota to group and user individually
-        2. Reconfigure the VM above the assigned Quota
-        3. Check whether VM  reconfiguration 'Denied' with Exceeded Quota or not
-
     Polarion:
         assignee: ghubale
         initialEstimate: 1/4h
         casecomponent: Quota
+        caseimportance: high
+        tags: quota
+        testSteps:
+            1. Assign Quota to group and user individually
+            2. Reconfigure the VM above the assigned Quota
+            3. Check whether VM  reconfiguration 'Denied' with Exceeded Quota or not
     """
     original_config = small_vm.configuration.copy()
     new_config = small_vm.configuration.copy()
@@ -329,21 +335,21 @@ def test_quota_vm_reconfigure(
 )
 def test_quota_infra(request, appliance, provider, setup_provider, admin_email, entities,
                      custom_prov_data, prov_data, catalog_item, context, vm_name, template_name):
-
     """This test case verifies the quota assigned by automation method for user and group
        is working correctly for the infra providers.
-
-    Steps:
-        1. Navigate to Automation > Automate > Explorer
-        2. Add quota automation methods to domain
-        3. Change 'quota_source_type' to 'user' or 'group'
-        4. Test quota by provisioning VMs over quota limit via UI or SSUI for user and group
-        5. Check whether quota is exceeded or not
 
     Polarion:
         assignee: ghubale
         initialEstimate: 1/4h
         casecomponent: Quota
+        caseimportance: medium
+        tags: quota
+        testSteps:
+            1. Navigate to Automation > Automate > Explorer
+            2. Add quota automation methods to domain
+            3. Change 'quota_source_type' to 'user' or 'group'
+            4. Test quota by provisioning VMs over quota limit via UI or SSUI for user and group
+            5. Check whether quota is exceeded or not
     """
     prov_data.update(custom_prov_data)
     with appliance.context.use(context):
@@ -378,23 +384,23 @@ def test_quota_infra(request, appliance, provider, setup_provider, admin_email, 
 def test_quota_catalog_bundle_infra(request, appliance, provider, setup_provider, admin_email,
                                     entities, custom_prov_data, prov_data, catalog_bundle, context,
                                     vm_name, template_name):
-
     """This test case verifies the quota assigned by automation method for user and group
        is working correctly for the infra providers by ordering catalog bundle.
-
-    Steps:
-        1. Navigate to Automation > Automate > Explorer
-        2. Add quota automation methods to domain
-        3. Change 'quota_source_type' to 'user' or 'group'
-        4. Create one or more catalogs to test quota by provisioning VMs over quota limit via UI or
-           SSUI for user and group
-        5. Add more than one catalog to catalog bundle and order catalog bundle
-        6. Check whether quota is exceeded or not
 
     Polarion:
         assignee: ghubale
         initialEstimate: 1/4h
         casecomponent: Quota
+        caseimportance: high
+        tags: quota
+        testSteps:
+            1. Navigate to Automation > Automate > Explorer
+            2. Add quota automation methods to domain
+            3. Change 'quota_source_type' to 'user' or 'group'
+            4. Create one or more catalogs to test quota by provisioning VMs over quota limit via UI
+               or SSUI for user and group
+            5. Add more than one catalog to catalog bundle and order catalog bundle
+            6. Check whether quota is exceeded or not
     """
     prov_data.update(custom_prov_data)
     with appliance.context.use(context):

--- a/cfme/tests/infrastructure/test_tenant_quota.py
+++ b/cfme/tests/infrastructure/test_tenant_quota.py
@@ -143,7 +143,9 @@ def test_tenant_quota_enforce_via_lifecycle_infra(appliance, provider, setup_pro
     Polarion:
         assignee: ghubale
         casecomponent: Infra
+        caseimportance: high
         initialEstimate: 1/8h
+        tags: quota
     """
     prov_data.update(custom_prov_data)
     prov_data['catalog']['vm_name'] = vm_name
@@ -183,13 +185,12 @@ def test_tenant_quota_enforce_via_service_infra(request, appliance, provider, se
                                                 custom_prov_data, catalog_item):
     """Tests quota enforcement via service infra
 
-    Metadata:
-        test_flag: quota
-
     Polarion:
         assignee: ghubale
         casecomponent: Infra
+        caseimportance: high
         initialEstimate: 1/8h
+        tags: quota
     """
     with appliance.context.use(context):
         service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
@@ -208,12 +209,11 @@ def test_tenant_quota_enforce_via_service_infra(request, appliance, provider, se
         catalog_item.delete()
 
 
-@pytest.mark.rhv2
-@pytest.mark.meta(blockers=[BZ(1626232, forced_streams=['5.10'])])
 # first arg of parametrize is the list of fixtures or parameters,
 # second arg is a list of lists, with each one a test is to be generated
 # sequence is important here
 # indirect is the list where we define which fixtures are to be passed values indirectly.
+@pytest.mark.rhv2
 @pytest.mark.parametrize(
     ['set_roottenant_quota', 'custom_prov_data'],
     [
@@ -228,13 +228,12 @@ def test_tenant_quota_vm_reconfigure(appliance, provider, setup_provider, set_ro
                                      small_vm, custom_prov_data):
     """Tests quota with vm reconfigure
 
-    Metadata:
-        test_flag: quota
-
     Polarion:
         assignee: ghubale
         casecomponent: Infra
+        caseimportance: high
         initialEstimate: 1/6h
+        tags: quota
     """
     original_config = small_vm.configuration.copy()
     new_config = small_vm.configuration.copy()
@@ -257,10 +256,13 @@ def test_tenant_quota_vm_reconfigure(appliance, provider, setup_provider, set_ro
 def test_setting_child_quota_more_than_parent(appliance, tenants_setup, parent_quota, child_quota,
                                               flash_text):
     """
+
     Polarion:
         assignee: ghubale
         casecomponent: Provisioning
+        caseimportance: high
         initialEstimate: 1/12h
+        tags: quota
     """
     test_parent, test_child = tenants_setup
     view = navigate_to(test_parent, 'ManageQuotas')
@@ -298,20 +300,19 @@ def test_setting_child_quota_more_than_parent(appliance, tenants_setup, parent_q
 def test_vm_migration_after_assigning_tenant_quota(appliance, setup_provider, small_vm,
                                                    set_roottenant_quota,
                                                    custom_prov_data, provider):
-    """prerequisite: Provider should be added
-
-    steps:
-
-    1. Create VM
-    2. Assign tenant quota
-    3. Migrate VM
-    4. Check whether migration is successfully done
-
+    """
 
     Polarion:
         assignee: ghubale
         casecomponent: Infra
+        caseimportance: high
         initialEstimate: 1/6h
+        tags: quota
+        testSteps:
+            1. Create VM
+            2. Assign tenant quota
+            3. Migrate VM
+            4. Check whether migration is successfully done
     """
 
     migrate_to = check_hosts(small_vm, provider)

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -174,12 +174,12 @@ class TestControlOnQuadicons(object):
     def test_power_off(self, appliance, testing_vm, ensure_vm_running, soft_assert):
         """Tests power off
 
-        Metadata:
-            test_flag: power_control, provision
-
         Polarion:
             assignee: ghubale
             initialEstimate: 1/6h
+            casecomponent: Infra
+            caseimportance: high
+            tags: power
         """
         testing_vm.wait_for_vm_state_change(desired_state=testing_vm.STATE_ON, timeout=720)
         testing_vm.power_control_from_cfme(option=testing_vm.POWER_OFF, cancel=False)
@@ -197,12 +197,12 @@ class TestControlOnQuadicons(object):
     def test_power_on_cancel(self, testing_vm, ensure_vm_stopped, soft_assert):
         """Tests power on cancel
 
-        Metadata:
-            test_flag: power_control, provision
-
         Polarion:
             assignee: ghubale
             initialEstimate: 1/4h
+            casecomponent: Infra
+            caseimportance: high
+            tags: power
         """
         testing_vm.wait_for_vm_state_change(desired_state=testing_vm.STATE_OFF, timeout=720)
         testing_vm.power_control_from_cfme(option=testing_vm.POWER_ON, cancel=True)
@@ -223,6 +223,9 @@ class TestControlOnQuadicons(object):
         Polarion:
             assignee: ghubale
             initialEstimate: 1/6h
+            casecomponent: Infra
+            caseimportance: high
+            tags: power
         """
         testing_vm.wait_for_vm_state_change(desired_state=testing_vm.STATE_OFF, timeout=720)
         testing_vm.power_control_from_cfme(option=testing_vm.POWER_ON, cancel=False)
@@ -249,6 +252,9 @@ class TestVmDetailsPowerControlPerProvider(object):
         Polarion:
             assignee: ghubale
             initialEstimate: 1/6h
+            casecomponent: Infra
+            caseimportance: high
+            tags: power
         """
         testing_vm.wait_for_vm_state_change(
             desired_state=testing_vm.STATE_ON, timeout=720, from_details=True)
@@ -280,6 +286,9 @@ class TestVmDetailsPowerControlPerProvider(object):
         Polarion:
             assignee: ghubale
             initialEstimate: 1/6h
+            casecomponent: Infra
+            caseimportance: high
+            tags: power
         """
         testing_vm.wait_for_vm_state_change(
             desired_state=testing_vm.STATE_OFF, timeout=720, from_details=True)
@@ -298,12 +307,12 @@ class TestVmDetailsPowerControlPerProvider(object):
     def test_suspend(self, appliance, testing_vm, ensure_vm_running, soft_assert):
         """Tests suspend
 
-        Metadata:
-            test_flag: power_control, provision
-
         Polarion:
             assignee: ghubale
             initialEstimate: 1/6h
+            casecomponent: Infra
+            caseimportance: high
+            tags: power
         """
         testing_vm.wait_for_vm_state_change(
             desired_state=testing_vm.STATE_ON, timeout=720, from_details=True)
@@ -336,12 +345,13 @@ class TestVmDetailsPowerControlPerProvider(object):
             self, appliance, testing_vm, ensure_vm_suspended, soft_assert):
         """Tests start from suspend
 
-        Metadata:
-            test_flag: power_control, provision
-
         Polarion:
             assignee: ghubale
             initialEstimate: 1/6h
+            casecomponent: Infra
+            caseimportance: high
+            tags: power
+
         """
         try:
             testing_vm.provider.refresh_provider_relationships()
@@ -446,9 +456,7 @@ def test_no_power_controls_on_archived_vm(appliance, testing_vm, archived_vm, so
 
 @pytest.mark.rhv3
 @pytest.mark.meta(blockers=[BZ(1520489, forced_streams=['5.9'],
-                               unblock=lambda provider: not provider.one_of(SCVMMProvider)),
-                            BZ(1659340, forced_streams=['5.9', '5.10'],
-                               unblock=lambda provider: not provider.one_of(RHEVMProvider))])
+                               unblock=lambda provider: not provider.one_of(SCVMMProvider))])
 def test_archived_vm_status(testing_vm, archived_vm):
     """Tests archived vm status
 
@@ -457,7 +465,10 @@ def test_archived_vm_status(testing_vm, archived_vm):
 
     Polarion:
         assignee: ghubale
-        initialEstimate: 1/10h
+        casecomponent: Infra
+        caseimportance: high
+        initialEstimate: 1/8h
+        tags: power
     """
     vm_state = testing_vm.find_quadicon(from_any_provider=True).data['state']
     assert (vm_state == 'archived')
@@ -467,12 +478,11 @@ def test_archived_vm_status(testing_vm, archived_vm):
 def test_orphaned_vm_status(testing_vm, orphaned_vm):
     """Tests orphaned vm status
 
-    Metadata:
-        test_flag: inventory
-
     Polarion:
         assignee: ghubale
         initialEstimate: 1/10h
+        casecomponent: Infra
+        tags: power
     """
     vm_state = testing_vm.find_quadicon(from_any_provider=True).data['state']
     assert (vm_state == 'orphaned')
@@ -522,6 +532,8 @@ def test_guest_os_reset(appliance, testing_vm_tools, ensure_vm_running, soft_ass
     Polarion:
         assignee: ghubale
         initialEstimate: 1/6h
+        casecomponent: Infra
+        tags: power
     """
     wait_for_vm_tools(testing_vm_tools)
     view = navigate_to(testing_vm_tools, "Details")
@@ -546,12 +558,12 @@ def test_guest_os_reset(appliance, testing_vm_tools, ensure_vm_running, soft_ass
 def test_guest_os_shutdown(appliance, testing_vm_tools, ensure_vm_running, soft_assert):
     """Tests vm guest os reset
 
-    Metadata:
-        test_flag: power_control
-
     Polarion:
         assignee: ghubale
         initialEstimate: 1/6h
+        caseimportance: high
+        casecomponent: Infra
+        tags: power
     """
     testing_vm_tools.wait_for_vm_state_change(
         desired_state=testing_vm_tools.STATE_ON, timeout=720, from_details=True)

--- a/cfme/tests/services/test_catalog_item.py
+++ b/cfme/tests/services/test_catalog_item.py
@@ -286,3 +286,33 @@ def test_restricted_catalog_items_select_for_catalog_bundle(appliance, request, 
         soft_assert(any(
             option.text == catalog_item.name for option in available_options), (
             'Restricted catalog item is not visible while bundle creation'))
+
+
+@pytest.mark.manual
+@test_requirements.service
+@pytest.mark.tier(1)
+def test_catalog_all_page_after_deleting_selected_template():
+    """
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/12h
+        caseimportance: low
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.10
+        casecomponent: Services
+        tags: service
+        testSteps:
+            1. Add provider (VMware or scvmm)
+            2. Create catalog item (Remember template you selected.)
+            3. Order Service catalog item
+            4. Go to details page of provider and click on templates
+            5. Either delete this template while provisioning process in progress or after
+               completing process.
+            6. Go to service > catalogs > service catalogs or catalog items
+            7. Click on catalog item you created or ordered
+
+    Bugzilla:
+        1652858
+    """
+    pass

--- a/cfme/tests/test_manual.py
+++ b/cfme/tests/test_manual.py
@@ -10,23 +10,6 @@ pytestmark = [pytest.mark.ignore_stream('5.9', '5.10', 'upstream')]
 
 
 @pytest.mark.manual
-@pytest.mark.tier(3)
-def test_automate_git_domain_import_top_level_directory():
-    """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1389823 Importing domain
-    from git should work with or without the top level domain directory.
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/6h
-        startsin: 5.7
-    """
-    pass
-
-
-@pytest.mark.manual
 def test_osp_vmware65_test_vm_migration_with_rhel_75_last_time_74():
     """
     OSP: vmware65-Test VM migration with RHEL 7.5 (last time 7.4)
@@ -115,7 +98,6 @@ def test_status_of_a_task_via_api_with_evmrole_administrator():
         title: Test status of a task via API with EvmRole_administrator
     """
     pass
-
 
 
 @pytest.mark.manual
@@ -1347,7 +1329,7 @@ def test_infrastructure_hosts_icons_states():
     Then do in console:
     su - postgres
     psql
-    \c vmdb_production
+    vmdb_production
     UPDATE hosts SET power_state = "preparing_for_maintenance" WHERE
     name="NAME OF THE TESTED HOST";
     UPDATE hosts SET power_state = "maintenance" WHERE name="NAME OF THE
@@ -2105,7 +2087,6 @@ def test_osp_test_immediately_migration_after_migration_plan_creation():
     pass
 
 
-
 @pytest.mark.manual
 @test_requirements.auth
 @pytest.mark.tier(3)
@@ -2501,7 +2482,6 @@ def test_osp_vmware67_test_vm_migration_with_really_long_name_upto_64_chars_work
     pass
 
 
-
 @pytest.mark.manual
 def test_osp_test_migrating_a_vm_using_migration_plan_with_name_which_has_all_special_characte():
     """
@@ -2851,7 +2831,6 @@ def test_upgrade_rubyrep_to_pglogical():
     pass
 
 
-
 @pytest.mark.manual
 @test_requirements.chargeback
 @pytest.mark.tier(2)
@@ -2898,7 +2877,6 @@ def test_osp_vmware67_test_vm_migration_with_windows_7():
         title: OSP: vmware67-Test VM migration with Windows 7
     """
     pass
-
 
 
 @pytest.mark.manual
@@ -2978,23 +2956,6 @@ def test_distributed_zone_delete_occupied():
         casecomponent: Appliance
         caseimportance: medium
         initialEstimate: 1/12h
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(2)
-def test_quota_source_user():
-    """
-    When copying and modifying
-    /System/CommonMethods/QuotaStateMachine/quota to user the user as the
-    quota source and when the user is tagged, the quotas are in effect.
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/8h
     """
     pass
 
@@ -4760,7 +4721,6 @@ def test_verify_that_changing_groups_while_in_ssui_updates_dashboard_items():
     pass
 
 
-
 @pytest.mark.manual
 @test_requirements.ansible
 def test_embed_tower_exec_play_stdout():
@@ -4893,29 +4853,6 @@ def test_osp_vmware67_test_vm_migration_from_nfs_storage_in_vmware_to_nfs_on_osp
         startsin: 5.10
         subcomponent: OSP
         title: OSP: vmware67-Test VM migration from NFS Storage in VMware to NFS on OSP
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(1)
-def test_automate_simulate_retry():
-    """
-    PR Link
-    Automate simulation now supports simulating the state machines.
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/4h
-        setup: Create a state machine that contains a couple of states from which one
-               of them retries at least once.
-        startsin: 5.6
-        testSteps:
-            1. Use automate simulation UI to call the state machine (Call_Instance)
-        expectedResults:
-            1. A Retry button appears.
     """
     pass
 
@@ -5547,7 +5484,6 @@ def test_upgrade_single_inplace_ipv6():
     pass
 
 
-
 @pytest.mark.manual
 def test_in_dynamic_dropdown_list_the_default_value_should_not_contain_all_the_values_of_the_l():
     """
@@ -5736,7 +5672,6 @@ def test_ec2_targeted_refresh_network():
         startsin: 5.9
     """
     pass
-
 
 
 @pytest.mark.manual
@@ -7338,21 +7273,6 @@ def test_drop_down_dialog_should_honor_the_order_of_values_as_they_are_inputted(
 
 
 @pytest.mark.manual
-@pytest.mark.tier(1)
-def test_customize_request_security_group():
-    """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1335989
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/4h
-    """
-    pass
-
-
-@pytest.mark.manual
 @pytest.mark.tier(2)
 def test_authentication_ldap_switch_groups():
     """
@@ -7766,23 +7686,6 @@ def test_ec2_targeted_refresh_network_port():
         caseimportance: medium
         initialEstimate: 2/3h
         startsin: 5.9
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(3)
-def test_automate_git_import_multiple_domains():
-    """
-    Import of multiple domains from a single git repo is not allowed
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        caseposneg: negative
-        initialEstimate: 1/12h
-        startsin: 5.10
     """
     pass
 
@@ -8272,33 +8175,6 @@ def test_edit_request_task():
 
 
 @pytest.mark.manual
-@pytest.mark.tier(1)
-def test_automate_relationship_trailing_spaces():
-    """
-    PR Link (Merged 2016-04-01)
-    Handle trailing whitespaces in automate instance relationships.
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/10h
-        setup: A fresh appliance.
-        startsin: 5.6
-        testSteps:
-            1. Create a class and its instance, also create second one,
-               that has a relationship field. Create an instance with the
-               relationship field pointing to the first class" instance but
-               add a couple of whitespaces after it.
-            2. Execute the AE model, eg. using Simulate.
-        expectedResults:
-            1.
-            2. Logs contain no resolution errors
-    """
-    pass
-
-
-@pytest.mark.manual
 @test_requirements.reconfigure
 @pytest.mark.tier(1)
 def test_vm_reconfig_add_remove_network_adapters_vsphere67_nested_mgmtnetwork():
@@ -8631,44 +8507,6 @@ def test_project_cloud_storage_quota_by_enforce():
 
 
 @pytest.mark.manual
-@pytest.mark.tier(1)
-def test_automate_generic_object_service_associations():
-    """
-    Use the attached domain to test this bug:
-    1) Import end enable the domain
-    2) Have at least one service created (Generic is enough)
-    3) Run rails console and create the object definition:
-    GenericObjectDefinition.create(
-    :name => "LoadBalancer",
-    :properties => {
-    :attributes   => {:location => "string"},
-    :associations => {:vms => "Vm", :services => "Service"},
-    }
-    )
-    4) Run tail -fn0 log/automation.log | egrep "ERROR|XYZ"
-    5) Simulate Request/GOTest with method execution
-    In the tail"ed log:
-    There should be no ERROR lines related to the execution.
-    There should be these two lines:
-    <AEMethod gotest> XYZ go object: #<MiqAeServiceGenericObject
-    ....something...>
-    <AEMethod gotest> XYZ load balancer got service:
-    #<MiqAeServiceService:....something....>
-    If there is "XYZ load balancer got service: nil", then this bug was
-    reproduced.
-    thx @lfu
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/8h
-        startsin: 5.7
-    """
-    pass
-
-
-@pytest.mark.manual
 def test_custom_button_in_sui():
     """
     https://bugzilla.redhat.com/show_bug.cgi?id=1450473
@@ -8680,24 +8518,6 @@ def test_custom_button_in_sui():
         caseimportance: medium
         initialEstimate: 1/4h
         title: Test Custom button in SUI
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(2)
-def test_automate_git_domain_displayed_in_dialog():
-    """
-    Check that the domain imported from git is displayed and usable in the
-    pop-up tree in the dialog editor.
-    You can use eg. https://github.com/ramrexx/CloudForms_Essentials.git
-    for that
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        initialEstimate: 1/15h
-        startsin: 5.7
     """
     pass
 
@@ -8724,23 +8544,6 @@ def test_verify_user_validation_works_fine_but_authentication_fails_if_no_group_
         initialEstimate: 1/4h
         title: verify user validation works fine but authentication fails
                if no group is assigned for user.
-    """
-    pass
-
-
-@pytest.mark.manual
-def test_osp_test_multiple_sources_to_single_target_mapping_for_clusters_ds_network():
-    """
-    OSP: Test multiple sources to single target mapping (For Clusters, DS,
-    Network)
-
-    Polarion:
-        assignee: ytale
-        casecomponent: V2V
-        initialEstimate: 1/8h
-        startsin: 5.10
-        subcomponent: OSP
-        title: OSP: Test multiple sources to single target mapping (For Clusters, DS, Network)
     """
     pass
 
@@ -8816,25 +8619,6 @@ def test_embed_tower_repo_list():
 
 
 @pytest.mark.manual
-@pytest.mark.tier(3)
-def test_automate_disabled_domains_in_domain_priority():
-    """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1331017 When the admin
-    clicks on a instance that has duplicate entries in two different
-    domains. If one domain is disabled it is still displayed in the UI for
-    the domain priority.
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: low
-        caseposneg: negative
-        initialEstimate: 1/12h
-    """
-    pass
-
-
-@pytest.mark.manual
 @test_requirements.storage
 def test_storage_volume_in_use_delete_openstack():
     """
@@ -8856,21 +8640,6 @@ def test_storage_volume_in_use_delete_openstack():
         caseimportance: medium
         initialEstimate: 1/16h
         startsin: 5.7
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(1)
-def test_automate_engine_database_connection():
-    """
-    All steps in: https://bugzilla.redhat.com/show_bug.cgi?id=1334909
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/8h
     """
     pass
 
@@ -9164,9 +8933,6 @@ def test_default_view_settings_should_apply_for_service_catalogs():
         title: Default view settings should apply for service catalogs
     """
     pass
-
-
-
 
 
 @pytest.mark.manual
@@ -10423,41 +10189,6 @@ def test_add_ec2_provider_with_instance_without_name():
 
 
 @pytest.mark.manual
-@pytest.mark.tier(3)
-def test_automate_check_quota_regression():
-    """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1554989
-    Update from 5.8.2 to 5.8.3 has broken custom automate method.  Error
-    is thrown for the check_quota instance method for an undefined method
-    provisioned_storage.
-    You"ll need to create an invalid VM provisioning request to reproduce
-    this issue.
-    The starting point is an appliance with a provider configured, that
-    can successfully provision a VM using lifecycle provisioning.
-    1. Add a second provider to use for VM lifecycle provisioning.
-    2. Add a 2nd zone called "test_zone". (Don"t add a second appliance
-    for this zone)
-    3. Set the zone of the second provider to be "test_zone".
-    4. Provision a VM for the second provider, using VM lifecycle
-    provisioning. (The provisioning request should remain in
-    pending/active status and should not get processed because there is no
-    appliance/workers for the "test_zone".)
-    5. Delete the template used in step 4.(Through the UI when you
-    navigate to virtual machines, templates is on the left nav bar, select
-    the template used in step 4 and select: "Remove from Inventory"
-    6. Provisioning a VM for the first provider, using VM lifecycle
-    provisioning should produce the reported error.
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/6h
-    """
-    pass
-
-
-@pytest.mark.manual
 @test_requirements.ansible
 def test_embed_tower_exec_play_against_openstack():
     """
@@ -11250,23 +10981,6 @@ def test_candu_graphs_vm_compare_cluster_vsphere65():
 
 
 @pytest.mark.manual
-@pytest.mark.tier(3)
-def test_automate_git_domain_import_with_no_connection():
-    """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1391208
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/6h
-        startsin: 5.7
-    """
-    pass
-
-
-
-@pytest.mark.manual
 @test_requirements.cloud_init
 @pytest.mark.tier(1)
 def test_cloud_init_cfme():
@@ -11279,23 +10993,6 @@ def test_cloud_init_cfme():
         endsin: 5.4
         initialEstimate: 1/2h
         startsin: 5.4
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(3)
-def test_automate_schema_field_without_type():
-    """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1365442
-    It shouldn"t be possible to add a field without specifying a type.
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        caseposneg: negative
-        initialEstimate: 1/12h
     """
     pass
 
@@ -11686,29 +11383,6 @@ def test_verify_login_fails_for_user_in_cfme_after_changing_the_password_in_saml
 
 @pytest.mark.manual
 @pytest.mark.tier(1)
-def test_automate_retry_onexit_increases():
-    """
-    To reproduce:
-    1) Import the attached file, it will create a domain called
-    OnExitRetry
-    2) Enable the domain
-    3) Go to Automate / Simulation
-    4) Simulate Request with instance OnExitRetry, execute methods
-    5) Click submit, open the tree on right and expand ae_state_retries
-    It should be 1 by now and subsequent clicks on Retry should raise the
-    number if it works properly.
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/8h
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(1)
 def test_proxy_invalid_azure():
     """
     With 5.7 there is a new feature that allows users to specific a
@@ -11985,23 +11659,6 @@ def test_proxy_valid_ec2():
 
 
 @pytest.mark.manual
-@pytest.mark.tier(3)
-def test_automate_simulation_result_has_hash_data():
-    """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1445089
-    The UI should display the result objects if the Simulation Result has
-    hash data.
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/6h
-    """
-    pass
-
-
-@pytest.mark.manual
 @test_requirements.auth
 @pytest.mark.tier(2)
 def test_verify_two_factor_authentication_works_with_user_password_and_otp():
@@ -12174,22 +11831,6 @@ def test_ldap_user_group():
             2. CFME configuration for multiple users/groups should work without any error.
             3. login should be successful upon valid credentials input.
             4. user should have access to only the data defined by him/group
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(3)
-def test_automate_git_import_without_master():
-    """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1508881
-    Git repository doesn"t have to have master branch
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/12h
     """
     pass
 
@@ -12501,22 +12142,6 @@ def test_utilization_host():
         caseimportance: medium
         initialEstimate: 1/8h
         testtype: integration
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(1)
-def test_state_machine_variable():
-    """
-    Test whether storing the state machine variable works and the vaule is
-    available in another state.
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/4h
     """
     pass
 
@@ -14022,30 +13647,6 @@ def test_verify_the_authentication_mode_is_displayed_correctly_for_new_trusted_f
 
 @pytest.mark.manual
 @pytest.mark.tier(2)
-def test_custom_button_disable():
-    """
-    Check if the button is disable or not (i.e. visible but blurry)
-    Steps
-    1)Add Button Group
-    2)Add a button to the newly created button group
-    3)Add an expression for disabling button (can use simple {"tag":
-    {"department":"Support"}} expression)
-    4)Add the Button group to a page
-    5)Check that button is enabled; if enabled pass else fail.
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/12h
-        startsin: 5.9
-        upstream: yes
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(2)
 def test_host_info_scvmm():
     """
     The purpose of this test is to verify that SCVMM-SP1 hosts are not
@@ -14216,22 +13817,6 @@ def test_osp_vmware67_test_vm_with_mutliple_nics_with_single_ip_ipv6_to_first_ni
 
 
 @pytest.mark.manual
-@pytest.mark.tier(3)
-def test_automate_git_import_deleted_tag():
-    """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1394194
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/12h
-        startsin: 5.7
-    """
-    pass
-
-
-@pytest.mark.manual
 @test_requirements.upgrade
 @pytest.mark.tier(2)
 def test_update_webui_ipv6():
@@ -14290,22 +13875,6 @@ def test_suspend_scvmm2016_from_collection():
         caseimportance: medium
         initialEstimate: 1/8h
         startsin: 5.7
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(1)
-def test_automate_service_quota_runs_only_once():
-    """
-    Steps described here:
-    https://bugzilla.redhat.com/show_bug.cgi?id=1317698
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/4h
     """
     pass
 
@@ -14956,40 +14525,6 @@ def test_remove_catalog_items_from_catalog_bundle_resource_list():
 
 
 @pytest.mark.manual
-@pytest.mark.tier(1)
-def test_automate_state_method():
-    """
-    PR link (merged 2016-03-24)
-    You can pass methods as states compared to the old method of passing
-    instances which had to be located in different classes. You use the
-    METHOD:: prefix
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/4h
-        setup: A fresh appliance.
-        startsin: 5.6
-        testSteps:
-            1. Create an automate class that has one state.
-            2. Create a method in the class, make the method output
-               something recognizable in the logs
-            3. Create an instance inside the class, and as a Value for the
-               state use: METHOD::method_name where method_name is the name
-               of the method you created
-            4. Run a simulation, use Request / Call_Instance to call your
-               state machine instance
-        expectedResults:
-            1. Class created
-            2. Method created
-            3. Instance created
-            4. The method got called, detectable by grepping logs
-    """
-    pass
-
-
-@pytest.mark.manual
 def test_osp_vmware60_test_vm_migration_with_windows_2016_server():
     """
     OSP: vmware60-Test VM migration with Windows 2016 server
@@ -15046,23 +14581,6 @@ def test_rightsize_cpu_values_correct_vsphere6():
 
 
 @pytest.mark.manual
-@pytest.mark.tier(2)
-def test_button_can_trigger_events():
-    """
-    In the button creation dialog there must be MiqEvent available for
-    System/Process entry.
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/60h
-        startsin: 5.6.1
-    """
-    pass
-
-
-@pytest.mark.manual
 @test_requirements.smartstate
 @pytest.mark.tier(1)
 def test_ssa_host_os_info():
@@ -15114,27 +14632,6 @@ def test_sui_auto_refresh_of_pages_of_sui_request_and_service_explorer_and_myord
         caseimportance: medium
         initialEstimate: 1/4h
         title: SUI : Auto-refresh of pages of SUI (Request and Service Explorer and MyOrders)
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(3)
-def test_automate_requests_tab_exposed():
-    """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1508490
-    Need to expose Automate => Requests tab from the Web UI without
-    exposing any other Automate tabs (i.e. Explorer, Customization,
-    Import/Export, Logs). The only way to expose this in the Web UI, is to
-    enable Services => Requests, and at least one tab from the Automate
-    section (i.e. Explorer, Customization, etc).
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/12h
-        startsin: 5.10
     """
     pass
 
@@ -15633,6 +15130,7 @@ def test_sui_session_timeout():
     """
     pass
 
+
 @pytest.mark.manual
 @test_requirements.auth
 @pytest.mark.tier(2)
@@ -16097,21 +15595,6 @@ def test_storage_ebs_volume_attach():
         assignee: mmojzis
         initialEstimate: 1/6h
         startsin: 5.8
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(3)
-def test_automate_git_credentials_changed():
-    """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1552274
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/6h
     """
     pass
 
@@ -16883,47 +16366,6 @@ def test_crosshair_op_host_vsphere6():
 
 
 @pytest.mark.manual
-@pytest.mark.tier(1)
-def test_automate_git_import_case_insensitive():
-    """
-    bin/rake evm:automate:import PREVIEW=false
-    GIT_URL=https://github.com/mkanoor/SimpleDomain REF=test2branch
-    This should not cause an error (the actual name of the branch is
-    Test2Branch).
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/8h
-        startsin: 5.7
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(1)
-def test_custom_button_enable():
-    """
-    Check if the button is enabled or not
-    Steps
-    1)Add Button Group
-    2)Add a button to the newly created button group
-    3)Add an expression for enabling button
-    4)Add the Button group to a page
-    5)Check that button is enabled; if enabled pass else fail.
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/12h
-        startsin: 5.9
-    """
-    pass
-
-
-@pytest.mark.manual
 @test_requirements.ansible
 @pytest.mark.tier(3)
 def test_service_ansible_playbook_retire_non_ascii():
@@ -16975,21 +16417,6 @@ def test_verify_invalid_user_login_fails():
         caseposneg: negative
         initialEstimate: 1/4h
         title: Verify invalid user login fails
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(1)
-def test_assert_failed_substitution():
-    """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1335669
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/4h
     """
     pass
 
@@ -17641,27 +17068,6 @@ def test_vm_terminate_deletedisk_azure():
         initialEstimate: 1/8h
         startsin: 5.6.1
         upstream: yes
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(3)
-def test_automate_import_namespace_attributes_updated():
-    """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1440226 1. Export an
-    Automate model
-    2. Change the display name and description in the exported namespace
-    yaml file
-    3. Run an import with the updated data
-    4. Check if the namespace attributes get updated.Display name and
-    description attributes should get updated
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: low
-        initialEstimate: 1/12h
     """
     pass
 
@@ -20293,24 +19699,6 @@ def test_appliance_log_error():
 
 
 @pytest.mark.manual
-@pytest.mark.tier(3)
-def test_automate_user_has_groups():
-    """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1411424
-    This method should work:  groups = $evm.vmdb(:user).first.miq_groups
-    $evm.log(:info, "Displaying the user"s groups: #{groups.inspect}")
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/12h
-        startsin: 5.8
-    """
-    pass
-
-
-@pytest.mark.manual
 @test_requirements.service
 @pytest.mark.tier(3)
 def test_automate_methods_from_dynamic_dialog_should_run_as_per_designed():
@@ -20527,26 +19915,6 @@ def test_verify_user_authentication_works_fine_if_default_evm_groups_are_already
 
 
 @pytest.mark.manual
-def test_osp_test_multi_host_migration_execution_if_more_than_one_host_present_migration_of_mu():
-    """
-    OSP: Test Multi-host migration execution, if more than one host
-    present, migration of multiple VMs should be spread across all
-    available host
-
-    Polarion:
-        assignee: ytale
-        casecomponent: V2V
-        initialEstimate: 1/8h
-        startsin: 5.10
-        subcomponent: OSP
-        title: OSP: Test Multi-host migration execution, if more than one
-               host present, migration of multiple VMs should be spread
-               across all available hosts
-    """
-    pass
-
-
-@pytest.mark.manual
 @test_requirements.quota
 @pytest.mark.tier(3)
 def test_quota_enforcement_for_cloud_volumes():
@@ -20671,22 +20039,6 @@ def test_service_dialog_saving_elements_when_switching_elements():
         caseimportance: medium
         initialEstimate: 1/4h
         title: Test service dialog saving elements when switching elements
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(3)
-def test_automate_quota_units():
-    """
-    Steps described here:
-    https://bugzilla.redhat.com/show_bug.cgi?id=1334318
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: low
-        initialEstimate: 1/4h
     """
     pass
 
@@ -25675,24 +25027,6 @@ def test_ssa_vm_files():
 
 
 @pytest.mark.manual
-@pytest.mark.tier(3)
-def test_automate_restrict_domain_crud():
-    """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1365493
-    When you create a role that can only view automate domains, it can
-    view automate domains, it cannot manipulate the domains themselves,
-    but can CRUD on namespaces, classes, instances ....
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/6h
-    """
-    pass
-
-
-@pytest.mark.manual
 @test_requirements.service
 @pytest.mark.tier(3)
 def test_vm_migrate_should_create_notifications_when_migrations_fail():
@@ -26067,29 +25401,6 @@ def test_osp_vmware67_test_vm_migration_from_iscsi_storage_in_vmware_to_iscsi_on
 
 
 @pytest.mark.manual
-@pytest.mark.tier(1)
-def test_custom_button_visibility():
-    """
-    This test is required to test the visibility option in the customize
-    button.
-    Steps
-    1)Create Button Group
-    2)Create a Button for the button group
-    3)Add the Button group to a page
-    4)Make write a positive visibility expression
-    5)If button is visible and clickable then pass else fail
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/12h
-        startsin: 5.9
-    """
-    pass
-
-
-@pytest.mark.manual
 @test_requirements.auth
 @pytest.mark.tier(3)
 def test_saml_verify_multiple_appliances_can_be_added_to_the_same_realm():
@@ -26103,23 +25414,6 @@ def test_saml_verify_multiple_appliances_can_be_added_to_the_same_realm():
         caseimportance: medium
         initialEstimate: 1/2h
         title: saml: Verify multiple appliances can be added to the same REALM.
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(3)
-def test_automate_embedded_method():
-    """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1523379
-    For a "new" method when adding Embedded Methods the UI hangs in the
-    tree view when the method is selected
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/12h
     """
     pass
 
@@ -26177,22 +25471,6 @@ def test_search_field_at_the_top_of_a_dynamic_drop_down_dialog_element_should_di
         initialEstimate: 1/4h
         startsin: 5.9
         title: search field at the top of a dynamic drop-down dialog element should display
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(3)
-def test_automate_git_verify_ssl():
-    """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1470738
-
-    Polarion:
-        assignee: dmisharo
-        casecomponent: Automate
-        caseimportance: low
-        initialEstimate: 1/12h
-        startsin: 5.7
     """
     pass
 


### PR DESCRIPTION
**Purpose or Intent**

- Moved test cases related to automate, quota, power control  manuals to respective file with manual tag
- Deleted already automated manual tests
- Improved polarion tags

This PR brings the following changes:

- Polarion refactoring: add assignee, casecomponent, initialEstimate and caseimportance wherever missing. Add setup, testSteps and expectedResults for manual testcases.
- Create new files ```automate/test_automate_manual.py```, ```cloud_infra_common/test_power_control_manual.py``` and ```cloud_infra_common/test_quota_manual.py```