### PR TITLE
[1LP][RFR] create osp container with wrapanapi

### DIFF
--- a/cfme/storage/object_store_object.py
+++ b/cfme/storage/object_store_object.py
@@ -124,6 +124,14 @@ class ObjectStoreObjectCollection(BaseCollection):
 
     ENTITY = ObjectStoreObject
 
+    @property
+    def manager(self):
+        coll = self.appliance.collections.object_managers.filter(
+            {"provider": self.filters.get('provider')}
+        )
+        # For each provider has single object type storage manager
+        return coll.all()[0]
+
     def all(self):
         """returning all Object Store Objects"""
         view = navigate_to(self, 'All')

--- a/cfme/tests/storage/test_object_store_container.py
+++ b/cfme/tests/storage/test_object_store_container.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
-import random
-
+import fauxfactory
 import pytest
 
 from cfme.cloud.provider.openstack import OpenStackProvider
-from cfme.utils.blockers import BZ
+from cfme.utils.wait import wait_for
 
 pytestmark = [
     pytest.mark.tier(3),
@@ -14,21 +13,31 @@ pytestmark = [
 
 
 @pytest.fixture(scope="module")
-def containers(appliance, provider):
-    collection = appliance.collections.object_store_containers.filter({'provider': provider})
-    containers = collection.all()
-    # TODO add create method and remove pytest skip as BZ 1490320 fix
-    yield containers if containers else pytest.skip("No Containers Available")
+def container(appliance, provider):
+    collection = appliance.collections.object_store_containers.filter({"provider": provider})
+    conts = collection.all()
+
+    if not conts:
+        # Note: Like to avoid creation with api client multiple time.
+        # Maintaining at least one container as creation not possible with UI for OSP.
+
+        cont = collection.instantiate(
+            key="cont_{}".format(fauxfactory.gen_alpha(3)), provider=provider
+        )
+        provider.mgmt.create_container(cont.key)
+        collection.manager.refresh()
+        wait_for(lambda: cont.exists, delay=30, timeout=1200, fail_func=provider.browser.refresh)
+        return cont
+    else:
+        return conts[0]
 
 
-@pytest.mark.meta(blockers=[BZ(1648243, forced_streams=["5.9"])])
-def test_add_remove_tag(containers):
+def test_add_remove_tag(container):
     """
     Polarion:
         assignee: anikifor
         initialEstimate: 1/4h
     """
-    container = random.choice(containers)
 
     # add tag with category Department and tag communication
     added_tag = container.add_tag()


### PR DESCRIPTION
Signed-off-by: Nikhil Dhandre <ndhandre@redhat.com>

Purpose or Intent
=================
Needs: https://github.com/ManageIQ/wrapanapi/pull/360

Most of time these test are skipping in absence of storage `container` or `object` so creating with `api` and trying to maintain single on OSP.

{{pytest: cfme/tests/storage/test_object_store_object.py cfme/tests/storage/test_object_store_container.py -v}} 