### PR TITLE
[RFR] Add in a wait_for between creating and removing the network security group

### DIFF
--- a/cfme/tests/cloud/test_cloud_events.py
+++ b/cfme/tests/cloud/test_cloud_events.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 """This module tests only cloud specific events"""
+import time
+
 import pytest
 
 from cfme.cloud.provider.azure import AzureProvider
@@ -78,6 +80,8 @@ def test_manage_nsg_group(appliance, provider, register_event):
 
     # creating and removing network security group
     provider.mgmt.create_netsec_group(nsg_name, resource_group)
+    # wait for a minute before deleting the security group so CFME has time to receive the event
+    time.sleep(60)
     provider.mgmt.remove_netsec_group(nsg_name, resource_group)
 
 


### PR DESCRIPTION
`test_manage_nsg_group` was failing because it didn't have time to register the event between creating and subsequently deleting the network security group. I have added a wait for that waits for a minute before deleting the network security group, this gives CFME time to receive the event from Azure. 

{{ pytest: --long-running --use-template-cache --use-provider azure cfme/tests/cloud/test_cloud_events.py::test_manage_nsg_group }}