### PR TITLE
[1LP][RFR] Use common view class for timelines view

### DIFF
--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -54,9 +54,9 @@ from widgetastic_manageiq import AttributeValueForm
 from widgetastic_manageiq import Checkbox
 from widgetastic_manageiq import InputButton
 from widgetastic_manageiq import ManageIQTree
+from widgetastic_manageiq import ServerTimelinesView
 from widgetastic_manageiq import SummaryFormItem
 from widgetastic_manageiq import SummaryTable
-from widgetastic_manageiq import TimelinesView
 from widgetastic_manageiq import WaitTab
 
 
@@ -840,7 +840,7 @@ class ServerDiagnosticsView(ConfigurationView):
         TAB_NAME = "Utilization"
 
     @View.nested
-    class timelines(WaitTab, TimelinesView):  # noqa
+    class timelines(WaitTab, ServerTimelinesView):  # noqa
         TAB_NAME = "Timelines"
 
     configuration = Dropdown('Configuration')

--- a/cfme/cloud/availability_zone.py
+++ b/cfme/cloud/availability_zone.py
@@ -12,6 +12,7 @@ from widgetastic_patternfly import Dropdown
 from cfme.base.login import BaseLoggedInPage
 from cfme.common import CustomButtonEventsMixin
 from cfme.common import Taggable
+from cfme.common import TimelinesView
 from cfme.common.candu_views import AzoneCloudUtilizationView
 from cfme.exceptions import ItemNotFound
 from cfme.modeling.base import BaseCollection
@@ -29,7 +30,6 @@ from widgetastic_manageiq import Search
 from widgetastic_manageiq import SummaryTable
 from widgetastic_manageiq import Table
 from widgetastic_manageiq import Text
-from widgetastic_manageiq import TimelinesView
 
 
 class AvailabilityZoneToolBar(View):
@@ -133,13 +133,7 @@ class AvailabilityZoneDetailsView(AvailabilityZoneView):
 
 
 class CloudAvailabilityZoneTimelinesView(TimelinesView, AvailabilityZoneView):
-    @property
-    def is_displayed(self):
-        return (
-            self.in_availability_zones and
-            self.breadcrumb.active_location == 'Timelines' and
-            self.context['object'].expected_details_breadcrumb in self.breadcrumb.locations and
-            self.is_timelines)
+    pass
 
 
 @attr.s

--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -10,6 +10,7 @@ from widgetastic_patternfly import CheckableBootstrapTreeview
 from widgetastic_patternfly import Dropdown
 
 from cfme.base.login import BaseLoggedInPage
+from cfme.common import TimelinesView
 from cfme.common.vm import VM
 from cfme.common.vm import VMCollection
 from cfme.common.vm_views import EditView
@@ -34,7 +35,6 @@ from widgetastic_manageiq import CompareToolBarActionsView
 from widgetastic_manageiq import ManageIQTree
 from widgetastic_manageiq import Search
 from widgetastic_manageiq import SummaryTable
-from widgetastic_manageiq import TimelinesView
 
 
 class InstanceDetailsToolbar(View):
@@ -170,12 +170,20 @@ class InstanceDetailsView(CloudInstanceView):
 
 
 class InstanceTimelinesView(TimelinesView, CloudInstanceView):
+
     @property
     def is_displayed(self):
-        expected_name = self.context['object'].name
+        if self.breadcrumb.is_displayed:
+            check_object = self.breadcrumb.locations
+        else:
+            # since in 5.10 there is no breadcrumb
+            check_object = self.title.text
+
         return (
-            self.in_cloud_instance and
-            self.title.text == 'Timelines for Instance "{}"'.format(expected_name))
+            self.context['object'].name in check_object and
+            # this last check is less specific due to BZ 1732517
+            "Timeline" in self.title.text
+        )
 
 
 class InstanceCompareView(CloudInstanceView):

--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -14,6 +14,7 @@ from cfme.cloud.tenant import ProviderTenantAllView
 from cfme.common import PolicyProfileAssignable
 from cfme.common import Taggable
 from cfme.common import TagPageView
+from cfme.common import TimelinesView
 from cfme.common.provider import BaseProvider
 from cfme.common.provider import CloudInfraProviderMixin
 from cfme.common.provider import provider_types
