### PR TITLE
[WIPTEST][NOREVIEW] Fix revert snapshot timeouts

### DIFF
--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -40,14 +40,14 @@ def provision_vm(provider, template):
 
 
 @pytest.fixture(scope="function")
-def small_test_vm(setup_provider, provider, small_template, request):
+def small_test_vm(setup_provider, provider, small_template):
     vm = provision_vm(provider, small_template)
     yield vm
     vm.cleanup_on_provider()
 
 
 @pytest.fixture(scope="function")
-def full_test_vm(setup_provider, provider, full_template, request):
+def full_test_vm(setup_provider, provider, full_template):
     vm = provision_vm(provider, full_template)
     yield vm
     vm.cleanup_on_provider()
@@ -170,7 +170,7 @@ def test_delete_all_snapshots(small_test_vm, provider):
              message="Waiting for second snapshot to disappear")
 
 
-def verify_revert_snapshot(full_test_vm, provider, soft_assert, request,
+def verify_revert_snapshot(full_test_vm, provider, soft_assert,
                            active_snapshot=False):
     if provider.one_of(RHEVMProvider):
         # RHV snapshots have only description, no name
@@ -250,7 +250,7 @@ def verify_revert_snapshot(full_test_vm, provider, soft_assert, request,
 )
 @pytest.mark.uncollectif(lambda provider: (provider.one_of(RHEVMProvider) and provider.version < 4),
                          'Must be RHEVM provider version >= 4')
-def test_verify_revert_snapshot(full_test_vm, provider, soft_assert, request):
+def test_verify_revert_snapshot(full_test_vm, provider, soft_assert):
     """Tests revert snapshot
 
     Metadata:
@@ -261,11 +261,11 @@ def test_verify_revert_snapshot(full_test_vm, provider, soft_assert, request):
         casecomponent: Infra
         initialEstimate: 1/4h
     """
-    verify_revert_snapshot(full_test_vm, provider, soft_assert, request)
+    verify_revert_snapshot(full_test_vm, provider, soft_assert)
 
 
 @pytest.mark.provider([VMwareProvider], override=True)
-def test_revert_active_snapshot(full_test_vm, provider, soft_assert, request):
+def test_revert_active_snapshot(full_test_vm, provider, soft_assert):
     """Tests revert active snapshot
 
     Metadata:
@@ -277,7 +277,7 @@ def test_revert_active_snapshot(full_test_vm, provider, soft_assert, request):
         caseimportance: medium
         initialEstimate: 1/3h
     """
-    verify_revert_snapshot(full_test_vm, provider, soft_assert, request,
+    verify_revert_snapshot(full_test_vm, provider, soft_assert,
                            active_snapshot=True)
 
 

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -192,7 +192,7 @@ def verify_revert_snapshot(full_test_vm, provider, soft_assert, register_event, 
     # The 'fail_func' ensures we close the connection that failed with exception.
     # Without this, the connection would hang there and wait_for would fail with timeout.
     wait_for(lambda: ssh_client.run_command('touch snapshot1.txt').success, num_sec=400,
-             delay=20, handle_exception=True, fail_func=ssh_client.close(),
+             delay=30, handle_exception=True, fail_func=ssh_client.close(),
              message="Waiting for successful SSH connection")
     # Create first snapshot
     snapshot1.create()

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -192,7 +192,7 @@ def verify_revert_snapshot(full_test_vm, provider, soft_assert, register_event, 
     # The 'fail_func' ensures we close the connection that failed with exception.
     # Without this, the connection would hang there and wait_for would fail with timeout.
     wait_for(lambda: ssh_client.run_command('touch snapshot1.txt').success, num_sec=400,
-             delay=20, handle_exception=True, fail_func=ssh_client.close(),
+             delay=100, handle_exception=True, fail_func=ssh_client.close(),
              message="Waiting for successful SSH connection")
     # Create first snapshot
     snapshot1.create()

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -192,7 +192,7 @@ def verify_revert_snapshot(full_test_vm, provider, soft_assert, register_event, 
     # The 'fail_func' ensures we close the connection that failed with exception.
     # Without this, the connection would hang there and wait_for would fail with timeout.
     wait_for(lambda: ssh_client.run_command('touch snapshot1.txt').success, num_sec=400,
-             delay=30, handle_exception=True, fail_func=ssh_client.close(),
+             delay=20, handle_exception=True, fail_func=ssh_client.close(),
              message="Waiting for successful SSH connection")
     # Create first snapshot
     snapshot1.create()

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -170,7 +170,7 @@ def test_delete_all_snapshots(small_test_vm, provider):
              message="Waiting for second snapshot to disappear")
 
 
-def verify_revert_snapshot(full_test_vm, provider, soft_assert, register_event, request,
+def verify_revert_snapshot(full_test_vm, provider, soft_assert, request,
                            active_snapshot=False):
     if provider.one_of(RHEVMProvider):
         # RHV snapshots have only description, no name
@@ -192,7 +192,7 @@ def verify_revert_snapshot(full_test_vm, provider, soft_assert, register_event, 
     # The 'fail_func' ensures we close the connection that failed with exception.
     # Without this, the connection would hang there and wait_for would fail with timeout.
     wait_for(lambda: ssh_client.run_command('touch snapshot1.txt').success, num_sec=400,
-             delay=100, handle_exception=True, fail_func=ssh_client.close(),
+             delay=20, handle_exception=True, fail_func=ssh_client.close(),
              message="Waiting for successful SSH connection")
     # Create first snapshot
     snapshot1.create()
@@ -250,7 +250,7 @@ def verify_revert_snapshot(full_test_vm, provider, soft_assert, register_event, 
 )
 @pytest.mark.uncollectif(lambda provider: (provider.one_of(RHEVMProvider) and provider.version < 4),
                          'Must be RHEVM provider version >= 4')
-def test_verify_revert_snapshot(full_test_vm, provider, soft_assert, register_event, request):
+def test_verify_revert_snapshot(full_test_vm, provider, soft_assert, request):
     """Tests revert snapshot
 
     Metadata:
@@ -261,11 +261,11 @@ def test_verify_revert_snapshot(full_test_vm, provider, soft_assert, register_ev
         casecomponent: Infra
         initialEstimate: 1/4h
     """
-    verify_revert_snapshot(full_test_vm, provider, soft_assert, register_event, request)
+    verify_revert_snapshot(full_test_vm, provider, soft_assert, request)
 
 
 @pytest.mark.provider([VMwareProvider], override=True)
-def test_revert_active_snapshot(full_test_vm, provider, soft_assert, register_event, request):
+def test_revert_active_snapshot(full_test_vm, provider, soft_assert, request):
     """Tests revert active snapshot
 
     Metadata:
@@ -277,7 +277,7 @@ def test_revert_active_snapshot(full_test_vm, provider, soft_assert, register_ev
         caseimportance: medium
         initialEstimate: 1/3h
     """
-    verify_revert_snapshot(full_test_vm, provider, soft_assert, register_event, request,
+    verify_revert_snapshot(full_test_vm, provider, soft_assert, request,
                            active_snapshot=True)
 
 


### PR DESCRIPTION
This is an effort to find out why there are timeouts occurring when running snapshot test 'test_revert_active_snapshot'. I will need to collect some data while changing timeout threshold on ssh connection. Opening this PR because I couldn't reproduce the behaviour on my local machine.

Please, don't review this just yet, it is a work in progress.

{{ pytest: -v --long-running cfme/tests/infrastructure/test_snapshot.py --use-provider vsphere65-nested }}