### PR TITLE
[WIP]Adding new test of service retire manual approval

### DIFF
--- a/cfme/tests/services/test_service_manual_approval.py
+++ b/cfme/tests/services/test_service_manual_approval.py
@@ -8,6 +8,7 @@ from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.services.service_catalogs import ServiceCatalogs
+from cfme.utils.appliance import ViaUI
 from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 from cfme.utils.update import update
@@ -24,6 +25,36 @@ pytestmark = [
                                           ['provisioning', 'datastore']],
                          scope="module"),
 ]
+
+
+@pytest.fixture(scope="function")
+def retirement_domain(request, appliance):
+    """Create new domain and copy instance from ManageIQ to this domain"""
+
+    dc = DomainCollection(appliance)
+    new_domain = dc.create(name=fauxfactory.gen_alphanumeric(), enabled=True)
+    request.addfinalizer(new_domain.delete_if_exists)
+    instance = (dc.instantiate(name='ManageIQ')
+        .namespaces.instantiate(name='Service')
+        .namespaces.instantiate(name='Retirement')
+        .namespaces.instantiate(name='StateMachines')
+        .classes.instantiate(name='ServiceRetirementRequestApproval')
+        .instances.instantiate(name='Default'))
+    instance.copy_to(new_domain)
+    return new_domain
+
+
+@pytest.fixture(scope="function")
+def retirement_instance(retirement_domain):
+    """Modify the instance in new domain to change it to manual approval instead of auto"""
+
+    instance = (retirement_domain.namespaces.instantiate(name='Service')
+        .namespaces.instantiate(name='Retirement')
+        .namespaces.instantiate(name='StateMachines')
+        .classes.instantiate(name='ServiceRetirementRequestApproval')
+        .instances.instantiate(name='Default'))
+    with update(instance):
+        instance.fields = {"approval_type": {"value": "manual"}}
 
 
 @pytest.fixture(scope="function")
@@ -87,3 +118,42 @@ def test_service_manual_approval(appliance, provider, modify_instance,
                                                                  partial_check=True)
     service_request.update(method='ui')
     assert service_request.row.approval_state.text == 'Pending Approval'
+
+
+def test_service_retire_manual_approval(appliance, service_vm, retirement_instance):
+    """" Test service retirement manual approval
+
+    Polarion:
+        assignee: nansari
+        initialEstimate: 1/2h
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.9
+        casecomponent: Services
+        setup:
+            1. Set Service retirement manual approval instead of auto
+        testSteps:
+            1. Add Service Catalog, Order the Service
+            2. Retire the service
+            3. Navigate to Service retirement request Details page
+            4. Manually approve the service retirement request
+        expectedResults:
+            1.
+            2.
+            3.
+            4. Admin should able to approve the retirement request
+
+    Bugzilla:
+        1697600
+    """
+    service, _ = service_vm
+    with appliance.context.use(ViaUI):
+        service.retire()
+        request_description = 'Service Retire for: {name}'.format(name=service.name)
+        service_request = appliance.collections.requests.instantiate(
+            description=request_description,
+            partial_check=True)
+        service_request.update(method='ui')
+        assert service_request.row.approval_state.text == 'Pending Approval'
+        service_request.approve_request(method='ui', reason="Approved")
+        assert service_request.row.approval_state.text == 'Approved'


### PR DESCRIPTION

Purpose or Intent
=================
{{ pytest: cfme/tests/services/test_service_manual_approval.py -k 'test_service_retire_manual_approval' --long-running --use-template-cache -sqvvv }}