### PR TITLE
[1LP][RFR]Update test_server_info test

### DIFF
--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -368,7 +368,19 @@ def test_server_info(appliance):
         caseimportance: medium
         initialEstimate: 1/3h
     """
-    assert all(item in appliance.rest_api.server_info for item in ('appliance', 'build', 'version'))
+    key_list = (
+        "enterprise_href",
+        "zone_href",
+        "region_href",
+        "plugins",
+        "appliance",
+        "server_href",
+        "version",
+        "build",
+        "time",
+    )
+
+    assert all(item in appliance.rest_api.server_info for item in key_list)
 
 
 def test_server_info_href(appliance):


### PR DESCRIPTION
Changes:
1. Update test `test_server_info` to test for the presence of all the keys. Reference [RHCFQE-10276](https://projects.engineering.redhat.com/browse/RHCFQE-10276) and [manageiq-api/pr-473](https://github.com/ManageIQ/manageiq-api/pull/473).


{{ pytest: cfme/tests/test_rest.py::test_server_info  --use-template-cache -sqvvv }}