### PR TITLE
[1LP][RFR] fixed is_displayed for ServerCollectLogsView

### DIFF
--- a/cfme/configure/configuration/diagnostics_settings.py
+++ b/cfme/configure/configuration/diagnostics_settings.py
@@ -380,8 +380,8 @@ class ServerCollectLogsView(ServerDiagnosticsView):
 
         try:
             # output 'title_template' is '[[1]]' which is not intended.
-            # Converting 'sid' into 'int' is giving desired output.
-            sid = int(sid[1])
+            # stripping square brackets to get the correct output
+            sid = sid.strip('[]')
         except ValueError:
             pass
 


### PR DESCRIPTION
{{ pytest: cfme/tests/configure/test_log_depot_operation.py -qsvvv --long-running }}

the previous solution didn't work if the server's number is more than 1 digit