### PR TITLE
[RFR] Add in a blocker statement for BZ 1687493

### DIFF
--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -264,6 +264,14 @@ class VMEvent(object):
                     elif evt.source_vm in self.vm.name and evt.event_type in self.tl_event:
                         found_events.append(evt)
                         break
+                    elif (
+                        self.event == 'create' and
+                        BZ(1687493, forced_stream=["5.9", "5.10"],
+                           unblock=lambda provider: not provider.one_of(RHEVMProvider)).blocks and
+                        self.vm.name in evt.message and evt.event_type in self.tl_event
+                    ):
+                        found_events.append(evt)
+                        break
                 else:
                     if evt.event_type in self.tl_event and evt.target in self.vm.name:
                         found_events.append(evt)


### PR DESCRIPTION
Adding a blocker statement for [BZ 1687493](https://bugzilla.redhat.com/show_bug.cgi?id=1687493), so that the test will pass event if the Source VM is not listed on the event details. 

{{ pytest: --use-provider rhv42 --use-template-cache cfme/tests/infrastructure/test_timelines.py::test_infra_timeline_create_event }}