### PR TITLE
[1LP][RFR] fix appliance test in 5.10

### DIFF
--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -53,7 +53,8 @@ def test_appliance_console(appliance):
         initialEstimate: 1/12h
     """
     command_set = ('ap | tee -a /tmp/opt.txt', 'ap')
-    appliance.appliance_console.run_commands(command_set)
+    appliance.appliance_console.run_commands(command_set, timeout=120)
+    logger.info(appliance.ssh_client.run_command("cat /tmp/opt.txt"))
     assert appliance.ssh_client.run_command("cat /tmp/opt.txt | grep '{} Virtual Appliance'"
                                             .format(appliance.product_name))
     assert appliance.ssh_client.run_command("cat /tmp/opt.txt | grep '{} Database:'"


### PR DESCRIPTION
{{pytest: --use-template-cache --long-running cfme/tests/cli/test_appliance_console.py::test_appliance_console}}