### PR TITLE
[RFR] Random updates related to vsphere55 yaml cleanup

### DIFF
--- a/cfme/tests/configure/test_proxy.py
+++ b/cfme/tests/configure/test_proxy.py
@@ -27,6 +27,8 @@ def proxy_machine():
     """
     depot_machine_name = random_vm_name('proxy')
     data = conf.cfme_data.get("proxy_template")
+    if data is None:
+        pytest.skip('Missing proxy_template in cfme_data.yaml, cannot deploy proxy')
     proxy_provider_key = data["provider"]
     proxy_template_name = data["template_name"]
     proxy_port = data['port']

--- a/cfme/tests/distributed/test_appliance_replication.py
+++ b/cfme/tests/distributed/test_appliance_replication.py
@@ -17,6 +17,7 @@ from cfme.utils.wait import wait_for
 pytestmark = [
     pytest.mark.long_running,
     test_requirements.distributed,
+    # TODO: refactor to use appliance fixtures that use sprout
     pytest.mark.uncollect(reason="test framework broke browser_steal"),
 ]
 
@@ -38,6 +39,7 @@ def get_replication_appliances(appliance):
        with unique region numbers.
     """
     ver_to_prov = str(appliance.version)
+    # FIXME: refactor to use appliance fixtures that use sprout, or pass provider name
     appl1 = provision_appliance(ver_to_prov, 'long-test_repl_A')
     appl2 = provision_appliance(ver_to_prov, 'long-test_repl_B')
     appl1.configure(region=1)

--- a/cfme/tests/v2v/test_csv_import.py
+++ b/cfme/tests/v2v/test_csv_import.py
@@ -9,7 +9,6 @@ from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import ONE_PER_VERSION
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
 from cfme.utils.wait import wait_for
 

--- a/conf/cfme_data.yaml.template
+++ b/conf/cfme_data.yaml.template
@@ -213,28 +213,6 @@ management_hosts:
         credentials: esx
         ipmi_credentials: ipmi
         user_assigned_os: VMware ESX
-appliance_provisioning:
-    default_provider: provider_name
-    default_flavors:
-        ec2:
-            - m3.medium
-        openstack:
-            - m1.medium
-    versions:
-        1.2.3: template_name_123
-        1.3.3: template_name_133
-    single_appliance:
-        name: name_single
-        version: 1.2.3
-    appliance_set:
-        primary_appliance:
-            name: name_primary
-            version: 1.3.3
-        secondary_appliances:
-            - name: name_secondary_1
-              version: 1.2.3
-            - name: name_secondary_2
-              version: 1.3.3
 
 auth_modes:
     ldap_server:


### PR DESCRIPTION
test_appliance_replication fixture needs rewritten to use existing sprout fixtures
provision_appliance method now requires provider name
update flavor picking in clone_template
pytest.skip in test_proxy when no proxy_template is available


clone_template tested locally.
