### PR TITLE
[1LP][RFR] Use a common exception ItemNotFound

### DIFF
--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -36,7 +36,7 @@ from cfme.configure.tasks import TasksView
 from cfme.dashboard import DashboardView
 from cfme.exceptions import BugException
 from cfme.exceptions import DestinationNotFound
-from cfme.exceptions import ZoneNotFound
+from cfme.exceptions import ItemNotFound
 from cfme.intelligence.chargeback import ChargebackView
 from cfme.intelligence.rss import RSSView
 from cfme.intelligence.timelines import CloudIntelTimelinesView
@@ -1383,7 +1383,7 @@ class ZoneDetails(CFMENavigateStep):
             self.view.zone.select()
             break
         else:
-            raise ZoneNotFound(
+            raise ItemNotFound(
                 "No unique Zones with the description '{}'".format(self.obj.description))
 
 
@@ -1401,7 +1401,7 @@ class SmartProxyAffinity(CFMENavigateStep):
             self.view.smart_proxy_affinity.select()
             break
         else:
-            raise ZoneNotFound(
+            raise ItemNotFound(
                 "No unique Zones with the description '{}'".format(self.obj.description))
 
 
@@ -1418,7 +1418,7 @@ class Advanced(CFMENavigateStep):
             self.view.advanced.select()
             break
         else:
-            raise ZoneNotFound(
+            raise ItemNotFound(
                 "No unique Zones with the description '{}'".format(self.obj.description))
 
 
@@ -1557,7 +1557,7 @@ def exists(self):
     try:
         navigate_to(self, 'Details')
         return True
-    except ZoneNotFound:
+    except ItemNotFound:
         return False
 
 

--- a/cfme/cloud/availability_zone.py
+++ b/cfme/cloud/availability_zone.py
@@ -13,7 +13,6 @@ from cfme.base.login import BaseLoggedInPage
 from cfme.common import CustomButtonEventsMixin
 from cfme.common import Taggable
 from cfme.common.candu_views import AzoneCloudUtilizationView
-from cfme.exceptions import AvailabilityZoneNotFound
 from cfme.exceptions import ItemNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
@@ -211,7 +210,7 @@ class AvailabilityZoneDetails(CFMENavigateStep):
         try:
             row = self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True)
         except ItemNotFound:
-            raise AvailabilityZoneNotFound('Could not locate Availability Zone "{}" on provider {}'
+            raise ItemNotFound('Could not locate Availability Zone "{}" on provider {}'
                                            .format(self.obj.name, self.obj.provider.name))
         row.click()
 

--- a/cfme/cloud/flavor.py
+++ b/cfme/cloud/flavor.py
@@ -16,7 +16,6 @@ from widgetastic_patternfly import View
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import Taggable
 from cfme.common import TaggableCollection
-from cfme.exceptions import FlavorNotFound
 from cfme.exceptions import ItemNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
@@ -266,7 +265,7 @@ class FlavorDetails(CFMENavigateStep):
         try:
             row = self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True)
         except ItemNotFound:
-            raise FlavorNotFound('Could not locate flavor "{}" on provider {}'
+            raise ItemNotFound('Could not locate flavor "{}" on provider {}'
                                  .format(self.obj.name, self.obj.provider.name))
         row.click()
 

--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -22,7 +22,6 @@ from cfme.common.vm_views import VMDetailsEntities
 from cfme.common.vm_views import VMEntities
 from cfme.common.vm_views import VMToolbar
 from cfme.exceptions import DestinationNotFound
-from cfme.exceptions import InstanceNotFound
 from cfme.exceptions import ItemNotFound
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -291,14 +290,14 @@ class Instance(VM):
         try:
             return view.entities.get_entity(name=self.name, surf_pages=True)
         except ItemNotFound:
-            raise InstanceNotFound("Instance '{}' not found in UI!".format(self.name))
+            raise ItemNotFound("Instance '{}' not found in UI!".format(self.name))
 
 
     def power_control_from_cfme(self, *args, **kwargs):
         """Power controls a VM from within CFME using details or collection
 
         Raises:
-            InstanceNotFound: the instance wasn't found when navigating
+            ItemNotFound: the instance wasn't found when navigating
             OptionNotAvailable: option param is not visible or enabled
         """
         # TODO push this to common.vm when infra vm classes have widgets
@@ -313,7 +312,9 @@ class Instance(VM):
             try:
                 row = view.entities.get_entity(name=self.name, surf_pages=True)
             except ItemNotFound:
-                raise InstanceNotFound('Failed to find instance in table: {}'.format(self.name))
+                raise ItemNotFound(
+                    'Failed to find instance in table: {}'.format(self.name)
+                )
             row.check()
 
         # cancel is the kwarg, when true we want item_select to dismiss the alert, flip the bool
@@ -532,7 +533,7 @@ class Details(CFMENavigateStep):
             row = self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True,
                                                              use_search=True)
         except ItemNotFound:
-            raise InstanceNotFound('Failed to locate instance with name "{}"'.format(self.obj.name))
+            raise ItemNotFound('Failed to locate instance with name "{}"'.format(self.obj.name))
         row.click()
 
     def resetter(self, *args, **kwargs):
@@ -549,7 +550,7 @@ class ArchiveDetails(CFMENavigateStep):
             row = self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True,
                                                              use_search=True)
         except ItemNotFound:
-            raise InstanceNotFound('Failed to locate instance with name "{}"'.format(self.obj.name))
+            raise ItemNotFound('Failed to locate instance with name "{}"'.format(self.obj.name))
         row.click()
 
     def resetter(self, *args, **kwargs):

--- a/cfme/cloud/instance/image.py
+++ b/cfme/cloud/instance/image.py
@@ -17,12 +17,11 @@ from cfme.common.vm_views import SetOwnershipView
 from cfme.common.vm_views import VMDetailsEntities
 from cfme.common.vm_views import VMEntities
 from cfme.exceptions import DestinationNotFound
-from cfme.exceptions import ImageNotFound
+from cfme.exceptions import ItemNotFound
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.providers import get_crud_by_name
-from widgetastic_manageiq import ItemNotFound
 from widgetastic_manageiq import ItemsToolBarViewSelector
 from widgetastic_manageiq import Search
 from widgetastic_manageiq import SummaryTable
@@ -223,7 +222,7 @@ class ImageDetails(CFMENavigateStep):
         try:
             row = self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True)
         except ItemNotFound:
-            raise ImageNotFound('Failed to locate image with name "{}"'.format(self.obj.name))
+            raise ItemNotFound('Failed to locate image with name "{}"'.format(self.obj.name))
         row.click()
 
 

--- a/cfme/cloud/keypairs.py
+++ b/cfme/cloud/keypairs.py
@@ -11,6 +11,7 @@ from widgetastic_patternfly import Dropdown
 
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import Taggable
+from cfme.exceptions import ItemNotFound
 from cfme.exceptions import KeyPairNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
@@ -21,7 +22,6 @@ from cfme.utils.wait import wait_for
 from widgetastic_manageiq import Accordion
 from widgetastic_manageiq import BaseEntitiesView
 from widgetastic_manageiq import BootstrapSelect
-from widgetastic_manageiq import ItemNotFound
 from widgetastic_manageiq import ItemsToolBarViewSelector
 from widgetastic_manageiq import ManageIQTree
 from widgetastic_manageiq import PaginationPane

--- a/cfme/cloud/security_groups.py
+++ b/cfme/cloud/security_groups.py
@@ -10,7 +10,6 @@ from widgetastic_patternfly import Dropdown
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import CustomButtonEventsMixin
 from cfme.exceptions import ItemNotFound
-from cfme.exceptions import SecurityGroupsNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
@@ -232,7 +231,7 @@ class Details(CFMENavigateStep):
         try:
             self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True).click()
         except ItemNotFound:
-            raise SecurityGroupsNotFound("Security Groups {} not found".format(
+            raise ItemNotFound("Security Groups {} not found".format(
                 self.obj.name))
 
 

--- a/cfme/cloud/tenant.py
+++ b/cfme/cloud/tenant.py
@@ -14,7 +14,7 @@ from widgetastic_patternfly import Input
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import Taggable
 from cfme.exceptions import DestinationNotFound
-from cfme.exceptions import TenantNotFound
+from cfme.exceptions import ItemNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.networks import ValidateStatsMixin
@@ -282,7 +282,7 @@ class Tenant(BaseEntity, Taggable, ValidateStatsMixin):
             view = navigate_to(self, 'Details')
         except NoSuchElementException as ex:
             # Catch general navigation exceptions and raise
-            raise TenantNotFound(
+            raise ItemNotFound(
                 'Exception while navigating to Tenant details: {}'.format(ex))
         view.toolbar.configuration.item_select('Delete Cloud Tenant')
 

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -20,7 +20,6 @@ from cfme.common.vm_views import VMPropertyDetailView
 from cfme.exceptions import CFMEException
 from cfme.exceptions import ItemNotFound
 from cfme.exceptions import OptionNotAvailable
-from cfme.exceptions import VmOrInstanceNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.services.requests import RequestsView
@@ -225,7 +224,7 @@ class BaseVM(
                 looking up archived or orphaned VMs
 
         Returns: entity of appropriate type
-        Raises: VmOrInstanceNotFound
+        Raises: ItemNotFound
         """
         # todo :refactor this method replace it with vm methods like get_state
         if from_any_provider:
@@ -237,7 +236,7 @@ class BaseVM(
         try:
             return view.entities.get_entity(name=self.name, surf_pages=True, use_search=use_search)
         except ItemNotFound:
-            raise VmOrInstanceNotFound("VM '{}' not found in UI!".format(self.name))
+            raise ItemNotFound("VM '{}' not found in UI!".format(self.name))
 
     def open_console(self, console='VM Console', invokes_alert=None):
         """
@@ -738,7 +737,7 @@ class VM(BaseVM):
         Raises:
             TimedOutError:
                 When instance does not come up to desired state in specified period of time.
-            InstanceNotFound:
+            ItemNotFound:
                 When unable to find the instance passed
         """
 

--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -17,7 +17,7 @@ from widgetastic_patternfly import Input
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.exceptions import displayed_not_implemented
-from cfme.exceptions import TemplateNotFound
+from cfme.exceptions import ItemNotFound
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import BaseEntitiesView
@@ -361,7 +361,7 @@ class ProvisionView(BaseLoggedInPage):
                                                         provider=provider_name).click()
             # image was not found, therefore raise an exception
             except IndexError:
-                raise TemplateNotFound('Cannot find template "{}" for provider "{}"'
+                raise ItemNotFound('Cannot find template "{}" for provider "{}"'
                                        .format(template_name, provider_name))
 
         def before_fill(self, values):

--- a/cfme/configure/about.py
+++ b/cfme/configure/about.py
@@ -2,7 +2,7 @@
 from widgetastic.widget import View
 from widgetastic_patternfly import AboutModal
 
-from cfme.exceptions import ElementOrBlockNotFound
+from cfme.exceptions import ItemNotFound
 from cfme.utils.appliance.implementations.ui import navigate_to
 
 # MIQ/CFME about field names
@@ -30,7 +30,7 @@ def get_detail(field, server):
     """
     Open the about modal and fetch the value for one of the fields
     'title' and 'trademark' fields are allowed and get the header/footer values
-    Raises ElementOrBlockNotFound if the field isn't in the about modal
+    Raises ItemNotFound if the field isn't in the about modal
     :param field: string label for the detail field
     :return: string value from the requested field
     """
@@ -43,7 +43,7 @@ def get_detail(field, server):
         else:
             return view.modal.items()[field]
     except KeyError:
-        raise ElementOrBlockNotFound('No field named {} found in "About" modal.'.format(field))
+        raise ItemNotFound('No field named {} found in "About" modal.'.format(field))
     finally:
         # close since its a blocking modal and will break further navigation
         view.modal.close()

--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -108,13 +108,6 @@ class CandidateNotFound(CFMEException):
         return self.message
 
 
-class ElementOrBlockNotFound(CFMEException):
-    """
-    Raised if an Element or a Block is not found whilst locating
-    """
-    pass
-
-
 class HostStatsNotContains(CFMEException):
     """
     Raised if the hosts information does not contain the specified key whilst running
@@ -174,14 +167,6 @@ class ProviderHasNoProperty(CFMEException):
     pass
 
 
-class ScheduleNotFound(CFMEException):
-    """
-    Raised if a schedule was not found in
-    :py:meth:`cfme.configure.configuration.Schedule.delete_by_name`
-    """
-    pass
-
-
 class RequestException(CFMEException):
     """
     Raised if a request was not found or multiple rows matched during _request functions in
@@ -197,71 +182,8 @@ class VmNotFoundViaIP(CFMEException):
     pass
 
 
-class VmOrInstanceNotFound(CFMEException):
-    pass
-
-
-class VmNotFound(VmOrInstanceNotFound):
-    """
-    Raised if a specific VM cannot be found.
-    """
-    pass
-
-
-class InstanceNotFound(VmOrInstanceNotFound):
-    """
-    Raised if a specific instance cannot be found.
-    """
-    pass
-
-
-class ImageNotFound(VmOrInstanceNotFound):
-    """
-    Raised if a specific image cannot be found
-    """
-    pass
-
-
-class TenantNotFound(CFMEException):
-    """
-        Raised if a specific tenant cannot be found
-        """
-    pass
-
-
-class TemplateNotFound(CFMEException):
-    """
-    Raised if a specific Template cannot be found.
-    """
-    pass
-
-
-class ClusterNotFound(CFMEException):
-    """Raised if a cluster is not found"""
-    pass
-
-
-class HostNotFound(CFMEException):
-    """Raised if a specific host cannot be found in UI."""
-    pass
-
-
 class NodeNotFound(CFMEException):
     """Raised if a specific container node cannot be found in the UI"""
-    pass
-
-
-class StackNotFound(CFMEException):
-    """
-    Raised if a specific stack cannot be found.
-    """
-    pass
-
-
-class FlavorNotFound(CFMEException):
-    """
-    Raised if a specific cloud flavor cannot be found in the UI
-    """
     pass
 
 
@@ -272,52 +194,9 @@ class KeyPairNotFound(CFMEException):
     pass
 
 
-class SecurityGroupsNotFound(CFMEException):
-    """
-    Raised if a specific cloud Security Groups cannot be found in the UI
-    """
-    pass
-
-
-class ResourcePoolNotFound(CFMEException):
-    """
-    Raised if a specific cloud key pair cannot be found in the UI
-    """
-    pass
-
-
-class AvailabilityZoneNotFound(CFMEException):
-    """
-    Raised if a specific Cloud Availability Zone cannot be found.
-    """
-    pass
-
-
-class VolumeNotFoundError(CFMEException):
-    """
-    Raised if a specific cloud volume cannot be found in the UI
-    """
-    pass
-
-
-class VolumeTypeNotFoundError(CFMEException):
-    """
-    Raised if a specific cloud volume type cannot be found in the UI
-    """
-    pass
-
-
 class OptionNotAvailable(CFMEException):
     """
     Raised if a specified option is not available.
-    """
-    pass
-
-
-class ZoneNotFound(CFMEException):
-    """
-    Raised when a specific Zone cannot be found in the method
-    :py:mod:`cfme.configure.configuration`.
     """
     pass
 
@@ -331,17 +210,8 @@ class UnknownProviderType(CFMEException):
     pass
 
 
-class AccordionItemNotFound(CFMEException):
-    """Raised when it's not possible to locate and accordion item."""
-
-
 class CannotScrollException(CFMEException):
     """Raised when even during the heaviest workarounds for scrolling failure comes."""
-
-
-class StorageManagerNotFound(CFMEException):
-    """Raised when a Storage Manager is not found"""
-    pass
 
 
 class CUCommandException(CFMEException):
@@ -368,18 +238,6 @@ class ItemNotFound(CFMEException):
 
 class ManyEntitiesFound(CFMEException):
     """Raised when one or no items were expected but several/many items were obtained instead."""
-
-
-class RoleNotFound(CFMEException):
-    """Raised when Deployment role not found"""
-
-
-class BackupNotFoundError(CFMEException):
-    """Raised when volume backup not found"""
-
-
-class SnapshotNotFoundError(CFMEException):
-    """Raised when volume snapshot not found"""
 
 
 class RBACOperationBlocked(CFMEException):

--- a/cfme/generic_objects/definition/ui.py
+++ b/cfme/generic_objects/definition/ui.py
@@ -8,13 +8,13 @@ from .definition_views import GenericObjectDefinitionAddView
 from .definition_views import GenericObjectDefinitionAllView
 from .definition_views import GenericObjectDefinitionDetailsView
 from .definition_views import GenericObjectDefinitionEditView
+from cfme.exceptions import ItemNotFound
 from cfme.generic_objects.instance.ui import GenericObjectInstanceAllView
 from cfme.utils.appliance import MiqImplementationContext
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.appliance.implementations.ui import ViaUI
-from widgetastic_manageiq import ItemNotFound
 
 
 @MiqImplementationContext.external_for(GenericObjectDefinitionCollection.create, ViaUI)

--- a/cfme/infrastructure/deployment_roles.py
+++ b/cfme/infrastructure/deployment_roles.py
@@ -15,7 +15,6 @@ from widgetastic_patternfly import Dropdown
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import PolicyProfileAssignable
 from cfme.exceptions import ItemNotFound
-from cfme.exceptions import RoleNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
@@ -232,7 +231,7 @@ class DeploymentRoleCollection(BaseCollection):
                 try:
                     view.entities.get_entity(name=role.name).check()
                 except ItemNotFound:
-                    raise RoleNotFound("Deployment role {} not found".format(role.name))
+                    raise ItemNotFound("Deployment role {} not found".format(role.name))
 
             view.toolbar.configuration.item_select('Remove selected items',
                                                    handle_alert=True)
@@ -242,7 +241,7 @@ class DeploymentRoleCollection(BaseCollection):
                          "Database".format(len(roles)))
             view.flash.assert_success_message(flash_msg)
         else:
-            raise RoleNotFound('No Deployment Role for Deletion')
+            raise ItemNotFound('No Deployment Role for Deletion')
 
 
 @navigator.register(DeploymentRoleCollection, 'All')
@@ -269,7 +268,7 @@ class Details(CFMENavigateStep):
             self.prerequisite_view.entities.get_entity(name=self.obj.name,
                                                        surf_pages=True).click()
         except ItemNotFound:
-            raise RoleNotFound("Deployment Role {} not found".format(self.obj.name))
+            raise ItemNotFound("Deployment Role {} not found".format(self.obj.name))
 
 
 @navigator.register(DeploymentRoles, 'AllForProvider')
@@ -294,4 +293,4 @@ class DetailsFromProvider(CFMENavigateStep):
         try:
             self.prerequisite_view.entities.get_entity(name=self.obj.name).click()
         except ItemNotFound:
-            raise RoleNotFound("Deployment Role {} not found".format(self.obj.name))
+            raise ItemNotFound("Deployment Role {} not found".format(self.obj.name))

--- a/cfme/infrastructure/resource_pool.py
+++ b/cfme/infrastructure/resource_pool.py
@@ -11,7 +11,6 @@ from widgetastic_patternfly import Dropdown
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import Taggable
 from cfme.exceptions import ItemNotFound
-from cfme.exceptions import ResourcePoolNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
@@ -239,5 +238,5 @@ class Details(CFMENavigateStep):
         try:
             row = self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True)
         except ItemNotFound:
-            raise ResourcePoolNotFound('Resource pool {} not found'.format(self.obj.name))
+            raise ItemNotFound('Resource pool {} not found'.format(self.obj.name))
         row.click()

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -46,7 +46,6 @@ from cfme.common.vm_views import VMToolbar
 from cfme.exceptions import DestinationNotFound
 from cfme.exceptions import displayed_not_implemented
 from cfme.exceptions import ItemNotFound
-from cfme.exceptions import VmOrInstanceNotFound
 from cfme.services.requests import RequestsView
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -1290,8 +1289,7 @@ class VmAllWithTemplatesDetails(CFMENavigateStep):
             entity_item = self.prerequisite_view.entities.get_entity(
                 name=self.obj.name, surf_pages=True)
         except ItemNotFound:
-            raise VmOrInstanceNotFound('Failed to locate VM/Template with name "{}"'.
-                                       format(self.obj.name))
+            raise ItemNotFound('Failed to locate VM/Template with name "{}"'.format(self.obj.name))
         entity_item.click()
 
     def resetter(self, *args, **kwargs):
@@ -1309,8 +1307,7 @@ class ArchiveDetails(CFMENavigateStep):
             entity_item = self.prerequisite_view.entities.get_entity(
                 name=self.obj.name, surf_pages=True)
         except ItemNotFound:
-            raise VmOrInstanceNotFound('Failed to locate VM/Template with name "{}"'.
-                                       format(self.obj.name))
+            raise ItemNotFound('Failed to locate VM/Template with name "{}"'.format(self.obj.name))
         entity_item.click()
 
     def resetter(self, *args, **kwargs):
@@ -1357,8 +1354,7 @@ class VmDetails(CFMENavigateStep):
             row = self.prerequisite_view.entities.get_entity(name=self.obj.name,
                                                              surf_pages=True)
         except ItemNotFound:
-            raise VmOrInstanceNotFound('Failed to locate VM/Template with name "{}"'.
-                                       format(self.obj.name))
+            raise ItemNotFound('Failed to locate VM/Template with name "{}"'.format(self.obj.name))
         row.click()
 
     def resetter(self, *args, **kwargs):

--- a/cfme/modeling/base.py
+++ b/cfme/modeling/base.py
@@ -7,16 +7,8 @@ from widgetastic.exceptions import NoSuchElementException
 from widgetastic.utils import VersionPick
 from widgetastic_patternfly import CandidateNotFound
 
-from cfme.exceptions import BackupNotFoundError
-from cfme.exceptions import FlavorNotFound
-from cfme.exceptions import ImageNotFound
-from cfme.exceptions import InstanceNotFound
 from cfme.exceptions import ItemNotFound
 from cfme.exceptions import KeyPairNotFound
-from cfme.exceptions import SecurityGroupsNotFound
-from cfme.exceptions import VmOrInstanceNotFound
-from cfme.exceptions import VolumeNotFoundError
-from cfme.exceptions import VolumeTypeNotFoundError
 from cfme.utils.appliance import NavigatableMixin
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.log import logger
@@ -180,21 +172,13 @@ class BaseEntity(NavigatableMixin):
         try:
             navigate_to(self, "Details")
         except (
-            BackupNotFoundError,
             CandidateNotFound,
-            FlavorNotFound,
-            ImageNotFound,
-            InstanceNotFound,
             ItemNotFound,
             KeyPairNotFound,
             NameError,
             NavigationDestinationNotFound,
             NoSuchElementException,
-            SecurityGroupsNotFound,
             TimedOutError,
-            VmOrInstanceNotFound,
-            VolumeNotFoundError,
-            VolumeTypeNotFoundError,
         ):
             return False
         else:

--- a/cfme/storage/volume.py
+++ b/cfme/storage/volume.py
@@ -19,7 +19,6 @@ from cfme.common import TaggableCollection
 from cfme.common import TagPageView
 from cfme.exceptions import displayed_not_implemented
 from cfme.exceptions import ItemNotFound
-from cfme.exceptions import VolumeNotFoundError
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
@@ -462,7 +461,7 @@ class VolumeCollection(BaseCollection, TaggableCollection):
                 try:
                     view.entities.get_entity(name=volume.name).check()
                 except ItemNotFound:
-                    raise VolumeNotFoundError("Volume {} not found".format(volume.name))
+                    raise ItemNotFound("Volume {} not found".format(volume.name))
 
             view.toolbar.configuration.item_select('Delete selected Cloud Volumes',
                                                    handle_alert=True)
@@ -470,7 +469,7 @@ class VolumeCollection(BaseCollection, TaggableCollection):
             for volume in volumes:
                 volume.wait_for_disappear()
         else:
-            raise VolumeNotFoundError('No Cloud Volume for Deletion')
+            raise ItemNotFound('No Cloud Volume for Deletion')
 
     def all(self):
         """returning all Volumes objects for respective storage manager type"""
@@ -519,7 +518,7 @@ class VolumeDetails(CFMENavigateStep):
                                                        surf_pages=True).click()
 
         except ItemNotFound:
-            raise VolumeNotFoundError('Volume {} not found'.format(self.obj.name))
+            raise ItemNotFound('Volume {} not found'.format(self.obj.name))
 
 
 @navigator.register(VolumeCollection, 'Add')

--- a/cfme/storage/volume_backup.py
+++ b/cfme/storage/volume_backup.py
@@ -16,7 +16,6 @@ from widgetastic_patternfly import Dropdown
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import Taggable
 from cfme.common import TagPageView
-from cfme.exceptions import BackupNotFoundError
 from cfme.exceptions import ItemNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
@@ -244,7 +243,7 @@ class VolumeBackupCollection(BaseCollection):
                 try:
                     view.entities.get_entity(name=backup.name).check()
                 except ItemNotFound:
-                    raise BackupNotFoundError("Volume backup {} not found".format(backup.name))
+                    raise ItemNotFound("Volume backup {} not found".format(backup.name))
 
             view.toolbar.configuration.item_select('Delete selected Backups', handle_alert=True)
 
@@ -259,7 +258,7 @@ class VolumeBackupCollection(BaseCollection):
                 )
 
         else:
-            raise BackupNotFoundError('No Volume Backups for Deletion')
+            raise ItemNotFound('No Volume Backups for Deletion')
 
 
 @navigator.register(VolumeBackupCollection, 'All')
@@ -282,7 +281,7 @@ class Details(CFMENavigateStep):
             self.prerequisite_view.entities.get_entity(name=self.obj.name,
                                                        surf_pages=True).click()
         except ItemNotFound:
-            raise BackupNotFoundError('Could not locate volume backup {}'.format(self.obj.name))
+            raise ItemNotFound('Could not locate volume backup {}'.format(self.obj.name))
 
 
 @navigator.register(VolumeBackup, 'EditTagsFromDetails')

--- a/cfme/storage/volume_snapshot.py
+++ b/cfme/storage/volume_snapshot.py
@@ -14,7 +14,6 @@ from cfme.base.ui import BaseLoggedInPage
 from cfme.common import Taggable
 from cfme.common import TagPageView
 from cfme.exceptions import ItemNotFound
-from cfme.exceptions import SnapshotNotFoundError
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
@@ -255,7 +254,9 @@ class Details(CFMENavigateStep):
             self.prerequisite_view.entities.get_entity(name=self.obj.name,
                                                        surf_pages=True).click()
         except ItemNotFound:
-            raise SnapshotNotFoundError('Could not locate volume snapshot {}'.format(self.obj.name))
+            raise ItemNotFound(
+                'Could not locate volume snapshot {}'.format(self.obj.name)
+            )
 
 
 @navigator.register(VolumeSnapshot, 'EditTagsFromDetails')

