### PR TITLE
[1LP][RFR] Adding global fixtures and formatting tests according to it

### DIFF
--- a/cfme/automate/explorer/klass.py
+++ b/cfme/automate/explorer/klass.py
@@ -72,12 +72,9 @@ class ClassDetailsView(AutomateExplorerView):
             self.in_explorer and
             self.title.text == 'Automate Class "{}"'.format(
                 self.context['object'].display_name or self.context['object'].name) and
-            self.datastore.is_opened and (
-                BZ(1611969, forced_streams=['5.10']).blocks or
-                check_tree_path(
-                    self.datastore.tree.currently_selected,
-                    self.context['object'].tree_path)
-            )
+            self.datastore.is_opened and
+            check_tree_path(self.datastore.tree.currently_selected,
+                            self.context['object'].tree_path, partial=True)
         )
 
 

--- a/cfme/fixtures/automate.py
+++ b/cfme/fixtures/automate.py
@@ -1,0 +1,32 @@
+import fauxfactory
+import pytest
+
+
+@pytest.fixture(scope='module')
+def domain(appliance):
+    """This fixture used to create automate domain - Datastore/Domain"""
+    domain = appliance.collections.domains.create(
+        name=fauxfactory.gen_alpha(),
+        description=fauxfactory.gen_alpha(),
+        enabled=True)
+    yield domain
+    domain.delete_if_exists()
+
+
+@pytest.fixture(scope="module")
+def namespace(domain):
+    """This fixture used to create automate namespace - Datastore/Domain/Namespace"""
+    yield domain.namespaces.create(
+        name=fauxfactory.gen_alpha(),
+        description=fauxfactory.gen_alpha()
+    )
+
+
+@pytest.fixture(scope="module")
+def klass(namespace):
+    """This fixture used to create automate class - Datastore/Domain/Namespace/Class"""
+    yield namespace.classes.create(
+        name=fauxfactory.gen_alpha(),
+        display_name=fauxfactory.gen_alpha(),
+        description=fauxfactory.gen_alpha()
+    )

--- a/cfme/fixtures/automate.py
+++ b/cfme/fixtures/automate.py
@@ -16,17 +16,21 @@ def domain(appliance):
 @pytest.fixture(scope="module")
 def namespace(domain):
     """This fixture used to create automate namespace - Datastore/Domain/Namespace"""
