### PR TITLE
[RFR] Py3 compact

### DIFF
--- a/cfme/utils/ssh.py
+++ b/cfme/utils/ssh.py
@@ -2,6 +2,7 @@
 import re
 import socket
 import sys
+from functools import total_ordering
 from os import path as os_path
 from subprocess import check_call
 
@@ -31,7 +32,8 @@ from cfme.utils.wait import wait_for
 RUNCMD_TIMEOUT = 1200.0
 
 
-@attr.s(frozen=True)
+@attr.s(frozen=True, cmp=False)
+@total_ordering
 class SSHResult(object):
     """Allows rich comparison for more convenient testing.
 
@@ -75,14 +77,19 @@ class SSHResult(object):
         # handling int(x)
         return self.rc
 
-    def __cmp__(self, other):
-        # Handling comparison to strings or numbers
-        # py3.6 compatible cmp syntax
-        # TODO: remove for full py3.6 compatibility
+    def __eq__(self, other):
         if isinstance(other, int):
-            return (self.rc > other) - (self.rc < other)
+            return self.rc == other
         elif isinstance(other, six.string_types):
-            return (self.output > other) - (self.output < other)
+            return self.output == other
+        else:
+            raise ValueError('You can only compare SSHResult with str or int')
+
+    def __lt__(self, other):
+        if isinstance(other, int):
+            return self.rc < other
+        elif isinstance(other, six.string_types):
+            return self.output < other
         else:
             raise ValueError('You can only compare SSHResult with str or int')
 

--- a/scripts/gen_ssl_cert.py
+++ b/scripts/gen_ssl_cert.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Script creates self signed SSL cert and the key necessary to sign it.
 # This is based off of the code in this article:


### PR DESCRIPTION
__fixing__ some problems related to switch to py3.

Regarding the SSHResult, I did some local testing:
```

In [4]: cfme.utils.ssh.SSHResult("ff", 3, "oo")                                                          
Out[4]: SSHResult(command='ff', rc=3)

In [5]: cfme.utils.ssh.SSHResult("ff", 3, "oo") == 3                                                     
Out[5]: True

In [6]: cfme.utils.ssh.SSHResult("ff", 3, "oo") == 2                                                     
Out[6]: False

In [7]: cfme.utils.ssh.SSHResult("ff", 3, "oo") < 2                                                      
Out[7]: False

In [8]: cfme.utils.ssh.SSHResult("ff", 3, "oo") > 2                                                      
Out[8]: True

In [9]: cfme.utils.ssh.SSHResult("ff", 3, "oo") > "oo"                                                   
Out[9]: False

In [10]: cfme.utils.ssh.SSHResult("ff", 3, "oo") == "oo"                                                 
Out[10]: True

In [11]: cfme.utils.ssh.SSHResult("ff", 3, "oo") < "ooo"                                                 
Out[11]: True
```
