### PR TITLE
[1LP][RFR] Fixed exception error while adding entry points

### DIFF
--- a/cfme/services/catalogs/catalog_items/__init__.py
+++ b/cfme/services/catalogs/catalog_items/__init__.py
@@ -3,8 +3,6 @@ import fauxfactory
 from cached_property import cached_property
 from navmazing import NavigateToAttribute
 from navmazing import NavigateToSibling
-from selenium.common.exceptions import NoSuchElementException
-from selenium.common.exceptions import StaleElementReferenceException
 from widgetastic.utils import WaitFillViewStrategy
 from widgetastic.widget import Checkbox
 from widgetastic.widget import ClickableMixin
@@ -36,23 +34,16 @@ from widgetastic_manageiq import WaitTab
 
 class EntryPoint(Input, ClickableMixin):
     def fill(self, value):
-        for _ in range(2):
-            try:
-                if super(EntryPoint, self).fill(value):
-                    self.parent_view.modal.cancel.click()
-                    # After changing default path values of 'retirement_entry_point',
-                    # 'reconfigure_entry_point' or 'provisioning_entry_point';
-                    # 'Select Entry Point Instance'(pop up) occures which also helps to select these
-                    # paths using tree structure. Here we have already filled these values through
-                    # text input. So to ignore this pop up clicking on cancel button is required.
-                    return True
-                return False
-            except (NoSuchElementException, StaleElementReferenceException):
-                # Sometimes while adding values in text box and cancelling pop up gives exceptions
-                # like NoSuchElementException and StaleElementReferenceException. Hence adding
-                # workaround for it and checking if it can be able to fill text box and cancel pop
-                # up by running it two times.
-                pass
+        if super(EntryPoint, self).fill(value):
+            self.parent_view.modal.cancel.wait_displayed('20s')
+            self.parent_view.modal.cancel.click()
+            # After changing default path values of 'retirement_entry_point',
+            # 'reconfigure_entry_point' or 'provisioning_entry_point';
+            # 'Select Entry Point Instance'(pop up) occures which also helps to select these paths
+            # using tree structure. Here we have already filled these values through text input.
+            # So to ignore this pop up clicking on cancel button is required.
+            return True
+        return False
 
 
 # Views


### PR DESCRIPTION
 Fixed Error:
```
>           raise StaleElementReferenceException("Couldn't handle it")
E           StaleElementReferenceException: Message: Couldn't handle it

../cfme_venv/lib/python2.7/site-packages/widgetastic/utils.py:686: StaleElementReferenceException
StaleElementReferenceException
Message: Couldn't handle it
```
{{ pytest: cfme/tests/cloud/test_tenant_quota.py -k 'test_service_cloud_tenant_quota_with_default_entry_point' --use-provider=complete -v }}