### PR TITLE
[1LP][RFR] Fixed root node issue for entry point selection

### DIFF
--- a/cfme/tests/cloud/test_tenant_quota.py
+++ b/cfme/tests/cloud/test_tenant_quota.py
@@ -28,11 +28,12 @@ def set_default(provider, request):
        be created with specific values for these entries.
     """
     with_prov = (
-        "/ManageIQ (Locked)/{}/VM/Provisioning/StateMachines/ProvisionRequestApproval/Default"
-        .format(provider.string_name)
+        "Datastore", "ManageIQ (Locked)", "{}".format(provider.string_name), "VM", "Provisioning",
+        "StateMachines", "ProvisionRequestApproval", "Default"
     )
     default = (
-        "/Service/Provisioning/StateMachines/ServiceProvision_Template/CatalogItemInitialization"
+        "Service", "Provisioning", "StateMachines", "ServiceProvision_Template",
+        "CatalogItemInitialization"
     )
 
     return with_prov if request.param else default

--- a/cfme/tests/infrastructure/test_tenant_quota.py
+++ b/cfme/tests/infrastructure/test_tenant_quota.py
@@ -34,11 +34,12 @@ def set_default(provider, request):
        be created with specific values for these entries.
     """
     with_prov = (
-        "/ManageIQ (Locked)/{}/VM/Provisioning/StateMachines/ProvisionRequestApproval/Default"
-        .format(provider.string_name)
+        "Datastore", "ManageIQ (Locked)", "{}".format(provider.string_name), "VM", "Provisioning",
+        "StateMachines", "ProvisionRequestApproval", "Default (Default)"
     )
     default = (
-        "/Service/Provisioning/StateMachines/ServiceProvision_Template/CatalogItemInitialization"
+        "Service", "Provisioning", "StateMachines", "ServiceProvision_Template",
+        "CatalogItemInitialization"
     )
     return with_prov if request.param else default
 


### PR DESCRIPTION
- This PR fixes root node not match error because of ```EntryPoint``` widget introduced.
- Error:
```
>                   'cause': 'Root node did not match {}'.format(self._repr_step(image, step))})
E               CandidateNotFound: path: ('M', 'a', 'n', 'a', 'g', 'e', 'I', 'Q', ' ', '(', 'L', 'o', 'c', 'k', 'e', 'd', ')', '/', 'I', 'n', 'f', 'r', 'a', 's', 't', 'r', 'u', 'c', 't', 'u', 'r', 'e', '/', 'V', 'M', '/', 'P', 'r', 'o', 'v', 'i', 's', 'i', 'o', 'n', 'i', 'n', 'g', '/', 'S', 't', 'a', 't', 'e', 'M', 'a', 'c', 'h', 'i', 'n', 'e', 's', '/', 'P', 'r', 'o', 'v', 'i', 's', 'i', 'o', 'n', 'R', 'e', 'q', 'u', 'e', 's', 't', 'A', 'p', 'p', 'r', 'o', 'v', 'a', 'l', '/', 'D', 'e', 'f', 'a', 'u', 'l', 't'), message: Could not find the item / in Boostrap tree automate_treebox, cause: Root node did not match /

/var/ci/cfme_venv/lib/python2.7/site-packages/widgetastic_patternfly/__init__.py:1415: CandidateNotFound
CandidateNotFound
path: ('M', 'a', 'n', 'a', 'g', 'e', 'I', 'Q', ' ', '(', 'L', 'o', 'c', 'k', 'e', 'd', ')', '/', 'I', 'n', 'f', 'r', 'a', 's', 't', 'r', 'u', 'c', 't', 'u', 'r', 'e', '/', 'V', 'M', '/', 'P', 'r', 'o', 'v', 'i', 's', 'i', 'o', 'n', 'i', 'n', 'g', '/', 'S', 't', 'a', 't', 'e', 'M', 'a', 'c', 'h', 'i', 'n', 'e', 's', '/', 'P', 'r', 'o', 'v', 'i', 's', 'i', 'o', 'n', 'R', 'e', 'q', 'u', 'e', 's', 't', 'A', 'p', 'p', 'r', 'o', 'v', 'a', 'l', '/', 'D', 'e', 'f', 'a', 'u', 'l', 't'), message: Could not find the item / in Boostrap tree automate_treebox, cause: Root node did not match /
```


{{ pytest: cfme/tests/ -k 'test_service_infra_tenant_quota_with_default_entry_point or test_service_cloud_tenant_quota_with_default_entry_point' --long-running -vvv --use-template-cache }}