### PR TITLE
[RFR] Create Ansible service dialog through REST API

### DIFF
--- a/cfme/fixtures/ansible_tower.py
+++ b/cfme/fixtures/ansible_tower.py
@@ -31,6 +31,7 @@ def ansible_tower_dialog_rest(request, appliance):
                                 "data_type": "string",
                                 "display": "edit",
                                 "required": False,
+                                "default_value": uid,
                                 "options": {
                                     "protected": False
                                 },
@@ -121,6 +122,5 @@ def ansible_tower_dialog(request, appliance):
         description=rest_resource.description)
     yield service_dialog
 
-    if not GH(8836).blocks or appliance.version != '5.11':
-        if service_dialog.exists:
-            service_dialog.delete()
+    if appliance.version < '5.11' or not GH(8836).blocks:
+        service_dialog.delete_if_exists()

--- a/cfme/fixtures/ansible_tower.py
+++ b/cfme/fixtures/ansible_tower.py
@@ -118,4 +118,7 @@ def ansible_tower_dialog(request, appliance):
     service_dialog = service_dialogs.instantiate(
         label=rest_resource.label,
         description=rest_resource.description)
-    return service_dialog
+    yield service_dialog
+
+    if service_dialog.exists:
+        service_dialog.delete()

--- a/cfme/fixtures/ansible_tower.py
+++ b/cfme/fixtures/ansible_tower.py
@@ -2,6 +2,7 @@ import fauxfactory
 import pytest
 
 from cfme.rest.gen_data import _creating_skeleton
+from cfme.utils.blockers import GH
 
 
 def ansible_tower_dialog_rest(request, appliance):
@@ -120,5 +121,6 @@ def ansible_tower_dialog(request, appliance):
         description=rest_resource.description)
     yield service_dialog
 
-    if service_dialog.exists:
-        service_dialog.delete()
+    if !GH(8836):
+        if service_dialog.exists:
+            service_dialog.delete()

--- a/cfme/fixtures/ansible_tower.py
+++ b/cfme/fixtures/ansible_tower.py
@@ -121,6 +121,6 @@ def ansible_tower_dialog(request, appliance):
         description=rest_resource.description)
     yield service_dialog
 
-    if !GH(8836):
+    if not GH(8836).blocks or appliance.version != '5.11':
         if service_dialog.exists:
             service_dialog.delete()

