### PR TITLE
[1LP][RFR] Fix test_provisioning.

### DIFF
--- a/cfme/automate/explorer/method.py
+++ b/cfme/automate/explorer/method.py
@@ -447,7 +447,7 @@ class MethodCollection(BaseCollection):
             location = location.capitalize()
 
         add_page.fill({'location': location})
-        if location == 'inline' or 'Inline':
+        if location.lower() == 'inline':
             add_page.wait_displayed()
             add_page.fill({
                 'inline_name': name,

--- a/cfme/automate/explorer/method.py
+++ b/cfme/automate/explorer/method.py
@@ -145,6 +145,7 @@ class MethodDetailsView(AutomateExplorerView):
     location = SummaryFormItem('Main Info', 'Location')
     created_on = SummaryFormItem('Main Info', 'Created On', text_filter=parsetime.from_iso_with_utc)
     inputs = Table(locator='#params_grid', assoc_column='Input Name')
+    script = ScriptBox()
 
     @property
     def is_displayed(self):

--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -506,7 +506,8 @@ class Taggable(TaggableCommonBase):
                 tag_category, tag_name = tag.split(':')
                 # instantiate category first, then use its tags collection to instantiate tag
                 tags_objs.append(
-                    self.appliance.collections.categories.instantiate(display_name=tag_category)
+                    self.appliance.collections.categories.instantiate(
+                        display_name=tag_category.strip())
                     .collections.tags.instantiate(display_name=tag_name.strip())
                 )
         return tags_objs

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -581,7 +581,8 @@ class BaseVMCollection(BaseCollection):
                 if provision_request.is_succeeded(method='ui'):
                     logger.info('Waiting for vm %s to appear on provider %s', vm.name,
                                 provider.key)
-                    wait_for(provider.mgmt.does_vm_exist, [vm.name], num_sec=600)
+                    wait_for(provider.mgmt.does_vm_exist, [vm.name],
+                             handle_exception=True, num_sec=600)
                 elif override:
                     logger.info('Overriding exception to check failure condition.')
                 else:

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -581,8 +581,7 @@ class BaseVMCollection(BaseCollection):
                 if provision_request.is_succeeded(method='ui'):
                     logger.info('Waiting for vm %s to appear on provider %s', vm.name,
                                 provider.key)
-                    wait_for(provider.mgmt.does_vm_exist, [vm.name],
-                             handle_exception=True, num_sec=600)
+                    wait_for(provider.mgmt.does_vm_exist, [vm.name], num_sec=600)
                 elif override:
                     logger.info('Overriding exception to check failure condition.')
                 else:

--- a/cfme/configure/configuration/server_settings.py
+++ b/cfme/configure/configuration/server_settings.py
@@ -215,8 +215,8 @@ class ServerInformation(Updateable, Pretty):
                     'ems_metrics_collector', 'reporting', 'ems_metrics_processor', 'scheduler',
                     'smartproxy', 'database_operations', 'smartstate', 'event', 'user_interface',
                     'web_services', 'ems_inventory', 'notifier', 'automate',
-                    'rhn_mirror', 'database_synchronization_role', 'git_owner', 'websocket',
-                    'storage_metrics_processor', 'storage_metrics_collector',
+                    'rhn_mirror', 'remote_console', 'database_synchronization_role', 'git_owner',
+                    'websocket', 'storage_metrics_processor', 'storage_metrics_collector',
                     'storage_metrics_coordinator', 'storage_inventory', 'vmdb_storage_bridge',
                     'cockpit_ws', 'remote_console')
 

--- a/cfme/tests/cloud_infra_common/test_provisioning.py
+++ b/cfme/tests/cloud_infra_common/test_provisioning.py
@@ -367,6 +367,7 @@ def copy_domains(original_request_class, domain):
 
 
 # Not collected for EC2 in generate_tests above
+@pytest.mark.meta(blockers=[BZ(1713632)])
 @pytest.mark.parametrize("disks", [1, 2])
 @pytest.mark.provider([OpenStackProvider], required_fields=[['provisioning', 'image']],
                       override=True)

--- a/cfme/tests/cloud_infra_common/test_provisioning.py
+++ b/cfme/tests/cloud_infra_common/test_provisioning.py
@@ -402,17 +402,13 @@ def test_cloud_provision_from_template_with_attached_disks(
 
     # Set up automate
     for i, volume in enumerate(volumes, 0):
+        device_mapping.append(
+            {'boot_index': 0 if i == 0 else -1,
+            'uuid': volume,
+            'device_name': device_name.format(chr(ord("a") + i))})
+
         if i == 0:
             provider.mgmt.capi.volumes.set_bootable(volume, True)
-            device_mapping.append(
-                {'boot_index': 0,
-                'uuid': volume,
-                'device_name': device_name.format(chr(ord("a") + i))})
-        else:
-            device_mapping.append(
-                {'boot_index': -1,
-                'uuid': volume,
-                'device_name': device_name.format(chr(ord("a") + i))})
 
     method = modified_request_class.methods.instantiate(name="openstack_PreProvision")
 

--- a/cfme/tests/cloud_infra_common/test_provisioning.py
+++ b/cfme/tests/cloud_infra_common/test_provisioning.py
@@ -460,10 +460,19 @@ def test_cloud_provision_from_template_with_attached_disks(
         wait_for(lambda: not instance.exists_on_provider, num_sec=180, delay=5)
 
     for volume_id in volumes:
-        assert vm_name in provider.mgmt.volume_attachments(volume_id)
+        attachments = provider.mgmt.volume_attachments(volume_id)
+        soft_assert(
+            vm_name in attachments,
+            'The vm {} not found among the attachemnts of volume {}:'.format(
+                vm_name, volume_id, attachments))
+
     for device in device_mapping:
-        assert (provider.mgmt.volume_attachments(device['uuid'])[vm_name]
-                == '/dev/{}'.format(device['device_name']))
+        provider_devpath = provider.mgmt.volume_attachments(device['uuid'])[vm_name]
+        expected_devpath = '/dev/{}'.format(device['device_name'])
+        soft_assert(
+            provider_devpath == expected_devpath,
+            'Device {} is not attached to expected path: {} but to: {}'.format(
+                device['uuid'], expected_devpath, provider_devpath))
 
 
 # Not collected for EC2 in generate_tests above

--- a/cfme/tests/cloud_infra_common/test_provisioning.py
+++ b/cfme/tests/cloud_infra_common/test_provisioning.py
@@ -364,14 +364,7 @@ def original_request_class(appliance):
 
 @pytest.fixture(scope="module")
 def modified_request_class(request, domain, original_request_class):
-    try:
-        # methods of this class might have been copied by other fixture, so this error can occur
-        original_request_class.copy_to(domain)
-    except Exception as ex:
-        if "Error during 'Automate Class copy'" in ex.message:
-            pass
-        else:
-            pytest.fail('Unexpected exception duing request class copy')
+    original_request_class.copy_to(domain)
     klass = (domain
              .namespaces.instantiate(name='Cloud')
              .namespaces.instantiate(name='VM')

--- a/cfme/tests/cloud_infra_common/test_provisioning.py
+++ b/cfme/tests/cloud_infra_common/test_provisioning.py
@@ -416,31 +416,32 @@ def test_cloud_provision_from_template_with_attached_disks(
 
     view = navigate_to(method, 'Details')
     former_method_script = view.script.get_value()
+
+    disk_mapping = []
+    for mapping in device_mapping:
+        one_field = dedent("""{{
+            :boot_index => {boot_index},
+            :uuid => "{uuid}",
+            :device_name => "{device_name}",
+            :source_type => "volume",
+            :destination_type => "volume",
+            :volume_size => 1,
+            :delete_on_termination => false
+        }}""")
+        disk_mapping.append(one_field.format(**mapping))
+
+    volume_method = dedent("""
+        clone_options = {{
+        :image_ref => nil,
+        :block_device_mapping_v2 => [
+            {}
+        ]
+        }}
+
+        prov = $evm.root["miq_provision"]
+        prov.set_option(:clone_options, clone_options)
+    """)
     with update(method):
-        disk_mapping = []
-        for mapping in device_mapping:
-            one_field = dedent("""{{
-                :boot_index => {boot_index},
-                :uuid => "{uuid}",
-                :device_name => "{device_name}",
-                :source_type => "volume",
-                :destination_type => "volume",
-                :volume_size => 1,
-                :delete_on_termination => false
-            }}""")
-            disk_mapping.append(one_field.format(**mapping))
-
-        volume_method = dedent("""
-            clone_options = {{
-            :image_ref => nil,
-            :block_device_mapping_v2 => [
-                {}
-            ]
-            }}
-
-            prov = $evm.root["miq_provision"]
-            prov.set_option(:clone_options, clone_options)
-        """)
         method.script = volume_method.format(",\n".join(disk_mapping))
 
     @request.addfinalizer

--- a/cfme/tests/cloud_infra_common/test_provisioning.py
+++ b/cfme/tests/cloud_infra_common/test_provisioning.py
@@ -455,7 +455,7 @@ def test_cloud_provision_from_template_with_attached_disks(
 
     @request.addfinalizer
     def delete_vm_and_wait_for_gone():
-        instance.mgmt.delete()
+        instance.cleanup_on_provider()
         wait_for(lambda: not instance.exists_on_provider, num_sec=180, delay=5)
 
     for volume_id in volumes:
@@ -530,7 +530,7 @@ def test_provision_with_boot_volume(request, instance_args, provider, soft_asser
 
     @request.addfinalizer
     def delete_vm_and_wait_for_gone():
-        instance.mgmt.delete()  # To make it possible to delete the volume
+        instance.cleanup_on_provider()  # To make it possible to delete the volume
         wait_for(lambda: not instance.exists_on_provider, num_sec=180, delay=5)
 
     request_description = 'Provision from [{}] to [{}]'.format(image, instance.name)

--- a/cfme/tests/cloud_infra_common/test_provisioning.py
+++ b/cfme/tests/cloud_infra_common/test_provisioning.py
@@ -402,6 +402,8 @@ def test_cloud_provision_from_template_with_attached_disks(
 
     # Set up automate
     for i, volume in enumerate(volumes, 0):
+        # note the boot_index specifies an ordering in which the disks are tried to
+        # boot from. The value -1 means "never".
         device_mapping.append(
             {'boot_index': 0 if i == 0 else -1,
             'uuid': volume,


### PR DESCRIPTION
This patch requires https://github.com/ManageIQ/wrapanapi/pull/370

Remove a `pytest.raises` as it seems to me that is shouldn't be there. It causes:
```
request = <SubRequest 'modified_request_class' for <Function 'test_cloud_provision_from_template_with_attached_disks[openstack-13-1]'>>
domain = <cfme.automate.explorer.domain.Domain object at 0x7f93cade6fd0>
original_request_class = <cfme.automate.explorer.klass.Class object at 0x7f93cb1fdb10>

    @pytest.fixture(scope="module")
    def modified_request_class(request, domain, original_request_class):
        with pytest.raises(Exception, match="error: Error during 'Automate Class copy'"):
            # methods of this class might have been copied by other fixture, so this error can occur
>           original_request_class.copy_to(domain)
E           Failed: DID NOT RAISE <type 'exceptions.Exception'>

cfme/tests/cloud_infra_common/test_provisioning.py:341: Failed
```

Fix VM from volume provisioning and register finalizers to do proper cleanup in correct order after.

Fix `test_cloud_provision_from_template_with_attached_disks` by switching to the `block_device_mapping_v2` as the `block_device_mapping` didn't work. Also, set the first disk as bootable so nova won't complain about attaching non-bootable disk.

{{ py.test: --use-provider rhos13 -v cfme/tests/cloud_infra_common/test_provisioning.py }}