### PR TITLE
[1LP][RFR] Add miq command for updating qe-test-coverage flag and generating BZ reports

### DIFF
--- a/cfme/fixtures/bzs.py
+++ b/cfme/fixtures/bzs.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 """Collection of fixtures for simplified work with bzs.
 
-The main purpose of this file is to add a pytest option for generates a BZ report, that
-gives information about the BZs that appear as coverage/automates metadata in the test_functions
+The main purpose of this file is to add a pytest option which generates a BZ report. This option
+gives information about the BZs that appear as coverage/automates metadata in test functions.
 """
-import pytest
 import yaml
 
 from cfme.fixtures.pytest_store import store
@@ -22,7 +21,6 @@ def pytest_addoption(parser):
     )
 
 
-@pytest.mark.trylast
 def pytest_collection_modifyitems(session, config, items):
     if not config.getvalue("generate_bz_report"):
         return

--- a/cfme/fixtures/bzs.py
+++ b/cfme/fixtures/bzs.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+"""Collection of fixtures for simplified work with bzs.
+
+The main purpose of this file is to add a pytest option for generates a BZ report, that
+gives information about the BZs that appear as coverage/automates metadata in the test_functions
+"""
+import pytest
+import yaml
+
+from cfme.fixtures.pytest_store import store
+from cfme.utils.blockers import BZ
+
+
+def pytest_addoption(parser):
+    group = parser.getgroup('Blocker options')
+    group.addoption(
+        '--generate-bz-report',
+        action='store_true',
+        default=False,
+        dest='generate_bz_report',
+        help='Generate a BZ report based on the automates/coverage metadata of test cases.'
+    )
+
+
+@pytest.mark.trylast
+def pytest_collection_modifyitems(session, config, items):
+    if not config.getvalue("generate_bz_report"):
+        return
+    store.terminalreporter.write("Loading automated/covered BZs ...\n", bold=True)
+    bz_list = []
+    for item in items:
+        if "automates" not in item._metadata and "coverage" not in item._metadata:
+            continue
+        # get list of bzs with coverage
+        if "automates" in item._metadata:
+            bz_list.extend(item._metadata["automates"])
+        if "coverage" in item._metadata:
+            bz_list.extend(item._metadata["coverage"])
+
+    if bz_list:
+        # remove duplicate BZs
+        bz_list = list(dict.fromkeys(bz_list))
+        # remove references that are an instance of BZ
+        bz_list = [bug.bug_id if isinstance(bug, BZ) else bug for bug in bz_list]
+        # get BZ info
+        info = BZ.bugzilla.get_bz_info(bz_list)
+        # output BZ info to yaml
+        with open("bz-report.yaml", "w") as outfile:
+            yaml.dump(info, outfile, default_flow_style=False)
+    else:
+        store.terminalreporter.write(
+            "ERROR: No BZs marked with 'automates'/'coverage' in that test module. A report will "
+            "not be generated.\n", bold=True
+        )

