### PR TITLE
[1LP][RFR] Refactor LogValidator

### DIFF
--- a/cfme/tests/ansible/test_embedded_ansible_services.py
+++ b/cfme/tests/ansible/test_embedded_ansible_services.py
@@ -678,7 +678,7 @@ def test_service_ansible_verbosity(
     # Log Validator
     log = LogValidator("/var/www/miq/vmdb/log/evm.log", matched_patterns=[pattern])
     # Start Log check or given pattern
-    log.fix_before_start()
+    log.start_monitoring()
 
     @request.addfinalizer
     def _revert():
@@ -701,7 +701,7 @@ def test_service_ansible_verbosity(
     )
     # Searching string '"verbosity"=>0' (example) in evm.log as Standard Output
     # is being logging in evm.log
-    log.validate_logs()
+    assert log.validate()
     logger.info("Pattern found {}".format(log.matched_patterns))
 
     view = navigate_to(ansible_service, "Details")

--- a/cfme/tests/ansible/test_embedded_ansible_services.py
+++ b/cfme/tests/ansible/test_embedded_ansible_services.py
@@ -701,7 +701,7 @@ def test_service_ansible_verbosity(
     )
     # Searching string '"verbosity"=>0' (example) in evm.log as Standard Output
     # is being logging in evm.log
-    assert log.validate()
+    assert log.validate(wait="60s")
     logger.info("Pattern found {}".format(log.matched_patterns))
 
     view = navigate_to(ansible_service, "Details")

--- a/cfme/tests/automate/custom_button/test_infra_objects.py
+++ b/cfme/tests/automate/custom_button/test_infra_objects.py
@@ -251,7 +251,7 @@ def test_custom_button_automate_infra_obj(appliance, request, submit, setup_obj,
         log = LogValidator(
             "/var/www/miq/vmdb/log/automation.log", matched_patterns=[request_pattern]
         )
-        log.fix_before_start()
+        log.start_monitoring()
 
         custom_button_group.item_select(button.text)
 
@@ -337,7 +337,7 @@ def test_custom_button_dialog_infra_obj(appliance, dialog, request, setup_obj, b
     log = LogValidator(
         "/var/www/miq/vmdb/log/automation.log", matched_patterns=[request_pattern]
     )
-    log.fix_before_start()
+    log.start_monitoring()
 
     # Submit order
     dialog_view.submit.click()

--- a/cfme/tests/automate/custom_button/test_service_vm_custom_button.py
+++ b/cfme/tests/automate/custom_button/test_service_vm_custom_button.py
@@ -224,10 +224,10 @@ def test_custom_button_with_dynamic_dialog_vm(
                 "/var/www/miq/vmdb/log/automation.log",
                 matched_patterns=["Attributes - Begin", 'name = "{}"'.format(service.vm_name)],
             )
-            log.fix_before_start()
+            log.start_monitoring()
             submit = "submit" if context is ViaUI else "submit_request"
             getattr(view, submit).click()
-            log.wait_for_log_validation()
+            assert log.validate(wait="120s")
 
 
 @pytest.mark.meta(automates=[1427430, 1450473, 1454910])
@@ -271,11 +271,11 @@ def test_custom_button_automate_service_vm(request, appliance, service_vm, butto
             log = LogValidator(
                 "/var/www/miq/vmdb/log/automation.log", matched_patterns=["Attributes - Begin"]
             )
-            log.fix_before_start()
+            log.start_monitoring()
 
             # Execute custom button on service vm
             custom_button_group = Dropdown(view, button_group.text)
             custom_button_group.item_select(button.text)
 
             # validate request in log
-            log.wait_for_log_validation()
+            assert log.validate(wait="120s")

--- a/cfme/tests/automate/test_domain.py
+++ b/cfme/tests/automate/test_domain.py
@@ -106,7 +106,7 @@ def test_domain_lock_disabled(klass):
         "/var/www/miq/vmdb/log/automation.log",
         matched_patterns=[r".*ERROR.*"],
     )
-    result.fix_before_start()
+    result.start_monitoring()
 
     # Executing automate method using simulation
     simulate(
@@ -120,7 +120,7 @@ def test_domain_lock_disabled(klass):
         request="Call_Instance",
         execute_methods=True,
     )
-    result.validate_logs()
+    assert result.validate(wait="60s")
 
     klass.namespace.domain.lock()
     view = navigate_to(klass.namespace.domain, 'Details')

--- a/cfme/tests/automate/test_instance.py
+++ b/cfme/tests/automate/test_instance.py
@@ -127,7 +127,6 @@ def test_automate_relationship_trailing_spaces(request, klass, namespace, domain
         initialEstimate: 1/10h
         caseimportance: medium
         caseposneg: positive
-        caseposneg: positive
         testtype: functional
         startsin: 5.9
         casecomponent: Automate

--- a/cfme/tests/automate/test_instance.py
+++ b/cfme/tests/automate/test_instance.py
@@ -127,6 +127,7 @@ def test_automate_relationship_trailing_spaces(request, klass, namespace, domain
         initialEstimate: 1/10h
         caseimportance: medium
         caseposneg: positive
+        caseposneg: positive
         testtype: functional
         startsin: 5.9
         casecomponent: Automate
@@ -206,7 +207,7 @@ def test_automate_relationship_trailing_spaces(request, klass, namespace, domain
         "/var/www/miq/vmdb/log/automation.log", matched_patterns=[".*{}.*".format(catch_string)],
         failure_patterns=[".*ERROR.*"]
     )
-    result.fix_before_start()
+    result.start_monitoring()
 
     # Executing the automate method of klass1 using simulation
     simulate(
@@ -218,7 +219,7 @@ def test_automate_relationship_trailing_spaces(request, klass, namespace, domain
             "instance": instance2.name,
         },
     )
-    result.validate_logs()
+    assert result.validate(wait="60s")
 
 
 @pytest.fixture(scope="module")
@@ -278,7 +279,7 @@ def test_check_system_request_calls_depr_conf_mgmt(appliance, copy_instance):
         appliance=appliance,
         request=copy_instance.name
     )
-    assert result.validate()
+    assert result.validate(wait="60s")
 
 
 @pytest.fixture(scope="module")
@@ -353,4 +354,4 @@ def test_quota_source_value(request, entity, search, copy_quota_instance, generi
     service_catalogs.order()
     provision_request.wait_for_request(method='ui')
     request.addfinalizer(lambda: provision_request.remove_request(method="rest"))
-    assert result.validate()
+    assert result.validate(wait="60s")

--- a/cfme/tests/automate/test_instance.py
+++ b/cfme/tests/automate/test_instance.py
@@ -272,13 +272,13 @@ def test_check_system_request_calls_depr_conf_mgmt(appliance, copy_instance):
     result = LogValidator(
         "/var/www/miq/vmdb/log/automation.log", matched_patterns=[".*{}.*".format(search)]
     )
-    result.fix_before_start()
+    result.start_monitoring()
     # Executing the automate instance - 'ansible_tower_job' using simulation
     simulate(
         appliance=appliance,
         request=copy_instance.name
     )
-    result.validate_logs()
+    assert result.validate()
 
 
 @pytest.fixture(scope="module")
@@ -341,7 +341,7 @@ def test_quota_source_value(request, entity, search, copy_quota_instance, generi
     result = LogValidator(
         "/var/www/miq/vmdb/log/automation.log", matched_patterns=[".*{}.*".format(search)]
     )
-    result.fix_before_start()
+    result.start_monitoring()
     service_catalogs = ServiceCatalogs(
         copy_quota_instance.appliance, catalog=generic_catalog_item.catalog,
         name=generic_catalog_item.name
@@ -353,4 +353,4 @@ def test_quota_source_value(request, entity, search, copy_quota_instance, generi
     service_catalogs.order()
     provision_request.wait_for_request(method='ui')
     request.addfinalizer(lambda: provision_request.remove_request(method="rest"))
-    result.validate_logs()
+    assert result.validate()

--- a/cfme/tests/automate/test_method.py
+++ b/cfme/tests/automate/test_method.py
@@ -271,7 +271,7 @@ def test_task_id_for_method_automation_log(request, generic_catalog_item):
     # service_request becomes active.
     wait_for(lambda: service_request.request_state == "active", fail_func=service_request.reload,
              timeout=60, delay=3)
-    assert result.validate()
+    assert result.validate(wait="60s")
 
 
 @pytest.mark.meta(blockers=[BZ(1704439)])
@@ -346,7 +346,7 @@ def test_send_email_method(smtp_test, klass):
         request="Call_Instance",
         execute_methods=True,
     )
-    assert result.validate()
+    assert result.validate(wait="60s")
 
     # TODO(GH-8820): This issue should be fixed to check mails sent to person in 'cc' and 'bcc'
     # Check whether the mail sent via automate method really arrives
@@ -446,7 +446,7 @@ def test_automate_generic_object_service_associations(appliance, klass, go_servi
             request="Call_Instance",
             execute_methods=True,
         )
-        assert result.validate()
+        assert result.validate(wait="60s")
 
 
 @pytest.mark.tier(1)

--- a/cfme/tests/automate/test_method.py
+++ b/cfme/tests/automate/test_method.py
@@ -261,7 +261,7 @@ def test_task_id_for_method_automation_log(request, generic_catalog_item):
     result = LogValidator(
         "/var/www/miq/vmdb/log/automation.log", matched_patterns=[".*Q-task_id.*"]
     )
-    result.fix_before_start()
+    result.start_monitoring()
     service_request = generic_catalog_item.appliance.rest_api.collections.service_templates.get(
         name=generic_catalog_item.name
     ).action.order()
@@ -271,7 +271,7 @@ def test_task_id_for_method_automation_log(request, generic_catalog_item):
     # service_request becomes active.
     wait_for(lambda: service_request.request_state == "active", fail_func=service_request.reload,
              timeout=60, delay=3)
-    result.validate_logs()
+    assert result.validate()
 
 
 @pytest.mark.meta(blockers=[BZ(1704439)])
@@ -332,7 +332,7 @@ def test_send_email_method(smtp_test, klass):
             )
         ],
     )
-    result.fix_before_start()
+    result.start_monitoring()
 
     # Executing automate method - send_email using simulation
     simulate(
@@ -346,7 +346,7 @@ def test_send_email_method(smtp_test, klass):
         request="Call_Instance",
         execute_methods=True,
     )
-    result.validate_logs()
+    assert result.validate()
 
     # TODO(GH-8820): This issue should be fixed to check mails sent to person in 'cc' and 'bcc'
     # Check whether the mail sent via automate method really arrives
@@ -432,7 +432,7 @@ def test_automate_generic_object_service_associations(appliance, klass, go_servi
                 r'.*XYZ load balancer got service: #<MiqAeServiceService.*'
             ],
         )
-        result.fix_before_start()
+        result.start_monitoring()
 
         # Executing automate method using simulation
         simulate(
@@ -446,7 +446,7 @@ def test_automate_generic_object_service_associations(appliance, klass, go_servi
             request="Call_Instance",
             execute_methods=True,
         )
-        result.validate_logs()
+        assert result.validate()
 
 
 @pytest.mark.tier(1)
@@ -467,7 +467,7 @@ def test_automate_service_quota_runs_only_once(appliance, generic_catalog_item):
         "/var/www/miq/vmdb/log/automation.log",
         matched_patterns=[pattern]
     )
-    result.fix_before_start()
+    result.start_monitoring()
     service_catalogs = ServiceCatalogs(
         appliance, catalog=generic_catalog_item.catalog, name=generic_catalog_item.name
     )

--- a/cfme/tests/automate/test_service_automate.py
+++ b/cfme/tests/automate/test_service_automate.py
@@ -111,13 +111,13 @@ def test_user_requester_for_lifecycle_provision(request, appliance, provider, se
             matched_patterns=[".*This is the user: {name}.*".format(
                 name=new_users[0].credential.principal)],
         )
-        result.fix_before_start()
+        result.start_monitoring()
         service_catalogs = ServiceCatalogs(
             appliance, catalog=generic_catalog_item.catalog, name=generic_catalog_item.name
         )
         provision_request = service_catalogs.order()
         provision_request.wait_for_request()
-        result.validate_logs()
+        assert result.validate()
 
     with new_users[1]:
         # Log in with second user and provision instance via lifecycle
@@ -126,7 +126,7 @@ def test_user_requester_for_lifecycle_provision(request, appliance, provider, se
             matched_patterns=[".*This is the user: {name}.*".format(
                 name=new_users[1].credential.principal)],
         )
-        result.fix_before_start()
+        result.start_monitoring()
         prov_data = {
             "catalog": {'vm_name': random_vm_name(context='provision')},
             "environment": {'automatic_placement': True},
@@ -141,4 +141,4 @@ def test_user_requester_for_lifecycle_provision(request, appliance, provider, se
         provision_request = appliance.collections.requests.instantiate(request_description)
         provision_request.wait_for_request(method='ui')
         request.addfinalizer(provision_request.remove_request)
-        result.validate_logs()
+        assert result.validate()

--- a/cfme/tests/automate/test_service_automate.py
+++ b/cfme/tests/automate/test_service_automate.py
@@ -117,7 +117,7 @@ def test_user_requester_for_lifecycle_provision(request, appliance, provider, se
         )
         provision_request = service_catalogs.order()
         provision_request.wait_for_request()
-        assert result.validate()
+        assert result.validate(wait="60s")
 
     with new_users[1]:
         # Log in with second user and provision instance via lifecycle
@@ -141,4 +141,4 @@ def test_user_requester_for_lifecycle_provision(request, appliance, provider, se
         provision_request = appliance.collections.requests.instantiate(request_description)
         provision_request.wait_for_request(method='ui')
         request.addfinalizer(provision_request.remove_request)
-        assert result.validate()
+        assert result.validate(wait="60s")

--- a/cfme/tests/cli/test_appliance_cli.py
+++ b/cfme/tests/cli/test_appliance_cli.py
@@ -145,19 +145,19 @@ def test_appliance_console_cli_external_auth(auth_type, ipa_crud, configured_app
     evm_tail = LogValidator('/var/www/miq/vmdb/log/evm.log',
                             matched_patterns=['.*{} to true.*'.format(auth_type)],
                             hostname=configured_appliance.hostname)
-    evm_tail.fix_before_start()
+    evm_tail.start_monitoring()
     cmd_set = 'appliance_console_cli --extauth-opts="/authentication/{}=true"'.format(auth_type)
     assert configured_appliance.ssh_client.run_command(cmd_set)
-    evm_tail.validate_logs()
+    assert evm_tail.validate()
 
     evm_tail = LogValidator('/var/www/miq/vmdb/log/evm.log',
                             matched_patterns=['.*{} to false.*'.format(auth_type)],
                             hostname=configured_appliance.hostname)
 
-    evm_tail.fix_before_start()
+    evm_tail.start_monitoring()
     cmd_unset = 'appliance_console_cli --extauth-opts="/authentication/{}=false"'.format(auth_type)
     assert configured_appliance.ssh_client.run_command(cmd_unset)
-    evm_tail.validate_logs()
+    assert evm_tail.validate()
 
 
 @pytest.fixture(scope='function')

--- a/cfme/tests/cli/test_appliance_cli.py
+++ b/cfme/tests/cli/test_appliance_cli.py
@@ -148,7 +148,7 @@ def test_appliance_console_cli_external_auth(auth_type, ipa_crud, configured_app
     evm_tail.start_monitoring()
     cmd_set = 'appliance_console_cli --extauth-opts="/authentication/{}=true"'.format(auth_type)
     assert configured_appliance.ssh_client.run_command(cmd_set)
-    assert evm_tail.validate()
+    assert evm_tail.validate(wait="30s")
 
     evm_tail = LogValidator('/var/www/miq/vmdb/log/evm.log',
                             matched_patterns=['.*{} to false.*'.format(auth_type)],
@@ -157,7 +157,7 @@ def test_appliance_console_cli_external_auth(auth_type, ipa_crud, configured_app
     evm_tail.start_monitoring()
     cmd_unset = 'appliance_console_cli --extauth-opts="/authentication/{}=false"'.format(auth_type)
     assert configured_appliance.ssh_client.run_command(cmd_unset)
-    assert evm_tail.validate()
+    assert evm_tail.validate(wait="30s")
 
 
 @pytest.fixture(scope='function')

--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -470,7 +470,7 @@ def test_appliance_console_external_auth(auth_type, ipa_crud, configured_applian
     evm_tail.start_monitoring()
     command_set = ('ap', RETURN, '13', auth_type.index, '5', RETURN, RETURN)
     configured_appliance.appliance_console.run_commands(command_set, timeout=30)
-    assert evm_tail.validate()
+    assert evm_tail.validate(wait="30s")
 
     evm_tail = LogValidator('/var/www/miq/vmdb/log/evm.log',
                             matched_patterns=['.*{} to false.*'.format(auth_type.option)],
@@ -479,7 +479,7 @@ def test_appliance_console_external_auth(auth_type, ipa_crud, configured_applian
     evm_tail.start_monitoring()
     command_set = ('ap', RETURN, '13', auth_type.index, '5', RETURN, RETURN)
     configured_appliance.appliance_console.run_commands(command_set, timeout=30)
-    assert evm_tail.validate()
+    assert evm_tail.validate(wait="30s")
 
 
 def test_appliance_console_external_auth_all(configured_appliance):
@@ -506,7 +506,7 @@ def test_appliance_console_external_auth_all(configured_appliance):
     command_set = ('ap', RETURN, TimedCommand('13', 20), '1', '2', TimedCommand('5', 20),
                    RETURN, RETURN)
     configured_appliance.appliance_console.run_commands(command_set)
-    assert evm_tail.validate()
+    assert evm_tail.validate("30s")
 
     evm_tail = LogValidator('/var/www/miq/vmdb/log/evm.log',
                             matched_patterns=['.*sso_enabled to false.*',
@@ -518,7 +518,7 @@ def test_appliance_console_external_auth_all(configured_appliance):
     command_set = ('ap', RETURN, TimedCommand('13', 20), '1', '2', TimedCommand('5', 20),
                    RETURN, RETURN)
     configured_appliance.appliance_console.run_commands(command_set)
-    assert evm_tail.validate()
+    assert evm_tail.validate(wait="30s")
 
 
 @pytest.mark.rhel_testing

--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -467,19 +467,19 @@ def test_appliance_console_external_auth(auth_type, ipa_crud, configured_applian
     evm_tail = LogValidator('/var/www/miq/vmdb/log/evm.log',
                             matched_patterns=['.*{} to true.*'.format(auth_type.option)],
                             hostname=configured_appliance.hostname)
-    evm_tail.fix_before_start()
+    evm_tail.start_monitoring()
     command_set = ('ap', RETURN, '13', auth_type.index, '5', RETURN, RETURN)
     configured_appliance.appliance_console.run_commands(command_set, timeout=30)
-    evm_tail.validate_logs()
+    assert evm_tail.validate()
 
     evm_tail = LogValidator('/var/www/miq/vmdb/log/evm.log',
                             matched_patterns=['.*{} to false.*'.format(auth_type.option)],
                             hostname=configured_appliance.hostname)
 
-    evm_tail.fix_before_start()
+    evm_tail.start_monitoring()
     command_set = ('ap', RETURN, '13', auth_type.index, '5', RETURN, RETURN)
     configured_appliance.appliance_console.run_commands(command_set, timeout=30)
-    evm_tail.validate_logs()
+    assert evm_tail.validate()
 
 
 def test_appliance_console_external_auth_all(configured_appliance):
@@ -502,11 +502,11 @@ def test_appliance_console_external_auth_all(configured_appliance):
                                               '.*saml_enabled to true.*',
                                               '.*local_login_disabled to true.*'],
                             hostname=configured_appliance.hostname)
-    evm_tail.fix_before_start()
+    evm_tail.start_monitoring()
     command_set = ('ap', RETURN, TimedCommand('13', 20), '1', '2', TimedCommand('5', 20),
                    RETURN, RETURN)
     configured_appliance.appliance_console.run_commands(command_set)
-    evm_tail.validate_logs()
+    assert evm_tail.validate()
 
     evm_tail = LogValidator('/var/www/miq/vmdb/log/evm.log',
                             matched_patterns=['.*sso_enabled to false.*',
@@ -514,11 +514,11 @@ def test_appliance_console_external_auth_all(configured_appliance):
                                               '.*local_login_disabled to false.*'],
                             hostname=configured_appliance.hostname)
 
-    evm_tail.fix_before_start()
+    evm_tail.start_monitoring()
     command_set = ('ap', RETURN, TimedCommand('13', 20), '1', '2', TimedCommand('5', 20),
                    RETURN, RETURN)
     configured_appliance.appliance_console.run_commands(command_set)
-    evm_tail.validate_logs()
+    assert evm_tail.validate()
 
 
 @pytest.mark.rhel_testing

--- a/cfme/tests/configure/test_database_ui.py
+++ b/cfme/tests/configure/test_database_ui.py
@@ -60,4 +60,4 @@ def test_configuration_database_garbage_collection(appliance):
     view = navigate_to(appliance.server.zone.region, 'Database')
     view.submit_db_garbage_collection_button.click()
     view.flash.assert_message('Database Garbage Collection successfully initiated')
-    assert evm_tail.validate()
+    assert evm_tail.validate(wait="30s")

--- a/cfme/tests/configure/test_database_ui.py
+++ b/cfme/tests/configure/test_database_ui.py
@@ -56,8 +56,8 @@ def test_configuration_database_garbage_collection(appliance):
                                 r'.*Queued the action: \[Database GC\] being run for user:.*'
                             ],
                             failure_patterns=[r'.*ERROR.*'])
-    evm_tail.fix_before_start()
+    evm_tail.start_monitoring()
     view = navigate_to(appliance.server.zone.region, 'Database')
     view.submit_db_garbage_collection_button.click()
     view.flash.assert_message('Database Garbage Collection successfully initiated')
-    evm_tail.validate_logs()
+    assert evm_tail.validate()

--- a/cfme/tests/containers/test_blacklisted_container_events.py
+++ b/cfme/tests/containers/test_blacklisted_container_events.py
@@ -157,7 +157,7 @@ def test_blacklisted_container_events(request, appliance, provider, app_creds):
         '/var/www/miq/vmdb/log/evm.log',
         matched_patterns=[r'.*event\_type\=\>\"POD\_CREATED\".*']
     )
-    evm_tail_no_blacklist.fix_before_start()
+    evm_tail_no_blacklist.start_monitoring()
 
     create_pod(provider=provider, namespace=project_name)
 
@@ -165,7 +165,7 @@ def test_blacklisted_container_events(request, appliance, provider, app_creds):
 
     assert "POD_CREATED" not in rails_result_no_blacklist
 
-    evm_tail_no_blacklist.validate_logs()
+    assert evm_tail_no_blacklist.validate()
 
     delete_pod(provider=provider, namespace=project_name)
 
@@ -186,11 +186,11 @@ def test_blacklisted_container_events(request, appliance, provider, app_creds):
         username=app_creds['sshlogin'],
         password=app_creds['password'])
 
-    evm_tail_blacklist.fix_before_start()
+    evm_tail_blacklist.start_monitoring()
 
     create_pod(provider=provider, namespace=project_name)
 
-    evm_tail_blacklist.validate_logs()
+    assert evm_tail_blacklist.validate()
 
     delete_pod(provider=provider, namespace=project_name)
 
@@ -205,7 +205,7 @@ def test_blacklisted_container_events(request, appliance, provider, app_creds):
     appliance.evmserverd.restart()
     appliance.wait_for_web_ui()
 
-    evm_tail_no_blacklist.fix_before_start()
+    evm_tail_no_blacklist.start_monitoring()
 
     create_pod(provider=provider, namespace=project_name)
 
@@ -215,4 +215,4 @@ def test_blacklisted_container_events(request, appliance, provider, app_creds):
     # catch. Only option was to add a short sleep here.
     time.sleep(10)
 
-    evm_tail_no_blacklist.validate_logs()
+    assert evm_tail_no_blacklist.validate()

--- a/cfme/tests/containers/test_blacklisted_container_events.py
+++ b/cfme/tests/containers/test_blacklisted_container_events.py
@@ -1,5 +1,3 @@
-import time
-
 import fauxfactory
 import pytest
 from wrapanapi.systems.container.rhopenshift import ApiException
@@ -208,11 +206,4 @@ def test_blacklisted_container_events(request, appliance, provider, app_creds):
     evm_tail_no_blacklist.start_monitoring()
 
     create_pod(provider=provider, namespace=project_name)
-
-    # After restarting evm, there was a delay in logging for a brief period. validate_logs() was
-    # being called before the log event was created and causing the test to fail. validate_logs()
-    # calls pytest.fail, so using wait_for() here was not possible since there is no exception to
-    # catch. Only option was to add a short sleep here.
-    time.sleep(10)
-
-    assert evm_tail_no_blacklist.validate()
+    assert evm_tail_no_blacklist.validate(wait="120s")

--- a/cfme/tests/containers/test_pause_resume_workers.py
+++ b/cfme/tests/containers/test_pause_resume_workers.py
@@ -76,7 +76,7 @@ def test_pause_and_resume_single_provider_api(appliance, provider, from_collecti
     evm_tail_disable = LogValidator('/var/www/miq/vmdb/log/evm.log',
                                     matched_patterns=[r'.*Disabling EMS \[{}\] id \[{}\].*'
                                                       .format(provider.name, str(provider.id))])
-    evm_tail_disable.fix_before_start()
+    evm_tail_disable.start_monitoring()
     if from_collections:
         rep_disable = appliance.collections.containers_providers.pause_providers(provider)
         # collections class returns a list of dicts containing the API response.
@@ -89,7 +89,7 @@ def test_pause_and_resume_single_provider_api(appliance, provider, from_collecti
                     .format(provider.name))
     soft_assert(not provider.is_provider_enabled, 'Provider {} is still enabled'
                 .format(provider.name))
-    evm_tail_disable.validate_logs()
+    assert evm_tail_disable.validate()
     # Verify all monitoring workers have been shut down
     assert wait_for(lambda: not check_ems_state_in_diagnostics(appliance, provider))
     # Create a project on the OpenShift provider via wrapanapi
@@ -117,7 +117,7 @@ def test_pause_and_resume_single_provider_api(appliance, provider, from_collecti
     evm_tail_enable = LogValidator('/var/www/miq/vmdb/log/evm.log',
                                    matched_patterns=[r'.*Enabling EMS \[{}\] id \[{}\].*'
                                                      .format(provider.name, str(provider.id))])
-    evm_tail_enable.fix_before_start()
+    evm_tail_enable.start_monitoring()
     if from_collections:
         rep_enable = appliance.collections.containers_providers.resume_providers(provider)
         soft_assert(rep_enable[0].get('success'), 'Enabling provider {} failed'
@@ -126,7 +126,7 @@ def test_pause_and_resume_single_provider_api(appliance, provider, from_collecti
         rep_enable = provider.resume()
         soft_assert(rep_enable.get('success'), 'Enabling provider {} failed'.format(provider.name))
     soft_assert(provider.is_provider_enabled, 'Provider {} is still disabled'.format(provider.name))
-    evm_tail_enable.validate_logs()
+    assert evm_tail_enable.validate()
     provider.refresh_provider_relationships()
     soft_assert(
         wait_for(

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -394,14 +394,14 @@ def test_action_prevent_ssa(request, appliance, configure_fleecing, vm, vm_on, p
             '.*Prevent current event from proceeding.*VM Analysis Request.*{}'.format(vm.name)
         ]
     )
-    policy_result.fix_before_start()
+    policy_result.start_monitoring()
 
     wait_for_ssa_enabled(vm)
 
     try:
         do_scan(vm)
     except TimedOutError:
-        policy_result.validate_logs()
+        assert policy_result.validate()
     else:
         pytest.fail("CFME did not prevent analysing the VM {}".format(vm.name))
 
@@ -437,7 +437,7 @@ def test_action_prevent_host_ssa(request, appliance, host, host_policy):
             '.*Prevent current event from proceeding.*Host Analysis Request.*{}'.format(host.name)
         ]
     )
-    policy_result.fix_before_start()
+    policy_result.start_monitoring()
 
     view = navigate_to(host, "Details")
 
@@ -456,7 +456,7 @@ def test_action_prevent_host_ssa(request, appliance, host, host_policy):
             message="Check if Drift History field is changed",
         )
     except TimedOutError:
-        policy_result.validate_logs()
+        assert policy_result.validate()
     else:
         pytest.fail("CFME did not prevent analysing the Host {}".format(host.name))
 
@@ -487,7 +487,7 @@ def test_action_power_on_logged(request, vm, vm_off, appliance, policy_for_testi
             )
         ]
     )
-    policy_result.fix_before_start()
+    policy_result.start_monitoring()
 
     # Set up the policy and prepare finalizer
     policy_for_testing.assign_actions_to_event("VM Power On", ["Generate log message"])
@@ -499,7 +499,7 @@ def test_action_power_on_logged(request, vm, vm_off, appliance, policy_for_testi
     # Start the VM
     vm.mgmt.ensure_state(VmState.RUNNING)
     # search logs wait_for log_validation
-    policy_result.wait_for_log_validation()
+    assert policy_result.validate()
 
 
 @pytest.mark.provider(
@@ -527,7 +527,7 @@ def test_action_power_on_audit(request, vm, vm_off, appliance, policy_for_testin
             )
         ]
     )
-    policy_result.fix_before_start()
+    policy_result.start_monitoring()
     # Set up the policy and prepare finalizer
     policy_for_testing.assign_actions_to_event("VM Power On", ["Generate Audit Event"])
 
@@ -539,7 +539,7 @@ def test_action_power_on_audit(request, vm, vm_off, appliance, policy_for_testin
     vm.mgmt.ensure_state(VmState.RUNNING)
 
     # Search the logs and wait for validation
-    policy_result.wait_for_log_validation()
+    assert policy_result.validate("180s")
 
 
 @pytest.mark.provider([VMwareProvider, RHEVMProvider], scope="module")

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -401,7 +401,7 @@ def test_action_prevent_ssa(request, appliance, configure_fleecing, vm, vm_on, p
     try:
         do_scan(vm)
     except TimedOutError:
-        assert policy_result.validate()
+        assert policy_result.validate(wait="120s")
     else:
         pytest.fail("CFME did not prevent analysing the VM {}".format(vm.name))
 
@@ -456,7 +456,7 @@ def test_action_prevent_host_ssa(request, appliance, host, host_policy):
             message="Check if Drift History field is changed",
         )
     except TimedOutError:
-        assert policy_result.validate()
+        assert policy_result.validate(wait="120s")
     else:
         pytest.fail("CFME did not prevent analysing the Host {}".format(host.name))
 
@@ -499,7 +499,7 @@ def test_action_power_on_logged(request, vm, vm_off, appliance, policy_for_testi
     # Start the VM
     vm.mgmt.ensure_state(VmState.RUNNING)
     # search logs wait_for log_validation
-    assert policy_result.validate()
+    assert policy_result.validate(wait="120s")
 
 
 @pytest.mark.provider(

--- a/cfme/tests/networks/nuage/test_automation.py
+++ b/cfme/tests/networks/nuage/test_automation.py
@@ -77,6 +77,6 @@ def test_embedded_ansible_executed_with_data_upon_event(request,
                                                                                    enterprise.id)
         ]
     )
-    evm_tail.fix_before_start()
+    evm_tail.start_monitoring()
     # search logs and wait for validation
-    evm_tail.wait_for_log_validation(timeout=300, delay=10, fail_condition=False)
+    assert evm_tail.validate(wait="300s")

--- a/cfme/tests/services/test_catalog_item.py
+++ b/cfme/tests/services/test_catalog_item.py
@@ -448,4 +448,4 @@ def test_service_provisioning_email(request, appliance, catalog_item):
     provision_request = appliance.collections.requests.instantiate(request_description)
     provision_request.wait_for_request(method='ui')
     request.addfinalizer(provision_request.remove_request)
-    assert result.validate()
+    assert result.validate(wait="60s")

--- a/cfme/tests/services/test_catalog_item.py
+++ b/cfme/tests/services/test_catalog_item.py
@@ -440,7 +440,7 @@ def test_service_provisioning_email(request, appliance, catalog_item):
     result = LogValidator(
         "/var/www/miq/vmdb/log/automation.log", failure_patterns=[".*Error during substitution.*"]
     )
-    result.fix_before_start()
+    result.start_monitoring()
     service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
     service_catalogs.order()
     request_description = ("Provisioning Service [{catalog_item_name}] from [{catalog_item_name}]"
@@ -448,4 +448,4 @@ def test_service_provisioning_email(request, appliance, catalog_item):
     provision_request = appliance.collections.requests.instantiate(request_description)
     provision_request.wait_for_request(method='ui')
     request.addfinalizer(provision_request.remove_request)
-    result.validate_logs()
+    assert result.validate()

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -461,7 +461,7 @@ class TestServiceRESTAPI(object):
                 ".*ERROR -- : <AEMethod update_service_retirement_status> Service Retire Error:",
             ],
         )
-        auto_log.fix_before_start()
+        auto_log.start_monitoring()
 
         if from_detail:
             service.action.retire()
@@ -475,7 +475,7 @@ class TestServiceRESTAPI(object):
             num_sec=50,
             delay=5,
         )
-        auto_log.wait_for_log_validation()
+        assert auto_log.validate(wait="180s")
 
         assert service.retirement_state == "initializing"
 

--- a/cfme/tests/test_appliance.py
+++ b/cfme/tests/test_appliance.py
@@ -407,7 +407,7 @@ def test_codename_in_log(appliance):
                       hostname=appliance.hostname)
     lv.start_monitoring()
     appliance.ssh_client.run_command('appliance_console_cli --server=restart')
-    assert lv.validate()
+    assert lv.validate(wait="60s")
     appliance.wait_for_web_ui()
 
 

--- a/cfme/tests/test_appliance.py
+++ b/cfme/tests/test_appliance.py
@@ -405,9 +405,9 @@ def test_codename_in_log(appliance):
     lv = LogValidator(log,
                       matched_patterns=[r'.*Codename: \w+$'],
                       hostname=appliance.hostname)
-    lv.fix_before_start()
+    lv.start_monitoring()
     appliance.ssh_client.run_command('appliance_console_cli --server=restart')
-    lv.wait_for_log_validation()
+    assert lv.validate()
     appliance.wait_for_web_ui()
 
 

--- a/cfme/utils/log_validator.py
+++ b/cfme/utils/log_validator.py
@@ -1,17 +1,26 @@
 import re
 
-import pytest
-from _pytest.outcomes import Failed
-
 from .ssh import SSHTail
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for
 
 
+class LogValidatorException(Exception):
+    """Its custom exception related to LogValidator"""
+
+    def __init__(self, pattern, message, line):
+        self.pattern = pattern
+        self.message = message
+        self.line = line
+
+    def __str__(self):
+        return repr("Pattern '{p}': {m}".format(p=self.pattern, m=self.message))
+
+
 class LogValidator(object):
     """
     Log content validator class provides methods
-    to fix the log content before test is started,
+    to monitor the log content before test is started,
     and validate the content of log during test execution,
     according to predefined patterns.
     Predefined patterns are:
@@ -25,6 +34,8 @@ class LogValidator(object):
     to be possible to skip particular ERROR log,
     but fail for wider range of other ERRORs.
 
+    Note: If failures pattern matched in log; It will raise `LogValidatorException`
+
     Args:
         remote_filename: path to the remote log file
         skip_patterns: array of skip regex patterns
@@ -37,8 +48,8 @@ class LogValidator(object):
                                   skip_patterns=['PARTICULAR_ERROR'],
                                   failure_patterns=['.*ERROR.*'],
                                   matched_patterns=['PARTICULAR_INFO'])
-          evm_tail.fix_before_start()
-          evm_tail.validate_logs()
+          evm_tail.start_monitoring()
+          evm_tail.validate()       # evm_tail.validate(wait="30s")
     """
 
     def __init__(self, remote_filename, **kwargs):
@@ -49,32 +60,46 @@ class LogValidator(object):
         self._remote_file_tail = SSHTail(remote_filename, **kwargs)
         self._matches = {key: 0 for key in self.matched_patterns}
 
-    def fix_before_start(self):
+    def start_monitoring(self):
         """Start monitoring log before action"""
         self._remote_file_tail.set_initial_file_end()
+        logger.info("Log monitoring has been started on remote file")
 
     def _check_skip_logs(self, line):
         for pattern in self.skip_patterns:
             if re.search(pattern, line):
-                logger.info('Skip pattern {} was matched on line {},\
-                            so skipping this line'.format(pattern, line))
+                logger.info(
+                    "Skip pattern %s was matched on line %s so skipping this line", pattern, line
+                )
                 return True
         return False
 
     def _check_fail_logs(self, line):
         for pattern in self.failure_patterns:
             if re.search(pattern, line):
-                pytest.fail('Failure pattern {} was matched on line {}'.format(pattern, line))
+                logger.error("Failure pattern %s was matched on line %s", pattern, line)
+                raise LogValidatorException(pattern, "Expected failure pattern found in log.", line)
 
     def _check_match_logs(self, line):
         for pattern in self.matched_patterns:
             if re.search(pattern, line):
-                logger.info('Expected pattern {} was matched on line {}'.format(pattern, line))
+                logger.info("Expected pattern %s was matched on line %s", pattern, line)
                 self._matches[pattern] = self._matches[pattern] + 1
 
     @property
+    def _validate(self):
+        for pattern, count in self.matches.items():
+            if count == 0:
+                logger.info("Expected '%s' pattern not found", pattern)
+                return False
+        return True
+
+    @property
     def matches(self):
-        """It will return pattern match count dictionary"""
+        """Collect match count in log
+
+        Returns (dict): Pattern match count dictionary
+        """
 
         for line in self._remote_file_tail:
             if self._check_skip_logs(line):
@@ -85,28 +110,22 @@ class LogValidator(object):
         logger.info("Matches found: {}".format(self._matches))
         return self._matches
 
-    def validate_logs(self):
-        """Validate log pattern"""
-        for pattern, count in self.matches.items():
-            if count == 0:
-                pytest.fail(
-                    'Expected pattern {} did not match; match count {}'.format(pattern, count)
-                )
+    def validate(self, wait=None, message="waiting for log validation", **kwargs):
+        """Validate log pattern
 
-    def wait_for_log_validation(
-            self, delay=5, num_sec=180, message="waiting for log validation", **kwargs
-    ):
-        """ Wait for log validation, takes the kwargs as wait_for. This function will reduce
-            duplicate functions in tests that wait_for log_validation. It is necessary to create
-            this function since _verify_match_logs raise pytest.fail() when it fails to find the
-            match pattern in the logs.
-
-            Note that you must call fix_before_start() before making use of this function.
+        Args:
+            wait: Wait for log validation (timeout)
+            message: Specific message.
+        Returns (bool): True if expected pattern matched in log else False
+        Raise:
+            TimeOutError: If failed to match pattern in respective timeout
+            LogValidatorException: If failure pattern matched
         """
-        def validate():
-            try:
-                self.validate_logs()
-                return True
-            except Failed:
-                return False
-        wait_for(validate, delay=delay, num_sec=num_sec, message=message, **kwargs)
+
+        if wait:
+            ret, _ = wait_for(
+                lambda: self._validate, delay=5, timeout=wait, message=message, **kwargs
+            )
+            return ret
+        else:
+            return self._validate


### PR DESCRIPTION
Signed-off-by: Nikhil Dhandre <ndhandre@redhat.com>

Purpose or Intent
=================
- Refactor method names as per converstation [PR-8918](https://github.com/ManageIQ/integration_tests/pull/8918#issuecomment-504006364)
    - `fix_before_start()` > `start_monitoring()`
    - `validate_logs()` > `validate()`
    - `wait_for_log_validation` > `validate(wait="....")`



{{pytest: cfme/tests -k 'test_custom_button_with_dynamic_dialog_vm or test_custom_button_automate_service_vm or test_domain_lock_disabled or test_custom_button_automate_infra_obj or test_custom_button_dialog_infra_obj or test_check_system_request_calls_depr_conf_mgmt or test_quota_source_value or test_task_id_for_method_automation_log or test_send_email_method or test_automate_generic_object_service_associations or test_automate_service_quota_runs_only_once or test_service_provisioning_email or test_codename_in_log or test_appliance_console_external_auth or test_appliance_console_external_auth_all or test_action_prevent_ssa or test_action_prevent_host_ssa or test_action_power_on_logged or test_action_power_on_audit or test_service_retirement_methods or test_service_ansible_verbosity or test_appliance_console_cli_external_auth or test_configuration_database_garbage_collection or test_blacklisted_container_events or test_pause_and_resume_single_provider_api or test_user_requester_for_lifecycle_provision or test_automate_relationship_trailing_spaces' -vv --long-running}}