### PR TITLE
[WIP] Moving parametrize structure with minimal global fixture

### DIFF
--- a/cfme/fixtures/v2v.py
+++ b/cfme/fixtures/v2v.py
@@ -194,15 +194,15 @@ def _form_data(source_provider, provider):
 
 
 @pytest.fixture(scope="function")
-def form_data_vm_map_obj_mini(request, appliance, second_provider, provider):
+def form_data_vm_map_obj_mini(request, appliance, source_provider, provider):
     """Fixture which provides minimal form_data, vm and map object structure for migration plan"""
-    form_data = _form_data(second_provider, provider)
-    source_datastores_list = second_provider.data.get("datastores", [])
+    form_data = _form_data(source_provider, provider)
+    source_datastores_list = source_provider.data.get("datastores", [])
     source_datastore = [d.name for d in source_datastores_list if d.type == "nfs"][0]
-    collection = second_provider.appliance.provider_based_collection(second_provider)
+    collection = source_provider.appliance.provider_based_collection(source_provider)
     vm_name = random_vm_name("v2v-auto")
     vm_obj = collection.instantiate(
-        vm_name, second_provider, template_name=rhel7_minimal(second_provider)["name"]
+        vm_name, source_provider, template_name=rhel7_minimal(source_provider)["name"]
     )
     vm_obj.create_on_provider(
         timeout=2400,

--- a/cfme/fixtures/v2v.py
+++ b/cfme/fixtures/v2v.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 from riggerlib import recursive_update
 from widgetastic.utils import partial_match
 
-from cfme.fixtures.provider import setup_or_skip
+from cfme.fixtures.provider import rhel7_minimal, setup_or_skip
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.utils.generators import random_vm_name

--- a/cfme/tests/v2v/test_post_migrations.py
+++ b/cfme/tests/v2v/test_post_migrations.py
@@ -37,11 +37,8 @@ def get_migrated_vm_obj(src_vm_obj, target_provider):
     return migrated_vm
 
 
-@pytest.mark.parametrize(
-    "form_data_vm_obj_single_datastore", [["nfs", "nfs", rhel7_minimal]], indirect=True
-)
 def test_migration_policy_tag(request, appliance, v2v_providers, host_creds, conversion_tags,
-                              form_data_vm_obj_single_datastore, soft_assert):
+                              form_data_vm_obj_mini, soft_assert):
     """Test policy to prevent source VM from starting if migration is complete
 
     Polarion:
@@ -50,7 +47,7 @@ def test_migration_policy_tag(request, appliance, v2v_providers, host_creds, con
         casecomponent: V2V
     """
     infrastructure_mapping_collection = appliance.collections.v2v_mappings
-    mapping = infrastructure_mapping_collection.create(form_data_vm_obj_single_datastore.form_data)
+    mapping = infrastructure_mapping_collection.create(form_data_vm_obj_mini.form_data)
 
     @request.addfinalizer
     def _cleanup():
@@ -58,12 +55,12 @@ def test_migration_policy_tag(request, appliance, v2v_providers, host_creds, con
 
     migration_plan_collection = appliance.collections.v2v_plans
     # vm_obj is a list, with only 1 VM object, hence [0]
-    vm_obj = form_data_vm_obj_single_datastore.vm_list[0]
+    vm_obj = form_data_vm_obj_mini.vm_list[0]
     migration_plan = migration_plan_collection.create(
         name="plan_{}".format(fauxfactory.gen_alphanumeric()),
         description="desc_{}".format(fauxfactory.gen_alphanumeric()),
         infra_map=mapping.name,
-        vm_list=form_data_vm_obj_single_datastore.vm_list,
+        vm_list=form_data_vm_obj_mini.vm_list,
         start_migration=True,
     )
 

--- a/cfme/tests/v2v/test_post_migrations.py
+++ b/cfme/tests/v2v/test_post_migrations.py
@@ -38,7 +38,7 @@ def get_migrated_vm_obj(src_vm_obj, target_provider):
 
 
 def test_migration_policy_tag(request, appliance, v2v_providers, host_creds, conversion_tags,
-                              form_data_vm_obj_mini, soft_assert):
+                              form_data_vm_map_obj_mini, soft_assert):
     """Test policy to prevent source VM from starting if migration is complete
 
     Polarion:
@@ -46,22 +46,15 @@ def test_migration_policy_tag(request, appliance, v2v_providers, host_creds, con
         initialEstimate: 1/4h
         casecomponent: V2V
     """
