### PR TITLE
[NOTEST][RFR] Common exists method in BaseEntity

### DIFF
--- a/cfme/ansible/credentials.py
+++ b/cfme/ansible/credentials.py
@@ -303,14 +303,6 @@ class Credential(BaseEntity, Taggable):
             view.flash.assert_message(
                 'Edit of Credential "{}" was canceled by the user.'.format(self.name))
 
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, "Details")
-            return True
-        except ItemNotFound:
-            return False
-
     def delete(self):
         view = navigate_to(self, "Details")
         if self.appliance.version < "5.9":

--- a/cfme/ansible/playbooks.py
+++ b/cfme/ansible/playbooks.py
@@ -87,14 +87,6 @@ class Playbook(BaseEntity, Taggable):
     name = attr.ib()
     repository = attr.ib()
 
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, "Details")
-            return True
-        except ItemNotFound:
-            return False
-
 
 @attr.s
 class PlaybooksCollection(BaseCollection):

--- a/cfme/ansible/repositories.py
+++ b/cfme/ansible/repositories.py
@@ -174,14 +174,6 @@ class Repository(BaseEntity, Fillable, Taggable):
             view.flash.assert_message(
                 'Edit of Repository "{}" cancelled by the user.'.format(self.name))
 
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, "Details")
-            return True
-        except ItemNotFound:
-            return False
-
     def delete(self):
         """Delete the repository in the UI."""
         view = navigate_to(self, "Details")

--- a/cfme/automate/buttons.py
+++ b/cfme/automate/buttons.py
@@ -315,14 +315,6 @@ class BaseButton(BaseEntity, Updateable):
                 view.submit_button.click()
             view.flash.assert_no_error()
 
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, "Details")
-            return True
-        except CandidateNotFound:
-            return False
-
     def delete_if_exists(self):
         if self.exists:
             self.delete()
@@ -759,14 +751,6 @@ class ButtonGroup(BaseEntity, Updateable):
             view = self.create_view(ButtonGroupObjectTypeView, wait="10s")
             view.flash.assert_no_error()
             view.flash.assert_message('Button Group "{}": Delete successful'.format(self.hover))
-
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, "Details")
-            return True
-        except CandidateNotFound:
-            return False
 
     def delete_if_exists(self):
         if self.exists:

--- a/cfme/automate/dialogs/service_dialogs.py
+++ b/cfme/automate/dialogs/service_dialogs.py
@@ -96,15 +96,6 @@ class Dialog(BaseEntity, Fillable):
         view.flash.assert_success_message(
             'Dialog "{}": Delete successful'.format(self.label))
 
-    @property
-    def exists(self):
-        """ Returns True if dialog exists"""
-        try:
-            navigate_to(self, 'Details')
-            return True
-        except (CandidateNotFound, ItemNotFound):
-            return False
-
     def delete_if_exists(self):
         if self.exists:
             self.delete()

--- a/cfme/automate/explorer/domain.py
+++ b/cfme/automate/explorer/domain.py
@@ -264,14 +264,6 @@ class Domain(BaseEntity, Fillable):
             view.flash.assert_message(
                 'Edit of Automate Domain "{}" was cancelled by the user'.format(self.name))
 
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, 'Details')
-            return True
-        except (CandidateNotFound, ItemNotFound, TimedOutError):
-            return False
-
     def delete_if_exists(self):
         if self.exists:
             self.delete()

--- a/cfme/automate/explorer/instance.py
+++ b/cfme/automate/explorer/instance.py
@@ -253,14 +253,6 @@ class Instance(BaseEntity, Copiable):
             result_view.flash.assert_message(
                 'Automate Instance "{}": Delete successful'.format(self.description or self.name))
 
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, 'Details')
-            return True
-        except CandidateNotFound:
-            return False
-
     def delete_if_exists(self):
         if self.exists:
             self.delete()

