### PR TITLE
[1LP][RFR] Updates for 5.11 configuration, set postgres permissions

### DIFF
--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -650,7 +650,7 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
             if loosen_pgssl:
                 self.db.loosen_pgssl()
                 restart_evm = True
-            if self.version >= '5.8':
+            if self.version < '5.11':
                 self.configure_vm_console_cert(log_callback=log_callback)
                 restart_evm = True
 
@@ -2378,6 +2378,11 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
         cert = conf.cfme_data['vm_console'].get('cert')
         if cert is None:
             raise Exception('vm_console:cert does not exist in cfme_data.yaml')
+
+        # 5.11 and upstream need pyopenssl for this certificate generation
+        # TODO convert the script to py3, use pip3 to install needed packages
+        if not self.is_downstream or self.version >= '5.11':
+            self.ssh_client.run_command('pip install pyopenssl')
 
         cert_file = os.path.join(cert.install_dir, 'server.cer')
         key_file = os.path.join(cert.install_dir, 'server.cer.key')

--- a/cfme/utils/appliance/db.py
+++ b/cfme/utils/appliance/db.py
@@ -434,6 +434,13 @@ class ApplianceDB(AppliancePlugin):
             'mount -a'
         ]
 
+        # Permissions modification for upstream or 5.11+
+        if not self.appliance.is_downstream or self.appliance.version >= '5.11':
+            commands_to_run.extend([
+                'chown postgres:postgres $APPLIANCE_PG_MOUNT_POINT',
+                'chmod 700 $APPLIANCE_PG_MOUNT_POINT'
+            ])
+
         for command in commands_to_run:
             result = self._run_cmd_show_output(command)
             if result.failed:


### PR DESCRIPTION
pyopenssl change may get removed in favor of the implementation in #8689.  Have it included here for testing, won't hurt.

The main workaround provided here is setting permissions on the mounted LV for the DB. PG10 uses the home dir as data dir mountpoint, needs specific ownership/permissions that were not needed in 5.10.