### PR TITLE
[RFR] Add cleanup to test provision from template using rest

### DIFF
--- a/cfme/tests/cloud_infra_common/test_provisioning.py
+++ b/cfme/tests/cloud_infra_common/test_provisioning.py
@@ -309,7 +309,17 @@ def test_provision_from_template_using_rest(appliance, request, provider, vm_nam
 
     wait_for(
         lambda: instance.exists,
-        num_sec=1000, delay=5, message="VM {} becomes visible".format(vm_name))
+        num_sec=1000, delay=5, message="VM {} becomes visible".format(vm_name)
+    )
+
+    @request.addfinalizer
+    def _cleanup():
+        logger.info('Instance cleanup, deleting %s', instance.name)
+        try:
+            instance.cleanup_on_provider()
+        except Exception as ex:
+            logger.warning('Exception while deleting instance fixture, continuing: {}'
+                           .format(ex.message))
 
 
 VOLUME_METHOD = ("""

--- a/cfme/tests/cloud_infra_common/test_provisioning.py
+++ b/cfme/tests/cloud_infra_common/test_provisioning.py
@@ -14,6 +14,7 @@ from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.infrastructure.provider import InfraProvider
+from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.markers.env_markers.provider import providers
 from cfme.utils import normalize_text
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -288,6 +289,9 @@ def test_provision_approval(appliance, provider, vm_name, smtp_test, request,
 
 @test_requirements.rest
 @pytest.mark.parametrize('auto', [True, False], ids=["Auto", "Manual"])
+@pytest.mark.meta(blockers=[
+    BZ(1720751, unblock=lambda provider: not provider.one_of(SCVMMProvider))
+])
 def test_provision_from_template_using_rest(appliance, request, provider, vm_name, auto):
     """ Tests provisioning from a template using the REST API.
 


### PR DESCRIPTION
Adding cleanup for `test_provision_from_template_using_rest`. This test case will create an instance/vm but does not clean it up when the test is finished. 

In testing this on PRT, I noticed a 5.11 BZ: 
https://bugzilla.redhat.com/show_bug.cgi?id=1720751

So I am adding that BZ as a blocker for the test on SCVMM. 

{{ pytest: --use-provider scvmm --long-running cfme/tests/cloud_infra_common/test_provisioning.py::test_provision_from_template_using_rest }}
