### PR TITLE
[RFR][NOTEST]reassigned more general ui tests

### DIFF
--- a/cfme/tests/automate/test_customization_paginator.py
+++ b/cfme/tests/automate/test_customization_paginator.py
@@ -62,7 +62,7 @@ def test_paginator_service_dialogs(some_dialogs, soft_assert, appliance):
         * During the cycling, assert the paginator does not get stuck.
 
     Polarion:
-        assignee: anikifor
+        assignee: pvala
         casecomponent: WebUI
         initialEstimate: 1/4h
     """

--- a/cfme/tests/automate/test_service_dialog.py
+++ b/cfme/tests/automate/test_service_dialog.py
@@ -358,7 +358,7 @@ def test_copying_customization_dialog():
         1342260
 
     Polarion:
-        assignee: anikifor
+        assignee: pvala
         casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/12h

--- a/cfme/tests/configure/test_config_manual.py
+++ b/cfme/tests/configure/test_config_manual.py
@@ -32,3 +32,44 @@ def test_validate_landing_pages_for_rbac():
             1. Landing pages which user has access to must be present in the dropdown list.
     """
     pass
+
+
+@pytest.mark.manual
+@test_requirements.settings
+@pytest.mark.tier(1)
+def test_my_settings_default_views_alignment():
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: Configuration
+        caseimportance: medium
+        initialEstimate: 1/20h
+        testSteps:
+            1. Go to My Settings -> Default Views
+        expectedResults:
+            1. All icons are aligned correctly
+    """
+    pass
+
+
+@pytest.mark.manual
+@test_requirements.configuration
+@pytest.mark.tier(1)
+def test_configure_icons_roles_by_server():
+    """
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: Configuration
+        caseimportance: low
+        initialEstimate: 1/15h
+        testSteps:
+            1. Go to Settings -> Configuration and enable all Server Roles.
+            2.Navigate to Settings -> Configuration -> Diagnostics -> CFME Region ->
+            Roles by Servers.
+            3. Click through all Roles and look for missing icons.
+        expectedResults:
+            1.
+            2.
+            3. No icons are missing
+    """
+    pass

--- a/cfme/tests/configure/test_paginator.py
+++ b/cfme/tests/configure/test_paginator.py
@@ -97,6 +97,7 @@ def schedule(appliance):
     schedule.delete()
 
 
+@test_requirements.configuration
 @pytest.mark.parametrize('place_info', general_list_pages,
                          ids=['{}_{}'.format(set_type[0], set_type[2].lower())
                               for set_type in general_list_pages])
@@ -105,7 +106,7 @@ def test_paginator_config_pages(appliance, place_info):
         Check paginator is visible for config pages
 
     Polarion:
-        assignee: anikifor
+        assignee: tpapaioa
         initialEstimate: 1/4h
         casecomponent: WebUI
     """
@@ -124,6 +125,7 @@ def test_paginator_config_pages(appliance, place_info):
     assert check_paginator_for_page(view) == paginator_expected_result
 
 
+@test_requirements.configuration
 @pytest.mark.parametrize('place_info', details_pages,
                          ids=['{}_{}'.format(set_type[0], set_type[2].lower())
                               for set_type in details_pages])
@@ -133,7 +135,7 @@ def test_paginator_details_page(appliance, place_info, schedule):
         If paginator is present, check that all options are present in items per page.
 
     Polarion:
-        assignee: anikifor
+        assignee: tpapaioa
         casecomponent: WebUI
         caseimportance: medium
         initialEstimate: 1/10h
@@ -173,7 +175,7 @@ def test_configure_diagnostics_pages_cfme_region():
     and check whether all sub pages are showing.
 
     Polarion:
-        assignee: anikifor
+        assignee: tpapaioa
         casecomponent: Configuration
         caseimportance: medium
         initialEstimate: 1/15h

--- a/cfme/tests/configure/test_server_name.py
+++ b/cfme/tests/configure/test_server_name.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
 import pytest
 
+from cfme import test_requirements
 from cfme.configure import about
 from cfme.utils.appliance.implementations.ui import navigate_to
+
+
+pytestmark = [test_requirements.general_ui]
 
 
 @pytest.mark.tier(3)
@@ -11,7 +15,7 @@ def test_server_name(request, appliance):
     """Tests that changing the server name updates the about page
 
     Polarion:
-        assignee: anikifor
+        assignee: pvala
         casecomponent: Configuration
         caseimportance: low
         initialEstimate: 1/15h

--- a/cfme/tests/networks/test_sdn_downloads.py
+++ b/cfme/tests/networks/test_sdn_downloads.py
@@ -2,6 +2,7 @@ import random
 
 import pytest
 
+from cfme import test_requirements
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.gce import GCEProvider
@@ -94,13 +95,14 @@ def test_download_pdf_summary(appliance, collection_type, provider):
 
 @pytest.mark.manual
 @pytest.mark.tier(1)
+@test_requirements.general_ui
 def test_pdf_summary_infra_provider():
     """
     Bugzilla:
         1651194
 
     Polarion:
-        assignee: anikifor
+        assignee: pvala
         casecomponent: WebUI
         caseimportance: medium
         initialEstimate: 1/8h

--- a/cfme/tests/webui/test_advanced_search.py
+++ b/cfme/tests/webui/test_advanced_search.py
@@ -5,12 +5,16 @@ import fauxfactory
 import pytest
 import six
 
+from cfme import test_requirements
 from cfme.infrastructure.config_management import ConfigManager
 from cfme.infrastructure.config_management import ConfigSystem
 from cfme.services.myservice import MyService
 from cfme.services.workloads import TemplatesImages
 from cfme.services.workloads import VmsInstances
 from cfme.utils.appliance.implementations.ui import navigate_to
