### PR TITLE
[1LP][RFR] added wait_for the Submit button to be enabled

### DIFF
--- a/cfme/services/service_catalogs/ui.py
+++ b/cfme/services/service_catalogs/ui.py
@@ -14,6 +14,7 @@ from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.appliance.implementations.ui import ViaUI
+from cfme.utils.wait import wait_for
 from widgetastic_manageiq import Accordion
 from widgetastic_manageiq import ManageIQTree
 
@@ -93,7 +94,7 @@ def order(self):
         view.fill(self.dialog_values)
     if self.ansible_dialog_values:
         view.fill(self.ansible_dialog_values)
-    view.submit_button.wait_displayed()
+    wait_for(lambda: not view.submit_button.disabled, timeout=7)
     view.submit_button.click()
     view = self.create_view(RequestsView, wait='10s')
     view.flash.assert_no_error()

--- a/cfme/tests/services/test_cloud_service_catalogs.py
+++ b/cfme/tests/services/test_cloud_service_catalogs.py
@@ -78,6 +78,11 @@ def test_cloud_catalog_item(appliance, vm_name, setup_provider, provider, dialog
             'customize': {
                 'admin_username': provisioning['customize_username'],
                 'root_password': provisioning['customize_password']}})
+    if provider.one_of(AzureProvider) and appliance.version < '5.10':
+        # in 5.9 instance types are lowercase
+        recursive_update(inst_args, {
+            'properties': {
+                'instance_type': partial_match((provisioning.get('instance_type', None)).lower())}})
 
     catalog_item = appliance.collections.catalog_items.create(
         provider.catalog_item_type,


### PR DESCRIPTION
{{ pytest: -v cfme/tests/services/test_provision_stack.py::test_provision_stack[azure]  --use-provider=complete }}

This is the fix for the error
```
TimedOutError: Could not do function <lambda>() at /var/ci/workspace/downstream-510z-tests-master-extcloud/cfme_venv/lib/python2.7/site-packages/widgetastic/widget/base.py:494 in time

../cfme_venv/lib/python2.7/site-packages/wait_for/__init__.py:180: TimedOutError
TimedOutError
Could not do function <lambda>() at /var/ci/workspace/downstream-510z-tests-master-extcloud/cfme_venv/lib/python2.7/site-packages/widgetastic/widget/base.py:494 in time
```

The button is always displayed, but is not always enabled, like here
![image](https://user-images.githubusercontent.com/42433123/53816306-9ecc1d80-3f63-11e9-85e8-6de14b150320.png)

Also added block for `5.9` instance type, because it's written in lowercase