### PR TITLE
[1LP][RFR] Changes related to CFME 5.11

### DIFF
--- a/cfme/tests/test_appliance.py
+++ b/cfme/tests/test_appliance.py
@@ -5,6 +5,7 @@ import os
 import pytest
 
 from cfme.utils import conf
+from cfme.utils.blockers import BZ
 from cfme.utils.log_validator import LogValidator
 from cfme.utils.wait import wait_for_decorator
 
@@ -187,6 +188,7 @@ def test_cpu_total(appliance):
     assert int(result.output) >= 4
 
 
+@pytest.mark.meta(blockers=[BZ(1712929, forced_streams=['5.11'])])  # against RHEL
 @pytest.mark.ignore_stream("upstream")
 def test_certificates_present(appliance, soft_assert):
     """Test whether the required product certificates are present.

--- a/cfme/tests/test_appliance.py
+++ b/cfme/tests/test_appliance.py
@@ -84,7 +84,7 @@ def test_evm_running(appliance):
     'evmserverd',
     'evminit',
     'sshd',
-    'postgresql',
+    'db_service',
 ])
 @pytest.mark.uncollectif(
     lambda appliance: appliance.is_pod)
@@ -98,14 +98,7 @@ def test_service_enabled(appliance, service):
         testtype: functional
         casecomponent: Appliance
     """
-    if service == 'postgresql':
-        service = appliance.db_service.unit_name
-    if appliance.os_version >= '7':
-        cmd = 'systemctl is-enabled {}'.format(service)
-    else:
-        cmd = 'chkconfig | grep {} | grep -q "5:on"'.format(service)
-    result = appliance.ssh_client.run_command(cmd)
-    assert result.success, result.output
+    assert getattr(appliance, service).enabled
 
 
 @pytest.mark.ignore_stream("upstream")

--- a/cfme/tests/test_appliance.py
+++ b/cfme/tests/test_appliance.py
@@ -99,7 +99,7 @@ def test_service_enabled(appliance, service):
         casecomponent: Appliance
     """
     if service == 'postgresql':
-        service = '{}-postgresql'.format(appliance.db.postgres_version)
+        service = str(appliance.db.service_name)
     if appliance.os_version >= '7':
         cmd = 'systemctl is-enabled {}'.format(service)
     else:

--- a/cfme/tests/test_appliance.py
+++ b/cfme/tests/test_appliance.py
@@ -302,7 +302,9 @@ def test_appliance_console_packages(appliance):
         initialEstimate: 1/4h
         casecomponent: Appliance
     """
-    assert appliance.ssh_client.run_command('scl --list | grep -v rh-ruby').success
+    if appliance.ssh_client.run_command('which scl').success:
+        # We have the scl command. Therefore we need to check the packages.
+        assert appliance.ssh_client.run_command('scl --list | grep -v rh-ruby').success
 
 
 @pytest.mark.manual

