### PR TITLE
[1LP][RFR] Automate config manager tests for REST

### DIFF
--- a/cfme/tests/infrastructure/test_config_management_rest.py
+++ b/cfme/tests/infrastructure/test_config_management_rest.py
@@ -250,7 +250,7 @@ def config_manager_rest(config_manager_obj):
 
 @pytest.mark.tier(3)
 @test_requirements.rest
-def test_config_manager_create(config_manager_rest):
+def test_config_manager_create_rest(config_manager_rest):
     """
     Polarion:
         assignee: pvala
@@ -267,7 +267,7 @@ def test_config_manager_create(config_manager_rest):
 
 @pytest.mark.tier(3)
 @test_requirements.rest
-def test_config_manager_edit(request, config_manager_rest):
+def test_config_manager_edit_rest(request, config_manager_rest):
     """Test editing a config manager using REST API.
 
     Polarion:
@@ -287,7 +287,7 @@ def test_config_manager_edit(request, config_manager_rest):
 @pytest.mark.tier(3)
 @test_requirements.rest
 @pytest.mark.parametrize("method", ["post", "delete"], ids=["POST", "DELETE"])
-def test_config_manager_delete_details(config_manager_rest, method):
+def test_config_manager_delete_rest(config_manager_rest, method):
     """Tests deletion of the config manager from detail using REST API.
 
     Polarion:

--- a/cfme/tests/test_rest_manual.py
+++ b/cfme/tests/test_rest_manual.py
@@ -82,24 +82,3 @@ def test_custom_logos_via_api():
         1578076
     """
     pass
-
-
-@pytest.mark.manual
-@test_requirements.rest
-@pytest.mark.tier(3)
-def test_add_ansible_tower_rest():
-    """
-    Polarion:
-        assignee: pvala
-        casecomponent: Rest
-        caseimportance: medium
-        initialEstimate: 1/10h
-        testSteps:
-            1. Add Ansible Tower via REST
-        expectedResults:
-            1. Provider must be added and validated successfully.
-
-    Bugzilla:
-        1621888
-    """
-    pass


### PR DESCRIPTION
Changes:
1. Add config_manager CRUD tests for REST
2. Add `create_rest`, `delete_rest` and `rest_api_entity` methods for Config Manager

{{ pytest: cfme/tests/infrastructure/test_config_management_rest.py -k "test_config_manager_create or test_config_manager_edit or test_config_manager_delete_details" --use-template-cache -sqvvv }}