### PR TITLE
[1LP][RFR] fixed active snapshot detection for RHEV

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -648,7 +648,16 @@ class InfraVm(VM):
             title = getattr(self, self.parent_vm.provider.SNAPSHOT_TITLE)
             view = navigate_to(self.parent_vm, 'SnapshotsAll')
             root_item = view.tree.expand_path(self.parent_vm.name)
-            return has_child(view.tree, '{} (Active)'.format(title), root_item)
+            from cfme.infrastructure.provider.rhevm import RHEVMProvider
+
+            if self.parent_vm.provider.one_of(RHEVMProvider):
+                child = view.tree.child_items(root_item)
+                last_snapshot = view.tree.child_items(child[0])[0]
+                return (len(child) == 1 and
+                        child[0].text == 'Active VM (Active)' and
+                        last_snapshot.text == title)
+            else:
+                return has_child(view.tree, '{} (Active)'.format(title), root_item)
 
         def create(self, force_check_memory=False):
             """Create a snapshot"""


### PR DESCRIPTION
{{ pytest: -v cfme/tests/infrastructure/test_snapshot.py::test_verify_revert_snapshot --long-running }}

According to the fix mentioned here https://bugzilla.redhat.com/show_bug.cgi?id=1561618#c6
"Active VM" is always the active snapshot, so instead of

before:
![image](https://user-images.githubusercontent.com/42433123/53419691-97909700-39da-11e9-8372-2b8402053ab4.png)

it looks like:
![image](https://user-images.githubusercontent.com/42433123/53419728-a8410d00-39da-11e9-9b59-42772e876041.png)
