### PR TITLE
[1LP][RFR] Fix test_set_retirement_date failures

### DIFF
--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -417,28 +417,12 @@ class PublishVmView(BaseLoggedInPage):
     is_displayed = displayed_not_implemented
 
 
-class RetirementView(BaseLoggedInPage):
+class RetirementViewWithOffset(BaseLoggedInPage):
     """
-    Set Retirement date view for vms/instances
-    The title actually as Instance|VM.VM_TYPE string in it, otherwise the same
+    Set Retirement Date view for VMs / Instances
     """
     title = Text('#explorer_title_text')
 
-    @View.nested
-    class form(View):  # noqa
-        retirement_date = Calendar(name='retirementDate')
-        remove_date = Image(locator='.//div[@id="retirement_date_div"]//a/img[@alt="Set to blank"]')
-        retirement_warning = BootstrapSelect(id='retirementWarning')
-        entities = View.nested(BaseNonInteractiveEntitiesView)
-        save = Button('Save')
-        cancel = Button('Cancel')
-
-    # TODO match quadicon and title
-    is_displayed = displayed_not_implemented
-
-
-class RetirementViewWithOffset(RetirementView):
-    """The form portion, with 59z+ offset mode selection"""
     @View.nested
     class form(View):  # noqa
         retirement_mode = BootstrapSelect(id='formMode')
@@ -463,6 +447,8 @@ class RetirementViewWithOffset(RetirementView):
         entities = View.nested(BaseNonInteractiveEntitiesView)
         save = Button('Save')
         cancel = Button('Cancel')
+
+    is_displayed = displayed_not_implemented
 
 
 class EditView(BaseLoggedInPage):

--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -3,7 +3,6 @@ import os
 
 from lxml.html import document_fromstring
 from widgetastic.widget import ConditionalSwitchableView
-from widgetastic.widget import Image
 from widgetastic.widget import ParametrizedView
 from widgetastic.widget import TableRow
 from widgetastic.widget import Text

--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -430,7 +430,7 @@ class RetirementViewWithOffset(BaseLoggedInPage):
 
         @retirement_date.register('Specific Date and Time', default=True)
         class RetirementDateSelectionView(View):
-            datetime_select = TextInput(id='retirement_date_datepicker')
+            datetime_select = Calendar('retirement_date_datepicker')
 
         @retirement_date.register('Time Delay from Now')
         class RetirementOffsetSelectionView(View):


### PR DESCRIPTION
Purpose or Intent
=================

In newer versions of Chrome, the test_set_retirement_date tests are failing. In the RetirementDateSelectionView, the clear() method of the TextInput class used by datetime_select makes the calendar pop-up disappear, so that when send_keys() is subsequently called, the calendar pops up a second time. This causes the default current date-time, e.g., '05/06/2019 15:45' to get re-populated, undoing the effect of clear(). The send_keys() method then pastes the intended retirement date-time, e.g., '05/08/2019 00:00', appending it onto the default current date-time to form an invalid date-time, '05/06/2019 15:4505/08/2019 00:00'. When the save() method is called, the web UI tries to turn this value into a valid date-time by stripping off the appended characters, saving it as '05/06/2019 15:45', which is not the intended value. The test then fails with an AssertionError because the saved retirement date does not match the intended retirement date.

There is already a subclass of the TextInput field in widgetastic_manageiq called Calendar, which is more appropriate to this field, is already used elsewhere for service retirement automation tests, and does not have this problem with its clear() method. This PR implements Calendar for this field, to fix test_set_retirement_date failures. As part of this pull request, I've also included the following changes:

1.) Removed the RetirementView class and made RetirementViewWithOffset a direct descendant of BaseLoggedInPage. For the last several versions, CFME has implemented both the 'Specific Date and Time' and 'Time Delay from Now' options for specifying the VM / Instance retirement date, so there is no need to maintain two distinct view classes.

2.) Address flake8 pre-commit failure by removing unused import of widgetastic.widget.Image from cfme/common/vm_views.py.

{{ pytest: cfme/tests/cloud_infra_common/test_retirement.py --long-running --use-provider vsphere67-nested -k test_set_retirement -vvvv }}