### PR TITLE
[RFR] Skip plugin config when --help is passed

### DIFF
--- a/cfme/fixtures/artifactor_plugin.py
+++ b/cfme/fixtures/artifactor_plugin.py
@@ -118,6 +118,8 @@ def pytest_addoption(parser):
 
 @pytest.mark.tryfirst
 def pytest_configure(config):
+    if config.getoption('--help'):
+        return
     art_client = get_client(
         art_config=env.get('artifactor', {}),
         pytest_config=config)

--- a/cfme/fixtures/node_annotate.py
+++ b/cfme/fixtures/node_annotate.py
@@ -30,6 +30,8 @@ class MarkFromMap(object):
 
 
 def pytest_configure(config):
+    if config.getoption('--help'):
+        return
     path = cfme_data.get('cfme_annotations_path')
     if path:
         to_parse = project_path.join(path)

--- a/cfme/fixtures/parallelizer/__init__.py
+++ b/cfme/fixtures/parallelizer/__init__.py
@@ -71,6 +71,9 @@ def pytest_addhooks(pluginmanager):
 @pytest.mark.trylast
 def pytest_configure(config):
     """Configures the parallel session, then fires pytest_parallel_configured."""
+    if config.getoption('--help'):
+        return
+
     reporter = terminalreporter.reporter()
     holder = config.pluginmanager.get_plugin(APPLIANCE_PLUGIN)
 

--- a/cfme/fixtures/portset.py
+++ b/cfme/fixtures/portset.py
@@ -21,6 +21,8 @@ def pytest_addoption(parser):
 
 @pytest.mark.tryfirst
 def pytest_configure(config):
+    if config.getoption('--help'):
+        return
     # SSH
     port_ssh = config.getoption("port_ssh")
     if port_ssh is not None:

--- a/cfme/fixtures/prov_filter.py
+++ b/cfme/fixtures/prov_filter.py
@@ -17,6 +17,8 @@ def pytest_configure(config):
     Note:
         Additional filter is added to the global_filters dict of active filters here.
     """
+    if config.getoption('--help'):
+        return
 
     cmd_filter = config.getvalueorskip('use_provider')
     if not cmd_filter:

--- a/cfme/fixtures/templateloader.py
+++ b/cfme/fixtures/templateloader.py
@@ -27,7 +27,12 @@ def pytest_configure(config):
             if appliance.get('is_dev', False):
                 is_dev = True
     tb_url = trackerbot.conf.get('url')
-    if store.parallelizer_role == 'master' or tb_url is None or is_dev:
+    if (
+        config.getoption('--help') or
+        store.parallelizer_role == 'master' or
+        tb_url is None or
+        is_dev
+    ):
         return
 
     # A further optimization here is to make the calls to trackerbot per provider

--- a/cfme/fixtures/ui_coverage.py
+++ b/cfme/fixtures/ui_coverage.py
@@ -248,6 +248,8 @@ class CoverageManager(object):
 
 class UiCoveragePlugin(object):
     def pytest_configure(self, config):
+        if config.getoption('--help'):
+            return
         # cleanup cruft from previous runs
         if store.parallelizer_role != 'slave':
             clean_coverage_dir()

--- a/cfme/markers/skipper.py
+++ b/cfme/markers/skipper.py
@@ -28,6 +28,9 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
+    if config.getoption('--help'):
+        return
+
     from cfme.fixtures.pytest_store import store
 
     marks_to_skip = []

--- a/cfme/test_framework/appliance.py
+++ b/cfme/test_framework/appliance.py
@@ -47,6 +47,8 @@ def appliances_from_cli(cli_appliances, appliance_version):
 @pytest.hookimpl(tryfirst=True)
 def pytest_configure(config):
 
+    if config.getoption('--help'):
+        return
     reporter = terminalreporter.reporter()
     if config.getoption('--dummy-appliance'):
         appliances = [DummyAppliance.from_config(config)]


### PR DESCRIPTION
Now it takes all of 5s to get the help text, instead of minutes.

Several of our plugins were running costly `pytest_configure` hooks regardless of other config context, like `--help`.  Specifically check for this in costly config methods, returning immediately.

This should have no functional effect on the plugins themselves, and no impact on the content of the help text.

Only impact should be much faster execution time when calling `py.test --help` in our test environment.

No starting artifactor
No pulling template caches
No instantiating appliance objects
No instantiating provider objects