### PR TITLE
[RFR] fix required icon/request

### DIFF
--- a/cfme/tests/automate/custom_button/test_buttons.py
+++ b/cfme/tests/automate/custom_button/test_buttons.py
@@ -211,7 +211,7 @@ def test_button_required(appliance, field):
             2. Assert flash message.
     """
     unassigned_gp = appliance.collections.button_groups.instantiate(
-        text="[Unassigned Buttons]", hover="Unassigned Buttons", type="Provider"
+        text="[Unassigned Buttons]", hover="Unassigned Buttons", type="VM and Instance"
     )
     button_coll = appliance.collections.buttons
     button_coll.group = unassigned_gp  # Need for supporting navigation


### PR DESCRIPTION
Signed-off-by: Nikhil Dhandre <ndhandre@redhat.com>

Purpose or Intent
=================

In 511 we disabled checkbox other than vm object so this test was failing 


{{pytest: cfme/tests/automate/custom_button/test_buttons.py::test_button_required}}