### PR TITLE
[1LP][RFR] Add 5.9 to the test_db_migrate_replication

### DIFF
--- a/cfme/tests/test_db_migrate.py
+++ b/cfme/tests/test_db_migrate.py
@@ -130,8 +130,9 @@ def test_db_migrate(temp_appliance_extended_db, db_url, db_version, db_desc):
 @pytest.mark.uncollectif(
     lambda appliance, dbversion:
         dbversion in ('scvmm_58', 'ec2_5540') and appliance.version < "5.9")
-@pytest.mark.parametrize('dbversion', ['ec2_5540', 'azure_5620', 'rhev_57', 'scvmm_58'],
-        ids=['55', '56', '57', '58'])
+@pytest.mark.parametrize('dbversion',
+    ['ec2_5540', 'azure_5620', 'rhev_57', 'scvmm_58', 'vmware_59'],
+    ids=['55', '56', '57', '58', '59'])
 def test_db_migrate_replication(temp_appliance_remote, dbversion, temp_appliance_global_region):
     """
     Polarion:

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -976,8 +976,10 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
             The credentials default to those found under ``ssh`` key in ``credentials.yaml``.
 
         """
-        if not self.is_ssh_running:
-            raise Exception('SSH is unavailable')
+        logger.debug('Waiting for SSH to %s to become connective.',
+                     self.hostname)
+        self.wait_for_ssh()
+        logger.debug('SSH to %s ready.', self.hostname)
 
         # IPAppliance.ssh_client only connects to its address
         if self.openshift_creds:

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -231,7 +231,7 @@ class ApplianceConsoleCli(object):
         self._run("--region {region} --internal --hostname {dbhostname} --username {username}"
             " --password {password} --dbname {dbname} --verbose --dbdisk {dbdisk}".format(
                 region=region, dbhostname=dbhostname, username=username, password=password,
-                dbname=dbname, dbdisk=dbdisk), timeout='4m')
+                dbname=dbname, dbdisk=dbdisk), timeout=4 * 60)
 
     def configure_appliance_internal_fetch_key(self, region, dbhostname,
             username, password, dbname, dbdisk, fetch_key, sshlogin, sshpass):

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -203,9 +203,10 @@ class ApplianceConsoleCli(object):
     def __init__(self, appliance):
         self.appliance = appliance
 
-    def _run(self, appliance_console_cli_command):
+    def _run(self, appliance_console_cli_command, timeout=10):
         return self.appliance.ssh_client.run_command(
-            "appliance_console_cli {}".format(appliance_console_cli_command))
+            "appliance_console_cli {}".format(appliance_console_cli_command),
+            timeout)
 
     def set_hostname(self, hostname):
         return self._run("--host {host}".format(host=hostname))
@@ -230,7 +231,7 @@ class ApplianceConsoleCli(object):
         self._run("--region {region} --internal --hostname {dbhostname} --username {username}"
             " --password {password} --dbname {dbname} --verbose --dbdisk {dbdisk}".format(
                 region=region, dbhostname=dbhostname, username=username, password=password,
-                dbname=dbname, dbdisk=dbdisk))
+                dbname=dbname, dbdisk=dbdisk), timeout='4m')
 
     def configure_appliance_internal_fetch_key(self, region, dbhostname,
             username, password, dbname, dbdisk, fetch_key, sshlogin, sshpass):

--- a/cfme/utils/ssh.py
+++ b/cfme/utils/ssh.py
@@ -25,6 +25,7 @@ from cfme.utils.quote import quote
 from cfme.utils.timeutil import parsetime
 from cfme.utils.version import Version
 from cfme.utils.version import VersionPicker
+from cfme.utils.wait import wait_for
 
 # Default blocking time before giving up on an ssh command execution,
 # in seconds (float)
@@ -222,7 +223,7 @@ class SSHClient(paramiko.SSHClient):
 
         if not self.connected:
             self._connect_kwargs.update(kwargs)
-            self._check_port()
+            wait_for(self._check_port, timeout='2m', delay=5)
             # Only install ssh keys if they aren't installed (or currently being installed)
             conn = super(SSHClient, self).connect(**self._connect_kwargs)
         else:


### PR DESCRIPTION
Purpose or Intent
=================
Start testing with 5.9 db backup.

juwatts:

{{ pytest: -v cfme/tests/test_db_migrate.py::test_db_migrate_replication[59]  --use-provider complete }}