### PR TITLE
[RFR][NOMERGE] moving tests and wrapanapi to py3winrm

### DIFF
--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -266,7 +266,7 @@ python-swiftclient==3.7.0
 pytz==2019.1
 pyvcloud==19.1.2
 pyvmomi==6.7.1.2018.12
-pywinrm==0.3.0
+py3winrm==0.0.1
 PyYAML==5.1
 pyzmq==18.0.1
 qtconsole==4.4.3
@@ -329,7 +329,8 @@ Werkzeug==0.15.2
 widgetastic.core==0.39
 widgetastic.patternfly==0.1.4
 widgetsnbextension==3.4.2
-wrapanapi==3.2.1
+#wrapanapi==3.2.1
+git+git://github.com/izapolsk/wrapanapi.git@move_to_py3
 wrapt==1.11.1
 xmltodict==0.12.0
 yaycl==0.3.0

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -258,7 +258,7 @@ python-swiftclient==3.7.0
 pytz==2019.1
 pyvcloud==19.1.2
 pyvmomi==6.7.1.2018.12
-pywinrm==0.3.0
+py3winrm==0.0.1
 PyYAML==5.1
 pyzmq==18.0.1
 qtconsole==4.4.3
@@ -314,7 +314,8 @@ Werkzeug==0.15.2
 widgetastic.core==0.39
 widgetastic.patternfly==0.1.4
 widgetsnbextension==3.4.2
-wrapanapi==3.2.1
+#wrapanapi==3.2.1
+git+git://github.com/izapolsk/wrapanapi.git@move_to_py3
 wrapt==1.11.1
 xmltodict==0.12.0
 yaycl==0.3.0

--- a/requirements/frozen_docs.py2.txt
+++ b/requirements/frozen_docs.py2.txt
@@ -265,7 +265,7 @@ python-swiftclient==3.7.0
 pytz==2019.1
 pyvcloud==19.1.2
 pyvmomi==6.7.1.2018.12
-pywinrm==0.3.0
+py3winrm==0.0.1
 PyYAML==5.1
 pyzmq==18.0.1
 qtconsole==4.4.3
@@ -328,7 +328,8 @@ Werkzeug==0.15.2
 widgetastic.core==0.39
 widgetastic.patternfly==0.1.4
 widgetsnbextension==3.4.2
-wrapanapi==3.2.1
+#wrapanapi==3.2.1
+git+git://github.com/izapolsk/wrapanapi.git@move_to_py3
 wrapt==1.11.1
 xmltodict==0.12.0
 yaycl==0.3.0

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -257,7 +257,7 @@ python-swiftclient==3.7.0
 pytz==2019.1
 pyvcloud==19.1.2
 pyvmomi==6.7.1.2018.12
-pywinrm==0.3.0
+py3winrm==0.0.1
 PyYAML==5.1
 pyzmq==18.0.1
 qtconsole==4.4.3
@@ -313,7 +313,8 @@ Werkzeug==0.15.2
 widgetastic.core==0.39
 widgetastic.patternfly==0.1.4
 widgetsnbextension==3.4.2
-wrapanapi==3.2.1
+#wrapanapi==3.2.1
+git+git://github.com/izapolsk/wrapanapi.git@move_to_py3
 wrapt==1.11.1
 xmltodict==0.12.0
 yaycl==0.3.0

--- a/requirements/template_docs.txt
+++ b/requirements/template_docs.txt
@@ -54,7 +54,7 @@ pytest-polarion-collect
 python-bugzilla>=1.2.0
 python-dateutil
 python-jenkins
-pywinrm
+py3winrm
 PyYAML
 requests
 riggerlib>=3.1.2


### PR DESCRIPTION
since pywinrm used in wrapanapi for interacting with scvmm doesn't accept pull requests and doesn't fix issues. we are forced to clone it and fix existing py3 issues.

This PR intends to test our clone of pywinrm and replace old package with our one. 