### PR TITLE
[WIPTEST] Refactoring quota test cases

### DIFF
--- a/cfme/tests/cloud/test_quota.py
+++ b/cfme/tests/cloud/test_quota.py
@@ -18,16 +18,30 @@ pytestmark = [
                          required_fields=[["provisioning", "image"]])]
 
 
+# DATA['data'] is a list of lists, with each one a test is to be generated sequence is important.
+# DATA['indirect'] is the list where we define which fixtures are to be passed values indirectly.
+# DATA['ids'] is list of ids to generate each test cases with different id
+DATA = {
+    'data': [
+        [("cpu", 1), {}, "", False],
+        [("storage", 0.001), {}, "", False],
+        [("memory", 2), {}, "", False],
+        [("vm", 1), {"catalog": {"num_vms": "4"}}, "###", True],
+    ],
+    'indirect': [],  # keeping it empty because it changes as per the test case
+    'ids': ["max_cpu", "max_storage", "max_memory", "max_vms"]
+}
+
+
 @pytest.fixture
 def prov_data(appliance, provisioning):
     """Keeping it as a fixture because we need to call 'provisioning' from this fixture as well as
        using this same fixture in various tests.
     """
-    instance_type = "d2s_v3" if appliance.version < "5.10" else "d2s_v3".capitalize()
     return {
         "catalog": {"vm_name": random_vm_name(context="quota")},
         "environment": {"automatic_placement": True},
-        "properties": {"instance_type": partial_match(instance_type)},
+        "properties": {"instance_type": partial_match("D2s_v3")},
         "customize": {
             "admin_username": provisioning["customize_username"],
             "root_password": provisioning["customize_password"],
@@ -36,22 +50,22 @@ def prov_data(appliance, provisioning):
 
 
 @pytest.fixture
-def set_child_tenant_quota(request, appliance, new_child):
+def set_child_tenant_quota(request, new_child):
     """This fixture assigns quota to child tenant"""
     field, value = request.param
     new_child.set_quota(**{"{}_cb".format(field): True, field: value})
     yield
-    appliance.server.login_admin()
+    new_child.appliance.server.login_admin()
     new_child.set_quota(**{"{}_cb".format(field): False})
 
 
 @pytest.fixture
-def set_project_quota(request, appliance, new_project):
+def set_project_quota(request, new_project):
     """This fixture assigns quota to project"""
     field, value = request.param
     new_project.set_quota(**{"{}_cb".format(field): True, field: value})
     yield
-    appliance.server.login_admin()
+    new_project.appliance.server.login_admin()
     new_project.set_quota(**{"{}_cb".format(field): False})
 
 
@@ -65,40 +79,37 @@ def new_tenant(appliance):
         parent=collection.get_root_tenant(),
     )
     yield tenant
-    if tenant.exists:
-        tenant.delete()
+    tenant.delete_if_exists()
 
 
 @pytest.fixture(scope="module")
-def new_child(appliance, new_tenant):
+def new_child(new_tenant):
     """The fixture creates new child tenant"""
-    child_tenant = appliance.collections.tenants.create(
+    child_tenant = new_tenant.appliance.collections.tenants.create(
         name="tenant_{}".format(fauxfactory.gen_alphanumeric()),
         description="tenant_des{}".format(fauxfactory.gen_alphanumeric()),
         parent=new_tenant,
     )
     yield child_tenant
-    if child_tenant.exists:
-        child_tenant.delete()
+    child_tenant.delete_if_exists()
 
 
 @pytest.fixture(scope="module")
-def new_group_child(appliance, new_child, new_tenant):
+def new_group_child(new_child, new_tenant):
     """This fixture creates new group assigned by new child tenant"""
-    group = appliance.collections.groups.create(
+    group = new_child.appliance.collections.groups.create(
         description="group_{}".format(fauxfactory.gen_alphanumeric()),
         role="EvmRole-super_administrator",
         tenant="My Company/{parent}/{child}".format(parent=new_tenant.name, child=new_child.name),
     )
     yield group
-    if group.exists:
-        group.delete()
+    group.delete_if_exists()
 
 
 @pytest.fixture(scope="module")
-def new_user_child(appliance, new_group_child):
+def new_user_child(new_group_child):
     """This fixture creates new user which assigned to new child tenant"""
-    user = appliance.collections.users.create(
+    user = new_group_child.appliance.collections.users.create(
         name="user_{}".format(fauxfactory.gen_alphanumeric().lower()),
         credential=Credential(principal='uid{}'.format(fauxfactory.gen_alphanumeric(4)),
                               secret='{password}'.format(password=fauxfactory.gen_alphanumeric(4))),
@@ -108,8 +119,7 @@ def new_user_child(appliance, new_group_child):
         value_assign="Database",
     )
     yield user
-    if user.exists:
-        user.delete()
+    user.delete_if_exists()
 
 
 @pytest.fixture(scope="module")
@@ -122,27 +132,25 @@ def new_project(appliance):
         parent=collection.get_root_tenant(),
     )
     yield project
-    if project.exists:
-        project.delete()
+    project.delete_if_exists()
 
 
 @pytest.fixture(scope="module")
-def new_group_project(appliance, new_project):
+def new_group_project(new_project):
     """This fixture creates new group and assigned by new project"""
-    group = appliance.collections.groups.create(
+    group = new_project.appliance.collections.groups.create(
         description="group_{}".format(fauxfactory.gen_alphanumeric()),
         role="EvmRole-super_administrator",
         tenant="My Company/{project}".format(project=new_project.name),
     )
     yield group
-    if group.exists:
-        group.delete()
+    group.delete_if_exists()
 
 
 @pytest.fixture(scope="module")
-def new_user_project(appliance, new_group_project):
+def new_user_project(new_group_project):
     """This fixture creates new user which is assigned to new group and project"""
-    user = appliance.collections.users.create(
+    user = new_group_project.appliance.collections.users.create(
         name="user_{}".format(fauxfactory.gen_alphanumeric().lower()),
         credential=Credential(principal='uid{}'.format(fauxfactory.gen_alphanumeric(4)),
                               secret='{password}'.format(password=fauxfactory.gen_alphanumeric(4))),
@@ -152,8 +160,7 @@ def new_user_project(appliance, new_group_project):
         value_assign="Database",
     )
     yield user
-    if user.exists:
-        user.delete()
+    user.delete_if_exists()
 
 
 # first arg of parametrize is the list of fixtures or parameters,
@@ -161,15 +168,8 @@ def new_user_project(appliance, new_group_project):
 # sequence is important here
 # indirect is the list where we define which fixtures are to be passed values indirectly.
 @pytest.mark.parametrize(
-    ["set_child_tenant_quota", "custom_prov_data", "extra_msg", "approve"],
-    [
-        [("cpu", 1), {}, "", False],
-        [("storage", 0.001), {}, "", False],
-        [("memory", 2), {}, "", False],
-        [("vm", 1), {"catalog": {"num_vms": "4"}}, "###", True],
-    ],
-    indirect=["set_child_tenant_quota"],
-    ids=["max_cpu", "max_storage", "max_memory", "max_vms"],
+    ["set_child_tenant_quota", "custom_prov_data", "extra_msg", "approve"], DATA['data'],
+    DATA["indirect"] + ["set_child_tenant_quota"], DATA['ids']
 )
 def test_child_tenant_quota_enforce_via_lifecycle_cloud(
     request,
@@ -206,7 +206,7 @@ def test_child_tenant_quota_enforce_via_lifecycle_cloud(
                     "email": fauxfactory.gen_email(),
                     "first_name": fauxfactory.gen_alphanumeric(),
                     "last_name": fauxfactory.gen_alphanumeric(),
-                    "manager_name": "{name}".format(name=fauxfactory.gen_alphanumeric()),
+                    "manager_name": fauxfactory.gen_alphanumeric(),
                 }
             },
         )
@@ -233,15 +233,8 @@ def test_child_tenant_quota_enforce_via_lifecycle_cloud(
 # sequence is important here
 # indirect is the list where we define which fixtures are to be passed values indirectly.
 @pytest.mark.parametrize(
-    ["set_project_quota", "custom_prov_data", "extra_msg", "approve"],
-    [
-        [("cpu", 1), {}, "", False],
-        [("storage", 0.001), {}, "", False],
-        [("memory", 2), {}, "", False],
-        [("vm", 1), {"catalog": {"num_vms": "4"}}, "###", True],
-    ],
-    indirect=["set_project_quota"],
-    ids=["max_cpu", "max_storage", "max_memory", "max_vms"],
+    ["set_project_quota", "custom_prov_data", "extra_msg", "approve"], DATA['data'],
+    DATA["indirect"] + ["set_project_quota"], DATA['ids']
 )
 def test_project_quota_enforce_via_lifecycle_cloud(
     request,
@@ -278,7 +271,7 @@ def test_project_quota_enforce_via_lifecycle_cloud(
                     "email": fauxfactory.gen_email(),
                     "first_name": fauxfactory.gen_alphanumeric(),
                     "last_name": fauxfactory.gen_alphanumeric(),
-                    "manager_name": "{name}".format(name=fauxfactory.gen_alphanumeric()),
+                    "manager_name": fauxfactory.gen_alphanumeric(),
                 }
             },
         )


### PR DESCRIPTION
- Creating setup using rest_api
- Added ```test_requirements```
- Removed deprecated code
- Removed unused/not required fixtures
- Added global variables as required
- Used global fixtures instead of local like ```domain```
- Used ```delete_if_exists()``` method for teardown
- Updated use of ```fauxfactory```
- Updated/added comments wherever required

- Depend on https://github.com/ManageIQ/integration_tests/pull/8678

{{ pytest: cfme/tests/ -k 'test_child_tenant_quota_enforce_via_lifecycle_cloud' or 'test_project_quota_enforce_via_lifecycle_cloud' or 'test_quota_tagging_cloud_via_lifecycle' or 'test_quota_tagging_cloud_via_services' or 'test_cloud_quota_by_lifecycle' or 'test_quota_cloud_via_services' or 'test_quota_tagging_infra_via_lifecycle' or 'test_quota_tagging_infra_via_services' or 'test_quota_vm_reconfigure' or 'test_quota_infra' or 'test_quota_catalog_bundle_infra' or 'test_quota' or 'test_user_quota_diff_groups' --long-running -v }}