### PR TITLE
[1LP][RFR] Automating Ansible Service Verbosity tests

### DIFF
--- a/cfme/tests/ansible/test_embedded_ansible_manual.py
+++ b/cfme/tests/ansible/test_embedded_ansible_manual.py
@@ -138,22 +138,6 @@ def test_embed_tower_monitor_resources():
     pass
 
 
-@pytest.mark.tier(3)
-def test_embed_tower_exec_play_stdout():
-    """
-    User/Admin is able to execute playbook and see stdout of it once
-    completed.
-
-    Polarion:
-        assignee: sbulage
-        casecomponent: Ansible
-        caseimportance: medium
-        initialEstimate: 1h
-        tags: ansible_embed
-    """
-    pass
-
-
 @pytest.mark.tier(2)
 def test_embed_ansible_next_gen():
     """
@@ -370,21 +354,6 @@ def test_embed_tower_exec_play_against_openstack():
     pass
 
 
-@pytest.mark.tier(3)
-def test_embed_tower_add_public_repo():
-    """
-    Ability to add public repo (without SCM credentials).
-
-    Polarion:
-        assignee: sbulage
-        casecomponent: Ansible
-        caseimportance: critical
-        initialEstimate: 1/6h
-        tags: ansible_embed
-    """
-    pass
-
-
 @pytest.mark.tier(1)
 def test_embed_tower_ui_requests_notifications():
     """
@@ -448,25 +417,6 @@ def test_embed_tower_credentials():
         caseimportance: critical
         initialEstimate: 1/12h
         tags: ansible_embed
-    """
-    pass
-
-
-@pytest.mark.tier(3)
-def test_embed_tower_enhanced_playbook_debug():
-    """
-    Enable Embedded Ansible and add repo with playbooks. Try to create new
-    service dialog and try to order the service. In the dialog, there
-    should be option to enable debugging of the playbook (I believe the
-    playbook is executed with -vvv option).
-
-    Polarion:
-        assignee: sbulage
-        casecomponent: Ansible
-        caseimportance: medium
-        initialEstimate: 1h
-        tags: ansible_embed
-        upstream: yes
     """
     pass
 
@@ -732,23 +682,6 @@ def test_service_ansible_playbook_with_already_existing_catalog_item_name():
         casecomponent: Ansible
         caseimportance: medium
         initialEstimate: 1/6h
-        tags: ansible_embed
-    """
-    pass
-
-
-@pytest.mark.tier(3)
-def test_service_ansible_verbosity():
-    """
-    BZ 1460788
-    Check if the different Verbosity levels can be applied to service and
-    monitor the std out
-
-    Polarion:
-        assignee: sbulage
-        casecomponent: Ansible
-        caseimportance: medium
-        initialEstimate: 1/2h
         tags: ansible_embed
     """
     pass

--- a/cfme/tests/ansible/test_embedded_ansible_services.py
+++ b/cfme/tests/ansible/test_embedded_ansible_services.py
@@ -639,7 +639,6 @@ def test_embed_tower_exec_play_against(
 @pytest.mark.tier(2)
 @pytest.mark.meta(automates=[BZ(1460788)])
 def test_service_ansible_verbosity(
-    request,
     ansible_catalog_item,
     ansible_service_catalog,
     ansible_service_request,
@@ -662,15 +661,20 @@ def test_service_ansible_verbosity(
         ansible_catalog_item.provisioning = {"verbosity": "3 (Debug)"}
         ansible_catalog_item.retirement = {"verbosity": "3 (Debug)"}
 
-    @request.addfinalizer
-    def _revert():
-        with update(ansible_catalog_item):
-            ansible_catalog_item.provisioning = {"verbosity": "0 (Normal)"}
-            ansible_catalog_item.retirement = {"verbosity": "0 (Normal)"}
-
     ansible_service_catalog.order()
     ansible_service_request.wait_for_request()
     view = navigate_to(ansible_service, "Details")
     # '3' denotes Debug level verbosity which is passed in the catalog creation.
     assert "3" == view.provisioning.details.get_text_of("Verbosity")
     assert "3" == view.retirement.details.get_text_of("Verbosity")
+    # Resetting verbosity value back to '0'
+    with update(ansible_catalog_item):
+        ansible_catalog_item.provisioning = {"verbosity": "0 (Normal)"}
+        ansible_catalog_item.retirement = {"verbosity": "0 (Normal)"}
+
+    ansible_service_catalog.order()
+    ansible_service_request.wait_for_request()
+    view = navigate_to(ansible_service, "Details")
+    # '0' denotes  level verbosity which is passed in the catalog creation.
+    assert "0" == view.provisioning.details.get_text_of("Verbosity")
+    assert "0" == view.retirement.details.get_text_of("Verbosity")


### PR DESCRIPTION
Removed few already automated tests `test_embed_tower_add_public_repo`  and added New test for `test_embed_tower_exec_play_stdout, test_embed_tower_enhanced_playbook_debug and test_service_ansible_verbosity` -->  Ansible Service with Verbosity.

PRT Run:

{{ pytest: cfme/tests/ansible/test_embedded_ansible_services.py -k test_service_ansible_verbosity -svvvv --long-running }}