### PR TITLE
[RFR] Update template_upload to block providers on streams

### DIFF
--- a/cfme/utils/template/base.py
+++ b/cfme/utils/template/base.py
@@ -76,6 +76,7 @@ class ProviderTemplateUpload(object):
     provider_type = None
     log_name = None
     image_pattern = None
+    blocked_streams = []
 
     def __init__(self, provider_key, stream, template_name, image_url=None, **kwargs):
         """
@@ -428,13 +429,19 @@ class ProviderTemplateUpload(object):
     @log_wrap("template upload script")
     def main(self):
         track = False
+        teardown = False
         try:
+            if self.stream in self.blocked_streams:
+                logger.info('This stream (%s) is blocked for the given provider type, %s',
+                            self.stream, self.provider_type)
+                return True
             if self.provider_type != 'openshift' and self.mgmt.does_template_exist(
                     self.template_name):
                 logger.info("(template-upload) [%s:%s:%s] Template already exists",
                             self.log_name, self.provider_key, self.template_name)
                 track = True
             else:
+                teardown = True
                 if self.decorated_run():
                     track = True
             if track and self.provider_type != 'openshift':
@@ -451,4 +458,5 @@ class ProviderTemplateUpload(object):
             return False
 
         finally:
-            self.teardown()
+            if teardown:
+                self.teardown()

--- a/cfme/utils/template/ec2.py
+++ b/cfme/utils/template/ec2.py
@@ -13,6 +13,7 @@ class EC2TemplateUpload(ProviderTemplateUpload):
     log_name = 'EC2'
     provider_type = 'ec2'
     image_pattern = re.compile(r'<a href="?\'?([^"\']*ec2[^"\'>]*)')
+    blocked_streams = ['upstream', 'downstream-511z']
 
     @property
     def bucket_name(self):

--- a/cfme/utils/template/gce.py
+++ b/cfme/utils/template/gce.py
@@ -13,6 +13,7 @@ class GoogleCloudTemplateUpload(ProviderTemplateUpload):
     provider_type = 'gce'
     log_name = 'GCE'
     image_pattern = re.compile(r'<a href="?\'?([^"\']*gce[^"\'>]*)')
+    blocked_streams = ['upstream', 'downstream-511z']
 
     @property
     def bucket_name(self):

--- a/cfme/utils/template/rhopenshift.py
+++ b/cfme/utils/template/rhopenshift.py
@@ -10,6 +10,7 @@ class OpenshiftTemplateUpload(ProviderTemplateUpload):
     log_name = "OPENSHIFT"
     provider_type = "openshift"
     image_pattern = re.compile(r'<a href="?\'?(openshift-pods/*)')
+    blocked_streams = ['upstream', 'downstream-511z']
 
     template_filenames = ()
 

--- a/cfme/utils/template/template_upload.py
+++ b/cfme/utils/template/template_upload.py
@@ -41,35 +41,42 @@ def parse_cmd_line():
         '--provider-type',
         dest='provider_type',
         choices=PROVIDER_TYPES,
-        help='Provider type')
+        help='Provider type'
+    )
     provider_group.add_argument(
         '--provider',
         nargs='+',
         dest='provider',
-        help='Specific provider keys list')
+        help='Specific provider keys list'
+    )
     parser.add_argument(
         '--glance',
         dest='glance_key',
         default=None,
-        help='key for the glance server information in cfme_data.template_upload')
+        help='key for the glance server information in cfme_data.template_upload'
+    )
     parser.add_argument(
         '--stream',
         dest='stream',
         help='Stream (downstream-59z)name for the image_url, or default to stable/latest in stream'
-             'Please check the cfme_data file for current streams.')
+             'Please check the cfme_data file for current streams.'
+    )
     parser.add_argument(
         '--image-url',
         dest='image_url',
-        help='URL for the image file to be uploaded. Please use with --stream.')
+        help='URL for the image file to be uploaded. Please use with --stream.'
+    )
     parser.add_argument(
         '--template-name',
         dest='template_name',
-        help='Set the name of the template')
+        help='Set the name of the template'
+    )
     parser.add_argument(
         '--print-name-only',
         dest='print_name_only',
         action="store_true",
-        help='Only print the template name that will be generated without actually running it.')
+        help='Only print the template name that will be generated without actually running it.'
+    )
 
     return parser.parse_known_args()
 
@@ -130,7 +137,7 @@ if __name__ == '__main__':
 
     thread_queue = []
 
-    # threaded loop
+    # create uploader objects for each provider
     for provider_type in provider_types:
         provider_keys = list_provider_keys(provider_type)
         if cmd_args.provider:


### PR DESCRIPTION
Specify for each provider type what streams should not be uploaded.

Might be better to have this in cfme_data.yaml?

We want to block upload of certain streams to certain provider types based on image availability.