### PR TITLE
[1LP][RFR] Fix test_cloud_events for changes in 5.10 vs 5.9

### DIFF
--- a/cfme/tests/cloud/test_cloud_events.py
+++ b/cfme/tests/cloud/test_cloud_events.py
@@ -24,7 +24,7 @@ def test_manage_nsg_group(appliance, provider, register_event):
     Polarion:
         assignee: jdupuy
         initialEstimate: 1/8h
-        casecomponent: Control
+        casecomponent: Events
         caseimportance: medium
     """
 
@@ -38,10 +38,20 @@ def test_manage_nsg_group(appliance, provider, register_event):
         # In 5.9 version `y` is a dict, not a yaml stream.
         data = yaml.safe_load(y) if appliance.version < '5.9' else y
 
-        return (data['resourceId'].endswith(nsg_name) and
-                (data['status']['value'] == 'Accepted' and
-                 data['subStatus']['value'] == 'Created') or
-                data['status']['value'] == 'Succeeded')
+        # In 5.10 data does not have 'status' or 'subStatus' key
+        if appliance.version < '5.10':
+            compare = (
+                data['resourceId'].endswith(nsg_name) and
+                (
+                    data['status']['value'] == 'Accepted' and
+                    data['subStatus']['value'] == 'Created'
+                ) or
+                data['status']['value'] == 'Succeeded'
+            )
+        else:
+            compare = data['resourceId'].endswith(nsg_name)
+
+        return compare
 
     fd_add_attr = {'full_data': 'will be ignored',
                    'cmp_func': add_cmp}
@@ -54,7 +64,13 @@ def test_manage_nsg_group(appliance, provider, register_event):
         # In 5.9 version `y` is a dict, not a yaml stream.
         data = yaml.safe_load(y) if appliance.version < '5.9' else y
 
-        return data['resourceId'].endswith(nsg_name) and data['status']['value'] == 'Succeeded'
+        if appliance.version < '5.10':
+            compare = (data['resourceId'].endswith(nsg_name) and
+                       data['status']['value'] == 'Succeeded')
+        else:
+            compare = data['resourceId'].endswith(nsg_name)
+
+        return compare
 
     fd_rm_attr = {'full_data': 'will be ignored',
                   'cmp_func': rm_cmp}
@@ -78,7 +94,7 @@ def test_vm_capture(appliance, request, provider, register_event):
     Polarion:
         assignee: jdupuy
         initialEstimate: 1/8h
-        casecomponent: Control
+        casecomponent: Events
         caseimportance: medium
     """
 
@@ -96,7 +112,13 @@ def test_vm_capture(appliance, request, provider, register_event):
         # In 5.9 version `y` is a dict, not a yaml stream.
         data = yaml.safe_load(y) if appliance.version < '5.9' else y
 
-        return data['resourceId'].endswith(vm.name) and data['status']['value'] == 'Succeeded'
+        if appliance.version < '5.10':
+            compare = (data['resourceId'].endswith(vm.name) and
+                       data['status']['value'] == 'Succeeded')
+        else:
+            compare = data['resourceId'].endswith(vm.name)
+
+        return compare
 
     full_data_attr = {'full_data': 'will be ignored',
                       'cmp_func': cmp_function}

--- a/cfme/tests/cloud/test_cloud_events.py
+++ b/cfme/tests/cloud/test_cloud_events.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """This module tests only cloud specific events"""
 import pytest
-import yaml
 
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.utils.generators import random_vm_name
@@ -35,8 +34,7 @@ def test_manage_nsg_group(appliance, provider, register_event):
     # we need to check raw data by regexps, since many azure events aren't parsed by CFME yet
 
     def add_cmp(_, y):
-        # In 5.9 version `y` is a dict, not a yaml stream.
-        data = yaml.safe_load(y) if appliance.version < '5.9' else y
+        data = y
 
         # In 5.10 data does not have 'status' or 'subStatus' key
         if appliance.version < '5.10':
@@ -61,8 +59,7 @@ def test_manage_nsg_group(appliance, provider, register_event):
                    event_type='networkSecurityGroups_write_EndRequest')
 
     def rm_cmp(_, y):
