### PR TITLE
[1LP][RFR] This PR will fix Breadcrumbs issue

### DIFF
--- a/cfme/modeling/base.py
+++ b/cfme/modeling/base.py
@@ -216,7 +216,7 @@ class BaseEntity(NavigatableMixin):
         .. code-block:: python
             expected_breadcrumb = self.context['object'].expected_details_breadcrumb
         """
-        return "{}{}".format(self.name, " (Summary)" if self.appliance.version < "5.11" else "")
+        return "{} (Summary)".format(self.name)
 
 
 @attr.s


### PR DESCRIPTION
PR #8788 introduced breadcrumbs checks for CFME 5.11, as it was different from CFME 5.10. But now devel reverted and looks like CFME 5.10.

By removing CF 5.11 check fix lot's of test failing at `is_displayed`.
I have cross-check `(Summary)` is added there in all files fixed in PR #8788 by navigating to each location.

PRT Run:

{{pytest: cfme/tests/ -k "test_manager_navigation or test_host_good_creds" -svvv --long-running}}
