### PR TITLE
[1LP][RFR] Update wt.patternfly requirements to 0.0.41 and remove root_items

### DIFF
--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -320,7 +320,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
 widgetastic.core==0.32.1
-widgetastic.patternfly==0.0.40
+widgetastic.patternfly==0.0.41
 widgetsnbextension==3.4.2
 wrapanapi==3.0.39
 wrapt==1.10.11

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -307,7 +307,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
 widgetastic.core==0.32.1
-widgetastic.patternfly==0.0.40
+widgetastic.patternfly==0.0.41
 widgetsnbextension==3.4.2
 wrapanapi==3.0.39
 wrapt==1.10.11

--- a/requirements/frozen_docs.py2.txt
+++ b/requirements/frozen_docs.py2.txt
@@ -174,7 +174,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
 widgetastic.core==0.32.1
-widgetastic.patternfly==0.0.40
+widgetastic.patternfly==0.0.41
 widgetsnbextension==3.4.2
 wrapt==1.10.11
 xmltodict==0.11.0

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -165,7 +165,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
 widgetastic.core==0.32.1
-widgetastic.patternfly==0.0.40
+widgetastic.patternfly==0.0.41
 widgetsnbextension==3.4.2
 wrapt==1.10.11
 xmltodict==0.11.0

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -72,10 +72,6 @@ class ManageIQTree(BootstrapTreeview):
     which have more than 1 root. Also a root_items property."""
 
     @property
-    def root_items(self):
-        return self.browser.elements(self.ROOT_ITEMS, parent=self)
-
-    @property
     def currently_selected(self):
         if self.selected_item is not None:
             nodeid = self.get_nodeid(self.selected_item).split(".")


### PR DESCRIPTION
Purpose or Intent
=================
This PR will bring in the most recent release of wt.patternfly (0.0.41). Since this release includes the `root_items` property, I have removed this from `ManageIQtree` in wt.manageiq.
{{ pytest: --long-running --use-provider vsphere6-nested cfme/tests/intelligence/test_reports_with_timelines.py }}
