### PR TITLE
[1LP][RFR] Fixed test cases related to automate in 5.11

### DIFF
--- a/cfme/automate/explorer/domain.py
+++ b/cfme/automate/explorer/domain.py
@@ -20,6 +20,7 @@ from cfme.utils import clear_property_cache
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator
+from cfme.utils.blockers import BZ
 from widgetastic_manageiq import Table
 from widgetastic_manageiq import UpDownSelect
 
@@ -240,6 +241,10 @@ class Domain(BaseEntity, Fillable):
             domains_view.flash.assert_message(
                 'Automate Domain "{}": Delete successful'.format(self.description or self.name))
 
+        # TODO(BZ-1704439): Remove the work-around once this BZ got fixed
+        if BZ(1704439).blocks:
+            self.browser.refresh()
+
     def lock(self):
         # Ensure this has correct data
         self.description
@@ -247,6 +252,11 @@ class Domain(BaseEntity, Fillable):
         details_page.configuration.item_select('Lock this Domain')
         details_page.flash.assert_no_error()
         details_page.flash.assert_message('The selected Automate Domain were marked as Locked')
+
+        # TODO(BZ-1704439): Remove the work-around once this BZ got fixed
+        if BZ(1704439).blocks:
+            self.browser.refresh()
+
         clear_property_cache(self, 'locked')
         assert self.locked
 
@@ -257,10 +267,20 @@ class Domain(BaseEntity, Fillable):
         details_page.configuration.item_select('Unlock this Domain')
         details_page.flash.assert_no_error()
         details_page.flash.assert_message('The selected Automate Domain were marked as Unlocked')
+
+        # TODO(BZ-1704439): Remove the work-around once this BZ got fixed
+        if BZ(1704439).blocks:
+            self.browser.refresh()
+
         clear_property_cache(self, 'locked')
         assert not self.locked
 
     def update(self, updates):
+
+        # TODO(BZ-1704439): Remove the work-around once this BZ got fixed
+        if BZ(1704439).blocks:
+            self.browser.refresh()
+
         view = navigate_to(self, 'Edit')
         changed = view.fill(updates)
         if changed:
@@ -326,6 +346,11 @@ class DomainCollection(BaseCollection):
             if enabled is None:
                 # Assume
                 enabled = False
+
+            # TODO(BZ-1704439): Remove the work-around once this BZ got fixed
+            if BZ(1704439).blocks:
+                self.browser.refresh()
+
             return self.instantiate(
                 name=name, description=description, enabled=enabled, locked=False)
 
@@ -391,6 +416,10 @@ class DomainCollection(BaseCollection):
         for domain in checked_domains:
             all_page.flash.assert_message(
                 'Automate Domain "{}": Delete successful'.format(domain.description or domain.name))
+
+        # TODO(BZ-1704439): Remove the work-around once this BZ got fixed
+        if BZ(1704439).blocks:
+            self.browser.refresh()
 
     def set_order(self, items):
         if not isinstance(items, (list, tuple)):

--- a/cfme/automate/explorer/instance.py
+++ b/cfme/automate/explorer/instance.py
@@ -23,6 +23,7 @@ from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator
+from cfme.utils.blockers import BZ
 from widgetastic_manageiq import Table
 
 
@@ -49,8 +50,8 @@ class InstanceDetailsView(AutomateExplorerView):
             self.in_explorer and
             self.title.text.startswith('Automate Instance [{}'.format(
                 self.context['object'].display_name or self.context['object'].name)) and
-            self.datastore.is_opened and check_tree_path(self.datastore.tree.currently_selected,
-                                                         self.context['object'].tree_path)
+            self.datastore.is_opened and (BZ(1704439).blocks or check_tree_path(
+                self.datastore.tree.currently_selected, self.context["object"].tree_path))
         )
 
 
@@ -216,6 +217,11 @@ class Instance(BaseEntity, Copiable):
         return self.parent_obj.tree_path_name_only + [self.name]
 
     def update(self, updates):
+
+        # TODO(BZ-1704439): Remove the work-around once this BZ got fixed
+        if BZ(1704439).blocks:
+            self.browser.refresh()
+
         view = navigate_to(self, 'Edit')
         changed = view.fill(updates)
         if changed:
@@ -248,6 +254,10 @@ class Instance(BaseEntity, Copiable):
             result_view.flash.assert_message(
                 'Automate Instance "{}": Delete successful'.format(self.description or self.name))
 