--- a/cfme/automate/explorer/klass.py
+++ b/cfme/automate/explorer/klass.py
@@ -242,14 +242,6 @@ class Class(BaseEntity, Copiable):
             view.flash.assert_message(
                 'Edit of Automate Class "{}" was cancelled by the user'.format(self.name))
 
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, 'Details')
-            return True
-        except CandidateNotFound:
-            return False
-
     def delete_if_exists(self):
         if self.exists:
             self.delete()

--- a/cfme/automate/explorer/method.py
+++ b/cfme/automate/explorer/method.py
@@ -424,14 +424,6 @@ class Method(BaseEntity, Copiable):
             result_view.flash.assert_message(
                 'Automate Method "{}": Delete successful'.format(self.name))
 
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, 'Details')
-            return True
-        except CandidateNotFound:
-            return False
-
     def delete_if_exists(self):
         if self.exists:
             self.delete()

--- a/cfme/automate/explorer/namespace.py
+++ b/cfme/automate/explorer/namespace.py
@@ -179,14 +179,6 @@ class Namespace(BaseEntity):
             view.flash.assert_message(
                 'Edit of Automate Namespace "{}" was cancelled by the user'.format(self.name))
 
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, 'Details')
-            return True
-        except CandidateNotFound:
-            return False
-
     def delete_if_exists(self):
         if self.exists:
             self.delete()

--- a/cfme/automate/provisioning_dialogs.py
+++ b/cfme/automate/provisioning_dialogs.py
@@ -146,14 +146,6 @@ class ProvisioningDialog(Updateable, Pretty, BaseEntity):
     def __str__(self):
         return self.name
 
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, 'Details')
-        except CandidateNotFound:
-            return False
-        return True
-
     def update(self, updates, cancel=False, reset=False):
         view = navigate_to(self, 'Edit')
         view.form.fill(updates)

--- a/cfme/cloud/flavor.py
+++ b/cfme/cloud/flavor.py
@@ -190,14 +190,6 @@ class Flavor(BaseEntity, Taggable):
         self.browser.refresh()
 
     @property
-    def exists(self):
-        try:
-            navigate_to(self, 'Details')
-            return True
-        except FlavorNotFound:
-            return False
-
-    @property
     def instance_count(self):
         """ number of instances using flavor.
 

--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -293,13 +293,6 @@ class Instance(VM):
         except ItemNotFound:
             raise InstanceNotFound("Instance '{}' not found in UI!".format(self.name))
 
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, 'Details')
-            return True
-        except InstanceNotFound:
-            return False
 
     def power_control_from_cfme(self, *args, **kwargs):
         """Power controls a VM from within CFME using details or collection

--- a/cfme/cloud/instance/image.py
+++ b/cfme/cloud/instance/image.py
@@ -141,15 +141,6 @@ class Image(Template):
     TO_OPEN_EDIT = "Edit this Image"
     QUADICON_TYPE = "image"
 
-    @property
-    def exists(self):
-        """Whether the image exists in CFME"""
-        try:
-            navigate_to(self, 'Details')
-        except ImageNotFound:
-            return False
-        return True
-
 
 @attr.s
 class ImageCollection(TemplateCollection):

--- a/cfme/cloud/keypairs.py
+++ b/cfme/cloud/keypairs.py
@@ -184,15 +184,6 @@ class KeyPair(BaseEntity, Taggable):
         view.toolbar.configuration.item_select('Download private key')
         view.flash.assert_no_error()
 
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, 'Details')
-        except KeyPairNotFound:
-            return False
-        else:
-            return True
-
 
 @attr.s
 class KeyPairCollection(BaseCollection):

--- a/cfme/cloud/security_groups.py
+++ b/cfme/cloud/security_groups.py
@@ -163,15 +163,6 @@ class SecurityGroup(BaseEntity, CustomButtonEventsMixin):
                 fail_func=self.refresh
             )
 
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, 'Details')
-        except SecurityGroupsNotFound:
-            return False
-        else:
-            return True
-
 
 @attr.s
 class SecurityGroupCollection(BaseCollection):

