### PR TITLE
[1LP][WIP] Add test for provider type selection

### DIFF
--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -117,6 +117,7 @@ class CloudProvider(BaseProvider, CloudInfraProviderMixin, Pretty, PolicyProfile
     template_name = "Images"
     db_types = ["CloudManager"]
     template_class = Image
+    collection_name = 'cloud_providers'
 
     name = attr.ib(default=None)
     key = attr.ib(default=None)

--- a/cfme/cloud/provider/azure.py
+++ b/cfme/cloud/provider/azure.py
@@ -47,6 +47,7 @@ class AzureProvider(CloudProvider):
     discover_name = "Azure"
     settings_key = 'ems_azure'
     log_name = 'azure'
+    ems_pretty_name = 'Azure'
 
     region = attr.ib(default=None)
     tenant_id = attr.ib(default=None)

--- a/cfme/cloud/provider/ec2.py
+++ b/cfme/cloud/provider/ec2.py
@@ -82,6 +82,7 @@ class EC2Provider(CloudProvider):
     discover_name = "Amazon EC2"
     settings_key = 'ems_amazon'
     log_name = 'aws'
+    ems_pretty_name = 'Amazon EC2'
 
     region = attr.ib(default=None)
     region_name = attr.ib(default=None)

--- a/cfme/cloud/provider/gce.py
+++ b/cfme/cloud/provider/gce.py
@@ -43,6 +43,7 @@ class GCEProvider(CloudProvider):
     db_types = ["Google::CloudManager"]
     endpoints_form = GCEEndpointForm
     settings_key = 'ems_google'
+    ems_pretty_name = 'Google Compute Engine'
 
     project = attr.ib(default=None)
     region = attr.ib(default=None)

--- a/cfme/cloud/provider/openstack.py
+++ b/cfme/cloud/provider/openstack.py
@@ -27,6 +27,7 @@ class OpenStackProvider(CloudProvider):
     endpoints_form = OpenStackInfraEndpointForm
     settings_key = 'ems_openstack'
     log_name = 'fog'
+    ems_pretty_name = 'OpenStack'
 
     # xpath locators for elements, to be used by selenium
     _console_connection_status_element = '//*[@id="noVNC_status"]'

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -104,6 +104,7 @@ class BaseProvider(Taggable, Updateable, Navigatable, BaseEntity, CustomButtonEv
     settings_key = None
     vm_class = None  # Set on type specific provider classes for VM/instance class
     template_class = None  # Set on type specific provider classes for VM template class
+    ems_pretty_name = None  # Set on type specific provider classes for ems type selection in UI
 
     endpoints = attr.ib(default=attr.Factory(factory=dict))
 

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -212,6 +212,7 @@ class ContainersProvider(BaseProvider, Pretty, PolicyProfileAssignable):
     refresh_text = 'Refresh items and relationships'
     resume_provider_text = "Resume this Containers Provider"
     pause_provider_text = "Pause this Containers Provider"
+    collection_name = 'containers_providers'
 
     name = attr.ib(default=None)
     key = attr.ib(default=None)

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -95,6 +95,7 @@ class OpenshiftProvider(ContainersProvider, ConsoleMixin, Taggable):
     db_types = ["Openshift::ContainerManager"]
     endpoints_form = ContainersProviderEndpointsForm
     settings_key = 'ems_openshift'
+    ems_pretty_name = 'OpenShift Container Platform'
 
     http_proxy = attr.ib(default=None)
     adv_http = attr.ib(default=None)

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -92,6 +92,7 @@ class InfraProvider(BaseProvider, CloudInfraProviderMixin, Pretty, Fillable,
     db_types = ["InfraManager"]
     hosts_menu_item = "Hosts"
     vm_name = "Virtual Machines"
+    collection_name = 'infra_providers'
 
     name = attr.ib(default=None)
     key = attr.ib(default=None)

--- a/cfme/infrastructure/provider/openstack_infra.py
+++ b/cfme/infrastructure/provider/openstack_infra.py
@@ -74,6 +74,7 @@ class OpenstackInfraProvider(InfraProvider):
     mgmt_class = OpenstackInfraSystem
     db_types = ["Openstack::InfraManager"]
     endpoints_form = OpenStackInfraEndpointForm
+    ems_pretty_name = 'OpenStack Platform Director'
     hosts_menu_item = "Nodes"
     bad_credentials_error_msg = (
         'Credential validation was not successful: ',

--- a/cfme/infrastructure/provider/rhevm.py
+++ b/cfme/infrastructure/provider/rhevm.py
@@ -68,6 +68,7 @@ class RHEVMProvider(InfraProvider):
     mgmt_class = RHEVMSystem
     db_types = ["Redhat::InfraManager"]
     endpoints_form = RHEVMEndpointForm
+    ems_pretty_name = 'Red Hat Virtualization'
     discover_dict = {"rhevm": True}
     settings_key = 'ems_redhat'
     # xpath locators for elements, to be used by selenium

--- a/cfme/infrastructure/provider/scvmm.py
+++ b/cfme/infrastructure/provider/scvmm.py
@@ -31,6 +31,7 @@ class SCVMMProvider(InfraProvider):
     mgmt_class = SCVMMSystem
     db_types = ["Microsoft::InfraManager"]
     endpoints_form = SCVMMEndpointForm
+    ems_pretty_name = 'Microsoft System Center VMM'
     discover_dict = {"scvmm": True}
     bad_credentials_error_msg = (
         'Credential validation was not successful: '

--- a/cfme/infrastructure/provider/virtualcenter.py
+++ b/cfme/infrastructure/provider/virtualcenter.py
@@ -35,6 +35,7 @@ class VMwareProvider(InfraProvider):
     mgmt_class = VMWareSystem
     db_types = ["Vmware::InfraManager"]
     endpoints_form = VirtualCenterEndpointForm
+    ems_pretty_name = 'VMware vCenter'
     discover_dict = {"vmware": True}
     settings_key = 'ems_vmware'
     # xpath locators for elements, to be used by selenium

--- a/cfme/markers/env_markers/provider.py
+++ b/cfme/markers/env_markers/provider.py
@@ -184,6 +184,7 @@ def all_required(miq_version, filters=None):
         filters: A list of filters
     """
     # Load the supportability YAML and extrace the providers portion
+    filters = filters or []  # default immutable
     stream = Version(miq_version).series()
     try:
         data_for_stream = conf.supportability[stream]['providers']

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -710,7 +710,6 @@ class TestProvidersRESTAPI(object):
             assert 'SecurityGroup' in security_groups[0]['type']
 
 
-
 @pytest.mark.provider([CloudProvider], override=True, selector=ONE)
 def test_tagvis_provision_fields(setup_provider, request, appliance, user_restricted, tag,
                                  soft_assert):

--- a/cfme/utils/providers.py
+++ b/cfme/utils/providers.py
@@ -162,6 +162,8 @@ class ProviderFilter(object):
             # to restricted_version; in addition, restricted_version should turn into
             # "version_restrictions" and it should be a sequence of restrictions with operators
             # so that we can create ranges like ">= 5.6" and "<= 5.8"
+            # FIXME in addition to comment above, we really need this to use supportability.yaml
+            # and not depend on provider yaml data for CFME/MIQ provider support mapping
             version_restrictions = []
             since_version = provider.data.get('since_version')
             if since_version:


### PR DESCRIPTION
Add test for selection of provider type
Based on supportability.yaml list of all supported providers for given appliance version
Add attribute to provider classes to define the ems pretty name that's listed for the type

Will be adding a supportability.yaml for integration_tests, and moving CFME's to supportability.local.yaml

Passed in 59z so I pushed branch, failing in 510z though, GCE is being looked for on the infra provider page

{{ pytest: cfme/tests/cloud_infra_common/test_discovery.py -k test_provider_type_support}}