### PR TITLE
[1LP][RFR] fixed random tag selection for 5.11

### DIFF
--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -305,14 +305,21 @@ class TaggableCommonBase(object):
     """Class represents common functionality for tagging via collection and entities pages"""
 
     def _set_random_tag(self, view):
-        random_cat = random.choice(view.form.tag_category.all_options).text
-        # '*' is added in UI almost to all categoly while tag selection,
+        if self.appliance.version > "5.11":
+            random_cat = random.choice(view.form.tag_category.all_options)
+        else:
+            random_cat = random.choice(view.form.tag_category.all_options).text
+        # '*' is added in UI almost to all category while tag selection,
         #  but doesn't need for Category object creation
         random_cat_cut = random_cat[:-1].strip() if random_cat[-1] == '*' else random_cat
         view.form.tag_category.fill(random_cat)
         # In order to get the right tags list we need to select category first to get loaded tags
-        random_tag = random.choice([tag_option for tag_option in view.form.tag_name.all_options
-                                    if "select" not in tag_option.text.lower()]).text
+        if self.appliance.version > "5.11":
+            random_tag = random.choice([tag_option for tag_option in view.form.tag_name.all_options
+                                        if "select" not in tag_option.lower()])
+        else:
+            random_tag = random.choice([tag_option for tag_option in view.form.tag_name.all_options
+                                        if "select" not in tag_option.text.lower()]).text
         category = self.appliance.collections.categories.instantiate(display_name=random_cat_cut)
         return category.collections.tags.instantiate(display_name=random_tag)
 

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -2745,7 +2745,11 @@ class ReactSelect(Widget, ClickableMixin):
     BASE_LOCATOR = ".//div[@id={}]"
     BY_VISIBLE_TEXT = './/div[contains(@id, "react-select") and contains(normalize-space(.), {})]'
     SELECTED_VALUE = './/div[contains(@class, "singleValue")]'
-    ALL_OPTIONS = './/*[self::span or self::div][normalize-space(text())]'
+    # exclude "sr-only" - it has always the same text "Only a single value can be assigned from
+    # these categories" - the "i" mark in the UI
+    # exclude "react-select__placeholder" - it has "Select tag category" or "Select tag value"
+    ALL_OPTIONS = ('.//*[self::span or self::div][not(contains(@class,"sr-only") or '
+                   'contains(@class, "react-select__placeholder")) and normalize-space(text())]')
     # fmt: on
 
     def __init__(self, parent, id=None, locator=None, can_hide_on_select=False, logger=None):
@@ -2762,7 +2766,7 @@ class ReactSelect(Widget, ClickableMixin):
     @property
     def is_open(self):
         try:
-            return self.browser.is_displayed('//div[@class="css-1paxw40-menu"]')
+            return self.browser.is_displayed('.//div[contains(@class, "css-1paxw40-menu")]')
         except StaleElementReferenceException:
             self.logger.warning(
                 "Got a StaleElementReferenceException in .is_open, but ignoring. Returned False."
@@ -2812,7 +2816,7 @@ class ReactSelect(Widget, ClickableMixin):
                     self.browser.click(self.BY_VISIBLE_TEXT.format(quote(item)), force_scroll=True)
                 except NoSuchElementException:
                     raise SelectItemNotFound(
-                        widget=self, item=item, options=[opt.text for opt in self.all_options]
+                        widget=self, item=item, options=[opt for opt in self.all_options]
                     )
         self.close()
 
@@ -2820,7 +2824,9 @@ class ReactSelect(Widget, ClickableMixin):
     def all_options(self):
         # need to open the dropdown to see all available options
         self.open()
-        options = [self.browser.text(e) for e in self.browser.elements(self.ALL_OPTIONS)]
+        options = [
+            self.browser.text(e).encode("utf-8") for e in self.browser.elements(self.ALL_OPTIONS)
+        ]
         self.close()
         return options
 


### PR DESCRIPTION
{{ pytest: -v cfme/tests/configure/test_access_control.py::test_user_remove_tag }}

`all_options` selected some wrong (invalid) options, so I modified the locator.
The other problem was with encoding, that is also fixed but please let me know if there's a better solution.