### PR TITLE
[1LP][RFR] new test to check template refresh relationships

### DIFF
--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -12,6 +12,7 @@ from widgetastic_patternfly import Dropdown
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.common.host_views import HostEntitiesView
+from cfme.utils.blockers import BZ
 from cfme.utils.version import VersionPicker
 from widgetastic_manageiq import Accordion
 from widgetastic_manageiq import BaseEntitiesView
@@ -94,9 +95,14 @@ class ProviderDetailsView(BaseLoggedInPage):
             name=self.context['object'].name,
             subtitle=subtitle
         )
-        return (self.logged_in_as_current_user and
-                self.breadcrumb.is_displayed and
-                self.breadcrumb.active_location == title)
+        if BZ(1703744).blocks:
+            return (self.logged_in_as_current_user and
+                    self.breadcrumb.is_displayed and
+                    self.breadcrumb.active_location in title)
+        else:
+            return (self.logged_in_as_current_user and
+                    self.breadcrumb.is_displayed and
+                    self.breadcrumb.active_location == title)
 
 
 class InfraProviderDetailsView(ProviderDetailsView):

--- a/cfme/tests/cloud_infra_common/test_relationships.py
+++ b/cfme/tests/cloud_infra_common/test_relationships.py
@@ -326,6 +326,28 @@ def test_host_refresh_relationships(provider, setup_provider):
     wait_for_relationship_refresh(provider)
 
 
+@pytest.mark.rhv3
+@pytest.mark.provider([InfraProvider])
+def test_template_refresh_relationships(appliance, provider, setup_provider):
+    """ Test that host refresh doesn't fail
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: Infra
+        caseimportance: high
+        initialEstimate: 1/8h
+        tags: relationship
+    """
+    templates_view = navigate_to(provider, 'ProviderTemplates')
+    template_names = templates_view.entities.entity_names
+    template_collection = appliance.provider_based_collection(provider=provider,
+                                                              coll_type='templates')
+
+    template = template_collection.instantiate(template_names[0], provider)
+    template.refresh_relationships()
+    wait_for_relationship_refresh(provider)
+
+
 @pytest.mark.manual
 @pytest.mark.tier(1)
 def test_inventory_refresh_westindia_azure():


### PR DESCRIPTION
{{ pytest: -v cfme/tests/cloud_infra_common/test_relationships.py::test_template_refresh_relationships }}

+ added `BZ.blocks` due to breadcrumb issue