--- a/cfme/tests/test_appliance.py
+++ b/cfme/tests/test_appliance.py
@@ -99,7 +99,7 @@ def test_service_enabled(appliance, service):
         casecomponent: Appliance
     """
     if service == 'postgresql':
-        service = str(appliance.db.service_name)
+        service = appliance.db_service.unit_name
     if appliance.os_version >= '7':
         cmd = 'systemctl is-enabled {}'.format(service)
     else:

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -34,7 +34,6 @@ from .db import ApplianceDB
 from .implementations.rest import ViaREST
 from .implementations.ssui import ViaSSUI
 from .implementations.ui import ViaUI
-from .services import DynaService
 from .services import SystemdException
 from .services import SystemdService
 from cfme.fixtures import ui_coverage
@@ -310,14 +309,15 @@ class IPAppliance(object):
     auditd = SystemdService.declare(unit_name='auditd')
     chronyd = SystemdService.declare(unit_name='chronyd')
     collectd = SystemdService.declare(unit_name='collectd')
+    evminit = SystemdService.declare(unit_name='evminit')
     evmserverd = SystemdService.declare(unit_name='evmserverd')
     httpd = SystemdService.declare(unit_name='httpd')
     merkyl = SystemdService.declare(unit_name='merkyl')
     nginx = SystemdService.declare(unit_name='nginx')
     rabbitmq_server = SystemdService.declare(unit_name='rabbitmq-server')
     sssd = SystemdService.declare(unit_name='sssd')
+    sshd = SystemdService.declare(unit_name='sshd')
     supervisord = SystemdService.declare(unit_name='supervisord')
-    db_service = DynaService.declare(service_name_getting_cmd="echo $APPLIANCE_PG_SERVICE")
     firewalld = SystemdService.declare(unit_name='firewalld')
     db = ApplianceDB.declare()
 
@@ -347,6 +347,10 @@ class IPAppliance(object):
         'openldap': '/etc/openldap/ldap.conf',
         'sssd': '/etc/sssd/sssd.conf'
     }
+
+    @cached_property
+    def db_service(self):
+        return SystemdService(self, unit_name=self.db.service_name)
 
     @property
     def as_json(self):

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -34,6 +34,7 @@ from .db import ApplianceDB
 from .implementations.rest import ViaREST
 from .implementations.ssui import ViaSSUI
 from .implementations.ui import ViaUI
+from .services import DynaService
 from .services import SystemdException
 from .services import SystemdService
 from cfme.fixtures import ui_coverage
@@ -309,7 +310,6 @@ class IPAppliance(object):
     auditd = SystemdService.declare(unit_name='auditd')
     chronyd = SystemdService.declare(unit_name='chronyd')
     collectd = SystemdService.declare(unit_name='collectd')
-    # db_service unit_name is initialized in the __init__()
     evmserverd = SystemdService.declare(unit_name='evmserverd')
     httpd = SystemdService.declare(unit_name='httpd')
     merkyl = SystemdService.declare(unit_name='merkyl')
@@ -317,6 +317,7 @@ class IPAppliance(object):
     rabbitmq_server = SystemdService.declare(unit_name='rabbitmq-server')
     sssd = SystemdService.declare(unit_name='sssd')
     supervisord = SystemdService.declare(unit_name='supervisord')
+    db_service = DynaService.declare(service_name_getting_cmd="echo $APPLIANCE_PG_SERVICE")
     db = ApplianceDB.declare()
 
     CONFIG_MAPPING = {
@@ -406,7 +407,6 @@ class IPAppliance(object):
             # only set when given so we can defer to therest api via the
             # cached property
             self.version = Version(version)
-        self.db_service = SystemdService.declare(unit_name=self.db.service_name)
 
     def unregister(self):
         """ unregisters appliance from RHSM/SAT6 """

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -309,7 +309,7 @@ class IPAppliance(object):
     auditd = SystemdService.declare(unit_name='auditd')
     chronyd = SystemdService.declare(unit_name='chronyd')
     collectd = SystemdService.declare(unit_name='collectd')
-    db_service = SystemdService.declare(unit_name=ApplianceDB.service_name)
+    # db_service unit_name is initialized in the __init__()
     evmserverd = SystemdService.declare(unit_name='evmserverd')
     httpd = SystemdService.declare(unit_name='httpd')
     merkyl = SystemdService.declare(unit_name='merkyl')
@@ -406,6 +406,7 @@ class IPAppliance(object):
             # only set when given so we can defer to therest api via the
             # cached property
             self.version = Version(version)
+        self.db_service = SystemdService.declare(unit_name=self.db.service_name)
 
     def unregister(self):
         """ unregisters appliance from RHSM/SAT6 """

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -318,6 +318,7 @@ class IPAppliance(object):
     sssd = SystemdService.declare(unit_name='sssd')
     supervisord = SystemdService.declare(unit_name='supervisord')
     db_service = DynaService.declare(service_name_getting_cmd="echo $APPLIANCE_PG_SERVICE")
+    firewalld = SystemdService.declare(unit_name='firewalld')
     db = ApplianceDB.declare()
 
     CONFIG_MAPPING = {
@@ -1035,6 +1036,13 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
         # FIXME: properly store ssh clients we made
         store.ssh_clients_to_close.append(ssh_client)
         return ssh_client
+
+    @cached_property
+    def default_iface(self):
+        default_iface_cmd = self.ssh_client.run_command(
+            "ip r | awk '/^default/ { print $5 }'")
+        assert default_iface_cmd.success
+        return default_iface_cmd.output.strip()
 
     @property
     def swap(self):

--- a/cfme/utils/appliance/db.py
+++ b/cfme/utils/appliance/db.py
@@ -12,6 +12,7 @@ from cfme.utils import datafile
 from cfme.utils import db
 from cfme.utils.conf import credentials
 from cfme.utils.path import scripts_path
+from cfme.utils.version import VersionPicker
 from cfme.utils.wait import wait_for
 
 
@@ -24,6 +25,12 @@ class ApplianceDBException(AppliancePluginException):
 class ApplianceDB(AppliancePlugin):
     """Holder for appliance DB related methods and functions"""
     _ssh_client = attr.ib(default=None)
+
+    @cached_property
+    def service_name(self):
+        return VersionPicker({
+            '5.10': 'rh-postgresql95-postgresql',
+            '5.11': 'postgresql'}).pick(self.appliance.version)
 
     @property
     def pg_prefix(self):

--- a/cfme/utils/appliance/db.py
+++ b/cfme/utils/appliance/db.py
@@ -29,12 +29,6 @@ class ApplianceDB(AppliancePlugin):
     def pg_prefix(self):
         return '/opt/rh/rh-postgresql95/root' if self.appliance.version < '5.11' else ''
 
-    @property
-    def service_name(self):
-        cmd_result = self.ssh_client.run_command("echo $APPLIANCE_PG_SERVICE")
-        assert cmd_result.success
-        return cmd_result.output
-
     @cached_property
     def client(self):
         # slightly crappy: anything that changes self.address should also del(self.client)

--- a/cfme/utils/appliance/db.py
+++ b/cfme/utils/appliance/db.py
@@ -25,9 +25,15 @@ class ApplianceDB(AppliancePlugin):
     """Holder for appliance DB related methods and functions"""
     _ssh_client = attr.ib(default=None)
 
-    # Until this needs a version pick, make it an attr
-    postgres_version = 'rh-postgresql95'
-    service_name = '{}-postgresql'.format(postgres_version)
+    @property
+    def pg_prefix(self):
+        return '/opt/rh/rh-postgresql95/root' if self.appliance.version < '5.11' else ''
+
+    @property
+    def service_name(self):
+        cmd_result = self.ssh_client.run_command("echo $APPLIANCE_PG_SERVICE")
+        assert cmd_result.success
+        return cmd_result.output
 
     @cached_property
     def client(self):
@@ -236,10 +242,11 @@ class ApplianceDB(AppliancePlugin):
         )
         client.run_command(cmd)
 
+        pg_prefix = self.pg_prefix
         # back up pg_hba.conf
-        scl = self.postgres_version
-        client.run_command('mv /opt/rh/{scl}/root/var/lib/pgsql/data/pg_hba.conf '
-                           '/opt/rh/{scl}/root/var/lib/pgsql/data/pg_hba.conf.sav'.format(scl=scl))
+        client.run_command(
+            'mv {pg_prefix}/var/lib/pgsql/data/pg_hba.conf '
+            '{pg_prefix}/var/lib/pgsql/data/pg_hba.conf.sav'.format(pg_prefix=pg_prefix))
 
         if with_ssl:
             ssl = 'hostssl all all all cert map=sslmap'
@@ -248,19 +255,18 @@ class ApplianceDB(AppliancePlugin):
 
         # rewrite pg_hba.conf
         write_pg_hba = dedent("""\
