### PR TITLE
[1LP][RFR] improved locator for ReactSelect

### DIFF
--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -250,12 +250,13 @@ class AssignedTags(ParametrizedView):
     PARAMETERS = ("tag",)
     ALL_TAGS = ".//a[contains(@class, 'pf-remove-button')]"
     tag_remove = Text(ParametrizedLocator(
-        ".//div[@class='category-label'][@title={tag|quote}]/parent::li/following-sibling::"
-        "li/descendant::a[contains(@class, 'pf-remove-button')]")
+        ".//div[@class='category-label'][normalize-space(@title)={tag|quote}]/parent::li/"
+        "following-sibling::li/descendant::a[contains(@class, 'pf-remove-button')]")
     )
 
     tag_value = Text(ParametrizedLocator(
-        ".//div[@class='category-label'][@title={tag|quote}]/parent::li/following-sibling::li/span")
+        ".//div[@class='category-label'][normalize-space(@title)={tag|quote}]/parent::li/"
+        "following-sibling::li/span")
     )
 
     def remove(self):

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -2743,7 +2743,7 @@ class ReactSelect(Widget, ClickableMixin):
     # fmt: off
     ROOT = ParametrizedLocator('{@locator}')
     BASE_LOCATOR = ".//div[@id={}]"
-    BY_VISIBLE_TEXT = './/*[self::span or self::div][contains(text(), {})]'
+    BY_VISIBLE_TEXT = './/div[contains(@id, "react-select") and contains(normalize-space(.), {})]'
     SELECTED_VALUE = './/div[contains(@class, "singleValue")]'
     ALL_OPTIONS = './/*[self::span or self::div][normalize-space(text())]'
     # fmt: on


### PR DESCRIPTION
The previous locator worked fine until it hit "Quota - Max Memory" tag category, that has 2 spaces in the html source code.

So I added `normalize-space` to the selection and removal of the tag.

Thanks to @ganeshhubale for letting me know about that failure.

{{ pytest: -v cfme/tests/infrastructure/test_quota_tagging.py::test_quota_tagging_infra_via_lifecycle }}