### PR TITLE
[1LP][RFR] Fix python command for test_send_test_email

### DIFF
--- a/cfme/utils/net.py
+++ b/cfme/utils/net.py
@@ -100,7 +100,7 @@ def net_check_remote(port, addr=None, machine_addr=None, ssh_creds=None, force=F
             )
         with ssh_client:
             # on exception => fails with return code 1
-            cmd = '''python -c "
+            cmd = '''python2 -c "
 import sys, socket
 addr = socket.gethostbyname('%s')
 socket.create_connection((addr, %d), timeout=10)


### PR DESCRIPTION
Purpose or Intent
==============

test_send_test_email fails in 5.11 because it runs the following command on the appliance:

cfme/utils/net.py:
****
def net_check_remote(port, addr=None, machine_addr=None, ssh_creds=None, force=False):
[...]
        with ssh_client:
            # on exception => fails with return code 1
            cmd = '''python -c "
import sys, socket
addr = socket.gethostbyname('%s')
socket.create_connection((addr, %d), timeout=10)
sys.exit(0)
            "''' % (addr, port)
            result = ssh_client.run_command(cmd)
[...]
****
The "python" symlink doesn't exist in 5.11:

# python
-bash: python: command not found
# ll /usr/bin/python*
lrwxrwxrwx. 1 root root    9 Dec 14 13:21 /usr/bin/python2 -> python2.7
-rwxr-xr-x. 1 root root 9264 Dec 14 13:21 /usr/bin/python2.7
lrwxrwxrwx. 1 root root   25 Jun  5 13:52 /usr/bin/python3 -> /etc/alternatives/python3
lrwxrwxrwx. 1 root root   31 Jan 23 13:39 /usr/bin/python3.6 -> /usr/libexec/platform-python3.6
lrwxrwxrwx. 1 root root   32 Jan 23 13:39 /usr/bin/python3.6m -> /usr/libexec/platform-python3.6m

Changing the command to use 'python2' resolves the issue. (CFME 5.10 and earlier only have python2, so using python2 instead of python3 ensures that the test runs successfully on all versions of CFME.)

{{ pytest: cfme/tests/configure/test_email.py -k test_send_test_email -vvvv }}