### PR TITLE
[1LP][WIPTEST] Fix Cloud Intel navigation

### DIFF
--- a/cfme/base/__init__.py
+++ b/cfme/base/__init__.py
@@ -132,6 +132,10 @@ class Server(BaseEntity, sentaku.modeling.ElementMixin):
         view.customlogos.save_button.click()
         view.flash.assert_no_error()
 
+    @property
+    def intel_name(self):
+        return "Overview" if self.appliance.version > "5.11" else "Cloud Intel"
+
 
 @attr.s
 class ServerCollection(BaseCollection, sentaku.modeling.ElementMixin):

--- a/cfme/base/__init__.py
+++ b/cfme/base/__init__.py
@@ -10,6 +10,8 @@ from cfme.utils import ParamClassName
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.log import logger
 from cfme.utils.pretty import Pretty
+from cfme.utils.version import Version
+from cfme.utils.version import VersionPicker
 
 
 @attr.s
@@ -28,6 +30,7 @@ class Server(BaseEntity, sentaku.modeling.ElementMixin):
     current_username = sentaku.ContextualMethod()
     current_group_name = sentaku.ContextualMethod()
     group_names = sentaku.ContextualMethod()
+    intel_name = VersionPicker({"5.11": "Overview", Version.lowest(): "Cloud Intel"})
 
     # zone = sentaku.ContextualProperty()
     # slave_servers = sentaku.ContextualProperty()
@@ -131,10 +134,6 @@ class Server(BaseEntity, sentaku.modeling.ElementMixin):
         logo_view.enable.fill(enable)
         view.customlogos.save_button.click()
         view.flash.assert_no_error()
-
-    @property
-    def intel_name(self):
-        return "Overview" if self.appliance.version > "5.11" else "Cloud Intel"
 
 
 @attr.s

--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -422,7 +422,7 @@ class RSS(CFMENavigateStep):
     prerequisite = NavigateToSibling('LoggedIn')
 
     def step(self, *args, **kwargs):
-        self.view.navigation.select('Cloud Intel', 'RSS')
+        self.view.navigation.select(self.view.context["object"].intel_name, 'RSS')
 
 
 @navigator.register(Server)
@@ -431,7 +431,7 @@ class CloudIntelTimelines(CFMENavigateStep):
     prerequisite = NavigateToSibling('LoggedIn')
 
     def step(self, *args, **kwargs):
-        self.view.navigation.select('Cloud Intel', 'Timelines')
+        self.view.navigation.select(self.view.context["object"].intel_name, 'Timelines')
 
 
 @navigator.register(Server)
@@ -461,7 +461,9 @@ class Dashboard(CFMENavigateStep):
     prerequisite = NavigateToSibling('LoggedIn')
 
     def step(self, *args, **kwargs):
-        self.prerequisite_view.navigation.select('Cloud Intel', 'Dashboard')
+        self.prerequisite_view.navigation.select(
+            self.view.context["object"].intel_name, "Dashboard"
+        )
 
 
 @navigator.register(Server)
@@ -470,7 +472,9 @@ class Chargeback(CFMENavigateStep):
     prerequisite = NavigateToSibling('LoggedIn')
 
     def step(self, *args, **kwargs):
-        self.prerequisite_view.navigation.select('Cloud Intel', 'Chargeback')
+        self.prerequisite_view.navigation.select(
+            self.view.context["object"].intel_name, "Chargeback"
+        )
 
 
 class ServerView(ConfigurationView):

--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -422,7 +422,7 @@ class RSS(CFMENavigateStep):
     prerequisite = NavigateToSibling('LoggedIn')
 
     def step(self, *args, **kwargs):
-        self.view.navigation.select(self.view.context["object"].intel_name, 'RSS')
+        self.view.navigation.select(self.obj.intel_name, 'RSS')
 
 
 @navigator.register(Server)
@@ -431,7 +431,7 @@ class CloudIntelTimelines(CFMENavigateStep):
     prerequisite = NavigateToSibling('LoggedIn')
 
     def step(self, *args, **kwargs):
-        self.view.navigation.select(self.view.context["object"].intel_name, 'Timelines')
+        self.view.navigation.select(self.obj.intel_name, 'Timelines')
 
 
 @navigator.register(Server)
@@ -462,7 +462,7 @@ class Dashboard(CFMENavigateStep):
 
     def step(self, *args, **kwargs):
         self.prerequisite_view.navigation.select(
-            self.view.context["object"].intel_name, "Dashboard"
+            self.obj.intel_name, "Dashboard"
         )
 
 
