### PR TITLE
[RFR] Fixed AttributeError while deleting multiple domains

### DIFF
--- a/cfme/automate/explorer/domain.py
+++ b/cfme/automate/explorer/domain.py
@@ -377,7 +377,7 @@ class DomainCollection(BaseCollection):
             for domain in domains:
                 if domain.table_display_name == row.name.text:
                     checked_domains.append(domain)
-                    row[0].check()
+                    row[0].click()
                     break
 
             if set(domains) == set(checked_domains):

--- a/cfme/automate/explorer/namespace.py
+++ b/cfme/automate/explorer/namespace.py
@@ -231,7 +231,7 @@ class NamespaceCollection(BaseCollection):
             for namespace in namespaces:
                 if namespace.name == name:
                     checked_namespaces.append(namespace)
-                    row[0].check()
+                    row[0].click()
                     break
 
             if set(namespaces) == set(checked_namespaces):


### PR DESCRIPTION
Fixed Error:
```
>                   row[0].check()
E                   AttributeError: 'TableColumn' object has no attribute 'check'

cfme/automate/explorer/domain.py:380: AttributeError
AttributeError
'TableColumn' object has no attribute 'check'
```
{{ pytest: cfme/tests/automate/ -k 'test_domain_delete_from_table or test_namespace_delete_from_table' -vv }}