### PR TITLE
[1LP][RFR] sprout fixes

### DIFF
--- a/sprout/appliances/tasks.py
+++ b/sprout/appliances/tasks.py
@@ -301,7 +301,7 @@ def kill_appliance(self, appliance_id, replace_in_pool=False, minutes=60):
     try:
         appliance = Appliance.objects.get(id=appliance_id)
     except ObjectDoesNotExist as e:
-        self.logger.error("It seems such appliance %s doesn't exit: %s", appliance_id, str(e))
+        self.logger.error("It seems such appliance %s doesn't exist: %s", appliance_id, str(e))
         return False
 
     workflow = [
@@ -863,7 +863,13 @@ def request_appliance_pool(self, appliance_pool_id, time_minutes):
 
 @singleton_task()
 def apply_lease_times_after_pool_fulfilled(self, appliance_pool_id, time_minutes):
-    pool = AppliancePool.objects.get(id=appliance_pool_id)
+    try:
+        pool = AppliancePool.objects.get(id=appliance_pool_id)
+    except ObjectDoesNotExist as e:
+        self.logger.error("It seems such appliance pool %s doesn't exist: %s", appliance_pool_id,
+                          str(e))
+        return False
+
     if pool.fulfilled:
         pool.logger.info("Applying lease time and renaming appliances")
         for appliance in pool.appliances:
@@ -1483,7 +1489,6 @@ def refresh_appliances_provider(self, provider_id):
             appliance.set_power_state(Appliance.Power.ORPHANED)
         with transaction.atomic():
             appliance.save()
-        retrieve_appliance_ip.delay(appliance.id)  # set the IP
         appliance.set_status('Appliance Refreshed')
 
 
@@ -1659,7 +1664,7 @@ def wait_appliance_ready(self, appliance_id):
                 kill_appliance.delay(appliance_id)
                 return
         if appliance.power_state == Appliance.Power.UNKNOWN or appliance.ip_address is None:
-            retrieve_appliance_ip.delay(appliance_id)
+            retrieve_appliance_ip.delay(appliance_id).get()
             self.retry(args=(appliance_id,), countdown=30, max_retries=45)
         if Appliance.objects.get(id=appliance_id).cfme.ipapp.is_web_ui_running():
             with transaction.atomic():
@@ -1923,7 +1928,7 @@ def disconnect_direct_lun(self, appliance_id):
     try:
         appliance = Appliance.objects.get(id=appliance_id)
     except ObjectDoesNotExist as e:
-        self.logger.error("It seems such appliance %s doesn't exit: %s", appliance_id, str(e))
+        self.logger.error("It seems such appliance %s doesn't exist: %s", appliance_id, str(e))
         return False
 
     if not appliance.provider.is_working:
@@ -1963,7 +1968,11 @@ def appliance_set_hostname(self, appliance_id):
 
 @singleton_task()
 def appliance_set_ansible_url(self, appliance_id):
-    appliance = Appliance.objects.get(id=appliance_id)
+    try:
+        appliance = Appliance.objects.get(id=appliance_id)
+    except ObjectDoesNotExist as e:
+        self.logger.error("It seems such appliance %s doesn't exist: %s", appliance_id, str(e))
+        return False
     if appliance.is_openshift and Version(appliance.version) >= '5.10':
         appliance.cfme.set_ansible_url()
 


### PR DESCRIPTION
We enountered several issues in sprout today.
Those need to be urgently handled because it affects whole sprout task processing queue.
This Pr intends to sort out below issues.
1. calling disconnect_current_lun and kill_appliance for already absent appliance
2. infinite loop in retrieve ip task
3. broken worker in wait_appliance_ready because of wrong callbacks statement
4. removed statements bombing task queue with many tasks.