### PR TITLE
[1LP][RFR] New Test: Testing service provisioning mail error in automation logs

### DIFF
--- a/cfme/tests/services/test_catalog_item.py
+++ b/cfme/tests/services/test_catalog_item.py
@@ -428,6 +428,7 @@ def test_service_provisioning_email(request, appliance, catalog_item):
     Polarion:
         assignee: nansari
         casecomponent: Services
+        caseposneg: negative
         initialEstimate: 1/4h
 
     Bugzilla:


### PR DESCRIPTION
- Testing service provisioning mail error in automation logs
- This test case scenario is based on BZ: 1668004
- This bug was reported on 5.10 but fixed in 5.11 only.

{{ pytest: cfme/tests/services/test_catalog_item.py -k 'test_service_provisioning_email' -vv }}