### PR TITLE
[RFR] Add a wait_for in getting the server_names

### DIFF
--- a/cfme/tests/cli/test_evmserverd.py
+++ b/cfme/tests/cli/test_evmserverd.py
@@ -42,10 +42,22 @@ def test_evmserverd_stop(appliance, request):
 
     server_name_key = 'Server'
 
+    @wait_for_decorator(timeout="2m", delay=5)
+    def get_server_names():
+        """ Wait for the server name to appear on the appliance.
+            This test was experiencing KeyErrors before this wait was included.
+        """
+        return all(
+            [bool(
+                server.get(server_name_key, False)
+            ) for server in appliance.ssh_client.status["servers"]]
+        )
+
     server_names = {
         server[server_name_key].rstrip('*')  # evm* shows up in status
         for server in appliance.ssh_client.status["servers"]
     }
+
     request.addfinalizer(appliance.evmserverd.start)
     appliance.evmserverd.stop()
 


### PR DESCRIPTION
This test was failing with the following error:

```
cfme/tests/cli/test_evmserverd.py:47: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

.0 = <listiterator object at 0x7f284f5e9390>

    server[server_name_key].rstrip('*')  # evm* shows up in status
>   for server in appliance.ssh_client.status["servers"]
        }
E       KeyError: 'Server'

cfme/tests/cli/test_evmserverd.py:47: KeyError
```

Adding a wait_for should in getting the server_name should remedy this. 

{{ pytest: --long-running --use-template-cache cfme/tests/cli/test_evmserverd.py::test_evmserverd_stop }}