### PR TITLE
[1LP][RFR] Adding ONE_PER_TYPE in ssui/services tests

### DIFF
--- a/cfme/tests/cloud_infra_common/test_cockpit_server.py
+++ b/cfme/tests/cloud_infra_common/test_cockpit_server.py
@@ -4,6 +4,7 @@ import pytest
 from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.infrastructure.provider import InfraProvider
+from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.generators import random_vm_name
 from cfme.utils.wait import wait_for
@@ -24,9 +25,8 @@ def new_vm(appliance, provider, request):
 
 
 @pytest.mark.rhv3
-@pytest.mark.uncollectif(
-    lambda appliance, provider: appliance.version < "5.9" or provider.one_of(GCEProvider))
-@pytest.mark.provider([CloudProvider, InfraProvider])
+@pytest.mark.uncollectif(lambda provider: provider.one_of(GCEProvider))
+@pytest.mark.provider([CloudProvider, InfraProvider], selector=ONE_PER_TYPE)
 @pytest.mark.parametrize('enable', [False, True], ids=['disabled', 'enabled'])
 def test_cockpit_server_role(appliance, provider, setup_provider, new_vm, enable):
     """ The test checks the cockpit "Web Console" button enable and disabled working.

--- a/cfme/tests/services/test_add_remove_vm_to_service.py
+++ b/cfme/tests/services/test_add_remove_vm_to_service.py
@@ -5,6 +5,7 @@ from cfme import test_requirements
 from cfme.automate.explorer.domain import DomainCollection
 from cfme.automate.simulation import simulate
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
+from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.services.myservice import MyService
 
@@ -17,7 +18,7 @@ pytestmark = [
     pytest.mark.long_running,
     pytest.mark.meta(server_roles="+automate"),
     pytest.mark.tier(3),
-    pytest.mark.provider([VMwareProvider], scope="module"),
+    pytest.mark.provider([VMwareProvider], selector=ONE_PER_TYPE, scope="module"),
 ]
 
 

--- a/cfme/tests/services/test_cloud_service_catalogs.py
+++ b/cfme/tests/services/test_cloud_service_catalogs.py
@@ -5,11 +5,12 @@ import pytest
 from riggerlib import recursive_update
 from widgetastic.utils import partial_match
 
+from cfme import test_requirements
 from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.cloud.provider.azure import AzureProvider
+from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.services.service_catalogs import ServiceCatalogs
-from cfme import test_requirements
 from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
@@ -20,7 +21,7 @@ pytestmark = [
     test_requirements.service,
     pytest.mark.meta(server_roles="+automate"),
     pytest.mark.tier(2),
-    pytest.mark.provider([CloudProvider],
+    pytest.mark.provider([CloudProvider], selector=ONE_PER_TYPE,
                          required_fields=[['provisioning', 'image']],
                          scope="module"),
 ]

--- a/cfme/tests/services/test_different_dialogs_in_catalogs.py
+++ b/cfme/tests/services/test_different_dialogs_in_catalogs.py
@@ -6,6 +6,7 @@ from widgetastic.utils import partial_match
 from cfme import test_requirements
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
+from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
@@ -19,7 +20,7 @@ pytestmark = [
     pytest.mark.usefixtures('setup_provider', 'catalog_item', 'uses_infra_providers'),
     test_requirements.service,
     pytest.mark.long_running,
-    pytest.mark.provider([InfraProvider],
+    pytest.mark.provider([InfraProvider], selector=ONE_PER_TYPE,
                          required_fields=[['provisioning', 'template'],
                                           ['provisioning', 'host'],
                                           ['provisioning', 'datastore']],

--- a/cfme/tests/services/test_myservice.py
+++ b/cfme/tests/services/test_myservice.py
@@ -5,6 +5,7 @@ import pytest
 
 from cfme import test_requirements
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
+from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.services.myservice import MyService
 from cfme.services.myservice.ui import MyServiceDetailView
 from cfme.services.service_catalogs import ServiceCatalogs
@@ -22,7 +23,7 @@ pytestmark = [
     pytest.mark.long_running,
     test_requirements.service,
     pytest.mark.tier(2),
-    pytest.mark.provider([VMwareProvider], scope="module"),
+    pytest.mark.provider([VMwareProvider], selector=ONE_PER_TYPE, scope="module"),
 ]
 
 

--- a/cfme/tests/services/test_provision_stack.py
+++ b/cfme/tests/services/test_provision_stack.py
@@ -7,6 +7,7 @@ from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.openstack import OpenStackProvider
+from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.services.myservice import MyService
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils.blockers import BZ
@@ -20,7 +21,7 @@ pytestmark = [
     test_requirements.stack,
     pytest.mark.tier(2),
     pytest.mark.usefixtures("setup_provider_modscope"),
-    pytest.mark.provider([CloudProvider],
+    pytest.mark.provider([CloudProvider], selector=ONE_PER_TYPE,
                          required_fields=[['provisioning', 'stack_provisioning']],
                          scope='module'),
 ]

--- a/cfme/tests/services/test_request.py
+++ b/cfme/tests/services/test_request.py
@@ -3,6 +3,7 @@ import pytest
 
 from cfme import test_requirements
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
+from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils.appliance.implementations.ui import navigate_to
 
@@ -12,7 +13,7 @@ pytestmark = [
     pytest.mark.long_running,
     test_requirements.service,
     pytest.mark.tier(3),
-    pytest.mark.provider([VMwareProvider], scope="module"),
+    pytest.mark.provider([VMwareProvider], selector=ONE_PER_TYPE, scope="module"),
 ]
 
 

--- a/cfme/tests/services/test_service_catalogs.py
+++ b/cfme/tests/services/test_service_catalogs.py
@@ -4,11 +4,10 @@ import pytest
 
 from cfme import test_requirements
 from cfme.infrastructure.provider import InfraProvider
-from cfme.infrastructure.provider.rhevm import RHEVMProvider
+from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.services.workloads import VmsInstances
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 from cfme.utils.rest import assert_response
 from cfme.utils.wait import wait_for_decorator
@@ -19,7 +18,7 @@ pytestmark = [
     pytest.mark.usefixtures('setup_provider', 'catalog_item', 'uses_infra_providers'),
     test_requirements.service,
     pytest.mark.long_running,
-    pytest.mark.provider([InfraProvider],
+    pytest.mark.provider([InfraProvider], selector=ONE_PER_TYPE,
                          required_fields=[['provisioning', 'template'],
                                           ['provisioning', 'host'],
                                           ['provisioning', 'datastore']],

--- a/cfme/tests/services/test_service_manual_approval.py
+++ b/cfme/tests/services/test_service_manual_approval.py
@@ -2,11 +2,12 @@
 import fauxfactory
 import pytest
 
+from cfme import test_requirements
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
+from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.automate.explorer.domain import DomainCollection
-from cfme import test_requirements
 from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 from cfme.utils.update import update
@@ -17,7 +18,7 @@ pytestmark = [
     pytest.mark.usefixtures('setup_provider', 'catalog_item', 'uses_infra_providers'),
     test_requirements.service,
     pytest.mark.long_running,
-    pytest.mark.provider([InfraProvider],
+    pytest.mark.provider([InfraProvider], selector=ONE_PER_TYPE,
                          required_fields=[['provisioning', 'template'],
                                           ['provisioning', 'host'],
                                           ['provisioning', 'datastore']],

--- a/cfme/tests/services/test_service_rbac.py
+++ b/cfme/tests/services/test_service_rbac.py
@@ -2,11 +2,12 @@ import fauxfactory
 import pytest
 
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
+from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.services.service_catalogs import ServiceCatalogs
 
 pytestmark = [
     pytest.mark.usefixtures('uses_infra_providers', 'setup_provider'),
-    pytest.mark.provider([VMwareProvider], scope="module")
+    pytest.mark.provider([VMwareProvider], selector=ONE_PER_TYPE, scope="module")
 ]
 
 

--- a/cfme/tests/ssui/test_ssui_dashboard.py
+++ b/cfme/tests/ssui/test_ssui_dashboard.py
@@ -4,12 +4,13 @@ from datetime import date, timedelta
 import fauxfactory
 import pytest
 
+from cfme import test_requirements
 import cfme.intelligence.chargeback.assignments as cb
 import cfme.intelligence.chargeback.rates as rates
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
+from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.services.dashboard import Dashboard
-from cfme import test_requirements
 from cfme.utils.appliance import ViaSSUI
 from cfme.utils.blockers import GH
 from cfme.utils.log import logger
@@ -23,7 +24,7 @@ pytestmark = [
     test_requirements.ssui,
     pytest.mark.long_running,
     pytest.mark.ignore_stream("upstream"),
-    pytest.mark.provider([InfraProvider],
+    pytest.mark.provider([InfraProvider], selector=ONE_PER_TYPE,
                          required_fields=[['provisioning', 'template'],
                                           ['provisioning', 'host'],
                                           ['provisioning', 'datastore']],

--- a/cfme/tests/ssui/test_ssui_myservice.py
+++ b/cfme/tests/ssui/test_ssui_myservice.py
@@ -8,14 +8,12 @@ from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.infrastructure.provider import InfraProvider
-from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
-from cfme.markers.env_markers.provider import providers
+from cfme.markers.env_markers.provider import providers, ONE_PER_TYPE
 from cfme.services.myservice import MyService
 from cfme.services.myservice.ssui import DetailsMyServiceView
 from cfme.utils import ssh
 from cfme.utils.appliance import ViaSSUI
-from cfme.utils.blockers import BZ
 from cfme.utils.conf import credentials
 from cfme.utils.log import logger
 from cfme.utils.providers import ProviderFilter
@@ -25,9 +23,12 @@ pytestmark = [
     pytest.mark.meta(server_roles="+automate"),
     test_requirements.ssui,
     pytest.mark.long_running,
-    pytest.mark.provider(gen_func=providers,
-                         filters=[ProviderFilter(classes=[InfraProvider, CloudProvider],
-                                                 required_fields=['provisioning'])])
+    pytest.mark.provider(
+        selector=ONE_PER_TYPE,
+        gen_func=providers,
+        filters=[ProviderFilter(
+            classes=[InfraProvider, CloudProvider],
+            required_fields=['provisioning'])])
 ]
 
 

--- a/cfme/tests/ssui/test_ssui_service_catalogs.py
+++ b/cfme/tests/ssui/test_ssui_service_catalogs.py
@@ -5,7 +5,7 @@ from cfme import test_requirements
 from cfme.cloud.provider import CloudProvider
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
-from cfme.markers.env_markers.provider import providers
+from cfme.markers.env_markers.provider import providers, ONE_PER_TYPE
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils.appliance import ViaSSUI
 from cfme.utils.blockers import BZ
@@ -16,9 +16,13 @@ pytestmark = [
     test_requirements.ssui,
     pytest.mark.long_running,
     pytest.mark.ignore_stream("upstream"),
-    pytest.mark.provider(gen_func=providers,
-                         filters=[ProviderFilter(classes=[InfraProvider, CloudProvider],
-                                                 required_fields=['provisioning'])])
+    pytest.mark.provider(
+        selector=ONE_PER_TYPE,
+        gen_func=providers,
+        filters=[ProviderFilter(
+            classes=[InfraProvider, CloudProvider],
+            required_fields=['provisioning'])]
+    )
 ]
 
 


### PR DESCRIPTION
Purpose or Intent
=================

{{pytest: --long-running  cfme/tests/cloud_infra_common/test_cockpit_server.py cfme/tests/services/test_add_remove_vm_to_service.py cfme/tests/services/test_cloud_service_catalogs.py cfme/tests/services/test_different_dialogs_in_catalogs.py cfme/tests/services/test_myservice.py cfme/tests/services/test_provision_stack.py cfme/tests/services/test_request.py cfme/tests/services/test_service_catalogs.py cfme/tests/services/test_service_manual_approval.py cfme/tests/services/test_service_rbac.py cfme/tests/ssui/test_ssui_dashboard.py cfme/tests/ssui/test_ssui_myservice.py cfme/tests/ssui/test_ssui_service_catalogs.py }}