### PR TITLE
[RFR]Fix updates

### DIFF
--- a/cfme/tests/cli/test_appliance_update.py
+++ b/cfme/tests/cli/test_appliance_update.py
@@ -65,7 +65,7 @@ def appliance_preupdate(old_version, appliance):
     repo file for update"""
 
     usable = []
-    sp = SproutClient.from_config()
+    sp = SproutClient.from_config(sprout_user_key=pytest.config.option.sprout_user_key or None)
     available_versions = set(sp.call_method('available_cfme_versions'))
     for a in available_versions:
         if a.startswith(old_version):

--- a/cfme/tests/cli/test_appliance_update.py
+++ b/cfme/tests/cli/test_appliance_update.py
@@ -71,12 +71,8 @@ def appliance_preupdate(old_version, appliance):
         if a.startswith(old_version):
             usable.append(Version(a))
     usable.sort(reverse=True)
-    try:
-        apps, pool_id = sp.provision_appliances(count=1, preconfigured=True,
-                                                lease_time=180, version=str(usable[0]))
-    except Exception as e:
-        logger.exception("Couldn't provision appliance with following error:{}".format(e))
-        raise SproutException('No provision available')
+    apps, pool_id = sp.provision_appliances(count=1, preconfigured=True,
+                                            lease_time=180, version=str(usable[0]))
 
     apps[0].db.extend_partition()
     urls = cfme_data["basic_info"][update_url]


### PR DESCRIPTION
Fix updates tests failing on auth error. Use the sprout_user_key from the cmdline.

{{py.test: --sprout-user-key sprout cfme/tests/cli/test_appliance_update.py::test_update_yum}}