-    infrastructure_mapping_collection = appliance.collections.v2v_mappings
-    mapping = infrastructure_mapping_collection.create(form_data_vm_obj_mini.form_data)
-
-    @request.addfinalizer
-    def _cleanup():
-        infrastructure_mapping_collection.delete(mapping)
-
     migration_plan_collection = appliance.collections.v2v_plans
     # vm_obj is a list, with only 1 VM object, hence [0]
-    vm_obj = form_data_vm_obj_mini.vm_list[0]
+    vm_obj = form_data_vm_map_obj_mini.vm_list[0]
     migration_plan = migration_plan_collection.create(
         name="plan_{}".format(fauxfactory.gen_alphanumeric()),
         description="desc_{}".format(fauxfactory.gen_alphanumeric()),
-        infra_map=mapping.name,
-        vm_list=form_data_vm_obj_mini.vm_list,
-        start_migration=True,
+        infra_map=form_data_vm_map_obj_mini.map_obj.name,
+        vm_list=form_data_vm_map_obj_mini.vm_list,
+        start_migration=True
     )
 
     # explicit wait for spinner of in-progress status card
@@ -84,7 +77,7 @@ def test_migration_policy_tag(request, appliance, v2v_providers, host_creds, con
         func_args=[migration_plan.name],
         message="migration plan is in progress, be patient please",
         delay=15,
-        num_sec=3600,
+        num_sec=3600
     )
     view.switch_to("Completed Plans")
     view.wait_displayed()

