### PR TITLE
[WIP] Set the wait_time in the sprout_appliances.

### DIFF
--- a/cfme/fixtures/appliance.py
+++ b/cfme/fixtures/appliance.py
@@ -29,6 +29,7 @@ def sprout_appliances(
     stream=None,
     provider_type=None,
     version=None,
+    wait_time=1800,
     **kwargs
 ):
     """ Provisions one or more appliances for testing
@@ -56,6 +57,7 @@ def sprout_appliances(
         preconfigured=preconfigured,
         stream=req_stream,
         lease_time=lease_time,
+        wait_time=wait_time,
         **kwargs
     )
     try:

--- a/cfme/tests/pod/test_appliance_crud.py
+++ b/cfme/tests/pod/test_appliance_crud.py
@@ -190,7 +190,6 @@ def temp_pod_appliance(appliance, provider, appliance_data, pytestconfig):
             provider_type='openshift',
             provider=provider.key,
             template_type='openshift_pod',
-            wait_time='1800'
     ) as appliances:
         with appliances[0] as appliance:
             appliance.openshift_creds = appliance_data['openshift_creds']


### PR DESCRIPTION
Getting an appliance from sprout started to fail on timeout:

cfme/fixtures/appliance.py:59: in sprout_appliances
    **kwargs
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = SproutClient(_proto='http', _host='infra-sprout.cfme2.lab.eng.rdu2.redhat.com', _port=80, _entry='appliances/api', _auth=('dockerbot', 'DKBRulz'))
count = 1, preconfigured = False, version = '5.10.6.0'
stream = 'downstream-510z', provider = None, provider_type = 'rhevm'
lease_time = 120, ram = None, cpu = None, kwargs = {}, wait_time = 900

    def provision_appliances(
            self, count=1, preconfigured=False, version=None, stream=None, provider=None,
            provider_type=None, lease_time=60, ram=None, cpu=None, **kwargs):
        # provisioning may take more time than it is expected in some cases
        wait_time = kwargs.pop('wait_time', 900)
        # If we specify version, stream is ignored because we will get that specific version
        if version:
            stream = get_stream(version)
        # If we specify stream but not version, sprout will give us latest version of that stream
        elif stream:
            pass
        # If we dont specify either, we will get the same version as current appliance
        else:
            stream = get_stream(current_appliance.version)
            version = current_appliance.version.vstring
        request_id = self.call_method(
            'request_appliances',
            preconfigured=preconfigured,
            version=version,
            provider_type=provider_type,
            group=stream,
            provider=provider,
            lease_time=lease_time,
            ram=ram,
            cpu=cpu,
            count=count,
            **kwargs
        )
        wait_for(
            lambda: self.call_method('request_check', str(request_id))['finished'],
            num_sec=wait_time,
>           message='provision {} appliance(s) from sprout'.format(count))
E       TimedOutError: Could not do provision 1 appliance(s) from sprout at /cfme_tests_te/cfme/test_framework/sprout/client.py:131 in time

This patch sets the timeout to 1800 seconds and removes setting of such
timeout from one callee of the sprout_appliances to prevent args name clash.