### PR TITLE
[1LP][RFR] Update LogValidator usage

### DIFF
--- a/cfme/tests/cli/test_appliance_cli.py
+++ b/cfme/tests/cli/test_appliance_cli.py
@@ -141,7 +141,7 @@ def test_appliance_console_cli_external_create(app_creds, dedicated_db_appliance
 
 @pytest.mark.parametrize('auth_type', ['sso_enabled', 'saml_enabled', 'local_login_disabled'],
     ids=['sso', 'saml', 'local_login'])
-def test_appliance_console_cli_external_auth(auth_type, ipa_crud, app_creds, configured_appliance):
+def test_appliance_console_cli_external_auth(auth_type, ipa_crud, configured_appliance):
     """
     Polarion:
         assignee: sbulage
@@ -150,9 +150,7 @@ def test_appliance_console_cli_external_auth(auth_type, ipa_crud, app_creds, con
     """
     evm_tail = LogValidator('/var/www/miq/vmdb/log/evm.log',
                             matched_patterns=['.*{} to true.*'.format(auth_type)],
-                            hostname=configured_appliance.hostname,
-                            username=app_creds['sshlogin'],
-                            password=app_creds['sshpass'])
+                            hostname=configured_appliance.hostname)
     evm_tail.fix_before_start()
     cmd_set = 'appliance_console_cli --extauth-opts="/authentication/{}=true"'.format(auth_type)
     assert configured_appliance.ssh_client.run_command(cmd_set)
@@ -160,9 +158,7 @@ def test_appliance_console_cli_external_auth(auth_type, ipa_crud, app_creds, con
 
     evm_tail = LogValidator('/var/www/miq/vmdb/log/evm.log',
                             matched_patterns=['.*{} to false.*'.format(auth_type)],
-                            hostname=configured_appliance.hostname,
-                            username=app_creds['sshlogin'],
-                            password=app_creds['sshpass'])
+                            hostname=configured_appliance.hostname)
 
     evm_tail.fix_before_start()
     cmd_unset = 'appliance_console_cli --extauth-opts="/authentication/{}=false"'.format(auth_type)

--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -447,7 +447,7 @@ def test_appliance_console_ipa(ipa_crud, configured_appliance):
 
 
 @pytest.mark.parametrize('auth_type', ext_auth_options, ids=[opt.name for opt in ext_auth_options])
-def test_appliance_console_external_auth(auth_type, app_creds, ipa_crud, configured_appliance):
+def test_appliance_console_external_auth(auth_type, ipa_crud, configured_appliance):
     """ Commands:
     1. 'ap' launches appliance_console,
     2. RETURN clears info screen,
@@ -465,9 +465,7 @@ def test_appliance_console_external_auth(auth_type, app_creds, ipa_crud, configu
 
     evm_tail = LogValidator('/var/www/miq/vmdb/log/evm.log',
                             matched_patterns=['.*{} to true.*'.format(auth_type.option)],
-                            hostname=configured_appliance.hostname,
-                            username=app_creds['sshlogin'],
-                            password=app_creds['sshpass'])
+                            hostname=configured_appliance.hostname)
     evm_tail.fix_before_start()
     command_set = ('ap', RETURN, '13', auth_type.index, '5', RETURN, RETURN)
     configured_appliance.appliance_console.run_commands(command_set, timeout=30)
@@ -475,9 +473,7 @@ def test_appliance_console_external_auth(auth_type, app_creds, ipa_crud, configu
 
     evm_tail = LogValidator('/var/www/miq/vmdb/log/evm.log',
                             matched_patterns=['.*{} to false.*'.format(auth_type.option)],
-                            hostname=configured_appliance.hostname,
-                            username=app_creds['sshlogin'],
-                            password=app_creds['sshpass'])
+                            hostname=configured_appliance.hostname)
 
     evm_tail.fix_before_start()
     command_set = ('ap', RETURN, '13', auth_type.index, '5', RETURN, RETURN)
@@ -485,7 +481,7 @@ def test_appliance_console_external_auth(auth_type, app_creds, ipa_crud, configu
     evm_tail.validate_logs()
 
 
-def test_appliance_console_external_auth_all(app_creds, configured_appliance):
+def test_appliance_console_external_auth_all(configured_appliance):
     """ Commands:
     1. 'ap' launches appliance_console,
     2. RETURN clears info screen,
@@ -503,9 +499,7 @@ def test_appliance_console_external_auth_all(app_creds, configured_appliance):
                             matched_patterns=['.*sso_enabled to true.*',
                                               '.*saml_enabled to true.*',
                                               '.*local_login_disabled to true.*'],
-                            hostname=configured_appliance.hostname,
-                            username=app_creds['sshlogin'],
-                            password=app_creds['password'])
+                            hostname=configured_appliance.hostname)
     evm_tail.fix_before_start()
     command_set = ('ap', RETURN, TimedCommand('13', 20), '1', '2', TimedCommand('5', 20),
                    RETURN, RETURN)
@@ -516,9 +510,7 @@ def test_appliance_console_external_auth_all(app_creds, configured_appliance):
                             matched_patterns=['.*sso_enabled to false.*',
                                               '.*saml_enabled to false.*',
                                               '.*local_login_disabled to false.*'],