--- a/cfme/scripting/bz.py
+++ b/cfme/scripting/bz.py
@@ -1,0 +1,186 @@
+"""
+Scripts for dealing with Bugzilla metadata, listing BZs with coverage, and setting qe_test_coverage
+flag. This script looks at test-case metadata for the flags "automates" and "coverage", and fetches
+information about the BZs listed there.
+
+For usage see, "miq bz --help"
+
+The basic usage of this command is via
+    .. code-block:: python
+    >>> miq bz <command> <directory>
+where <command> is one of report, list, or coverage, and <directory> is the testing directory, e.g.
+"cfme/tests/control/"
+
+To list BZs that this script would set coverage for, you can do,
+    .. code-block:: python
+    >>> miq bz coverage <directory>
+This will print out the ids of BZs that could have qe_test_coverage switched to '+'
+To then set qe_test_coverage on those BZs, you can do,
+    .. code-block:: python
+    >>> miq bz coverage --set <directory>
+"""
+import os
+import sys
+from collections import namedtuple
+
+import click
+import pytest
+import yaml
+
+from cfme.utils.blockers import BZ
+from cfme.utils.log import logger
+
+STATUS = {
+    "open_bzs": {"val": "true", "text": "are open"},
+    "closed_bzs": {"val": "false", "text": "are closed"},
+    "all_bzs": {"val": None, "text": "have coverage"}
+}
+
+
+def get_report(directory):
+    click.echo("Generating a BZ report in bz-report.yaml")
+    pytest.main([
+        "--use-provider", "complete",
+        "--long-running",
+        "--use-template-cache",
+        "--collect-only",
+        "-q",
+        "--generate-bz-report", directory
+    ])
+    # read the generated yaml
+    try:
+        with open("bz-report.yaml", "r") as stream:
+            info = yaml.load(stream, Loader=yaml.BaseLoader)
+    except IOError:
+        msg = (
+            "ERROR: File bz-report.yaml not found, something went wrong during report generation.\n"
+            "       Likely no BZs were found in {} with 'automates'/'coverage',"
+            " so a report wasn't generated.".format(directory)
+        )
+        click.secho(msg, err=True, bold=True, fg="red")
+        sys.exit(0)
+    return info
+
+
+def get_qe_test_coverage(info, open_only=True):
+    """
+    Given info (what is returned from yaml.load on bz-report.yaml),
+    This function screens and returns only BZs which are OPEN, if open_only=True, otherwise it
+    returns all BZs
+    """
+    BZTestCoverage = namedtuple("BZTestCoverage", ["id", "qe_test_coverage"])
+
+    bz_list = []
+    for bug_id in info.keys():
+        if open_only and info[bug_id]["is_open"] == "false":
+            continue
+        # get qe_test_coverage_flag
+        qe_test_coverage = "?"
+        for flag in info[bug_id]["flags"]:
+            if flag["name"] == "qe_test_coverage":
+                qe_test_coverage = flag["status"]
+                break
+        # append the BZ
+        bz_list.append(BZTestCoverage(id=bug_id, qe_test_coverage=qe_test_coverage))
+
+    return bz_list
+
+
+def cleanup():
+    click.echo("Removing the BZ report file, bz-report.yaml")
+    try:
+        os.remove("bz-report.yaml")
+    except OSError:
+        logger.exception("bz-report.yaml not found")
+
+
+@click.group(help="Functions for generating reports on BZs included in test suite metadata")
+def main():
+    pass
+
+
+@main.command(help="Generate BZ report on BZs that have coverage given a directory")
+@click.argument("directory", default="cfme/tests/")
+def report(directory):
+    get_report(directory)
+
+
+@main.command(help="List open/closed BZs that have test coverage")
+@click.argument("directory", default="cfme/tests/")
+@click.option(
+    "--all",
+    "-a",
+    "bz_status",
+    is_flag=True,
+    help="list all BZs with coverage",
+    default=True,
+    show_default=True,
+    flag_value="all_bzs",
+)
+@click.option(
+    "--open",
+    "-o",
+    "bz_status",
+    is_flag=True,
+    help="list open BZs with coverage",
+    default=False,
+    show_default=True,
+    flag_value="open_bzs"
+)
+@click.option(
+    "--closed",
+    "-c",
+    "bz_status",
+    is_flag=True,
+    help="list closed BZs with coverage",
+    default=False,
+    show_default=True,
+    flag_value="closed_bzs"
+)
+def list(directory, bz_status):
+    info = get_report(directory)
+
+    # get dict of information
+    status = STATUS[bz_status]
+
+    if status["val"]:
+        bz_list = [bug_id for bug_id in info.keys() if info[bug_id]["is_open"] == status["val"]]
+    else:
+        bz_list = [bug_id for bug_id in info.keys()]
+
+    if bz_list:
+        click.echo("The following BZ's {}: \n{}".format(status["text"], "\n".join(bz_list)))
+    else:
+        click.echo("I found no BZ's that {} BZ's".format(status["text"]))
+    cleanup()
+
+
+@main.command(help="Set QE test coverage flag based on automates/coverage metadata")
+@click.argument("directory", default="cfme/tests")
+@click.option(
+    "-s",
+    "--set",
+    "set_bzs",
+    is_flag=True,
+    help="Set QE test coverage on BZs that are marked in coverage/auotmates test metadata",
+    default=False,
+    show_default=True
+)
+def coverage(directory, set_bzs):
+    info = get_report(directory)
+
+    # get list of open BZs that are open and should have test coverage set
+    bz_list = get_qe_test_coverage(info, open_only=True)
+
+    click.echo("\nThe following BZs should have qe_test_coverage set to '+': ")
+    for bz in bz_list:
+        click.echo("    id: {}, qe_test_coverage: {}\n".format(bz.id, bz.qe_test_coverage))
+
+    if set_bzs:
+        click.echo("Setting qe_test_coverage on the above BZs to '+'...")
+        ids = [int(bz.id)for bz in bz_list]
+        BZ.bugzilla.set_flags(ids, {"qe_test_coverage": "+"})
+        click.echo("Done.")
+
+    # remove bz-report.yaml
+    cleanup()

