### PR TITLE
[1LP][RFR] Fix is displayed archived instances

### DIFF
--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -152,11 +152,17 @@ class InstanceDetailsView(CloudInstanceView):
             relationship_provider_name = relationships.get_text_of('Cloud Provider')
         except (NameError, NoSuchElementException):
             logger.warning('No "Cloud Provider" Relationship, assume instance view not displayed')
-            raise NotImplementedError("This view has no unique markers for is_displayed check")
-        return (
-            self.in_cloud_instance and
-            self.entities.title.text == 'Instance "{}"'.format(expected_name) and
-            relationship_provider_name == expected_provider)
+            # for archived instances the relationship_provider_name is removed from the summary
+            # table
+            return (
+                self.in_cloud_instance and
+                self.entities.title.text == 'Instance "{}"'.format(expected_name)
+            )
+        else:
+            return (
+                self.in_cloud_instance and
+                self.entities.title.text == 'Instance "{}"'.format(expected_name) and
+                relationship_provider_name == expected_provider)
 
     toolbar = View.nested(InstanceDetailsToolbar)
     sidebar = View.nested(InstanceAccordion)

--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -150,6 +150,11 @@ class InstanceDetailsView(CloudInstanceView):
             # Not displayed when the instance is archived
             relationships = self.entities.summary('Relationships')
             relationship_provider_name = relationships.get_text_of('Cloud Provider')
+            return (
+                self.in_cloud_instance and
+                self.entities.title.text == 'Instance "{}"'.format(expected_name) and
+                relationship_provider_name == expected_provider
+            )
         except (NameError, NoSuchElementException):
             logger.warning('No "Cloud Provider" Relationship, assume instance view not displayed')
             # for archived instances the relationship_provider_name is removed from the summary
@@ -158,11 +163,6 @@ class InstanceDetailsView(CloudInstanceView):
                 self.in_cloud_instance and
                 self.entities.title.text == 'Instance "{}"'.format(expected_name)
             )
-        else:
-            return (
-                self.in_cloud_instance and
-                self.entities.title.text == 'Instance "{}"'.format(expected_name) and
-                relationship_provider_name == expected_provider)
 
     toolbar = View.nested(InstanceDetailsToolbar)
     sidebar = View.nested(InstanceAccordion)

--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -390,10 +390,14 @@ def test_cloud_timeline_rename_event(new_instance, soft_assert, azone):
     inst_event.catch_in_timelines(soft_assert, targets)
 
 
+@pytest.mark.meta(automates=[1730819], blockers=[BZ(1730819, forced_streams=["5.11"])])
 def test_cloud_timeline_delete_event(new_instance, soft_assert, azone):
     """
     Metadata:
         test_flag: timelines, events
+
+    Bugzilla:
+        1730819
 
     Polarion:
         assignee: jdupuy


### PR DESCRIPTION
1) Fixing `is_displayed` on archived instances, as they do not display the "Cloud Provider" row in the "Relationships" table. This was causing `test_cloud_timeline_delete_event` to skip when it shouldn't
2) Adding BZ metadata to the above test case for https://bugzilla.redhat.com/show_bug.cgi?id=1730819

{{ pytest: --use-provider azure cfme/tests/cloud/test_cloud_timelines.py::test_cloud_timeline_delete_event }}
