### PR TITLE
[1LP][RFR] Global fixture update and some tests tag fix

### DIFF
--- a/cfme/ansible/credentials.py
+++ b/cfme/ansible/credentials.py
@@ -461,7 +461,7 @@ class EditTagsFromListCollection(CFMENavigateStep):
             row = self.prerequisite_view.paginator.find_row_on_pages(
                 table=self.prerequisite_view.credentials,
                 name=self.obj.name)
-            row[0].click()
+            row[0].check()
         except NoSuchElementException:
             raise ItemNotFound('Could not locate ansible credential table row with name {}'
                                .format(self.obj.name))

--- a/cfme/ansible/repositories.py
+++ b/cfme/ansible/repositories.py
@@ -368,7 +368,7 @@ class EditTagsFromListCollection(CFMENavigateStep):
             row = self.prerequisite_view.paginator.find_row_on_pages(
                 table=self.prerequisite_view.entities,
                 name=self.obj.name)
-            row[0].click()
+            row[0].check()
         except NoSuchElementException:
             raise ItemNotFound('Could not locate ansible repository table row with name {}'
                                .format(self.obj.name))

--- a/cfme/tests/ansible/test_embedded_ansible_tags.py
+++ b/cfme/tests/ansible/test_embedded_ansible_tags.py
@@ -2,10 +2,12 @@ import fauxfactory
 import pytest
 
 from cfme import test_requirements
+from cfme.utils.blockers import BZ
 from cfme.utils.wait import wait_for
 
 pytestmark = [
     pytest.mark.long_running,
+    pytest.mark.meta(blockers=[BZ(1677548, forced_streams=["5.11"])]),
     test_requirements.ansible,
     test_requirements.tag,
 ]


### PR DESCRIPTION
Blocking this test(s) for CFME 5.11 due to BZ.

PRT Run:

{{ pytest: cfme/tests/ansible/test_embedded_ansible_tags.py -k "test_tag_ansible_repository or test_tagvis_ansible_repository" -svvvv --long-running }}