### PR TITLE
[1LP][RFR] Undo workaround for BZ 1668849

### DIFF
--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -63,20 +63,6 @@ def address(self):
     return self.appliance.url
 
 
-def prepare_server_name(name):
-    # there is a bug in CF 5.10 UI when it has different number of spaces in different html attrs
-    # this is temporary workaround until BZ(1668849)  is fixed
-    if BZ(1668849).blocks:
-        new_name = re.escape(name)
-        new_name = new_name.replace(r'\ ', r'\s*')
-        new_name = re.compile(new_name)
-    else:
-        import warnings
-        warnings.warn('REMOVE ME: BZ#1668849 and/or revert whole commit')
-        new_name = name
-    return new_name
-
-
 class LoginPage(View):
     flash = FlashMessages('.//div[@id="flash_msg_div"]')
 
@@ -537,21 +523,18 @@ class ServerView(ConfigurationView):
         if not (self.in_configuration and self.accordions.settings.is_displayed):
             return False
 
-        # checking  that tree contains all expected entities
-        currently_selected = self.accordions.settings.tree.currently_selected
-        if not ({self.context['object'].zone.region.settings_string, "Zones",
-                 "Zone: {} (current)".format(self.context['object'].zone.description)} <=
-                set(currently_selected)):
-            return False
+        # check that tree contains all expected entities
+        expected_list = [
+            self.context['object'].zone.region.settings_string,
+            "Zones",
+            "Zone: {} (current)".format(self.context['object'].zone.description),
+            "Server: {name} [{sid}]{current}".format(
+                 name = self.context['object'].name,
+                 sid = self.context['object'].sid,
+                 current = '' if self.context['object'] in self.context['object'].slave_servers
+                 else ' (current)')]
 
-        if not (re.match(prepare_server_name(("Server: {name} [{sid}]{current}".format(
-                name=self.context['object'].name,
-                sid=self.context['object'].sid,
-                current='' if self.context['object'] in self.context['object'].slave_servers else
-                ' (current)'))), currently_selected[-1])):
-            return False
-
-        return True
+        return (self.accordions.settings.tree.currently_selected == expected_list)
 
 
 @navigator.register(Server, 'Details')
@@ -564,11 +547,10 @@ class Details(CFMENavigateStep):
             self.obj.zone.region.settings_string,
             "Zones",
             "Zone: {} (current)".format(self.obj.appliance.server.zone.description),
-            prepare_server_name("Server: {name} [{sid}]{current}".format(
-                name=self.obj.appliance.server.name,
-                sid=self.obj.sid,
+            "Server: {name} [{sid}]{current}".format(
+                name = self.obj.appliance.server.name,
+                sid = self.obj.sid,
                 current='' if self.obj in self.obj.slave_servers else ' (current)'))
-        )
         self.prerequisite_view.accordions.settings.tree.click_path(*path)
 
 
@@ -816,20 +798,14 @@ class ServerDiagnosticsView(ConfigurationView):
 
     @property
     def is_displayed(self):
-        currently_selected = self.accordions.diagnostics.tree.currently_selected
-        if not ({self.context['object'].zone.region.settings_string,
-                 "Zone: {} (current)".format(self.context['object'].zone.description)}
-                <= set(currently_selected)):
-            return False
-
-        if not (re.match(prepare_server_name("Server: {name} [{sid}]{current}".format(
-                name=self.context['object'].name,
-                sid=self.context['object'].sid,
-                current='' if self.context['object'] in self.context['object'].slave_servers else
-                ' (current)')), currently_selected[-1])):
-            return False
-
-        return True
+        expected_list = [self.context['object'].zone.region.settings_string,
+            "Zone: {} (current)".format(self.context['object'].zone.description),
+            "Server: {name} [{sid}]{current}".format(
+                name = self.context['object'].name,
+                sid = self.context['object'].sid,
+                current = '' if self.context['object'] in self.context['object'].slave_servers
+                else ' (current)')]
+        return (self.accordions.diagnostics.tree.currently_selected == expected_list)
 
 
 class ServerDiagnosticsCollectLogsView(ServerDiagnosticsView):
@@ -847,10 +823,10 @@ class Diagnostics(CFMENavigateStep):
         self.prerequisite_view.accordions.diagnostics.tree.click_path(
             self.obj.zone.region.settings_string,
             "Zone: {} (current)".format(self.obj.zone.description),
-            prepare_server_name("Server: {name} [{sid}]{current}".format(
-                name=self.obj.appliance.server.name,
-                sid=self.obj.sid,
-                current='' if self.obj in self.obj.slave_servers else ' (current)')))
+            "Server: {name} [{sid}]{current}".format(
+                name = self.obj.appliance.server.name,
+                sid = self.obj.sid,
+                current = '' if self.obj in self.obj.slave_servers else ' (current)'))
 
 
 @navigator.register(Server)
@@ -1034,8 +1010,8 @@ class RegionView(ConfigurationView):
 
     @property
     def is_displayed(self):
-        match_string = [self.context['object'].settings_string]
-        return self.accordions.settings.tree.currently_selected == match_string
+        expected_list = [self.context['object'].settings_string]
+        return (self.accordions.settings.tree.currently_selected == expected_list)
 
 
 class RegionChangeNameView(RegionView):

