### PR TITLE
[1LP][RFR] Fix AttributeError in HandleModalsMixin.handle_alert

### DIFF
--- a/cfme/configure/access_control/__init__.py
+++ b/cfme/configure/access_control/__init__.py
@@ -1008,7 +1008,7 @@ class Role(Updateable, Pretty, BaseEntity):
 
     pretty_attrs = ['name', 'product_features']
 
-    name = attr.ib(default=None)
+    name = attr.ib()
     vm_restriction = attr.ib(default=None)
     product_features = attr.ib(default=None)
 
@@ -1135,7 +1135,7 @@ class Role(Updateable, Pretty, BaseEntity):
 class RoleCollection(BaseCollection):
     ENTITY = Role
 
-    def create(self, name=None, vm_restriction=None, product_features=None, cancel=False):
+    def create(self, name, vm_restriction=None, product_features=None, cancel=False):
         """ Create role method
 
         Args:
@@ -1151,7 +1151,6 @@ class RoleCollection(BaseCollection):
                 for currently selected role
         """
         flash_blocked_msg = "Name has already been taken"
-
         role = self.instantiate(
             name=name, vm_restriction=vm_restriction, product_features=product_features
         )

--- a/cfme/fixtures/tag.py
+++ b/cfme/fixtures/tag.py
@@ -21,11 +21,12 @@ def category(appliance):
         display_name=fauxfactory.gen_alphanumeric(length=32)
     )
     yield cg
+    appliance.server.login_admin()
     cg.delete_if_exists()
 
 
 @pytest.fixture(scope="session")
-def tag(category):
+def tag(category, appliance):
     """
         Returns random created tag object
         Object can be used in all test run session
@@ -35,6 +36,7 @@ def tag(category):
         display_name=fauxfactory.gen_alphanumeric(length=32)
     )
     yield tag
+    appliance.server.login_admin()
     tag.delete_if_exists()
 
 
@@ -47,6 +49,7 @@ def role(appliance):
         name='role{}'.format(fauxfactory.gen_alphanumeric()),
         vm_restriction='None')
     yield role
+    appliance.server.login_admin()
     role.delete_if_exists()
 
 
@@ -61,6 +64,7 @@ def group_with_tag(appliance, role, category, tag):
         tag=([category.display_name, tag.display_name], True)
     )
     yield group
+    appliance.server.login_admin()
     group.delete_if_exists()
 
 
@@ -78,6 +82,7 @@ def user_restricted(appliance, group_with_tag, new_credential):
         cost_center='Workload',
         value_assign='Database')
     yield user
+    appliance.server.login_admin()
     user.delete_if_exists()
 
 
@@ -86,9 +91,8 @@ def new_credential():
     """
         Returns credentials object used for new user in test module
     """
-    # Todo remove .lower() for principal after 1486041 fix
     return Credential(
-        principal='uid{}'.format(fauxfactory.gen_alphanumeric().lower()), secret='redhat')
+        principal='uid{}'.format(fauxfactory.gen_alphanumeric()), secret='redhat')
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
When there is no wait, there's no check against the fact that the modal is actually present.

Addressing the following failure mode specifically:
```
>           self.logger.info('handling alert: %r', popup.text)
E           AttributeError: 'NoneType' object has no attribute 'text'

cfme/utils/appliance/implementations/common.py:80: AttributeError
AttributeError
'NoneType' object has no attribute 'text'
```

Local testing looks good, included some cases that failed in automation for PRT.

Not necessarily trying to resolve all PRT failures that might happen in these modules.

{{ pytest: cfme/tests/configure/test_access_control.py cfme/tests/configure/test_landing_page.py cfme/tests/infrastructure/test_quota.py }}