### PR TITLE
[WIPTEST] Concurrent migrations test

### DIFF
--- a/cfme/tests/v2v/test_v2v_migrations_single_vcenter.py
+++ b/cfme/tests/v2v/test_v2v_migrations_single_vcenter.py
@@ -415,6 +415,7 @@ def test_concurrent_migrations(request, appliance, v2v_providers, host_creds, co
     @request.addfinalizer
     def _cleanup():
         infrastructure_mapping_collection.delete(mapping)
+        settings_view = navigate_to(mapping, "MigrationSettings")
         settings_view.max_limit.set_value(10)
 
     migration_plan2 = migration_plan_collection.create(

--- a/cfme/tests/v2v/test_v2v_migrations_single_vcenter.py
+++ b/cfme/tests/v2v/test_v2v_migrations_single_vcenter.py
@@ -410,7 +410,7 @@ def test_concurrent_migrations(request, appliance, v2v_providers, host_creds, co
     )
 
     settings_view = navigate_to(mapping, "MigrationSettings")
-    settings_view.max_limit.set_value(1)
+    settings_view.max_limit.set_value(3)
     settings_view.apply_btn.click()
 
     @request.addfinalizer

--- a/cfme/tests/v2v/test_v2v_migrations_single_vcenter.py
+++ b/cfme/tests/v2v/test_v2v_migrations_single_vcenter.py
@@ -411,12 +411,14 @@ def test_concurrent_migrations(request, appliance, v2v_providers, host_creds, co
 
     settings_view = navigate_to(mapping, "MigrationSettings")
     settings_view.max_limit.set_value(1)
+    settings_view.apply_btn.click()
 
     @request.addfinalizer
     def _cleanup():
         infrastructure_mapping_collection.delete(mapping)
         settings_view = navigate_to(mapping, "MigrationSettings")
         settings_view.max_limit.set_value(10)
+        settings_view.apply_btn.click()
 
     migration_plan2 = migration_plan_collection.create(
         name="plan_{}".format(fauxfactory.gen_alphanumeric()),
@@ -426,9 +428,7 @@ def test_concurrent_migrations(request, appliance, v2v_providers, host_creds, co
         start_migration=True
     )
 
-    view = appliance.browser.create_view(
-        navigator.get_class(migration_plan_collection, "All").VIEW.pick()
-    )
+    view = navigate_to(migration_plan_collection, 'All')
 
     def _card_info(plan):
         if view.progress_card.is_plan_started:
@@ -446,7 +446,7 @@ def test_concurrent_migrations(request, appliance, v2v_providers, host_creds, co
         delay=5,
         num_sec=1800,
         message="migration plan {migration_plan2} is in progress, be patient please".format(
-            migration_plan2.name)
+            migration_plan2=migration_plan2.name)
     )
 
     # wait until first plan is in progress

--- a/cfme/v2v/migrations.py
+++ b/cfme/v2v/migrations.py
@@ -14,7 +14,7 @@ from widgetastic_manageiq import (
     MigrationDashboardStatusCard, Stepper
 )
 from widgetastic_patternfly import (Text, TextInput, Button, BootstrapSelect, SelectorDropdown,
-                                    Dropdown)
+                                    Dropdown, BreadCrumb)
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.exceptions import ItemNotFound
@@ -329,16 +329,12 @@ class MigrationDashboardView(BaseLoggedInPage):
     paginator_view = View.include(v2vPaginatorPane, use_parent=True)
     search_box = TextInput(locator=".//div[contains(@class,'input-group')]/input")
     clear_filters = Text(".//a[text()='Clear All Filters']")
+    breadcrumb = BreadCrumb()
 
     @property
     def is_displayed(self):
-        # TODO: Remove next line, after fix for https://github.com/ManageIQ/manageiq-v2v/issues/726
-        # has been backported to downstream 510z
-        return ((self.navigation.currently_selected == ['Compute', 'Migration'] or
-            self.navigation.currently_selected == ['Compute', 'Migration', 'Migration Plans']) and
-            (len(self.browser.elements(".//div[contains(@class,'spinner')]")) == 0) and
-            (len(self.browser.elements('.//div[contains(@class,"card-pf")]')) > 0) and
-            len(self.browser.elements(".//div[contains(@class,'pficon-warning-triangle-o')]")) < 1)
+        return (self.breadcrumb.active_location == 'Migration' and
+                self.navigation.currently_selected == ['Compute', 'Migration', 'Migration Plans'])
 
     def switch_to(self, section):
         """Switches to Not Started, In Progress, Complete or Archived Plans section."""

--- a/cfme/v2v/migrations.py
+++ b/cfme/v2v/migrations.py
@@ -11,7 +11,7 @@ from widgetastic.utils import ParametrizedLocator
 from widgetastic_manageiq import (
     InfraMappingTreeView, MultiSelectList, MigrationPlansList, InfraMappingList, Paginator,
     Table, MigrationPlanRequestDetailsList, RadioGroup, HiddenFileInput, MigrationProgressBar,
-    MigrationDashboardStatusCard
+    MigrationDashboardStatusCard, Stepper
 )
 from widgetastic_patternfly import (Text, TextInput, Button, BootstrapSelect, SelectorDropdown,
                                     Dropdown)
@@ -677,6 +677,17 @@ class MigrationPlanRequestDetailsView(View):
         return not any(migration_plan_in_progress_tracker)
 
 
+class MigrationSettingsView(BaseLoggedInPage):
+    title = Text('//div[contains(@class, "migration-settings")]/h2')
+    max_limit = Stepper(locator='//div[contains(@class, "bootstrap-touchspin-injected")]')
+    apply_btn = Button('Apply')
+
+    @property
+    def is_displayed(self):
+        return (self.navigation.currently_selected == ['Compute', 'Migration', 'Migration Settings']
+                and self.title.text == 'Concurrent Migrations')
+
+
 # Collections Entities
 
 
@@ -904,3 +915,12 @@ class MigrationPlanRequestDetails(CFMENavigateStep):
                     self.obj.ENTITY.name)
             except NoSuchElementException:
                 self.prerequisite_view.progress_card.select_plan(self.obj.ENTITY.name)
+
+
+@navigator.register(InfrastructureMapping, 'MigrationSettings')
+class MigrationSettings(CFMENavigateStep):
+    prerequisite = NavigateToAttribute('appliance.server', 'LoggedIn')
+    VIEW = MigrationSettingsView
+
+    def step(self):
+        self.prerequisite_view.navigation.select('Compute', 'Migration', 'Migration Settings')


### PR DESCRIPTION
{{pytest: cfme/tests/v2v/test_v2v_migrations_single_vcenter.py -k test_concurrent_migrations --use-provider rhv42 --use-provider vsphere65-nested --provider-limit 2 -vvvv }}


PRT should pass after, 
- [x] Following failure is due to widget's class not found, this should fix with https://github.com/ManageIQ/manageiq-v2v/issues/872
```
E           NoSuchElementException: Message: Could not find an element './/input[contains(@class, "bootstrap-touchspin")]'
```
- [ ] https://bugzilla.redhat.com/show_bug.cgi?id=1698761
- [ ] https://bugzilla.redhat.com/show_bug.cgi?id=1702085  