--- a/cfme/cloud/tenant.py
+++ b/cfme/cloud/tenant.py
@@ -293,14 +293,6 @@ class Tenant(BaseEntity, Taggable, ValidateStatsMixin):
             result = self.wait_for_disappear(600)
         return result
 
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, 'Details')
-        except NoSuchElementException:
-            return False
-        else:
-            return True
 
 
 @attr.s

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -183,14 +183,6 @@ class BaseVM(
             self.find_quadicon().check()
             view.toolbar.configuration.item_select(self.REMOVE_SELECTED, handle_alert=not cancel)
 
-    @property
-    def exists(self):
-        """Checks presence of the quadicon in the CFME."""
-        try:
-            navigate_to(self, 'Details')
-            return True
-        except VmOrInstanceNotFound:
-            return False
 
     @property
     def ip_address(self):

--- a/cfme/configure/access_control/__init__.py
+++ b/cfme/configure/access_control/__init__.py
@@ -294,13 +294,6 @@ class User(Updateable, Pretty, BaseEntity, Taggable):
                 self.browser.get_attribute(
                     'onClick', self.browser.element(view.cancel_password_change)))
 
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, 'Details')
-            return True
-        except CandidateNotFound:
-            return False
 
     @property
     def description(self):
@@ -828,14 +821,6 @@ class Group(BaseEntity, Taggable):
         view = navigate_to(self, 'EditGroupSequence')
         return view.group_order_selector.items
 
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, 'Details')
-            return True
-        except CandidateNotFound:
-            return False
-
 
 @attr.s
 class GroupCollection(BaseCollection):
@@ -1170,13 +1155,6 @@ class Role(Updateable, Pretty, BaseEntity):
         else:
             return False
 
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, 'Details')
-            return True
-        except CandidateNotFound:
-            return False
 
 @attr.s
 class RoleCollection(BaseCollection):
@@ -1502,14 +1480,6 @@ class Tenant(Updateable, BaseEntity, Taggable):
             return False
         else:
             return self.tree_path == other.tree_path
-
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, 'Details')
-            return True
-        except CandidateNotFound:
-            return False
 
     @property
     def tree_path(self):

--- a/cfme/configure/configuration/analysis_profile.py
+++ b/cfme/configure/configuration/analysis_profile.py
@@ -4,7 +4,6 @@ from copy import deepcopy
 import attr
 from navmazing import NavigateToAttribute
 from navmazing import NavigateToSibling
-from navmazing import NavigationDestinationNotFound
 from widgetastic.widget import ConditionalSwitchableView
 from widgetastic.widget import Text
 from widgetastic.widget import View
@@ -325,15 +324,6 @@ class AnalysisProfile(Pretty, Updateable, BaseEntity):
         view.flush_widget_cache()
         assert view.is_displayed
         return new_profile
-
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, 'Details')
-        except (NavigationDestinationNotFound, CandidateNotFound):
-            return False
-        else:
-            return True
 
 
 @attr.s

--- a/cfme/containers/container.py
+++ b/cfme/containers/container.py
@@ -11,7 +11,6 @@ from cfme.containers.provider import ContainerObjectDetailsBaseView
 from cfme.containers.provider import GetRandomInstancesMixin
 from cfme.containers.provider import Labelable
 from cfme.containers.provider import LoggingableView
-from cfme.exceptions import ItemNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
@@ -78,16 +77,6 @@ class Container(BaseEntity, Taggable, Labelable):
     @property
     def project_name(self):
         return self.pod.project_name
-
-    @property
-    def exists(self):
-        """Return True if the Container exists"""
-        try:
-            navigate_to(self, 'Details')
-        except ItemNotFound:
-            return False
-        else:
-            return True
 
 
 @attr.s

--- a/cfme/containers/image.py
+++ b/cfme/containers/image.py
@@ -14,7 +14,6 @@ from cfme.containers.provider import ContainerObjectDetailsEntities
 from cfme.containers.provider import GetRandomInstancesMixin
 from cfme.containers.provider import Labelable
 from cfme.containers.provider import LoadDetailsMixin
