### PR TITLE
[RFR] Add a widget to deal with sectioned bootstrap selects, fix action tests

### DIFF
--- a/cfme/control/explorer/actions.py
+++ b/cfme/control/explorer/actions.py
@@ -19,9 +19,12 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.pretty import Pretty
 from cfme.utils.update import Updateable
+from cfme.utils.version import Version
+from cfme.utils.version import VersionPicker
 from widgetastic_manageiq import CheckboxSelect
 from widgetastic_manageiq import ManageIQTree
 from widgetastic_manageiq import MultiBoxSelect
+from widgetastic_manageiq import SectionedBootstrapSelect
 from widgetastic_manageiq import SummaryFormItem
 
 
@@ -63,7 +66,10 @@ class ActionFormCommon(ControlExplorerView):
     email_recipient = Input("to")
     vcenter_attr_name = Input("attribute")
     vcenter_attr_value = Input("value")
-    tag = ManageIQTree("action_tags_treebox")
+    tag = VersionPicker({
+        Version.lowest(): ManageIQTree("action_tags_treebox"),
+        "5.11": SectionedBootstrapSelect("tag")
+    })
     remove_tag = CheckboxSelect("action_options_div")
     run_ansible_playbook = View.nested(RunAnsiblePlaybookFromView)
     cancel_button = Button("Cancel")

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -54,6 +54,7 @@ from widgetastic_patternfly import Button
 from widgetastic_patternfly import Dropdown
 from widgetastic_patternfly import Input
 from widgetastic_patternfly import NavDropdown
+from widgetastic_patternfly import SelectItemNotFound
 from widgetastic_patternfly import SelectorDropdown
 from widgetastic_patternfly import Tab
 from widgetastic_patternfly import VerticalNavigation
@@ -92,6 +93,83 @@ class ManageIQTree(BootstrapTreeview):
             return result
         else:
             return None
+
+
+class SectionedBootstrapSelect(BootstrapSelect):
+    """ Refactor to allow for bootstrap select that have sections. """
+
+    SectionOption = namedtuple("SectionOption", ["text", "value", "section_id"])
+    SECTIONS = ".//li[contains(@class, 'dropdown-header')]"
+    OPTIONS = ".//li[contains(@class, 'data-original-index') and contains(@class, 'data-optgroup')]"
+    SECTION_ELEMENTS = './/li[@data-optgroup="{}"]'
+
+    @property
+    def all_sections(self):
+        return [
+            self.Option(self.browser.text(el), el.get_attribute("data-optgroup"))
+            for el in self.browser.elements(self.SECTIONS, parent=self)
+        ]
+
+    @property
+    def all_options(self):
+        return [
+            self.SectionOption(
+                self.browser.text(
+                    self.browser.element(".//span[contains(@class, 'text')]", parent=el)
+                ),
+                el.get_attribute("data-original-index"),
+                el.get_attribute("data-optgroup"),
+            )
+            for el in self.browser.elements("./div/ul/li", parent=self)
+            if not el.get_attribute("class")
+        ]
+
+    def get_section_id_by_text(self, text):
+        for section in self.all_sections:
+            if section.text == text:
+                return section.value
+        raise NoSuchElementException("No section named {}".format(text))
+
+    def get_elements_in_section(self, text):
+        return self.browser.elements(
+            self.SECTION_ELEMENTS.format(self.get_section_id_by_text(text))
+        )
+
+    def select_item_in_section(self, section_text, item_text):
+        """ Selects an element in a section, only supports a single item
+
+        Args:
+            item_text: text of the item in the section
+            section_text: text of the section which contains the item
+        """
+        self.open()
+        # get the elements in the section
+        section_elements = self.get_elements_in_section(section_text.upper())
+        for el in section_elements:
+            try:
+                text_element = self.browser.element(".//span[contains(@class, 'text')]", parent=el)
+            except NoSuchElementException:
+                continue
+            if self.browser.text(text_element) == item_text:
+                self.browser.click(text_element)
+                self.close()
+                break
+        else:
+            raise SelectItemNotFound(
+                widget=self, item=item_text, options=[opt.text for opt in self.all_options]
+            )
+
+    def fill(self, values):
+        """ Values is assumed to have the tag category and the tag name """
+        before = self.selected_option
+        if len(values) == 3:
+            section_text = values[1]
+        else:
+            section_text = values[0]
+        item_text = values[-1]
+        self.select_item_in_section(section_text, item_text)
+        after = self.selected_option
+        return before != after
 
 
 class SummaryFormItem(Widget):

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -101,12 +101,16 @@ class SectionedBootstrapSelect(BootstrapSelect):
     SectionOption = namedtuple("SectionOption", ["text", "value", "section_id"])
     SECTIONS = ".//li[contains(@class, 'dropdown-header')]"
     OPTIONS = ".//li[contains(@class, 'data-original-index') and contains(@class, 'data-optgroup')]"
+    OPTION_ITEMS = "./div/ul/li"
     SECTION_ELEMENTS = './/li[@data-optgroup="{}"]'
+    GROUP_INDEX = "data-optgroup"
+    ITEM_INDEX = "data-original-index"
+    ITEM_TEXT = ".//span[contains(@class, 'text')]"
 
     @property
     def all_sections(self):
         return [
-            self.Option(self.browser.text(el), el.get_attribute("data-optgroup"))
+            self.Option(self.browser.text(el), el.get_attribute(self.GROUP_INDEX))
             for el in self.browser.elements(self.SECTIONS, parent=self)
         ]
 
@@ -114,13 +118,11 @@ class SectionedBootstrapSelect(BootstrapSelect):
     def all_options(self):
         return [
             self.SectionOption(
-                self.browser.text(
-                    self.browser.element(".//span[contains(@class, 'text')]", parent=el)
-                ),
-                el.get_attribute("data-original-index"),
-                el.get_attribute("data-optgroup"),
+                self.browser.text(self.browser.element(self.ITEM_TEXT, parent=el)),
+                el.get_attribute(self.ITEM_INDEX),
+                el.get_attribute(self.GROUP_INDEX),
             )
-            for el in self.browser.elements("./div/ul/li", parent=self)
+            for el in self.browser.elements(self.OPTION_ITEMS, parent=self)
             if not el.get_attribute("class")
         ]
 
@@ -147,7 +149,7 @@ class SectionedBootstrapSelect(BootstrapSelect):
         section_elements = self.get_elements_in_section(section_text.upper())
         for el in section_elements:
             try:
-                text_element = self.browser.element(".//span[contains(@class, 'text')]", parent=el)
+                text_element = self.browser.element(self.ITEM_TEXT, parent=el)
             except NoSuchElementException:
                 continue
             if self.browser.text(text_element) == item_text:


### PR DESCRIPTION
Implementing a widget to deal with sectioned bootstrap selects, like the one present on the actions tagging page. 

This is meant to address the changes brought in CFME 5.11 with https://github.com/ManageIQ/manageiq-ui-classic/pull/5535

Since that page is not in the final state, this widget is more of a hack than a full-fledged implementation. The single bootstrap select will eventually be replaced by the tagging editor, which is essentially two bootstrap selects (one for the tag category, and one for the tag itself). This PR is a workaround until https://bugzilla.redhat.com/show_bug.cgi?id=1715397 is fixed. 

Fixes broken action tests which are impacting many tests that follow them.  

{{ pytest: --use-template-cache --long-running cfme/tests/control/test_basic.py::test_action_crud }}
