### PR TITLE
[1LP][RFR] New test for automate: Checking schema creation without 'Type'

### DIFF
--- a/cfme/tests/automate/test_automate_manual.py
+++ b/cfme/tests/automate/test_automate_manual.py
@@ -424,34 +424,6 @@ def test_automate_git_domain_import_with_no_connection():
 
 @pytest.mark.manual
 @test_requirements.automate
-@pytest.mark.tier(3)
-def test_automate_schema_field_without_type():
-    """
-    It shouldn't be possible to add a field without specifying a type.
-
-    Polarion:
-        assignee: ghubale
-        casecomponent: Automate
-        caseimportance: medium
-        caseposneg: negative
-        initialEstimate: 1/12h
-        tags: automate
-        testSteps:
-            1. Create a schema field that does not specify a type
-            2. Save the schema
-        expectedResults:
-            1.
-            2. it is not possible to add a field that does not specify the type
-               (assertion, attribute, relationship, ...)
-
-    Bugzilla:
-        1365442
-    """
-    pass
-
-
-@pytest.mark.manual
-@test_requirements.automate
 @pytest.mark.tier(1)
 def test_automate_retry_onexit_increases():
     """

--- a/cfme/tests/automate/test_class.py
+++ b/cfme/tests/automate/test_class.py
@@ -3,6 +3,7 @@ import fauxfactory
 import pytest
 
 from cfme import test_requirements
+from cfme.automate.explorer.klass import ClassSchemaEditView
 from cfme.utils.update import update
 
 pytestmark = [test_requirements.automate]
@@ -169,3 +170,33 @@ def test_class_display_name_unset_from_ui(get_namespace):
     with update(a_class):
         a_class.display_name = ""
     assert a_class.exists
+
+
+@pytest.mark.tier(3)
+def test_automate_schema_field_without_type(klass):
+    """It shouldn't be possible to add a field without specifying a type.
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: Automate
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/12h
+        tags: automate
+        testSteps:
+            1. Create a schema field that does not specify a type
+            2. Save the schema
+        expectedResults:
+            1.
+            2. it is not possible to add a field that does not specify the type
+               (assertion, attribute, relationship, ...)
+
+    Bugzilla:
+        1365442
+    """
+    with pytest.raises(AssertionError):
+        klass.schema.add_fields({'name': 'execute', 'data_type': 'String'})
+    view = klass.create_view(ClassSchemaEditView)
+    assert view.schema.save_button.disabled
+    assert view.schema.reset_button.disabled
+    assert not view.schema.cancel_button.disabled


### PR DESCRIPTION
- Adding test case for checking schema creation without providing 'Type'
- This test case is related to [BZ:1365442](https://bugzilla.redhat.com/show_bug.cgi?id=1365442) 

{{ pytest: cfme/tests/automate/test_class.py -k 'test_automate_schema_field_without_type' -vv }}