### PR TITLE
[1LP][RFR] Avoid flash check with bz

### DIFF
--- a/cfme/tests/automate/custom_button/test_cloud_objects.py
+++ b/cfme/tests/automate/custom_button/test_cloud_objects.py
@@ -149,6 +149,7 @@ def test_custom_button_display_cloud_obj(appliance, request, display, setup_objs
             assert custom_button_group.has_item(button.text)
 
 
+@pytest.mark.meta(automates=[1635797, 1574403, 1640592, 1710350, 1732436])
 @pytest.mark.uncollectif(
     lambda appliance, button_group: not bool([obj for obj in OBJ_TYPE_59 if obj in button_group])
     and appliance.version < "5.10"
@@ -229,6 +230,7 @@ def test_custom_button_dialog_cloud_obj(appliance, dialog, request, setup_objs, 
             assert False, "Expected 1 requests not found in automation log"
 
 
+@pytest.mark.meta(automates=[1628224])
 @pytest.mark.uncollectif(
     lambda appliance, button_group: not bool([obj for obj in OBJ_TYPE_59 if obj in button_group])
     and appliance.version < "5.10"

--- a/cfme/tests/automate/custom_button/test_cloud_objects.py
+++ b/cfme/tests/automate/custom_button/test_cloud_objects.py
@@ -180,6 +180,8 @@ def test_custom_button_dialog_cloud_obj(appliance, dialog, request, setup_objs, 
         1555331
         1574403
         1640592
+        1710350
+        1732436
     """
 
     group, obj_type = button_group
@@ -210,7 +212,9 @@ def test_custom_button_dialog_cloud_obj(appliance, dialog, request, setup_objs, 
 
         # Submit order request
         dialog_view.submit.click()
-        view.flash.assert_message("Order Request was Submitted")
+
+        if not (BZ(1732436, forced_streams=["5.10", "5.11"]).blocks and obj_type == "PROVIDER"):
+            view.flash.assert_message("Order Request was Submitted")
 
         # Check for request in automation log
         try:

--- a/cfme/tests/automate/custom_button/test_container_objects.py
+++ b/cfme/tests/automate/custom_button/test_container_objects.py
@@ -156,6 +156,9 @@ def test_custom_button_dialog_container_obj(appliance, dialog, request, setup_ob
             6. Fill dialog and submit
             7. Check for the proper flash message related to button execution
             8. Check request in automation log
+
+    Bugzilla:
+        1732489
     """
 
     group, obj_type = button_group
@@ -183,7 +186,9 @@ def test_custom_button_dialog_container_obj(appliance, dialog, request, setup_ob
 
     # Submit order
     dialog_view.submit.click()
-    view.flash.assert_message("Order Request was Submitted")
+
+    if not (BZ(1732489, forced_streams=["5.10", "5.11"]).blocks and obj_type == "PROVIDER"):
+        view.flash.assert_message("Order Request was Submitted")
 
     # Check for request in automation log
     try:

--- a/cfme/tests/automate/custom_button/test_container_objects.py
+++ b/cfme/tests/automate/custom_button/test_container_objects.py
@@ -123,6 +123,7 @@ def test_custom_button_display_container_obj(request, display, setup_obj, button
 
 
 @pytest.mark.meta(
+    automates=[1729903, 1732489],
     blockers=[
         BZ(
             1729903,
@@ -158,6 +159,7 @@ def test_custom_button_dialog_container_obj(appliance, dialog, request, setup_ob
             8. Check request in automation log
 
     Bugzilla:
+        1729903
         1732489
     """
 

--- a/cfme/tests/automate/custom_button/test_service_objects.py
+++ b/cfme/tests/automate/custom_button/test_service_objects.py
@@ -143,9 +143,11 @@ def serv_button_group(appliance, request):
     reason="Generic object custom button not supported by SSUI",
 )
 @pytest.mark.meta(
+    automates=[1650066],
     blockers=[
         BZ(
             1650066,
+            forced_streams=["5.11"],
             unblock=lambda display, context: not (
                 context is ViaSSUI and display in ["List", "Single and list"]
             ),
@@ -255,7 +257,7 @@ def test_custom_button_automate_service_obj(
         # BZ-1650066: no custom button on All page
         destinations = (
             ["Details"]
-            if context == ViaSSUI and BZ(1650066).blocks
+            if context == ViaSSUI and BZ(1650066, forced_streams=["5.11"]).blocks
             else ["All", "Details"]
         )
         for destination in destinations:
@@ -341,7 +343,7 @@ def test_custom_button_text_display(appliance, context, serv_button_group, servi
         navigate_to = ssui_nav if context is ViaSSUI else ui_nav
         destinations = (
             ["Details"]
-            if (BZ(1650066).blocks and context is ViaSSUI)
+            if (BZ(1650066, forced_streams=["5.11"]).blocks and context is ViaSSUI)
             else ["All", "Details"]
         )
         for destination in destinations:

--- a/cfme/tests/automate/custom_button/test_service_vm_custom_button.py
+++ b/cfme/tests/automate/custom_button/test_service_vm_custom_button.py
@@ -138,7 +138,7 @@ def test_custom_button_display_service_vm(request, appliance, service_vm, button
 @test_requirements.customer_stories
 @pytest.mark.tier(1)
 # Dynamic dialog problem 1729594
-@pytest.mark.meta(automates=[1687061], blockers=[BZ(1729594), BZ(1729594)])
+@pytest.mark.meta(automates=[1687061], blockers=[BZ(1729594), BZ(1729046)])
 def test_custom_button_with_dynamic_dialog_vm(
     appliance, provider, request, service_vm, setup_dynamic_dialog
 ):


### PR DESCRIPTION
Signed-off-by: Nikhil Dhandre <ndhandre@redhat.com>

Purpose or Intent
=================

Just avoid flash check as it lands on wrong page. As we are getting proper request no need to block tests.

{{pytest: cfme/tests/automate/custom_button/test_service_objects.py}}