+            # TODO(BZ-1704439): Remove the work-around once this BZ got fixed
+            if BZ(1704439).blocks:
+                self.browser.refresh()
+
 
 @attr.s
 class InstanceCollection(BaseCollection):
@@ -279,6 +289,11 @@ class InstanceCollection(BaseCollection):
             add_page.add_button.click()
             add_page.flash.assert_no_error()
             add_page.flash.assert_message('Automate Instance "{}" was added'.format(name))
+
+            # TODO(BZ-1704439): Remove the work-around once this BZ got fixed
+            if BZ(1704439).blocks:
+                self.browser.refresh()
+
             return self.instantiate(
                 name=name,
                 display_name=display_name,
@@ -320,6 +335,10 @@ class InstanceCollection(BaseCollection):
         for instance in checked_instances:
             all_page.flash.assert_message(
                 'Automate Instance "{}": Delete successful'.format(instance.name))
+
+        # TODO(BZ-1704439): Remove the work-around once this BZ got fixed
+        if BZ(1704439).blocks:
+            self.browser.refresh()
 
 
 @navigator.register(InstanceCollection)

--- a/cfme/tests/automate/test_domain.py
+++ b/cfme/tests/automate/test_domain.py
@@ -9,7 +9,6 @@ from cfme.automate.explorer.klass import ClassCopyView
 from cfme.automate.explorer.method import MethodCopyView
 from cfme.exceptions import OptionNotAvailable
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.blockers import BZ
 from cfme.utils.update import update
 
 pytestmark = [test_requirements.automate]
@@ -217,25 +216,15 @@ def test_domain_lock_unlock(domain, appliance):
     assert not details.configuration.is_displayed
     # class
     details = navigate_to(cls, 'Details')
-    if appliance.version < '5.10':
-        assert details.configuration.items == ['Copy selected Instances']
-        assert not details.configuration.item_enabled('Copy selected Instances')
-    else:
-        assert not details.configuration.is_enabled
+    assert not details.configuration.is_enabled
     details.schema.select()
     assert not details.configuration.is_displayed
     # instance
     details = navigate_to(inst, 'Details')
-    if appliance.version < '5.10':
-        assert details.configuration.items == ['Copy this Instance']
-    else:
-        assert not details.configuration.is_enabled
+    assert not details.configuration.is_enabled
     # method
     details = navigate_to(meth, 'Details')
-    if appliance.version < '5.10':
-        assert details.configuration.items == ['Copy this Method']
-    else:
-        assert not details.configuration.is_enabled
+    assert not details.configuration.is_enabled
     # Unlock it
     domain.unlock()
     # Check that it is editable
@@ -258,7 +247,6 @@ def test_domain_lock_unlock(domain, appliance):
 
 
 @pytest.mark.tier(1)
-@pytest.mark.meta(blockers=[BZ(1686762)])
 def test_object_attribute_type_in_automate_schedule(appliance):
     """
     Polarion:

--- a/cfme/tests/automate/test_method.py
+++ b/cfme/tests/automate/test_method.py
@@ -6,6 +6,7 @@ from cfme import test_requirements
 from cfme.automate.explorer.klass import ClassDetailsView
 from cfme.automate.simulation import simulate
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import BZ
 from cfme.utils.log_validator import LogValidator
 from cfme.utils.update import update
 from cfme.utils.wait import wait_for
@@ -40,7 +41,8 @@ def test_method_crud(klass):
         script='$evm.log(:info, ":P")',
     )
     view = method.create_view(ClassDetailsView)
-    view.flash.assert_message('Automate Method "{}" was added'.format(method.name))
+    if not BZ(1704439).blocks:
+        view.flash.assert_message('Automate Method "{}" was added'.format(method.name))
     assert method.exists
     origname = method.name
     with update(method):


### PR DESCRIPTION
- Fixed test cases of ```Automate``` which are failing because of BZ: 1704439

{{ pytest: cfme/tests/automate/ -k 'test_domain_crud or test_domain_delete_from_table or test_duplicate_domain_disallowed or test_duplicate_namespace_disallowed or test_wrong_namespace_name or test_namespace_delete_from_table or test_namespace_crud or test_duplicate_class_disallowed or test_same_class_name_different_namespace or test_class_crud or test_method_crud or test_duplicate_method_disallowed or test_task_id_for_method_automation_log or test_instance_crud or test_instance_display_name_unset_from_ui or test_duplicate_instance_disallowed' -vvv }}