### PR TITLE
[1LP][RFR] Test case updated for 5.10z

### DIFF
--- a/cfme/tests/automate/test_service_automate.py
+++ b/cfme/tests/automate/test_service_automate.py
@@ -7,7 +7,6 @@ from cfme.base.credential import Credential
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.provisioning import do_vm_provisioning
 from cfme.services.service_catalogs import ServiceCatalogs
-from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log_validator import LogValidator
 
@@ -30,11 +29,8 @@ def new_users(appliance):
 
     yield users
     for user in users:
-        if not BZ(1720273).blocks:
-            user.delete_if_exists()
-        else:
-            user = appliance.rest_api.collections.users.get(name=user.name)
-            user.action.delete()
+        user = appliance.rest_api.collections.users.get(name=user.name)
+        user.action.delete()
 
 
 @pytest.fixture(scope='function')
@@ -76,7 +72,7 @@ def service_validate_request(domain):
 
 @pytest.mark.tier(3)
 @pytest.mark.provider([VMwareProvider], scope="module")
-@pytest.mark.ignore_stream("5.10")
+@pytest.mark.meta(automates=[1671563, 1720273, 1728706])
 def test_user_requester_for_lifecycle_provision(request, appliance, provider, setup_provider,
                                                 new_users, generic_catalog_item,
                                                 infra_validate_request, service_validate_request,
@@ -92,6 +88,7 @@ def test_user_requester_for_lifecycle_provision(request, appliance, provider, se
     Bugzilla:
          1671563
          1720273
+         1728706
     """
     script = """
     user = $evm.root['user']

--- a/cfme/tests/automate/test_simulation.py
+++ b/cfme/tests/automate/test_simulation.py
@@ -10,6 +10,7 @@ from cfme.utils.blockers import BZ
 pytestmark = [test_requirements.automate, pytest.mark.tier(2)]
 
 
+@pytest.mark.meta(automates=[1719322])
 def test_object_attributes(appliance):
     """
     Polarion:
@@ -35,7 +36,7 @@ def test_object_attributes(appliance):
             # Selecting object attribute type
             view.target_type.select_by_visible_text(object_type.text)
             # Checking whether dependent objects(object attribute selection) are loaded or not
-            assert view.target_object.all_options > 0
+            assert len(view.target_object.all_options) > 0
 
 
 @pytest.fixture(scope='function')
@@ -49,6 +50,7 @@ def copy_class(domain):
 
 
 @pytest.mark.tier(1)
+@pytest.mark.meta(automates=[1335669])
 def test_assert_failed_substitution(copy_class):
     """
     Polarion:


### PR DESCRIPTION
## Purpose or Intent
- This BZ(1728706) is hot fix for 5.10z. Hence updating this test case for 5.10z
- Fixed Error for ```test_object_attributes```:
```
>               assert view.target_object.all_options > 0
E               TypeError: '>' not supported between instances of 'list' and 'int'

cfme/tests/automate/test_simulation.py:38: TypeError
TypeError
b"'>' not supported between instances of 'list' and 'int'"
```

### PRT Run

 {{ pytest: cfme/tests/automate/ -k 'test_user_requester_for_lifecycle_provision or test_object_attributes' --use-template-cache -qsvv }}
