### PR TITLE
[1LP][RFR] Optimize assign events for policies

### DIFF
--- a/cfme/tests/ansible/test_embedded_ansible_actions.py
+++ b/cfme/tests/ansible/test_embedded_ansible_actions.py
@@ -102,7 +102,7 @@ def policy_for_testing(appliance, full_template_vm_modscope, provider, ansible_a
     yield
 
     if policy.exists:
-        policy.assign_events()
+        policy.unassign_events("Tag Complete")
         provider.unassign_policy_profiles(policy_profile.description)
         policy_profile.delete()
         policy.delete()

--- a/cfme/tests/cloud_infra_common/test_events.py
+++ b/cfme/tests/cloud_infra_common/test_events.py
@@ -73,7 +73,11 @@ def test_vm_create(request, appliance, vm_crud, provider, register_event):
     request.addfinalizer(policy.delete)
 
     policy.assign_events("VM Create Complete")
-    request.addfinalizer(policy.assign_events)
+
+    @request.addfinalizer
+    def _cleanup():
+        policy.unassign_events("VM Create Complete")
+
     policy.assign_actions_to_event("VM Create Complete", action)
 
     profile = appliance.collections.policy_profiles.create(

--- a/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
+++ b/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
@@ -234,7 +234,7 @@ def ssa_compliance_policy(appliance):
     policy.assign_events("VM Provision Complete")
     policy.assign_actions_to_event("VM Provision Complete", ["Initiate SmartState Analysis for VM"])
     yield policy
-    policy.assign_events()
+    policy.unassign_events("VM Provision Complete")
     policy.delete()
 
 
@@ -406,7 +406,7 @@ def ssa_policy(appliance, ssa_action):
     policy.assign_events("VM Analysis Start")
     policy.assign_actions_to_event("VM Analysis Start", ssa_action)
     yield policy
-    policy.assign_events()
+    policy.unassign_events("VM Analysis Start")
 
 
 def detect_system_type(vm):

--- a/cfme/tests/control/test_basic.py
+++ b/cfme/tests/control/test_basic.py
@@ -165,7 +165,6 @@ EVENTS = [
     "Host Disconnect",
     "Host Maintenance Enter Request",
     "Host Maintenance Exit Request",
-    "Host Provision Complete",
     "Host Reboot Request",
     "Host Removed from Cluster",
     "Host Reset Request",
@@ -526,7 +525,10 @@ def test_control_assign_actions_to_event(request, policy_class, policy, action):
     if type(policy) in CONTROL_POLICIES:
         event = random.choice(EVENTS)
         policy.assign_events(event)
-        request.addfinalizer(policy.assign_events)
+
+        @request.addfinalizer
+        def _cleanup():
+            policy.unassign_events(event)
     else:
         prefix = policy.TREE_NODE if not policy.TREE_NODE == "Vm" else policy.TREE_NODE.upper()
         if policy.TREE_NODE == "Physical Infrastructure" and BZ(1700070).blocks:

--- a/cfme/tests/intelligence/test_reports_with_timelines.py
+++ b/cfme/tests/intelligence/test_reports_with_timelines.py
@@ -125,7 +125,7 @@ def generate_policy_event(request, appliance, provider, vm_crud, register_event)
     request.addfinalizer(policy.delete)
 
     policy.assign_events("VM Create Complete")
-    request.addfinalizer(policy.assign_events)
+
     policy.assign_actions_to_event("VM Create Complete", action)
 
     profile = appliance.collections.policy_profiles.create(

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -394,18 +394,17 @@ class BootstrapSwitchSelect(View):
         return list(set(values) - set(self.selected_text))
 
     def fill(self, values):
-        if set(values) == set(self.selected_text):
-            return False
+        if values:
+            updated = False
+            for value in values:
+                switch = self.switch_by_text(value)
+                before = switch.read()
+                switch.fill(not switch.selected)
+                if not updated and before != switch.read():
+                    updated = True
+            return updated
         else:
-            for value in self._values_to_remove(values):
-                self.switch_by_text(value).fill(False)
-            for value in self._values_to_add(values):
-                self.switch_by_text(value).fill(True)
-            try:
-                del self.selected_text
-            except AttributeError:
-                pass
-            return True
+            return False
 
     def read(self):
         return self.selected_text


### PR DESCRIPTION
Purpose or Intent
=================
The current implementation of `BootstrapSwitchSelect`'s fill method is quite slow (taking around 10 s before a fill when assigning events to a policy), since it looks at each switch on the page and decides whether or not it's selected. 

This PR modifies the fill method of `BootstrapSwitchSelect` that allows for a faster fill of the page. It is less cautious than the original fill method since it does not look at the events which are already selected. 

This PR also introduces an `unassign_events` function that takes in the names of the events you'd like to unassign from the policy. I have modified tests to use this function for cleanup, as it is more explicit (and faster) than using `assign_events()`  

{{ pytest: --long-running --use-template-cache cfme/tests/control/test_basic.py::test_assign_two_random_events_to_control_policy cfme/tests/control/test_basic.py::test_control_assign_actions_to_event }} 