### PR TITLE
[1LP][RFR] This PR updates files for global fixture and removes depricated arguments

### DIFF
--- a/cfme/tests/cloud/test_quota.py
+++ b/cfme/tests/cloud/test_quota.py
@@ -190,6 +190,7 @@ def test_child_tenant_quota_enforce_via_lifecycle_cloud(
         casecomponent: Cloud
         caseimportance: high
         initialEstimate: 1/8h
+        tags: quota
         testSteps:
             1. Create a child tenant
             2. Assign quota to child tenant
@@ -261,6 +262,7 @@ def test_project_quota_enforce_via_lifecycle_cloud(
         casecomponent: Cloud
         caseimportance: high
         initialEstimate: 1/8h
+        tags: quota
         testSteps:
             1. Create a project
             2. Assign quota to project

--- a/cfme/tests/cloud/test_tenant.py
+++ b/cfme/tests/cloud/test_tenant.py
@@ -26,7 +26,6 @@ def tenant(provider, setup_provider, appliance):
             provider.mgmt.remove_tenant(tenant.name)
 
 
-@pytest.mark.meta(blockers=[BZ(1462137, forced_streams=["5.9", "5.8"])])
 def test_tenant_crud(tenant):
     """ Tests tenant create and delete
 

--- a/cfme/tests/cloud/test_tenant_quota.py
+++ b/cfme/tests/cloud/test_tenant_quota.py
@@ -12,6 +12,7 @@ from cfme.utils.generators import random_vm_name
 
 pytestmark = [
     test_requirements.quota,
+    pytest.mark.usefixtures('setup_provider'),
     pytest.mark.provider([OpenStackProvider], required_fields=[['provisioning', 'image']],
                          scope="module")]
 
@@ -110,22 +111,24 @@ def catalog_item(appliance, provider, provisioning, template_name, dialog, catal
     indirect=['set_roottenant_quota'],
     ids=['max_cpu', 'max_storage', 'max_memory', 'max_vms']
 )
-def test_tenant_quota_enforce_via_lifecycle_cloud(request, appliance, provider, setup_provider,
-                                            set_roottenant_quota, extra_msg, custom_prov_data,
-                                            approve, prov_data, vm_name, template_name):
+def test_tenant_quota_enforce_via_lifecycle_cloud(request, appliance, provider,
+                                                  set_roottenant_quota, extra_msg, custom_prov_data,
+                                                  approve, prov_data, vm_name, template_name):
     """Test Tenant Quota in UI
 
     Polarion:
         assignee: ghubale
         casecomponent: Cloud
         initialEstimate: 1/10h
+        tags: quota
     """
     prov_data.update(custom_prov_data)
     prov_data['catalog']['vm_name'] = vm_name
     prov_data.update({
         'request': {'email': 'test_{}@example.com'.format(fauxfactory.gen_alphanumeric())}})
     prov_data.update({'template_name': template_name})
-    request_description = 'Provision from [{}] to [{}{}]'.format(template_name, vm_name, extra_msg)
+    request_description = 'Provision from [{template}] to [{vm}{msg}]'.format(
+        template=template_name, vm=vm_name, msg=extra_msg)
     appliance.collections.cloud_instances.create(vm_name, provider, prov_data, auto_approve=approve,
                                                  override=True,
                                                  request_description=request_description)
@@ -154,16 +157,16 @@ def test_tenant_quota_enforce_via_lifecycle_cloud(request, appliance, provider, 
     indirect=['set_roottenant_quota', 'custom_prov_data', 'set_default'],
     ids=['max_cpu', 'max_storage', 'max_memory', 'max_vms']
 )
-def test_tenant_quota_enforce_via_service_cloud(request, appliance, provider, setup_provider,
-                                                context, set_roottenant_quota, set_default,
-                                                custom_prov_data, extra_msg, template_name,
-                                                catalog_item):
+def test_tenant_quota_enforce_via_service_cloud(request, appliance, context, set_roottenant_quota,
+                                                set_default, custom_prov_data, extra_msg,
+                                                template_name, catalog_item):
     """Test Tenant Quota in UI and SSUI
 
     Polarion:
         assignee: ghubale
         casecomponent: Cloud
         initialEstimate: 1/10h
+        tags: quota
     """
     with appliance.context.use(context):
         service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
@@ -211,6 +214,7 @@ def test_service_cloud_tenant_quota_with_default_entry_point(request, appliance,
         casecomponent: Cloud
         caseimportance: medium
         initialEstimate: 1/12h
+        tags: quota
         testSteps:
             1. Add cloud provider
             2. Set quota for root tenant - 'My Company'

--- a/cfme/tests/cloud_infra_common/test_discovery.py
+++ b/cfme/tests/cloud_infra_common/test_discovery.py
@@ -60,22 +60,18 @@ def wait_for_vm_state_changes(vm, timeout=600):
 def test_vm_discovery(request, setup_provider, provider, vm_crud):
     """ Tests whether cfme will discover a vm change (add/delete) without being manually refreshed.
 
-    Prerequisities:
-        * Desired provider set up
-
-    Steps:
-        * Create a virtual machine on the provider.
-        * Wait for the VM to appear
-        * Delete the VM from the provider (not using CFME)
-        * Wait for the VM to become Archived.
-
-    Metadata:
-        test_flag: discovery
-
     Polarion:
         assignee: ghubale
         casecomponent: Infra
         initialEstimate: 1/4h
+        tags: power
+        setup:
+            1. Desired provider set up
+        testSteps:
+            1. Create a virtual machine on the provider.
+            2. Wait for the VM to appear
+            3. Delete the VM from the provider (not using CFME)
+            4. Wait for the VM to become Archived.
     """
 
     @request.addfinalizer

--- a/cfme/tests/cloud_infra_common/test_quota_with_multiple_providers.py
+++ b/cfme/tests/cloud_infra_common/test_quota_with_multiple_providers.py
@@ -21,7 +21,7 @@ pytestmark = [
 ]
 
 
-def test_show_quota_used_on_tenant_screen(request, appliance, v2v_providers):
+def test_show_quota_used_on_tenant_screen(appliance, v2v_providers):
     """Test show quota used on tenant quota screen even when no quotas are set.
 
     Polarion:

--- a/cfme/tests/cloud_infra_common/test_relationships.py
+++ b/cfme/tests/cloud_infra_common/test_relationships.py
@@ -139,8 +139,8 @@ def wait_for_relationship_refresh(provider):
     view = navigate_to(provider, 'Details')  # resetter selects summary view
     logger.info('Waiting for relationship refresh')
     wait_for(
-        lambda: (view.entities.summary("Status").get_text_of('Last Refresh') ==
-                 'Success - Less Than A Minute Ago'),
+        lambda: (view.entities.summary("Status").get_text_of('Last Refresh')
+                 == 'Success - Less Than A Minute Ago'),
         delay=15,
         timeout=110,
         fail_func=view.browser.refresh)
@@ -152,9 +152,6 @@ def wait_for_relationship_refresh(provider):
 @pytest.mark.provider([InfraProvider], selector=ONE_PER_TYPE)
 def test_host_relationships(appliance, provider, setup_provider, host, relationship, view):
     """Tests relationship navigation for a host
-
-    Metadata:
-        test_flag: inventory
 
     Polarion:
         assignee: ghubale
@@ -178,9 +175,6 @@ def test_host_relationships(appliance, provider, setup_provider, host, relations
 @pytest.mark.provider([InfraProvider], selector=ONE_PER_TYPE)
 def test_infra_provider_relationships(appliance, provider, setup_provider, relationship, view):
     """Tests relationship navigation for an infrastructure provider
-
-    Metadata:
-        test_flag: inventory
 
     Polarion:
         assignee: ghubale
@@ -306,9 +300,6 @@ def test_tagvis_cloud_provider_children(prov_child_visibility, setup_provider, r
 def test_provider_refresh_relationship(provider, setup_provider):
     """Tests provider refresh
 
-    Metadata:
-        test_flag: inventory
-
     Polarion:
         assignee: ghubale
         casecomponent: Infra
@@ -325,8 +316,6 @@ def test_provider_refresh_relationship(provider, setup_provider):
 def test_host_refresh_relationships(provider, setup_provider):
     """ Test that host refresh doesn't fail
 
-    https://bugzilla.redhat.com/show_bug.cgi?id=1658240
-
     Polarion:
         assignee: ghubale
         casecomponent: Infra
@@ -337,6 +326,9 @@ def test_host_refresh_relationships(provider, setup_provider):
             1. Go to a host summary page in cfme
             2. From configuration -> select "Refresh Relationships and Power State"
             3. No error, host inventory properly refreshes
+
+    Bugzilla:
+        1658240
     """
     host = provider.hosts.all()[0]
     host.refresh(cancel=True)

--- a/cfme/tests/infrastructure/test_child_tenant.py
+++ b/cfme/tests/infrastructure/test_child_tenant.py
@@ -14,7 +14,7 @@ from cfme.utils.generators import random_vm_name
 pytestmark = [
     test_requirements.quota,
     pytest.mark.meta(server_roles="+automate"),
-    pytest.mark.usefixtures('uses_infra_providers'),
+    pytest.mark.usefixtures('setup_provider', 'uses_infra_providers'),
     pytest.mark.long_running,
     pytest.mark.provider([VMwareProvider, RHEVMProvider], scope="module", selector=ONE_PER_TYPE)
 ]
@@ -90,7 +90,7 @@ def new_user(appliance, new_group, new_credential):
     user = collection.create(
         name='user_{}'.format(fauxfactory.gen_alphanumeric()),
         credential=new_credential,
-        email='xyz@redhat.com',
+        email=fauxfactory.gen_email(),
         groups=new_group,
         cost_center='Workload',
         value_assign='Database')
@@ -119,14 +119,11 @@ def new_user(appliance, new_group, new_credential):
     indirect=['set_child_tenant_quota'],
     ids=['max_cpu', 'max_storage', 'max_memory', 'max_vms']
 )
-def test_child_tenant_quota_enforce_via_lifecycle_infra(appliance, provider, setup_provider,
-                                                        new_user, set_child_tenant_quota, extra_msg,
+def test_child_tenant_quota_enforce_via_lifecycle_infra(appliance, provider, new_user,
+                                                        set_child_tenant_quota, extra_msg,
                                                         custom_prov_data, approve, prov_data,
                                                         vm_name, template_name):
     """Test child tenant feature via lifecycle method.
-
-    Metadata:
-        test_flag: quota
 
     Polarion:
         assignee: ghubale
@@ -141,8 +138,8 @@ def test_child_tenant_quota_enforce_via_lifecycle_infra(appliance, provider, set
                            vm_name=vm_name, provisioning_data=prov_data, wait=False, request=None)
 
         # nav to requests page to check quota validation
-        request_description = 'Provision from [{}] to [{}{}]'.format(template_name, vm_name,
-                                                                     extra_msg)
+        request_description = 'Provision from [{template}] to [{vm}{msg}]'.format(
+            template=template_name, vm=vm_name, msg=extra_msg)
         provision_request = appliance.collections.requests.instantiate(request_description)
         if approve:
             provision_request.approve_request(method='ui', reason="Approved")

--- a/cfme/tests/infrastructure/test_tenant_quota.py
+++ b/cfme/tests/infrastructure/test_tenant_quota.py
@@ -12,14 +12,13 @@ from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils.appliance import ViaSSUI
 from cfme.utils.appliance import ViaUI
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
 
 pytestmark = [
     test_requirements.quota,
     pytest.mark.meta(server_roles="+automate"),
     test_requirements.vm_migrate,
-    pytest.mark.usefixtures('uses_infra_providers'),
+    pytest.mark.usefixtures('setup_provider', 'uses_infra_providers'),
     pytest.mark.provider([VMwareProvider, RHEVMProvider], scope="module", selector=ONE_PER_TYPE)
 ]
 
@@ -133,13 +132,10 @@ def check_hosts(small_vm, provider):
     indirect=['set_roottenant_quota'],
     ids=['max_cpu', 'max_storage', 'max_memory', 'max_vms']
 )
-def test_tenant_quota_enforce_via_lifecycle_infra(appliance, provider, setup_provider,
-                                            set_roottenant_quota, extra_msg, custom_prov_data,
-                                            approve, prov_data, vm_name, template_name):
+def test_tenant_quota_enforce_via_lifecycle_infra(appliance, provider, set_roottenant_quota,
+                                                  extra_msg, custom_prov_data, approve, prov_data,
+                                                  vm_name, template_name):
     """Test Tenant Quota in UI and SSUI
-
-    Metadata:
-        test_flag: quota
 
     Polarion:
         assignee: ghubale
@@ -154,7 +150,8 @@ def test_tenant_quota_enforce_via_lifecycle_infra(appliance, provider, setup_pro
                        provisioning_data=prov_data, wait=False, request=None)
 
     # nav to requests page to check quota validation
-    request_description = 'Provision from [{}] to [{}{}]'.format(template_name, vm_name, extra_msg)
+    request_description = 'Provision from [{template}] to [{vm}{msg}]'.format(
+        template=template_name, vm=vm_name, msg=extra_msg)
     provision_request = appliance.collections.requests.instantiate(request_description)
     if approve:
         provision_request.approve_request(method='ui', reason="Approved")
@@ -163,8 +160,6 @@ def test_tenant_quota_enforce_via_lifecycle_infra(appliance, provider, setup_pro
 
 
 @pytest.mark.rhv3
-@pytest.mark.meta(blockers=[BZ(1633540, forced_streams=['5.10'],
-    unblock=lambda provider: not provider.one_of(RHEVMProvider))])
 # first arg of parametrize is the list of fixtures or parameters,
 # second arg is a list of lists, with each one a test is to be generated
 # sequence is important here
@@ -181,9 +176,8 @@ def test_tenant_quota_enforce_via_lifecycle_infra(appliance, provider, setup_pro
     indirect=['set_roottenant_quota', 'custom_prov_data'],
     ids=['max_cpu', 'max_storage', 'max_memory', 'max_vms']
 )
-def test_tenant_quota_enforce_via_service_infra(request, appliance, provider, setup_provider,
-                                                context, set_roottenant_quota, extra_msg,
-                                                custom_prov_data, catalog_item):
+def test_tenant_quota_enforce_via_service_infra(request, appliance, context, set_roottenant_quota,
+                                                extra_msg, custom_prov_data, catalog_item):
     """Tests quota enforcement via service infra
 
     Polarion:
@@ -225,8 +219,7 @@ def test_tenant_quota_enforce_via_service_infra(request, appliance, provider, se
     indirect=['set_roottenant_quota'],
     ids=['max_cores', 'max_sockets', 'max_memory']
 )
-def test_tenant_quota_vm_reconfigure(appliance, provider, setup_provider, set_roottenant_quota,
-                                     small_vm, custom_prov_data):
+def test_tenant_quota_vm_reconfigure(appliance, set_roottenant_quota, small_vm, custom_prov_data):
     """Tests quota with vm reconfigure
 
     Polarion:
@@ -257,7 +250,6 @@ def test_tenant_quota_vm_reconfigure(appliance, provider, setup_provider, set_ro
 def test_setting_child_quota_more_than_parent(appliance, tenants_setup, parent_quota, child_quota,
                                               flash_text):
     """
-
     Polarion:
         assignee: ghubale
         casecomponent: Provisioning
@@ -298,11 +290,9 @@ def test_setting_child_quota_more_than_parent(appliance, tenants_setup, parent_q
     indirect=['set_roottenant_quota'],
     ids=['max_cores']
 )
-def test_vm_migration_after_assigning_tenant_quota(appliance, setup_provider, small_vm,
-                                                   set_roottenant_quota,
+def test_vm_migration_after_assigning_tenant_quota(appliance, small_vm, set_roottenant_quota,
                                                    custom_prov_data, provider):
     """
-
     Polarion:
         assignee: ghubale
         casecomponent: Infra

--- a/cfme/tests/infrastructure/test_vm_ownership.py
+++ b/cfme/tests/infrastructure/test_vm_ownership.py
@@ -130,18 +130,19 @@ def test_rename_vm(small_vm):
 
     """Test for rename the VM.
        This feature is included in 5.10z.
-    Steps:
-    1. Add VMware provider
-    2. Provision VM
-    3. Navigate to details page of VM
-    4. Click on Configuration > Rename this VM > Enter new name
-    5. Click on submit
-    6. Check whether VM is renamed or not
 
     Polarion:
         assignee: ghubale
         initialEstimate: 1/4h
         casecomponent: Infra
+        tags: power
+        testSteps:
+            1. Add VMware provider
+            2. Provision VM
+            3. Navigate to details page of VM
+            4. Click on Configuration > Rename this VM > Enter new name
+            5. Click on submit
+            6. Check whether VM is renamed or not
     """
     view = navigate_to(small_vm, 'Details')
     vm_name = small_vm.name


### PR DESCRIPTION
- Adds 'tags:' wherever missing
- Updating polarion tags
- Removed deprecated code like imports, not used test arguments etc
- Updated email generating with faux factory
- Removed verified BZs
- Added 'setup_provider' as global fixture in quota test's file
- Removed 5.8 dependency

{{ pytest: cfme/tests/infrastructure/test_project_quota.py::test_project_quota_enforce_via_lifecycle_infra --use-provider=rhv41 --long-running -vv }}

Note: Running only one test case to see whether it is able to set up provider or not(Quota test cases are taking too much time to finish)