### PR TITLE
[1LP][RFR] Allow currently_selected to work with trees with multiple roots

### DIFF
--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -175,10 +175,16 @@ class ReportTimelineView(CloudIntelTimelinesView):
 
     @property
     def is_displayed(self):
+        expected_tree = [
+            self.context["object"].type or self.context["object"].company_name,
+            self.context["object"].subtype or "Custom",
+            self.context["object"].menu_name
+        ]
+
         return (
             self.logged_in_as_current_user and
             self.navigation.currently_selected == ['Cloud Intel', 'Timelines'] and
-            self.title.text == self.context["object"].title
+            self.timelines.tree.currently_selected == expected_tree
         )
 
 

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -68,7 +68,35 @@ class DynamicTableAddError(Exception):
 
 
 # TODO: replace below calls with direct calls later
-ManageIQTree = BootstrapTreeview
+class ManageIQTree(BootstrapTreeview):
+    """ Refactor of BootstrapTreeview to add currently_selected for times
+    which have more than 1 root. Also a root_items property."""
+
+    @property
+    def root_items(self):
+        return self.browser.elements(self.ROOT_ITEMS, parent=self)
+
+    @property
+    def currently_selected(self):
+        if self.selected_item is not None:
+            nodeid = self.get_nodeid(self.selected_item).split(".")
+            if self.root_item_count > 1:
+                root_ids = [self.get_nodeid(root_item).split(".") for root_item in self.root_items]
+                # find my root_id by comparing first two numbers in nodeid
+                for root_id in root_ids:
+                    if root_id[0:2] == nodeid[0:2]:
+                        root_id_len = len(root_id)
+                        break
+            else:
+                root_id_len = len(self.get_nodeid(self.root_item).split("."))
+            result = []
+            for end in range(root_id_len, len(nodeid) + 1):
+                current_nodeid = ".".join(nodeid[:end])
+                text = self.browser.text(self.get_item_by_nodeid(current_nodeid))
+                result.append(text)
+            return result
+        else:
+            return None
 
 
 class SummaryFormItem(Widget):

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -67,9 +67,8 @@ class DynamicTableAddError(Exception):
     pass
 
 
-# TODO: replace below calls with direct calls later
 class ManageIQTree(BootstrapTreeview):
-    """ Refactor of BootstrapTreeview to add currently_selected for times
+    """ Refactor of BootstrapTreeview to add currently_selected for tree-views
     which have more than 1 root. Also a root_items property."""
 
     @property


### PR DESCRIPTION
Purpose or Intent
=================

__Extending__ `ManageIQTree` such that it inherits `BootstrapTreeview` rather than being equivalent to it, this will allow us to define MIQ specific functions for the `BootstrapTreeview`s that are present in MIQ. 

I have modified the `currently_selected` property to be able to deal with trees that have more than one root. As a smoke test, I have modified the Reports Timeline view to use this method. 

{{ pytest: --long-running --use-provider vsphere6-nested cfme/tests/intelligence/test_reports_with_timelines.py }}