-from cfme.exceptions import ItemNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
@@ -56,16 +55,6 @@ class Image(BaseEntity, Taggable, Labelable, LoadDetailsMixin, PolicyProfileAssi
     name = attr.ib()
     id = attr.ib()
     provider = attr.ib()
-
-    @property
-    def exists(self):
-        """Return True if the Image exists"""
-        try:
-            navigate_to(self, 'Details')
-        except ItemNotFound:
-            return False
-        else:
-            return True
 
     @cached_property
     def sha256(self):

--- a/cfme/containers/image_registry.py
+++ b/cfme/containers/image_registry.py
@@ -8,7 +8,6 @@ from cfme.common import TagPageView
 from cfme.containers.provider import ContainerObjectAllBaseView
 from cfme.containers.provider import ContainerObjectDetailsBaseView
 from cfme.containers.provider import GetRandomInstancesMixin
-from cfme.exceptions import ItemNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance import Navigatable
@@ -41,16 +40,6 @@ class ImageRegistry(BaseEntity, Taggable, Navigatable):
     @property
     def name(self):
         return self.host
-
-    @property
-    def exists(self):
-        """Return True if the Image Registry exists"""
-        try:
-            navigate_to(self, 'Details')
-        except ItemNotFound:
-            return False
-        else:
-            return True
 
 
 @attr.s

--- a/cfme/containers/node.py
+++ b/cfme/containers/node.py
@@ -3,7 +3,6 @@
 import attr
 from navmazing import NavigateToAttribute
 from navmazing import NavigateToSibling
-from widgetastic.exceptions import NoSuchElementException
 from widgetastic.widget import View
 from widgetastic_patternfly import BreadCrumb
 
@@ -73,17 +72,6 @@ class Node(BaseEntity, Taggable, Labelable, PolicyProfileAssignable, ConsoleMixi
 
     name = attr.ib()
     provider = attr.ib()
-
-    @property
-    def exists(self):
-        """Return True if the Node exists"""
-        # TODO: move this to some ContainerObjectBase so it'll be shared among all objects
-        try:
-            navigate_to(self, 'Details')
-        except NoSuchElementException:
-            return False
-        else:
-            return True
 
 
 @attr.s

--- a/cfme/containers/pod.py
+++ b/cfme/containers/pod.py
@@ -47,16 +47,6 @@ class Pod(BaseEntity, Taggable, Labelable):
     project_name = attr.ib()
     provider = attr.ib()
 
-    @property
-    def exists(self):
-        """Return True if the Pod exists"""
-        try:
-            navigate_to(self, 'Details')
-        except ItemNotFound:
-            return False
-        else:
-            return True
-
 
 @attr.s
 class PodCollection(GetRandomInstancesMixin, BaseCollection):

--- a/cfme/containers/project.py
+++ b/cfme/containers/project.py
@@ -9,7 +9,6 @@ from cfme.containers.provider import ContainerObjectAllBaseView
 from cfme.containers.provider import ContainerObjectDetailsBaseView
 from cfme.containers.provider import GetRandomInstancesMixin
 from cfme.containers.provider import Labelable
-from cfme.exceptions import ItemNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
@@ -46,16 +45,6 @@ class Project(BaseEntity, Taggable, Labelable):
 
     name = attr.ib()
     provider = attr.ib()
-
-    @property
-    def exists(self):
-        """Return True if the Project exists"""
-        try:
-            navigate_to(self, 'Details')
-        except ItemNotFound:
-            return False
-        else:
-            return True
 
 
 @attr.s

--- a/cfme/containers/replicator.py
+++ b/cfme/containers/replicator.py
@@ -9,7 +9,6 @@ from cfme.containers.provider import ContainerObjectAllBaseView
 from cfme.containers.provider import ContainerObjectDetailsBaseView
 from cfme.containers.provider import GetRandomInstancesMixin
 from cfme.containers.provider import Labelable
-from cfme.exceptions import ItemNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
@@ -38,16 +37,6 @@ class Replicator(BaseEntity, Taggable, Labelable):
     name = attr.ib()
     project_name = attr.ib()
     provider = attr.ib()
-
-    @property
-    def exists(self):
-        """Return True if the Replicator exists"""
-        try:
-            navigate_to(self, 'Details')
-        except ItemNotFound:
-            return False
-        else:
-            return True
 
 
 @attr.s

--- a/cfme/containers/route.py
+++ b/cfme/containers/route.py
@@ -9,7 +9,6 @@ from cfme.containers.provider import ContainerObjectAllBaseView
 from cfme.containers.provider import ContainerObjectDetailsBaseView
 from cfme.containers.provider import GetRandomInstancesMixin
 from cfme.containers.provider import Labelable
-from cfme.exceptions import ItemNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
@@ -38,16 +37,6 @@ class Route(BaseEntity, Taggable, Labelable):
     name = attr.ib()
     project_name = attr.ib()
     provider = attr.ib()
-
-    @property
-    def exists(self):
-        """Return True if the Route exists"""
-        try:
-            navigate_to(self, 'Details')
-        except ItemNotFound:
-            return False
-        else:
-            return True
 
 
 @attr.s

--- a/cfme/containers/service.py
+++ b/cfme/containers/service.py
@@ -10,7 +10,6 @@ from cfme.containers.provider import ContainerObjectDetailsBaseView
 from cfme.containers.provider import GetRandomInstancesMixin
 from cfme.containers.provider import Labelable
 from cfme.containers.provider import LoggingableView
-from cfme.exceptions import ItemNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
@@ -55,16 +54,6 @@ class Service(BaseEntity, Taggable, Labelable):
     name = attr.ib()
     project_name = attr.ib()
     provider = attr.ib()
-
-    @property
-    def exists(self):
-        """Return True if the Service exists"""
-        try:
-            navigate_to(self, 'Details')
-        except ItemNotFound:
-            return False
-        else:
-            return True
 
 
 @attr.s

--- a/cfme/containers/template.py
+++ b/cfme/containers/template.py
@@ -9,7 +9,6 @@ from cfme.containers.provider import ContainerObjectAllBaseView
 from cfme.containers.provider import ContainerObjectDetailsBaseView
 from cfme.containers.provider import GetRandomInstancesMixin
 from cfme.containers.provider import Labelable
-from cfme.exceptions import ItemNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
@@ -38,16 +37,6 @@ class Template(BaseEntity, Taggable, Labelable):
     name = attr.ib()
     project_name = attr.ib()
     provider = attr.ib()
-
-    @property
-    def exists(self):
-        """Return True if the Template exists"""
-        try:
-            navigate_to(self, 'Details')
-        except ItemNotFound:
-            return False
-        else:
-            return True
 
 
 @attr.s

--- a/cfme/containers/volume.py
+++ b/cfme/containers/volume.py
@@ -9,7 +9,6 @@ from cfme.containers.provider import ContainerObjectAllBaseView
 from cfme.containers.provider import ContainerObjectDetailsBaseView
 from cfme.containers.provider import GetRandomInstancesMixin
 from cfme.containers.provider import Labelable
-from cfme.exceptions import ItemNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
@@ -37,16 +36,6 @@ class Volume(BaseEntity, Taggable, Labelable):
 
     name = attr.ib()
     provider = attr.ib()
-
-    @property
-    def exists(self):
-        """Return True if the Volume exists"""
-        try:
-            navigate_to(self, 'Details')
-        except ItemNotFound:
-            return False
-        else:
-            return True
 
 
 @attr.s

--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -461,14 +461,6 @@ class Report(BaseEntity, Updateable):
         )
         return saved_report
 
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, "Details")
-            return True
-        except (CandidateNotFound, TimedOutError):
-            return False
-
 
 @attr.s
 class ReportsCollection(BaseCollection):
