### PR TITLE
[RFR] Fix UnboundLocalError in test_resource_allocation

### DIFF
--- a/cfme/tests/intelligence/chargeback/test_resource_allocation.py
+++ b/cfme/tests/intelligence/chargeback/test_resource_allocation.py
@@ -376,17 +376,16 @@ def new_chargeback_rate():
                 {'per_time': 'Hourly', 'variable_rate': '2'}}
     )
     compute.create()
-    if not BZ(1532368, forced_streams=['5.9']).blocks:
-        storage = rates.StorageRate(description=desc,
-            fields={'Allocated Disk Storage':
-                    {'per_time': 'Hourly', 'variable_rate': '3'}}
-        )
+    storage = rates.StorageRate(description=desc,
+        fields={'Allocated Disk Storage':
+                {'per_time': 'Hourly', 'variable_rate': '3'}}
+    )
     storage.create()
     yield desc
 
     if compute.exists:
         compute.delete()
-    if not BZ(1532368, forced_streams=['5.9']).blocks and storage.exists:
+    if storage.exists:
         storage.delete()
 
 


### PR DESCRIPTION
Not looking for complete test passing, just fixing the UnboundLocalError that was happening in 59z because this BZ was being forced. The BZ is closed/fixed in 59z and 510z, so I removed it. Bad pattern was causing UnboundLocal, pattern removed.