### PR TITLE
[1LP][RFR] New Test: Checking power operations on archived/orphaned vms

### DIFF
--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -298,9 +298,10 @@ class Instance(VM):
         Args:
         Returns: entity of appropriate type
         """
-        view = navigate_to(self.parent, 'All')
-        view.toolbar.view_selector.select('Grid View')
-
+        archived = kwargs.pop('archived', None)
+        if not archived:
+            view = navigate_to(self.parent, 'All')
+        self.view.toolbar.view_selector.select('Grid View')
         try:
             return view.entities.get_entity(name=self.name, surf_pages=True)
         except ItemNotFound:
@@ -491,6 +492,30 @@ class InstanceCollection(VMCollection):
             entities = [e for e in entities if e.name == name]
 
         return entities
+
+
+class ArchivedInstancesAllView(InstanceAllView):
+    """This view is for all Archived Instances page"""
+
+    @property
+    def is_displayed(self):
+        selected = self.view.sidebar.instances_by_provider.tree.currently_selected
+        return (
+            self.in_cloud_instance and
+            self.entities.title.text == 'Archived Instances' and
+            selected == ['Instances by Provider', '<Archived>']
+        )
+
+
+@navigator.register(InstanceCollection, 'ArchivedAll')
+@navigator.register(Instance, 'ArchivedAll')
+class ArchivedInstances(CFMENavigateStep):
+    VIEW = ArchivedInstancesAllView
+    prerequisite = NavigateToSibling('All')
+
+    def step(self, *args, **kwargs):
+        self.view.sidebar.instances_by_provider.tree.click_path('Instances by Provider',
+                                                                '<Archived>')
 
 
 @navigator.register(InstanceCollection, 'All')

--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -298,10 +298,9 @@ class Instance(VM):
         Args:
         Returns: entity of appropriate type
         """
-        archived = kwargs.pop('archived', None)
-        if not archived:
-            view = navigate_to(self.parent, 'All')
-        self.view.toolbar.view_selector.select('Grid View')
+        view = navigate_to(self.parent, 'All')
+        view.toolbar.view_selector.select('Grid View')
+
         try:
             return view.entities.get_entity(name=self.name, surf_pages=True)
         except ItemNotFound:
@@ -499,7 +498,7 @@ class ArchivedInstancesAllView(InstanceAllView):
 
     @property
     def is_displayed(self):