@@ -565,14 +557,6 @@ class SavedReport(Updateable, BaseEntity):
             view.flash.assert_no_error()
             # TODO Doesn't work due to this BZ https://bugzilla.redhat.com/show_bug.cgi?id=1489387
             # view.flash.assert_message("Successfully deleted Saved Report from the CFME Database")
-
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, "Details")
-            return True
-        except (CandidateNotFound, TimedOutError):
-            return False
 
 
 @attr.s

--- a/cfme/modeling/base.py
+++ b/cfme/modeling/base.py
@@ -7,7 +7,6 @@ from widgetastic.exceptions import NoSuchElementException
 from widgetastic.utils import VersionPick
 from widgetastic_patternfly import CandidateNotFound
 
-
 from cfme.exceptions import BackupNotFoundError
 from cfme.exceptions import FlavorNotFound
 from cfme.exceptions import ImageNotFound

--- a/cfme/modeling/base.py
+++ b/cfme/modeling/base.py
@@ -2,10 +2,26 @@ from collections import Callable
 
 import attr
 from cached_property import cached_property
+from navmazing import NavigationDestinationNotFound
+from widgetastic.exceptions import NoSuchElementException
 from widgetastic.utils import VersionPick
+from widgetastic_patternfly import CandidateNotFound
 
