### PR TITLE
[1LP][RFR] Automate test case: test_non_admin_user_reports_access_rest AND modify gen_data access_control functions

### DIFF
--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -368,14 +368,19 @@ def automation_requests_data(vm, requests_collection=False, approve=True, num=4)
     return [data for _ in range(num)]
 
 
-def groups(request, appliance, role, tenant, num=1):
+def groups(request, appliance, role, tenant, num=1, **kwargs):
     data = []
     for _ in range(num):
-        data.append({
-            "description": "group_description_{}".format(fauxfactory.gen_alphanumeric()),
-            "role": {"href": role.href},
-            "tenant": {"href": tenant.href}
-        })
+        data.append(
+            {
+                "description": kwargs.get(
+                    "description",
+                    "group_description_{}".format(fauxfactory.gen_alphanumeric()),
+                ),
+                "role": {"href": role.href},
+                "tenant": {"href": tenant.href},
+            }
+        )
 
     groups = _creating_skeleton(request, appliance, "groups", data)
     if num == 1:
@@ -383,10 +388,14 @@ def groups(request, appliance, role, tenant, num=1):
     return groups
 
 
-def roles(request, appliance, num=1):
+def roles(request, appliance, num=1, **kwargs):
     data = []
     for _ in range(num):
-        data.append({"name": "role_name_{}".format(fauxfactory.gen_alphanumeric())})
+        data.append(
+            {
+                "name": kwargs.get("name", "role_name_{}".format(fauxfactory.gen_alphanumeric()))
+            }
+        )
 
     roles = _creating_skeleton(request, appliance, "roles", data)
     if num == 1:
@@ -412,16 +421,16 @@ def copy_role(appliance, orig_name, new_name=None):
     return new_role[0]
 
 
-def tenants(request, appliance, num=1):
+def tenants(request, appliance, num=1, **kwargs):
     parent = appliance.rest_api.collections.tenants.get(name='My Company')
     data = []
     for _ in range(num):
         uniq = fauxfactory.gen_alphanumeric()
         data.append({
-            'description': 'test_tenants_{}'.format(uniq),
-            'name': 'test_tenants_{}'.format(uniq),
-            'divisible': 'true',
-            'use_config_for_attributes': 'false',
+            'description': kwargs.get("description", 'test_tenants_{}'.format(uniq)),
+            'name': kwargs.get("name", 'test_tenants_{}'.format(uniq)),
+            'divisible': kwargs.get("divisible", 'true'),
+            'use_config_for_attributes': kwargs.get("use_config_for_attributes", 'false'),
             'parent': {'href': parent.href}
         })
 
@@ -431,20 +440,22 @@ def tenants(request, appliance, num=1):
     return tenants
 
 
-def users(request, appliance, num=1):
+def users(request, appliance, num=1, **kwargs):
     data = []
     for _ in range(num):
         uniq = fauxfactory.gen_alphanumeric(4).lower()
-        data.append({
-            "userid": "user_{}".format(uniq),
-            "name": "name_{}".format(uniq),
-            "password": fauxfactory.gen_alphanumeric(),
-            "email": "user@example.com",
-            "group": {"description": "EvmGroup-user_self_service"}
-        })
+        data.append(
+            {
+                "userid": kwargs.get("userid", "user_{}".format(uniq)),
+                "name": kwargs.get("name", "name_{}".format(uniq)),
+                "password": kwargs.get("password", fauxfactory.gen_alphanumeric()),
+                "email": kwargs.get("email", "{}@example.com".format(uniq)),
+                "group": {"description": kwargs.get("group", "EvmGroup-user_self_service")},
+            }
+        )
 
-    resources = _creating_skeleton(request, appliance, "users", data)
-    return resources, data
+    users = _creating_skeleton(request, appliance, "users", data)
+    return users, data
 
 
 def _creating_skeleton(request, appliance, col_name, col_data, col_action='create',
@@ -486,17 +497,6 @@ def mark_vm_as_template(appliance, provider, vm_name):
     return appliance.rest_api.collections.templates.get(name=vm_name)
 
 
-def arbitration_settings(request, appliance, num=2):
-    data = []
-    for _ in range(num):
-        uniq = fauxfactory.gen_alphanumeric(5)
-        data.append({
-            'name': 'test_settings_{}'.format(uniq),
-            'display_name': 'Test Settings {}'.format(uniq)})
-
-    return _creating_skeleton(request, appliance, 'arbitration_settings', data)
-
-
 def orchestration_templates(request, appliance, num=2):
     data = []
     for _ in range(num):
@@ -523,36 +523,6 @@ def arbitration_profiles(request, appliance, provider, num=2):
         })
 
     return _creating_skeleton(request, appliance, 'arbitration_profiles', data)
