### PR TITLE
[1LP][RFR] New test: Testing automate simulate 'Retry' button using state machines

### DIFF
--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -1655,6 +1655,7 @@ class AutomateSimulationView(BaseLoggedInPage):
     submit_button = Button(title='Submit Automation Simulation with the specified options')
     reset_button = Button(title="Reset all options")
     cancel_button = Button(title="Cancel Simulation to go back to Button details")
+    retry_button = Button(title="Retry state machine simulation, with preserved attributes")
 
     result_tree = ManageIQTree(tree_id='ae_simulation_treebox')
 

--- a/cfme/tests/automate/test_automate_manual.py
+++ b/cfme/tests/automate/test_automate_manual.py
@@ -69,40 +69,6 @@ def test_quota_source_user():
 
 
 @pytest.mark.tier(1)
-def test_automate_simulate_retry():
-    """
-    Automate simulation now supports simulating the state machines.
-
-    Polarion:
-        assignee: ghubale
-        initialEstimate: 1/4h
-        caseimportance: medium
-        caseposneg: positive
-        testtype: functional
-        startsin: 5.6
-        casecomponent: Automate
-        tags: automate
-        title: Test automate simulate retry
-        setup:
-            1. Create a state machine that contains a couple of states
-        testSteps:
-            1. Create an Automate model that has a State Machine that can end in a retry
-            2. Run a simulation to test the Automate Model from Step 1
-            3. When the Automation ends in a retry, we should be able to resubmit the request
-            4. Use automate simulation UI to call the state machine (Call_Instance)
-        expectedResults:
-            1.
-            2.
-            3.
-            4. A Retry button should appear.
-
-    Bugzilla:
-        1299579
-    """
-    pass
-
-
-@pytest.mark.tier(1)
 def test_customize_request_security_group():
     """
     Polarion:


### PR DESCRIPTION
- This test case create schema which includes state machines
- Adding method for retry button and to execute it using 'State' machines
- Adding 'retry_button' to the 'Automatesimulation' view page
- Checking whether 'Retry' button is displayed after simulation

{{ pytest: cfme/tests/automate/test_method.py -k 'test_automate_simulate_retry' -v }}