### PR TITLE
[1LP][RFR] fixed test_vm_filter_with_user_input

### DIFF
--- a/cfme/tests/infrastructure/test_advanced_search_vms.py
+++ b/cfme/tests/infrastructure/test_advanced_search_vms.py
@@ -78,7 +78,7 @@ def test_vm_filter_without_user_input(appliance, vm_view, vms, subset_of_vms,
         assert vm in vms_present, "Could not find VM {} after filtering!".format(vm)
 
 
-@pytest.mark.meta(blockers=[BZ(1715550)])
+@pytest.mark.meta(blockers=[BZ(1715550, forced_streams=["5.10", "5.11"])])
 def test_vm_filter_with_user_input(
         appliance, vm_view, vms, subset_of_vms, expression_for_vms_subset):
     """


### PR DESCRIPTION
1. Unfortunately, this test was uncollected because of `required_fields=['large']` - we don't have such providers in yamls, therefore BZ 1715550 was missed.
So I removed it.

2. After that, there was scope mismatch, so I also fixed it.

3. The last problem was with the test itself. As described in the bug, nothing happens when 'Apply" is clicked, therefore this test will never fail as the filtering doesn't occur. I updated the test to check that after filtering the number of VMs is at least less than originally and now the test is failing.

4. Added BZ to block this test.

{{ pytest: -v cfme/tests/infrastructure/test_advanced_search_vms.py}}