### PR TITLE
[RFR] added BZ for ServerCollectLogsEditView is_displayed

### DIFF
--- a/cfme/configure/configuration/diagnostics_settings.py
+++ b/cfme/configure/configuration/diagnostics_settings.py
@@ -17,6 +17,7 @@ from cfme.utils.appliance import NavigatableMixin
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator
+from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 from cfme.utils.pretty import Pretty
 from cfme.utils.timeutil import parsetime
@@ -456,12 +457,16 @@ class ServerCollectLogsEditView(ServerCollectLogsView):
 
     @property
     def is_displayed(self):
-        return(
-            self.in_server_collect_logs and
-            self.depot_type.is_displayed and
-            ('Editing Log Depot Settings for Server'in self.edit_form_title.text or
-             'Editing Log Depot Settings for Zone' in self.edit_form_title.text)
-        )
+        if BZ(1717902).blocks:
+            return (self.in_server_collect_logs and
+                    self.depot_type.is_displayed
+                    )
+        else:
+            return (self.in_server_collect_logs and
+                    self.depot_type.is_displayed and
+                    ('Editing Log Depot Settings for Server' in self.edit_form_title.text or
+                     'Editing Log Depot Settings for Zone' in self.edit_form_title.text)
+                    )
 
 
 class ServerCollectLog(CollectLogsBase):


### PR DESCRIPTION
no tests as rhv43 provider is down (it has a template for log collection)

5.10
![image](https://user-images.githubusercontent.com/42433123/59090850-35ff9300-890e-11e9-8862-c58e5b6214c1.png)

5.11
![image](https://user-images.githubusercontent.com/42433123/59090859-3c8e0a80-890e-11e9-81ff-0e525aec4324.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1717902

Discovered in #8888 failures