### PR TITLE
[1LP][RFR] workaround for server name in 5.10

### DIFF
--- a/cfme/configure/configuration/diagnostics_settings.py
+++ b/cfme/configure/configuration/diagnostics_settings.py
@@ -6,7 +6,7 @@ from widgetastic_manageiq import SummaryFormItem, Table
 from widgetastic.exceptions import RowNotFound
 from widgetastic.widget import View, Text
 
-from cfme.base.ui import ServerDiagnosticsView
+from cfme.base.ui import ServerDiagnosticsView, prepare_server_name
 from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.utils.appliance import NavigatableMixin
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep, navigate_to
@@ -520,8 +520,8 @@ class DiagnosticsCollectLogs(CFMENavigateStep):
         self.prerequisite_view.accordions.diagnostics.tree.click_path(
             self.appliance.server_region_string(),
             "Zone: {} (current)".format(self.appliance.server.zone.description),
-            "Server: {} [{}] (current)".format(self.appliance.server.name,
-                                               self.appliance.server.sid))
+            prepare_server_name("Server: {} [{}] (current)".format(self.appliance.server.name,
+                                self.appliance.server.sid)))
         self.prerequisite_view.collectlogs.select()
 
 
@@ -536,8 +536,8 @@ class DiagnosticsCollectLogsSlave(CFMENavigateStep):
         self.prerequisite_view.accordions.diagnostics.tree.click_path(
             self.appliance.server_region_string(),
             "Zone: {} (current)".format(self.appliance.server.zone.description),
-            "Server: {} [{}]".format(slave_server.name,
-                                     int(slave_server.sid)))
+            prepare_server_name("Server: {} [{}]".format(slave_server.name,
+                                int(slave_server.sid))))
         self.prerequisite_view.collectlogs.select()
 
 

--- a/cfme/configure/configuration/server_settings.py
+++ b/cfme/configure/configuration/server_settings.py
@@ -703,10 +703,10 @@ class AuthenticationSetting(NavigatableMixin, Updateable, Pretty):
             logger.info('Authentication form reset, returning')
             return
         elif changed:
-            if validate and mode not in [AUTH_MODES['database'], AUTH_MODES['external'],
-                                         AUTH_MODES['ldap'], AUTH_MODES['ldaps']]:
-                view.form.auth_settings.validate.click()
-                view.flash.assert_no_error()
+            if validate and mode not in [AUTH_MODES['database'], AUTH_MODES['external']]:
+                if view.form.auth_settings.validate.is_displayed:
+                    view.form.auth_settings.validate.click()
+                    view.flash.assert_no_error()
             # FIXME BZ 1527239 This button goes disabled if a password field is 'changed' to same
             # on exception, log and continue
             # no exception - assert flash messages

--- a/cfme/configure/configuration/server_settings.py
+++ b/cfme/configure/configuration/server_settings.py
@@ -703,7 +703,8 @@ class AuthenticationSetting(NavigatableMixin, Updateable, Pretty):
             logger.info('Authentication form reset, returning')
             return
         elif changed:
-            if validate and mode not in [AUTH_MODES['database'], AUTH_MODES['external']]:
+            if validate and mode not in [AUTH_MODES['database'], AUTH_MODES['external'],
+                                         AUTH_MODES['ldap'], AUTH_MODES['ldaps']]:
                 view.form.auth_settings.validate.click()
                 view.flash.assert_no_error()
             # FIXME BZ 1527239 This button goes disabled if a password field is 'changed' to same

--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -318,7 +318,7 @@ wcwidth==0.1.7
 webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
-widgetastic.core==0.32.0
+widgetastic.core==0.32.1
 widgetastic.patternfly==0.0.40
 widgetsnbextension==3.4.2
 wrapanapi==3.0.37

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -305,7 +305,7 @@ wcwidth==0.1.7
 webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
-widgetastic.core==0.32.0
+widgetastic.core==0.32.1
 widgetastic.patternfly==0.0.40
 widgetsnbextension==3.4.2
 wrapanapi==3.0.37

--- a/requirements/frozen_docs.py2.txt
+++ b/requirements/frozen_docs.py2.txt
@@ -171,7 +171,7 @@ wcwidth==0.1.7
 webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
-widgetastic.core==0.32.0
+widgetastic.core==0.32.1
 widgetastic.patternfly==0.0.40
 widgetsnbextension==3.4.2
 wrapt==1.10.11

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -162,7 +162,7 @@ wcwidth==0.1.7
 webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
-widgetastic.core==0.32.0
+widgetastic.core==0.32.1
 widgetastic.patternfly==0.0.40
 widgetsnbextension==3.4.2
 wrapt==1.10.11


### PR DESCRIPTION
There is an issue in new appliances 5.9/5.10 appliances when server name is displayed wrongly.
This is temporary fix for tests which fail due to that issue.
REQUIRES: https://github.com/RedHatQE/widgetastic.core/pull/137

{{ pytest: --long-running --use-template-cache cfme/tests/integration/test_cfme_auth.py cfme/tests/intelligence/chargeback/test_chargeback_long_term_rates.py cfme/tests/v2v/test_v2v_migrations_ui.py cfme/tests/services/test_service_rbac.py cfme/tests/configure/test_access_control.py cfme/tests/intelligence/reports/test_validate_chargeback_report.py }}