### PR TITLE
[RFR]Vds ui tests

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -66,7 +66,6 @@ from widgetastic_manageiq import SnapshotMemorySwitch
 from widgetastic_manageiq import SummaryTable
 from widgetastic_manageiq import Table
 from widgetastic_manageiq import TimelinesView
-from widgetastic_manageiq.vm_reconfigure import CDDVDTable
 from widgetastic_manageiq.vm_reconfigure import DisksTable
 
 

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -66,6 +66,7 @@ from widgetastic_manageiq import SnapshotMemorySwitch
 from widgetastic_manageiq import SummaryTable
 from widgetastic_manageiq import Table
 from widgetastic_manageiq import TimelinesView
+from widgetastic_manageiq.vm_reconfigure import CDDVDTable
 from widgetastic_manageiq.vm_reconfigure import DisksTable
 
 


### PR DESCRIPTION
Purpose or Intent
=================


__Adding tests__ for feature  DVSwitch displayed and tagging. 

Depends on merge of #8942 to fix Tagging UI. 

{{pytest: cfme/tests/infrastructure/test_vmware_provider.py --use-provider complete -k 'test_vmware_vds_ui' }}