### PR TITLE
[1LP][RFR][NOTEST] Removing the duplicate test

### DIFF
--- a/cfme/tests/services/test_catalog.py
+++ b/cfme/tests/services/test_catalog.py
@@ -34,24 +34,6 @@ def test_catalog_crud(appliance):
 
 
 @pytest.mark.sauce
-def test_catalog_duplicate_name(appliance):
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        caseimportance: medium
-        initialEstimate: 1/8h
-        tags: service
-    """
-    catalog_name = fauxfactory.gen_alphanumeric()
-    cat = appliance.collections.catalogs.create(name=catalog_name, description='my catalog')
-    with pytest.raises(AssertionError):
-        appliance.collections.catalogs.create(name=catalog_name, description='my catalog')
-    view = cat.create_view(CatalogsView)
-    view.flash.assert_message('Name has already been taken')
-
-
-@pytest.mark.sauce
 def test_permissions_catalog_add(appliance, request):
     """ Tests that a catalog can be added only with the right permissions
 


### PR DESCRIPTION
Purpose or Intent
=================
Removing Test test_catalog_duplicate_name as its duplicate of this test https://github.com/ManageIQ/integration_tests/blob/c1d0d217ad297bff1e0dbde502a85a1195f23462/cfme/tests/configure/test_access_control.py#L1455