### PR TITLE
[1LP][RFR] drawer isn't closed in both UI and SSUI 

### DIFF
--- a/cfme/utils/appliance/implementations/ssui.py
+++ b/cfme/utils/appliance/implementations/ssui.py
@@ -58,6 +58,22 @@ class MiqSSUIBrowser(Browser):
 class MiqSSUIBrowserPlugin(DefaultPlugin):
 
     ENSURE_PAGE_SAFE = jsmin('''
+        try {
+            var drawer = angular.element(document.getElementsByTagName("pf-notification-drawer"));
+            if (drawer && drawer.is(':visible')){
+                drawer.hide();
+            };
+
+            var eventNotificationsService = drawer.injector().get('eventNotifications');
+            eventNotificationsService.clearAll(
+                ManageIQ.angular.eventNotificationsData.state.groups[0]
+            );
+            eventNotificationsService.clearAll(
+                ManageIQ.angular.eventNotificationsData.state.groups[1]
+            );
+        } catch(err) {
+        }
+
         function checkProgressBar() {
             try {
                 return $('#ngProgress').attr('style').indexOf('width: 0%') > -1;

--- a/cfme/utils/appliance/implementations/ui.py
+++ b/cfme/utils/appliance/implementations/ui.py
@@ -66,8 +66,12 @@ class MiqBrowserPlugin(DefaultPlugin):
 
     ENSURE_PAGE_SAFE = jsmin('''\
         try {
-            var eventNotificationsService = angular.element('#notification-app')
-                .injector().get('eventNotifications');
+            var drawer = angular.element(document.getElementById("miq-notifications-drawer"));
+            if (drawer && drawer.is(':visible')){
+                drawer.hide();
+            };
+
+            var eventNotificationsService = drawer.injector().get('eventNotifications');
             eventNotificationsService.clearAll(
                 ManageIQ.angular.eventNotificationsData.state.groups[0]
             );


### PR DESCRIPTION
There is notification drawer in both UI and SSUI. It was likely absent in SSUI earlier.
That drawer sometimes shows up what makes selenium loose focus or switch frames.
We decided to hide notification drawer until we really need it. 
As far as I'm concerned js code used in UI doesn't handle this case for the time being.
As for SSUI such code is absent at all.

This PR intends to sort out this issue with notification drawers.
