### PR TITLE
[1LP][RFR] remove automate_menu_name

### DIFF
--- a/cfme/automate/__init__.py
+++ b/cfme/automate/__init__.py
@@ -6,7 +6,6 @@ from widgetastic_patternfly import Button, Dropdown, Input
 
 from cfme.base import Server
 from cfme.base.login import BaseLoggedInPage
-from cfme.base.ui import automate_menu_name
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep
 
 
@@ -16,8 +15,8 @@ class AutomateCustomizationView(BaseLoggedInPage):
     def in_customization(self):
         return (
             self.logged_in_as_current_user and
-            self.navigation.currently_selected == automate_menu_name(
-                self.context['object'].appliance) + ['Customization'])
+            self.navigation.currently_selected == ["Automation", "Automate", "Customization"]
+        )
 
     @property
     def is_displayed(self):
@@ -54,7 +53,7 @@ class AutomateCustomization(CFMENavigateStep):
     prerequisite = NavigateToSibling('LoggedIn')
 
     def step(self, *args, **kwargs):
-        self.view.navigation.select(*automate_menu_name(self.obj.appliance) + ['Customization'])
+        self.view.navigation.select(*["Automation", "Automate", "Customization"])
 
 
 class DialogForm(AutomateCustomizationView):

--- a/cfme/automate/dialogs/__init__.py
+++ b/cfme/automate/dialogs/__init__.py
@@ -4,7 +4,6 @@ from widgetastic_manageiq import Accordion, ManageIQTree, DialogButton, DragandD
 from widgetastic_patternfly import Button, Dropdown, Input
 
 from cfme.base.login import BaseLoggedInPage
-from cfme.base.ui import automate_menu_name
 
 
 class AutomateCustomizationView(BaseLoggedInPage):
@@ -12,8 +11,8 @@ class AutomateCustomizationView(BaseLoggedInPage):
     def in_customization(self):
         return (
             self.logged_in_as_current_user and
-            self.navigation.currently_selected == automate_menu_name(
-                self.context['object'].appliance) + ['Customization'])
+            self.navigation.currently_selected == ["Automation", "Automate", "Customization"]
+        )
 
     @property
     def is_displayed(self):

--- a/cfme/automate/explorer/__init__.py
+++ b/cfme/automate/explorer/__init__.py
@@ -6,7 +6,6 @@ from widgetastic_patternfly import Dropdown
 
 from cfme.base import Server
 from cfme.base.login import BaseLoggedInPage
-from cfme.base.ui import automate_menu_name
 from cfme.utils.appliance.implementations.ui import navigator, CFMENavigateStep
 from widgetastic_manageiq import Accordion, ManageIQTree, Splitter
 
@@ -16,8 +15,8 @@ class AutomateExplorerView(BaseLoggedInPage):
     def in_explorer(self):
         return (
             self.logged_in_as_current_user and
-            self.navigation.currently_selected == automate_menu_name(
-                self.context['object'].appliance) + ['Explorer'])
+            self.navigation.currently_selected == ["Automation", "Automate", "Explorer"]
+        )
 
     @property
     def is_displayed(self):
@@ -37,7 +36,7 @@ class AutomateExplorer(CFMENavigateStep):
     prerequisite = NavigateToSibling('LoggedIn')
 
     def step(self, *args, **kwargs):
-        self.view.navigation.select(*automate_menu_name(self.obj.appliance) + ['Explorer'])
+        self.view.navigation.select(*["Automation", "Automate", "Explorer"])
 
 
 def check_tree_path(actual, desired, partial=False):

--- a/cfme/automate/provisioning_dialogs.py
+++ b/cfme/automate/provisioning_dialogs.py
@@ -7,7 +7,6 @@ from widgetastic_patternfly import Dropdown, BootstrapSelect, CandidateNotFound
 from widgetastic_manageiq import Button, Table, PaginationPane, SummaryForm, ScriptBox
 
 from cfme.base.login import BaseLoggedInPage
-from cfme.base.ui import automate_menu_name
 from cfme.modeling.base import BaseCollection, BaseEntity
 from cfme.utils.appliance.implementations.ui import navigator, navigate_to, CFMENavigateStep
 from cfme.utils.pretty import Pretty
@@ -48,11 +47,10 @@ class ProvDiagForm(View):
 class ProvDiagView(BaseLoggedInPage):
     @property
     def in_customization(self):
-        expected_navigation = automate_menu_name(self.context['object'].appliance)
-        expected_navigation.append('Customization')
         return (
             self.logged_in_as_current_user and
-            self.navigation.currently_selected == expected_navigation)
+            self.navigation.currently_selected == ["Automation", "Automate", "Customization"]
+        )
 
     # sidebar are the same on all, details, etc
     sidebar = View.nested(AutomateCustomizationView)

--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -305,13 +305,6 @@ def group_names(self):
     return view.group_names if view.logged_in else None
 
 
-def automate_menu_name(appliance):
-    if appliance.version < '5.8':
-        return ['Automate']
-    else:
-        return ['Automation', 'Automate']
-
-
 # ######################## SERVER NAVS ################################
 
 @navigator.register(Server)
@@ -1626,8 +1619,8 @@ class AutomateSimulationView(BaseLoggedInPage):
     def is_displayed(self):
         return (
             self.logged_in_as_current_user and
-            self.navigation.currently_selected == automate_menu_name(
-                self.context['object'].appliance) + ['Simulation'])
+            self.navigation.currently_selected == ["Automation", "Automate", "Simulation"]
+        )
 
     instance = BootstrapSelect('instance_name')
     message = Input(name='object_message')
@@ -1650,8 +1643,7 @@ class AutomateSimulation(CFMENavigateStep):
     prerequisite = NavigateToSibling('LoggedIn')
 
     def step(self, *args, **kwargs):
-        self.prerequisite_view.navigation.select(
-            *automate_menu_name(self.obj.appliance) + ['Simulation'])
+        self.prerequisite_view.navigation.select(*["Automation", "Automate", "Simulation"])
 
 
 class AutomateImportExportBaseView(BaseLoggedInPage):
@@ -1664,9 +1656,9 @@ class AutomateImportExportBaseView(BaseLoggedInPage):
     def in_import_export(self):
         return (
             self.logged_in_as_current_user and
-            self.navigation.currently_selected == automate_menu_name(
-                self.context['object'].appliance) + ['Import / Export'] and
-            self.title.text == 'Import / Export')
+            self.navigation.currently_selected == ["Automation", "Automate", "Import / Export"] and
+            self.title.text == "Import / Export"
+        )
 
     @property
     def is_displayed(self):
@@ -1708,5 +1700,4 @@ class AutomateImportExport(CFMENavigateStep):
     prerequisite = NavigateToSibling('LoggedIn')
 
     def step(self, *args, **kwargs):
-        self.prerequisite_view.navigation.select(
-            *automate_menu_name(self.obj.appliance) + ['Import / Export'])
+        self.prerequisite_view.navigation.select(*["Automation", "Automate", "Import / Export"])


### PR DESCRIPTION
Signed-off-by: Nikhil Dhandre <ndhandre@redhat.com>

Purpose or Intent
=================
-  removed `automate_menu_name` which was used for navigation tree selection related to automate


{{pytest: cfme/tests/automate/ -k "test_class_crud or test_paginator or test_domain_crud or test_automate_git_domain_removed_from_disk or test_instance_crud or test_method_crud or test_namespace_crud or test_provisioning_dialog_crud or test_crud_service_dialog" -vv}}