@@ -473,7 +473,7 @@ class Chargeback(CFMENavigateStep):
 
     def step(self, *args, **kwargs):
         self.prerequisite_view.navigation.select(
-            self.view.context["object"].intel_name, "Chargeback"
+            self.obj.intel_name, "Chargeback"
         )
 
 

--- a/cfme/dashboard.py
+++ b/cfme/dashboard.py
@@ -221,8 +221,10 @@ class DashboardView(BaseLoggedInPage):
     @property
     def is_displayed(self):
         return (
-            self.logged_in_as_current_user and
-            self.navigation.currently_selected == ['Cloud Intel', 'Dashboard'])
+            self.logged_in_as_current_user
+            and self.navigation.currently_selected
+            == [self.context["object"].appliance.server.intel_name, "Dashboard"]
+        )
 
 
 class ParticularDashboardView(DashboardView):
@@ -455,7 +457,7 @@ class DashboardCollection(BaseCollection):
     def refresh(self):
         """Refreshes the dashboard view by forcibly clicking the navigation again."""
         view = navigate_to(self.appliance.server, 'Dashboard')
-        view.navigation.select('Cloud Intel', 'Dashboard')
+        view.navigation.select(self.appliance.server.intel_name, 'Dashboard')
 
     @property
     def zoomed_name(self):

--- a/cfme/intelligence/chargeback/__init__.py
+++ b/cfme/intelligence/chargeback/__init__.py
@@ -15,8 +15,10 @@ class ChargebackView(BaseLoggedInPage):
     @property
     def in_chargeback(self):
         return (
-            self.logged_in_as_current_user and
-            self.navigation.currently_selected == ['Cloud Intel', 'Chargeback'])
+            self.logged_in_as_current_user
+            and self.navigation.currently_selected
+            == [self.context["object"].appliance.server.intel_name, "Chargeback"]
+        )
 
     @property
     def is_displayed(self):
@@ -41,4 +43,6 @@ class IntelChargeback(CFMENavigateStep):
     prerequisite = NavigateToSibling("LoggedIn")
 
     def step(self, *args, **kwargs):
-        self.prerequisite_view.navigation.select("Cloud Intel", "Chargeback")
+        self.prerequisite_view.navigation.select(
+            self.view.context["object"].intel_name, "Chargeback"
+        )

--- a/cfme/intelligence/chargeback/__init__.py
+++ b/cfme/intelligence/chargeback/__init__.py
@@ -44,5 +44,5 @@ class IntelChargeback(CFMENavigateStep):
 
     def step(self, *args, **kwargs):
         self.prerequisite_view.navigation.select(
-            self.view.context["object"].intel_name, "Chargeback"
+            self.obj.intel_name, "Chargeback"
         )

--- a/cfme/intelligence/reports/__init__.py
+++ b/cfme/intelligence/reports/__init__.py
@@ -70,7 +70,7 @@ class CloudIntelReports(CFMENavigateStep):
     prerequisite = NavigateToSibling("LoggedIn")
 
     def step(self, *args, **kwargs):
-        self.view.navigation.select(self.view.context["object"].intel_name, "Reports")
+        self.view.navigation.select(self.obj.intel_name, "Reports")
 
     def resetter(self, *args, **kwargs):
         self.view.saved_reports.open()

--- a/cfme/intelligence/reports/__init__.py
+++ b/cfme/intelligence/reports/__init__.py
@@ -20,8 +20,9 @@ class CloudIntelReportsView(BaseLoggedInPage):
     @property
     def in_intel_reports(self):
         return (
-            self.logged_in_as_current_user and
-            self.navigation.currently_selected == ["Cloud Intel", "Reports"]
+            self.logged_in_as_current_user
+            and self.navigation.currently_selected
+            == [self.context["object"].appliance.server.intel_name, "Reports"]
         )
 
     @property
@@ -69,7 +70,7 @@ class CloudIntelReports(CFMENavigateStep):
     prerequisite = NavigateToSibling("LoggedIn")
 
     def step(self, *args, **kwargs):
-        self.view.navigation.select("Cloud Intel", "Reports")
+        self.view.navigation.select(self.view.context["object"].intel_name, "Reports")
 
     def resetter(self, *args, **kwargs):
         self.view.saved_reports.open()

