### PR TITLE
[1LP][RFR] Automate test: test_delete_advanced_search filter via REST

### DIFF
--- a/cfme/tests/webui/test_rest.py
+++ b/cfme/tests/webui/test_rest.py
@@ -1,7 +1,6 @@
 import fauxfactory
 import pytest
 
-from cfme.infrastructure.provider import InfraProvider
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.rest import delete_resources_from_collection
 from cfme.utils.rest import delete_resources_from_detail
@@ -13,7 +12,7 @@ def search_filter_obj(appliance, request):
     filter_value = fauxfactory.gen_string("alphanumeric", 10)
     param_filter = "Infrastructure Provider : Name"
 
-    view = navigate_to(InfraProvider, "All")
+    view = navigate_to(appliance.collections.infra_providers, "All")
 
     view.search.save_filter(
         "fill_field({}, =, {})".format(param_filter, filter_value),

--- a/cfme/tests/webui/test_rest.py
+++ b/cfme/tests/webui/test_rest.py
@@ -1,0 +1,61 @@
+import fauxfactory
+import pytest
+
+from cfme.infrastructure.provider import InfraProvider
+from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.rest import delete_resources_from_collection
+from cfme.utils.rest import delete_resources_from_detail
+
+
+@pytest.fixture(params=[True, False], ids=["global", "local"])
+def search_filter_obj(appliance, request):
+    filter_name = fauxfactory.gen_string("alphanumeric", 10)
+    filter_value = fauxfactory.gen_string("alphanumeric", 10)
+    param_filter = "Infrastructure Provider : Name"
+
+    view = navigate_to(InfraProvider, "All")
+
+    view.search.save_filter(
+        "fill_field({}, =, {})".format(param_filter, filter_value),
+        filter_name,
+        global_search=request.param,
+    )
+    view.search.close_advanced_search()
+    view.flash.assert_no_error()
+    search_filter = appliance.rest_api.collections.search_filters.get(
+        description=filter_name
+    )
+    return search_filter
+
+
+def test_delete_advanced_search_filter_from_collection(request, search_filter_obj):
+    """Tests deleting search_filter from collection.
+
+    Metadata:
+        test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        casecomponent: WebUI
+        caseimportance: low
+        initialEstimate: 1/4h
+        tags: Rest
+    """
+    delete_resources_from_collection([search_filter_obj])
+
+
+@pytest.mark.parametrize("method", ["POST", "DELETE"])
+def test_delete_advanced_search_filter_from_detail(request, method, search_filter_obj):
+    """Tests deleting search_filter from detail.
+
+    Metadata:
+        test_flag: rest
+
+    Polarion:
+        assignee: pvala
+        casecomponent: WebUI
+        caseimportance: low
+        initialEstimate: 1/4h
+        tags: Rest
+    """
+    delete_resources_from_detail(resources=[search_filter_obj], method=method)


### PR DESCRIPTION
This PR brings the following changes:
1. Add 2 new test cases:
  1. `test_delete_advanced_search_filter_from_collection`
  2. `test_delete_advanced_search_filter_from_detail`

{{ pytest: cfme/tests/webui/test_rest.py --use-template-cache -sqvvv }}