### PR TITLE
[RFR] Skip the cluster test if the host is unclustered

### DIFF
--- a/cfme/tests/cloud_infra_common/test_relationships.py
+++ b/cfme/tests/cloud_infra_common/test_relationships.py
@@ -106,6 +106,8 @@ def get_obj(relationship, appliance, **kwargs):
         provider = kwargs.get("provider")
         view = navigate_to(host, "Details")
         cluster_name = view.entities.summary("Relationships").get_text_of("Cluster")
+        if cluster_name == "None":
+            pytest.skip("Host {} is not a clustered host".format(host.name))
         obj = cluster_col.instantiate(name=cluster_name, provider=provider)
     elif relationship in ["Datastores", "VMs", "Templates"]:
         obj = kwargs.get("host")


### PR DESCRIPTION
@ganeshhubale pointed out that this `test_host_relationships` would sometimes fail on SCVMM providers. This is because not all of the hosts on SCVMM are clustered hosts. For the portion of the test that checks the `Cluster` link, if a host is unclustered, I have implemented a skip. 

@ganeshhubale, @jawatts and I discussed also passing in this case, since CFME is properly reporting the relationship for that particular host, i.e. that the host is not clustered. What do you think? 

{{ pytest: --use-provider scvmm --use-template-cache cfme/tests/cloud_infra_common/test_relationships.py::test_host_relationships }}
