### PR TITLE
[1LP][RFR] Update Taggable.get_tags

### DIFF
--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -409,7 +409,8 @@ class Taggable(TaggableCommonBase):
     standardized widgetastic views
     """
 
-    def add_tag(self, tag=None, cancel=False, reset=False, details=True, dashboard=False):
+    def add_tag(self, tag=None, cancel=False, reset=False, details=True, dashboard=False,
+                exists_check=False):
         """ Add tag to tested item
 
         Args:
@@ -419,8 +420,9 @@ class Taggable(TaggableCommonBase):
             details (bool): set False if tag should be added for list selection,
                             default is details page
             dashboard (bool): Set to True if tag should be added via the Dashboard view
+            exists_check (bool): Set to True to check if tag exists before trying to add
         """
-        if tag and tag in self.get_tags():
+        if exists_check and tag and tag in self.get_tags():
             logger.warning('Trying to add tag [%s] already assigned to entity [%s]', tag, self)
             return tag
         if details and not dashboard:

--- a/cfme/configure/configuration/region_settings.py
+++ b/cfme/configure/configuration/region_settings.py
@@ -71,19 +71,15 @@ class Tag(Pretty, BaseEntity, Updateable):
 
     def __eq__(self, other):
         # compare the display_name attributes of the tag and its parent category
-        display_name_match = (
+        # display name itself is unique in MIQ
+        # use getattr in case other is not actually a tag
+        # provide default Category object so we can call display_name regardless
+        return (
             self.display_name == getattr(other, 'display_name') and
             self.category.display_name == getattr(other, 'category',
                                                   Category(parent=None, display_name=None)
                                                   ).display_name
         )
-        name_match = (
-            self.name == getattr(other, 'name') and
-            self.category.name == getattr(other, 'category',
-                                          Category(parent=None, display_name=None)
-                                          ).name
-        )
-        return display_name_match and name_match
 
     def update(self, updates):
         """ Update category method """

--- a/cfme/configure/configuration/region_settings.py
+++ b/cfme/configure/configuration/region_settings.py
@@ -54,7 +54,7 @@ class CompanyTagsAllView(RegionView):
         )
 
 
-@attr.s
+@attr.s(cmp=False)
 class Tag(Pretty, BaseEntity, Updateable):
     """ Class represents a category in CFME UI
 
@@ -68,6 +68,22 @@ class Tag(Pretty, BaseEntity, Updateable):
 
     display_name = attr.ib()
     name = attr.ib(default=None)
+
+    def __eq__(self, other):
+        # compare the display_name attributes of the tag and its parent category
+        display_name_match = (
+            self.display_name == getattr(other, 'display_name') and
+            self.category.display_name == getattr(other, 'category',
+                                                  Category(parent=None, display_name=None)
+                                                  ).display_name
+        )
+        name_match = (
+            self.name == getattr(other, 'name') and
+            self.category.name == getattr(other, 'category',
+                                          Category(parent=None, display_name=None)
+                                          ).name
+        )
+        return display_name_match and name_match
 
     def update(self, updates):
         """ Update category method """

--- a/cfme/fixtures/candu.py
+++ b/cfme/fixtures/candu.py
@@ -62,11 +62,8 @@ def candu_tag_vm(provider, enable_candu_category):
     """Add location tag to VM if not available"""
     collection = provider.appliance.provider_based_collection(provider)
     vm = collection.instantiate('cu-24x7', provider)
-    available_tags = vm.get_tags()
     tag = enable_candu_category.collections.tags.instantiate(name="london", display_name="London")
-
-    if tag.display_name not in [item.display_name for item in available_tags]:
-        vm.add_tag(tag)
+    vm.add_tag(tag)  # add _tag checks if its there first
     return vm
 
 

--- a/cfme/fixtures/candu.py
+++ b/cfme/fixtures/candu.py
@@ -63,7 +63,7 @@ def candu_tag_vm(provider, enable_candu_category):
     collection = provider.appliance.provider_based_collection(provider)
     vm = collection.instantiate('cu-24x7', provider)
     tag = enable_candu_category.collections.tags.instantiate(name="london", display_name="London")
-    vm.add_tag(tag)  # add _tag checks if its there first
+    vm.add_tag(tag, exists_check=True)
     return vm
 
 