-                            hostname=configured_appliance.hostname,
-                            username=app_creds['sshlogin'],
-                            password=app_creds['password'])
+                            hostname=configured_appliance.hostname)
 
     evm_tail.fix_before_start()
     command_set = ('ap', RETURN, TimedCommand('13', 20), '1', '2', TimedCommand('5', 20),

--- a/cfme/tests/containers/test_blacklisted_container_events.py
+++ b/cfme/tests/containers/test_blacklisted_container_events.py
@@ -155,10 +155,8 @@ def test_blacklisted_container_events(request, appliance, provider, app_creds):
 
     evm_tail_no_blacklist = LogValidator(
         '/var/www/miq/vmdb/log/evm.log',
-        matched_patterns=['.*event\_type\=\>\"POD\_CREATED\".*'],
-        hostname=appliance.hostname,
-        username=app_creds['sshlogin'],
-        password=app_creds['password'])
+        matched_patterns=['.*event\_type\=\>\"POD\_CREATED\".*']
+    )
     evm_tail_no_blacklist.fix_before_start()
 
     create_pod(provider=provider, namespace=project_name)

--- a/cfme/tests/containers/test_pause_resume_workers.py
+++ b/cfme/tests/containers/test_pause_resume_workers.py
@@ -59,7 +59,7 @@ def test_pause_and_resume_provider_workers(appliance, provider):
 
 @pytest.mark.ignore_stream('5.9')
 @pytest.mark.parametrize('from_collections', [True, False], ids=['from_collection', 'from_entity'])
-def test_pause_and_resume_single_provider_api(appliance, provider, from_collections, app_creds,
+def test_pause_and_resume_single_provider_api(appliance, provider, from_collections,
                                               soft_assert, request):
     """
     Test enabling and disabling a single provider via the CFME API through the ManageIQ API Client
@@ -76,10 +76,7 @@ def test_pause_and_resume_single_provider_api(appliance, provider, from_collecti
 
     evm_tail_disable = LogValidator('/var/www/miq/vmdb/log/evm.log',
                                     matched_patterns=['.*Disabling EMS \[{}\] id \[{}\].*'
-                                                      .format(provider.name, str(provider.id))],
-                                    hostname=appliance.hostname,
-                                    username=app_creds['sshlogin'],
-                                    password=app_creds['password'])
+                                                      .format(provider.name, str(provider.id))])
     evm_tail_disable.fix_before_start()
     if from_collections:
         rep_disable = appliance.collections.containers_providers.pause_providers(provider)
@@ -116,10 +113,7 @@ def test_pause_and_resume_single_provider_api(appliance, provider, from_collecti
         ), 'Project {p} exists even though provider has been disabled'.format(p=project_name))
     evm_tail_enable = LogValidator('/var/www/miq/vmdb/log/evm.log',
                                    matched_patterns=['.*Enabling EMS \[{}\] id \[{}\].*'
-                                                     .format(provider.name, str(provider.id))],
-                                   hostname=appliance.hostname,
-                                   username=app_creds['sshlogin'],
-                                   password=app_creds['password'])
+                                                     .format(provider.name, str(provider.id))])
     evm_tail_enable.fix_before_start()
     if from_collections:
         rep_enable = appliance.collections.containers_providers.resume_providers(provider)

--- a/cfme/utils/ssh.py
+++ b/cfme/utils/ssh.py
@@ -130,24 +130,21 @@ class SSHClient(paramiko.SSHClient):
         self.f_stdout = connect_kwargs.pop('stdout', sys.stdout)
         self.f_stderr = connect_kwargs.pop('stderr', sys.stderr)
 
-        # load the defaults for ssh
-        default_connect_kwargs = {
-            'timeout': 10,
-            'allow_agent': False,
-            'look_for_keys': False,
-            'gss_auth': False
-        }
-        # Load credentials and destination from confs, if connect_kwargs is empty
-        if not connect_kwargs.get('hostname'):
-            default_connect_kwargs['hostname'] = store.current_appliance.hostname
-            default_connect_kwargs['port'] = ports.SSH
-            default_connect_kwargs['username'] = conf.credentials['ssh']['username']
-            default_connect_kwargs['password'] = conf.credentials['ssh']['password']
-        default_connect_kwargs['port'] = connect_kwargs.pop('port', ports.SSH)
+        # load the defaults for ssh, including current_appliance and default credentials keys
+        compiled_kwargs = dict(
+            timeout=10,
+            allow_agent=False,
+            look_for_keys=False,
+            gss_auth=False,
+            hostname=store.current_appliance.hostname,
+            username=conf.credentials['ssh']['username'],
+            password=conf.credentials['ssh']['password'],
+            port=ports.SSH,
+        )
 
-        # Overlay defaults with any passed-in kwargs and store
-        default_connect_kwargs.update(connect_kwargs)
-        self._connect_kwargs = default_connect_kwargs
+        # Overlay defaults with any passed-in kwargs and assign to _connect_kwargs
+        compiled_kwargs.update(connect_kwargs)
+        self._connect_kwargs = compiled_kwargs
         self.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         _client_session.append(self)
 


### PR DESCRIPTION
Don't pass hostname/username/password if its just the default or current test appliance
Its just duplicating SSHClient default behavior.

PRT failures in run 30978 are not related to the LogValidator/SSHClient changes, but issues with sprout or with the test.