### PR TITLE
[1LP][RFR] Update openshift template upload, block 5.11

### DIFF
--- a/cfme/utils/template/rhopenshift.py
+++ b/cfme/utils/template/rhopenshift.py
@@ -138,6 +138,10 @@ yaml.safe_dump(data, stream=open("{file}", "w"))'"""
             logger.info("%s:%s No podtesting tag.", self.log_name, self.provider_key)
             return
 
+        if '511' in self.stream or 'upstream' in self.stream:
+            logger.info('Podified appliances not available for 5.11+ or upstream')
+            return False
+
         if self.does_template_exist():
             logger.info("Template already exists.")
             return True


### PR DESCRIPTION
 Output looks like:
```
(.py2env)  #  cfme/utils/template/template_upload.py --image-url http://file.cloudforms.lab.eng.rdu2.redhat.com/builds/cfme/5.11/stable --provider cm-pod1                

Matching stream name based on image_url base: http://file.cloudforms.lab.eng.rdu2.redhat.com/builds/cfme/5.11
(template-upload) [OPENSHIFT:cm-pod1:cfme-5.11.0.2-20190430] BEGIN template upload script
(template-upload) [OPENSHIFT:cm-pod1:cfme-5.11.0.2-20190430] BEGIN run upload template
Podified appliances not available for 5.11+ or upstream
(template-upload) [OPENSHIFT:cm-pod1:cfme-5.11.0.2-20190430] FAIL run upload template
(template-upload) [OPENSHIFT:cm-pod1:cfme-5.11.0.2-20190430] END template upload script
```
