### PR TITLE
[1LP][RFR]Automate test: test_report_edit_secondary_display_filter AND update E…

### DIFF
--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -175,8 +175,15 @@ class ReportDetailsView(CloudIntelReportsView):
         user = SummaryFormItem("", "User")
         group = SummaryFormItem("", "EVM Group")
         updated_on = SummaryFormItem("", "Updated On")
-        report_schedule_data = Table('//*[@id="report_info"]/table[1]')
-        report_widgets_data = Table('//*[@id="report_info"]/table[2]')
+        # xpath is defined based on the value of the second title head of table
+        report_schedule_data = Table(
+            '//*[@id="report_info"]//th[contains(text(), "Name")]'
+            '/parent::tr/parent::thead/parent::table'
+        )
+        report_widgets_data = Table(
+            '//*[@id="report_info"]//th[contains(text(), "Title")]'
+            '/parent::tr/parent::thead/parent::table'
+        )
         queue_button = Button("Queue")
 
     @View.nested

--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -34,6 +34,7 @@ from cfme.utils.wait import wait_for
 from widgetastic_manageiq import InputButton
 from widgetastic_manageiq import PaginationPane
 from widgetastic_manageiq import ReportToolBarViewSelector
+from widgetastic_manageiq import SummaryFormItem
 from widgetastic_manageiq import Table
 from widgetastic_manageiq import WaitTab
 from widgetastic_manageiq.expression_editor import ExpressionEditor
@@ -78,8 +79,20 @@ class CustomReportFormCommon(CloudIntelReportsView):
         interval = BootstrapSelect("cb_interval")
         interval_size = BootstrapSelect("cb_interval_size")
         interval_end = BootstrapSelect("cb_end_interval_offset")
-        primary_filter = ExpressionEditor()
-        secondary_filter = ExpressionEditor()
+        primary_record_filter = Button("contains", "Record Filter")
+        secondary_display_filter = Button("contains", "Display Filter")
+
+        @View.nested
+        class primary_filter(ExpressionEditor):     # noqa
+            def child_widget_accessed(self, widget):
+                if self.parent.primary_record_filter.is_displayed:
+                    self.parent.primary_record_filter.click()
+
+        @View.nested
+        class secondary_filter(ExpressionEditor):   # noqa
+            def child_widget_accessed(self, widget):
+                if self.parent.secondary_display_filter.is_displayed:
+                    self.parent.secondary_display_filter.click()
 
     @View.nested
     class summary(WaitTab):  # noqa
@@ -152,6 +165,17 @@ class ReportDetailsView(CloudIntelReportsView):
     @View.nested
     class report_info(WaitTab):  # noqa
         TAB_NAME = "Report Info"
+        report_id = SummaryFormItem("", "ID")
+        title = SummaryFormItem("", "Title")
+        primary_filter = SummaryFormItem("", "Primary (Record) Filter")
+        secondary_filter = SummaryFormItem("", "Secondary (Display) Filter")
+        sort_by = SummaryFormItem("", "Sort By")
+        based_on = SummaryFormItem("", "Based On")
+        user = SummaryFormItem("", "User")
+        group = SummaryFormItem("", "EVM Group")
+        updated_on = SummaryFormItem("", "Updated On")
+        report_schedule_data = Table('//*[@id="report_info"]/table[1]')
+        report_widgets_data = Table('//*[@id="report_info"]/table[2]')
         queue_button = Button("Queue")
 
     @View.nested

--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -165,6 +165,7 @@ class ReportDetailsView(CloudIntelReportsView):
     @View.nested
     class report_info(WaitTab):  # noqa
         TAB_NAME = "Report Info"
+        # Keeping `group_title` empty since the summary form has no title
         report_id = SummaryFormItem("", "ID")
         title = SummaryFormItem("", "Title")
         primary_filter = SummaryFormItem("", "Primary (Record) Filter")

--- a/cfme/tests/intelligence/reports/test_reports.py
+++ b/cfme/tests/intelligence/reports/test_reports.py
@@ -2,6 +2,7 @@ import fauxfactory
 import pytest
 
 from cfme import test_requirements
