### PR TITLE
[1LP][RFR] Fix toolbar download button for details page

### DIFF
--- a/cfme/ansible/credentials.py
+++ b/cfme/ansible/credentials.py
@@ -61,7 +61,7 @@ class CredentialDetailsView(CredentialsBaseView):
     @View.nested
     class toolbar(View):  # noqa
         configuration = Dropdown("Configuration")
-        download = Button(title="Download summary in PDF format")
+        download = Button(title="Print or export summary")
         policy = Dropdown(text='Policy')
 
     @View.nested

--- a/cfme/ansible/playbooks.py
+++ b/cfme/ansible/playbooks.py
@@ -53,7 +53,7 @@ class PlaybookDetailsView(PlaybookBaseView):
     class toolbar(View):   # noqa
         configuration = Dropdown("Configuration")
         policy = Dropdown(text='Policy')
-        download_button = Button(title="Print or export summary")
+        download = Button(title="Print or export summary")
 
     breadcrumb = BreadCrumb(locator='.//ol[@class="breadcrumb"]')
     entities = View.nested(PlaybookDetailsEntities)

--- a/cfme/ansible/playbooks.py
+++ b/cfme/ansible/playbooks.py
@@ -53,7 +53,7 @@ class PlaybookDetailsView(PlaybookBaseView):
     class toolbar(View):   # noqa
         configuration = Dropdown("Configuration")
         policy = Dropdown(text='Policy')
-        download_button = Button(title="Download summary in PDF format")
+        download_button = Button(title="Print or export summary")
 
     breadcrumb = BreadCrumb(locator='.//ol[@class="breadcrumb"]')
     entities = View.nested(PlaybookDetailsEntities)

--- a/cfme/ansible/repositories.py
+++ b/cfme/ansible/repositories.py
@@ -60,7 +60,7 @@ class RepositoryDetailsView(RepositoryBaseView):
     class toolbar(View):  # noqa
         refresh = Button(title="Refresh this page")
         configuration = Dropdown("Configuration")
-        download = Button(title="Download summary in PDF format")
+        download = Button(title="Print or export summary")
         policy = Dropdown(text='Policy')
 
     @View.nested

--- a/cfme/cloud/availability_zone.py
+++ b/cfme/cloud/availability_zone.py
@@ -44,7 +44,7 @@ class AvailabilityZoneDetailsToolBar(View):
     """View containing the toolbar widgets"""
     policy = Dropdown('Policy')
     monitoring = Dropdown('Monitoring')
-    download = Button(title='Download summary in PDF format')  # Title attribute, no displayed text
+    download = Button(title='Print or export summary')  # Title attribute, no displayed text
 
     view_selector = View.nested(ItemsToolBarViewSelector)
 

--- a/cfme/cloud/flavor.py
+++ b/cfme/cloud/flavor.py
@@ -57,7 +57,7 @@ class FlavorEntities(BaseEntitiesView):
 
 class FlavorDetailsToolBar(View):
     policy = Dropdown('Policy')
-    download = Button(title='Download summary in PDF format')
+    download = Button(title='Print or export summary')
     configuration = Dropdown('Configuration')
 
 

--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -47,7 +47,7 @@ class InstanceDetailsToolbar(View):
     lifecycle = Dropdown('Lifecycle')
     monitoring = Dropdown('Monitoring')
     power = Dropdown('Instance Power Functions')  # title
-    download = Button(title='Download summary in PDF format')
+    download = Button(title='Print or export summary')
     access = Dropdown("Access")
 
 

--- a/cfme/cloud/instance/image.py
+++ b/cfme/cloud/instance/image.py
@@ -48,7 +48,7 @@ class ImageDetailsToolbar(View):
     configuration = Dropdown('Configuration')
     lifecycle = Dropdown('Lifecycle')
     policy = Dropdown('Policy')
-    download = Button(title='Download summary in PDF format')
+    download = Button(title='Print or export summary')
 
 
 class ImageDetailsEntities(VMDetailsEntities):

--- a/cfme/cloud/keypairs.py
+++ b/cfme/cloud/keypairs.py
@@ -42,7 +42,7 @@ class KeyPairToolbar(View):
 class KeyPairDetailsToolbar(View):
     policy = Dropdown('Policy')
     configuration = Dropdown('Configuration')
-    download = Button(title='Download summary in PDF format')
+    download = Button(title='Print or export summary')
 
 
 class KeyPairDetailsAccordion(View):