--- a/cfme/scripting/bz.py
+++ b/cfme/scripting/bz.py
@@ -83,8 +83,10 @@ def get_qe_test_coverage(info, bz_status):
             if flag["name"] == "qe_test_coverage":
                 qe_test_coverage = flag["status"]
                 break
-        # append the BZ
-        bz_list.append(BZTestCoverage(id=bug_id, qe_test_coverage=qe_test_coverage))
+
+        # append the BZ if its coverage isn't correct
+        if qe_test_coverage != "+":
+            bz_list.append(BZTestCoverage(id=bug_id, qe_test_coverage=qe_test_coverage))
 
     return bz_list
 

--- a/cfme/scripting/miq.py
+++ b/cfme/scripting/miq.py
@@ -2,6 +2,7 @@ import click
 
 from artifactor.__main__ import main as art_main
 from cfme.scripting.appliance import main as app_main
+from cfme.scripting.bz import main as bz_main
 from cfme.scripting.conf import main as conf_main
 from cfme.scripting.ipyshell import main as shell_main
 from cfme.scripting.polarion import main as polarion_main
@@ -25,6 +26,7 @@ cli.add_command(conf_main, name="conf")
 cli.add_command(sprout_main, name="sprout")
 cli.add_command(setup_main, name="setup-env")
 cli.add_command(polarion_main, name="polarion")
+cli.add_command(bz_main, name="bz")
 
 if __name__ == '__main__':
     cli()