-    yield domain.namespaces.create(
+    namespace = domain.namespaces.create(
         name=fauxfactory.gen_alpha(),
         description=fauxfactory.gen_alpha()
     )
+    yield namespace
+    namespace.delete_if_exists()
 
 
 @pytest.fixture(scope="module")
 def klass(namespace):
     """This fixture used to create automate class - Datastore/Domain/Namespace/Class"""
-    yield namespace.classes.create(
+    klass = namespace.classes.create(
         name=fauxfactory.gen_alpha(),
         display_name=fauxfactory.gen_alpha(),
         description=fauxfactory.gen_alpha()
     )
+    yield klass
+    klass.delete_if_exists()

--- a/cfme/test_framework/pytest_plugin.py
+++ b/cfme/test_framework/pytest_plugin.py
@@ -106,6 +106,7 @@ pytest_plugins = (
     'cfme.fixtures.v2v',
     'cfme.fixtures.networks',
     'cfme.fixtures.nuage',
+    'cfme.fixtures.automate',
 
     'cfme.metaplugins',
 )

--- a/cfme/tests/automate/test_class.py
+++ b/cfme/tests/automate/test_class.py
@@ -36,8 +36,7 @@ def test_class_crud(get_namespace):
         initialEstimate: 1/30h
         tags: automate
     """
-    namespace = get_namespace
-    a_class = namespace.classes.create(
+    a_class = get_namespace.classes.create(
         name=fauxfactory.gen_alphanumeric(),
         display_name=fauxfactory.gen_alphanumeric(),
         description=fauxfactory.gen_alphanumeric()
@@ -62,8 +61,7 @@ def test_schema_crud(get_namespace):
         initialEstimate: 1/20h
         tags: automate
     """
-    namespace = get_namespace
-    a_class = namespace.classes.create(
+    a_class = get_namespace.classes.create(
         name=fauxfactory.gen_alphanumeric(),
         display_name=fauxfactory.gen_alphanumeric(),
         description=fauxfactory.gen_alphanumeric()
@@ -106,11 +104,10 @@ def test_duplicate_class_disallowed(get_namespace):
         initialEstimate: 1/30h
         tags: automate
     """
-    namespace = get_namespace
     name = fauxfactory.gen_alphanumeric()
-    namespace.classes.create(name=name)
+    get_namespace.classes.create(name=name)
     with pytest.raises(Exception, match="Name has already been taken"):
-        namespace.classes.create(name=name)
+        get_namespace.classes.create(name=name)
 
 
 @pytest.mark.tier(2)
@@ -159,8 +156,7 @@ def test_class_display_name_unset_from_ui(get_namespace):
         initialEstimate: 1/30h
         tags: automate
     """
-    namespace = get_namespace
-    a_class = namespace.classes.create(
+    a_class = get_namespace.classes.create(
         name=fauxfactory.gen_alphanumeric(),
         display_name=fauxfactory.gen_alphanumeric(),
         description=fauxfactory.gen_alphanumeric()

--- a/cfme/tests/automate/test_class.py
+++ b/cfme/tests/automate/test_class.py
@@ -12,17 +12,19 @@ pytestmark = [test_requirements.automate]
     scope="function",
     params=["plain", "nested_existing"])
 def get_namespace(request, domain):
-    ns = domain.namespaces.create(
+    namespace = domain.namespaces.create(
         name=fauxfactory.gen_alpha(),
         description=fauxfactory.gen_alpha()
     )
     if request.param == 'plain':
-        return ns
+        yield namespace
     else:
-        return ns.namespaces.create(
+        namespace = namespace.namespaces.create(
             name=fauxfactory.gen_alpha(),
             description=fauxfactory.gen_alpha()
         )
+        yield namespace
+    namespace.delete_if_exists()
 
 
 @pytest.mark.sauce

--- a/cfme/tests/automate/test_domain.py
+++ b/cfme/tests/automate/test_domain.py
@@ -46,7 +46,7 @@ def test_domain_crud(request, enabled, appliance):
 
 
 @pytest.mark.tier(1)
-def test_domain_edit_enabled(request, appliance):
+def test_domain_edit_enabled(domain, appliance):
     """
     Polarion:
         assignee: ghubale
@@ -55,11 +55,6 @@ def test_domain_edit_enabled(request, appliance):
         caseimportance: high
         tags: automate
     """
-    domain = appliance.collections.domains.create(
-        name=fauxfactory.gen_alpha(),
-        description=fauxfactory.gen_alpha(),
-        enabled=True)
-    request.addfinalizer(domain.delete_if_exists)
     assert domain.exists
     view = navigate_to(domain, 'Details')
     assert 'Disabled' not in view.title.text
@@ -115,7 +110,7 @@ def test_domain_delete_from_table(request, appliance):
 
 
 @pytest.mark.tier(2)
-def test_duplicate_domain_disallowed(request, appliance):
+def test_duplicate_domain_disallowed(domain, appliance):
     """
     Polarion:
         assignee: ghubale
@@ -125,11 +120,7 @@ def test_duplicate_domain_disallowed(request, appliance):
         initialEstimate: 1/60h
         tags: automate
     """
-    domain = appliance.collections.domains.create(
-        name=fauxfactory.gen_alpha(),
-        description=fauxfactory.gen_alpha(),
-        enabled=True)
-    request.addfinalizer(domain.delete_if_exists)
+    assert domain.exists
     with pytest.raises(Exception, match="Name has already been taken"):
         appliance.collections.domains.create(
             name=domain.name,
@@ -187,7 +178,7 @@ def test_domain_name_wrong(appliance):
 
 
 @pytest.mark.tier(2)
-def test_domain_lock_unlock(request, appliance):
+def test_domain_lock_unlock(domain, appliance):
     """
     Polarion:
         assignee: ghubale
@@ -196,12 +187,6 @@ def test_domain_lock_unlock(request, appliance):
         caseimportance: medium
         tags: automate
     """
-    domain = appliance.collections.domains.create(
-        name=fauxfactory.gen_alpha(),
-        description=fauxfactory.gen_alpha(),
-        enabled=True)
-
-    request.addfinalizer(domain.delete)
     ns1 = domain.namespaces.create(name='ns1')
     ns2 = ns1.namespaces.create(name='ns2')
     cls = ns2.classes.create(name='class1')

--- a/cfme/tests/automate/test_domain.py
+++ b/cfme/tests/automate/test_domain.py
@@ -187,6 +187,7 @@ def test_domain_lock_unlock(domain, appliance):
         caseimportance: medium
         tags: automate
     """
+    assert domain.exists
     ns1 = domain.namespaces.create(name='ns1')
     ns2 = ns1.namespaces.create(name='ns2')
     cls = ns2.classes.create(name='class1')

--- a/cfme/tests/automate/test_instance.py
+++ b/cfme/tests/automate/test_instance.py
@@ -3,39 +3,10 @@ import fauxfactory
 import pytest
 
 from cfme import test_requirements
-from cfme.automate.explorer.domain import DomainCollection
 from cfme.automate.simulation import simulate
 from cfme.utils.update import update
 
 pytestmark = [test_requirements.automate]
-
-
-@pytest.fixture(scope='module')
-def domain(appliance):
-    dc = DomainCollection(appliance)
-    d = dc.create(
-        name='test_{}'.format(fauxfactory.gen_alpha()),
-        description='desc_{}'.format(fauxfactory.gen_alpha()),
-        enabled=True)
-    yield d
-    d.delete()
-
-
-@pytest.fixture(scope="module")
-def namespace(request, domain):
-    return domain.namespaces.create(
-        name=fauxfactory.gen_alpha(),
-        description=fauxfactory.gen_alpha()
-    )
-
-
-@pytest.fixture(scope="module")
-def klass(request, namespace):
-    return namespace.classes.create(
-        name=fauxfactory.gen_alpha(),
-        display_name=fauxfactory.gen_alpha(),
-        description=fauxfactory.gen_alpha()
-    )
 
 
 @pytest.mark.sauce
@@ -66,7 +37,7 @@ def test_instance_crud(klass):
 
 @pytest.mark.tier(2)
 @pytest.mark.polarion('RHCF3-20871')
-def test_duplicate_instance_disallowed(request, klass):
+def test_duplicate_instance_disallowed(klass):
     """
     Polarion:
         assignee: ghubale
@@ -84,7 +55,7 @@ def test_duplicate_instance_disallowed(request, klass):
 
 @pytest.mark.tier(3)
 @pytest.mark.polarion('RHCF3-20872')
-def test_instance_display_name_unset_from_ui(request, klass):
+def test_instance_display_name_unset_from_ui(klass):
     """
     Polarion:
         assignee: ghubale

--- a/cfme/tests/automate/test_method.py
+++ b/cfme/tests/automate/test_method.py
@@ -3,40 +3,11 @@ import fauxfactory
 import pytest
 
 from cfme import test_requirements
-from cfme.automate.explorer.domain import DomainCollection
 from cfme.automate.explorer.klass import ClassDetailsView
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.update import update
 
 pytestmark = [test_requirements.automate]
-
-
-@pytest.fixture(scope='module')
-def domain(appliance):
-    dc = DomainCollection(appliance)
-    d = dc.create(
-        name='test_{}'.format(fauxfactory.gen_alpha()),
-        description='desc_{}'.format(fauxfactory.gen_alpha()),
-        enabled=True)
-    yield d
-    d.delete()
-
-
-@pytest.fixture(scope="module")
-def namespace(domain):
-    return domain.namespaces.create(
-        name=fauxfactory.gen_alpha(),
-        description=fauxfactory.gen_alpha()
-    )
-
-
-@pytest.fixture(scope="module")
-def klass(namespace):
-    return namespace.classes.create(
-        name=fauxfactory.gen_alpha(),
-        display_name=fauxfactory.gen_alpha(),
-        description=fauxfactory.gen_alpha()
-    )
 
 
 @pytest.mark.sauce
@@ -113,7 +84,7 @@ def test_automate_method_inputs_crud(appliance, klass):
 
 
 @pytest.mark.tier(2)
-def test_duplicate_method_disallowed(request, klass):
+def test_duplicate_method_disallowed(klass):
     """
     Polarion:
         assignee: ghubale

--- a/cfme/tests/automate/test_namespace.py
+++ b/cfme/tests/automate/test_namespace.py
@@ -2,19 +2,10 @@
 import fauxfactory
 import pytest
 
-from cfme.automate.explorer.domain import DomainCollection
+from cfme import test_requirements
 from cfme.utils.update import update
 
-
-@pytest.fixture(scope='module')
-def domain(appliance):
-    dc = DomainCollection(appliance)
-    d = dc.create(
-        name='test_{}'.format(fauxfactory.gen_alpha()),
-        description='desc_{}'.format(fauxfactory.gen_alpha()),
-        enabled=True)
-    yield d
-    d.delete()
+pytestmark = [test_requirements.automate]
 
 
 @pytest.fixture(
@@ -32,7 +23,7 @@ def parent_namespace(request, domain):
 
 @pytest.mark.sauce
 @pytest.mark.tier(1)
-def test_namespace_crud(request, parent_namespace):
+def test_namespace_crud(parent_namespace):
     """
     Polarion:
         assignee: ghubale
@@ -56,7 +47,7 @@ def test_namespace_crud(request, parent_namespace):
 
 
 @pytest.mark.tier(1)
-def test_namespace_delete_from_table(request, parent_namespace):
+def test_namespace_delete_from_table(parent_namespace):
     """
     Polarion:
         assignee: ghubale
@@ -78,7 +69,7 @@ def test_namespace_delete_from_table(request, parent_namespace):
 
 
 @pytest.mark.tier(2)
-def test_duplicate_namespace_disallowed(request, parent_namespace):
+def test_duplicate_namespace_disallowed(parent_namespace):
     """
     Polarion:
         assignee: ghubale

--- a/cfme/tests/automate/test_smoke.py
+++ b/cfme/tests/automate/test_smoke.py
@@ -3,7 +3,6 @@
 import pytest
 
 from cfme import test_requirements
-from cfme.automate.explorer.domain import DomainCollection
 
 pytestmark = [
     test_requirements.automate,
@@ -30,8 +29,7 @@ def test_domain_present(domain_name, soft_assert, appliance):
             2. Open the Automate Explorer.
             3. Verify that all of the required domains are present.
     """
-    dc = DomainCollection(appliance)
-    domain = dc.instantiate(name=domain_name)
+    domain = appliance.collections.domains.instantiate(name=domain_name)
     soft_assert(domain.exists, "Domain {} does not exist!".format(domain_name))
     soft_assert(domain.locked, "Domain {} is not locked!".format(domain_name))
     soft_assert(

--- a/cfme/tests/automate/test_vmware_methods.py
+++ b/cfme/tests/automate/test_vmware_methods.py
@@ -70,8 +70,8 @@ def testing_vm(setup_provider, provider):
 
 def test_vmware_vimapi_hotadd_disk(
         appliance, request, testing_group, testing_vm, domain, cls):
-    """Tests hot adding a disk to vmware vm. This test exercises the ``VMware_HotAdd_Disk`` method,
-       located in ``/Integration/VMware/VimApi``
+    """Tests hot adding a disk to vmware vm. This test exercises the `VMware_HotAdd_Disk` method,
+       located in `/Integration/VMware/VimApi`
 
     Polarion:
         assignee: ghubale

--- a/cfme/tests/automate/test_vmware_methods.py
+++ b/cfme/tests/automate/test_vmware_methods.py
@@ -8,10 +8,8 @@ from widgetastic.widget import View
 from widgetastic_patternfly import Dropdown
 
 from cfme import test_requirements
-from cfme.automate.explorer.domain import DomainCollection
 from cfme.base.login import BaseLoggedInPage
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
-from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for
@@ -29,20 +27,7 @@ pytestmark = [
 
 
 @pytest.fixture(scope="module")
-def domain_collection(appliance):
-    return DomainCollection(appliance)
-
-
-@pytest.fixture(scope="module")
-def domain(request, domain_collection):
-    domain = domain_collection.create(name=fauxfactory.gen_alphanumeric(), enabled=True)
-    yield domain
-    if domain.exists:
-        domain.delete()
-
-
-@pytest.fixture(scope="module")
-def cls(request, domain):
+def cls(domain):
     original_class = domain.parent\
         .instantiate(name='ManageIQ')\
         .namespaces.instantiate(name='System')\
@@ -52,7 +37,7 @@ def cls(request, domain):
 
 
 @pytest.fixture(scope="module")
-def testing_group(appliance, request):
+def testing_group(appliance):
     group_desc = fauxfactory.gen_alphanumeric()
     group = appliance.collections.button_groups.create(
         text=group_desc,
@@ -83,11 +68,10 @@ def testing_vm(setup_provider, provider):
         vm.cleanup_on_provider()
 
 
-@pytest.mark.meta(blockers=[1211627, BZ(1311221, forced_streams=['5.5'])])
 def test_vmware_vimapi_hotadd_disk(
-        appliance, request, testing_group, provider, testing_vm, domain, cls):
-    """ Tests hot adding a disk to vmware vm.
-    This test exercises the ``VMware_HotAdd_Disk`` method, located in ``/Integration/VMware/VimApi``
+        appliance, request, testing_group, testing_vm, domain, cls):
+    """Tests hot adding a disk to vmware vm. This test exercises the ``VMware_HotAdd_Disk`` method,
+       located in ``/Integration/VMware/VimApi``
 
     Polarion:
         assignee: ghubale
@@ -101,6 +85,9 @@ def test_vmware_vimapi_hotadd_disk(
                The button shall belong in the VM and instance button group.
             3. After the button is created, it goes to a VM's summary page, clicks the button.
             4. The test waits until the capacity of disks is raised.
+
+    Bugzillas:
+        1211627, 1311221
     """
     meth = cls.methods.create(
         name='load_value_{}'.format(fauxfactory.gen_alpha()),


### PR DESCRIPTION
- Added global fixtures for automate
    - ```domain``` : This fixture used to create automate domain - Datastore/Domain
    - ```namespace```: This fixture used to create automate namespace - Datastore/Domain/Namespace
    - ```class```: This fixture used to create automate class - Datastore/Domain/Namespace/Class
- Removed deprecated code from tests
- Removed less than ```5.9``` dependency
- Used global fixtures in automate tests

Note: Running the test cases which uses newly added global fixtures
 
{{ pytest: cfme/tests/automate/ -k "test_duplicate_domain_disallowed or test_domain_edit_enabled or test_class_crud or test_schema_crud or test_schema_duplicate_field_disallowed or test_duplicate_class_disallowed or test_same_class_name_different_namespace or test_class_display_name_unset_from_ui or test_duplicate_instance_disallowed or test_instance_display_name_unset_from_ui or test_namespace_crud or test_namespace_delete_from_table or test_duplicate_namespace_disallowed or test_domain_present or test_vmware_vimapi_hotadd_disk" -vvv --long-running }}