--- a/cfme/cloud/security_groups.py
+++ b/cfme/cloud/security_groups.py
@@ -38,7 +38,7 @@ class SecurityGroupToolbar(View):
 class SecurityGroupDetailsToolbar(View):
     configuration = Dropdown('Configuration')
     policy = Dropdown('Policy')
-    download = Button(title='Download summary in PDF format')
+    download = Button(title='Print or export summary')
 
 
 class SecurityGroupDetailsAccordion(View):

--- a/cfme/cloud/stack.py
+++ b/cfme/cloud/stack.py
@@ -44,7 +44,7 @@ class StackDetailsToolbar(View):
     configuration = Dropdown('Configuration')
     policy = Dropdown('Policy')
     lifecycle = Dropdown('Lifecycle')
-    download = Button('Download summary in PDF format')
+    download = Button('Print or export summary')
 
 
 class StackSubpageToolbar(View):

--- a/cfme/cloud/tenant.py
+++ b/cfme/cloud/tenant.py
@@ -55,7 +55,7 @@ class TenantDetailsToolbar(View):
     """The toolbar on the tenant details page"""
     configuration = Dropdown('Configuration')
     policy = Dropdown('Policy')
-    download = Button('Download summary in PDF format')
+    download = Button('Print or export summary')
 
 
 class TenantDetailsAccordion(View):

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -54,7 +54,7 @@ class ProviderDetailsToolBar(View):
     reload = Button(title='Refresh this page')
     policy = Dropdown(text='Policy')
     authentication = Dropdown(text='Authentication')
-    download = Button(title='Download summary in PDF format')
+    download = Button(title='Print or export summary')
 
     view_selector = View.nested(DetailsToolBarViewSelector)
 

--- a/cfme/control/log.py
+++ b/cfme/control/log.py
@@ -14,7 +14,7 @@ class ControlLogView(BaseLoggedInPage):
     title = Text(".//div[@id='main-content']//h1")
     subtitle = Text(".//div[@id='main_div']/h3")
     refresh_button = Button(id="refresh_log")
-    download_button = Button(id="fetch_log")
+    download = Button(id="fetch_log")
 
     @property
     def is_displayed(self):
@@ -22,7 +22,7 @@ class ControlLogView(BaseLoggedInPage):
             self.title.text == "Log" and
             "Last 1000 lines from server" in self.subtitle.text and
             self.refresh_button.is_displayed and
-            self.download_button.is_displayed
+            self.download.is_displayed
         )
 
 

--- a/cfme/infrastructure/cluster.py
+++ b/cfme/infrastructure/cluster.py
@@ -53,7 +53,7 @@ class ClusterDetailsToolbar(View):
     configuration = Dropdown('Configuration')
     policy = Dropdown('Policy')
     monitoring = Dropdown('Monitoring')
-    download = Button('Download summary in PDF format')
+    download = Button('Print or export summary')
 
 
 class ClusterDetailsAccordion(View):

--- a/cfme/infrastructure/config_management.py
+++ b/cfme/infrastructure/config_management.py
@@ -54,7 +54,7 @@ class ConfigManagementDetailsToolbar(View):
     refresh = Button(title='Refresh this page')
     lifecycle = Dropdown('Lifecycle')
     policy = Dropdown('Policy')
-    download = Button(title='Download summary in PDF format')
+    download = Button(title='Print or export summary')
     view_selector = View.nested(ItemsToolBarViewSelector)
 
 

--- a/cfme/infrastructure/deployment_roles.py
+++ b/cfme/infrastructure/deployment_roles.py
@@ -42,7 +42,7 @@ class DeploymentRoleDetailsToolbar(View):
     configuration = Dropdown('Configuration')
     policy = Dropdown('Policy')
     monitoring = Dropdown('Monitoring')
-    download = Button(title='Download summary in PDF format')
+    download = Button(title='Print or export summary')
 
 
 class DeploymentRoleComparisonToolbar(View):

--- a/cfme/infrastructure/resource_pool.py
+++ b/cfme/infrastructure/resource_pool.py
@@ -39,7 +39,7 @@ class ResourcePoolDetailsToolbar(View):
     """The toolbar on the details page"""
     configuration = Dropdown('Configuration')
     policy = Dropdown('Policy')
