### PR TITLE
[1LP][RFR] New test: Include test cases to assert removal of RSS and Timelines pages

### DIFF
--- a/cfme/tests/intelligence/test_timelines_rss_removed.py
+++ b/cfme/tests/intelligence/test_timelines_rss_removed.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+import pytest
+from selenium.common.exceptions import NoSuchElementException
+
+from cfme.utils.appliance.implementations.ui import navigate_to
+
+
+@pytest.mark.tier(2)
+def test_timelines_removed(appliance):
+    """
+    Test that Cloud Intel->Timelines have been removed in upstream and 5.11 builds.
+    Designed to pass for CFME 5.10.
+
+    Bugzillas:
+        * 1672933
+
+    Polarion:
+        assignee: jdupuy
+        initialEstimate: 1/12h
+        casecomponent: WebUI
+        caseimportance: medium
+    """
+    if appliance.is_downstream and appliance.version < "5.11":
+        navigate_to(appliance.server, "CloudIntelTimelines")
+    else:
+        with pytest.raises(NoSuchElementException):
+            navigate_to(appliance.server, "CloudIntelTimelines")
+
+
+@pytest.mark.tier(2)
+def test_rss_removed(appliance):
+    """
+    Test that Cloud Intel->RSS has been removed in upstream and 5.11 builds.
+    Designed to pass for CFME 5.10.
+
+    Bugzillas:
+        * 1672933
+
+    Polarion:
+        assignee: jdupuy
+        initialEstimate: 1/12h
+        casecomponent: WebUI
+        caseimportance: medium
+    """
+    if appliance.is_downstream and appliance.version < "5.11":
+        navigate_to(appliance.server, "RSS")
+    else:
+        with pytest.raises(NoSuchElementException):
+            navigate_to(appliance.server, "RSS")


### PR DESCRIPTION
Purpose or Intent
=================
Creating a new test for this [RFE BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1672933). Designed to test this [PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/5271) on upstream builds. 

{{ pytest: --use-template-cache cfme/tests/intelligence/test_timelines_rss_removed.py }}