### PR TITLE
[1LP][RFR][NOTEST] CB: new manual tests

### DIFF
--- a/cfme/tests/automate/custom_button/test_generic_objects.py
+++ b/cfme/tests/automate/custom_button/test_generic_objects.py
@@ -337,7 +337,12 @@ def test_custom_button_open_url_evm_obj(setup_obj, button_group):
             3. Create a custom button with open_url option and respective method
             4. Navigate to object Detail page
             5. Execute custom button
-            6. Check new tab open or not with respective url
+        expectedResults:
+            1.
+            2.
+            3.
+            4.
+            5. New tab should open with respective url
 
     Bugzilla:
         1550002

--- a/cfme/tests/automate/custom_button/test_generic_objects.py
+++ b/cfme/tests/automate/custom_button/test_generic_objects.py
@@ -316,3 +316,30 @@ def test_custom_button_expression_evm_obj(appliance, request, setup_obj, button_
             assert not custom_button_group.is_displayed
             setup_obj.add_tag(tag)
             assert button.text in custom_button_group.items
+
+
+@pytest.mark.manual
+def test_custom_button_open_url_evm_obj(setup_obj, button_group):
+    """ Test Open url functionality of custom button.
+
+    Polarion:
+        assignee: ndhandre
+        initialEstimate: 1/2h
+        caseimportance: high
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.11
+        casecomponent: CustomButton
+        tags: custom_button
+        testSteps:
+            1. Create ruby method for url functionality
+            2. Create custom button group with the Object type
+            3. Create a custom button with open_url option and respective method
+            4. Navigate to object Detail page
+            5. Execute custom button
+            6. Check new tab open or not with respective url
+
+    Bugzilla:
+        1550002
+    """
+    pass

--- a/cfme/tests/automate/custom_button/test_infra_objects.py
+++ b/cfme/tests/automate/custom_button/test_infra_objects.py
@@ -419,7 +419,7 @@ def test_custom_button_expression_infra_obj(
 
 
 @pytest.mark.uncollectif(lambda button_group: "VM_INSTANCE" not in button_group)
-def test_open_url(request, setup_obj, button_group, method):
+def test_custom_button_open_url_infra_obj(request, setup_obj, button_group, method):
     """ Test Open url functionality of custom button.
 
     Polarion:

--- a/cfme/tests/automate/custom_button/test_infra_objects.py
+++ b/cfme/tests/automate/custom_button/test_infra_objects.py
@@ -438,7 +438,13 @@ def test_custom_button_open_url_infra_obj(request, setup_obj, button_group, meth
             4. Create a custom button with open_url option and respective method
             5. Navigate to object Detail page
             6. Execute custom button
-            7. Check new tab open or not with respective url
+        expectedResults:
+            1.
+            2.
+            3.
+            4.
+            5.
+            6. New tab should open with respective url
     """
 
     group, obj_type = button_group

--- a/cfme/tests/automate/custom_button/test_service_objects.py
+++ b/cfme/tests/automate/custom_button/test_service_objects.py
@@ -681,3 +681,30 @@ def test_custom_button_dialog_service_obj(
             assert False, "Expected {count} requests not found in automation log".format(
                 count=str(1)
             )
+
+
+@pytest.mark.manual
+def test_custom_button_open_url_service_obj(objects, button_group):
+    """ Test Open url functionality of custom button.
+
+    Polarion:
+        assignee: ndhandre
+        initialEstimate: 1/2h
+        caseimportance: high
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.11
+        casecomponent: CustomButton
+        tags: custom_button
+        testSteps:
+            1. Create ruby method for url functionality
+            2. Create custom button group with the Object type
+            3. Create a custom button with open_url option and respective method
+            4. Navigate to object Detail page
+            5. Execute custom button
+            6. Check new tab open or not with respective url
+
+    Bugzilla:
+        1550002
+    """
+    pass

--- a/cfme/tests/automate/custom_button/test_service_objects.py
+++ b/cfme/tests/automate/custom_button/test_service_objects.py
@@ -702,7 +702,12 @@ def test_custom_button_open_url_service_obj(objects, button_group):
             3. Create a custom button with open_url option and respective method
             4. Navigate to object Detail page
             5. Execute custom button
-            6. Check new tab open or not with respective url
+        expectedResults:
+            1.
+            2.
+            3.
+            4.
+            5. New tab should open with respective url
 
     Bugzilla:
         1550002


### PR DESCRIPTION
Signed-off-by: Nikhil Dhandre <ndhandre@redhat.com>

Purpose or Intent
=================
Previously only `VM` object supporting open url and new support going to be add in next release for now adding manual test.

- Added as per custom button test structure.... so as automate ids going to match with manual. 