### PR TITLE
[WIP] Update change ownership view for 5.11

### DIFF
--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -18,6 +18,8 @@ from cfme.base.login import BaseLoggedInPage
 from cfme.exceptions import displayed_not_implemented
 from cfme.exceptions import ItemNotFound
 from cfme.utils.log import logger
+from cfme.utils.version import LOWEST
+from cfme.utils.version import VersionPicker
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import BaseEntitiesView
 from widgetastic_manageiq import BaseNonInteractiveEntitiesView
@@ -32,6 +34,7 @@ from widgetastic_manageiq import MultiBoxSelect
 from widgetastic_manageiq import PaginationPane
 from widgetastic_manageiq import ParametrizedSummaryTable
 from widgetastic_manageiq import RadioGroup
+from widgetastic_manageiq import ReactSelect
 from widgetastic_manageiq import Table
 from widgetastic_manageiq import WaitTab
 
@@ -481,10 +484,19 @@ class SetOwnershipView(BaseLoggedInPage):
     """
     @View.nested
     class form(View):  # noqa
-        user_name = BootstrapSelect('user_name')
-        group_name = BootstrapSelect('group_name')
+        user_name = VersionPicker({
+            LOWEST: BootstrapSelect('user_name'),
+            "5.11": ReactSelect('user_name')
+        })
+        group_name = VersionPicker({
+            LOWEST: BootstrapSelect('group_name'),
+            "5.11": ReactSelect('group_name')
+        })
         entities = View.nested(BaseNonInteractiveEntitiesView)
-        save_button = Button('Save')
+        save_button = VersionPicker({
+            LOWEST: Button('Save'),
+            "5.11": Button('Submit')
+        })
         reset_button = Button('Reset')
         cancel_button = Button('Cancel')
 


### PR DESCRIPTION
Purpose or Intent
==============

Update SetOwnershipView to reflect changes in CFME 5.11. Using VersionPicker, we either use the original view for 5.10 and earlier, or implement the following changes for 5.11:

1.) user_name and group_name are now ReactSelect instead of BootstrapSelect
2.) The 'Save' button is now the 'Submit' button.

{{ pytest: --long-running cfme/tests/intelligence/reports/test_metering_report.py -vvv }}