### PR TITLE
[1LP][RFR] Automate Test: test_rbac_move_custom_report

### DIFF
--- a/cfme/intelligence/reports/menus.py
+++ b/cfme/intelligence/reports/menus.py
@@ -195,12 +195,8 @@ class ReportMenu(BaseEntity):
             selected_options = selected_menu.parent_view.report_select.all_options
             for report in reports:
                 if report in selected_options:
-                    raise Exception(
-                        "Report already present in the menu {}/{}. Cannot move.".format(
-                            folder, subfolder
-                        )
-                    )
-
+                    # pass, since the report is already present
+                    pass
             # fill method replaces all the options in all_options with the value passed as argument
             # We do not want to replace any value, we just want to move the new reports to a given
             # menu. This is a work-around for that purpose.

--- a/cfme/intelligence/reports/menus.py
+++ b/cfme/intelligence/reports/menus.py
@@ -195,7 +195,11 @@ class ReportMenu(BaseEntity):
             selected_options = selected_menu.parent_view.report_select.all_options
             for report in reports:
                 if report in selected_options:
-                    raise Exception("Report already present. Cannot move.")
+                    raise Exception(
+                        "Report already present in the menu {}/{}. Cannot move.".format(
+                            folder, subfolder
+                        )
+                    )
 
             # fill method replaces all the options in all_options with the value passed as argument
             # We do not want to replace any value, we just want to move the new reports to a given

--- a/cfme/intelligence/reports/menus.py
+++ b/cfme/intelligence/reports/menus.py
@@ -180,6 +180,30 @@ class ReportMenu(BaseEntity):
             view.manager.commit()
             view.save_button.click()
 
+    def move_reports(self, group, folder, subfolder, reports):
+        """ Moves a list of reports to a given menu
+        Args:
+            group: User group
+            folder: Parent of the subfolder where reports are to be moved.
+            subfolder: Subfolder under which the reports are to be moved.
+            reports: List of reports that are to be moved.
+        """
+        if not isinstance(reports, list):
+            reports = [reports]
+
+        with self.manage_subfolder(group, folder, subfolder) as selected_menu:
+            selected_options = selected_menu.parent_view.report_select.all_options
+            for report in reports:
+                if report in selected_options:
+                    raise Exception("Report already present. Cannot move.")
+
+            # fill method replaces all the options in all_options with the value passed as argument
+            # We do not want to replace any value, we just want to move the new reports to a given
+            # menu. This is a work-around for that purpose.
+            reports.extend(selected_options)
+
+            selected_menu.parent_view.report_select.fill(reports)
+
 
 @attr.s
 class ReportMenusCollection(BaseCollection):

--- a/cfme/intelligence/reports/menus.py
+++ b/cfme/intelligence/reports/menus.py
@@ -253,7 +253,7 @@ class EditReportMenus(CFMENavigateStep):
     )
 
     def step(self, *args, **kwargs):
