### PR TITLE
[RFR] Use wait_for_log_validation where possible

### DIFF
--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -13,7 +13,6 @@ Required YAML keys:
 """
 import fauxfactory
 import pytest
-from _pytest.outcomes import Failed
 from wrapanapi import VmState
 
 from . import do_scan
@@ -493,15 +492,8 @@ def test_action_power_on_logged(request, vm, vm_off, appliance, policy_for_testi
 
     # Start the VM
     vm.mgmt.ensure_state(VmState.RUNNING)
-
-    def validate_logs():
-        try:
-            policy_result.validate_logs()
-            return True
-        except Failed:
-            return False
-
-    wait_for(validate_logs, num_sec=180, message="log search", delay=5)
+    # search logs wait_for log_validation
+    policy_result.wait_for_log_validation()
 
 
 @pytest.mark.provider(
@@ -540,15 +532,8 @@ def test_action_power_on_audit(request, vm, vm_off, appliance, policy_for_testin
     # Start the VM
     vm.mgmt.ensure_state(VmState.RUNNING)
 
-    # Search the logs
-    def validate_logs():
-        try:
-            policy_result.validate_logs()
-            return True
-        except Failed:
-            return False
-
-    wait_for(validate_logs, num_sec=180, message="log search", delay=5)
+    # Search the logs and wait for validation
+    policy_result.wait_for_log_validation()
 
 
 @pytest.mark.provider([VMwareProvider, RHEVMProvider], scope="module")

--- a/cfme/tests/networks/nuage/test_automation.py
+++ b/cfme/tests/networks/nuage/test_automation.py
@@ -1,10 +1,8 @@
 import pytest
-from _pytest.outcomes import Failed
 from wrapanapi.utils.random import random_name
 
 from cfme.utils.log_validator import LogValidator
 from cfme.utils.update import update
-from cfme.utils.wait import wait_for
 
 
 def test_auth_attributes_of_nuage_ae_class(appliance):
@@ -80,16 +78,5 @@ def test_embedded_ansible_executed_with_data_upon_event(request,
         ]
     )
     evm_tail.fix_before_start()
-
-    # LogValidator.validate_logs throws `Failed` exception which inherits `BaseException`.
-    # wait_for function checks for `Exception` which inherits `BaseException` when
-    # 'handle_exception' parameter is used. We can't make use of this functionality because
-    # `Failed` exception is not caught with `Exception` class, hence the helper function.
-    def validate_logs():
-        try:
-            evm_tail.validate_logs()
-            return True
-        except Failed:
-            return False
-
-    wait_for(validate_logs, timeout=300, delay=10, fail_condition=False)
+    # search logs and wait for validation
+    evm_tail.wait_for_log_validation(timeout=300, delay=10, fail_condition=False)


### PR DESCRIPTION
PR to make use of the `wait_for_log_validation()` function of the `LogValidator`.

{{ pytest: --use-template-cache --use-provider vsphere65-nested --long-running cfme/tests/networks/nuage/test_automation.py::test_embedded_ansible_executed_with_data_upon_event cfme/tests/control/test_actions.py::test_action_power_on_audit cfme/tests/control/test_actions.py::test_action_power_on_logged }}