--- a/cfme/fixtures/tag.py
+++ b/cfme/fixtures/tag.py
@@ -106,7 +106,7 @@ def check_item_visibility(tag, user_restricted):
         Returns: None
         """
         if vis_expect:
-            vis_object.add_tag(tag=tag)
+            vis_object.add_tag(tag=tag, exists_check=True)
         else:
             if tag in vis_object.get_tags():
                 vis_object.remove_tag(tag=tag)

--- a/cfme/fixtures/tag.py
+++ b/cfme/fixtures/tag.py
@@ -54,14 +54,14 @@ def role(appliance):
 
 
 @pytest.fixture(scope="module")
-def group_with_tag(appliance, role, category, tag):
+def group_with_tag(appliance, role, tag):
     """
         Returns group object with set up tag filter used in test module
     """
     group = appliance.collections.groups.create(
         description='grp{}'.format(fauxfactory.gen_alphanumeric()),
         role=role.name,
-        tag=([category.display_name, tag.display_name], True)
+        tag=([tag.category.display_name, tag.display_name], True)
     )
     yield group
     appliance.server.login_admin()
@@ -108,12 +108,7 @@ def check_item_visibility(tag, user_restricted):
         if vis_expect:
             vis_object.add_tag(tag=tag)
         else:
-            tags = vis_object.get_tags()
-            tag_assigned = any(
-                object_tags.category.display_name == tag.category.display_name and
-                object_tags.display_name == tag.display_name for object_tags in tags
-            )
-            if tag_assigned:
+            if tag in vis_object.get_tags():
                 vis_object.remove_tag(tag=tag)
         with user_restricted:
             try:

--- a/cfme/tests/ansible/test_embedded_ansible_services.py
+++ b/cfme/tests/ansible/test_embedded_ansible_services.py
@@ -161,12 +161,9 @@ def test_service_ansible_playbook_tagging(ansible_catalog_item):
             4. Remove the given tag
     """
     added_tag = ansible_catalog_item.add_tag()
-    assert any(tag.category.display_name == added_tag.category.display_name and
-               tag.display_name == added_tag.display_name
-               for tag in ansible_catalog_item.get_tags()), (
-        'Assigned tag was not found on the details page')
+    assert added_tag in ansible_catalog_item.get_tags(), 'Assigned tag was not found'
     ansible_catalog_item.remove_tag(added_tag)
-    assert ansible_catalog_item.get_tags() == []
+    assert added_tag not in ansible_catalog_item.get_tags()
 
 
 @pytest.mark.tier(2)

--- a/cfme/tests/ansible/test_embedded_ansible_tags.py
+++ b/cfme/tests/ansible/test_embedded_ansible_tags.py
@@ -47,17 +47,15 @@ def check_tag_place(soft_assert):
         tag = item.add_tag(details=tag_place)
         tags = item.get_tags()
         soft_assert(
-            [object_tags if object_tags.category.display_name == tag.category.display_name and
-             object_tags.display_name == tag.display_name else None for object_tags in tags], (
-                "{}: {} not in ({})".format(tag.category.display_name, tag.display_name, str(tags)))
+            tag in tags,
+            "{}: {} not in ({})".format(tag.category.display_name, tag.display_name, tags)
         )
 
         item.remove_tag(tag=tag, details=tag_place)
         tags = item.get_tags()
         soft_assert(
-            not [object_tags if object_tags.category.display_name == tag.category.display_name and
-                 object_tags.display_name == tag.display_name else None for object_tags in tags], (
-                "{}: {} not in ({})".format(tag.category.display_name, tag.display_name, str(tags)))
+            tag not in tags,
+            "{}: {} should not be in ({})".format(tag.category.display_name, tag.display_name, tags)
         )
     return _check_tag_place
 

