### PR TITLE
[1LP][RFR] Fixed power dropdown 

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -124,7 +124,7 @@ class InfraVmDetailsToolbar(InfraGenericDetailsToolbar):
     """Toolbar for VM details differs from All VMs&TemplatesView
     """
     access = Dropdown("Access")
-    power = Dropdown('VM Power Functions')
+    power = Dropdown(text='Power')
 
 
 class VmsTemplatesAccordion(View):

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -428,6 +428,15 @@ def test_no_template_power_control(provider, soft_assert):
 
 
 @pytest.mark.rhv3
+@pytest.mark.meta(
+    blockers=[
+        BZ(
+            1723805,
+            forced_streams=["5.11"],
+            unblock=lambda provider: not provider.one_of(SCVMMProvider),
+        )
+    ]
+)
 def test_no_power_controls_on_archived_vm(appliance, testing_vm, archived_vm, soft_assert):
     """ Ensures that no power button is displayed from details view of archived vm
 

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -432,7 +432,6 @@ def test_no_template_power_control(provider, soft_assert):
     blockers=[
         BZ(
             1723805,
-            forced_streams=["5.11"],
             unblock=lambda provider: not provider.one_of(SCVMMProvider),
         )
     ]


### PR DESCRIPTION
- This PR fixed ```Power``` dropdown xpath issue after getting disabled.
- Fixed error:
```
>           raise NoSuchElementException('Could not find an element {}'.format(repr(locator)))
E           NoSuchElementException: Message: Could not find an element Locator(by='xpath', locator=u'.//div[contains(@class, "dropdown") and ./button[normalize-space(.)="VM Power Functions" or normalize-space(@title)="VM Power Functions"]]')

/var/ci/cfme_venv/lib/python2.7/site-packages/widgetastic/browser.py:347: NoSuchElementException
NoSuchElementException
Message: Could not find an element Locator(by='xpath', locator=u'.//div[contains(@class, "dropdown") and ./button[normalize-space(.)="VM Power Functions" or normalize-space(@title)="VM Power Functions"]]')
```

{{ pytest: cfme/tests/infrastructure/test_vm_power_control.py -k 'test_no_power_controls_on_archived_vm' -qsvvvv --use-template-cache --use-provider=complete --long-running }}