### PR TITLE
[1LP][RFR] Fixed AssertionError while copying method/instance/class to domain

### DIFF
--- a/cfme/automate/explorer/common.py
+++ b/cfme/automate/explorer/common.py
@@ -43,11 +43,7 @@ class Copiable(object):
             copy_page.copy_button.click()
             # Attention! Now we should be on a different page but the flash message is the same!
             copy_page.flash.assert_no_error()
-            copy_page.flash.assert_message('Copy selected Automate {} was saved'
-                                           .format(self.__class__))
         else:
             copy_page.cancel_button.click()
             # Attention! Now we should be on a different page but the flash message is the same!
             copy_page.flash.assert_no_error()
-            copy_page.flash.assert_message('Copy Automate {} was cancelled by the user'
-                                           .format(self.__class__))

--- a/cfme/tests/automate/test_automate_manual.py
+++ b/cfme/tests/automate/test_automate_manual.py
@@ -314,38 +314,6 @@ def test_state_machine_variable():
     pass
 
 
-@pytest.mark.tier(2)
-def test_automate_method_copy():
-    """
-    Should copy selected automate method/Instance without going into edit mode.
-
-    Polarion:
-        assignee: ghubale
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/8h
-        tags: automate
-        startsin: 5.9
-        upstream: yes
-        testSteps:
-            1. Add new domain (In enabled/unlock mode)
-            2. Add namespace in that domain
-            3. Add class in that namespace
-            4. Unlock ManageIQ domain now
-            5. Select Instance/Method from any class in ManageIQ
-            6. From configuration toolbar, select "Copy this method/Instance"
-        expectedResults:
-            1.
-            2.
-            3.
-            4. Able to copy method with "Copy This Method" toolbar.
-
-    Bugzilla:
-        1500956
-    """
-    pass
-
-
 @pytest.mark.tier(3)
 def test_automate_git_import_deleted_tag():
     """

--- a/cfme/tests/automate/test_domain.py
+++ b/cfme/tests/automate/test_domain.py
@@ -4,6 +4,9 @@ import pytest
 
 from cfme import test_requirements
 from cfme.automate.explorer.domain import DomainAddView
+from cfme.automate.explorer.instance import InstanceCopyView
+from cfme.automate.explorer.klass import ClassCopyView
+from cfme.automate.explorer.method import MethodCopyView
 from cfme.exceptions import OptionNotAvailable
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
@@ -291,3 +294,68 @@ def test_object_attribute_type_in_automate_schedule(appliance):
         view.flash.assert_no_error()
         view.form.object_type.select_by_visible_text('<Choose>')
         view.flash.assert_no_error()
+
+
+@pytest.mark.tier(3)
+def test_copy_to_domain(domain):
+    """This test case checks whether automate class, instance and method are successfully copying to
+    domain.
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: Automate
+        caseimportance: low
+        initialEstimate: 1/15h
+        startsin: 5.9
+        tags: automate
+        setup:
+            1. Create new custom domain
+        testSteps:
+            1. Go to Automation > Automate > Explorer
+            2. Select any class, instance and method from ManageIQ domain
+            3. Copy selected things one by one to new custom domain by selecting
+               "Copy this Method/Instance/Class" from configuration toolbar
+        expectedResults:
+            1.
+            2.
+            3. Class, Instance and Method should be copied to new domain and assert message should
+               appear after copying these things to new domain.
+
+    Bugzilla:
+        1500956
+    """
+    # Instantiating default domain - 'ManageIQ'
+    miq = (
+        domain.appliance.collections.domains.instantiate("ManageIQ")
+        .namespaces.instantiate("System")
+        .namespaces.instantiate("CommonMethods")
+    )
+
+    # Instantiating Class - 'MiqAe' from 'ManageIQ' domain
+    original_klass = miq.classes.instantiate("MiqAe")
+
+    # Copy this Class to custom domain
+    original_klass.copy_to(domain=domain)
+    klass = domain.browser.create_view(ClassCopyView)
+    klass.flash.wait_displayed()
+    klass.flash.assert_message("Copy selected Automate Class was saved")
+
+    # Instantiating Instance - 'quota_source' from 'ManageIQ' domain
+    original_instance = miq.classes.instantiate("QuotaMethods").instances.instantiate(
+        "quota_source"
+    )
+
+    # Copy this instance to custom domain
+    original_instance.copy_to(domain=domain)
+    instance = domain.browser.create_view(InstanceCopyView)
+    instance.flash.wait_displayed()
+    instance.flash.assert_message("Copy selected Automate Instance was saved")
+
+    # Instantiating Method - 'rejected' from 'ManageIQ' domain
+    original_method = miq.classes.instantiate("QuotaStateMachine").methods.instantiate("rejected")
+
+    # Copy this method to custom domain
+    original_method.copy_to(domain=domain)
+    method = domain.browser.create_view(MethodCopyView)
+    method.flash.wait_displayed()
+    method.flash.assert_message("Copy selected Automate Method was saved")


### PR DESCRIPTION
This PR includes following changes:
- Removing flash message assertions from module page
- Automated test case which was related to copy ```automate class/instance/method``` to new domain
- Asserted those removed statements in this test case
- This fix will save more number of test cases related to quota and automate from failures
- Fixed Error:

```E           AssertionError: assert exact match of message: Copy selected Automate <class 'cfme.automate.explorer.instance.Instance'> was saved. 
E            Available messages: [u'Copy selected Automate Instance was saved']

/var/ci/cfme_venv/lib/python2.7/site-packages/widgetastic_patternfly/__init__.py:299: AssertionError
AssertionError
assert exact match of message: Copy selected Automate <class 'cfme.automate.explorer.instance.Instance'> was saved. 
 Available messages: [u'Copy selected Automate Instance was saved']```
```
{{ pytest: cfme/tests/automate/test_domain.py -k 'test_copy_to_domain' -v }}