--- a/cfme/tests/automate/custom_button/test_cloud_objects.py
+++ b/cfme/tests/automate/custom_button/test_cloud_objects.py
@@ -373,7 +373,7 @@ def test_custom_button_expression_cloud_obj(
     for setup_obj in setup_objs:
         view = navigate_to(setup_obj, "Details")
         custom_button_group = Dropdown(view, group.text)
-        if tag.display_name in [item.display_name for item in setup_obj.get_tags()]:
+        if tag in setup_obj.get_tags():
             if expression == "enablement":
                 assert custom_button_group.item_enabled(button.text)
                 setup_obj.remove_tag(tag)

--- a/cfme/tests/automate/custom_button/test_container_objects.py
+++ b/cfme/tests/automate/custom_button/test_container_objects.py
@@ -239,7 +239,7 @@ def test_custom_button_expression_container_obj(
     view = navigate_to(setup_obj, "Details")
     custom_button_group = Dropdown(view, group.text)
 
-    if tag.display_name in [item.display_name for item in setup_obj.get_tags()]:
+    if tag in setup_obj.get_tags():
         if expression == "enablement":
             assert custom_button_group.item_enabled(button.text)
             setup_obj.remove_tag(tag)

--- a/cfme/tests/automate/custom_button/test_generic_objects.py
+++ b/cfme/tests/automate/custom_button/test_generic_objects.py
@@ -290,7 +290,7 @@ def test_custom_button_expression_evm_obj(appliance, request, setup_obj, button_
     view = navigate_to(setup_obj, "Details")
     custom_button_group = Dropdown(view, group.text)
 
-    if tag.display_name in [item.display_name for item in setup_obj.get_tags()]:
+    if tag in setup_obj.get_tags():
         if expression == "enablement":
             assert custom_button_group.item_enabled(button.text)
             setup_obj.remove_tag(tag)

--- a/cfme/tests/automate/custom_button/test_infra_objects.py
+++ b/cfme/tests/automate/custom_button/test_infra_objects.py
@@ -409,7 +409,7 @@ def test_custom_button_expression_infra_obj(
     view = navigate_to(setup_obj, "Details")
     custom_button_group = Dropdown(view, group.text)
 
-    if tag.display_name in [item.display_name for item in setup_obj.get_tags()]:
+    if tag in setup_obj.get_tags():
         if expression == "enablement":
             assert custom_button_group.item_enabled(button.text)
             setup_obj.remove_tag(tag)

--- a/cfme/tests/automate/custom_button/test_service_objects.py
+++ b/cfme/tests/automate/custom_button/test_service_objects.py
@@ -418,7 +418,7 @@ def test_custom_button_expression_service_obj(
 
     # Check without tag
     with appliance.context.use(ViaUI):
-        if tag.display_name in [item.display_name for item in obj.get_tags()]:
+        if tag in obj.get_tags():
             obj.remove_tag(tag)
 
     with appliance.context.use(context):
@@ -441,8 +441,7 @@ def test_custom_button_expression_service_obj(
 
     # Check with tag
     with appliance.context.use(ViaUI):
-        if tag.display_name not in [item.display_name for item in obj.get_tags()]:
-            obj.add_tag(tag)
+        obj.add_tag(tag)  # add_tag checks if its there first
 
     with appliance.context.use(context):
         view = navigate_to(obj, dest_name)

--- a/cfme/tests/cloud/test_keypairs.py
+++ b/cfme/tests/cloud/test_keypairs.py
@@ -171,18 +171,9 @@ def test_keypair_add_and_remove_tag(keypair):
             5. Delete keypair.
     """
     added_tag = keypair.add_tag()
-    tagged_value = keypair.get_tags()
-    assert (
-        tag.category.display_name == added_tag.category.display_name and
-        tag.display_name == added_tag.display_name
-        for tag in keypair.get_tags()), (
-        'Assigned tag was not found on the details page')
-
+    assert added_tag in keypair.get_tags(), 'Assigned tag was not found on keypair'
     keypair.remove_tag(added_tag)
-    tagged_value1 = keypair.get_tags()
-    assert tagged_value1 != tagged_value, "Remove tag failed."
-    # Above small conversion in assert statement convert 'tagged_value' in tuple("a","b") and then
-    # compare with tag which is tuple. As get_tags will return assigned tag in list format["a: b"].
+    assert added_tag not in keypair.get_tags(), "Remove tag failed."
 
     keypair.delete(wait=True)
 

--- a/cfme/tests/cloud_infra_common/test_provisioning.py
+++ b/cfme/tests/cloud_infra_common/test_provisioning.py
@@ -606,18 +606,13 @@ def test_provision_with_tag(appliance, vm_name, tag, provider, request):
         casecomponent: Tagging
         initialEstimate: 1/4h
     """
-
     inst_args = {'purpose': {
         'apply_tags': Check_tree.CheckNode(
             ['{} *'.format(tag.category.display_name), tag.display_name])}}
     collection = appliance.provider_based_collection(provider)
     instance = collection.create(vm_name, provider, form_values=inst_args)
     request.addfinalizer(instance.cleanup_on_provider)
-    tags = instance.get_tags()
-    assert any(
-        instance_tag.category.display_name == tag.category.display_name and
-        instance_tag.display_name == tag.display_name for instance_tag in tags), (
-        "{}: {} not in ({})".format(tag.category.display_name, tag.display_name, str(tags)))
+    assert tag in instance.get_tags(), 'Provisioned instance does not have expected tag'
 
 
 @pytest.mark.manual

--- a/cfme/tests/cloud_infra_common/test_tag_objects.py
+++ b/cfme/tests/cloud_infra_common/test_tag_objects.py
@@ -87,12 +87,13 @@ def tagging_check(tag, request):
         """
         test_item.add_tag(tag=tag, details=tag_place)
         tags = test_item.get_tags()
-        assert any(
-            object_tags.category.display_name == tag.category.display_name and
-            object_tags.display_name == tag.display_name for object_tags in tags), (
-            "{}: {} not in ({})".format(tag.category.display_name, tag.display_name, str(tags)))
+        assert tag in tags, (
+            "{}: {} not in ({})".format(tag.category.display_name, tag.display_name, tags))
 
         test_item.remove_tag(tag=tag, details=tag_place)
+        tags = test_item.get_tags()
+        assert tag not in tags, (
+            "{}: {} in ({})".format(tag.category.display_name, tag.display_name, tags))
         request.addfinalizer(lambda: tag_cleanup(test_item, tag))
 
     return _tagging_check

--- a/cfme/tests/infrastructure/test_config_management.py
+++ b/cfme/tests/infrastructure/test_config_management.py
@@ -145,10 +145,7 @@ def test_config_system_tag(request, config_system, tag):
         casecomponent: Ansible
     """
     config_system.add_tag(tag=tag, details=False)
-    tags = config_system.get_tags()
-    msg = "Failed to setup a configuration system's tag"
-    tag_info = '{}: {}'.format(tag.category.display_name, tag.display_name)
-    assert tag_info in ['{}: {}'.format(t.category.display_name, t.display_name) for t in tags], msg
+    assert tag in config_system.get_tags(), "Tag not found on configuration system after adding"
 
 
 @pytest.mark.tier(3)
@@ -165,17 +162,13 @@ def test_ansible_tower_job_templates_tag(request, config_manager, tag):
     Bugzilla:
         1673104
     """
-    collection = config_manager.appliance.collections.ansible_tower_job_templates
     try:
-        job_template = collection.all()[0]
+        job_template = config_manager.appliance.collections.ansible_tower_job_templates.all()[0]
     except IndexError:
         pytest.skip("No job template was found")
     job_template.add_tag(tag=tag, details=False)
     request.addfinalizer(lambda: job_template.remove_tag(tag=tag))
-    tags = job_template.get_tags()
-    msg = "Failed to setup a configuration system's tag"
-    tag_info = '{}: {}'.format(tag.category.display_name, tag.display_name)
-    assert tag_info in ['{}: {}'.format(t.category.display_name, t.display_name) for t in tags], msg
+    assert tag in job_template.get_tags(), "Tag not found on configuration system after adding"
 
 
 # def test_config_system_reprovision(config_system):

--- a/cfme/tests/infrastructure/test_config_management.py
+++ b/cfme/tests/infrastructure/test_config_management.py
@@ -24,29 +24,6 @@ def config_system(config_manager):
     return fauxfactory.gen_choice(config_manager.systems)
 
 
-@pytest.fixture(scope="module")
-def category(appliance):
-    cg = appliance.collections.categories.create(
-        name=fauxfactory.gen_alphanumeric(8).lower(),
-        description=fauxfactory.gen_alphanumeric(32),
-        display_name=fauxfactory.gen_alphanumeric(32)
-    )
-    yield cg
-    if cg.exists:
-        cg.delete()
-
-
-@pytest.fixture(scope="module")
-def tag(category):
-    tag = category.collections.tags.create(
-        name=fauxfactory.gen_alphanumeric(8).lower(),
-        display_name=fauxfactory.gen_alphanumeric(32)
-    )
-    yield tag
-    if tag.exists:
-        tag.delete()
-
-
 @pytest.mark.tier(3)
 def test_config_manager_detail_config_btn(request, config_manager):
     """
@@ -137,7 +114,7 @@ def test_config_manager_remove(config_manager):
 @pytest.mark.tier(3)
 @test_requirements.tag
 @pytest.mark.uncollectif(lambda config_manager_obj: config_manager_obj.type == "Ansible Tower")
-def test_config_system_tag(request, config_system, tag):
+def test_config_system_tag(request, config_system, tag, appliance):
     """
     Polarion:
         assignee: anikifor
@@ -145,7 +122,7 @@ def test_config_system_tag(request, config_system, tag):
         casecomponent: Ansible
     """
     config_system.add_tag(tag=tag, details=False)
-    assert tag in config_system.get_tags(), "Tag not found on configuration system after adding"
+    assert tag in config_system.get_tags(), "Added tag not found on configuration system"
 
 
 @pytest.mark.tier(3)
@@ -168,7 +145,7 @@ def test_ansible_tower_job_templates_tag(request, config_manager, tag):
         pytest.skip("No job template was found")
     job_template.add_tag(tag=tag, details=False)
     request.addfinalizer(lambda: job_template.remove_tag(tag=tag))
-    assert tag in job_template.get_tags(), "Tag not found on configuration system after adding"
+    assert tag in job_template.get_tags(), "Added tag not found on configuration system"
 
 
 # def test_config_system_reprovision(config_system):

--- a/cfme/tests/infrastructure/test_vmware_provider.py
+++ b/cfme/tests/infrastructure/test_vmware_provider.py
@@ -202,11 +202,13 @@ def test_vmware_vds_ui_tagging(appliance, provider, soft_assert):
     switches = [switch for switch in switches_collection.all() if switch.name == 'DSwitch']
     assert switches, "There are no DSwitches on Networking Page"
     s = switches[0]
-    s.add_tag((appliance.collections.categories.instantiate(display_name='Owner')
-            .collections.tags.instantiate(display_name='Production Linux Team')))
+    s.add_tag(
+        appliance.collections.categories.instantiate(display_name='Owner')
+        .collections.tags.instantiate(display_name='Production Linux Team')
+    )
     added_tags = [tag for tag in s.get_tags()
-                if (tag.name == 'Owner') and
-                (tag.display_name == 'Production Linux Team')]
+                  if (tag.category.display_name == 'Owner') and
+                  (tag.display_name == 'Production Linux Team')]
     assert added_tags, "Failed to retrieve correct tags"
 
 

--- a/cfme/tests/infrastructure/test_vmware_provider.py
+++ b/cfme/tests/infrastructure/test_vmware_provider.py
@@ -200,16 +200,14 @@ def test_vmware_vds_ui_tagging(appliance, provider, soft_assert):
     """
     switches_collection = appliance.collections.infra_switches
     switches = [switch for switch in switches_collection.all() if switch.name == 'DSwitch']
-    assert switches, "There are no DSwitches on Networking Page"
-    s = switches[0]
-    s.add_tag(
-        appliance.collections.categories.instantiate(display_name='Owner')
-        .collections.tags.instantiate(display_name='Production Linux Team')
-    )
-    added_tags = [tag for tag in s.get_tags()
-                  if (tag.category.display_name == 'Owner') and
-                  (tag.display_name == 'Production Linux Team')]
-    assert added_tags, "Failed to retrieve correct tags"
+    try:
+        switch = switches[0]
+    except IndexError:
+        pytest.skip("There are no DSwitches for provider %s", provider)
+    owner_tag = appliance.collections.categories.instantiate(
+        display_name='Owner').collections.tags.instantiate(display_name='Production Linux Team')
+    switch.add_tag(owner_tag)
+    assert owner_tag in switch.get_tags(), "Failed to retrieve correct tags"
 
 
 @pytest.mark.manual


### PR DESCRIPTION
Don't set the Tag.name attribute to the Category.display_name
Update test_vmware_vds_ui_tagging
Update add_tag to check for tag existing already

Marking RFR as PRT run 32832 passed `test_vmware_vds_ui_tagging`.  Including the test_tag_objects module as well for a broader run.

{{ pytest: cfme/tests/infrastructure/test_vmware_provider.py::test_vmware_vds_ui_tagging cfme/tests/cloud_infra_common/test_tag_objects.py cfme/tests/infrastructure/test_config_management.py::test_config_system_tag cfme/tests/infrastructure/test_config_management.py::test_ansible_tower_job_templates_tag cfme/tests/cloud_infra_common/test_provisioning.py::test_provision_with_tag cfme/tests/automate/custom_button/test_generic_objects.py cfme/tests/automate/custom_button/test_service_objects.py::test_custom_button_expression_service_obj cfme/tests/ansible/test_embedded_ansible_tags.py cfme/tests/cloud/test_keypairs.py::test_keypair_add_and_remove_tag --use-provider vsphere67-nested --use-provider ec2 -vvvv }}
