### PR TITLE
[1LP][RFR] removing entity_id type convertion to int

### DIFF
--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -1692,7 +1692,7 @@ class ReportDataControllerMixin(object):
         result = self.browser.execute_script(js_cmd)
         self.browser.plugin.ensure_page_safe()
         try:
-            return [int(eid["id"]) for eid in result]
+            return [eid["id"] for eid in result]
         except (TypeError, IndexError):
             return None
 


### PR DESCRIPTION
 it isn't correctly perceived by js code in some cases

{{pytest: --use-provider ocp-39-hawk --long-running cfme/tests/containers/test_node.py }}