@@ -32,19 +33,10 @@ from cfme.utils.log import logger
 from cfme.utils.pretty import Pretty
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import ItemsToolBarViewSelector
-from widgetastic_manageiq import TimelinesView
 
 
 class CloudProviderTimelinesView(TimelinesView, BaseLoggedInPage):
-    breadcrumb = BreadCrumb()
-
-    @property
-    def is_displayed(self):
-        return (
-            self.logged_in_as_current_user and
-            self.navigation.currently_selected == ['Compute', 'Clouds', 'Providers'] and
-            self.context['object'].expected_details_breadcrumb in self.breadcrumb.locations and
-            self.is_timelines)
+    pass
 
 
 class CloudProviderInstancesView(BaseLoggedInPage):

--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -28,12 +28,14 @@ from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.log import logger
+from cfme.utils.version import LOWEST
 from cfme.utils.version import Version
 from cfme.utils.version import VersionPicker
 from cfme.utils.wait import TimedOutError
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import BaseNonInteractiveEntitiesView
 from widgetastic_manageiq import ReactSelect
+from widgetastic_manageiq import ServerTimelinesView
 
 
 class ManagePoliciesView(BaseLoggedInPage):
@@ -818,3 +820,23 @@ class CustomButtonEvents(CFMENavigateStep):
             table.click_at("Custom Button Events")
         else:
             raise DestinationNotFound("Custom button event count 0")
+
+
+class TimelinesView(ServerTimelinesView):
+    """
+    represents common Timelines page, parent class for vm, host, cluster, availability zone,
+    and provider's timelines page
+    """
+
+    @property
+    def is_displayed(self):
+        expected_name = VersionPicker({
+            LOWEST: self.context['object'].expected_details_breadcrumb,
+            "5.11": self.context['object'].name
+        }).pick(self.extra.appliance.version)
+
+        return (
+            expected_name in self.breadcrumb.locations and
+            # this last check is less specific due to BZ 1732517
+            "Timeline" in self.title.text
+        )

--- a/cfme/common/host_views.py
+++ b/cfme/common/host_views.py
@@ -11,6 +11,7 @@ from widgetastic_patternfly import CheckableBootstrapTreeview
 from widgetastic_patternfly import Dropdown
 
 from cfme.base.login import BaseLoggedInPage
+from cfme.common import TimelinesView
 from cfme.exceptions import displayed_not_implemented
 from cfme.utils.log import logger
 from widgetastic_manageiq import Accordion
@@ -26,7 +27,6 @@ from widgetastic_manageiq import PaginationPane
 from widgetastic_manageiq import ParametrizedSummaryTable
 from widgetastic_manageiq import Search
 from widgetastic_manageiq import Table
-from widgetastic_manageiq import TimelinesView
 from widgetastic_manageiq import WaitTab
 
 
@@ -149,14 +149,7 @@ class HostDriftAnalysis(ComputeInfrastructureHostsView):
 
 class HostTimelinesView(TimelinesView, ComputeInfrastructureHostsView):
     """Represents a Host Timelines page."""
-    breadcrumb = BreadCrumb()
-
-    @property
-    def is_displayed(self):
-        return (
-            self.in_compute_infrastructure_hosts and
-            self.context['object'].expected_details_breadcrumb in self.breadcrumb.locations and
-            self.is_timelines)
+    pass
 
 
 class HostDiscoverView(ComputeInfrastructureHostsView):

--- a/cfme/common/physical_server_views.py
+++ b/cfme/common/physical_server_views.py
@@ -10,6 +10,7 @@ from widgetastic_patternfly import BreadCrumb
 from widgetastic_patternfly import Dropdown
 
 from cfme.base.login import BaseLoggedInPage
+from cfme.common import TimelinesView
 from widgetastic_manageiq import BaseEntitiesView
 from widgetastic_manageiq import BaseNonInteractiveEntitiesView
 from widgetastic_manageiq import BootstrapTreeview
@@ -19,7 +20,6 @@ from widgetastic_manageiq import JSBaseEntity
 from widgetastic_manageiq import ManageIQTree
 from widgetastic_manageiq import Search
 from widgetastic_manageiq import SummaryTable
-from widgetastic_manageiq import TimelinesView
 
 
 class ComputePhysicalInfrastructureServersView(BaseLoggedInPage):