-        selected = self.view.sidebar.instances_by_provider.tree.currently_selected
+        selected = self.sidebar.instances_by_provider.tree.currently_selected
         return (
             self.in_cloud_instance and
             self.entities.title.text == 'Archived Instances' and

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -231,13 +231,15 @@ class BaseVM(
         Returns: entity of appropriate type
         Raises: ItemNotFound
         """
-        # todo :refactor this method replace it with vm methods like get_state
+        # TODO(all): Refactor this method replace it with vm methods like get_state
         if from_any_provider:
             view = navigate_to(self.parent, 'All')
         elif from_archived_all:
-            view = navigate_to(self.appliance.collections.infra_vms, 'ArchivedAll')
+            view = navigate_to(self.appliance.provider_based_collection(self.provider),
+                               'ArchivedAll')
         elif from_orphaned_all:
-            view = navigate_to(self.appliance.collections.infra_vms, 'OrphanedAll')
+            view = navigate_to(self.appliance.provider_based_collection(self.provider),
+                               'OrphanedAll')
         else:
             view = navigate_to(self, 'AllForProvider', use_resetter=False)
 

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -220,7 +220,8 @@ class BaseVM(
         else:
             return False
 
-    def find_quadicon(self, from_any_provider=False, use_search=True):
+    def find_quadicon(self, from_any_provider=False, from_archived_all=False,
+                      from_orphaned_all=False, use_search=True):
         """Find and return a quadicon belonging to a specific vm
 
         Args:
@@ -233,6 +234,10 @@ class BaseVM(
         # todo :refactor this method replace it with vm methods like get_state
         if from_any_provider:
             view = navigate_to(self.parent, 'All')
+        elif from_archived_all:
+            view = navigate_to(self.appliance.collections.infra_vms, 'ArchivedAll')
+        elif from_orphaned_all:
+            view = navigate_to(self.appliance.collections.infra_vms, 'OrphanedAll')
         else:
             view = navigate_to(self, 'AllForProvider', use_resetter=False)
 

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -175,37 +175,35 @@ class VmsTemplatesAllView(InfraVmView):
             self.entities.title.text == 'All VMs & Templates')
 
     def reset_page(self):
+        """It resets the 'search filter' to empty or removes the value of 'search filter' if already
+        present"""
         self.entities.search.remove_search_filters()
 
 
 class OrphanedVmsAllView(VmsTemplatesAllView):
     """This view is for all Orphaned Vms page"""
+
     @property
     def is_displayed(self):
+        selected = self.sidebar.vmstemplates.tree.currently_selected
         return (
             self.in_infra_vms
-            and self.sidebar.vmstemplates.tree.currently_selected
-            == ["All VMs & Templates", "<Orphaned>"]
+            and selected == ["All VMs & Templates", "<Orphaned>"]
             and self.entities.title.text == "Orphaned VM or Templates"
         )
-
-    def reset_page(self):
-        self.entities.search.remove_search_filters()
 
 
 class ArchivedVmsAllView(VmsTemplatesAllView):
     """This view is for all Archived Vms page"""
+
     @property
     def is_displayed(self):
+        selected = self.sidebar.vmstemplates.tree.currently_selected
         return (
             self.in_infra_vms
-            and self.sidebar.vmstemplates.tree.currently_selected
-            == ["All VMs & Templates", "<Archived>"]
+            and selected == ["All VMs & Templates", "<Archived>"]
             and self.entities.title.text == "Archived VM or Templates"
         )
-
-    def reset_page(self):
-        self.entities.search.remove_search_filters()
 
 
 class VmTemplatesAllForProviderView(InfraVmView):

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -11,6 +11,7 @@ from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
 from cfme.utils.wait import RefreshTimer
@@ -746,11 +747,18 @@ class TestInstanceRESTAPI(object):
         soft_assert(self.verify_vm_power_state(vm, terminated_states), "instance not terminated")
 
 
+@pytest.mark.meta(automates=[1701188, 1655477, 1686015, 1738584])
 def test_power_options_on_archived_instance_all_page(testing_instance):
     """This test case is to check Power option drop-down button is disabled on archived and orphaned
        instances all page. Also it performs the power operations on instance and checked expected
        flash messages.
-       Note: Cloud instances can not be orphaned - BZ: 1701188
+       Note: Cloud instances can not be orphaned
+
+    Bugzilla:
+        1701188
+        1655477
+        1686015
+        1738584
 
     Polarion:
         assignee: ghubale
@@ -765,35 +773,28 @@ def test_power_options_on_archived_instance_all_page(testing_instance):
             1. Add provider cloud provider
             2. Navigate to Archived instance all page
             3. Select any instance and click on power option drop-down
-        expectedResults:
-            1.
-            2.
-            3. As we don't perform any power operations on archived instances. So power
-               button drop-down should not present there at all or it must show desired flash
-               messages for those actions.
-
-    Bugzilla:
-        1701188, 1655477, 1686015
     """
     testing_instance.mgmt.delete()
     testing_instance.wait_for_instance_state_change(desired_state="archived", timeout=1200)
     cloud_instance = testing_instance.appliance.collections.cloud_instances
     view = navigate_to(cloud_instance, 'ArchivedAll')
 
-    # Checking power drop down is disabled on 'ArchivedAll' view
-    assert not view.toolbar.power.is_enabled
-
     # Selecting particular archived instance
-    testing_instance.find_quadicon(archived=True).check()
+    testing_instance.find_quadicon(from_archived_all=True).check()
 
     # After selecting particular archived instance; 'Power' drop down gets enabled.
     # Reading all the options available in 'power' drop down
     for action in view.toolbar.power.items:
+        if action == "Resume" and BZ(1738584, forced_streams=['5.10', '5.11']).blocks:
+            continue
+
         # Performing power actions on archived instance
         view.toolbar.power.item_select(action, handle_alert=True)
-        if action == 'Power On':
-            action = 'Start'
-        elif action == 'Power Off':
-            action = 'Stop'
-        view.flash.assert_message('{} action does not apply to selected items'.format(action))
+        if action == 'Soft Reboot':
+            action = 'Restart Guest'
+        elif action == 'Hard Reboot':
+            action = 'Reset'
+        elif action == 'Delete':
+            action = 'Terminate'
+        view.flash.assert_message(f'{action} action does not apply to selected items')
         view.flash.dismiss()

--- a/cfme/tests/cloud_infra_common/test_power_control_manual.py
+++ b/cfme/tests/cloud_infra_common/test_power_control_manual.py
@@ -269,37 +269,6 @@ def test_power_operations_from_global_region(provider, context):
 
 
 @pytest.mark.tier(2)
-def test_power_options_on_archived_orphaned_vms_all_page():
-    """
-    This test case is to check Power option drop-down button is disabled on archived and orphaned
-    VMs all page.
-
-    Polarion:
-        assignee: ghubale
-        initialEstimate: 1/2h
-        caseimportance: low
-        caseposneg: positive
-        testtype: functional
-        startsin: 5.9
-        casecomponent: Control
-        tags: power
-        testSteps:
-            1. Add provider infrastructure provider
-            2. Navigate to Archived or orphaned VMs all page
-            3. Select any VM and click on power option drop-down
-        expectedResults:
-            1.
-            2.
-            3. As we don't perform any power operations on archived or orphaned VMs. So power
-               button drop-down should not present there at all.
-
-    Bugzilla:
-        1655477
-    """
-    pass
-
-
-@pytest.mark.tier(2)
 def test_check_compliance_policy_option_on_vm_summery_page():
     """
     Polarion:

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -695,7 +695,7 @@ def test_power_options_on_archived_orphaned_vms_all_page(archive_orphan_vm, test
             3. Select any VM and click on power option drop-down
     """
     infra_vms = testing_vm.appliance.collections.infra_vms
-    if archive_orphan_vm == "archived_vm":
+    if archive_orphan_vm[0] == "archived_vm":
         view = navigate_to(infra_vms, 'ArchivedAll')
 
         # Checking power drop down is disabled on 'ArchivedAll' view
@@ -721,6 +721,5 @@ def test_power_options_on_archived_orphaned_vms_all_page(archive_orphan_vm, test
             action = 'Start'
         elif action == 'Power Off':
             action = 'Stop'
-        # for m in view.flash.messages:
-        #     m.dismiss()
         view.flash.assert_message('{} action does not apply to selected items'.format(action))
+        view.flash.dismiss()

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -656,7 +656,7 @@ def test_retire_vm_with_vm_user_role(new_user, appliance, testing_vm):
                                                    from_details=True)
 
 
-@pytest.fixture(params=['archived_vm', 'orphaned_vm'])
+@pytest.fixture(params=['archived', 'orphaned'])
 def archive_orphan_vm(request, provider, testing_vm):
     """This fixture is used to create archived or orphaned VM"""
     if request.param == "archived_vm":
@@ -669,7 +669,7 @@ def archive_orphan_vm(request, provider, testing_vm):
         provider.delete_if_exists(cancel=False)
         testing_vm.wait_for_vm_state_change(desired_state='orphaned', timeout=720,
                                             from_details=False, from_any_provider=True)
-    yield request.param
+    yield (request.param, testing_vm)
 
 
 def test_power_options_on_archived_orphaned_vms_all_page(archive_orphan_vm, testing_vm):
@@ -721,4 +721,6 @@ def test_power_options_on_archived_orphaned_vms_all_page(archive_orphan_vm, test
             action = 'Start'
         elif action == 'Power Off':
             action = 'Stop'
+        # for m in view.flash.messages:
+        #     m.dismiss()
         view.flash.assert_message('{} action does not apply to selected items'.format(action))

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -35,7 +35,7 @@ def vm_name():
 
 
 @pytest.fixture(scope="function")
-def testing_vm(appliance, request, provider, vm_name):
+def testing_vm(appliance, provider, vm_name):
     """Fixture to provision vm to the provider being tested"""
     vm = appliance.collections.infra_vms.instantiate(vm_name, provider)
 
@@ -48,7 +48,7 @@ def testing_vm(appliance, request, provider, vm_name):
 
 
 @pytest.fixture(scope="function")
-def archived_vm(provider, testing_vm):
+def archived_vm(testing_vm):
     """Fixture to archive testing VM"""
     testing_vm.mgmt.delete()
     testing_vm.wait_for_vm_state_change(desired_state='archived', timeout=720,
@@ -64,7 +64,7 @@ def orphaned_vm(provider, testing_vm):
 
 
 @pytest.fixture(scope="function")
-def testing_vm_tools(appliance, request, provider, vm_name, full_template):
+def testing_vm_tools(appliance, provider, vm_name, full_template):
     """Fixture to provision vm with preinstalled tools to the provider being tested"""
     vm = appliance.collections.infra_vms.instantiate(vm_name, provider, full_template.name)
 
@@ -654,3 +654,71 @@ def test_retire_vm_with_vm_user_role(new_user, appliance, testing_vm):
         testing_vm.retire()
         assert testing_vm.wait_for_vm_state_change(desired_state="retired", timeout=720,
                                                    from_details=True)
+
+
+@pytest.fixture(params=['archived_vm', 'orphaned_vm'])
+def archive_orphan_vm(request, provider, testing_vm):
+    """This fixture is used to create archived or orphaned VM"""
+    if request.param == "archived_vm":
+        # Archive VM by retiring it
+        testing_vm.mgmt.delete()
+        testing_vm.wait_for_vm_state_change(desired_state='archived', timeout=720,
+                                            from_details=False, from_any_provider=True)
+    else:
+        # Orphan VM by removing provider from CFME
+        provider.delete_if_exists(cancel=False)
+        testing_vm.wait_for_vm_state_change(desired_state='orphaned', timeout=720,
+                                            from_details=False, from_any_provider=True)
+    yield request.param
+
+
+def test_power_options_on_archived_orphaned_vms_all_page(archive_orphan_vm, testing_vm):
+    """This test case is to check Power option drop-down button is disabled on archived and orphaned
+    VMs all page. Also it performs the power operations on vm and checked expected flash messages.
+
+    Bugzilla:
+        1655477
+        1686015
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/2h
+        caseimportance: low
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.9
+        casecomponent: Control
+        tags: power
+        testSteps:
+            1. Add provider infrastructure provider
+            2. Navigate to Archived or orphaned VMs all page
+            3. Select any VM and click on power option drop-down
+    """
+    infra_vms = testing_vm.appliance.collections.infra_vms
+    if archive_orphan_vm == "archived_vm":
+        view = navigate_to(infra_vms, 'ArchivedAll')
+
+        # Checking power drop down is disabled on 'ArchivedAll' view
+        assert not view.toolbar.power.is_enabled
+
+        # Selecting particular archived vm
+        testing_vm.find_quadicon(from_archived_all=True).check()
+    else:
+        view = navigate_to(infra_vms, 'OrphanedAll')
+
+        # Checking power drop down is disabled on 'OrphanedAll' view
+        assert not view.toolbar.power.is_enabled
+
+        # Selecting particular orphaned vm
+        testing_vm.find_quadicon(from_orphaned_all=True).check()
+
+    # After selecting particular archived/orphaned vm; 'Power' drop down gets enabled.
+    # Reading all the options available in 'power' drop down
+    for action in view.toolbar.power.items:
+        # Performing power actions on archived/orphaned vm
+        view.toolbar.power.item_select(action, handle_alert=True)
+        if action == 'Power On':
+            action = 'Start'
+        elif action == 'Power Off':
+            action = 'Stop'
+        view.flash.assert_message('{} action does not apply to selected items'.format(action))


### PR DESCRIPTION
- This test case is to check Power option drop-down button is disabled on archived and orphaned
  VMs all page. Also it performs the power operations on vm and checked expected flash messages.
- Added two new views:
    - **OrphanedVmsAllView**: for all page of orphaned vms
    - **ArchivedVmsAllView**: for all page of archived vms
- Added fixture:
    - **archive_orphan_vm**: To create orphaned/archived vms
- Improved **find_quadicon** method as it is used to find quadicon and check the particular vm.
    - Added ```from_archived_all``` and ```from_orphaned_all```


{{ pytest:  cfme/tests/ -k "test_power_options_on_archived_orphaned_vms_all_page or test_power_options_on_archived_instance_all_page or test_quadicon_terminate_cancel" --long-running -vv }}