### PR TITLE
[RFR] Fix collection test compliance

### DIFF
--- a/cfme/tests/control/test_compliance.py
+++ b/cfme/tests/control/test_compliance.py
@@ -88,7 +88,14 @@ def compliance_vm(configure_fleecing, provider, full_template_modscope):
     name = "{}-{}".format("test-compliance", fauxfactory.gen_alpha(4))
     collection = provider.appliance.provider_based_collection(provider)
     vm = collection.instantiate(name, provider, full_template_modscope.name)
-    vm.create_on_provider(allow_skip="default")
+    # TODO: remove this check once issue with SSA on other hosts in vSphere 6.5 is figured out
+    if provider.version == 6.5:
+        vm.create_on_provider(
+            allow_skip="default",
+            host=conf.cfme_data['management_systems'][provider.key]['hosts'][0].name
+        )
+    else:
+        vm.create_on_provider(allow_skip="default")
     vm.mgmt.ensure_state(VmState.RUNNING)
     if not vm.exists:
         vm.wait_to_appear(timeout=900)

--- a/cfme/tests/control/test_compliance.py
+++ b/cfme/tests/control/test_compliance.py
@@ -122,6 +122,9 @@ def test_check_package_presence(request, appliance, compliance_vm, analysis_prof
     """This test checks compliance by presence of a certain "kernel" package which is expected
     to be present on the full_template.
 
+    Metadata:
+        test_flag: provision, policy
+
     Polarion:
         assignee: jdupuy
         initialEstimate: 1/4h
@@ -156,6 +159,9 @@ def test_check_package_presence(request, appliance, compliance_vm, analysis_prof
 def test_check_files(request, appliance, compliance_vm, analysis_profile):
     """This test checks presence and contents of a certain file. Due to caching, an existing file
     is checked.
+
+    Metadata:
+        test_flag: provision, policy
 
     Polarion:
         assignee: jdupuy
@@ -197,6 +203,10 @@ def test_check_files(request, appliance, compliance_vm, analysis_profile):
 
 def test_compliance_with_unconditional_policy(host, assign_policy_for_testing):
     """
+
+    Metadata:
+        test_flag: policy
+
     Polarion:
         assignee: jdupuy
         initialEstimate: 1/6h


### PR DESCRIPTION
Purpose or Intent
=================
Performing some maintenance for `test_compliance`. 

1) Adding policy `test_flag` so that these tests won't collect against the IMS provider
2) For vSphere 6.5, SSA is not working on hosts other than host-01. This is causing test failures for some of the tests in `test_compliance`. For now, we provision onto host-01 only, but we can remove this check once we know why SSA is failing for the other hosts. 

{{ pytest: --use-provider vsphere65-nested --use-template-cache cfme/tests/control/test_compliance.py::test_check_files cfme/tests/control/test_compliance.py::test_check_package_presence }}
