### PR TITLE
[RFR] removed a blocker for test_restart_workers

### DIFF
--- a/cfme/tests/configure/test_workers.py
+++ b/cfme/tests/configure/test_workers.py
@@ -26,7 +26,6 @@ DROPDOWNS = [
 @pytest.mark.tier(3)
 @pytest.mark.sauce
 @pytest.mark.nondestructive
-@pytest.mark.meta(blockers=[BZ(1672758)])
 def test_restart_workers(appliance):
     """
     Polarion:


### PR DESCRIPTION
{{ pytest: -v cfme/tests/configure/test_workers.py::test_restart_workers }}

The test was skipped but the BZ was verified for `5.10` (in a clone of the mentioned BZ)