### PR TITLE
[1LP][RFR]New Test: test_report_fullscreen_enabled

### DIFF
--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -435,6 +435,8 @@ class Report(BaseEntity, Updateable):
         view.flash.assert_no_error()
         if wait_for_finish:
             # Get the queued_at value to always target the correct row
+            if view.saved_reports.paginator.sorted_by['sortDir'] != "DESC":
+                view.saved_reports.paginator.sort(sort_by="Queued At", ascending=False)
             queued_at = view.saved_reports.table[0]["Queued At"].text
 
             def _get_state():

--- a/cfme/tests/intelligence/reports/test_reports_manual.py
+++ b/cfme/tests/intelligence/reports/test_reports_manual.py
@@ -240,31 +240,6 @@ def test_reports_create_schedule_send_report():
 
 @pytest.mark.manual
 @test_requirements.report
-@pytest.mark.tier(3)
-def test_report_fullscreen_enabled():
-    """
-    Polarion:
-        assignee: pvala
-        casecomponent: Reporting
-        caseimportance: low
-        initialEstimate: 1/12h
-        setup:
-            1. Navigate to Cloud > Intel > Reports > All Reports
-        testSteps:
-            1. Select a report that would generate a populated report on queueing.
-                Queue it, navigate to it's `Details` page, click on Configuration and check the `Show Fullscreen Report` option.
-            2. Select a report that would generate an empty report on queueing.
-                Queue it, navigate to it's `Details` page, click on Configuration and check the `Show Fullscreen Report` option.
-        expectedResults:
-            1. `Show Fullscreen Report` option is Enabled.
-            2. `Show Fullscreen Report` option is Disabled.
-
-    """
-    pass
-
-
-@pytest.mark.manual
-@test_requirements.report
 @pytest.mark.tier(1)
 def test_date_should_be_change_in_editing_reports_scheduled():
     """

--- a/cfme/tests/intelligence/reports/test_tenant_quota_reports.py
+++ b/cfme/tests/intelligence/reports/test_tenant_quota_reports.py
@@ -1,7 +1,12 @@
 import pytest
 
+from cfme import test_requirements
 from cfme.utils.appliance.implementations.ui import navigate_to
 
+pytestmark = [
+    test_requirements.report,
+    pytest.mark.tier(3)
+]
 
 property_mapping = {
     "cpu": "Allocated Virtual CPUs",
@@ -12,7 +17,7 @@ property_mapping = {
 }
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def set_and_get_tenant_quota(appliance):
     root_tenant = appliance.collections.tenants.get_root_tenant()
 
@@ -37,15 +42,27 @@ def set_and_get_tenant_quota(appliance):
     data = dict()
     for key, value in property_mapping.items():
         suffix = "GB" if "GB" in value else "Count"
-        data[value] = '{data_value} {suffix}'.format(
-            data_value=tenant_quota_data[key], suffix=suffix)
+        data[value] = "{data_value} {suffix}".format(
+            data_value=tenant_quota_data[key], suffix=suffix
+        )
 
     yield data
 
     root_tenant.set_quota(**reset_data)
 
 
-def test_queue_tenant_quota_reports(appliance, request, set_and_get_tenant_quota):
+@pytest.fixture(scope="function")
+def tenant_report(appliance):
+    tenant_report = appliance.collections.reports.instantiate(
+        type="Tenants", subtype="Tenant Quotas", menu_name="Tenant Quotas"
+    ).queue(wait_for_finish=True)
+
+    yield tenant_report
+
+    tenant_report.delete()
+
+
+def test_queue_tenant_quota_reports(set_and_get_tenant_quota, tenant_report):
     """This test case sets the tenant quota, generates a 'Tenant Quota' report
         and compares both the data.
 
@@ -54,14 +71,49 @@ def test_queue_tenant_quota_reports(appliance, request, set_and_get_tenant_quota
         casecomponent: Reporting
         caseimportance: high
         initialEstimate: 1/10h
+        tags: report
+        setup:
+            1. Set tenant quota
+            2. Create the report
+        testSteps:
+            1. Compare the 'total quota' data in the reports and the quota that was set initially.
+        expectedResults:
+            1. Both the data must be same.
     """
-    tenant_report = appliance.collections.reports.instantiate(
-        type="Tenants", subtype="Tenant Quotas", menu_name="Tenant Quotas"
-    ).queue(wait_for_finish=True)
-    request.addfinalizer(tenant_report.delete)
-
     report_data = dict()
     for row in tenant_report.data.rows:
         if row["Quota Name"] in property_mapping.values():
             report_data[row["Quota Name"]] = row["Total Quota"]
     assert report_data == set_and_get_tenant_quota
+
+
+def test_report_fullscreen_enabled(request, tenant_report, set_and_get_tenant_quota, soft_assert):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: Reporting
+        caseimportance: low
+        initialEstimate: 1/12h
+        tags: report
+        setup:
+            1. Navigate to Cloud > Intel > Reports > All Reports
+        testSteps:
+            1. Select a report that would generate an empty report on queueing.
+            Queue it, navigate to it's `Details` page, click on Configuration and
+            check the `Show Fullscreen Report` option.
+            2. Select a report that would generate a populated report on queueing.
+            Queue it, navigate to it's `Details` page, click on Configuration and
+            check the `Show Fullscreen Report` option.
+        expectedResults:
+            1. `Show Fullscreen Report` option is Disabled.
+            2. `Show Fullscreen Report` option is Enabled.
+    """
+    empty_report = tenant_report
+    view = navigate_to(empty_report, "Details", use_resetter=False)
+    assert not view.configuration.item_enabled("Show full screen Report")
+
+    non_empty_report = tenant_report.parent.parent.queue(wait_for_finish=True)
+    request.addfinalizer(non_empty_report.delete)
+
+    view = navigate_to(non_empty_report, "Details", use_resetter=False)
+    assert view.configuration.item_enabled("Show full screen Report")


### PR DESCRIPTION
This PR brings the following changes:
1. Automate test: `test_report_fullscreen_enabled`
2. Change the scope of fixtures
3. Remove unnecessary arguments from test function
4. Update polarion doc strings of tests.
5. Fix linting.

{{ pytest: cfme/tests/intelligence/reports/test_tenant_quota_reports.py --use-template-cache -sqvvvv}}