-        self.view.edit_report_menus.tree.click_path(
+        self.prerequisite_view.edit_report_menus.tree.click_path(
             "All EVM Groups", self.obj.group
         )
 
@@ -264,4 +264,4 @@ class ReportMenus(CFMENavigateStep):
     prerequisite = NavigateToAttribute("appliance.server", "CloudIntelReports")
 
     def step(self, *args, **kwargs):
-        self.view.edit_report_menus.tree.click_path("All EVM Groups")
+        self.prerequisite_view.edit_report_menus.tree.click_path("All EVM Groups")

--- a/cfme/tests/intelligence/reports/test_menus.py
+++ b/cfme/tests/intelligence/reports/test_menus.py
@@ -5,12 +5,14 @@ import pytest
 import yaml
 
 from cfme import test_requirements
+from cfme.base.credential import Credential
+from cfme.rest.gen_data import users as _users
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.path import data_path
 
-pytestmark = [test_requirements.report]
+pytestmark = [pytest.mark.tier(3), test_requirements.report]
 
-report_crud_dir = data_path.join("reports_crud")
+REPORT_CRUD_DIR = data_path.join("reports_crud")
 
 # EvmGroup-super_administrator -> user `admin`
 # If we add more, will need relogin + user creation
@@ -36,9 +38,9 @@ def report_menus(group, appliance):
 
 def crud_files_reports():
     result = []
-    if not report_crud_dir.exists:
-        report_crud_dir.mkdir()
-    for file_name in report_crud_dir.listdir():
+    if not REPORT_CRUD_DIR.exists:
+        REPORT_CRUD_DIR.mkdir()
+    for file_name in REPORT_CRUD_DIR.listdir():
         if file_name.isfile() and file_name.basename.endswith(".yaml"):
             result.append(file_name.basename)
     return result
@@ -46,11 +48,17 @@ def crud_files_reports():
 
 @pytest.fixture(params=crud_files_reports())
 def custom_report_values(request):
-    with report_crud_dir.join(request.param).open(mode="r") as rep_yaml:
+    with REPORT_CRUD_DIR.join(request.param).open(mode="r") as rep_yaml:
         return yaml.safe_load(rep_yaml)
 
 
-@pytest.mark.tier(3)
+@pytest.fixture(scope="function")
+def get_custom_report(appliance, custom_report_values):
+    custom_report = appliance.collections.reports.create(**custom_report_values)
+    yield custom_report
+    custom_report.delete()
+
+
 @pytest.mark.parametrize("group", GROUPS)
 def test_shuffle_top_level(appliance, group, report_menus):
     """
@@ -73,7 +81,6 @@ def test_shuffle_top_level(appliance, group, report_menus):
     assert table == order, "The order differs!"
 
 
-@pytest.mark.tier(3)
 @pytest.mark.parametrize("group", GROUPS)
 def test_shuffle_first_level(appliance, group, report_menus):
     """
@@ -87,8 +94,10 @@ def test_shuffle_first_level(appliance, group, report_menus):
     view = navigate_to(appliance.collections.reports, "All")
     tree = view.reports.tree.read_contents()[1]
     # Select some folder that has at least 3 children
-    folders = map(lambda item: item[0],
-                  filter(lambda item: isinstance(item[1], list) and len(item[1]) >= 3, tree))
+    folders = map(
+        lambda item: item[0],
+        filter(lambda item: isinstance(item[1], list) and len(item[1]) >= 3, tree),
+    )
 
     selected_folder = random.choice(folders)
     # Shuffle the order
@@ -103,26 +112,65 @@ def test_shuffle_first_level(appliance, group, report_menus):
     assert table == order, "The order differs!"
 
 
-@pytest.mark.tier(3)
 @pytest.mark.parametrize("group", GROUPS)
-def test_add_reports_to_available_reports_menu(appliance, request, group,
-                                               report_menus, custom_report_values):
-    """This test case moves custom menu to existing menus
+def test_add_reports_to_available_reports_menu(
+    appliance, request, group, report_menus, get_custom_report
+):
+    """This test case moves custom report to existing menus
 
     Polarion:
         assignee: pvala
         casecomponent: Reporting
-        caseimportance: high
         initialEstimate: 1/10h
     """
-
-    custom_report = appliance.collections.reports.create(**custom_report_values)
-    request.addfinalizer(custom_report.delete)
     folder = random.choice(report_menus.get_folders(group))
     sub_folder = random.choice(report_menus.get_subfolders(group, folder))
-    with report_menus.manage_subfolder(group, folder, sub_folder) as selected:
-        selected.available_options.fill(custom_report.menu_name)
-        selected.move_into_button.click()
+    report_menus.move_reports(group, folder, sub_folder, get_custom_report.menu_name)
     report = appliance.collections.reports.instantiate(
-        type=folder, subtype=sub_folder, menu_name=custom_report.menu_name)
+        type=folder, subtype=sub_folder, menu_name=get_custom_report.menu_name
+    )
     assert report.exists
+
+
+@pytest.fixture()
+def rbac_user(appliance, request, group):
+    user, user_data = _users(request, appliance, group=group)
+    yield appliance.collections.users.instantiate(
+        name=user[0].name,
+        credential=Credential(
+            principal=user_data[0]["userid"], secret=user_data[0]["password"]
+        ),
+        groups=[group],
+    )
+
+    if user[0].exists:
+        user[0].action.delete()
+
+
+@pytest.mark.tier(1)
+@pytest.mark.parametrize("group", ["EvmGroup-administrator"])
+def test_rbac_move_custom_report(
+    appliance, request, group, get_custom_report, report_menus, rbac_user
+):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: Reporting
+        caseimportance: medium
+        initialEstimate: 1/5h
+        startsin: 5.10
+        testSteps:
+            1. Create a custom report, select a group and move the report to a certain menu.
+            2. Create a user belonging to the previously selected group.
+            3. Login with the user and check if the report is available under that menu.
+
+    Bugzilla:
+        1670293
+    """
+    folder, subfolder = "Tenants", "Tenant Quotas"
+    report_menus.move_reports(group, folder, subfolder, get_custom_report.menu_name)
+    with rbac_user:
+        rbac_report = appliance.collections.reports.instantiate(
+            type=folder, subtype=subfolder, menu_name=get_custom_report.menu_name
+        )
+        assert rbac_report.exists

--- a/cfme/tests/intelligence/reports/test_reports_manual.py
+++ b/cfme/tests/intelligence/reports/test_reports_manual.py
@@ -244,36 +244,6 @@ def test_import_export_report():
 
 @pytest.mark.manual
 @test_requirements.report
-@pytest.mark.tier(1)
-def test_reports_manage_report_menu_accordion_with_users():
-    """
-    Bugzilla:
-        1535023
-
-    Polarion:
-        assignee: pvala
-        casecomponent: Reporting
-        caseimportance: medium
-        initialEstimate: 1/6h
-        startsin: 5.8
-        setup:
-            1. Create a new report called report01
-            2. Create a new user under EvmGroup-super_administrator called
-            testuser
-            3. "Edit Report Menus" and add the report01 under EvmGroup-
-            super_administrator"s Provisioning -> Activities
-            4. Login using testuser and navigate to Reports
-        testSteps:
-            1. Check if the report01 is present under Provisioning -> Activities
-        expectedResults:
-            1. The report01 must be present under Provisioning -> Activities
-    """
-    pass
-
-
-@pytest.mark.manual
-@test_requirements.report
-@pytest.mark.tier(1)
 def test_report_menus_moving_reports():
     """
     Polarion:


### PR DESCRIPTION
This PR brings the following changes:
1. Add a new method `move_reports` to move custom reports to a different menu.
2. Automate a test case: test_rbac_move_custom_report
3. Add 2 fixtures: `get_custom_report` and `rbac_user`.
3. Blackify test_menus.py (kindly ignore this for now)
4. Add test_requirements.
5. Add a new view `AllReportMenusView` and a navigator to the view.
6. Remove `handle_alert` from `logout` function which raises error on logout.


{{ pytest: cfme/tests/intelligence/reports/test_menus.py::test_rbac_move_custom_report --use-template-cache -sqvvv }}