### PR TITLE
[1LP][RFR] Fixed schema field issue in automate

### DIFF
--- a/cfme/tests/automate/test_class.py
+++ b/cfme/tests/automate/test_class.py
@@ -194,8 +194,9 @@ def test_automate_schema_field_without_type(klass):
     Bugzilla:
         1365442
     """
+    schema_field = fauxfactory.gen_alphanumeric()
     with pytest.raises(AssertionError):
-        klass.schema.add_fields({'name': 'execute', 'data_type': 'String'})
+        klass.schema.add_fields({'name': schema_field, 'data_type': 'String'})
     view = klass.create_view(ClassSchemaEditView)
     assert view.schema.save_button.disabled
     assert view.schema.reset_button.disabled

--- a/cfme/tests/automate/test_domain_priority.py
+++ b/cfme/tests/automate/test_domain_priority.py
@@ -228,6 +228,7 @@ def test_automate_disabled_domains_in_domain_priority(request, klass):
     Bugzilla:
         1331017
     """
+    schema_field = fauxfactory.gen_alphanumeric()
     # Create one more domain
     other_domain = klass.appliance.collections.domains.create(name=fauxfactory.gen_alphanumeric(),
                                                               description=fauxfactory.gen_alpha(),
@@ -242,12 +243,12 @@ def test_automate_disabled_domains_in_domain_priority(request, klass):
     )
     request.addfinalizer(method.delete_if_exists)
 
-    klass.schema.add_fields({'name': 'execute', 'type': 'Method', 'data_type': 'String'})
+    klass.schema.add_fields({'name': schema_field, 'type': 'Method', 'data_type': 'String'})
     instance = klass.instances.create(
         name=fauxfactory.gen_alphanumeric(),
         display_name=fauxfactory.gen_alphanumeric(),
         description=fauxfactory.gen_alphanumeric(),
-        fields={'execute': {'value': method.name}}
+        fields={schema_field: {'value': method.name}}
     )
     request.addfinalizer(instance.delete_if_exists)
 

--- a/cfme/tests/automate/test_method.py
+++ b/cfme/tests/automate/test_method.py
@@ -274,7 +274,6 @@ def test_task_id_for_method_automation_log(request, generic_catalog_item):
     result.validate_logs()
 
 
-@pytest.mark.meta(blockers=[BZ(1704439)])
 @pytest.mark.meta(server_roles="+notifier")
 def test_send_email_method(smtp_test, klass):
     """
@@ -291,6 +290,7 @@ def test_send_email_method(smtp_test, klass):
     mail_to = fauxfactory.gen_email()
     mail_cc = fauxfactory.gen_email()
     mail_bcc = fauxfactory.gen_email()
+    schema_field = fauxfactory.gen_alphanumeric()
 
     # Ruby code to send emails
     script = (
@@ -307,7 +307,7 @@ def test_send_email_method(smtp_test, klass):
     script = script.format(mail_cc=mail_cc, mail_bcc=mail_bcc, mail_to=mail_to)
 
     # Adding schema for executing method - send_email which helps to send emails
-    klass.schema.add_fields({'name': 'execute', 'type': 'Method', 'data_type': 'String'})
+    klass.schema.add_fields({'name': schema_field, 'type': 'Method', 'data_type': 'String'})
 
     # Adding method - send_email for sending mails
     method = klass.methods.create(
@@ -321,7 +321,7 @@ def test_send_email_method(smtp_test, klass):
         name=fauxfactory.gen_alphanumeric(),
         display_name=fauxfactory.gen_alphanumeric(),
         description=fauxfactory.gen_alphanumeric(),
-        fields={'execute': {'value': method.name}}
+        fields={schema_field: {'value': method.name}}
     )
 
     result = LogValidator(
@@ -391,6 +391,7 @@ def test_automate_generic_object_service_associations(appliance, klass, go_servi
     Bugzilla:
         1410920
     """
+    schema_field = fauxfactory.gen_alphanumeric()
     # Ruby code
     script = 'go_class = $evm.vmdb(:generic_object_definition).find_by(:name => "{name}")\n'.format(
         name=generic_object_definition.name
@@ -408,7 +409,7 @@ def test_automate_generic_object_service_associations(appliance, klass, go_servi
     )
     with appliance.context.use(ViaUI):
         # Adding schema for executing method
-        klass.schema.add_fields({'name': 'execute', 'type': 'Method', 'data_type': 'String'})
+        klass.schema.add_fields({'name': schema_field, 'type': 'Method', 'data_type': 'String'})
 
         # Adding method
         method = klass.methods.create(
@@ -422,7 +423,7 @@ def test_automate_generic_object_service_associations(appliance, klass, go_servi
             name=fauxfactory.gen_alphanumeric(),
             display_name=fauxfactory.gen_alphanumeric(),
             description=fauxfactory.gen_alphanumeric(),
-            fields={'execute': {'value': method.name}}
+            fields={schema_field: {'value': method.name}}
         )
 
         result = LogValidator(

--- a/cfme/tests/cloud/test_quota.py
+++ b/cfme/tests/cloud/test_quota.py
@@ -347,7 +347,8 @@ def automate_flavor_method(appliance, klass, namespace):
                   exit MIQ_STOP\n
                 end\n
     """
-    klass.schema.add_fields({'name': 'execute', 'type': 'Method', 'data_type': 'String'})
+    schema_field = fauxfactory.gen_alphanumeric()
+    klass.schema.add_fields({'name': schema_field, 'type': 'Method', 'data_type': 'String'})
     method = klass.methods.create(
         name=fauxfactory.gen_alphanumeric(),
         display_name=fauxfactory.gen_alphanumeric(),
@@ -358,7 +359,7 @@ def automate_flavor_method(appliance, klass, namespace):
         name=fauxfactory.gen_alphanumeric(),
         display_name=fauxfactory.gen_alphanumeric(),
         description=fauxfactory.gen_alphanumeric(),
-        fields={'execute': {'value': method.name}}
+        fields={schema_field: {'value': method.name}}
     )
     yield instance
     instance.delete()

--- a/cfme/tests/intelligence/reports/test_widgets.py
+++ b/cfme/tests/intelligence/reports/test_widgets.py
@@ -162,7 +162,7 @@ def test_generate_widget_content_by_automate(request, appliance, klass, namespac
             1445932
     """
     widget_name = fauxfactory.gen_alphanumeric()
-
+    schema_field = fauxfactory.gen_alphanumeric()
     # Added method with given code
     method = klass.methods.create(
         name=fauxfactory.gen_alphanumeric(),
@@ -174,12 +174,12 @@ def test_generate_widget_content_by_automate(request, appliance, klass, namespac
     )
 
     # Edited schema of class to execute method using instance
-    klass.schema.add_fields({'name': 'execute', 'type': 'Method', 'data_type': 'String'})
+    klass.schema.add_fields({'name': schema_field, 'type': 'Method', 'data_type': 'String'})
 
     # Added new instance
     instance = klass.instances.create(
         name=fauxfactory.gen_alphanumeric(),
-        fields={'execute': {'value': '{method}'.format(method=method.name)}}
+        fields={schema_field: {'value': method.name}}
     )
 
     # Created chart widget


### PR DESCRIPTION
- This PR improves the class schema fields naming because class schema fields must be unique.

{{ pytest: cfme/tests/automate/ -k 'test_generate_widget_content_by_automate or test_automate_disabled_domains_in_domain_priority or test_automate_schema_field_without_type or test_automate_generic_object_service_associations or test_send_email_method or test_domain_lock_disabled or test_object_attribute_type_in_automate_schedule' -vv }}