### PR TITLE
[1LP][RFR] Use re.search instead of re.match in LogValidator

### DIFF
--- a/cfme/utils/log_validator.py
+++ b/cfme/utils/log_validator.py
@@ -60,7 +60,7 @@ class LogValidator(object):
 
     def _check_skip_logs(self, line):
         for pattern in self.skip_patterns:
-            if re.match(pattern, line):
+            if re.search(pattern, line):
                 logger.info('Skip pattern {} was matched on line {},\
                             so skipping this line'.format(pattern, line))
                 return True
@@ -68,12 +68,12 @@ class LogValidator(object):
 
     def _check_fail_logs(self, line):
         for pattern in self.failure_patterns:
-            if re.match(pattern, line):
+            if re.search(pattern, line):
                 pytest.fail('Failure pattern {} was matched on line {}'.format(pattern, line))
 
     def _check_match_logs(self, line):
         for pattern in self.matched_patterns:
-            if re.match(pattern, line):
+            if re.search(pattern, line):
                 logger.info('Expected pattern {} was matched on line {}'.format(pattern, line))
                 self.matches[pattern] = True
 


### PR DESCRIPTION
Purpose or Intent
=================
The `LogValidator` currently uses `re.match()` to verify the presence of a pattern in the line(s) of a log. `re.match()` begins its search at the start of a file, so if you have a pattern you want to match that may appear later in the line, you must put `.*` at the start of your pattern. 

With `re.search()` no such preamble is necessary. 

{{ pytest: --long-running --use-template-cache --use-provider complete cfme/tests/networks/nuage/test_automation.py::test_embedded_ansible_executed_with_data_upon_event cfme/tests/containers/test_pause_resume_workers.py::test_pause_and_resume_single_provider_api }}

Example: 

```python,
In [1]: import re                                                                                                                                                                                                  

In [2]: pattern = r'Prevent current event from proceeding.'                                                                                                                                                        

In [3]: line = "[----] I, [2019-04-22T15:15:35.609182 #64720:7fcf60]  INFO -- : MIQ(action-invoke) Invoking action [Prevent current event from proceeding] for successful policy [action_testing: policy IVuOowZAKO
   ...: ], event: [VM Analysis Request], entity name: [long-test-action-r3xy], entity type: [Virtual Machine (VMware)], sequence: [1], synchronous? [true]"                                                        

In [4]: re.match(pattern, line)                                                                                                                                                                                    

In [5]: re.match(pattern, line).group()                                                                                                                                                                            
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-5-ea2a62ddb834> in <module>
----> 1 re.match(pattern, line).group()

AttributeError: 'NoneType' object has no attribute 'group'

In [6]: re.search(pattern, line).group()                                                                                                                                                                           
Out[6]: 'Prevent current event from proceeding]'

In [7]: pattern = r'.*Prevent current event from proceeding.'                                                                                                                                                      

In [8]: re.match(pattern, line).group()                                                                                                                                                                            
Out[8]: '[----] I, [2019-04-22T15:15:35.609182 #64720:7fcf60]  INFO -- : MIQ(action-invoke) Invoking action [Prevent current event from proceeding]'

In [9]: re.search(pattern, line).group()                                                                                                                                                                           
Out[9]: '[----] I, [2019-04-22T15:15:35.609182 #64720:7fcf60]  INFO -- : MIQ(action-invoke) Invoking action [Prevent current event from proceeding]'

```
As you can see by `In [8]` and `In [9]`, this should not impact tests which already have `.*` in their matched_patterns. 
