### PR TITLE
[1LP][RFR]New Test: test_reports_disable_enable_schedule_from_summary

### DIFF
--- a/cfme/intelligence/reports/schedules.py
+++ b/cfme/intelligence/reports/schedules.py
@@ -22,6 +22,7 @@ from cfme.utils.update import Updateable
 from widgetastic_manageiq import AlertEmail
 from widgetastic_manageiq import Calendar
 from widgetastic_manageiq import PaginationPane
+from widgetastic_manageiq import SummaryForm
 from widgetastic_manageiq import Table
 
 
@@ -111,6 +112,7 @@ class EditScheduleView(SchedulesFormCommon):
 
 class ScheduleDetailsView(CloudIntelReportsView):
     title = Text("#explorer_title_text")
+    schedule_info = SummaryForm("Schedule Info")
 
     @property
     def is_displayed(self):

--- a/cfme/tests/intelligence/reports/test_reports_schedules.py
+++ b/cfme/tests/intelligence/reports/test_reports_schedules.py
@@ -6,6 +6,7 @@ import yaml
 from cfme import test_requirements
 from cfme.intelligence.reports.schedules import NewScheduleView
 from cfme.intelligence.reports.schedules import ScheduleDetailsView
+from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.path import data_path
 from cfme.utils.wait import wait_for
 
@@ -178,4 +179,25 @@ def test_reports_disable_enable_schedule(appliance, schedule):
     schedules.disable_schedules(schedule)
     assert not schedule.enabled
     schedules.enable_schedules(schedule)
+    assert schedule.enabled
+
+
+@pytest.mark.ignore_stream("5.10")
+def test_reports_disable_enable_schedule_from_summary(appliance, schedule):
+    """
+    This test checks if schedule can be enabled/disabled from it's summary page.
+
+    Polarion:
+        assignee: pvala
+        casecomponent: Reporting
+        initialEstimate: 1/10h
+    Bugzilla:
+        1559335
+    """
+    view = navigate_to(schedule, "Details")
+    view.configuration.item_select("Disable this Schedule")
+    assert not schedule.enabled
+    # enabled directs to Schedules `All` page, we need to navigate back to Details page
+    navigate_to(schedule, "Details")
+    view.configuration.item_select("Enable this Schedule")
     assert schedule.enabled

--- a/cfme/tests/intelligence/reports/test_reports_schedules.py
+++ b/cfme/tests/intelligence/reports/test_reports_schedules.py
@@ -183,6 +183,7 @@ def test_reports_disable_enable_schedule(appliance, schedule):
 
 
 @pytest.mark.ignore_stream("5.10")
+@pytest.mark.meta(automates=[1559335])
 def test_reports_disable_enable_schedule_from_summary(appliance, schedule):
     """
     This test checks if schedule can be enabled/disabled from it's summary page.
@@ -191,6 +192,7 @@ def test_reports_disable_enable_schedule_from_summary(appliance, schedule):
         assignee: pvala
         casecomponent: Reporting
         initialEstimate: 1/10h
+
     Bugzilla:
         1559335
     """

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -260,13 +260,12 @@ class SummaryForm(Widget):
         """
 
         multiple_lines = self.get_item(item_name).text.splitlines()
-        if multiple_lines:
-            if len(multiple_lines) > 1:
-                return multiple_lines
-            else:
-                return multiple_lines[0]
-        else:
+        if not multiple_lines:
             return ""
+        elif len(multiple_lines) == 1:
+            return multiple_lines[0]
+        else:
+            return multiple_lines
 
     def read(self):
         return {item: self.get_text_of(item) for item in self.items}

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -260,10 +260,13 @@ class SummaryForm(Widget):
         """
 
         multiple_lines = self.get_item(item_name).text.splitlines()
-        if len(multiple_lines) > 1:
-            return multiple_lines
+        if multiple_lines:
+            if len(multiple_lines) > 1:
+                return multiple_lines
+            else:
+                return multiple_lines[0]
         else:
-            return multiple_lines[0]
+            return ""
 
     def read(self):
         return {item: self.get_text_of(item) for item in self.items}


### PR DESCRIPTION
Changes:
1. New Test: test_reports_disable_enable_schedule_from_summary
[RHCFQE-11727](https://projects.engineering.redhat.com/browse/RHCFQE-11727)
2. Add a new widget `schedules_info`
3. Fix `get_text_of` which used to fail if the item had no value.

{{ pytest: cfme/tests/intelligence/reports/test_reports_schedules.py -k "test_reports_disable_enable_schedule" --use-template-cache -sqvvv }}