--- a/cfme/storage/volume_type.py
+++ b/cfme/storage/volume_type.py
@@ -11,7 +11,6 @@ from cfme.base.login import BaseLoggedInPage
 from cfme.common import Taggable
 from cfme.common import TaggableCollection
 from cfme.exceptions import ItemNotFound
-from cfme.exceptions import VolumeTypeNotFoundError
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.storage.volume import VolumeToolbar
@@ -111,4 +110,4 @@ class VolumeTypeDetails(CFMENavigateStep):
         try:
             self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True).click()
         except ItemNotFound:
-            raise VolumeTypeNotFoundError('Volume Type {} not found'.format(self.obj.name))
+            raise ItemNotFound('Volume Type {} not found'.format(self.obj.name))

--- a/cfme/tests/cloud_infra_common/test_tag_visibility.py
+++ b/cfme/tests/cloud_infra_common/test_tag_visibility.py
@@ -3,7 +3,7 @@ import pytest
 
 from cfme import test_requirements
 from cfme.cloud.provider import CloudProvider
-from cfme.exceptions import VmOrInstanceNotFound
+from cfme.exceptions import ItemNotFound
 from cfme.infrastructure.provider import InfraProvider
 from cfme.markers.env_markers.provider import ONE
 from cfme.markers.env_markers.provider import ONE_PER_TYPE
