### PR TITLE
[1LP][RFR] handling modals in 5.11

### DIFF
--- a/cfme/services/catalogs/catalog_items/__init__.py
+++ b/cfme/services/catalogs/catalog_items/__init__.py
@@ -5,6 +5,7 @@ import fauxfactory
 from cached_property import cached_property
 from navmazing import NavigateToAttribute
 from navmazing import NavigateToSibling
+from widgetastic.utils import VersionPick
 from widgetastic.utils import WaitFillViewStrategy
 from widgetastic.widget import Checkbox
 from widgetastic.widget import ClickableMixin
@@ -30,6 +31,7 @@ from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.blockers import BZ
 from cfme.utils.pretty import Pretty
 from cfme.utils.update import Updateable
+from cfme.utils.version import LOWEST
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import AutomateRadioGroup
 from widgetastic_manageiq import FonticonPicker
@@ -334,10 +336,15 @@ class BaseCatalogItem(BaseEntity, Updateable, Pretty, Taggable):
 
     def delete(self):
         view = navigate_to(self, 'Details')
-        view.configuration.item_select('Remove Catalog Item', handle_alert=True)
+        view.configuration.item_select(VersionPick({LOWEST: 'Remove Catalog Item',
+                                                    '5.11': 'Delete Catalog Item'}),
+                                       handle_alert=True)
+
         view = self.create_view(AllCatalogItemView)
         assert view.is_displayed
-        view.flash.assert_success_message('The selected Catalog Item was deleted')
+        view.flash.assert_success_message(VersionPick(
+            {LOWEST: 'The selected Catalog Item was deleted',
+             '5.11': 'The catalog item "{}" has been successfully deleted'.format(self.name)}))
 
     def add_button_group(self, **kwargs):
         button_name = kwargs.get("text", "gp_{}".format(fauxfactory.gen_alpha()))

--- a/cfme/utils/appliance/implementations/common.py
+++ b/cfme/utils/appliance/implementations/common.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from time import sleep
+
 from selenium.webdriver.support import expected_conditions
 from widgetastic_patternfly import Modal
 
@@ -54,6 +56,9 @@ class HandleModalsMixin(object):
 
         def _check_alert_present():
             if modal.is_displayed:
+                # infinispinner if accept button is clicked too quick in  modal
+                # BZ(1713399)
+                sleep(1)
                 return modal
             return expected_conditions.alert_is_present()
 

--- a/cfme/utils/appliance/implementations/common.py
+++ b/cfme/utils/appliance/implementations/common.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+from selenium.webdriver.support import expected_conditions
+from widgetastic_patternfly import Modal
+
+from cfme.utils.wait import TimedOutError
+from cfme.utils.wait import wait_for
+
+
+class HandleModalsMixin(object):
+    @property
+    def _modal_alert(self):
+        return Modal(parent=self)
+
+    def get_alert(self):
+        """Returns the current alert object.
+
+        Raises:
+            :py:class:`selenium.common.exceptions.NoAlertPresentException`
+        """
+        if not self.handles_alerts:
+            return None
+        modal = self._modal_alert
+        return modal if modal.is_displayed else self.selenium.switch_to_alert()
+
+    def handle_alert(self, cancel=False, wait=30.0, squash=False, prompt=None, check_present=False):
+        """Handles an alert popup.
+
+        Args:
+            cancel: Whether or not to cancel the alert.
+                Accepts the Alert (False) by default.
+            wait: Time to wait for an alert to appear.
+                Default 30 seconds, can be set to 0 to disable waiting.
+            squash: Whether or not to squash errors during alert handling.
+                Default False
+            prompt: If the alert is a prompt, specify the keys to type in here
+            check_present: Does not squash
+                :py:class:`selenium.common.exceptions.NoAlertPresentException`
+
+        Returns:
+            ``True`` if the alert was handled, ``False`` if exceptions were
+            squashed, ``None`` if there was no alert.
+
+        No exceptions will be raised if ``squash`` is True and ``check_present`` is False.
+
+        Raises:
+            :py:class:`wait_for.TimedOutError`: If the alert popup does not appear
+            :py:class:`selenium.common.exceptions.NoAlertPresentException`: If no alert is present
+                when accepting or dismissing the alert.
+        """
+        if not self.handles_alerts:
+            return None
+
+        modal = self._modal_alert
+
+        def _check_alert_present():
+            if modal.is_displayed:
+                return modal
+            return expected_conditions.alert_is_present()
+
+        # throws timeout exception if not found
+        try:
+            if wait:
+                wait_for(lambda: _check_alert_present, num_sec=wait)
+
+            popup = self.get_alert()
+            self.logger.info('handling alert: %r', popup.text)
+            if prompt is not None:
+                self.logger.info('  answering prompt: %r', prompt)
+                if isinstance(popup, Modal):
+                    popup.fill(prompt)
+                else:
+                    popup.send_keys(prompt)
+            if cancel:
+                self.logger.info('  dismissing')
+                popup.dismiss()
+            else:
+                self.logger.info('  accepting')
+                popup.accept()
+            # Should any problematic "double" alerts appear here, we don't care, just blow'em away.
+            self.dismiss_any_alerts()
+            return True
+        except TimedOutError:
+            if check_present:
+                raise
+            else:
+                return None
+        except Exception:
+            if squash:
+                return False
+            else:
+                raise

