### PR TITLE
[1LP][RFR] fixed storage container tests

### DIFF
--- a/cfme/storage/object_store_container.py
+++ b/cfme/storage/object_store_container.py
@@ -134,6 +134,7 @@ class ObjectStoreContainerCollection(BaseCollection):
         containers = []
 
         # ToDo: use all_entity_names method as JS API issue (#2898) resolve.
+        view.entities.elements.wait_displayed()
         for item in view.entities.elements.read():
             if self.filters.get('provider').name in item['Cloud Provider']:
                 containers.append(self.instantiate(key=item['Key'],


### PR DESCRIPTION
failing because table with entities isn't displayed yet

{{pytest: --use-template-cache --long-running --use-provider=rhos13 cfme/tests/storage/test_object_store_container.py}}