### PR TITLE
[RFR] Fix test_provision_approval.

### DIFF
--- a/scripts/smtp_collector.py
+++ b/scripts/smtp_collector.py
@@ -70,7 +70,7 @@ def write(what, end="\n"):
 
 class EmailServer(SMTPServer):
     """Simple e-mail server. What does it do is that every mail is put in the database."""
-    def process_message(self, peer, mailfrom, rcpttos, data):
+    def process_message(self, peer, mailfrom, rcpttos, data, **kwargs):
         message = email.message_from_string(data)
         payload = message.get_payload()
         if isinstance(payload, list):
@@ -199,7 +199,7 @@ def clear_database():
 
 
 def run_email_server(port=1025):
-    EmailServer(("0.0.0.0", port), None)
+    EmailServer(("0.0.0.0", port), None, decode_data=True)
     try:
         asyncore.loop()
     except KeyboardInterrupt:


### PR DESCRIPTION
The test_provision_approval started failing after switching to Py3 due to
adding of an argument `mail_options`.

The argument `data` of the `process_message` is `bytes` unless the argument to SMTPServer
`decode_data=True` in which case we get the utf-8 decoded string.



{{pytest: cfme/tests/cloud_infra_common/test_provisioning.py::test_provision_approval -v}}
