### PR TITLE
[1LP][RFR] Don't obscure the tracebacks.

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -794,12 +794,12 @@ class VM(BaseVM):
         try:
             if find_in_cfme:
                 self.wait_to_appear(timeout=timeout, load_details=False)
-        except Exception as e:
+        except Exception:
             logger.warn("Couldn't find VM or Instance '%s' in CFME", self.name)
             if delete_on_failure:
                 logger.info("Removing VM or Instance from mgmt system")
                 self.cleanup_on_provider()
-            raise e
+            raise
         return vm
 
     def cleanup_on_provider(self):

--- a/cfme/tests/cloud_infra_common/test_html5_vm_console.py
+++ b/cfme/tests/cloud_infra_common/test_html5_vm_console.py
@@ -165,12 +165,12 @@ def test_html5_vm_console(appliance, provider, configure_websocket, vm_obj,
             # file using partial file name. Known issue, being worked on.
             command_result = ssh_client.run_command("rm blather", ensure_user=True)
             assert command_result
-    except Exception as e:
+    except Exception:
         # Take a screenshot if an exception occurs
         vm_console.switch_to_console()
         take_screenshot("ConsoleScreenshot")
         vm_console.switch_to_appliance()
-        raise e
+        raise
     finally:
         vm_console.close_console_window()
         # Logout is required because when running the Test back 2 back against RHV and VMware

--- a/cfme/tests/cloud_infra_common/test_provisioning.py
+++ b/cfme/tests/cloud_infra_common/test_provisioning.py
@@ -468,7 +468,7 @@ def test_provision_with_boot_volume(request, instance_args, provider, soft_asser
         except Exception as e:
             logger.info(
                 "Provision failed {}: {}".format(e, provision_request.request_state))
-            raise e
+            raise
         msg = "Provisioning failed with the message {}".format(
             provision_request.row.last_message.text)
         assert provision_request.is_succeeded(method='ui'), msg
@@ -537,7 +537,7 @@ def test_provision_with_additional_volume(request, instance_args, provider, smal
     except Exception as e:
         logger.info(
             "Provision failed {}: {}".format(e, provision_request.request_state))
-        raise e
+        raise
     assert provision_request.is_succeeded(method='ui'), (
         "Provisioning failed with the message {}".format(
             provision_request.row.last_message.text))

--- a/cfme/tests/cloud_infra_common/test_vm_ownership.py
+++ b/cfme/tests/cloud_infra_common/test_vm_ownership.py
@@ -264,9 +264,6 @@ def test_template_set_ownership(appliance, request, provider, setup_provider, vm
         template.set_ownership(user=user_no_owner)
         # set ownership back to admin
         template.set_ownership(user=user_admin)
-    except Exception as e:
-        # in case of any unforseen exception, raise it
-        raise e
     finally:
         # in every case, delete template we created
         template.mgmt.delete()

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -332,7 +332,7 @@ class TestVmDetailsPowerControlPerProvider(object):
             if testing_vm.provider.one_of(RHEVMProvider):
                 logger.warning('working around bz1174858, ignoring timeout')
             else:
-                raise e
+                raise
         soft_assert(testing_vm.mgmt.is_suspended, "vm not suspended")
         # BUG - https://bugzilla.redhat.com/show_bug.cgi?id=1101604
         if not testing_vm.provider.one_of(RHEVMProvider):

--- a/cfme/tests/infrastructure/test_webmks_console.py
+++ b/cfme/tests/infrastructure/test_webmks_console.py
@@ -166,9 +166,9 @@ def test_webmks_vm_console(request, appliance, provider, vm_obj, configure_webso
         command_result = ssh_client.run_command("rm blather", ensure_user=True)
         assert command_result
 
-    except Exception as e:
+    except Exception:
         # Take a screenshot if an exception occurs
         vm_console.switch_to_console()
         take_screenshot("ConsoleScreenshot")
         vm_console.switch_to_appliance()
-        raise e
+        raise

--- a/cfme/tests/ssui/test_ssui_myservice.py
+++ b/cfme/tests/ssui/test_ssui_myservice.py
@@ -210,9 +210,9 @@ def test_vm_console(request, appliance, setup_provider, context, configure_webso
                 command_result = vm_ssh_client.run_command("rm blather", ensure_user=True)
                 assert command_result
 
-            except Exception as e:
+            except Exception:
                 # Take a screenshot if an exception occurs
                 vm_console.switch_to_console()
                 take_screenshot("ConsoleScreenshot")
                 vm_console.switch_to_appliance()
-                raise e
+                raise


### PR DESCRIPTION
if one does:
```
In [1]: try:
   ...:     raise Exception("fff")
   ...: except Exception as e:
   ...:     print "Zde"
   ...:     raise e
   ...: 
Zde
---------------------------------------------------------------------------
Exception                                 Traceback (most recent call last)
<ipython-input-1-8b4b63314306> in <module>()
      3 except Exception as e:
      4     print "Zde"
----> 5     raise e

Exception: fff
```
...then the traceback to the real exception raise line is lost,
as seen above. For re-raising the caught exception we can
use just the `raise` keyword. This makes sure the traceback is preserved:
```
In [1]: try:
   ...:     raise Exception("fff")
   ...: except Exception:
   ...:     print "Here"
   ...:     raise
   ...:
Here
---------------------------------------------------------------------------
Exception                                 Traceback (most recent call last)
<ipython-input-1-6810a980af00> in <module>()
      1 try:
----> 2     raise Exception("fff")
      3 except Exception:
      4     print "Here"
      5     raise

Exception: fff
```


