### PR TITLE
[1LP][RFR] Check collectonly before registering UiCoveragePlugin

### DIFF
--- a/cfme/fixtures/ui_coverage.py
+++ b/cfme/fixtures/ui_coverage.py
@@ -307,6 +307,6 @@ def pytest_addoption(parser):
 
 
 def pytest_cmdline_main(config):
-    # Only register the plugin worker if ui coverage is enabled
-    if config.option.ui_coverage:
+    # Only register the plugin worker if ui coverage is enabled and we're not using collect-only
+    if config.option.ui_coverage and not config.option.collectonly:
         config.pluginmanager.register(UiCoveragePlugin(), name="ui-coverage")


### PR DESCRIPTION
We were still trying to install coverage when using --ui-coverage and --collect-only.

This could be achived with a mutually exclusive argparse group, but both are part of the larger `cfme` group.

If the team prefers, I can take that route, but this seemed an appropriate check to me, without preventing both from being included in a py.test call.