### PR TITLE
[1LP][RFR] Automate test: test_configuration_dropdown_roles_by_server

### DIFF
--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -47,9 +47,11 @@ from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 from widgetastic_manageiq import AttributeValueForm
 from widgetastic_manageiq import Checkbox
+from widgetastic_manageiq import DiagnosticsTreeView
 from widgetastic_manageiq import InputButton
 from widgetastic_manageiq import ManageIQTree
 from widgetastic_manageiq import ServerTimelinesView
+from widgetastic_manageiq import SummaryForm
 from widgetastic_manageiq import SummaryFormItem
 from widgetastic_manageiq import SummaryTable
 from widgetastic_manageiq import WaitTab
@@ -1199,6 +1201,13 @@ class RegionDiagnosticsView(ConfigurationView):
     @View.nested
     class rolesbyservers(WaitTab):  # noqa
         TAB_NAME = "Roles by Servers"
+        title = Text(
+            '//*[@id="zone_tree_div"]/'
+            'h3[contains(normalize-space(.), "Status of Regional Roles for Servers in Region")]'
+        )
+        tree = DiagnosticsTreeView("roles_by_server_treebox")
+        selected_item = SummaryForm("Selected Item")
+        configuration = Dropdown("Configuration")
 
     @View.nested
     class replication(WaitTab):  # noqa
@@ -1207,6 +1216,13 @@ class RegionDiagnosticsView(ConfigurationView):
     @View.nested
     class serversbyroles(WaitTab):  # noqa
         TAB_NAME = "Servers by Roles"
+        title = Text(
+            '//*[@id="zone_tree_div"]/'
+            'h3[contains(normalize-space(.), "Status of Regional Roles for Servers in Region")]'
+        )
+        tree = DiagnosticsTreeView("servers_by_role_treebox")
+        selected_item = SummaryForm("Selected Item")
+        configuration = Dropdown("Configuration")
 
     @View.nested
     class servers(WaitTab):  # noqa

--- a/cfme/tests/configure/test_config_diagnostics.py
+++ b/cfme/tests/configure/test_config_diagnostics.py
@@ -65,6 +65,6 @@ def test_configuration_dropdown_roles_by_server(appliance, request):
 
     assert log.validate(wait="20s")
 
-    if BZ(1734393, forced_streams=["5.11", "5.10"]).blocks:
+    if BZ(1734393, forced_streams=["5.10"]).blocks:
         view.rolesbyservers.tree.select_item("SmartState Analysis")
     assert "available" in view.rolesbyservers.tree.currently_selected_role

