### PR TITLE
[1LP][RFR] Fix test operations

### DIFF
--- a/cfme/tests/services/test_operations.py
+++ b/cfme/tests/services/test_operations.py
@@ -69,7 +69,7 @@ def generated_request(appliance, provider, provisioning, template_name, vm_name)
             {'host_name': {'name': host},
              'datastore_name': {'name': datastore}},
         'network':
-            {'vlan': partial_match(provisioning['vlan'])}
+            {'vlan': partial_match(provisioning['vlan'] if provisioning.get('vlan') else None)}
     }
 
     # Same thing, different names. :\


### PR DESCRIPTION
```
        }
E       KeyError: 'vlan'

cfme/tests/services/test_operations.py:72: KeyError
KeyError
'vlan'
```