### PR TITLE
[1LP][WIPTEST] Add unicode format for string

### DIFF
--- a/cfme/configure/access_control/__init__.py
+++ b/cfme/configure/access_control/__init__.py
@@ -640,7 +640,7 @@ class Group(BaseEntity, Taggable):
                    'group_tenant': self.tenant})
         view.add_button.click()
         view = self.create_view(AllGroupView)
-        view.flash.assert_success_message('Group "{}" was saved'.format(self.description))
+        view.flash.assert_success_message(u'Group "{}" was saved'.format(self.description))
         assert view.is_displayed
 
     def add_group_from_ldap_lookup(self):


### PR DESCRIPTION
__Fixing__ unicode errors in `test_login_retrieve_group`. This continues the work that has been started in PR #8606.

This PR is changing only one string and that's it. There's more interesting PR in cfme-qe-yamls that this PR depends on. When that gets merged, we should be finally green.

{{ pytest: -v --long-running cfme/tests/integration/test_cfme_auth.py -k test_login_retrieve_group }}