### PR TITLE
[1LP][RFR] Automating Ansible tests for Branched Repo and Link to playbook

### DIFF
--- a/cfme/ansible/repositories.py
+++ b/cfme/ansible/repositories.py
@@ -75,6 +75,16 @@ class RepositoryDetailsView(RepositoryBaseView):
         )
 
 
+class PlaybookRepositoryView(RepositoryDetailsView):
+
+    @property
+    def is_displayed(self):
+        return (
+            self.in_ansible_repositories and
+            self.title.text == "{} (All Playbooks)".format(self.context['object'].name)
+        )
+
+
 class RepositoryFormView(RepositoryBaseView):
     name = Input(name="name")
     description = Input(name="description")
@@ -355,6 +365,15 @@ class Edit(CFMENavigateStep):
 
     def step(self, *args, **kwargs):
         self.prerequisite_view.toolbar.configuration.item_select("Edit this Repository")
+
+
+@navigator.register(Repository, "Playbooks")
+class PlaybookRepository(CFMENavigateStep):
+    VIEW = PlaybookRepositoryView
+    prerequisite = NavigateToSibling("Details")
+
+    def step(self, *args, **kwargs):
+        self.prerequisite_view.entities.summary("Relationships").click_at("Playbooks")
 
 
 @navigator.register(Repository, 'EditTags')

--- a/cfme/ansible/repositories.py
+++ b/cfme/ansible/repositories.py
@@ -75,7 +75,7 @@ class RepositoryDetailsView(RepositoryBaseView):
         )
 
 
-class PlaybookRepositoryView(RepositoryDetailsView):
+class RepositoryPlaybooksView(RepositoryDetailsView):
 
     @property
     def is_displayed(self):
@@ -368,8 +368,8 @@ class Edit(CFMENavigateStep):
 
 
 @navigator.register(Repository, "Playbooks")
-class PlaybookRepository(CFMENavigateStep):
-    VIEW = PlaybookRepositoryView
+class RepositoryPlaybooks(CFMENavigateStep):
+    VIEW = RepositoryPlaybooksView
     prerequisite = NavigateToSibling("Details")
 
     def step(self, *args, **kwargs):

--- a/cfme/tests/ansible/test_embedded_ansible_manual.py
+++ b/cfme/tests/ansible/test_embedded_ansible_manual.py
@@ -257,69 +257,6 @@ def test_embed_tower_repo_tag():
 
 
 @pytest.mark.tier(3)
-def test_embed_tower_repo_links():
-    """
-    test clicking #of playbooks cell will navigate to the Playbooks area,
-    filtered by the associated repo name.
-
-    Polarion:
-        assignee: sbulage
-        casecomponent: Ansible
-        caseimportance: medium
-        initialEstimate: 1/6h
-        tags: ansible_embed
-    """
-    pass
-
-
-@pytest.mark.tier(1)
-def test_embed_tower_add_branch_repo():
-    """
-    Ability to add repo with branch (without SCM credentials).
-
-    Polarion:
-        assignee: sbulage
-        casecomponent: Ansible
-        caseimportance: critical
-        initialEstimate: 1/6h
-        tags: ansible_embed
-    """
-    pass
-
-
-@pytest.mark.tier(1)
-def test_embed_tower_repo_list():
-    """
-    After all processes are running add a few repo"s for playbooks. Check
-    that all these repos appear in the repo list section in the ui, With
-    the correct status and the correct quantity of playbooks.
-
-    Polarion:
-        assignee: sbulage
-        casecomponent: Ansible
-        initialEstimate: 1/6h
-        tags: ansible_embed
-    """
-    pass
-
-
-@pytest.mark.tier(1)
-def test_embed_tower_repos_available():
-    """
-    Repositories are included under Ansible, Check Empty State pattern is
-    displayed when none exist.
-
-    Polarion:
-        assignee: sbulage
-        casecomponent: Ansible
-        caseimportance: critical
-        initialEstimate: 1/6h
-        tags: ansible_embed
-    """
-    pass
-
-
-@pytest.mark.tier(3)
 def test_embed_tower_repo_details():
     """
     test clicking on a repo name should show details of the repository.

--- a/cfme/tests/ansible/test_embedded_ansible_manual.py
+++ b/cfme/tests/ansible/test_embedded_ansible_manual.py
@@ -39,22 +39,6 @@ def test_embed_tower_retire_service_with_instances_ec2():
 
 
 @pytest.mark.tier(3)
-def test_embed_tower_playbook_links():
-    """
-    There are links to repo"s within the playbook table. Clicking in this
-    cell will navigate to the details of the Repo.
-
-    Polarion:
-        assignee: sbulage
-        casecomponent: Ansible
-        caseimportance: medium
-        initialEstimate: 1/6h
-        tags: ansible_embed
-    """
-    pass
-
-
-@pytest.mark.tier(3)
 def test_embed_tower_exec_play_against_machine_multi_appliance():
     """
     User/Admin is able to execute playbook without creating Job Temaplate


### PR DESCRIPTION
Already automated manual tests: `test_embed_tower_repo_list`, `test_embed_tower_repos_available`.
This PR automating manual tests: `test_embed_tower_repo_links`, `test_embed_tower_add_branch_repo`, `test_embed_tower_playbook_links`.

PRT Run:

{{ pytest: cfme/tests/ansible/test_embedded_ansible_basic.py -k "test_embedded_ansible_repository_playbook_link or test_embedded_ansible_repository_branch_crud" -svvvv --long-running }}