### PR TITLE
[1LP][RFR] block test with BZ-1729594

### DIFF
--- a/cfme/tests/automate/custom_button/test_container_objects.py
+++ b/cfme/tests/automate/custom_button/test_container_objects.py
@@ -122,6 +122,15 @@ def test_custom_button_display_container_obj(request, display, setup_obj, button
         assert custom_button_group.has_item(button.text)
 
 
+@pytest.mark.meta(
+    blockers=[
+        BZ(
+            1729903,
+            forced_streams=["5.11"],
+            unblock=lambda button_group: "CONTAINER_VOLUMES" not in button_group,
+        )
+    ]
+)
 @pytest.mark.uncollectif(
     lambda appliance, button_group: not bool([obj for obj in OBJ_TYPE_59 if obj in button_group])
     and appliance.version < "5.10"

--- a/cfme/tests/automate/custom_button/test_service_vm_custom_button.py
+++ b/cfme/tests/automate/custom_button/test_service_vm_custom_button.py
@@ -12,6 +12,7 @@ from cfme.utils.appliance import ViaSSUI
 from cfme.utils.appliance import ViaUI
 from cfme.utils.appliance.implementations.ssui import navigate_to as ssui_nav
 from cfme.utils.appliance.implementations.ui import navigate_to as ui_nav
+from cfme.utils.blockers import BZ
 from cfme.utils.log_validator import LogValidator
 
 
@@ -136,7 +137,8 @@ def test_custom_button_display_service_vm(request, appliance, service_vm, button
 
 @test_requirements.customer_stories
 @pytest.mark.tier(1)
-@pytest.mark.meta(automates=[1687061])
+# Dynamic dialog problem 1729594
+@pytest.mark.meta(automates=[1687061], blockers=[BZ(1729594), BZ(1729594)])
 def test_custom_button_with_dynamic_dialog_vm(
     appliance, provider, request, service_vm, setup_dynamic_dialog
 ):
@@ -176,6 +178,7 @@ def test_custom_button_with_dynamic_dialog_vm(
     Bugzilla:
         1687061
         1722817
+        1729594
     """
     dialog, ele_name = setup_dynamic_dialog
     # Create button group


### PR DESCRIPTION
Signed-off-by: Nikhil Dhandre <ndhandre@redhat.com>

{{pytest: cfme/tests/automate/custom_button/test_container_objects.py::test_custom_button_dialog_container_obj --use-provider ocp-39-hawk  -v}}