+
+from cfme.exceptions import BackupNotFoundError
+from cfme.exceptions import FlavorNotFound
+from cfme.exceptions import ImageNotFound
+from cfme.exceptions import InstanceNotFound
+from cfme.exceptions import ItemNotFound
+from cfme.exceptions import KeyPairNotFound
+from cfme.exceptions import SecurityGroupsNotFound
+from cfme.exceptions import VmOrInstanceNotFound
+from cfme.exceptions import VolumeNotFoundError
+from cfme.exceptions import VolumeTypeNotFoundError
 from cfme.utils.appliance import NavigatableMixin
+from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.log import logger
+from cfme.utils.wait import TimedOutError
 
 
 def load_appliance_collections():
@@ -159,6 +175,31 @@ class BaseEntity(NavigatableMixin):
             raise AttributeError("collections")
 
         return EntityCollections.for_entity(self, spec)
+
+    @property
+    def exists(self):
+        try:
+            navigate_to(self, "Details")
+        except (
+            BackupNotFoundError,
+            CandidateNotFound,
+            FlavorNotFound,
+            ImageNotFound,
+            InstanceNotFound,
+            ItemNotFound,
+            KeyPairNotFound,
+            NameError,
+            NavigationDestinationNotFound,
+            NoSuchElementException,
+            SecurityGroupsNotFound,
+            TimedOutError,
+            VmOrInstanceNotFound,
+            VolumeNotFoundError,
+            VolumeTypeNotFoundError,
+        ):
+            return False
+        else:
+            return True
 
 
 @attr.s

--- a/cfme/networks/cloud_network.py
+++ b/cfme/networks/cloud_network.py
@@ -1,7 +1,6 @@
 import attr
 from navmazing import NavigateToAttribute
 from navmazing import NavigateToSibling
-from widgetastic.exceptions import NoSuchElementException
 from widgetastic.utils import Version
 from widgetastic.utils import VersionPick
 
@@ -38,15 +37,6 @@ class CloudNetwork(Taggable, BaseEntity, CustomButtonEventsMixin):
     def provider(self):
         from cfme.networks.provider import NetworkProvider
         return parent_of_type(self, NetworkProvider)
-
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, 'Details')
-        except (ItemNotFound, NoSuchElementException):
-            return False
-        else:
-            return True
 
     @property
     def parent_provider(self):

--- a/cfme/networks/network_router.py
+++ b/cfme/networks/network_router.py
@@ -1,7 +1,6 @@
 import attr
 from navmazing import NavigateToAttribute
 from navmazing import NavigateToSibling
-from widgetastic.exceptions import NoSuchElementException
 
 from cfme.common import CustomButtonEventsMixin
 from cfme.common import Taggable
