### PR TITLE
[1LP][RFR] Storage volume tests also for ec2

### DIFF
--- a/cfme/storage/manager.py
+++ b/cfme/storage/manager.py
@@ -22,13 +22,16 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.providers import get_crud_by_name
 
+from volume import StorageManagerVolumeAllView
+from volume import VolumeAddView
+from volume import AttachInstanceView
+from volume import DetachInstanceView
+
 from widgetastic_manageiq import Accordion
 from widgetastic_manageiq import ManageIQTree
 from widgetastic_manageiq import PaginationPane
 from widgetastic_manageiq import SummaryTable
 from widgetastic_manageiq import Table
-from volume import StorageManagerVolumeAllView, VolumeAddView, AttachInstanceView, DetachInstanceView
-
 
 
 class StorageManagerToolbar(View):

--- a/cfme/storage/manager.py
+++ b/cfme/storage/manager.py
@@ -21,11 +21,14 @@ from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.providers import get_crud_by_name
+
 from widgetastic_manageiq import Accordion
 from widgetastic_manageiq import ManageIQTree
 from widgetastic_manageiq import PaginationPane
 from widgetastic_manageiq import SummaryTable
 from widgetastic_manageiq import Table
+from volume import StorageManagerVolumeAllView, VolumeAddView, AttachInstanceView, DetachInstanceView
+
 
 
 class StorageManagerToolbar(View):
@@ -245,6 +248,48 @@ class StorageManagerDetails(CFMENavigateStep):
             row.click()
         except NoSuchElementException:
             raise ItemNotFound('Could not locate {}'.format(self.obj.name))
+
+
+@navigator.register(StorageManager, 'Volumes')
+class StorageManagerVolumesAll(CFMENavigateStep):
+    VIEW = StorageManagerVolumeAllView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self, *args, **kwargs):
+        volume_count = self.prerequisite_view.entities.relationships.get_text_of("Cloud Volumes")
+        if int(volume_count) > 0:
+            self.prerequisite_view.entities.relationships.click_at("Cloud Volumes")
+        else:
+            raise ItemNotFound('{} has no volumes'.format(self.obj.name))
+
+
+@navigator.register(StorageManager, 'VolumesAdd')
+class StorageManagerVolumesAdd(CFMENavigateStep):
+    VIEW = VolumeAddView
+    prerequisite = NavigateToSibling('Volumes')
+
+    def step(self, *args, **kwargs):
+        self.prerequisite_view.toolbar.configuration.item_select('Add a new Cloud Volume')
+
+
+@navigator.register(StorageManager, 'VolumeAttachInstance')
+class AttachInstance(CFMENavigateStep):
+    VIEW = AttachInstanceView
+    prerequisite = NavigateToSibling('Volumes')
+
+    def step(self, *args, **kwargs):
+        self.prerequisite_view.toolbar.configuration.item_select('Attach selected Cloud Volume to '
+                                                                 'an Instance')
+
+
+@navigator.register(StorageManager, 'VolumeDetachInstance')
+class DetachInstance(CFMENavigateStep):
+    VIEW = DetachInstanceView
+    prerequisite = NavigateToSibling('Volumes')
+
+    def step(self, *args, **kwargs):
+        self.prerequisite_view.toolbar.configuration.item_select('Detach selected Cloud Volume from'
+                                                                 ' an Instance')
 
 
 @navigator.register(StorageManager, 'EditTagsFromDetails')

--- a/cfme/storage/manager.py
+++ b/cfme/storage/manager.py
@@ -257,14 +257,15 @@ class StorageManagerVolumesAll(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self, *args, **kwargs):
-        volume_count = self.prerequisite_view.entities.relationships.get_text_of("Cloud Volumes")
-        if int(volume_count) > 0:
+        volume_count = int(
+            self.prerequisite_view.entities.relationships.get_text_of("Cloud Volumes"))
+        if volume_count > 0:
             self.prerequisite_view.entities.relationships.click_at("Cloud Volumes")
         else:
             raise ItemNotFound('{} has no volumes'.format(self.obj.name))
 
 
-@navigator.register(StorageManager, 'VolumesAdd')
+@navigator.register(StorageManager, 'AddVolume')
 class StorageManagerVolumesAdd(CFMENavigateStep):
     VIEW = VolumeAddView
     prerequisite = NavigateToSibling('Volumes')

--- a/cfme/storage/manager.py
+++ b/cfme/storage/manager.py
@@ -17,16 +17,14 @@ from cfme.common import TagPageView
 from cfme.exceptions import ItemNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
+from cfme.storage.volume import AttachInstanceView
+from cfme.storage.volume import DetachInstanceView
+from cfme.storage.volume import StorageManagerVolumeAllView
+from cfme.storage.volume import VolumeAddView
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.providers import get_crud_by_name
-
-from volume import StorageManagerVolumeAllView
-from volume import VolumeAddView
-from volume import AttachInstanceView
-from volume import DetachInstanceView
-
 from widgetastic_manageiq import Accordion
 from widgetastic_manageiq import ManageIQTree
 from widgetastic_manageiq import PaginationPane

