### PR TITLE
[1LP][RFR] Add in a wait_for LogValidator

### DIFF
--- a/cfme/utils/log_validator.py
+++ b/cfme/utils/log_validator.py
@@ -84,7 +84,9 @@ class LogValidator(object):
             if pattern not in self.matches:
                 pytest.fail('Expected pattern {} did not match'.format(pattern))
 
-    def wait_for_log_validation(self, **kwargs):
+    def wait_for_log_validation(
+            self, delay=5, num_sec=180, message="waiting for log validation", **kwargs
+    ):
         """ Wait for log validation, takes the kwargs as wait_for. This function will reduce
             duplicate functions in tests that wait_for log_validation. It is necessary to create
             this function since _verify_match_logs raise pytest.fail() when it fails to find the
@@ -98,4 +100,4 @@ class LogValidator(object):
                 return True
             except Failed:
                 return False
-        wait_for(validate, **kwargs)
+        wait_for(validate, delay=delay, num_sec=num_sec, message=message, **kwargs)

--- a/cfme/utils/log_validator.py
+++ b/cfme/utils/log_validator.py
@@ -1,9 +1,11 @@
 import re
 
 import pytest
+from _pytest.outcomes import Failed
 
 from .ssh import SSHTail
 from cfme.utils.log import logger
+from cfme.utils.wait import wait_for
 
 
 class LogValidator(object):
@@ -81,3 +83,19 @@ class LogValidator(object):
         for pattern in self.matched_patterns:
             if pattern not in self.matches:
                 pytest.fail('Expected pattern {} did not match'.format(pattern))
+
+    def wait_for_log_validation(self, **kwargs):
+        """ Wait for log validation, takes the kwargs as wait_for. This function will reduce
+            duplicate functions in tests that wait_for log_validation. It is necessary to create
+            this function since _verify_match_logs raise pytest.fail() when it fails to find the
+            match pattern in the logs.
+
+            Note that you must call fix_before_start() before making use of this function.
+        """
+        def validate():
+            try:
+                self.validate_logs()
+                return True
+            except Failed:
+                return False
+        wait_for(validate, **kwargs)


### PR DESCRIPTION
Adding a simple `wait_for_log_validation` for the `LogValidator`. This can be used in the following way, 

```python,
from cfme.utils.log_validator import LogValidator
test = LogValidator("/root/test.log", matched_patterns=[".*blah"])
test.fix_before_start()
test.wait_for_log_validation(timeout=300, delay=1)
# make a file on appliance with "[----] blah" on the line and we should find it
```
