### PR TITLE
[1LP][RFR]Automate test: test_default_view_settings_should_apply_for_service_ca…

### DIFF
--- a/cfme/configure/settings.py
+++ b/cfme/configure/settings.py
@@ -254,6 +254,7 @@ class DefaultViewsForm(View):
         catalog_items = ViewButtonGroup('Services', 'Catalog Items')
         templates = ViewButtonGroup('Services', 'Templates & Images')
         vms_instances = ViewButtonGroup('Services', 'VMs & Instances')
+        service_catalogs = ViewButtonGroup('Services', 'Service Catalogs')
 
     @View.nested
     class containers(View):                                                             # noqa
@@ -478,6 +479,7 @@ class DefaultViews(Updateable, NavigatableMixin):
                                                'configuration_management_providers'],
         'VMs': ['infrastructure', 'vms'],
         'My Services': ['services', 'my_services'],
+        'Service Catalogs': ['services', 'service_catalogs'],
         'Catalog Items': ['services', 'catalog_items'],
         'Templates & Images': ['services', 'templates'],
         'VMs & Instances': ['services', 'vms_instances'],

--- a/cfme/services/service_catalogs/ui.py
+++ b/cfme/services/service_catalogs/ui.py
@@ -3,6 +3,7 @@ from navmazing import NavigateToSibling
 from widgetastic.widget import Text
 from widgetastic.widget import View
 from widgetastic_patternfly import Button
+from widgetastic_patternfly import Dropdown
 
 from cfme.base import Server
 from cfme.base.login import BaseLoggedInPage
@@ -16,6 +17,7 @@ from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.appliance.implementations.ui import ViaUI
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import Accordion
+from widgetastic_manageiq import ItemsToolBarViewSelector
 from widgetastic_manageiq import ManageIQTree
 
 
@@ -33,6 +35,12 @@ class ServicesCatalogsView(BaseLoggedInPage):
         ACCORDION_NAME = "Service Catalogs"
 
         tree = ManageIQTree()
+
+    @View.nested
+    class toolbar(View):                # noqa
+        reload = Button(title='Refresh this page')
+        download = Dropdown(text='Download')
+        view_selector = View.nested(ItemsToolBarViewSelector)
 
     @property
     def is_displayed(self):

--- a/cfme/tests/configure/test_default_views_infra.py
+++ b/cfme/tests/configure/test_default_views_infra.py
@@ -7,6 +7,7 @@ from six import string_types
 from cfme import test_requirements
 from cfme.exceptions import ItemNotFound
 from cfme.services.myservice import MyService
+from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.services.workloads import TemplatesImages
 from cfme.services.workloads import VmsInstances
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -21,12 +22,13 @@ pytestmark = [pytest.mark.tier(3),
 # due to navmazing or collections. all items have to be put back once navigation change is fully
 # done
 
-gtl_params = {
+GTL_PARAMS = {
     'Infrastructure Providers': 'infra_providers',  # collection name
     'VMs': 'infra_vms',  # collection name
     'My Services': MyService,
     'VMs & Instances': VmsInstances,
-    'Templates & Images': TemplatesImages
+    'Templates & Images': TemplatesImages,
+    'Service Catalogs': ServiceCatalogs
 }
 
 
@@ -89,8 +91,11 @@ def test_default_view_infra_reset(appliance):
     assert not view.tabs.default_views.reset.disabled
 
 
-@pytest.mark.parametrize('group_name', gtl_params.keys(), scope="module")
+@pytest.mark.parametrize('group_name', GTL_PARAMS.keys(), scope="module")
 @pytest.mark.parametrize('view', ['List View', 'Tile View', 'Grid View'])
+@pytest.mark.uncollectif(
+    lambda view, group_name: view == "Grid View" and group_name == "Service Catalogs"
+)
 def test_infra_default_view(appliance, group_name, view):
     """This test case changes the default view of an infra related page and asserts the change.
 
@@ -100,8 +105,11 @@ def test_infra_default_view(appliance, group_name, view):
         caseimportance: high
         initialEstimate: 1/10h
         tags: settings
+
+    Bugzilla:
+        1553337
     """
-    page = _get_page(gtl_params[group_name], appliance)
+    page = _get_page(GTL_PARAMS[group_name], appliance)
     default_views = appliance.user.my_settings.default_views
     old_default = default_views.get_default_view(group_name)
     default_views.set_default_view(group_name, view)

--- a/cfme/tests/services/test_service_catalogs.py
+++ b/cfme/tests/services/test_service_catalogs.py
@@ -345,23 +345,6 @@ def test_reconfigure_service_fields_empty_after_deploying_service():
 
 @pytest.mark.manual
 @pytest.mark.tier(2)
-def test_default_view_settings_should_apply_for_service_catalogs():
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        testtype: functional
-        initialEstimate: 1/4h
-        startsin: 5.9
-        tags: service
-    Bugzilla:
-        1553337
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(2)
 def test_order_service_after_deleting_provider():
     """
     Polarion:

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -2050,7 +2050,7 @@ class ViewSelector(View):
     @property
     def selected(self):
         if self.is_displayed:
-            return next(btn.title for btn in self._view_buttons if btn.active)
+            return next(btn.title for btn in self._view_buttons if btn.is_displayed and btn.active)
         else:
             return None
 
@@ -2082,7 +2082,11 @@ class ItemsToolBarViewSelector(ViewSelector):
 
     @property
     def is_displayed(self):
-        return self.grid_button.is_displayed
+        return (
+            self.grid_button.is_displayed
+            or self.list_button.is_displayed
+            or self.tile_button.is_displayed
+        )
 
 
 class DetailsToolBarViewSelector(ViewSelector):


### PR DESCRIPTION
Changes:
1. Automate a test case `test_default_view_settings_should_apply_for_service_catalogs` by adding `Service Catalogs` as a parameter to an already automated similar test and remove the manual test.
2. Add `toolbar` to ServiceCatalogs All page.
3. The toolbar does not have a grid button view_selector, because of which `is_displayed` of `ItemsToolBarViewSelector` fails, which eventually fails `selected` property of the view_selector. Fix that.
4. `gtl_params` is a global variable, capitalize it.

{{ pytest: cfme/tests/configure/test_default_views_infra.py::test_infra_default_view --use-template-cache -sqvvv }}