### PR TITLE
[RFR] Change iterator use in FirefoxProfile.set_preference

### DIFF
--- a/cfme/utils/browser.py
+++ b/cfme/utils/browser.py
@@ -54,8 +54,7 @@ def _load_firefox_profile():
     profile_dict = json.loads(profile_json)
 
     profile = FirefoxProfile(firefox_profile_tmpdir)
-    for pref, _ in profile_dict.items():
-        profile.set_preference(*pref)
+    [profile.set_preference(*pref) for pref in profile_dict.items()]
     profile.update_preferences()
     return profile
 


### PR DESCRIPTION
Causing failure across the framework, this iterator was changed with move to py3
