### PR TITLE
[1LP][RFR] fix tests screwed up by v2v osp provider

### DIFF
--- a/cfme/tests/openstack/cloud/test_flavors.py
+++ b/cfme/tests/openstack/cloud/test_flavors.py
@@ -11,7 +11,9 @@ from cfme.utils.wait import wait_for
 
 pytestmark = [
     pytest.mark.usefixtures("setup_provider"),
-    pytest.mark.provider([OpenStackProvider], scope='function')
+    pytest.mark.provider([OpenStackProvider], scope='function', required_fields=[
+        ['provisioning', 'cloud_tenant'],
+        ['provisioning', 'cloud_network']])
 ]
 
 

--- a/cfme/tests/openstack/cloud/test_instances.py
+++ b/cfme/tests/openstack/cloud/test_instances.py
@@ -18,7 +18,10 @@ from cfme.utils.wait import wait_for_decorator
 
 pytestmark = [
     pytest.mark.usefixtures("setup_provider_modscope"),
-    pytest.mark.provider([OpenStackProvider], scope='module')
+    pytest.mark.provider([OpenStackProvider], scope='module', required_fields=[
+        ['provisioning', 'cloud_tenant'],
+        ['provisioning', 'cloud_network'],
+        ['provisioning', 'instance_type']])
 ]
 
 

--- a/cfme/tests/openstack/cloud/test_volume_backup.py
+++ b/cfme/tests/openstack/cloud/test_volume_backup.py
@@ -10,7 +10,8 @@ from cfme.utils.wait import wait_for_decorator
 
 pytestmark = [
     pytest.mark.usefixtures("setup_provider"),
-    pytest.mark.provider([OpenStackProvider])
+    pytest.mark.provider([OpenStackProvider], required_fields=[
+        ['provisioning', 'cloud_tenant']])
 ]
 
 VOLUME_SIZE = 1


### PR DESCRIPTION
```
>       prov_data = provider.data['provisioning']
E       KeyError: 'provisioning'

cfme/tests/openstack/cloud/test_flavors.py:41: KeyError
KeyError
'provisioning'
```