### PR TITLE
[1LP][RFR] New container crud test and remove flash assert in BaseProvider

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -237,17 +237,11 @@ class BaseProvider(Taggable, Updateable, Navigatable, BaseEntity, CustomButtonEv
             if cancel:
                 created = False
                 add_view.cancel.click()
-                cancel_text = ('Add of {} Provider was '
-                               'cancelled by the user'.format(self.string_name))
-
-                main_view.flash.assert_message(cancel_text)
                 main_view.flash.assert_no_error()
             else:
                 add_view.add.click()
                 if main_view.is_displayed:
-                    success_text = '{} Providers "{}" was saved'.format(self.string_name,
-                                                                        self.name)
-                    main_view.flash.assert_message(success_text)
+                    main_view.flash.assert_no_error()
                 else:
                     add_view.flash.assert_no_error()
                     raise AssertionError("Provider wasn't added. It seems form isn't accurately"
@@ -605,10 +599,8 @@ class BaseProvider(Taggable, Updateable, Navigatable, BaseEntity, CustomButtonEv
         view.toolbar.configuration.item_select(item_title.format(self.string_name),
                                                handle_alert=not cancel)
         if not cancel:
-            msg = ('Delete initiated for 1 {} Provider from '
-                   'the {} Database'.format(self.string_name, self.appliance.product_name))
             main_view = self.create_view(navigator.get_class(self, 'All').VIEW, wait='10s')
-            main_view.flash.assert_success_message(msg)
+            main_view.flash.assert_no_error()
 
     def delete_rest(self):
         """Deletes a provider from CFME using REST"""

--- a/cfme/test_requirements.py
+++ b/cfme/test_requirements.py
@@ -144,6 +144,12 @@ control = pytest.mark.requirement(
     assignee_id='mmojzis',
 )
 
+containers = pytest.mark.requirement(
+    "Containers",
+    description='Integration of OpenShift in MIQ/CFME',
+    assignee_id='juwatts',
+)
+
 dashboard = pytest.mark.requirement(
     "Dashboard",
     description='MIQ/CFME Dashboards creation, usability',

--- a/cfme/tests/containers/test_container_provider_crud.py
+++ b/cfme/tests/containers/test_container_provider_crud.py
@@ -1,0 +1,66 @@
+import fauxfactory
+import pytest
+
+from cfme import test_requirements
+from cfme.common.provider_views import ContainerProvidersView
+from cfme.containers.provider import ContainersProvider
+from cfme.markers.env_markers.provider import ONE_PER_VERSION
+from cfme.utils.blockers import BZ
+from cfme.utils.update import update
+
+
+pytestmark = [
+    pytest.mark.tier(1),
+    test_requirements.containers,
+    pytest.mark.provider(
+        [ContainersProvider],
+        scope='function',
+        selector=ONE_PER_VERSION),
+    pytest.mark.meta(
+        blockers=[BZ(1713504, forced_streams=['5.11'])]
+    ),
+]
+
+
+def test_container_provider_crud(request, appliance, has_no_providers, provider):
+
+    """
+    Polarion:
+        assignee: juwatts
+        caseimportance: critical
+        casecomponent: Containers
+        initialEstimate: 1/6h
+    """
+
+    provider.create()
+
+    request.addfinalizer(lambda: provider.delete_if_exists(cancel=False))
+
+    view = appliance.browser.create_view(ContainerProvidersView)
+
+    view.flash.assert_success_message('{} Providers "{}" was saved'.format(provider.string_name,
+                                                                           provider.name))
+
+    assert provider.exists
+
+    with update(provider):
+        provider.name = fauxfactory.gen_alpha(8).lower()
+
+    assert view.is_displayed
+
+    view.flash.assert_success_message(
+        'Containers Provider "{}" was saved'.format(provider.name))
+
+    assert provider.name == str(view.entities.get_first_entity().data.get('name', {}))
+
+    provider.delete(cancel=False)
+
+    assert view.is_displayed
+
+    view.flash.assert_success_message('Delete initiated for 1 {} Provider from '
+                                      'the {} Database'.format(provider.string_name,
+                                                               appliance.product_name))
+
+    provider.wait_for_delete()
+
+    assert not provider.exists


### PR DESCRIPTION
Removing flash message assertions for setup and delete in `BaseProvider`.
Add new containers provider crud test

{{ pytest: cfme/tests/containers/test_container_provider_crud.py --use-provider ocp-39-hawk }}