--- a/cfme/fixtures/ansible_tower.py
+++ b/cfme/fixtures/ansible_tower.py
@@ -1,0 +1,121 @@
+import fauxfactory
+import pytest
+
+from cfme.rest.gen_data import _creating_skeleton
+
+
+def ansible_tower_dialog_rest(request, appliance):
+    """Creates service dialog using REST API."""
+    uid = fauxfactory.gen_alphanumeric()
+    data = {
+        "description": "my ansible dialog {}".format(uid),
+        "buttons": "submit,cancel",
+        "label": uid,
+        "dialog_tabs": [
+            {
+                "description": "Basic Information",
+                "display": "edit",
+                "label": "Basic Information",
+                "position": 0,
+                "dialog_groups": [
+                    {
+                        "description": "Basic 1",
+                        "display": "edit",
+                        "label": "Options",
+                        "position": 0,
+                        "dialog_fields": [
+                            {
+                                "name": "service_name",
+                                "description": "Name of the new service",
+                                "data_type": "string",
+                                "display": "edit",
+                                "required": False,
+                                "options": {
+                                    "protected": False
+                                },
+                                "label": "Service Name",
+                                "position": 0,
+                                "reconfigurable": True,
+                                "visible": True,
+                                "type": "DialogFieldTextBox",
+                                "resource_action": {
+                                    "resource_type": "DialogField"
+                                }
+                            },
+                            {
+                                "name": "limit",
+                                "description": "A",
+                                "data_type": "string",
+                                "display": "edit",
+                                "required": False,
+                                "options": {
+                                    "protected": False
+                                },
+                                "label": "Limit",
+                                "position": 1,
+                                "reconfigurable": True,
+                                "visible": True,
+                                "type": "DialogFieldTextBox",
+                                "resource_action": {
+                                    "resource_type": "DialogField"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "description": "Basic 2",
+                        "display": "edit",
+                        "label": "Survey",
+                        "position": 1,
+                        "dialog_fields": [
+                            {
+                                "name": "param_Department",
+                                "description": "",
+                                "display": "edit",
+                                "required": True,
+                                "default_value": "QE",
+                                "values": [
+                                    [
+                                        "HR",
+                                        "HR"
+                                    ],
+                                    [
+                                        "PM",
+                                        "PM"
+                                    ],
+                                    [
+                                        "QE",
+                                        "QE"
+                                    ]
+                                ],
+                                "options": {},
+                                "label": "Survey",
+                                "position": 0,
+                                "reconfigurable": True,
+                                "visible": True,
+                                "type": "DialogFieldDropDownList",
+                                "resource_action": {
+                                    "resource_type": "DialogField"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+    service_dialog = _creating_skeleton(request, appliance, "service_dialogs",
+        [data])
+    return service_dialog[0]
+
+
+@pytest.fixture(scope="function")
+def ansible_tower_dialog(request, appliance):
+    """Returns service dialog object."""
+    rest_resource = ansible_tower_dialog_rest(request, appliance)
+    service_dialogs = appliance.collections.service_dialogs
+    service_dialog = service_dialogs.instantiate(
+        label=rest_resource.label,
+        description=rest_resource.description)
+    return service_dialog

--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -74,8 +74,9 @@ def tags(request, appliance, categories):
     return _creating_skeleton(request, appliance, 'tags', tags, substr_search=True)
 
 
+"""
 def dialog_rest(request, appliance):
-    """Creates service dialog using REST API."""
+    Creates service dialog using REST API.
     uid = fauxfactory.gen_alphanumeric()
     data = {
         "description": "my dialog {}".format(uid),
@@ -118,9 +119,10 @@ def dialog_rest(request, appliance):
 
     service_dialog = _creating_skeleton(request, appliance, "service_dialogs", [data])
     return service_dialog[0]
+"""
 
 
-def ansible_dialog_rest(request, appliance):
+def dialog_rest(request, appliance):
     """Creates service dialog using REST API."""
     uid = fauxfactory.gen_alphanumeric()
     data = {
@@ -221,9 +223,9 @@ def ansible_dialog_rest(request, appliance):
         ]
     }
 
-    ansible_service_dialog = _creating_skeleton(request, appliance, "ansible_service_dialogs",
+    service_dialog = _creating_skeleton(request, appliance, "service_dialogs",
         [data])
-    return ansible_service_dialog[0]
+    return service_dialog[0]
 
 
 def dialog(request, appliance):

--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -226,16 +226,6 @@ def ansible_dialog_rest(request, appliance):
     return ansible_service_dialog[0]
 
 
-def ansible_dialog(request, appliance):
-    """Returns service dialog object."""
-    rest_resource = ansible_dialog_rest(request, appliance)
-    service_dialogs = appliance.collections.service_dialogs
-    service_dialog = service_dialogs.instantiate(
-        label=rest_resource.label,
-        description=rest_resource.description)
-    return service_dialog
-
-
 def dialog(request, appliance):
     """Returns service dialog object."""
     rest_resource = dialog_rest(request, appliance)

--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -74,7 +74,6 @@ def tags(request, appliance, categories):
     return _creating_skeleton(request, appliance, 'tags', tags, substr_search=True)
 
 
-"""
 def dialog_rest(request, appliance):
     Creates service dialog using REST API.
     uid = fauxfactory.gen_alphanumeric()
@@ -118,113 +117,6 @@ def dialog_rest(request, appliance):
     }
 
     service_dialog = _creating_skeleton(request, appliance, "service_dialogs", [data])
-    return service_dialog[0]
-"""
-
-
-def dialog_rest(request, appliance):
-    """Creates service dialog using REST API."""
-    uid = fauxfactory.gen_alphanumeric()
-    data = {
-        "description": "my ansible dialog {}".format(uid),
-        "buttons": "submit,cancel",
-        "label": uid,
-        "dialog_tabs": [
-            {
-                "description": "Basic Information",
-                "display": "edit",
-                "label": "Basic Information",
-                "position": 0,
-                "dialog_groups": [
-                    {
-                        "description": "Basic 1",
-                        "display": "edit",
-                        "label": "Options",
-                        "position": 0,
-                        "dialog_fields": [
-                            {
-                                "name": "service_name",
-                                "description": "Name of the new service",
-                                "data_type": "string",
-                                "display": "edit",
-                                "required": False,
-                                "options": {
-                                    "protected": False
-                                },
-                                "label": "Service Name",
-                                "position": 0,
-                                "reconfigurable": True,
-                                "visible": True,
-                                "type": "DialogFieldTextBox",
-                                "resource_action": {
-                                    "resource_type": "DialogField"
-                                }
-                            },
-                            {
-                                "name": "limit",
-                                "description": "A",
-                                "data_type": "string",
-                                "display": "edit",
-                                "required": False,
-                                "options": {
-                                    "protected": False
-                                },
-                                "label": "Limit",
-                                "position": 1,
-                                "reconfigurable": True,
-                                "visible": True,
-                                "type": "DialogFieldTextBox",
-                                "resource_action": {
-                                    "resource_type": "DialogField"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "description": "Basic 2",
-                        "display": "edit",
-                        "label": "Survey",
-                        "position": 1,
-                        "dialog_fields": [
-                            {
-                                "name": "param_Department",
-                                "description": "",
-                                "display": "edit",
-                                "required": True,
-                                "default_value": "QE",
-                                "values": [
-                                    [
-                                        "HR",
-                                        "HR"
-                                    ],
-                                    [
-                                        "PM",
-                                        "PM"
-                                    ],
-                                    [
-                                        "QE",
-                                        "QE"
-                                    ]
-                                ],
-                                "options": {},
-                                "label": "Survey",
-                                "position": 0,
-                                "reconfigurable": True,
-                                "visible": True,
-                                "type": "DialogFieldDropDownList",
-                                "resource_action": {
-                                    "resource_type": "DialogField"
-                                }
-                            }
-                        ]
-                    }
-                ]
-            }
-        ]
-    }
-
-    service_dialog = _creating_skeleton(request, appliance, "service_dialogs",
-        [data])
     return service_dialog[0]
 
 

--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -120,6 +120,122 @@ def dialog_rest(request, appliance):
     return service_dialog[0]
 
 
+def ansible_dialog_rest(request, appliance):
+    """Creates service dialog using REST API."""
+    uid = fauxfactory.gen_alphanumeric()
+    data = {
+        "description": "my ansible dialog {}".format(uid),
+        "buttons": "submit,cancel",
+        "label": uid,
+        "dialog_tabs": [
+            {
+                "description": "Basic Information",
+                "display": "edit",
+                "label": "Basic Information",
+                "position": 0,
+                "dialog_groups": [
+                    {
+                        "description": "Basic 1",
+                        "display": "edit",
+                        "label": "Options",
+                        "position": 0,
+                        "dialog_fields": [
+                            {
+                                "name": "service_name",
+                                "description": "Name of the new service",
+                                "data_type": "string",
+                                "display": "edit",
+                                "required": False,
+                                "options": {
+                                    "protected": False
+                                },
+                                "label": "Service Name",
+                                "position": 0,
+                                "reconfigurable": True,
+                                "visible": True,
+                                "type": "DialogFieldTextBox",
+                                "resource_action": {
+                                    "resource_type": "DialogField"
+                                }
+                            },
+                            {
+                                "name": "limit",
+                                "description": "A",
+                                "data_type": "string",
+                                "display": "edit",
+                                "required": False,
+                                "options": {
+                                    "protected": False
+                                },
+                                "label": "Limit",
+                                "position": 1,
+                                "reconfigurable": True,
+                                "visible": True,
+                                "type": "DialogFieldTextBox",
+                                "resource_action": {
+                                    "resource_type": "DialogField"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "description": "Basic 2",
+                        "display": "edit",
+                        "label": "Survey",
+                        "position": 1,
+                        "dialog_fields": [
+                            {
+                                "name": "param_Department",
+                                "description": "",
+                                "display": "edit",
+                                "required": True,
+                                "default_value": "QE",
+                                "values": [
+                                    [
+                                        "HR",
+                                        "HR"
+                                    ],
+                                    [
+                                        "PM",
+                                        "PM"
+                                    ],
+                                    [
+                                        "QE",
+                                        "QE"
+                                    ]
+                                ],
+                                "options": {},
+                                "label": "Survey",
+                                "position": 0,
+                                "reconfigurable": True,
+                                "visible": True,
+                                "type": "DialogFieldDropDownList",
+                                "resource_action": {
+                                    "resource_type": "DialogField"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+    ansible_service_dialog = _creating_skeleton(request, appliance, "ansible_service_dialogs",
+        [data])
+    return ansible_service_dialog[0]
+
+
+def ansible_dialog(request, appliance):
+    """Returns service dialog object."""
+    rest_resource = ansible_dialog_rest(request, appliance)
+    service_dialogs = appliance.collections.service_dialogs
+    service_dialog = service_dialogs.instantiate(
+        label=rest_resource.label,
+        description=rest_resource.description)
+    return service_dialog
+
+
 def dialog(request, appliance):
     """Returns service dialog object."""
     rest_resource = dialog_rest(request, appliance)

--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -75,7 +75,7 @@ def tags(request, appliance, categories):
 
 
 def dialog_rest(request, appliance):
-    Creates service dialog using REST API.
+    """Creates service dialog using REST API."""
     uid = fauxfactory.gen_alphanumeric()
     data = {
         "description": "my dialog {}".format(uid),

--- a/cfme/test_framework/pytest_plugin.py
+++ b/cfme/test_framework/pytest_plugin.py
@@ -52,6 +52,7 @@ pytest_plugins = (
     'cfme.fixtures.prov_filter',
 
     'cfme.fixtures.appliance',
+    'cfme.fixtures.ansible_tower',
     'cfme.fixtures.embedded_ansible',
     'cfme.fixtures.single_appliance_sprout',
     'cfme.fixtures.dev_branch',

--- a/cfme/tests/services/test_config_provider_servicecatalogs.py
+++ b/cfme/tests/services/test_config_provider_servicecatalogs.py
@@ -47,17 +47,17 @@ def config_manager(config_manager_obj):
 
 
 @pytest.fixture(scope="function")
-def catalog_item(appliance, request, config_manager, dialog, catalog, job_type):
+def catalog_item(appliance, request, config_manager, ansible_dialog, catalog, job_type):
     config_manager_obj = config_manager
     provider_name = config_manager_obj.yaml_data.get('name')
     template = config_manager_obj.yaml_data['provisioning_data'][job_type]
     catalog_item = appliance.collections.catalog_items.create(
         appliance.collections.catalog_items.ANSIBLE_TOWER,
-        name=dialog.label,
+        name=ansible_dialog.label,
         description="my catalog",
         display_in=True,
         catalog=catalog,
-        dialog=dialog,
+        dialog=ansible_dialog,
         provider='{} Automation Manager'.format(provider_name),
         config_template=template)
     request.addfinalizer(catalog_item.delete)

--- a/cfme/tests/services/test_config_provider_servicecatalogs.py
+++ b/cfme/tests/services/test_config_provider_servicecatalogs.py
@@ -1,6 +1,7 @@
 import pytest
 
 from cfme import test_requirements
+from cfme.rest.gen_data import ansible_dialog_rest as _ansible_dialog_rest
 from cfme.services.myservice import MyService
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils import testgen
@@ -62,6 +63,11 @@ def catalog_item(appliance, request, config_manager, ansible_dialog, catalog, jo
         config_template=template)
     request.addfinalizer(catalog_item.delete)
     return catalog_item
+
+
+@pytest.fixture(scope="function")
+def ansible_dialog(request, appliance):
+    _ansible_dialog_rest(request, appliance)
 
 
 def test_order_tower_catalog_item(appliance, catalog_item, request, job_type):

--- a/cfme/tests/services/test_config_provider_servicecatalogs.py
+++ b/cfme/tests/services/test_config_provider_servicecatalogs.py
@@ -12,9 +12,8 @@ from cfme.utils.log import logger
 pytestmark = [
     test_requirements.service,
     pytest.mark.tier(2),
-    pytest.mark.parametrize('job_type', ['template', 'workflow', 'template_survey',
-        'template_limit'],
-        ids=['template_job', 'workflow_job', 'template_survey_job', 'template_limit_job'],
+    pytest.mark.parametrize('job_type', ['template', 'template_limit', 'template_survey'],
+        ids=['template_job', 'template_limit_job', 'template_survey_job'],
         scope='module'),
     pytest.mark.ignore_stream('upstream'),
     pytest.mark.uncollectif(lambda appliance,
@@ -79,8 +78,7 @@ def test_order_tower_catalog_item(appliance, config_manager, catalog_item, reque
         caseimportance: high
     """
     if job_type == 'template_limit':
-        config_manager_obj = config_manager
-        host = config_manager_obj.yaml_data['provisioning_data']['inventory_host']
+        host = config_manager.yaml_data['provisioning_data']['inventory_host']
         dialog_values = {'limit': host}
         service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name,
             dialog_values=dialog_values)

--- a/cfme/tests/services/test_config_provider_servicecatalogs.py
+++ b/cfme/tests/services/test_config_provider_servicecatalogs.py
@@ -38,7 +38,7 @@ def pytest_generate_tests(metafunc):
     testgen.parametrize(metafunc, argnames, new_argvalues, ids=new_idlist, scope='module')
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def config_manager(config_manager_obj):
     """ Fixture that provides a random config manager and sets it up"""
     if config_manager_obj.type == "Ansible Tower":

--- a/cfme/tests/services/test_config_provider_servicecatalogs.py
+++ b/cfme/tests/services/test_config_provider_servicecatalogs.py
@@ -1,7 +1,7 @@
 import pytest
 
 from cfme import test_requirements
-from cfme.rest.gen_data import ansible_dialog_rest as _ansible_dialog_rest
+# from cfme.rest.gen_data import ansible_dialog_rest as _ansible_dialog_rest
 from cfme.services.myservice import MyService
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils import testgen
@@ -48,27 +48,27 @@ def config_manager(config_manager_obj):
 
 
 @pytest.fixture(scope="function")
-def catalog_item(appliance, request, config_manager, ansible_dialog, catalog, job_type):
+def catalog_item(appliance, request, config_manager, dialog, catalog, job_type):
     config_manager_obj = config_manager
     provider_name = config_manager_obj.yaml_data.get('name')
     template = config_manager_obj.yaml_data['provisioning_data'][job_type]
     catalog_item = appliance.collections.catalog_items.create(
         appliance.collections.catalog_items.ANSIBLE_TOWER,
-        name=ansible_dialog.label,
+        name=dialog.label,
         description="my catalog",
         display_in=True,
         catalog=catalog,
-        dialog=ansible_dialog,
+        dialog=dialog,
         provider='{} Automation Manager'.format(provider_name),
         config_template=template)
     request.addfinalizer(catalog_item.delete)
     return catalog_item
 
-
+"""
 @pytest.fixture(scope="function")
 def ansible_dialog(request, appliance):
     _ansible_dialog_rest(request, appliance)
-
+"""
 
 def test_order_tower_catalog_item(appliance, catalog_item, request, job_type):
     """Tests ordering of catalog items for Ansible Template and Workflow jobs
@@ -81,7 +81,9 @@ def test_order_tower_catalog_item(appliance, catalog_item, request, job_type):
         casecomponent: Services
         caseimportance: high
     """
-    service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
+    dialog_values = {'Limit': "10.8.198.0"}
+    service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name,
+        dialog_values=dialog_values)
     service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
     cells = {'Description': catalog_item.name}

--- a/cfme/tests/services/test_config_provider_servicecatalogs.py
+++ b/cfme/tests/services/test_config_provider_servicecatalogs.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 
 from cfme import test_requirements

--- a/cfme/tests/services/test_config_provider_servicecatalogs.py
+++ b/cfme/tests/services/test_config_provider_servicecatalogs.py
@@ -81,7 +81,7 @@ def test_order_tower_catalog_item(appliance, catalog_item, request, job_type):
         casecomponent: Services
         caseimportance: high
     """
-    dialog_values = {'Limit': "10.8.198.0"}
+    dialog_values = {'limit': "10.8.198.0"}
     service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name,
         dialog_values=dialog_values)
     service_catalogs.order()


### PR DESCRIPTION
1)Created Ansible service dialog through REST API
2)The existing tests through which Tower catalog items are ordered now use the new service dialog
3)Also added a new test to verify that Ansible jobs run on limited hosts.