--- a/cfme/utils/appliance/implementations/ssui.py
+++ b/cfme/utils/appliance/implementations/ssui.py
@@ -9,6 +9,7 @@ from navmazing import NavigateStep
 from selenium.common.exceptions import NoSuchElementException
 from widgetastic.browser import Browser
 from widgetastic.browser import DefaultPlugin
+from widgetastic_patternfly import Modal
 
 from . import Implementation
 from cfme import exceptions
@@ -17,6 +18,7 @@ from cfme.utils.browser import manager
 from cfme.utils.log import create_sublogger
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for
+from cfme.utils.wait import TimedOutError
 
 
 class MiqSSUIBrowser(Browser):
@@ -53,6 +55,52 @@ class MiqSSUIBrowser(Browser):
     @property
     def product_version(self):
         return self.appliance.version
+
+    def handle_modal(self, cancel=False, wait=10.0, squash=False, fill=None):
+        try:
+            modal = Modal(parent=self)
+            if wait:
+                wait_for(lambda: modal.is_displayed, num_sec=wait)
+
+            if modal.is_displayed:
+                if fill is not None:
+                    modal.fill(fill)
+
+                if cancel:
+                    self.logger.info('  dismissing')
+                    # modal.dismiss()
+                    modal.cancel()
+                else:
+                    self.logger.info('  accepting')
+                    # modal.accept()
+                    modal.submit()
+
+                return True
+
+        except TimedOutError:
+            self.logger.warning("modal dialog didn't show up")
+            return None
+
+        except Exception:
+            if squash:
+                return False
+            else:
+                raise
+
+    def handle_alert(self, cancel=False, wait=30.0, squash=False, prompt=None, check_present=False,
+                     handle_modal=True, handle_alert=True, **kwargs):
+        results = []
+        if handle_modal:
+            results.append(self.handle_modal(cancel=cancel, wait=wait, squash=squash, **kwargs))
+
+        if handle_alert:
+            results.append(super(MiqSSUIBrowser, self).handle_alert(cancel=cancel,
+                                                                    wait=wait,
+                                                                    squash=squash,
+                                                                    prompt=prompt,
+                                                                    check_present=check_present))
+
+        return results[0] if results[0] else results[-1]
 
 
 class MiqSSUIBrowserPlugin(DefaultPlugin):

--- a/cfme/utils/appliance/implementations/ssui.py
+++ b/cfme/utils/appliance/implementations/ssui.py
@@ -20,7 +20,7 @@ from cfme.utils.log import logger
 from cfme.utils.wait import wait_for
 
 
