### PR TITLE
[1LP][RFR] Automate test case: test_change_truncate_long_text_save_button_enabled

### DIFF
--- a/cfme/tests/configure/test_default_filters.py
+++ b/cfme/tests/configure/test_default_filters.py
@@ -17,6 +17,7 @@ def test_default_filters_reset(appliance):
         casecomponent: Configuration
         caseimportance: high
         initialEstimate: 1/8h
+        tags: settings
     """
     tree_path = ['Cloud', 'Instances', 'Images', 'Platform / Openstack']
     view = navigate_to(appliance.user.my_settings, "DefaultFilters")
@@ -33,6 +34,7 @@ def test_cloudimage_defaultfilters(appliance):
         casecomponent: Configuration
         caseimportance: medium
         initialEstimate: 1/6h
+        tags: settings
     """
     filters = [['Cloud', 'Instances', 'Images', 'Platform / Amazon']]
     tree_path = ['All Images', 'Global Filters', 'Platform / Amazon']
@@ -48,6 +50,7 @@ def test_cloudinstance_defaultfilters(appliance):
         casecomponent: Configuration
         caseimportance: medium
         initialEstimate: 1/6h
+        tags: settings
     """
     filters = [['Cloud', 'Instances', 'Instances', 'Platform / Openstack']]
     tree_path = ['All Instances', 'Global Filters', 'Platform / Openstack']
@@ -63,6 +66,7 @@ def test_infrastructurehost_defaultfilters(appliance):
         casecomponent: Configuration
         caseimportance: medium
         initialEstimate: 1/6h
+        tags: settings
     """
     filters = [['Infrastructure', 'Hosts', 'Platform / HyperV']]
     appliance.user.my_settings.default_filters.update({'filters': [(k, True) for k in filters]})
@@ -78,6 +82,7 @@ def test_infrastructurevms_defaultfilters(appliance):
         casecomponent: Configuration
         caseimportance: medium
         initialEstimate: 1/6h
+        tags: settings
     """
     filters = [['Infrastructure', 'Virtual Machines', 'VMs', 'Platform / VMware']]
     tree_path = ['All VMs', 'Global Filters', 'Platform / VMware']
@@ -93,6 +98,7 @@ def test_infrastructuretemplates_defaultfilters(appliance):
         casecomponent: Configuration
         caseimportance: medium
         initialEstimate: 1/6h
+        tags: settings
     """
     filters = [['Infrastructure', 'Virtual Machines', 'Templates', 'Platform / Redhat']]
     tree_path = ['All Templates', 'Global Filters', 'Platform / Redhat']
@@ -108,6 +114,7 @@ def test_servicetemplateandimages_defaultfilters(appliance, request):
         casecomponent: Configuration
         caseimportance: medium
         initialEstimate: 1/6h
+        tags: settings
     """
     filters = [['Services', 'Workloads', 'Templates & Images', 'Platform / Microsoft']]
     tree_path = ['All Templates & Images', 'Global Filters', 'Platform / Microsoft']
@@ -126,6 +133,7 @@ def test_servicevmsandinstances_defaultfilters(appliance, request):
         casecomponent: Configuration
         caseimportance: medium
         initialEstimate: 1/6h
+        tags: settings
     """
     filters = [['Services', 'Workloads', 'VMs & Instances', 'Platform / Openstack']]
     tree_path = ['All VMs & Instances', 'Global Filters', 'Platform / Openstack']

--- a/cfme/tests/configure/test_default_views_cloud.py
+++ b/cfme/tests/configure/test_default_views_cloud.py
@@ -38,6 +38,7 @@ def test_default_view_cloud_reset(appliance):
         casecomponent: Cloud
         caseimportance: high
         initialEstimate: 1/20h
