### PR TITLE
[1LP][RFR]fix schedules and enhance a test for BZ 1729882

### DIFF
--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -408,6 +408,7 @@ class Report(BaseEntity, Updateable):
                 "subfilter_type": self.subtype,
                 "report_type": self.menu_name,
             },
+            timer=timer,
             email=email,
             email_options=email_options
         )

--- a/cfme/intelligence/reports/schedules.py
+++ b/cfme/intelligence/reports/schedules.py
@@ -236,6 +236,7 @@ class ScheduleCollection(BaseCollection):
             description=description,
             active=active,
             report_filter=report_filter,
+            timer=timer,
             email=email,
             email_options=email_options
         )

--- a/cfme/tests/intelligence/reports/test_crud.py
+++ b/cfme/tests/intelligence/reports/test_crud.py
@@ -85,7 +85,7 @@ def test_custom_report_crud(custom_report_values, appliance):
 
 @pytest.mark.sauce
 @pytest.mark.tier(3)
-@pytest.mark.meta(automates=[BZ(1729882), BZ(1202412), BZ(1446052)])
+@pytest.mark.meta(automates=[1729882, 1202412, 1446052])
 def test_reports_schedule_crud(schedule_data, appliance):
     """
     Polarion:
@@ -119,7 +119,7 @@ def test_reports_schedule_crud(schedule_data, appliance):
     run_at = view.schedule_info.get_text_of("Run At")
     assert updated_timer["run"].lower() in run_at
 
-    if not BZ(1729882, forced_streams=["5.10", "5.11"]).blocks:
+    if not BZ(1729882, forced_streams=["5.10"]).blocks:
         assert str(date.day) in run_at
 
     # queue

--- a/cfme/tests/intelligence/reports/test_reports_schedules.py
+++ b/cfme/tests/intelligence/reports/test_reports_schedules.py
@@ -107,6 +107,7 @@ def test_schedule_queue(appliance, request, interval, schedule_data):
     request.addfinalizer(schedule.delete_if_exists)
 
     schedule.queue()
+    assert schedule.timer == TIMER[interval]
     view = schedule.create_view(ScheduleDetailsView)
     view.flash.assert_message("The selected Schedule has been queued to run")
 


### PR DESCRIPTION
Changes:
1. While creating/editing schedule, `timer` attribute was not filled, this PR fixes that.
2. Enhance `test_reports_schedule_crud`  to cover BZ 1729882 and automate [RHCF3-36149](https://polarion.engineering.redhat.com/polarion/redirect/project/RHCF3/workitem?id=RHCF3-36149)

{{ pytest: cfme/tests/intelligence/reports -k "test_reports_schedule_crud or test_schedule_queue" --use-template-cache -sqvvv }}