-        cat > /opt/rh/{scl}/root/var/lib/pgsql/data/pg_hba.conf <<EOF
+        cat > {pg_prefix}/var/lib/pgsql/data/pg_hba.conf <<EOF
         local all postgres,root trust
         host all all 0.0.0.0/0 md5
         {ssl}
         EOF
-        """.format(ssl=ssl, scl=scl))
+        """.format(ssl=ssl, pg_prefix=pg_prefix))
         client.run_command(write_pg_hba)
         client.run_command("chown postgres:postgres "
-            "/opt/rh/{scl}/root/var/lib/pgsql/data/pg_hba.conf".format(scl=scl))
+            "{pg_prefix}/var/lib/pgsql/data/pg_hba.conf".format(pg_prefix=pg_prefix))
 
         # restart postgres
-        result = client.run_command("systemctl restart {scl}-postgresql".format(scl=scl))
-        return result.rc
+        return self.appliance.db_service.restart()
 
     def _run_cmd_show_output(self, cmd):
         """
@@ -508,7 +514,8 @@ class ApplianceDB(AppliancePlugin):
             rbt_repl = {
                 'miq_lib': '/var/www/miq/lib',
                 'region': region,
-                'postgres_version': self.postgres_version,
+                'postgres_svcname': self.service_name,
+                'postgres_prefix': self.pg_prefix,
                 'db_mounted': str(db_mounted),
             }
 

--- a/cfme/utils/appliance/services.py
+++ b/cfme/utils/appliance/services.py
@@ -13,7 +13,9 @@ class SystemdException(AppliancePluginException):
 
 
 @attr.s
-class BaseService(AppliancePlugin):
+class SystemdService(AppliancePlugin):
+    unit_name = attr.ib(type=str)
+
     @logger_wrap('SystemdService command runner: {}')
     def _run_service_command(
         self,
@@ -112,19 +114,3 @@ class BaseService(AppliancePlugin):
             unit_name='',
             log_callback=log_callback
         )
-
-
-@attr.s
-class SystemdService(BaseService):
-    unit_name = attr.ib(type=str)
-
-
-@attr.s
-class DynaService(BaseService):
-    service_name_getting_cmd = attr.ib(type=str)
-
-    @property
-    def unit_name(self):
-        cmd_result = self.appliance.ssh_client.run_command(self.service_name_getting_cmd)
-        assert cmd_result.success
-        return cmd_result.output

--- a/cfme/utils/appliance/services.py
+++ b/cfme/utils/appliance/services.py
@@ -13,9 +13,7 @@ class SystemdException(AppliancePluginException):
 
 
 @attr.s
-class SystemdService(AppliancePlugin):
-    unit_name = attr.ib()
-
+class BaseService(AppliancePlugin):
     @logger_wrap('SystemdService command runner: {}')
     def _run_service_command(
         self,
@@ -114,3 +112,19 @@ class SystemdService(AppliancePlugin):
             unit_name='',
             log_callback=log_callback
         )
+
+
+@attr.s
+class SystemdService(BaseService):
+    unit_name = attr.ib(type=str)
+
+
+@attr.s
+class DynaService(BaseService):
+    service_name_getting_cmd = attr.ib(type=str)
+
+    @property
+    def unit_name(self):
+        cmd_result = self.appliance.ssh_client.run_command(self.service_name_getting_cmd)
+        assert cmd_result.success
+        return cmd_result.output

--- a/cfme/utils/ssh.py
+++ b/cfme/utils/ssh.py
@@ -137,7 +137,6 @@ class SSHClient(paramiko.SSHClient):
             allow_agent=False,
             look_for_keys=False,
             gss_auth=False,
-            hostname=store.current_appliance.hostname,
             username=conf.credentials['ssh']['username'],
             password=conf.credentials['ssh']['password'],
             port=ports.SSH,
@@ -145,6 +144,9 @@ class SSHClient(paramiko.SSHClient):
 
         # Overlay defaults with any passed-in kwargs and assign to _connect_kwargs
         compiled_kwargs.update(connect_kwargs)
+        if not compiled_kwargs['hostname']:
+            compiled_kwargs['hostname'] = store.current_appliance.hostname,
+
         self._connect_kwargs = compiled_kwargs
         self.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         _client_session.append(self)

--- a/scripts/data/enable-internal-db.rbt
+++ b/scripts/data/enable-internal-db.rbt
@@ -27,8 +27,8 @@ config.post_activation
 # bash-fu to put an appliance into a testing state for this script
 # assumes sdb, update disk device as needed
 systemctl stop evmserverd
-/etc/init.d/${postgres_version}-postgresql stop
-umount /opt/rh/${postgres_version}/root/var/lib/pgsql/data/
+/etc/init.d/${postgres_svcname} stop
+umount ${postgres_prefix}/var/lib/pgsql/data/
 lvremove -f vg_data/lv_pg
 vgremove vg_data
 pvremove /dev/sdb1

--- a/scripts/restore.py
+++ b/scripts/restore.py
@@ -54,7 +54,7 @@ psql_output = run_command(
 count = psql_output.split("\n")[2].strip()
 if count > 2:
     logger.info("Too many postgres threads({})... restarting".format(count))
-    run_command("systemctl restart {}-postgresql".format(current_appliance.db.postgres_version))
+    current_appliance.db_service.restart()
     time.sleep(60)
 run_command(
     "cd /var/www/miq/vmdb/backup_and_restore/;"


### PR DESCRIPTION
It seems that in CFME 5.11, the postgress is no longer a one from SCL.
We need to change some path prefixes and service names to because of
that.

There are also some problems with the tests verifying ssl chains. I don't know the reason for the openssl command to fail so I am disabling these tests as the curl connection works in the end.

CFME 5.11 uses netfilter instead of iptables so checking whether iptables rules exist is wrong on 5.11. We can rather check whether the firewalld services are present in the managiq zone and whether this zone is attached to the eth0 interface.

{{py.test: -v --long-running cfme/tests/test_appliance.py}}