### PR TITLE
[RFR] fixing scopes of some global fixtures

### DIFF
--- a/cfme/fixtures/service_fixtures.py
+++ b/cfme/fixtures/service_fixtures.py
@@ -20,18 +20,34 @@ from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def dialog(request, appliance):
     return _dialog(request, appliance)
 
 
 @pytest.fixture(scope="module")
+def dialog_modscope(request, appliance):
+    return _dialog(request, appliance)
+
+
+@pytest.fixture(scope="function")
 def catalog(request, appliance):
+    return _catalog(request, appliance)
+
+
+@pytest.fixture(scope="module")
+def catalog_modscope(request, appliance):
     return _catalog(request, appliance)
 
 
 @pytest.fixture(scope="function")
 def catalog_item(appliance, provider, provisioning, dialog, catalog):
+    catalog_item = create_catalog_item(appliance, provider, provisioning, dialog, catalog)
+    return catalog_item
+
+
+@pytest.fixture(scope="module")
+def catalog_item_modscope(appliance, provider, provisioning, dialog, catalog):
     catalog_item = create_catalog_item(appliance, provider, provisioning, dialog, catalog)
     return catalog_item
 


### PR DESCRIPTION
Changing some global fixture scopes affected some existing tests. This PR restores scopes for those global fixtures.

{{pytest: --long-running cfme/tests/services/test_generic_service_catalogs.py}}