--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -529,10 +529,10 @@ class ServerView(ConfigurationView):
             "Zones",
             "Zone: {} (current)".format(self.context['object'].zone.description),
             "Server: {name} [{sid}]{current}".format(
-                 name = self.context['object'].name,
-                 sid = self.context['object'].sid,
-                 current = '' if self.context['object'] in self.context['object'].slave_servers
-                 else ' (current)')]
+                name=self.context['object'].name,
+                sid=self.context['object'].sid,
+                current='' if self.context['object'] in self.context['object'].slave_servers
+                else ' (current)')]
 
         return (self.accordions.settings.tree.currently_selected == expected_list)
 
@@ -548,8 +548,8 @@ class Details(CFMENavigateStep):
             "Zones",
             "Zone: {} (current)".format(self.obj.appliance.server.zone.description),
             "Server: {name} [{sid}]{current}".format(
-                name = self.obj.appliance.server.name,
-                sid = self.obj.sid,
+                name=self.obj.appliance.server.name,
+                sid=self.obj.sid,
                 current='' if self.obj in self.obj.slave_servers else ' (current)'))
         self.prerequisite_view.accordions.settings.tree.click_path(*path)
 
@@ -801,10 +801,10 @@ class ServerDiagnosticsView(ConfigurationView):
         expected_list = [self.context['object'].zone.region.settings_string,
             "Zone: {} (current)".format(self.context['object'].zone.description),
             "Server: {name} [{sid}]{current}".format(
-                name = self.context['object'].name,
-                sid = self.context['object'].sid,
-                current = '' if self.context['object'] in self.context['object'].slave_servers
-                else ' (current)')]
+            name=self.context['object'].name,
+            sid=self.context['object'].sid,
+            current='' if self.context['object'] in self.context['object'].slave_servers
+            else ' (current)')]
         return (self.accordions.diagnostics.tree.currently_selected == expected_list)
 
 
@@ -824,9 +824,10 @@ class Diagnostics(CFMENavigateStep):
             self.obj.zone.region.settings_string,
             "Zone: {} (current)".format(self.obj.zone.description),
             "Server: {name} [{sid}]{current}".format(
-                name = self.obj.appliance.server.name,
-                sid = self.obj.sid,
-                current = '' if self.obj in self.obj.slave_servers else ' (current)'))
+                name=self.obj.appliance.server.name,
+                sid=self.obj.sid,
+                current='' if self.obj in self.obj.slave_servers
+                else ' (current)'))
 
 
 @navigator.register(Server)

--- a/cfme/configure/configuration/diagnostics_settings.py
+++ b/cfme/configure/configuration/diagnostics_settings.py
@@ -10,7 +10,6 @@ from widgetastic_patternfly import Button
 from widgetastic_patternfly import Dropdown
 from widgetastic_patternfly import Input
 
-from cfme.base.ui import prepare_server_name
 from cfme.base.ui import ServerDiagnosticsView
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
@@ -549,8 +548,8 @@ class DiagnosticsCollectLogs(CFMENavigateStep):
         self.prerequisite_view.accordions.diagnostics.tree.click_path(
             self.appliance.server_region_string(),
             "Zone: {} (current)".format(self.appliance.server.zone.description),
-            prepare_server_name("Server: {} [{}] (current)".format(self.appliance.server.name,
-                                self.appliance.server.sid)))
+            "Server: {} [{}] (current)".format(self.appliance.server.name,
+                                self.appliance.server.sid))
         self.prerequisite_view.collectlogs.select()
 
 

--- a/cfme/configure/configuration/diagnostics_settings.py
+++ b/cfme/configure/configuration/diagnostics_settings.py
@@ -564,8 +564,7 @@ class DiagnosticsCollectLogsSlave(CFMENavigateStep):
         self.prerequisite_view.accordions.diagnostics.tree.click_path(
             self.appliance.server_region_string(),
             "Zone: {} (current)".format(self.appliance.server.zone.description),
-            prepare_server_name("Server: {} [{}]".format(slave_server.name,
-                                int(slave_server.sid))))
+            "Server: {} [{}]".format(slave_server.name, int(slave_server.sid)))
         self.prerequisite_view.collectlogs.select()
 
 


### PR DESCRIPTION
Purpose or Intent
==============

In 5.11.0.4, the following tests fail, because the is_displayed() method for ServerView and ServerDiagnosticsView fail to return True.

ServerView:
Server, Authentication, Workers, Custom Logos, Advanced tabs

test_paginator_config_pages[servers_details]
test_paginator_config_pages[servers_authentication]
test_paginator_config_pages[servers_workers]
test_paginator_config_pages[servers_customlogos]
test_paginator_config_pages[servers_advanced]

ServerDiagnosticsView:
Summary, Workers, Collect Logs, CFME Log, Audit Log, Production Log, Utilization, and Timelines tabs

test_paginator_config_pages[servers_diagnosticsdetails]
test_paginator_config_pages[servers_diagnosticsworkers]
test_paginator_config_pages[servers_serverdiagnosticscollectlogs]
test_paginator_config_pages[servers_cfmelog]
test_paginator_config_pages[servers_auditlog]
test_paginator_config_pages[servers_productionlog]
test_paginator_config_pages[servers_utilization]
test_paginator_config_pages[servers_timelines]

These failures are due to the workaround for BZ 1668849 introduced in commit 879354a2ad.

Bug 1668849 - Server looses its name when Authentication settings are changed
https://bugzilla.redhat.com/show_bug.cgi?id=1668849

This BZ is now VERIFIED, and undoing the workaround fixes the test failures. Tests now pass for both 5.10 and 5.11.

{{ pytest: cfme/tests/configure/test_paginator.py -vvvv }}