--- a/cfme/test_framework/pytest_plugin.py
+++ b/cfme/test_framework/pytest_plugin.py
@@ -60,6 +60,7 @@ pytest_plugins = (
     'cfme.fixtures.appliance_update',
     'cfme.fixtures.blockers',
     'cfme.fixtures.browser',
+    'cfme.fixtures.bzs',
     'cfme.fixtures.cfme_data',
     'cfme.fixtures.datafile',
     'cfme.fixtures.depot',

--- a/cfme/tests/control/test_bugs.py
+++ b/cfme/tests/control/test_bugs.py
@@ -234,7 +234,7 @@ def vm_compliance_policy_profile(appliance, compliance_condition):
     policy.delete()
 
 
-@pytest.mark.meta(blockers=[BZ(1155284)])
+@pytest.mark.meta(blockers=[BZ(1155284)], automates=[1155284])
 def test_scope_windows_registry_stuck(request, appliance, infra_provider):
     """If you provide Scope checking windows registry, it messes CFME up. Recoverable.
 

--- a/cfme/utils/bz.py
+++ b/cfme/utils/bz.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 import re
 from collections import Sequence
+from contextlib import contextmanager
 
 import six
 from bugzilla import Bugzilla as _Bugzilla
+from bugzilla.transport import BugzillaError
 from cached_property import cached_property
 from miq_version import LATEST
 from miq_version import Version
+from yaycl import AttrDict
 
 from cfme.utils.conf import credentials
 from cfme.utils.conf import env
@@ -204,6 +207,48 @@ class Bugzilla(object):
             if bug.release_flag and version.is_in_series(bug.release_flag):
                 return bug
         return None
+
+    @contextmanager
+    def logged_into_bugzilla(self):
+        bz_creds = credentials.get("bugzilla", None)
+
+        # login to bzapi
+        if not bz_creds:
+            raise BugzillaError("No bugzilla creds available")
+        try:
+            yield self.bugzilla.login(bz_creds.get("username"), bz_creds.get("password"))
+        except BugzillaError:
+            logger.exception("Unable to login to Bugzilla with those creds.")
+            raise
+        else:
+            self.bugzilla.logout()
+
+    def set_flags(self, idlist, flags):
+        # set the flags
+        with self.logged_into_bugzilla():
+            for bug in self.bugzilla.getbugs(idlist):
+                result = bug.updateflags(flags)
+                logger.info("Got %s from updating %s", result, bug)
+
+    def get_bz_info(self, idlist):
+        """ Get information about the BZs in idlist """
+        logger.info("Getting information about the following BZ's: %s", idlist)
+
+        # build info
+        with self.logged_into_bugzilla():
+            info = {}
+            for bug_id, bug in zip(idlist, self.bugzilla.getbugs(idlist)):
+                # assign some attrs for each BZ
+                info[bug_id] = AttrDict()
+                info[bug_id].description = bug.description
+                info[bug_id].summary = bug.summary
+                info[bug_id].flags = bug.flags
+                info[bug_id].qa_contact = bug.qa_contact
+                info[bug_id].is_open = bug.is_open
+                info[bug_id].status = bug.status
+                info[bug_id].keywords = bug.keywords
+                info[bug_id].blocks = bug.blocks
+        return info
 
 
 def check_fixed_in(fixed_in, version_series):

--- a/cfme/utils/bz.py
+++ b/cfme/utils/bz.py
@@ -214,7 +214,8 @@ class Bugzilla(object):
 
         # login to bzapi
         if not bz_creds:
-            raise BugzillaError("No bugzilla creds available")
+            # error out if there are no creds available in yamls
+            raise BugzillaError("No creds available to log into Bugzilla")
         try:
             yield self.bugzilla.login(bz_creds.get("username"), bz_creds.get("password"))
         except BugzillaError:


### PR DESCRIPTION
This PR adds a `miq` command to check tests marked with the `pytest.mark.meta(automates=[<bug_id>])` and `pytest.mark.meta(coverage=[<bug_id>])` and output information about them. 

The basic usage is a follows:
```python,
miq bz <command> <directory>
```
where <command> is one of report, list, or coverage, and <directory> is the testing directory, e.g.
"cfme/tests/control/"

To list BZs that this script would set coverage for, you can do,
```python,
miq bz coverage <directory>
```
This will print out the ids of BZs that could have qe_test_coverage switched to '+'
To then set qe_test_coverage on those BZs, you can do,
```python,
miq bz coverage --set <directory>
```

**Note to reviewers**: if you'd like to test this command, it is easiest to setup a test function in a new file (e.g. cfme/utils/tests/test_bz_coverage.py)  
```python,
@pytest.mark.meta(coverage=[1692537])
def test_automates():
    pass
```
The run `miq bz coverage cfme/utils/tests/test_bz_coverage.py`. This should be output at the end of the test run, 
```
The following BZs should have qe_test_coverage set to '+': 
    id: 1692537, qe_test_coverage: -
```
You can change the ID to anything you'd like to check if it works. Note that running it with `--set` will actually change the coverage flag, so be wary about running with that option.  