### PR TITLE
[RFR] Fix parallelizer decode

### DIFF
--- a/cfme/fixtures/parallelizer/__init__.py
+++ b/cfme/fixtures/parallelizer/__init__.py
@@ -314,14 +314,13 @@ class ParallelSession(object):
                 yield
                 if polls % poll_report_modulo == 0:
                     remaining_time = int(poll_num_sec - (time() - start_time))
-                    self.print_message(
-                        '{} still shutting down, '
-                        'will continue polling for {} seconds '
-                        .format(slaveid.decode('ascii'), remaining_time), blue=True)
+                    self.print_message('{} shutting down, will continue polling for {} seconds'
+                                       .format(slaveid.decode('ascii'), remaining_time),
+                                       blue=True)
                 sleep(poll_sleep_time)
 
         # start the poll
-        for poll in sleep_and_poll():
+        for _ in sleep_and_poll():
             ec = process.poll()
             if ec is None:
                 continue
@@ -581,14 +580,13 @@ class ParallelSession(object):
                 prov = provs[0]
                 # Already too many slaves with provider
                 app = slave.appliance
-                self.print_message(
-                    'cleansing appliance', slave, purple=True)
+                self.print_message('removing providers from appliance', slave, purple=True)
                 try:
                     app.delete_all_providers()
                 except Exception as e:
-                    self.print_message(
-                        'cloud not cleanse', slave, red=True)
-                    self.print_message('error:', e, red=True)
+                    self.print_message('exception during provider removal: {}'.format(e),
+                                       slave,
+                                       red=True)
             slave.provider_allocation = [prov]
             self._pool.remove(test_group)
             return test_group


### PR DESCRIPTION
We're hitting an exception trying to call decode on the exception object, because the call to print_message was passing the wrong object.

Changed things up a bit, no longer trying to pass the exception itself to print_message.

Cleaned up some print_message calls otherwise as well.