### PR TITLE
[1LP][RFR] Add tests for automating Tower workflow jobs

### DIFF
--- a/cfme/tests/services/test_ansible_workflow_servicecatalogs.py
+++ b/cfme/tests/services/test_ansible_workflow_servicecatalogs.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-:
 import pytest
 
 from cfme import test_requirements
@@ -44,13 +44,14 @@ def config_manager(config_manager_obj):
 
 
 @pytest.fixture(scope="function")
-def catalog_item(appliance, request, config_manager, dialog, catalog, job_type):
+def catalog_item(appliance, request, config_manager, dialog, catalog):
+    job_type = 'workflow'
     config_manager_obj = config_manager
     provider_name = config_manager_obj.yaml_data.get('name')
     template = config_manager_obj.yaml_data['provisioning_data'][job_type]
     catalog_item = appliance.collections.catalog_items.create(
         appliance.collections.catalog_items.ANSIBLE_TOWER,
-        name={}_dialog.label.format(job_type),
+        name=dialog.label,
         description="my catalog",
         display_in=True,
         catalog=catalog,
@@ -61,8 +62,8 @@ def catalog_item(appliance, request, config_manager, dialog, catalog, job_type):
     return catalog_item
 
 
-def test_tower_workflow_item(appliance, config_manager, catalog_item, request, job_type):
-    """Tests ordering of catalog items for Ansible Template and Workflow jobs
+def test_tower_workflow_item(appliance, config_manager, catalog_item, request):
+    """Tests ordering of catalog items for Ansible Workflow templates
     Metadata:
         test_flag: provision
 
@@ -72,7 +73,6 @@ def test_tower_workflow_item(appliance, config_manager, catalog_item, request, j
         casecomponent: Services
         caseimportance: high
     """
-    job_type = 'workflow'
     service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
     service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
@@ -86,8 +86,8 @@ def test_tower_workflow_item(appliance, config_manager, catalog_item, request, j
 
 
 @pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:8610')])
-def test_retire_ansible_service(appliance, catalog_item, request, job_type):
-    """Tests retiring of catalog items for Ansible Template and Workflow jobs
+def test_retire_ansible_service(appliance, catalog_item, request):
+    """Tests retiring of catalog items for Ansible Workflow templates
     Metadata:
         test_flag: provision
 
@@ -97,7 +97,6 @@ def test_retire_ansible_service(appliance, catalog_item, request, job_type):
         caseimportance: medium
         initialEstimate: 1/4h
     """
-    job_type = 'workflow'
     service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
     service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)

--- a/cfme/tests/services/test_ansible_workflow_servicecatalogs.py
+++ b/cfme/tests/services/test_ansible_workflow_servicecatalogs.py
@@ -6,7 +6,6 @@ from cfme.services.myservice import MyService
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils import testgen
 from cfme.utils.blockers import BZ
-from cfme.utils.blockers import GH
 from cfme.utils.log import logger
 
 
@@ -48,7 +47,10 @@ def ansible_workflow_catitem(appliance, request, tower_manager, dialog, catalog)
     job_type = 'workflow'
     config_manager_obj = tower_manager
     provider_name = config_manager_obj.yaml_data.get('name')
-    template = config_manager_obj.yaml_data['provisioning_data'][job_type]
+    if config_manager_obj.yaml_data['provisioning_data'][job_type]:
+        template = config_manager_obj.yaml_data['provisioning_data'][job_type]
+    else:
+        pytest.skip("No such Ansible template: {} found in cfme_data.yaml".format(job_type))
     catalog_item = appliance.collections.catalog_items.create(
         appliance.collections.catalog_items.ANSIBLE_TOWER,
         name=dialog.label,
@@ -89,7 +91,6 @@ def test_tower_workflow_item(appliance, tower_manager, ansible_workflow_catitem,
     )
 
 
-@pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:8610')])
 def test_retire_ansible_workflow(appliance, ansible_workflow_catalog_item, request):
     """Tests retiring of catalog items for Ansible Workflow templates
     Metadata:

--- a/cfme/tests/services/test_ansible_workflow_servicecatalogs.py
+++ b/cfme/tests/services/test_ansible_workflow_servicecatalogs.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from cfme import test_requirements
+from cfme.services.myservice import MyService
+from cfme.services.service_catalogs import ServiceCatalogs
+from cfme.utils import testgen
+from cfme.utils.blockers import GH
+from cfme.utils.log import logger
+
+
+pytestmark = [
+    test_requirements.service,
+    pytest.mark.tier(2),
+    pytest.mark.ignore_stream('upstream')]
+
+
+def pytest_generate_tests(metafunc):
+    # Filter out providers without provisioning data or hosts defined
+    argnames, argvalues, idlist = testgen.config_managers(metafunc)
+    new_idlist = []
+    new_argvalues = []
+    for i, argvalue_tuple in enumerate(argvalues):
+        args = dict(zip(argnames, argvalue_tuple))
+
+        if not args['config_manager_obj'].yaml_data['provisioning']:
+            continue
+
+        new_idlist.append(idlist[i])
+        new_argvalues.append(argvalues[i])
+
+    testgen.parametrize(metafunc, argnames, new_argvalues, ids=new_idlist, scope='module')
+
+
+@pytest.fixture(scope="module")
+def config_manager(config_manager_obj):
+    """ Fixture that provides a random config manager and sets it up"""
+    if config_manager_obj.type == "Ansible Tower":
+        config_manager_obj.create(validate=True)
+    else:
+        config_manager_obj.create()
+    yield config_manager_obj
+    config_manager_obj.delete()
+
+
+@pytest.fixture(scope="function")
+def catalog_item(appliance, request, config_manager, dialog, catalog, job_type):
+    config_manager_obj = config_manager
+    provider_name = config_manager_obj.yaml_data.get('name')
+    template = config_manager_obj.yaml_data['provisioning_data'][job_type]
+    catalog_item = appliance.collections.catalog_items.create(
+        appliance.collections.catalog_items.ANSIBLE_TOWER,
+        name={}_dialog.label.format(job_type),
+        description="my catalog",
+        display_in=True,
+        catalog=catalog,
+        dialog=dialog,
+        provider='{} Automation Manager'.format(provider_name),
+        config_template=template)
+    request.addfinalizer(catalog_item.delete)
+    return catalog_item
+
+
+def test_tower_workflow_item(appliance, config_manager, catalog_item, request, job_type):
+    """Tests ordering of catalog items for Ansible Template and Workflow jobs
+    Metadata:
+        test_flag: provision
+
+    Polarion:
+        assignee: nachandr
+        initialEstimate: 1/4h
+        casecomponent: Services
+        caseimportance: high
+    """
+    job_type = 'workflow'
+    service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
+    service_catalogs.order()
+    logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
+    cells = {'Description': catalog_item.name}
+    order_request = appliance.collections.requests.instantiate(cells=cells, partial_check=True)
+    order_request.wait_for_request(method='ui')
+    msg = 'Request failed with the message {}'.format(order_request.row.last_message.text)
+    assert order_request.is_succeeded(method='ui'), msg
+    appliance.user.my_settings.default_views.set_default_view('Configuration Management Providers',
+                                                              'List View')
+
+
+@pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:8610')])
+def test_retire_ansible_service(appliance, catalog_item, request, job_type):
+    """Tests retiring of catalog items for Ansible Template and Workflow jobs
+    Metadata:
+        test_flag: provision
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: Services
+        caseimportance: medium
+        initialEstimate: 1/4h
+    """
+    job_type = 'workflow'
+    service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
+    service_catalogs.order()
+    logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
+    cells = {'Description': catalog_item.name}
+    order_request = appliance.collections.requests.instantiate(cells=cells, partial_check=True)
+    order_request.wait_for_request(method='ui')
+    msg = "Request failed with the message {}".format(order_request.row.last_message.text)
+    assert order_request.is_succeeded(method='ui'), msg
+    myservice = MyService(appliance, catalog_item.name)
+    myservice.retire()

--- a/cfme/tests/services/test_ansible_workflow_servicecatalogs.py
+++ b/cfme/tests/services/test_ansible_workflow_servicecatalogs.py
@@ -5,6 +5,7 @@ from cfme import test_requirements
 from cfme.services.myservice import MyService
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils import testgen
+from cfme.utils.blockers import BZ
 from cfme.utils.blockers import GH
 from cfme.utils.log import logger
 
@@ -12,7 +13,8 @@ from cfme.utils.log import logger
 pytestmark = [
     test_requirements.service,
     pytest.mark.tier(2),
-    pytest.mark.ignore_stream('upstream')]
+    pytest.mark.ignore_stream('upstream')
+]
 
 
 def pytest_generate_tests(metafunc):
@@ -33,20 +35,18 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.fixture(scope="module")
-def config_manager(config_manager_obj):
-    """ Fixture that provides a random config manager and sets it up"""
+def tower_manager(config_manager_obj):
+    """ Fixture that sets up Ansible Tower"""
     if config_manager_obj.type == "Ansible Tower":
         config_manager_obj.create(validate=True)
-    else:
-        config_manager_obj.create()
     yield config_manager_obj
     config_manager_obj.delete()
 
 
 @pytest.fixture(scope="function")
-def catalog_item(appliance, request, config_manager, dialog, catalog):
+def ansible_workflow_catitem(appliance, request, tower_manager, dialog, catalog):
     job_type = 'workflow'
-    config_manager_obj = config_manager
+    config_manager_obj = tower_manager
     provider_name = config_manager_obj.yaml_data.get('name')
     template = config_manager_obj.yaml_data['provisioning_data'][job_type]
     catalog_item = appliance.collections.catalog_items.create(
@@ -58,11 +58,12 @@ def catalog_item(appliance, request, config_manager, dialog, catalog):
         dialog=dialog,
         provider='{} Automation Manager'.format(provider_name),
         config_template=template)
-    request.addfinalizer(catalog_item.delete)
-    return catalog_item
+    yield catalog_item
+    catalog_item.delete_if_exists()
 
 
-def test_tower_workflow_item(appliance, config_manager, catalog_item, request):
+@pytest.mark.meta(automates=[BZ(1719051)])
+def test_tower_workflow_item(appliance, tower_manager, ansible_workflow_catitem, request):
     """Tests ordering of catalog items for Ansible Workflow templates
     Metadata:
         test_flag: provision
@@ -73,20 +74,23 @@ def test_tower_workflow_item(appliance, config_manager, catalog_item, request):
         casecomponent: Services
         caseimportance: high
     """
-    service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
+    service_catalogs = ServiceCatalogs(appliance, ansible_workflow_catitem.catalog,
+        ansible_workflow_catitem.name)
     service_catalogs.order()
-    logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
-    cells = {'Description': catalog_item.name}
+    logger.info('Waiting for cfme provision request for service %s', ansible_workflow_catitem.name)
+    cells = {'Description': ansible_workflow_catitem.name}
     order_request = appliance.collections.requests.instantiate(cells=cells, partial_check=True)
     order_request.wait_for_request(method='ui')
     msg = 'Request failed with the message {}'.format(order_request.row.last_message.text)
     assert order_request.is_succeeded(method='ui'), msg
-    appliance.user.my_settings.default_views.set_default_view('Configuration Management Providers',
-                                                              'List View')
+    appliance.user.my_settings.default_views.set_default_view(
+        'Configuration Management Providers',
+        'List View'
+    )
 
 
 @pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:8610')])
-def test_retire_ansible_service(appliance, catalog_item, request):
+def test_retire_ansible_workflow(appliance, ansible_workflow_catalog_item, request):
     """Tests retiring of catalog items for Ansible Workflow templates
     Metadata:
         test_flag: provision
@@ -97,13 +101,14 @@ def test_retire_ansible_service(appliance, catalog_item, request):
         caseimportance: medium
         initialEstimate: 1/4h
     """
-    service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
+    service_catalogs = ServiceCatalogs(appliance, ansible_workflow_catitem.name.catalog,
+        ansible_workflow_catitem.name)
     service_catalogs.order()
-    logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
-    cells = {'Description': catalog_item.name}
+    logger.info('Waiting for cfme provision request for service %s', ansible_workflow_catitem.name)
+    cells = {'Description': ansible_workflow_catitem.name}
     order_request = appliance.collections.requests.instantiate(cells=cells, partial_check=True)
     order_request.wait_for_request(method='ui')
     msg = "Request failed with the message {}".format(order_request.row.last_message.text)
     assert order_request.is_succeeded(method='ui'), msg
-    myservice = MyService(appliance, catalog_item.name)
+    myservice = MyService(appliance, ansible_workflow_catitem.name)
     myservice.retire()

--- a/cfme/tests/services/test_ansible_workflow_servicecatalogs.py
+++ b/cfme/tests/services/test_ansible_workflow_servicecatalogs.py
@@ -91,7 +91,7 @@ def test_tower_workflow_item(appliance, tower_manager, ansible_workflow_catitem,
     )
 
 
-def test_retire_ansible_workflow(appliance, ansible_workflow_catalog_item, request):
+def test_retire_ansible_workflow(appliance, ansible_workflow_catitem, request):
     """Tests retiring of catalog items for Ansible Workflow templates
     Metadata:
         test_flag: provision
@@ -102,7 +102,7 @@ def test_retire_ansible_workflow(appliance, ansible_workflow_catalog_item, reque
         caseimportance: medium
         initialEstimate: 1/4h
     """
-    service_catalogs = ServiceCatalogs(appliance, ansible_workflow_catitem.name.catalog,
+    service_catalogs = ServiceCatalogs(appliance, ansible_workflow_catitem.catalog,
         ansible_workflow_catitem.name)
     service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', ansible_workflow_catitem.name)

--- a/cfme/tests/services/test_ansible_workflow_servicecatalogs.py
+++ b/cfme/tests/services/test_ansible_workflow_servicecatalogs.py
@@ -35,7 +35,7 @@ def pytest_generate_tests(metafunc):
 
 @pytest.fixture(scope="module")
 def tower_manager(config_manager_obj):
-    """ Fixture that sets up Ansible Tower"""
+    """ Fixture that sets up Ansible Tower provider"""
     if config_manager_obj.type == "Ansible Tower":
         config_manager_obj.create(validate=True)
     yield config_manager_obj
@@ -48,8 +48,7 @@ def ansible_workflow_catitem(appliance, request, tower_manager, dialog, catalog)
     config_manager_obj = tower_manager
     provider_name = config_manager_obj.yaml_data.get('name')
     try:
-        if config_manager_obj.yaml_data['provisioning_data'][job_type]:
-            template = config_manager_obj.yaml_data['provisioning_data'][job_type]
+        template = config_manager_obj.yaml_data['provisioning_data'][job_type]
     except KeyError:
         pytest.skip("No such Ansible template: {} found in cfme_data.yaml".format(job_type))
     catalog_item = appliance.collections.catalog_items.create(

--- a/cfme/tests/services/test_ansible_workflow_servicecatalogs.py
+++ b/cfme/tests/services/test_ansible_workflow_servicecatalogs.py
@@ -47,9 +47,10 @@ def ansible_workflow_catitem(appliance, request, tower_manager, dialog, catalog)
     job_type = 'workflow'
     config_manager_obj = tower_manager
     provider_name = config_manager_obj.yaml_data.get('name')
-    if config_manager_obj.yaml_data['provisioning_data'][job_type]:
-        template = config_manager_obj.yaml_data['provisioning_data'][job_type]
-    else:
+    try:
+        if config_manager_obj.yaml_data['provisioning_data'][job_type]:
+            template = config_manager_obj.yaml_data['provisioning_data'][job_type]
+    except KeyError:
         pytest.skip("No such Ansible template: {} found in cfme_data.yaml".format(job_type))
     catalog_item = appliance.collections.catalog_items.create(
         appliance.collections.catalog_items.ANSIBLE_TOWER,


### PR DESCRIPTION
#  Purpose or Intent
- __Adding tests__ for Ansible workflow jobs

Tested with
{{ py.test:  cfme/tests/services/test_ansible_workflow_servicecatalogs.py }}

PRT results:
510 - Passed
511 - Passed