### PR TITLE
[1LP][RFR] New manual testcases

### DIFF
--- a/cfme/tests/cloud/test_snapshot.py
+++ b/cfme/tests/cloud/test_snapshot.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from cfme import test_requirements
+from cfme.cloud.provider.openstack import OpenStackProvider
+
+
+@pytest.mark.manual
+@pytest.mark.provider([OpenStackProvider])
+@test_requirements.snapshot
+@pytest.mark.tier(1)
+def test_osp_snapshot_buttons():
+    """
+    Test new OSP snapshot button and make sure Snapshot link is removed from Instance Details
+    page.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: Cloud
+        caseimportance: medium
+        initialEstimate: 1/4h
+        startsin: 5.10
+        setup:
+            1. Have OSP provider added and test instance created
+        testSteps:
+            1. Navigate to test instance
+            2. Make sure the snapshot button is displayed in the top menu
+            3. Try snapshot crud
+            4. Navigate to instance summary screen; Check if the original Snapshot link is present
+        expectedResults:
+            1. Test instance summary page displayed
+            2. Snapshot button displayed
+            3. Snapshot created; Snapshot deleted
+            4. Snapshot link is not displayed
+    Bugzilla:
+        1690954
+    """
+    pass

--- a/cfme/tests/cloud_infra_common/test_genealogy.py
+++ b/cfme/tests/cloud_infra_common/test_genealogy.py
@@ -84,3 +84,32 @@ def test_vm_genealogy_detected(
             raise pytest.fail("The parent template not detected!")
         assert small_template.name in vm_crud_ancestors, \
             "{} is not in {}'s ancestors".format(small_template.name, vm_crud.name)
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+@test_requirements.genealogy
+def test_compare_button_enabled():
+    """
+    Test that compare button is enabled
+
+    Polarion:
+        assignee: apagac
+        casecomponent: Infra
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.10.4
+        setup:
+            1. Have a provider with some VMs added
+        testSteps:
+            1. Set the parent-child relationship for at least two VMs
+            2. Open one of the VM's genealogy screen from its summary
+            3. Check at least two checkboxes in the genealogy tree
+        expectedResults:
+            1. Genealogy set
+            2. Genealogy screen displayed
+            3. Compare button enabled
+    Bugzilla:
+        1694712
+    """
+    pass

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -9,6 +9,7 @@ from cfme.base.credential import Credential
 from cfme.common.provider import base_types
 from cfme.configure.access_control import AddUserView
 from cfme.configure.tasks import TasksView
+from cfme.containers.provider.openshift import OpenshiftProvider
 from cfme.exceptions import RBACOperationBlocked
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import ONE
@@ -1927,5 +1928,74 @@ def test_tenant_visibility_miq_ae_namespaces_all_parents():
         tags: cfme_tenancy
         initialEstimate: 1/4h
         startsin: 5.5
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.ignore_stream('5.10')
+@test_requirements.rbac
+@pytest.mark.tier(2)
+def test_tags_manual_features():
+    """
+    Test that user can edit tags of an VM when he has role created by disabling 'Everything'
+    and then enabling every other checkbox.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: Configuration
+        caseimportance: high
+        initialEstimate: 1/5h
+        startsin: 5.11
+        setup:
+            1. Have an infra provider added and testvm created
+        testSteps:
+            1. Create new role. Disable 'Everything' and then manually enable each check box
+                except 'Everything'.
+            2. Create new group based on this role; Create new user as a member of this group
+            3. Login as newly created user
+            4. Navigate to testing vm and try to Policy -> Edit Tags
+        expectedResults:
+            1. New role created
+            2. New group created; New user created
+            3. Login successful
+            4. Edit Tags screen displayed; no error in evm.log
+    Bugzilla:
+        1684472
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.provider([OpenshiftProvider], override=True)
+@test_requirements.rbac
+@pytest.mark.tier(2)
+def test_host_clusters_pod_filter():
+    """
+    Test that user with Hosts & Clusters filter is able to see pods belonging to that filter only
+
+    Polarion:
+        assignee: apagac
+        casecomponent: Configuration
+        caseimportance: high
+        initialEstimate: 1/4h
+        startsin: 5.10.3
+        setup:
+            1. Have at least two OCP providers added with some pods
+        testSteps:
+            1. Create new role with Everything -> Compute enabled only
+            2. Create new group based on this role and in Hosts & Clusters tab check one of the
+                OCP providers
+            3. Create an user as a member of this group
+            4. Login as the new user and navigate to Compute -> Containers -> Providers
+            5. Navigate to Compute -> Containers -> Pods
+        expectedResults:
+            1. Role created
+            2. Group created
+            3. User created
+            4. Only one OCP provider displayed; this is the one checked in Hosts & Clusters
+            5. Only pods from one OCP provider are displayed
+    Bugzilla:
+        1631694
     """
     pass


### PR DESCRIPTION
__New__ manual tests added as a result of qe_test_coverage flag.

Created new file `test_snapshot.py` in tests/cloud for snapshot testing with cloud providers. More manual tests will go to this file in PR #8636 

Added new manual tests to existing files.