### PR TITLE
[1LP][RFR]Automate test: test_custom_logos_via_api AND add widgets for CustomLo…

### DIFF
--- a/cfme/base/__init__.py
+++ b/cfme/base/__init__.py
@@ -105,17 +105,22 @@ class Server(BaseEntity, sentaku.modeling.ElementMixin):
         )
         assert result.ok
 
-    def upload_custom_logos(self, file_type, file_data=None, enable=True):
+    def upload_custom_logo(self, file_type, file_data=None, enable=True):
         """
-        This function can be used to upload custom logos and text and use them.
+        This function can be used to upload custom logo or text and use them.
 
         Args:
             file_type (str) : Can be either of [logo, login_logo, brand, favicon, logintext]
-            file_data (str) : Text data if file_type is logintext else image name to be uploaded
+            file_data (str) : Text data if file_type is logintext else image path to be uploaded
             enable (bool) : True to use the custom logo/text else False
         """
         view = navigate_to(self, "CustomLogos")
-        logo_view = getattr(view.customlogos, file_type)
+        try:
+            logo_view = getattr(view.customlogos, file_type)
+        except AttributeError:
+            raise AttributeError(
+                "File type not in ('logo', 'login_logo', 'brand', 'favicon', 'logintext)."
+            )
         if file_data:
             if file_type == "logintext":
                 logo_view.fill({"login_text": file_data})
@@ -125,6 +130,7 @@ class Server(BaseEntity, sentaku.modeling.ElementMixin):
             view.flash.assert_no_error()
         logo_view.enable.fill(enable)
         view.customlogos.save_button.click()
+        view.flash.assert_no_error()
 
 
 @attr.s

--- a/cfme/base/__init__.py
+++ b/cfme/base/__init__.py
@@ -105,6 +105,27 @@ class Server(BaseEntity, sentaku.modeling.ElementMixin):
         )
         assert result.ok
 
+    def upload_custom_logos(self, file_type, file_data=None, enable=True):
+        """
+        This function can be used to upload custom logos and text and use them.
+
+        Args:
+            file_type (str) : Can be either of [logo, login_logo, brand, favicon, logintext]
+            file_data (str) : Text data if file_type is logintext else image name to be uploaded
+            enable (bool) : True to use the custom logo/text else False
+        """
+        view = navigate_to(self, "CustomLogos")
+        logo_view = getattr(view.customlogos, file_type)
+        if file_data:
+            if file_type == "logintext":
+                logo_view.fill({"login_text": file_data})
+            else:
+                logo_view.fill({"image": file_data})
+                logo_view.upload_button.click()
+            view.flash.assert_no_error()
+        logo_view.enable.fill(enable)
+        view.customlogos.save_button.click()
+
 
 @attr.s
 class ServerCollection(BaseCollection, sentaku.modeling.ElementMixin):

--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -12,9 +12,11 @@ from widgetastic.widget import FileInput
 from widgetastic.widget import Image
 from widgetastic.widget import Table
 from widgetastic.widget import Text
+from widgetastic.widget import TextInput
 from widgetastic.widget import View
 from widgetastic_patternfly import Accordion
 from widgetastic_patternfly import BootstrapSelect
+from widgetastic_patternfly import BootstrapSwitch
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import CheckableBootstrapTreeview
 from widgetastic_patternfly import DatePicker
@@ -50,6 +52,7 @@ from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 from widgetastic_manageiq import AttributeValueForm
 from widgetastic_manageiq import Checkbox
+from widgetastic_manageiq import InputButton
 from widgetastic_manageiq import ManageIQTree
 from widgetastic_manageiq import SummaryFormItem
 from widgetastic_manageiq import SummaryTable
@@ -513,6 +516,43 @@ class ServerView(ConfigurationView):
     @View.nested
     class customlogos(WaitTab):  # noqa
         TAB_NAME = "Custom Logos"
+        save_button = Button("Save")
+        reset_button = Button("Reset")
+
+        @View.nested
+        class logo(View):   # noqa
+            image = FileInput(id="upload_logo")
+            upload_button = InputButton(
+                locator='//div[contains(.,"Dimensions - 350x70.")]/input'
+            )
+            enable = BootstrapSwitch(id="server_uselogo")
+
+        @View.nested
+        class login_logo(View):    # noqa
+            image = FileInput(id="login_logo")
+            upload_button = InputButton(
+                locator='//div[contains(.,"Dimensions - 1280x1000.")]/input'
+            )
+            enable = BootstrapSwitch(id="server_useloginlogo")
+
+        @View.nested
+        class brand(View):    # noqa
+            image = FileInput(id="brand_logo")
+            upload_button = InputButton(
+                locator='//div[normalize-space()="* Requirements: File-type - PNG;"]/input'
+            )
+            enable = BootstrapSwitch(id="server_usebrand")
+
+        @View.nested
+        class favicon(View):    # noqa
+            image = FileInput(id="favicon_logo")
+            upload_button = InputButton(locator='//div[contains(.,"ICO")]/input')
+            enable = BootstrapSwitch(id="server_usefavicon")
+
+        @View.nested
+        class logintext(View):    # noqa
+            login_text = TextInput(id="login_text")
+            enable = BootstrapSwitch(id="server_uselogintext")
 
     @View.nested
     class advanced(WaitTab):  # noqa

--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -1245,12 +1245,12 @@ def test_custom_logos_via_api(appliance, image_type, request):
         image = image_file_path("logo.png")
         expected_name = "/upload/custom_{}.png"
 
-    appliance.server.upload_custom_logos(file_type=image_type, file_data=image)
+    appliance.server.upload_custom_logo(file_type=image_type, file_data=image)
 
     # reset appliance to use default logos
     @request.addfinalizer
     def _finalize():