+        tags: settings
     """
     view = navigate_to(appliance.user.my_settings, "DefaultViews")
     assert view.tabs.default_views.reset.disabled
@@ -58,6 +59,7 @@ def test_cloud_default_view(appliance, group_name, expected_view):
         casecomponent: Cloud
         caseimportance: high
         initialEstimate: 1/10h
+        tags: settings
     """
     page = gtl_params[group_name]
     default_views = appliance.user.my_settings.default_views
@@ -71,7 +73,7 @@ def test_cloud_default_view(appliance, group_name, expected_view):
 
 
 @pytest.mark.parametrize('expected_view',
-                         ['Expanded View', 'Compressed View', 'Details Mode', 'Exists Mode'])
+                        ['Expanded View', 'Compressed View', 'Details Mode', 'Exists Mode'])
 def test_cloud_compare_view(appliance, expected_view):
     """This test changes the default view/mode for comparison between cloud provider instances
     and asserts the change.
@@ -81,6 +83,7 @@ def test_cloud_compare_view(appliance, expected_view):
         casecomponent: Cloud
         caseimportance: high
         initialEstimate: 1/10h
+        tags: settings
     """
 
     if expected_view in ['Expanded View', 'Compressed View']:

--- a/cfme/tests/configure/test_default_views_infra.py
+++ b/cfme/tests/configure/test_default_views_infra.py
@@ -78,6 +78,7 @@ def test_default_view_infra_reset(appliance):
         casecomponent: Infra
         caseimportance: high
         initialEstimate: 1/20h
+        tags: settings
     """
     view = navigate_to(appliance.user.my_settings, "DefaultViews")
     assert view.tabs.default_views.reset.disabled
@@ -98,6 +99,7 @@ def test_infra_default_view(appliance, group_name, view):
         casecomponent: Infra
         caseimportance: high
         initialEstimate: 1/10h
+        tags: settings
     """
     page = _get_page(gtl_params[group_name], appliance)
     default_views = appliance.user.my_settings.default_views
@@ -122,6 +124,7 @@ def test_infra_compare_view(appliance, expected_view):
         casecomponent: Infra
         caseimportance: high
         initialEstimate: 1/10h
+        tags: settings
     """
     if expected_view in ['Expanded View', 'Compressed View']:
         group_name, selector_type = 'Compare', 'views_selector'
@@ -145,6 +148,7 @@ def test_vm_visibility_off(appliance):
         casecomponent: Infra
         caseimportance: medium
         initialEstimate: 1/10h
+        tags: settings
     """
     appliance.user.my_settings.default_views.set_default_view_switch_off()
     assert not check_vm_visibility(appliance)
@@ -157,6 +161,7 @@ def test_vm_visibility_on(appliance):
         casecomponent: Infra
         caseimportance: medium
         initialEstimate: 1/5h
+        tags: settings
     """
     appliance.user.my_settings.default_views.set_default_view_switch_on()
     assert check_vm_visibility(appliance, check=True)

--- a/cfme/tests/configure/test_landing_page.py
+++ b/cfme/tests/configure/test_landing_page.py
@@ -151,6 +151,7 @@ def test_landing_page_admin(start_page, appliance, my_settings, request):
         casecomponent: Configuration
         caseimportance: medium
         initialEstimate: 1/8h
+        tags: settings
     """
     request.addfinalizer(lambda: set_to_default('Cloud Intel / Dashboard', my_settings))
     assert set_landing_page(start_page, appliance, my_settings)

--- a/cfme/tests/configure/test_timeprofile.py
+++ b/cfme/tests/configure/test_timeprofile.py
@@ -21,6 +21,7 @@ def test_time_profile_crud(appliance):
         casecomponent: Configuration
         caseimportance: high
         initialEstimate: 1/8h
