### PR TITLE
[1LP][RFR] Add in blocker BZs and fix tests that can be fixed for cloud timelines

### DIFF
--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -160,6 +160,9 @@ class InstEvent(object):
         self.inst.mgmt.stop()
         return self.inst.mgmt.start()
 
+    def _restart(self):
+        return self.inst.mgmt.restart()
+
     def _rename_vm(self):
         logger.info('%r will be renamed', self.inst.name)
         new_name = "{}-renamed".format(self.inst.name)
@@ -256,7 +259,10 @@ class InstEvent(object):
                     evt=self.event, tgt=target))
 
 
-@pytest.mark.meta(blockers=[BZ(1670550, forced_streams=['5.10'])])
+@pytest.mark.meta(blockers=[BZ(1670550, forced_streams=['5.10']),
+                            BZ(1671521,
+                               unblock=lambda provider: not provider.one_of(AzureProvider),
+                               forced_streams=['5.9', '5.10'])])
 def test_cloud_timeline_create_event(new_instance, soft_assert, azone):
     """
     Metadata:
@@ -274,8 +280,7 @@ def test_cloud_timeline_create_event(new_instance, soft_assert, azone):
     inst_event.catch_in_timelines(soft_assert, targets)
 
 
-@pytest.mark.meta(blockers=[BZ(1542962, forced_streams=['5.8']),
-                            BZ(1670474,
+@pytest.mark.meta(blockers=[BZ(1670474,
                                unblock=lambda provider: not provider.one_of(EC2Provider),
                                forced_streams=['5.9', '5.10'])])
 def test_cloud_timeline_policy_event(new_instance, control_policy, soft_assert):
@@ -295,7 +300,10 @@ def test_cloud_timeline_policy_event(new_instance, control_policy, soft_assert):
     inst_event.catch_in_timelines(soft_assert, targets, policy_events=True)
 
 
-@pytest.mark.meta(blockers=[BZ(1670550, forced_streams=['5.10'])])
+@pytest.mark.meta(blockers=[BZ(1670550, forced_streams=['5.10']),
+                            BZ(1671521,
+                               unblock=lambda provider: not provider.one_of(AzureProvider),
+                               forced_streams=['5.9', '5.10'])])
 def test_cloud_timeline_stop_event(new_instance, soft_assert, azone):
     """
     Metadata:
@@ -313,7 +321,10 @@ def test_cloud_timeline_stop_event(new_instance, soft_assert, azone):
     inst_event.catch_in_timelines(soft_assert, targets)
 
 
-@pytest.mark.meta(blockers=[BZ(1670550, forced_streams=['5.10'])])
+@pytest.mark.meta(blockers=[BZ(1670550, forced_streams=['5.10']),
+                            BZ(1671521,
+                               unblock=lambda provider: not provider.one_of(AzureProvider),
+                               forced_streams=['5.9', '5.10'])])
 def test_cloud_timeline_start_event(new_instance, soft_assert, azone):
     """
     Metadata:
@@ -331,6 +342,9 @@ def test_cloud_timeline_start_event(new_instance, soft_assert, azone):
     inst_event.catch_in_timelines(soft_assert, targets)
 
 
+@pytest.mark.meta(blockers=[BZ(1671521,
+                               unblock=lambda provider: not provider.one_of(AzureProvider),
+                               forced_streams=['5.9', '5.10'])])
 def test_cloud_timeline_diagnostic(new_instance, mark_vm_as_appliance, soft_assert):
     """Check Configuration/diagnostic/timelines.
 
@@ -348,8 +362,7 @@ def test_cloud_timeline_diagnostic(new_instance, mark_vm_as_appliance, soft_asse
     inst_event.catch_in_timelines(soft_assert, targets)
 
 
-@pytest.mark.meta(blockers=[BZ(1537520, forced_streams=['5.8']),
-                            BZ(1670550, forced_streams=['5.10'])])
+@pytest.mark.meta(blockers=[BZ(1670550, forced_streams=['5.10'])])
 @pytest.mark.provider([EC2Provider], override=True, scope='function')
 def test_cloud_timeline_rename_event(new_instance, soft_assert, azone):
     """
@@ -368,7 +381,10 @@ def test_cloud_timeline_rename_event(new_instance, soft_assert, azone):
     inst_event.catch_in_timelines(soft_assert, targets)
 
 
-@pytest.mark.meta(blockers=[BZ(1670550, forced_streams=['5.10'])])
+@pytest.mark.meta(blockers=[BZ(1670550, forced_streams=['5.10']),
+                            BZ(1671521,
+                               unblock=lambda provider: not provider.one_of(AzureProvider),
+                               forced_streams=['5.9', '5.10'])])
 @pytest.mark.uncollectif(lambda provider, appliance: provider.one_of(EC2Provider) and
                          appliance.version < "5.9")
 def test_cloud_timeline_delete_event(new_instance, soft_assert, azone):

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -2720,7 +2720,12 @@ class TimelinesFilter(View):
     # todo: implement correct switch between management/policy views when switchable views done
     apply = Text(locator='.//div[contains(@class, "timeline-apply")]')
     # management controls
-    detailed_events = Checkbox(name="showDetailedEvents")
+    detailed_events = VersionPick(
+        {
+            Version.lowest(): Checkbox(name="showDetailedEvents"),
+            "5.10": BootstrapSelect(id="tl_levels_management"),
+        }
+    )
     # policy controls
     policy_event_category = BootstrapSelect(id="tl_category_policy")
     policy_event_status = RadioGroup(locator='//span[contains(@class, "timeline-option")]')


### PR DESCRIPTION
Purpose or Intent
=================

__Adding__ BZ blocker metadata for [BZ 1670474](https://bugzilla.redhat.com/show_bug.cgi?id=1670474) and [BZ 1670550](https://bugzilla.redhat.com/show_bug.cgi?id=1670550). These bugs are causing test failures for cloud timeline events. 

__Fixing__ `detailed_events` for 5.10, since the checkbox was replaced by a BootstrapSelect.

{{ pytest: --long-running --use-provider complete cfme/tests/cloud/test_cloud_timelines.py }}
