### PR TITLE
[WIPTEST] Fixed reorder elements in service dialogs

### DIFF
--- a/cfme/automate/dialogs/__init__.py
+++ b/cfme/automate/dialogs/__init__.py
@@ -8,6 +8,7 @@ from widgetastic_patternfly import Input
 from cfme.base.login import BaseLoggedInPage
 from widgetastic_manageiq import Accordion
 from widgetastic_manageiq import DialogButton
+from widgetastic_manageiq import DialogElement
 from widgetastic_manageiq import DragandDropElements
 from widgetastic_manageiq import ManageIQTree
 
@@ -35,6 +36,7 @@ class AutomateCustomizationView(BaseLoggedInPage):
 class DialogForm(AutomateCustomizationView):
     title = Text('//div[@id= "main-content"]//h1')
     sub_title = Text('//div[@id= "main-content"]//h2')
+    element = DialogElement()
 
     label = Input(id='name')
     description = Input(id="description")

--- a/cfme/automate/dialogs/dialog_element.py
+++ b/cfme/automate/dialogs/dialog_element.py
@@ -164,6 +164,7 @@ class Element(BaseEntity):
         if add_element:
             dragged_element = second_element.get('element_information').get('choose_type')
             box_label = second_element.get('element_information').get('ele_label')
+            view.cancel_button.click()
             view.dd.drag_and_drop(dragged_element, box_label)
             view.element.edit_element(dragged_element)
             view.fill(second_element)
@@ -244,4 +245,6 @@ class Edit(CFMENavigateStep):
     prerequisite = NavigateToAttribute('dialog', 'Edit')
 
     def step(self, *args, **kwargs):
-        self.prerequisite_view.element.edit_element("Text Box")
+        self.prerequisite_view.element.edit_element(
+            self.obj.element_data[0]['element_information']['ele_label']
+        )


### PR DESCRIPTION
- This PR fixes ```AttributeError``` for two tests.
- Fixed Error:
```
>       self.prerequisite_view.element.edit_element("Text Box")
E       AttributeError: 'EditDialogView' object has no attribute 'element'

cfme/automate/dialogs/dialog_element.py:247: AttributeError
AttributeError
'EditDialogView' object has no attribute 'element'
```

{{pytest: cfme/tests/automate/test_service_dialog.py -vv }}
