### PR TITLE
[1LP][RFR] Added Azure and Network credentials with Credentials modal page refactor.

### DIFF
--- a/cfme/ansible/credentials.py
+++ b/cfme/ansible/credentials.py
@@ -87,74 +87,115 @@ class CredentialFormView(CredentialsBaseView):
     @credential_form.register("Machine")
     class CredentialFormMachineView(View):
         username = Input(locator='.//input[@title="Username for this credential"]')
-        password = Input(locator='.//input[@title="Password for this credential"][2]')
+        password = Input(
+            locator='.//input[@title="Password for this credential" and "not @disabled"]'
+        )
         private_key = TextInput(
-            locator='.//textarea[@title="RSA or DSA private key to be used instead of password"][2]'
+            locator='.//textarea[@title="RSA or DSA private key to be used instead of password"'
+            'and "not @disabled"]'
         )
         private_key_phrase = Input(
-            locator='.//input[@title="Passphrase to unlock SSH private key if encrypted"][2]')
+            locator='.//input[@title="Passphrase to unlock SSH private key if encrypted"'
+            'and "not @disabled"]'
+        )
         privilage_escalation = BootstrapSelect("{{name}}")
         privilage_escalation_username = Input(
-            locator='.//input[@title="Privilege escalation username"]')
+            locator='.//input[@title="Privilege escalation username"]'
+        )
         privilage_escalation_password = Input(
-            locator='.//input[@title="Password for privilege escalation method"][2]')
+            locator='.//input[@title="Password for privilege escalation method"'
+            'and "not @disabled"]'
+        )
 
     @credential_form.register("Scm")
     class CredentialFormScmView(View):
         username = Input(locator='.//input[@title="Username for this credential"]')
-        password = Input(locator='.//input[@title="Password for this credential"][2]')
+        password = Input(
+            locator='.//input[@title="Password for this credential" and "not @disabled"]'
+        )
         private_key = TextInput(
-            locator='.//textarea[@title="RSA or DSA private key to be used instead of password"][2]'
+            locator='.//textarea[@title="RSA or DSA private key to be used instead of password"'
+            'and "not @disabled"]'
         )
         private_key_phrase = Input(
-            locator='.//input[@title="Passphrase to unlock SSH private key if encrypted"][2]')
+            locator='.//input[@title="Passphrase to unlock SSH private key if encrypted"'
+            'and "not @disabled"]'
+        )
 
     @credential_form.register("Vault")
     class CredentialFormVaultView(View):
-        vault_password = Input(locator='.//input[@title="Vault password"][2]')
+        vault_password = Input(
+            locator='.//input[@title="Vault password" and "not @disabled"]'
+        )
 
     @credential_form.register("Amazon")
     class CredentialFormAmazonView(View):
-        access_key = Input(locator='.//input[@title="AWS Access Key for this credential"]')
-        secret_key = Input(locator='.//input[@title="AWS Secret Key for this credential"][2]')
+        access_key = Input(
+            locator='.//input[@title="AWS Access Key for this credential"]'
+        )
+        secret_key = Input(
+            locator='.//input[@title="AWS Secret Key for this credential" and "not @disabled"]'
+        )
         sts_token = Input(
-            locator='.//input[@title="Security Token Service(STS) Token for this credential"][2]')
+            locator='.//input[@title="Security Token Service(STS) Token for this credential"'
+            'and "not @disabled"]'
+        )
 
     @credential_form.register("VMware")
     class CredentialFormVMwareView(View):
         username = Input(locator='.//input[@title="Username for this credential"]')
-        password = Input(locator='.//input[@title="Password for this credential"][2]')
+        password = Input(
+            locator='.//input[@title="Password for this credential" and "not @disabled"]'
+        )
         vcenter_host = Input(
-            locator='.//input[@title="The hostname or IP address of the vCenter Host"]')
+            locator='.//input[@title="The hostname or IP address of the vCenter Host"]'
+        )
 
     @credential_form.register("OpenStack")
     class CredentialFormOpenStackView(View):