@@ -91,11 +91,7 @@ class PhysicalServerDetailsView(ComputePhysicalInfrastructureServersView):
 
 class PhysicalServerTimelinesView(TimelinesView, ComputePhysicalInfrastructureServersView):
     """Represents a PhysicalServer Timelines page."""
-
-    @property
-    def is_displayed(self):
-        return (self.in_compute_physical_infrastructure_servers and
-                super(TimelinesView, self).is_displayed)
+    pass
 
 
 class PhysicalServerProvisionView(BaseLoggedInPage):

--- a/cfme/common/physical_switch_views.py
+++ b/cfme/common/physical_switch_views.py
@@ -8,13 +8,13 @@ from widgetastic_patternfly import Accordion
 from widgetastic_patternfly import Dropdown
 
 from cfme.base.login import BaseLoggedInPage
+from cfme.common import TimelinesView
 from widgetastic_manageiq import BaseEntitiesView
 from widgetastic_manageiq import BreadCrumb
 from widgetastic_manageiq import ItemsToolBarViewSelector
 from widgetastic_manageiq import JSBaseEntity
 from widgetastic_manageiq import ManageIQTree
 from widgetastic_manageiq import SummaryTable
-from widgetastic_manageiq import TimelinesView
 
 
 class ComputePhysicalInfrastructureSwitchesView(BaseLoggedInPage):
@@ -79,11 +79,7 @@ class PhysicalSwitchDetailsView(ComputePhysicalInfrastructureSwitchesView):
 
 class PhysicalSwitchTimelinesView(TimelinesView, ComputePhysicalInfrastructureSwitchesView):
     """Represents a PhysicalSwitch Timelines page."""
-
-    @property
-    def is_displayed(self):
-        return (self.in_compute_physical_infrastructure_switches and
-                super(TimelinesView, self).is_displayed)
+    pass
 
 
 class PhysicalSwitchProvisionView(BaseLoggedInPage):

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -11,6 +11,7 @@ from widgetastic_patternfly import BreadCrumb
 from widgetastic_patternfly import Dropdown
 
 from cfme.base.login import BaseLoggedInPage
+from cfme.common import TimelinesView
 from cfme.common.host_views import HostEntitiesView
 from cfme.utils.blockers import BZ
 from cfme.utils.version import VersionPicker
@@ -27,7 +28,6 @@ from widgetastic_manageiq import PaginationPane
 from widgetastic_manageiq import ParametrizedStatusBox
 from widgetastic_manageiq import ParametrizedSummaryTable
 from widgetastic_manageiq import Search
-from widgetastic_manageiq import TimelinesView
 from widgetastic_manageiq import WaitTab
 
 
@@ -141,17 +141,7 @@ class ProviderTimelinesView(TimelinesView, BaseLoggedInPage):
     """
      represents Timelines page
     """
-    breadcrumb = BreadCrumb()
-
-    @property
-    def is_displayed(self):
-        expected_name = self.context['object'].name
-        return (
-            self.logged_in_as_current_user and
-            self.navigation.currently_selected == ['Compute', 'Infrastructure', 'Providers'] and
-            ('{} (Summary)'.format(expected_name) in self.breadcrumb.locations or
-                '{} (Dashboard)'.format(expected_name) in self.breadcrumb.locations) and
-            self.is_timelines)
+    pass
 
 
 class InfraProvidersDiscoverView(BaseLoggedInPage):

--- a/cfme/containers/node.py
+++ b/cfme/containers/node.py
@@ -4,12 +4,12 @@ import attr
 from navmazing import NavigateToAttribute
 from navmazing import NavigateToSibling
 from widgetastic.widget import View
-from widgetastic_patternfly import BreadCrumb
 
 from cfme.common import PolicyProfileAssignable
 from cfme.common import Taggable
 from cfme.common import TaggableCollection
 from cfme.common import TagPageView
+from cfme.common import TimelinesView
 from cfme.common.provider_views import ProviderDetailsToolBar
 from cfme.common.vm_console import ConsoleMixin
 from cfme.containers.provider import ContainerObjectAllBaseView
@@ -24,7 +24,6 @@ from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.providers import get_crud_by_name
 from widgetastic_manageiq import Button
 from widgetastic_manageiq import Text
-from widgetastic_manageiq import TimelinesView
 
 
 class NodeDetailsToolBar(ProviderDetailsToolBar):
