### PR TITLE
[RFR] remove manual case test_diagnostic_timelines

### DIFF
--- a/cfme/tests/test_manual.py
+++ b/cfme/tests/test_manual.py
@@ -3530,18 +3530,6 @@ def test_osp_vmware67_test_vm_migration_from_nfs_storage_in_vmware_to_nfs_on_osp
 
 
 @pytest.mark.manual
-def test_diagnostic_timelines():
-    """
-    None
-
-    Polarion:
-        assignee: jdupuy
-        initialEstimate: 1/4h
-    """
-    pass
-
-
-@pytest.mark.manual
 def test_group_quota_via_ssui():
     """
     Polarion:


### PR DESCRIPTION
This test case is automated by https://github.com/ManageIQ/integration_tests/blob/387e9235a8659974138b0df4b5dfbc491c29410e/cfme/tests/cloud/test_cloud_timelines.py#L349
