### PR TITLE
[1LP][RFR] Add BZ blocker for Azure memory metric

### DIFF
--- a/cfme/tests/candu/test_azone_graph.py
+++ b/cfme/tests/candu/test_azone_graph.py
@@ -40,7 +40,7 @@ def azone(appliance, provider):
 @pytest.mark.parametrize("graph_type", GRAPHS)
 @pytest.mark.meta(
     blockers=[BZ(1724415, unblock=lambda provider, graph_type: not provider.one_of(AzureProvider)
-    and not graph_type is "azone_memory")]
+    and graph_type != "azone_memory")]
 )
 @pytest.mark.uncollectif(lambda provider, graph_type: provider.one_of(EC2Provider)
     and graph_type in ["azone_memory", "azone_disk"])

--- a/cfme/tests/candu/test_azone_graph.py
+++ b/cfme/tests/candu/test_azone_graph.py
@@ -39,8 +39,9 @@ def azone(appliance, provider):
 @pytest.mark.parametrize("interval", INTERVAL)
 @pytest.mark.parametrize("graph_type", GRAPHS)
 @pytest.mark.meta(
-    blockers=[BZ(1724415, unblock=lambda provider, graph_type: not provider.one_of(AzureProvider)
-    and graph_type != "azone_memory")]
+    blockers=[BZ(1724415, forced_streams=['5.10', '5.11'],
+        unblock=lambda provider, graph_type: not provider.one_of(AzureProvider) and
+        graph_type != "azone_memory")]
 )
 @pytest.mark.uncollectif(lambda provider, graph_type: provider.one_of(EC2Provider)
     and graph_type in ["azone_memory", "azone_disk"])

--- a/cfme/tests/candu/test_azone_graph.py
+++ b/cfme/tests/candu/test_azone_graph.py
@@ -39,7 +39,8 @@ def azone(appliance, provider):
 @pytest.mark.parametrize("interval", INTERVAL)
 @pytest.mark.parametrize("graph_type", GRAPHS)
 @pytest.mark.meta(
-    blockers=[BZ(1671580, unblock=lambda provider: not provider.one_of(AzureProvider))]
+    blockers=[BZ(1724415, unblock=lambda provider, graph_type: not provider.one_of(AzureProvider)
+    and not graph_type is "azone_memory")]
 )
 @pytest.mark.uncollectif(lambda provider, graph_type: provider.one_of(EC2Provider)
     and graph_type in ["azone_memory", "azone_disk"])

--- a/cfme/tests/candu/test_utilization_metrics.py
+++ b/cfme/tests/candu/test_utilization_metrics.py
@@ -111,6 +111,7 @@ def query_metric_db(appliance, provider, metric, vm_name=None, host_name=None):
 
 
 @pytest.mark.rhv2
+@pytest.mark.meta(automates=[BZ(1671580)])
 # Tests to check that specific metrics are being collected
 def test_raw_metric_vm_cpu(metrics_collection, appliance, provider):
     """
@@ -136,6 +137,7 @@ def test_raw_metric_vm_cpu(metrics_collection, appliance, provider):
 
 
 @pytest.mark.rhv2
+@pytest.mark.meta(automates=[BZ(1671580)])
 @pytest.mark.meta(
     blockers=[BZ(1724415, forced_streams=['5.10', '5.11'],
         unblock=lambda provider: not provider.one_of(AzureProvider))]
@@ -168,6 +170,7 @@ def test_raw_metric_vm_memory(metrics_collection, appliance, provider):
 
 
 @pytest.mark.rhv2
+@pytest.mark.meta(automates=[BZ(1671580)])
 def test_raw_metric_vm_network(metrics_collection, appliance, provider):
     """
     Polarion:
@@ -188,6 +191,7 @@ def test_raw_metric_vm_network(metrics_collection, appliance, provider):
 @pytest.mark.rhv2
 @pytest.mark.uncollectif(
     lambda provider: provider.one_of(EC2Provider))
+@pytest.mark.meta(automates=[BZ(1671580)])
 def test_raw_metric_vm_disk(metrics_collection, appliance, provider):
     """
     Polarion:

--- a/cfme/tests/candu/test_utilization_metrics.py
+++ b/cfme/tests/candu/test_utilization_metrics.py
@@ -112,9 +112,6 @@ def query_metric_db(appliance, provider, metric, vm_name=None, host_name=None):
 
 @pytest.mark.rhv2
 # Tests to check that specific metrics are being collected
-@pytest.mark.meta(
-    blockers=[BZ(1671580, unblock=lambda provider: not provider.one_of(AzureProvider))]
-)
 def test_raw_metric_vm_cpu(metrics_collection, appliance, provider):
     """
     Polarion:
@@ -140,7 +137,7 @@ def test_raw_metric_vm_cpu(metrics_collection, appliance, provider):
 
 @pytest.mark.rhv2
 @pytest.mark.meta(
-    blockers=[BZ(1671580, unblock=lambda provider: not provider.one_of(AzureProvider))]
+    blockers=[BZ(1724415, unblock=lambda provider: not provider.one_of(AzureProvider))]
 )
 @pytest.mark.uncollectif(
     lambda provider: provider.one_of(EC2Provider) or provider.one_of(GCEProvider))
@@ -170,9 +167,6 @@ def test_raw_metric_vm_memory(metrics_collection, appliance, provider):
 
 
 @pytest.mark.rhv2
-@pytest.mark.meta(
-    blockers=[BZ(1671580, unblock=lambda provider: not provider.one_of(AzureProvider))]
-)
 def test_raw_metric_vm_network(metrics_collection, appliance, provider):
     """
     Polarion:
@@ -193,9 +187,6 @@ def test_raw_metric_vm_network(metrics_collection, appliance, provider):
 @pytest.mark.rhv2
 @pytest.mark.uncollectif(
     lambda provider: provider.one_of(EC2Provider))
-@pytest.mark.meta(
-    blockers=[BZ(1671580, unblock=lambda provider: not provider.one_of(AzureProvider))]
-)
 def test_raw_metric_vm_disk(metrics_collection, appliance, provider):
     """
     Polarion:

--- a/cfme/tests/candu/test_utilization_metrics.py
+++ b/cfme/tests/candu/test_utilization_metrics.py
@@ -137,7 +137,8 @@ def test_raw_metric_vm_cpu(metrics_collection, appliance, provider):
 
 @pytest.mark.rhv2
 @pytest.mark.meta(
-    blockers=[BZ(1724415, unblock=lambda provider: not provider.one_of(AzureProvider))]
+    blockers=[BZ(1724415, forced_streams=['5.10', '5.11'],
+        unblock=lambda provider: not provider.one_of(AzureProvider))]
 )
 @pytest.mark.uncollectif(
     lambda provider: provider.one_of(EC2Provider) or provider.one_of(GCEProvider))


### PR DESCRIPTION
{{pytest: cfme/tests/candu/test_utilization_metrics.py --use-provider azure}}

PRT results:
With the fix, test_raw_metric_vm_memory[azure-common]  is being skipped for both 510 and 511, like expected.
The test_raw_metric_vm_disk[azure-common] is failing because there is no disk activity on the Azure VM and it doesn't have to do anything with this PR. I'll investigate and fix the disk activity issue.