### PR TITLE
[1LP][RFR] fixed get_text_of in SummaryTable

### DIFF
--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -699,9 +699,9 @@ class SummaryTable(VanillaTable):
         """
         fields = self.get_field(field_name)
         if isinstance(fields, (list, tuple)):
-            return [field.text for field in fields]
+            return [self.browser.text(field) for field in fields]
         else:
-            return fields[1].text
+            return self.browser.text(fields[1])
 
     def get_img_of(self, field_name):
         """Returns the information about the image in the field with this name.


### PR DESCRIPTION
## Purpose or Intent
I see this is failing in 5.11 with `E       AssertionError: assert ' Testing: testing' == 'Testing: testing'`, so this removes extra spaces and `test_tag_mapping_azure_instances` passes.

### PRT Run
{{ pytest: -v cfme/tests/cloud/test_tag_mapping.py::test_tag_mapping_azure_instances --use-provider=complete }}