### PR TITLE
[RFR] Add in test_requirements where necessary for FAs

### DIFF
--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -3,6 +3,7 @@ import fauxfactory
 import pytest
 from wrapanapi.exceptions import NotFoundError
 
+from cfme import test_requirements
 from cfme.base.ui import ServerDiagnosticsView
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.ec2 import EC2Provider
@@ -18,7 +19,9 @@ pytestmark = [
     pytest.mark.tier(2),
     # Only onr prov out of the 2 is taken, if not supplying --use-provider=complete
     pytest.mark.provider([AzureProvider, EC2Provider]),
-    pytest.mark.usefixtures('setup_provider')
+    pytest.mark.usefixtures('setup_provider'),
+    test_requirements.timelines,
+    test_requirements.events,
 ]
 
 

--- a/cfme/tests/cloud_infra_common/test_events.py
+++ b/cfme/tests/cloud_infra_common/test_events.py
@@ -3,6 +3,7 @@
 import fauxfactory
 import pytest
 
+from cfme import test_requirements
 from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.control.explorer.policies import VMControlPolicy
@@ -20,6 +21,7 @@ pytestmark = [
     pytest.mark.tier(2),
     pytest.mark.provider(gen_func=providers, filters=[all_prov, excluded],
                          scope='module'),
+    test_requirements.events,
 ]
 
 

--- a/cfme/tests/control/test_rest_control.py
+++ b/cfme/tests/control/test_rest_control.py
@@ -14,7 +14,8 @@ from cfme.utils.rest import query_resource_attributes
 from cfme.utils.wait import wait_for
 
 pytestmark = [
-    test_requirements.rest
+    test_requirements.rest,
+    test_requirements.control
 ]
 
 

--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -1,6 +1,7 @@
 import fauxfactory
 import pytest
 
+from cfme import test_requirements
 from cfme.base.ui import ServerDiagnosticsView
 from cfme.control.explorer.policies import VMControlPolicy
 from cfme.infrastructure.provider import InfraProvider
@@ -24,6 +25,8 @@ pytestmark = [
     pytest.mark.tier(2),
     pytest.mark.provider(gen_func=providers, filters=[excluded, all_infra_prov]),
     pytest.mark.usefixtures('setup_provider'),
+    test_requirements.timelines,
+    test_requirements.events,
 ]
 
 


### PR DESCRIPTION
Making use of #8672 to add requirement metadata for my test cases. 

I've added requirements for timelines and events tests and also a control test. 