--- a/cfme/tests/v2v/test_post_migrations.py
+++ b/cfme/tests/v2v/test_post_migrations.py
@@ -47,13 +47,12 @@ def test_migration_policy_tag(request, appliance, v2v_providers, host_creds, con
         casecomponent: V2V
     """
     migration_plan_collection = appliance.collections.v2v_plans
-    # vm_obj is a list, with only 1 VM object, hence [0]
-    vm_obj = form_data_vm_map_obj_mini.vm_list[0]
+    vm_obj = form_data_vm_map_obj_mini.vm_list
     migration_plan = migration_plan_collection.create(
         name="plan_{}".format(fauxfactory.gen_alphanumeric()),
         description="desc_{}".format(fauxfactory.gen_alphanumeric()),
         infra_map=form_data_vm_map_obj_mini.map_obj.name,
-        vm_list=form_data_vm_map_obj_mini.vm_list,
+        vm_list=[form_data_vm_map_obj_mini.vm_list],
         start_migration=True
     )
 
@@ -107,8 +106,7 @@ def test_migrations_vm_attributes(request, appliance, v2v_providers, host_creds,
                                   form_data_vm_map_obj_mini):
     """Tests cpu, socket, core, memory attributes on migrated vm"""
     migration_plan_collection = appliance.collections.v2v_plans
-    # vm_obj is a list, with only 1 VM object, hence [0]
-    src_vm_obj = form_data_vm_map_obj_mini.vm_list[0]
+    src_vm_obj = form_data_vm_map_obj_mini.vm_list
     source_view = navigate_to(src_vm_obj, "Details")
     summary = source_view.entities.summary("Properties").get_text_of("Container")
     source_cpu, source_socket, source_core, source_memory = re.findall("\d+", summary)
@@ -116,7 +114,7 @@ def test_migrations_vm_attributes(request, appliance, v2v_providers, host_creds,
         name="plan_{}".format(fauxfactory.gen_alphanumeric()),
         description="desc_{}".format(fauxfactory.gen_alphanumeric()),
         infra_map=form_data_vm_map_obj_mini.map_obj.name,
-        vm_list=form_data_vm_map_obj_mini.vm_list,
+        vm_list=[form_data_vm_map_obj_mini.vm_list],
         start_migration=True
     )
 

--- a/cfme/tests/v2v/test_post_migrations.py
+++ b/cfme/tests/v2v/test_post_migrations.py
@@ -103,33 +103,20 @@ def test_migration_policy_tag(request, appliance, v2v_providers, host_creds, con
     soft_assert(vm_state == "off")
 
 
-@pytest.mark.parametrize(
-    "form_data_vm_obj_single_datastore", [["nfs", "nfs", rhel7_minimal]], indirect=True
-)
 def test_migrations_vm_attributes(request, appliance, v2v_providers, host_creds, conversion_tags,
-                                  form_data_vm_obj_single_datastore):
+                                  form_data_vm_map_obj_mini):
     """Tests cpu, socket, core, memory attributes on migrated vm"""
-    infrastructure_mapping_collection = appliance.collections.v2v_mappings
-    mapping = infrastructure_mapping_collection.create(
-        form_data_vm_obj_single_datastore.form_data
-    )
-
-    @request.addfinalizer
-    def _cleanup():
-        infrastructure_mapping_collection.delete(mapping)
-
+    migration_plan_collection = appliance.collections.v2v_plans
     # vm_obj is a list, with only 1 VM object, hence [0]
-    src_vm_obj = form_data_vm_obj_single_datastore.vm_list[0]
+    src_vm_obj = form_data_vm_map_obj_mini.vm_list[0]
     source_view = navigate_to(src_vm_obj, "Details")
     summary = source_view.entities.summary("Properties").get_text_of("Container")
     source_cpu, source_socket, source_core, source_memory = re.findall("\d+", summary)
-
-    migration_plan_collection = appliance.collections.v2v_plans
     migration_plan = migration_plan_collection.create(
         name="plan_{}".format(fauxfactory.gen_alphanumeric()),
         description="desc_{}".format(fauxfactory.gen_alphanumeric()),
-        infra_map=mapping.name,
-        vm_list=form_data_vm_obj_single_datastore.vm_list,
+        infra_map=form_data_vm_map_obj_mini.map_obj.name,
+        vm_list=form_data_vm_map_obj_mini.vm_list,
         start_migration=True
     )
 

--- a/cfme/tests/v2v/test_v2v_ansible.py
+++ b/cfme/tests/v2v/test_v2v_ansible.py
@@ -86,11 +86,8 @@ def catalog_item(request, appliance, machine_credential, ansible_repository, pla
     return cat_item
 
 
-@pytest.mark.parametrize(
-    "form_data_vm_obj_single_datastore", [["nfs", "nfs", rhel7_minimal]], indirect=True
-)
 def test_migration_playbooks(request, appliance, v2v_providers, host_creds, conversion_tags,
-                             ansible_repository, form_data_vm_obj_single_datastore):
+                             ansible_repository, form_data_vm_map_obj_mini):
     """Test for migrating vms with pre and post playbooks"""
     creds = credentials[v2v_providers.vmware_provider.data.templates.get("rhel7_minimal").creds]
     CREDENTIALS = (
@@ -114,24 +111,15 @@ def test_migration_playbooks(request, appliance, v2v_providers, host_creds, conv
         request, appliance, credential.name, ansible_repository, "retire"
     )
 
-    infrastructure_mapping_collection = appliance.collections.v2v_mappings
-    mapping = infrastructure_mapping_collection.create(
-        form_data_vm_obj_single_datastore.form_data
-    )
-
-    @request.addfinalizer
-    def _cleanup():
-        infrastructure_mapping_collection.delete(mapping)
-
     # vm_obj is a list, with only 1 VM object, hence [0]
-    src_vm_obj = form_data_vm_obj_single_datastore.vm_list[0]
+    src_vm_obj = form_data_vm_map_obj_mini.vm_list[0]
 
     migration_plan_collection = appliance.collections.v2v_plans
     migration_plan = migration_plan_collection.create(
         name="plan_{}".format(fauxfactory.gen_alphanumeric()),
         description="desc_{}".format(fauxfactory.gen_alphanumeric()),
-        infra_map=mapping.name,
-        vm_list=form_data_vm_obj_single_datastore.vm_list,
+        infra_map=form_data_vm_map_obj_mini.map_obj.name,
+        vm_list=form_data_vm_map_obj_mini.vm_list,
         start_migration=True,
         pre_playbook=provision_catalog.name,
         post_playbook=retire_catalog.name,

--- a/cfme/tests/v2v/test_v2v_ansible.py
+++ b/cfme/tests/v2v/test_v2v_ansible.py
@@ -111,15 +111,13 @@ def test_migration_playbooks(request, appliance, v2v_providers, host_creds, conv
         request, appliance, credential.name, ansible_repository, "retire"
     )
 
-    # vm_obj is a list, with only 1 VM object, hence [0]
-    src_vm_obj = form_data_vm_map_obj_mini.vm_list[0]
-
+    src_vm_obj = form_data_vm_map_obj_mini.vm_list
     migration_plan_collection = appliance.collections.v2v_plans
     migration_plan = migration_plan_collection.create(
         name="plan_{}".format(fauxfactory.gen_alphanumeric()),
         description="desc_{}".format(fauxfactory.gen_alphanumeric()),
         infra_map=form_data_vm_map_obj_mini.map_obj.name,
-        vm_list=form_data_vm_map_obj_mini.vm_list,
+        vm_list=[form_data_vm_map_obj_mini.vm_list],
         start_migration=True,
         pre_playbook=provision_catalog.name,
         post_playbook=retire_catalog.name,

--- a/cfme/tests/v2v/test_v2v_migrations_single_vcenter.py
+++ b/cfme/tests/v2v/test_v2v_migrations_single_vcenter.py
@@ -51,7 +51,7 @@ def test_single_vm_migration_power_state_tags_retirement(request, appliance, v2v
     """
     # Test VM migration power state and tags are preserved
     # as this is single_vm_migration it only has one vm_obj, which we extract on next line
-    src_vm = form_data_vm_map_obj_mini.vm_list[0]
+    src_vm = form_data_vm_map_obj_mini.vm_list
     if power_state not in src_vm.mgmt.state:
         if power_state == 'RUNNING':
             src_vm.mgmt.start()
@@ -66,7 +66,7 @@ def test_single_vm_migration_power_state_tags_retirement(request, appliance, v2v
     migration_plan = migration_plan_collection.create(
         name="plan_{}".format(fauxfactory.gen_alphanumeric()), description="desc_{}"
         .format(fauxfactory.gen_alphanumeric()), infra_map=form_data_vm_map_obj_mini.map_obj.name,
-        vm_list=form_data_vm_map_obj_mini.vm_list, start_migration=True)
+        vm_list=[form_data_vm_map_obj_mini.vm_list], start_migration=True)
 
     # explicit wait for spinner of in-progress status card
     view = appliance.browser.create_view(
@@ -189,7 +189,7 @@ def test_migration_special_char_name(request, appliance, v2v_providers, host_cre
     migration_plan = migration_plan_collection.create(
         name="{}".format(fauxfactory.gen_special()), description="desc_{}"
         .format(fauxfactory.gen_alphanumeric()), infra_map=form_data_vm_map_obj_mini.map_obj.name,
-        vm_list=form_data_vm_map_obj_mini.vm_list, start_migration=True)
+        vm_list=[form_data_vm_map_obj_mini.vm_list], start_migration=True)
 
     # explicit wait for spinner of in-progress status card
     view = appliance.browser.create_view(
@@ -212,7 +212,7 @@ def test_migration_special_char_name(request, appliance, v2v_providers, host_cre
             migration_plan.name))
     # validate MAC address matches between source and target VMs
     assert view.migration_plans_completed_list.is_plan_succeeded(migration_plan.name)
-    src_vm = form_data_vm_map_obj_mini.vm_list[0]
+    src_vm = form_data_vm_map_obj_mini.vm_list
     migrated_vm = get_migrated_vm_obj(src_vm, v2v_providers.rhv_provider)
     assert src_vm.mac_address == migrated_vm.mac_address
 
@@ -310,18 +310,17 @@ def test_migration_with_edited_mapping(request, appliance, v2v_providers, edited
             caseimportance: medium
             initialEstimate: 1/4h
         """
-    # vm_obj is a list, with only 1 VM object, hence [0]
-    src_vm_obj = form_data_vm_map_obj_mini.vm_list[0]
+    src_vm_obj = form_data_vm_map_obj_mini.vm_list
     _form_data, edited_form_data = edited_form_data
-
+    mapping = form_data_vm_map_obj_mini.map_obj
     mapping.update(edited_form_data)
 
     migration_plan_collection = appliance.collections.v2v_plans
     migration_plan = migration_plan_collection.create(
         name="plan_{}".format(fauxfactory.gen_alphanumeric()),
         description="desc_{}".format(fauxfactory.gen_alphanumeric()),
-        infra_map=form_data_vm_map_obj_mini.map_obj.name,
-        vm_list=form_data_vm_map_obj_mini.vm_list,
+        infra_map=mapping.name,
+        vm_list=[form_data_vm_map_obj_mini.vm_list],
         start_migration=True)
 
     # explicit wait for spinner of in-progress status card

--- a/cfme/tests/v2v/test_v2v_schedule_migrations.py
+++ b/cfme/tests/v2v/test_v2v_schedule_migrations.py
@@ -27,11 +27,8 @@ pytestmark = [
 ]
 
 
-@pytest.mark.parametrize('form_data_vm_obj_single_datastore', [['nfs', 'nfs', rhel7_minimal]],
- indirect=True)
 def test_single_vm_scheduled_migration(request, appliance, v2v_providers, host_creds,
-                                    conversion_tags, soft_assert,
-                                    form_data_vm_obj_single_datastore):
+                                    conversion_tags, soft_assert, form_data_vm_map_obj_mini):
     """
     Polarion:
         assignee: kkulkarn
@@ -40,19 +37,11 @@ def test_single_vm_scheduled_migration(request, appliance, v2v_providers, host_c
         subcomponent: RHV
         upstream: yes
     """
-    infrastructure_mapping_collection = appliance.collections.v2v_mappings
-    mapping = infrastructure_mapping_collection.create(
-        form_data_vm_obj_single_datastore.form_data)
-
-    @request.addfinalizer
-    def _cleanup():
-        infrastructure_mapping_collection.delete(mapping)
-
     migration_plan_collection = appliance.collections.v2v_plans
     migration_plan = migration_plan_collection.create(
         name="plan_{}".format(fauxfactory.gen_alphanumeric()), description="desc_{}"
-        .format(fauxfactory.gen_alphanumeric()), infra_map=mapping.name,
-        vm_list=form_data_vm_obj_single_datastore.vm_list, start_migration=False)
+        .format(fauxfactory.gen_alphanumeric()), infra_map=form_data_vm_map_obj_mini.map_obj.name,
+        vm_list=form_data_vm_map_obj_mini.vm_list, start_migration=False)
     view = navigate_to(migration_plan_collection, 'All')
 
     # Test scheduled Migration

--- a/cfme/tests/v2v/test_v2v_schedule_migrations.py
+++ b/cfme/tests/v2v/test_v2v_schedule_migrations.py
@@ -41,7 +41,7 @@ def test_single_vm_scheduled_migration(request, appliance, v2v_providers, host_c
     migration_plan = migration_plan_collection.create(
         name="plan_{}".format(fauxfactory.gen_alphanumeric()), description="desc_{}"
         .format(fauxfactory.gen_alphanumeric()), infra_map=form_data_vm_map_obj_mini.map_obj.name,
-        vm_list=form_data_vm_map_obj_mini.vm_list, start_migration=False)
+        vm_list=[form_data_vm_map_obj_mini.vm_list], start_migration=False)
     view = navigate_to(migration_plan_collection, 'All')
 
     # Test scheduled Migration


### PR DESCRIPTION
{{pytest: cfme/tests/v2v/test_post_migrations.py -k test_migrations_vm_attributes --use-provider rhv42 --use-provider vsphere65-nested --provider-limit 2 -vvvv }}

This is just proposal, going to move other tests with same pattern form v2v directory.