### PR TITLE
[1LP][RFR] Fix No providers available skip message.

### DIFF
--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -346,7 +346,7 @@ def provider_app_crud(provider_class, appliance):
         prov.appliance = appliance
         return prov
     except IndexError:
-        pytest.skip("No {} providers available (required)".format(provider_class.type))
+        pytest.skip("No {} providers available (required)".format(provider_class.type_name))
 
 
 def provision_vm(request, provider):


### PR DESCRIPTION
The propety of the provider class is not "dereferenced" when
accessed from class, so we get something like this in the skip message:

```
In [2]: VMwareProvider.type
Out[2]: <property at 0x7fc9090b0470>
```
which is not too helpful. It is better to use the type_name

{ py.test: cfme/tests/cli/test_appliance_console_db_restore.py::test_appliance_console_restore_pg_basebackup_replicated }