--- a/cfme/tests/configure/test_config_diagnostics.py
+++ b/cfme/tests/configure/test_config_diagnostics.py
@@ -1,0 +1,70 @@
+import pytest
+
+from cfme import test_requirements
+from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import BZ
+from cfme.utils.log_validator import LogValidator
+
+
+@test_requirements.general_ui
+@pytest.mark.meta(automates=[1715466, 1455283, 1404280, 1734393])
+@pytest.mark.tier(1)
+def test_configuration_dropdown_roles_by_server(appliance, request):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: Configuration
+        caseimportance: high
+        initialEstimate: 1/15h
+        testSteps:
+            1. Navigate to Settings -> Configuration -> Diagnostics -> CFME Region ->
+                Roles by Servers.
+            2. Select a Role and check the `Configuration` dropdown in toolbar.
+            3. Check the `Suspend Role` option.
+            4. Click the `Suspend Role` option and suspend the role
+                and monitor production.log for error -
+                `Error caught: [ActiveRecord::RecordNotFound] Couldn't find MiqServer with 'id'=0`
+        expectedResults:
+            1.
+            2. `Configuration` dropdown must be enabled/active.
+            3. `Suspend Role` must be enabled.
+            4. Role must be suspended and there must be no error in the logs.
+
+    Bugzilla:
+        1715466
+        1455283
+        1404280
+        1734393
+    """
+    # 1
+    view = navigate_to(appliance.server.zone.region, "RolesByServers")
+
+    # 2
+    view.rolesbyservers.tree.select_item("SmartState Analysis")
+    assert view.rolesbyservers.configuration.is_displayed
+
+    # 3
+    assert view.rolesbyservers.configuration.item_enabled("Suspend Role")
+
+    # 4
+    log = LogValidator(
+        "/var/www/miq/vmdb/log/production.log",
+        failure_patterns=[
+            ".*Error caught: .*ActiveRecord::RecordNotFound.* Couldn't find MiqServer with 'id'=.*"
+        ],
+    )
+
+    log.start_monitoring()
+    view.rolesbyservers.configuration.item_select("Suspend Role", handle_alert=True)
+
+    request.addfinalizer(
+        lambda: view.rolesbyservers.configuration.item_select("Start Role", handle_alert=True)
+    )
+
+    view.flash.assert_message("Suspend successfully initiated")
+
+    assert log.validate(wait="20s")
+
+    if BZ(1734393, forced_streams=["5.11", "5.10"]).blocks:
+        view.rolesbyservers.tree.select_item("SmartState Analysis")
+    assert "available" in view.rolesbyservers.tree.currently_selected_role

--- a/cfme/tests/configure/test_config_manual.py
+++ b/cfme/tests/configure/test_config_manual.py
@@ -77,39 +77,6 @@ def test_configure_icons_roles_by_server():
 
 @pytest.mark.manual
 @test_requirements.general_ui
-@pytest.mark.meta(coverage=[1715466, 1455283, 1404280])
-@pytest.mark.tier(1)
-def test_configuration_dropdown_roles_by_server():
-    """
-    Polarion:
-        assignee: pvala
-        casecomponent: Configuration
-        caseimportance: high
-        initialEstimate: 1/15h
-        testSteps:
-            1. Navigate to Settings -> Configuration -> Diagnostics -> CFME Region ->
-                Roles by Servers.
-            2. Select a Role and check the `Configuration` dropdown in toolbar.
-            3. Check the `Suspend Role` option.
-            4. Click the `Suspend Role` option and suspend the role
-                and monitor production.log for error -
-                `Error caught: [ActiveRecord::RecordNotFound] Couldn't find MiqServer with 'id'=0`
-        expectedResults:
-            1.
-            2. `Configuration` dropdown must be enabled/active.
-            3. `Suspend Role` must be enabled.
-            4. Role must be suspended and there must be no error in the logs.
-
-    Bugzilla:
-        1715466
-        1455283
-        1404280
-    """
-    pass
-
-
-@pytest.mark.manual
-@test_requirements.general_ui
 @pytest.mark.tier(1)
 @pytest.mark.meta(coverage=[1498090])
 def test_diagnostics_server():

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -5766,6 +5766,8 @@ class EntryPoint(View, ClickableMixin):
 class DiagnosticsTreeView(BootstrapTreeview):
     @property
     def items(self):
+        # read_contents method returns [:server_info, [:role1, :role2,..]]
+        # and since we only need roles, we use indexing
         return self.read_contents()[-1]
 
     def select_item(self, name, parent=None):
@@ -5784,4 +5786,6 @@ class DiagnosticsTreeView(BootstrapTreeview):
 
     @property
     def currently_selected_role(self):
+        # currently_selected returns [:server_info, :role_info] and since we only need
+        # currently selected role, we use indexing
         return self.currently_selected[-1]

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -61,6 +61,7 @@ from widgetastic_patternfly import Tab
 from widgetastic_patternfly import VerticalNavigation
 
 from cfme.exceptions import ItemNotFound
+from cfme.exceptions import ManyEntitiesFound
 
 
 class DynamicTableAddError(Exception):
@@ -5760,3 +5761,27 @@ class EntryPoint(View, ClickableMixin):
     @property
     def is_displayed(self):
         return self.textbox.is_displayed
+
+
+class DiagnosticsTreeView(BootstrapTreeview):
+    @property
+    def items(self):
+        return self.read_contents()[-1]
+
+    def select_item(self, name, parent=None):
+        if not parent:
+            parent = self.root_item
+        item_lst = self.child_items_with_text(parent, name)
+        if len(item_lst) == 1:
+            item_lst[0].click()
+            return True
+        elif len(item_lst) > 1:
+            raise ManyEntitiesFound(
+                "More than 1 items partially matching name '{}' found.".format(name)
+            )
+        else:
+            raise ItemNotFound("No items partially matching name '{}' found.".format(name))
+
+    @property
+    def currently_selected_role(self):
+        return self.currently_selected[-1]


### PR DESCRIPTION
## Purpose or Intent
- __Adding tests__ `test_configuration_dropdown_roles_by_server` that covers BZ
- __Extending__ add missing widgets to `rolesbyservers` and `serversbyroles`.

### PRT Run
{{ pytest: cfme/tests/configure/test_config_diagnostics.py -v }}