-        username = Input(locator='.//input[@title="The username to use to connect to OpenStack"]')
-        password = Input(locator='.//input[@title="The password or API'
-                                 ' key to use to connect to OpenStack"][2]')
+        username = Input(
+            locator='.//input[@title="The username to use to connect to OpenStack"]'
+        )
+        password = Input(
+            locator='.//input[@title="The password or API'
+            ' key to use to connect to OpenStack" and "not @disabled"]'
+        )
         authentication_url = Input(
             locator='.//input[@title="The host to authenticate with. '
-            'For example, https://openstack.business.com/v2.0"]')
-        project = Input(locator='.//input[@title="This is the tenant name. This value '
-            'is usually the same as the username"]')
-        domain = Input(locator='.//input[@title="OpenStack domains define administrative '
-            'boundaries. It is only needed for Keystone v3 authentication URLs"]')
+            'For example, https://openstack.business.com/v2.0"]'
+        )
+        project = Input(
+            locator='.//input[@title="This is the tenant name. This value '
+            'is usually the same as the username"]'
+        )
+        domain = Input(
+            locator='.//input[@title="OpenStack domains define administrative '
+            'boundaries. It is only needed for Keystone v3 authentication URLs"]'
+        )
 
     @credential_form.register("Red Hat Virtualization")
     class CredentialFormRHVView(View):
         username = Input(locator='.//input[@title="Username for this credential"]')
-        password = Input(locator='.//input[@title="Password for this credential"][2]')
+        password = Input(
+            locator='.//input[@title="Password for this credential" and "not @disabled"]'
+        )
         host = Input(locator='.//input[@title="The host to authenticate with"]')
 
     @credential_form.register("Google Compute Engine")
     class CredentialFormGCEView(View):
-        service_account = Input(locator='.//input[@title="The email address assigned to '
-            'the Google Compute Engine service account"]')
-        priv_key = TextInput(locator='.//textarea[@title="Contents of the PEM file associated with '
-            'the service account email"]')
-        project = Input(locator='.//input[@title="The GCE assigned identification. It is '
-            'constructed as two words followed by a three digit number, such as: '
-            'squeamish-ossifrage-123"]')
+        service_account = Input(
+            locator='.//input[@title="The email address assigned to '
+            'the Google Compute Engine service account"]'
+        )
+        priv_key = TextInput(
+            locator='.//textarea[@title="Contents of the PEM file associated with '
+            'the service account email"]'
+        )
+        project = Input(
+            locator='.//input[@title="The GCE assigned identification. It is '
+            "constructed as two words followed by a three digit number, such as: "
+            'squeamish-ossifrage-123"]'
+        )
 
     @credential_form.register("Azure")
     class CredentialFormAzureView(View):
@@ -190,10 +231,12 @@ class CredentialFormView(CredentialsBaseView):
             locator='.//input[@title="Password used by the authorize mechanism"]'
         )
         ssh_key = TextInput(
-            locator='.//textarea[@title="RSA or DSA private key to be used instead of password"][2]'
+            locator='.//textarea[@title="RSA or DSA private key to be used instead of password"'
+            'and "not @disabled"]'
         )
         private_key_phrase = Input(
-            locator='.//input[@title="Passphrase to unlock SSH private key if encrypted"][2]'
+            locator='.//input[@title="Passphrase to unlock SSH private key if encrypted"'
+            'and "not @disabled"]'
         )
 
     cancel_button = Button("Cancel")

--- a/cfme/ansible/credentials.py
+++ b/cfme/ansible/credentials.py
@@ -156,6 +156,46 @@ class CredentialFormView(CredentialsBaseView):
             'constructed as two words followed by a three digit number, such as: '
             'squeamish-ossifrage-123"]')
 
