### PR TITLE
[1LP][RFR] Add a skip if the template is not available in customization templates

### DIFF
--- a/cfme/tests/services/test_iso_service_catalogs.py
+++ b/cfme/tests/services/test_iso_service_catalogs.py
@@ -33,7 +33,12 @@ pytestmark = [
 @pytest.fixture(scope="module")
 def iso_cust_template(provider, appliance):
     iso_cust_template = provider.data['provisioning']['iso_kickstart']
-    return get_template_from_config(iso_cust_template, create=True, appliance=appliance)
+    try:
+        return get_template_from_config(iso_cust_template, create=True, appliance=appliance)
+    except KeyError:
+        pytest.skip("No such template '{}' available in 'customization_templates'".format(
+            iso_cust_template
+        ))
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
{{ pytest: --use-template-cache --long-running --use-provider rhv43 cfme/tests/services/test_iso_service_catalogs.py -k test_rhev_iso_servicecatalog }}

@lina-nikiforova This test was failing with a `KeyError` due to the template `rhel74` not being available in the `customization_templates`, this PR will skip the test for now. 