-    download = Button(title='Download summary in PDF format')
+    download = Button(title='Print or export summary')
 
 
 class ResourcePoolDetailsAccordion(View):

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -107,7 +107,7 @@ class InfraGenericDetailsToolbar(View):
     configuration = Dropdown('Configuration')
     policy = Dropdown('Policy')
     monitoring = Dropdown("Monitoring")
-    download = Button(title='Download summary in PDF format')
+    download = Button(title='Print or export summary')
     lifecycle = Dropdown('Lifecycle')
 
     @ParametrizedView.nested

--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -196,12 +196,12 @@ class SavedReportDetailsView(CloudIntelReportsView):
     class download(ParametrizedView):  # noqa
         PARAMETERS = ("format", )
         ALL_LINKS = ".//a[starts-with(@name, 'download_choice__render_report_')]"
-        download_button = Button(title="Download")
+        download = Button(title="Download")
         link = Text(ParametrizedLocator(".//a[normalize-space()={format|quote}]"))
 
         def __init__(self, *args, **kwargs):
             ParametrizedView.__init__(self, *args, **kwargs)
-            self.download_button.click()
+            self.download.click()
             self.link.click()
 
         @classmethod

--- a/cfme/networks/views.py
+++ b/cfme/networks/views.py
@@ -13,8 +13,6 @@ from cfme.base.login import BaseLoggedInPage
 from cfme.common.provider_views import ProviderAddView
 from cfme.common.provider_views import ProviderEditView
 from cfme.exceptions import displayed_not_implemented
-from cfme.utils.version import Version
-from cfme.utils.version import VersionPicker
 from widgetastic_manageiq import BaseEntitiesView
 from widgetastic_manageiq import ItemsToolBarViewSelector
 from widgetastic_manageiq import ManageIQTree
@@ -35,8 +33,7 @@ class NetworkProviderToolBar(View):
 class NetworkProviderDetailsToolBar(NetworkProviderToolBar):
     """ Represents provider details toolbar """
     monitoring = Dropdown(text='Monitoring')
-    download = VersionPicker({Version.lowest(): Button(title='Download summary in PDF format'),
-                              "5.10": Button(title='Print or export summary')})
+    download = Button(title='Print or export summary')
 
 
 class NetworkProviderSideBar(View):
@@ -142,8 +139,7 @@ class BalancerToolBar(View):
 
 class BalancerDetailsToolBar(BalancerToolBar):
     """ Represents details toolbar of balancer summary """
-    download = VersionPicker({Version.lowest(): Button(title='Download summary in PDF format'),
-                              "5.10": Button(title='Print or export summary')})
+    download = Button(title='Print or export summary')
 
 
 class BalancerSideBar(View):
@@ -221,8 +217,7 @@ class CloudNetworkToolBar(View):
 class CloudNetworkDetailsToolBar(View):
     """ Represents provider details toolbar """
     policy = Dropdown(text='Policy')
-    download = VersionPicker({Version.lowest(): Button(title='Download summary in PDF format'),
-                              "5.10": Button(title='Print or export summary')})
+    download = Button(title='Print or export summary')
 
 
 class CloudNetworkSideBar(View):
@@ -326,8 +321,7 @@ class NetworkPortToolBar(View):
 class NetworkPortDetailsToolBar(View):
     """ Represents toolbar of summary of port """
     policy = Dropdown(text='Policy')
-    download = VersionPicker({Version.lowest(): Button(title='Download summary in PDF format'),
-                              "5.10": Button(title='Print or export summary')})
+    download = Button(title='Print or export summary')
 
 
 class NetworkPortSideBar(View):
@@ -419,8 +413,7 @@ class NetworkRouterDetailsToolBar(View):
     configuration = Dropdown(text='Configuration')
     policy = Dropdown(text='Policy')
     edit = Dropdown(text='Edit')
-    download = VersionPicker({Version.lowest(): Button(title='Download summary in PDF format'),
-                              "5.10": Button(title='Print or export summary')})
+    download = Button(title='Print or export summary')
 
 
 class NetworkRouterSideBar(View):
@@ -540,8 +533,7 @@ class SecurityGroupToolBar(View):
 class SecurityGroupDetailsToolBar(View):
     """ Represents provider details toolbar """
     policy = Dropdown(text='Policy')
-    download = VersionPicker({Version.lowest(): Button(title='Download summary in PDF format'),
-                              "5.10": Button(title='Print or export summary')})
+    download = Button(title='Print or export summary')
     view_selector = View.nested(ItemsToolBarViewSelector)
 
 
