### PR TITLE
[1LP][RFR] Fixed CandidateNotFound issue

### DIFF
--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -5739,7 +5739,7 @@ class EntryPoint(View, ClickableMixin):
         """
 
         # `domain` not become part of value
-        if self.value and self.value in "/".join(value):
+        if self.value and "/".join(value) in self.value:
             return False
 
         if value:


### PR DESCRIPTION
- This PR fixes test cases related to quota and service where quota is getting checked with ordering service catalogs. 
- This issue breaks more number of test cases in 5.10 and 5.11 as well.
-  This PR fixes:
```
>                   'cause': 'Root node did not match {}'.format(self._repr_step(image, step))})
E               CandidateNotFound: path: ('Provisioning', 'StateMachines', 'ServiceProvision_Template', 'CatalogItemInitialization'), message: Could not find the item Service in Boostrap tree automate_treebox, cause: Root node did not match Service

/var/ci/cfme_venv/lib/python2.7/site-packages/widgetastic_patternfly/__init__.py:1422: CandidateNotFound
CandidateNotFound
path: ('Provisioning', 'StateMachines', 'ServiceProvision_Template', 'CatalogItemInitialization'), message: Could not find the item Service in Boostrap tree automate_treebox, cause: Root node did not match Service
```



{{ pytest: cfme/tests/cloud/test_tenant_quota.py::test_tenant_quota_enforce_via_service_cloud[openstack-13-max_cpu-ViaSSUI] --use-provider=rhos13 --long-running --use-template-cache -qsvvv }}