-        appliance.server.upload_custom_logos(file_type=image_type, enable=False)
+        appliance.server.upload_custom_logo(file_type=image_type, enable=False)
 
     href = "https://{}/api/product_info".format(appliance.hostname)
     api = appliance.rest_api
@@ -1258,6 +1258,6 @@ def test_custom_logos_via_api(appliance, image_type, request):
     # wait until product info is updated
     wait_for(lambda: api.product_info != api.get(href), delay=5, timeout=100)
 
-    # fetch the latest produce_info
+    # fetch the latest product_info
     branding_info = api.get(href)["branding_info"]
     assert branding_info[image_type] == expected_name.format(image_type)

--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """This module contains REST API specific tests."""
+import os
 import random
 from datetime import datetime
 from datetime import timedelta
@@ -13,6 +14,8 @@ from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import ONE
 from cfme.rest.gen_data import automation_requests_data
 from cfme.rest.gen_data import vm as _vm
+from cfme.utils.conf import cfme_data
+from cfme.utils.ftp import FTPClientWrapper
 from cfme.utils.rest import assert_response
 from cfme.utils.rest import delete_resources_from_collection
 from cfme.utils.rest import delete_resources_from_detail
@@ -1192,3 +1195,69 @@ def test_supported_provider_options(appliance, soft_assert):
                 "regions" in provider,
                 "Regions information not present in the provider OPTIONS.",
             )
+
+
+def image_file_path(file_name):
+    """ Returns file path of the file"""
+    fs = FTPClientWrapper(cfme_data.ftpserver.entities.others)
+    file_path = fs.download(file_name, os.path.join("/tmp", file_name))
+    return file_path
+
+
+@test_requirements.rest
+@pytest.mark.meta(automates=[1578076])
+@pytest.mark.tier(3)
+@pytest.mark.uncollectif(
+    lambda appliance, image_type: image_type == "favicon" and appliance.version < 5.11
+)
+@pytest.mark.parametrize("image_type", ["logo", "brand", "login_logo", "favicon"])
+def test_custom_logos_via_api(appliance, image_type, request):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: Configuration
+        caseimportance: medium
+        initialEstimate: 1/10h
+        setup:
+            1. Navigate to Configuration > Server > Custom Logos
+            2. Change the brand, logo, login_logo and favicon
+        testSteps:
+            1.  Send a GET request: /api/product_info and
+                check the value of image type in branding_info
+        expectedResults:
+            1. Response: {
+                ...
+                "branding_info": {
+                    "brand": "/upload/custom_brand.png",
+                    "logo": "/upload/custom_logo.png",
+                    "login_logo": "/upload/custom_login_logo.png",
+                    "favicon": "/upload/custom_favicon.ico"
+                }
+            }
+
+    Bugzilla:
+        1578076
+    """
+    if image_type == "favicon":
+        image = image_file_path("icon.ico")
+        expected_name = "/upload/custom_{}.ico"
+    else:
+        image = image_file_path("logo.png")
+        expected_name = "/upload/custom_{}.png"
+
+    appliance.server.upload_custom_logos(file_type=image_type, file_data=image)
+
+    # reset appliance to use default logos
+    @request.addfinalizer
+    def _finalize():
+        appliance.server.upload_custom_logos(file_type=image_type, enable=False)
+
+    href = "https://{}/api/product_info".format(appliance.hostname)
+    api = appliance.rest_api
+
+    # wait until product info is updated
+    wait_for(lambda: api.product_info != api.get(href), delay=5, timeout=100)
+
+    # fetch the latest produce_info
+    branding_info = api.get(href)["branding_info"]
+    assert branding_info[image_type] == expected_name.format(image_type)

--- a/cfme/tests/test_rest_manual.py
+++ b/cfme/tests/test_rest_manual.py
@@ -29,42 +29,6 @@ def test_create_rhev_provider_with_metric():
 
 @pytest.mark.manual
 @test_requirements.rest
-@pytest.mark.tier(3)
-def test_custom_logos_via_api():
-    """
-    Polarion:
-        assignee: pvala
-        casecomponent: Configuration
-        caseimportance: medium
-        initialEstimate: 1/10h
-        setup:
-            1. Navigate to Configuration > Server > Custom Logos
-            2. Change the brand, logo, login_logo and favicon
-        testSteps:
-            1.  Send a GET request: /api/product_info
-        expectedResults:
-            1. Response: {
-                "name": "ManageIQ",
-                "name_full": "ManageIQ",
-                "copyright": "Copyright (c) 2019 ManageIQ. Sponsored by Red Hat Inc.",
-                "support_website": "http://www.manageiq.org",
-                "support_website_text": "ManageIQ.org",
-                "branding_info": {
-                    "brand": "/upload/custom_brand.png",
-                    "logo": "/upload/custom_logo.png",
-                    "login_logo": "/upload/custom_login_logo.png",
-                    "favicon": "/upload/custom_favicon.ico"
-                }
-            }
-
-    Bugzilla:
-        1578076
-    """
-    pass
-
-
-@pytest.mark.manual
-@test_requirements.rest
 def test_automation_request_task():
     """
     Polarion:


### PR DESCRIPTION
Changes introduced with this PR:
1. Automate test: test_custom_logos_via_api
2. Add missing widgets for `CustomLogos`.

{{ pytest: cfme/tests/test_rest.py::test_custom_logos_via_api --use-template-cache -sqvvv }}

PS: I feel the need to appreciate @digitronik's effort in helping me with this PR. Thanks Nikhil :)