@@ -97,15 +96,6 @@ class NetworkRouter(Taggable, BaseEntity, CustomButtonEventsMixin, ValidateStats
             self.ext_network = None
         if ext_network:
             self.ext_network = ext_network
-
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, 'Details')
-        except (ItemNotFound, NoSuchElementException):
-            return False
-        else:
-            return True
 
     @property
     def cloud_network(self):

--- a/cfme/networks/subnet.py
+++ b/cfme/networks/subnet.py
@@ -1,7 +1,6 @@
 import attr
 from navmazing import NavigateToAttribute
 from navmazing import NavigateToSibling
-from widgetastic.exceptions import NoSuchElementException
 
 from cfme.common import CustomButtonEventsMixin
 from cfme.common import Taggable
@@ -40,15 +39,6 @@ class Subnet(Taggable, BaseEntity, CustomButtonEventsMixin, ValidateStatsMixin):
     _collections = {
         'network_ports': NetworkPortCollection,
     }
-
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, 'Details')
-        except (ItemNotFound, NoSuchElementException):
-            return False
-        else:
-            return True
 
     def edit(self, new_name, gateway=None):
         """Edit cloud subnet

--- a/cfme/physical/physical_chassis.py
+++ b/cfme/physical/physical_chassis.py
@@ -13,7 +13,6 @@ from cfme.base.login import BaseLoggedInPage
 from cfme.common import PolicyProfileAssignable
 from cfme.common import Taggable
 from cfme.exceptions import HostStatsNotContains
-from cfme.exceptions import ItemNotFound
 from cfme.exceptions import ProviderHasNoProperty
 from cfme.exceptions import StatsDoNotMatch
 from cfme.modeling.base import BaseCollection
@@ -70,19 +69,6 @@ class PhysicalChassis(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, T
         view = navigate_to(self, "Details")
         view.toolbar.custom_button(button).item_select(option, handle_alert=handle_alert)
         return view
-
-    @property
-    def exists(self):
-        """Checks if the physical_chassis exists in the UI.
-
-        Returns: :py:class:`bool`
-        """
-        try:
-            navigate_to(self, 'Details')
-        except ItemNotFound:
-            return False
-        else:
-            return True
 
     @variable(alias='ui')
     def chassis_name(self):

--- a/cfme/physical/physical_rack.py
+++ b/cfme/physical/physical_rack.py
@@ -10,7 +10,6 @@ from widgetastic_patternfly import Dropdown
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.common import Taggable
-from cfme.exceptions import ItemNotFound
 from cfme.exceptions import ProviderHasNoProperty
 from cfme.exceptions import RackStatsDoesNotContain
 from cfme.exceptions import StatsDoNotMatch
@@ -98,19 +97,6 @@ class PhysicalRack(BaseEntity, Updateable, Pretty, Taggable):
     def rack_name(self):
         view = navigate_to(self, "Details")
         return view.entities.properties.get_text_of("Rack name")
-
-    @property
-    def exists(self):
-        """Checks if the physical_rack exists in the UI.
-
-        Returns: :py:class:`bool`
-        """
-        try:
-            navigate_to(self, 'Details')
-        except ItemNotFound:
-            return False
-        else:
-            return True
 
     def validate_stats(self, ui=False):
         """ Validates that the detail page matches the physical rack's information.

--- a/cfme/services/catalogs/catalog.py
+++ b/cfme/services/catalogs/catalog.py
@@ -4,7 +4,6 @@ from navmazing import NavigateToSibling
 from widgetastic.utils import Parameter
 from widgetastic.widget import Text
 from widgetastic_patternfly import Button
-from widgetastic_patternfly import CandidateNotFound
 from widgetastic_patternfly import Input
 
 from . import ServicesCatalogView
@@ -119,14 +118,6 @@ class Catalog(BaseEntity, Updateable, Pretty, Taggable):
         view.flash.assert_no_error()
         view.flash.assert_success_message(
             'Catalog "{}": Delete successful'.format(self.description or self.name))
