### PR TITLE
[1LP][RFR] clone dialog is broken. uncollecting tests until those are fixed

### DIFF
--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -426,7 +426,7 @@ def test_action_prevent_event(request, vm, vm_off, policy_for_testing):
         pytest.fail("CFME did not prevent starting of the VM {}".format(vm.name))
 
 
-@pytest.mark.meta(blockers=[1439331])
+@pytest.mark.meta(blockers=[BZ(1439331)])
 @pytest.mark.provider(
     [VMwareProvider, RHEVMProvider, OpenStackProvider, AzureProvider],
     scope="module"
@@ -892,7 +892,7 @@ def test_action_untag(request, vm, vm_off, policy_for_testing, appliance, tag):
 
 
 @pytest.mark.provider([VMwareProvider], scope="module")
-@pytest.mark.meta(blockers=[1381255])
+@pytest.mark.meta(blockers=[BZ(1685201)])
 def test_action_cancel_clone(appliance, request, provider, vm_name, vm_big, policy_for_testing,
         compliance_policy):
     """This test checks if 'Cancel vCenter task' action works.

--- a/cfme/tests/infrastructure/test_vm_clone.py
+++ b/cfme/tests/infrastructure/test_vm_clone.py
@@ -5,7 +5,9 @@ from widgetastic_patternfly import DropdownItemNotFound
 
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
+from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
+
 
 pytestmark = [
     pytest.mark.meta(roles="+automate"),
@@ -40,6 +42,7 @@ def create_vm(appliance, provider, request):
 
 
 @pytest.mark.uncollectif(lambda provider: not provider.one_of(VMwareProvider))
+@pytest.mark.meta(blockers=[BZ(1685201)])
 def test_vm_clone(appliance, provider, clone_vm_name, create_vm):
     """
     Polarion:


### PR DESCRIPTION
{{ pytest: --long-running cfme/tests/control/test_actions.py::test_action_cancel_clone cfme/tests/infrastructure/test_vm_clone.py::test_vm_clone}}