### PR TITLE
[1LP][RFR] import_datastore fixture

### DIFF
--- a/cfme/fixtures/automate.py
+++ b/cfme/fixtures/automate.py
@@ -68,10 +68,11 @@ def custom_instance(request_cls):
     return method
 
 
+@pytest.fixture()
 def import_datastore(appliance, request):
     """This fixture will help to import datastore file"""
 
-    def domain(file_name, domain_from, domain_into=None):
+    def domain(file_name, from_domain, to_domain=None):
         # Download datastore file from FTP server
         fs = FTPClientWrapper(cfme_data.ftpserver.entities.datastores)
         file_path = fs.download(file_name)
@@ -80,7 +81,7 @@ def import_datastore(appliance, request):
         datastore = appliance.collections.automate_import_exports.instantiate(
             import_type="file", file_path=file_path
         )
-        request.addfinalizer(datastore.delete_if_exists)
-        return datastore.import_domain_from(domain_from, domain_into=None)
+        domain = datastore.import_domain_from(from_domain, to_domain)
+        request.addfinalizer(domain.delete_if_exists)
+        return domain
     return domain
-

--- a/cfme/fixtures/automate.py
+++ b/cfme/fixtures/automate.py
@@ -1,3 +1,5 @@
+from collections import namedtuple
+
 import fauxfactory
 import pytest
 
@@ -68,20 +70,37 @@ def custom_instance(request_cls):
     return method
 
 
+# DatastoreImport help to pass import data to fixture import_datastore
+DatastoreImport = namedtuple("DatastoreImport", ["file_name", "from_domain", "to_domain"])
+
+
 @pytest.fixture()
-def import_datastore(appliance, request):
-    """This fixture will help to import datastore file"""
+def import_datastore(appliance, import_data):
+    """This fixture will help to import datastore file.
 
-    def domain(file_name, from_domain, to_domain=None):
-        # Download datastore file from FTP server
-        fs = FTPClientWrapper(cfme_data.ftpserver.entities.datastores)
-        file_path = fs.download(file_name)
+    To invoke this fixture, we need to pass parametrize import data with the help
+    of `DatastoreImport`namedtuple.
 
-        # Import datastore file to appliance
-        datastore = appliance.collections.automate_import_exports.instantiate(
-            import_type="file", file_path=file_path
+    Usage:
+        .. code-block:: python
+
+        @pytest.mark.parametrize(
+        "import_data", [DatastoreImport("datastore.zip", "from_daomin_name", "to_domain_name")]
         )
-        domain = datastore.import_domain_from(from_domain, to_domain)
-        request.addfinalizer(domain.delete_if_exists)
-        return domain
-    return domain
+        def test_foo(import_datastore, import_data):
+            pass
+    """
+
+    # Download datastore file from FTP server
+    fs = FTPClientWrapper(cfme_data.ftpserver.entities.datastores)
+    file_path = fs.download(import_data.file_name)
+
+    # Import datastore file to appliance
+    datastore = appliance.collections.automate_import_exports.instantiate(
+        import_type="file", file_path=file_path
+    )
+    domain = datastore.import_domain_from(import_data.from_domain, import_data.to_domain)
+
+    yield domain
+
+    domain.delete_if_exists()

--- a/cfme/tests/automate/test_file_import.py
+++ b/cfme/tests/automate/test_file_import.py
@@ -1,11 +1,17 @@
 import pytest
 
 from cfme import test_requirements
+from cfme.fixtures.automate import DatastoreImport
 
 pytestmark = [test_requirements.automate, pytest.mark.tier(3)]
 
 
-def test_domain_import_file(import_datastore):
+@pytest.mark.parametrize(
+    "import_data",
+    [DatastoreImport("bz_1715396.zip", "BZ_1715396", None)],
+    ids=["sample_domain"],
+)
+def test_domain_import_file(import_datastore, import_data):
     """This test case Verifies that a domain can be imported from file.
 
     Polarion:
@@ -24,5 +30,4 @@ def test_domain_import_file(import_datastore):
             2.
             3. Import should work. Check imported or not.
     """
-    domain = import_datastore(file_name="bz_1715396.zip", from_domain="BZ_1715396")
-    assert domain.exists
+    assert import_datastore.exists

--- a/cfme/tests/automate/test_file_import.py
+++ b/cfme/tests/automate/test_file_import.py
@@ -1,0 +1,28 @@
+import pytest
+
+from cfme import test_requirements
+
+pytestmark = [test_requirements.automate, pytest.mark.tier(3)]
+
+
+def test_domain_import_file(import_datastore):
+    """This test case Verifies that a domain can be imported from file.
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/6h
+        caseimportance: medium
+        startsin: 5.7
+        casecomponent: Automate
+        tags: automate
+        testSteps:
+            1. Navigate to Automation > Automate > Import/Export
+            2. Upload zip datastore file
+            3. Select domain which like to import
+        expectedResults:
+            1.
+            2.
+            3. Import should work. Check imported or not.
+    """
+    domain = import_datastore(file_name="bz_1715396.zip", from_domain="BZ_1715396")
+    assert domain.exists


### PR DESCRIPTION
Signed-off-by: Nikhil Dhandre <ndhandre@redhat.com>


Purpose or Intent
=================
- Intention of this PR is just add one global fixture to import datastore files
- Adding one supporting test; I know its bad; this test should not use `gloable` fixture but these steps should be part of test as its basic test. but just for adding this in support of global fixture.
  
{{pytest: cfme/tests/automate/test_file_import.py -v}}