### PR TITLE
[1LP][RFR][NOTEST] Remove BZ meta and unassign a test case

### DIFF
--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -324,10 +324,7 @@ class Report(BaseEntity, Updateable):
 
     @company_name.default
     def company_name_default(self):
-        if self.appliance.version < "5.9":
-            return "My Company (All EVM Groups)"
-        else:
-            return "My Company (All Groups)"
+        return "My Company (All Groups)"
 
     def update(self, updates):
         view = navigate_to(self, "Edit")
@@ -336,7 +333,7 @@ class Report(BaseEntity, Updateable):
             view.save_button.click()
         else:
             view.cancel_button.click()
-        view = self.create_view(ReportDetailsView, override=updates, wait="60s")
+        view = self.create_view(ReportDetailsView, override=updates, wait="5s")
         view.flash.assert_no_error()
         if changed:
             view.flash.assert_message(

--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -336,7 +336,7 @@ class Report(BaseEntity, Updateable):
             view.save_button.click()
         else:
             view.cancel_button.click()
-        view = self.create_view(ReportDetailsView, override=updates, wait="5s")
+        view = self.create_view(ReportDetailsView, override=updates, wait="60s")
         view.flash.assert_no_error()
         if changed:
             view.flash.assert_message(

--- a/cfme/tests/cloud_infra_common/test_provisioning.py
+++ b/cfme/tests/cloud_infra_common/test_provisioning.py
@@ -261,12 +261,14 @@ def test_provision_approval(appliance, provider, vm_name, smtp_test, request,
         BZ(
             1662638,
             forced_streams=["5.9", "5.10", "upstream"],
-            unblock=lambda provider: provider.one_of(VMwareProvider)
-            and provider.version == "6.5",
+            unblock=not (
+                lambda provider: provider.one_of(VMwareProvider)
+                and provider.version == 6.5
+            ),
         )
     ]
 )
-@pytest.mark.parametrize('auto', [True, False], ids=["Auto", "Manual"])
+@pytest.mark.parametrize('auto', [False], ids=["Manual"])
 def test_provision_from_template_using_rest(appliance, request, provider, vm_name, auto):
     """ Tests provisioning from a template using the REST API.
 

--- a/cfme/tests/cloud_infra_common/test_provisioning.py
+++ b/cfme/tests/cloud_infra_common/test_provisioning.py
@@ -256,19 +256,7 @@ def test_provision_approval(appliance, provider, vm_name, smtp_test, request,
     wait_for(verify, message="email receive check", delay=5)
 
 
-@pytest.mark.meta(
-    blockers=[
-        BZ(
-            1662638,
-            forced_streams=["5.9", "5.10", "upstream"],
-            unblock=not (
-                lambda provider: provider.one_of(VMwareProvider)
-                and provider.version == 6.5
-            ),
-        )
-    ]
-)
-@pytest.mark.parametrize('auto', [False], ids=["Manual"])
+@pytest.mark.parametrize('auto', [True, False], ids=["Auto", "Manual"])
 def test_provision_from_template_using_rest(appliance, request, provider, vm_name, auto):
     """ Tests provisioning from a template using the REST API.
 

--- a/cfme/tests/infrastructure/test_provisioning_rest.py
+++ b/cfme/tests/infrastructure/test_provisioning_rest.py
@@ -84,18 +84,6 @@ def clean_vm(appliance, provider, vm_name):
     appliance.collections.infra_vms.instantiate(vm_name, provider).cleanup_on_provider()
 
 
-@pytest.mark.meta(
-    blockers=[
-        BZ(
-            1662638,
-            forced_streams=["5.9", "5.10", "upstream"],
-            unblock=not (
-                lambda provider: provider.one_of(VMwareProvider)
-                and provider.version == 6.5
-            ),
-        )
-    ]
-)
 @pytest.mark.rhv2
 # Here also available the ability to create multiple provision request, but used the save
 # href and method, so it doesn't make any sense actually
@@ -190,18 +178,6 @@ def test_provision_vlan(request, appliance, provision_data, vnic_profile, provid
             format(profile_via_provider.name, profile_name)
 
 
-@pytest.mark.meta(
-    blockers=[
-        BZ(
-            1662638,
-            forced_streams=["5.9", "5.10", "upstream"],
-            unblock=not (
-                lambda provider: provider.one_of(VMwareProvider)
-                and provider.version == 6.5
-            ),
-        )
-    ]
-)
 @pytest.mark.rhv3
 @pytest.mark.meta(server_roles="+notifier")
 def test_provision_emails(request, provision_data, provider, appliance, smtp_test):

--- a/cfme/tests/infrastructure/test_provisioning_rest.py
+++ b/cfme/tests/infrastructure/test_provisioning_rest.py
@@ -89,8 +89,10 @@ def clean_vm(appliance, provider, vm_name):
         BZ(
             1662638,
             forced_streams=["5.9", "5.10", "upstream"],
-            unblock=lambda provider: provider.one_of(VMwareProvider)
-            and provider.version == "6.5",
+            unblock=not (
+                lambda provider: provider.one_of(VMwareProvider)
+                and provider.version == 6.5
+            ),
         )
     ]
 )
@@ -193,8 +195,10 @@ def test_provision_vlan(request, appliance, provision_data, vnic_profile, provid
         BZ(
             1662638,
             forced_streams=["5.9", "5.10", "upstream"],
-            unblock=lambda provider: provider.one_of(VMwareProvider)
-            and provider.version == "6.5",
+            unblock=not (
+                lambda provider: provider.one_of(VMwareProvider)
+                and provider.version == 6.5
+            ),
         )
     ]
 )

--- a/cfme/tests/perf/workloads/test_provisioning.py
+++ b/cfme/tests/perf/workloads/test_provisioning.py
@@ -77,9 +77,7 @@ def test_provisioning(appliance, request, scenario):
     Memory Monitor creates graphs and summary at the end of each scenario.
 
     Polarion:
-        assignee: pvala
-        casecomponent: Rest
-        caseimportance: high
+        assignee: rhcf3_machine
         initialEstimate: 1/4h
     """
 


### PR DESCRIPTION
This PR brings the following changes:
1. Unassign a test case: `test_provisioning`
2. Remove BZ meta - not required anymore.
