### PR TITLE
[1LP][RFR] Move convenience methods to use SystemdService plugin for appliance

### DIFF
--- a/cfme/tests/cli/test_appliance_update.py
+++ b/cfme/tests/cli/test_appliance_update.py
@@ -176,8 +176,8 @@ def test_update_embedded_ansible_webui(enabled_embedded_appliance, appliance, ol
              num_sec=900, delay=20, handle_exception=True,
              message='Waiting for appliance to update')
     assert wait_for(func=lambda: enabled_embedded_appliance.is_embedded_ansible_running, num_sec=90)
-    assert wait_for(func=lambda: enabled_embedded_appliance.is_rabbitmq_running, num_sec=60)
-    assert wait_for(func=lambda: enabled_embedded_appliance.is_nginx_running, num_sec=60)
+    assert wait_for(func=lambda: enabled_embedded_appliance.rabbitmq_server.running, num_sec=60)
+    assert wait_for(func=lambda: enabled_embedded_appliance.nginx.running, num_sec=60)
     repositories = enabled_embedded_appliance.collections.ansible_repositories
     name = "example_{}".format(fauxfactory.gen_alpha())
     description = "edited_{}".format(fauxfactory.gen_alpha())

--- a/cfme/utils/appliance/services.py
+++ b/cfme/utils/appliance/services.py
@@ -39,7 +39,8 @@ class SystemdService(AppliancePlugin):
         with self.appliance.ssh_client as ssh:
             cmd = 'systemctl {} {}'.format(quote(command), quote(unit))
             log_callback('Running {}'.format(cmd))
-            result = ssh.run_command(cmd)
+            result = ssh.run_command(cmd,
+                                     container=self.appliance.ansible_pod_name)
 
         if expected_exit_code is not None and result.rc != expected_exit_code:
             # TODO: Bring back address


### PR DESCRIPTION
{{ pytest: --long-running cfme/tests/ansible/test_embedded_ansible_crud.py  }}

There is some flaky behavior in the new tests checking for some EmbeddedAnsible process. @sbulage is going to address these test failures. I've changed the fixture name here, but that's unrelated to the process state changes that cause the test to fail.