### PR TITLE
[WIPTEST] Fixed host relationships for scvmm

### DIFF
--- a/cfme/tests/cloud_infra_common/test_relationships.py
+++ b/cfme/tests/cloud_infra_common/test_relationships.py
@@ -105,6 +105,7 @@ def get_obj(relationship, appliance, **kwargs):
         host = kwargs.get("host")
         provider = kwargs.get("provider")
         view = navigate_to(host, "Details")
+        wait_for(lambda: True, timeout=15)
         cluster_name = view.entities.summary("Relationships").get_text_of("Cluster")
         obj = cluster_col.instantiate(name=cluster_name, provider=provider)
     elif relationship in ["Datastores", "VMs", "Templates"]:


### PR DESCRIPTION
{{pytest: cfme/tests/cloud_infra_common/test_relationships.py -k 'test_host_relationships' --use-provider=scvmm --long-running -vv}}

Fixed Error:
```

>       ][-1]  # FIXME this is raising an IndexError for being out of range, list must be empty
E       IndexError: list index out of range

cfme/infrastructure/cluster.py:182: IndexError
IndexError
list index out of range
```