### PR TITLE
[1LP][RFR] This will add workaround for AMI image selection.

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -422,6 +422,24 @@ class BaseProvider(Taggable, Updateable, Navigatable, BaseEntity, CustomButtonEv
             events_connection["endpoint"]["security_protocol"] = security_protocol
         connection_configs.append(events_connection)
 
+    def _fill_smartstate_endpoint_dicts(self, provider_attributes, connection_configs):
+        """Fills dicts with smartstate endpoint data.
+
+        Helper method for ``self.create_rest``
+        """
+        if "smartstate" not in self.endpoints:
+            return
+
+        endpoint_rsa = self.endpoints["smartstate"]
+        if isinstance(provider_attributes["credentials"], dict):
+            provider_attributes["credentials"] = [provider_attributes["credentials"]]
+
+        provider_attributes["credentials"].append({
+            "userid": endpoint_rsa.credentials.principal,
+            "password": endpoint_rsa.credentials.secret,
+            "auth_type": "smartstate_docker",
+        })
+
     def _compile_connection_configurations(self, provider_attributes, connection_configs):
         """Compiles together all dicts with data for ``connection_configurations``.
 
@@ -469,6 +487,7 @@ class BaseProvider(Taggable, Updateable, Navigatable, BaseEntity, CustomButtonEv
         self._fill_candu_endpoint_dicts(provider_attributes, connection_configs)
         self._fill_rsa_endpoint_dicts(provider_attributes, connection_configs)
         self._fill_amqp_endpoint_dicts(provider_attributes, connection_configs)
+        self._fill_smartstate_endpoint_dicts(provider_attributes, connection_configs)
         self._compile_connection_configurations(provider_attributes, connection_configs)
 
         try:

--- a/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
+++ b/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
@@ -33,7 +33,6 @@ from cfme.utils.wait import wait_for_decorator
 
 pytestmark = [
     pytest.mark.tier(3),
-    pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:8152')]),
     test_requirements.smartstate,
 ]
 
@@ -186,6 +185,11 @@ def set_agent_creds(appliance, request, provider):
             }
         }
     }
+    if BZ(1684203, forced_streams=['5.10']).blocks:
+        # there is an issue with AMI which is used by CloudForms by default
+        # this is temporary workaround
+        new_ami = 'RHEL-Atomic_7.6_HVM_GA-20190306-x86_64-0-Access2-GP2'
+        agent_data['ems']['ems_amazon']['agent_coordinator']['agent_ami_name'] = new_ami
     appliance.update_advanced_settings(agent_data)
 
 
@@ -631,7 +635,6 @@ def test_ssa_schedule(ssa_vm, schedule_ssa, soft_assert, vm_system_type):
 @pytest.mark.rhv1
 @pytest.mark.tier(2)
 @pytest.mark.long_running
-@pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:8157')])
 def test_ssa_vm(ssa_vm, soft_assert, vm_system_type):
     """ Tests SSA can be performed and returns sane results
 


### PR DESCRIPTION
Adding new AMI usage due to BZ 1684203 for EC2 SSA testing.

PRT run:

{{ pytest: cfme/tests/cloud_infra_common/test_vm_instance_analysis.py -k test_ssa_vm -qsvvvv --use-provider ec2west --long-running }}