### PR TITLE
[1LP][RFR] New Test: Removal of openshift "Deployment" from automate domain

### DIFF
--- a/cfme/tests/automate/test_automate_manual.py
+++ b/cfme/tests/automate/test_automate_manual.py
@@ -776,27 +776,6 @@ def test_user_requester_for_lifecycle_provision():
 
 
 @pytest.mark.tier(1)
-@pytest.mark.ignore_stream("5.10")
-def test_remove_openshift_deployment_in_automate():
-    """This test case will test successful removal of OpenShift Deployment removed from Automate
-
-    Polarion:
-        assignee: ghubale
-        initialEstimate: 1/8h
-        caseimportance: high
-        caseposneg: positive
-        testtype: functional
-        startsin: 5.11
-        casecomponent: Automate
-        tags: automate
-
-    Bugzilla:
-        1672937
-    """
-    pass
-
-
-@pytest.mark.tier(1)
 def test_vm_naming_number_padding():
     """
     Polarion:

--- a/cfme/tests/automate/test_namespace.py
+++ b/cfme/tests/automate/test_namespace.py
@@ -4,6 +4,7 @@ import pytest
 
 from cfme import test_requirements
 from cfme.automate.explorer.namespace import NamespaceAddView
+from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.update import update
 
 pytestmark = [test_requirements.automate]
@@ -120,3 +121,25 @@ def test_wrong_namespace_name(request, domain):
     wrong_namespace = namespace.instantiate(name=wrong_namespace)
     request.addfinalizer(wrong_namespace.delete_if_exists)
     assert not wrong_namespace.exists
+
+
+@pytest.mark.tier(1)
+@pytest.mark.ignore_stream("5.10")
+def test_remove_openshift_deployment_in_automate(appliance):
+    """This test case will test successful removal of OpenShift "Deployment" from Automate domain -
+    ManageIQ.
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/20h
+        caseimportance: high
+        caseposneg: negative
+        testtype: functional
+        startsin: 5.11
+        casecomponent: Automate
+
+    Bugzilla:
+        1672937
+    """
+    view = navigate_to(appliance.collections.domains, 'All')
+    assert not view.datastore.tree.has_path('Datastore', 'ManageIQ (Locked)', 'Deployment')


### PR DESCRIPTION
- Testing removal of openshift "Deployment" from automate domain - ManageIQ

{{ pytest: cfme/tests/automate/test_namespace.py -k 'test_remove_openshift_deployment_in_automate' -vv }}