### PR TITLE
[1LP][RFR] Testing invalid value for assertion field

### DIFF
--- a/cfme/tests/automate/test_automate_manual.py
+++ b/cfme/tests/automate/test_automate_manual.py
@@ -479,22 +479,6 @@ def test_automate_git_import_case_insensitive():
     pass
 
 
-@pytest.mark.tier(1)
-def test_assert_failed_substitution():
-    """
-    Polarion:
-        assignee: ghubale
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/4h
-        tags: automate
-
-    Bigzilla:
-        1335669
-    """
-    pass
-
-
 @pytest.mark.tier(3)
 def test_automate_import_namespace_attributes_updated():
     """

--- a/cfme/tests/automate/test_simulation.py
+++ b/cfme/tests/automate/test_simulation.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
+import fauxfactory
 import pytest
 
 from cfme import test_requirements
+from cfme.automate.simulation import simulate
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 
@@ -34,3 +36,51 @@ def test_object_attributes(appliance):
             view.target_type.select_by_visible_text(object_type.text)
             # Checking whether dependent objects(object attribute selection) are loaded or not
             assert view.target_object.all_options > 0
+
+
+@pytest.fixture(scope='function')
+def copy_class(domain):
+    # Take the 'Request' class and copy it to custom domain.
+    domain.parent.instantiate(name="ManageIQ").namespaces.instantiate(
+        name="System"
+    ).classes.instantiate(name="Request").copy_to(domain.name)
+    klass = domain.namespaces.instantiate(name="System").classes.instantiate(name="Request")
+    return klass
+
+
+@pytest.mark.tier(1)
+def test_assert_failed_substitution(copy_class):
+    """
+    Polarion:
+        assignee: ghubale
+        casecomponent: Automate
+        caseimportance: medium
+        initialEstimate: 1/4h
+        caseposneg: negative
+        tags: automate
+
+    Bugzilla:
+        1335669
+    """
+    # Adding instance and invalid value for assertion field - 'guard'
+    instance = copy_class.instances.create(
+        name=fauxfactory.gen_alphanumeric(),
+        display_name=fauxfactory.gen_alphanumeric(),
+        description=fauxfactory.gen_alphanumeric(),
+        fields={'guard': {'value': "${/#this_value_does_not_exist}"}}
+    )
+
+    # Executing automate instance using simulation
+    with pytest.raises(AssertionError,
+                       match="Automation Error: Attribute this_value_does_not_exist not found"):
+        simulate(
+            appliance=copy_class.appliance,
+            attributes_values={
+                "namespace": copy_class.namespace.name,
+                "class": copy_class.name,
+                "instance": instance.name,
+            },
+            message="create",
+            request="Call_Instance",
+            execute_methods=True,
+        )


### PR DESCRIPTION
- Testing invalid value for assertion field in class schema
- Simulation(execution) of instance with invalid value of ```assertion``` type field should give error message on simulation page.

{{ pytest: cfme/tests/automate/test_simulation.py -k 'test_assert_failed_substitution'  -vv }}
