### PR TITLE
Pass url positionally as its name is changing in manageiq_client

### DIFF
--- a/cfme/base/__init__.py
+++ b/cfme/base/__init__.py
@@ -85,7 +85,7 @@ class Server(BaseEntity, sentaku.modeling.ElementMixin):
     @property
     def advanced_settings(self):
         """GET servers/:id/settings api endpoint to query server configuration"""
-        return self.appliance.rest_api.get(url=self._api_settings_url)
+        return self.appliance.rest_api.get(self._api_settings_url)
 
     def update_advanced_settings(self, settings_dict):
         """PATCH settings from the server's api/server/:id/settings endpoint


### PR DESCRIPTION
Purpose or Intent
=================

See https://github.com/ManageIQ/manageiq-api-client-python/issues/45, @valaparthvi is __Extending__ upstream API to not reserve `url` keyword argument, so that she can add test case for adding AnsibleTower via REST API.

For now https://github.com/ManageIQ/manageiq-api-client-python/pull/46 preserved backward compatibility — `get(url=..., **...)` still works — but it might get dropped later.

Also for consistency - over 30 calls in this project pass it positionally.  (Same in some other projects on the internet.  This was the _only_ call I found passing it by name.) 

@valaparthvi please review