### PR TITLE
[1LP][RFR] Chargeback rate edit/delete test fixes

### DIFF
--- a/cfme/intelligence/chargeback/rates.py
+++ b/cfme/intelligence/chargeback/rates.py
@@ -12,11 +12,11 @@ from widgetastic.widget import Text
 from widgetastic.widget import View
 from widgetastic_patternfly import BootstrapSelect
 from widgetastic_patternfly import Button
+from widgetastic_patternfly import CandidateNotFound
 from widgetastic_patternfly import Dropdown
 from widgetastic_patternfly import Input
 
 from . import ChargebackView
-from cfme.exceptions import CandidateNotFound
 from cfme.exceptions import ChargebackRateNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
@@ -128,7 +128,7 @@ class AddComputeChargebackView(RatesView):
 
 class EditComputeChargebackView(AddComputeChargebackView):
 
-    save_button = Button(title='Save Changes')
+    save_button = Button('Save')
     reset_button = Button(title='Reset Changes')
 
     @property
@@ -136,7 +136,8 @@ class EditComputeChargebackView(AddComputeChargebackView):
         return (
             self.in_chargeback and
             self.title.text == 'Compute Chargeback Rate "{}"'
-                               .format(self.context['object'].description)
+                               .format(self.context['object'].description) and
+            self.save_button.is_displayed
         )
 
 
@@ -150,7 +151,8 @@ class EditStorageChargebackView(EditComputeChargebackView):
         return (
             self.in_chargeback and
             self.title.text == 'Storage Chargeback Rate "{}"'
-                               .format(self.context['object'].description)
+                               .format(self.context['object'].description) and
+            self.save_button.is_displayed
         )
 
 
@@ -391,8 +393,7 @@ class StorageRateDetails(CFMENavigateStep):
                 "Rates",
                 "Storage", self.obj.description
             )
-        except Exception as ex:
-            # TODO don't diaper here
+        except CandidateNotFound as ex:
             raise ChargebackRateNotFound('Exception navigating to StorageRate {} "Details": {}'
                                          .format(self.obj.description, ex))
 

--- a/cfme/tests/intelligence/test_chargeback.py
+++ b/cfme/tests/intelligence/test_chargeback.py
@@ -123,22 +123,21 @@ def test_chargeback_rate(rate_resource, rate_type, rate_action, request, chargeb
         'Chargeback Rate "{}" was added'.format(cb_rate.description))
     assert cb_rate.exists
 
-    if 'delete' in rate_action:
+    if rate_action == 'delete':
         cb_rate.delete()
-        view = cb_rate.create_view(navigator.get_class(cb_rate, 'Details').VIEW, wait=10)
         view.flash.assert_success_message(
             'Chargeback Rate "{}": Delete successful'.format(cb_rate.description))
         assert not cb_rate.exists
 
-    if 'update' in rate_action:
+    if rate_action == 'edit':
         with update(cb_rate):
             cb_rate.description = '{}_edited'.format(cb_rate.description)
-            if 'compute' in rate_action:
+            if rate_resource == 'compute':
                 cb_rate.fields = {
                     'Fixed Compute Cost 1': random_per_time(fixed_rate='500'),
                     'Allocated CPU Count': random_per_time(fixed_rate='100'),
                 }
-            elif 'storage' in rate_action:
+            elif rate_resource == 'storage':
                 cb_rate.fields = {
                     'Fixed Storage Cost 1': random_per_time(fixed_rate='100'),
                     'Fixed Storage Cost 2': random_per_time(fixed_rate='200'),


### PR DESCRIPTION
Purpose or Intent
==============

1.) Editing of chargeback rate didn't work, because there is no difference in is_displayed between RatesDetailView and Edit{Compute,Storage}ChargebackView. Added am_i_here that returns False for both {Compute,Storage}RateEdit to force successful navigation.

2.) test_chargeback_rate never actually ran the 'edit' tests, because the code checked for a rate_action value of 'update' instead of 'edit'. Also, there was a bug in checking rate_action instead of rate_resource for the type of chargeback rate to edit.

3.) Updated cfme/intelligence/chargeback/rates.py to import CandidateNotFound from widgetastic_patternfly instead of the outdated cfme.exceptions version. The step methods for {Compute,Storage}RateDetails were unable to catch the correct exception. Also updated StorageRateDetails to match ComputeRateDetails and catch only CandidateNotFound instead of all Exceptions.

4.) Removed a call to create_view after deleting a chargeback rate. Not sure it's necessary, since it results in a navigation error, and the flash message can be seen without it, using the existing view.

{{ pytest: cfme/tests/intelligence/test_chargeback.py -k test_chargeback_rate -vvvv }}