+
+
+pytestmark = [test_requirements.filtering]
 
 Param = namedtuple("Param", ["collection", "destination", "entity", "filter", "my_filters"])
 

--- a/cfme/tests/webui/test_filter_conditions.py
+++ b/cfme/tests/webui/test_filter_conditions.py
@@ -1,0 +1,29 @@
+import pytest
+
+from cfme import test_requirements
+
+
+pytestmark = [test_requirements.filtering]
+
+
+@pytest.mark.manual
+@pytest.mark.tier(0)
+def test_create_filter_with_multiple_conditions():
+    """
+    Polarion:
+        assignee: anikifor
+        casecomponent: WebUI
+        caseimportance: high
+        initialEstimate: 1/5h
+        setup:
+            1. Navigate to Compute > Infrastructure > Providers.
+            2. Click on Advanced Search Filter.
+        testSteps:
+            1. Create an expression with multiple types of condition. Eg: arg_1 AND arg_2 OR arg_3
+        expectedResults:
+            1. Expression must be created successfully.
+
+    Bugzilla:
+        1660460
+    """
+    pass

--- a/cfme/tests/webui/test_general_ui.py
+++ b/cfme/tests/webui/test_general_ui.py
@@ -336,7 +336,7 @@ def test_configuration_icons_trusted_forest_settings():
 def test_cloud_icons_instances():
     """
     Polarion:
-        assignee: anikifor
+        assignee: pvala
         casecomponent: WebUI
         caseimportance: medium
         initialEstimate: 1/20h
@@ -349,7 +349,6 @@ def test_cloud_icons_instances():
 
 
 @pytest.mark.manual
-@test_requirements.general_ui
 @pytest.mark.tier(1)
 def test_key_pairs_quadicon():
     """
@@ -357,7 +356,7 @@ def test_key_pairs_quadicon():
         1352914
 
     Polarion:
-        assignee: anikifor
+        assignee: pvala
         casecomponent: Cloud
         caseimportance: low
         initialEstimate: 1/20h
@@ -372,30 +371,13 @@ def test_key_pairs_quadicon():
 
 
 @pytest.mark.manual
-@test_requirements.filtering
-@pytest.mark.tier(2)
-def test_search_is_displayed_myservices():
-    """
-    Polarion:
-        assignee: anikifor
-        casecomponent: WebUI
-        caseimportance: medium
-        initialEstimate: 1/30h
-        testSteps:
-            1. Go to Services -> My Services
-            2. Check whether Search Bar and Advanced Search button are displayed
-    """
-    pass
-
-
-@pytest.mark.manual
 @pytest.mark.tier(1)
 def test_misclicking_checkbox_vms():
     """
     BZ1627387
 
     Polarion:
-        assignee: anikifor
+        assignee: pvala
         casecomponent: Infra
         caseimportance: low
         initialEstimate: 1/8h
@@ -405,11 +387,10 @@ def test_misclicking_checkbox_vms():
 
 
 @pytest.mark.manual
-@test_requirements.general_ui
 def test_timeout():
     """
     Polarion:
-        assignee: anikifor
+        assignee: pvala
         caseimportance: medium
         casecomponent: WebUI
         initialEstimate: 1/4h
@@ -425,67 +406,6 @@ def test_timeout():
 
 
 @pytest.mark.manual
-@test_requirements.configuration
-@pytest.mark.tier(1)
-def test_my_settings_default_views_alignment():
-    """
-    Polarion:
-        assignee: anikifor
-        casecomponent: Configuration
-        caseimportance: medium
-        initialEstimate: 1/20h
-        testSteps:
-            1. Go to My Settings -> Default Views
-            2. See that all icons are aligned correctly
-    """
-    pass
-
-
-@pytest.mark.manual
-@test_requirements.configuration
-@pytest.mark.tier(1)
-def test_configure_icons_roles_by_server():
-    """
-    Polarion:
-        assignee: anikifor
-        casecomponent: Configuration
-        caseimportance: low
-        initialEstimate: 1/15h
-        testSteps:
-            1. Go to Settings -> Configuration and enable all Server Roles.
-            2.Navigate to Settings -> Configuration -> Diagnostics -> CFME Region ->
-            Roles by Servers.
-            3. Click through all Roles and look for missing icons.
-    """
-    pass
-
-
-@pytest.mark.manual
-@test_requirements.general_ui
-@pytest.mark.tier(0)
-def test_create_filter_with_multiple_conditions():
-    """
-    Polarion:
-        assignee: pvala
-        casecomponent: WebUI
-        caseimportance: medium
-        initialEstimate: 1/5h
-        setup:
-            1. Navigate to Compute > Infrastructure > Providers.
-            2. Click on Advanced Search Filter.
-        testSteps:
-            1. Create an expression with multiple types of condition. Eg: arg_1 AND arg_2 OR arg_3
-        expectedResults:
-            1. Expression must be created successfully.
-
-    Bugzilla:
-        1660460
-    """
-    pass
-
-
-@pytest.mark.manual
-@test_requirements.general_ui
 @pytest.mark.tier(2)
 def test_welcoming_page():
     """
@@ -508,7 +428,6 @@ def test_welcoming_page():
 
 
 @pytest.mark.manual()
-@test_requirements.general_ui
 @pytest.mark.tier(0)
 def test_custom_navigation_menu():
     """


### PR DESCRIPTION
1. reassigned some `general_ui` tests to pvala
2. marked some tests with `configuration` requirements and reassigned to tpapaioa
3. found some tests that should belong to `searching and filtering` and reassigned them to myself