### PR TITLE
[1LP][RFR] Added key pair tests for ec2

### DIFF
--- a/cfme/cloud/keypairs.py
+++ b/cfme/cloud/keypairs.py
@@ -2,12 +2,17 @@
 import attr
 from navmazing import NavigateToAttribute
 from navmazing import NavigateToSibling
+from navmazing import NavigationDestinationNotFound
 from widgetastic.exceptions import MoveTargetOutOfBoundsException
+from widgetastic.exceptions import NoSuchElementException
 from widgetastic.widget import View
 from widgetastic_patternfly import BootstrapNav
 from widgetastic_patternfly import BreadCrumb
 from widgetastic_patternfly import Button
+from widgetastic_patternfly import CandidateNotFound
 from widgetastic_patternfly import Dropdown
+
+
 
 from cfme.base.ui import BaseLoggedInPage
 from cfme.common import Taggable
@@ -18,6 +23,7 @@ from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator
+from cfme.utils.wait import TimedOutError
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import Accordion
 from widgetastic_manageiq import BaseEntitiesView
@@ -29,6 +35,7 @@ from widgetastic_manageiq import Search
 from widgetastic_manageiq import SummaryTable
 from widgetastic_manageiq import Text
 from widgetastic_manageiq import TextInput
+
 
 
 class KeyPairToolbar(View):
@@ -184,6 +191,24 @@ class KeyPair(BaseEntity, Taggable):
         view = navigate_to(self, "Details")
         view.toolbar.configuration.item_select('Download private key')
         view.flash.assert_no_error()
+
+    @property
+    def exists(self):
+        try:
+            wait_for(lambda: navigate_to(self, "Details"), num_sec=10, delay=2,
+                     handle_exception=True)
+        except (
+            CandidateNotFound,
+            ItemNotFound,
+            KeyPairNotFound,
+            NameError,
+            NavigationDestinationNotFound,
+            NoSuchElementException,
+            TimedOutError,
+        ):
+            return False
+        else:
+            return True
 
 
 @attr.s

