### PR TITLE
[WIPTEST]fix failing test_report_view

### DIFF
--- a/cfme/tests/intelligence/reports/test_views.py
+++ b/cfme/tests/intelligence/reports/test_views.py
@@ -19,8 +19,8 @@ pytestmark = [
 def report(appliance):
     report = appliance.collections.reports.instantiate(
         type="Configuration Management",
-        subtype="Hosts",
-        menu_name="Virtual Infrastructure Platforms",
+        subtype="Virtual Machines",
+        menu_name="Guest OS Information - any OS",
     ).queue(wait_for_finish=True)
     yield report
     if report.exists:


### PR DESCRIPTION
Changes:
1. Change the report which is the subject of this test. Old report sometimes failed for cloud, the changed report will work for both infra and cloud providers.


{{ pytest: cfme/tests/intelligence/reports/test_views.py --use-provider=rhos13 --use-template-cache -sqvvv }}