### PR TITLE
[1LP][RFR] Add BZ Blocker for 5.11 bug 1727929

### DIFF
--- a/cfme/tests/configure/test_analysis_profiles.py
+++ b/cfme/tests/configure/test_analysis_profiles.py
@@ -5,6 +5,7 @@ import pytest
 from cfme import test_requirements
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator
+from cfme.utils.blockers import BZ
 from cfme.utils.update import update
 
 pytestmark = [pytest.mark.tier(3), test_requirements.configuration]
@@ -70,6 +71,7 @@ def analysis_profile_collection(appliance):
 
 @pytest.mark.sauce
 @pytest.mark.tier(2)
+@pytest.mark.meta(blockers=[BZ(1727929)])
 def test_vm_analysis_profile_crud(appliance, soft_assert, analysis_profile_collection):
     """CRUD for VM analysis profiles.
 


### PR DESCRIPTION
Purpose or Intent
==============

A 5.11 BZ prevents test_vm_analysis_profile_crud from running successfully. Adding blocker for that test/stream.

Bug 1727929 - Unable to save changes to VM Analysis Profile's categories
https://bugzilla.redhat.com/show_bug.cgi?id=1727929

{{ pytest: cfme/tests/configure/test_analysis_profiles.py -k test_vm_analysis_profile_crud -vvvv }}