### PR TITLE
[1LP][RFR] Move create_view to enable error check

### DIFF
--- a/cfme/configure/access_control/__init__.py
+++ b/cfme/configure/access_control/__init__.py
@@ -878,7 +878,6 @@ class GroupCollection(BaseCollection):
         else:
             view.add_button.click()
             flash_message = 'Group "{}" was saved'.format(group.description)
-        view = self.create_view(AllGroupView, wait='10s')
 
         try:
             view.flash.assert_message(flash_blocked_msg)
@@ -886,6 +885,7 @@ class GroupCollection(BaseCollection):
         except AssertionError:
             pass
 
+        view = self.create_view(AllGroupView, wait='10s')
         view.flash.assert_success_message(flash_message)
 
         # To ensure that the group list is updated


### PR DESCRIPTION
__Fixing__ `test_group_description_required_error_validation`, when creating a group without description.

I simply moved `create_view` below error checking, that was already present in the file:
```
try:
    view.flash.assert_message(flash_blocked_msg)
    raise RBACOperationBlocked(flash_blocked_msg)
except AssertionError:
    pass
```
Nothing else changed.

{{ pytest: -v --long-running cfme/tests/configure/test_access_control.py --use-provider vsphere65-nested -k test_group_description_required_error_validation }}