--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -213,9 +213,11 @@ class ReportTimelineView(CloudIntelTimelinesView):
         # since Timeline doesn't include `All Reports` in it's tree_path,
         # which is why tree.currently_selected is checked against tree_path[1:]
         return (
-            self.logged_in_as_current_user and
-            self.navigation.currently_selected == ['Cloud Intel', 'Timelines'] and
-            self.timelines.tree.currently_selected == self.context["object"].tree_path[1:]
+            self.logged_in_as_current_user
+            and self.navigation.currently_selected
+            == [self.context["object"].appliance.server.intel_name, "Timelines"]
+            and self.timelines.tree.currently_selected
+            == self.context["object"].tree_path[1:]
         )
 
 

--- a/cfme/intelligence/rss.py
+++ b/cfme/intelligence/rss.py
@@ -10,5 +10,7 @@ class RSSView(BaseLoggedInPage):
     @property
     def is_displayed(self):
         return (
-            self.logged_in_as_current_user and
-            self.navigation.currently_selected == ['Cloud Intel', 'RSS'])
+            self.logged_in_as_current_user
+            and self.navigation.currently_selected
+            == [self.context["object"].appliance.server.intel_name, "RSS"]
+        )

--- a/cfme/intelligence/timelines.py
+++ b/cfme/intelligence/timelines.py
@@ -13,8 +13,9 @@ class CloudIntelTimelinesView(BaseLoggedInPage):
     @property
     def is_displayed(self):
         return (
-            self.logged_in_as_current_user and
-            self.navigation.currently_selected == ['Cloud Intel', 'Timelines']
+            self.logged_in_as_current_user
+            and self.navigation.currently_selected
+            == [self.context["object"].appliance.server.intel_name, "Timelines"]
         )
 
     @View.nested

--- a/cfme/tests/configure/test_landing_page.py
+++ b/cfme/tests/configure/test_landing_page.py
@@ -50,11 +50,6 @@ ALL_LANDING_PAGES = list(SPECIAL_LANDING_PAGES.keys()) + [
     "Automation / Automate / Log",
     "Automation / Automate / Requests",
     "Automation / Automate / Simulation",
-    "Cloud Intel / Chargeback",
-    "Cloud Intel / Dashboard",
-    "Cloud Intel / RSS",
-    "Cloud Intel / Reports",
-    "Cloud Intel / Timelines",
     "Compute / Clouds / Availability Zones",
     "Compute / Clouds / Flavors",
     "Compute / Clouds / Host Aggregates",
@@ -128,6 +123,10 @@ ALL_LANDING_PAGES = list(SPECIAL_LANDING_PAGES.keys()) + [
 ]
 
 PAGES_NOT_IN_510 = [
+    "Overview / Chargeback",
+    "Overview / Dashboard",
+    "Overview / Reports",
+    "Overview / Utilization",
     "Compute / Physical Infrastructure / Chassis",
     "Compute / Physical Infrastructure / Overview",
     "Compute / Physical Infrastructure / Providers",
@@ -140,7 +139,10 @@ PAGES_NOT_IN_510 = [
 ]
 
 PAGES_NOT_IN_511 = [
+    "Cloud Intel / Chargeback",
+    "Cloud Intel / Dashboard",
     "Cloud Intel / RSS",
+    "Cloud Intel / Reports",
     "Cloud Intel / Timelines",
     "Monitor / Alerts / Most Recent Alerts",
     "Optimize / Bottlenecks",

--- a/cfme/tests/intelligence/reports/test_crud.py
+++ b/cfme/tests/intelligence/reports/test_crud.py
@@ -145,6 +145,7 @@ def test_menuwidget_crud(appliance):
         casecomponent: Reporting
         initialEstimate: 1/12h
     """
+    dashboard = "{} / Dashboard".format(appliance.server.intel_name)
     w = appliance.collections.dashboard_report_widgets.create(
         appliance.collections.dashboard_report_widgets.MENU,
         fauxfactory.gen_alphanumeric(),
@@ -152,7 +153,7 @@ def test_menuwidget_crud(appliance):
         active=True,
         shortcuts={
             "Services / Catalogs": fauxfactory.gen_alphanumeric(),
-            "Cloud Intel / Dashboard": fauxfactory.gen_alphanumeric(),
+            dashboard: fauxfactory.gen_alphanumeric(),
         },
         visibility="<To All Users>"
     )


### PR DESCRIPTION
Purpose or Intent
=================

__Fixing__ navigation to 'Cloud Intel' because, since 5.11, "Cloud Intel" has been changed to "Overview", by adding a new property called `intel_name` to `Server` that returns appropriate name.

Few tests on 5.11.0.15 are failing because of [BZ 1724209](https://bugzilla.redhat.com/show_bug.cgi?id=1724209), but since they're passing for 5.10, I'm assuming these changes are alright.
{{ pytest: cfme/tests/intelligence/reports/test_crud.py -vvv }}