--- a/cfme/storage/volume.py
+++ b/cfme/storage/volume.py
@@ -37,7 +37,6 @@ from widgetastic_manageiq import BootstrapSelect
 from widgetastic_manageiq import BootstrapSwitch
 from widgetastic_manageiq import ItemsToolBarViewSelector
 from widgetastic_manageiq import ManageIQTree
-from widgetastic_manageiq import PaginationPane
 from widgetastic_manageiq import Search
 from widgetastic_manageiq import SummaryTable
 
@@ -86,7 +85,6 @@ class VolumeView(BaseLoggedInPage):
 class VolumeAllView(VolumeView):
     toolbar = View.nested(VolumeToolbar)
     search = View.nested(Search)
-    paginator = PaginationPane()
     including_entities = View.include(BaseEntitiesView, use_parent=True)
 
     @property
@@ -268,9 +266,9 @@ class Volume(BaseEntity, CustomButtonEventsMixin, Updateable, Taggable):
         except TimedOutError:
             logger.error('Timed out waiting for Volume to disappear, continuing')
 
-    def update(self, updates, storage_manager=None):
+    def update(self, updates, storage_manager=None, from_manager=None):
         """Edit cloud volume"""
-        if storage_manager:
+        if from_manager:
             view = navigate_to(storage_manager, 'Volumes')
             view.entities.get_entity(name=self.name).check()
             view.toolbar.configuration.item_select('Edit selected Cloud Volume')
@@ -287,9 +285,9 @@ class Volume(BaseEntity, CustomButtonEventsMixin, Updateable, Taggable):
         return volume_collection.instantiate(
             name=updates.get('volume_name'), provider=self.provider)
 
-    def delete(self, wait=True, storage_manager=None):
+    def delete(self, wait=True, storage_manager=None, from_manager=None):
         """Delete the Volume"""
-        if storage_manager:
+        if from_manager:
             view = navigate_to(storage_manager, 'Volumes')
             view.entities.get_entity(name=self.name).check()
             view.toolbar.configuration.item_select(
@@ -345,8 +343,8 @@ class Volume(BaseEntity, CustomButtonEventsMixin, Updateable, Taggable):
                 return snapshot_collection.instantiate(name, self.provider)
 
     def attach_instance(self, name, mountpoint=None, cancel=False, reset=False,
-                        storage_manager=None):
-        if storage_manager:
+                        storage_manager=None, from_manager=None):
+        if from_manager:
             view = navigate_to(storage_manager, 'Volumes')
             view.entities.get_entity(name=self.name).check()
             view.toolbar.configuration.item_select('Attach selected Cloud Volume to an Instance')
@@ -370,8 +368,8 @@ class Volume(BaseEntity, CustomButtonEventsMixin, Updateable, Taggable):
                 view = self.create_view(VolumeDetailsView)
                 view.flash.assert_no_error()
 
-    def detach_instance(self, name, cancel=False, storage_manager=None):
-        if storage_manager:
+    def detach_instance(self, name, cancel=False, storage_manager=None, from_manager=None):
+        if from_manager:
             view = navigate_to(storage_manager, 'Volumes')
             view.entities.get_entity(name=self.name).check()
             view.toolbar.configuration.item_select('Detach selected Cloud Volume from an Instance')
@@ -470,7 +468,7 @@ class VolumeCollection(BaseCollection, TaggableCollection):
             name: volume name
             storage_manager: storage manager name
             tenant: tenant name
-            size: volume size in GB
+            volume_size: volume size in GB
             provider: provider
             cancel: bool
 
