### PR TITLE
[1LP][RFR] fixed VolumeAddForm for ec2

### DIFF
--- a/cfme/storage/volume.py
+++ b/cfme/storage/volume.py
@@ -142,7 +142,10 @@ class VolumeAddForm(View):
     volume_type = BootstrapSelect(name=VersionPicker({Version.lowest(): 'aws_volume_type',
                                                       '5.10': 'volume_type'}))
     volume_size = TextInput(name='size')
-    az = BootstrapSelect(name='aws_availability_zone_id')  # is for ec2 block storage only
+    # az is for ec2 block storage only
+    az = BootstrapSelect(
+        name=VersionPicker(
+            {Version.lowest(): 'aws_availability_zone_id', '5.11': 'availability_zone_id'}))
     iops = TextInput(name='aws_iops')  # is for ec2 block storage only
     encryption = BootstrapSwitch(name="aws_encryption")  # is for ec2 block storage only
     add = Button('Add')


### PR DESCRIPTION
## Purpose or Intent
attribute name has changed in 5.11 and during `test_storage_volume_snapshot_edit_tag_from_detail[ec2]` I got
```
NoSuchElementException: Message: Could not find an element Locator(by='xpath', locator=u'.//div[contains(@class, "bootstrap-select")]/select[normalize-space(@name)="aws_availability_zone_id"]/..')
```

### PRT Run
{{ pytest: -v cfme/tests/storage/test_volume_snapshot.py::test_storage_volume_snapshot_edit_tag_from_detail[ec2] }}