### PR TITLE
[WIP]Add new tests for report menus, new method move_reports, fix typos

### DIFF
--- a/cfme/intelligence/reports/menus.py
+++ b/cfme/intelligence/reports/menus.py
@@ -180,6 +180,30 @@ class ReportMenu(BaseEntity):
             view.manager.commit()
             view.save_button.click()
 
+    def move_reports(self, group, folder, subfolder, reports):
+        """ Moves a list of reports to a given menu
+        Args:
+            group: User group
+            folder: Parent of the subfolder where reports are to be moved.
+            subfolder: Subfolder under which the reports are to be moved.
+            reports: List of reports that are to be moved.
+        """
+        if not isinstance(reports, list):
+            reports = [reports]
+
+        with self.manage_subfolder(group, folder, subfolder) as selected_menu:
+            selected_options = selected_menu.parent_view.report_select.all_options
+            for report in reports:
+                if report in selected_options:
+                    raise Exception("Report already present. Cannot move.")
+
+            # fill method replaces all the options in all_options with the value passed as argument
+            # We do not want to replace any value, we just want to move the new reports to a given
+            # menu. This is a work-around for that purpose.
+            reports.extend(selected_options)
+
+            selected_menu.parent_view.report_select.fill(reports)
+
 
 @attr.s
 class ReportMenusCollection(BaseCollection):

--- a/cfme/tests/intelligence/reports/test_reports_manual.py
+++ b/cfme/tests/intelligence/reports/test_reports_manual.py
@@ -380,36 +380,6 @@ def test_import_export_report():
 
 @pytest.mark.manual
 @test_requirements.report
-@pytest.mark.tier(1)
-def test_reports_manage_report_menu_accordion_with_users():
-    """
-    Bugzilla:
-        1535023
-
-    Polarion:
-        assignee: pvala
-        casecomponent: Reporting
-        caseimportance: medium
-        initialEstimate: 1/6h
-        startsin: 5.8
-        setup:
-            1. Create a new report called report01
-            2. Create a new user under EvmGroup-super_administrator called
-            testuser
-            3. "Edit Report Menus" and add the report01 under EvmGroup-
-            super_administrator"s Provisioning -> Activities
-            4. Login using testuser and navigate to Reports
-        testSteps:
-            1. Check if the report01 is present under Provisioning -> Activities
-        expectedResults:
-            1. The report01 must be present under Provisioning -> Activities
-    """
-    pass
-
-
-@pytest.mark.manual
-@test_requirements.report
-@pytest.mark.tier(1)
 def test_report_menus_moving_reports():
     """
     Polarion:


### PR DESCRIPTION
This PR brings the following changes:
1. Automate test: `test_reports_manage_report_menu_accordion_with_users`
2. Add a new test: `test_reports_menu_with_duplicate_reports`
3. Add a new method `move_reports` that helps to move one or more reports to a different report menu.
4. Linting fixes.

{{pytest: cfme/tests/intelligence/reports/test_menus.py --use-template-cache -sqvvv }}
