### PR TITLE
[1LP][RFR] Remove fixtured collections from control tests

### DIFF
--- a/cfme/control/explorer/conditions.py
+++ b/cfme/control/explorer/conditions.py
@@ -16,6 +16,7 @@ from cfme.utils import ParamClassName
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator
+from cfme.utils.blockers import BZ
 from cfme.utils.pretty import Pretty
 from cfme.utils.update import Updateable
 from widgetastic_manageiq.expression_editor import ExpressionEditor
@@ -159,6 +160,7 @@ class ConditionDetailsView(ControlExplorerView):
             self.title.text == '{} Condition "{}"'.format(self.context["object"].FIELD_VALUE,
                 self.context["object"].description) and
             self.conditions.is_opened
+            # TODO add in a check against the tree once BZ 1683697 is fixed
         )
 
 
@@ -224,7 +226,7 @@ class BaseCondition(BaseEntity, Updateable, Pretty):
             assert view.is_displayed
             view.flash.assert_no_error()
         else:
-            view = self.create_view(ConditionClassAllView, wait="10s")
+            view = self.create_view(ConditionClassAllView, wait="20s")
             view.flash.assert_success_message('Condition "{}": Delete successful'.format(
                 self.description))
 
@@ -271,6 +273,8 @@ class ConditionCollection(BaseCollection):
         view.add_button.click()
         view = condition.create_view(ConditionDetailsView, wait="10s")
         view.flash.assert_success_message('Condition "{}" was added'.format(condition.description))
+        if BZ(1683697, forced_streams=["5.9", "5.10"]).blocks:
+            navigate_to(self.appliance.server, 'ControlExplorer', force=True)
         return condition
 
     def all(self):

--- a/cfme/tests/control/test_basic.py
+++ b/cfme/tests/control/test_basic.py
@@ -242,10 +242,7 @@ ALERT_PROFILES = [
 def two_random_policies(appliance):
     # Physical Infrastucture policies excluded
     policy_collection = appliance.collections.policies
-    if appliance.version < "5.9":
-        policies = [policy_class for policy_class in POLICIES if policy_class not in PHYS_POLICIES]
-    else:
-        policies = POLICIES
+    policies = POLICIES
     policy_1 = policy_collection.create(
         random.choice(policies),
         fauxfactory.gen_alphanumeric()
@@ -513,8 +510,9 @@ def test_assign_two_random_events_to_control_policy(control_policy, control_poli
     soft_assert(control_policy.is_event_assigned(random_events[1]))
 
 
+# TODO: fix this test in 5.10 in a later PR
 @pytest.mark.tier(2)
-@pytest.mark.meta(blockers=[BZ(1565576, forced_streams=["5.9"],
+@pytest.mark.meta(blockers=[BZ(1565576, forced_streams=["5.9", "5.10"],
                   unblock=lambda policy_class: policy_class is not PHYS_POLICIES[0])])
 def test_control_assign_actions_to_event(request, policy_class, policy, action):
     """

--- a/cfme/tests/control/test_bugs.py
+++ b/cfme/tests/control/test_bugs.py
@@ -284,8 +284,7 @@ def test_check_compliance_history(request, virtualcenter_provider, vmware_vm, ap
         vmware_vm.name)
 
 
-@pytest.mark.meta(blockers=[BZ(1395965, forced_streams=["5.6", "5.7"]),
-                            BZ(1491576, forced_streams=["5.7"])])
+@pytest.mark.meta(blockers=[BZ(1395965), BZ(1491576)])
 def test_delete_all_actions_from_compliance_policy(request, appliance):
     """We should not allow a compliance policy to be saved
     if there are no actions on the compliance event.
@@ -336,6 +335,8 @@ def test_control_identical_descriptions(request, create_function, collections, a
         collections[create_function.name].create(*args, **kwargs)
     except (TimedOutError, AssertionError):
         flash.assert_message("Description has already been taken")
+        # force navigation away from the page so the browser is not stuck on the edit page
+        navigate_to(appliance.server, 'ControlExplorer', force=True)
 
 
 @pytest.mark.meta(blockers=[BZ(1231889)], automates=[1231889])


### PR DESCRIPTION
Minor refactor to get rid of all of the fixtures of the following form: 

```
@pytest.fixture
def collection:
    return appliance.collections.collection
```

from `test_alerts.py`, `test_basic.py`, and `test_bugs.py`. Also fixing a couple of views for policies by removing a BZ that has since been fixed. Fixing the test `test_delete_all_actions_from_compliance_policy`. Registering a [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1683697) against condition creation, since this was causing test failures in `test_basic`. 

{{ pytest: --long-running cfme/tests/control/test_bugs.py::test_control_identical_descriptions }}