### PR TITLE
[1LP][RFR] Added new manual test cases

### DIFF
--- a/cfme/tests/automate/test_automate_manual.py
+++ b/cfme/tests/automate/test_automate_manual.py
@@ -876,7 +876,7 @@ def test_user_requester_for_lifecycle_provision():
     Polarion:
         assignee: ghubale
         casecomponent: Automate
-        caseimportance: medium
+        caseimportance: high
         initialEstimate: 1/6h
         tags: automate
         testSteps:
@@ -894,6 +894,26 @@ def test_user_requester_for_lifecycle_provision():
 
     Bugzilla:
          1671563
+    """
+    pass
+
+
+@pytest.mark.tier(1)
+@pytest.mark.ignore_stream("5.10")
+def test_remove_openshift_deployment_in_automate():
+    """
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/8h
+        caseimportance: high
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.11
+        casecomponent: Automate
+        tags: automate
+
+    Bugzilla:
+        1672937
     """
     pass
 
@@ -919,5 +939,25 @@ def test_vm_naming_number_padding():
 
     Bugzilla:
         1688672
+    """
+    pass
+
+
+@pytest.mark.tier(1)
+@pytest.mark.ignore_stream("5.10")
+def test_vm_name_automate_method():
+    """
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/8h
+        caseimportance: high
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.11
+        casecomponent: Automate
+        tags: automate
+
+    Bugzilla:
+        1677573
     """
     pass

--- a/cfme/tests/automate/test_automate_manual.py
+++ b/cfme/tests/automate/test_automate_manual.py
@@ -657,7 +657,7 @@ def test_automate_embedded_method():
     Polarion:
         assignee: ghubale
         casecomponent: Automate
-        caseimportance: medium
+        caseimportance: high
         initialEstimate: 1/12h
         tags: automate
 
@@ -901,7 +901,8 @@ def test_user_requester_for_lifecycle_provision():
 @pytest.mark.tier(1)
 @pytest.mark.ignore_stream("5.10")
 def test_remove_openshift_deployment_in_automate():
-    """
+    """This test case will test successful removal of OpenShift Deployment removed from Automate
+
     Polarion:
         assignee: ghubale
         initialEstimate: 1/8h
@@ -946,7 +947,8 @@ def test_vm_naming_number_padding():
 @pytest.mark.tier(1)
 @pytest.mark.ignore_stream("5.10")
 def test_vm_name_automate_method():
-    """
+    """This test case will check redesign of vm_name automated method
+
     Polarion:
         assignee: ghubale
         initialEstimate: 1/8h
