### PR TITLE
[1LP][RFR] New Test: Testing object attributes on simulation page

### DIFF
--- a/cfme/tests/automate/test_simulation.py
+++ b/cfme/tests/automate/test_simulation.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from cfme import test_requirements
+from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import BZ
+
+pytestmark = [test_requirements.automate, pytest.mark.tier(2)]
+
+
+def test_object_attributes(appliance):
+    """
+    Polarion:
+        assignee: ghubale
+        casecomponent: Automate
+        caseimportance: medium
+        initialEstimate: 1/16h
+
+    Bugzilla:
+        1719322
+    """
+    view = navigate_to(appliance.server, "AutomateSimulation")
+    # Collecting all the options available for object attribute type
+    for object_type in view.target_type.all_options[1:]:
+        view.reset_button.click()
+        if BZ(1719322, forced_streams=['5.10', '5.11']).blocks and object_type.text in [
+            "Group",
+            "EVM Group",
+            "Tenant",
+        ]:
+            continue
+        else:
+            # Selecting object attribute type
+            view.target_type.select_by_visible_text(object_type.text)
+            # Checking whether dependent objects(object attribute selection) are loaded or not
+            assert view.target_object.all_options > 0


### PR DESCRIPTION
- Testing if object attribute's type and dependent objects to select are loading succefully or not
- This PR contains new file: ```test_simulation.py```. This file will include all the tests related to simulation page.

{{ pytest: cfme/tests/automate/test_simulation.py -k 'test_object_attributes' -vv }}