### PR TITLE
[1LP][RFR] Change appliance instantiation to use from_provider

### DIFF
--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2945,7 +2945,7 @@ def provision_appliance(
     template = provider.get_template(template_name)
     template.deploy(**deploy_args)
 
-    return Appliance(provider_name, vm_name)
+    return Appliance.from_provider(provider_name, vm_name)
 
 
 class ApplianceStack(LocalStack):


### PR DESCRIPTION
Use `Appliance.from_provider()` to instantiate the appliance object in `provision_appliance`. This should fix this error that's seen with the current implementation: 
```python,
Traceback (most recent call last):
  File "/home/jdupuy/cfme_tests/cfme_venv/lib/python2.7/site-packages/IPython/core/interactiveshell.py", line 2878, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-6-921e85341915>", line 1, in <module>
    create_appliance(provider, image_name)
  File "/home/jdupuy/cfme_tests/integration_tests/cfme/tests/infrastructure/test_scvmm_specific.py", line 112, in create_appliance
    return provision_appliance(provider.key, version=version, template=template_name)
  File "/home/jdupuy/cfme_tests/integration_tests/cfme/utils/appliance/__init__.py", line 2952, in provision_appliance
    return Appliance(provider_name, vm_name)
  File "/home/jdupuy/cfme_tests/integration_tests/cfme/utils/appliance/__init__.py", line 377, in __init__
    ui_protocol, list(self.PROTOCOL_PORT_MAPPING.keys())))
TypeError: Wrong protocol 'cfme_51041_4HA0Ej5A' passed, expected ['http', 'https']```