### PR TITLE
[1LP][RFR] Removing locator to support modified progress bar widget

### DIFF
--- a/cfme/v2v/migrations.py
+++ b/cfme/v2v/migrations.py
@@ -334,7 +334,7 @@ class MigrationDashboardView(BaseLoggedInPage):
     sort_type_dropdown = SelectorDropdown('id', 'sortTypeMenu')
     sort_direction = Text(locator=".//span[contains(@class,'sort-direction')]")
     # TODO: XPATH requested to devel (repo:miq_v2v_ui_plugin issues:415)
-    progress_card = MigrationProgressBar(locator='.//div[3]/div/div[3]/div[3]/div/div')
+    progress_card = MigrationProgressBar()
     not_started_plans = MigrationDashboardStatusCard(name="Not Started")
     in_progress_plans = MigrationDashboardStatusCard(name="In Progress")
     completed_plans = MigrationDashboardStatusCard(name="Complete")


### PR DESCRIPTION
What was the issue?

PR https://github.com/ManageIQ/integration_tests/commit/d8a116d811c664360f84bca9fb2fac84c51f17e6#diff-264354a78406ae4ca6d836bd7388d376L5040  removed locator from Widget but we are still using it in older structure which failing ~50 TCs.

```
>       return method(self, *new_args, **new_kwargs)
E       TypeError: __init__() got an unexpected keyword argument 'locator'

/var/ci/cfme_venv/lib/python2.7/site-packages/widgetastic/widget/base.py:67: TypeError
TypeError
__init__() got an unexpected keyword argument 'locator'
```

{{pytest: cfme/tests/v2v/test_v2v_migrations.py --use-provider vsphere67-nested --use-provider rhv42 --provider-limit 2 -vvvv -k 'test_single_datastore_single_vm_migration[virtualcenter-6.7-rhevm-4.2-form_data_vm_obj_single_datastore0]'}}

@digitronik please review! Tested locally, migration passed.


