### PR TITLE
[1LP][RFR] Nav work around for 5.11.0.16

### DIFF
--- a/cfme/services/myservice/ui.py
+++ b/cfme/services/myservice/ui.py
@@ -55,9 +55,16 @@ class MyServicesView(BaseLoggedInPage):
 
     @property
     def in_myservices(self):
+        # Slicing in currently_selected is workaround for BZ-1733489
+        nav_selected = (
+            self.navigation.currently_selected[:2]
+            if BZ(1733489).blocks
+            else self.navigation.currently_selected
+        )
         return (
             self.logged_in_as_current_user and
-            self.navigation.currently_selected == ["Services", "My Services"])
+            nav_selected == ["Services", "My Services"]
+        )
 
     @property
     def is_displayed(self):


### PR DESCRIPTION
Signed-off-by: Nikhil Dhandre <ndhandre@redhat.com>

<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent

In latest build `MyServiceView` is broken due to `VeriticalNav`; It will break all tests related to `service.` `currently_selected` returning value like  `['Services', 'My Services', 'Services', 'Providers']`. 
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->
some local checks
```
ipdb> self.navigation.currently_selected                                          
['Services', 'My Services', 'Services', 'Providers']
ipdb> self.navigation.currently_selected                                          
['Storage', 'Block Storage', 'Managers']
ipdb> self.navigation.currently_selected                                          
['Services', 'Catalogs']
```
![vertical_nav_bar](https://user-images.githubusercontent.com/11618054/61940001-2e757580-afb2-11e9-9273-8091b8d7d1ef.png)

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->

{{pytest: cfme/tests/automate/custom_button/test_service_vm_custom_button.py::test_custom_button_with_dynamic_dialog_vm -v}}
