### PR TITLE
[1LP][RFR]Collections refactor for 511, fix failing test and other cleanup

### DIFF
--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -49,7 +49,7 @@ def wait_for_requests(requests):
     wait_for(_finished, num_sec=45, delay=5, message="requests finished")
 
 
-COLLECTIONS_IN_510 = {
+COLLECTIONS_ALL = {
     "actions",
     "alert_definition_profiles",
     "alert_definitions",
@@ -87,6 +87,7 @@ COLLECTIONS_IN_510 = {
     "custom_button_sets",
     "custom_buttons",
     "customization_scripts",
+    "customization_templates",
     "data_stores",
     "enterprises",
     "event_streams",
@@ -121,6 +122,8 @@ COLLECTIONS_IN_510 = {
     "providers",
     "provision_dialogs",
     "provision_requests",
+    "pxe_images",
+    "pxe_servers",
     "rates",
     "regions",
     "reports",
@@ -152,13 +155,13 @@ COLLECTIONS_IN_510 = {
     "zones",
 }
 
-
-COLLECTIONS_NEWER_THAN_510 = {"customization_templates", "pxe_images", "pxe_servers"}
+COLLECTIONS_NOT_IN_510 = {"customization_templates", "pxe_images", "pxe_servers"}
 COLLECTIONS_NOT_IN_511 = {"container_deployments"}
 
+COLLECTIONS_IN_510 = COLLECTIONS_ALL - COLLECTIONS_NOT_IN_510
+COLLECTIONS_IN_511 = COLLECTIONS_ALL - COLLECTIONS_NOT_IN_511
 COLLECTIONS_IN_UPSTREAM = COLLECTIONS_IN_510
-COLLECTIONS_IN_511 = (COLLECTIONS_IN_510 | COLLECTIONS_NEWER_THAN_510) - COLLECTIONS_NOT_IN_511
-COLLECTIONS_ALL = COLLECTIONS_IN_510 | COLLECTIONS_IN_511
+
 # non-typical collections without "id" and "resources", or additional parameters are required
 COLLECTIONS_OMITTED = {"automate_workspaces", "metric_rollups", "settings"}
 
@@ -167,7 +170,8 @@ def _collection_not_in_this_version(appliance, collection_name):
     return (
         (collection_name not in COLLECTIONS_IN_UPSTREAM and appliance.version.is_in_series(
             'upstream')) or
-        (collection_name not in COLLECTIONS_IN_511 and appliance.version.is_in_series('5.11'))
+        (collection_name not in COLLECTIONS_IN_511 and appliance.version.is_in_series('5.11')) or
+        (collection_name not in COLLECTIONS_IN_510 and appliance.version.is_in_series('5.10'))
     )
 
 

--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -49,7 +49,7 @@ def wait_for_requests(requests):
     wait_for(_finished, num_sec=45, delay=5, message="requests finished")
 
 
-COLLECTIONS_IN_59 = {
+COLLECTIONS_IN_510 = {
     "actions",
     "alert_definition_profiles",
     "alert_definitions",
@@ -63,21 +63,32 @@ COLLECTIONS_IN_59 = {
     "categories",
     "chargebacks",
     "cloud_networks",
+    "cloud_object_store_containers",
     "cloud_subnets",
+    "cloud_templates",
     "cloud_tenants",
+    "cloud_volume_types",
     "cloud_volumes",
     "clusters",
     "conditions",
     "configuration_script_payloads",
     "configuration_script_sources",
+    "configuration_scripts",
     "container_deployments",
+    "container_groups",
+    "container_images",
     "container_nodes",
     "container_projects",
+    "container_templates",
+    "container_volumes",
     "containers",
+    "conversion_hosts",
     "currencies",
     "custom_button_sets",
     "custom_buttons",
+    "customization_scripts",
     "data_stores",
+    "enterprises",
     "event_streams",
     "events",
     "features",
@@ -98,7 +109,11 @@ COLLECTIONS_IN_59 = {
     "notifications",
     "orchestration_stacks",
     "orchestration_templates",
+    "physical_chassis",
+    "physical_racks",
     "physical_servers",
+    "physical_storages",
+    "physical_switches",
     "pictures",
     "policies",
     "policy_actions",
@@ -114,15 +129,19 @@ COLLECTIONS_IN_59 = {
     "resource_pools",
     "results",
     "roles",
+    "search_filters",
     "security_groups",
     "servers",
     "service_catalogs",
     "service_dialogs",
+    "service_offerings",
     "service_orders",
+    "service_parameters_sets",
     "service_requests",
     "service_templates",
     "services",
     "settings",
+    "switches",
     "tags",
     "tasks",
     "templates",
@@ -134,32 +153,12 @@ COLLECTIONS_IN_59 = {
 }
 
 
-COLLECTIONS_NEWER_THAN_59 = {
-    "cloud_object_store_containers",
-    "cloud_templates",
-    "cloud_volume_types",
-    "configuration_scripts",
-    "container_groups",
-    "container_images",
-    "container_templates",
-    "container_volumes",
-    "conversion_hosts",
-    "customization_scripts",
-    "enterprises",
-    "physical_chassis",
-    "physical_racks",
-    "physical_storages",
-    "physical_switches",
-    "search_filters",
-    "service_offerings",
-    "service_parameters_sets",
-    "switches"
-}
+COLLECTIONS_NEWER_THAN_510 = {"customization_templates", "pxe_images", "pxe_servers"}
+COLLECTIONS_NOT_IN_511 = {"container_deployments"}
 
-
-COLLECTIONS_IN_UPSTREAM = COLLECTIONS_IN_59
-COLLECTIONS_IN_510 = COLLECTIONS_IN_59 | COLLECTIONS_NEWER_THAN_59
-COLLECTIONS_ALL = COLLECTIONS_IN_59 | COLLECTIONS_IN_510
+COLLECTIONS_IN_UPSTREAM = COLLECTIONS_IN_510
+COLLECTIONS_IN_511 = (COLLECTIONS_IN_510 | COLLECTIONS_NEWER_THAN_510) - COLLECTIONS_NOT_IN_511
+COLLECTIONS_ALL = COLLECTIONS_IN_510 | COLLECTIONS_IN_511
 # non-typical collections without "id" and "resources", or additional parameters are required
 COLLECTIONS_OMITTED = {"automate_workspaces", "metric_rollups", "settings"}
 
@@ -168,7 +167,7 @@ def _collection_not_in_this_version(appliance, collection_name):
     return (
         (collection_name not in COLLECTIONS_IN_UPSTREAM and appliance.version.is_in_series(
             'upstream')) or
-        (collection_name not in COLLECTIONS_IN_510 and appliance.version.is_in_series('5.10'))
+        (collection_name not in COLLECTIONS_IN_511 and appliance.version.is_in_series('5.11'))
     )
 
 
@@ -478,15 +477,15 @@ def test_datetime_filtering(appliance, provider):
     older_resources = _get_filtered_resources('<')
     newer_resources = _get_filtered_resources('>')
     matching_resources = _get_filtered_resources('=')
-    # BZ1437529
-    assert matching_resources
+
+    assert not matching_resources
+
     if older_resources:
         last_older = collection.get(id=older_resources[-1]['id'])
         assert last_older.created_on < baseline_vm.created_on
     if newer_resources:
         first_newer = collection.get(id=newer_resources[0]['id'])
-        # BZ1437529
-        assert first_newer.created_on > baseline_vm.created_on
+        assert first_newer.created_on == baseline_vm.created_on
 
 
 def test_date_filtering(appliance, provider):
@@ -675,9 +674,8 @@ def test_attributes_present(appliance, collection_name):
         assert 'id' in resource
         assert 'href' in resource
         assert resource['href'] == '{}/{}'.format(collection._href, resource['id'])
-        if appliance.version >= '5.8':
-            assert 'href_slug' in resource
-            assert resource['href_slug'] == '{}/{}'.format(collection.name, resource['id'])
+        assert 'href_slug' in resource
+        assert resource['href_slug'] == '{}/{}'.format(collection.name, resource['id'])
 
 
 @pytest.mark.parametrize('vendor', ['Microsoft', 'Redhat', 'Vmware'])

--- a/cfme/tests/test_rest_manual.py
+++ b/cfme/tests/test_rest_manual.py
@@ -8,27 +8,6 @@ from cfme import test_requirements
 @pytest.mark.manual
 @test_requirements.rest
 @pytest.mark.tier(3)
-def test_cloud_volume_types():
-    """
-    Polarion:
-        assignee: pvala
-        casecomponent: Cloud
-        caseimportance: high
-        initialEstimate: 1/30h
-        startsin: 5.10
-        setup:
-            1. Add a cloud provider to the appliance.
-        testSteps:
-            1. Send GET request: /api/cloud_volume_types/:id
-        expectedResults:
-            1. Successful 200 OK response.
-    """
-    pass
-
-
-@pytest.mark.manual
-@test_requirements.rest
-@pytest.mark.tier(3)
 def test_create_rhev_provider_with_metric():
     """
     Polarion:


### PR DESCRIPTION
Changes introduced with the PR:
1. Fix failing test `test_datetime_filtering` - [BZ1437529](https://bugzilla.redhat.com/show_bug.cgi?id=1437529) was closed with NOTABUG, and some changes introduced to the test with #8675 caused the test to fail. Reverting all the changes fixed the test failure.

2. Remove a test from test_rest_manual.py that is already covered. 

3. Refactor collections in `test_rest.py` to support 5.11 and 5.10, removing references older than 5.10

{{ pytest: cfme/tests/test_rest.py --use-template-cache -sqvvv }}