### PR TITLE
[1LP][RFR][NOTEST] reassigned test_email

### DIFF
--- a/cfme/tests/configure/test_email.py
+++ b/cfme/tests/configure/test_email.py
@@ -1,6 +1,12 @@
 import pytest
 
+from cfme import test_requirements
 from cfme.utils.wait import wait_for
+
+
+pytestmark = [
+    test_requirements.configuration
+]
 
 
 @pytest.mark.tier(3)
@@ -8,7 +14,7 @@ def test_send_test_email(smtp_test, random_string, appliance):
     """ This test checks whether the mail sent for testing really arrives.
 
     Polarion:
-        assignee: anikifor
+        assignee: tpapaioa
         casecomponent: Configuration
         caseimportance: critical
         initialEstimate: 1/10h


### PR DESCRIPTION
Reassigned `test_send_test_email` and marked as `configuration` requirement after some discussion with @mshriver 