### PR TITLE
[1LP][WIPTEST] Fix unicode errors

### DIFF
--- a/cfme/configure/access_control/__init__.py
+++ b/cfme/configure/access_control/__init__.py
@@ -640,7 +640,7 @@ class Group(BaseEntity, Taggable):
                    'group_tenant': self.tenant})
         view.add_button.click()
         view = self.create_view(AllGroupView)
-        view.flash.assert_success_message('Group "{}" was saved'.format(self.description))
+        view.flash.assert_success_message(u'Group "{}" was saved'.format(self.description))
         assert view.is_displayed
 
     def add_group_from_ldap_lookup(self):

--- a/cfme/tests/integration/test_cfme_auth.py
+++ b/cfme/tests/integration/test_cfme_auth.py
@@ -306,7 +306,7 @@ def test_user_group_switching(appliance, auth_user, auth_mode, auth_provider, so
         # pick non-evm group when there are multiple groups for the user
         if 'evmgroup' not in group.lower():
             # create group in CFME via retrieve_group which looks it up on auth_provider
-            logger.info('Retrieving a user group that is non evm built-in: {}'.format(group))
+            logger.info(u'Retrieving a user group that is non evm built-in: {}'.format(group))
             retrieved_groups.append(retrieve_group(appliance,
                                                    auth_mode,
                                                    auth_user.username,
@@ -329,19 +329,19 @@ def test_user_group_switching(appliance, auth_user, auth_mode, auth_provider, so
         # check retrieved groups are there
         for group in retrieved_groups:
             soft_assert(group.description in view.group_names,
-                        'user group "{}" not displayed in UI groups list "{}"'
+                        u'user group "{}" not displayed in UI groups list "{}"'
                         .format(group, view.group_names))
 
         # change to the other groups
         for other_group in display_other_groups:
-            soft_assert(other_group in auth_user.groups, 'Group {} in UI not expected for user {}'
+            soft_assert(other_group in auth_user.groups, u'Group {} in UI not expected for user {}'
                                                          .format(other_group, auth_user))
             view.change_group(other_group)
-            assert view.is_displayed, ('Not logged in after switching to group {} for {}'
+            assert view.is_displayed, (u'Not logged in after switching to group {} for {}'
                                        .format(other_group, auth_user))
             # assert selected group has changed
             soft_assert(other_group == view.current_groupname,
-                        'After switching to group {}, its not displayed as active'
+                        u'After switching to group {}, its not displayed as active'
                         .format(other_group))
 
     appliance.server.login_admin()

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -1062,7 +1062,7 @@ class SettingsGroupSubmenu(NavDropdown):
                 )
             )
         element = self.browser.element(
-            "./ul/li[normalize-space(.)={}]".format(quote(item)), parent=self
+            u"./ul/li[normalize-space(.)={}]".format(quote(item)), parent=self
         )
         return "disabled" not in self.browser.classes(element)
 
@@ -1077,8 +1077,8 @@ class SettingsGroupSubmenu(NavDropdown):
             raise WidgetOperationFailed("Cannot click disabled item {}".format(item))
 
         self.expand()
-        self.logger.info("selecting item {}".format(item))
-        self.browser.click("./ul/li[normalize-space(.)={}]".format(quote(item)), parent=self)
+        self.logger.info(u"selecting item {}".format(item))
+        self.browser.click(u"./ul/li[normalize-space(.)={}]".format(quote(item)), parent=self)
 
     def read(self):
         """ Returns the text of the group element """


### PR DESCRIPTION
__Fixing__ `test_user_group_switching`.

I introduced unicode characters to auth testing, which broke this test that didn't expect it. This is the fix.

I had to make changes also to widgetastic_manageiq.

{{ pytest: -v --long-running cfme/tests/integration/test_cfme_auth.py -k test_user_group_switching }}