### PR TITLE
[RFR] Fix service bundles in bundle test

### DIFF
--- a/cfme/tests/services/test_generic_service_catalogs.py
+++ b/cfme/tests/services/test_generic_service_catalogs.py
@@ -68,6 +68,7 @@ def test_delete_catalog_item_deletes_service(appliance, catalog_item):
         service_catalogs.order()
 
 
+@pytest.mark.ignore_stream("5.10")
 def test_service_circular_reference(appliance, catalog_item):
     """
     Polarion:
@@ -118,6 +119,7 @@ def test_service_generic_catalog_bundle(appliance, catalog_item):
     assert provision_request.is_succeeded(), msg
 
 
+@pytest.mark.ignore_stream("5.10")
 def test_bundles_in_bundle(appliance, catalog_item):
     """
     Polarion:


### PR DESCRIPTION

Purpose or Intent
=================
Creating bundles in bundle is not supported now
https://bugzilla.redhat.com/show_bug.cgi?id=1678368

{{pytest: cfme/tests/services/test_generic_service_catalogs.py -k test_bundles_in_bundle -v}}
