### PR TITLE
[WIPTEST] Update ApiException Import for podified appliance crud

### DIFF
--- a/cfme/tests/pod/test_appliance_crud.py
+++ b/cfme/tests/pod/test_appliance_crud.py
@@ -4,7 +4,7 @@ import pytest
 import tempfile
 import yaml
 
-from kubernetes.client.rest import ApiException
+from wrapanapi.systems.container.rhopenshift import ApiException
 from pytest import config
 from time import sleep
 


### PR DESCRIPTION
{{ pytest: cfme/tests/pod/test_appliance_crud.py -k test_pod_appliance_basic_ipa_auth --use-provider cm-pod2 --long-running --use-template-cache }}