### PR TITLE
[RFR] Allow for the event VM_MIGRATION_FAILED

### DIFF
--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -127,6 +127,7 @@ class VMEvent(object):
                 'RelocateVM_Task',
                 'VM_MIGRATION_DONE',
                 'VM_MIGRATION_FAILED_FROM_TO',  # allow for failure of migration
+                'VM_MIGRATION_FAILED',
             ),
             'tl_category': 'Migration/Vmotion',
             'db_event_type': 'VmMigratedEvent',


### PR DESCRIPTION
The test case `test_infra_timeline_migrate_event` will sometimes fail if the migration fails for whatever reason. Since we are testing events and not migration, we need to allow for these failure events. Adding `VM_MIGRATION_FAILED` to the searched for events on the timeline. 

{{ pytest: --use-template-cache --use-provider rhv43 cfme/tests/infrastructure/test_timelines.py::test_infra_timeline_migrate_event }} 