### PR TITLE
[1LP][RFR] Enhance gen_data functions

### DIFF
--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -368,8 +368,9 @@ def automation_requests_data(vm, requests_collection=False, approve=True, num=4)
     return [data for _ in range(num)]
 
 
-def groups(request, appliance, role, tenant, num=1, **kwargs):
+def groups(request, appliance, role, num=1, **kwargs):
     data = []
+    tenant = kwargs.get("tenant", appliance.rest_api.collections.tenants.get(name="My Company"))
     for _ in range(num):
         data.append(
             {
@@ -393,7 +394,17 @@ def roles(request, appliance, num=1, **kwargs):
     for _ in range(num):
         data.append(
             {
-                "name": kwargs.get("name", "role_name_{}".format(fauxfactory.gen_alphanumeric()))
+                "name": kwargs.get(
+                    "name", "role_name_{}".format(fauxfactory.gen_alphanumeric())
+                ),
+                "features": kwargs.get(
+                    "features",
+                    [
+                        {"identifier": "vm_explorer"},
+                        {"identifier": "ems_infra_tag"},
+                        {"identifier": "miq_report_run"},
+                    ],
+                ),
             }
         )
 

--- a/cfme/tests/configure/test_rest_access_control.py
+++ b/cfme/tests/configure/test_rest_access_control.py
@@ -317,7 +317,7 @@ class TestGroupsViaREST(object):
     @pytest.fixture(scope="function")
     def groups(self, request, appliance, roles, tenants):
         num_groups = 3
-        response = _groups(request, appliance, roles, tenants, num=num_groups)
+        response = _groups(request, appliance, roles, num=num_groups, tenant=tenants)
         assert_response(appliance)
         assert len(response) == num_groups
         return response

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -1481,8 +1481,7 @@ class TestServiceRequests(object):
 
     @pytest.fixture(scope='class')
     def new_group(self, request, appliance, new_role):
-        tenant = appliance.rest_api.collections.tenants.get(name='My Company')
-        return groups(request, appliance, new_role, tenant, num=1)
+        return groups(request, appliance, new_role, num=1)
 
     @pytest.fixture(scope='class')
     def user_auth(self, request, appliance, new_group):


### PR DESCRIPTION
This PR brings the following changes:
1. Enhance `roles` to accept features.
2. Use `My Company` tenant by default if no tenant is explicitly provided in `groups` function.
3. Make corresponding changes to tests.

{{ pytest: cfme/tests/configure/test_rest_access_control.py cfme/tests/services/test_rest_services.py::TestServiceRequests --use-template-cache -sqvvvv --long-running }}