### PR TITLE
[RFR] Add severity to alerts test

### DIFF
--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -194,6 +194,8 @@ def test_alert_vm_turned_on_more_than_twice_in_past_15_minutes(
     with update(alert):
         alert.active = True
         alert.emails = fauxfactory.gen_email()
+        if appliance.version >= "5.11.0.7":
+            alert.severity = "Error"
 
     setup_for_alerts(request, [alert], "VM Power On", vm.name, provider)
 


### PR DESCRIPTION
severity is a required field in 5.11

{{ pytest: --use-provider vsphere6-nested --long-running cfme/tests/control/test_alerts.py::test_alert_vm_turned_on_more_than_twice_in_past_15_minutes }}
