### PR TITLE
[RFR] Use ubuntu 14.04 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ stages:
 - linting
 - test
 - deploy
+dist: trusty
 
 jobs:
   include:


### PR DESCRIPTION
just a band-aid for travis until #9053 is merged. Recently travis was updated to use ubuntu 16.04 by default, which breaks our quickstart. So here force it to use 14.04 until #9053 is merged. 