### PR TITLE
[RFR] Remove finally clause from _get_vm method in control/test_actions.py

### DIFF
--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -132,7 +132,6 @@ def _get_vm(request, provider, template_name, vm_name):
             vm.cleanup_on_provider()
         except TimedOutError:
             logger.error("Could not delete VM %s!", vm_name)
-    finally:
         # If this happened, we should skip all tests from this provider in this module
         pytest.skip(message)
 


### PR DESCRIPTION
rc-regression, this `finally` block should not exist, as that skips all tests.  Recent change also caused `message` reference triggering an `UnboundLocal`

Not necessarily expecting this module to completely pass PRT, but I'm looking to not hit any `UnboundLocal` or other failing results connected to whether this skip is called or not.