### PR TITLE
[1LP][RFR] Fixed playbook method crud operations

### DIFF
--- a/cfme/automate/explorer/method.py
+++ b/cfme/automate/explorer/method.py
@@ -319,14 +319,14 @@ class MethodEditView(AutomateExplorerView):
 
     @property
     def is_displayed(self):
-        return (
-            self.in_explorer and
-            self.datastore.is_opened and
-            'Editing Automate Method "{}"'.format(self.context['object'].name) in self.title.text
-            and (BZ(1704439).blocks or check_tree_path(
-                self.datastore.tree.currently_selected,
-                self.context['object'].tree_path, partial=True))
-        )
+        return (self.in_explorer
+                and self.datastore.is_opened
+                and ('Editing Automate Method "{}"'.format(self.context["object"].name)
+                     in self.title.text)
+                and check_tree_path(self.datastore.tree.currently_selected,
+                                    self.context["object"].tree_path, partial=True
+                                    )
+                )
 
 
 class Method(BaseEntity, Copiable):
@@ -409,10 +409,6 @@ class Method(BaseEntity, Copiable):
 
     def update(self, updates):
 
-        # TODO(BZ-1704439): Remove the work-around once this BZ got fixed
-        if BZ(1704439).blocks:
-            self.browser.refresh()
-
         view = navigate_to(self, 'Edit')
         changed = view.fill(updates)
         if changed:
@@ -457,9 +453,7 @@ class MethodCollection(BaseCollection):
 
         add_page = navigate_to(self, 'Add')
 
-        if self.browser.product_version < '5.11':
-            location = location
-        else:
+        if self.browser.product_version > '5.11' and location.islower():
             location = location.capitalize()
 
         add_page.fill({'location': location})
@@ -473,7 +467,8 @@ class MethodCollection(BaseCollection):
                 'inputs': inputs,
                 'embedded_method': embedded_method
             })
-        if location == 'playbook':
+        if location.lower() == 'playbook':
+            add_page.wait_displayed()
             add_page.fill({
                 'playbook_name': name,
                 'playbook_display_name': display_name,

--- a/cfme/automate/simulation.py
+++ b/cfme/automate/simulation.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.wait import wait_for
 
 
 def simulate(
@@ -46,6 +47,11 @@ def simulate(
         'avp': attributes_values,
     })
     view.submit_button.click()
+    wait_for(
+        lambda: view.flash.is_displayed,
+        delay=10,
+        timeout=120
+    )
     view.flash.assert_no_error()
     view.flash.assert_message('Automation Simulation has been run')
     # TODO: After fixing the tree

--- a/cfme/tests/ansible/test_embedded_ansible_automate.py
+++ b/cfme/tests/ansible/test_embedded_ansible_automate.py
@@ -9,7 +9,6 @@ from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.services.service_catalogs.ui import OrderServiceCatalogView
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.blockers import BZ
 from cfme.utils.conf import credentials
 from cfme.utils.update import update
 from cfme.utils.wait import TimedOutError
@@ -115,13 +114,13 @@ def alert_profile(appliance, alert, full_template_vm_modscope):
     _alert_profile.delete_if_exists()
 
 
-@pytest.mark.meta(automates=[BZ(1729999)])
-@pytest.mark.meta(blockers=[BZ(1729999, forced_streams=['5.10'])])
+@pytest.mark.meta(automates=[1729999])
 def test_automate_ansible_playbook_method_type_crud(appliance, ansible_repository, klass):
     """CRUD test for ansible playbook method.
 
     Bugzilla:
         1729999
+        1740769
 
     Polarion:
         assignee: ghubale

--- a/cfme/tests/automate/test_method.py
+++ b/cfme/tests/automate/test_method.py
@@ -11,6 +11,7 @@ from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils.appliance.implementations.rest import ViaREST
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import ViaUI
+from cfme.utils.blockers import BZ
 from cfme.utils.log_validator import FailPatternMatchError
 from cfme.utils.log_validator import LogValidator
 from cfme.utils.update import update
@@ -49,7 +50,7 @@ def test_method_crud(klass):
         script='$evm.log(:info, ":P")',
     )
     view = method.create_view(ClassDetailsView)
-    view.flash.assert_message('Automate Method "{}" was added'.format(method.name))
+    view.flash.assert_message(f'Automate Method "{method.name}" was added')
     assert method.exists
     origname = method.name
     with update(method):

--- a/cfme/tests/automate/test_method.py
+++ b/cfme/tests/automate/test_method.py
@@ -11,7 +11,6 @@ from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils.appliance.implementations.rest import ViaREST
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import ViaUI
-from cfme.utils.blockers import BZ
 from cfme.utils.log_validator import FailPatternMatchError
 from cfme.utils.log_validator import LogValidator
 from cfme.utils.update import update
@@ -50,8 +49,7 @@ def test_method_crud(klass):
         script='$evm.log(:info, ":P")',
     )
     view = method.create_view(ClassDetailsView)
-    if not BZ(1704439).blocks:
-        view.flash.assert_message('Automate Method "{}" was added'.format(method.name))
+    view.flash.assert_message('Automate Method "{}" was added'.format(method.name))
     assert method.exists
     origname = method.name
     with update(method):


### PR DESCRIPTION
- This PR fixes crud operation of ```automate method type - playbook```
- Also changes in the naming of the automate method types for playbook and inline are resolved in this PR
- This PR updates test case with global fixture 
## PRT RUN
{{ pytest: cfme/tests/ansible/test_embedded_ansible_automate.py -k "test_automate_ansible_playbook_method_type_crud or test_automate_ansible_playbook_method_type" --long-running  -vvvvv }}