### PR TITLE
[RFR] Remove manual control case

### DIFF
--- a/cfme/tests/control/test_basic.py
+++ b/cfme/tests/control/test_basic.py
@@ -733,20 +733,3 @@ def test_control_policy_simulation_displayed():
         initialEstimate: 1/6h
     """
     pass
-
-
-@pytest.mark.manual
-@test_requirements.control
-@pytest.mark.tier(3)
-def test_control_import_with_incorrect_schema():
-    """
-    Test importing yaml with incorrect schema.
-
-    Polarion:
-        assignee: jdupuy
-        casecomponent: Control
-        caseimportance: low
-        caseposneg: negative
-        initialEstimate: 1/12h
-    """
-    pass

--- a/cfme/tests/control/test_import_policies.py
+++ b/cfme/tests/control/test_import_policies.py
@@ -21,11 +21,6 @@ def import_invalid_yaml_file(request):
     return data_path.join("ui/control/invalid.yaml").realpath().strpath
 
 
-@pytest.fixture(scope="module")
-def policy_profile_collection(appliance):
-    return appliance.collections.policy_profiles
-
-
 @pytest.mark.meta(blockers=[1106456, 1198111], automates=[1198111])
 def test_import_policies(appliance, import_policy_file):
     """
@@ -52,7 +47,7 @@ def test_control_import_invalid_yaml_file(appliance, import_invalid_yaml_file):
         import_export.import_file(appliance, import_invalid_yaml_file)
 
 
-def test_control_import_existing_policies(appliance, import_policy_file, policy_profile_collection):
+def test_control_import_existing_policies(appliance, import_policy_file):
     """
     Polarion:
         assignee: jdupuy
@@ -62,7 +57,7 @@ def test_control_import_existing_policies(appliance, import_policy_file, policy_
         initialEstimate: 1/12h
     """
     import_export.import_file(appliance, import_policy_file)
-    first_import = policy_profile_collection.all_policy_profile_names
+    first_import = appliance.collections.policy_profiles.all_policy_profile_names
     import_export.import_file(appliance, import_policy_file)
-    second_import = policy_profile_collection.all_policy_profile_names
+    second_import = appliance.collections.policy_profiles.all_policy_profile_names
     assert first_import == second_import


### PR DESCRIPTION
Removing the manual case `test_control_import_with_incorrect_schema` because this is automated by [`test_control_import_invalid_yaml_file`](https://github.com/ManageIQ/integration_tests/blob/5fbeb7a5f0903a9ddb998b57e6a68242a3f023cf/cfme/tests/control/test_import_policies.py#L41)

Also removing a fixtured collection in `test_import_policies.py`

{{ pytest: --use-template-cache cfme/tests/control/test_import_policies.py }}