### PR TITLE
[1LP][RFR] added template cleanup on provider

### DIFF
--- a/cfme/tests/infrastructure/test_publish_vm_to_template.py
+++ b/cfme/tests/infrastructure/test_publish_vm_to_template.py
@@ -61,6 +61,10 @@ def test_publish_vm_to_template(request, setup_provider, vm_crud):
     template_name = random_vm_name(context='pblsh')
     template = vm_crud.publish_to_template(template_name)
 
-    request.addfinalizer(template.delete)
+    @request.addfinalizer
+    def _cleanup():
+        template.delete()
+        # also delete the template from the provider
+        template.mgmt.delete()
 
     assert template.exists, 'Published template does not exist.'


### PR DESCRIPTION
Thanks @valaparthvi for pointing to this: templates were left on the provider after `test_publish_vm_to_template`.

{{ pytest: -v cfme/tests/infrastructure/test_publish_vm_to_template.py::test_publish_vm_to_template }}