### PR TITLE
[1LP][WIPTEST] Fix failing tests

### DIFF
--- a/cfme/cloud/provider/openstack.py
+++ b/cfme/cloud/provider/openstack.py
@@ -33,7 +33,7 @@ class OpenStackProvider(CloudProvider):
     _ctrl_alt_del_xpath = '//*[@id="sendCtrlAltDelButton"]'
 
     api_port = attr.ib(default=None)
-    api_version = attr.ib(default=None)
+    api_version = attr.ib(default="Keystone v3")
     sec_protocol = attr.ib(default=None)
     amqp_sec_protocol = attr.ib(default=None)
     keystone_v3_domain_id = attr.ib(default=None)


### PR DESCRIPTION
Since `api_version` was not mentioned while instantiating the provider, these tests resulted in failure, which was due to a [change](https://github.com/valaparthvi/integration_tests/commit/76555b31dc707f93109226557347ac945450dbdc#diff-e51a1694ce7a4e4346808ac3a43a2cf8R77) Mike introduced a few days ago.

{{ pytest : cfme/tests/cloud/test_providers.py -k "test_host_name_required_validation_cloud or test_api_port_blank_validation or test_hostname_max_character_validation_cloud or test_api_port_max_character_validation_cloud" --use-template-cache -sqvvv }}