### PR TITLE
[1LP][RFR] Add BZ marker and update test_server_name patterns for filling

### DIFF
--- a/cfme/tests/configure/test_server_name.py
+++ b/cfme/tests/configure/test_server_name.py
@@ -31,7 +31,7 @@ def test_server_name(request, appliance):
         appliance.rename(old_server_name)
 
     new_server_name = "RENAME-TEST"
-    assert view.server.basic_information.appliance_name.fill('updated-evm-name')
+    assert view.server.basic_information.appliance_name.fill(new_server_name)
     assert view.server.save.is_enabled
     view.server.save.click()  # no boolean return
     assert appliance.server.name == new_server_name

--- a/cfme/tests/configure/test_server_name.py
+++ b/cfme/tests/configure/test_server_name.py
@@ -9,7 +9,8 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 pytestmark = [test_requirements.general_ui]
 
 
-@pytest.mark.tier(3)
+@pytest.mark.tier(1)
+@pytest.mark.meta(automates=[1635178])
 @pytest.mark.sauce
 def test_server_name(request, appliance):
     """Tests that changing the server name updates the about page
@@ -23,27 +24,29 @@ def test_server_name(request, appliance):
 
     view = navigate_to(appliance.server, 'Details')
     old_server_name = view.server.basic_information.appliance_name.read()
+    assert old_server_name != ''  # name should at least be set
 
     @request.addfinalizer
     def _ensure_name_reset():
-        appliance.server.settings.update_basic_information({'appliance_name': old_server_name})
+        appliance.rename(old_server_name)
 
-    new_server_name = "{}-TEST".format(old_server_name)
-    appliance.server.settings.update_basic_information({'appliance_name': new_server_name})
-    flash_message = (
-        'Configuration settings saved for {} Server "{} [{}]" in Zone "{}"'.format(
-            appliance.product_name,
-            appliance.server.name,
-            appliance.server.sid,
-            appliance.server.zone.name))
+    new_server_name = "RENAME-TEST"
+    assert view.server.basic_information.appliance_name.fill('updated-evm-name')
+    assert view.server.save.is_enabled
+    view.server.save.click()  # no boolean return
+    assert appliance.server.name == new_server_name
 
-    view.flash.assert_message(flash_message)
+    view.flash.assert_success_message(
+        'Configuration settings saved for {} Server "{} [{}]" in Zone "{}"'
+        .format(appliance.product_name,
+                appliance.server.name,
+                appliance.server.sid,
+                appliance.server.zone.name)
+    )
 
     # CFME updates about box only after any navigation BZ(1408681) - closed wontfix
     navigate_to(appliance.server, 'Dashboard')
 
     # opens and closes about modal
-    current_server_name = about.get_detail(about.SERVER, server=appliance.server)
-
-    assert new_server_name == current_server_name, (
+    assert new_server_name == about.get_detail(about.SERVER, server=appliance.server), (
         "Server name in About section does not match the new name")

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2101,6 +2101,19 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
     def region(self):
         return "Region {}".format(self.server.zone.region.number)
 
+    def rename(self, new_name):
+        """Changes appliance name
+
+        Args:
+            new_name: Name to set
+
+        Note:
+            Database must be up and running and evm service must be (re)started afterwards
+            for the name change to take effect.
+        """
+        vmdb_config = {'server': {'name': new_name}}
+        self.update_advanced_settings(vmdb_config)
+
     @cached_property
     def company_name(self):
         return self.advanced_settings["server"]["company"]
@@ -2741,19 +2754,6 @@ class Appliance(IPAppliance):
 
     def does_vm_exist(self):
         return self.provider.mgmt.does_vm_exist(self.vm_name)
-
-    def rename(self, new_name):
-        """Changes appliance name
-
-        Args:
-            new_name: Name to set
-
-        Note:
-            Database must be up and running and evm service must be (re)started afterwards
-            for the name change to take effect.
-        """
-        vmdb_config = {'server': {'name': new_name}}
-        self.update_advanced_settings(vmdb_config)
 
     def destroy(self):
         """Destroys the VM this appliance is running as


### PR DESCRIPTION
{{pytest: cfme/tests/configure/test_server_name.py }}

PRT RESULTS:
5.11 failure is addressed in wt.patternfly PR #98 and #9084  (which will include update to wt.patternfly)