### PR TITLE
[1LP][RFR] Add bugzilla-docstrings to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     exclude: ^(sprout|scripts|cfme/fixtures/rdb.py)
   - id: flake8
     language_version: python3.6
-    additional_dependencies: [polarion-docstrings,bugzilla-docstrings]
+    additional_dependencies: [polarion-docstrings, bugzilla-docstrings]
 - repo: https://github.com/asottile/pyupgrade
   rev: v1.10.1
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     exclude: ^(sprout|scripts|cfme/fixtures/rdb.py)
   - id: flake8
     language_version: python3.6
-    additional_dependencies: [polarion-docstrings]
+    additional_dependencies: [polarion-docstrings,bugzilla-docstrings]
 - repo: https://github.com/asottile/pyupgrade
   rev: v1.10.1
   hooks:

--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -106,6 +106,7 @@ boto3==1.6.6
 botocore==1.9.6
 bottle==0.12.16
 bottle-sqlite==0.1.3
+bugzilla-docstrings==0.0.1
 cached-property==1.5.1
 cachetools==3.1.0
 certifi==2019.3.9

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -103,6 +103,7 @@ boto3==1.6.6
 botocore==1.9.6
 bottle==0.12.16
 bottle-sqlite==0.1.3
+bugzilla-docstrings==0.0.1
 cached-property==1.5.1
 cachetools==3.1.0
 certifi==2019.3.9


### PR DESCRIPTION
Purpose or Intent
=================

This PR adds the flake8 plugin[ `bugzilla-docstrings`](https://pypi.org/project/bugzilla-docstrings/) to our pre-commit config. This plugin makes sure that BZs placed under `Bugzilla:` are just numbers, and that each BZ is on its own line, as described by #8684.  

Note that this plugin does not check and make sure that the `Bugzilla:` field is present in the docstring, since not all tests are written against BZs. It also does not currently look for variations of Bugzilla, such as `BZ`, or `Bugzillas`. It only looks at what is written below `Bugzilla:`.  
