### PR TITLE
[WIP] Smoke tests for OSP and RHV

### DIFF
--- a/cfme/tests/v2v/test_v2v_migrations.py
+++ b/cfme/tests/v2v/test_v2v_migrations.py
@@ -14,6 +14,7 @@ from cfme.fixtures.provider import win10_template
 from cfme.fixtures.provider import win2012_template
 from cfme.fixtures.provider import win2016_template
 from cfme.fixtures.provider import win7_template
+from cfme.fixtures.v2v_fixtures import get_migrated_vm
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import ONE_PER_VERSION
@@ -35,13 +36,6 @@ pytestmark = [
     ),
     pytest.mark.usefixtures("v2v_provider_setup"),
 ]
-
-
-def get_migrated_vm_obj(src_vm_obj, target_provider):
-    """Returns the migrated_vm obj from target_provider."""
-    collection = target_provider.appliance.provider_based_collection(target_provider)
-    migrated_vm = collection.instantiate(src_vm_obj.name, target_provider)
-    return migrated_vm
 
 
 @pytest.mark.parametrize(
@@ -93,7 +87,7 @@ def test_single_datastore_single_vm_migration(
     assert migration_plan.wait_for_state("Completed")
     assert migration_plan.wait_for_state("Successful")
 
-    migrated_vm = get_migrated_vm_obj(src_vm_obj, provider)
+    migrated_vm = get_migrated_vm(src_vm_obj, provider)
     assert src_vm_obj.mac_address == migrated_vm.mac_address
 
 
@@ -140,7 +134,7 @@ def test_single_network_single_vm_migration(
     )
     # validate MAC address matches between source and target VMs
     src_vm = mapping_data_vm_obj_single_network.vm_list.pop()
-    migrated_vm = get_migrated_vm_obj(src_vm, provider)
+    migrated_vm = get_migrated_vm(src_vm, provider)
     assert src_vm.mac_address == migrated_vm.mac_address
 
 
@@ -189,7 +183,7 @@ def test_dual_datastore_dual_vm_migration(
     src_vms_list = mapping_data_dual_vm_obj_dual_datastore.vm_list
     # validate MAC address matches between source and target VMs
     for src_vm in src_vms_list:
-        migrated_vm = get_migrated_vm_obj(src_vm, provider)
+        migrated_vm = get_migrated_vm(src_vm, provider)
         soft_assert(src_vm.mac_address == migrated_vm.mac_address)
 
 
@@ -231,7 +225,7 @@ def test_dual_nics_migration(request, appliance, provider, mapping_data_vm_obj_d
     assert migration_plan.wait_for_state("Successful")
     # validate MAC address matches between source and target VMs
     src_vm = mapping_data_vm_obj_dual_nics.vm_list.pop()
-    migrated_vm = get_migrated_vm_obj(src_vm, provider)
+    migrated_vm = get_migrated_vm(src_vm, provider)
     assert set(src_vm.mac_address.split(", ")) == set(migrated_vm.mac_address.split(", "))
 
 
@@ -274,7 +268,7 @@ def test_dual_disk_vm_migration(
 
     # validate MAC address matches between source and target VMs
     src_vm = mapping_data_vm_obj_single_datastore.vm_list.pop()
-    migrated_vm = get_migrated_vm_obj(src_vm, provider)
+    migrated_vm = get_migrated_vm(src_vm, provider)
     assert src_vm.mac_address == migrated_vm.mac_address
 
 
@@ -329,5 +323,5 @@ def test_migrations_different_os_templates(
     src_vms_list = mapping_data_multiple_vm_obj_single_datastore.vm_list
     # validate MAC address matches between source and target VMs
     for src_vm in src_vms_list:
-        migrated_vm = get_migrated_vm_obj(src_vm, provider)
+        migrated_vm = get_migrated_vm(src_vm, provider)
         soft_assert(src_vm.mac_address == migrated_vm.mac_address)

--- a/cfme/tests/v2v/test_v2v_migrations.py
+++ b/cfme/tests/v2v/test_v2v_migrations.py
@@ -17,7 +17,6 @@ from cfme.fixtures.provider import win7_template
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import ONE_PER_VERSION
-from cfme.utils.blockers import BZ
 
 pytestmark = [
     test_requirements.v2v,

--- a/cfme/tests/v2v/test_v2v_migrations.py
+++ b/cfme/tests/v2v/test_v2v_migrations.py
@@ -48,7 +48,6 @@ def get_migrated_vm_obj(src_vm_obj, target_provider):
 @pytest.mark.parametrize(
     "mapping_data_vm_obj_single_datastore",
     [
-        ["nfs", "nfs", rhel7_minimal],
         ["nfs", "iscsi", rhel7_minimal],
         ["iscsi", "iscsi", rhel7_minimal],
         ["iscsi", "nfs", rhel7_minimal],
@@ -333,50 +332,3 @@ def test_migrations_different_os_templates(
     for src_vm in src_vms_list:
         migrated_vm = get_migrated_vm_obj(src_vm, provider)
         soft_assert(src_vm.mac_address == migrated_vm.mac_address)
-
-
-@pytest.mark.parametrize(
-    "v2v_provider_setup, mapping_data_multiple_vm_obj_single_datastore",
-    [["SSH", ["nfs", "nfs", [rhel7_minimal]]]],
-    indirect=True,
-)
-@pytest.mark.meta(blockers=[BZ(1707983, forced_streams=['5.10'])])
-def test_single_vm_migration_with_ssh(
-    request, appliance, provider, mapping_data_multiple_vm_obj_single_datastore
-):
-    """
-    Polarion:
-        assignee: sshveta
-        caseimportance: high
-        caseposneg: positive
-        testtype: functional
-        startsin: 5.10
-        casecomponent: V2V
-        initialEstimate: 1h
-    """
-    infrastructure_mapping_collection = appliance.collections.v2v_infra_mappings
-    mapping_data = mapping_data_multiple_vm_obj_single_datastore.infra_mapping_data
-    mapping = infrastructure_mapping_collection.create(**mapping_data)
-
-    @request.addfinalizer
-    def _cleanup():
-        infrastructure_mapping_collection.delete(mapping)
-
-    migration_plan_collection = appliance.collections.v2v_migration_plans
-    migration_plan = migration_plan_collection.create(
-        name="plan_{}".format(fauxfactory.gen_alphanumeric()),
-        description="desc_{}".format(fauxfactory.gen_alphanumeric()),
-        infra_map=mapping.name,
-        target_provider=provider,
-        vm_list=mapping_data_multiple_vm_obj_single_datastore.vm_list,
-    )
-
-    assert migration_plan.wait_for_state("Started")
-    assert migration_plan.wait_for_state("In_Progress")
-    assert migration_plan.wait_for_state("Completed")
-    assert migration_plan.wait_for_state("Successful")
-
-    # validate MAC address matches between source and target VMs
-    src_vm = mapping_data_multiple_vm_obj_single_datastore.vm_list.pop()
-    migrated_vm = get_migrated_vm_obj(src_vm, provider)
-    assert src_vm.mac_address == migrated_vm.mac_address

--- a/cfme/tests/v2v/test_v2v_smoke.py
+++ b/cfme/tests/v2v/test_v2v_smoke.py
@@ -5,9 +5,11 @@ import pytest
 from cfme import test_requirements
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.fixtures.provider import rhel7_minimal
+from cfme.fixtures.v2v_fixtures import get_migrated_vm
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import ONE_PER_VERSION
+
 
 pytestmark = [
     test_requirements.v2v,
@@ -28,66 +30,12 @@ pytestmark = [
 ]
 
 
-def get_migrated_vm_obj(src_vm_obj, target_provider):
-    """Returns the migrated_vm obj from target_provider."""
-    collection = target_provider.appliance.provider_based_collection(target_provider)
-    migrated_vm = collection.instantiate(src_vm_obj.name, target_provider)
-    return migrated_vm
-
-
-@pytest.mark.parametrize(
-    "mapping_data_vm_obj_single_datastore",
-    [
-        ["nfs", "nfs", rhel7_minimal]
-    ],
-    indirect=True,
-)
-def test_migration_plan(
-    request, appliance, provider, mapping_data_vm_obj_single_datastore
-):
-    """
-    Polarion:
-        assignee: sshveta
-        casecomponent: V2V
-        initialEstimate: 1/4h
-        caseimportance: high
-        caseposneg: positive
-        testtype: functional
-        startsin: 5.10
-    """
-    infrastructure_mapping_collection = appliance.collections.v2v_infra_mappings
-    mapping_data = mapping_data_vm_obj_single_datastore.infra_mapping_data
-    mapping = infrastructure_mapping_collection.create(**mapping_data)
-
-    @request.addfinalizer
-    def _cleanup():
-        infrastructure_mapping_collection.delete(mapping)
-
-    # vm_obj is a list, with only 1 VM object, hence [0]
-    src_vm_obj = mapping_data_vm_obj_single_datastore.vm_list[0]
-
-    migration_plan_collection = appliance.collections.v2v_migration_plans
-    migration_plan = migration_plan_collection.create(
-        name="plan_{}".format(fauxfactory.gen_alphanumeric()),
-        description="desc_{}".format(fauxfactory.gen_alphanumeric()),
-        infra_map=mapping.name,
-        vm_list=mapping_data_vm_obj_single_datastore.vm_list
-    )
-    assert migration_plan.wait_for_state("Started")
-    assert migration_plan.wait_for_state("In_Progress")
-    assert migration_plan.wait_for_state("Completed")
-    assert migration_plan.wait_for_state("Successful")
-    # validate MAC address matches between source and target VMs
-    migrated_vm = get_migrated_vm_obj(src_vm_obj, provider)
-    assert src_vm_obj.mac_address == migrated_vm.mac_address
-
-
 @pytest.mark.parametrize(
     "v2v_provider_setup, mapping_data_multiple_vm_obj_single_datastore",
-    [["SSH", ["nfs", "nfs", [rhel7_minimal]]]],
+    [["SSH", ["nfs", "nfs", [rhel7_minimal]]], ["VDDK", ["nfs", "nfs", [rhel7_minimal]]]],
     indirect=True,
 )
-def test_single_vm_migration_with_ssh(
+def test_single_vm_migration_with_ssh_and_vddk(
     request, appliance, provider, mapping_data_multiple_vm_obj_single_datastore
 ):
     """
@@ -124,5 +72,5 @@ def test_single_vm_migration_with_ssh(
 
     # validate MAC address matches between source and target VMs
     src_vm = mapping_data_multiple_vm_obj_single_datastore.vm_list.pop()
-    migrated_vm = get_migrated_vm_obj(src_vm, provider)
+    migrated_vm = get_migrated_vm(src_vm, provider)
     assert src_vm.mac_address == migrated_vm.mac_address

--- a/cfme/tests/v2v/test_v2v_smoke.py
+++ b/cfme/tests/v2v/test_v2v_smoke.py
@@ -17,7 +17,7 @@ pytestmark = [
         classes=[RHEVMProvider, OpenStackProvider],
         selector=ONE_PER_VERSION,
         required_flags=["v2v"],
-        scope="module"
+        scope="module",
     ),
     pytest.mark.provider(
         classes=[VMwareProvider],
@@ -26,13 +26,20 @@ pytestmark = [
         required_flags=["v2v"],
         scope="module",
     ),
-    pytest.mark.usefixtures("v2v_provider_setup")
+    pytest.mark.usefixtures("v2v_provider_setup"),
 ]
 
 
 @pytest.mark.parametrize(
     "v2v_provider_setup, mapping_data_multiple_vm_obj_single_datastore",
-    [["SSH", ["nfs", "nfs", [rhel7_minimal]]], ["VDDK", ["nfs", "nfs", [rhel7_minimal]]]],
+    [
+        [
+            "SSH", ["nfs", "nfs", [rhel7_minimal]]
+        ],
+        [
+            "VDDK", ["nfs", "nfs", [rhel7_minimal]]
+        ]
+    ],
     indirect=True,
 )
 def test_single_vm_migration_with_ssh_and_vddk(

--- a/cfme/tests/v2v/test_v2v_smoke_tests.py
+++ b/cfme/tests/v2v/test_v2v_smoke_tests.py
@@ -3,6 +3,7 @@ import fauxfactory
 import pytest
 
 from cfme import test_requirements
+from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.fixtures.provider import rhel7_minimal
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
@@ -11,7 +12,10 @@ from cfme.markers.env_markers.provider import ONE_PER_VERSION
 pytestmark = [
     test_requirements.v2v,
     pytest.mark.provider(
-        classes=[RHEVMProvider], selector=ONE_PER_VERSION, required_flags=["v2v"], scope="module"
+        classes=[RHEVMProvider, OpenStackProvider],
+        selector=ONE_PER_VERSION,
+        required_flags=["v2v"],
+        scope="module"
     ),
     pytest.mark.provider(
         classes=[VMwareProvider],
@@ -76,3 +80,49 @@ def test_migration_plan(
     # validate MAC address matches between source and target VMs
     migrated_vm = get_migrated_vm_obj(src_vm_obj, provider)
     assert src_vm_obj.mac_address == migrated_vm.mac_address
+
+
+@pytest.mark.parametrize(
+    "v2v_provider_setup, mapping_data_multiple_vm_obj_single_datastore",
+    [["SSH", ["nfs", "nfs", [rhel7_minimal]]]],
+    indirect=True,
+)
+def test_single_vm_migration_with_ssh(
+    request, appliance, provider, mapping_data_multiple_vm_obj_single_datastore
+):
+    """
+    Polarion:
+        assignee: sshveta
+        caseimportance: high
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.10
+        casecomponent: V2V
+        initialEstimate: 1h
+    """
+    infrastructure_mapping_collection = appliance.collections.v2v_infra_mappings
+    mapping_data = mapping_data_multiple_vm_obj_single_datastore.infra_mapping_data
+    mapping = infrastructure_mapping_collection.create(**mapping_data)
+
+    @request.addfinalizer
+    def _cleanup():
+        infrastructure_mapping_collection.delete(mapping)
+
+    migration_plan_collection = appliance.collections.v2v_migration_plans
+    migration_plan = migration_plan_collection.create(
+        name="plan_{}".format(fauxfactory.gen_alphanumeric()),
+        description="desc_{}".format(fauxfactory.gen_alphanumeric()),
+        infra_map=mapping.name,
+        target_provider=provider,
+        vm_list=mapping_data_multiple_vm_obj_single_datastore.vm_list,
+    )
+
+    assert migration_plan.wait_for_state("Started")
+    assert migration_plan.wait_for_state("In_Progress")
+    assert migration_plan.wait_for_state("Completed")
+    assert migration_plan.wait_for_state("Successful")
+
+    # validate MAC address matches between source and target VMs
+    src_vm = mapping_data_multiple_vm_obj_single_datastore.vm_list.pop()
+    migrated_vm = get_migrated_vm_obj(src_vm, provider)
+    assert src_vm.mac_address == migrated_vm.mac_address


### PR DESCRIPTION
{{pytest: cfme/tests/v2v/test_v2v_smoke.py --use-provider rhv43 --use-provider vsphere67-ims --provider-limit 2 -vvvv}}


To be used with RHV CI pipeline . 
It includes two basic tests for VDDK and SSH for RHV and OSP each.