### PR TITLE
[1LP][RFR] Block alert_profile_crud test due to BZ

### DIFF
--- a/cfme/tests/control/test_basic.py
+++ b/cfme/tests/control/test_basic.py
@@ -633,6 +633,7 @@ def test_control_alert_copy(alert):
 
 @pytest.mark.sauce
 @pytest.mark.tier(2)
+@pytest.mark.meta(blockers=[BZ(1723815)], automates=[BZ(1723815)])
 def test_alert_profile_crud(request, appliance, alert_profile_class):
     """
     Polarion:

--- a/cfme/tests/control/test_basic.py
+++ b/cfme/tests/control/test_basic.py
@@ -148,7 +148,6 @@ EVENTS = [
     "Container Node Schedulable",
     "Pod Deadline Exceeded",
     "Pod Failed Scheduling",
-    "Pod Failed Sync",
     "Pod Failed Validation",
     "Pod Insufficient Free CPU",
     "Pod Insufficient Free Memory",


### PR DESCRIPTION
This test is breaking a lot of the basic control tests because it gets stuck on the edit alert profile page due to https://bugzilla.redhat.com/show_bug.cgi?id=1723815

{{ pytest: --long-running --use-template-cache cfme/tests/control/test_basic.py }}
