### PR TITLE
[1LP][RFR] Update paramiko 2.6

### DIFF
--- a/requirements/frozen.py2.txt
+++ b/requirements/frozen.py2.txt
@@ -215,7 +215,7 @@ oslo.utils==3.40.3
 ovirt-engine-sdk-python==4.3.0
 packaging==19.0
 pandocfilters==1.4.2
-paramiko==2.4.2
+paramiko==2.6
 parsedatetime==2.4
 pathlib2==2.3.3
 pbr==5.1.3
@@ -226,6 +226,7 @@ pika==1.0.1
 Pillow==6.0.0
 pluggy==0.6.0
 polarion-docstrings==0.16.1
+pre-commit==1.17.0
 prettytable==0.7.2
 progress==1.5
 prometheus-client==0.6.0

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -207,7 +207,7 @@ oslo.utils==3.40.3
 ovirt-engine-sdk-python==4.3.0
 packaging==19.0
 pandocfilters==1.4.2
-paramiko==2.4.2
+paramiko==2.6
 parsedatetime==2.4
 parso==0.4.0
 pbr==5.1.3
@@ -218,6 +218,7 @@ pika==1.0.1
 Pillow==6.0.0
 pluggy==0.6.0
 polarion-docstrings==0.16.1
+pre-commit==1.17.0
 prettytable==0.7.2
 progress==1.5
 prometheus-client==0.6.0

--- a/requirements/frozen_docs.py2.txt
+++ b/requirements/frozen_docs.py2.txt
@@ -214,7 +214,7 @@ oslo.utils==3.40.3
 ovirt-engine-sdk-python==4.3.0
 packaging==19.0
 pandocfilters==1.4.2
-paramiko==2.4.2
+paramiko==2.6
 parsedatetime==2.4
 pathlib2==2.3.3
 pbr==5.1.3

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -206,7 +206,7 @@ oslo.utils==3.40.3
 ovirt-engine-sdk-python==4.3.0
 packaging==19.0
 pandocfilters==1.4.2
-paramiko==2.4.2
+paramiko==2.6
 parsedatetime==2.4
 parso==0.4.0
 pbr==5.1.3


### PR DESCRIPTION
2.4.2 was warning on cryptography deprecations.
2.6 appears compatible with our current use on inspection, and includes a move to a version of cryptography that is not deprecated