### PR TITLE
[1LP][RFR] removed a check for load balancers for 5.11

### DIFF
--- a/cfme/tests/networks/test_tag_tagvis.py
+++ b/cfme/tests/networks/test_tag_tagvis.py
@@ -59,6 +59,9 @@ def child_visibility(appliance, network_provider, relationship, view):
 
 @pytest.mark.parametrize("relationship,view", network_test_items,
                          ids=[rel[0] for rel in network_test_items])
+@pytest.mark.uncollectif(
+    lambda relationship, appliance: "Load Balancers" in relationship and appliance.version > "5.11",
+    reason="Cloud Load Balancers are removed in 5.11, see BZ 1672949")
 def test_tagvis_network_provider_children(provider, appliance, request, relationship, view,
                                           tag, user_restricted):
     """


### PR DESCRIPTION
## Purpose or Intent
I thought it's a bug but it's a feature https://bugzilla.redhat.com/show_bug.cgi?id=1672949

### PRT Run
{{ pytest: -v cfme/tests/networks/test_tag_tagvis.py::test_tagvis_network_provider_children   --use-template-cache --use-provider=complete }}

The test `test_tagvis_network_provider_children[cloud-Load Balancers]` should not be collected for 5.11