### PR TITLE
[1LP][RFR] fix simulation 511 changes

### DIFF
--- a/cfme/automate/buttons.py
+++ b/cfme/automate/buttons.py
@@ -285,10 +285,10 @@ class BaseButton(BaseEntity, Updateable):
     ):
         view = navigate_to(self, "simulate")
 
-        # Group and User are EVM type objects
+        # Group and User are EVM type objects. workaround for <5.11
         target_type = (
             "EVM {}".format(self.group.type)
-            if self.group.type in ["Group", "User"]
+            if self.group.type in ["Group", "User"] and self.appliance.version < "5.11"
             else self.group.type
         )
 

--- a/cfme/tests/automate/custom_button/test_buttons.py
+++ b/cfme/tests/automate/custom_button/test_buttons.py
@@ -342,14 +342,11 @@ def test_custom_button_quotes(appliance, provider, setup_provider, dialog, reque
 @pytest.mark.meta(
     blockers=[BZ(1535215, forced_streams=["5.10"], unblock=lambda button_tag: button_tag != "Evm")]
 )
-@pytest.mark.uncollectif(
-    lambda appliance, button_tag: appliance.version < "5.10" and button_tag == "Evm",
-    reason="for lower version evm custom button object not supported",
-)
 @pytest.mark.provider([VMwareProvider], override=True, scope="function", selector=ONE_PER_TYPE)
 @pytest.mark.parametrize("button_tag", ["Evm", "Build"])
 def test_custom_button_simulation(request, appliance, provider, setup_provider, button_tag):
     """ Test whether custom button works with simulation option
+    Note: For version less than 5.10 EVM custom button object not supported.
 
     Polarion:
         assignee: ndhandre


### PR DESCRIPTION
Signed-off-by: Nikhil Dhandre <ndhandre@redhat.com>

Purpose or Intent
=================
- https://bugzilla.redhat.com/show_bug.cgi?id=1535215 FIXED for 511
- Now EVM prefix not found evm objects in simulation.

- need https://github.com/ManageIQ/integration_tests/pull/8776 for a run

{{pytest: cfme/tests/automate/custom_button/test_buttons.py::test_custom_button_simulation}}