### PR TITLE
[1LP][RFR] CB attribute override test

### DIFF
--- a/cfme/automate/buttons.py
+++ b/cfme/automate/buttons.py
@@ -519,8 +519,8 @@ class ButtonCollection(BaseCollection):
         view.fill({"advanced": {"system": system, "request": request}})
 
         if attributes is not None:
-            for i, dict_ in enumerate(attributes, 1):
-                view.advanced.attribute(i).fill(dict_)
+            for i, attribute in enumerate(attributes, 1):
+                view.advanced.attribute(i).fill({"key": attribute[0], "value": attribute[1]})
 
         if roles:
             view.advanced.role_show.fill("<By Role>")


### PR DESCRIPTION
Signed-off-by: Nikhil Dhandre <ndhandre@redhat.com>


Purpose or Intent
=================

{{pytest: cfme/tests/automate/custom_button/test_buttons.py::test_attribute_override -vvv}}