--- a/cfme/tests/cloud/test_keypairs.py
+++ b/cfme/tests/cloud/test_keypairs.py
@@ -6,6 +6,7 @@ from cfme import test_requirements
 from cfme.cloud.keypairs import KeyPairAllView
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.openstack import OpenStackProvider
+from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 
@@ -30,15 +31,15 @@ def keypair(appliance, provider):
 @pytest.mark.tier(3)
 def test_keypair_crud(appliance, provider):
     """ This will test whether it will create new Keypair and then deletes it.
-    Steps:
-        * Provide Keypair name.
-        * Select Cloud Provider.
-        * Also delete it.
-
     Polarion:
-        assignee: mnadeem
+        assignee: mmojzis
         casecomponent: Cloud
+        caseimportance: high
         initialEstimate: 1/4h
+        testSteps:
+            1. Create keypair.
+            2. Read keypair.
+            3. Delete keypair.
     """
     keypair = appliance.collections.cloud_keypairs.create(
         name=fauxfactory.gen_alphanumeric(),
@@ -53,16 +54,15 @@ def test_keypair_crud(appliance, provider):
 @pytest.mark.tier(3)
 def test_keypair_crud_with_key(provider, appliance):
     """ This will test whether it will create new Keypair and then deletes it.
-
-    Steps:
-        * Provide Keypair name.
-        * Select Cloud Provider.
-        * Also delete it.
-
     Polarion:
-        assignee: mnadeem
+        assignee: mmojzis
         casecomponent: Cloud
+        caseimportance: high
         initialEstimate: 1/4h
+        testSteps:
+            1. Create keypair.
+            2. Read keypair.
+            3. Delete keypair.
     """
     key = RSA.generate(1024)
     public_key = key.publickey().exportKey('OpenSSH')
@@ -80,38 +80,33 @@ def test_keypair_crud_with_key(provider, appliance):
 @pytest.mark.tier(3)
 def test_keypair_create_cancel(provider, appliance):
     """ This will test cancelling on adding a keypair
-
-    Steps:
-        * Provide Keypair name.
-        * Select Cloud Provider.
-        * Also delete it.
-
     Polarion:
-        assignee: mnadeem
+        assignee: mmojzis
         casecomponent: WebUI
+        caseimportance: low
         initialEstimate: 1/4h
+        testSteps:
+            1. Cancel creating keypair.
     """
     keypair = appliance.collections.cloud_keypairs.create(
         name="",
         provider=provider,
         cancel=True
     )
-    view = keypair.create_view(KeyPairAllView)
-    assert view.flash.assert_message('Add of new Key Pair was cancelled by the user')
+    assert not keypair.exists
 
 
-@pytest.mark.uncollectif(lambda provider: provider.one_of(OpenStackProvider))
+@pytest.mark.provider([EC2Provider], override=True, scope="module", selector=ONE_PER_TYPE)
 @pytest.mark.tier(3)
 def test_keypair_create_validation(provider, appliance):
     """ This will test validating the new of name of the key pair
-
-    Steps:
-        * Try to add key pair with empty name.
-
     Polarion:
-        assignee: mnadeem
+        assignee: mmojzis
         casecomponent: WebUI
+        caseimportance: low
         initialEstimate: 1/4h
+        testSteps:
+            1. Try to add key pair with empty name.
     """
     keypair_collection = appliance.collections.cloud_keypairs
     view = navigate_to(keypair_collection, 'Add')
@@ -121,21 +116,20 @@ def test_keypair_create_validation(provider, appliance):
 
 @test_requirements.tag
 @pytest.mark.uncollectif(lambda provider: provider.one_of(EC2Provider))
+@pytest.mark.provider([OpenStackProvider], override=True, scope="module", selector=ONE_PER_TYPE)
 def test_keypair_add_and_remove_tag(keypair):
     """ This will test whether it will add and remove tag for newly created Keypair or not
     and then deletes it.
-
-    Steps:
-        * Provide Keypair name.
-        * Select Cloud Provider.
-        * Add tag to Keypair.
-        * Remove tag from Keypair
-        * Also delete it.
-
     Polarion:
         assignee: anikifor
         casecomponent: Tagging
         initialEstimate: 1/4h
+        testSteps:
+            1. Create keypair.
+            2. Read keypair.
+            3. Add tag to Keypair.
+            4. Remove tag from Keypair.
+            5. Delete keypair.
     """
     added_tag = keypair.add_tag()
     tagged_value = keypair.get_tags()
@@ -160,8 +154,9 @@ def test_keypair_add_and_remove_tag(keypair):
 def test_download_private_key(keypair):
     """
     Polarion:
-        assignee: mnadeem
+        assignee: mmojzis
         casecomponent: Cloud
+        caseimportance: medium
         initialEstimate: 1/4h
     """
     keypair.download_private_key()

--- a/cfme/tests/test_manual.py
+++ b/cfme/tests/test_manual.py
@@ -1915,26 +1915,6 @@ def test_utilization_cluster():
 
 
 @pytest.mark.manual
-@test_requirements.service
-@pytest.mark.tier(3)
-def test_add_cloud_key_pair():
-    """
-    Add Cloud key pair
-    Add Ec2 provider, Clouds - Key pair, Give any name , select provider.
-    Click on Add .
-
-    Polarion:
-        assignee: mmojzis
-        casecomponent: Services
-        caseimportance: medium
-        initialEstimate: 1/16h
-        startsin: 5.5
-        title: Add Cloud Key pair
-    """
-    pass
-
-
-@pytest.mark.manual
 def test_osp_vmware65_test_vm_with_multiple_nics_with_single_ip_ipv6_to_first_nic_and_ipv4_to_():
     """
     OSP: vmware65-Test VM with multiple NICs with single IP (IPv6 to first
@@ -3492,24 +3472,6 @@ def test_osp_test_migration_using_vddk_connection_type_for_vmware():
         startsin: 5.10
         subcomponent: OSP
         title: OSP: Test Migration using VDDK (Connection type for VMware)
-    """
-    pass
-
-
-@pytest.mark.manual
-@test_requirements.service
-@pytest.mark.tier(3)
-def test_cloud_key_pair_validation():
-    """
-    Cloud - Key pair - without filling data , click on add
-
-    Polarion:
-        assignee: mmojzis
-        casecomponent: Services
-        caseimportance: medium
-        initialEstimate: 1/16h
-        startsin: 5.5
-        title: Cloud Key pair validation
     """
     pass
 


### PR DESCRIPTION
Added key pair tests for ec2
It's failing for 5.11 - when I fix all 5.10 problems with automation I will start fixing 5.11.
Also it was failing in 5.10 when calling keypair.exists so I overriden that method and added wait_for which fixes it. I know this is dumb fix, but didn't find any better way. So if you know how to fix it better then please tell me. Thanks.