### PR TITLE
[1LP][RFR] Close socket connection in utils.net.check_port

### DIFF
--- a/cfme/utils/net.py
+++ b/cfme/utils/net.py
@@ -72,10 +72,11 @@ def net_check(port, addr=None, force=False):
             addr = sockaddr[0]
             # Then try to connect to the port
             try:
-                socket.create_connection((addr, port), timeout=10)
-                _ports[addr][port] = True
+                socket.create_connection((addr, port), timeout=10).close()  # immediately close
             except socket.error:
                 _ports[addr][port] = False
+            else:
+                _ports[addr][port] = True
         except Exception:
             _ports[addr][port] = False
     return _ports[addr][port]


### PR DESCRIPTION
We're getting a warning for leaving this socket connection open:

`[WARNING] [py.warnings] ./cfme/utils/net.py:75: ResourceWarning: unclosed <socket.socket fd=27, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 39936), raddr=('127.0.0.1', 53007)>`

