### PR TITLE
[1LP][RFR] New Test: Tesing quota check while provisioning services

### DIFF
--- a/cfme/tests/automate/test_automate_manual.py
+++ b/cfme/tests/automate/test_automate_manual.py
@@ -306,30 +306,6 @@ def test_automate_git_import_deleted_tag():
 
 
 @pytest.mark.tier(1)
-def test_automate_service_quota_runs_only_once():
-    """
-    Polarion:
-        assignee: ghubale
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/4h
-        tags: automate
-        testSteps:
-            1. Provision a service.
-            2. Check the automation.log to see both quota checks, one for
-               ServiceTemplateProvisionRequest_created,
-               and ServiceTemplateProvisionRequest_starting.
-        expectedResults:
-            1.
-            2. Quota executed once.
-
-    Bugzilla:
-        1317698
-    """
-    pass
-
-
-@pytest.mark.tier(1)
 def test_automate_state_method():
     """
     You can pass methods as states compared to the old method of passing

--- a/cfme/tests/automate/test_method.py
+++ b/cfme/tests/automate/test_method.py
@@ -472,4 +472,4 @@ def test_automate_service_quota_runs_only_once(appliance, generic_catalog_item):
     )
     provision_request = service_catalogs.order()
     provision_request.wait_for_request()
-    assert result.match_count()[result.matched_patterns[0]] == 1
+    assert result.matches[result.matched_patterns[0]] == 1

--- a/cfme/tests/automate/test_method.py
+++ b/cfme/tests/automate/test_method.py
@@ -462,9 +462,10 @@ def test_automate_service_quota_runs_only_once(appliance, generic_catalog_item):
     Bugzilla:
         1317698
     """
+    pattern = ".*Getting Tenant Quota Values for:.*"
     result = LogValidator(
         "/var/www/miq/vmdb/log/automation.log",
-        matched_patterns=[".*Getting Tenant Quota Values for:.*"]
+        matched_patterns=[pattern]
     )
     result.fix_before_start()
     service_catalogs = ServiceCatalogs(
@@ -472,4 +473,4 @@ def test_automate_service_quota_runs_only_once(appliance, generic_catalog_item):
     )
     provision_request = service_catalogs.order()
     provision_request.wait_for_request()
-    assert result.matches[result.matched_patterns[0]] == 1
+    assert result.matches[pattern] == 1

--- a/cfme/utils/log_validator.py
+++ b/cfme/utils/log_validator.py
@@ -101,3 +101,12 @@ class LogValidator(object):
             except Failed:
                 return False
         wait_for(validate, delay=delay, num_sec=num_sec, message=message, **kwargs)
+
+    def match_count(self):
+        patterns = {key: 0 for key in self.matched_patterns}
+
+        for line in self._remote_file_tail:
+            for pattern, count in patterns.items():
+                if re.search(pattern, line):
+                    patterns[pattern] = count + 1
+        return patterns

--- a/cfme/utils/log_validator.py
+++ b/cfme/utils/log_validator.py
@@ -101,12 +101,3 @@ class LogValidator(object):
             except Failed:
                 return False
         wait_for(validate, delay=delay, num_sec=num_sec, message=message, **kwargs)
-
-    def match_count(self):
-        patterns = {key: 0 for key in self.matched_patterns}
-
-        for line in self._remote_file_tail:
-            for pattern, count in patterns.items():
-                if re.search(pattern, line):
-                    patterns[pattern] = count + 1
-        return patterns


### PR DESCRIPTION
- Testing whether quota check is done for once while provisioning services
- This line: ```Getting Tenant Quota Values for:``` should be visible once in automation logs
- Added ```match_count``` function in ```logvalidator```

Waiting for this PR #8918 

{{ pytest: cfme/tests/automate/test_method.py -k 'test_automate_service_quota_runs_only_once' -vv }}