### PR TITLE
[1LP][RFR] Global fixture for custom button support. 

### DIFF
--- a/cfme/fixtures/provider.py
+++ b/cfme/fixtures/provider.py
@@ -382,7 +382,7 @@ def big_template_modscope(provider):
     return _get_template(provider, 'big_template')
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="module")
 def provisioning(provider):
     try:
         return provider.data['provisioning']

--- a/cfme/fixtures/service_fixtures.py
+++ b/cfme/fixtures/service_fixtures.py
@@ -166,7 +166,7 @@ def service_vm(appliance, provider, catalog_item):
 
     collection = provider.appliance.provider_based_collection(provider)
     vm_name = "{}0001".format(catalog_item.prov_data["catalog"]["vm_name"])
-    vm = collection.instantiate("{}0001".format(vm_name), provider).cleanup_on_provider()
+    vm = collection.instantiate("{}0001".format(vm_name), provider)
 
     service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
     provision_request = service_catalogs.order()


### PR DESCRIPTION
Purpose or Intent
=================
- Added global fixture for returning `service` and respective `vm` object.
- This fixture going to use in upcoming `custom button` test cases
- I found this functionality in one of service test so removed that local fixture added small improvement and move to global.
- Yup there is one more global fixture which order catalog but returning item name. which not useful for everyone. 

{{pytest: cfme/tests/services/test_add_remove_vm_to_service.py -v --long-running}}

