### PR TITLE
[1LP][RFR][NOTEST] fix Could not find provider Embedded Ansible

### DIFF
--- a/cfme/infrastructure/cluster.py
+++ b/cfme/infrastructure/cluster.py
@@ -350,7 +350,10 @@ class ClusterCollection(BaseCollection):
             providers_db = {
                 prov.id: get_crud_by_name(prov.name)
                 for prov in providers
-                if not (getattr(prov, "parent_ems_id", False) or ("Manager" in prov.name))
+                if not (
+                    getattr(prov, "parent_ems_id", False)
+                    or ("Manager" in prov.name or prov.name == "Embedded Ansible")
+                )
             }
             cluster_obj = [
                 self.instantiate(name=cluster.name, provider=providers_db[cluster.ems_id])

--- a/cfme/infrastructure/datastore.py
+++ b/cfme/infrastructure/datastore.py
@@ -343,7 +343,10 @@ class DatastoreCollection(BaseCollection):
         provider_db = {
             prov.id: get_crud_by_name(prov.name)
             for prov in self.appliance.rest_api.collections.providers.all
-            if not (getattr(prov, "parent_ems_id", False) or ("Manager" in prov.name))
+            if not (
+                getattr(prov, "parent_ems_id", False)
+                or ("Manager" in prov.name or prov.name == "Embedded Ansible")
+            )
         }
         datastores = [
             self.instantiate(name=name, provider=provider_db[prov_id])


### PR DESCRIPTION
Signed-off-by: Nikhil Dhandre <ndhandre@redhat.com>

Nearly 23 test are affected due to this... 

Tested locally... can not reproduce with one or two test as this happened only if embedded ansible enabled. 
```
In [1]: [p.name for p in appliance.rest_api.collections.providers]                
(rest-api) [RESTAPI] GET https://10.8.196.115/api/providers {'expand': 'resources'}
Out[1]: 
['Embedded Ansible',
 'RHOS13',
 'RHOS13 Network Manager',
 'RHOS13 Cinder Manager',
 'RHOS13 Swift Manager',
 'vSphere 6.7 (nested)']

In [2]: appliance.collections.clusters.all()                                      
Out[2]: [Cluster(name='Cluster', provider=VMwareProvider(endpoints={'default': <cfme.infrastructure.provider.virtualcenter.VirtualCenterEndpoint object at 0x7f45ce01ef28>}, name='vSphere 6.7 (nested)', key='vsphere67-nested', zone='default', start_ip='10.8.197.68', end_ip='10.8.197.68', provider_data=None))]

In [3]: appliance.collections.datastores.all()                                    
Out[3]: 
[Datastore(name='iso_datastore_NO_VMs', provider=VMwareProvider(endpoints={'default': <cfme.infrastructure.provider.virtualcenter.VirtualCenterEndpoint object at 0x7f45ce5467b8>}, name='vSphere 6.7 (nested)', key='vsphere67-nested', zone='default', start_ip='10.8.197.68', end_ip='10.8.197.68', provider_data=None), type=None),
 Datastore(name='NFS_Datastore_1', provider=VMwareProvider(endpoints={'default': <cfme.infrastructure.provider.virtualcenter.VirtualCenterEndpoint object at 0x7f45ce5467b8>}, name='vSphere 6.7 (nested)', key='vsphere67-nested', zone='default', start_ip='10.8.197.68', end_ip='10.8.197.68', provider_data=None), type=None),
 Datastore(name='iSCSI_Datastore_1', provider=VMwareProvider(endpoints={'default': <cfme.infrastructure.provider.virtualcenter.VirtualCenterEndpoint object at 0x7f45ce5467b8>}, name='vSphere 6.7 (nested)', key='vsphere67-nested', zone='default', start_ip='10.8.197.68', end_ip='10.8.197.68', provider_data=None), type=None),
 Datastore(name='DoNotUse_iSCSI_Datastore_ibm_old', provider=VMwareProvider(endpoints={'default': <cfme.infrastructure.provider.virtualcenter.VirtualCenterEndpoint object at 0x7f45ce5467b8>}, name='vSphere 6.7 (nested)', key='vsphere67-nested', zone='default', start_ip='10.8.197.68', end_ip='10.8.197.68', provider_data=None), type=None)]
```