### PR TITLE
[1LP][RFR] Change naming of widgets, use button click method for ExpressionEditor

### DIFF
--- a/widgetastic_manageiq/expression_editor.py
+++ b/widgetastic_manageiq/expression_editor.py
@@ -145,7 +145,6 @@ class ExpressionEditor(View, Pretty):
     def __locator__(self):
         return self.ROOT
 
-    # TODO: update these methods to use the button's click method
     def click_undo(self):
         self.undo.click()
 
@@ -213,14 +212,13 @@ class ExpressionEditor(View, Pretty):
         els = self.browser.elements(self.EXPRESSION_TEXT, parent=self._expressions_root)
         if len(els) > 1:
             return False
-        no_expression_text = "???" if self.browser.product_version < "5.10" else "<new element>"
-        return self.expression_text == no_expression_text
+        return self.expression_text == "<new element>"
 
     def any_expression_present(self):
         return not self.no_expression_present()
 
     def is_editing(self):
-        no_expression_text = "???" if self.browser.product_version < "5.10" else "<new element>"
+        no_expression_text = "<new element>"
         try:
             self.browser.element(
                 "{}[contains(normalize-space(text()), {})]".format(


### PR DESCRIPTION
Minor refactor of the `expression_editor` to,

1. Remove lingering CFME 5.9 refs
2. Rename widgets to lowercase
3. Make use of built-in button `click` method

{{ pytest: --use-template-cache --long-running cfme/tests/control/test_basic.py::test_modify_condition_expression }}