@@ -961,3 +963,29 @@ def test_vm_name_automate_method():
         1677573
     """
     pass
+
+
+@pytest.mark.tier(1)
+def test_null_coalescing_fields():
+    """
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/8h
+        caseimportance: high
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.10
+        casecomponent: Automate
+        tags: automate
+        testSteps:
+            1.  Create a Ruby method or Ansible playbook method with Input Parameters.
+            2.  Use Data Type null coalescing
+            3.  Make the default value something like this : ${#var3} || ${#var2} || ${#var1}
+        expectedResults:
+            1.
+            2.
+            3. Normal null coalescing behavior
+
+    Bugzilla:
+        1698184
+    """

--- a/cfme/tests/automate/test_git_import.py
+++ b/cfme/tests/automate/test_git_import.py
@@ -176,7 +176,8 @@ def test_domain_import_git(
 @pytest.mark.tier(1)
 @pytest.mark.ignore_stream("5.10")
 def test_import_export_domain_with_ansible_method():
-    """
+    """This test case tests support of Export/Import of Domain with Ansible Method
+
     Polarion:
         assignee: ghubale
         initialEstimate: 1/8h
@@ -186,6 +187,14 @@ def test_import_export_domain_with_ansible_method():
         startsin: 5.11
         casecomponent: Automate
         tags: automate
+        setup:
+            1. Start server_roles - 'git_owner'
+        testSteps:
+            1. Navigate to Automation > Automate > Import/Export
+            2. Import/Export 'Domain' using ansible method
+        expectedResults:
+            1.
+            2. Domain should get imported and seen in domain list
 
     Bugzilla:
         1677575

--- a/cfme/tests/automate/test_git_import.py
+++ b/cfme/tests/automate/test_git_import.py
@@ -1,11 +1,13 @@
 import pytest
 from six.moves.urllib.parse import urlparse
 
+from cfme import test_requirements
 from cfme.automate.import_export import AutomateGitRepository
 from cfme.utils.appliance.implementations.ui import navigate_to
 
 
 pytestmark = [
+    test_requirements.automate,
     pytest.mark.meta(server_roles="+git_owner"),
 ]
 
@@ -168,3 +170,24 @@ def test_domain_import_git(
     domain = repo.import_domain_from(**{param_type: param_value})
     request.addfinalizer(domain.delete)
     assert domain.exists
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+@pytest.mark.ignore_stream("5.10")
+def test_import_export_domain_with_ansible_method():
+    """
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/8h
+        caseimportance: high
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.11
+        casecomponent: Automate
+        tags: automate
+
+    Bugzilla:
+        1677575
+    """
+    pass

--- a/cfme/tests/cloud_infra_common/test_power_control_manual.py
+++ b/cfme/tests/cloud_infra_common/test_power_control_manual.py
@@ -3,9 +3,9 @@ import pytest
 
 from cfme import test_requirements
 
+pytestmark = [test_requirements.power, pytest.mark.manual]
 
-@pytest.mark.manual
-@test_requirements.power
+
 @pytest.mark.tier(2)
 def test_shutdown_guest_scvmm():
     """
@@ -36,8 +36,6 @@ def test_shutdown_guest_scvmm():
     pass
 
 
-@pytest.mark.manual
-@test_requirements.power
 @pytest.mark.tier(1)
 def test_vm_relationship_datastore_fileshare_scvmm():
     """
@@ -67,9 +65,6 @@ def test_vm_relationship_datastore_fileshare_scvmm():
     pass
 
 
-@pytest.mark.manual
-@test_requirements.power
-@test_requirements.power
 @pytest.mark.tier(2)
 def test_suspend_scvmm2016_from_collection():
     """
@@ -98,8 +93,6 @@ def test_suspend_scvmm2016_from_collection():
     pass
 
 
-@pytest.mark.manual
-@test_requirements.power
 @pytest.mark.tier(2)
 def test_restart_guest_scvmm2016():
     """
@@ -133,8 +126,6 @@ def test_restart_guest_scvmm2016():
     pass
 
 
-@pytest.mark.manual
-@test_requirements.power
 @pytest.mark.tier(2)
 def test_restart_guest_scvmm():
     """
@@ -168,8 +159,6 @@ def test_restart_guest_scvmm():
     pass
 
 
-@pytest.mark.manual
-@test_requirements.power
 @pytest.mark.tier(2)
 def test_power_controls_on_archived_vm():
     """
@@ -201,8 +190,6 @@ def test_power_controls_on_archived_vm():
     pass
 
 
-@pytest.mark.manual
-@test_requirements.power
 @pytest.mark.tier(2)
 def test_power_controls_on_vm_in_stack_cloud():
     """
@@ -234,8 +221,6 @@ def test_power_controls_on_vm_in_stack_cloud():
     pass
 
 
-@pytest.mark.manual
-@test_requirements.power
 @pytest.mark.tier(2)
 def test_power_operations_from_global_region():
     """
@@ -271,8 +256,6 @@ def test_power_operations_from_global_region():
     pass
 
 
-@pytest.mark.manual
-@test_requirements.power
 @pytest.mark.tier(2)
 def test_power_options_on_archived_orphaned_vms_all_page():
     """
@@ -304,8 +287,6 @@ def test_power_options_on_archived_orphaned_vms_all_page():
     pass
 
 
-@pytest.mark.manual
-@test_requirements.power
 @pytest.mark.tier(2)
 def test_check_compliance_policy_option_on_vm_summery_page():
     """
@@ -332,5 +313,31 @@ def test_check_compliance_policy_option_on_vm_summery_page():
 
     Bugzilla:
         1560107
+    """
+    pass
+
+
+@pytest.mark.tier(2)
+@pytest.mark.ignore_stream("5.10")
+def test_power_states_with_respective_provider():
+    """
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/12h
+        caseimportance: medium
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.11
+        casecomponent: Control
+        tags: power
+        testSteps:
+            1. Provision Azure Instance
+            2. In Instance detail page, select Resume from Lifecycle menu
+        expectedResults:
+            1.
+            2. Should not have Resume button there or disable button upon provider
+
+    Bugzilla:
+        1541447
     """
     pass

--- a/cfme/tests/cloud_infra_common/test_quota_manual.py
+++ b/cfme/tests/cloud_infra_common/test_quota_manual.py
@@ -3,9 +3,9 @@ import pytest
 
 from cfme import test_requirements
 
+pytestmark = [test_requirements.quota, pytest.mark.manual]
 
-@pytest.mark.manual
-@test_requirements.quota
+
 @pytest.mark.tier(1)
 def test_custom_service_dialog_quota_flavors():
     """
@@ -40,8 +40,6 @@ def test_custom_service_dialog_quota_flavors():
     pass
 
 
-@pytest.mark.manual
-@test_requirements.quota
 @pytest.mark.tier(3)
 def test_quota_for_simultaneous_service_catalog_request_with_different_users():
     """
@@ -75,9 +73,8 @@ def test_quota_for_simultaneous_service_catalog_request_with_different_users():
     pass
 
 
-@pytest.mark.manual
-@test_requirements.quota
 @pytest.mark.tier(2)
+@pytest.mark.ignore_stream('5.10')
 def test_instance_quota_reconfigure_with_flavors():
     """
     Test reconfiguration of instance using flavors after setting quota but this is RFE which is not
@@ -110,8 +107,6 @@ def test_instance_quota_reconfigure_with_flavors():
     pass
 
 
-@pytest.mark.manual
-@test_requirements.service
 @pytest.mark.tier(3)
 def test_quota_for_ansible_service():
     """
@@ -143,8 +138,6 @@ def test_quota_for_ansible_service():
     pass
 
 
-@pytest.mark.manual
-@test_requirements.quota
 @pytest.mark.tier(1)
 def test_quota_calculation_using_service_dialog_overrides():
     """
@@ -185,8 +178,6 @@ def test_quota_calculation_using_service_dialog_overrides():
     pass
 
 
-@pytest.mark.manual
-@test_requirements.quota
 @pytest.mark.tier(3)
 def test_service_template_provisioning_quota_for_number_of_vms_using_custom_dialog():
     """
@@ -219,8 +210,6 @@ def test_service_template_provisioning_quota_for_number_of_vms_using_custom_dial
     pass
 
 
-@pytest.mark.manual
-@test_requirements.quota
 @pytest.mark.tier(3)
 def test_quota_enforcement_for_cloud_volumes():
     """
@@ -254,8 +243,6 @@ def test_quota_enforcement_for_cloud_volumes():
     pass
 
 
-@pytest.mark.manual
-@test_requirements.quota
 @pytest.mark.tier(2)
 def test_quota_with_invalid_service_request():
     """
@@ -302,8 +289,6 @@ def test_quota_with_invalid_service_request():
     pass
 
 
-@pytest.mark.manual
-@test_requirements.quota
 @pytest.mark.tier(2)
 def test_simultaneous_tenant_quota():
     """
@@ -343,8 +328,6 @@ def test_simultaneous_tenant_quota():
     pass
 
 
-@pytest.mark.manual
-@test_requirements.quota
 @pytest.mark.tier(2)
 def test_notification_show_notification_when_quota_is_exceed():
     """
@@ -372,8 +355,6 @@ def test_notification_show_notification_when_quota_is_exceed():
     pass
 
 
-@pytest.mark.manual
-@test_requirements.quota
 @pytest.mark.tier(1)
 def test_quota_not_fails_after_vm_reconfigure_disk_remove():
     """
@@ -402,8 +383,6 @@ def test_quota_not_fails_after_vm_reconfigure_disk_remove():
     pass
 
 
-@pytest.mark.manual
-@test_requirements.quota
 @pytest.mark.tier(1)
 def test_quota_exceed_mail_with_more_info_link():
     """
@@ -426,8 +405,6 @@ def test_quota_exceed_mail_with_more_info_link():
     pass
 
 
-@pytest.mark.manual
-@test_requirements.quota
 @pytest.mark.tier(1)
 def test_dynamic_product_feature_for_tenant_quota():
     """

--- a/cfme/tests/services/test_catalog_item.py
+++ b/cfme/tests/services/test_catalog_item.py
@@ -282,7 +282,7 @@ def test_restricted_catalog_items_select_for_catalog_bundle(appliance, request, 
 def test_catalog_all_page_after_deleting_selected_template():
     """
     Polarion:
-        assignee: ghubale
+        assignee: nansari
         initialEstimate: 1/12h
         caseimportance: low
         caseposneg: positive


### PR DESCRIPTION
Following updated to this PR:
- Added new manual test cases
- Updated files with test_requirements
- Removed tests which are already automated like [custom button](https://github.com/ManageIQ/integration_tests/search?q=test+custom+button+expression&unscoped_q=test+custom+button+expression)
- Some tests are RFE; hence not added teststeps.
- Removed 5.9 dependency
