### PR TITLE
[1LP][RFR] Remove blocker for resolved bz 1656873

### DIFF
--- a/cfme/tests/configure/test_workers.py
+++ b/cfme/tests/configure/test_workers.py
@@ -4,7 +4,6 @@ from collections import namedtuple
 import pytest
 
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.blockers import BZ
 from cfme.utils.wait import wait_for
 
 Dropdown = namedtuple('Dropdown', 'dropdown id')
@@ -48,7 +47,6 @@ def test_restart_workers(appliance):
 
 @pytest.mark.tier(2)
 @pytest.mark.parametrize("dropdown", [x.dropdown for x in DROPDOWNS], ids=[x.id for x in DROPDOWNS])
-@pytest.mark.meta(blockers=[BZ(1656873)])
 def test_set_memory_threshold_in_ui(appliance, dropdown):
     """
     Bugzilla:


### PR DESCRIPTION
Purpose or Intent
==============

Removing blocker for resolved BZ 1656873. test_set_memory_threshold_in_ui test cases should now run successfully.

{{ pytest: cfme/tests/configure/test_workers.py -k test_set_memory_threshold_in_ui -vvvv }}