### PR TITLE
[1LP][RFR] Fixed v2v_providers naming issue

### DIFF
--- a/cfme/tests/cloud_infra_common/test_quota_with_multiple_providers.py
+++ b/cfme/tests/cloud_infra_common/test_quota_with_multiple_providers.py
@@ -24,7 +24,7 @@ pytestmark = [
 
 @test_requirements.quota
 @pytest.mark.tier(2)
-def test_show_quota_used_on_tenant_screen(appliance, v2v_providers):
+def test_show_quota_used_on_tenant_screen(appliance, v2v_provider_setup):
     """Test show quota used on tenant quota screen even when no quotas are set.
 
     Polarion:
@@ -42,9 +42,11 @@ def test_show_quota_used_on_tenant_screen(appliance, v2v_providers):
             5. Go to tenant quota table.
             6. Check whether number of VMs are equal to number of VMs in 'in use' column.
     """
-    v2v_providers.vmware_provider.refresh_provider_relationships
-    v2v_providers.rhv_provider.refresh_provider_relationships
-    vm_count = v2v_providers.rhv_provider.num_vm() + v2v_providers.vmware_provider.num_vm()
+    v2v_provider_setup.vmware_provider.refresh_provider_relationships
+    v2v_provider_setup.rhv_provider.refresh_provider_relationships
+    vm_count = (
+        v2v_provider_setup.rhv_provider.num_vm() + v2v_provider_setup.vmware_provider.num_vm()
+    )
     root_tenant = appliance.collections.tenants.get_root_tenant()
     view = navigate_to(root_tenant, "Details")
     for row in view.table:


### PR DESCRIPTION
- The name ```v2v_providers``` is now changed to ```v2v_provider_setup```
- Fixed Error:
```
>       available fixtures: LineMatcher, _pytest, amazon_auth_provider, ansible_catalog, ansible_catalog_item, ansible_repository, ansible_service, ansible_service_catalog, ansible_service_request, ansible_tower_dialog, anypython, app_creds, app_creds_modscope, appliance, appliance_police, appliance_preupdate, appliance_with_preset_time, appliance_with_providers, auth_provider, .........
>       use 'pytest --fixtures [testpath]' for help on them.

/var/ci/workspace/downstream-510z-tests-master/integration_tests/cfme/tests/cloud_infra_common/test_quota_with_multiple_providers.py:25
FixtureLookupError
```



{{ pytest: cfme/tests/cloud_infra_common/test_quota_with_multiple_providers.py -k 'test_show_quota_used_on_tenant_screen'  --use-provider={vsphere67-nested,rhv43} --provider-limit 2 --long-running }}