### PR TITLE
Updating is_displayed for catalog all page

### DIFF
--- a/cfme/services/catalogs/catalog.py
+++ b/cfme/services/catalogs/catalog.py
@@ -49,6 +49,7 @@ class CatalogsView(ServicesCatalogView):
         return (
             self.in_explorer and
             self.catalogs.is_opened and
+            self.title.text == "All Catalogs" and
             self.catalogs.tree.currently_selected == ["All Catalogs"])
 
 


### PR DESCRIPTION
Signed-off-by: mnadeem92 <mnadeem@redhat.com>

is_displayed for catalog all page returns True even if the view is on Add catalog page. This patch will fix the issue.

Closes #8532

{{pytest: cfme/tests/services/test_catalog.py::test_catalog_crud -v}}