-class MiqSSUIBrowser(Browser, HandleModalsMixin):
+class MiqSSUIBrowser(HandleModalsMixin, Browser):
     def __init__(self, selenium, endpoint, extra_objects=None):
         extra_objects = extra_objects or {}
         extra_objects.update({

--- a/cfme/utils/appliance/implementations/ssui.py
+++ b/cfme/utils/appliance/implementations/ssui.py
@@ -9,19 +9,18 @@ from navmazing import NavigateStep
 from selenium.common.exceptions import NoSuchElementException
 from widgetastic.browser import Browser
 from widgetastic.browser import DefaultPlugin
-from widgetastic_patternfly import Modal
 
 from . import Implementation
+from .common import HandleModalsMixin
 from cfme import exceptions
 from cfme.fixtures.pytest_store import store
 from cfme.utils.browser import manager
 from cfme.utils.log import create_sublogger
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for
-from cfme.utils.wait import TimedOutError
 
 
-class MiqSSUIBrowser(Browser):
+class MiqSSUIBrowser(Browser, HandleModalsMixin):
     def __init__(self, selenium, endpoint, extra_objects=None):
         extra_objects = extra_objects or {}
         extra_objects.update({
@@ -55,52 +54,6 @@ class MiqSSUIBrowser(Browser):
     @property
     def product_version(self):
         return self.appliance.version
-
-    def handle_modal(self, cancel=False, wait=10.0, squash=False, fill=None):
-        try:
-            modal = Modal(parent=self)
-            if wait:
-                wait_for(lambda: modal.is_displayed, num_sec=wait)
-
-            if modal.is_displayed:
-                if fill is not None:
-                    modal.fill(fill)
-
-                if cancel:
-                    self.logger.info('  dismissing')
-                    # modal.dismiss()
-                    modal.cancel()
-                else:
-                    self.logger.info('  accepting')
-                    # modal.accept()
-                    modal.submit()
-
-                return True
-
-        except TimedOutError:
-            self.logger.warning("modal dialog didn't show up")
-            return None
-
-        except Exception:
-            if squash:
-                return False
-            else:
-                raise
-
-    def handle_alert(self, cancel=False, wait=30.0, squash=False, prompt=None, check_present=False,
-                     handle_modal=True, handle_alert=True, **kwargs):
-        results = []
-        if handle_modal:
-            results.append(self.handle_modal(cancel=cancel, wait=wait, squash=squash, **kwargs))
-
-        if handle_alert:
-            results.append(super(MiqSSUIBrowser, self).handle_alert(cancel=cancel,
-                                                                    wait=wait,
-                                                                    squash=squash,
-                                                                    prompt=prompt,
-                                                                    check_present=check_present))
-
-        return results[0] if results[0] else results[-1]
 
 
 class MiqSSUIBrowserPlugin(DefaultPlugin):

--- a/cfme/utils/appliance/implementations/ui.py
+++ b/cfme/utils/appliance/implementations/ui.py
@@ -231,7 +231,7 @@ class MiqBrowserPlugin(DefaultPlugin):
         self.browser.page_dirty = None
 
 
-class MiqBrowser(Browser, HandleModalsMixin):
+class MiqBrowser(HandleModalsMixin, Browser):
     def __init__(self, selenium, endpoint, extra_objects=None):
         extra_objects = extra_objects or {}
         extra_objects.update({

--- a/cfme/utils/appliance/implementations/ui.py
+++ b/cfme/utils/appliance/implementations/ui.py
@@ -21,6 +21,7 @@ from widgetastic.browser import DefaultPlugin
 from widgetastic.utils import VersionPick
 from widgetastic.widget import Text
 from widgetastic.widget import View
+from widgetastic_patternfly import Modal
 
 from . import Implementation
 from cfme import exceptions
@@ -30,6 +31,7 @@ from cfme.utils.log import create_sublogger
 from cfme.utils.log import logger
 from cfme.utils.version import Version
 from cfme.utils.wait import wait_for
+from cfme.utils.wait import TimedOutError
 
 VersionPick.VERSION_CLASS = Version
 
@@ -263,6 +265,52 @@ class MiqBrowser(Browser):
     @property
     def product_version(self):
         return self.appliance.version
+
+    def handle_modal(self, cancel=False, wait=10.0, squash=False, fill=None):
+        try:
+            modal = Modal(parent=self)
+            if wait:
+                wait_for(lambda: modal.is_displayed, num_sec=wait)
+
+            if modal.is_displayed:
+                if fill is not None:
+                    modal.fill(fill)
+
+                if cancel:
+                    self.logger.info('  dismissing')
+                    # modal.dismiss()
+                    modal.cancel()
+                else:
+                    self.logger.info('  accepting')
+                    # modal.accept()
+                    modal.submit()
+
+                return True
+
+        except TimedOutError:
+            self.logger.warning("modal dialog didn't show up")
+            return None
+
+        except Exception:
+            if squash:
+                return False
+            else:
+                raise
+
+    def handle_alert(self, cancel=False, wait=30.0, squash=False, prompt=None, check_present=False,
+                     handle_modal=True, handle_alert=True, **kwargs):
+        results = []
+        if handle_modal:
+            results.append(self.handle_modal(cancel=cancel, wait=wait, squash=squash, **kwargs))
+
+        if handle_alert:
+            results.append(super(MiqBrowser, self).handle_alert(cancel=cancel,
+                                                                wait=wait,
+                                                                squash=squash,
+                                                                prompt=prompt,
+                                                                check_present=check_present))
+
+        return results[0] if results[0] else results[-1]
 
 
 def can_skip_badness_test(fn):

--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -327,8 +327,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.15.2
 widgetastic.core==0.37
-#widgetastic.patternfly==0.1.2
-git+git://github.com/john-dupuy/widgetastic.patternfly.git@add-modal-widget#widgetastic.patternfly
+widgetastic.patternfly==0.1.3
 widgetsnbextension==3.4.2
 wrapanapi==3.1.6
 wrapt==1.11.1

--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -327,7 +327,8 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.15.2
 widgetastic.core==0.37
-widgetastic.patternfly==0.1.2
+#widgetastic.patternfly==0.1.2
+git+git://github.com/john-dupuy/widgetastic.patternfly.git@add-modal-widget#widgetastic.patternfly
 widgetsnbextension==3.4.2
 wrapanapi==3.1.6
 wrapt==1.11.1

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -312,7 +312,8 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.15.2
 widgetastic.core==0.37
-widgetastic.patternfly==0.1.2
+#widgetastic.patternfly==0.1.2
+git+git://github.com/john-dupuy/widgetastic.patternfly.git@add-modal-widget#widgetastic.patternfly
 widgetsnbextension==3.4.2
 wrapanapi==3.1.6
 wrapt==1.11.1

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -312,8 +312,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.15.2
 widgetastic.core==0.37
-#widgetastic.patternfly==0.1.2
-git+git://github.com/john-dupuy/widgetastic.patternfly.git@add-modal-widget#widgetastic.patternfly
+widgetastic.patternfly==0.1.3
 widgetsnbextension==3.4.2
 wrapanapi==3.1.6
 wrapt==1.11.1

--- a/requirements/frozen_docs.py2.txt
+++ b/requirements/frozen_docs.py2.txt
@@ -326,8 +326,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.15.2
 widgetastic.core==0.37
-#widgetastic.patternfly==0.1.2
-git+git://github.com/john-dupuy/widgetastic.patternfly.git@add-modal-widget#widgetastic.patternfly
+widgetastic.patternfly==0.1.3
 widgetsnbextension==3.4.2
 wrapanapi==3.1.6
 wrapt==1.11.1

--- a/requirements/frozen_docs.py2.txt
+++ b/requirements/frozen_docs.py2.txt
@@ -326,7 +326,8 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.15.2
 widgetastic.core==0.37
-widgetastic.patternfly==0.1.2
+#widgetastic.patternfly==0.1.2
+git+git://github.com/john-dupuy/widgetastic.patternfly.git@add-modal-widget#widgetastic.patternfly
 widgetsnbextension==3.4.2
 wrapanapi==3.1.6
 wrapt==1.11.1

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -311,8 +311,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.15.2
 widgetastic.core==0.37
-#widgetastic.patternfly==0.1.2
-git+git://github.com/john-dupuy/widgetastic.patternfly.git@add-modal-widget#widgetastic.patternfly
+widgetastic.patternfly==0.1.3
 widgetsnbextension==3.4.2
 wrapanapi==3.1.6
 wrapt==1.11.1

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -311,7 +311,8 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.15.2
 widgetastic.core==0.37
-widgetastic.patternfly==0.1.2
+#widgetastic.patternfly==0.1.2
+git+git://github.com/john-dupuy/widgetastic.patternfly.git@add-modal-widget#widgetastic.patternfly
 widgetsnbextension==3.4.2
 wrapanapi==3.1.6
 wrapt==1.11.1


### PR DESCRIPTION
trying to kill two rabbits by one shot

{{ pytest: --use-template-cache --long-running cfme/tests/services/test_config_provider_servicecatalogs.py }}

fixing issue: https://github.com/ManageIQ/integration_tests/issues/8836


this implementation isn't final yet.
I lean towards to creating parametraized decorator like

```
@handle_modal(action=cancel, wait='10s')
view.configuration.item_select('Remove Catalog Item'), handle_alert=True)

```

