### PR TITLE
[RFR] fix log-validator

### DIFF
--- a/cfme/utils/ssh.py
+++ b/cfme/utils/ssh.py
@@ -144,8 +144,8 @@ class SSHClient(paramiko.SSHClient):
 
         # Overlay defaults with any passed-in kwargs and assign to _connect_kwargs
         compiled_kwargs.update(connect_kwargs)
-        if not compiled_kwargs['hostname']:
-            compiled_kwargs['hostname'] = store.current_appliance.hostname,
+        if not compiled_kwargs.get("hostname"):
+            compiled_kwargs["hostname"] = store.current_appliance.hostname
 
         self._connect_kwargs = compiled_kwargs
         self.set_missing_host_key_policy(paramiko.AutoAddPolicy())


### PR DESCRIPTION
Signed-off-by: Nikhil Dhandre <ndhandre@redhat.com>


Purpose or Intent
=================
fix : 
```Exception: SSH connection to ('192.168.122.230',):22 failed, port unavailable```

{{pytest:  cfme/tests/automate/test_method.py -k 'test_task_id_for_method_automation_log' -v}}