### PR TITLE
[1LP][RFR] make test_collect_single_servers work

### DIFF
--- a/cfme/tests/configure/test_log_depot_operation.py
+++ b/cfme/tests/configure/test_log_depot_operation.py
@@ -22,7 +22,8 @@ from cfme.utils.ftp import FTPClient
 from cfme.utils.ssh import SSHClient
 from cfme.utils.update import update
 
-pytestmark = [pytest.mark.long_running, test_requirements.log_depot]
+pytestmark = [pytest.mark.long_running, test_requirements.log_depot,
+              pytest.mark.meta(blockers=[BZ(1706903)])]
 
 
 class LogDepotType(object):

--- a/cfme/tests/configure/test_log_depot_operation.py
+++ b/cfme/tests/configure/test_log_depot_operation.py
@@ -397,8 +397,7 @@ def test_collect_single_servers(log_depot, appliance, depot_machine_ip, request,
         collect_logs.depot_name = fauxfactory.gen_alphanumeric()
         collect_logs.uri = uri
         collect_logs.username = log_depot.credentials.username
-        # password update needs EditView fill fix
-        # collect_logs.password = log_depot.credentials.password
+        collect_logs.password = log_depot.credentials.password
     request.addfinalizer(collect_logs.clear)
     if collect_type == 'all':
         collect_logs.collect_all()


### PR DESCRIPTION
The test actually works and I got them passed in 5.10.6.1

{{ pytest: -v cfme/tests/configure/test_log_depot_operation.py::test_collect_single_servers  --long-running }}