### PR TITLE
[1LP][RFR] fix test advanced search

### DIFF
--- a/widgetastic_manageiq/expression_editor.py
+++ b/widgetastic_manageiq/expression_editor.py
@@ -56,6 +56,7 @@ class ExpressionEditor(View, Pretty):
 
     @View.nested
     class field_form_view(View):  # noqa
+        fill_strategy = WaitFillViewStrategy()
         type = BootstrapSelect("chosen_typ")
         field = BootstrapSelect("chosen_field")
         key = BootstrapSelect("chosen_key")


### PR DESCRIPTION
Purpose or Intent
=================
__Updating tests__ for new UX feature
When there is no provider, "add new provider" page appears now.. And search is not available at this page. So it's needed to add providers before checking advanced search.

Also separated tests into classes.

One test fail (TimeoutError) is not related to changes, doesn't happen locally where it runs faster. 

{{pytest: cfme/tests/webui/test_advanced_search.py --use-template-cache --use-provider=complete --use-provider=container -v}}