### PR TITLE
[1LP][RFR] fix grouping tests by provider in test paralellizer

### DIFF
--- a/cfme/fixtures/parallelizer/__init__.py
+++ b/cfme/fixtures/parallelizer/__init__.py
@@ -151,8 +151,11 @@ class ParallelSession(object):
         self.test_groups = self._test_item_generator()
 
         self._pool = []
-        from cfme.utils.conf import cfme_data
-        self.provs = sorted(set(cfme_data['management_systems'].keys()),
+
+        # necessary to get list of supported providers
+        version = appliances[0].version
+        from cfme.markers.env_markers.provider import all_required
+        self.provs = sorted([p.the_id for p in all_required(version, filters=[])],
                             key=len, reverse=True)
         self.used_prov = set()
 
@@ -525,6 +528,8 @@ class ParallelSession(object):
 
     def get(self, slave):
 
+        # we assume that there is only one provider of the same type and version
+        # because there is no better way to group tests w/o provider initialization
         def provs_of_tests(test_group):
             found = set()
             for test in test_group:

--- a/cfme/markers/env_markers/provider.py
+++ b/cfme/markers/env_markers/provider.py
@@ -158,6 +158,15 @@ class DataProvider(object):
     type_name = attr.ib()
     version = attr.ib()
     klass = attr.ib(default=attr.Factory(data_provider_types, takes_self=True))
+    the_id = attr.ib(init=False)
+
+    def __attrs_post_init__(self):
+        ver = self.version if self.version else None
+        if ver:
+            the_id = "{}-{}".format(self.type_name, self.version)
+        else:
+            the_id = "{}".format(self.type_name)
+        object.__setattr__(self, "the_id", the_id)
 
     def one_of(self, *classes):
         return issubclass(self.klass, classes)
@@ -336,14 +345,7 @@ def providers(metafunc, filters=None, selector=ALL, fixture_name='provider'):
         argvalues.append(pytest.param(data_prov))
 
         # Use the provider key for idlist, helps with readable parametrized test output
-        if metafunc.config.getoption('legacy_ids'):
-            the_id = "{}".format(data_prov.key)
-        else:
-            ver = data_prov.version if data_prov.version else None
-            if ver:
-                the_id = "{}-{}".format(data_prov.type_name, data_prov.version)
-            else:
-                the_id = "{}".format(data_prov.type_name)
+        the_id = str(data_prov.key) if metafunc.config.getoption('legacy_ids') else data_prov.the_id
 
         # Now we modify the id based on what selector we chose
         if metafunc.config.getoption('disable_selectors'):

--- a/cfme/markers/env_markers/provider.py
+++ b/cfme/markers/env_markers/provider.py
@@ -4,6 +4,7 @@ from distutils.version import LooseVersion
 import attr
 import pytest
 import six
+from cached_property import cached_property
 
 from cfme.markers.env import EnvironmentMarker
 from cfme.utils import conf
@@ -158,15 +159,13 @@ class DataProvider(object):
     type_name = attr.ib()
     version = attr.ib()
     klass = attr.ib(default=attr.Factory(data_provider_types, takes_self=True))
-    the_id = attr.ib(init=False)
 
-    def __attrs_post_init__(self):
-        ver = self.version if self.version else None
-        if ver:
-            the_id = "{}-{}".format(self.type_name, self.version)
+    @cached_property
+    def the_id(self):
+        if self.version:
+            return "{}-{}".format(self.type_name, self.version)
         else:
-            the_id = "{}".format(self.type_name)
-        object.__setattr__(self, "the_id", the_id)
+            return "{}".format(self.type_name)
 
     def one_of(self, *classes):
         return issubclass(self.klass, classes)


### PR DESCRIPTION
fixing grouping tests by provider in order to speed up parallelized testing.
It turned out that provider "supportability" + DataProvider changes broke grouping tests by providers.

this PR means to fix this grouping issue.