### PR TITLE
[1LP][RFR] Unicode hack for auth group

### DIFF
--- a/cfme/configure/access_control/__init__.py
+++ b/cfme/configure/access_control/__init__.py
@@ -530,7 +530,7 @@ class DetailsGroupView(ConfigurationView):
     def is_displayed(self):
         return (
             self.accordions.accesscontrol.is_opened and
-            self.title.text == 'EVM Group "{}"'.format(self.context['object'].description)
+            self.title.text == u'EVM Group "{}"'.format(self.context['object'].description)
         )
 
 
@@ -712,11 +712,11 @@ class Group(BaseEntity, Taggable):
                 not having appropriate permissions OR delete is not allowed
                 for currently selected group
         """
-        flash_success_msg = 'EVM Group "{}": Delete successful'.format(self.description)
+        flash_success_msg = u'EVM Group "{}": Delete successful'.format(self.description)
         flash_blocked_msg_list = [
-            ('EVM Group "{}": '
-             'Error during delete: A read only group cannot be deleted.'.format(self.description)),
-            ('EVM Group "{}": Error during delete: '
+            (u'EVM Group "{}": Error during delete: '
+             'A read only group cannot be deleted.'.format(self.description)),
+            (u'EVM Group "{}": Error during delete: '
              'The group has users assigned that do not '
              'belong to any other group'.format(self.description))]
         delete_group_txt = 'Delete this Group'

--- a/cfme/tests/integration/test_cfme_auth.py
+++ b/cfme/tests/integration/test_cfme_auth.py
@@ -204,7 +204,7 @@ def test_login_retrieve_group(appliance, request, auth_mode, auth_provider, soft
                     'user full name "{}" did not match UI display name "{}"'
                     .format(user_obj.name, view.current_fullname))
         soft_assert(group.description in view.group_names,
-                    'user group "{}" not displayed in UI groups list "{}"'
+                    u'user group "{}" not displayed in UI groups list "{}"'
                     .format(group.description, view.group_names))
 
     appliance.server.login_admin()  # context should get us back to admin, just in case


### PR DESCRIPTION
__Fixing__ `test_login_retrieve_group` when working with non-ASCII characters in group description.

This applies to python version < 3.

If we want to work with unicode characters, there are two main problems:
1. How to get unicode character into our test without being escaped
2. How to work with unicode character in our code

For the first problem, as far as I can tell, we are loading our yamls with yaycl. This gets us `AttrDict` with strings. For authentication testing, there's `auth_data.yaml` that we are loading and then using in tests. We can specify unicode character in the yaml file like this: `SR-APP-EPM-Membre-\xe9`. The problem is that after loading this kind of string with yaycl, it escapes the character like so: `SR-APP-EPM-Membre-\\xe9`. It doesn't know that we want a unicode character there. The workaround for this would be to override the value at runtime: `auth_data['test_data']['test_users'][16]['groups'][1] = u"SR-APP-EPM-Membre-\xe9"`. This is ugly and it puts our data in our code and generally a bad idea.
Or we can just put the unicode character in our yaml like so: `SR-APP-EPM-Membre-é` and hope for the best, which is what I am doing.

For the second problem, we now introduced an unicode character to out tests and they did not expect that. This means converting all strings we are working with to unicode. I just did it where it matters for this particular test, introducing some level of inconsistency.

This PR will be failing until the string in question gets changed in `auth_data.yaml`.

{{ pytest: -v --long-running cfme/tests/integration/test_cfme_auth.py -k test_login_retrieve_group }}