### PR TITLE
[NOTEST] [RFR] EC2cleanup boto3 refactor from object to dict

### DIFF
--- a/scripts/ec2cleanup.py
+++ b/scripts/ec2cleanup.py
@@ -103,11 +103,11 @@ def delete_unused_loadbalancers(provider_mgmt, excluded_elbs, output):
     provider_name = provider_mgmt.kwargs['name']
     try:
         for elb in provider_mgmt.get_all_unused_loadbalancers():
-            if excluded_elbs and elb.name in excluded_elbs:
-                logger.info("  Excluding Elastic LoadBalancer id: %r", elb.name)
+            if excluded_elbs and elb.get("LoadBalancerName") in excluded_elbs:
+                logger.info("  Excluding Elastic LoadBalancer id: %r", elb.get("LoadBalancerName"))
                 continue
             else:
-                elb_list.append([provider_name, elb.name])
+                elb_list.append([provider_name, elb.get("LoadBalancerName")])
                 provider_mgmt.delete_loadbalancer(loadbalancer=elb)
         logger.info("  Deleted Elastic LoadBalancers: %r", elb_list)
         if elb_list:

--- a/scripts/ec2cleanup.py
+++ b/scripts/ec2cleanup.py
@@ -1,11 +1,10 @@
 import argparse
 import sys
 import time
-import pytz
-
 from datetime import datetime
 from datetime import timedelta
 
+import pytz
 from tabulate import tabulate
 
 from cfme.utils.log import add_stdout_handler
@@ -140,7 +139,7 @@ def delete_unused_network_interfaces(provider_mgmt, excluded_enis, output):
                             eni.get("NetworkInterfaceId"))
                 continue
             else:
-                eni_list.append([provider_name,eni.get("NetworkInterfaceId")])
+                eni_list.append([provider_name, eni.get("NetworkInterfaceId")])
                 provider_mgmt.ec2_connection.delete_network_interface(
                     NetworkInterfaceId=eni.get("NetworkInterfaceId"))
         logger.info("  Deleted Elastic Network Interfaces: %r", eni_list)


### PR DESCRIPTION
Wrapanapi ec2 is moving to boto3 and in boto3 response returns dict instead of object so I needed to change calling of elb.name.
Depends on this PR:
https://github.com/ManageIQ/wrapanapi/pull/362

{{ pytest: cfme/tests/cloud* --use-provider ec2west --long-running }}