+    @credential_form.register("Azure")
+    class CredentialFormAzureView(View):
+        username = Input(
+            locator='.//input[@title="The username to use to connect to the '
+            'Microsoft Azure account"]'
+        )
+        password = Input(
+            locator='.//input[@title="The password to use to connect to the '
+            'Microsoft Azure account"]'
+        )
+        subscription_id = Input(
+            locator='.//input[@title="The Subscription UUID for the Microsoft Azure account"]'
+        )
+        tenant_id = Input(
+            locator='.//input[@title="The Tenant ID for the Microsoft Azure account"]'
+        )
+        client_secret = Input(
+            locator='.//input[@title="The Client Secret for the Microsoft Azure account"]'
+        )
+        client_id = Input(
+            locator='.//input[@title="The Client ID for the Microsoft Azure account"]'
+        )
+
+    @credential_form.register("Network")
+    class CredentialFormNetworkView(View):
+        username = Input(locator='.//input[@title="Username for this credential"]')
+        password = Input(locator='.//input[@title="Password for this credential"]')
+        authorize = Input(
+            locator='.//input[@title="Whether to use the authorize mechanism"]'
+        )
+        authorize_password = Input(
+            locator='.//input[@title="Password used by the authorize mechanism"]'
+        )
+        ssh_key = TextInput(
+            locator='.//textarea[@title="RSA or DSA private key to be used instead of password"][2]'
+        )
+        private_key_phrase = Input(
+            locator='.//input[@title="Passphrase to unlock SSH private key if encrypted"][2]'
+        )
+
     cancel_button = Button("Cancel")
 
 
@@ -212,6 +252,97 @@ class CredentialEditView(CredentialFormView):
                 continue
 
 
+def machine_credentials(credentials):
+    return {
+        "username": credentials.get("username"),
+        "password": credentials.get("password"),
+        "private_key": credentials.get("private_key"),
+        "private_key_phrase": credentials.get("private_key_phrase"),
+        "privilage_escalation": credentials.get("privilage_escalation"),
+        "privilage_escalation_username": credentials.get("privilage_escalation_username"),
+        "privilage_escalation_password": credentials.get("privilage_escalation_password"),
+    }
+
+
+def scm_credentials(credentials):
+    return {
+        "username": credentials.get("username"),
+        "password": credentials.get("password"),
+        "private_key": credentials.get("private_key"),
+        "private_key_phrase": credentials.get("private_key_phrase")
+    }
+
+
+def vault_credentials(credentials):
+    return {
+        "vault_password": credentials.get("vault_password")
+    }
+
+
+def amazon_credentials(credentials):
+    return {
+        "access_key": credentials.get("access_key"),
+        "secret_key": credentials.get("secret_key"),
+        "sts_token": credentials.get("sts_token"),
+    }
+
+
+def azure_credentials(credentials):
+    return {
+        "username": credentials.get("username"),
+        "password": credentials.get("password"),
+        "subscription_id": credentials.get("subscription_id"),
+        "tenant_id": credentials.get("tenant_id"),
+        "client_secret": credentials.get("client_secret"),
+        "client_id": credentials.get("client_id"),
+    }
+
+
+def network_credentials(credentials):
+    return {
+        "username": credentials.get("username"),
+        "password": credentials.get("password"),
+        "authorize": credentials.get("authorize"),
+        "authorize_password": credentials.get("authorize_password"),
+        "ssh_key": credentials.get("ssh_key"),
+        "private_key_phrase": credentials.get("private_key_phrase"),
+    }
+
+
+def vmware_credentials(credentials):
+    return {
+        "username": credentials.get("username"),
+        "password": credentials.get("password"),
+        "vcenter_host": credentials.get("vcenter_host")
+    }
+
+
+def openstack_credentials(credentials):
+    return {
+        "username": credentials.get("username"),
+        "password": credentials.get("password"),
+        "authentication_url": credentials.get("authentication_url"),
+        "project": credentials.get("project"),
+        "domain": credentials.get("domain")
+    }
+
+
+def gce_credentials(credentials):
+    return {
+        "service_account": credentials.get("service_account"),
+        "priv_key": credentials.get("priv_key"),
+        "project": credentials.get("project")
+    }
+
+
+def rhv_credentials(credentials):
+    return {
+        "username": credentials.get("username"),
+        "password": credentials.get("password"),
+        "host": credentials.get("host")
+    }
+
+
 class Credential(BaseEntity, Taggable):
     """A class representing one Embedded Ansible credential in the UI."""
 
@@ -229,60 +360,17 @@ class Credential(BaseEntity, Taggable):
     __repr__ = object.__repr__
 
     def update(self, updates):
