### PR TITLE
[1LP][RFR]Automate test: test_sent_text_custom_report_with_long_condition

### DIFF
--- a/cfme/tests/intelligence/reports/test_reports.py
+++ b/cfme/tests/intelligence/reports/test_reports.py
@@ -1,5 +1,3 @@
-import os
-
 import fauxfactory
 import pytest
 
@@ -20,11 +18,10 @@ pytestmark = [test_requirements.report, pytest.mark.tier(3), pytest.mark.sauce]
 def get_report(appliance, request):
     def _report(file_name, menu_name):
         collection = appliance.collections.reports
-        file_name = "{}.yaml".format(file_name)
 
         # download the report from server
         fs = FTPClientWrapper(cfme_data.ftpserver.entities.reports)
-        file_path = fs.download(file_name, os.path.join("/tmp", file_name))
+        file_path = fs.download(file_name)
 
         # import the report
         collection.import_report(file_path)
@@ -204,7 +201,7 @@ def test_report_edit_secondary_display_filter(
     Bugzilla:
         1565171
     """
-    report = get_report("filter_report", "test_filter_report")
+    report = get_report("filter_report.yaml", "test_filter_report")
     report.update(
         {
             "filter": {
@@ -250,7 +247,7 @@ def test_report_edit_secondary_display_filter(
 @pytest.mark.meta(server_roles="+notifier", automates=[1677839])
 @pytest.mark.provider([InfraProvider], selector=ONE_PER_CATEGORY)
 def test_send_text_custom_report_with_long_condition(
-    appliance, setup_provider, smtp_test, soft_assert, request, get_report
+    appliance, setup_provider, smtp_test, request, get_report
 ):
     """
     Polarion:
@@ -270,7 +267,7 @@ def test_send_text_custom_report_with_long_condition(
     Bugzilla:
         1677839
     """
-    report = get_report("long_condition_report", "test_long_condition_report")
+    report = get_report("long_condition_report.yaml", "test_long_condition_report")
     data = {
         "timer": {"hour": "12", "minute": "10"},
         "email": {"to_emails": "test@example.com"},
@@ -292,4 +289,4 @@ def test_send_text_custom_report_with_long_condition(
         == 1
     )
     # assert that the pattern was not found in the logs
-    soft_assert(log.validate(), "Found error message in the logs.")
+    assert log.validate(), "Found error message in the logs."

--- a/cfme/tests/intelligence/reports/test_reports.py
+++ b/cfme/tests/intelligence/reports/test_reports.py
@@ -310,8 +310,9 @@ def test_send_text_custom_report_with_long_condition(
     schedule = report.create_schedule(**data)
 
     # prepare LogValidator
-    pattern = ".*negative argument.*"
-    log = LogValidator("/var/www/miq/vmdb/log/evm.log", matched_patterns=[pattern])
+    log = LogValidator(
+        "/var/www/miq/vmdb/log/evm.log", failure_patterns=[".*negative argument.*"]
+    )
 
     log.start_monitoring()
     schedule.queue()
@@ -325,4 +326,4 @@ def test_send_text_custom_report_with_long_condition(
     )
 
     # assert that the pattern was not found in the logs
-    soft_assert(not log.validate(), "Found error message in the logs.")
+    soft_assert(log.validate(), "Found error message in the logs.")

--- a/cfme/tests/intelligence/reports/test_reports.py
+++ b/cfme/tests/intelligence/reports/test_reports.py
@@ -8,7 +8,6 @@ from cfme.markers.env_markers.provider import ONE_PER_CATEGORY
 from cfme.rest.gen_data import users as _users
 from cfme.utils.log_validator import LogValidator
 from cfme.utils.rest import assert_response
-from cfme.utils.wait import wait_for
 
 pytestmark = [test_requirements.report, pytest.mark.tier(3), pytest.mark.sauce]
 
@@ -318,12 +317,6 @@ def test_send_text_custom_report_with_long_condition(
     schedule.queue()
 
     # assert that the mail was sent
-    wait_for(
-        lambda: len(smtp_test.get_emails(to_address=data["email"]["to_emails"])) == 1,
-        timeout=200,
-        delay=5,
-        msg="Mail was not sent. Some error occured.",
-    )
-
+    assert len(smtp_test.wait_for_emails(wait=200, to_address=data["email"]["to_emails"])) == 1
     # assert that the pattern was not found in the logs
     soft_assert(log.validate(), "Found error message in the logs.")

--- a/cfme/tests/intelligence/reports/test_reports_manual.py
+++ b/cfme/tests/intelligence/reports/test_reports_manual.py
@@ -211,31 +211,6 @@ def test_custom_reports_with_timelines(report_type):
 @pytest.mark.manual
 @test_requirements.report
 @pytest.mark.tier(1)
-def test_sent_text_custom_report_with_long_condition():
-    """
-    Polarion:
-        assignee: pvala
-        casecomponent: Reporting
-        caseimportance: medium
-        initialEstimate: 1/3h
-        setup:
-            1. Create a report containing 1 or 2 columns
-                and add a report filter with a long condition.(Refer BZ for more detail)
-            2. Create a schedule for the report and check send_txt.
-        testSteps:
-            1. Queue the schedule and monitor evm log.
-        expectedResults:
-            1. There should be no error in the log and report must be sent successfully.
-
-    Bugzilla:
-        1677839
-    """
-    pass
-
-
-@pytest.mark.manual
-@test_requirements.report
-@pytest.mark.tier(1)
 def test_vm_volume_free_space_less_than_20_percent():
     """
     Polarion:

--- a/cfme/utils/smtp_collector_client.py
+++ b/cfme/utils/smtp_collector_client.py
@@ -2,6 +2,7 @@
 import requests
 
 from cfme.utils.timeutil import parsetime
+from cfme.utils.wait import wait_for
 
 
 class SMTPCollectorClient(object):
@@ -65,3 +66,12 @@ class SMTPCollectorClient(object):
 
     def get_html_report(self):
         return self._query(requests.get, "messages.html").text.strip()
+
+    def wait_for_emails(self, wait=60, **filter):
+        result = wait_for(
+            lambda: self.get_emails(**filter),
+            timeout=wait,
+            delay=5,
+            msg="Mail not found.",
+        )
+        return result.out

--- a/cfme/utils/smtp_collector_client.py
+++ b/cfme/utils/smtp_collector_client.py
@@ -68,10 +68,10 @@ class SMTPCollectorClient(object):
         return self._query(requests.get, "messages.html").text.strip()
 
     def wait_for_emails(self, wait=60, **filter):
-        result = wait_for(
-            lambda: self.get_emails(**filter),
+        wait_for(
+            lambda: len(self.get_emails(**filter)) > 0,
             timeout=wait,
             delay=5,
             msg="Mail not found.",
         )
-        return result.out
+        return self.get_emails(**filter)


### PR DESCRIPTION
1. Adding test_send_text_custom_report_with_long_condition to automate BZ 1677839.
2. Adding a fixture to create reports for `test_send_text_custom_report_with_long_condition` and `test_report_edit_secondary_display_filter`.

{{ pytest: cfme/tests/intelligence/reports/test_reports.py -k "test_send_text_custom_report_with_long_condition or  test_report_edit_secondary_display_filter" --use-template-cache -sqvvvv }}