+from cfme.intelligence.reports.reports import ReportDetailsView
 from cfme.rest.gen_data import users as _users
 from cfme.utils.rest import assert_response
 
@@ -149,3 +150,87 @@ def test_new_report_fields(appliance, based_on, request):
     report = appliance.collections.reports.create(**data)
     request.addfinalizer(report.delete_if_exists)
     assert report.exists
+
+
+@pytest.mark.tier(1)
+def test_report_edit_secondary_display_filter(appliance, request, soft_assert):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: Reporting
+        caseimportance: medium
+        initialEstimate: 1/6h
+        setup:
+            1. Create/Copy a report with secondary (display) filter.
+        testSteps:
+            1. Edit the secondary filter and test if the report was updated.
+        expectedResults:
+            1. Secondary filter must be editable and it must be updated.
+
+    Bugzilla:
+        1565171
+    """
+    report_data = {
+        "title": "Testing report",
+        "menu_name": "testing report",
+        "base_report_on": "Instances",
+        "report_fields": [
+            "Active",
+            "EVM Custom Attributes : Name",
+            "EVM Custom Attributes : Region Description",
+            "EVM Custom Attributes : Region Number",
+            "Name",
+        ],
+        "consolidation": {
+            "group_records": [
+                "EVM Custom Attributes : Name",
+                "EVM Custom Attributes : Region Description",
+                "EVM Custom Attributes : Region Number",
+            ]
+        },
+        "filter": {
+            "primary_filter": "fill_field(Instance : Active, IS NOT NULL)",
+            "secondary_filter": "fill_field(EVM Custom Attributes : Name, INCLUDES, A)",
+        },
+    }
+
+    report = appliance.collections.reports.create(**report_data)
+    request.addfinalizer(report.delete_if_exists)
+
+    data = {
+        "filter": {
+            "primary_filter": (
+                "fill_find("
+                "field=Instance.Guest Applications : Name, skey=STARTS WITH, "
+                "value=kernel, check=Check Count, ckey= = , cvalue=1"
+                ");select_first_expression;click_or;fill_find("
+                "field=Instance.Guest Applications : Name, skey=STARTS WITH, "
+                "value=kernel, check=Check Count, ckey= = , cvalue=1)"
+            ),
+            "secondary_filter": (
+                "fill_field(EVM Custom Attributes : Name, INCLUDES, A);"
+                " select_first_expression;click_or;fill_field"
+                "(EVM Custom Attributes : Region Description, INCLUDES, E)"
+            ),
+        }
+    }
+    report.update(data)
+
+    view = report.create_view(ReportDetailsView)
+
+    primary_filter = (
+        '( FIND Instance.Guest Applications : Name STARTS WITH "kernel" CHECK COUNT = 1'
+        ' OR FIND Instance.Guest Applications : Name STARTS WITH "kernel" CHECK COUNT = 1 )'
+    )
+    secondary_filter = (
+        '( Instance.EVM Custom Attributes : Name INCLUDES "A"'
+        ' OR Instance.EVM Custom Attributes : Region Description INCLUDES "E" )'
+    )
+    soft_assert(
+        view.report_info.primary_filter.read() == primary_filter,
+        "Primary Filter did not match.",
+    )
+    soft_assert(
+        view.report_info.secondary_filter.read() == secondary_filter,
+        "Secondary Filter did not match.",
+    )


### PR DESCRIPTION
Changes introduced with the PR:
1. Automate test: test_report_edit_secondary_display_filter
2. Fix primary_filter and secondary_filter so that right data can be accessed.
3. Enhance the ExpressionEditor `read` method to return a complete expression when required, earlier it only used to return the first expression of the multiple expressions present and remove 5.9 references from ExpressionEditor.

{{ pytest: cfme/tests/intelligence/reports/test_reports.py::test_report_edit_secondary_display_filter
 cfme/tests/control/test_bugs.py::test_policy_condition_multiple_ors cfme/tests/control/test_basic.py::test_modify_condition_expression
 --use-template-cache --long-running -sqvvv }}