### PR TITLE
[1LP][RFR] Refactored test_csv_imports.py

### DIFF
--- a/cfme/fixtures/v2v_fixtures.py
+++ b/cfme/fixtures/v2v_fixtures.py
@@ -443,9 +443,6 @@ def mapping_data_multiple_vm_obj_single_datastore(request, appliance, source_pro
             "description": "Single Datastore migration of VM from {ds_type1} to {ds_type2},".format(
                 ds_type1=request.param[0], ds_type2=request.param[1]
             ),
-            "networks": [
-                component_generator("vlans", source_provider, provider, "VM Network", "ovirtmgmt")
-            ],
         },
     )
     vm_list = []

--- a/cfme/tests/v2v/test_csv_import.py
+++ b/cfme/tests/v2v/test_csv_import.py
@@ -100,8 +100,8 @@ def check_vm_status(appliance, infra_map, error_text=None, filetype='csv', conte
         plan_view.instance_properties.table.wait_displayed()
         table_data = plan_view.instance_properties.table.read()[0]
         error_msg = {
-            "security_group": table_data["OpenStack Security Group"],
-            "flavor": table_data["OpenStack Flavor"]}
+            "security_group": str(table_data["OpenStack Security Group"]),
+            "flavor": str(table_data["OpenStack Flavor"])}
     plan_view.cancel_btn.click()
     return error_msg
 

--- a/cfme/tests/v2v/test_csv_import.py
+++ b/cfme/tests/v2v/test_csv_import.py
@@ -2,9 +2,11 @@ import tempfile
 
 import fauxfactory
 import pytest
+from widgetastic.exceptions import NoSuchElementException
 from widgetastic.exceptions import UnexpectedAlertPresentException
 
 from cfme import test_requirements
