### PR TITLE
[RFR] Add a default severity for CFME 5.11

### DIFF
--- a/cfme/control/explorer/alerts.py
+++ b/cfme/control/explorer/alerts.py
@@ -25,7 +25,6 @@ from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.log import logger
 from cfme.utils.pretty import Pretty
 from cfme.utils.update import Updateable
-from cfme.utils.version import current_version
 from widgetastic_manageiq import AlertEmail
 from widgetastic_manageiq import MonitorStatusCard
 from widgetastic_manageiq import SNMPForm
@@ -377,7 +376,7 @@ class AlertCollection(BaseCollection):
         view = navigate_to(self, "Add")
         if driving_event is None and evaluate is None:
             driving_event = view.driving_event.all_options[1].text
-        if severity is None and current_version() >= "5.11.0.7":
+        if severity is None and self.appliance.version >= "5.11.0.7":
             # set default severity to "Info" only for "5.11"
             severity = view.severity.all_options[1].text
         # instantiate the alert

--- a/cfme/control/explorer/alerts.py
+++ b/cfme/control/explorer/alerts.py
@@ -25,6 +25,7 @@ from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.log import logger
 from cfme.utils.pretty import Pretty
 from cfme.utils.update import Updateable
+from cfme.utils.version import current_version
 from widgetastic_manageiq import AlertEmail
 from widgetastic_manageiq import MonitorStatusCard
 from widgetastic_manageiq import SNMPForm
@@ -376,6 +377,9 @@ class AlertCollection(BaseCollection):
         view = navigate_to(self, "Add")
         if driving_event is None and evaluate is None:
             driving_event = view.driving_event.all_options[1].text
+        if severity is None and current_version() >= "5.11.0.7":
+            # set default severity to "Info" only for "5.11"
+            severity = view.severity.all_options[1].text
         # instantiate the alert
         alert = self.instantiate(description, severity=severity, active=active, based_on=based_on,
             evaluate=evaluate, driving_event=driving_event,


### PR DESCRIPTION
Purpose or Intent
=================
This BZ https://bugzilla.redhat.com/show_bug.cgi?id=1653427 (and this PR https://github.com/ManageIQ/manageiq-ui-classic/pull/5326) added alert severity back into CFME 5.11. This PR is setting the default severity for created alerts to "Info". "Severity" is a required field, so this is necessary for creating an alert in CFME 5.11. 

{{ pytest: --use-template-cache --long-running cfme/tests/control/test_basic.py::test_alert_crud }}
