### PR TITLE
[1LP][RFR] Automate test: test_vm_retirement_requester

### DIFF
--- a/cfme/tests/infrastructure/test_infra_manual.py
+++ b/cfme/tests/infrastructure/test_infra_manual.py
@@ -56,30 +56,3 @@ def test_add_infra_provider_screen():
             5. Form must not be validated.
     """
     pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(1)
-def test_check_vm_retirement_requester():
-    """
-    Polarion:
-        assignee: pvala
-        casecomponent: Infra
-        caseimportance: medium
-        initialEstimate: 1/2h
-        setup:
-            1. Add a provider, here VMware vCenter 6.7
-            2. Provision a VM.
-            3. Once the VM has been provisioned, retire the VM.
-            4. Create a report(See attachment in BZ).
-        testSteps:
-            1. Queue the report while the VM is still retiring
-                and check the requester column for the VM.
-            2. Queue the report again once the VM has been retired
-                and check the requester column for the VM.
-        expectedResults:
-            1. Requester name must be visible.
-            2. Requester name must be visible.
-
-    Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1638502
-    """


### PR DESCRIPTION
This PR brings the following changes:
1. Automate test case: test_vm_retirement_requester
2. Add a fixture `retire_vm` to retire the vm.
3. Add a fixture `vm_retirement_report` to generate report.
4. Blackify the file.

{{pytest: cfme/tests/infrastructure/test_vm_retirement_rest.py::test_check_vm_retirement_requester --use-template-cache -sqvvv }}