### PR TITLE
[1LP][RFR]Change provider_attribute key for passing azure tenant id

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -284,7 +284,7 @@ class BaseProvider(Taggable, Updateable, Navigatable, BaseEntity, CustomButtonEv
                     provider_attributes['uid_ems'] = self.keystone_v3_domain_id
 
         if self.type_name == "azure":
-            provider_attributes["uid_ems"] = self.tenant_id
+            provider_attributes["azure_tenant_id"] = self.tenant_id
             provider_attributes["provider_region"] = self.region.lower().replace(" ", "")
             if getattr(self, "subscription_id", None):
                 provider_attributes["subscription"] = self.subscription_id


### PR DESCRIPTION
Changes:
1. Change the key name that passes azure `tenant_id` while creating Azure provider via REST. According to the enhancement card [RHCFQE-7605](https://projects.engineering.redhat.com/browse/RHCFQE-7605) and [manageiq-api/pr-279](https://github.com/ManageIQ/manageiq-api/pull/279/files) `azure_tenant_id` key must be used to pass `tenant_id`, while `uid_ems` is the key that will be used to return the `tenant_id` in the response.

{{ pytest: cfme/tests/cloud_infra_common/test_rest_providers.py --use-provider=azure }}