### PR TITLE
[1LP][RFR] Update physical infrastructure test collection

### DIFF
--- a/cfme/fixtures/physical_switch.py
+++ b/cfme/fixtures/physical_switch.py
@@ -4,9 +4,11 @@ import pytest
 @pytest.fixture(scope="function")
 def physical_switch(appliance, provider, setup_provider):
     try:
-        physical_switch = appliance.rest_api.collections.physical_switches.filter(
+        physical_switch = appliance.rest_api.collectiions.physical_switches.filter(
             {"provider": provider}
         ).all()[0]
     except IndexError:
         pytest.skip('No physical switch on provider')
+    except AttributeError:
+        pytest.skip('No physical switches in rest API collection')
     return physical_switch

--- a/cfme/fixtures/physical_switch.py
+++ b/cfme/fixtures/physical_switch.py
@@ -2,6 +2,11 @@ import pytest
 
 
 @pytest.fixture(scope="function")
-def physical_switch(appliance):
-    physical_switch = appliance.rest_api.collections.physical_switches[0]
+def physical_switch(appliance, provider, setup_provider):
+    try:
+        physical_switch = appliance.rest_api.collections.physical_switches.filter(
+            {"provider": provider}
+        ).all()[0]
+    except IndexError:
+        pytest.skip('No physical switch on provider')
     return physical_switch

--- a/cfme/tests/physical_infrastructure/api/test_physical_server_api.py
+++ b/cfme/tests/physical_infrastructure/api/test_physical_server_api.py
@@ -20,8 +20,13 @@ DELAY = 60
 
 
 @pytest.fixture(scope="module")
-def physical_server(setup_provider_modscope, appliance):
-    physical_server = appliance.rest_api.collections.physical_servers[0]
+def physical_server(appliance, provider, setup_provider_modscope):
+    try:
+        physical_server = appliance.rest_api.collections.physical_servers.filter(
+            {"provider": provider}
+        ).all()[0]
+    except IndexError:
+        pytest.skip('No physical server on provider')
     return physical_server
 
 

--- a/cfme/tests/physical_infrastructure/api/test_physical_server_api.py
+++ b/cfme/tests/physical_infrastructure/api/test_physical_server_api.py
@@ -27,6 +27,8 @@ def physical_server(appliance, provider, setup_provider_modscope):
         ).all()[0]
     except IndexError:
         pytest.skip('No physical server on provider')
+    except AttributeError:
+        pytest.skip('No physical server attribute in REST collection')
     return physical_server
 
 

--- a/cfme/tests/physical_infrastructure/test_physical_rack.py
+++ b/cfme/tests/physical_infrastructure/test_physical_rack.py
@@ -4,7 +4,8 @@ import pytest
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.physical.provider.lenovo import LenovoProvider
 
-pytestmark = [pytest.mark.tier(3), pytest.mark.provider([LenovoProvider], scope="function")]
+pytestmark = [pytest.mark.tier(3),
+              pytest.mark.provider([LenovoProvider], scope="function")]
 
 
 @pytest.fixture(scope="module")
@@ -14,7 +15,7 @@ def physical_rack(appliance, provider, setup_provider):
         physical_racks = appliance.collections.physical_racks.filter({"provider": provider}).all()
         return physical_racks[0]
     except IndexError:
-        pytest.skip("No rack resource found")
+        pytest.skip("No rack resource on provider")
 
 
 def test_physical_rack_details_dropdowns(physical_rack):
@@ -27,19 +28,14 @@ def test_physical_rack_details_dropdowns(physical_rack):
     physical_rack.refresh()
 
 
-def physical_rack_collection(appliance, provider, setup_provider_modscope):
-    # Get and return the physical rack collection
-    return appliance.collections.physical_racks
-
-
-def test_physical_racks_view_dropdowns(physical_rack_collection):
+def test_physical_racks_view_dropdowns(appliance, physical_rack):
     """Navigate to the physical racks page and verify that the dropdown menus are present
 
     Polarion:
         assignee: rhcf3_machine
         initialEstimate: 1/4h
     """
-    physical_racks_view = navigate_to(physical_rack_collection, 'All')
+    physical_racks_view = navigate_to(appliance.collections.physical_racks, 'All')
 
     configuration_items = physical_racks_view.toolbar.configuration.items
     assert "Refresh Relationships and Power States" in configuration_items

--- a/cfme/tests/physical_infrastructure/ui/test_physical_overview.py
+++ b/cfme/tests/physical_infrastructure/ui/test_physical_overview.py
@@ -3,11 +3,13 @@ import pytest
 from cfme.physical.provider.lenovo import LenovoProvider
 from cfme.utils.appliance.implementations.ui import navigate_to
 
-pytestmark = [pytest.mark.tier(3),
-    pytest.mark.provider([LenovoProvider])]
+pytestmark = [
+    pytest.mark.tier(3),
+    pytest.mark.provider([LenovoProvider]),
+    pytest.mark.usefixtures('appliance', 'provider', 'setup_provider')]
 
 
-def test_physical_overview_page(appliance, setup_provider):
+def test_physical_overview_page(appliance):
     """
     Polarion:
         assignee: rhcf3_machine

--- a/cfme/tests/physical_infrastructure/ui/test_physical_switch_list.py
+++ b/cfme/tests/physical_infrastructure/ui/test_physical_switch_list.py
@@ -7,7 +7,7 @@ from cfme.physical.provider.lenovo import LenovoProvider
 pytestmark = [pytest.mark.tier(3), pytest.mark.provider([LenovoProvider], scope="module")]
 
 
-def test_physical_switches_view_displayed(appliance):
+def test_physical_switches_view_displayed(appliance, physical_switch):
     """Navigate to the physical switches page and verify that switches are displayed
 
     Polarion:
@@ -18,7 +18,7 @@ def test_physical_switches_view_displayed(appliance):
     assert physical_switches_view.is_displayed
 
 
-def test_physical_switches_view_dropdowns(appliance):
+def test_physical_switches_view_dropdowns(appliance, physical_switch):
     """Navigate to the physical switches page and verify that the dropdown menus are present
 
     Polarion:


### PR DESCRIPTION
physical infra tests were collecting when no provider was available, although they needed a provider to be present for the test and fixtures to work.

Updated fixtures to cleanly skip instead of raise IndexError when a provider doesn't have the necessary physical entities present.

Fixes one FixtureLookupError created by a method that wasn't decorated as a fixture.