### PR TITLE
[1LP][RFR] Update tests and fixtures to resolve KeyError on yaml keyword

### DIFF
--- a/cfme/fixtures/provider.py
+++ b/cfme/fixtures/provider.py
@@ -384,7 +384,12 @@ def big_template_modscope(provider):
 
 @pytest.fixture(scope="function")
 def provisioning(provider):
-    return provider.data['provisioning']
+    try:
+        return provider.data['provisioning']
+    except KeyError:
+        logger.warning('Tests using the provisioning fixture '
+                       'should include required_fields in their ProviderFilter marker')
+        pytest.skip('Missing "provisioning" field in provider data')
 
 
 @pytest.fixture(scope="function")

--- a/cfme/tests/cloud_infra_common/test_discovery.py
+++ b/cfme/tests/cloud_infra_common/test_discovery.py
@@ -15,7 +15,11 @@ from cfme.utils.wait import TimedOutError
 pytestmark = [
     pytest.mark.tier(2),
     test_requirements.discovery,
-    pytest.mark.provider([BaseProvider], scope='module')
+    pytest.mark.provider(
+        [BaseProvider],
+        scope='module',
+        required_fields=[['templates', 'small_template']]  # default for create_on_provider
+    )
 ]
 
 
@@ -79,7 +83,12 @@ def test_vm_discovery(request, setup_provider, provider, vm_crud):
         vm_crud.cleanup_on_provider()
         if_scvmm_refresh_provider(provider)
 
-    vm_crud.create_on_provider(allow_skip="default")
+    try:
+        vm_crud.create_on_provider(allow_skip="default")
+    except KeyError:
+        msg = 'Missing template for provider {}'.format(provider.key)
+        logger.exception(msg)
+        pytest.skip(msg)
     if_scvmm_refresh_provider(provider)
 
     try:

--- a/cfme/tests/storage/test_volume.py
+++ b/cfme/tests/storage/test_volume.py
@@ -15,7 +15,11 @@ pytestmark = [
     test_requirements.storage,
     pytest.mark.ignore_stream("upstream"),
     pytest.mark.usefixtures('setup_provider'),
-    pytest.mark.provider([OpenStackProvider], scope='module'),
+    pytest.mark.provider(
+        [OpenStackProvider],
+        scope='module',
+        required_fields=[['provisioning', 'cloud_tenant']]
+    ),
 ]
 
 STORAGE_SIZE = 1
@@ -111,7 +115,6 @@ def test_storage_volume_crud(appliance, provider):
     assert not volume.exists
 
 
-@pytest.mark.meta(blockers=[BZ(1648243, forced_streams=["5.9"])])
 def test_storage_volume_edit_tag(volume):
     """ Test add and remove tag to storage volume
 
@@ -140,7 +143,6 @@ def test_storage_volume_edit_tag(volume):
     assert not tag_available
 
 
-@pytest.mark.meta(blockers=[BZ(1648243, forced_streams=["5.9"])])
 def test_multiple_cloud_volumes_tag_edit(appliance, soft_assert):
     """Test tag can be added to multiple volumes at once
 

--- a/cfme/tests/storage/test_volume_backup.py
+++ b/cfme/tests/storage/test_volume_backup.py
@@ -7,9 +7,15 @@ from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 
 
-pytestmark = [pytest.mark.ignore_stream("upstream"),
-              pytest.mark.usefixtures('setup_provider'),
-              pytest.mark.provider([OpenStackProvider], scope='module')]
+pytestmark = [
+    pytest.mark.ignore_stream("upstream"),
+    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.provider(
+        [OpenStackProvider],
+        scope='module',
+        required_fields=[['provisioning', 'cloud_tenant']]
+    )
+]
 
 STORAGE_SIZE = 1
 
@@ -57,7 +63,6 @@ def test_storage_volume_backup_create(backup):
     assert backup.size == STORAGE_SIZE
 
 
-@pytest.mark.meta(blockers=[BZ(1648243, forced_streams=["5.9"])])
 @pytest.mark.tier(3)
 def test_storage_volume_backup_edit_tag_from_detail(backup):
     """
@@ -79,7 +84,6 @@ def test_storage_volume_backup_edit_tag_from_detail(backup):
 
 
 @pytest.mark.tier(3)
-@pytest.mark.uncollectif(lambda appliance: appliance.version < '5.9')
 def test_storage_volume_backup_delete(backup):
     """ Volume backup deletion method not support by 5.8
 

--- a/cfme/tests/storage/test_volume_snapshot.py
+++ b/cfme/tests/storage/test_volume_snapshot.py
@@ -15,7 +15,11 @@ pytestmark = [
     test_requirements.storage,
     pytest.mark.ignore_stream("upstream"),
     pytest.mark.usefixtures('setup_provider'),
-    pytest.mark.provider([OpenStackProvider], scope='module')
+    pytest.mark.provider(
+        [OpenStackProvider],
+        scope='module',
+        required_fields=[['provisioning', 'cloud_tenant']]
+    )
 ]
 
 STORAGE_SIZE = 1
@@ -164,7 +168,6 @@ def test_storage_volume_snapshot_crud(volume):
     assert not snapshot.exists
 
 
-@pytest.mark.meta(blockers=[BZ(1648243, forced_streams=["5.9"])])
 @pytest.mark.tier(3)
 def test_storage_volume_snapshot_edit_tag_from_detail(snapshot, tag):
     """ Test tags for snapshot


### PR DESCRIPTION
Test markers were missing a required field that they were assuming would be there - `provisioning`

This was missing on a CFME provider that was not intended for general provisioning tests, and is not excluding that marker
The CFME yaml has also been updated to change test collection for CFME, but this doesn't impact MIQ testing.

The fixtures and test markers now explicitly state the assumed yaml fields they will be using for provisioning, and some KeyErrors are explcitily caught, just in case.

Labeling rc-regression-fix, other maintainers feel free to remove if you don't think that's appropriate. Over 50 tests failing with `KeyError` right now in our `complete` provider collection because of these test modules.

I don't expect the PRT run to be clean, this should prevent ~40 tests from being collected in the first place, and then several more will be skipped because they're using a utility to create VMs.