### PR TITLE
[1LP][WIPTEST] Automate test control icons simulation

### DIFF
--- a/cfme/control/simulation.py
+++ b/cfme/control/simulation.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from navmazing import NavigateToSibling
+from widgetastic.utils import WaitFillViewStrategy
 from widgetastic.widget import Checkbox
 from widgetastic.widget import Select
 from widgetastic.widget import View
@@ -10,10 +11,12 @@ from cfme.base.login import BaseLoggedInPage
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigator
 from widgetastic_manageiq import ManageIQTree
+from widgetastic_manageiq import SquashButton
 
 
 class ControlSimulationView(BaseLoggedInPage):
     """Basic view for Control/Simulation tab."""
+    fill_strategy = WaitFillViewStrategy()
     event_type = Select(id="event_typ")
     event_value = Select(id="event_value")
     filter_type = Select(id="filter_typ")
@@ -29,8 +32,7 @@ class ControlSimulationView(BaseLoggedInPage):
 
     @View.nested
     class simulation_results(View):  # noqa
-        # TODO: match the squash button
-        # squash_button = Button(id="squash_button", title="Expand All")
+        squash_button = SquashButton()
         tree = ManageIQTree("rsop_treebox")
 
     @property

--- a/cfme/control/simulation.py
+++ b/cfme/control/simulation.py
@@ -1,28 +1,43 @@
 # -*- coding: utf-8 -*-
 from navmazing import NavigateToSibling
+from widgetastic.widget import Checkbox
 from widgetastic.widget import Select
+from widgetastic.widget import View
 from widgetastic_patternfly import Button
 
 from cfme.base import Server
 from cfme.base.login import BaseLoggedInPage
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigator
+from widgetastic_manageiq import ManageIQTree
 
 
 class ControlSimulationView(BaseLoggedInPage):
     """Basic view for Control/Simulation tab."""
-    event_selection = Select(id="event_typ")
-    vm_selection = Select(id="filter_typ")
+    event_type = Select(id="event_typ")
+    event_value = Select(id="event_value")
+    filter_type = Select(id="filter_typ")
+    filter_value = Select(id="filter_value")
     submit_button = Button("Submit")
     reset_button = Button("Reset")
-    # TODO Add simulation results tree. That tree can
-    # be shown only after filling aforedefined widgets.
+
+    @View.nested
+    class options(View):  # noqa
+        out_of_scope = Checkbox(name="out_of_scope")
+        show_successful = Checkbox(name="passed")
+        show_failed = Checkbox(name="failed")
+
+    @View.nested
+    class simulation_results(View):  # noqa
+        # TODO: match the squash button
+        # squash_button = Button(id="squash_button", title="Expand All")
+        tree = ManageIQTree("rsop_treebox")
 
     @property
     def is_displayed(self):
         return (
-            self.event_selection.is_displayed and
-            self.vm_selection.is_displayed and
+            self.event_type.is_displayed and
+            self.filter_type.is_displayed and
             self.submit_button.is_displayed and
             self.reset_button.is_displayed
         )

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -39,8 +39,7 @@ from cfme.utils.wait import wait_for
 
 pytestmark = [
     pytest.mark.long_running,
-    pytest.mark.meta(server_roles="+automate +smartproxy +smartstate",
-                     blockers=[BZ(1633606, forced_streams=['5.10'])]),
+    pytest.mark.meta(server_roles="+automate +smartproxy +smartstate"),
     pytest.mark.tier(2),
     test_requirements.control
 ]
