### PR TITLE
[RFR] Update wt.pf, fix test_provisioning fixtures, add remote_console role

### DIFF
--- a/cfme/configure/configuration/server_settings.py
+++ b/cfme/configure/configuration/server_settings.py
@@ -218,7 +218,7 @@ class ServerInformation(Updateable, Pretty):
                     'rhn_mirror', 'database_synchronization_role', 'git_owner', 'websocket',
                     'storage_metrics_processor', 'storage_metrics_collector',
                     'storage_metrics_coordinator', 'storage_inventory', 'vmdb_storage_bridge',
-                    'cockpit_ws')
+                    'cockpit_ws', 'remote_console')
 
     _basic_information = ['hostname', 'company_name', 'appliance_name', 'appliance_zone',
                           'time_zone', 'locale']

--- a/cfme/tests/cloud_infra_common/test_provisioning.py
+++ b/cfme/tests/cloud_infra_common/test_provisioning.py
@@ -339,9 +339,14 @@ def original_request_class(appliance):
 
 @pytest.fixture(scope="module")
 def modified_request_class(request, domain, original_request_class):
-    with pytest.raises(Exception, match="error: Error during 'Automate Class copy'"):
+    try:
         # methods of this class might have been copied by other fixture, so this error can occur
         original_request_class.copy_to(domain)
+    except Exception as ex:
+        if "Error during 'Automate Class copy'" in ex.message:
+            pass
+        else:
+            pytest.fail('Unexpected exception duing request class copy')
     klass = (domain
              .namespaces.instantiate(name='Cloud')
              .namespaces.instantiate(name='VM')

--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -327,7 +327,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.15.2
 widgetastic.core==0.37
-widgetastic.patternfly==0.1.0
+widgetastic.patternfly==0.1.2
 widgetsnbextension==3.4.2
 wrapanapi==3.1.4
 wrapt==1.11.1

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -312,7 +312,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.15.2
 widgetastic.core==0.37
-widgetastic.patternfly==0.1.0
+widgetastic.patternfly==0.1.2
 widgetsnbextension==3.4.2
 wrapanapi==3.1.4
 wrapt==1.11.1

--- a/requirements/frozen_docs.py2.txt
+++ b/requirements/frozen_docs.py2.txt
@@ -326,7 +326,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.15.2
 widgetastic.core==0.37
-widgetastic.patternfly==0.1.0
+widgetastic.patternfly==0.1.2
 widgetsnbextension==3.4.2
 wrapanapi==3.1.4
 wrapt==1.11.1

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -311,7 +311,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.15.2
 widgetastic.core==0.37
-widgetastic.patternfly==0.1.0
+widgetastic.patternfly==0.1.2
 widgetsnbextension==3.4.2
 wrapanapi==3.1.4
 wrapt==1.11.1


### PR DESCRIPTION
This exception doesn't always occur during the fixture, which obviously causes test failures.  Only occurring on the rhos provider tests, so only including it for PRT.

{{ pytest: --long-running --use-provider rhos13 cfme/tests/cloud_infra_common/test_provisioning.py }}