### PR TITLE
[1LP][RFR] Fixes for UI navigation in test_paginator_config_pages

### DIFF
--- a/cfme/tests/configure/test_paginator.py
+++ b/cfme/tests/configure/test_paginator.py
@@ -6,6 +6,7 @@ from widgetastic_patternfly import Dropdown
 from cfme import test_requirements
 from cfme.configure.configuration.region_settings import RedHatUpdates
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import BZ
 
 general_list_pages = [
     ('servers', None, 'Details', False),
@@ -27,29 +28,24 @@ general_list_pages = [
     ('servers', None, 'DatabaseSettings', True),
     ('servers', None, 'DatabaseClientConnections', True),
     ('servers', None, 'DatabaseUtilization', False),
-
     ('regions', None, 'Details', False),
     ('regions', None, 'ImportTags', False),
     ('regions', None, 'Import', False),
     ('regions', None, 'HelpMenu', False),
     ('regions', None, 'Advanced', False),
-    ('regions', None, 'Diagnostics', False),
     ('regions', None, 'DiagnosticsZones', False),
     ('regions', None, 'OrphanedData', False),
     ('regions', None, 'Servers', True),
     ('regions', None, 'ServersByRoles', False),
     ('regions', None, 'RolesByServers', False),
-    ('zones', None, 'Details', False),
+    ('zones', None, 'Zone', False),
     ('zones', None, 'SmartProxyAffinity', False),
     ('zones', None, 'Advanced', False),
-    ('zones', None, 'Diagnostics', False),
     ('zones', None, 'ServersByRoles', False),
     ('zones', None, 'Servers', True),
     ('zones', None, 'CANDUGapCollection', False),
     ('zones', None, 'RolesByServers', False),
-    ('zones', None, 'ZoneCollectLogs', False),
-
-
+    ('zones', None, 'CollectLogs', False),
     ('candus', None, 'Details', False),
     ('map_tags', None, 'All', False),
     ('categories', None, 'All', False),
@@ -101,6 +97,13 @@ def schedule(appliance):
 @pytest.mark.parametrize('place_info', general_list_pages,
                          ids=['{}_{}'.format(set_type[0], set_type[2].lower())
                               for set_type in general_list_pages])
+@pytest.mark.meta(blockers=[BZ(1724747, forced_streams=['5.11'], unblock=lambda place_info:
+                      '{}_{}'.format(place_info[0], place_info[2].lower())
+                      not in ['zones_diagnostics', 'zones_serversbyroles', 'zones_servers',
+                      'zones_candugapcollection', 'zones_rolesbyservers', 'zones_collectlogs']),
+                  BZ(1726345, forced_streams=['5.11'], unblock=lambda place_info:
+                      '{}_{}'.format(place_info[0], place_info[2].lower())
+                      not in ['regions_serversbyroles'])])
 def test_paginator_config_pages(appliance, place_info):
     """
         Check paginator is visible for config pages

--- a/cfme/tests/configure/test_paginator.py
+++ b/cfme/tests/configure/test_paginator.py
@@ -44,7 +44,7 @@ general_list_pages = [
     ('zones', None, 'Advanced', False),
     ('zones', None, 'Diagnostics', False),
     ('zones', None, 'ServersByRoles', False),
-    ('zones', None, 'Servers', False),
+    ('zones', None, 'Servers', True),
     ('zones', None, 'CANDUGapCollection', False),
     ('zones', None, 'RolesByServers', False),
     ('zones', None, 'ZoneCollectLogs', False),


### PR DESCRIPTION
Purpose or Intent
==============

1.) If more than one test_paginator_config_pages test for a tab under the Zone Diagnostics configuration page runs as part of the same pytest command, navigation between the tabs was not happening. This is fixed by adding am_i_here methods, which return False, to the NavigateStep classes for each tab. This matches the existing behavior of the tabs on the Region Diagnostics page.

2.) The same fix is also applied to the Zone and Advanced tabs under Configuration > Settings > Zone, which share the same ZoneDetailsView class.

3.) test_paginator_config_pages[zones_servers] was failing because the test case expected no paginator to be present, but a paginator has been added.

4.) There is a bug in the UI for 5.11, in which the Zone Diagnostics configuration page does not display. I've filed a BZ (1724747) and added a blocker to skip the associated tests for 5.11.

5.) Another 5.11 UI bug prevents the Region Diagnostics Servers by Roles configuration page from displaying. BZ 1726345 is also added as a blocker for that test case.

{{ pytest: cfme/tests/configure/test_paginator.py -k test_paginator_config_pages -vvvv }}