### PR TITLE
[1LP][RFR] New tests for BZs qe_test_coverage

### DIFF
--- a/cfme/tests/cloud/test_snapshot.py
+++ b/cfme/tests/cloud/test_snapshot.py
@@ -128,3 +128,40 @@ def test_notification_for_snapshot_delete_failure_ec2():
         1449243
     """
     pass
+
+
+@pytest.mark.manual
+@pytest.mark.provider([OpenStackProvider])
+@test_requirements.snapshot
+@pytest.mark.tier(2)
+def test_snapshot_cloud_tenant():
+    """
+    Verify that snapshot created on an instance belonging to a non-admin tenant also belongs
+    to the same non-admin tenant.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: Cloud
+        caseimportance: high
+        initialEstimate: 1/4h
+        startsin: 5.10
+        setup:
+            1. Have OSP provider added
+            2. Have non-admin cloud tenant created
+            3. Deploy a new instance with non-admin cloud tenant
+        testSteps:
+            1. Create snapshot on newly deployed instance
+            2. Navigate Compute -> Cloud -> Tenants -> <your tenant> -> Images
+            3. Verify the snapshot is displayed here
+            4. Navigate Compute -> Cloud -> Tenants -> admin -> Images
+            5. Verify the snapshot is NOT displayed here
+        expectedResults:
+            1. Snapshot created
+            2. Navigation successful
+            3. Snapshot displayed for non-admin tenant
+            4. Navigation successful
+            5. Snapshot NOT displayed for admin tenant
+    Bugzilla:
+        1685300
+    """
+    pass

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -1993,3 +1993,31 @@ def test_host_clusters_pod_filter():
         1631694
     """
     pass
+
+
+@pytest.mark.manual
+@test_requirements.rbac
+@pytest.mark.tier(2)
+def test_my_tasks_api():
+    """
+    Test that user with My Tasks product feature can see only his tasks via API
+
+    Polarion:
+        assignee: apagac
+        casecomponent: Configuration
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.10
+        testSteps:
+            1. Create a user with Settings -> Tasks -> View -> My Tasks (but not All Tasks),
+                for example EvmRole-support
+            2. Navigate to Tasks via UI, verify you can see only "My Tasks"
+            3. Query API with the user: curl -k "https://<username>:<password>@<IP>/api/tasks/"
+        expectedResults:
+            1. User created
+            2. "My Tasks" displayed
+            3. Only tasks belonging to the user displayed
+    Bugzilla:
+        1639387
+    """
+    pass

--- a/cfme/tests/infrastructure/test_vm_reconfigure.py
+++ b/cfme/tests/infrastructure/test_vm_reconfigure.py
@@ -300,6 +300,39 @@ def test_vm_reconfig_resize_disk_hot(disk_type, disk_mode):
 
 @pytest.mark.manual
 @pytest.mark.tier(1)
+@pytest.mark.ignore_stream('5.10')
+@pytest.mark.provider([VMwareProvider], override=True)
+@pytest.mark.parametrize('disk_type', ['thin', 'thick'])
+@pytest.mark.parametrize(
+    'disk_mode', ['persistent', 'independent_persistent', 'independent_nonpersistent'])
+def test_vm_reconfig_resize_disk_snapshot(disk_type, disk_mode, provider):
+    """
+    Polarion:
+        assignee: nansari
+        initialEstimate: 1/6h
+        testtype: functional
+        startsin: 5.11
+        casecomponent: Infra
+        caseposneg: negative
+        tags: reconfigure
+        setup:
+            1. Have a VM running on vsphere provider
+        testSteps:
+            1. Go to Compute -> infrastructure -> Virtual Machines -> Select Vm
+            2. Create a snapshot for selected VM
+            3. Go to VM reconfiguration and try to resize disk of the VM
+        expectedResults:
+            1. VM selected
+            2. Snapshot created
+            3. Resize is not allowed when snapshots are attached
+    Bugzilla:
+        1631448
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
 @pytest.mark.provider([VMwareProvider], override=True)
 @pytest.mark.parametrize(
     'adapters_type', ['DPortGroup', 'VmNetwork', 'MgmtNetwork', 'VmKernel'])

--- a/cfme/tests/ssui/test_ssui_myservice.py
+++ b/cfme/tests/ssui/test_ssui_myservice.py
@@ -216,3 +216,30 @@ def test_vm_console(request, appliance, setup_provider, context, configure_webso
                 take_screenshot("ConsoleScreenshot")
                 vm_console.switch_to_appliance()
                 raise
+
+
+@pytest.mark.manual
+@test_requirements.ssui
+@pytest.mark.tier(2)
+@pytest.mark.parametrize('context', [ViaSSUI])
+def test_suspend_vm_service_details(context):
+    """
+    Test suspending VM from SSUI service details page.
+
+    Polarion:
+        assignee: apagac
+        casecomponent: Infra
+        caseimportance: medium
+        initialEstimate: 1/4h
+        setup:
+            1. Have a service catalog item that provisions a VM
+        testSteps:
+            1. In SSUI, navigate to My Services -> <service name> to see service details
+            2. In Resources section, choose 'Suspend' from dropdown
+        expectedResults:
+            1. Service details displayed
+            2. VM is suspended; VM is NOT in Unknown Power State
+    Bugzilla:
+        1670373
+    """
+    pass


### PR DESCRIPTION
__Adding__ new tests as a result of qe_test_coverage flag.

I left @niyazRedhat as assignee in `test_vm_reconfig_resize_disk_snapshot`, since he has already two very similar tests in there. Please let me know if that's the correct way to do this.