### PR TITLE
[1LP][RFR] Adding actions metadata for the tests in test_actions

### DIFF
--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -856,6 +856,9 @@ def test_action_cancel_clone(
     For this test we need big template otherwise CFME won't have enough time
     to cancel the task https://bugzilla.redhat.com/show_bug.cgi?id=1383372#c9
 
+    Metadata:
+        test_flag: policy, actions
+
     Bugzilla:
         1383372
         1685201
@@ -912,7 +915,7 @@ def test_action_check_compliance(
     compliant or not. After reloading vm details screen the compliance status should be changed.
 
     Metadata:
-        test_flag: policy
+        test_flag: policy, actions
 
     Polarion:
         assignee: jdupuy


### PR DESCRIPTION
Adding actions metadata to these tests as they were collecting against providers they shouldn't be collecting against. 

{{ pytest: --use-provider complete --use-template-cache --collect-only cfme/tests/control/test_actions.py }}
