### PR TITLE
[RFR] follow-up for #8543

### DIFF
--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -458,7 +458,9 @@ class Taggable(TaggableCommonBase):
                 tag_category, tag_name = tag.split(':')
                 category = self.appliance.collections.categories.instantiate(
                     display_name=tag_category)
-                tags.append(category.collections.tags.instantiate(display_name=tag_name.strip()))
+                tags.append(category.collections.tags.instantiate(
+                    display_name=tag_name.strip(),
+                    name=tag_category.strip()))
         return tags
 
 

--- a/cfme/tests/cloud/test_tag_mapping.py
+++ b/cfme/tests/cloud/test_tag_mapping.py
@@ -91,6 +91,7 @@ def test_tag_mapping_azure_instances(tagged_vm, map_tags):
             3.
             4. Field value is "My Company Tags Testing: testing"
     """
+    tagged_vm.provider.refresh_provider_relationships()
     view = navigate_to(tagged_vm, 'Details')
 
     def my_company_tags():
@@ -98,7 +99,8 @@ def test_tag_mapping_azure_instances(tagged_vm, map_tags):
     # sometimes it's not updated immediately after provider refresh
     wait_for(
         my_company_tags,
-        timeout=300,
+        timeout=600,
+        delay=45,
         fail_func=view.toolbar.reload.click
     )
     assert view.tag.get_text_of('My Company Tags')[0] == 'Testing: testing'
@@ -210,7 +212,10 @@ def test_mapping_tags(
 
     # check the tag shows up
     provider.refresh_provider_relationships(method='ui')
-    soft_assert('{}: {}'.format(category.name, tag_value) in entity.get_tags())
+    soft_assert(any(
+        tag.category.display_name == category.name and tag.display_name == tag_value
+        for tag in entity.get_tags()
+    ), '{}: {} was not found in tags'.format(category.name, tag_value))
 
     # delete it
     map_tag.delete()

--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -329,7 +329,7 @@ Werkzeug==0.15.2
 widgetastic.core==0.37
 widgetastic.patternfly==0.1.2
 widgetsnbextension==3.4.2
-wrapanapi==3.1.6
+wrapanapi==3.1.8
 wrapt==1.11.1
 xmltodict==0.12.0
 yaycl==0.3.0

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -314,7 +314,7 @@ Werkzeug==0.15.2
 widgetastic.core==0.37
 widgetastic.patternfly==0.1.2
 widgetsnbextension==3.4.2
-wrapanapi==3.1.6
+wrapanapi==3.1.8
 wrapt==1.11.1
 xmltodict==0.12.0
 yaycl==0.3.0

--- a/requirements/frozen_docs.py2.txt
+++ b/requirements/frozen_docs.py2.txt
@@ -328,7 +328,7 @@ Werkzeug==0.15.2
 widgetastic.core==0.37
 widgetastic.patternfly==0.1.2
 widgetsnbextension==3.4.2
-wrapanapi==3.1.6
+wrapanapi==3.1.8
 wrapt==1.11.1
 xmltodict==0.12.0
 yaycl==0.3.0

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -313,7 +313,7 @@ Werkzeug==0.15.2
 widgetastic.core==0.37
 widgetastic.patternfly==0.1.2
 widgetsnbextension==3.4.2
-wrapanapi==3.1.6
+wrapanapi==3.1.8
 wrapt==1.11.1
 xmltodict==0.12.0
 yaycl==0.3.0


### PR DESCRIPTION
As promised in #8543 I'm fixing the errors in tagging tests

{{ pytest: --long-running -vvvv --use-provider complete cfme/tests/cloud/test_tag_mapping.py  }}

I don't know how `def get_tags` worked before, but I saw sometime ago also empty name in Tag property, so I believe this fix going to fix more tests.

https://github.com/ManageIQ/wrapanapi/pull/382 This is also needed for this fix.