### PR TITLE
[RFR] Fix failing test_tenant_quota_reports test

### DIFF
--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -520,7 +520,7 @@ class SavedReport(Updateable, BaseEntity):
         try:
             headers = tuple([hdr.encode("utf-8") for hdr in view.table.headers])
             body = []
-            for _ in view.paginator.pages():
+            for _ in range(view.paginator.pages_amount):
                 for row in view.table.rows():
                     if not all([c[1].is_displayed for c in row]):
                         # This is a temporary workaround for cases we have row span

--- a/cfme/tests/intelligence/reports/test_tenant_quota_reports.py
+++ b/cfme/tests/intelligence/reports/test_tenant_quota_reports.py
@@ -8,7 +8,7 @@ pytestmark = [
     pytest.mark.tier(3)
 ]
 
-property_mapping = {
+PROPERTY_MAPPING = {
     "cpu": "Allocated Virtual CPUs",
     "memory": "Allocated Memory in GB",
     "storage": "Allocated Storage in GB",
@@ -40,7 +40,7 @@ def set_and_get_tenant_quota(appliance):
     root_tenant.set_quota(**tenant_quota_data)
 
     data = dict()
-    for key, value in property_mapping.items():
+    for key, value in PROPERTY_MAPPING.items():
         suffix = "GB" if "GB" in value else "Count"
         data[value] = "{data_value} {suffix}".format(
             data_value=tenant_quota_data[key], suffix=suffix
@@ -82,7 +82,7 @@ def test_queue_tenant_quota_reports(set_and_get_tenant_quota, tenant_report):
     """
     report_data = dict()
     for row in tenant_report.data.rows:
-        if row["Quota Name"] in property_mapping.values():
+        if row["Quota Name"] in PROPERTY_MAPPING.values():
             report_data[row["Quota Name"]] = row["Total Quota"]
     assert report_data == set_and_get_tenant_quota
 


### PR DESCRIPTION
This PR brings the following changes:
1. Fix failing `test_queue_tenant_quota_reports` test
2. Use Uppercase for global variable `property_mapping`.

{{ pytest: cfme/tests/intelligence/reports/test_tenant_quota_reports.py --use-template-cache -sqvvv }}