### PR TITLE
[1LP][RFR] Automate test case for creating an appliance in SCVMM

### DIFF
--- a/cfme/tests/infrastructure/test_scvmm_specific.py
+++ b/cfme/tests/infrastructure/test_scvmm_specific.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import re
-import urllib2
 
 import fauxfactory
 import pytest
+import urllib2
 
 from cfme import test_requirements
 from cfme.infrastructure.provider.scvmm import SCVMMProvider

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2674,7 +2674,7 @@ class Appliance(IPAppliance):
 
         appliance = cls(**app_kwargs)
         appliance.vm_name = vm_name
-        appliance.provider = provider.mgmt
+        appliance.provider = provider
         appliance.provider_key = provider_key
         return appliance
 
@@ -2739,12 +2739,10 @@ class Appliance(IPAppliance):
 
     @cached_property
     def mgmt(self):
-        # in this case provider is the wrapanapi mgmt class
-        return self.provider.get_vm(self.vm_name)
+        return self.provider.mgmt.get_vm(self.vm_name)
 
     def does_vm_exist(self):
-        # in this case provider is the wrapanapi mgmt class
-        return self.provider.does_vm_exist(self.vm_name)
+        return self.provider.mgmt.does_vm_exist(self.vm_name)
 
     def rename(self, new_name):
         """Changes appliance name
@@ -2803,23 +2801,23 @@ class Appliance(IPAppliance):
     @property
     def is_on_rhev(self):
         from cfme.infrastructure.provider.rhevm import RHEVMProvider
-        return isinstance(self.provider, RHEVMProvider.mgmt_class)
+        return isinstance(self.provider.mgmt, RHEVMProvider.mgmt_class)
 
     @property
     def is_on_vsphere(self):
         from cfme.infrastructure.provider.virtualcenter import VMwareProvider
-        return isinstance(self.provider, VMwareProvider.mgmt_class)
+        return isinstance(self.provider.mgmt, VMwareProvider.mgmt_class)
 
     @property
     def is_on_openshift(self):
         from cfme.containers.provider.openshift import OpenshiftProvider
-        return isinstance(self.provider, OpenshiftProvider.mgmt_class)
+        return isinstance(self.provider.mgmt, OpenshiftProvider.mgmt_class)
 
     @logger_wrap("Setting ansible url: {}")
     def set_ansible_url(self, log_callback=None):
         if self.is_on_openshift:
             try:
-                config_map = self.provider.get_appliance_tags(self.project)
+                config_map = self.provider.mgmt.get_appliance_tags(self.project)
                 url = config_map['cfme-openshift-embedded-ansible']['url']
                 tag = config_map['cfme-openshift-embedded-ansible']['tag']
                 config = {'embedded_ansible': {'container': {'image_name': url, 'image_tag': tag}}}

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2739,10 +2739,12 @@ class Appliance(IPAppliance):
 
     @cached_property
     def mgmt(self):
-        return self.provider.mgmt.get_vm(self.vm_name)
+        # in this case provider is the wrapanapi mgmt class
+        return self.provider.get_vm(self.vm_name)
 
     def does_vm_exist(self):
-        return self.provider.mgmt.does_vm_exist(self.vm_name)
+        # in this case provider is the wrapanapi mgmt class
+        return self.provider.does_vm_exist(self.vm_name)
 
     def rename(self, new_name):
         """Changes appliance name
@@ -2943,6 +2945,10 @@ def provision_appliance(
     if prov_data["type"] == "virtualcenter":
         if "allowed_datastores" in prov_data:
             deploy_args["allowed_datastores"] = prov_data["allowed_datastores"]
+
+    if prov_data["type"] == "scvmm":
+        if "host_group" in prov_data.provisioning:
+            deploy_args["host_group"] = prov_data.provisioning["host_group"]
 
     template = provider.get_template(template_name)
     template.deploy(**deploy_args)

--- a/scripts/clone_template.py
+++ b/scripts/clone_template.py
@@ -360,7 +360,7 @@ def main(**kwargs):
                 ssh_client.get_file('/root/anaconda-post.log',
                                     log_path.join('anaconda-post.log').strpath)
             ssh_client.close()
-        destroy_vm(app.provider, deploy_args['vm_name'])
+        destroy_vm(app.provider.mgmt, deploy_args['vm_name'])
         return 10
 
     if kwargs.get('outfile') or kwargs.get('deploy'):


### PR DESCRIPTION
This PR automates the test case to provision a CFME appliance on SCVMM. It goes through the steps of downloading the VHD, creating the template, deploying the template to a VM, configuring the appliance, and waiting for the web ui to become accessible. 

In the process of this PR, I've fix a minor bug in the `Appliance` class. In that class, provider refers to the wrapanapi system class, not the integration_tests provider class, so I fixed this where necessary. 

~~Depends on wrapanapi PR https://github.com/ManageIQ/wrapanapi/pull/378~~
~~Depends on wrapanapi PR https://github.com/ManageIQ/wrapanapi/pull/380~~
~~Depends on wrapanapi PR https://github.com/ManageIQ/wrapanapi/pull/384~~

{{ pytest: --long-running --use-template-cache --use-provider complete cfme/tests/infrastructure/test_scvmm_specific.py::test_create_appliance_on_scvmm_using_the_vhd_image }}