### PR TITLE
[1LP][RFR] New Test: Testing instance(ansible_tower_job) calls the proper automate method

### DIFF
--- a/cfme/tests/automate/test_automate_manual.py
+++ b/cfme/tests/automate/test_automate_manual.py
@@ -701,24 +701,44 @@ def test_automate_buttons_requests():
 
 
 @pytest.mark.tier(1)
-def test_check_system_request_calls_depr_configurationmanagement():
+def test_refresh_git_current_user():
     """
     Polarion:
         assignee: ghubale
         initialEstimate: 1/8h
-        caseimportance: low
+        caseimportance: medium
         caseposneg: positive
         testtype: functional
-        startsin: 5.10
+        startsin: 5.9
         casecomponent: Automate
         tags: automate
         testSteps:
-            1. Copy /System/Request/ansible_tower_job instance to new domain
-            2. Run that instance using simulation
-            3. See automation log
-
+            1. created non-super user 'ganesh' along with default 'admin' user.
+            2. Using admin user imported git repo.:
+               'https://github.com/ramrexx/CloudForms_Essentials.git'
+            3. Logged in with admin and refreshed domain- 'CloudForms_Essentials'.
+               Then checked all tasks.
+            4. Found user name 'admin' next to 'Refresh git repository'.
+            5. Then checked instances in that domain by logging in with user 'ganesh' and 'admin'.
+            6. Logged in with non-super user 'ganesh' and refreshed domain- 'CloudForms_Essentials'.
+               Then checked all tasks.
+            7. Found user name 'ganesh' next to 'Refresh git repository'.
+            8. Then checked instances in that domain by logging in with user 'ganesh' and 'admin'.
+        expectedResults:
+            1.
+            2.
+            3.
+            4.
+            5. It shows that
+               e.g. 'Automate Instance [Provisioning - Updated 2019-01-15 11:41:43 UTC by admin]'
+            6.
+            7.
+            8. It shows that
+               e.g. 'Automate Instance [Provisioning - Updated 2019-01-15 11:44:43 UTC by ganesh]'
+               Hence, correct user that calls refresh automation domain from git branch is shown.
     Bugzilla:
-        1615444
+        1592428
+>>>>>>> New Test:
     """
     pass
 

--- a/cfme/tests/automate/test_automate_manual.py
+++ b/cfme/tests/automate/test_automate_manual.py
@@ -701,49 +701,6 @@ def test_automate_buttons_requests():
 
 
 @pytest.mark.tier(1)
-def test_refresh_git_current_user():
-    """
-    Polarion:
-        assignee: ghubale
-        initialEstimate: 1/8h
-        caseimportance: medium
-        caseposneg: positive
-        testtype: functional
-        startsin: 5.9
-        casecomponent: Automate
-        tags: automate
-        testSteps:
-            1. created non-super user 'ganesh' along with default 'admin' user.
-            2. Using admin user imported git repo.:
-               'https://github.com/ramrexx/CloudForms_Essentials.git'
-            3. Logged in with admin and refreshed domain- 'CloudForms_Essentials'.
-               Then checked all tasks.
-            4. Found user name 'admin' next to 'Refresh git repository'.
-            5. Then checked instances in that domain by logging in with user 'ganesh' and 'admin'.
-            6. Logged in with non-super user 'ganesh' and refreshed domain- 'CloudForms_Essentials'.
-               Then checked all tasks.
-            7. Found user name 'ganesh' next to 'Refresh git repository'.
-            8. Then checked instances in that domain by logging in with user 'ganesh' and 'admin'.
-        expectedResults:
-            1.
-            2.
-            3.
-            4.
-            5. It shows that
-               e.g. 'Automate Instance [Provisioning - Updated 2019-01-15 11:41:43 UTC by admin]'
-            6.
-            7.
-            8. It shows that
-               e.g. 'Automate Instance [Provisioning - Updated 2019-01-15 11:44:43 UTC by ganesh]'
-               Hence, correct user that calls refresh automation domain from git branch is shown.
-    Bugzilla:
-        1592428
->>>>>>> New Test:
-    """
-    pass
-
-
-@pytest.mark.tier(1)
 def test_list_of_diff_vm_storages_via_rails():
     """
     Polarion:

--- a/cfme/tests/automate/test_instance.py
+++ b/cfme/tests/automate/test_instance.py
@@ -226,11 +226,15 @@ def copy_instance(domain):
     """
     This fixture copies the instance '/ManageIQ/System/Request/ansible_tower_job' to new domain.
     """
-    domain.parent.instantiate(name="ManageIQ").namespaces.instantiate(
-        name="System"
-    ).classes.instantiate(name="Request").instances.instantiate(name="ansible_tower_job").copy_to(
-        domain.name
+    # Instantiating class 'Request'
+    klass = (
+        domain.parent.instantiate(name="ManageIQ")
+        .namespaces.instantiate(name="System")
+        .classes.instantiate(name="Request")
     )
+
+    # Instantiating instance 'ansible_tower_job' and copying it to new domain
+    klass.instances.instantiate(name="ansible_tower_job").copy_to(domain.name)
     instance = (
         domain.namespaces.instantiate(name="System")
         .classes.instantiate(name="Request")
@@ -240,7 +244,7 @@ def copy_instance(domain):
 
 
 @pytest.mark.tier(1)
-def test_check_system_request_calls_depr_configurationmanagement(appliance, copy_instance):
+def test_check_system_request_calls_depr_conf_mgmt(appliance, copy_instance):
     """
     Polarion:
         assignee: ghubale


### PR DESCRIPTION
- Testing instance(```/System/Request/ansible_tower_job```) calls the updated automate method(```/AutomationManagement/AnsibleTower/Operations/StateMachines/Job/default```)
- It should **not call deprecated** ```/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job/default``` method.

{{ pytest: cfme/tests/automate/test_instance.py -k 'test_check_system_request_calls_depr_conf_mgmt' -vv }}

juwatts:
https://github.com/ManageIQ/integration_tests/pull/8723 needs to be merged first