### PR TITLE
[RFR] Fix chargeback/test_resource_allocation compute/storage rate creation

### DIFF
--- a/cfme/tests/intelligence/chargeback/test_chargeback_long_term_rates.py
+++ b/cfme/tests/intelligence/chargeback/test_chargeback_long_term_rates.py
@@ -388,7 +388,7 @@ def new_compute_rate(appliance, interval):
             entity.delete_if_exists()
         except Exception as ex:
             pytest.fail(
-                'Exception while cleaning up compute/storage rates for chargeback report tests. {}'
+                'Exception cleaning up compute/storage rate for chargeback long term rate tests. {}'
                 .format(ex)
             )
 


### PR DESCRIPTION
This test module wasn't updated with the PR bringing in compute/storage rate collection

May not see 100% pass on PRT, but I'm looking to resolve the TypeError that was occurring in the fixture.
```
E       TypeError: __init__() takes at least 3 arguments (3 given)

cfme/tests/intelligence/chargeback/test_resource_allocation.py:376: TypeError
TypeError
__init__() takes at least 3 arguments (3 given)
```

{{ pytest: --long-running cfme/tests/intelligence/chargeback/test_resource_allocation.py }}