-        machine_credential_fill_dict = {
-            "username": updates.get("username"),
-            "password": updates.get("password"),
-            "private_key": updates.get("private_key"),
-            "private_key_phrase": updates.get("private_key_phrase"),
-            "privilage_escalation": updates.get("privilage_escalation"),
-            "privilage_escalation_username": updates.get("privilage_escalation_username"),
-            "privilage_escalation_password": updates.get("privilage_escalation_password"),
-        }
-        scm_credential_fill_dict = {
-            "username": updates.get("username"),
-            "password": updates.get("password"),
-            "private_key": updates.get("private_key"),
-            "private_key_phrase": updates.get("private_key_phrase")
-        }
-        vault_credential_fill_dict = {
-            "vault_password": updates.get("vault_password")
-        }
-        amazon_credential_fill_dict = {
-            "access_key": updates.get("access_key"),
-            "secret_key": updates.get("secret_key"),
-            "sts_token": updates.get("sts_token"),
-        }
-        vmware_credential_fill_dict = {
-            "username": updates.get("username"),
-            "password": updates.get("password"),
-            "vcenter_host": updates.get("vcenter_host")
-        }
-        openstack_credential_fill_dict = {
-            "username": updates.get("username"),
-            "password": updates.get("password"),
-            "authentication_url": updates.get("authentication_url"),
-            "project": updates.get("project"),
-            "domain": updates.get("domain")
-        }
-        gce_credential_fill_dict = {
-            "service_account": updates.get("service_account"),
-            "priv_key": updates.get("priv_key"),
-            "project": updates.get("project")
-        }
-        rhv_credential_fill_dict = {
-            "username": updates.get("username"),
-            "password": updates.get("password"),
-            "host": updates.get("host")
-        }
         credential_type_map = {
-            "Machine": machine_credential_fill_dict,
-            "Scm": scm_credential_fill_dict,
-            "Vault": vault_credential_fill_dict,
-            "Amazon": amazon_credential_fill_dict,
-            "VMware": vmware_credential_fill_dict,
-            "OpenStack": openstack_credential_fill_dict,
-            "Red Hat Virtualization": rhv_credential_fill_dict,
-            "Google Compute Engine": gce_credential_fill_dict
+            "Machine": machine_credentials(updates),
+            "Scm": scm_credentials(updates),
+            "Vault": vault_credentials(updates),
+            "Amazon": amazon_credentials(updates),
+            "Azure": azure_credentials(updates),
+            "Network": network_credentials(updates),
+            "VMware": vmware_credentials(updates),
+            "OpenStack": openstack_credentials(updates),
+            "Red Hat Virtualization": rhv_credentials(updates),
+            "Google Compute Engine": gce_credentials(updates)
         }
         edit_page = navigate_to(self, "Edit")
         changed = edit_page.fill({"name": updates.get("name")})
@@ -328,60 +416,17 @@ class CredentialsCollection(BaseCollection):
 
     def create(self, name, credential_type, **credentials):
         add_page = navigate_to(self, "Add")
