### PR TITLE
[1LP][RFR] Automate BZ: Add in test_case for buttons on action-edit page

### DIFF
--- a/cfme/tests/control/test_bugs.py
+++ b/cfme/tests/control/test_bugs.py
@@ -512,6 +512,6 @@ def test_edit_action_buttons(action_for_testing):
 
     assert view.save_button.disabled
     assert view.reset_button.disabled
-    # prep for deletion of the action during teardown
+    # click the cancel button and navigate to "Details" so that the action can be deleted
     view.cancel_button.click()
     navigate_to(action_for_testing, "Details")

--- a/cfme/tests/control/test_bugs.py
+++ b/cfme/tests/control/test_bugs.py
@@ -181,6 +181,17 @@ def setup_disk_usage_alert(appliance):
     assert not result.failed
 
 
+@pytest.fixture
+def action_for_testing(appliance):
+    action_ = appliance.collections.actions.create(
+        fauxfactory.gen_alphanumeric(),
+        action_type="Tag",
+        action_values={"tag": ("My Company Tags", "Department", "Accounting")}
+    )
+    yield action_
+    action_.delete()
+
+
 @pytest.mark.meta(blockers=[BZ(1155284)])
 def test_scope_windows_registry_stuck(request, appliance, infra_provider):
     """If you provide Scope checking windows registry, it messes CFME up. Recoverable.
@@ -481,3 +492,26 @@ def test_accordion_after_condition_creation(appliance, condition_class):
     assert view.conditions.tree.currently_selected == [
         "All Conditions", "{} Conditions".format(condition_class.TREE_NODE), condition.description
     ]
+
+
+@pytest.mark.meta(blockers=[BZ(1708434)], automates=[1708434])
+def test_edit_action_buttons(action_for_testing):
+    """
+    This tests the bug where the save/reset button are always enabled, even on initial load.
+
+    Bugzilla:
+        1708434
+
+    Polarion:
+        assignee: jdupuy
+        casecomponent: Control
+        caseimportance: medium
+        initialEstimate: 1/30h
+    """
+    view = navigate_to(action_for_testing, "Edit")
+
+    assert view.save_button.disabled
+    assert view.reset_button.disabled
+    # prep for deletion of the action during teardown
+    view.cancel_button.click()
+    navigate_to(action_for_testing, "Details")

--- a/cfme/utils/bz.py
+++ b/cfme/utils/bz.py
@@ -323,7 +323,8 @@ class BugWrapper(object):
     @property
     def is_opened(self):
         states = self._bugzilla.open_states
-        if not self.upstream_bug and appliance_is_downstream():
+        if appliance_is_downstream():
+            # for downstream appliances, "POST" and "MODIFIED" are considered open states
             states.add('POST')
             states.add('MODIFIED')
         return self.status in states


### PR DESCRIPTION
This PR is meant to provider automated test coverage for the BZ 1708434.

Regarding the comment below, @jawatts and I spent some time debugging this and decided that a change to the `is_opened` property in `cfme.utils.bz` was necessary. The bug this test case was written against is on the latest downstream build. New BZs that are written against the latest build are considered to be upstream bugs, since they are also broken in the upstream build. Upstream bugs are also considered to be bugs that have no version string. However, in this case, for the downstream build, we want to consider the states of `POST` and `MODIFIED` as open for the BZ, since the bug is not fixed in the latest downstream build. This is remedied by changing `and` to `or`. 

{{ pytest: --use-template-cache cfme/tests/control/test_bugs.py::test_edit_action_buttons }}