-
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, 'Details')
-            return True
-        except (NameError, CandidateNotFound):
-            return False
 
 
 @attr.s

--- a/cfme/services/catalogs/catalog_items/__init__.py
+++ b/cfme/services/catalogs/catalog_items/__init__.py
@@ -10,7 +10,6 @@ from widgetastic.widget import Text
 from widgetastic.widget import View
 from widgetastic_patternfly import BootstrapSelect
 from widgetastic_patternfly import Button
-from widgetastic_patternfly import CandidateNotFound
 from widgetastic_patternfly import Input
 
 from cfme.common import Taggable
@@ -333,14 +332,6 @@ class BaseCatalogItem(BaseEntity, Updateable, Pretty, Taggable):
         wait_for(lambda: view.is_displayed, timeout=5)
         view.flash.assert_no_error()
         return button_name
-
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, 'Details')
-            return True
-        except CandidateNotFound:
-            return False
 
     @property
     def catalog_name(self):

--- a/cfme/services/catalogs/orchestration_template.py
+++ b/cfme/services/catalogs/orchestration_template.py
@@ -7,7 +7,6 @@ from widgetastic.widget import Text
 from widgetastic.widget import View
 from widgetastic_patternfly import BootstrapSelect
 from widgetastic_patternfly import Button
-from widgetastic_patternfly import CandidateNotFound
 from widgetastic_patternfly import Input
 
 from . import ServicesCatalogView
@@ -204,14 +203,6 @@ class OrchestrationTemplate(BaseEntity, Updateable, Pretty, Taggable):
         service_dialog = self.parent.parent.collections.service_dialogs.instantiate(
             label=dialog_name)
         return service_dialog
-
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, "Details")
-            return True
-        except CandidateNotFound:
-            return False
 
 
 @attr.s

--- a/cfme/storage/manager.py
+++ b/cfme/storage/manager.py
@@ -163,14 +163,6 @@ class StorageManager(BaseEntity, CustomButtonEventsMixin, Taggable, PolicyProfil
         view = self.create_view(StorageManagerDetailsView)
         view.flash.assert_no_error()
 
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, 'Details')
-            return True
-        except ItemNotFound:
-            return False
-
 
 @attr.s
 class BlockManagerCollection(BaseCollection):

--- a/cfme/storage/volume.py
+++ b/cfme/storage/volume.py
@@ -347,14 +347,6 @@ class Volume(BaseEntity, CustomButtonEventsMixin, Updateable, Taggable):
             view.flash.assert_no_error()
 
     @property
-    def exists(self):
-        try:
-            navigate_to(self, 'Details')
-            return True
-        except VolumeNotFoundError:
-            return False
-
-    @property
     def status(self):
         """ status of cloud volume.
         Returns:

--- a/cfme/storage/volume_backup.py
+++ b/cfme/storage/volume_backup.py
@@ -167,14 +167,6 @@ class VolumeBackup(BaseEntity, Taggable):
         self.browser.refresh()
 
     @property
-    def exists(self):
-        try:
-            navigate_to(self, 'Details')
-            return True
-        except BackupNotFoundError:
-            return False
-
-    @property
     def size(self):
         """size of cloud volume backup.
 

--- a/cfme/storage/volume_type.py
+++ b/cfme/storage/volume_type.py
@@ -86,14 +86,6 @@ class VolumeType(BaseEntity, Updateable, Taggable):
         self.provider.refresh_provider_relationships()
         self.browser.refresh()
 
-    @property
-    def exists(self):
-        try:
-            navigate_to(self, 'Details')
-            return True
-        except VolumeTypeNotFoundError:
-            return False
-
 
 @attr.s
 class VolumeTypeCollection(BaseCollection, TaggableCollection):


### PR DESCRIPTION
This PR brings the following changes:
1. Write a common `exists` method in `BaseEntity` that does simple navigation to `Details` page and returns `True` if there are no exceptions. (as suggested by @mshriver )
2. Delete all `exists` method that used this way of checking existence. Other methods that use a different way have been kept as is.