### PR TITLE
[WIPTEST] Remove Step from dialog_element Edit class

### DIFF
--- a/cfme/automate/dialogs/dialog_element.py
+++ b/cfme/automate/dialogs/dialog_element.py
@@ -242,6 +242,3 @@ class Edit(CFMENavigateStep):
     VIEW = EditElementView
 
     prerequisite = NavigateToAttribute('dialog', 'Edit')
-
-    def step(self, *args, **kwargs):
-        self.prerequisite_view.element.edit_element("Text Box")


### PR DESCRIPTION
`def step()` is not needed here. Navigation will go to the edit page. This fixes:
```
>       self.prerequisite_view.element.edit_element("Text Box")
E       AttributeError: 'EditDialogView' object has no attribute 'element'

cfme/automate/dialogs/dialog_element.py:247: AttributeError
AttributeError
'EditDialogView' object has no attribute 'element'
```

{{ pytest: cfme/tests/automate/test_service_dialog.py -v --long-running }}
