### PR TITLE
[RFR] Block retire test in 5.11, remove unused appliance fixtures

### DIFF
--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -324,7 +324,7 @@ def test_action_prevent_event(request, vm, vm_off, policy_for_testing):
 @pytest.mark.provider(
     [VMwareProvider, RHEVMProvider, OpenStackProvider, AzureProvider], scope="module"
 )
-@pytest.mark.meta(blockers=[BZ(1702018)], automates=[1702018])
+@pytest.mark.meta(blockers=[BZ(1702018, forced_streams=["5.11"])], automates=[1702018])
 def test_action_prevent_vm_retire(request, vm, vm_on, policy_for_testing):
     """This test sets the policy that prevents VM retiring.
 
@@ -365,7 +365,7 @@ def test_action_prevent_vm_retire(request, vm, vm_on, policy_for_testing):
 
 @pytest.mark.provider([VMwareProvider], scope="module")
 @pytest.mark.meta(automates=[1433084])
-def test_action_prevent_ssa(request, appliance, configure_fleecing, vm, vm_on, policy_for_testing):
+def test_action_prevent_ssa(request, configure_fleecing, vm, vm_on, policy_for_testing):
     """Tests preventing Smart State Analysis.
 
     This test sets the policy that prevents VM analysis.
@@ -408,7 +408,7 @@ def test_action_prevent_ssa(request, appliance, configure_fleecing, vm, vm_on, p
 
 @pytest.mark.provider([VMwareProvider, RHEVMProvider], scope="module")
 @pytest.mark.meta(automates=[1437910])
-def test_action_prevent_host_ssa(request, appliance, host, host_policy):
+def test_action_prevent_host_ssa(request, host, host_policy):
     """Tests preventing Smart State Analysis on a host.
 
     This test sets the policy that prevents host analysis.
@@ -464,7 +464,7 @@ def test_action_prevent_host_ssa(request, appliance, host, host_policy):
 @pytest.mark.provider(
     [VMwareProvider, RHEVMProvider, OpenStackProvider, AzureProvider], scope="module"
 )
-def test_action_power_on_logged(request, vm, vm_off, appliance, policy_for_testing):
+def test_action_power_on_logged(request, vm, vm_off, policy_for_testing):
     """ This test tests action 'Generate log message'.
 
     This test sets the policy that it logs powering on of the VM. Then it powers up the vm and
@@ -505,7 +505,7 @@ def test_action_power_on_logged(request, vm, vm_off, appliance, policy_for_testi
 @pytest.mark.provider(
     [VMwareProvider, RHEVMProvider, OpenStackProvider, AzureProvider], scope="module"
 )
-def test_action_power_on_audit(request, vm, vm_off, appliance, policy_for_testing):
+def test_action_power_on_audit(request, vm, vm_off, policy_for_testing):
     """ This test tests action 'Generate Audit Event'.
 
     This test sets the policy that it logs powering on of the VM. Then it powers up the vm and


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1702018 also impacts 5.11. This BZ is causing the VM that is used for the other tests in this module to be retired. 

{{ pytest: --use-provider vsphere6-nested --long-running cfme/tests/control/test_actions.py::test_action_prevent_vm_retire }}