### PR TITLE
[RFR] Adding two blocking BZs to tests

### DIFF
--- a/cfme/tests/cloud/test_cloud_events.py
+++ b/cfme/tests/cloud/test_cloud_events.py
@@ -5,6 +5,7 @@ import time
 import pytest
 
 from cfme.cloud.provider.azure import AzureProvider
+from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
 
@@ -85,12 +86,16 @@ def test_manage_nsg_group(appliance, provider, register_event):
     provider.mgmt.remove_netsec_group(nsg_name, resource_group)
 
 
+@pytest.mark.meta(blockers=[BZ(1724312)], automates=[1724312])
 def test_vm_capture(appliance, request, provider, register_event):
     """
     tests that generalize and capture vm azure events are received and parsed by CFME
 
     Metadata:
         test_flag: events, provision
+
+    Bugzilla:
+        1724312
 
     Polarion:
         assignee: jdupuy

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -185,12 +185,16 @@ def vm_off(vm):
 @pytest.mark.provider(
     [VMwareProvider, RHEVMProvider, OpenStackProvider, AzureProvider], scope="module"
 )
+@pytest.mark.meta(blockers=[BZ(1531547)], automates=[1531547])
 def test_action_start_virtual_machine_after_stopping(request, vm, vm_on, policy_for_testing):
     """ This test tests action 'Start Virtual Machine'
 
     This test sets the policy that it turns on the VM when it is turned off
     (https://www.youtube.com/watch?v=UOn4gxj2Dso), then turns the VM off and waits for it coming
     back alive.
+
+    Bugzilla:
+        1531547
 
     Metadata:
         test_flag: actions, provision


### PR DESCRIPTION
Blocking two tests due to BZs: 
https://bugzilla.redhat.com/show_bug.cgi?id=1531547
https://bugzilla.redhat.com/show_bug.cgi?id=1724312

These BZs impact `test_action_start_virtual_machine_after_stopping` and `test_vm_capture` respectively. 