### PR TITLE
[1LP][RFR] Fix failing tests

### DIFF
--- a/cfme/tests/configure/test_default_views_infra.py
+++ b/cfme/tests/configure/test_default_views_infra.py
@@ -149,6 +149,7 @@ def test_infra_compare_view(appliance, expected_view):
     default_views.set_default_view(group_name, old_default)
 
 
+@pytest.mark.ignore_stream("5.11")
 def test_vm_visibility_off(appliance):
     """
     Polarion:
@@ -157,11 +158,13 @@ def test_vm_visibility_off(appliance):
         caseimportance: medium
         initialEstimate: 1/10h
         tags: settings
+        endsin: 5.10
     """
     appliance.user.my_settings.default_views.set_default_view_switch_off()
     assert not check_vm_visibility(appliance)
 
 
+@pytest.mark.ignore_stream("5.11")
 def test_vm_visibility_on(appliance):
     """
     Polarion:
@@ -170,6 +173,7 @@ def test_vm_visibility_on(appliance):
         caseimportance: medium
         initialEstimate: 1/5h
         tags: settings
+        endsin: 5.10
     """
     appliance.user.my_settings.default_views.set_default_view_switch_on()
     assert check_vm_visibility(appliance, check=True)


### PR DESCRIPTION
## Purpose or Intent

- __Fixing__  `test_vm_visibility_off` and `test_vm_visibility_on` by marking the test with ignore_stream for 5.11 since the feature is no longer available on it.

### PRT Run
- {{pytest: cfme/tests/configure/test_default_views_infra.py -k "test_vm_visibility" -v}}
