### PR TITLE
[RFR] fixed fixture scope mismatch

### DIFF
--- a/cfme/tests/infrastructure/test_vm_reconfigure.py
+++ b/cfme/tests/infrastructure/test_vm_reconfigure.py
@@ -9,7 +9,7 @@ from cfme.utils.wait import wait_for
 
 
 pytestmark = [
-    pytest.mark.usefixtures('setup_provider_modscope'),
+    pytest.mark.usefixtures('setup_provider'),
     pytest.mark.long_running,
     pytest.mark.tier(2),
     pytest.mark.provider([VMwareProvider, RHEVMProvider],
@@ -45,7 +45,7 @@ def reconfigure_vm(vm, config):
 
 
 @pytest.fixture(scope='function')
-def small_vm(appliance, provider, small_template_modscope):
+def small_vm(appliance, provider, small_template):
     """This fixture is function-scoped, because there is no un-ambiguous way how to search for
     reconfigure request in UI in situation when you have two requests for the same reconfiguration
     and for the same VM name. This happens if you run test_vm_reconfig_add_remove_hw_cold and then
@@ -54,7 +54,7 @@ def small_vm(appliance, provider, small_template_modscope):
     are unique as a result."""
     vm = appliance.collections.infra_vms.instantiate(random_vm_name(context='reconfig'),
                                                      provider,
-                                                     small_template_modscope.name)
+                                                     small_template.name)
     vm.create_on_provider(find_in_cfme=True, allow_skip="default")
     vm.refresh_relationships()
 


### PR DESCRIPTION
{{ pytest: -v cfme/tests/infrastructure/test_vm_reconfigure.py::test_vm_reconfig_add_remove_hw_hot  --long-running }}

Fixed the error
```
ScopeMismatch: You tried to access the 'function' scoped fixture 'provider' with a 'module' scoped request object, involved factories
cfme/fixtures/provider.py:283: def setup_provider_modscope(request, provider)
../.cfme/lib/python2.7/site-packages/_pytest/fixtures.py:242: def get_direct_param_fixture_func(request)
```