@@ -478,7 +476,7 @@ class VolumeCollection(BaseCollection, TaggableCollection):
             object for the :py:class: cfme.storage.volume.Volume
         """
         if from_manager:
-            view = navigate_to(storage_manager, 'VolumesAdd')
+            view = navigate_to(storage_manager, 'AddVolume')
         else:
             view = navigate_to(self, 'Add')
 
@@ -524,9 +522,9 @@ class VolumeCollection(BaseCollection, TaggableCollection):
         else:
             raise ItemNotFound('No Cloud Volume for Deletion')
 
-    def all(self, storage_manager=None):
+    def all(self, storage_manager=None, from_manager=None):
         """returning all Volumes objects for respective storage manager type"""
-        if storage_manager:
+        if from_manager:
             view = navigate_to(storage_manager, 'Volumes')
         else:
             view = navigate_to(self, 'All')

--- a/cfme/storage/volume.py
+++ b/cfme/storage/volume.py
@@ -27,6 +27,8 @@ from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.log import logger
 from cfme.utils.providers import get_crud_by_name
 from cfme.utils.update import Updateable
+from cfme.utils.version import Version
+from cfme.utils.version import VersionPicker
 from cfme.utils.wait import TimedOutError
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import Accordion
@@ -138,7 +140,8 @@ class VolumeAddForm(View):
     storage_manager = BootstrapSelect(name='storage_manager_id')
     tenant = BootstrapSelect(name='cloud_tenant_id')  # is for openstack block storage only
     volume_name = TextInput(name='name')
-    volume_type = BootstrapSelect(name='volume_type')
+    volume_type = BootstrapSelect(name=VersionPicker({Version.lowest(): 'aws_volume_type',
+                                                      '5.10': 'volume_type'}))
     volume_size = TextInput(name='size')
     az = BootstrapSelect(name='aws_availability_zone_id')  # is for ec2 block storage only
     iops = TextInput(name='aws_iops')  # is for ec2 block storage only

--- a/cfme/storage/volume.py
+++ b/cfme/storage/volume.py
@@ -13,6 +13,7 @@ from widgetastic_patternfly import Dropdown
 from widgetastic_patternfly import Input
 
 from cfme.base.ui import BaseLoggedInPage
+from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.common import CustomButtonEventsMixin
 from cfme.common import Taggable
 from cfme.common import TaggableCollection
@@ -270,7 +271,7 @@ class Volume(BaseEntity, CustomButtonEventsMixin, Updateable, Taggable):
         """Edit cloud volume"""
         if from_manager:
             view = navigate_to(storage_manager, 'Volumes')
-            view.entities.get_entity(name=self.name).check()
+            view.entities.get_entity(surf_pages=True, name=self.name).check()
             view.toolbar.configuration.item_select('Edit selected Cloud Volume')
             view = view.browser.create_view(VolumeEditView, additional_context={'object': self})
         else:
@@ -289,7 +290,7 @@ class Volume(BaseEntity, CustomButtonEventsMixin, Updateable, Taggable):
         """Delete the Volume"""
         if from_manager:
             view = navigate_to(storage_manager, 'Volumes')
-            view.entities.get_entity(name=self.name).check()
+            view.entities.get_entity(surf_pages=True, name=self.name).check()
             view.toolbar.configuration.item_select(
                 'Delete selected Cloud Volumes', handle_alert=True)
         else:
@@ -346,7 +347,7 @@ class Volume(BaseEntity, CustomButtonEventsMixin, Updateable, Taggable):
                         storage_manager=None, from_manager=None):
         if from_manager:
             view = navigate_to(storage_manager, 'Volumes')
-            view.entities.get_entity(name=self.name).check()
+            view.entities.get_entity(surf_pages=True, name=self.name).check()
             view.toolbar.configuration.item_select('Attach selected Cloud Volume to an Instance')
             view = view.browser.create_view(AttachInstanceView, additional_context={'object': self})
         else:
@@ -371,7 +372,7 @@ class Volume(BaseEntity, CustomButtonEventsMixin, Updateable, Taggable):
     def detach_instance(self, name, cancel=False, storage_manager=None, from_manager=None):
         if from_manager:
             view = navigate_to(storage_manager, 'Volumes')
-            view.entities.get_entity(name=self.name).check()
+            view.entities.get_entity(surf_pages=True, name=self.name).check()
             view.toolbar.configuration.item_select('Detach selected Cloud Volume from an Instance')
             view = view.browser.create_view(DetachInstanceView, additional_context={'object': self})
         else:
@@ -397,7 +398,10 @@ class Volume(BaseEntity, CustomButtonEventsMixin, Updateable, Taggable):
         """
         view = navigate_to(self.parent, 'All')
         view.toolbar.view_selector.select("List View")
-        view.browser.refresh()
+        if self.provider.one_of(OpenStackProvider):
+            self.refresh()
+        else:
+            view.browser.refresh()
 
         for item in view.entities.elements.read():
             if self.name in item['Name']:

--- a/cfme/tests/storage/test_volume.py
+++ b/cfme/tests/storage/test_volume.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import fauxfactory
 import pytest
-
 from wrapanapi import VmState
 
 from cfme import test_requirements
@@ -116,6 +115,8 @@ def test_storage_volume_create_cancelled_validation(appliance, provider, from_ma
     view.flash.assert_message('Add of new Cloud Volume was cancelled by the user')
 
 
+@pytest.mark.uncollectif(lambda appliance, from_manager: appliance.version < '5.10' and
+                         from_manager == "from_manager")
 @pytest.mark.tier(1)
 def test_storage_volume_crud(appliance, provider, from_manager):
     """ Test storage volume crud
@@ -160,6 +161,8 @@ def test_storage_volume_crud(appliance, provider, from_manager):
     assert not volume.exists
 
 
+@pytest.mark.uncollectif(lambda appliance, from_manager: appliance.version < '5.10' and
+                         from_manager == "from_manager")
 @pytest.mark.meta(blockers=[BZ(1684939, forced_streams=["5.9", "5.10", "upstream"],
                                unblock=lambda provider: provider.one_of(EC2Provider))])
 @pytest.mark.tier(1)


### PR DESCRIPTION
Extending storage volume tests also for ec2.
Also in volume crud changing volume size and then checking whether it was changed.

Tests are failing because of ec2cleanup script which deletes volumes before all the tests are completed.
I know that this code could be somewhere messy so please tell me how to improve it. Thanks.

{{pytest: cfme/tests/storage/test_volume.py --use-provider complete}}