### PR TITLE
[RFR, NOTEST] Remove prince from the packages on appliance.

### DIFF
--- a/cfme/tests/test_appliance.py
+++ b/cfme/tests/test_appliance.py
@@ -19,7 +19,6 @@ pytestmark = [pytest.mark.smoke, pytest.mark.tier(1)]
     'nfs-utils',
     'libnfsidmap',
     'ipmitool',
-    'prince',
     'rhn-client-tools',
     'rhn-check',
     'rhnlib',


### PR DESCRIPTION
The package prince is no longer required for generating the PDF reports.
We shouldn't check it's presence on the CFME appliance.