+from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.fixtures.v2v_fixtures import infra_mapping_default_data
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
@@ -16,7 +18,10 @@ from cfme.utils.wait import wait_for
 pytestmark = [
     test_requirements.v2v,
     pytest.mark.provider(
-        classes=[RHEVMProvider], selector=ONE_PER_VERSION, required_flags=["v2v"], scope="module"
+        classes=[RHEVMProvider, OpenStackProvider],
+        selector=ONE_PER_VERSION,
+        required_flags=["v2v"],
+        scope="module",
     ),
     pytest.mark.provider(
         classes=[VMwareProvider],
@@ -57,8 +62,8 @@ def migration_plan(appliance, infra_map, csv=True):
     return view
 
 
-def import_and_check(appliance, infra_map, error_text=None,
-                     filetype='csv', content=False, table_hover=False, alert=False):
+def import_and_check(appliance, infra_map, error_text=None, filetype='csv', content=False,
+                     table_hover=False, alert=False, security_group=False):
     plan_view = migration_plan(appliance, infra_map)
     temp_file = tempfile.NamedTemporaryFile(suffix='.{}'.format(filetype))
     if content:
@@ -76,13 +81,24 @@ def import_and_check(appliance, infra_map, error_text=None,
         else:
             # click on the checkbox to select VM (column 0)
             plan_view.vms.table[0][1].widget.click()
-        error_msg = plan_view.vms.popover_text.read()
+        if not security_group:
+            error_msg = plan_view.vms.popover_text.read()
     else:
         if alert:
             error_msg = plan_view.browser.get_alert().text
-            plan_view.browser.handle_alert()
+            try:
+                plan_view.browser.handle_alert()
+            except NoSuchElementException:
+                pass
         else:
             error_msg = plan_view.vms.error_text.text
+    if security_group:
+        plan_view.next_btn.click()
+        plan_view.instance_properties.table.wait_displayed()
+        table_data = plan_view.instance_properties.table.read()[0]
+        error_msg = {
+            "security_group": table_data["OpenStack Security Group"],
+            "flavor": table_data["OpenStack Flavor"]}
     plan_view.cancel_btn.click()
     return bool(error_msg == error_text)
 
@@ -115,15 +131,11 @@ def test_non_csv(appliance, infra_map):
     """Test non-csv file import
     Polarion:
         assignee: ytale
-        caseimportance: high
         caseposneg: negative
-        testtype: functional
         startsin: 5.10
         casecomponent: V2V
         customerscenario: true
         initialEstimate: 1/8h
-        subcomponent: RHV
-        upstream: yes
     """
     error_text = "Invalid file extension. Only .csv files are accepted."
     assert import_and_check(appliance, infra_map, error_text, filetype='txt', alert=True)
@@ -133,15 +145,11 @@ def test_blank_csv(appliance, infra_map):
     """Test csv with blank file
     Polarion:
         assignee: ytale
-        caseimportance: high
         caseposneg: negative
-        testtype: functional
         startsin: 5.10
         casecomponent: V2V
         customerscenario: true
         initialEstimate: 1/8h
-        subcomponent: RHV
-        upstream: yes
     """
     error_msg = "Error: Possibly a blank .CSV file"
     assert import_and_check(appliance, infra_map, error_msg)
@@ -151,15 +159,11 @@ def test_column_headers(appliance, infra_map):
     """Test csv with unsupported column header
     Polarion:
         assignee: ytale
-        caseimportance: high
         caseposneg: positive
-        testtype: functional
         startsin: 5.10
         casecomponent: V2V
         customerscenario: true
         initialEstimate: 1/8h
-        subcomponent: RHV
-        upstream: yes
     """
     content = fauxfactory.gen_alpha(10)
     error_msg = "Error: Required column 'Name' does not exist in the .CSV file"
@@ -170,15 +174,11 @@ def test_inconsistent_columns(appliance, infra_map):
     """Test csv with extra inconsistent column value
     Polarion:
         assignee: ytale
-        caseimportance: high
         caseposneg: negative
-        testtype: functional
         startsin: 5.10
         casecomponent: V2V
         customerscenario: true
         initialEstimate: 1/8h
-        subcomponent: RHV
-        upstream: yes
     """
     content = "Name\n{}, {}".format(fauxfactory.gen_alpha(10), fauxfactory.gen_alpha(10))
     error_msg = "Error: Number of columns is inconsistent on line 2"
@@ -189,15 +189,11 @@ def test_csv_empty_vm(appliance, infra_map):
     """Test csv with empty column value
     Polarion:
         assignee: ytale
-        caseimportance: high
         caseposneg: positive
-        testtype: functional
         startsin: 5.10
         casecomponent: V2V
         customerscenario: true
         initialEstimate: 1/8h
-        subcomponent: RHV
-        upstream: yes
     """
     content = "Name\n\n"
     error_msg = "Empty name specified"
@@ -209,15 +205,11 @@ def test_csv_invalid_vm(appliance, infra_map):
     """Test csv with invalid vm name
     Polarion:
         assignee: ytale
-        caseimportance: high
         caseposneg: negative
-        testtype: functional
         startsin: 5.10
         casecomponent: V2V
         customerscenario: true
         initialEstimate: 1/8h
-        subcomponent: RHV
-        upstream: yes
     """
     content = "Name\n{}".format(fauxfactory.gen_alpha(10))
     error_msg = "VM does not exist"
@@ -229,15 +221,11 @@ def test_csv_valid_vm(appliance, infra_map, valid_vm):
     """Test csv with valid vm name
     Polarion:
         assignee: ytale
-        caseimportance: high
         caseposneg: positive
-        testtype: functional
         startsin: 5.10
         casecomponent: V2V
         customerscenario: true
         initialEstimate: 1/8h
-        subcomponent: RHV
-        upstream: yes
     """
     content = "Name\n{}".format(valid_vm)
     error_msg = "VM available for migration"
@@ -249,15 +237,11 @@ def test_csv_duplicate_vm(appliance, infra_map, valid_vm):
     """Test csv with duplicate vm name
     Polarion:
         assignee: ytale
-        caseimportance: high
         caseposneg: positive
-        testtype: functional
         startsin: 5.10
         casecomponent: V2V
         customerscenario: true
         initialEstimate: 1/8h
-        subcomponent: RHV
-        upstream: yes
     """
     content = "Name\n{}\n{}".format(valid_vm, valid_vm)
     error_msg = "Duplicate VM"
@@ -269,17 +253,36 @@ def test_csv_archived_vm(appliance, infra_map, archived_vm):
     """Test csv with archived vm name
     Polarion:
         assignee: ytale
-        caseimportance: high
         caseposneg: positive
-        testtype: functional
         startsin: 5.10
         casecomponent: V2V
         customerscenario: true
         initialEstimate: 1/8h
-        subcomponent: RHV
-        upstream: yes
     """
     content = "Name\n{}".format(archived_vm)
     error_msg = "VM is inactive"
     assert import_and_check(appliance, infra_map, error_msg,
                             content=content, table_hover=True)
+
+
+@pytest.mark.uncollectif(lambda provider: provider.one_of(RHEVMProvider))
+def test_csv_security_group_flavor(appliance, infra_map, valid_vm, provider):
+    """Test csv with openstack security group and flavor
+    Polarion:
+        assignee: ytale
+        caseposneg: positive
+        startsin: 5.10
+        casecomponent: V2V
+        customerscenario: true
+        initialEstimate: 1/4h
+    """
+    security_group = provider.data.security_groups.admin[1]
+    flavor = provider.data.flavors[1]
+    content = "Name,Security Group,Flavor\n{valid_vm},{security_group},{flavor}".format(
+        valid_vm=valid_vm,
+        security_group=security_group,
+        flavor=flavor,
+    )
+    error_msg = {"security_group": security_group, "flavor": flavor}
+    assert import_and_check(appliance, infra_map, error_msg,
+                            content=content, table_hover=True, security_group=True)


### PR DESCRIPTION
{{pytest: cfme/tests/v2v/test_csv_import.py --use-provider={rhv43,osp13-ims} --use-provider vsphere67-ims --provider-limit 3 -vvvv}}

- Fixed non-csv test failure
- Added security group and flavor tests
- Fixed tests to accomodate OSP
- Fixed IndexError from network component to run OSP tests