### PR TITLE
[1LP][RFR] New Test: Test object atrribute type in automation schedule

### DIFF
--- a/cfme/configure/configuration/system_schedules.py
+++ b/cfme/configure/configuration/system_schedules.py
@@ -70,6 +70,11 @@ class ScheduleAddEditEntities(View):
     start_hour = BootstrapSelect("start_hour")
     start_minute = BootstrapSelect("start_min")
 
+    # After selecting action_type == automation tasks
+    request = Input(name='object_request')
+    object_type = BootstrapSelect('target_class')
+    object_selection = BootstrapSelect('target_id')
+
 
 class ScheduleAllView(ConfigurationView):
     """ Shedule All view on the shedule configuration page"""

--- a/cfme/tests/automate/test_automate_manual.py
+++ b/cfme/tests/automate/test_automate_manual.py
@@ -997,27 +997,3 @@ def test_user_requester_for_lifecycle_provision():
          1671563
     """
     pass
-
-
-@pytest.mark.tier(1)
-def test_automate_schedule_crud():
-    """
-    Polarion:
-        assignee: ghubale
-        casecomponent: Automate
-        initialEstimate: 1/15h
-        startsin: 5.8
-        tags: automate
-        testSteps:
-            1. Create a schedule, selecting Automation Tasks under Action.
-            2. Select a value from the dropdown list under Object Attribute Type.
-            3. Undo the selection by selecting "<Choose>" from the dropdown.
-        expectedResults:
-            1.
-            2.
-            3. No pop-up window with Internal Server Error.
-
-    Bugzilla:
-         1479570
-    """
-    pass

--- a/cfme/tests/automate/test_domain.py
+++ b/cfme/tests/automate/test_domain.py
@@ -310,6 +310,7 @@ def test_object_attribute_type_in_automate_schedule(appliance):
     view.form.action_type.select_by_visible_text('Automation Tasks')
     all_options = view.form.object_type.all_options
     if len(all_options) < 2:
+        # There should be more than one options available because <choose> is default option
         raise OptionNotAvailable("Options not available")
     for options in all_options:
         view.form.object_type.select_by_visible_text(options.text)

--- a/cfme/tests/configure/test_schedule_operations.py
+++ b/cfme/tests/configure/test_schedule_operations.py
@@ -200,7 +200,6 @@ def test_schedule_timer(appliance, run_types, host_with_credentials, request, cu
 
     )
 
-
     @request.addfinalizer
     def _finalize():
         if schedule.exists:


### PR DESCRIPTION
- Added test case for checking whether internal server error is occuring while selecting object atrribute type
- Added following widgets in ```ScheduleAddEditEntities```:
```
# After selecting action_type == automation tasks
    request = Input(name='object_request')
    object_type = BootstrapSelect('target_class')
    object_selection = BootstrapSelect('target_id')
```
- This test case is created as per the the BZs: [1479570](https://bugzilla.redhat.com/show_bug.cgi?id=1479570) and [1686762](https://bugzilla.redhat.com/show_bug.cgi?id=1686762)
- Also changed name of test case and behaviour of the test case as per above BZs test scenarios

{{ pytest: cfme/tests/automate/test_domain.py -k 'test_object_attribute_type_in_automate_schedule' -vv }}