### PR TITLE
[1LP][RFR] modified blocker for test_provider_log_level

### DIFF
--- a/cfme/tests/configure/test_logs.py
+++ b/cfme/tests/configure/test_logs.py
@@ -106,7 +106,12 @@ def test_provider_log_updated(appliance, provider, log_exists):
     assert log_before != log_after, "Log hashes are the same"
 
 
-@pytest.mark.meta(blockers=[BZ(1633656, forced_streams=['5.10', 'upstream'])])
+@pytest.mark.meta(blockers=[BZ(1633656,
+                               unblock=lambda provider: provider.one_of(AzureProvider, EC2Provider),
+                               forced_streams=["5.10", "upstream"]
+                               )
+                            ]
+                  )
 def test_provider_log_level(appliance, provider, log_exists):
     """
     Tests that log level in advanced settings affects log files


### PR DESCRIPTION
{{ pytest: -v cfme/tests/configure/test_logs.py::test_provider_log_level --use-provider=complete }}

The blocker is not valid for the whole test, it got changed during removing `5.9` references, so I'm restoring it.