@@ -166,15 +165,7 @@ class Utilization(CFMENavigateStep):
 
 class NodeTimelinesView(TimelinesView, NodeView):
     """Timeline page for Nodes"""
-    breadcrumb = BreadCrumb()
-
-    @property
-    def is_displayed(self):
-        """Is this page currently being displayed"""
-        return (
-            self.in_node and
-            self.context['object'].expected_details_breadcrumb in self.breadcrumb.locations and
-            self.is_timelines)
+    pass
 
 
 @navigator.register(Node, 'Timelines')

--- a/cfme/infrastructure/cluster.py
+++ b/cfme/infrastructure/cluster.py
@@ -13,6 +13,7 @@ from widgetastic_patternfly import Dropdown
 from cfme.base.login import BaseLoggedInPage
 from cfme.common import CustomButtonEventsMixin
 from cfme.common import Taggable
+from cfme.common import TimelinesView
 from cfme.common.candu_views import ClusterInfraUtilizationView
 from cfme.exceptions import ItemNotFound
 from cfme.modeling.base import BaseCollection
@@ -32,7 +33,6 @@ from widgetastic_manageiq import ManageIQTree
 from widgetastic_manageiq import Search
 from widgetastic_manageiq import SummaryTable
 from widgetastic_manageiq import Text
-from widgetastic_manageiq import TimelinesView
 
 
 # TODO: since Cluster always requires provider, it will use only one way to get to Cluster Detail's
@@ -145,15 +145,7 @@ class ClusterDetailsView(ClusterView):
 
 class ClusterTimelinesView(TimelinesView, ClusterView):
     """The timelines page of a cluster"""
-    breadcrumb = BreadCrumb()
-
-    @property
-    def is_displayed(self):
-        """Determine if this page is currently being displayed"""
-        return (
-            self.in_cluster and
-            self.context['object'].expected_details_breadcrumb in self.breadcrumb.locations and
-            self.is_timelines)
+    pass
 
 
 @attr.s

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -27,6 +27,7 @@ from widgetastic_patternfly import Dropdown
 from widgetastic_patternfly import Input as WInput
 
 from cfme.base.login import BaseLoggedInPage
+from cfme.common import TimelinesView
 from cfme.common.vm import Template
 from cfme.common.vm import TemplateCollection
 from cfme.common.vm import VM
@@ -65,7 +66,6 @@ from widgetastic_manageiq import Search
 from widgetastic_manageiq import SnapshotMemorySwitch
 from widgetastic_manageiq import SummaryTable
 from widgetastic_manageiq import Table
-from widgetastic_manageiq import TimelinesView
 from widgetastic_manageiq.vm_reconfigure import DisksTable
 
 
@@ -329,13 +329,20 @@ class InfraVmDetailsView(InfraVmView):
 
 
 class InfraVmTimelinesView(TimelinesView, InfraVmView):
+
     @property
     def is_displayed(self):
-        expected_name = self.context['object'].name
+        if self.breadcrumb.is_displayed:
+            check_object = self.breadcrumb.locations
+        else:
+            # since in 5.10 there is no breadcrumb
+            check_object = self.title.text
+
         return (
-            self.in_infra_vms and
-            self.title.text == 'Timelines for Virtual Machine "{}"'.format(expected_name))
-    # Timelines for Virtual Machine "landon-test"
+            self.context['object'].name in check_object and
+            # this last check is less specific due to BZ 1732517
+            "Timeline" in self.title.text
+        )
 
 
 class InfraVmReconfigureView(BaseLoggedInPage):

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -3091,7 +3091,7 @@ class TimelinesChart(View):
         return events
 
 
-class TimelinesView(View):
+class ServerTimelinesView(View):
     """represents Timelines page
     """
 
@@ -3108,12 +3108,7 @@ class TimelinesView(View):
 
     @property
     def is_displayed(self):
-        return self.title.text == "Timelines"
-
-    @property
-    def is_timelines(self):
-        """method to check title text for base Timelines without overriding is_displayed"""
-        return self.title.text == "Timelines"
+        return "Timeline" in self.title.text
 
 
 class AttributeValueForm(View):


### PR DESCRIPTION
Fixing the `is_displayed` properties in 5.11. I would also like to fix cluster and host views since those are also impacting these tests. 

{{ pytest: --use-provider vsphere6-nested cfme/tests/infrastructure/test_timelines.py::test_infra_timeline_create_event }}
