### PR TITLE
[1LP][RFR] New Navigate Key to Force Navigation and Remove Browser Refreshes

### DIFF
--- a/cfme/configure/access_control/__init__.py
+++ b/cfme/configure/access_control/__init__.py
@@ -398,7 +398,7 @@ class UserCollection(BaseCollection):
         assert view.is_displayed
 
         # To ensure tree update
-        view.browser.refresh()
+        navigate_to(self, 'All', force=True)
         return user
 
 
@@ -904,7 +904,7 @@ class GroupCollection(BaseCollection):
         view.flash.assert_success_message(flash_message)
 
         # To ensure that the group list is updated
-        view.browser.refresh()
+        navigate_to(self, 'All', force=True)
         return group
 
 

--- a/cfme/containers/image.py
+++ b/cfme/containers/image.py
@@ -14,7 +14,6 @@ from cfme.containers.provider import ContainerObjectDetailsEntities
 from cfme.containers.provider import GetRandomInstancesMixin
 from cfme.containers.provider import Labelable
 from cfme.containers.provider import LoadDetailsMixin
-from cfme.containers.provider import refresh_and_navigate
 from cfme.exceptions import ItemNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
@@ -123,7 +122,7 @@ class Image(BaseEntity, Taggable, Labelable, LoadDetailsMixin, PolicyProfileAssi
 
     @property
     def compliance_status(self):
-        view = refresh_and_navigate(self, 'Details')
+        view = navigate_to(self, 'Details', force=True)
         return view.entities.compliance.read().get('Status').strip()
 
     @property

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -774,14 +774,6 @@ def navigate_and_get_rows(provider, obj, count, silent_failure=False):
     return sample(rows, min(count, len(rows)))
 
 
-def refresh_and_navigate(*args, **kwargs):
-    # Refreshing the page and navigate - we need this for cases that we already in
-    # the page and want to reload it
-    view = navigate_to(*args, **kwargs)
-    view.browser.refresh()
-    return view
-
-
 class GetRandomInstancesMixin(object):
 
     def get_random_instances(self, count=1):

--- a/cfme/tests/containers/test_cockpit.py
+++ b/cfme/tests/containers/test_cockpit.py
@@ -46,11 +46,10 @@ def test_cockpit_button_access(appliance, provider, cockpit, request):
 
     for node in nodes:
 
-        view = (navigate_to(node, 'Details') if node else
+        view = (navigate_to(node, 'Details', force=True) if node else
                 pytest.skip("Could not determine node of {}".format(provider.name)))
 
         if cockpit:
-            appliance.server.browser.refresh()
             assert not view.toolbar.web_console.disabled
             view.toolbar.web_console.click()
             webconsole = node.vm_console
@@ -61,5 +60,4 @@ def test_cockpit_button_access(appliance, provider, cockpit, request):
             assert view.is_displayed
             view.flash.assert_no_error()
         else:
-            appliance.server.browser.refresh()
             assert view.toolbar.web_console.disabled

--- a/cfme/tests/containers/test_containers_smartstate_analysis.py
+++ b/cfme/tests/containers/test_containers_smartstate_analysis.py
@@ -7,7 +7,6 @@ import pytest
 from cfme.containers.image import Image
 from cfme.containers.provider import ContainersProvider
 from cfme.containers.provider import ContainersTestItem
-from cfme.containers.provider import refresh_and_navigate
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.wait import wait_for
@@ -82,7 +81,7 @@ def test_check_compliance(random_image_instance):
 
 def get_table_attr(instance, table_name, attr):
     # Trying to read the table <table_name> attribute <attr>
-    view = refresh_and_navigate(instance, 'Details')
+    view = navigate_to(instance, 'Details', force=True)
     table = getattr(view.entities, table_name, None)
     if table:
         return table.read().get(attr)

--- a/cfme/tests/containers/test_containers_smartstate_analysis_multiple_images.py
+++ b/cfme/tests/containers/test_containers_smartstate_analysis_multiple_images.py
@@ -7,7 +7,6 @@ import pytest
 from cfme.containers.image import Image
 from cfme.containers.provider import ContainersProvider
 from cfme.containers.provider import ContainersTestItem
-from cfme.containers.provider import refresh_and_navigate
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.wait import wait_for
@@ -82,7 +81,7 @@ def test_check_compliance(provider, random_image_instances, appliance):
 
 def get_table_attr(instance, table_name, attr):
     # Trying to read the table <table_name> attribute <attr>
-    view = refresh_and_navigate(instance, 'Details')
+    view = navigate_to(instance, 'Details', force=True)
     table = getattr(view.entities, table_name, None)
     if table:
         return table.read().get(attr)

--- a/cfme/tests/containers/test_labels.py
+++ b/cfme/tests/containers/test_labels.py
@@ -12,7 +12,6 @@ from cfme.containers.pod import PodCollection
 from cfme.containers.project import Project
 from cfme.containers.project import ProjectCollection
 from cfme.containers.provider import ContainersProvider
-from cfme.containers.provider import refresh_and_navigate
 from cfme.containers.replicator import Replicator
 from cfme.containers.replicator import ReplicatorCollection
 from cfme.containers.route import Route
@@ -21,6 +20,7 @@ from cfme.containers.service import Service
 from cfme.containers.service import ServiceCollection
 from cfme.containers.template import Template
 from cfme.containers.template import TemplateCollection
+from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import GH
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for
@@ -45,7 +45,7 @@ TEST_OBJECTS = (
 
 
 def check_labels_in_ui(instance, name, expected_value):
-    view = refresh_and_navigate(instance, 'Details')
+    view = navigate_to(instance, 'Details', force=True)
     if view.entities.labels.is_displayed:
         try:
             return view.entities.labels.get_text_of(name) == str(expected_value)

--- a/cfme/tests/containers/test_manageiq_ansible_custom_attributes.py
+++ b/cfme/tests/containers/test_manageiq_ansible_custom_attributes.py
@@ -1,7 +1,6 @@
 import pytest
 
 from cfme.containers.provider import ContainersProvider
-from cfme.containers.provider import refresh_and_navigate
 from cfme.utils.ansible import create_tmp_directory
 from cfme.utils.ansible import fetch_miq_ansible_module
 from cfme.utils.ansible import remove_tmp_files
@@ -41,8 +40,7 @@ def ansible_custom_attributes():
 
 
 def verify_custom_attributes(appliance, provider, custom_attributes_to_verify):
-    view = navigate_to(provider, 'Details')
-    appliance.server.browser.refresh()
+    view = navigate_to(provider, 'Details', force=True)
     assert view.entities.summary('Custom Attributes').is_displayed
     for custom_attribute in custom_attributes_to_verify:
         assert (
@@ -76,7 +74,7 @@ def test_manageiq_ansible_add_custom_attributes(appliance, ansible_custom_attrib
                          values_to_update=custom_attributes_to_add,
                          script_type='custom_attributes')
     run_ansible('remove_custom_attributes')
-    view = refresh_and_navigate(provider, 'Details')
+    view = navigate_to(provider, 'Details', force=True)
     assert not view.entities.summary('Custom Attributes').is_displayed
 
 
@@ -106,7 +104,7 @@ def test_manageiq_ansible_edit_custom_attributes(appliance, ansible_custom_attri
                          values_to_update=custom_attributes_to_edit,
                          script_type='custom_attributes')
     run_ansible('remove_custom_attributes')
-    view = refresh_and_navigate(provider, 'Details')
+    view = navigate_to(provider, 'Details', force=True)
     assert not view.entities.summary('Custom Attributes').is_displayed
 
 
@@ -139,7 +137,7 @@ def test_manageiq_ansible_add_custom_attributes_same_name(appliance, ansible_cus
                          values_to_update=custom_attributes_to_edit,
                          script_type='custom_attributes')
     run_ansible('remove_custom_attributes')
-    view = refresh_and_navigate(provider, 'Details')
+    view = navigate_to(provider, 'Details', force=True)
     assert not view.entities.summary('Custom Attributes').is_displayed
 
 
@@ -166,8 +164,7 @@ def test_manageiq_ansible_add_custom_attributes_bad_user(appliance, ansible_cust
                          script_type='custom_attributes')
     run_result = run_ansible('add_custom_attributes_bad_user')
     assert 'Authentication failed' in run_result
-    view = refresh_and_navigate(provider, 'Details')
-    appliance.server.browser.refresh()
+    view = navigate_to(provider, 'Details', force=True)
     assert not view.entities.summary('Custom Attributes').is_displayed
 
 
@@ -195,6 +192,5 @@ def test_manageiq_ansible_remove_custom_attributes(appliance, ansible_custom_att
                          values_to_update=custom_attributes_to_add,
                          script_type='custom_attributes')
     run_ansible('remove_custom_attributes')
-    view = refresh_and_navigate(provider, 'Details')
-    appliance.server.browser.refresh()
+    view = navigate_to(provider, 'Details', force=True)
     assert not view.entities.summary('Custom Attributes').is_displayed

--- a/cfme/tests/containers/test_provider_openscap_policy_attached.py
+++ b/cfme/tests/containers/test_provider_openscap_policy_attached.py
@@ -5,7 +5,6 @@ import dateparser
 import pytest
 
 from cfme.containers.provider import ContainersProvider
-from cfme.containers.provider import refresh_and_navigate
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.wait import wait_for
@@ -55,7 +54,7 @@ def openscap_assigned_rand_image(provider, random_image_instance):
 
 def get_table_attr(instance, table_name, attr):
     # Trying to read the table <table_name> attribute <attr>
-    view = refresh_and_navigate(instance, 'Details')
+    view = navigate_to(instance, 'Details', force=True)
     table = getattr(view.entities, table_name, None)
     if table:
         return table.read().get(attr)

--- a/cfme/tests/containers/test_ssa_set_cve_image_inspector_per_provider.py
+++ b/cfme/tests/containers/test_ssa_set_cve_image_inspector_per_provider.py
@@ -6,7 +6,6 @@ import pytest
 
 from cfme.common.provider_views import ContainerProvidersView
 from cfme.containers.provider import ContainersProvider
-from cfme.containers.provider import refresh_and_navigate
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.wait import wait_for
@@ -109,7 +108,7 @@ def set_image_inspector_registry(appliance, provider, soft_assert):
 
 def get_table_attr(instance, table_name, attr):
     # Trying to read the table <table_name> attribute <attr>
-    view = refresh_and_navigate(instance, 'Details')
+    view = navigate_to(instance, 'Details', force=True)
     table = getattr(view.entities, table_name, None)
     if table:
         return table.read().get(attr)

--- a/cfme/tests/containers/test_static_custom_attributes.py
+++ b/cfme/tests/containers/test_static_custom_attributes.py
@@ -9,8 +9,8 @@ import pytest
 from manageiq_client.api import APIException
 
 from cfme.containers.provider import ContainersProvider
-from cfme.containers.provider import refresh_and_navigate
 from cfme.containers.provider.openshift import CustomAttribute
+from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 
@@ -40,7 +40,7 @@ VALUE_UPDATES = ['2018-07-12', 'ADF231VRWQ1', '1']
 @pytest.fixture(scope='function')
 def add_delete_custom_attributes(provider):
     provider.add_custom_attributes(*ATTRIBUTES_DATASET)
-    view = refresh_and_navigate(provider, 'Details')
+    view = navigate_to(provider, 'Details', force=True)
     assert view.entities.summary('Custom Attributes').is_displayed
     yield
     try:
@@ -64,7 +64,7 @@ def test_add_static_custom_attributes(add_delete_custom_attributes, provider):
         initialEstimate: 1/6h
     """
 
-    view = refresh_and_navigate(provider, 'Details')
+    view = navigate_to(provider, 'Details', force=True)
     custom_attr_ui = view.entities.summary('Custom Attributes')
     for attr in ATTRIBUTES_DATASET:
         assert attr.name in custom_attr_ui.fields
@@ -93,7 +93,7 @@ def test_edit_static_custom_attributes(provider):
     for ii, value in enumerate(VALUE_UPDATES):
         edited_attribs[ii].value = value
     provider.edit_custom_attributes(*edited_attribs)
-    view = refresh_and_navigate(provider, 'Details')
+    view = navigate_to(provider, 'Details', force=True)
     custom_attr_ui = view.entities.summary('Custom Attributes')
     for attr in edited_attribs:
         assert attr.name in custom_attr_ui.fields
@@ -118,7 +118,7 @@ def test_delete_static_custom_attributes(add_delete_custom_attributes, request, 
     """
 
     provider.delete_custom_attributes(*ATTRIBUTES_DATASET)
-    view = refresh_and_navigate(provider, 'Details')
+    view = navigate_to(provider, 'Details', force=True)
     if view.entities.summary('Custom Attributes').is_displayed:
         for attr in ATTRIBUTES_DATASET:
             assert attr.name not in view.entities.summary('Custom Attributes').fields
@@ -165,7 +165,7 @@ def test_add_attribute_with_empty_name(provider):
         )
         pytest.fail('You have added custom attribute with empty name'
                     'and didn\'t get an error!')
-    view = refresh_and_navigate(provider, 'Details')
+    view = navigate_to(provider, 'Details', force=True)
     if view.entities.summary('Custom Attributes').is_displayed:
         assert "" not in view.entities.summary('Custom Attributes').fields
 
@@ -185,7 +185,7 @@ def test_add_date_attr_with_wrong_value(provider):
         pytest.fail('You have added custom attribute of type'
                     '{} with value of {} and didn\'t get an error!'
                     .format(ca.field_type, ca.value))
-    view = refresh_and_navigate(provider, 'Details')
+    view = navigate_to(provider, 'Details', force=True)
     if view.entities.summary('Custom Attributes').is_displayed:
         assert 'nondate' not in view.entities.summary('Custom Attributes').fields
 
@@ -267,7 +267,7 @@ def test_very_long_name_with_special_characters(request, provider):
     ca = CustomAttribute(get_random_string(1000), 'very_long_name', None)
     request.addfinalizer(lambda: provider.delete_custom_attributes(ca))
     provider.add_custom_attributes(ca)
-    view = refresh_and_navigate(provider, 'Details')
+    view = navigate_to(provider, 'Details', force=True)
     assert ca.name in view.entities.summary('Custom Attributes').fields
 
 
@@ -283,5 +283,5 @@ def test_very_long_value_with_special_characters(request, provider):
     ca = CustomAttribute('very long value', get_random_string(1000), None)
     request.addfinalizer(lambda: provider.delete_custom_attributes(ca))
     provider.add_custom_attributes(ca)
-    view = refresh_and_navigate(provider, 'Details')
+    view = navigate_to(provider, 'Details', force=True)
     assert ca.value == view.entities.summary('Custom Attributes').get_text_of(ca.name)

--- a/cfme/utils/appliance/implementations/ssui.py
+++ b/cfme/utils/appliance/implementations/ssui.py
@@ -140,7 +140,7 @@ class SSUINavigateStep(NavigateStep):
         )
 
     def go(self, _tries=0, *args, **kwargs):
-        nav_args = {'use_resetter': True, 'wait_for_view': 10}
+        nav_args = {'use_resetter': True, 'wait_for_view': 10, 'force_nav': False}
 
         self.log_message("Beginning SUI Navigation...", level="info")
         start_time = time.time()
@@ -169,7 +169,7 @@ class SSUINavigateStep(NavigateStep):
             self.log_message(
                 "Exception raised [{}] whilst checking if already here".format(e), level="error")
 
-        if not here:
+        if not here or nav_args['force_nav']:
             self.log_message("Prerequisite Needed")
             self.prerequisite_view = self.prerequisite()
             self.do_nav(_tries, *args, **kwargs)

--- a/cfme/utils/appliance/implementations/ui.py
+++ b/cfme/utils/appliance/implementations/ui.py
@@ -521,7 +521,7 @@ class CFMENavigateStep(NavigateStep):
         )
 
     def go(self, _tries=0, *args, **kwargs):
-        nav_args = {'use_resetter': True, 'wait_for_view': 10}
+        nav_args = {'use_resetter': True, 'wait_for_view': 10, 'force_nav': False}
         self.log_message("Beginning Navigation...", level="info")
         start_time = time.time()
         if _tries > 2:
@@ -547,7 +547,7 @@ class CFMENavigateStep(NavigateStep):
         except Exception as e:
             self.log_message(
                 "Exception raised [{}] whilst checking if already here".format(e), level="error")
-        if not here:
+        if not here or nav_args['force_nav']:
             self.log_message("Prerequisite Needed")
             self.prerequisite_view = self.prerequisite()
             try:

--- a/cfme/utils/appliance/implementations/ui.py
+++ b/cfme/utils/appliance/implementations/ui.py
@@ -511,17 +511,19 @@ class CFMENavigateStep(NavigateStep):
         str_msg = "[UI-NAV/{}/{}]: {}".format(class_name, self._name, msg)
         getattr(logger, level)(str_msg)
 
-    def construct_message(self, here, resetter, view, duration, waited):
+    def construct_message(self, here, resetter, view, duration, waited, force):
         str_here = "Already Here" if here else "Needed Navigation"
         str_resetter = "Resetter Used" if resetter else "No Resetter"
         str_view = "View Returned" if view else "No View Available"
         str_waited = "Waited on View" if waited else "No Wait on View"
-        return "{}/{}/{}/{} (elapsed {}ms)".format(
-            str_here, str_resetter, str_view, str_waited, duration
+        str_force = "Force Navigation Used" if force else "Navigation Not Forced"
+        return "{here}/{resetter}/{view}/{waited}/{force} (elapsed {duration}ms)".format(
+            here=str_here, resetter=str_resetter, view=str_view, waited=str_waited,
+            force=str_force, duration=duration
         )
 
     def go(self, _tries=0, *args, **kwargs):
-        nav_args = {'use_resetter': True, 'wait_for_view': 10, 'force_nav': False}
+        nav_args = {'use_resetter': True, 'wait_for_view': 10, 'force': False}
         self.log_message("Beginning Navigation...", level="info")
         start_time = time.time()
         if _tries > 2:
@@ -538,6 +540,7 @@ class CFMENavigateStep(NavigateStep):
         here = False
         resetter_used = False
         waited = False
+        force_used = False
         try:
             here = self.check_for_badness(self.am_i_here, _tries, nav_args, *args, **kwargs)
         except NotImplementedError:
@@ -547,7 +550,9 @@ class CFMENavigateStep(NavigateStep):
         except Exception as e:
             self.log_message(
                 "Exception raised [{}] whilst checking if already here".format(e), level="error")
-        if not here or nav_args['force_nav']:
+        if not here or nav_args['force']:
+            if nav_args['force']:
+                force_used = True
             self.log_message("Prerequisite Needed")
             self.prerequisite_view = self.prerequisite()
             try:
@@ -573,7 +578,8 @@ class CFMENavigateStep(NavigateStep):
                 message="Waiting for view [{}] to display".format(view.__class__.__name__)
             )
         self.log_message(
-            self.construct_message(here, resetter_used, view, duration, waited), level="info"
+            self.construct_message(here, resetter_used, view, duration, waited, force_used),
+            level="info"
         )
         return view
 


### PR DESCRIPTION
Add a new nav_arg, force_nav, to force navigate to a view. 

{{ pytest: cfme/tests/containers/test_cockpit.py cfme/tests/containers/test_labels.py cfme/tests/containers/test_manageiq_ansible_custom_attributes.py cfme/tests/containers/test_static_custom_attributes.py --use-provider ocp-39-hawk }}