### PR TITLE
[RFR] Remove condition to fix deleting expressions

### DIFF
--- a/widgetastic_manageiq/expression_editor.py
+++ b/widgetastic_manageiq/expression_editor.py
@@ -272,7 +272,7 @@ class ExpressionEditor(View, Pretty):
         before = self.expression_text.encode("utf-8").strip()
         prog()
         wait_for(
-            lambda: self.expression_text != "<new element>" and self.expression_text != before,
+            lambda: self.expression_text != before,
             handle_exception=True,
             num_sec=10,
             message="updated expression text to appear",


### PR DESCRIPTION
__Fixing__ `test_group_crud_with_tag` when deleting existing expressions.

The `wait_for` in question here checks also for `self.expression_text != "<new element>"`. When deleting expressions during testing, we use:

```
while self.any_expression_present():
        self.select_first_expression()
        self.click_remove()
```
so we are deleting expression after expression and in the end, we are left with `"<new element>"` string. The condition that I removed from here would never be True for this case.

{{ pytest: -v --long-running cfme/tests/control/test_basic.py::test_modify_condition_expression }}