### PR TITLE
[1LP][RFR] Move `delete_if_exists` to BaseEntity

### DIFF
--- a/cfme/automate/buttons.py
+++ b/cfme/automate/buttons.py
@@ -315,10 +315,6 @@ class BaseButton(BaseEntity, Updateable):
                 view.submit_button.click()
             view.flash.assert_no_error()
 
-    def delete_if_exists(self):
-        if self.exists:
-            self.delete()
-
 
 @attr.s
 class DefaultButton(BaseButton):
@@ -751,11 +747,6 @@ class ButtonGroup(BaseEntity, Updateable):
             view = self.create_view(ButtonGroupObjectTypeView, wait="10s")
             view.flash.assert_no_error()
             view.flash.assert_message('Button Group "{}": Delete successful'.format(self.hover))
-
-    def delete_if_exists(self):
-        if self.exists:
-            self.delete()
-
 
 @attr.s
 class ButtonGroupCollection(BaseCollection):

--- a/cfme/automate/dialogs/service_dialogs.py
+++ b/cfme/automate/dialogs/service_dialogs.py
@@ -96,10 +96,6 @@ class Dialog(BaseEntity, Fillable):
         view.flash.assert_success_message(
             'Dialog "{}": Delete successful'.format(self.label))
 
-    def delete_if_exists(self):
-        if self.exists:
-            self.delete()
-
 
 @attr.s
 class DialogCollection(BaseCollection):

--- a/cfme/automate/explorer/domain.py
+++ b/cfme/automate/explorer/domain.py
@@ -264,10 +264,6 @@ class Domain(BaseEntity, Fillable):
             view.flash.assert_message(
                 'Edit of Automate Domain "{}" was cancelled by the user'.format(self.name))
 
-    def delete_if_exists(self):
-        if self.exists:
-            self.delete()
-
 
 @attr.s
 class DomainCollection(BaseCollection):

--- a/cfme/automate/explorer/instance.py
+++ b/cfme/automate/explorer/instance.py
@@ -253,10 +253,6 @@ class Instance(BaseEntity, Copiable):
             result_view.flash.assert_message(
                 'Automate Instance "{}": Delete successful'.format(self.description or self.name))
 
-    def delete_if_exists(self):
-        if self.exists:
-            self.delete()
-
 
 @attr.s
 class InstanceCollection(BaseCollection):

--- a/cfme/automate/explorer/klass.py
+++ b/cfme/automate/explorer/klass.py
@@ -242,10 +242,6 @@ class Class(BaseEntity, Copiable):
             view.flash.assert_message(
                 'Edit of Automate Class "{}" was cancelled by the user'.format(self.name))
 
-    def delete_if_exists(self):
-        if self.exists:
-            self.delete()
-
 
 @attr.s
 class ClassCollection(BaseCollection):

--- a/cfme/automate/explorer/method.py
+++ b/cfme/automate/explorer/method.py
@@ -424,10 +424,6 @@ class Method(BaseEntity, Copiable):
             result_view.flash.assert_message(
                 'Automate Method "{}": Delete successful'.format(self.name))
 
-    def delete_if_exists(self):
-        if self.exists:
-            self.delete()
-
 
 @attr.s
 class MethodCollection(BaseCollection):

--- a/cfme/automate/explorer/namespace.py
+++ b/cfme/automate/explorer/namespace.py
@@ -179,10 +179,6 @@ class Namespace(BaseEntity):
             view.flash.assert_message(
                 'Edit of Automate Namespace "{}" was cancelled by the user'.format(self.name))
 
-    def delete_if_exists(self):
-        if self.exists:
-            self.delete()
-
 
 @attr.s
 class NamespaceCollection(BaseCollection):

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -624,16 +624,6 @@ class BaseProvider(Taggable, Updateable, Navigatable, BaseEntity, CustomButtonEv
             return self.create(cancel=False, validate_credentials=True,
                                check_existing=True, validate_inventory=True)
 
-    def delete_if_exists(self, *args, **kwargs):
-        """Combines ``.exists`` and ``.delete()`` as a shortcut for ``request.addfinalizer``
-
-        Returns: True if provider existed and delete was initiated, False otherwise
-        """
-        if self.exists:
-            self.delete(*args, **kwargs)
-            return True
-        return False
-
     @variable(alias='rest')
     def is_refreshed(self, refresh_timer=None, refresh_delta=600):
         if refresh_timer:

--- a/cfme/control/explorer/actions.py
+++ b/cfme/control/explorer/actions.py
@@ -222,10 +222,6 @@ class Action(BaseEntity, Updateable, Pretty):
             .filter(actions.description == self.description)\
             .count() > 0
 
-    def delete_if_exists(self):
-        if self.exists:
-            self.delete()
-
 
 @attr.s
 class ActionCollection(BaseCollection):

--- a/cfme/modeling/base.py
+++ b/cfme/modeling/base.py
@@ -200,6 +200,21 @@ class BaseEntity(NavigatableMixin):
         else:
             return True
 
+    def delete_if_exists(self, *args, **kwargs):
+        """Combines ``.exists`` and ``.delete()`` as a shortcut for ``request.addfinalizer``
+
+        Raises
+            NotImplementedError: If the ``.delete()`` is not implemented for the object
+        Returns: True if object existed and delete was initiated, False otherwise
+        """
+        if self.exists:
+            try:
+                self.delete(*args, **kwargs)
+                return True
+            except AttributeError:
+                raise NotImplementedError("Delete method is not implemented.")
+        return False
+
 
 @attr.s
 class CollectionProperty(object):

--- a/cfme/services/catalogs/catalog_items/__init__.py
+++ b/cfme/services/catalogs/catalog_items/__init__.py
@@ -294,10 +294,6 @@ class BaseCatalogItem(BaseEntity, Updateable, Pretty, Taggable):
         assert view.is_displayed
         view.flash.assert_success_message('The selected Catalog Item was deleted')
 
-    def delete_if_exists(self):
-        if self.exists:
-            self.delete()
-
     def add_button_group(self):
         button_name = fauxfactory.gen_alpha()
         view = navigate_to(self, 'AddButtonGroup')


### PR DESCRIPTION
Changes introduced with the PR:
1. Move `delete_if_exists` method to `BaseEntity`. The method raises a `NotImplementedError` if `delete` method has not been implemented for an entity.
2. Remove `delete_if_exists` from all other places.

{{ pytest: cfme/tests/automate/custom_button/test_generic_objects.py::test_custom_button_display cfme/tests/automate/test_class.py::test_class_crud cfme/tests/automate/test_domain.py::test_domain_crud cfme/tests/automate/test_namespace.py::test_wrong_namespace_name cfme/tests/automate/test_service_dialog.py::test_checkbox_dialog_element cfme/tests/cloud/test_providers.py::test_add_cancelled_validation_cloud  --use-template-cache -sqvvvv }}