### PR TITLE
[WIP][NOTEST]Enable black on pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
   - id: black
     args: [--safe, --line-length, '100']
     language_version: python3.6
-    <<: *exclude
+    exclude: ^(cfme/(?!tests)|scripts)
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v2.0.0
   hooks:


### PR DESCRIPTION
Changes:
1. Enable black to run on `cfme/tests` in pre-commit

How black works while running pre-commit locally?  
1. Add your changes to git.
2. Commit your changes to git - If the files don't comply with Black formatting,  pre-commit will fail at Black and apply Black to the files that were added to git, else Black passes, just like any other pre-commit hook.
3. If the Black hook failed in step 2, re-add your changes to git and commit, Black should pass this time.