-        machine_credential_fill_dict = {
-            "username": credentials.get("username"),
-            "password": credentials.get("password"),
-            "private_key": credentials.get("private_key"),
-            "private_key_phrase": credentials.get("private_key_phrase"),
-            "privilage_escalation": credentials.get("privilage_escalation"),
-            "privilage_escalation_username": credentials.get("privilage_escalation_username"),
-            "privilage_escalation_password": credentials.get("privilage_escalation_password")
-        }
-        scm_credential_fill_dict = {
-            "username": credentials.get("username"),
-            "password": credentials.get("password"),
-            "private_key": credentials.get("private_key"),
-            "private_key_phrase": credentials.get("private_key_phrase")
-        }
-        vault_credential_fill_dict = {
-            "vault_password": credentials.get("vault_password")
-        }
-        amazon_credential_fill_dict = {
-            "access_key": credentials.get("access_key"),
-            "secret_key": credentials.get("secret_key"),
-            "sts_token": credentials.get("sts_token"),
-        }
-        vmware_credential_fill_dict = {
-            "username": credentials.get("username"),
-            "password": credentials.get("password"),
-            "vcenter_host": credentials.get("vcenter_host")
-        }
-        openstack_credential_fill_dict = {
-            "username": credentials.get("username"),
-            "password": credentials.get("password"),
-            "authentication_url": credentials.get("authentication_url"),
-            "project": credentials.get("project"),
-            "domain": credentials.get("domain")
-        }
-        rhv_credential_fill_dict = {
-            "username": credentials.get("username"),
-            "password": credentials.get("password"),
-            "host": credentials.get("host")
-        }
-        gce_credential_fill_dict = {
-            "service_account": credentials.get("service_account"),
-            "priv_key": credentials.get("priv_key"),
-            "project": credentials.get("project")
-        }
         credential_type_map = {
-            "Machine": machine_credential_fill_dict,
-            "Scm": scm_credential_fill_dict,
-            "Vault": vault_credential_fill_dict,
-            "Amazon": amazon_credential_fill_dict,
-            "VMware": vmware_credential_fill_dict,
-            "OpenStack": openstack_credential_fill_dict,
-            "Red Hat Virtualization": rhv_credential_fill_dict,
-            "Google Compute Engine": gce_credential_fill_dict
+            "Machine": machine_credentials(credentials),
+            "Scm": scm_credentials(credentials),
+            "Vault": vault_credentials(credentials),
+            "Amazon": amazon_credentials(credentials),
+            "Azure": azure_credentials(credentials),
+            "Network": network_credentials(credentials),
+            "VMware": vmware_credentials(credentials),
+            "OpenStack": openstack_credentials(credentials),
+            "Red Hat Virtualization": rhv_credentials(credentials),
+            "Google Compute Engine": gce_credentials(credentials)
         }
 
         add_page.fill({"name": name, "credential_type": credential_type})

--- a/cfme/tests/ansible/test_embedded_ansible_basic.py
+++ b/cfme/tests/ansible/test_embedded_ansible_basic.py
@@ -102,6 +102,24 @@ CREDENTIALS = [
             "project": fauxfactory.gen_alpha(),
         },
     ),
+    (
+        "Network",
+        {
+            "username": fauxfactory.gen_alpha(),
+            "password": fauxfactory.gen_alpha(),
+        },
+    ),
+    (
+        "Azure",
+        {
+            "username": fauxfactory.gen_alpha(),
+            "password": fauxfactory.gen_alpha(),
+            "subscription_id": fauxfactory.gen_alpha(),
+            "tenant_id": fauxfactory.gen_alpha(),
+            "client_secret": fauxfactory.gen_alpha(),
+            "client_id": fauxfactory.gen_alpha(),
+        },
+    ),
 ]
 
 
@@ -219,10 +237,8 @@ def test_embedded_ansible_credential_crud(credentials_collection, wait_for_ansib
             credential.service_account = updated_value
         elif credential.credential_type == "Amazon":
             credential.access_key = updated_value
-            # credential.username = updated_value
         else:
             credential.username = updated_value
-            # credential.access_key = updated_value
     view = navigate_to(credential, "Details")
 
     def wait_for_changes(field_name):

--- a/cfme/tests/ansible/test_embedded_ansible_manual.py
+++ b/cfme/tests/ansible/test_embedded_ansible_manual.py
@@ -374,20 +374,6 @@ def test_embed_tower_ha():
 
 
 @pytest.mark.tier(1)
-def test_embed_tower_add_azure_credentials():
-    """
-    Add Azure credentials.
-
-    Polarion:
-        assignee: sbulage
-        casecomponent: Ansible
-        initialEstimate: 1/2h
-        tags: ansible_embed
-    """
-    pass
-
-
-@pytest.mark.tier(1)
 def test_embed_tower_add_network_credentials():
     """
     Add Network credentials.


### PR DESCRIPTION
This PR contains enhancement in Credentials Modal Page:

- [x] Refactored Credentials page: Redundant addition of Credentials `dict` in `create` and `update`.
- [x] Added `Azure` and `Network` Credentials.
- [x] Automated manual tests.

PRT Run: 
{{ pytest: cfme/tests/ansible/test_embedded_ansible_basic.py -k test_embedded_ansible_credential_crud -svvvv --long-running }}