### PR TITLE
[RFR] Add wait_for_web_ui after Restarting Server

### DIFF
--- a/cfme/tests/test_appliance.py
+++ b/cfme/tests/test_appliance.py
@@ -417,6 +417,8 @@ def test_codename_in_log(appliance):
         else:
             return True
 
+    appliance.wait_for_web_ui()
+
 
 def test_codename_in_stdout(appliance):
     """
@@ -436,6 +438,8 @@ def test_codename_in_stdout(appliance):
         r = appliance.ssh_client.run_command(
             r'journalctl -u evmserverd -c "{}" | egrep -i "codename: \w+$"'.format(cursor))
         return r.success
+
+    appliance.wait_for_web_ui()
 
 
 @test_requirements.distributed


### PR DESCRIPTION
Fix the following error seen when running smoke tests:

```INTERNALERROR> APIException: JSONDecodeError: <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
INTERNALERROR> <html><head>
INTERNALERROR> <title>503 Service Unavailable</title>
INTERNALERROR> </head><body>
INTERNALERROR> <h1>Service Unavailable</h1>
INTERNALERROR> <p>The server is temporarily unable to service your
INTERNALERROR> request due to maintenance downtime or capacity
INTERNALERROR> problems. Please try again later.</p>
INTERNALERROR> </body></html>
```

{{ pytest: cfme/tests/test_appliance.py --use-provider complete }}