### PR TITLE
[RFR]Add tree path in reports

### DIFF
--- a/cfme/intelligence/reports/saved.py
+++ b/cfme/intelligence/reports/saved.py
@@ -30,7 +30,6 @@ class AllSavedReportsView(CloudIntelReportsView):
 
 
 class SavedReportDetailsView(BaseSavedReportDetailsView):
-
     @property
     def is_displayed(self):
         return (
@@ -79,6 +78,15 @@ class SavedReport(BaseEntity):
             view.flash.assert_no_error()
             view.flash.assert_message("Successfully deleted Saved Report from the CFME Database")
 
+    @property
+    def tree_path(self):
+        return [
+            "Saved Reports",
+            "All Saved Reports",
+            self.name,
+            self.run_at_datetime
+        ]
+
 
 @attr.s
 class SavedReportsCollection(BaseCollection):
@@ -100,9 +108,4 @@ class ScheduleDetails(CFMENavigateStep):
     prerequisite = NavigateToAttribute("parent", "All")
 
     def step(self, *args, **kwargs):
-        self.view.saved_reports.tree.click_path(
-            "Saved Reports",
-            "All Saved Reports",
-            self.obj.name,
-            self.obj.run_at_datetime
-        )
+        self.view.saved_reports.tree.click_path(*self.obj.tree_path)


### PR DESCRIPTION
This PR brings the following changes:
1. Add `tree_path` property for reports and saved_reports.
2. Add `delete_if_exists` method for reports, saved_reports and schedules.
3. Use `tree_path`in all `is_displayed` methods.

{{ pytest: cfme/tests/intelligence/test_reports_with_timelines.py cfme/tests/intelligence/reports/test_reports_schedules.py cfme/tests/intelligence/reports/test_crud.py cfme/tests/intelligence/reports/test_reports_schedules.py --use-template-cache -sqvvvv }}