### PR TITLE
[1LP][RFR] Make BZ references uniform

### DIFF
--- a/cfme/tests/ansible/test_embedded_ansible_basic.py
+++ b/cfme/tests/ansible/test_embedded_ansible_basic.py
@@ -338,6 +338,9 @@ def test_embedded_ansible_credential_with_private_key(request, wait_for_ansible,
     Adding new ssh credentials via Automation/Ansible/Credentials, add new credentials does not
     actually create new credentials with ssh keys.
 
+    Bugzilla:
+        1439589
+
     Polarion:
         assignee: sbulage
         casecomponent: Ansible

--- a/cfme/tests/ansible/test_embedded_ansible_manual.py
+++ b/cfme/tests/ansible/test_embedded_ansible_manual.py
@@ -173,7 +173,10 @@ def test_embed_tower_exec_play_stdout():
 @pytest.mark.tier(2)
 def test_embed_ansible_next_gen():
     """
-    Follow BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1511126
+    Follow BZ referenced below for test steps
+
+    Bugzilla:
+        1511126
 
     Polarion:
         assignee: sbulage
@@ -255,7 +258,9 @@ def test_embed_tower_ui_requests_notifications_negative():
     add a repo with the same name as a current repo and check the
     notifications display correctly. With a Red banner to show it was
     unsuccessful.
-    https://bugzilla.redhat.com/show_bug.cgi?id=1471868
+
+    Bugzilla:
+        1471868
 
     Polarion:
         assignee: sbulage
@@ -270,7 +275,9 @@ def test_embed_tower_ui_requests_notifications_negative():
 def test_embed_tower_repo_tag():
     """
     RBAC - tag Ansible repo and allow new user see only this repo.
-    https://bugzilla.redhat.com/show_bug.cgi?id=1526217
+
+    Bugzilla:
+        1526217
 
     Polarion:
         assignee: sbulage
@@ -365,7 +372,9 @@ def test_embed_tower_exec_play_against_openstack():
     """
     Execute playbook against Openstack provider.
     Workaround must be applied:
-    https://bugzilla.redhat.com/show_bug.cgi?id=1511017
+
+    Bugzilla:
+        1511017
 
     Polarion:
         assignee: sbulage
@@ -398,7 +407,9 @@ def test_embed_tower_ui_requests_notifications():
     After all processes are running and websockets role is enabled, add a
     new repo to embedded tower and check the notifications display
     correctly. With a Green banner to show it was successful.
-    https://bugzilla.redhat.com/show_bug.cgi?id=1471868
+
+    Bugzilla:
+        1471868
 
     Polarion:
         assignee: sbulage
@@ -540,7 +551,9 @@ def test_embed_ansible_catalog_items():
     """
     test adding new playbook catalogs and items to remote and global
     region
-    https://bugzilla.redhat.com/show_bug.cgi?id=1449696
+
+    Bugzilla:
+        1449696
 
     Polarion:
         assignee: sbulage
@@ -571,7 +584,9 @@ def test_embed_tower_add_private_repo():
 @pytest.mark.tier(3)
 def test_service_ansible_service_name():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1505929
+    Bugzilla:
+        1505929
+
     After creating the service using ansible playbook type add a new text
     field to service dialog named "service_name" and then use that service
     to order the service which will have a different name than the service
@@ -592,7 +607,9 @@ def test_embed_tower_repo_url_validation():
     """
     After all processes are running fill out a new repo with resolvable
     /un-resolvable url, use the validation button to check its correct.
-    https://bugzilla.redhat.com/show_bug.cgi?id=1478958
+
+    Bugzilla:
+        1478958
 
     Polarion:
         assignee: sbulage
@@ -606,7 +623,9 @@ def test_embed_tower_repo_url_validation():
 @pytest.mark.tier(1)
 def test_embed_tower_playbooks_tag():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1526218
+    Bugzilla:
+        1526218
+
     RBAC - tag playbooks and allow user to see just this taged playbook.
 
     Polarion:
@@ -687,7 +706,9 @@ def test_embed_tower_add_machine_credentials_machine_root_pass():
 @pytest.mark.tier(1)
 def test_embed_tower_creds_tag():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1526219
+    Bugzilla:
+        1526219
+
     RBAC - tag credentials and allow new user see just this credential.
 
     Polarion:
@@ -702,7 +723,9 @@ def test_embed_tower_creds_tag():
 @pytest.mark.tier(2)
 def test_embed_tower_order_service_extra_vars():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1444831
+    Bugzilla:
+        1444831
+
     Execute playbook with extra variables which will be passed to Tower.
 
     Polarion:
@@ -717,7 +740,8 @@ def test_embed_tower_order_service_extra_vars():
 @pytest.mark.tier(3)
 def test_service_ansible_playbook_with_already_existing_catalog_item_name():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1509809
+    Bugzilla:
+        1509809
 
     Polarion:
         assignee: sbulage
@@ -749,8 +773,10 @@ def test_service_ansible_verbosity():
 @pytest.mark.tier(3)
 def test_service_ansible_playbook_cloud_credentials():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1444092When the service is
-    viewed in my services it should also show that the cloud credentials
+    Bugzilla:
+        1444092
+
+    When the service is viewed in my services it should also show that the cloud credentials
     were attached to the service.
 
     Polarion:
@@ -783,8 +809,10 @@ def test_service_ansible_playbook_order_credentials_usecredsfromservicedialog():
 @pytest.mark.tier(3)
 def test_service_ansible_playbook_machine_credentials_service_details_opsui():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1515561  When the service
-    is viewed in my services it should also show that the cloud and
+    Bugzilla:
+        1515561
+
+    When the service is viewed in my services it should also show that the cloud and
     machine credentials were attached to the service.
 
     Polarion:
@@ -800,8 +828,10 @@ def test_service_ansible_playbook_machine_credentials_service_details_opsui():
 @pytest.mark.tier(3)
 def test_service_ansible_playbook_machine_credentials_service_details_sui():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1540689  When the service
-    is viewed in my services it should also show that the cloud and
+    Bugzilla:
+        1540689
+
+    When the service is viewed in my services it should also show that the cloud and
     machine credentials were attached to the service.
 
     Polarion:
@@ -817,8 +847,10 @@ def test_service_ansible_playbook_machine_credentials_service_details_sui():
 @pytest.mark.tier(3)
 def test_custom_button_order_ansible_playbook_service():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1449361 An Ansible Service
-    Playbook can be ordered from a Custom Button
+    Bugzilla:
+        1449361
+
+    An Ansible Service Playbook can be ordered from a Custom Button
 
     Polarion:
         assignee: sbulage
@@ -833,10 +865,11 @@ def test_custom_button_order_ansible_playbook_service():
 @pytest.mark.tier(3)
 def test_service_ansible_overridden_extra_vars():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1444107Once a Ansible
-    Playbook Service Dialog is built, it has default parameters, which can
-    be overridden at "ordering" time. Check if the overridden parameters
-    are passed.
+    Bugzilla:
+        1444107
+
+    Once a Ansible Playbook Service Dialog is built, it has default parameters, which can
+    be overridden at "ordering" time. Check if the overridden parameters are passed.
 
     Polarion:
         assignee: sbulage
@@ -851,7 +884,11 @@ def test_service_ansible_overridden_extra_vars():
 @pytest.mark.tier(3)
 def test_service_ansible_linked_vms_opsui_sui():
     """
-    Associated with BZhttps://bugzilla.redhat.com/show_bug.cgi?id=1510797
+    Associated with BZ
+
+    Bugzilla:
+        1510797
+
     Please follow the steps below to recreate the scenario: 1. Enable
     Embedded Ansible role.
     2. Wait until it will be enabled.
@@ -888,7 +925,9 @@ def test_service_ansible_linked_vms_opsui_sui():
 def test_service_ansible_playbook_standard_output_non_ascii_hostname():
     """
     Look for Standard ouptut
-    https://bugzilla.redhat.com/show_bug.cgi?id=1534039
+
+    Bugzilla:
+        1534039
 
     Polarion:
         assignee: sbulage
@@ -920,7 +959,10 @@ def test_service_ansible_playbook_retire_non_ascii():
 @pytest.mark.tier(3)
 def test_automate_ansible_playbook_method_type_verbosity():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1542665
+
+    Bugzilla:
+        1542665
+
     Check if ansible playbook method  can work with different verbosity
     levels.
 

--- a/cfme/tests/ansible/test_embedded_ansible_services.py
+++ b/cfme/tests/ansible/test_embedded_ansible_services.py
@@ -539,6 +539,9 @@ def test_custom_button_ansible_credential_list(custom_service_button, service_ca
 def test_ansible_group_id_in_payload(service_catalog, service_request, service):
     """Test if group id is presented in manageiq payload.
 
+    Bugzilla:
+        1480019
+
     In order to get manageiq payload the service's standard output should be parsed.
 
     Bugzilla:

--- a/cfme/tests/automate/custom_button/test_buttons.py
+++ b/cfme/tests/automate/custom_button/test_buttons.py
@@ -126,7 +126,8 @@ def test_button_crud(appliance, dialog, request, buttongroup, obj_type):
             6. Assert that the button no longer exists.
 
     Bugzilla:
-        1143019, 1205235
+        1143019
+        1205235
     """
     button_gp = buttongroup(obj_type)
     button = button_gp.buttons.create(
@@ -171,7 +172,8 @@ def test_button_avp_displayed(appliance, dialog, request):
             2. Locate the section with attribute/value pairs.
 
     Bugzilla:
-        1229348, 1460774
+        1229348
+        1460774
     """
     # This is optional, our nav tree does not have unassigned button
     buttongroup = appliance.collections.button_groups.create(

--- a/cfme/tests/automate/custom_button/test_catalog_custom_button.py
+++ b/cfme/tests/automate/custom_button/test_catalog_custom_button.py
@@ -23,7 +23,7 @@ def test_custom_group_on_catalog_item_crud(generic_catalog_item):
             3. Fill info and save button
             4. Delete created button group
     Bugzilla:
-        * 1687289
+        1687289
     """
 
     btn_data = {

--- a/cfme/tests/automate/custom_button/test_cloud_objects.py
+++ b/cfme/tests/automate/custom_button/test_cloud_objects.py
@@ -172,7 +172,10 @@ def test_custom_button_dialog_cloud_obj(appliance, dialog, request, setup_objs, 
             8. Check for the proper flash message related to button execution
 
     Bugzilla:
-        1635797, 1555331, 1574403, 1640592
+        1635797
+        1555331
+        1574403
+        1640592
     """
 
     group, obj_type = button_group
@@ -247,7 +250,8 @@ def test_custom_button_automate_cloud_obj(appliance, request, submit, setup_objs
             9 One by one: separate requests for all entities execution
 
     Bugzilla:
-        1628224, 1642147
+        1628224
+        1642147
     """
 
     group, obj_type = button_group

--- a/cfme/tests/automate/custom_button/test_infra_objects.py
+++ b/cfme/tests/automate/custom_button/test_infra_objects.py
@@ -298,7 +298,12 @@ def test_custom_button_dialog_infra_obj(appliance, dialog, request, setup_obj, b
             7. Check for the proper flash message related to button execution
 
     Bugzilla:
-        1635797, 1555331, 1574403, 1640592, 1641669, 1685555
+        1635797
+        1555331
+        1574403
+        1640592
+        1641669
+        1685555
     """
 
     group, obj_type = button_group

--- a/cfme/tests/automate/custom_button/test_service_objects.py
+++ b/cfme/tests/automate/custom_button/test_service_objects.py
@@ -397,7 +397,8 @@ def test_custom_button_expression_service_obj(
             5. Check: button should enable/visible with tag
 
     Bugzilla:
-        1509959, 1513498
+        1509959
+        1513498
     """
 
     # ToDo: Add support for Generic Object by adding tagging ability from All page.
@@ -522,8 +523,11 @@ def test_custom_button_on_vm_resource_detail(context):
             7. Check for the flash message "Order Request was Submitted" and
                check automation log for the request (Note request as per method attach to button in
                step-1).
+
     Bugzilla:
-        1427430, 1450473, 1454910
+        1427430
+        1450473
+        1454910
     """
     pass
 

--- a/cfme/tests/automate/test_domain.py
+++ b/cfme/tests/automate/test_domain.py
@@ -281,7 +281,8 @@ def test_object_attribute_type_in_automate_schedule(appliance):
             5. No pop-up window with Internal Server Error.
 
     Bugzilla:
-         1479570, 1686762
+         1479570
+         1686762
     """
     view = navigate_to(appliance.collections.system_schedules, 'Add')
     view.form.action_type.select_by_visible_text('Automation Tasks')

--- a/cfme/tests/automate/test_service_dialog.py
+++ b/cfme/tests/automate/test_service_dialog.py
@@ -354,7 +354,8 @@ def test_mandatory_entry_point_with_dynamic_element(appliance):
 @pytest.mark.tier(1)
 def test_copying_customization_dialog():
     """
-    BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1342260
+    Bugzilla:
+        1342260
 
     Polarion:
         assignee: anikifor

--- a/cfme/tests/automate/test_vmware_methods.py
+++ b/cfme/tests/automate/test_vmware_methods.py
@@ -86,8 +86,9 @@ def test_vmware_vimapi_hotadd_disk(
             3. After the button is created, it goes to a VM's summary page, clicks the button.
             4. The test waits until the capacity of disks is raised.
 
-    Bugzillas:
-        1211627, 1311221
+    Bugzilla:
+        1211627
+        1311221
     """
     meth = cls.methods.create(
         name='load_value_{}'.format(fauxfactory.gen_alpha()),

--- a/cfme/tests/candu/__init__.py
+++ b/cfme/tests/candu/__init__.py
@@ -38,7 +38,8 @@ def compare_data_with_unit(table_data, graph_data, legends, tolerance=1):
     Note: Mainly, when we check graph for some tag the unit in table reading missing. The unit
         conversion totally depends on manual observation.
 
-    BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1367560
+    Bugzilla:
+        1367560
     """
     for row in table_data:
         for key, data in graph_data.items():

--- a/cfme/tests/candu/test_graph_groupbytag.py
+++ b/cfme/tests/candu/test_graph_groupbytag.py
@@ -53,8 +53,8 @@ def test_tagwise(candu_db_restore, interval, graph_type, gp_by, host):
         * Check tag assigned to VM available in chart legends
         * Compare table and graph data
 
-    Bugzillas:
-        * 1367560
+    Bugzilla:
+        1367560
 
     Polarion:
         assignee: nachandr

--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -834,7 +834,9 @@ def test_appliance_console_check_default_ip():
 def test_appliance_ssl():
     """
     Test ssl connections to postgres database from other appliances.
-    https://bugzilla.redhat.com/show_bug.cgi?id=1482697
+
+    Bugzilla:
+        1482697
 
     Polarion:
         assignee: sbulage
@@ -877,7 +879,9 @@ def test_appliance_console_restore_ha_standby_node():
 def test_appliance_console_cancel():
     """
     Test option to navigate back from all submenus in appliance_console
-    https://bugzilla.redhat.com/show_bug.cgi?id=1438844
+
+    Bugzilla:
+        1438844
 
     Polarion:
         assignee: sbulage
@@ -924,7 +928,9 @@ def test_appliance_console_network_conf_negative():
 def test_appliance_console_vmdb_httpd():
     """
     check that httpd starts after restarting vmdb
-    https://bugzilla.redhat.com/show_bug.cgi?id=1337525
+
+    Bugzilla:
+        1337525
 
     Polarion:
         assignee: sbulage
@@ -1066,7 +1072,9 @@ def test_appliance_console_extend_storage_negative():
 def test_appliance_console_static_dns():
     """
     test setting secondary dns and check it"s saved as the new default
-    https://bugzilla.redhat.com/show_bug.cgi?id=1439348
+
+    Bugzilla:
+        1439348
 
     Polarion:
         assignee: sbulage

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -396,7 +396,9 @@ def test_openstack_provider_has_api_version(appliance):
 
 def test_openstack_provider_has_dashboard(appliance, openstack_provider):
     """Check whether dashboard view is available for Openstack provider
-    https://bugzilla.redhat.com/show_bug.cgi?id=1487142
+
+    Bugzilla:
+        1487142
 
     Polarion:
         assignee: anikifor
@@ -516,20 +518,20 @@ def test_cloud_names_grid_floating_ips(appliance, ec2_provider, soft_assert):
 @pytest.mark.tier(3)
 def test_display_network_topology(appliance, openstack_provider):
     """
-        Bugzilla:
-            1343553
-
-        Steps to Reproduce:
-        1. Add RHOS undercloud provider
-        2. Make sure it has no floating IPs
-        3. Go to Networks -> Topology
-        4. Topology should be shown without errors.
+    Bugzilla:
+        1343553
 
     Polarion:
         assignee: anikifor
         casecomponent: WebUI
         caseimportance: medium
         initialEstimate: 1/8h
+        testSteps:
+            1. Add RHOS undercloud provider
+            2. Make sure it has no floating IPs
+            3. Go to Networks -> Topology
+            4. Topology should be shown without errors.
+
     """
     floating_ips_collection = appliance.collections.network_floating_ips
     view = navigate_to(floating_ips_collection, "All")

--- a/cfme/tests/cloud/test_tenant.py
+++ b/cfme/tests/cloud/test_tenant.py
@@ -148,7 +148,8 @@ def test_dynamic_product_feature_for_tenant_quota(request, appliance, new_tenant
                  other tenants quota.
 
     Bugzilla:
-        1655012, 1468795
+        1655012
+        1468795
     """
     user_ = []
     role_ = []

--- a/cfme/tests/cloud_infra_common/test_policy_simulation.py
+++ b/cfme/tests/cloud_infra_common/test_policy_simulation.py
@@ -31,8 +31,13 @@ pytestmark = [
 )
 def test_policy_simulation_ui(appliance, provider, navigation):
     """
-    Bugzillas:
-        * 1670456, 1686617, 1686619, 1688359, 1550503
+    Bugzilla:
+        1670456
+        1686617
+        1686619
+        1688359
+        1550503
+
     Polarion:
         assignee: jdupuy
         casecomponent: Control

--- a/cfme/tests/cloud_infra_common/test_provisioning_manual.py
+++ b/cfme/tests/cloud_infra_common/test_provisioning_manual.py
@@ -42,7 +42,10 @@ def test_provision_request_approved_msg():
 def test_none_public_ip_provision_azure():
     """
     Testing provision w/o public IP - to cover -
-    https://bugzilla.redhat.com/show_bug.cgi?id=1497202
+
+    Bugzilla:
+        1497202
+
     1.Provision VM
     2.Verify we don"t have public IP
 
@@ -144,7 +147,10 @@ def test_provision_with_storage_profile_vsphere():
 def test_vm_placement_with_duplicated_folder_name_vmware():
     """
     This testcase is related to -
-    https://bugzilla.redhat.com/show_bug.cgi?id=1414136
+
+    Bugzilla:
+        1414136
+
     Description of problem:
     Duplicate folder names between host & vm/templates causes placement
     issues
@@ -167,7 +173,9 @@ def test_vm_placement_with_duplicated_folder_name_vmware():
 @pytest.mark.tier(1)
 def test_multiple_vm_provision_with_public_ip_azure():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1531275
+    Bugzilla:
+        1531275
+
     Wait for BZ to get resolved first. Design solution still wasn"t made
     "This isn"t a dup of the other ticket, as the distinction is single vs
     multiple VM"s. So, what we need to do is alter the UI to allow two
@@ -213,6 +221,9 @@ def test_provision_image_managed_azure():
     See RFE - https://bugzilla.redhat.com/show_bug.cgi?id=1452227
     See Create Manage Image - https://docs.microsoft.com/en-us/azure
     /virtual-machines/windows/capture-image-resource Section 1
+
+    Bugzilla:
+        1452227
 
     Polarion:
         assignee: jhenner
@@ -299,7 +310,9 @@ def test_provision_host_maintenancemode_scvmm():
 @pytest.mark.tier(1)
 def test_service_provision_managed_image_azure():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1470491
+    Bugzilla:
+        1470491
+
     1. Provision Service using azure managed disk/image
 
     Polarion:
@@ -334,7 +347,9 @@ def test_admin_username_azure():
 @pytest.mark.tier(2)
 def test_create_provisioning_dialog_without_dialog_type():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1344080
+    Bugzilla:
+        1344080
+
     Create provision dialog without selecting dialog type
     Automate - Customization - Provisioning dialog
     Configuration - Add a new dialog
@@ -359,7 +374,9 @@ def test_create_provisioning_dialog_without_dialog_type():
 @pytest.mark.tier(2)
 def test_auto_placement_provision_to_dvswitch_vlan_vmware():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1467399
+    Bugzilla:
+        1467399
+
     Description of problem: issue appeared after 1458363
     Auto_placement provision into DVS vlan fails with Error "Destination
     placement_ds_name not provided]" if provider Network with the same

--- a/cfme/tests/cloud_infra_common/test_quota_manual.py
+++ b/cfme/tests/cloud_infra_common/test_quota_manual.py
@@ -284,7 +284,8 @@ def test_quota_with_invalid_service_request():
                Q-task_id([miq_provision_787])"
 
     Bugzilla:
-        1534589, 1531914
+        1534589
+        1531914
     """
     pass
 
@@ -322,8 +323,8 @@ def test_simultaneous_tenant_quota():
                are cancelled
 
     Bugzilla:
-        1456819, 1401251
-
+        1456819
+        1401251
     """
     pass
 

--- a/cfme/tests/cloud_infra_common/test_relationships.py
+++ b/cfme/tests/cloud_infra_common/test_relationships.py
@@ -324,7 +324,8 @@ def test_host_refresh_relationships(provider, setup_provider):
 @pytest.mark.tier(1)
 def test_inventory_refresh_westindia_azure():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1473619
+    Bugzilla:
+        1473619
 
     Polarion:
         assignee: anikifor

--- a/cfme/tests/cloud_infra_common/test_vm_instance_analysis_manual.py
+++ b/cfme/tests/cloud_infra_common/test_vm_instance_analysis_manual.py
@@ -41,6 +41,9 @@ def test_ssa_datastore_files_unicode():
     """
     Make sure https://bugzilla.redhat.com/show_bug.cgi?id=1221149 is fixed
 
+    Bugzilla:
+        1221149
+
     Polarion:
         assignee: sbulage
         casecomponent: SmartState
@@ -836,7 +839,9 @@ def test_ssa_vm_azure_region():
     """
     1. Add an Azure Instance in one region and assign it to a Resource
     Group from another region.
-    BZ link: https://bugzilla.redhat.com/show_bug.cgi?id=1503295
+
+    Bugzilla:
+        1503295
 
     Polarion:
         assignee: sbulage
@@ -920,7 +925,9 @@ def test_ssa_vm_ec2_rhel():
     Perform SSA on RHEL instance.
     Cross-check whether smartstate instance created from AMI mentioned in
     production.yml.
-    BZ:https://bugzilla.redhat.com/show_bug.cgi?id=1547228
+
+    Bugzilla:
+        1547228
 
     Polarion:
         assignee: sbulage
@@ -934,7 +941,8 @@ def test_ssa_vm_ec2_rhel():
 
 def test_ssa_vm_ec2_agent_tracker():
     """
-    BZ link:  https://bugzilla.redhat.com/show_bug.cgi?id=1557452
+    Bugzilla:
+        1557452
 
     Polarion:
         assignee: sbulage
@@ -1198,7 +1206,8 @@ def test_ssa_vm_cancel_task():
     """
     Start SSA on VM and wait snapshot to create.
     Cancel the task immediately.
-    BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1538347
+    Bugzilla:
+        1538347
 
     Polarion:
         assignee: sbulage
@@ -1264,7 +1273,9 @@ def test_ssa_vm_ec2_vpc():
     3. Turn on "DNS resolution", "DNS hostname" to "yes";
     4. Deploy an agent on this VPC;
     5. Run SSA job;
-    BZ link: https://bugzilla.redhat.com/show_bug.cgi?id=1557377
+
+    Bugzilla:
+        1557377
 
     Polarion:
         assignee: sbulage
@@ -1824,6 +1835,9 @@ def test_ssa_with_snapshot_scvmm2():
     test.
     I"ll do these one off tests for a while.
 
+    Bugzilla:
+        1376172
+
     Polarion:
         assignee: sbulage
         casecomponent: SmartState
@@ -2109,6 +2123,9 @@ def test_ssa_files_azure_rhel():
 def test_ssa_vm_files_unicode():
     """
     Make sure https://bugzilla.redhat.com/show_bug.cgi?id=1221149 is fixed
+
+    Bugzilla:
+        1221149
 
     Polarion:
         assignee: sbulage

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -1752,7 +1752,9 @@ def test_superadmin_child_tenant_delete_parent_catalog(appliance, group_collecti
     You"re able to see Catalog items of parent and ancestor tenants.  If
     your role has permission to modify catalog items / delete them, and
     you can to see ones from ancestor tenants, then you can delete them.
-    https://bugzilla.redhat.com/show_bug.cgi?id=1375713
+
+    Bugzilla:
+        1375713
 
     Polarion:
         assignee: mnadeem

--- a/cfme/tests/configure/test_config_manual.py
+++ b/cfme/tests/configure/test_config_manual.py
@@ -10,7 +10,8 @@ from cfme import test_requirements
 @pytest.mark.tier(3)
 def test_validate_landing_pages_for_rbac():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1450012
+    Bugzilla:
+        1450012
 
     Polarion:
         assignee: pvala

--- a/cfme/tests/configure/test_log_depot_operation_manual.py
+++ b/cfme/tests/configure/test_log_depot_operation_manual.py
@@ -195,7 +195,9 @@ def test_log_collect_current_zone_all_unconfigured():
 def test_log_collection_via_ftp_over_ipv6():
     """
     Bug 1452224 - Log Collection fails via IPv6
-    https://bugzilla.redhat.com/show_bug.cgi?id=1452224
+
+    Bugzilla:
+        1452224
 
     An IPv6 FTP server can be validated for log collection, and log
     collection succeeds.

--- a/cfme/tests/configure/test_region.py
+++ b/cfme/tests/configure/test_region.py
@@ -22,7 +22,8 @@ def test_empty_region_description(appliance):
 def test_description_change(appliance, request):
     """Test changing region description
 
-    BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1350808
+    Bugzilla:
+        1350808
 
     Polarion:
         assignee: jhenner

--- a/cfme/tests/configure/test_tag.py
+++ b/cfme/tests/configure/test_tag.py
@@ -122,7 +122,8 @@ def test_updated_tag_name_on_vm(provider, tag, request):
     This test checks that tags don't disappear from the UI after their name (not displayed name) is
     changed.
 
-    https://bugzilla.redhat.com/show_bug.cgi?id=1668730
+    Bugzilla:
+        1668730
 
     Polarion:
         assignee: anikifor

--- a/cfme/tests/configure/test_visual_infra.py
+++ b/cfme/tests/configure/test_visual_infra.py
@@ -388,7 +388,8 @@ def test_change_truncate_long_text_save_button_enabled(appliance):
         This test checks if setting long_text enables the save button
         and if it is saved successfully
 
-        BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1650461
+    Bugzilla:
+        1650461
 
     Polarion:
         assignee: pvala

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -425,7 +425,9 @@ def test_action_prevent_ssa(request, appliance, configure_fleecing, vm, vm_on, p
     """Tests preventing Smart State Analysis.
 
     This test sets the policy that prevents VM analysis.
-    https://bugzilla.redhat.com/show_bug.cgi?id=1433084
+
+    Bugzilla:
+        1433084
 
     Metadata:
         test_flag: actions, provision
@@ -456,7 +458,9 @@ def test_action_prevent_host_ssa(request, appliance, host, host_policy):
     """Tests preventing Smart State Analysis on a host.
 
     This test sets the policy that prevents host analysis.
-    https://bugzilla.redhat.com/show_bug.cgi?id=1437910
+
+    Bugzilla:
+        1437910
 
     Metadata:
         test_flag: actions, provision
@@ -859,6 +863,9 @@ def test_action_cancel_clone(appliance, request, provider, vm_name, vm_big, poli
     """This test checks if 'Cancel vCenter task' action works.
     For this test we need big template otherwise CFME won't have enough time
     to cancel the task https://bugzilla.redhat.com/show_bug.cgi?id=1383372#c9
+
+    Bugzilla:
+        1383372
 
     Polarion:
         assignee: jdupuy

--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -370,6 +370,9 @@ def test_alert_hardware_reconfigured(request, appliance, configure_fleecing, smt
     depending on what has been done in your step 2, not the result of step 4. Step 4 is just to
     trigger the event.
 
+    Bugzilla:
+        1396544
+
     Metadata:
         test_flag: alerts, provision
 

--- a/cfme/tests/control/test_control_simulation.py
+++ b/cfme/tests/control/test_control_simulation.py
@@ -25,8 +25,9 @@ FILL_DATA = {
 @pytest.mark.tier(1)
 def test_control_icons_simulation(appliance):
     """
-    Bugzillas:
-        * 1349147, 1690572
+    Bugzilla:
+        1349147
+        1690572
 
     Polarion:
         assignee: jdupuy

--- a/cfme/tests/infrastructure/test_scvmm_specific.py
+++ b/cfme/tests/infrastructure/test_scvmm_specific.py
@@ -72,7 +72,9 @@ def test_template_info_scvmm():
 @pytest.mark.tier(1)
 def test_vm_mac_scvmm():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1514461
+    Bugzilla:
+        1514461
+
     Test case covers this BZ - we can"t get MAC ID of VM at the moment
 
     Polarion:
@@ -186,7 +188,9 @@ def test_host_info_scvmm2016():
 @pytest.mark.tier(1)
 def test_check_disk_allocation_size_scvmm():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1490440
+    Bugzilla:
+        1490440
+
     Steps to Reproduce:
     1.Provision VM and check it"s "Total Datastore Used Space"
     2.go to VMM and create Vm"s Checkpoint
@@ -209,7 +213,9 @@ def test_vm_volume_specchar1_scvmm():
     Special Test to verify that VMs that have Volumes with no drive letter
     assigned don"t cause systemic SCVMM provider errors.  This is a low
     priority test.
-    https://bugzilla.redhat.com/show_bug.cgi?id=1353285
+
+    Bugzilla:
+        1353285
 
     Polarion:
         assignee: jdupuy

--- a/cfme/tests/infrastructure/test_vm_reconfigure.py
+++ b/cfme/tests/infrastructure/test_vm_reconfigure.py
@@ -359,8 +359,8 @@ def test_reconfigure_vm_vmware_mem_multiple():
 def test_vm_reconfig_attach_iso_vsphere67_nested():
     """
 
-    Bugzillas:
-        * 1533728
+    Bugzilla:
+        1533728
 
     Polarion:
         assignee: nansari
@@ -446,7 +446,7 @@ def test_reconfigure_add_disk_cold():
     """ Test adding 16th disk to test how a new scsi controller is handled.
 
     Bugzilla:
-        * 1337310
+        1337310
 
     Polarion:
         assignee: nansari
@@ -471,7 +471,7 @@ def test_reconfigure_add_disk_cold_controller_sas():
     """
 
     Bugzilla:
-        * 1445874
+        1445874
 
     Polarion:
         assignee: nansari

--- a/cfme/tests/infrastructure/test_vmware_provider.py
+++ b/cfme/tests/infrastructure/test_vmware_provider.py
@@ -82,7 +82,7 @@ def test_vmware_guests_linked_clone():
     Ideally they shouldn't mark them all as linked_clone=t
 
     Bugzilla:
-        * 1588908
+        1588908
 
     Polarion:
         assignee: kkulkarn
@@ -115,7 +115,7 @@ def test_vmware_reconfigure_vm_controller_type():
     Controller Type should be listed.
 
     Bugzilla:
-        * 1650441
+        1650441
 
     Polarion:
         assignee: kkulkarn
@@ -173,7 +173,7 @@ def test_vmware_inaccessible_datastore():
     VMware sometimes has datastores that are inaccessible, and CloudForms should indicate that.
 
     Bugzilla:
-        * 1684656
+        1684656
 
     Polarion:
         assignee: kkulkarn
@@ -200,7 +200,7 @@ def test_vmware_cdrom_dropdown_not_blank():
     Test CD/DVD Drives dropdown lists ISO files, dropdown is not blank
 
     Bugzilla:
-        * 1689369
+        1689369
 
     Polarion:
         assignee: kkulkarn
@@ -232,7 +232,7 @@ def test_vmware_inaccessible_datastore_vm_provisioning():
     during provisioning when using "Choose Automatically" as an option under environment tab.
 
     Bugzilla:
-        * 1694137
+        1694137
 
     Polarion:
         assignee: kkulkarn
@@ -260,7 +260,7 @@ def test_vmware_provisioned_vm_host_relationship():
     VMware VMs provisioned through cloudforms should have host relationship.
 
     Bugzilla:
-        * 1657341
+        1657341
 
     Polarion:
         assignee: kkulkarn

--- a/cfme/tests/intelligence/reports/test_reports_manual.py
+++ b/cfme/tests/intelligence/reports/test_reports_manual.py
@@ -10,7 +10,10 @@ from cfme import test_requirements
 @pytest.mark.tier(1)
 def test_reports_should_generate_with_no_errors_in_logs():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1592480#c21
+    Bugzilla:
+        1592480
+
+    See comment 21 of BZ above
 
     Polarion:
         assignee: pvala
@@ -42,7 +45,8 @@ def test_reports_should_generate_with_no_errors_in_logs():
 @pytest.mark.tier(1)
 def test_reports_generate_persistent_volumes():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1563861
+    Bugzilla:
+        1563861
 
     Polarion:
         assignee: pvala
@@ -92,7 +96,8 @@ def test_reports_import_invalid_file():
 @pytest.mark.tier(1)
 def test_reports_generate_custom_conditional_filter_report():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1521167
+    Bugzilla:
+        1521167
 
     Polarion:
         assignee: pvala
@@ -188,7 +193,8 @@ def test_reports_create_schedule_for_base_report_one_time_a_day():
 @pytest.mark.tier(1)
 def test_after_setting_certain_types_of_filters_filter_tab_should_be_accessible_and_editable():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1519809
+    Bugzilla:
+        1519809
 
     Polarion:
         assignee: pvala
@@ -218,7 +224,8 @@ def test_after_setting_certain_types_of_filters_filter_tab_should_be_accessible_
 @pytest.mark.tier(1)
 def test_date_should_be_change_in_editing_reports_scheduled():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1446052
+    Bugzilla:
+        1446052
 
     Polarion:
         assignee: pvala
@@ -245,7 +252,8 @@ def test_date_should_be_change_in_editing_reports_scheduled():
 @pytest.mark.tier(1)
 def test_report_export_import_run_custom_report():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1498471
+    Bugzilla:
+        1498471
 
     Polarion:
         assignee: pvala
@@ -297,7 +305,8 @@ def test_reports_create_schedule_for_base_report_hourly():
 @pytest.mark.tier(1)
 def test_report_secondary_display_filter_should_be_editable():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1565171
+    Bugzilla:
+        1565171
 
     Polarion:
         assignee: pvala
@@ -374,7 +383,8 @@ def test_import_export_report():
 @pytest.mark.tier(1)
 def test_reports_manage_report_menu_accordion_with_users():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1535023
+    Bugzilla:
+        1535023
 
     Polarion:
         assignee: pvala
@@ -498,7 +508,8 @@ def test_sent_text_custom_report_with_long_condition():
         expectedResults:
             1. There should be no error in the log and report must be sent successfully.
 
-    Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1677839
+    Bugzilla:
+        1677839
     """
     pass
 
@@ -522,7 +533,8 @@ def test_vm_volume_free_space_less_than_20_percent():
             1. It should report only those VMs which has volume free space less than
                 or equal to 20%.
 
-    Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1686281
+    Bugzilla:
+        1686281
     """
     pass
 
@@ -548,7 +560,8 @@ def test_reports_filter_content():
             1.
             2. Content must be filtered.
 
-    Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1678150
+    Bugzilla:
+        1678150
     """
     pass
 
@@ -577,6 +590,7 @@ def test_reports_sort_column():
             2.
             3. Both the orders must be same.
 
-    Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1678150
+    Bugzilla:
+        1678150
     """
     pass

--- a/cfme/tests/intelligence/test_timelines_rss_removed.py
+++ b/cfme/tests/intelligence/test_timelines_rss_removed.py
@@ -11,8 +11,8 @@ def test_timelines_removed(appliance):
     Test that Cloud Intel->Timelines have been removed in upstream and 5.11 builds.
     Designed to pass for CFME 5.10.
 
-    Bugzillas:
-        * 1672933
+    Bugzilla:
+        1672933
 
     Polarion:
         assignee: jdupuy
@@ -33,8 +33,8 @@ def test_rss_removed(appliance):
     Test that Cloud Intel->RSS has been removed in upstream and 5.11 builds.
     Designed to pass for CFME 5.10.
 
-    Bugzillas:
-        * 1672933
+    Bugzilla:
+        1672933
 
     Polarion:
         assignee: jdupuy

--- a/cfme/tests/networks/test_sdn_downloads.py
+++ b/cfme/tests/networks/test_sdn_downloads.py
@@ -96,7 +96,8 @@ def test_download_pdf_summary(appliance, collection_type, provider):
 @pytest.mark.tier(1)
 def test_pdf_summary_infra_provider():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1651194
+    Bugzilla:
+        1651194
 
     Polarion:
         assignee: anikifor

--- a/cfme/tests/services/test_catalog_item.py
+++ b/cfme/tests/services/test_catalog_item.py
@@ -390,7 +390,8 @@ def test_copy_catalog_item():
             1. Create catalog and catalog item
             2. Make a copy of catalog item
 
-    Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1678149
+    Bugzilla:
+        1678149
     """
     pass
 
@@ -410,6 +411,7 @@ def test_service_select_tenants():
             2. Create catalog item with tenants
             3. login with tenant and check the services
 
-    Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1678123
+    Bugzilla:
+        1678123
     """
     pass

--- a/cfme/tests/services/test_dynamicdd_dialogelement.py
+++ b/cfme/tests/services/test_dynamicdd_dialogelement.py
@@ -203,7 +203,6 @@ def test_expression_method_definitions_should_not_fail_with_script_error_in_a_di
 @pytest.mark.tier(3)
 def test_dialog_text_box_triggers_fields_shouldnt_refresh_too_soon_often():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1614321
     Polarion:
         assignee: nansari
         casecomponent: Services
@@ -334,12 +333,12 @@ def test_second_dialog_dynamic_element_should_be_able_to_read_the_previous_textb
 @pytest.mark.tier(1)
 def test_automation_executed_on_field_refresh_are_called_twice_in_self_service_dialogs():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1576873
     Polarion:
         assignee: nansari
         casecomponent: Services
         testtype: functional
         initialEstimate: 1/4h
+
     Bugzilla:
         1576873
     """

--- a/cfme/tests/services/test_generic_service_catalogs.py
+++ b/cfme/tests/services/test_generic_service_catalogs.py
@@ -285,6 +285,7 @@ def test_copy_catalog_bundle():
             2. Create catalog bundle
             3. Make a copy of catalog bundle
 
-    Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1678149
+    Bugzilla:
+        1678149
     """
     pass

--- a/cfme/tests/services/test_myservice.py
+++ b/cfme/tests/services/test_myservice.py
@@ -200,6 +200,7 @@ def test_service_state():
             2. Order the catalog item
             3. Go to My services and check service state
 
-    Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1678123
+    Bugzilla:
+        1678123
     """
     pass

--- a/cfme/tests/services/test_provision_stack.py
+++ b/cfme/tests/services/test_provision_stack.py
@@ -281,7 +281,9 @@ def test_error_message_azure():
     field.  Users will no longer have to drill down to Stack/Resources to
     figure out the error.
     This is currently working correctly as of 5.8.0.12
-    https://bugzilla.redhat.com/show_bug.cgi?id=1410794
+
+    Bugzilla:
+        1410794
 
     Polarion:
         assignee: anikifor

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -319,7 +319,7 @@ class TestServiceRESTAPI(object):
             test_flag: rest
 
         Bugzilla:
-            * 1414852
+            1414852
 
         Polarion:
             assignee: nansari
@@ -944,7 +944,7 @@ class TestServiceTemplateRESTAPI(object):
             test_flag: rest
 
         Bugzilla:
-            * 1427338
+            1427338
 
         Polarion:
             assignee: nansari

--- a/cfme/tests/test_appliance.py
+++ b/cfme/tests/test_appliance.py
@@ -291,6 +291,7 @@ def test_appliance_console_packages(appliance):
 def test_appliance_chrony_conf():
     """
     check that iburst exists within /etc/chrony.conf.
+
     Bugzilla:
         1308606
 
@@ -393,6 +394,7 @@ def test_appliance_replicate_database_disconnection():
 def test_appliance_log_error():
     """
     check logs for errors such as
+
     Bugzilla:
         1392087
 

--- a/cfme/tests/test_db_migrate_manual.py
+++ b/cfme/tests/test_db_migrate_manual.py
@@ -11,12 +11,12 @@ def test_upgrade_dedicated_db_migration_local():
     Test that you can locally migrate a dedicated database after upgrade.
     Previously it was missing the database.yml during setup with would
     case the rake task to fail.
+
     Bugzilla:
         1478986
         1561075
         1590846
         1578957
-
 
     Polarion:
         assignee: jhenner
@@ -114,7 +114,9 @@ def test_upgrade_custom_css():
 @pytest.mark.tier(2)
 def test_upgrade_custom_widgets():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1375313
+    Bugzilla:
+        1375313
+
     Upgrade appliance with custom widgets added
 
     Polarion:
@@ -142,7 +144,8 @@ def test_upgrade_custom_widgets():
 def test_rh_rhsm_sat6_cred_save_crud():
     """
     Switch between rhsm and sat6 setup
-    https://bugzilla.redhat.com/show_bug.cgi?id=1463389
+    Bugzilla:
+        1463389
 
     Polarion:
         assignee: jhenner
@@ -205,7 +208,9 @@ def test_upgrade_multi_ext_inplace():
 @pytest.mark.tier(2)
 def test_update_custom_widgets():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1375313
+    Bugzilla:
+        1375313
+
     Upgrade appliance with custom widgets added
 
     Polarion:
@@ -279,7 +284,9 @@ def test_rh_registration_ui_proxy():
 @pytest.mark.tier(2)
 def test_update_webui_custom_css():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1553841
+    Bugzilla:
+        1553841
+
     Test css customization"s function correctly after webui update.
 
     Polarion:
@@ -305,7 +312,9 @@ def test_update_webui_custom_css():
 def test_rh_registration_proxy_crud():
     """
     Check proxy settings get added and removed from /etc/rhsm/rhsm.conf
-    https://bugzilla.redhat.com/show_bug.cgi?id=1463289
+
+    Bugzilla:
+        1463289
 
     Polarion:
         assignee: jhenner
@@ -333,7 +342,9 @@ def test_rh_unregistration_ui():
     """
     Check that you can unregister an appliance from subscriptions through
     the ui.
-    https://bugzilla.redhat.com/show_bug.cgi?id=1464387
+
+    Bugzilla:
+        1464387
 
     Polarion:
         assignee: jhenner
@@ -422,7 +433,9 @@ def test_update_webui_ipv6():
 def test_upgrade_check_repo_names():
     """
     Checks default rpm repos on a upgraded appliance
-    https://bugzilla.redhat.com/show_bug.cgi?id=1411890
+
+    Bugzilla:
+        1411890
 
     Polarion:
         assignee: jhenner
@@ -549,7 +562,9 @@ def test_update_webui_ha():
 def test_rh_rhsm_reregistering():
     """
     Switch between rhsm and sat6 registration
-    https://bugzilla.redhat.com/show_bug.cgi?id=1461716
+
+    Bugzilla:
+        1461716
 
     Polarion:
         assignee: jhenner

--- a/cfme/tests/test_manual.py
+++ b/cfme/tests/test_manual.py
@@ -86,7 +86,8 @@ def test_nor_cpu_values_correct_rhv41():
 @test_requirements.rbac
 def test_status_of_a_task_via_api_with_evmrole_administrator():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1535962
+    Bugzilla:
+        1535962
 
     Polarion:
         assignee: apagac
@@ -386,9 +387,10 @@ def test_appliance_terminates_unresponsive_worker_process():
     If a queue message consumes significant memory and takes longer than
     the 10 minute queue timeout, the appliance will kill the worker after
     the stopping_timeout.
-    Steps to test:
-    https://bugzilla.redhat.com/show_bug.cgi?id=1395736#c30
-    https://bugzilla.redhat.com/show_bug.cgi?id=1395736#c31
+    Steps to test (see BZ below, comments 30 and 31).
+
+    Bugzilla:
+        1395736
 
     Polarion:
         assignee: tpapaioa
@@ -493,7 +495,8 @@ def test_osp_vmware67_test_vm_migration_with_windows_2016_server():
 @pytest.mark.tier(1)
 def test_rhos_test_notification_for_snapshot_delete_failure():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1581793
+    Bugzilla:
+        1581793
     Test if cfme can report failure when deleting snapshot from RHOS.
 
     Polarion:
@@ -541,7 +544,8 @@ def test_distributed_zone_failover_cu_data_processor():
 @pytest.mark.tier(3)
 def test_sui_stack_service_vm_detail_page_should_show_correct_data():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1467569
+    Bugzilla:
+        1467569
 
     Polarion:
         assignee: sshveta
@@ -558,7 +562,8 @@ def test_sui_stack_service_vm_detail_page_should_show_correct_data():
 @pytest.mark.tier(1)
 def test_notification_for_snapshot_actions_on_openstack():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1429313
+    Bugzilla:
+        1429313
     Test task notification for snapshot tasks: success and failure of
     create and delete snapshot.
 
@@ -1192,7 +1197,10 @@ def test_that_non_admin_users_can_view_catalog_items_in_ssui():
     """
     Verify user with a non-administrator role can login to the SSUI and
     view catalog items that are tagged for them to see
-    See https://bugzilla.redhat.com/show_bug.cgi?id=1465642
+
+    Bugzilla:
+        1465642
+
     Note: in order for this to work, all ownership limitations must be
     removed.
 
@@ -1272,7 +1280,8 @@ def test_storage_ebs_volume_crud():
 @pytest.mark.manual('manualonly')
 def test_ec2_deploy_cfme_image():
     """
-    BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1413835
+    Bugzilla:
+        1413835
     Requirement: CFME image imported as AMI in EC2 environment - should be
     imported automatically with every build
     1) Deploy appliance:
@@ -1389,7 +1398,10 @@ def test_osp_test_migration_plan_filtering_for_plans_table_list_on_overview_and_
 def test_retirement_date_uses_correct_time_zone():
     """
     Bug 1565128 - Wrong timezone when selecting retirement time
-    https://bugzilla.redhat.com/show_bug.cgi?id=1565128
+
+    Bugzilla:
+        1565128
+
     After saving VM retirement date/time (using both "Specific Date and
     Time" and "Time Delay from Now" options), the displayed Retirement
     Date has the correct date and time-zone appropriate time.
@@ -1477,7 +1489,9 @@ def test_azone_cpu_usage_azure():
 @pytest.mark.manual
 def test_orchestration_link_mismatch():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1601523
+
+    Bugzilla:
+        1601523
 
     Polarion:
         assignee: sshveta
@@ -1634,7 +1648,8 @@ def test_distributed_zone_delete_occupied():
 @test_requirements.rbac
 def test_can_add_child_tenant_to_tenant():
     """
-    BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1387088
+    Bugzilla:
+        1387088
     1. Go to Configuration -> Access Control
     2. Select a Tenant
     3. Use "Configuration" Toolbar to navigate to "Add child Tenant to
@@ -1679,7 +1694,10 @@ def test_azure_instance_password_requirements_azure():
     Create provision request with password which doesn"t meet requirements
     - warning message should appear in UI
     Additional details are in
-    https://bugzilla.redhat.com/show_bug.cgi?id=1454812
+
+    Bugzilla:
+        1454812
+
     The supplied password must be between 8-123 characters long and must
     satisfy at least 3 of password complexity requirements from the
     following:
@@ -1987,7 +2005,9 @@ def test_webmks_console_firefox_vsphere65_fedora27():
 def test_webmks_console_passwordwithspecialchars():
     """
     VMware WebMKS Remote Console Test based on
-    https://bugzilla.redhat.com/show_bug.cgi?id=1545927
+
+    Bugzilla:
+        1545927
 
     Polarion:
         assignee: apagac
@@ -3377,7 +3397,9 @@ def test_osp_vmware_65_test_vm_name_with_punycode_characters():
 def test_config_manager_accordion_tree():
     """
     Make sure there is accordion tree, once Tower is added to the UI.
-    https://bugzilla.redhat.com/show_bug.cgi?id=1560552
+
+    Bugzilla:
+        1560552
 
     Polarion:
         assignee: nachandr
@@ -3424,7 +3446,9 @@ def test_bottleneck_datastore():
 @pytest.mark.manual
 def test_ec2_api_filter_limit():
     """
-    BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1612086
+    Bugzilla:
+        1612086
+
     The easiest way to simulate AWS API Limit for > 200 items is to enable
     and disable public images:
     Requirement: Have an ec2 provider
@@ -3556,7 +3580,9 @@ def test_cluster_graph_by_vm_tag_vsphere6():
 @test_requirements.rbac
 def test_can_add_project_to_tenant():
     """
-    BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1387088
+    Bugzilla:
+        1387088
+
     1. Go to Configuration -> Access Control
     2. Select a Tenant
     3. Use "Configuration" Toolbar to navigate to "Add Project to this
@@ -3599,7 +3625,9 @@ def test_osp_test_if_non_csv_files_can_be_imported():
 def test_no_rbac_warnings_in_logs_when_viewing_satellite_provider():
     """
     RBAC-related warnings logged when viewing Satellite provider in web UI
-    https://bugzilla.redhat.com/show_bug.cgi?id=1565266
+
+    Bugzilla:
+        1565266
     1.) Add Satellite provider.
     2.) Click on items under Providers accordion.
     3.) View evm.log. No WARN-level messages should be logged.
@@ -3924,7 +3952,9 @@ def test_upgrade_single_inplace_ipv6():
 @pytest.mark.tier(1)
 def test_notification_for_snapshot_delete_failure():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1449243
+    Bugzilla:
+        1449243
+
     Requires ec2 access via web-ui.
 
     Polarion:
@@ -4069,7 +4099,9 @@ def test_candu_graphs_vm_compare_host_vsphere65():
 @pytest.mark.tier(1)
 def test_sdn_nsg_firewall_rules_azure():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1520196
+    Bugzilla:
+        1520196
+
     1. Add Network Security group on Azure with coma separated port ranges
     `1023,1025` rule inbound/outbound ( ATM this feature is not allowed in
     East US region of Azure - try West/Central)
@@ -4412,7 +4444,8 @@ def test_update_yum_bad_version_59017():
 @test_requirements.rbac
 def test_vm_request_approval_by_user_in_different_group():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1545395
+    Bugzilla:
+        1545395
 
     Polarion:
         assignee: apagac
@@ -4505,8 +4538,10 @@ def test_verify_ldap_group_lookup_fails_with_correct_error_message_for_invalid_u
     1. configure ldap.
     2. specify wrong user details while group look up, verify group lookup
     fails with correct error message.
-    refer the BZ:
-    https://bugzilla.redhat.com/show_bug.cgi?id=1378213
+    refer the BZ below
+
+    Bugzilla:
+        1378213
 
     Polarion:
         assignee: apagac
@@ -4654,7 +4689,8 @@ def test_distributed_delete_offline_worker_appliance():
 @pytest.mark.tier(2)
 def test_playbook_with_already_existing_dialogs_name():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1449345
+    Bugzilla:
+        1449345
 
     Polarion:
         assignee: sshveta
@@ -4707,7 +4743,10 @@ def test_pg_stat_activity_view_in_postgres_should_show_worker_information():
     pg_stat_activity view in postgres should show worker information.
     Bug 1445928 - It is impossible to identify the source
     process/appliance for each connection in pg_stat_activity
-    https://bugzilla.redhat.com/show_bug.cgi?id=1445928
+
+    Bugzilla:
+        1445928
+
     # su - postgres
     # psql vmdb_production
     vmdb_production=# select pid, application_name from pg_stat_activity;
@@ -5168,7 +5207,8 @@ def test_ec2_targeted_refresh_stack():
 @pytest.mark.tier(2)
 def test_ssui_test_snapshot_vm_memory_checkbox_when_creating_snapshot_for_powered_off_vm():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1600043
+    Bugzilla:
+        1600043
 
     Polarion:
         assignee: apagac
@@ -5190,7 +5230,8 @@ def test_ssui_test_snapshot_vm_memory_checkbox_when_creating_snapshot_for_powere
 @pytest.mark.tier(2)
 def test_heat_stacks_in_non_admin_tenants_shall_also_be_collected():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1290005
+    Bugzilla:
+        1290005
 
     Polarion:
         assignee: sshveta
@@ -5626,7 +5667,10 @@ def test_verify_purging_of_old_records():
     VmdbMetric, Metric, and Container-related records are purged
     regularly.
     Bug 1348625 - We might not be purging all tables that we should be
-    https://bugzilla.redhat.com/show_bug.cgi?id=1348625
+
+    Bugzilla:
+        1348625
+
     [----] I, [2017-05-19T07:48:23.994536 #63471:985134]  INFO -- :
     MIQ(DriftState.purge_by_date) Purging Drift states older than
     [2016-11-20 11:48:20 UTC]...Complete - Deleted 0 records"
@@ -5869,8 +5913,9 @@ def test_verify_that_users_can_access_help_documentation():
     """
     Verify that admin and user"s with access to Documentation can view the
     PDF documents
-    Relevant BZ:
-    https://bugzilla.redhat.com/show_bug.cgi?id=1563241
+
+    Bugzilla:
+        1563241
 
     Polarion:
         assignee: apagac
@@ -5915,7 +5960,9 @@ def test_osp_test_user_can_download_post_migration_ansible_playbook_log():
 @test_requirements.rbac
 def test_requests_in_ui_and_api():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1608554
+    Bugzilla:
+        1608554
+
     1. Login with user with Services > My Services > Requests > Operate
     enabled
     2. View Services > Requests
@@ -6140,7 +6187,8 @@ def test_config_manager_remove_objects_ansible_tower_310():
 @pytest.mark.tier(1)
 def test_set_ownership_back_to_default():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1483512
+    Bugzilla:
+        1483512
 
     Polarion:
         assignee: apagac
@@ -6158,7 +6206,10 @@ def test_set_ownership_back_to_default():
 def test_vm_placement_with_duplicated_folder_name_vmware():
     """
     This testcase is related to -
-    https://bugzilla.redhat.com/show_bug.cgi?id=1414136
+
+    Bugzilla:
+        1414136
+
     Description of problem:
     Duplicate folder names between host & vm/templates causes placement
     issues
@@ -6183,7 +6234,10 @@ def test_can_only_select_this_regions_zones_when_changing_server_zone():
     """
     Bug 1470283 - zones of sub region show up as zones appliances of a
     central region can move to
-    https://bugzilla.redhat.com/show_bug.cgi?id=1470283
+
+    Bugzilla:
+        1470283
+
     Configure 1 appliance for use as a reporting db server, with region
     99. Create zones zone-99-a and zone-99-b.
     Configure a 2nd appliance as a remote appliance, with region 0. Create
@@ -6286,8 +6340,8 @@ def test_ec2_flavor_list_up_to_date():
 @pytest.mark.tier(3)
 def test_verify_ldap_user_login_when_email_has_an_apostrophe_character():
     """
-    refer the BZ:
-    https://bugzilla.redhat.com/show_bug.cgi?id=1379420
+    Bugzilla:
+        1379420
 
     Polarion:
         assignee: apagac
@@ -6354,7 +6408,11 @@ def test_candu_graphs_vm_compare_cluster_vsphere65():
 def test_verify_ldap_authentication_works_without_groups_from_ldap_by_uncheck_the_get_user_gro():
     """
     verify LDAP authentication works without groups from LDAP
-    refer this bz: https://bugzilla.redhat.com/show_bug.cgi?id=1302345
+    refer the following BZ.
+
+    Bugzilla:
+        1302345
+
     Steps:
     1.In Configuration->Authentication, set the auth mode to LDAP.
     LDAP Hostname: "cfme-openldap-rhel7.cfme.lab.eng.rdu2.redhat.com"
@@ -6856,7 +6914,9 @@ def test_osp_vmware67_test_vm_migration_from_nfs_storage_in_vmware_to_iscsi_on_o
 @test_requirements.rbac
 def test_view_quotas_without_manage_quota_permisson():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1535556
+    Bugzilla:
+        1535556
+
     1. disable "manage quota" from the role of a user
     2. try to view quotas as that user
     copy the EVMRole-tenant_quota_administrator role, disable Settings ->
@@ -6944,7 +7004,9 @@ def test_bundle_stack_deployment():
 @test_requirements.rbac
 def test_provider_refresh_via_api():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1602413
+    Bugzilla:
+        1602413
+
     1. set up a new user with a new group based on vm_user plus api access
     and refresh access to cloud and infrastructure providers
     2. issue a refresh using the classic ui with that user
@@ -7138,7 +7200,9 @@ def test_group_by_tag_azone_gce():
 @pytest.mark.tier(1)
 def test_snapshot_tree_view_functionality():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1398239
+    Bugzilla:
+        1398239
+
     Just test the snapshot tree view. Create a bunch of snapshots and see
     if the snapshot tree seems right. Check if the last created snapshot
     is active. Revert to some snapshot, then create another bunch of
@@ -7227,7 +7291,10 @@ def test_osp_vmware60_test_vm_with_multiple_disks():
 def test_notification_window_events_show_in_timestamp_order():
     """
     Bug 1469534 - The notification events are out of order
-    https://bugzilla.redhat.com/show_bug.cgi?id=1469534
+
+    Bugzilla:
+        1469534
+
     If multiple event notifications are created near-simultaneously (e.g.,
     several VM"s are provisioned), then clicking on the bell icon in the
     top right of the web UI displays the event notifications in timestamp
@@ -7361,8 +7428,11 @@ def test_verify_orchestration_catalog_items_can_only_use_providers_that_are_visi
 @pytest.mark.tier(2)
 def test_osp_test_osp_volumes_are_cleaned_up_if_migration_fails_to_create_instance():
     """
-    V2V Test for https://bugzilla.redhat.com/show_bug.cgi?id=1651352
-    https://bugzilla.redhat.com/show_bug.cgi?id=1653412
+    V2V Test following BZs
+
+    Bugzilla:
+        1651352
+        1653412
 
     Polarion:
         assignee: ytale
@@ -7399,7 +7469,8 @@ def test_consistent_capitalization_of_cpu_when_creating_compute_chargeback_rate(
 @pytest.mark.tier(2)
 def test_show_tag_info_for_playbook_services():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1449020
+    Bugzilla:
+        1449020
 
     Polarion:
         assignee: sshveta
@@ -7421,6 +7492,9 @@ def test_snapshot_link_in_vm_summary_page_after_deleting_snapshot():
     vm summary page use the history button and try to go back to
     snapshots. Go to the vm summary page again and try to click snapshots
     link, it should work.
+
+    Bugzilla:
+        1395116
 
     Polarion:
         assignee: apagac
@@ -7502,6 +7576,9 @@ def test_automate_method_copy():
     5. Select Instance/Method from any class in ManageIQ
     6. From configuration toolbar, select `Copy this method/Instance`
     Additional info: https://bugzilla.redhat.com/show_bug.cgi?id=1500956
+
+    Bugzilla:
+        1500956
 
     Polarion:
         assignee: ghubale
@@ -7657,8 +7734,10 @@ def test_validate_cost_monthly_usage_network():
 def test_vm_tempate_ownership_nogroup():
     """
     test assigning no groups ownership for vm and templates
-    https://bugzilla.redhat.com/show_bug.cgi?id=1330022
-    https://bugzilla.redhat.com/show_bug.cgi?id=1456681
+    Bugzilla:
+        1330022
+        1456681
+
     UPDATE: There was no movement on BZ 1456681 for a long time. If this
     BZ is not resolved, we don"t know how exactly the ownership should
     behave in certain situations and this testcase will always fail.
@@ -7882,7 +7961,8 @@ def test_check_all_availability_zones_for_amazon_provider():
 @pytest.mark.tier(2)
 def test_sui_timeline_should_display_snapshots_at_the_time_of_creation():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1490510
+    Bugzilla:
+        1490510
 
     Polarion:
         assignee: apagac
@@ -7966,7 +8046,9 @@ def test_config_manager_change_zone():
     """
     Add Ansible Tower in multi appliance, add it to appliance with UI. Try
     to change to zone where worker is enabled.
-    https://bugzilla.redhat.com/show_bug.cgi?id=1353015
+
+    Bugzilla:
+        1353015
 
     Polarion:
         assignee: nachandr
@@ -8162,7 +8244,8 @@ def test_remove_display_name_for_user_in_ldap_and_verify_auth():
 @pytest.mark.manual
 def test_ec2_security_group_record_values():
     """
-    BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1540283
+    Bugzilla:
+        1540283
 
     Polarion:
         assignee: mmojzis
@@ -8370,8 +8453,11 @@ def test_distributed_zone_create_duplicate():
 def test_edit_vm():
     """
     Edit infra vm and cloud instance
-    https://bugzilla.redhat.com/show_bug.cgi?id=1399141
-    https://bugzilla.redhat.com/show_bug.cgi?id=1399144
+
+    Bugzilla:
+        1399141
+        1399144
+
     When editing cloud instance, genealogy should be present on the edit
     page.
     When you have two providers - one infra and one cloud - added, there
@@ -8573,7 +8659,10 @@ def test_verify_that_errored_out_queue_messages_are_removed():
     Verify that errored-out queue messages are removed.
     Bug 1460263 - shutdown_and_exit messages get marked as error and never
     removed from miq_queue table
-    https://bugzilla.redhat.com/show_bug.cgi?id=1460263
+
+    Bugzilla:
+        1460263
+
     # appliance_console
     -> Stop EVM Server Processes
     -> Start EVM Server Processes
@@ -8597,7 +8686,10 @@ def test_satellite_credential_validation_times_out_with_error_message():
     """
     Bug 1564601 - Satellite credential validation times out with no error
     message
-    https://bugzilla.redhat.com/show_bug.cgi?id=1564601
+
+    Bugzilla:
+        1564601
+
     When adding a new Satellite configuration provider, if the URL cannot
     be accessed because of a firewall dropping packets, then credential
     validation should time out after 2 minutes with a flash message.
@@ -8636,7 +8728,9 @@ def test_verify_session_timeout_works_fine_for_external_auth():
 @pytest.mark.tier(3)
 def test_button_groups_created_on_orchestration_type_heat_service_catalog_items_are_not_seen_o():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1496190
+
+    Bugzilla:
+        1496190
 
     Polarion:
         assignee: sshveta
@@ -8654,7 +8748,9 @@ def test_button_groups_created_on_orchestration_type_heat_service_catalog_items_
 @pytest.mark.tier(1)
 def test_default_value_on_dropdown_inside_dialog():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1516721
+
+    Bugzilla:
+        1516721
 
     Polarion:
         assignee: apagac
@@ -8896,7 +8992,9 @@ def test_set_hostname_from_appliance_console_and_configure_external_auth():
     1. ssh to appliance, and run appliance_console command
     2. change the appliance hostname with valid FQDN
     3. Verify External auth configuration does not fail.
-    https://bugzilla.redhat.com/show_bug.cgi?id=1360928
+
+    Bugzilla:
+        1360928
 
     Polarion:
         assignee: apagac
@@ -8913,7 +9011,9 @@ def test_set_hostname_from_appliance_console_and_configure_external_auth():
 @pytest.mark.tier(2)
 def test_restricted_user_rbac_for_access_control():
     """
-    Related to BZ#1311399
+    Bugzilla:
+        1311399
+
     Navigate to Configure ==> Configuration ==> Access Control.
     Create a new role with "VM & Template Access Restriction" as "Only
     User or Group Owned" or "Only User Owned".  Make sure all the module
@@ -8941,7 +9041,10 @@ def test_verify_ldap_group_retrieval_works_fine_for_groups_with_descriptions_whi
     """
     verify ldap group retrieval works fine for groups with descriptions
     which are base64 decoded , one random sample having an "é"
-    Refer the BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1367600
+    Refer the following BZ.
+
+    Bugzilla:
+        1367600
 
     Polarion:
         assignee: apagac
@@ -8978,7 +9081,10 @@ def test_osp_vmware65_test_vm_migration_with_really_long_name_upto_64_chars_work
 def test_vms_retirement_state_field_is_capitalized_correctly():
     """
     Bug 1518926 - Inconsistent capitalization for Retirement State field
-    https://bugzilla.redhat.com/show_bug.cgi?id=1518926
+
+    Bugzilla:
+        1518926
+
     When a VM is retiring or retired, the VM should show a "Retirement
     State" field, not "Retirement state".
 
@@ -9101,7 +9207,9 @@ def test_chargeback_report_monthly():
 @pytest.mark.manual
 def test_duplicate_groups_when_setting_ownership_to_multiple_items():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1589009
+    Bugzilla:
+        1589009
+
     1. Navigate to Infrastructure -> Provider -> Vmware
     2. select multiple vms and go to Configuration -> Set ownership
     3. Under group list, duplicate group names listed.
@@ -9122,7 +9230,9 @@ def test_orphaned_vms_get_excluded_from_used_quota_counts():
     """
     Test that used Quota gets recounted and reduced, when a VM is
     orphaned.
-    https://bugzilla.redhat.com/show_bug.cgi?id=1515979
+
+    Bugzilla:
+        1515979
 
     Polarion:
         assignee: ghubale
@@ -9540,7 +9650,10 @@ def test_active_tasks_get_timed_out_when_they_run_too_long():
     active tasks get timed out when they run too long
     Bug 1397600 - After killing reporting worker, report status still says
     Running
-    https://bugzilla.redhat.com/show_bug.cgi?id=1397600
+
+    Bugzilla:
+        1397600
+
     ****
     1.) Set task timeout check frequency and timeout values:
     :task_timeout_check_frequency: 600
@@ -9584,7 +9697,9 @@ def test_replication_central_admin_adhoc_provision_template():
 @test_requirements.rbac
 def test_ordering_service_by_non_admin_user():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1546944
+    Bugzilla:
+        1546944
+
     1. Go to Access Control, Create a role named "service_role" with below
     roles should be enabled i.e. Compute and Services.
     2. Create a user i.e. "service_user" based on this "service_role"
@@ -10190,7 +10305,9 @@ def test_html5_console_firefox_vsphere55_fedora28():
 @pytest.mark.tier(2)
 def test_html5_console_inaddproviderhoststartvncportpresent():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1514594
+    Bugzilla:
+        1514594
+
     Check to see if the Add provider screen has the Host VNC Start Port
     and Host VNC End port.
 
@@ -10731,7 +10848,10 @@ def test_html5_console_firefox_vsphere6_fedora26():
 @pytest.mark.tier(2)
 def test_html5_console_vsphere6_ssui():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1597393VMware VNC Remote
+    Bugzilla:
+        1597393
+
+    VMware VNC Remote
     Console does not work in SSUI with following error:
     There was an error opening the console. undefined
     Steps to Reproduce:
@@ -11047,7 +11167,8 @@ def test_html5_console_firefox_vsphere55_win2012():
 @pytest.mark.tier(2)
 def test_html5_console_rhv():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1573739
+    Bugzilla:
+        1573739
 
     Polarion:
         assignee: apagac
@@ -11261,7 +11382,8 @@ def test_html5_console_chrome_ssui_win7():
 @pytest.mark.tier(2)
 def test_html5_console_check_consistency_of_behavior():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1525692
+    Bugzilla:
+        1525692
 
     Polarion:
         assignee: apagac
@@ -12286,7 +12408,8 @@ def test_azone_disk_io_azure():
 @pytest.mark.tier(2)
 def test_monitor_ansible_playbook_std_output():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1444853
+    Bugzilla:
+        1444853
 
     Polarion:
         assignee: apagac
@@ -12303,7 +12426,9 @@ def test_monitor_ansible_playbook_std_output():
 def test_appliance_log_error():
     """
     check logs for errors such as
-    https://bugzilla.redhat.com/show_bug.cgi?id=1392087
+
+    Bugzilla:
+        1392087
 
     Polarion:
         assignee: jhenner
@@ -12338,7 +12463,10 @@ def test_verify_external_authentication_with_openldap_proxy_to_3_different_domai
     """
     verify external authentication with OpenLDAP proxy to 3 different
     domains
-    refer the bz: https://bugzilla.redhat.com/show_bug.cgi?id=1306436
+    refer the bz below
+
+    Bugzilla:
+        1306436
 
     Polarion:
         assignee: apagac
@@ -12371,7 +12499,8 @@ def test_distributed_zone_failover_notifier_singleton():
 @pytest.mark.tier(1)
 def test_dialog_items_default_values_on_different_screens():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1540273
+    Bugzilla:
+        1540273
 
     Polarion:
         assignee: apagac
@@ -12408,7 +12537,8 @@ def test_verify_user_authentication_works_fine_if_default_evm_groups_are_already
 @test_requirements.snapshot
 def test_creating_second_snapshot_on_suspended_vm():
     """
-    https://bugzilla.redhat.com/show_bug.cgi?id=1419872
+    Bugzilla:
+        1419872
 
     Polarion:
         assignee: apagac
@@ -12575,7 +12705,10 @@ def test_notification_window_can_be_closed_by_clicking_x():
     """
     Bug 1427484 - Add "X" option to enable closing the Notification window
     by it.
-    https://bugzilla.redhat.com/show_bug.cgi?id=1427484
+
+    Bugzilla:
+        1427484
+
     After clicking the bell icon in the top right of the web UI, the "x"
     in the top right corner of the notification window can be clicked to
     close it.
@@ -12594,7 +12727,9 @@ def test_notification_window_can_be_closed_by_clicking_x():
 @pytest.mark.manual
 def test_storage_ebs_volume_crud_from_manager_list():
     """
-    BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1449293
+    Bugzilla:
+        1449293
+
     Requires:
     test_storage_ebs_added
     Steps to test:
@@ -12796,7 +12931,9 @@ def test_add_multiple_iso_datastore():
 def test_monitor_ansible_playbook_logging_output():
     """
     bugzilla.redhat.com/1518952
-    https://bugzilla.redhat.com/show_bug.cgi?id=1518952
+
+    Bugzilla:
+        1518952
 
     Polarion:
         assignee: apagac
@@ -12857,7 +12994,9 @@ def test_black_console_ext_auth_options_skip():
 def test_candu_collection_tab():
     """
     Test case to cover -
-    https://bugzilla.redhat.com/show_bug.cgi?id=1393675
+    Bugzilla:
+        1393675
+
     from BZ comments:
     "for QE testing you can only replicate that in the UI by running a
     refresh and immediately destroying the provider and hope that it runs
@@ -13944,7 +14083,10 @@ def test_vmrc_console_novmrccredsinprovider():
     Leave the VMRC Creds blank in the provider add/edit dialog and observe
     behavior trying to launch console. It should fail. Also observe the
     message in VMRC Console Creds tab about what will happen if creds left
-    blank. https://bugzilla.redhat.com/show_bug.cgi?id=1550612
+    blank.
+
+    Bugzilla:
+        1550612
 
     Polarion:
         assignee: apagac
@@ -15371,8 +15513,10 @@ def test_vmrc_console_ie11_vsphere67_win2012():
 def test_vmrc_console_addremovevmwarecreds():
     """
     Add VMware VMRC Console Credentials to a VMware Provider and then
-    Remove it. As per BZ:
-    https://bugzilla.redhat.com/show_bug.cgi?id=1559957
+    Remove it.
+
+    Bugzilla:
+        1559957
 
     Polarion:
         assignee: apagac
@@ -16420,7 +16564,9 @@ def test_vmrc_console_usecredwithlimitedvmrcaccess():
     floppy. So if you can see your VMRC Console can"t do these operations
     with user_interact, mark this test as passed. As the sole purpose of
     this test is to validate correct user and permissions are being used.
-    https://bugzilla.redhat.com/show_bug.cgi?id=1479840
+
+    Bugzilla:
+        1479840
 
     Polarion:
         assignee: apagac
@@ -16715,7 +16861,6 @@ def test_verify_benchmark_timings_are_correct():
     """
     Bug 1424716 - Benchmark timings are incorrect for all workers in
     evm.log
-    https://bugzilla.redhat.com/show_bug.cgi?id=1424716
     Timings logged in evm.log are/seem to be reasonable values:
     [----] I, [2017-09-21T14:53:01.220711 #23936:ded140]  INFO -- :
     MIQ(ManageIQ::Providers::Vmware::InfraManager::Refresher#refresh) EMS:
@@ -16732,6 +16877,9 @@ def test_verify_benchmark_timings_are_correct():
     :db_save_inventory=>9.141719341278076,
     :save_inventory=>9.141741275787354,
     :ems_refresh=>10.612204551696777}
+
+    Bugzilla:
+        1424716
 
     Polarion:
         assignee: tpapaioa

--- a/cfme/tests/webui/test_general_ui.py
+++ b/cfme/tests/webui/test_general_ui.py
@@ -230,7 +230,9 @@ def test_infrastructure_filter_20k_vms(appliance, create_20k_vms):
 def test_consistent_breadcrumbs():
     """
     BreadCrumbs should be consistent across whole CloudForms UI
-    https://bugzilla.redhat.com/show_bug.cgi?id=1678192
+
+    Bugzilla:
+        1678192
 
     Polarion:
         assignee: anikifor
@@ -272,7 +274,8 @@ def test_ui_pinning_after_relog():
 @test_requirements.general_ui
 def test_ui_notification_icon():
     """
-    BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1489798
+    Bugzilla:
+        1489798
 
     Polarion:
         assignee: anikifor
@@ -352,7 +355,8 @@ def test_cloud_icons_instances():
 @pytest.mark.tier(1)
 def test_key_pairs_quadicon():
     """
-    BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1352914
+    Bugzilla:
+        1352914
 
     Polarion:
         assignee: anikifor
@@ -477,7 +481,7 @@ def test_create_filter_with_multiple_conditions():
             1. Expression must be created successfully.
 
     Bugzilla:
-        * 1660460
+        1660460
     """
     pass
 
@@ -500,7 +504,7 @@ def test_welcoming_page():
             1. Welcome/Landing page must show the next action, ie. `Add a Provider
 
     Bugzilla:
-        * 1678190
+        1678190
     """
     pass
 
@@ -523,6 +527,6 @@ def test_custom_navigation_menu():
             1. Custom menu must be visible.
 
     Bugzilla:
-        * 1678151
+        1678151
     """
     pass


### PR DESCRIPTION
We have many places in tests where we reference BZs by different names. We should choose a uniform name for consistency in our code base. Since, `Bugzilla` seemed to be used the most, I chose that one. 

The scope of this PR is just to make the docblock BZ reference uniform. Later PRs will make use of a script to add meta data, such as `automates` to the test function. 

For reference the proper way to format BZs in the docblock going forward will be:

```python

def test_bugzilla(): 
    """
    Bugzilla:
        <bug_id1>
        <bug_id2>
        <bug_id3>
        ...
    """
    pass
```
Just the number (BZ ID) without a `*` or anything else preceding. I am working on a flake plugin to check this field. Each BZ id related to a test case should appear on its own line. 