### PR TITLE
[NOTEST][RFR]Removing test test_vmware_guests_linked_clone as this feature is no longer valid

### DIFF
--- a/cfme/tests/infrastructure/test_vmware_provider.py
+++ b/cfme/tests/infrastructure/test_vmware_provider.py
@@ -103,41 +103,6 @@ def test_vmware_vds_ui_display(soft_assert, appliance, provider):
         'on networking page')
 
 
-@pytest.mark.manual
-@pytest.mark.tier(1)
-def test_vmware_guests_linked_clone():
-    """
-    VMware guests are incorrectly marked as linked_clone true, remove attribute
-    VMs are incorrectly marked as Linked Clones.
-    Every VM discovered from VMware provider has "linked_clone": true.
-    However, none of the VMs is sharing a disk or has a snapshot.
-    Ideally they shouldn't mark them all as linked_clone=t
-
-    Bugzilla:
-        1588908
-
-    Polarion:
-        assignee: kkulkarn
-        casecomponent: Infra
-        caseimportance: critical
-        initialEstimate: 1/3h
-        testtype: integration
-        testSteps:
-            1.Integrate VMware provider in CFME
-            2.Check the total number of VMs present
-            # psql -U postgres -d vmdb_production -c "select name from vms where vendor='vmware';" |
-            wc -l
-            3.Now, check the total number of VMs having linked_clone set as True:
-            # psql -U postgres -d vmdb_production -c "select name from vms where vendor='vmware'
-            and linked_clone='t';" | wc -l
-        expectedResults:
-            1.
-            2.Should return VM count
-            3.Should return VM count where linked_clone='t' and should be less than count in step2.
-    """
-    pass
-
-
 @pytest.mark.tier(1)
 @pytest.mark.meta(blockers=[BZ(1650441, forced_streams=['5.10', '5.11'])])
 def test_vmware_reconfigure_vm_controller_type(appliance, provider):


### PR DESCRIPTION
Purpose or Intent
=================

__Removing__ test for linked clones as the feature will be removed and is declared unreliable, hence makes no sense to test it any more **https://bugzilla.redhat.com/show_bug.cgi?id=1588908#c15**

