### PR TITLE
[1LP][RFR] Use role with product features

### DIFF
--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -700,7 +700,10 @@ def test_role_crud(appliance):
         initialEstimate: 1/8h
         tags: rbac
     """
-    role = new_role(appliance)
+    role = _mk_role(appliance, name=None, vm_restriction=None,
+                    product_features=[(['Everything'], False),
+                                      (['Everything', 'Settings', 'Configuration'], True),
+                                      (['Everything', 'Services', 'Catalogs Explorer'], True)])
     with update(role):
         role.name = "{}edited".format(role.name)
     copied_role = role.copy()


### PR DESCRIPTION
__Fixing__ `test_permissions_role_crud` for 5.10 and making it a bit nicer in 5.9.

The change here is use `_mk_role` instead of original `new_role`, reason being that we need to specify some product features to be enabled for testing user instead of having enabled everything, which is default.

Test is creating a role, group and a user with product features Configuration and Catalogs Explorer enabled, everything else is disabled. Then this user logs in and tries to perform role-related crud testing. Up until now, the role that this user creates had enabled all product features.

In 5.9, this is ok, because user can create role with permissions higher than he himself has. He however can't create group or new user with it. This means that it is secure, and this role testing PASSes.

In 5.10, this is not ok, because the user doesn't even see the role that he created in the Roles tree and test fails.

We are talking about a testing role, something that we need to create, copy and delete. There is no point having a role with all product features here. So I used `_mk_role` that is already used in this file, and specified couple of features for fun. These are the same as our testing user has, but do not necessarily have to be.

{{ pytest: -v --long-running cfme/tests/configure/test_access_control.py -k test_permissions_role_crud }}
