### PR TITLE
[RFR] Adding casecomonenet to CMQE tests and Moving Manual Tests

### DIFF
--- a/cfme/tests/containers/test_ad_hoc_metrics.py
+++ b/cfme/tests/containers/test_ad_hoc_metrics.py
@@ -46,6 +46,7 @@ def test_ad_hoc_metrics_overview(provider, metrics_up_and_running):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     assert is_ad_hoc_greyed(provider), (
@@ -58,6 +59,7 @@ def test_ad_hoc_metrics_select_filter(provider, metrics_up_and_running):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     view = navigate_to(provider, 'AdHoc')

--- a/cfme/tests/containers/test_alerts.py
+++ b/cfme/tests/containers/test_alerts.py
@@ -18,5 +18,7 @@ def test_add_alerts_provider(provider):
     Polarion:
         assignee: juwatts
         initialEstimate: 1/4h
+        caseimportance: low
+        casecomponent: Containers
     """
     provider.setup()

--- a/cfme/tests/containers/test_basic_metrics.py
+++ b/cfme/tests/containers/test_basic_metrics.py
@@ -67,6 +67,7 @@ def test_basic_metrics(provider):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     try:
@@ -90,6 +91,7 @@ def test_validate_metrics_collection_db(provider,
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     assert provider.wait_for_collected_metrics(
@@ -105,6 +107,7 @@ def test_validate_metrics_collection_provider_gui(appliance, provider,
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     view = navigate_to(provider, "Details")
@@ -125,6 +128,7 @@ def test_flash_msg_not_contains_html_tags(provider):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     edit_view = navigate_to(provider, 'Edit')
@@ -152,6 +156,7 @@ def test_typo_in_metrics_endpoint_type(provider):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
 

--- a/cfme/tests/containers/test_breadcrumbs.py
+++ b/cfme/tests/containers/test_breadcrumbs.py
@@ -48,6 +48,7 @@ def test_breadcrumbs(provider, appliance, soft_assert):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     for data_set in TESTED_OBJECTS:

--- a/cfme/tests/containers/test_chargeback.py
+++ b/cfme/tests/containers/test_chargeback.py
@@ -274,6 +274,7 @@ def test_chargeback_rate_fixed_1(
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     abstract_test_chargeback_cost(
@@ -287,6 +288,7 @@ def test_chargeback_rate_fixed_2(
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     abstract_test_chargeback_cost(
@@ -299,6 +301,7 @@ def test_chargeback_rate_cpu_cores(
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     abstract_test_chargeback_cost(
@@ -311,6 +314,7 @@ def test_chargeback_rate_memory_used(
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     abstract_test_chargeback_cost(
@@ -326,6 +330,7 @@ def test_chargeback_rate_network_io(
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     abstract_test_chargeback_cost(

--- a/cfme/tests/containers/test_cockpit.py
+++ b/cfme/tests/containers/test_cockpit.py
@@ -26,6 +26,7 @@ def test_cockpit_button_access(appliance, provider, cockpit, request):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
 

--- a/cfme/tests/containers/test_configurable_menus.py
+++ b/cfme/tests/containers/test_configurable_menus.py
@@ -30,6 +30,8 @@ def test_datawarehouse_invisible(is_datawarehouse_menu_visible):
     """
     Polarion:
         assignee: juwatts
+        caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/4h
     """
     # This should be the default state

--- a/cfme/tests/containers/test_containers_smartstate_analysis.py
+++ b/cfme/tests/containers/test_containers_smartstate_analysis.py
@@ -60,6 +60,7 @@ def test_manage_policies_navigation(random_image_instance):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     random_image_instance.assign_policy_profiles('OpenSCAP profile')
@@ -71,6 +72,7 @@ def test_check_compliance(random_image_instance):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     random_image_instance.assign_policy_profiles('OpenSCAP profile')
@@ -95,6 +97,7 @@ def test_containers_smartstate_analysis(provider, test_item, soft_assert,
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     if test_item.is_openscap:
@@ -140,6 +143,7 @@ def test_containers_smartstate_analysis_api(provider, test_item, soft_assert,
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
 

--- a/cfme/tests/containers/test_containers_smartstate_analysis_multiple_images.py
+++ b/cfme/tests/containers/test_containers_smartstate_analysis_multiple_images.py
@@ -62,6 +62,7 @@ def test_check_compliance(provider, random_image_instances, appliance):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     collection = appliance.collections.container_images
@@ -95,6 +96,7 @@ def test_containers_smartstate_analysis(provider, test_item,
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     collection = appliance.collections.container_images

--- a/cfme/tests/containers/test_containers_summary.py
+++ b/cfme/tests/containers/test_containers_summary.py
@@ -35,6 +35,7 @@ def test_containers_summary_objects(provider, soft_assert):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     view = navigate_to(ContainersOverview, 'All')

--- a/cfme/tests/containers/test_labels.py
+++ b/cfme/tests/containers/test_labels.py
@@ -82,6 +82,7 @@ def test_labels_create(provider, soft_assert, random_labels):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     provider.refresh_provider_relationships()
@@ -107,6 +108,7 @@ def test_labels_remove(provider, soft_assert, random_labels):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     # Removing the labels

--- a/cfme/tests/containers/test_logging.py
+++ b/cfme/tests/containers/test_logging.py
@@ -74,6 +74,7 @@ def test_external_logging_activated(provider, appliance, test_item, kibana_loggi
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     test_collection = ([provider] if test_item.obj is ContainersProvider

--- a/cfme/tests/containers/test_manageiq_ansible_custom_attributes.py
+++ b/cfme/tests/containers/test_manageiq_ansible_custom_attributes.py
@@ -57,6 +57,7 @@ def test_manageiq_ansible_add_custom_attributes(ansible_custom_attributes, provi
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     setup_ansible_script(provider, script='add_custom_attributes',
@@ -84,6 +85,7 @@ def test_manageiq_ansible_edit_custom_attributes(ansible_custom_attributes, prov
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     setup_ansible_script(provider, script='add_custom_attributes',
@@ -112,6 +114,7 @@ def test_manageiq_ansible_add_custom_attributes_same_name(ansible_custom_attribu
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     setup_ansible_script(provider, script='add_custom_attributes',
@@ -142,6 +145,7 @@ def test_manageiq_ansible_add_custom_attributes_bad_user(ansible_custom_attribut
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     setup_ansible_script(provider, script='add_custom_attributes_bad_user',
@@ -166,6 +170,7 @@ def test_manageiq_ansible_remove_custom_attributes(ansible_custom_attributes, pr
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     setup_ansible_script(provider, script='add_custom_attributes',

--- a/cfme/tests/containers/test_node.py
+++ b/cfme/tests/containers/test_node.py
@@ -19,6 +19,7 @@ def test_nodes_navigate(soft_assert, appliance):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     for dest in TEST_DEST:

--- a/cfme/tests/containers/test_overview_data_integrity.py
+++ b/cfme/tests/containers/test_overview_data_integrity.py
@@ -67,6 +67,7 @@ def test_containers_overview_data_integrity(appliance, soft_assert):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     view = navigate_to(ContainersOverview, 'All')

--- a/cfme/tests/containers/test_pause_resume_workers.py
+++ b/cfme/tests/containers/test_pause_resume_workers.py
@@ -41,6 +41,7 @@ def test_pause_and_resume_provider_workers(appliance, provider):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     view = navigate_to(provider, "Details")
@@ -69,6 +70,7 @@ def test_pause_and_resume_single_provider_api(appliance, provider, from_collecti
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     evm_tail_disable = LogValidator('/var/www/miq/vmdb/log/evm.log',

--- a/cfme/tests/containers/test_project_quota_historical_data.py
+++ b/cfme/tests/containers/test_project_quota_historical_data.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+pytestmark = [
+    pytest.mark.tier(0),
+    pytest.mark.ignore_stream('5.9')]
+
+
+@pytest.mark.manual
+def test_cmqe_add_new_resource_quota():
+    """
+    Add new resource quota
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        casecomponent: Containers
+        initialEstimate: 1h
+        title: CMQE - Add New Resource Quota
+        testSteps:
+            1. On the Openshift provider, create different namespaces and
+               assign them Resource Quotas. Assign different fractional
+               values to the CPU quotas like  `1.152` or `0.087` or `87m`.
+            2. Refresh the CFME appliance
+            3. Check the containers_quota_items table in the database
+            4. Navigate to the namespace in the CFME GUI.
+            5. Refresh the CFME appliance
+            6. Check the containers_quota_items table in the database
+        expectedResults:
+            1. Resource Quota assigned successfully.
+            2. Appliance refreshed successfully.
+            3. Database in `container_quota_items` table should contain
+               both old and current values.            Newly added quotas
+               should have `created_at` field set.
+            4. Verify the GUI displays the correct data and the fractional
+               values are formatted properly.
+            5. Appliance refreshed successfully.
+            6. Verify duplicate records were not added to the table
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_cmqe_modify_existing_resource_quota():
+    """
+    Modify Existing Quota
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        casecomponent: Containers
+        initialEstimate: 1h
+        title: CMQE - Modify Existing Resource Quota
+        testSteps:
+            1. Modify the existing Resource Quota that was added;
+            2. Refresh the CFME appliance
+            3. Check the containers_quota_items table in the database
+            4. Navigate to the namespace in the CFME GUI.
+            5. Modify the existing Resource Quota again
+            6. Refresh the CFME appliance
+            7. Check the containers_quota_items table in the database
+            8. Navigate to the namespace in the CFME GUI.
+        expectedResults:
+            1. Verify the update was successful
+            2. Appliance refreshed successfully.
+            3. Verify the modified values (eg. increased cpu) should appear
+               as multiple rows — old value with `deleted_on` field set,
+               and new value with approximately same `created_at`.
+            4. Verify the GUI displays the correct data and the fractional
+               values are formatted properly.
+            5. Verify the update was successful
+            6. Appliance refreshed successfully.
+            7. Verify multiple values with both (created_at, deleted_on)
+               set and only last one with deleted_on=null.
+            8. Verify the GUI displays the correct data and the fractional
+               values are formatted properly.
+    """
+    pass
+
+
+@pytest.mark.manual
+def test_cmqe_delete_existing_resource_quota():
+    """
+    Delete existing Resource Quota
+
+    Polarion:
+        assignee: juwatts
+        caseimportance: medium
+        casecomponent: Containers
+        initialEstimate: 1h
+        title: CMQE - Delete Existing Resource Quota
+        testSteps:
+            1. Delete the existing Resource Quota that was added;
+            2. Refresh the CFME appliance
+            3. Check the containers_quota_items table in the database
+            4. Navigate to the namespace in the CFME GUI.
+        expectedResults:
+            1. Verify the Resource Quota was deleted successfully
+            2. Appliance refreshed successfully.
+            3. Verify the deleted Resource Quotas should still exist, with
+               `deleted_on` field set.
+            4. Verify the GUI displays no data referencing Resource Quota.
+    """
+    pass

--- a/cfme/tests/containers/test_projects_dashboard.py
+++ b/cfme/tests/containers/test_projects_dashboard.py
@@ -81,6 +81,7 @@ def test_projects_dashboard_pods(provider, soft_assert, container_project_instan
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     api_pod_names = get_api_pods_names(provider)
@@ -105,6 +106,7 @@ def test_projects_dashboard_icons(provider, appliance, soft_assert, container_pr
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     api_values = get_api_object_counts(appliance, PROJECT_NAME, provider)
@@ -134,6 +136,7 @@ def test_project_has_provider(appliance, soft_assert, provider):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     projects_collection = appliance.collections.container_projects

--- a/cfme/tests/containers/test_properties.py
+++ b/cfme/tests/containers/test_properties.py
@@ -92,6 +92,7 @@ def test_properties(provider, appliance, test_item, soft_assert):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     instances = test_item.collection_object(appliance).all()
@@ -120,6 +121,7 @@ def test_pods_conditions(provider, appliance, soft_assert):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     selected_pods_cfme = appliance.collections.container_pods.all()

--- a/cfme/tests/containers/test_provider_configuration_menu.py
+++ b/cfme/tests/containers/test_provider_configuration_menu.py
@@ -30,6 +30,7 @@ def test_edit_selected_containers_provider(provider):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     '''Testing Configuration -> Edit... button functionality
@@ -54,6 +55,7 @@ def test_ocp_operator_out_of_the_box(appliance):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
 
@@ -87,6 +89,7 @@ def test_pause_and_resume_provider(provider):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
 

--- a/cfme/tests/containers/test_provider_openscap_policy_attached.py
+++ b/cfme/tests/containers/test_provider_openscap_policy_attached.py
@@ -68,6 +68,7 @@ def test_check_compliance_provider_policy(provider, soft_assert, delete_all_cont
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     # Perform SSA Scan then check compliance with last know configuration

--- a/cfme/tests/containers/test_relationships.py
+++ b/cfme/tests/containers/test_relationships.py
@@ -49,6 +49,7 @@ def test_relationships_tables(soft_assert, provider, has_persistent_volume, appl
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     instances = ([provider] if test_item.obj is ContainersProvider
@@ -92,6 +93,7 @@ def test_container_status_relationships_data_integrity(provider, appliance, soft
     Polarion:
         assignee: juwatts
         initialEstimate: 1/4h
+        caseimportance: medium
         casecomponent: Containers
     """
 

--- a/cfme/tests/containers/test_reload_button_provider.py
+++ b/cfme/tests/containers/test_reload_button_provider.py
@@ -18,6 +18,7 @@ def test_reload_button_provider(provider):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
 

--- a/cfme/tests/containers/test_reports.py
+++ b/cfme/tests/containers/test_reports.py
@@ -66,6 +66,7 @@ def test_container_reports_base_on_options(soft_assert, appliance):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     view = navigate_to(appliance.collections.reports, 'Add')
@@ -95,6 +96,7 @@ def test_report_pods_per_ready_status(appliance, soft_assert, provider):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     pods_per_ready_status = provider.pods_per_ready_status()
@@ -117,6 +119,7 @@ def test_report_nodes_by_capacity(appliance, soft_assert, node_hardwares_db_data
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     report = get_report(appliance, 'Nodes By Capacity')
@@ -151,6 +154,7 @@ def test_report_nodes_by_cpu_usage(appliance, soft_assert, vporizer):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     report = get_report(appliance, 'Nodes By CPU Usage')
@@ -171,6 +175,7 @@ def test_report_nodes_by_memory_usage(appliance, soft_assert, vporizer):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     report = get_report(appliance, 'Nodes By Memory Usage')
@@ -191,6 +196,7 @@ def test_report_number_of_nodes_per_cpu_cores(appliance, soft_assert, node_hardw
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     report = get_report(appliance, 'Nodes by Number of CPU Cores')
@@ -210,6 +216,7 @@ def test_report_projects_by_number_of_pods(appliance, soft_assert):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
 
@@ -236,6 +243,7 @@ def test_report_projects_by_cpu_usage(appliance, soft_assert, vporizer):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     report = get_report(appliance, 'Projects By CPU Usage')
@@ -257,6 +265,7 @@ def test_report_projects_by_memory_usage(appliance, soft_assert, vporizer):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     report = get_report(appliance, 'Projects By Memory Usage')
@@ -278,6 +287,7 @@ def test_report_pod_counts_for_container_images_by_project(appliance, provider, 
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     report = get_report(appliance, 'Pod counts For Container Images by Project', candu=True)
@@ -312,6 +322,7 @@ def test_report_recently_discovered_pods(appliance, provider, soft_assert):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     report = get_report(appliance, 'Recently Discovered Pods')
@@ -329,6 +340,7 @@ def test_report_number_of_images_per_node(appliance, provider, soft_assert):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     pods_api = provider.mgmt.list_pods()
@@ -354,6 +366,7 @@ def test_report_projects_by_number_of_containers(appliance, provider, soft_asser
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     report = get_report(appliance, 'Projects by Number of Containers')

--- a/cfme/tests/containers/test_search_bar.py
+++ b/cfme/tests/containers/test_search_bar.py
@@ -33,6 +33,7 @@ def test_search_bar(provider, appliance, soft_assert):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     for collection_name in COLLECTION_NAMES:

--- a/cfme/tests/containers/test_ssa_set_cve_image_inspector_per_provider.py
+++ b/cfme/tests/containers/test_ssa_set_cve_image_inspector_per_provider.py
@@ -155,6 +155,7 @@ def test_cve_location_update_value(provider, soft_assert, delete_all_container_t
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     # Perform SSA Scan then check compliance with last know configuration
@@ -175,6 +176,7 @@ def test_image_inspector_registry_update_value(provider, soft_assert, delete_all
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     # Perform SSA Scan then check compliance with last know configuration

--- a/cfme/tests/containers/test_ssl_providers.py
+++ b/cfme/tests/containers/test_ssl_providers.py
@@ -57,6 +57,7 @@ def test_add_provider_naming_conventions(provider, appliance, soft_assert, sync_
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     for provider_name in provider_names:
@@ -90,6 +91,7 @@ def test_add_provider_ssl(provider, default_sec_protocol, soft_assert, sync_ssl_
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     new_provider = copy(provider)
@@ -130,6 +132,7 @@ def test_add_mertics_provider_ssl(provider, appliance, test_item,
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     if not provider.endpoints.get('metrics', False):
@@ -166,6 +169,7 @@ def test_setup_with_wrong_port(provider, sec_protocol, sync_ssl_certificate):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     new_provider = copy(provider)

--- a/cfme/tests/containers/test_start_page.py
+++ b/cfme/tests/containers/test_start_page.py
@@ -48,6 +48,7 @@ def test_start_page(appliance, soft_assert):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     for data_set in data_sets:

--- a/cfme/tests/containers/test_static_custom_attributes.py
+++ b/cfme/tests/containers/test_static_custom_attributes.py
@@ -58,6 +58,7 @@ def test_add_static_custom_attributes(add_delete_custom_attributes, provider):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
 
@@ -81,6 +82,7 @@ def test_edit_static_custom_attributes(provider):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
 
@@ -109,6 +111,7 @@ def test_delete_static_custom_attributes(add_delete_custom_attributes, request, 
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
 
@@ -151,6 +154,7 @@ def test_add_attribute_with_empty_name(provider):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     with pytest.raises(APIException):
@@ -170,6 +174,7 @@ def test_add_date_attr_with_wrong_value(provider):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     ca = CustomAttribute('nondate', "koko", 'Date')
@@ -189,6 +194,7 @@ def test_edit_non_exist_attribute(provider):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     ca = choice(ATTRIBUTES_DATASET)
@@ -216,6 +222,7 @@ def test_delete_non_exist_attribute(provider):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     ca = choice(ATTRIBUTES_DATASET)
@@ -232,6 +239,7 @@ def test_add_already_exist_attribute(provider):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     ca = choice(ATTRIBUTES_DATASET)
@@ -251,6 +259,7 @@ def test_very_long_name_with_special_characters(request, provider):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     ca = CustomAttribute(get_random_string(1000), 'very_long_name', None)
@@ -266,6 +275,7 @@ def test_very_long_value_with_special_characters(request, provider):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     ca = CustomAttribute('very long value', get_random_string(1000), None)

--- a/cfme/tests/containers/test_table_views.py
+++ b/cfme/tests/containers/test_table_views.py
@@ -54,6 +54,7 @@ def test_default_views(appliance, random_default_views):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     for collection_name in objects_mapping.keys():
@@ -72,6 +73,7 @@ def test_table_views(appliance):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     for collection_name in objects_mapping.keys():

--- a/cfme/tests/containers/test_tables_fields.py
+++ b/cfme/tests/containers/test_tables_fields.py
@@ -74,6 +74,7 @@ def test_tables_fields(provider, test_item, soft_assert, appliance):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     view = navigate_to((test_item.obj if test_item.obj is ContainersProvider
@@ -104,6 +105,7 @@ def test_containers_details_view_title(appliance):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     random_container = appliance.collections.containers.all().pop()

--- a/cfme/tests/containers/test_tables_sort.py
+++ b/cfme/tests/containers/test_tables_sort.py
@@ -34,6 +34,7 @@ def test_tables_sort(test_item, soft_assert, appliance):
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
     view = navigate_to((test_item.obj if test_item.obj is ContainersProvider

--- a/cfme/tests/containers/test_tags.py
+++ b/cfme/tests/containers/test_tags.py
@@ -54,6 +54,7 @@ def test_tag_container_objects(soft_assert, test_param, appliance, provider, req
     Polarion:
         assignee: juwatts
         caseimportance: medium
+        casecomponent: Containers
         initialEstimate: 1/6h
     """
 

--- a/cfme/tests/test_manual.py
+++ b/cfme/tests/test_manual.py
@@ -778,31 +778,6 @@ def test_embed_tower_playbooks():
 
 
 @pytest.mark.manual
-def test_cmqe_delete_existing_resource_quota():
-    """
-    Delete existing Resource Quota
-
-    Polarion:
-        assignee: juwatts
-        caseimportance: medium
-        initialEstimate: 1h
-        title: CMQE - Delete Existing Resource Quota
-        testSteps:
-            1. &nbsp;Delete the&nbsp;existing Resource Quota that was added in&nbsp;&nbsp;
-            2. Refresh the CFME appliance
-            3. Check the containers_quota_items table in the database
-            4. Navigate to the namespace in the CFME GUI.
-        expectedResults:
-            1. Verify the Resource Quota was deleted successfully
-            2. Appliance refreshed successfully.
-            3. Verify the deleted Resource Quotas should still exist, with
-               `deleted_on` field set.
-            4. Verify the GUI displays no data referencing Resource Quota.
-    """
-    pass
-
-
-@pytest.mark.manual
 def test_osp_vmware60_test_vm_migration_with_really_long_name_upto_64_chars_worked_not_65_char():
     """
     OSP: vmware60-Test VM migration with really long name(Upto 64 chars
@@ -2630,43 +2605,6 @@ def test_osp_test_flavors_can_be_selected_creating_migration_plan():
         startsin: 5.10
         subcomponent: OSP
         title: OSP: Test flavors can be selected creating migration plan
-    """
-    pass
-
-
-@pytest.mark.manual
-def test_cmqe_modify_existing_resource_quota():
-    """
-    Modify Existing Quota
-
-    Polarion:
-        assignee: juwatts
-        caseimportance: medium
-        initialEstimate: 1h
-        title: CMQE - Modify Existing Resource Quota
-        testSteps:
-            1. Modify the existing Resource Quota that was added in &nbsp;
-            2. Refresh the CFME appliance
-            3. Check the containers_quota_items table in the database
-            4. Navigate to the namespace in the CFME GUI.
-            5. Modify the existing Resource Quota again
-            6. Refresh the CFME appliance
-            7. Check the containers_quota_items table in the database
-            8. Navigate to the namespace in the CFME GUI.
-        expectedResults:
-            1. Verify the update was successful
-            2. Appliance refreshed successfully.
-            3. Verify the modified values (eg. increased cpu) should appear
-               as multiple rows — old value with `deleted_on` field set,
-               and new value with approximately same `created_at`.
-            4. Verify the GUI displays the correct data and the fractional
-               values are formatted properly.
-            5. Verify the update was successful
-            6. Appliance refreshed successfully.
-            7. Verify multiple values with both (created_at, deleted_on)
-               set and only last one with deleted_on=null.
-            8. Verify the GUI displays the correct data and the fractional
-               values are formatted properly.
     """
     pass
 
@@ -6122,39 +6060,6 @@ def test_embed_tower_invisible():
         caseimportance: medium
         initialEstimate: 1/12h
         startsin: 5.8
-    """
-    pass
-
-
-@pytest.mark.manual
-def test_cmqe_add_new_resource_quota():
-    """
-    Add new resource quota
-
-    Polarion:
-        assignee: juwatts
-        caseimportance: medium
-        initialEstimate: 1h
-        title: CMQE - Add New Resource Quota
-        testSteps:
-            1. On the Openshift provider, create different namespaces and
-               assign them Resource Quotas. Assign different fractional
-               values to the CPU quotas like  `1.152` or `0.087` or `87m`.
-            2. Refresh the CFME appliance
-            3. Check the containers_quota_items table in the database
-            4. Navigate to the namespace in the CFME GUI.
-            5. Refresh the CFME appliance
-            6. Check the containers_quota_items table in the database
-        expectedResults:
-            1. Resource Quota assigned successfully.
-            2. Appliance refreshed successfully.
-            3. Database in `container_quota_items` table should contain
-               both old and current values.            Newly added quotas
-               should have `created_at` field set.
-            4. Verify the GUI displays the correct data and the fractional
-               values are formatted properly.
-            5. Appliance refreshed successfully.
-            6. Verify duplicate records were not added to the table
     """
     pass
 


### PR DESCRIPTION
PR makes the following changes:
- Adds casecomponent: Containers to all cmqe tests
- Moves manual CMQE tests out of test_manual.py and into the containers folder