@@ -940,26 +939,3 @@ def test_action_check_compliance(request, provider, vm, vm_name, policy_for_test
     view = navigate_to(vm.crud, "Details")
     view.toolbar.reload.click()
     assert vm.crud.compliant
-
-
-@pytest.mark.manual
-@test_requirements.general_ui
-@pytest.mark.tier(1)
-def test_control_icons_simulation():
-    """
-    Polarion:
-        assignee: jdupuy
-        casecomponent: Control
-        caseimportance: medium
-        initialEstimate: 1/15h
-        testSteps:
-            1. Have an infrastructure provider
-            2. Go to Control -> Simulation
-            3. Select:
-                Type: Datastore Operation
-                Event: Datastore Analysis Complete
-                VM Selection: By Clusters, Default
-            4. Submit
-            5. Check for all icons in this page
-    """
-    pass

--- a/cfme/tests/control/test_control_simulation.py
+++ b/cfme/tests/control/test_control_simulation.py
@@ -17,7 +17,8 @@ FILL_DATA = {
     "event_type": "Datastore Operation",
     "event_value": "Datastore Analysis Complete",
     "filter_type": "By Clusters",
-    "filter_value": "Cluster"
+    "filter_value": "Cluster",
+    "submit_button": True
 }
 
 
@@ -50,14 +51,12 @@ def test_control_icons_simulation(appliance):
     """
     view = navigate_to(appliance.server, "ControlSimulation")
     view.fill(FILL_DATA)
-    view.wait_displayed()
-    view.submit_button.click()
     # Now check all the icons
     assert view.simulation_results.squash_button.is_displayed
     # Check the tree icons
     tree = view.simulation_results.tree
     # Check the root_item
-    assert tree.image_getter(tree.root_item) is not None
+    assert tree.image_getter(tree.root_item)
     # Check all the child items
     for child_item in tree.child_items(tree.root_item):
-        assert tree.image_getter(child_item) is not None
+        assert tree.image_getter(child_item)

--- a/cfme/tests/control/test_control_simulation.py
+++ b/cfme/tests/control/test_control_simulation.py
@@ -8,6 +8,7 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 pytestmark = [
     pytest.mark.long_running,
     pytest.mark.provider(classes=[InfraProvider], selector=ONE_PER_CATEGORY),
+    pytest.mark.usefixtures("setup_provider"),
     test_requirements.control,
 ]
 

--- a/cfme/tests/control/test_control_simulation.py
+++ b/cfme/tests/control/test_control_simulation.py
@@ -16,15 +16,15 @@ FILL_DATA = {
     "event_type": "Datastore Operation",
     "event_value": "Datastore Analysis Complete",
     "filter_type": "By Clusters",
-    "filter_value": "Default",
+    "filter_value": "Cluster"
 }
 
 
 @pytest.mark.tier(1)
-def test_control_icons_simulation(appliance, provider):
+def test_control_icons_simulation(appliance):
     """
     Bugzillas:
-        * 1349147
+        * 1349147, 1690572
 
     Polarion:
         assignee: jdupuy
@@ -49,8 +49,11 @@ def test_control_icons_simulation(appliance, provider):
     """
     view = navigate_to(appliance.server, "ControlSimulation")
     view.fill(FILL_DATA)
+    view.wait_displayed()
     view.submit_button.click()
     # Now check all the icons
+    assert view.simulation_results.squash_button.is_displayed
+    # Check the tree icons
     tree = view.simulation_results.tree
     # Check the root_item
     assert tree.image_getter(tree.root_item) is not None

--- a/cfme/tests/control/test_control_simulation.py
+++ b/cfme/tests/control/test_control_simulation.py
@@ -1,0 +1,59 @@
+import pytest
+
+from cfme import test_requirements
+from cfme.infrastructure.provider import InfraProvider
+from cfme.markers.env_markers.provider import ONE_PER_CATEGORY
+from cfme.utils.appliance.implementations.ui import navigate_to
+
+pytestmark = [
+    pytest.mark.long_running,
+    pytest.mark.provider(classes=[InfraProvider], selector=ONE_PER_CATEGORY),
+    test_requirements.control,
+]
+
+
+FILL_DATA = {
+    "event_type": "Datastore Operation",
+    "event_value": "Datastore Analysis Complete",
+    "filter_type": "By Clusters",
+    "filter_value": "Default",
+}
+
+
+@pytest.mark.tier(1)
+def test_control_icons_simulation(appliance, provider):
+    """
+    Bugzillas:
+        * 1349147
+
+    Polarion:
+        assignee: jdupuy
+        casecomponent: Control
+        caseimportance: medium
+        initialEstimate: 1/15h
+        testSteps:
+            1. Have an infrastructure provider
+            2. Go to Control -> Simulation
+            3. Select:
+                Type: Datastore Operation
+                Event: Datastore Analysis Complete
+                VM Selection: By Clusters, Default
+            4. Submit
+            5. Check for all icons in this page
+        expectedResults:
+            1.
+            2.
+            3.
+            4.
+            5. All the icons should be present
+    """
+    view = navigate_to(appliance.server, "ControlSimulation")
+    view.fill(FILL_DATA)
+    view.submit_button.click()
+    # Now check all the icons
+    tree = view.simulation_results.tree
+    # Check the root_item
+    assert tree.image_getter(tree.root_item) is not None
+    # Check all the child items
+    for child_item in tree.child_items(tree.root_item):
+        assert tree.image_getter(child_item) is not None

--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -321,7 +321,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
 widgetastic.core==0.32.1
-widgetastic.patternfly==0.0.41
+widgetastic.patternfly==0.0.42
 widgetsnbextension==3.4.2
 wrapanapi==3.0.44
 wrapt==1.10.11

--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -321,7 +321,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
 widgetastic.core==0.32.1
-widgetastic.patternfly==0.0.42
+widgetastic.patternfly==0.1.0
 widgetsnbextension==3.4.2
 wrapanapi==3.0.44
 wrapt==1.10.11

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -308,7 +308,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
 widgetastic.core==0.32.1
-widgetastic.patternfly==0.0.41
+widgetastic.patternfly==0.0.42
 widgetsnbextension==3.4.2
 wrapanapi==3.0.44
 wrapt==1.10.11

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -308,7 +308,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
 widgetastic.core==0.32.1
-widgetastic.patternfly==0.0.42
+widgetastic.patternfly==0.1.0
 widgetsnbextension==3.4.2
 wrapanapi==3.0.44
 wrapt==1.10.11

--- a/requirements/frozen_docs.py2.txt
+++ b/requirements/frozen_docs.py2.txt
@@ -175,7 +175,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
 widgetastic.core==0.32.1
-widgetastic.patternfly==0.0.42
+widgetastic.patternfly==0.1.0
 widgetsnbextension==3.4.2
 wrapt==1.10.11
 xmltodict==0.11.0

--- a/requirements/frozen_docs.py2.txt
+++ b/requirements/frozen_docs.py2.txt
@@ -175,7 +175,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
 widgetastic.core==0.32.1
-widgetastic.patternfly==0.0.41
+widgetastic.patternfly==0.0.42
 widgetsnbextension==3.4.2
 wrapt==1.10.11
 xmltodict==0.11.0

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -166,7 +166,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
 widgetastic.core==0.32.1
-widgetastic.patternfly==0.0.42
+widgetastic.patternfly==0.1.0
 widgetsnbextension==3.4.2
 wrapt==1.10.11
 xmltodict==0.11.0

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -166,7 +166,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.14.1
 widgetastic.core==0.32.1
-widgetastic.patternfly==0.0.41
+widgetastic.patternfly==0.0.42
 widgetsnbextension==3.4.2
 wrapt==1.10.11
 xmltodict==0.11.0

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -1391,10 +1391,9 @@ class DialogButton(Button):
 class SquashButton(Button):
     """ This button requires a specific locator"""
 
-    def __locator__(self):
-        return './/div[contains(@class, "btn") and @id="squash_button" {}]'.format(
-            self.locator_conditions
-        )
+    ROOT = ParametrizedLocator(
+        './/div[contains(@class, "btn") and @id="squash_button" {@locator_conditions}]'
+    )
 
 
 class DragandDropElements(View):

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -1388,6 +1388,15 @@ class DialogButton(Button):
         )
 
 
+class SquashButton(Button):
+    """ This button requires a specific locator"""
+
+    def __locator__(self):
+        return './/div[contains(@class, "btn") and @id="squash_button" {}]'.format(
+            self.locator_conditions
+        )
+
+
 class DragandDropElements(View):
     """Drag elements to a drop place."""
 


### PR DESCRIPTION
Purpose or Intent
=================
Automating `test_control_icons_simulation` and moving it into a new module. This requires some widgets to be added to the view for the Control->Simulation page, so I've done that. 

Depends on minor widgetastic.patternfly PRs [here](https://github.com/RedHatQE/widgetastic.patternfly/pull/85) and [here](https://github.com/RedHatQE/widgetastic.patternfly/pull/88) 

{{ pytest: --long-running --use-provider complete --use-template-cache cfme/tests/control/test_control_simulation.py }}