### PR TITLE
[1LP][RFR] Fixed Embedded Ansible CRUD test file by re-ordering sub-tests

### DIFF
--- a/cfme/tests/ansible/test_embedded_ansible_crud.py
+++ b/cfme/tests/ansible/test_embedded_ansible_crud.py
@@ -41,39 +41,6 @@ def test_embedded_ansible_enable(embedded_appliance):
         container=embedded_appliance.ansible_pod_name)
 
 
-@pytest.mark.tier(3)
-def test_embedded_ansible_disable(embedded_appliance):
-    """Tests whether the embedded ansible role and all workers have stopped correctly
-
-    Polarion:
-        assignee: sbulage
-        casecomponent: Ansible
-        caseimportance: critical
-        initialEstimate: 1/6h
-        tags: ansible_embed
-    """
-    assert wait_for(lambda: embedded_appliance.rabbitmq_server.running, num_sec=30)
-    assert wait_for(lambda: embedded_appliance.nginx.running, num_sec=30)
-    embedded_appliance.disable_embedded_ansible_role()
-
-    if not embedded_appliance.is_pod:
-        assert wait_for(lambda: embedded_appliance.supervisord.running,
-                        fail_cond=True,
-                        num_sec=180)
-        assert wait_for(lambda: embedded_appliance.rabbitmq_server.running,
-                        fail_cond=True,
-                        num_sec=60)
-        assert wait_for(lambda: embedded_appliance.nginx.running,
-                        fail_cond=True,
-                        num_sec=30)
-    else:
-        @wait_for_decorator(num_sec=300)
-        def is_ansible_pod_stopped():
-            # todo: implement appropriate methods in appliance
-            return embedded_appliance.ssh_client.run_command(
-                'oc get pods|grep ansible', ensure_host=True).failed
-
-
 @pytest.mark.tier(1)
 def test_embedded_ansible_event_catcher_process(embedded_appliance):
     """
@@ -133,3 +100,36 @@ def test_embedded_ansible_logs(embedded_appliance):
     # Retrieving setup log file from list and asserting with length
     # Setup log file contains date/time string in it.
     assert "setup" in diff[0]
+
+
+@pytest.mark.tier(3)
+def test_embedded_ansible_disable(embedded_appliance):
+    """Tests whether the embedded ansible role and all workers have stopped correctly
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: Ansible
+        caseimportance: critical
+        initialEstimate: 1/6h
+        tags: ansible_embed
+    """
+    assert wait_for(lambda: embedded_appliance.rabbitmq_server.running, num_sec=30)
+    assert wait_for(lambda: embedded_appliance.nginx.running, num_sec=30)
+    embedded_appliance.disable_embedded_ansible_role()
+
+    if not embedded_appliance.is_pod:
+        assert wait_for(lambda: embedded_appliance.supervisord.running,
+                        fail_cond=False,
+                        num_sec=180)
+        assert wait_for(lambda: embedded_appliance.rabbitmq_server.running,
+                        fail_cond=False,
+                        num_sec=80)
+        assert wait_for(lambda: embedded_appliance.nginx.running,
+                        fail_cond=False,
+                        num_sec=30)
+    else:
+        @wait_for_decorator(num_sec=300)
+        def is_ansible_pod_stopped():
+            # todo: implement appropriate methods in appliance
+            return embedded_appliance.ssh_client.run_command(
+                'oc get pods|grep ansible', ensure_host=True).failed

--- a/cfme/tests/ansible/test_embedded_ansible_crud.py
+++ b/cfme/tests/ansible/test_embedded_ansible_crud.py
@@ -3,7 +3,6 @@ import pytest
 from cfme import test_requirements
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for
-from cfme.utils.wait import wait_for_decorator
 
 pytestmark = [
     pytest.mark.ignore_stream("upstream"),
@@ -126,9 +125,4 @@ def test_embedded_ansible_disable(embedded_appliance):
         )
         assert wait_for(lambda: not embedded_appliance.nginx.is_active, num_sec=30)
     else:
-        @wait_for_decorator(num_sec=300)
-        def is_ansible_pod_stopped():
-            # todo: implement appropriate methods in appliance
-            return embedded_appliance.ssh_client.run_command(
-                "oc get pods|grep ansible", ensure_host=True
-            ).failed
+        assert wait_for(lambda: embedded_appliance.is_ansible_pod_stopped, num_sec=300)

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -1755,6 +1755,12 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
             return None
 
     @property
+    def is_ansible_pod_stopped(self):
+        return self.ssh_client.run_command(
+            "oc get pods|grep ansible", ensure_host=True
+        ).failed
+
+    @property
     def is_embedded_ansible_role_enabled(self):
         return self.server_roles.get("embedded_ansible", False)
 

--- a/cfme/utils/appliance/services.py
+++ b/cfme/utils/appliance/services.py
@@ -51,7 +51,6 @@ class SystemdService(AppliancePlugin):
             else:
                 self.logger.error(msg)
             raise SystemdException(msg)
-
         return result
 
     def stop(self, log_callback=None):
@@ -85,6 +84,14 @@ class SystemdService(AppliancePlugin):
     @property
     def enabled(self):
         return self._run_service_command('is-enabled').rc == 0
+
+    @property
+    def is_active(self):
+        result = self._run_service_command("status")
+        if 'inactive' in result.output:
+            return False
+        else:
+            return True
 
     @property
     def running(self):


### PR DESCRIPTION
PRT Run:

{{ pytest: cfme/tests/ansible/test_embedded_ansible_crud.py --long-running }}

Fixes #8702 