### PR TITLE
[RFR] fixed FixtureLookupError bug

### DIFF
--- a/cfme/tests/configure/test_register_appliance.py
+++ b/cfme/tests/configure/test_register_appliance.py
@@ -24,7 +24,7 @@ These tests do not check registration results in the web UI, only through SSH.
 
 
 def pytest_generate_tests(metafunc):
-    if metafunc.function in {test_rh_updates}:
+    if metafunc.function in {test_rh_updates, test_rhsm_registration_check_repo_names}:
         return
     """ Generates tests specific to RHSM or SAT6 with proxy-on or off """
     argnames = ['reg_method', 'reg_data', 'proxy_url', 'proxy_creds']
@@ -37,8 +37,10 @@ def pytest_generate_tests(metafunc):
         all_reg_data = conf.cfme_data.get('redhat_updates', {})['streams'][stream]
     except KeyError:
         logger.warning('Could not find rhsm data for stream in yaml')
-        pytest.mark.uncollect(
-            metafunc.function, message='Could not find rhsm data for stream in yaml')
+        metafunc.parametrize(argnames, [
+            pytest.param(
+                None, None, None, None,
+                marks=pytest.mark.uncollect("Could not find rhsm data for stream in yaml"))])
         return
 
     if 'reg_method' in metafunc.fixturenames:
@@ -62,7 +64,7 @@ def pytest_generate_tests(metafunc):
             argid = '{}-{}'.format(reg_method, 'proxy_off')
             idlist.append(argid)
             argvalues.append(argval)
-        metafunc.parametrize(argnames, argvalues, ids=idlist, scope="function")
+        return metafunc.parametrize(argnames, argvalues, ids=idlist, scope="function")
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
```
>       available fixtures: LineMatcher, _pytest, amazon_auth_provider, ansible_catalog, ansible_catalog_item, ansible_repository, ansible_service_catalog, anypython, app_creds, app_creds_modscope, appliance, appliance_police, appliance_preupdate, appliance_with_preset_time, appliance_with_providers, auth_provider, azure_provider, big_template, big_template_modscope, blocker, blockers, browser, bug, cache, candu_tag_vm, capfd, capfdbinary, caplog, capsys, capsysbinary, catalog, catalog_item, category, cfme_data, cfme_log_level_rails_debug, check_item_visibility, cloud_provider, collect_data, configure_auth, configure_console_vnc, configure_console_webmks, configure_websocket, configured_appliance, console_template, console_template_modscope, containers_provider, conversion_tags, dashboards, datafile, dedicated_db_appliance, dialog, disable_forgery_protection, doctest_namespace, dportgroup_template, dportgroup_template_modscope, dual_disk_template, dual_disk_template_modscope, dual_network_template, dual_network_template_modscope, ec2_provider, edited_form_data, enable_candu, enable_candu_category, enabled_embedded_appliance, ensure_resolvable_hostname, ensure_vm_paused, ensure_vm_running, ensure_vm_stopped, ensure_vm_suspended, ensure_websocket_role_disabled, ext_appliances_with_providers, fix_merkyl_workaround, fix_missing_hostname, fixtureconf, form_data_dual_vm_obj_dual_datastore, form_data_multiple_vm_obj_single_datastore, form_data_single_datastore, form_data_single_network, form_data_vm_obj_dual_nics, form_data_vm_obj_single_datastore, form_data_vm_obj_single_network, full_template, full_template_modscope, full_template_vm, full_template_vm_modscope, gce_provider, generate_version_files, group_with_tag, ha_appliances_with_providers, ha_multiple_preupdate_appliances, has_no_azure_providers, has_no_cloud_providers, has_no_containers_providers, has_no_ec2_providers, has_no_gce_providers, has_no_infra_providers, has_no_kubevirt_providers, has_no_lenovo_providers, has_no_networks_providers, has_no_nuage_providers, has_no_openshift_providers, has_no_openstack_infra_providers, has_no_openstack_providers, has_no_physical_providers, has_no_providers, has_no_providers_modscope, has_no_redfish_providers, has_no_rhevm_providers, has_no_scvmm_providers, has_no_vcloud_providers, has_no_virtualcenter_providers, has_persistent_volume, host_creds, infra_provider, ipa_auth_provider, ipa_crud, is_appliance, kubevirt_provider, lenovo_provider, linecomp, logger, maximized, merkyl_inspector, merkyl_setup, meta, monkeypatch, multiple_preupdate_appliances, networks_provider, new_credential, nuage_provider, objects, openshift_provider, openstack_infra_provider, openstack_provider, order_ansible_service_in_ops_ui, order_service, physical_provider, physical_switch, provisioning, pxe_server_crud, pytestconfig, random_string, random_uuid_as_string, record_xml_attribute, record_xml_property, recwarn, redfish_provider, register_event, replicated_appliances_with_providers, rhel69_template, rhel69_template_modscope, rhel74_template, rhel74_template_modscope, rhel7_minimal, rhel7_minimal_modscope, rhevm_provider, role, scvmm_provider, setup_aws_auth_provider, setup_ipa_auth_provider, setup_only_one_provider, setup_perf_provider, setup_provider, setup_provider_clsscope, setup_provider_funcscope, setup_provider_modscope, small_template, small_template_modscope, smtp_test, soft_assert, tag, take_screenshot, targeted_refresh, temp_appliance_preconfig, temp_appliance_preconfig_clsscope, temp_appliance_preconfig_funcscope, temp_appliance_preconfig_funcscope_upgrade, temp_appliance_preconfig_modscope, temp_appliance_unconfig, temp_appliance_unconfig_clsscope, temp_appliance_unconfig_funcscope, temp_appliance_unconfig_funcscope_rhevm, temp_appliance_unconfig_modscope, temp_appliances_unconfig, temp_appliances_unconfig_clsscope, temp_appliances_unconfig_funcscope, temp_appliances_unconfig_funcscope_rhevm, temp_appliances_unconfig_modscope, template, testdir, tmpdir, tmpdir_factory, ubuntu16_template, ubuntu16_template_modscope, ui_worker_pid, unconfigured_appliance, unconfigured_appliance_secondary, unconfigured_appliances, user_restricted, uses_cloud_providers, uses_db, uses_event_listener, uses_infra_providers, uses_providers, uses_pxe, uses_ssh, v2v_providers, vcloud_provider, virtualcenter_provider, vporizer, wait_for_ansible, widgets_generated, win10_template, win10_template_modscope, win2012_template, win2012_template_modscope, win2016_template, win2016_template_modscope, win7_template, win7_template_modscope, with_nuage_sandbox, with_nuage_sandbox_modscope
>       use 'pytest --fixtures [testpath]' for help on them.

/var/ci/workspace/downstream-510z-tests-master/integration_tests/cfme/tests/configure/test_register_appliance.py:129
FixtureLookupError

```

{{pytest: --use-template-cache --long-running cfme/tests/configure/test_register_appliance.py}}