+        tags: settings
     """
     collection = appliance.collections.time_profiles
     time_profile = collection.create(
@@ -43,6 +44,7 @@ def test_time_profile_name_max_character_validation(appliance):
         casecomponent: Configuration
         caseimportance: medium
         initialEstimate: 1/8h
+        tags: settings
     """
     collection = appliance.collections.time_profiles
     time_profile = collection.create(
@@ -107,6 +109,7 @@ def test_time_profile_description_required_error_validation(appliance, soft_asse
         casecomponent: Configuration
         caseimportance: medium
         initialEstimate: 1/8h
+        tags: settings
     """
     collection = appliance.collections.time_profiles
     time_profile = collection.instantiate(description='UTC', scope='Current User',
@@ -129,6 +132,7 @@ def test_time_profile_copy(appliance):
         casecomponent: Configuration
         caseimportance: medium
         initialEstimate: 1/8h
+        tags: settings
     """
     collection = appliance.collections.time_profiles
     time_profile = collection.create(

--- a/cfme/tests/configure/test_visual_cloud.py
+++ b/cfme/tests/configure/test_visual_cloud.py
@@ -95,6 +95,7 @@ def test_cloud_grid_page_per_item(appliance, request, page, value, set_grid):
         casecomponent: Configuration
         caseimportance: medium
         initialEstimate: 1/10h
+        tags: settings
     """
     if isinstance(page, six.string_types):
         page = getattr(appliance.collections, page)
@@ -126,6 +127,7 @@ def test_cloud_tile_page_per_item(appliance, request, page, value, set_tile):
         casecomponent: Configuration
         caseimportance: medium
         initialEstimate: 1/10h
+        tags: settings
     """
     if isinstance(page, six.string_types):
         page = getattr(appliance.collections, page)
@@ -157,6 +159,7 @@ def test_cloud_list_page_per_item(appliance, request, page, value, set_list):
         casecomponent: Configuration
         caseimportance: medium
         initialEstimate: 1/10h
+        tags: settings
     """
     if isinstance(page, six.string_types):
         page = getattr(appliance.collections, page)
@@ -189,6 +192,7 @@ def test_cloud_start_page(request, appliance, start_page):
         casecomponent: Configuration
         caseimportance: medium
         initialEstimate: 1/6h
+        tags: settings
     """
     request.addfinalizer(lambda: set_default_page(appliance))
     appliance.user.my_settings.visual.login_page = start_page
@@ -204,6 +208,7 @@ def test_cloudprovider_noquads(request, set_cloud_provider_quad):
         casecomponent: Configuration
         caseimportance: medium
         initialEstimate: 1/10h
+        tags: settings
     """
     view = navigate_to(CloudProvider, 'All')
     view.toolbar.view_selector.select('Grid View')

--- a/cfme/tests/configure/test_visual_infra.py
+++ b/cfme/tests/configure/test_visual_infra.py
@@ -407,13 +407,13 @@ def test_change_truncate_long_text_save_button_enabled(appliance):
             2. Value is changed successfully.
     """
     view = navigate_to(appliance.user.my_settings, "Visual")
-
-    available_options = [_.text for _ in view.tabs.visual.grid_tile_icons.long_text.all_options]
-    available_options.remove(view.tabs.visual.grid_tile_icons.long_text.selected_option)
+    visual = view.tabs.visual
+    available_options = [option.text for option in visual.grid_tile_icons.long_text.all_options]
+    available_options.remove(visual.grid_tile_icons.long_text.selected_option)
     selected_choice = choice(available_options)
 
-    view.tabs.visual.grid_tile_icons.long_text.fill(selected_choice)
+    visual.grid_tile_icons.long_text.fill(selected_choice)
     assert not view.tabs.visual.save.disabled
 
-    view.tabs.visual.save.click()
-    assert view.tabs.visual.grid_tile_icons.long_text.selected_option == selected_choice
+    visual.save.click()
+    assert visual.grid_tile_icons.long_text.selected_option == selected_choice


### PR DESCRIPTION
This PR brings the following changes:
1. Automate test: `test_change_truncate_long_text_save_button_enabled`
2. Add `settings` tag to related test cases.


{{ pytest: cfme/tests/configure/test_visual_infra.py::test_change_truncate_long_text_save_button_enabled --use-template-cache -sqvvv }}