### PR TITLE
[1LP][RFR] Automate test: test_rest_metric_rollups

### DIFF
--- a/cfme/tests/test_rest_manual.py
+++ b/cfme/tests/test_rest_manual.py
@@ -8,20 +8,18 @@ from cfme import test_requirements
 @pytest.mark.manual
 @test_requirements.rest
 @pytest.mark.tier(3)
-def test_rest_metric_rollups():
+def test_cloud_volume_types():
     """
     Polarion:
         assignee: pvala
         casecomponent: Rest
-        caseimportance: medium
-        initialEstimate: 1/10h
+        caseimportance: high
+        initialEstimate: 1/30h
+        startsin: 5.10
         setup:
-            1. Add a provider to the appliance.
-            2. Enable C&U on the appliance.
-            3. Wait for few minutes.
+            1. Add a cloud provider to the appliance.
         testSteps:
-            1. Send GET request:
-            /api/vms/:id/metric_rollups?capture_interval=hourly&start_date=':today_date'
+            1. Send GET request: /api/cloud_volume_types/:id
         expectedResults:
             1. Successful 200 OK response.
     """


### PR DESCRIPTION
Changes:
1. Automate test: test_rest_metric_rollups - not enabling candu, because we only want to check if the endpoint works and does not give any error.
2. Move `test_settings_collections` to `test_query_simple_collections`, and also test `automate_workspaces` collections which wasn't tested earlier.

{{ pytest: cfme/tests/test_rest.py -k "test_query_simple_collections or test_rest_metric_rollups" --use-template-cache -sqvvv }}