### PR TITLE
[1LP][RFR] Separate test_assign_and_unassign_tag for different providers and minimize parametrization 

### DIFF
--- a/cfme/tests/configure/test_tag.py
+++ b/cfme/tests/configure/test_tag.py
@@ -19,11 +19,25 @@ from cfme.utils.update import update
 from cfme.utils.wait import wait_for
 
 
-CLOUD_COLLECTION = ["availability_zones", "cloud_networks",
-        "cloud_networks", "cloud_subnets", "flavors", "network_routers", "security_groups"]
-INFRA_COLLECTION = ["clusters", "hosts", "data_stores", "providers", "resource_pools",
-        "services", "service_templates", "tenants", "vms", ]
-
+CLOUD_COLLECTION = [
+    "availability_zones",
+    "cloud_networks",
+    "cloud_subnets",
+    "flavors",
+    "network_routers",
+    "security_groups",
+]
+INFRA_COLLECTION = [
+    "clusters",
+    "hosts",
+    "data_stores",
+    "providers",
+    "resource_pools",
+    "services",
+    "service_templates",
+    "tenants",
+    "vms",
+]
 pytestmark = [
     pytest.mark.provider(classes=[InfraProvider], selector=ONE),
     pytest.mark.usefixtures('setup_provider')

--- a/cfme/tests/intelligence/reports/test_generate_report.py
+++ b/cfme/tests/intelligence/reports/test_generate_report.py
@@ -5,7 +5,8 @@
 import pytest
 
 from cfme import test_requirements
-from cfme.infrastructure.provider.virtualcenter import VMwareProvider
+from cfme.infrastructure.provider import InfraProvider
+from cfme.markers.env_markers.provider import ONE
 # from selenium.common.exceptions import NoSuchElementException
 # from utils.log import logger
 
@@ -14,7 +15,7 @@ pytestmark = [
     pytest.mark.tier(3),
     test_requirements.report,
     pytest.mark.usefixtures('setup_provider'),
-    pytest.mark.provider([VMwareProvider], scope='module'),
+    pytest.mark.provider([InfraProvider], scope='module', selector=ONE),
 ]
 
 

--- a/cfme/tests/intelligence/reports/test_views.py
+++ b/cfme/tests/intelligence/reports/test_views.py
@@ -2,10 +2,8 @@
 import pytest
 
 from cfme import test_requirements
-from cfme.cloud.provider.ec2 import EC2Provider
-from cfme.cloud.provider.openstack import OpenStackProvider
-from cfme.infrastructure.provider.rhevm import RHEVMProvider
-from cfme.infrastructure.provider.virtualcenter import VMwareProvider
+from cfme.common.provider import BaseProvider
+from cfme.markers.env_markers.provider import ONE
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 
@@ -13,8 +11,7 @@ pytestmark = [
     pytest.mark.tier(3),
     test_requirements.report,
     pytest.mark.usefixtures('setup_provider'),
-    pytest.mark.provider([OpenStackProvider, EC2Provider, RHEVMProvider, VMwareProvider],
-                         scope='module')
+    pytest.mark.provider([BaseProvider], selector=ONE, scope='module')
 ]
 
 
@@ -33,9 +30,9 @@ def report(appliance):
 
 @pytest.mark.rhv3
 @pytest.mark.parametrize('view_mode', ['Hybrid View', 'Graph View', 'Tabular View'])
-@pytest.mark.meta(blockers=[BZ(1401560)])
 def test_report_view(report, view_mode):
     """Tests provisioning via PXE
+    Bugzilla: 1401560
 
     Metadata:
         test_flag: report
@@ -46,6 +43,6 @@ def test_report_view(report, view_mode):
         caseimportance: high
         initialEstimate: 1/6h
     """
-    view = navigate_to(report, 'Details')
+    view = navigate_to(report, 'Details', force=True)
     view.view_selector.select(view_mode)
     assert view.view_selector.selected == view_mode, "View setting failed for {}".format(view)


### PR DESCRIPTION
This PR brings the following change:
1. Separate `test_assign_and_unassign_tag` for cloud and infra providers since few collections work only with specific providers and supported only on specific appliance versions.
2. Minimize parametrization for `test_views.py` and `test_generate_reports.py` since it's not required.

{{ pytest: cfme/tests/configure/test_tag.py::TestTagsViaREST::test_assign_and_unassign_tag cfme/tests/intelligence/reports/test_views.py cfme/tests/intelligence/reports/test_generate_report.py --use-template-cache -sqvvv }}