### PR TITLE
[1LP][RFR]Automate test:test_filter_by_flavor_via_api

### DIFF
--- a/cfme/tests/openstack/cloud/test_flavors.py
+++ b/cfme/tests/openstack/cloud/test_flavors.py
@@ -1,12 +1,16 @@
 """Tests for Openstack cloud Flavors"""
+from random import choice
+
 import fauxfactory
 import pytest
 from widgetastic.utils import partial_match
 
+from cfme import test_requirements
 from cfme.cloud.instance.openstack import OpenStackInstance
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator
+from cfme.utils.rest import assert_response
 from cfme.utils.wait import wait_for
 
 pytestmark = [
@@ -282,3 +286,28 @@ def test_create_instance_with_private_flavor(instance_with_private_flavor, provi
     view = navigate_to(instance_with_private_flavor, 'Details')
     power_state = view.entities.summary('Power Management').get_text_of('Power State')
     assert power_state == OpenStackInstance.STATE_ON
+
+
+@test_requirements.rest
+@pytest.mark.tier(3)
+def test_filter_by_flavor_via_api(appliance):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: Rest
+        caseimportance: medium
+        initialEstimate: 1/10h
+        setup:
+            1.Add a cloud provider.
+        testSteps:
+            1. Send a GET request: /api/vms?filter[]=flavor.name="<flavor_name>"
+        expectedResults:
+            1. Should receive a 200 OK response. Should not get any internal server error.
+
+    Bugzilla:
+        1596069
+    """
+    flavor = choice(appliance.rest_api.collections.flavors.all)
+    url = "/api/vms?filter[]=flavor.name='{}'".format(flavor.name)
+    appliance.rest_api.get(appliance.url_path(url))
+    assert_response(appliance)

--- a/cfme/tests/test_rest_manual.py
+++ b/cfme/tests/test_rest_manual.py
@@ -8,27 +8,6 @@ from cfme import test_requirements
 @pytest.mark.manual
 @test_requirements.rest
 @pytest.mark.tier(3)
-def test_cloud_volume_types():
-    """
-    Polarion:
-        assignee: pvala
-        casecomponent: Rest
-        caseimportance: high
-        initialEstimate: 1/30h
-        startsin: 5.10
-        setup:
-            1. Add a cloud provider to the appliance.
-        testSteps:
-            1. Send GET request: /api/cloud_volume_types/:id
-        expectedResults:
-            1. Successful 200 OK response.
-    """
-    pass
-
-
-@pytest.mark.manual
-@test_requirements.rest
-@pytest.mark.tier(3)
 def test_rest_metric_rollups():
     """
     Polarion:
@@ -86,69 +65,6 @@ def test_populate_default_dialog_values(auth_type):
             1635673
             1650252
             1639413
-    """
-    pass
-
-
-@pytest.mark.manual
-@test_requirements.rest
-@pytest.mark.tier(3)
-def test_filter_by_flavor_via_api():
-    """
-    Polarion:
-        assignee: pvala
-        casecomponent: Rest
-        caseimportance: medium
-        initialEstimate: 1/10h
-        setup:
-            1.Add a cloud provider.
-        testSteps:
-            1. send a GET request: /api/vms?filter[]=flavor.name="<flavor_name>"
-        expectedResults:
-            1. Should receive a 200 OK response. Should not get any internal server error.
-
-    Bugzilla:
-        1596069
-    """
-    pass
-
-
-@pytest.mark.manual
-@test_requirements.rest
-@pytest.mark.tier(0)
-def test_bulk_query_attributes():
-    """
-    Polarion:
-        assignee: pvala
-        casecomponent: Rest
-        caseimportance: medium
-        initialEstimate: 1/10h
-        setup:
-            1. Add an infrastructure provider.
-        testSteps:
-            1. Send a request.
-                POST https://xxxx/api/hosts?expand=resources,tags
-                    &attributes=hostname,id,ems_cluster_id,cpu_total_cores,cpu_cores_per_socket
-                Body: {
-                    "action": "query",
-                    "resources": [{
-                        "ems_cluster_id": ":cluster_id"
-                    }]
-                }
-        expectedResults:
-            1. Response: {
-                "results": [{
-                    "href": "https://xxxx/api/hosts/:hosts_id",
-                    "hostname": "xxxx",
-                    "id": ":hosts_id,
-                    "ems_cluster_id": ":cluster_id",
-                    "cpu_total_cores": 20,
-                    "cpu_cores_per_socket": 10
-                }]
-            }
-
-    Bugzilla:
-        1643342
     """
     pass
 


### PR DESCRIPTION
Changes:
1. Remove tests no longer in need to automate.
2. Automate test case: test_filter_by_flavor_via_api

{{ pytest: cfme/tests/openstack/cloud/test_flavors.py::test_filter_by_flavor_via_api --use-template-cache -sqvvv }}