@@ -635,8 +627,7 @@ class SubnetDetailsToolBar(View):
     """ Represents provider details toolbar """
     configuration = Dropdown(text='Configuration')
     policy = Dropdown(text='Policy')
-    download = VersionPicker({Version.lowest(): Button(title='Download summary in PDF format'),
-                              "5.10": Button(title='Print or export summary')})
+    download = Button(title='Print or export summary')
 
 
 class SubnetAddView(BaseLoggedInPage):
@@ -869,8 +860,7 @@ class FloatingIpToolBar(View):
 class FloatingIpDetailsToolBar(View):
     """ Represents toolbar of summary of port """
     policy = Dropdown(text='Policy')
-    download = VersionPicker({Version.lowest(): Button(title='Download summary in PDF format'),
-                              "5.10": Button(title='Print or export summary')})
+    download = Button(title='Print or export summary')
 
 
 class FloatingIpDetailsSideBar(View):

--- a/cfme/storage/manager.py
+++ b/cfme/storage/manager.py
@@ -44,7 +44,7 @@ class StorageManagerDetailsToolbar(View):
     configuration = Dropdown('Configuration')
     policy = Dropdown('Policy')
     monitoring = Dropdown('Monitoring')
-    download = Button(title='Download summary in PDF format')
+    download = Button(title='Print or export summary')
 
 
 class StorageManagerEntities(View):

--- a/cfme/storage/object_store_container.py
+++ b/cfme/storage/object_store_container.py
@@ -38,7 +38,7 @@ class ObjectStoreContainerToolbar(View):
 class ObjectStoreContainerDetailsToolbar(View):
     """The toolbar on the Object Store Containers detail page"""
     policy = Dropdown('Policy')
-    download = Button(title='Download summary in PDF format')
+    download = Button(title='Print or export summary')
 
 
 class ObjectStoreContainerDetailsEntities(View):

--- a/cfme/storage/object_store_object.py
+++ b/cfme/storage/object_store_object.py
@@ -37,7 +37,7 @@ class ObjectStoreObjectToolbar(View):
 class ObjectStoreObjectDetailsToolbar(View):
     """The toolbar on the Object Store Object detail page"""
     policy = Dropdown('Policy')
-    download = Button(title='Download summary in PDF format')
+    download = Button(title='Print or export summary')
 
 
 class ObjectStoreObjectDetailsEntities(View):

--- a/cfme/storage/volume.py
+++ b/cfme/storage/volume.py
@@ -52,7 +52,7 @@ class VolumeToolbar(View):
 class VolumeDetailsToolbar(View):
     configuration = Dropdown('Configuration')
     policy = Dropdown('Policy')
-    download = Button('Download summary in PDF format')
+    download = Button('Print or export summary')
 
 
 class VolumeDetailsEntities(View):

--- a/cfme/storage/volume_backup.py
+++ b/cfme/storage/volume_backup.py
@@ -45,7 +45,7 @@ class VolumeBackupDetailsToolbar(View):
     """The toolbar on the Volume Backup detail page"""
     configuration = Dropdown('Configuration')
     policy = Dropdown('Policy')
-    download = Button('Download summary in PDF format')
+    download = Button('Print or export summary')
 
 
 class VolumeBackupDetailsEntities(View):

--- a/cfme/storage/volume_snapshot.py
+++ b/cfme/storage/volume_snapshot.py
@@ -41,7 +41,7 @@ class VolumeSnapshotDetailsToolbar(View):
     """The toolbar on the Volume Snapshot detail page"""
     configuration = Dropdown('Configuration')
     policy = Dropdown('Policy')
-    download = Button('Download summary in PDF format')
+    download = Button('Print or export summary')
 
 
 class VolumeSnapshotDetailsEntities(View):

--- a/cfme/storage/volume_type.py
+++ b/cfme/storage/volume_type.py
@@ -45,7 +45,7 @@ class VolumeTypeAllView(VolumeTypeView):
 
 class VolumeTypeDetailsToolbar(View):
     policy = Dropdown('Policy')
-    download = Button('Download summary in PDF format')
+    download = Button('Print or export summary')
 
 
 class VolumeTypeDetailsEntities(View):


### PR DESCRIPTION
Changes:
1. Since 5.10, the title of the download button in the toolbar has been changed from `Download summary in PDF format` to `Print or export Summary`, change that for automation.

I didn't find any tests using this download feature, so not testing the changes, but I have tested it locally and it works fine.