### PR TITLE
[RFR] Fix expression test for component ui changes

### DIFF
--- a/cfme/automate/buttons.py
+++ b/cfme/automate/buttons.py
@@ -485,6 +485,9 @@ class ButtonCollection(BaseCollection):
                 view.advanced.enablement.define_exp.click()
 
             view.advanced.enablement.expression.fill_tag(tag=tag, value=enablement["value"])
+            view.advanced.enablement.disabled_text.fill(
+                "Tag - {} : {}".format(enablement["tag"], enablement["value"])
+            )
 
         view.fill({"advanced": {"system": system, "request": request}})
 

--- a/cfme/tests/automate/custom_button/test_cloud_objects.py
+++ b/cfme/tests/automate/custom_button/test_cloud_objects.py
@@ -1,3 +1,5 @@
+import re
+
 import fauxfactory
 import pytest
 from widgetastic_patternfly import Dropdown
@@ -352,6 +354,7 @@ def test_custom_button_expression_cloud_obj(
 
     group, obj_type = button_group
     exp = {expression: {"tag": "My Company Tags : Department", "value": "Engineering"}}
+    disabled_txt = "Tag - My Company Tags : Department : Engineering"
     button = group.buttons.create(
         text=fauxfactory.gen_alphanumeric(),
         hover=fauxfactory.gen_alphanumeric(),
@@ -370,13 +373,12 @@ def test_custom_button_expression_cloud_obj(
     for setup_obj in setup_objs:
         view = navigate_to(setup_obj, "Details")
         custom_button_group = Dropdown(view, group.text)
-
-        # TODO(ndhandre): add hover check if group disabled
         if tag.display_name in [item.display_name for item in setup_obj.get_tags()]:
             if expression == "enablement":
                 assert custom_button_group.item_enabled(button.text)
                 setup_obj.remove_tag(tag)
                 assert not custom_button_group.is_enabled
+                assert re.search(disabled_txt, custom_button_group.hover)
             elif expression == "visibility":
                 assert button.text in custom_button_group.items
                 setup_obj.remove_tag(tag)
@@ -384,6 +386,7 @@ def test_custom_button_expression_cloud_obj(
         else:
             if expression == "enablement":
                 assert not custom_button_group.is_enabled
+                assert re.search(disabled_txt, custom_button_group.hover)
                 setup_obj.add_tag(tag)
                 assert custom_button_group.item_enabled(button.text)
             elif expression == "visibility":

--- a/cfme/tests/automate/custom_button/test_cloud_objects.py
+++ b/cfme/tests/automate/custom_button/test_cloud_objects.py
@@ -369,29 +369,21 @@ def test_custom_button_expression_cloud_obj(
 
     for setup_obj in setup_objs:
         view = navigate_to(setup_obj, "Details")
-        custom_button_group = Dropdown(view, group.hover)
+        custom_button_group = Dropdown(view, group.text)
 
-        # Note: For higher version (5.10+), button group having single button;
-        # If button is disabled then group disabled.
-
+        # TODO(ndhandre): add hover check if group disabled
         if tag.display_name in [item.display_name for item in setup_obj.get_tags()]:
             if expression == "enablement":
                 assert custom_button_group.item_enabled(button.text)
                 setup_obj.remove_tag(tag)
-                if appliance.version < "5.10":
-                    assert not custom_button_group.item_enabled(button.text)
-                else:
-                    assert not custom_button_group.is_enabled
+                assert not custom_button_group.is_enabled
             elif expression == "visibility":
                 assert button.text in custom_button_group.items
                 setup_obj.remove_tag(tag)
                 assert not custom_button_group.is_displayed
         else:
             if expression == "enablement":
-                if appliance.version < "5.10":
-                    assert not custom_button_group.item_enabled(button.text)
-                else:
-                    assert not custom_button_group.is_enabled
+                assert not custom_button_group.is_enabled
                 setup_obj.add_tag(tag)
                 assert custom_button_group.item_enabled(button.text)
             elif expression == "visibility":

--- a/cfme/tests/automate/custom_button/test_container_objects.py
+++ b/cfme/tests/automate/custom_button/test_container_objects.py
@@ -234,26 +234,22 @@ def test_custom_button_expression_container_obj(
     tag = tag_cat.collections.tags.instantiate(name="engineering", display_name="Engineering")
 
     view = navigate_to(setup_obj, "Details")
-    custom_button_group = Dropdown(view, group.hover)
+    custom_button_group = Dropdown(view, group.text)
+
+    # TODO(ndhandre): add hover check if group disabled
 
     if tag.display_name in [item.display_name for item in setup_obj.get_tags()]:
         if expression == "enablement":
             assert custom_button_group.item_enabled(button.text)
             setup_obj.remove_tag(tag)
-            if appliance.version < "5.10":
-                assert not custom_button_group.item_enabled(button.text)
-            else:
-                assert not custom_button_group.is_enabled
+            assert not custom_button_group.is_enabled
         elif expression == "visibility":
             assert button.text in custom_button_group.items
             setup_obj.remove_tag(tag)
             assert not custom_button_group.is_displayed
     else:
         if expression == "enablement":
-            if appliance.version < "5.10":
-                assert not custom_button_group.item_enabled(button.text)
-            else:
-                assert not custom_button_group.is_enabled
+            assert not custom_button_group.is_enabled
             setup_obj.add_tag(tag)
             assert custom_button_group.item_enabled(button.text)
         elif expression == "visibility":

--- a/cfme/tests/automate/custom_button/test_container_objects.py
+++ b/cfme/tests/automate/custom_button/test_container_objects.py
@@ -1,3 +1,5 @@
+import re
+
 import fauxfactory
 import pytest
 from widgetastic_patternfly import Dropdown
@@ -218,6 +220,7 @@ def test_custom_button_expression_container_obj(
 
     group, obj_type = button_group
     exp = {expression: {"tag": "My Company Tags : Department", "value": "Engineering"}}
+    disabled_txt = "Tag - My Company Tags : Department : Engineering"
     button = group.buttons.create(
         text=fauxfactory.gen_alphanumeric(),
         hover=fauxfactory.gen_alphanumeric(),
@@ -236,13 +239,12 @@ def test_custom_button_expression_container_obj(
     view = navigate_to(setup_obj, "Details")
     custom_button_group = Dropdown(view, group.text)
 
-    # TODO(ndhandre): add hover check if group disabled
-
     if tag.display_name in [item.display_name for item in setup_obj.get_tags()]:
         if expression == "enablement":
             assert custom_button_group.item_enabled(button.text)
             setup_obj.remove_tag(tag)
             assert not custom_button_group.is_enabled
+            assert re.search(disabled_txt, custom_button_group.hover)
         elif expression == "visibility":
             assert button.text in custom_button_group.items
             setup_obj.remove_tag(tag)
@@ -250,6 +252,7 @@ def test_custom_button_expression_container_obj(
     else:
         if expression == "enablement":
             assert not custom_button_group.is_enabled
+            assert re.search(disabled_txt, custom_button_group.hover)
             setup_obj.add_tag(tag)
             assert custom_button_group.item_enabled(button.text)
         elif expression == "visibility":

--- a/cfme/tests/automate/custom_button/test_generic_objects.py
+++ b/cfme/tests/automate/custom_button/test_generic_objects.py
@@ -1,3 +1,5 @@
+import re
+
 import fauxfactory
 import pytest
 from widgetastic_patternfly import Dropdown
@@ -268,6 +270,7 @@ def test_custom_button_expression_evm_obj(appliance, request, setup_obj, button_
 
     group, obj_type = button_group
     exp = {expression: {"tag": "My Company Tags : Department", "value": "Engineering"}}
+    disabled_txt = "Tag - My Company Tags : Department : Engineering"
 
     button = group.buttons.create(
         text=fauxfactory.gen_alphanumeric(),
@@ -287,13 +290,12 @@ def test_custom_button_expression_evm_obj(appliance, request, setup_obj, button_
     view = navigate_to(setup_obj, "Details")
     custom_button_group = Dropdown(view, group.text)
 
-    # TODO(ndhandre): add hover check if group disabled
-
     if tag.display_name in [item.display_name for item in setup_obj.get_tags()]:
         if expression == "enablement":
             assert custom_button_group.item_enabled(button.text)
             setup_obj.remove_tag(tag)
             assert not custom_button_group.is_enabled
+            assert re.search(disabled_txt, custom_button_group.hover)
         elif expression == "visibility":
             assert button.text in custom_button_group.items
             setup_obj.remove_tag(tag)
@@ -305,6 +307,7 @@ def test_custom_button_expression_evm_obj(appliance, request, setup_obj, button_
             assert custom_button_group.item_enabled(button.text)
         elif expression == "visibility":
             assert not custom_button_group.is_displayed
+            assert re.search(disabled_txt, custom_button_group.hover)
             setup_obj.add_tag(tag)
             assert button.text in custom_button_group.items
 

--- a/cfme/tests/automate/custom_button/test_generic_objects.py
+++ b/cfme/tests/automate/custom_button/test_generic_objects.py
@@ -285,7 +285,10 @@ def test_custom_button_expression_evm_obj(appliance, request, setup_obj, button_
     tag = tag_cat.collections.tags.instantiate(name="engineering", display_name="Engineering")
 
     view = navigate_to(setup_obj, "Details")
-    custom_button_group = Dropdown(view, group.hover)
+    custom_button_group = Dropdown(view, group.text)
+
+    # TODO(ndhandre): add hover check if group disabled
+
     if tag.display_name in [item.display_name for item in setup_obj.get_tags()]:
         if expression == "enablement":
             assert custom_button_group.item_enabled(button.text)

--- a/cfme/tests/automate/custom_button/test_infra_objects.py
+++ b/cfme/tests/automate/custom_button/test_infra_objects.py
@@ -1,3 +1,4 @@
+import re
 from textwrap import dedent
 
 import fauxfactory
@@ -381,6 +382,7 @@ def test_custom_button_expression_infra_obj(
 
     group, obj_type = button_group
     exp = {expression: {"tag": "My Company Tags : Department", "value": "Engineering"}}
+    disabled_txt = "Tag - My Company Tags : Department : Engineering"
     button = group.buttons.create(
         text=fauxfactory.gen_alphanumeric(),
         hover=fauxfactory.gen_alphanumeric(),
@@ -399,13 +401,12 @@ def test_custom_button_expression_infra_obj(
     view = navigate_to(setup_obj, "Details")
     custom_button_group = Dropdown(view, group.text)
 
-    # TODO(ndhandre): add hover check if group disabled
-
     if tag.display_name in [item.display_name for item in setup_obj.get_tags()]:
         if expression == "enablement":
             assert custom_button_group.item_enabled(button.text)
             setup_obj.remove_tag(tag)
             assert not custom_button_group.is_enabled
+            assert re.search(disabled_txt, custom_button_group.hover)
         elif expression == "visibility":
             assert button.text in custom_button_group.items
             setup_obj.remove_tag(tag)
@@ -413,6 +414,7 @@ def test_custom_button_expression_infra_obj(
     else:
         if expression == "enablement":
             assert not custom_button_group.is_enabled
+            assert re.search(disabled_txt, custom_button_group.hover)
             setup_obj.add_tag(tag)
             assert custom_button_group.item_enabled(button.text)
         elif expression == "visibility":

--- a/cfme/tests/automate/custom_button/test_infra_objects.py
+++ b/cfme/tests/automate/custom_button/test_infra_objects.py
@@ -374,6 +374,9 @@ def test_custom_button_expression_infra_obj(
             3. Navigate to object Detail page
             4. Check: button should not enable/visible without tag
             5. Check: button should enable/visible with tag
+
+    Bugzilla:
+        1705141
     """
 
     group, obj_type = button_group
@@ -394,29 +397,22 @@ def test_custom_button_expression_infra_obj(
     tag = tag_cat.collections.tags.instantiate(name="engineering", display_name="Engineering")
 
     view = navigate_to(setup_obj, "Details")
-    custom_button_group = Dropdown(view, group.hover)
+    custom_button_group = Dropdown(view, group.text)
 
-    # Note: For higher version (5.10+), button group having single button;
-    # If button is disabled then group disabled.
+    # TODO(ndhandre): add hover check if group disabled
 
     if tag.display_name in [item.display_name for item in setup_obj.get_tags()]:
         if expression == "enablement":
             assert custom_button_group.item_enabled(button.text)
             setup_obj.remove_tag(tag)
-            if appliance.version < "5.10":
-                assert not custom_button_group.item_enabled(button.text)
-            else:
-                assert not custom_button_group.is_enabled
+            assert not custom_button_group.is_enabled
         elif expression == "visibility":
             assert button.text in custom_button_group.items
             setup_obj.remove_tag(tag)
             assert not custom_button_group.is_displayed
     else:
         if expression == "enablement":
-            if appliance.version < "5.10":
-                assert not custom_button_group.item_enabled(button.text)
-            else:
-                assert not custom_button_group.is_enabled
+            assert not custom_button_group.is_enabled
             setup_obj.add_tag(tag)
             assert custom_button_group.item_enabled(button.text)
         elif expression == "visibility":


### PR DESCRIPTION
Signed-off-by: Nikhil Dhandre <ndhandre@redhat.com>

Purpose or Intent
=================
- As 510 also moved to new ui-component
https://github.com/ManageIQ/ui-components/pull/372

- Added fix for 510.. 511 will fails due to tag... need to fix tag.

{{pytest: cfme/tests/automate/custom_button -k 'test_custom_button_expression'}}