### PR TITLE
[RFR] Fixed AttributeError for AddCatalogItemView

### DIFF
--- a/cfme/services/catalogs/catalog_items/__init__.py
+++ b/cfme/services/catalogs/catalog_items/__init__.py
@@ -31,6 +31,14 @@ class EntryPoint(Input):
             return True
         return False
 
+    def click(self):
+        # After clicking on widget - 'retirement_entry_point', 'reconfigure_entry_point' or
+        # 'provisioning_entry_point'; 'Select Entry Point Instance'(pop up) occures which
+        # helps to select provided paths using tree structure.
+        # 'Click' property is added to these widgets because some tests are selecting provided
+        # paths only via modal tree(using pop up).
+        self.browser.click(self)
+
 
 # Views
 class BasicInfoForm(ServicesCatalogView):

--- a/cfme/services/catalogs/catalog_items/__init__.py
+++ b/cfme/services/catalogs/catalog_items/__init__.py
@@ -3,7 +3,7 @@ import fauxfactory
 from cached_property import cached_property
 
 from navmazing import NavigateToAttribute, NavigateToSibling
-from widgetastic.widget import Text, Checkbox, View
+from widgetastic.widget import Text, Checkbox, ClickableMixin, View
 from widgetastic.utils import WaitFillViewStrategy
 from widgetastic_manageiq import FonticonPicker, ManageIQTree, WaitTab
 from widgetastic_patternfly import Button, Input, BootstrapSelect, CandidateNotFound
@@ -19,7 +19,7 @@ from cfme.utils.version import LOWEST, VersionPicker
 from cfme.utils.wait import wait_for
 
 
-class EntryPoint(Input):
+class EntryPoint(Input, ClickableMixin):
     def fill(self, value):
         if super(EntryPoint, self).fill(value):
             self.parent_view.modal.cancel.click()
@@ -30,14 +30,6 @@ class EntryPoint(Input):
             # So to ignore this pop up clicking on cancel button is required.
             return True
         return False
-
-    def click(self):
-        # After clicking on widget - 'retirement_entry_point', 'reconfigure_entry_point' or
-        # 'provisioning_entry_point'; 'Select Entry Point Instance'(pop up) occures which
-        # helps to select provided paths using tree structure.
-        # 'Click' property is added to these widgets because some tests are selecting provided
-        # paths only via modal tree(using pop up).
-        self.browser.click(self)
 
 
 # Views

--- a/cfme/tests/automate/test_git_import.py
+++ b/cfme/tests/automate/test_git_import.py
@@ -64,7 +64,7 @@ def test_automate_git_domain_displayed_in_service(appliance, imported_domain, br
     collection = appliance.collections.catalog_items
     cat_item = collection.instantiate(collection.GENERIC, "test")
     view = navigate_to(cat_item, "Add")
-    view.field_entry_point.fill("")
+    view.provisioning_entry_point.click()
     view.modal.tree.click_path(
         "Datastore",
         "{0} ({1}) ({0}) (Locked)".format(imported_domain.name, branch),
@@ -76,5 +76,5 @@ def test_automate_git_domain_displayed_in_service(appliance, imported_domain, br
     )
     view.modal.include_domain.fill(True)
     view.modal.apply.click()
-    assert view.field_entry_point.value == ("/{}/Service/Provisioning/StateMachines/"
+    assert view.provisioning_entry_point.value == ("/{}/Service/Provisioning/StateMachines/"
         "ServiceProvision_Template/CatalogItemInitialization".format(imported_domain.name))


### PR DESCRIPTION
{{ pytest: cfme/tests/automate/test_git_import.py::test_automate_git_domain_displayed_in_service -v }}

Fixed Error:
```
>       view.field_entry_point.fill("")
E       AttributeError: 'AddCatalogItemView' object has no attribute 'field_entry_point'

cfme/tests/automate/test_git_import.py:66: AttributeError
AttributeError
'AddCatalogItemView' object has no attribute 'field_entry_point'
```