### PR TITLE
[1LP][RFR] Remove appliance dependencies from cfme.utils.bz and move them to cfme.utils.blockers

### DIFF
--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -962,8 +962,6 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
 
     @cached_property
     def build(self):
-        if not self.is_downstream:
-            return 'master'
         try:
             return self.rest_api.server_info['build']
         except (AttributeError, KeyError, IOError):

--- a/cfme/utils/blockers.py
+++ b/cfme/utils/blockers.py
@@ -184,14 +184,14 @@ class BZ(Blocker):
     @property
     def can_test_on_current_upstream_appliance(self):
         bug = self.data
-        if not bug.can_test_on_upstream:
-            return False
-        if version.appliance_is_downstream():
+        if bug is None:  # if bug is None, then it is not a blocker and we can test it
+            return True
+        if not bug.can_test_on_upstream:  # if bug is not fixed in upstream, we can't test it!
             return False
 
         change_states = {"POST", "MODIFIED"}
-        # With these states, the change is in upstream
-        if bug.status not in {"POST", "MODIFIED", "ON_QA", "VERIFIED", "RELEASE_PENDING"}:
+        # With these states, the change is not in upstream
+        if bug.status in {"NEW", "ON_DEV", "ASSIGNED"}:
             return False
         history = bug.get_history_raw()["bugs"][0]["history"]
         changes = []

--- a/cfme/utils/blockers.py
+++ b/cfme/utils/blockers.py
@@ -183,6 +183,19 @@ class BZ(Blocker):
 
     @property
     def can_test_on_current_upstream_appliance(self):
+        """
+        This property is designed for use with the blocks property and is answering the question:
+
+        "If I have a bug, and that bug is in a "POST" or "MODIFIED" state, and if I have an
+        upstream appliance, is the build date of my current upstream appliance after
+        the fix for the bug was merged?"
+
+        If so, then it will return True, because the bug's fix is included in your current
+        upstream appliance.
+
+        If you happen to be on an older version of an upstream appliance that doesn't have the fix,
+        then it will return False.
+        """
         bug = self.data
         if bug is None:  # if bug is None, then it is not a blocker and we can test it
             return True


### PR DESCRIPTION
I recently faced some confusion in dealing with the BZ objects. A lot of it stemmed from the fact that `BugWrapper` in `cfme.utils.bz` gives information relative to the appliance that you're using for testing. My thought is that `cfme.utils.bz` should give information about the BZ _independent_ of the appliance on which you're testing. This appliance specific stuff should be evaluated in the `BZ()` blocker class in `cfme.utils.blockers`.