-        # In 5.9 version `y` is a dict, not a yaml stream.
-        data = yaml.safe_load(y) if appliance.version < '5.9' else y
+        data = y
 
         if appliance.version < '5.10':
             compare = (data['resourceId'].endswith(nsg_name) and
@@ -109,8 +106,7 @@ def test_vm_capture(appliance, request, provider, register_event):
     request.addfinalizer(vm.cleanup_on_provider)
 
     def cmp_function(_, y):
-        # In 5.9 version `y` is a dict, not a yaml stream.
-        data = yaml.safe_load(y) if appliance.version < '5.9' else y
+        data = y
 
         if appliance.version < '5.10':
             compare = (data['resourceId'].endswith(vm.name) and

--- a/cfme/tests/cloud/test_cloud_events.py
+++ b/cfme/tests/cloud/test_cloud_events.py
@@ -33,8 +33,8 @@ def test_manage_nsg_group(appliance, provider, register_event):
     # registering add/remove network security group events
     # we need to check raw data by regexps, since many azure events aren't parsed by CFME yet
 
-    def add_cmp(_, y):
-        data = y
+    def add_cmp(_, data):
+        """ comparison function, data is expected to be a dictionary, containing the keys below """
 
         # In 5.10 data does not have 'status' or 'subStatus' key
         if appliance.version < '5.10':
@@ -58,8 +58,8 @@ def test_manage_nsg_group(appliance, provider, register_event):
     register_event(fd_add_attr, source=provider.type.upper(),
                    event_type='networkSecurityGroups_write_EndRequest')
 
-    def rm_cmp(_, y):
-        data = y
+    def rm_cmp(_, data):
+        """ comparison function, data is expected to be a dictionary, containing the keys below """
 
         if appliance.version < '5.10':
             compare = (data['resourceId'].endswith(nsg_name) and
@@ -105,9 +105,8 @@ def test_vm_capture(appliance, request, provider, register_event):
     # # deferred delete vm
     request.addfinalizer(vm.cleanup_on_provider)
 
-    def cmp_function(_, y):
-        data = y
-
+    def cmp_function(_, data):
+        """ comparison function, data is expected to be a dictionary containing the keys below """
         if appliance.version < '5.10':
             compare = (data['resourceId'].endswith(vm.name) and
                        data['status']['value'] == 'Succeeded')

--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -322,7 +322,7 @@ Werkzeug==0.14.1
 widgetastic.core==0.32.1
 widgetastic.patternfly==0.0.41
 widgetsnbextension==3.4.2
-wrapanapi==3.0.39
+wrapanapi==3.0.41
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -309,7 +309,7 @@ Werkzeug==0.14.1
 widgetastic.core==0.32.1
 widgetastic.patternfly==0.0.41
 widgetsnbextension==3.4.2
-wrapanapi==3.0.39
+wrapanapi==3.0.41
 wrapt==1.10.11
 xmltodict==0.11.0
 yaycl==0.3.0


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ both tests in `test_cloud_events` for CFME 5.10. An error was occuring in the `cmp_func` for these events. The data returned for the event does not have `status` or `subStatus` in CFME 5.10. 

{{ pytest: --long-running --use-provider azure cfme/tests/cloud/test_cloud_events.py }}

Exception that was seen: 
```
2019-01-23 14:21:05,143 [I] [cfme] (events) [(BaseEvent(source=AZURE, full_data=will be ignored, event_type=networkSecurityGroups_write_EndRequest), 0), (BaseEvent(source=AZURE, full_data=will be ignored, event_type=networkSecurityGroups_delete_EndRequest), 0)] (cfme/utils/events.py:270)
2019-01-23 14:21:05,406 [I] [cfme] (rest-api) [RESTAPI] GET https://10.16.5.92/api/event_streams/919 {} (/home/jdupuy/cfme_tests/cfme_venv/lib/python2.7/site-packages/manageiq_client/api.py:109)
2019-01-23 14:21:05,714 [E] [cfme] (events) An exception during matching events occurred. (cfme/utils/events.py:240)
Traceback (most recent call last):
  File "/home/jdupuy/cfme_tests/integration_tests/cfme/utils/events.py", line 234, in process_events
    if exp_event['event'].matches(got_event):
  File "/home/jdupuy/cfme_tests/integration_tests/cfme/utils/events.py", line 103, in matches
    if not self.event_attrs[attr].match(evt.event_attrs[attr]):
  File "/home/jdupuy/cfme_tests/integration_tests/cfme/utils/events.py", line 37, in match
    return self.cmp_func(self.value, attr.value)
  File "/home/jdupuy/cfme_tests/integration_tests/cfme/tests/cloud/test_cloud_events.py", line 57, in rm_cmp
    return data['resourceId'].endswith(nsg_name) and data['status']['value'] == 'Succeeded'
KeyError: 'status'```


