### PR TITLE
[RFR] fixed nodata tests and visual configuration view

### DIFF
--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -77,16 +77,19 @@ class InstanceEntity(JSBaseEntity):
 
             data_dict['policy'] = policy
         elif data_dict.get('quad'):
-            # 5.10 doesn't have quadicon
-            data_dict['os'] = data_dict['quad']['topLeft']['tooltip']
-            data_dict['vendor'] = data_dict['quad']['bottomLeft']['tooltip']
             try:
-                data_dict['no_snapshots'] = data_dict['total_snapshots']
-            # openstack instances require this
+                # 5.10 doesn't have quadicon
+                data_dict['os'] = data_dict['quad']['topLeft']['tooltip']
+                data_dict['vendor'] = data_dict['quad']['bottomLeft']['tooltip']
+                try:
+                    data_dict['no_snapshots'] = data_dict['total_snapshots']
+                # openstack instances require this
+                except KeyError:
+                    data_dict['no_snapshots'] = data_dict['quad']['bottomRight']['text']
+                data_dict['state'] = data_dict['quad']['topRight']['tooltip']
             except KeyError:
-                data_dict['no_snapshots'] = data_dict['quad']['bottomRight']['text']
-            data_dict['state'] = data_dict['quad']['topRight']['tooltip']
-
+                self.logger.warning("quad data isn't available. "
+                                    "what's available {}".format(data_dict))
         return data_dict
 
 

--- a/cfme/configure/settings.py
+++ b/cfme/configure/settings.py
@@ -187,8 +187,9 @@ class VisualForm(View):
 
     @View.nested
     class grid_tile_icons(View):    # noqa
-        infra_provider_quad = BootstrapSwitch('quadicons_ems')
-        cloud_provider_quad = BootstrapSwitch('quadicons_ems_cloud')
+        infra_provider_quad = BootstrapSwitch('quadicons_infra_manager')
+        cloud_provider_quad = BootstrapSwitch('quadicons_cloud_manager')
+        containers_provider_quad = BootstrapSwitch('quadicons_container_manager')
         host_quad = BootstrapSwitch('quadicons_host')
         datastore_quad = BootstrapSwitch('quadicons_storage')
         vm_quad = BootstrapSwitch('quadicons_vm')

--- a/cfme/configure/settings.py
+++ b/cfme/configure/settings.py
@@ -21,6 +21,8 @@ from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.log import logger
 from cfme.utils.pretty import Pretty
 from cfme.utils.update import Updateable
+from cfme.utils.version import Version
+from cfme.utils.version import VersionPicker
 from widgetastic_manageiq import BootstrapSelect
 from widgetastic_manageiq import Table
 from widgetastic_manageiq import Text
@@ -187,8 +189,11 @@ class VisualForm(View):
 
     @View.nested
     class grid_tile_icons(View):    # noqa
-        infra_provider_quad = BootstrapSwitch('quadicons_infra_manager')
-        cloud_provider_quad = BootstrapSwitch('quadicons_cloud_manager')
+        infra_provider_quad = BootstrapSwitch(VersionPicker({Version.lowest(): 'quadicons_ems',
+                                                            '5.10': 'quadicons_infra_manager'}))
+        cloud_provider_quad = BootstrapSwitch(VersionPicker(
+            {Version.lowest(): 'quadicons_ems_cloud', '5.10': 'quadicons_cloud_manager'}))
+
         containers_provider_quad = BootstrapSwitch('quadicons_container_manager')
         host_quad = BootstrapSwitch('quadicons_host')
         datastore_quad = BootstrapSwitch('quadicons_storage')

--- a/cfme/tests/configure/test_visual_cloud.py
+++ b/cfme/tests/configure/test_visual_cloud.py
@@ -212,5 +212,4 @@ def test_cloudprovider_noquads(request, set_cloud_provider_quad):
     """
     view = navigate_to(CloudProvider, 'All')
     view.toolbar.view_selector.select('Grid View')
-    # Here data property will return an empty dict when the Quadrants option is deactivated.
-    assert not view.entities.get_first_entity().data
+    assert 'topRight' not in view.entities.get_first_entity().data.get('quad', {})

--- a/cfme/tests/configure/test_visual_infra.py
+++ b/cfme/tests/configure/test_visual_infra.py
@@ -304,8 +304,7 @@ def test_infraprovider_noquads(request, set_infra_provider_quad):
     """
     view = navigate_to(InfraProvider, 'All')
     view.toolbar.view_selector.select('Grid View')
-    # Here data property will return an empty dict when the Quadrants option is deactivated.
-    assert not view.entities.get_first_entity().data
+    assert 'topRight' not in view.entities.get_first_entity().data.get('quad', {})
 
 
 def test_host_noquads(appliance, request, set_host_quad):
@@ -323,8 +322,7 @@ def test_host_noquads(appliance, request, set_host_quad):
     host_collection = appliance.collections.hosts
     view = navigate_to(host_collection, 'All')
     view.toolbar.view_selector.select('Grid View')
-    # Here data property will return an empty dict when the Quadrants option is deactivated.
-    assert not view.entities.get_first_entity().data
+    assert 'topRight' not in view.entities.get_first_entity().data.get('quad', {})
 
 
 def test_datastore_noquads(request, set_datastore_quad, appliance):
@@ -342,8 +340,7 @@ def test_datastore_noquads(request, set_datastore_quad, appliance):
     dc = DatastoreCollection(appliance)
     view = navigate_to(dc, 'All')
     view.toolbar.view_selector.select('Grid View')
-    # Here data property will return an empty dict when the Quadrants option is deactivated.
-    assert not view.entities.get_first_entity().data
+    assert 'topRight' not in view.entities.get_first_entity().data.get('quad', {})
 
 
 def test_vm_noquads(appliance, request, set_vm_quad):
@@ -360,8 +357,7 @@ def test_vm_noquads(appliance, request, set_vm_quad):
     """
     view = navigate_to(appliance.collections.infra_vms, 'VMsOnly')
     view.toolbar.view_selector.select('Grid View')
-    # Here data property will return an empty dict when the Quadrants option is deactivated.
-    assert not view.entities.get_first_entity().data
+    assert 'topRight' not in view.entities.get_first_entity().data.get('quad', {})
 
 
 @pytest.mark.meta(blockers=['GH#ManageIQ/manageiq:11215'])
@@ -379,8 +375,7 @@ def test_template_noquads(appliance, set_template_quad):
     """
     view = navigate_to(appliance.collections.infra_templates, 'TemplatesOnly')
     view.toolbar.view_selector.select('Grid View')
-    # Here data property will return an empty dict when the Quadrants option is deactivated.
-    assert not view.entities.get_first_entity().data
+    assert 'topRight' not in view.entities.get_first_entity().data.get('quad', {})
 
 
 def test_change_truncate_long_text_save_button_enabled(appliance):


### PR DESCRIPTION
visual tests have been relied on data provided by NonJSEntities which was replaced with JSEntities long time ago. 
In addition visual configuration view widgets have had wrong ids.