### PR TITLE
[1LP][RFR] Update cluster property to fetch info through REST

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -982,8 +982,13 @@ class InfraVm(VM):
 
     @property
     def cluster(self):
-        all_clusters = self.provider.get_clusters()
-        return next(cl for cl in all_clusters if cl.id == self.cluster_id)
+        vm_api = self.appliance.rest_api.collections.vms.get(name=self.name)
+        cluster_api = self.appliance.rest_api.collections.clusters.get(id=vm_api.ems_cluster_id)
+        cluster_api.reload(attributes='name')
+        return self.appliance.collections.clusters.instantiate(
+            name=cluster_api.name,
+            provider=self.provider
+        )
 
     @property
     def host(self):


### PR DESCRIPTION
{{ pytest: cfme/tests/infrastructure/test_timelines.py }}

It looks like this is the only usage of vm_object.cluster.So, I'd like this test to be run on PRT against the new PR.

PRT results:
I'm still waiting on PRT results since Sprout is unable to provision an appliance at the moment.
I have tested this PR locally using this code segment .
http://pastebin.test.redhat.com/758518

With these code changes, the relevant information is fetched via REST API and not UI ; Using REST API speeds up the process .