### PR TITLE
[RFR] retrieve ip and rename happen at the same time

### DIFF
--- a/sprout/appliances/tasks.py
+++ b/sprout/appliances/tasks.py
@@ -1009,9 +1009,9 @@ def clone_template_to_appliance(self, appliance_id, lease_time_minutes=None, yum
     tasks = [
         clone_template_to_appliance__clone_template.si(appliance_id, lease_time_minutes),
         clone_template_to_appliance__wait_present.si(appliance_id),
+        appliance_rename.si(appliance_id),
         appliance_power_on.si(appliance_id),
         retrieve_appliance_ip.si(appliance_id),
-        appliance_rename.si(appliance_id),
         appliance_set_ansible_url.si(appliance_id)
     ]
     if yum_update:


### PR DESCRIPTION
moving rename to happen before retrieve ip. so, those won't interfere with each other.