@@ -112,7 +112,7 @@ def check_vm_visibility(user_restricted, appliance):
             try:
                 navigate_to(vm, 'VMsOnlyDetails')
                 actual_visibility = True
-            except VmOrInstanceNotFound:
+            except ItemNotFound:
                 actual_visibility = False
         assert actual_visibility == vis_expect, (
             'VM visibility is not as expected, expected {}'.format(vis_expect)

--- a/cfme/tests/cloud_infra_common/test_vm_ownership.py
+++ b/cfme/tests/cloud_infra_common/test_vm_ownership.py
@@ -4,7 +4,7 @@ import pytest
 from cfme import test_requirements
 from cfme.base.credential import Credential
 from cfme.cloud.provider import CloudProvider
-from cfme.exceptions import VmOrInstanceNotFound
+from cfme.exceptions import ItemNotFound
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.utils.blockers import BZ
@@ -142,7 +142,7 @@ def check_vm_exists(vm_ownership):
     try:
         vm_ownership.find_quadicon(from_any_provider=True)
         return True
-    except VmOrInstanceNotFound:
+    except ItemNotFound:
         return False
 
 

--- a/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
+++ b/cfme/tests/openstack/infrastructure/test_host_lifecycle.py
@@ -1,6 +1,6 @@
 import pytest
 
-from cfme.exceptions import HostNotFound
+from cfme.exceptions import ItemNotFound
 from cfme.infrastructure.openstack_node import OpenstackNode
 from cfme.infrastructure.provider.openstack_infra import OpenstackInfraProvider
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -25,7 +25,7 @@ def host(provider):
         vms = int(view.entities.summary('Relationships').get_text_of('VMs'))
         if 'Compute' in host.name and vms == 0:
             return host
-    raise HostNotFound('There is no proper host for tests')
+    raise ItemNotFound('There is no proper host for tests')
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
This PR brings the following changes:
1. Use a common `ItemNotFound` exception when an item is not found.
2. Removed Exceptions - `ElementOrBlockNotFound`,  `VmOrInstanceNotFound`, `VmNotFound`, `InstanceNotFound`, `ImageNotFound`, `TenantNotFound`, `TenantNotFound`, `HostNotFound`,  `FlavorNotFound`, `SecurityGroupsNotFound`, `ResourcePoolNotFound`, `AvailabilityZoneNotFound`, `VolumeNotFoundError`, `VolumeTypeNotFoundError`, `ZoneNotFound`,  , `RoleNotFound`, `BackupNotFoundError`, `SnapshotNotFoundError`.
2. Remove unused exceptions such as - `AccordionItemNotFound`, `ScheduleNotFound`, `StackNotFound`, `ClusterNotFound`, `StorageManagerNotFound`.
3. Replace almost all exceptions similar to `ItemNotFound` exception with it. Some exceptions have not been changed since they might not be custom exceptions, they might be defined by other frameworks or seem required.