### PR TITLE
[1LP][RFR] Automate test: test_delete_automate_domain_via_api

### DIFF
--- a/cfme/tests/automate/test_rest.py
+++ b/cfme/tests/automate/test_rest.py
@@ -1,14 +1,25 @@
 # -*- coding: utf-8 -*-
 """REST API specific automate tests."""
+import fauxfactory
 import pytest
 
 from cfme import test_requirements
+from cfme.utils.rest import delete_resources_from_collection
+from cfme.utils.rest import delete_resources_from_detail
 
 
-pytestmark = [test_requirements.rest]
+pytestmark = [test_requirements.rest, pytest.mark.tier(3)]
 
 
-@pytest.mark.tier(3)
+@pytest.fixture(scope="function")
+def domain_rest(appliance, domain):
+    domain = appliance.collections.domains.create(
+        name=fauxfactory.gen_alpha(), description=fauxfactory.gen_alpha(), enabled=True
+    )
+    yield appliance.rest_api.collections.automate_domains.get(name=domain.name)
+    domain.delete_if_exists()
+
+
 def test_rest_search_automate(appliance):
     """
     Polarion:
@@ -29,3 +40,26 @@ def test_rest_search_automate(appliance):
     filtered_depth = _do_query(depth='-1', search_options='state_machines')
     assert len(full_depth) > len(more_depth) > len(rest_api.collections.automate)
     assert len(full_depth) > len(filtered_depth) > 0
+
+
+@pytest.mark.ignore_stream("5.10")
+@pytest.mark.parametrize("method", ["POST", "DELETE"])
+def test_delete_automate_domain_from_detail(appliance, domain_rest, method):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: Rest
+        initialEstimate: 1/10h
+    """
+    delete_resources_from_detail([domain_rest], method=method, num_sec=50)
+
+
+@pytest.mark.ignore_stream("5.10")
+def test_delete_automate_domain_from_collection(appliance, domain_rest):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: Rest
+        initialEstimate: 1/10h
+    """
+    delete_resources_from_collection([domain_rest], not_found=True, num_sec=50)

--- a/cfme/tests/test_rest_manual.py
+++ b/cfme/tests/test_rest_manual.py
@@ -103,24 +103,3 @@ def test_add_ansible_tower_rest():
         1621888
     """
     pass
-
-
-@pytest.mark.manual
-@test_requirements.rest
-@pytest.mark.tier(3)
-@pytest.mark.parametrize("method", ["POST", "DELETE"])
-def test_delete_automate_domain_via_api(method):
-    """
-    Polarion:
-        assignee: pvala
-        casecomponent: Rest
-        caseimportance: high
-        initialEstimate: 1/10h
-        setup:
-            1. Create an automate domain.
-        testSteps:
-            1. Delete the automate domain via REST
-        expectedResults:
-            1. Domain must be deleted successfully.
-    """
-    pass


### PR DESCRIPTION
Changes:
1. Add a fixture `domain_rest` to create domain.
2. Add 2 tests:
    1. `test_delete_automate_domain_from_collection`
    2. `test_delete_automate_domain_from_detail`

{{ pytest: cfme/tests/automate/test_rest.py -k "test_delete_automate_domain"  --use-template-cache -sqvvv }}