### PR TITLE
[RFR] Default to vddk 6.5 in vddk_url fixture

### DIFF
--- a/cfme/fixtures/appliance.py
+++ b/cfme/fixtures/appliance.py
@@ -16,6 +16,7 @@ import pytest
 
 from cfme.test_framework.sprout.client import SproutClient
 from cfme.utils import conf
+from cfme.utils.log import logger
 
 
 @contextmanager
@@ -199,9 +200,10 @@ def get_vddk_url(provider):
     except (KeyError, AttributeError):
         pytest.skip('VDDK URL/Version not found in cfme_data.basic_info')
     if url is None:
-        pytest.skip("There is no vddk url for this VMware provider version")
-    else:
-        return url
+        logger.warning("Using VDDK {}, as VDDK {} was unavailable".format("v6_5", vddk_version))
+        url = conf.cfme_data.basic_info.vddk_url.get("v6_5")
+
+    return url
 
 
 @pytest.fixture(scope="function")

--- a/cfme/fixtures/appliance.py
+++ b/cfme/fixtures/appliance.py
@@ -195,13 +195,20 @@ def get_vddk_url(provider):
         major = str(provider.version)
         minor = "0"
     vddk_version = "v{}_{}".format(major, minor)
+
     try:
-        url = conf.cfme_data.basic_info.vddk_url.get(vddk_version)
+        vddk_urls = conf.cfme_data.basic_info.vddk_url
     except (KeyError, AttributeError):
-        pytest.skip('VDDK URL/Version not found in cfme_data.basic_info')
+        pytest.skip("VDDK URLs not found in cfme_data.basic_info")
+
+    if vddk_version not in vddk_urls:
+        logger.warning("Using VDDK %s, as VDDK %s was unavailable", "v6_5", vddk_version)
+        vddk_version = "v6_5"
+
+    url = vddk_urls.get(vddk_version)
+
     if url is None:
-        logger.warning("Using VDDK {}, as VDDK {} was unavailable".format("v6_5", vddk_version))
-        url = conf.cfme_data.basic_info.vddk_url.get("v6_5")
+        pytest.skip("VDDK {} is unavailable, skipping test".format(vddk_version))
 
     return url
 


### PR DESCRIPTION
Purpose or Intent
=================
A few tests are skipping because we don't have a `vddk_url` for VSphere 6.7. This PR will make tests use `vddk v6_5` for these skipped tests. 

{{pytest: --long-running --use-template-cache --use-provider vsphere67-nested cfme/tests/control/test_alerts.py::test_alert_hardware_reconfigured }}