-
-
-def arbitration_rules(request, appliance, num=2):
-    data = []
-    for _ in range(num):
-        data.append({
-            'description': 'test admin rule {}'.format(fauxfactory.gen_alphanumeric(5)),
-            'operation': 'inject',
-            'expression': {'EQUAL': {'field': 'User-userid', 'value': 'admin'}}
-        })
-
-    return _creating_skeleton(request, appliance, 'arbitration_rules', data)
-
-
-def blueprints(request, appliance, num=2):
-    data = []
-    for _ in range(num):
-        uniq = fauxfactory.gen_alphanumeric(5)
-        data.append({
-            'name': 'test_blueprint_{}'.format(uniq),
-            'description': 'Test Blueprint {}'.format(uniq),
-            'ui_properties': {
-                'service_catalog': {},
-                'service_dialog': {},
-                'automate_entrypoints': {},
-                'chart_data_model': {}
-            }
-        })
-
-    return _creating_skeleton(request, appliance, 'blueprints', data)
 
 
 def conditions(request, appliance, num=2):

--- a/cfme/tests/configure/test_rest_access_control.py
+++ b/cfme/tests/configure/test_rest_access_control.py
@@ -3,7 +3,6 @@ import fauxfactory
 import pytest
 
 from cfme import test_requirements
-from cfme.rest.gen_data import _creating_skeleton
 from cfme.rest.gen_data import groups as _groups
 from cfme.rest.gen_data import roles as _roles
 from cfme.rest.gen_data import tenants as _tenants
@@ -485,10 +484,6 @@ class TestUsersViaREST(object):
             assert appliance.new_rest_api_instance(auth=user_auth)
 
     @pytest.mark.tier(3)
-    @pytest.mark.uncollectif(
-        lambda appliance: appliance.version < '5.9',
-        reason='fix for BZ 1486041 was not back ported to 5.8'
-    )
     def test_create_uppercase_user(self, request, appliance):
         """Tests creating user with userid containing uppercase letters.
 
@@ -509,12 +504,11 @@ class TestUsersViaREST(object):
             "name": "REST User {}".format(uniq),
             "password": fauxfactory.gen_alphanumeric(),
             "email": "user@example.com",
-            "group": {"description": "EvmGroup-user_self_service"}
+            "group": "EvmGroup-user_self_service"
         }
-
-        user = _creating_skeleton(request, appliance, 'users', [data])[0]
+        user, _ = _users(request, appliance, **data)
         assert_response(appliance)
-        user_auth = (user.userid, data['password'])
+        user_auth = (user[0].userid, data['password'])
         assert appliance.new_rest_api_instance(auth=user_auth)
 
     @pytest.mark.tier(2)

--- a/cfme/tests/intelligence/reports/test_reports.py
+++ b/cfme/tests/intelligence/reports/test_reports.py
@@ -1,0 +1,45 @@
+import pytest
+
+from cfme import test_requirements
+from cfme.rest.gen_data import users as _users
+from cfme.utils.rest import assert_response
+
+pytestmark = [test_requirements.report, pytest.mark.tier(3), pytest.mark.sauce]
+
+
+@pytest.fixture(scope="function")
+def rbac_api(appliance, request):
+    user, user_data = _users(
+        request, appliance, password="smartvm", group="EvmGroup-user"
+    )
+    api = appliance.new_rest_api_instance(
+        entry_point=appliance.rest_api._entry_point,
+        auth=(user[0].userid, user_data[0]["password"]),
+    )
+    assert_response(api)
+    yield api
+    appliance.rest_api.collections.users.action.delete(id=user[0].id)
+
+
+@test_requirements.rest
+@pytest.mark.tier(1)
+def test_non_admin_user_reports_access_rest(appliance, request, rbac_api):
+    """ This test checks if a non-admin user with proper privileges can access all reports via API.
+
+    Polarion:
+        assignee: pvala
+        casecomponent: Rest
+        caseimportance: medium
+        initialEstimate: 1/12h
+        tags: report
+        setup:
+            1. Create a user with privilege to access reports and REST.
+            2. Instantiate a MiqApi instance with the user.
+        testSteps:
+            1. Access all reports with the new user with the help of newly instantiated API.
+        expectedResults:
+            1. User should be able to access all reports.
+    """
+    report_data = rbac_api.collections.reports.all
+    assert_response(appliance)
+    assert len(report_data)


### PR DESCRIPTION
This PR brings the following changes:
1.  Create a separate file `intelligence/reports/test_reports.py` which includes all functional test cases of reports, this is a part of future refactoring of reports code.
2. Automate a test case: test_non_admin_user_reports_access_rest
3. Modify `users`, `roles`, `groups`, and `tenants` function to accept kwargs
4. Remove functions related to deprecated features.
5. Modify test cases using these functions to work well.

{{ pytest: cfme/tests/configure/test_rest_access_control.py cfme/tests/intelligence/reports/test_reports.py --use-template-cache -sqvvvv }}