### PR TITLE
[1LP][RFR] Simplify return in template_upload, null cache for sprout.Appliance.v…

### DIFF
--- a/cfme/utils/template/base.py
+++ b/cfme/utils/template/base.py
@@ -380,8 +380,7 @@ class ProviderTemplateUpload(object):
             try:
                 out = self.execute_ssh_command('systemctl status appliance-initialize',
                                                client_args=client_args)
-                return True if all(
-                    check in out.output for check in app_init_complete_check) else False
+                return all(check in out.output for check in app_init_complete_check)
             except Exception:
                 # Have seen instances where IP is resolvable but SSH connect failed.
                 logger.info('SSH connection failed, trying again')
@@ -407,6 +406,7 @@ class ProviderTemplateUpload(object):
         # Check to make sure appliance-initialization has run
         wait_for(func=check_appliance_init,
                  func_args=[client_args],
+                 fail_condition=False,
                  delay=5,
                  timeout=300,
                  message='Waiting for appliance-initialization to complete')

--- a/sprout/appliances/tasks.py
+++ b/sprout/appliances/tasks.py
@@ -1784,6 +1784,7 @@ def appliance_rename(self, appliance_id):
         self.logger.info("Renaming {}/{} to {}".format(appliance_id, appliance.name, new_name))
         appliance.vm_mgmt.rename(new_name)
         appliance.name = new_name
+        del appliance.vm_mgmt  # its cached and based on appliance VM name
         appliance.save(update_fields=['name'])
     return appliance.name
 


### PR DESCRIPTION
After renaming appliance, cached vm_mgmt property is invalid and returns None.