### PR TITLE
[WIPTEST] Bump wait_for to display less trash in the traceback.

### DIFF
--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -320,7 +320,7 @@ uritemplate==3.0.0
 urllib3==1.24.1
 virtualenv==16.4.3
 vspk==5.3.2
-wait-for==1.0.11
+wait-for==1.0.12
 warlock==1.3.0
 wcwidth==0.1.7
 webencodings==0.5.1

--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -320,7 +320,7 @@ uritemplate==3.0.0
 urllib3==1.24.1
 virtualenv==16.4.3
 vspk==5.3.2
-wait-for==1.0.12
+wait-for==1.0.13
 warlock==1.3.0
 wcwidth==0.1.7
 webencodings==0.5.1

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -305,7 +305,7 @@ uritemplate==3.0.0
 urllib3==1.24.1
 virtualenv==16.4.3
 vspk==5.3.2
-wait-for==1.0.12
+wait-for==1.0.13
 warlock==1.3.0
 wcwidth==0.1.7
 webencodings==0.5.1

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -305,7 +305,7 @@ uritemplate==3.0.0
 urllib3==1.24.1
 virtualenv==16.4.3
 vspk==5.3.2
-wait-for==1.0.11
+wait-for==1.0.12
 warlock==1.3.0
 wcwidth==0.1.7
 webencodings==0.5.1

--- a/requirements/frozen_docs.py2.txt
+++ b/requirements/frozen_docs.py2.txt
@@ -319,7 +319,7 @@ uritemplate==3.0.0
 urllib3==1.24.1
 virtualenv==16.4.3
 vspk==5.3.2
-wait-for==1.0.11
+wait-for==1.0.12
 warlock==1.3.0
 wcwidth==0.1.7
 webencodings==0.5.1

--- a/requirements/frozen_docs.py2.txt
+++ b/requirements/frozen_docs.py2.txt
@@ -319,7 +319,7 @@ uritemplate==3.0.0
 urllib3==1.24.1
 virtualenv==16.4.3
 vspk==5.3.2
-wait-for==1.0.12
+wait-for==1.0.13
 warlock==1.3.0
 wcwidth==0.1.7
 webencodings==0.5.1

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -304,7 +304,7 @@ uritemplate==3.0.0
 urllib3==1.24.1
 virtualenv==16.4.3
 vspk==5.3.2
-wait-for==1.0.11
+wait-for==1.0.12
 warlock==1.3.0
 wcwidth==0.1.7
 webencodings==0.5.1

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -304,7 +304,7 @@ uritemplate==3.0.0
 urllib3==1.24.1
 virtualenv==16.4.3
 vspk==5.3.2
-wait-for==1.0.12
+wait-for==1.0.13
 warlock==1.3.0
 wcwidth==0.1.7
 webencodings==0.5.1


### PR DESCRIPTION
The newer wait_for doesn't display its own traceback frames which saves space on screen.

{{ py.test: -sv --use-provider 'complete' -m smoke }}